### PR TITLE
Fix window sizing on HiDPI/4K monitors

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import { getCurrentWindow, currentMonitor, LogicalSize } from "@tauri-apps/api/window";
+  import { getCurrentWindow, currentMonitor, PhysicalSize } from "@tauri-apps/api/window";
   import { listBoxes, checkAndInstallUpdate } from "./lib/api";
   import { createBoxConnection, type BoxConnection } from "./lib/ws";
   import { removeBoxState, resetOnboarding } from "./lib/store.svelte";
@@ -41,10 +41,13 @@
     const appWindow = getCurrentWindow();
     const monitor = await currentMonitor();
     if (!monitor) return;
+    // Work in physical pixels so window appears as the same fraction of screen
+    // regardless of OS scaling / DPI
+    const scale = monitor.scaleFactor;
     const shortest = Math.min(monitor.size.width, monitor.size.height);
-    const size = Math.round(Math.max(MIN_SIZE, Math.min(MAX_SIZE, shortest * SCREEN_FRACTION)));
+    const size = Math.round(Math.max(MIN_SIZE * scale, Math.min(MAX_SIZE * scale, shortest * SCREEN_FRACTION)));
 
-    await appWindow.setSize(new LogicalSize(size, size));
+    await appWindow.setSize(new PhysicalSize(size, size));
     await appWindow.center();
   }
 


### PR DESCRIPTION
## Summary

- Window was using \`LogicalSize\` with physical pixel values from \`monitor.size\`, mixing units
- On 4K monitors at 200% OS scaling, the window appeared half the intended size relative to screen
- Fix: use \`PhysicalSize\` and scale MIN/MAX bounds by \`scaleFactor\` so the window always appears as the same physical fraction of the screen regardless of DPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)