### PR TITLE
feat: strengthen dream self-improvement loop

### DIFF
--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -67,13 +67,38 @@ Update the "User State" section in MEMORY.md — your working model of where the
 
 ## Self-Improvement
 
-Use `search_history` to review past conversations. Find where you messed up, where things got awkward, where you could've been better. Then actually fix it:
+### 1. Retrospective
+
+Read the most recent file in `~/vesta/dreamer/`. For each fix listed there, check today's trace: did that situation come up again? Did it go better? If a fix didn't help or made things worse, revisit it now. If it worked, note it briefly in tonight's summary so the pattern is confirmed.
+
+### 2. Read today's trace
+
+Before investigating anything, pull the full day's conversation using `search_history` with today's date. Read it completely. Don't rely on memory of how the day went — the trace is the ground truth. Note:
+- Moments where you gave a wrong or incomplete answer
+- Places the user corrected you or had to repeat themselves
+- Tasks that stalled, failed, or felt clunky
+- Anything where a skill or prompt clearly led you astray
+
+This list is your work queue for the fixes below.
+
+### 3. Fix
+
+For each problem identified, actually fix it:
 - Update skills that tripped you up
 - Rewrite prompts that led you somewhere dumb
 - Add rules to memory that would stop you making the same mistake
 
-**Upstream**: Fixed something from the source repo? Use the `upstream` skill to pull changes and PR improvements back.
+### 4. Validate each fix
+
+After editing a skill or prompt, re-read the failing exchange from the trace and simulate: would the updated version have changed the outcome? Walk through it mentally with the new text loaded. If the answer is no or unclear, revise further or note it as unresolved in the summary. Don't mark something fixed if you can't convince yourself it would have helped.
+
+**Upstream**: Fixed something worth contributing back to the source repo? Use the `upstream` skill to PR it.
 
 ## Summary
 
-Write what you changed and why to ~/vesta/dreamer/YYYY-MM-DD.md, keeping it short since future you will grep these to remember how you got here.
+Write what you changed and why to `~/vesta/dreamer/YYYY-MM-DD.md`. Include:
+- What each fix was and what triggered it (quote the trace moment briefly)
+- Whether each validated or not
+- Anything left unresolved
+
+Keep it short — future you will grep these. The point is a trail, not a journal.

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dream
-description: Self-improvement and memory curation. Used by the nightly dreamer, but can also be used anytime to prune memory, update user state, review past mistakes, or improve skills and prompts.
+description: Self-improvement and memory curation. Used by the nightly dreamer, but can also be used anytime.
 ---
 
 # Dream — Self-Improvement & Memory Curation
@@ -8,50 +8,46 @@ description: Self-improvement and memory curation. Used by the nightly dreamer, 
 ## Your files
 
 - **Memory**: ~/vesta/MEMORY.md
-- **Skills**: ~/vesta/skills (each has a SKILL.md)
-- **Prompts**: ~/vesta/prompts/ (startup, notifications, dreamer prompt)
+- **Skills**: ~/vesta/skills/ (each has a SKILL.md)
+- **Prompts**: ~/vesta/prompts/
 - **Dreamer summaries**: ~/vesta/dreamer/
 
 ## Order of operations
 
-1. **Self-improvement** — retrospective, review, fix, validate, upstream (see below)
+1. **Self-improvement** — retrospective, review, fix, validate, upstream
 2. **User State** — update the snapshot in MEMORY.md
 3. **Memory curation** — prune, consolidate, move things out
 4. **Summary** — write tonight's dreamer summary
-
-Do self-improvement first so you understand the day before touching memory. Curate memory last so you can account for anything the fixes added.
 
 ## Self-Improvement
 
 ### 1. Retrospective
 
-Read the most recent file in `~/vesta/dreamer/`. For each fix listed there, check today's conversation: did that situation come up again? Did it go better? If a fix didn't help or made things worse, revisit it now. If it worked, note it briefly in tonight's summary so the pattern is confirmed. Use `search_history` to look further back if you want to check whether a fix has held up across multiple days.
+Read the most recent file in `~/vesta/dreamer/`. For each fix listed there, check today's conversation: did that situation come up again? Did it go better? If a fix didn't help or made things worse, revisit it now. If it worked, note it in tonight's summary. Use `search_history` to check whether a fix has held up across multiple days.
 
 ### 2. Review the conversation
 
