### PR TITLE
fix: window sizing and version badge polish

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import { getCurrentWindow, currentMonitor, PhysicalSize } from "@tauri-apps/api/window";
+  import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
   import { listBoxes, checkAndInstallUpdate, runInstallScript } from "./lib/api";
   import { createBoxConnection, type BoxConnection } from "./lib/ws";
   import { removeBoxState, resetOnboarding } from "./lib/store.svelte";
@@ -33,21 +33,15 @@
     transitioning = false;
   }
 
-  const SCREEN_FRACTION = 0.28;
-  const MIN_SIZE = 380;
-  const MAX_SIZE = 760;
+  const SCREEN_FRACTION = 0.6;
+  const MIN_SIZE = 400; // logical px
+  const MAX_SIZE = 800; // logical px
 
   async function scaleToMonitor() {
     const appWindow = getCurrentWindow();
-    const monitor = await currentMonitor();
-    if (!monitor) return;
-    // Work in physical pixels so window appears as the same fraction of screen
-    // regardless of OS scaling / DPI
-    const scale = monitor.scaleFactor;
-    const shortest = Math.min(monitor.size.width, monitor.size.height);
-    const size = Math.round(Math.max(MIN_SIZE * scale, Math.min(MAX_SIZE * scale, shortest * SCREEN_FRACTION)));
-
-    await appWindow.setSize(new PhysicalSize(size, size));
+    const shortest = Math.min(window.screen.width, window.screen.height);
+    const size = Math.round(Math.max(MIN_SIZE, Math.min(MAX_SIZE, shortest * SCREEN_FRACTION)));
+    await appWindow.setSize(new LogicalSize(size, size));
     await appWindow.center();
   }
 

--- a/app/src/components/BoxView.svelte
+++ b/app/src/components/BoxView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
+  import { appVersion as appVersionPromise } from "../lib/version";
   import type { BoxConnection } from "../lib/ws";
   import { boxStatus, startBox, stopBox, restartBox, deleteBox, authenticate, backupBox, restoreBox } from "../lib/api";
   import { getBoxOp, setBoxOp, clearBoxOp, setBoxError, type BoxOperation } from "../lib/store.svelte";
@@ -24,6 +25,7 @@
     onBack: () => void;
   } = $props();
 
+  let appVersion = $state("");
   let statusLoaded = $state(false);
   let status = $state<BoxStatus>("unknown");
   let authenticated = $state(false);
@@ -131,11 +133,12 @@
     }
   }
 
-  onMount(() => {
+  onMount(async () => {
     refresh();
     poll = setInterval(refresh, 5000);
     document.addEventListener("click", onDocClick);
     document.addEventListener("keydown", onKeydown);
+    appVersion = await appVersionPromise;
   });
 
   onDestroy(() => {
@@ -344,7 +347,9 @@
     </div>
   </div>
 
-
+  {#if appVersion}
+    <span class="version">v{appVersion}</span>
+  {/if}
 </div>
 
 <style>
@@ -844,7 +849,24 @@
     pointer-events: none;
   }
 
+  .version {
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 10px;
+    font-weight: 400;
+    letter-spacing: 0.02em;
+    color: #c4bdb5;
+    user-select: none;
+    pointer-events: none;
+  }
+
   @media (prefers-color-scheme: dark) {
+    .version {
+      color: #5a5450;
+    }
+
     .name {
       color: #e8e0d8;
     }

--- a/app/src/components/GridView.svelte
+++ b/app/src/components/GridView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import { getVersion } from "@tauri-apps/api/app";
+  import { appVersion as appVersionPromise } from "../lib/version";
   import { listBoxes, startBox, stopBox, restartBox, deleteBox, backupBox, restoreBox } from "../lib/api";
   import { getBoxOp, setBoxOp, clearBoxOp, busyBoxName } from "../lib/store.svelte";
   import { save, open } from "@tauri-apps/plugin-dialog";
@@ -81,7 +81,7 @@
     poll = setInterval(refresh, 5000);
     document.addEventListener("click", onDocClick);
     document.addEventListener("keydown", onKeydown);
-    appVersion = await getVersion();
+    appVersion = await appVersionPromise;
   });
 
   onDestroy(() => {

--- a/app/src/lib/version.ts
+++ b/app/src/lib/version.ts
@@ -1,0 +1,3 @@
+import { getVersion } from "@tauri-apps/api/app";
+
+export const appVersion: Promise<string> = getVersion();


### PR DESCRIPTION
## Summary

- **Window sizing (Wayland fix)**: `scaleToMonitor()` now uses `LogicalSize` + `window.screen` instead of `PhysicalSize` + `currentMonitor()`. The previous approach returned physical pixels without accounting for DPI scaling, causing the window to appear too small on HiDPI/Wayland displays. `window.screen` already provides logical dimensions, so no manual scaling is needed.
- **Larger default window**: `SCREEN_FRACTION` increased from 0.28 to 0.6 (60% of the shorter screen dimension), with `MIN_SIZE` 400 and `MAX_SIZE` 800, giving a more usable default size.
- **Version badge on BoxView**: BoxView was missing the version badge that GridView already displayed. Now both views show it consistently.
- **Cached `getVersion()` call**: Extracted into `app/src/lib/version.ts` as a module-level promise so both GridView and BoxView share a single Tauri IPC call instead of each firing one on mount.

## Test plan

- [ ] Launch app on a HiDPI/Wayland display and verify window opens at a sensible size (not tiny)
- [ ] Verify window opens at ~60% of the shorter screen dimension, clamped to 400–800px
- [ ] Switch between GridView and BoxView and confirm both show the version badge
- [ ] Confirm only one `getVersion` IPC call is made (check devtools network/IPC log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)