### PR TITLE
fix: stop console reconnecting text from flickering

### DIFF
--- a/app/src/components/Console.svelte
+++ b/app/src/components/Console.svelte
@@ -43,11 +43,10 @@
   }
 
   async function startStream() {
-    streamEnded = false;
     try {
       await streamLogs(name, (ev: LogEvent) => {
         if (!alive) return;
-        if (ev.kind === "Line") { retryDelay = 1000; addLine(ev.text); }
+        if (ev.kind === "Line") { streamEnded = false; retryDelay = 1000; addLine(ev.text); }
         if (ev.kind === "Error") addLine(`error: ${ev.message}`);
         if (ev.kind === "End") scheduleRetry();
       });


### PR DESCRIPTION
## Summary
- Only clear `streamEnded` when a log line actually arrives, not on each retry attempt
- Prevents the "reconnecting" text from jumping up and down during retries

## Test plan
- [ ] Open console when container is stopped — should show "reconnecting" stably without flickering

🤖 Generated with [Claude Code](https://claude.com/claude-code)