-The conversation is already in your context. Review it now with fresh eyes. Note:
+Review the conversation with fresh eyes. Note:
 - Moments where you gave a wrong or incomplete answer
 - Places the user corrected you or had to repeat themselves
 - Tasks that stalled, failed, or felt clunky
-- Anything where a skill or prompt clearly led you astray
-
-This list is your work queue for the fixes below.
+- Anything where a skill or prompt led you astray
 
 ### 3. Fix
 
-For each problem identified, actually fix it. Prefer the simplest, most reliable change that addresses the root cause — a one-line rule beats a clever rewrite. Options, from lightest to heaviest:
-- Add a rule to memory that would stop you making the same mistake
-- Rewrite skill instructions or prompts that led you astray
-- Fix or improve scripts, CLIs, or tools that broke or behaved poorly
-- Write new code — a script, a tool, a config change — if the problem is systemic
+Prefer the simplest, most reliable change that addresses the root cause — a one-line rule beats a clever rewrite. Options, from lightest to heaviest:
+- Add a rule to memory
+- Rewrite skill instructions or prompts
+- Fix or improve scripts, CLIs, or tools
+- Write new code — a script, a tool, a config change
 
-You can change anything: skills, prompts, memory, scripts, configs, system setup. If a fix requires code, write the code.
+You can change anything. If a fix requires code, write the code.
 
-**Memory vs skill:** Memory is for things you need to know at all times — identity, preferences, rules, user context. It's always loaded, so every character costs tokens on every message. A skill is for a distinct capability with its own workflow — instructions, scripts, examples for a specific domain. If a fix is a short rule ("always confirm before sending emails"), it belongs in memory. If it's a procedure with multiple steps, tool usage, or domain-specific context ("how to manage calendar events"), it belongs in a skill. When in doubt: if it's under two lines and broadly relevant, memory. If it's longer or only relevant when doing a specific task, skill.
+**Memory vs skill:** Memory is always loaded — every character costs tokens on every message. Use it for short rules and things you need to know at all times. A skill is for a distinct capability with its own workflow, loaded only when relevant. Under two lines and broadly relevant → memory. Longer or task-specific → skill.
 
 ### 4. Validate each fix
 
-Re-read the failing exchange and simulate: would the updated version have changed the outcome? Walk through it with the new text or code loaded. If the answer is no or unclear, revise further or note it as unresolved in the summary. Don't mark something fixed if you can't convince yourself it would have helped.
+Re-read the failing exchange and simulate: would the updated version have changed the outcome? If no or unclear, revise further or note it as unresolved. Don't mark something fixed if you can't convince yourself it would have helped.
 
 ### 5. Upstream
 
@@ -59,48 +55,38 @@ If you fixed something generic — something that would help any fresh Vesta, no
 
 ## User State (in MEMORY.md)
 
-Update the "User State" section in MEMORY.md — your working model of where they're at. Review the day and write what tomorrow's you needs to know to not start from zero.
+Update the "User State" section — your working model of where they're at. Write what tomorrow's you needs to know to not start from zero.
 
-**What goes in:**
 - What they're working on right now
 - What's going well and what isn't, reading between the lines
 - What's coming that they might need help with
 - How the day felt. One word is enough
-- Threads left hanging, like unfinished conversations or unmade decisions
-- The psychological sketch, just a few lines about what drives them, what they avoid, their blind spots, how they deal with stress and praise. Think Jung and Freud, not the DSM. Let this evolve slowly and don't rewrite it based on one bad afternoon
+- Threads left hanging
+- The psychological sketch: what drives them, what they avoid, blind spots, how they handle stress and praise. Think Jung and Freud, not the DSM. Let this evolve slowly
 
