### PR TITLE
Rename 'sign in' to 're authenticate' in app UI

### DIFF
--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1133,7 +1133,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.94"
+version = "0.1.95"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/app/src/components/BoxView.svelte
+++ b/app/src/components/BoxView.svelte
@@ -198,7 +198,7 @@
       }
       connection.resetReconnect();
       await syncStatus();
-    }, "sign in failed");
+    }, "re authentication failed");
   }
 
   async function handleRestart() {
@@ -309,7 +309,7 @@
         {#if alive}
           <button class="action-btn primary" onclick={onChat} data-tip="open chat">chat</button>
         {:else if running && !authenticated}
-          <button class="action-btn primary" disabled={busy} onclick={handleAuth} data-tip="sign in to claude">sign in</button>
+          <button class="action-btn primary" disabled={busy} onclick={handleAuth} data-tip="re authenticate to claude">re authenticate</button>
         {/if}
         <button class="action-btn" disabled={busy} onclick={toggleRun} data-tip={running ? "stop" : "start"}>
           {running ? "stop" : "start"}
@@ -331,7 +331,7 @@
                 <button class="menu-item" disabled={busy} onclick={() => { menuOpen = false; handleRestart(); }} data-tip="restart box">restart</button>
               {/if}
               {#if running && authenticated}
-                <button class="menu-item" disabled={busy} onclick={() => { menuOpen = false; handleAuth(); }} data-tip="re-authenticate claude">sign in</button>
+                <button class="menu-item" disabled={busy} onclick={() => { menuOpen = false; handleAuth(); }} data-tip="re-authenticate claude">re authenticate</button>
               {/if}
               <button class="menu-item" disabled={busy} onclick={() => { menuOpen = false; handleBackup(); }} data-tip="export to file">backup</button>
               <button class="menu-item" disabled={busy} onclick={() => { menuOpen = false; handleRestore(); }} data-tip="restore from file">load backup</button>

--- a/app/src/components/Onboarding.svelte
+++ b/app/src/components/Onboarding.svelte
@@ -369,7 +369,7 @@
 
     {:else if step === "auth"}
       <div class="step step-anim">
-        <h1>sign in to claude</h1>
+        <h1>re authenticate to claude</h1>
         {#if authCodeNeeded}
           <p class="sub">paste the code from the browser below.</p>
           <form onsubmit={(e) => { e.preventDefault(); handleSubmitCode(); }}>
@@ -381,9 +381,9 @@
           <p class="sub">verifying code...</p>
           <ProgressBar message="verifying..." />
         {:else if authUrl}
-          <p class="sub">sign in via the browser window that opened.<br/>if it didn't open, use the link below.</p>
+          <p class="sub">re authenticate via the browser window that opened.<br/>if it didn't open, use the link below.</p>
           <a class="auth-link" href={authUrl} target="_blank" rel="noopener">{authUrl.slice(0, 50)}...</a>
-          <ProgressBar message="waiting for sign in..." />
+          <ProgressBar message="waiting for re authentication..." />
         {:else}
           <p class="sub">opening browser...</p>
           <ProgressBar message="waiting..." />


### PR DESCRIPTION
## Summary
- Renames all 'sign in' labels and messages to 're authenticate' in the Tauri/Svelte desktop app

## Test plan
- [ ] Visual check of onboarding flow shows 're authenticate' text
- [ ] Button in BoxView shows 're authenticate'
- [ ] Menu item shows 're authenticate'

🤖 Generated with [Claude Code](https://claude.com/claude-code)