### PR TITLE
refactor: architectural cleanup of app frontend

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -3,9 +3,8 @@
   import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
   import { listBoxes, checkAndInstallUpdate, runInstallScript } from "./lib/api";
   import { createBoxConnection, type BoxConnection } from "./lib/ws";
-  import { removeBoxState, resetOnboarding, updateOnboarding } from "./lib/store.svelte";
+  import { removeBoxState } from "./lib/store.svelte";
   import { detectPlatform } from "./lib/platform";
-  import type { BoxActivityState } from "./lib/types";
   import Onboarding from "./components/Onboarding.svelte";
   import BoxView from "./components/BoxView.svelte";
   import Chat from "./components/Chat.svelte";
@@ -21,7 +20,7 @@
   let transitioning = $state(false);
   let selectedBox = $state<{ name: string; wsPort: number } | null>(null);
   let boxConnection = $state<BoxConnection | null>(null);
-  let initialActivity: BoxActivityState = "idle";
+  let onboardingInitialName = $state("");
   let hasBoxes = $state(false);
   let updateInfo = $state<{ version: string; installing: boolean } | null>(null);
 
@@ -62,7 +61,7 @@
       } else if (boxes.length > 1) {
         view = "grid";
       } else if (boxes.length === 1 && !boxes[0].authenticated) {
-        updateOnboarding({ name: boxes[0].name, step: "name" });
+        onboardingInitialName = boxes[0].name;
         view = "onboarding";
       } else {
         view = "onboarding";
@@ -84,10 +83,9 @@
 
   onDestroy(clearConnection);
 
-  function handleSelectBox(name: string, wsPort: number, activity: BoxActivityState = "idle") {
+  function handleSelectBox(name: string, wsPort: number) {
     boxConnection?.disconnect();
     selectedBox = { name, wsPort };
-    initialActivity = activity;
     boxConnection = createBoxConnection(wsPort);
     boxConnection.connect();
     setView("box-home");
@@ -112,6 +110,7 @@
 
   async function handleOnboardingComplete(name: string) {
     hasBoxes = true;
+    onboardingInitialName = "";
     const boxes = await listBoxes().catch(() => []);
     const box = boxes.find((b) => b.name === name);
     if (box) {
@@ -123,7 +122,6 @@
     } else {
       await setView("grid");
     }
-    resetOnboarding();
   }
 
   let isDark = $derived(view === "box-console" || view === "box-chat");
@@ -179,33 +177,34 @@
     {:else if view === "grid"}
       <GridView
         onSelect={handleSelectBox}
-        onCreate={() => setView("onboarding")}
-        onChat={(name, wsPort, activity) => { handleSelectBox(name, wsPort, activity); setView("box-chat"); }}
-        onConsole={(name, wsPort, activity) => { handleSelectBox(name, wsPort, activity); setView("box-console"); }}
+        onCreate={() => { onboardingInitialName = ""; setView("onboarding"); }}
+        onChat={(name, wsPort) => { handleSelectBox(name, wsPort); setView("box-chat"); }}
+        onConsole={(name, wsPort) => { handleSelectBox(name, wsPort); setView("box-console"); }}
       />
     {:else if view === "onboarding"}
-      <Onboarding onComplete={handleOnboardingComplete} onCancel={hasBoxes ? () => setView("grid") : undefined} />
-    {:else if view === "box-home" && selectedBox && boxConnection}
-      <BoxView
-        name={selectedBox.name}
-        connection={boxConnection}
-        {initialActivity}
-        onChat={() => setView("box-chat")}
-        onConsole={() => setView("box-console")}
-        onDestroyed={handleDestroyed}
-        onBack={handleBackToGrid}
-      />
-    {:else if view === "box-chat" && selectedBox && boxConnection}
-      <Chat
-        name={selectedBox.name}
-        connection={boxConnection}
-        onBack={() => setView("box-home")}
-      />
-    {:else if view === "box-console" && selectedBox}
-      <Console
-        name={selectedBox.name}
-        onBack={() => setView("box-home")}
-      />
+      <Onboarding onComplete={handleOnboardingComplete} onCancel={hasBoxes ? () => setView("grid") : undefined} initialName={onboardingInitialName} />
+    {:else if (view === "box-home" || view === "box-chat" || view === "box-console") && selectedBox && boxConnection}
+      <div class="box-stack">
+        <div class="box-layer" class:box-hidden={view !== "box-home"} inert={view !== "box-home"}>
+          <BoxView
+            name={selectedBox.name}
+            connection={boxConnection}
+            onChat={() => setView("box-chat")}
+            onConsole={() => setView("box-console")}
+            onDestroyed={handleDestroyed}
+            onBack={handleBackToGrid}
+          />
+        </div>
+        {#if view === "box-chat"}
+          <div class="overlay-layer">
+            <Chat name={selectedBox.name} connection={boxConnection} onBack={() => setView("box-home")} />
+          </div>
+        {:else if view === "box-console"}
+          <div class="overlay-layer">
+            <Console name={selectedBox.name} onBack={() => setView("box-home")} />
+          </div>
+        {/if}
+      </div>
     {/if}
   </main>
 
@@ -476,6 +475,33 @@
   main > :global(*) {
     flex: 1;
     min-height: 0;
+  }
+
+  .box-stack {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .box-layer {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .box-layer.box-hidden {
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  .overlay-layer {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
   }
 
   main.ready {

--- a/app/src/components/BoxView.svelte
+++ b/app/src/components/BoxView.svelte
@@ -3,7 +3,7 @@
   import { appVersion as appVersionPromise } from "../lib/version";
   import type { BoxConnection } from "../lib/ws";
   import { boxStatus, startBox, stopBox, restartBox, rebuildBox, deleteBox, authenticate, backupBox, restoreBox } from "../lib/api";
-  import { getBoxOp, setBoxOp, clearBoxOp, setBoxError, type BoxOperation } from "../lib/store.svelte";
+  import { getBoxOp, setBoxError, withBoxOp, type BoxOperation } from "../lib/store.svelte";
   import { save, open } from "@tauri-apps/plugin-dialog";
   import type { BoxStatus, BoxActivityState } from "../lib/types";
   import AuthFlow from "./AuthFlow.svelte";
@@ -11,7 +11,6 @@
   let {
     name,
     connection,
-    initialActivity = "idle",
     onChat,
     onConsole,
     onDestroyed,
@@ -19,7 +18,6 @@
   }: {
     name: string;
     connection: BoxConnection;
-    initialActivity?: BoxActivityState;
     onChat: () => void;
     onConsole: () => void;
     onDestroyed: () => void;
@@ -56,7 +54,7 @@
   let restoring = $derived(operation === "restoring");
   let busy = $derived(operation !== "idle");
 
-  let boxStateVal = $state<BoxActivityState>(initialActivity);
+  let boxStateVal = $state<BoxActivityState>("idle");
   let idleTimer: ReturnType<typeof setTimeout> | null = null;
 
   $effect(() => {
@@ -159,22 +157,9 @@
     document.removeEventListener("keydown", onKeydown);
   });
 
-  async function withBoxOp(op: BoxOperation, fn: () => Promise<void>, fallback: string) {
-    if (busy) return;
-    setBoxError(name, "");
-    setBoxOp(name, op);
-    try {
-      await fn();
-    } catch (e: any) {
-      setBoxError(name, e?.message || fallback);
-    } finally {
-      clearBoxOp(name);
-    }
-  }
-
   async function toggleRun() {
     const wasStopping = running;
-    await withBoxOp(running ? "stopping" : "starting", async () => {
+    await withBoxOp(name, running ? "stopping" : "starting", async () => {
       if (wasStopping) {
         await stopBox(name);
       } else {
@@ -190,7 +175,7 @@
       confirming = true;
       return;
     }
-    await withBoxOp("deleting", async () => {
+    await withBoxOp(name, "deleting", async () => {
       await deleteBox(name);
       onDestroyed();
     }, "failed to delete");
@@ -202,7 +187,7 @@
   }
 
   async function handleAuth() {
-    await withBoxOp("authenticating", async () => {
+    await withBoxOp(name, "authenticating", async () => {
       await authenticate(name);
       if (running) {
         await restartBox(name);
@@ -215,7 +200,7 @@
   }
 
   async function handleRestart() {
-    await withBoxOp("starting", async () => {
+    await withBoxOp(name, "starting", async () => {
       await restartBox(name);
       connection.resetReconnect();
       await syncStatus();
@@ -223,7 +208,7 @@
   }
 
   async function handleRebuild() {
-    await withBoxOp("rebuilding", async () => {
+    await withBoxOp(name, "rebuilding", async () => {
       await rebuildBox(name);
       connection.resetReconnect();
       await syncStatus();
@@ -239,7 +224,7 @@
       filters: [{ name: "Backup", extensions: ["tar.gz"] }],
     });
     if (!path) return;
-    await withBoxOp("backing-up", async () => {
+    await withBoxOp(name, "backing-up", async () => {
       await backupBox(name, path);
       connection.resetReconnect();
       await syncStatus();
@@ -255,7 +240,7 @@
       directory: false,
     });
     if (!path) return;
-    await withBoxOp("restoring", async () => {
+    await withBoxOp(name, "restoring", async () => {
       await restoreBox(path, name, true);
       connection.resetReconnect();
       await syncStatus();
@@ -299,7 +284,7 @@
     onpointerleave={onOrbLeave}
     onpointermove={onOrbMove}
   >
-    <div class="orb-container" class:orb-loading={!statusLoaded} bind:this={orbEl} class:alive={fullyAlive} class:booting={operational && !boxReady} class:dead={statusLoaded && ((!alive && !starting && !authenticating) || deleting || dead)} class:stopping class:starting class:authenticating class:deleting class:thinking={fullyAlive && boxStateVal === 'thinking'} class:tool-use={fullyAlive && boxStateVal === 'tool_use'}>
+    <div class="orb-container" class:orb-loading={!statusLoaded} bind:this={orbEl} class:alive={fullyAlive} class:booting={operational && !boxReady} class:dead={statusLoaded && ((!alive && !starting && !authenticating) || deleting || dead)} class:stopping class:starting class:authenticating class:deleting class:thinking={boxStateVal === 'thinking'} class:tool-use={boxStateVal === 'tool_use'}>
       <div class="orb-glow"></div>
       <div class="orb-body">
         <div class="orb-highlight"></div>

--- a/app/src/components/GridView.svelte
+++ b/app/src/components/GridView.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from "svelte";
   import { appVersion as appVersionPromise } from "../lib/version";
   import { listBoxes, startBox, stopBox, restartBox, deleteBox, backupBox, restoreBox } from "../lib/api";
-  import { getBoxOp, setBoxOp, clearBoxOp, busyBoxName } from "../lib/store.svelte";
+  import { getBoxOp, busyBoxName, withBoxOp } from "../lib/store.svelte";
   import { save, open } from "@tauri-apps/plugin-dialog";
   import { createBoxConnection, type BoxConnection } from "../lib/ws";
   import type { ListEntry, BoxActivityState } from "../lib/types";
@@ -15,10 +15,10 @@
     onChat,
     onConsole,
   }: {
-    onSelect: (name: string, wsPort: number, activity: BoxActivityState) => void;
+    onSelect: (name: string, wsPort: number) => void;
     onCreate: () => void;
-    onChat: (name: string, wsPort: number, activity: BoxActivityState) => void;
-    onConsole: (name: string, wsPort: number, activity: BoxActivityState) => void;
+    onChat: (name: string, wsPort: number) => void;
+    onConsole: (name: string, wsPort: number) => void;
   } = $props();
 
   let boxes = $state<ListEntry[]>([]);
@@ -118,32 +118,24 @@
 
   async function handleToggle(box: ListEntry) {
     if (busyBoxName()) return;
-    setBoxOp(box.name, box.status === "running" ? "stopping" : "starting");
-    try {
+    const op = box.status === "running" ? "stopping" : "starting";
+    const fallback = box.status === "running" ? "failed to stop" : "failed to start";
+    await withBoxOp(box.name, op, async () => {
       if (box.status === "running") {
         await stopBox(box.name);
       } else {
         await startBox(box.name);
       }
       await refresh();
-    } catch (e) {
-      console.warn("toggle failed:", e);
-    } finally {
-      clearBoxOp(box.name);
-    }
+    }, fallback);
   }
 
   async function handleRestart(box: ListEntry) {
     if (busyBoxName()) return;
-    setBoxOp(box.name, "starting");
-    try {
+    await withBoxOp(box.name, "starting", async () => {
       await restartBox(box.name);
       await refresh();
-    } catch (e) {
-      console.warn("restart failed:", e);
-    } finally {
-      clearBoxOp(box.name);
-    }
+    }, "failed to restart");
   }
 
   async function handleBackup(box: ListEntry) {
@@ -153,15 +145,10 @@
       filters: [{ name: "Backup", extensions: ["tar.gz"] }],
     });
     if (!path) return;
-    setBoxOp(box.name, "backing-up");
-    try {
+    await withBoxOp(box.name, "backing-up", async () => {
       await backupBox(box.name, path);
       await refresh();
-    } catch (e) {
-      console.warn("backup failed:", e);
-    } finally {
-      clearBoxOp(box.name);
-    }
+    }, "backup failed");
   }
 
   async function handleRestore(box: ListEntry) {
@@ -171,15 +158,10 @@
       directory: false,
     });
     if (!path) return;
-    setBoxOp(box.name, "restoring");
-    try {
+    await withBoxOp(box.name, "restoring", async () => {
       await restoreBox(path, box.name, true);
       await refresh();
-    } catch (e) {
-      console.warn("restore failed:", e);
-    } finally {
-      clearBoxOp(box.name);
-    }
+    }, "restore failed");
   }
 
   async function handleDelete(boxName: string) {
@@ -187,16 +169,11 @@
       confirming = boxName;
       return;
     }
-    setBoxOp(boxName, "deleting");
     confirming = null;
-    try {
+    await withBoxOp(boxName, "deleting", async () => {
       await deleteBox(boxName);
       await refresh();
-    } catch (e) {
-      console.warn("delete failed:", e);
-    } finally {
-      clearBoxOp(boxName);
-    }
+    }, "failed to delete");
   }
 
   function menuAction(fn: () => void) {
@@ -219,7 +196,7 @@
   <div class="grid cols-{gridCols}" class:few={gridCols < 3}>
     {#each boxes as box}
       <div class="card-wrapper">
-        <button class="card" class:busy={isBoxBusy(box.name)} onclick={() => onSelect(box.name, box.ws_port, activityStates[box.name] ?? "idle")}>
+        <button class="card" class:busy={isBoxBusy(box.name)} onclick={() => onSelect(box.name, box.ws_port)}>
           <div class="mini-orb-container {orbClass(box, activityStates[box.name])}">
             <div class="mini-orb-glow"></div>
             <div class="mini-orb-body">
@@ -251,8 +228,8 @@
                 <button class="menu-item muted" onclick={menuAction(() => { confirming = null; })}>cancel</button>
               {:else}
                 {#if box.alive}
-                  <button class="menu-item" onclick={menuAction(() => onChat(box.name, box.ws_port, activityStates[box.name] ?? "idle"))}>chat</button>
-                  <button class="menu-item" onclick={menuAction(() => onConsole(box.name, box.ws_port, activityStates[box.name] ?? "idle"))}>console</button>
+                  <button class="menu-item" onclick={menuAction(() => onChat(box.name, box.ws_port))}>chat</button>
+                  <button class="menu-item" onclick={menuAction(() => onConsole(box.name, box.ws_port))}>console</button>
                 {/if}
                 <button class="menu-item" disabled={!!busyBoxName()} onclick={menuAction(() => handleToggle(box))}>{box.status === "running" ? "stop" : "start"}</button>
                 {#if box.status === "running"}
@@ -402,6 +379,11 @@
   }
 
   /* --- Mini Orb --- */
+  @property --mini-c1 { syntax: "<color>"; inherits: true; initial-value: #b8ceb0; }
+  @property --mini-c2 { syntax: "<color>"; inherits: true; initial-value: #7a9e70; }
+  @property --mini-c3 { syntax: "<color>"; inherits: true; initial-value: #5a7e50; }
+  @property --mini-glow { syntax: "<color>"; inherits: true; initial-value: rgba(138, 180, 120, 0.35); }
+
   .mini-orb-container {
     position: relative;
     width: 36px;
@@ -423,11 +405,11 @@
     position: absolute;
     inset: 6px;
     border-radius: 50%;
-    background: radial-gradient(circle at 38% 32%, #b8ceb0, #7a9e70 50%, #5a7e50);
+    background: radial-gradient(circle at 38% 32%, var(--mini-c1), var(--mini-c2) 50%, var(--mini-c3));
     box-shadow:
       inset 0 -3px 8px rgba(0, 0, 0, 0.15),
       inset 0 2px 4px rgba(255, 255, 255, 0.15);
-    transition: background 0.8s var(--spring), box-shadow 0.8s var(--spring);
+    transition: --mini-c1 0.8s var(--spring), --mini-c2 0.8s var(--spring), --mini-c3 0.8s var(--spring), box-shadow 0.8s var(--spring);
   }
 
   .mini-orb-highlight {
@@ -446,9 +428,9 @@
     position: absolute;
     inset: -2px;
     border-radius: 50%;
-    background: radial-gradient(circle, rgba(138, 180, 120, 0.35), transparent 70%);
+    background: radial-gradient(circle, var(--mini-glow), transparent 70%);
     filter: blur(6px);
-    transition: opacity 0.8s var(--spring), background 0.8s var(--spring);
+    transition: opacity 0.8s var(--spring), --mini-glow 0.8s var(--spring);
   }
 
   /* Alive */
@@ -466,26 +448,30 @@
 
   /* Active — thinking / tool use (amber) */
   .mini-orb-container.active {
+    --mini-c1: #e8d0a0;
+    --mini-c2: #c4a060;
+    --mini-c3: #a08040;
+    --mini-glow: rgba(200, 170, 100, 0.4);
     animation: float 2s ease-in-out infinite;
   }
 
   .mini-orb-container.active .mini-orb-body {
-    background: radial-gradient(circle at 38% 32%, #e8d0a0, #c4a060 50%, #a08040);
     animation: orb-breathe 1.2s ease-in-out infinite;
   }
 
   .mini-orb-container.active .mini-orb-glow {
-    background: radial-gradient(circle, rgba(200, 170, 100, 0.4), transparent 70%);
     animation: glow-pulse 1.2s ease-in-out infinite;
   }
 
   /* Booting — alive but WS not ready */
   .mini-orb-container.booting {
+    --mini-c1: #c4deb8;
+    --mini-c2: #8ab880;
+    --mini-c3: #6a9e5a;
     animation: float 3s ease-in-out infinite;
   }
 
   .mini-orb-container.booting .mini-orb-body {
-    background: radial-gradient(circle at 38% 32%, #c4deb8, #8ab880 50%, #6a9e5a);
     animation: orb-breathe 2s ease-in-out infinite;
   }
 
@@ -495,22 +481,30 @@
 
   /* Auth — running but not signed in */
   .mini-orb-container.auth {
+    --mini-c1: #c0d0e8;
+    --mini-c2: #80a0c4;
+    --mini-c3: #6080a4;
+    --mini-glow: rgba(100, 150, 200, 0.35);
     animation: float 3s ease-in-out infinite;
   }
 
   .mini-orb-container.auth .mini-orb-body {
-    background: radial-gradient(circle at 38% 32%, #c0d0e8, #80a0c4 50%, #6080a4);
     animation: orb-breathe 2s ease-in-out infinite;
   }
 
   .mini-orb-container.auth .mini-orb-glow {
-    background: radial-gradient(circle, rgba(100, 150, 200, 0.35), transparent 70%);
     animation: glow-pulse 2s ease-in-out infinite;
   }
 
   /* Dead / Stopped */
+  .mini-orb-container.dead {
+    --mini-c1: #c4bdb5;
+    --mini-c2: #a09890;
+    --mini-c3: #8b7e74;
+    --mini-glow: rgba(160, 152, 144, 0.2);
+  }
+
   .mini-orb-container.dead .mini-orb-body {
-    background: radial-gradient(circle at 38% 32%, #c4bdb5, #a09890 50%, #8b7e74);
     box-shadow:
       inset 0 -3px 8px rgba(0, 0, 0, 0.1),
       inset 0 2px 4px rgba(255, 255, 255, 0.05);
@@ -519,7 +513,6 @@
 
   .mini-orb-container.dead .mini-orb-glow {
     opacity: 0.15;
-    background: radial-gradient(circle, rgba(160, 152, 144, 0.2), transparent 70%);
   }
 
   .mini-orb-container.dead .mini-orb-highlight {

--- a/app/src/components/Onboarding.svelte
+++ b/app/src/components/Onboarding.svelte
@@ -2,21 +2,19 @@
   import { onMount, onDestroy } from "svelte";
   import { open } from "@tauri-apps/plugin-dialog";
   import { createBox, boxStatus, authenticate, startBox, waitForReady, checkPlatform, setupPlatform, restoreBox, listBoxes } from "../lib/api";
-  import { getOnboarding, updateOnboarding } from "../lib/store.svelte";
-  import type { PlatformStatus } from "../lib/types";
+  import type { PlatformStatus, OnboardingStep } from "../lib/types";
   import ProgressBar from "./ProgressBar.svelte";
   import AuthFlow from "./AuthFlow.svelte";
 
-  let { onComplete, onCancel }: { onComplete: (name: string) => void; onCancel?: () => void } = $props();
+  let { onComplete, onCancel, initialName }: { onComplete: (name: string) => void; onCancel?: () => void; initialName?: string } = $props();
 
-  let ob = $derived(getOnboarding());
-  let step = $derived(ob.step);
-  let boxName = $derived(ob.name);
-  let error = $derived(ob.error);
-  let showRawError = $derived(ob.showRawError);
-  let busy = $derived(ob.busy);
-  let createMsg = $derived(ob.createMsg);
-  let platform = $derived(ob.platform);
+  let step = $state<OnboardingStep>(initialName ? "name" : "platform");
+  let boxName = $state(initialName ?? "");
+  let error = $state<{ friendly: string | null; raw: string } | null>(null);
+  let showRawError = $state(false);
+  let busy = $state(false);
+  let createMsg = $state("");
+  let platform = $state<PlatformStatus | null>(null);
 
   let transitioning = $state(false);
   let msgTimer: ReturnType<typeof setInterval> | null = null;
@@ -35,9 +33,9 @@
     if (step === "platform" && !platform) {
       try {
         const status = await checkPlatform();
-        updateOnboarding({ platform: status });
+        platform = status;
         if (status.ready || status.platform !== "windows") {
-          updateOnboarding({ step: "name" });
+          step = "name";
           return;
         }
         // auto-run setup for distro/service issues (WSL already installed)
@@ -52,10 +50,10 @@
 
   function startMessages() {
     let i = 0;
-    updateOnboarding({ createMsg: CREATE_MESSAGES[0] });
+    createMsg = CREATE_MESSAGES[0];
     msgTimer = setInterval(() => {
       i = (i + 1) % CREATE_MESSAGES.length;
-      updateOnboarding({ createMsg: CREATE_MESSAGES[i] });
+      createMsg = CREATE_MESSAGES[i];
     }, 3000);
   }
 
@@ -69,10 +67,10 @@
 
   let normalizedPreview = $derived(normalizeName(boxName));
 
-  async function goTo(next: typeof step) {
+  async function goTo(next: OnboardingStep) {
     transitioning = true;
     await new Promise((r) => setTimeout(r, 150));
-    updateOnboarding({ step: next });
+    step = next;
     transitioning = false;
   }
 
@@ -94,57 +92,59 @@
 
   function setError(e: unknown, fallback: string) {
     const err = e as { message?: string };
-    updateOnboarding({ error: formatError(err.message || fallback) });
+    error = formatError(err.message || fallback);
   }
 
   function cancelToName() {
     cancelled = true;
     stopMessages();
-    updateOnboarding({ busy: false, error: null, showRawError: false, step: "name" });
+    busy = false;
+    error = null;
+    showRawError = false;
+    step = "name";
   }
 
   async function recheckPlatform() {
-    updateOnboarding({ busy: true, error: null });
+    busy = true;
+    error = null;
     try {
       const status = await checkPlatform();
-      updateOnboarding({ platform: status });
+      platform = status;
       if (status.ready) {
         await goTo("name");
       }
     } catch (e) {
       setError(e, "failed to check platform");
     } finally {
-      updateOnboarding({ busy: false });
+      busy = false;
     }
   }
 
   async function handlePlatformSetup() {
-    updateOnboarding({ busy: true, error: null });
+    busy = true;
+    error = null;
     try {
       const result = await setupPlatform();
-      updateOnboarding({ platform: result });
+      platform = result;
       if (result.ready) {
         await goTo("name");
       } else if (result.needs_reboot) {
         // stay on platform step, UI will show reboot message
       } else if (result.message) {
-        updateOnboarding({ error: { friendly: result.message, raw: result.message } });
+        error = { friendly: result.message, raw: result.message };
       }
     } catch (e) {
       setError(e, "setup failed");
     } finally {
-      updateOnboarding({ busy: false });
+      busy = false;
     }
-  }
-
-  async function waitUntilReady(name: string) {
-    await waitForReady(name, 30);
   }
 
   async function handleCreate() {
     const name = normalizedPreview;
     if (!name || busy) return;
-    updateOnboarding({ busy: true, error: null });
+    busy = true;
+    error = null;
     cancelled = false;
 
     startMessages();
@@ -156,7 +156,7 @@
       if (info.status !== "not_found") {
         if (info.status === "running" && info.authenticated && info.agent_ready) {
           stopMessages();
-          updateOnboarding({ busy: false });
+          busy = false;
           await goTo("done");
           return;
         }
@@ -167,7 +167,7 @@
           } catch (e) {
             if (cancelled) return;
             stopMessages();
-            updateOnboarding({ busy: false });
+            busy = false;
             setError(e, "failed to start box");
             await goTo("name");
             return;
@@ -176,7 +176,7 @@
 
         if (cancelled) return;
         stopMessages();
-        updateOnboarding({ busy: false });
+        busy = false;
         await goTo("auth");
         await runAuth();
         return;
@@ -199,21 +199,22 @@
       setError(e, "something went wrong");
       await goTo("name");
     } finally {
-      updateOnboarding({ busy: false });
+      busy = false;
     }
   }
 
   async function runAuth() {
     const name = normalizedPreview;
-    updateOnboarding({ busy: true, error: null });
+    busy = true;
+    error = null;
     try {
       await authenticate(name);
       await startBox(name);
-      await waitUntilReady(name);
-      updateOnboarding({ busy: false });
+      await waitForReady(name, 30);
+      busy = false;
       await goTo("done");
     } catch (e) {
-      updateOnboarding({ busy: false });
+      busy = false;
       setError(e, "authentication failed");
     }
   }
@@ -227,28 +228,28 @@
     });
     if (!path) return;
     const before = new Set((await listBoxes().catch(() => [])).map((b) => b.name));
-    updateOnboarding({ busy: true, error: null });
+    busy = true;
+    error = null;
     startMessages();
     await goTo("creating");
     try {
       await restoreBox(path);
       const after = await listBoxes().catch(() => []);
       const restored = after.find((b) => !before.has(b.name));
-      if (restored) updateOnboarding({ name: restored.name });
+      if (restored) boxName = restored.name;
       stopMessages();
-      updateOnboarding({ busy: false });
+      busy = false;
       await goTo("done");
     } catch (e) {
       stopMessages();
-      updateOnboarding({ busy: false });
+      busy = false;
       setError(e, "restore failed");
       await goTo("name");
     }
   }
 
   function handleComplete() {
-    const name = normalizeName(boxName);
-    onComplete(name);
+    onComplete(normalizedPreview);
   }
 
   onDestroy(() => { stopMessages(); });
@@ -303,7 +304,7 @@
           {#if error}
             <p class="error">{error.friendly ?? "something went wrong."}</p>
             {#if error.raw.length > 80 || !error.friendly}
-              <button class="btn details-toggle" onclick={() => updateOnboarding({ showRawError: !showRawError })}>{showRawError ? "hide details" : "show details"}</button>
+              <button class="btn details-toggle" onclick={() => { showRawError = !showRawError; }}>{showRawError ? "hide details" : "show details"}</button>
               {#if showRawError}<pre class="error-details">{error.raw}</pre>{/if}
             {/if}
           {/if}
@@ -335,13 +336,13 @@
             class="name-input"
             placeholder="name your box"
             value={boxName}
-            oninput={(e) => updateOnboarding({ name: (e.target as HTMLInputElement).value })}
+            oninput={(e) => { boxName = (e.target as HTMLInputElement).value; }}
             autofocus
           />
           {#if error}
             <p class="error">{error.friendly ?? "something went wrong."}</p>
             {#if error.raw.length > 80 || !error.friendly}
-              <button type="button" class="btn details-toggle" onclick={() => updateOnboarding({ showRawError: !showRawError })}>{showRawError ? "hide details" : "show details"}</button>
+              <button type="button" class="btn details-toggle" onclick={() => { showRawError = !showRawError; }}>{showRawError ? "hide details" : "show details"}</button>
               {#if showRawError}<pre class="error-details">{error.raw}</pre>{/if}
             {/if}
           {/if}
@@ -358,7 +359,7 @@
         {#if error}
           <p class="error">{error.friendly ?? "something went wrong."}</p>
           {#if error.raw.length > 80 || !error.friendly}
-            <button class="btn details-toggle" onclick={() => updateOnboarding({ showRawError: !showRawError })}>{showRawError ? "hide details" : "show details"}</button>
+            <button class="btn details-toggle" onclick={() => { showRawError = !showRawError; }}>{showRawError ? "hide details" : "show details"}</button>
             {#if showRawError}<pre class="error-details">{error.raw}</pre>{/if}
           {/if}
           <button class="btn primary" onclick={() => goTo("name")}>try again</button>
@@ -373,7 +374,7 @@
         {#if error}
           <p class="error">{error.friendly ?? "something went wrong."}</p>
           {#if error.raw.length > 80 || !error.friendly}
-            <button class="btn details-toggle" onclick={() => updateOnboarding({ showRawError: !showRawError })}>{showRawError ? "hide details" : "show details"}</button>
+            <button class="btn details-toggle" onclick={() => { showRawError = !showRawError; }}>{showRawError ? "hide details" : "show details"}</button>
             {#if showRawError}<pre class="error-details">{error.raw}</pre>{/if}
           {/if}
           <button class="btn primary" onclick={runAuth}>retry</button>

--- a/app/src/lib/store.svelte.ts
+++ b/app/src/lib/store.svelte.ts
@@ -1,5 +1,3 @@
-import type { PlatformStatus } from "./types";
-
 // ── Per-box operation state ────────────────────────────────────
 
 export type BoxOperation = "idle" | "stopping" | "starting" | "authenticating" | "deleting" | "rebuilding" | "backing-up" | "restoring";
@@ -15,7 +13,7 @@ export function getBoxOp(name: string): BoxOpState {
   return boxStates[name] ?? { operation: "idle", error: "" };
 }
 
-export function setBoxOp(name: string, operation: BoxOperation, error = "") {
+function setBoxOp(name: string, operation: BoxOperation, error = "") {
   boxStates[name] = { operation, error };
 }
 
@@ -28,7 +26,7 @@ export function setBoxError(name: string, error: string) {
   }
 }
 
-export function clearBoxOp(name: string) {
+function clearBoxOp(name: string) {
   boxStates[name] = { operation: "idle", error: "" };
 }
 
@@ -44,48 +42,15 @@ export function busyBoxName(): string | null {
   return null;
 }
 
-// ── Onboarding state ───────────────────────────────────────────
-
-export type OnboardingStep = "platform" | "name" | "creating" | "auth" | "done";
-
-type OnboardingState = {
-  step: OnboardingStep;
-  name: string;
-  error: { friendly: string | null; raw: string } | null;
-  showRawError: boolean;
-  platform: PlatformStatus | null;
-  authUrl: string | null;
-  authCodeNeeded: boolean;
-  authCodeSubmitted: boolean;
-  authCode: string;
-  busy: boolean;
-  createMsg: string;
-};
-
-const DEFAULT_ONBOARDING: OnboardingState = {
-  step: "platform",
-  name: "",
-  error: null,
-  showRawError: false,
-  platform: null,
-  authUrl: null,
-  authCodeNeeded: false,
-  authCodeSubmitted: false,
-  authCode: "",
-  busy: false,
-  createMsg: "",
-};
-
-let onboarding = $state<OnboardingState>({ ...DEFAULT_ONBOARDING });
-
-export function getOnboarding(): OnboardingState {
-  return onboarding;
-}
-
-export function updateOnboarding(patch: Partial<OnboardingState>) {
-  onboarding = { ...onboarding, ...patch };
-}
-
-export function resetOnboarding() {
-  onboarding = { ...DEFAULT_ONBOARDING };
+export async function withBoxOp(name: string, op: BoxOperation, fn: () => Promise<void>, fallback: string): Promise<void> {
+  if (getBoxOp(name).operation !== "idle") return;
+  setBoxError(name, "");
+  setBoxOp(name, op);
+  try {
+    await fn();
+  } catch (e: unknown) {
+    setBoxError(name, (e as { message?: string })?.message || fallback);
+  } finally {
+    clearBoxOp(name);
+  }
 }

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -35,6 +35,8 @@ export interface PlatformStatus {
 
 export type BoxActivityState = "idle" | "thinking" | "tool_use";
 
+export type OnboardingStep = "platform" | "name" | "creating" | "auth" | "done";
+
 type BaseEvent = { ts?: string };
 
 export type VestaEvent =


### PR DESCRIPTION
## Summary

- **Shared `withBoxOp`**: Moved from BoxView-local to `store.svelte.ts`; `setBoxOp`/`clearBoxOp` are now internal. GridView handlers now use it — errors are surfaced to box state instead of silently `console.warn`'d.
- **Remove `initialActivity` dead prop**: BoxView read activity state from its WebSocket store directly — the prop was never actually used for anything meaningful after connection opened.
- **Mini-orb CSS custom properties**: GridView mini-orbs now use `@property` CSS vars (`--mini-c1/c2/c3/--mini-glow`) matching the main orb pattern, enabling smooth color transitions between states.
- **Onboarding local state**: Removed `getOnboarding`/`updateOnboarding`/`resetOnboarding` from `store.svelte.ts`. Onboarding state is now `$state` in `Onboarding.svelte` with an `initialName` prop for the pre-authenticated box case.
- **Persistent BoxView**: BoxView stays mounted when navigating to chat/console views. Chat/Console overlay with `position: absolute`. Eliminates the remount flash, status reload, and orb re-animation on back-navigation.
- **Orb flash fix**: Removed `fullyAlive &&` guard from `thinking`/`tool-use` CSS class bindings so orb colors are pre-set while `orb-loading` disables transitions.

## Test plan

- [ ] Single-box startup: orb appears without green→orange flash
- [ ] Open chat, press back — BoxView state preserved (no reload, orb already positioned)
- [ ] Open console, press back — same
- [ ] Grid view: mini-orbs transition smoothly between alive/active/dead states
- [ ] Onboarding from fresh install (platform check)
- [ ] Onboarding with pre-existing unauthenticated box (starts at name step)
- [ ] Create box from grid "+" — fresh onboarding (no stale name)
- [ ] GridView operations (stop/start/backup) — errors now show in box op state

🤖 Generated with [Claude Code](https://claude.com/claude-code)