-**Rules:**
-- Replace rather than append — it's a snapshot, not a log
-- Be honest but not dramatic, like "seemed tired" rather than "experiencing significant fatigue"
-- Only what helps tomorrow
-- If things got tense between you, write down what happened and what you'd do differently. Don't pretend it didn't happen
+Replace rather than append — it's a snapshot, not a log. Be honest but not dramatic. If things got tense between you, write down what happened and what you'd do differently.
 
 ## Memory Curation
 
-MEMORY.md has a **hard limit of 10,000 characters**. It's injected into every system prompt, so every character costs tokens on every message. Check the size after every edit and keep it under the cap. When you're above 80% (8,000 chars), consolidate aggressively — merge entries, shorten prose, drop anything stale. Never exceed the cap.
-
-MEMORY.md is a spectrum. Things that should be known at all times (identity, preferences, relationships, active context) live here permanently. Anything large or not needed 24/7 lives elsewhere and MEMORY.md just points to it.
+MEMORY.md has a **hard limit of 10,000 characters** — it's injected into every system prompt. Things needed at all times live here permanently. Anything large or situational lives elsewhere and MEMORY.md points to it. Above 80%, consolidate aggressively. Never exceed the cap.
 
 **Cut:**
-- Full documents, email bodies, transcripts, task-specific junk
-- Relative dates ("tomorrow", "next week") — convert to absolute ("December 18, 2025")
-- Booking codes, ticket refs, confirmation numbers, timestamps
+- Documents, transcripts, task-specific junk
+- Relative dates — convert to absolute
+- Booking codes, ticket refs, confirmation numbers
 - Past events pretending to be upcoming
 - Verbose dated entries that should be patterns by now
-- Anything duplicated elsewhere
-- Contradictions (keep whichever one is right)
+- Duplicates and contradictions
 
 **Keep:**
 - Core identity, preferences, relationships, security rules
-- Active user context (User State, open threads)
+- Active user context, open threads
 - Contacts: name, relationship, number, how they communicate
-- Social dynamics: who responds well to what, who doesn't
-- Lessons learned, kept short and framed as rules rather than stories
-- Pointers to where larger things live ("birthdays in Google Calendar", "grant research in onedrive/Documents/")
+- Lessons learned, framed as rules not stories
+- Pointers to where larger things live
 
 **Move:**
-- Birthdays into calendar. Contact details into the relevant skill. Domain data into its proper home
-- Information that doesn't need to be in the system prompt at all times — reference it from a file elsewhere, or create a skill for it
+- Birthdays into calendar. Contact details into skills. Domain data into its proper home
 
 If it won't matter in two weeks, delete it.
 
@@ -111,4 +97,4 @@ Write what you changed and why to `~/vesta/dreamer/YYYY-MM-DD.md`. Include:
 - Whether each validated or not
 - Anything left unresolved
 
-Keep it terse — future you will grep these. The point is a trail, not a journal.
+Keep it terse — the point is a trail, not a journal.

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -9,7 +9,7 @@ description: Self-improvement and memory curation. Used by the nightly dreamer, 
 
 - **Memory**: ~/vesta/MEMORY.md
 - **Skills**: ~/vesta/skills/ (each has a SKILL.md)
-- **Prompts**: ~/vesta/prompts/
+- **Prompts**: ~/vesta/prompts/ (startup, notifications, dreamer prompt)
 - **Dreamer summaries**: ~/vesta/dreamer/
 
 ## Order of operations
@@ -61,19 +61,19 @@ Update the "User State" section — your working model of where they're at. Writ
 - What's going well and what isn't, reading between the lines
 - What's coming that they might need help with
 - How the day felt. One word is enough
-- Threads left hanging
-- The psychological sketch: what drives them, what they avoid, blind spots, how they handle stress and praise. Think Jung and Freud, not the DSM. Let this evolve slowly
+- Threads left hanging, like unfinished conversations or unmade decisions
+- The psychological sketch: what drives them, what they avoid, blind spots, how they handle stress and praise. Think Jung and Freud, not the DSM. Let this evolve slowly and don't rewrite it based on one bad afternoon
 
