### PR TITLE
fix(agent): stream assistant output for all messages

### DIFF
--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -298,7 +298,7 @@ async def process_message(msg: str, *, state: vm.State, config: vm.VestaConfig, 
     if state.history is not None:
         role = "user" if is_user else "system"
         history_save(state.history, role, msg, session_id=state.session_id)
-    responses = await converse(msg, state=state, config=config, show_output=is_user)
+    responses = await converse(msg, state=state, config=config, show_output=True)
     return responses, state
 
 

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1133,7 +1133,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.100"
+version = "0.1.101"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -118,7 +118,7 @@
       selectedBox = { name: box.name, wsPort: box.ws_port };
       boxConnection = createBoxConnection(box.ws_port);
       boxConnection.connect();
-      await setView("box-home");
+      await setView("box-chat");
     } else {
       await setView("grid");
     }


### PR DESCRIPTION
## Summary
- `converse()` was called with `show_output=False` for non-user messages (notifications, greetings, proactive checks), which silently collected all response text without emitting anything to the event bus or docker logs
- Text was only emitted after the entire conversation completed — if the user sent a message mid-conversation, the interrupt caused the held responses to finally appear, making it look like messages were stuck until user interaction
- Fix: always pass `show_output=True` so assistant text streams in real-time

## Root cause
`process_message()` passed `show_output=is_user` to `converse()`. For all non-user-initiated messages (`is_user=False`), this meant lines 271-273 of `client.py` silently appended text to a `responses` list instead of calling `_emit()`. The responses were only emitted in `_process_message_safely` after `converse()` returned — which could be minutes later if the agent was doing multiple tool calls.

## Test plan
- [ ] Send a notification while the agent is idle — verify the response streams into the chat in real-time
- [ ] Send a user message while the agent is processing a notification — verify the notification response appears before the user message, not after
- [ ] Check docker logs show assistant messages in real-time for notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)