### PR TITLE
feat: rebuild command, chat rendering fixes, re-auth UI

### DIFF
--- a/agent/skills/whatsapp/cli/SETUP.md
+++ b/agent/skills/whatsapp/cli/SETUP.md
@@ -89,5 +89,3 @@ All transcription runs in-process -- no external scripts or services needed.
 | Variable | Default | Description |
 |---|---|---|
 | `WHISPER_MODEL` | `/usr/local/share/ggml-small.en.bin` | Path to the GGML whisper model file |
-| `WHATSAPP_DATA_DIR` | `~/.whatsapp` | Directory for WhatsApp session data and message DB |
-| `WHATSAPP_NOTIFICATIONS_DIR` | (none) | Directory where notification files are written |

--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -223,6 +223,7 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
 
     responses: list[str] = []
     assistant_texts: list[str] = []
+    pending_text: str | None = None
     sub_agent_context: str | None = None
     response_iter = client.receive_response().__aiter__()
 
@@ -266,12 +267,24 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 continue
             filtered = filter_tool_lines(text)
             if filtered and not has_tool_use:
+                if pending_text:
+                    logger.assistant(pending_text)
+                    state.event_bus.emit({"type": "assistant", "text": pending_text})
+                    assistant_texts.append(pending_text)
+                    pending_text = None
                 logger.assistant(filtered)
                 state.event_bus.emit({"type": "assistant", "text": filtered})
                 assistant_texts.append(filtered)
+            elif filtered:
+                pending_text = filtered
     finally:
         if interrupt_task and not interrupt_task.done():
             await _cancel_task(interrupt_task)
+
+    if pending_text and show_output:
+        logger.assistant(pending_text)
+        state.event_bus.emit({"type": "assistant", "text": pending_text})
+        assistant_texts.append(pending_text)
 
     if state.history is not None:
         combined = "\n".join(r for r in (assistant_texts or responses) if r and r.strip())

--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -230,6 +230,7 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
         logger.assistant(t)
         state.event_bus.emit({"type": "assistant", "text": t})
         assistant_texts.append(t)
+
     response_iter = client.receive_response().__aiter__()
 
     interrupt_task: asyncio.Task[tp.Any] | None = None

--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -225,6 +225,11 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
     assistant_texts: list[str] = []
     pending_text: str | None = None
     sub_agent_context: str | None = None
+
+    def _emit(t: str) -> None:
+        logger.assistant(t)
+        state.event_bus.emit({"type": "assistant", "text": t})
+        assistant_texts.append(t)
     response_iter = client.receive_response().__aiter__()
 
     interrupt_task: asyncio.Task[tp.Any] | None = None
@@ -268,13 +273,9 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
             filtered = filter_tool_lines(text)
             if filtered and not has_tool_use:
                 if pending_text:
-                    logger.assistant(pending_text)
-                    state.event_bus.emit({"type": "assistant", "text": pending_text})
-                    assistant_texts.append(pending_text)
+                    _emit(pending_text)
                     pending_text = None
-                logger.assistant(filtered)
-                state.event_bus.emit({"type": "assistant", "text": filtered})
-                assistant_texts.append(filtered)
+                _emit(filtered)
             elif filtered:
                 pending_text = filtered
     finally:
@@ -282,9 +283,7 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
             await _cancel_task(interrupt_task)
 
     if pending_text and show_output:
-        logger.assistant(pending_text)
-        state.event_bus.emit({"type": "assistant", "text": pending_text})
-        assistant_texts.append(pending_text)
+        _emit(pending_text)
 
     if state.history is not None:
         combined = "\n".join(r for r in (assistant_texts or responses) if r and r.strip())

--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -117,6 +117,7 @@ async def queue_greeting(queue: asyncio.Queue[tuple[str, bool]], *, config: vm.V
 async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, config: vm.VestaConfig) -> None:
     try:
         if is_user:
+            logger.user(msg)
             state.event_bus.emit({"type": "user", "text": msg})
         else:
             preview = msg[:200] + "..." if len(msg) > 200 else msg

--- a/app/src-tauri/src/commands/agents.rs
+++ b/app/src-tauri/src/commands/agents.rs
@@ -37,6 +37,11 @@ pub async fn delete_agent(name: String) -> Result<(), VestaError> {
 }
 
 #[tauri::command]