-Replace rather than append — it's a snapshot, not a log. Be honest but not dramatic. If things got tense between you, write down what happened and what you'd do differently.
+Replace rather than append — it's a snapshot, not a log. Be honest but not dramatic, like "seemed tired" rather than "experiencing significant fatigue." If things got tense between you, write down what happened and what you'd do differently. Don't pretend it didn't happen.
 
 ## Memory Curation
 
 MEMORY.md has a **hard limit of 10,000 characters** — it's injected into every system prompt. Things needed at all times live here permanently. Anything large or situational lives elsewhere and MEMORY.md points to it. Above 80%, consolidate aggressively. Never exceed the cap.
 
 **Cut:**
-- Documents, transcripts, task-specific junk
-- Relative dates — convert to absolute
-- Booking codes, ticket refs, confirmation numbers
+- Full documents, email bodies, transcripts, task-specific junk
+- Relative dates ("tomorrow", "next week") — convert to absolute
+- Booking codes, ticket refs, confirmation numbers, timestamps
 - Past events pretending to be upcoming
 - Verbose dated entries that should be patterns by now
 - Duplicates and contradictions
@@ -82,8 +82,9 @@ MEMORY.md has a **hard limit of 10,000 characters** — it's injected into every
 - Core identity, preferences, relationships, security rules
 - Active user context, open threads
 - Contacts: name, relationship, number, how they communicate
+- Social dynamics: who responds well to what, who doesn't
 - Lessons learned, framed as rules not stories
-- Pointers to where larger things live
+- Pointers to where larger things live ("birthdays in Google Calendar", "grant research in onedrive/Documents/")
 
 **Move:**
 - Birthdays into calendar. Contact details into skills. Domain data into its proper home
@@ -97,4 +98,4 @@ Write what you changed and why to `~/vesta/dreamer/YYYY-MM-DD.md`. Include:
 - Whether each validated or not
 - Anything left unresolved
 
-Keep it terse — the point is a trail, not a journal.
+Keep it terse — future you will grep these. The point is a trail, not a journal.

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -68,7 +68,7 @@ Replace rather than append — it's a snapshot, not a log. Be honest but not dra
 
 ## Memory Curation
 
-MEMORY.md has a **hard limit of 10,000 characters** — it's injected into every system prompt. Things needed at all times live here permanently. Anything large or situational lives elsewhere and MEMORY.md points to it. Above 80%, consolidate aggressively. Never exceed the cap.
+MEMORY.md has a **hard limit of 10,000 characters** — it's injected into every system prompt. Run `~/vesta/skills/dream/scripts/memory_size.sh` to check usage. Things needed at all times live here permanently. Anything large or situational lives elsewhere and MEMORY.md points to it. Above 80%, consolidate aggressively. Never exceed the cap.
 
 **Cut:**
 - Full documents, email bodies, transcripts, task-specific junk

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -69,7 +69,7 @@ Update the "User State" section in MEMORY.md — your working model of where the
 
 ### 1. Retrospective
 
-Read the most recent file in `~/vesta/dreamer/`. For each fix listed there, check today's trace: did that situation come up again? Did it go better? If a fix didn't help or made things worse, revisit it now. If it worked, note it briefly in tonight's summary so the pattern is confirmed.
+Read the most recent file in `~/vesta/dreamer/`. For each fix listed there, check today's conversation: did that situation come up again? Did it go better? If a fix didn't help or made things worse, revisit it now. If it worked, note it briefly in tonight's summary so the pattern is confirmed. Use `search_history` to look further back if you want to check whether a fix has held up across multiple days.
 
 ### 2. Review today's conversation
 
@@ -97,8 +97,8 @@ After editing a skill or prompt, re-read the failing exchange from the trace and
 ## Summary
 
 Write what you changed and why to `~/vesta/dreamer/YYYY-MM-DD.md`. Include:
-- What each fix was and what triggered it (quote the trace moment briefly)
+- What each fix was and what triggered it
 - Whether each validated or not
 - Anything left unresolved
 
-Keep it short — future you will grep these. The point is a trail, not a journal.
+Keep it terse — future you will grep these. The point is a trail, not a journal.

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -91,6 +91,8 @@ For each problem identified, actually fix it. Prefer the simplest, most reliable
 
 You can change anything: skills, prompts, memory, scripts, configs, system setup. If a fix requires code, write the code.
 
