### PR TITLE
fix(agent): emit assistant text immediately, remove pending_text

### DIFF
--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -223,7 +223,6 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
 
     responses: list[str] = []
     assistant_texts: list[str] = []
-    pending_text: str | None = None
     sub_agent_context: str | None = None
 
     def _emit(t: str) -> None:
@@ -262,7 +261,7 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 break
 
             msg = tp.cast(Message, result)
-            texts, sub_agent_context, session_id, has_tool_use = _parse_sdk_message(msg, sub_agent_context=sub_agent_context)
+            texts, sub_agent_context, session_id, _ = _parse_sdk_message(msg, sub_agent_context=sub_agent_context)
             if session_id and session_id != state.session_id:
                 persist_session_id(session_id, state=state, config=config)
             text = "\n".join(texts) if texts else None
@@ -272,19 +271,11 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 responses.append(text)
                 continue
             filtered = filter_tool_lines(text)
-            if filtered and not has_tool_use:
-                if pending_text:
-                    _emit(pending_text)
-                    pending_text = None
+            if filtered:
                 _emit(filtered)
-            elif filtered:
-                pending_text = filtered
     finally:
         if interrupt_task and not interrupt_task.done():
             await _cancel_task(interrupt_task)
-
-    if pending_text and show_output:
-        _emit(pending_text)
 
     if state.history is not None:
         combined = "\n".join(r for r in (assistant_texts or responses) if r and r.strip())


### PR DESCRIPTION
## Summary
- Removes `pending_text` buffering in `converse()` that held assistant text during tool-use sequences
- Text is now emitted to the event bus (and docker logs) as soon as it arrives from the model

## Root cause
When the model's `AssistantMessage` contained both text and a `ToolUseBlock`, the text was stored in `pending_text` instead of being emitted. It was only flushed when:
1. A non-tool message arrived later, OR
2. The response stream ended, OR
3. The user sent a message (triggering an interrupt)

This caused assistant messages to be invisible for the entire duration of tool execution — up to minutes. Consecutive tool messages also overwrote `pending_text`, losing intermediate text entirely.

## Test plan
- [ ] Trigger a notification that causes tool calls — verify assistant text appears alongside tool activity, not after
- [ ] Send a user message during agent tool execution — verify no text is lost or delayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)