### PR TITLE
Navigate to onboarding when all boxes deleted

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -95,10 +95,16 @@
     setView("grid");
   }
 
-  function handleDestroyed() {
+  async function handleDestroyed() {
     if (selectedBox) removeBoxState(selectedBox.name);
     clearConnection();
-    setView("grid");
+    const remaining = await listBoxes().catch(() => []);
+    if (remaining.length === 0) {
+      hasBoxes = false;
+      setView("onboarding");
+    } else {
+      setView("grid");
+    }
   }
 
   async function handleOnboardingComplete(name: string) {


### PR DESCRIPTION
When all boxes/agents are deleted, the app now returns to the onboarding screen instead of showing an empty grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)