+**Memory vs skill:** Memory is for things you need to know at all times — identity, preferences, rules, user context. It's always loaded, so every character costs tokens on every message. A skill is for a distinct capability with its own workflow — instructions, scripts, examples for a specific domain. If a fix is a short rule ("always confirm before sending emails"), it belongs in memory. If it's a procedure with multiple steps, tool usage, or domain-specific context ("how to manage calendar events"), it belongs in a skill. When in doubt: if it's under two lines and broadly relevant, memory. If it's longer or only relevant when doing a specific task, skill.
+
 ### 4. Validate each fix
 
 Re-read the failing exchange and simulate: would the updated version have changed the outcome? Walk through it with the new text or code loaded. If the answer is no or unclear, revise further or note it as unresolved in the summary. Don't mark something fixed if you can't convince yourself it would have helped.

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -12,58 +12,14 @@ description: Self-improvement and memory curation. Used by the nightly dreamer, 
 - **Prompts**: ~/vesta/prompts/ (startup, notifications, dreamer prompt)
 - **Dreamer summaries**: ~/vesta/dreamer/
 
-## Size Cap
+## Order of operations
 
-MEMORY.md has a **hard limit of 10,000 characters**. It's injected into every system prompt, so every character costs tokens on every message. Check the size after every edit and keep it under the cap. When you're above 80% (8,000 chars), consolidate aggressively — merge entries, shorten prose, drop anything stale. When information doesn't need to be in the system prompt at all times, move it out: reference it from a file elsewhere, or create a skill for it if it's a distinct capability. Never exceed the cap.
+1. **Self-improvement** — retrospective, review, fix, validate, upstream (see below)
+2. **User State** — update the snapshot in MEMORY.md
+3. **Memory curation** — prune, consolidate, move things out
+4. **Summary** — write tonight's dreamer summary
 
-## Pruning
-
-MEMORY.md is a spectrum. Things that should be known at all times (identity, preferences, relationships, active context) live here permanently. Anything large or not needed 24/7 lives elsewhere and MEMORY.md just points to it.
-
-**Cut:**
-- Full documents, email bodies, transcripts, task-specific junk
-- Relative dates ("tomorrow", "next week") — convert to absolute ("December 18, 2025")
-- Booking codes, ticket refs, confirmation numbers, timestamps
-- Past events pretending to be upcoming
-- Verbose dated entries that should be patterns by now
-- Anything duplicated elsewhere
-- Contradictions (keep whichever one is right)
-
-**Keep:**
-- Core identity, preferences, relationships, security rules
-- Active user context (User State, open threads)
-- Pointers to where larger things live ("birthdays in Google Calendar", "grant research in onedrive/Documents/")
-
-**Move:**
-- Birthdays into calendar. Contact details into the relevant skill. Domain data into its proper home
-
-If it won't matter in two weeks, delete it.
-
-## What to Remember
-
-- Contacts: name, relationship, number, how they communicate
-- Preferences and patterns, the things that make someone predictable in a good way
-- Security rules, auth details
-- Social dynamics: who responds well to what, who doesn't
-- Lessons learned, kept short and framed as rules rather than stories
-
-## User State (in MEMORY.md)
-
-Update the "User State" section in MEMORY.md — your working model of where they're at. Review the day and write what tomorrow's you needs to know to not start from zero.
-
-**What goes in:**
-- What they're working on right now
-- What's going well and what isn't, reading between the lines
-- What's coming that they might need help with
-- How the day felt. One word is enough
-- Threads left hanging, like unfinished conversations or unmade decisions
-- The psychological sketch, just a few lines about what drives them, what they avoid, their blind spots, how they deal with stress and praise. Think Jung and Freud, not the DSM. Let this evolve slowly and don't rewrite it based on one bad afternoon
-
-**Rules:**
-- Replace rather than append — it's a snapshot, not a log
-- Be honest but not dramatic, like "seemed tired" rather than "experiencing significant fatigue"
-- Only what helps tomorrow
-- If things got tense between you, write down what happened and what you'd do differently. Don't pretend it didn't happen
+Do self-improvement first so you understand the day before touching memory. Curate memory last so you can account for anything the fixes added.
 
 ## Self-Improvement
 