+pub async fn rebuild_agent(name: String) -> Result<(), VestaError> {
+    cli::rebuild_agent(&name).await
+}
+
+#[tauri::command]
 pub async fn backup_agent(name: String, output: String) -> Result<(), VestaError> {
     cli::backup_agent(&name, &output).await
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -50,6 +50,7 @@ pub fn run() {
             commands::agents::stop_agent,
             commands::agents::restart_agent,
             commands::agents::delete_agent,
+            commands::agents::rebuild_agent,
             commands::agents::backup_agent,
             commands::agents::restore_agent,
             commands::agents::wait_for_ready,

--- a/app/src-tauri/src/runtime/cli.rs
+++ b/app/src-tauri/src/runtime/cli.rs
@@ -331,6 +331,11 @@ pub async fn delete_agent(name: &str) -> Result<(), VestaError> {
     Ok(())
 }
 
+pub async fn rebuild_agent(name: &str) -> Result<(), VestaError> {
+    run_with_timeout(&["rebuild", name], SETUP_TIMEOUT_SECS).await?;
+    Ok(())
+}
+
 // ── Auth operations ────────────────────────────────────────────
 
 pub async fn obtain_and_inject_credentials(

--- a/app/src/components/AuthFlow.svelte
+++ b/app/src/components/AuthFlow.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import { listen } from "@tauri-apps/api/event";
+  import { openUrl } from "@tauri-apps/plugin-opener";
+  import { submitAuthCode } from "../lib/api";
+  import ProgressBar from "./ProgressBar.svelte";
+
+  let { onCancel }: { onCancel?: () => void } = $props();
+
+  let authUrl = $state<string | null>(null);
+  let authCodeNeeded = $state(false);
+  let authCodeSubmitted = $state(false);
+  let authCode = $state("");
+  let error = $state<string | null>(null);
+  let unlisteners: (() => void)[] = [];
+
+  async function handleSubmitCode() {
+    if (!authCode.trim()) return;
+    await submitAuthCode(authCode.trim());
+    authCodeNeeded = false;
+    authCodeSubmitted = true;
+  }
+
+  onMount(() => {
+    listen<string>("auth-url", (e) => { authUrl = e.payload; }).then((fn) => unlisteners.push(fn));
+    listen<string>("auth-code-needed", () => { authCodeNeeded = true; }).then((fn) => unlisteners.push(fn));
+    listen<string>("auth-code-invalid", () => {
+      authCodeNeeded = true;
+      authCodeSubmitted = false;
+      authCode = "";
+      error = "invalid auth code — try again";
+    }).then((fn) => unlisteners.push(fn));
+  });
+
+  onDestroy(() => { for (const fn of unlisteners) fn(); });
+</script>
+
+<div class="auth-flow">
+  <h1>authenticate claude</h1>
+  {#if authCodeNeeded}
+    <p class="sub">paste the code from the browser below.</p>
+    <form onsubmit={(e) => { e.preventDefault(); handleSubmitCode(); }}>
+      <!-- svelte-ignore a11y_autofocus -->
+      <input type="text" class="name-input" placeholder="paste code here" bind:value={authCode} autofocus />
+      <button class="btn primary full" type="submit" disabled={!authCode.trim()}>submit</button>
+    </form>
+  {:else if authCodeSubmitted}
+    <p class="sub">verifying code...</p>
+    <ProgressBar message="verifying..." />
+  {:else if authUrl}
+    <p class="sub">authenticate via the browser window that opened.<br/>if it didn't open, use the link below.</p>
+    <button class="auth-link" onclick={() => openUrl(authUrl!)}>{authUrl.slice(0, 50)}...</button>
+    <ProgressBar message="waiting for authentication..." />
+  {:else}
+    <p class="sub">opening browser...</p>
+    <ProgressBar message="waiting..." />
+  {/if}
+  {#if error}
+    <p class="error">{error}</p>
+  {/if}
+  {#if onCancel}
+    <button class="btn cancel" onclick={onCancel}>cancel</button>
+  {/if}
+</div>
+
+<style>
+  .auth-flow {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+  }
+
+  h1 {
+    font-size: 22px;
+    font-weight: 600;
+    color: #1a1816;
+    margin-bottom: 8px;
+    letter-spacing: -0.03em;
+  }
+
+  .sub {
+    font-size: 13px;
+    color: #7a726a;
+    margin-bottom: 28px;
+    line-height: 1.6;
+    font-weight: 400;
+    text-align: center;
+  }
+
+  .error {
+    color: #c45450;
+    font-size: 12px;
+    margin: 6px 0 8px;
+    font-weight: 450;
+    animation: shake 0.3s ease;
+  }
+
+  @keyframes shake {
+    0%, 100% { transform: translateX(0); }
+    25% { transform: translateX(-3px); }
+    75% { transform: translateX(3px); }
+  }
+
+  .btn {
+    padding: 8px 24px;
+    border-radius: 8px;
+    corner-shape: squircle;
+    font-size: 13px;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    border: none;
+    transition: all 0.2s var(--spring-bouncy);
+    letter-spacing: 0.01em;
+  }
+
+  .btn.primary {
+    background: #1a1816;
+    color: #f0ece7;
+  }
+
+  .btn.primary:hover {
+    background: #2d2a26;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+  }
+
+  .btn.primary:active {
+    transform: scale(0.97);
+    box-shadow: none;
+  }
+
+  .btn.primary:disabled {
+    opacity: 0.25;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+    pointer-events: none;
+  }
+
+  .btn.full { width: 100%; }
+
+  .btn.cancel {
+    background: transparent;
+    color: #7a726a;
+    margin-top: 16px;
+  }
+
+  .btn.cancel:hover { color: #1a1816; }
+
+  .name-input {
+    width: 100%;
+    padding: 12px 16px;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 8px;
+    corner-shape: squircle;
+    font-size: 14px;
+    font-family: inherit;
+    background: rgba(255, 255, 255, 0.95);
+    color: #1a1816;
+    margin-bottom: 12px;
+    outline: none;
+    transition: all 0.2s var(--spring);
+    text-align: center;
+    letter-spacing: 0.01em;
+  }
+
+  .name-input:focus {
+    border-color: rgba(0, 0, 0, 0.2);
+    box-shadow: 0 0 0 3px rgba(139, 126, 116, 0.2);
+  }
+
+  .name-input::placeholder { color: #c4bdb5; }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+  }
+
+  .auth-link {
+    font-size: 11px;
+    color: #7a726a;
+    word-break: break-all;
+    margin-bottom: 16px;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    cursor: pointer;
+    background: none;
+    border: none;
+    font-family: inherit;
+    transition: color 0.15s;
+  }
+
+  .auth-link:hover { color: #1a1816; }
+
+  @media (prefers-color-scheme: dark) {
+    h1 { color: #e8e0d8; }
+    .sub { color: #8a8078; }
+    .name-input {
+      background: rgba(255, 255, 255, 0.06);
+      border-color: rgba(255, 255, 255, 0.08);
+      color: #e8e0d8;
+    }
+    .name-input:focus { border-color: rgba(255, 255, 255, 0.18); }
+    .name-input::placeholder { color: #5a5450; }
+    .btn.primary { background: #e8e0d8; color: #1c1b1a; }
+    .btn.primary:hover { background: #f0ece7; }
+    .btn.cancel { color: #8a8078; }
+    .btn.cancel:hover { color: #e8e0d8; }
+    .auth-link { color: #8a8078; }
+    .auth-link:hover { color: #e8e0d8; }
+  }
+</style>

--- a/app/src/components/BoxView.svelte
+++ b/app/src/components/BoxView.svelte
@@ -148,7 +148,6 @@
     document.addEventListener("click", onDocClick);
     document.addEventListener("keydown", onKeydown);
     appVersion = await appVersionPromise;
-
   });
 
   onDestroy(() => {

--- a/app/src/components/BoxView.svelte
+++ b/app/src/components/BoxView.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
+  import { listen } from "@tauri-apps/api/event";
+  import { openUrl } from "@tauri-apps/plugin-opener";
   import { appVersion as appVersionPromise } from "../lib/version";
   import type { BoxConnection } from "../lib/ws";
-  import { boxStatus, startBox, stopBox, restartBox, rebuildBox, deleteBox, authenticate, backupBox, restoreBox } from "../lib/api";
+  import { boxStatus, startBox, stopBox, restartBox, rebuildBox, deleteBox, authenticate, submitAuthCode, backupBox, restoreBox } from "../lib/api";
   import { getBoxOp, setBoxOp, clearBoxOp, setBoxError, type BoxOperation } from "../lib/store.svelte";
   import { save, open } from "@tauri-apps/plugin-dialog";
   import type { BoxStatus, BoxActivityState } from "../lib/types";
@@ -32,6 +34,11 @@
   let boxReady = $state(false);
   let confirming = $state(false);
   let menuOpen = $state(false);
+  let authUrl = $state<string | null>(null);
+  let authCodeNeeded = $state(false);
+  let authCodeSubmitted = $state(false);
+  let authCode = $state("");
+  let authUnlisteners: (() => void)[] = [];
   let hovered = $state(false);
   let poll: ReturnType<typeof setInterval>;
   let creatureEl: HTMLDivElement;
@@ -147,6 +154,14 @@
     document.addEventListener("click", onDocClick);
     document.addEventListener("keydown", onKeydown);
     appVersion = await appVersionPromise;
+
+    listen<string>("auth-url", (e) => { authUrl = e.payload; }).then((fn) => authUnlisteners.push(fn));
+    listen<string>("auth-code-needed", () => { authCodeNeeded = true; }).then((fn) => authUnlisteners.push(fn));
+    listen<string>("auth-code-invalid", () => {
+      authCodeNeeded = true;
+      authCodeSubmitted = false;
+      authCode = "";
+    }).then((fn) => authUnlisteners.push(fn));
   });
 
   onDestroy(() => {
@@ -156,6 +171,7 @@
     if (rafId) { cancelAnimationFrame(rafId); rafId = 0; }
     document.removeEventListener("click", onDocClick);
     document.removeEventListener("keydown", onKeydown);
+    for (const fn of authUnlisteners) fn();
   });
 
   async function withBoxOp(op: BoxOperation, fn: () => Promise<void>, fallback: string) {
@@ -201,6 +217,10 @@
   }
 
   async function handleAuth() {
+    authUrl = null;
+    authCodeNeeded = false;
+    authCodeSubmitted = false;
+    authCode = "";
     await withBoxOp("authenticating", async () => {
       await authenticate(name);
       if (running) {
@@ -211,6 +231,15 @@
       connection.resetReconnect();
       await syncStatus();
     }, "authentication failed");
+    authUrl = null;
+    authCodeNeeded = false;
+  }
+
+  async function handleSubmitAuthCode() {
+    if (!authCode.trim()) return;
+    await submitAuthCode(authCode.trim());
+    authCodeNeeded = false;
+    authCodeSubmitted = true;
   }
 
   async function handleRestart() {
@@ -317,6 +346,25 @@
         {/if}
       </span>
     </div>
+
+    {#if authenticating && (authUrl || authCodeNeeded || authCodeSubmitted)}
+      <div class="auth-panel">
+        {#if authCodeNeeded}
+          <form class="auth-code-form" onsubmit={(e) => { e.preventDefault(); handleSubmitAuthCode(); }}>
+            <!-- svelte-ignore a11y_autofocus -->
+            <input class="auth-code-input" type="text" placeholder="paste code here" bind:value={authCode} autofocus />
+            <button class="action-btn primary" type="submit" disabled={!authCode.trim()}>submit</button>
+          </form>
+        {:else if authCodeSubmitted}
+          <span class="auth-status">verifying...</span>
+        {:else if authUrl}
+          <button class="auth-link" onclick={() => openUrl(authUrl!)}>{authUrl.slice(0, 40)}...</button>
+          <span class="auth-status">waiting for auth...</span>
+        {:else}
+          <span class="auth-status">opening browser...</span>
+        {/if}
+      </div>
+    {/if}
 
     <div class="actions" class:visible={showActions && !deleting && !stopping && !starting && !authenticating && !backingUp && !restoring} inert={!showActions || deleting || stopping || starting || authenticating || backingUp || restoring}>
       {#if confirming}
@@ -722,6 +770,77 @@
     0%, 100% { transform: translateX(0); }
     25% { transform: translateX(-3px); }
     75% { transform: translateX(3px); }
+  }
+
+  /* --- Auth panel --- */
+  .auth-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    animation: viewIn 0.3s var(--spring);
+  }
+
+  .auth-code-form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    width: 220px;
+  }
+
+  .auth-code-input {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+    corner-shape: squircle;
+    background: rgba(255, 255, 255, 0.8);
+    font-family: inherit;
+    font-size: 12px;
+    color: #3d3a36;
+    outline: none;
+    text-align: center;
+    transition: border-color 0.15s;
+  }
+
+  .auth-code-input:focus {
+    border-color: rgba(0, 0, 0, 0.2);
+  }
+
+  .auth-status {
+    font-size: 11px;
+    color: #807870;
+    letter-spacing: 0.04em;
+  }
+
+  .auth-link {
+    font-size: 11px;
+    color: #6080a4;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-decoration: underline;
+    padding: 0;
+    font-family: inherit;
+    max-width: 220px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .auth-code-input {
+      background: rgba(255, 255, 255, 0.06);
+      border-color: rgba(255, 255, 255, 0.08);
+      color: #e8e0d8;
+    }
+    .auth-code-input:focus {
+      border-color: rgba(255, 255, 255, 0.18);
+    }
+    .auth-link {
+      color: #80a0c4;
+    }
   }
 
   /* --- Actions --- */

--- a/app/src/components/BoxView.svelte
+++ b/app/src/components/BoxView.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from "svelte";
   import { appVersion as appVersionPromise } from "../lib/version";
   import type { BoxConnection } from "../lib/ws";
-  import { boxStatus, startBox, stopBox, restartBox, deleteBox, authenticate, backupBox, restoreBox } from "../lib/api";
+  import { boxStatus, startBox, stopBox, restartBox, rebuildBox, deleteBox, authenticate, backupBox, restoreBox } from "../lib/api";
   import { getBoxOp, setBoxOp, clearBoxOp, setBoxError, type BoxOperation } from "../lib/store.svelte";
   import { save, open } from "@tauri-apps/plugin-dialog";
   import type { BoxStatus, BoxActivityState } from "../lib/types";
@@ -221,6 +221,14 @@
     }, "failed to restart");
   }
 
+  async function handleRebuild() {
+    await withBoxOp("rebuilding", async () => {
+      await rebuildBox(name);
+      connection.resetReconnect();
+      await syncStatus();
+    }, "failed to rebuild");
+  }
+
   async function handleBackup() {
     if (busy) return;
     setBoxError(name, "");
@@ -263,7 +271,7 @@
   const OP_LABELS: Record<BoxOperation, string> = {
     "idle": "", "stopping": "stopping...", "starting": "starting...",
     "authenticating": "signing in...", "deleting": "deleting...",
-    "backing-up": "backing up...", "restoring": "restoring...",
+    "rebuilding": "rebuilding...", "backing-up": "backing up...", "restoring": "restoring...",
   };
   let statusLabel = $derived(
     errorMsg ? errorMsg
@@ -341,6 +349,7 @@
               {/if}
               {#if running}
                 <button class="menu-item" disabled={busy} onclick={() => { menuOpen = false; handleRestart(); }} data-tip="restart box">restart</button>
+                <button class="menu-item" disabled={busy} onclick={() => { menuOpen = false; handleRebuild(); }} data-tip="rebuild container from latest image">rebuild</button>
               {/if}
               {#if running && authenticated}
                 <button class="menu-item" disabled={busy} onclick={() => { menuOpen = false; handleAuth(); }} data-tip="authenticate claude">authenticate</button>

--- a/app/src/components/BoxView.svelte
+++ b/app/src/components/BoxView.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import { listen } from "@tauri-apps/api/event";
-  import { openUrl } from "@tauri-apps/plugin-opener";
   import { appVersion as appVersionPromise } from "../lib/version";
   import type { BoxConnection } from "../lib/ws";
-  import { boxStatus, startBox, stopBox, restartBox, rebuildBox, deleteBox, authenticate, submitAuthCode, backupBox, restoreBox } from "../lib/api";
+  import { boxStatus, startBox, stopBox, restartBox, rebuildBox, deleteBox, authenticate, backupBox, restoreBox } from "../lib/api";
   import { getBoxOp, setBoxOp, clearBoxOp, setBoxError, type BoxOperation } from "../lib/store.svelte";
   import { save, open } from "@tauri-apps/plugin-dialog";
   import type { BoxStatus, BoxActivityState } from "../lib/types";
+  import AuthFlow from "./AuthFlow.svelte";
 
   let {
     name,
@@ -34,11 +33,6 @@
   let boxReady = $state(false);
   let confirming = $state(false);
   let menuOpen = $state(false);
-  let authUrl = $state<string | null>(null);
-  let authCodeNeeded = $state(false);
-  let authCodeSubmitted = $state(false);
-  let authCode = $state("");
-  let authUnlisteners: (() => void)[] = [];
   let hovered = $state(false);
   let poll: ReturnType<typeof setInterval>;
   let creatureEl: HTMLDivElement;
@@ -155,13 +149,6 @@
     document.addEventListener("keydown", onKeydown);
     appVersion = await appVersionPromise;
 
-    listen<string>("auth-url", (e) => { authUrl = e.payload; }).then((fn) => authUnlisteners.push(fn));
-    listen<string>("auth-code-needed", () => { authCodeNeeded = true; }).then((fn) => authUnlisteners.push(fn));
-    listen<string>("auth-code-invalid", () => {
-      authCodeNeeded = true;
-      authCodeSubmitted = false;
-      authCode = "";
-    }).then((fn) => authUnlisteners.push(fn));
   });
 
   onDestroy(() => {
@@ -171,7 +158,6 @@
     if (rafId) { cancelAnimationFrame(rafId); rafId = 0; }
     document.removeEventListener("click", onDocClick);
     document.removeEventListener("keydown", onKeydown);
-    for (const fn of authUnlisteners) fn();
   });
 
   async function withBoxOp(op: BoxOperation, fn: () => Promise<void>, fallback: string) {
@@ -217,10 +203,6 @@
   }
 
   async function handleAuth() {
-    authUrl = null;
-    authCodeNeeded = false;
-    authCodeSubmitted = false;
-    authCode = "";
     await withBoxOp("authenticating", async () => {
       await authenticate(name);
       if (running) {
@@ -231,15 +213,6 @@
       connection.resetReconnect();
       await syncStatus();
     }, "authentication failed");
-    authUrl = null;
-    authCodeNeeded = false;
-  }
-
-  async function handleSubmitAuthCode() {
-    if (!authCode.trim()) return;
-    await submitAuthCode(authCode.trim());
-    authCodeNeeded = false;
-    authCodeSubmitted = true;
   }
 
   async function handleRestart() {
@@ -347,22 +320,9 @@
       </span>
     </div>
 
-    {#if authenticating && (authUrl || authCodeNeeded || authCodeSubmitted)}
+    {#if authenticating}
       <div class="auth-panel">
-        {#if authCodeNeeded}
-          <form class="auth-code-form" onsubmit={(e) => { e.preventDefault(); handleSubmitAuthCode(); }}>
-            <!-- svelte-ignore a11y_autofocus -->
-            <input class="auth-code-input" type="text" placeholder="paste code here" bind:value={authCode} autofocus />
-            <button class="action-btn primary" type="submit" disabled={!authCode.trim()}>submit</button>
-          </form>
-        {:else if authCodeSubmitted}
-          <span class="auth-status">verifying...</span>
-        {:else if authUrl}
-          <button class="auth-link" onclick={() => openUrl(authUrl!)}>{authUrl.slice(0, 40)}...</button>
-          <span class="auth-status">waiting for auth...</span>
-        {:else}
-          <span class="auth-status">opening browser...</span>
-        {/if}
+        <AuthFlow />
       </div>
     {/if}
 
@@ -774,73 +734,8 @@
 
   /* --- Auth panel --- */
   .auth-panel {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 10px;
+    width: 280px;
     animation: viewIn 0.3s var(--spring);
-  }
-
-  .auth-code-form {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 8px;
-    width: 220px;
-  }
-
-  .auth-code-input {
-    width: 100%;
-    padding: 8px 12px;
-    border: 1px solid rgba(0, 0, 0, 0.1);
-    border-radius: 8px;
-    corner-shape: squircle;
-    background: rgba(255, 255, 255, 0.8);
-    font-family: inherit;
-    font-size: 12px;
-    color: #3d3a36;
-    outline: none;
-    text-align: center;
-    transition: border-color 0.15s;
-  }
-
-  .auth-code-input:focus {
-    border-color: rgba(0, 0, 0, 0.2);
-  }
-
-  .auth-status {
-    font-size: 11px;
-    color: #807870;
-    letter-spacing: 0.04em;
-  }
-
-  .auth-link {
-    font-size: 11px;
-    color: #6080a4;
-    background: none;
-    border: none;
-    cursor: pointer;
-    text-decoration: underline;
-    padding: 0;
-    font-family: inherit;
-    max-width: 220px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .auth-code-input {
-      background: rgba(255, 255, 255, 0.06);
-      border-color: rgba(255, 255, 255, 0.08);
-      color: #e8e0d8;
-    }
-    .auth-code-input:focus {
-      border-color: rgba(255, 255, 255, 0.18);
-    }
-    .auth-link {
-      color: #80a0c4;
-    }
   }
 
   /* --- Actions --- */

--- a/app/src/components/Chat.svelte
+++ b/app/src/components/Chat.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, tick, flushSync } from "svelte";
+  import { onDestroy, tick, untrack } from "svelte";
   import { get } from "svelte/store";
   import { openUrl } from "@tauri-apps/plugin-opener";
   import type { BoxConnection } from "../lib/ws";
@@ -52,37 +52,39 @@
   let lastSyncedLen = 0;
   let pendingUserTexts = new Map<string, number>();
 
+  // Bridge Svelte store to $state so the processing effect runs in reactive context
+  let _evts = $state<VestaEvent[]>([]);
+  $effect(() => connection.messages.subscribe((v) => { _evts = v; }));
+
   $effect(() => {
-    const unsub = connection.messages.subscribe((evts: VestaEvent[]) => {
-      flushSync(() => {
-        if (evts.length < lastSyncedLen) {
-          lines = [];
-          nextId = 0;
-          lastSyncedLen = 0;
-          pendingUserTexts.clear();
-          suppressAnim = true;
-          requestAnimationFrame(() => { suppressAnim = false; });
-        }
-        if (evts.length === lastSyncedLen) return;
-        for (let i = lastSyncedLen; i < evts.length; i++) {
-          const ev = evts[i];
-          if (ev.type === "user") {
-            const count = pendingUserTexts.get(ev.text) ?? 0;
-            if (count > 0) {
-              if (count === 1) pendingUserTexts.delete(ev.text);
-              else pendingUserTexts.set(ev.text, count - 1);
-              continue;
-            }
+    const evts = _evts; // tracked — effect re-runs when store updates
+    untrack(() => {
+      if (evts.length < lastSyncedLen) {
+        lines = [];
+        nextId = 0;
+        lastSyncedLen = 0;
+        pendingUserTexts.clear();
+        suppressAnim = true;
+        requestAnimationFrame(() => { suppressAnim = false; });
+      }
+      if (evts.length === lastSyncedLen) return;
+      for (let i = lastSyncedLen; i < evts.length; i++) {
+        const ev = evts[i];
+        if (ev.type === "user") {
+          const count = pendingUserTexts.get(ev.text) ?? 0;
+          if (count > 0) {
+            if (count === 1) pendingUserTexts.delete(ev.text);
+            else pendingUserTexts.set(ev.text, count - 1);
+            continue;
           }
-          const line = eventToLine(ev);
-          if (line) lines.push(line);
         }
-        if (lines.length > MAX_MESSAGES) lines.splice(0, lines.length - MAX_MESSAGES);
-        lastSyncedLen = evts.length;
-      });
-      scroller.scroll();
+        const line = eventToLine(ev);
+        if (line) lines.push(line);
+      }
+      if (lines.length > MAX_MESSAGES) lines.splice(0, lines.length - MAX_MESSAGES);
+      lastSyncedLen = evts.length;
     });
-    return () => unsub();
+    tick().then(() => scroller.scroll());
   });
 
   $effect(() => {

--- a/app/src/components/Chat.svelte
+++ b/app/src/components/Chat.svelte
@@ -50,39 +50,43 @@
   }
 
   let lastSyncedLen = 0;
-
   let pendingUserTexts = new Map<string, number>();
 
+  // Bridge store into Svelte's reactive system so $effect tracks changes
+  let currentMessages = $state<VestaEvent[]>([]);
+
   $effect(() => {
-    const unsub = connection.messages.subscribe((evts: VestaEvent[]) => {
-      if (evts.length < lastSyncedLen) {
-        lines = [];
-        nextId = 0;
-        lastSyncedLen = 0;
-        pendingUserTexts.clear();
-        suppressAnim = true;
-        requestAnimationFrame(() => { suppressAnim = false; });
-      }
-      if (evts.length === lastSyncedLen) return;
-      for (let i = lastSyncedLen; i < evts.length; i++) {
-        const ev = evts[i];
-        if (ev.type === "user") {
-          const count = pendingUserTexts.get(ev.text) ?? 0;
-          if (count > 0) {
-            if (count === 1) pendingUserTexts.delete(ev.text);
-            else pendingUserTexts.set(ev.text, count - 1);
-            continue;
-          }
-        }
-        const line = eventToLine(ev);
-        if (line) lines.push(line);
-      }
-      if (lines.length > MAX_MESSAGES) lines.splice(0, lines.length - MAX_MESSAGES);
-      lastSyncedLen = evts.length;
-      lines = lines;
-      scroller.scroll();
-    });
+    const unsub = connection.messages.subscribe((v: VestaEvent[]) => { currentMessages = v; });
     return () => unsub();
+  });
+
+  $effect(() => {
+    const evts = currentMessages;
+    if (evts.length < lastSyncedLen) {
+      lines = [];
+      nextId = 0;
+      lastSyncedLen = 0;
+      pendingUserTexts.clear();
+      suppressAnim = true;
+      requestAnimationFrame(() => { suppressAnim = false; });
+    }
+    if (evts.length === lastSyncedLen) return;
+    for (let i = lastSyncedLen; i < evts.length; i++) {
+      const ev = evts[i];
+      if (ev.type === "user") {
+        const count = pendingUserTexts.get(ev.text) ?? 0;
+        if (count > 0) {
+          if (count === 1) pendingUserTexts.delete(ev.text);
+          else pendingUserTexts.set(ev.text, count - 1);
+          continue;
+        }
+      }
+      const line = eventToLine(ev);
+      if (line) lines.push(line);
+    }
+    if (lines.length > MAX_MESSAGES) lines.splice(0, lines.length - MAX_MESSAGES);
+    lastSyncedLen = evts.length;
+    scroller.scroll();
   });
 
   $effect(() => {

--- a/app/src/components/Chat.svelte
+++ b/app/src/components/Chat.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, tick } from "svelte";
+  import { onDestroy, tick, flushSync } from "svelte";
   import { get } from "svelte/store";
   import { openUrl } from "@tauri-apps/plugin-opener";
   import type { BoxConnection } from "../lib/ws";
@@ -52,41 +52,37 @@
   let lastSyncedLen = 0;
   let pendingUserTexts = new Map<string, number>();
 
-  // Bridge store into Svelte's reactive system so $effect tracks changes
-  let currentMessages = $state<VestaEvent[]>([]);
-
   $effect(() => {
-    const unsub = connection.messages.subscribe((v: VestaEvent[]) => { currentMessages = v; });
-    return () => unsub();
-  });
-
-  $effect(() => {
-    const evts = currentMessages;
-    if (evts.length < lastSyncedLen) {
-      lines = [];
-      nextId = 0;
-      lastSyncedLen = 0;
-      pendingUserTexts.clear();
-      suppressAnim = true;
-      requestAnimationFrame(() => { suppressAnim = false; });
-    }
-    if (evts.length === lastSyncedLen) return;
-    for (let i = lastSyncedLen; i < evts.length; i++) {
-      const ev = evts[i];
-      if (ev.type === "user") {
-        const count = pendingUserTexts.get(ev.text) ?? 0;
-        if (count > 0) {
-          if (count === 1) pendingUserTexts.delete(ev.text);
-          else pendingUserTexts.set(ev.text, count - 1);
-          continue;
+    const unsub = connection.messages.subscribe((evts: VestaEvent[]) => {
+      flushSync(() => {
+        if (evts.length < lastSyncedLen) {
+          lines = [];
+          nextId = 0;
+          lastSyncedLen = 0;
+          pendingUserTexts.clear();
+          suppressAnim = true;
+          requestAnimationFrame(() => { suppressAnim = false; });
         }
-      }
-      const line = eventToLine(ev);
-      if (line) lines.push(line);
-    }
-    if (lines.length > MAX_MESSAGES) lines.splice(0, lines.length - MAX_MESSAGES);
-    lastSyncedLen = evts.length;
-    scroller.scroll();
+        if (evts.length === lastSyncedLen) return;
+        for (let i = lastSyncedLen; i < evts.length; i++) {
+          const ev = evts[i];
+          if (ev.type === "user") {
+            const count = pendingUserTexts.get(ev.text) ?? 0;
+            if (count > 0) {
+              if (count === 1) pendingUserTexts.delete(ev.text);
+              else pendingUserTexts.set(ev.text, count - 1);
+              continue;
+            }
+          }
+          const line = eventToLine(ev);
+          if (line) lines.push(line);
+        }
+        if (lines.length > MAX_MESSAGES) lines.splice(0, lines.length - MAX_MESSAGES);
+        lastSyncedLen = evts.length;
+      });
+      scroller.scroll();
+    });
+    return () => unsub();
   });
 
   $effect(() => {

--- a/app/src/components/Onboarding.svelte
+++ b/app/src/components/Onboarding.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import { listen } from "@tauri-apps/api/event";
   import { open } from "@tauri-apps/plugin-dialog";
-  import { openUrl } from "@tauri-apps/plugin-opener";
-  import { createBox, boxStatus, authenticate, submitAuthCode, startBox, waitForReady, checkPlatform, setupPlatform, restoreBox, listBoxes } from "../lib/api";
+  import { createBox, boxStatus, authenticate, startBox, waitForReady, checkPlatform, setupPlatform, restoreBox, listBoxes } from "../lib/api";
   import { getOnboarding, updateOnboarding } from "../lib/store.svelte";
   import type { PlatformStatus } from "../lib/types";
   import ProgressBar from "./ProgressBar.svelte";
+  import AuthFlow from "./AuthFlow.svelte";
 
   let { onComplete, onCancel }: { onComplete: (name: string) => void; onCancel?: () => void } = $props();
 
@@ -18,21 +17,10 @@
   let busy = $derived(ob.busy);
   let createMsg = $derived(ob.createMsg);
   let platform = $derived(ob.platform);
-  let authUrl = $derived(ob.authUrl);
-  let authCodeNeeded = $derived(ob.authCodeNeeded);
-  let authCodeSubmitted = $derived(ob.authCodeSubmitted);
-  let authCode = $derived(ob.authCode);
 
   let transitioning = $state(false);
   let msgTimer: ReturnType<typeof setInterval> | null = null;
   let cancelled = $state(false);
-  let unlisteners: (() => void)[] = [];
-
-  async function handleSubmitCode() {
-    if (!authCode.trim()) return;
-    await submitAuthCode(authCode.trim());
-    updateOnboarding({ authCodeNeeded: false, authCodeSubmitted: true });
-  }
 
   const CREATE_MESSAGES = [
     "setting things up...",
@@ -43,23 +31,6 @@
   ];
 
   onMount(async () => {
-    listen<string>("auth-url", (event) => {
-      updateOnboarding({ authUrl: event.payload });
-    }).then((fn) => { unlisteners.push(fn); });
-
-    listen<string>("auth-code-needed", () => {
-      updateOnboarding({ authCodeNeeded: true });
-    }).then((fn) => { unlisteners.push(fn); });
-
-    listen<string>("auth-code-invalid", () => {
-      updateOnboarding({
-        authCodeNeeded: true,
-        authCodeSubmitted: false,
-        authCode: "",
-        error: { friendly: "invalid auth code — try again", raw: "auth-code-invalid" },
-      });
-    }).then((fn) => { unlisteners.push(fn); });
-
     // Only run initial setup if we're on the platform step and haven't loaded platform yet
     if (step === "platform" && !platform) {
       try {
@@ -234,7 +205,7 @@
 
   async function runAuth() {
     const name = normalizedPreview;
-    updateOnboarding({ busy: true, error: null, authUrl: null, authCodeNeeded: false, authCodeSubmitted: false, authCode: "" });
+    updateOnboarding({ busy: true, error: null });
     try {
       await authenticate(name);
       await startBox(name);
@@ -280,7 +251,7 @@
     onComplete(name);
   }
 
-  onDestroy(() => { stopMessages(); for (const fn of unlisteners) fn(); });
+  onDestroy(() => { stopMessages(); });
 </script>
 
 <div class="onboarding" class:transitioning>
@@ -398,25 +369,7 @@
 
     {:else if step === "auth"}
       <div class="step step-anim">
-        <h1>authenticate claude</h1>
-        {#if authCodeNeeded}
-          <p class="sub">paste the code from the browser below.</p>
-          <form onsubmit={(e) => { e.preventDefault(); handleSubmitCode(); }}>
-            <!-- svelte-ignore a11y_autofocus -->
-            <input type="text" class="name-input" placeholder="paste code here" value={authCode} oninput={(e) => updateOnboarding({ authCode: (e.target as HTMLInputElement).value })} autofocus />
-            <button class="btn primary full" type="submit" disabled={!authCode.trim()}>submit</button>
-          </form>
-        {:else if authCodeSubmitted}
-          <p class="sub">verifying code...</p>
-          <ProgressBar message="verifying..." />
-        {:else if authUrl}
-          <p class="sub">authenticate via the browser window that opened.<br/>if it didn't open, use the link below.</p>
-          <button class="auth-link" onclick={() => openUrl(authUrl!)}>{authUrl!.slice(0, 50)}...</button>
-          <ProgressBar message="waiting for authentication..." />
-        {:else}
-          <p class="sub">opening browser...</p>
-          <ProgressBar message="waiting..." />
-        {/if}
+        <AuthFlow onCancel={cancelToName} />
         {#if error}
           <p class="error">{error.friendly ?? "something went wrong."}</p>
           {#if error.raw.length > 80 || !error.friendly}
@@ -425,7 +378,6 @@
           {/if}
           <button class="btn primary" onclick={runAuth}>retry</button>
         {/if}
-        <button class="btn cancel" onclick={cancelToName}>cancel</button>
       </div>
 
     {:else if step === "done"}

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -32,6 +32,10 @@ export async function deleteBox(name: string): Promise<void> {
   return invoke("delete_agent", { name });
 }
 
+export async function rebuildBox(name: string): Promise<void> {
+  return invoke("rebuild_agent", { name });
+}
+
 export async function backupBox(name: string, output: string): Promise<void> {
   return invoke("backup_agent", { name, output });
 }

--- a/app/src/lib/store.svelte.ts
+++ b/app/src/lib/store.svelte.ts
@@ -2,7 +2,7 @@ import type { PlatformStatus } from "./types";
 
 // ── Per-box operation state ────────────────────────────────────
 
-export type BoxOperation = "idle" | "stopping" | "starting" | "authenticating" | "deleting" | "backing-up" | "restoring";
+export type BoxOperation = "idle" | "stopping" | "starting" | "authenticating" | "deleting" | "rebuilding" | "backing-up" | "restoring";
 
 type BoxOpState = {
   operation: BoxOperation;


### PR DESCRIPTION
## Summary

- **Rebuild command**: add a rebuild option in the box menu (next to restart) — wired through the full stack: CLI runtime → Tauri command → API → UI, using `SETUP_TIMEOUT_SECS` (600s)
- **Chat messages not rendering**: fix Svelte 5 reactivity — bridge the Svelte writable store to `$state` via two effects so `lines.push()` runs inside the reactive context and DOM updates fire immediately
- **Assistant text suppressed by tool use**: buffer text that arrives while `has_tool_use=True` and emit it once the tool call ends, so responses appear even when they follow a tool call
- **User messages missing from logs**: emit `logger.user()` in `_process_message_safely` so sent messages appear in container logs
- **Re-authentication UI**: when clicking authenticate from BoxView (not onboarding), the auth-url/auth-code-needed events had no listener — extract a shared `AuthFlow.svelte` component used in both BoxView and Onboarding

## Test plan
- [ ] Send a message in chat — response appears immediately without needing to send another message
- [ ] User messages appear in container logs (`docker logs vesta-<name>`)
- [ ] Assistant replies that follow tool calls appear correctly
- [ ] \"Rebuild\" appears in box menu when container is running; shows \"rebuilding...\" status
- [ ] Clicking authenticate from BoxView shows the browser URL and code-paste input (same as onboarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)