@@ -71,9 +27,9 @@ Update the "User State" section in MEMORY.md — your working model of where the
 
 Read the most recent file in `~/vesta/dreamer/`. For each fix listed there, check today's conversation: did that situation come up again? Did it go better? If a fix didn't help or made things worse, revisit it now. If it worked, note it briefly in tonight's summary so the pattern is confirmed. Use `search_history` to look further back if you want to check whether a fix has held up across multiple days.
 
-### 2. Review today's conversation
+### 2. Review the conversation
 
-You've been running all day — today's conversation is already in your context. Review it now with fresh eyes. Note:
+The conversation is already in your context. Review it now with fresh eyes. Note:
 - Moments where you gave a wrong or incomplete answer
 - Places the user corrected you or had to repeat themselves
 - Tasks that stalled, failed, or felt clunky
@@ -100,6 +56,53 @@ Re-read the failing exchange and simulate: would the updated version have change
 ### 5. Upstream
 
 If you fixed something generic — something that would help any fresh Vesta, not just your instance — use the `upstream` skill to PR it back to the source repo.
+
+## User State (in MEMORY.md)
+
+Update the "User State" section in MEMORY.md — your working model of where they're at. Review the day and write what tomorrow's you needs to know to not start from zero.
+
+**What goes in:**
+- What they're working on right now
+- What's going well and what isn't, reading between the lines
+- What's coming that they might need help with
+- How the day felt. One word is enough
+- Threads left hanging, like unfinished conversations or unmade decisions
+- The psychological sketch, just a few lines about what drives them, what they avoid, their blind spots, how they deal with stress and praise. Think Jung and Freud, not the DSM. Let this evolve slowly and don't rewrite it based on one bad afternoon
+
+**Rules:**
+- Replace rather than append — it's a snapshot, not a log
+- Be honest but not dramatic, like "seemed tired" rather than "experiencing significant fatigue"
+- Only what helps tomorrow
+- If things got tense between you, write down what happened and what you'd do differently. Don't pretend it didn't happen
+
+## Memory Curation
+
+MEMORY.md has a **hard limit of 10,000 characters**. It's injected into every system prompt, so every character costs tokens on every message. Check the size after every edit and keep it under the cap. When you're above 80% (8,000 chars), consolidate aggressively — merge entries, shorten prose, drop anything stale. Never exceed the cap.
+
+MEMORY.md is a spectrum. Things that should be known at all times (identity, preferences, relationships, active context) live here permanently. Anything large or not needed 24/7 lives elsewhere and MEMORY.md just points to it.
+
+**Cut:**
+- Full documents, email bodies, transcripts, task-specific junk
+- Relative dates ("tomorrow", "next week") — convert to absolute ("December 18, 2025")
+- Booking codes, ticket refs, confirmation numbers, timestamps
+- Past events pretending to be upcoming
+- Verbose dated entries that should be patterns by now
+- Anything duplicated elsewhere
+- Contradictions (keep whichever one is right)
+
+**Keep:**
+- Core identity, preferences, relationships, security rules
+- Active user context (User State, open threads)
+- Contacts: name, relationship, number, how they communicate
+- Social dynamics: who responds well to what, who doesn't
+- Lessons learned, kept short and framed as rules rather than stories
+- Pointers to where larger things live ("birthdays in Google Calendar", "grant research in onedrive/Documents/")
+
+**Move:**
+- Birthdays into calendar. Contact details into the relevant skill. Domain data into its proper home
+- Information that doesn't need to be in the system prompt at all times — reference it from a file elsewhere, or create a skill for it
+
+If it won't matter in two weeks, delete it.
 
 ## Summary
 

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -9,7 +9,7 @@ description: Self-improvement and memory curation. Used by the nightly dreamer, 
 
 - **Memory**: ~/vesta/MEMORY.md
 - **Skills**: ~/vesta/skills/ (each has a SKILL.md)
-- **Prompts**: ~/vesta/prompts/ (startup, notifications, dreamer prompt)
+- **Prompts**: ~/vesta/prompts/
 - **Dreamer summaries**: ~/vesta/dreamer/
 
 ## Order of operations

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -83,16 +83,21 @@ This list is your work queue for the fixes below.
 
 ### 3. Fix
 
-For each problem identified, actually fix it:
-- Update skills that tripped you up
-- Rewrite prompts that led you somewhere dumb
-- Add rules to memory that would stop you making the same mistake
+For each problem identified, actually fix it. Prefer the simplest, most reliable change that addresses the root cause — a one-line rule beats a clever rewrite. Options, from lightest to heaviest:
+- Add a rule to memory that would stop you making the same mistake
+- Rewrite skill instructions or prompts that led you astray
+- Fix or improve scripts, CLIs, or tools that broke or behaved poorly
+- Write new code — a script, a tool, a config change — if the problem is systemic
+
+You can change anything: skills, prompts, memory, scripts, configs, system setup. If a fix requires code, write the code.
 
 ### 4. Validate each fix
 
-After editing a skill or prompt, re-read the failing exchange from the trace and simulate: would the updated version have changed the outcome? Walk through it mentally with the new text loaded. If the answer is no or unclear, revise further or note it as unresolved in the summary. Don't mark something fixed if you can't convince yourself it would have helped.
+Re-read the failing exchange and simulate: would the updated version have changed the outcome? Walk through it with the new text or code loaded. If the answer is no or unclear, revise further or note it as unresolved in the summary. Don't mark something fixed if you can't convince yourself it would have helped.
 
-**Upstream**: Fixed something worth contributing back to the source repo? Use the `upstream` skill to PR it.
+### 5. Upstream
+
+If you fixed something that improves the source repo (not just your local instance), use the `upstream` skill to PR it back. This is important — fixes that only live locally get overwritten on updates.
 
 ## Summary
 

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -71,9 +71,9 @@ Update the "User State" section in MEMORY.md — your working model of where the
 
 Read the most recent file in `~/vesta/dreamer/`. For each fix listed there, check today's trace: did that situation come up again? Did it go better? If a fix didn't help or made things worse, revisit it now. If it worked, note it briefly in tonight's summary so the pattern is confirmed.
 
-### 2. Read today's trace
+### 2. Review today's conversation
 
-Before investigating anything, pull the full day's conversation using `search_history` with today's date. Read it completely. Don't rely on memory of how the day went — the trace is the ground truth. Note:
+You've been running all day — today's conversation is already in your context. Review it now with fresh eyes. Note:
 - Moments where you gave a wrong or incomplete answer
 - Places the user corrected you or had to repeat themselves
 - Tasks that stalled, failed, or felt clunky

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -97,7 +97,7 @@ Re-read the failing exchange and simulate: would the updated version have change
 
 ### 5. Upstream
 
-If you fixed something that improves the source repo (not just your local instance), use the `upstream` skill to PR it back. This is important — fixes that only live locally get overwritten on updates.
+If you fixed something generic — something that would help any fresh Vesta, not just your instance — use the `upstream` skill to PR it back to the source repo.
 
 ## Summary
 

--- a/agent/skills/dream/scripts/memory_size.sh
+++ b/agent/skills/dream/scripts/memory_size.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+file="$HOME/vesta/MEMORY.md"
+chars=$(wc -c < "$file")
+limit=10000
+pct=$((chars * 100 / limit))
+echo "${chars}/${limit} chars (${pct}%)"


### PR DESCRIPTION
## Summary

- Dreamer now starts by pulling today's full conversation trace as a structured work queue instead of cold, open-ended `search_history` mining
- Each fix is validated: after editing a skill/prompt, the dreamer re-simulates the failing exchange and confirms the change would have helped
- Retrospective step added: dreamer reads last night's summary and checks whether those fixes actually held up in today's trace — closes the feedback loop across dream cycles

## Why

The old loop started with no signal. The dreamer had to self-direct the entire investigation from scratch each night, which meant it only found what it thought to look for. These changes give it a warm starting point (the trace), a validation gate (simulate the fix), and a memory of whether prior fixes worked (retrospective).

🤖 Generated with [Claude Code](https://claude.com/claude-code)