### PR TITLE
fix(agent): fix chat messages stuck until user sends another message

### DIFF
--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -256,10 +256,16 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 await _cancel_task(anext_task)
                 # Cancelling anext_task finalizes response_iter, so drain leftover
                 # messages with a fresh iterator to keep the stream clean.
+                # Emit any text so it's not lost.
                 try:
                     drain = client.receive_response().__aiter__()
-                    while await asyncio.wait_for(anext(drain, None), timeout=5.0) is not None:
-                        pass
+                    while (leftover := await asyncio.wait_for(anext(drain, None), timeout=5.0)) is not None:
+                        texts, _, _, _ = _parse_sdk_message(tp.cast(Message, leftover), sub_agent_context=sub_agent_context)
+                        text = "\n".join(texts) if texts else None
+                        if text and show_output:
+                            filtered = filter_tool_lines(text)
+                            if filtered:
+                                _emit(filtered)
                 except (TimeoutError, StopAsyncIteration):
                     pass
                 break

--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -254,14 +254,14 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 logger.interrupt("Conversation interrupted by new message")
                 await attempt_interrupt(state, config=config, reason="New message interrupt")
                 await _cancel_task(anext_task)
-                # Drain remaining messages from the interrupted conversation so they
-                # don't leak into the next converse() call's receive_response() iterator.
+                # Cancelling anext_task finalizes response_iter, so drain with a fresh
+                # iterator to consume any leftover messages from the interrupted turn.
                 try:
+                    drain_iter = client.receive_response().__aiter__()
                     while True:
-                        leftover = await asyncio.wait_for(anext(response_iter, _STOP), timeout=5.0)
+                        leftover = await asyncio.wait_for(anext(drain_iter, _STOP), timeout=5.0)
                         if leftover is _STOP:
                             break
-                        # Emit any text that was already generated before the interrupt
                         leftover_msg = tp.cast(Message, leftover)
                         texts, _, _, _ = _parse_sdk_message(leftover_msg, sub_agent_context=sub_agent_context)
                         text = "\n".join(texts) if texts else None

--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -223,7 +223,6 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
 
     responses: list[str] = []
     assistant_texts: list[str] = []
-    pending_text: str | None = None
     sub_agent_context: str | None = None
 
     def _emit(t: str) -> None:
@@ -262,7 +261,7 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 break
 
             msg = tp.cast(Message, result)
-            texts, sub_agent_context, session_id, has_tool_use = _parse_sdk_message(msg, sub_agent_context=sub_agent_context)
+            texts, sub_agent_context, session_id, _ = _parse_sdk_message(msg, sub_agent_context=sub_agent_context)
             if session_id and session_id != state.session_id:
                 persist_session_id(session_id, state=state, config=config)
             text = "\n".join(texts) if texts else None
@@ -272,19 +271,11 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 responses.append(text)
                 continue
             filtered = filter_tool_lines(text)
-            if filtered and not has_tool_use:
-                if pending_text:
-                    _emit(pending_text)
-                    pending_text = None
+            if filtered:
                 _emit(filtered)
-            elif filtered:
-                pending_text = filtered
     finally:
         if interrupt_task and not interrupt_task.done():
             await _cancel_task(interrupt_task)
-
-    if pending_text and show_output:
-        _emit(pending_text)
 
     if state.history is not None:
         combined = "\n".join(r for r in (assistant_texts or responses) if r and r.strip())

--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -254,6 +254,23 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 logger.interrupt("Conversation interrupted by new message")
                 await attempt_interrupt(state, config=config, reason="New message interrupt")
                 await _cancel_task(anext_task)
+                # Drain remaining messages from the interrupted conversation so they
+                # don't leak into the next converse() call's receive_response() iterator.
+                try:
+                    while True:
+                        leftover = await asyncio.wait_for(anext(response_iter, _STOP), timeout=5.0)
+                        if leftover is _STOP:
+                            break
+                        # Emit any text that was already generated before the interrupt
+                        leftover_msg = tp.cast(Message, leftover)
+                        texts, _, _, _ = _parse_sdk_message(leftover_msg, sub_agent_context=sub_agent_context)
+                        text = "\n".join(texts) if texts else None
+                        if text and show_output:
+                            filtered = filter_tool_lines(text)
+                            if filtered:
+                                _emit(filtered)
+                except (TimeoutError, StopAsyncIteration):
+                    pass
                 break
 
             result = anext_task.result()

--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -254,21 +254,12 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 logger.interrupt("Conversation interrupted by new message")
                 await attempt_interrupt(state, config=config, reason="New message interrupt")
                 await _cancel_task(anext_task)
-                # Cancelling anext_task finalizes response_iter, so drain with a fresh
-                # iterator to consume any leftover messages from the interrupted turn.
+                # Cancelling anext_task finalizes response_iter, so drain leftover
+                # messages with a fresh iterator to keep the stream clean.
                 try:
-                    drain_iter = client.receive_response().__aiter__()
-                    while True:
-                        leftover = await asyncio.wait_for(anext(drain_iter, _STOP), timeout=5.0)
-                        if leftover is _STOP:
-                            break
-                        leftover_msg = tp.cast(Message, leftover)
-                        texts, _, _, _ = _parse_sdk_message(leftover_msg, sub_agent_context=sub_agent_context)
-                        text = "\n".join(texts) if texts else None
-                        if text and show_output:
-                            filtered = filter_tool_lines(text)
-                            if filtered:
-                                _emit(filtered)
+                    drain = client.receive_response().__aiter__()
+                    while await asyncio.wait_for(anext(drain, None), timeout=5.0) is not None:
+                        pass
                 except (TimeoutError, StopAsyncIteration):
                     pass
                 break

--- a/agent/tests/test_unit.py
+++ b/agent/tests/test_unit.py
@@ -675,7 +675,7 @@ async def test_converse_emits_text_immediately_with_tool_use():
             emitted.append(event["text"])
         original_emit(event)
 
-    state.event_bus.emit = tracking_emit
+    state.event_bus.emit = tracking_emit  # type: ignore[assignment]
 
     mock_client = MagicMock()
     mock_client.query = AsyncMock()

--- a/agent/tests/test_unit.py
+++ b/agent/tests/test_unit.py
@@ -640,6 +640,54 @@ async def test_converse_works_normally_without_interrupt():
     assert not mock_client.interrupt.called, "interrupt should not have been called"
 
 
+@pytest.mark.anyio
+async def test_converse_emits_text_immediately_with_tool_use():
+    """Text in messages that also have tool_use must be emitted immediately, not buffered."""
+    from claude_agent_sdk import AssistantMessage, TextBlock, ToolUseBlock
+    from vesta.core.client import converse
+
+    emitted: list[str] = []
+    emit_order: list[str] = []
+
+    def _assistant_msg(content):
+        msg = MagicMock(spec=AssistantMessage)
+        msg.content = content
+        return msg
+
+    async def response_with_tool_use():
+        # Message 1: text + tool_use (was buffered by pending_text)
+        yield _assistant_msg([TextBlock("restarting daemon"), ToolUseBlock("1", "Bash", {})])
+        emit_order.append("after_msg1")
+        # Message 2: another text + tool_use (would have overwritten pending_text)
+        yield _assistant_msg([TextBlock("checking status"), ToolUseBlock("2", "Bash", {})])
+        emit_order.append("after_msg2")
+        # Message 3: pure text (no tool_use)
+        yield _assistant_msg([TextBlock("all done")])
+
+    config = vm.VestaConfig()
+    state = vm.State()
+    state.event_bus = EventBus()
+
+    original_emit = state.event_bus.emit
+    def tracking_emit(event):
+        if isinstance(event, dict) and event.get("type") == "assistant":
+            emitted.append(event["text"])
+        original_emit(event)
+    state.event_bus.emit = tracking_emit
+
+    mock_client = MagicMock()
+    mock_client.query = AsyncMock()
+    mock_client.receive_response = MagicMock(return_value=response_with_tool_use())
+    mock_client.interrupt = AsyncMock()
+    state.client = mock_client
+
+    await converse("test", state=state, config=config, show_output=True)
+
+    assert emitted == ["restarting daemon", "checking status", "all done"], (
+        f"All text must be emitted immediately, got: {emitted}"
+    )
+
+
 # --- Nightly restart ---
 
 

--- a/agent/tests/test_unit.py
+++ b/agent/tests/test_unit.py
@@ -669,10 +669,12 @@ async def test_converse_emits_text_immediately_with_tool_use():
     state.event_bus = EventBus()
 
     original_emit = state.event_bus.emit
+
     def tracking_emit(event):
         if isinstance(event, dict) and event.get("type") == "assistant":
             emitted.append(event["text"])
         original_emit(event)
+
     state.event_bus.emit = tracking_emit
 
     mock_client = MagicMock()
@@ -683,9 +685,7 @@ async def test_converse_emits_text_immediately_with_tool_use():
 
     await converse("test", state=state, config=config, show_output=True)
 
-    assert emitted == ["restarting daemon", "checking status", "all done"], (
-        f"All text must be emitted immediately, got: {emitted}"
-    )
+    assert emitted == ["restarting daemon", "checking status", "all done"], f"All text must be emitted immediately, got: {emitted}"
 
 
 # --- Nightly restart ---

--- a/agent/tests/test_unit.py
+++ b/agent/tests/test_unit.py
@@ -647,7 +647,6 @@ async def test_converse_emits_text_immediately_with_tool_use():
     from vesta.core.client import converse
 
     emitted: list[str] = []
-    emit_order: list[str] = []
 
     def _assistant_msg(content):
         msg = MagicMock(spec=AssistantMessage)
@@ -655,13 +654,8 @@ async def test_converse_emits_text_immediately_with_tool_use():
         return msg
 
     async def response_with_tool_use():
-        # Message 1: text + tool_use (was buffered by pending_text)
         yield _assistant_msg([TextBlock("restarting daemon"), ToolUseBlock("1", "Bash", {})])
-        emit_order.append("after_msg1")
-        # Message 2: another text + tool_use (would have overwritten pending_text)
         yield _assistant_msg([TextBlock("checking status"), ToolUseBlock("2", "Bash", {})])
-        emit_order.append("after_msg2")
-        # Message 3: pure text (no tool_use)
         yield _assistant_msg([TextBlock("all done")])
 
     config = vm.VestaConfig()
@@ -686,6 +680,104 @@ async def test_converse_emits_text_immediately_with_tool_use():
     await converse("test", state=state, config=config, show_output=True)
 
     assert emitted == ["restarting daemon", "checking status", "all done"], f"All text must be emitted immediately, got: {emitted}"
+
+
+@pytest.mark.anyio
+async def test_interrupt_does_not_leak_or_lose_messages():
+    """End-to-end: after an interrupt, leftover messages must be emitted (not lost)
+    and must NOT leak into the next converse() call."""
+    import time
+
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+    from vesta.core.client import converse
+
+    def _assistant_msg(content):
+        msg = MagicMock(spec=AssistantMessage)
+        msg.content = content
+        return msg
+
+    def _result_msg():
+        msg = MagicMock(spec=ResultMessage)
+        msg.content = []
+        return msg
+
+    # Shared message queue — simulates the SDK's internal anyio stream.
+    # Both converse() calls read from the same queue via receive_response(),
+    # just like the real SDK where one _query._message_receive is shared.
+    message_queue: asyncio.Queue[tp.Any] = asyncio.Queue()
+    _SENTINEL = object()
+
+    async def _receive_response():
+        """Yields messages from the shared queue until ResultMessage."""
+        while True:
+            msg = await message_queue.get()
+            yield msg
+            if isinstance(msg, ResultMessage):
+                return
+
+    emitted: list[tuple[str, float]] = []  # (text, timestamp)
+
+    config = vm.VestaConfig(interrupt_timeout=0.5)
+    state = vm.State()
+    state.event_bus = EventBus()
+
+    original_emit = state.event_bus.emit
+
+    def tracking_emit(event):
+        if isinstance(event, dict) and event.get("type") == "assistant":
+            emitted.append((event["text"], time.monotonic()))
+        original_emit(event)
+
+    state.event_bus.emit = tracking_emit  # type: ignore[assignment]
+
+    mock_client = MagicMock()
+    mock_client.query = AsyncMock()
+    mock_client.receive_response = MagicMock(side_effect=lambda: _receive_response())
+    mock_client.interrupt = AsyncMock()
+    state.client = mock_client
+
+    # --- Conversation 1: gets interrupted, has a leftover message ---
+    state.interrupt_event = asyncio.Event()
+
+    async def simulate_conversation_1():
+        # Model does a tool call (no text)
+        await message_queue.put(_assistant_msg([ToolUseBlock("1", "Bash", {})]))
+        await asyncio.sleep(0.1)
+        # Interrupt fires while model is "thinking"
+        assert state.interrupt_event is not None
+        state.interrupt_event.set()
+        await asyncio.sleep(0.1)
+        # Model's response arrives AFTER interrupt (this is the leaked message)
+        await message_queue.put(_assistant_msg([TextBlock("here are the files")]))
+        await message_queue.put(_result_msg())
+
+    asyncio.create_task(simulate_conversation_1())
+    await converse("list files in /tmp", state=state, config=config, show_output=True)
+
+    # The leftover "here are the files" should have been emitted during drain
+    assert any(text == "here are the files" for text, _ in emitted), (
+        f"Leftover message must be emitted during drain, got: {[t for t, _ in emitted]}"
+    )
+    # --- Conversation 2: should NOT see leftover messages from conversation 1 ---
+    state.interrupt_event = None
+    emitted_before_conv2 = len(emitted)
+
+    async def simulate_conversation_2():
+        await asyncio.sleep(0.3)  # Simulate model thinking
+        await message_queue.put(_assistant_msg([TextBlock("fresh response")]))
+        await message_queue.put(_result_msg())
+
+    asyncio.create_task(simulate_conversation_2())
+    t_conv2_start = time.monotonic()
+    await converse("well?", state=state, config=config, show_output=True)
+
+    conv2_messages = emitted[emitted_before_conv2:]
+    assert len(conv2_messages) == 1, f"Expected 1 message in conv2, got: {[t for t, _ in conv2_messages]}"
+    assert conv2_messages[0][0] == "fresh response", f"Conv2 should get fresh response, got: {conv2_messages[0][0]}"
+
+    # The fresh response should NOT arrive instantly (0ms) — that would mean it leaked
+    delay_ms = (conv2_messages[0][1] - t_conv2_start) * 1000
+    assert delay_ms > 100, f"Response arrived in {delay_ms:.0f}ms — too fast, likely a leaked message from conv1"
 
 
 # --- Nightly restart ---

--- a/agent/tests/test_unit.py
+++ b/agent/tests/test_unit.py
@@ -640,259 +640,274 @@ async def test_converse_works_normally_without_interrupt():
     assert not mock_client.interrupt.called, "interrupt should not have been called"
 
 
+# --- Converse / streaming e2e helpers ---
+
+
+def _assistant_msg(content):
+    from claude_agent_sdk import AssistantMessage
+
+    msg = MagicMock(spec=AssistantMessage)
+    msg.content = content
+    return msg
+
+
+def _result_msg():
+    from claude_agent_sdk import ResultMessage
+
+    msg = MagicMock(spec=ResultMessage)
+    msg.content = []
+    return msg
+
+
+def _make_converse_harness(*, use_shared_queue: bool = False):
+    """Build a converse() test harness with tracking and a mock SDK client.
+
+    Returns (state, config, mock_client, emitted, message_queue).
+    message_queue is only set if use_shared_queue=True (for multi-converse tests).
+    """
+    import time
+
+    emitted: list[tuple[str, float]] = []
+    config = vm.VestaConfig(interrupt_timeout=0.5)
+    state = vm.State()
+    state.event_bus = EventBus()
+
+    original_emit = state.event_bus.emit
+
+    def tracking_emit(event):
+        if isinstance(event, dict) and event.get("type") == "assistant":
+            emitted.append((event["text"], time.monotonic()))
+        original_emit(event)
+
+    state.event_bus.emit = tracking_emit  # type: ignore[assignment]
+
+    mock_client = MagicMock()
+    mock_client.query = AsyncMock()
+    mock_client.interrupt = AsyncMock()
+    state.client = mock_client
+
+    message_queue: asyncio.Queue[tp.Any] | None = None
+    if use_shared_queue:
+        message_queue = asyncio.Queue()
+
+        async def _receive_response():
+            from claude_agent_sdk import ResultMessage
+
+            while True:
+                msg = await message_queue.get()
+                yield msg
+                if isinstance(msg, ResultMessage):
+                    return
+
+        mock_client.receive_response = MagicMock(side_effect=lambda: _receive_response())
+
+    return state, config, mock_client, emitted, message_queue
+
+
+# --- Converse / streaming regression tests ---
+
+
+def test_filter_tool_lines():
+    """filter_tool_lines must keep normal text and only strip [TOOL]/[TASK] prefixed lines."""
+    from vesta.core.client import filter_tool_lines
+
+    assert filter_tool_lines("hello world") == "hello world"
+    assert filter_tool_lines("[TOOL] Bash: ls\nthe result") == "the result"
+    assert filter_tool_lines("[TASK] [browser]: search\nfound it") == "found it"
+    assert filter_tool_lines("[TOOL] done\n[TASK] done") == ""
+    assert filter_tool_lines("line one\n  \nline two") == "line one\nline two"
+    assert filter_tool_lines("") == ""
+
+
+def test_process_message_always_streams():
+    """process_message must always pass show_output=True — regression guard."""
+    import ast
+    import inspect
+
+    from vesta.core.client import process_message
+
+    source = inspect.getsource(process_message)
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.keyword) and node.arg == "show_output":
+            val = node.value
+            assert isinstance(val, ast.Constant) and val.value is True, (
+                f"process_message must pass show_output=True to converse(), found show_output={ast.dump(val)}"
+            )
+
+
 @pytest.mark.anyio
 async def test_converse_emits_text_immediately_with_tool_use():
     """Text in messages that also have tool_use must be emitted immediately, not buffered."""
-    from claude_agent_sdk import AssistantMessage, TextBlock, ToolUseBlock
+    from claude_agent_sdk import TextBlock, ToolUseBlock
     from vesta.core.client import converse
 
-    emitted: list[str] = []
-
-    def _assistant_msg(content):
-        msg = MagicMock(spec=AssistantMessage)
-        msg.content = content
-        return msg
+    state, config, mock_client, emitted, _ = _make_converse_harness()
 
     async def response_with_tool_use():
         yield _assistant_msg([TextBlock("restarting daemon"), ToolUseBlock("1", "Bash", {})])
         yield _assistant_msg([TextBlock("checking status"), ToolUseBlock("2", "Bash", {})])
         yield _assistant_msg([TextBlock("all done")])
 
-    config = vm.VestaConfig()
-    state = vm.State()
-    state.event_bus = EventBus()
-
-    original_emit = state.event_bus.emit
-
-    def tracking_emit(event):
-        if isinstance(event, dict) and event.get("type") == "assistant":
-            emitted.append(event["text"])
-        original_emit(event)
-
-    state.event_bus.emit = tracking_emit  # type: ignore[assignment]
-
-    mock_client = MagicMock()
-    mock_client.query = AsyncMock()
     mock_client.receive_response = MagicMock(return_value=response_with_tool_use())
-    mock_client.interrupt = AsyncMock()
-    state.client = mock_client
 
     await converse("test", state=state, config=config, show_output=True)
 
-    assert emitted == ["restarting daemon", "checking status", "all done"], f"All text must be emitted immediately, got: {emitted}"
+    texts = [t for t, _ in emitted]
+    assert texts == ["restarting daemon", "checking status", "all done"], f"All text must be emitted immediately, got: {texts}"
 
 
 @pytest.mark.anyio
-async def test_interrupt_does_not_leak_or_lose_messages():
-    """End-to-end: after an interrupt, leftover messages must be emitted (not lost)
+async def test_interrupt_drains_stream_and_emits_leftovers():
+    """After an interrupt, leftover messages must be emitted (not lost)
     and must NOT leak into the next converse() call."""
     import time
 
-    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+    from claude_agent_sdk import TextBlock, ToolUseBlock
     from vesta.core.client import converse
 
-    def _assistant_msg(content):
-        msg = MagicMock(spec=AssistantMessage)
-        msg.content = content
-        return msg
+    state, config, mock_client, emitted, message_queue = _make_converse_harness(use_shared_queue=True)
+    assert message_queue is not None
 
-    def _result_msg():
-        msg = MagicMock(spec=ResultMessage)
-        msg.content = []
-        return msg
-
-    # Shared message queue — simulates the SDK's internal anyio stream.
-    # Both converse() calls read from the same queue via receive_response(),
-    # just like the real SDK where one _query._message_receive is shared.
-    message_queue: asyncio.Queue[tp.Any] = asyncio.Queue()
-    _SENTINEL = object()
-
-    async def _receive_response():
-        """Yields messages from the shared queue until ResultMessage."""
-        while True:
-            msg = await message_queue.get()
-            yield msg
-            if isinstance(msg, ResultMessage):
-                return
-
-    emitted: list[tuple[str, float]] = []  # (text, timestamp)
-
-    config = vm.VestaConfig(interrupt_timeout=0.5)
-    state = vm.State()
-    state.event_bus = EventBus()
-
-    original_emit = state.event_bus.emit
-
-    def tracking_emit(event):
-        if isinstance(event, dict) and event.get("type") == "assistant":
-            emitted.append((event["text"], time.monotonic()))
-        original_emit(event)
-
-    state.event_bus.emit = tracking_emit  # type: ignore[assignment]
-
-    mock_client = MagicMock()
-    mock_client.query = AsyncMock()
-    mock_client.receive_response = MagicMock(side_effect=lambda: _receive_response())
-    mock_client.interrupt = AsyncMock()
-    state.client = mock_client
-
-    # --- Conversation 1: gets interrupted, has a leftover message ---
+    # --- Conv 1: interrupted, has a leftover ---
     state.interrupt_event = asyncio.Event()
 
-    async def simulate_conversation_1():
-        # Model does a tool call (no text)
+    async def sim_conv1():
         await message_queue.put(_assistant_msg([ToolUseBlock("1", "Bash", {})]))
         await asyncio.sleep(0.1)
-        # Interrupt fires while model is "thinking"
         assert state.interrupt_event is not None
         state.interrupt_event.set()
         await asyncio.sleep(0.1)
-        # Model's response arrives AFTER interrupt (this is the leaked message)
         await message_queue.put(_assistant_msg([TextBlock("here are the files")]))
         await message_queue.put(_result_msg())
 
-    asyncio.create_task(simulate_conversation_1())
-    await converse("list files in /tmp", state=state, config=config, show_output=True)
+    asyncio.create_task(sim_conv1())
+    await converse("list /tmp", state=state, config=config, show_output=True)
 
-    # The leftover "here are the files" should have been emitted during drain
-    assert any(text == "here are the files" for text, _ in emitted), (
-        f"Leftover message must be emitted during drain, got: {[t for t, _ in emitted]}"
-    )
-    # --- Conversation 2: should NOT see leftover messages from conversation 1 ---
+    assert any(t == "here are the files" for t, _ in emitted), f"Leftover must be emitted during drain: {[t for t, _ in emitted]}"
+
+    # --- Conv 2: must NOT see conv 1's leftovers ---
     state.interrupt_event = None
-    emitted_before_conv2 = len(emitted)
+    n_before = len(emitted)
 
-    async def simulate_conversation_2():
-        await asyncio.sleep(0.3)  # Simulate model thinking
+    async def sim_conv2():
+        await asyncio.sleep(0.3)
         await message_queue.put(_assistant_msg([TextBlock("fresh response")]))
         await message_queue.put(_result_msg())
 
-    asyncio.create_task(simulate_conversation_2())
-    t_conv2_start = time.monotonic()
+    asyncio.create_task(sim_conv2())
+    t0 = time.monotonic()
     await converse("well?", state=state, config=config, show_output=True)
 
-    conv2_messages = emitted[emitted_before_conv2:]
-    assert len(conv2_messages) == 1, f"Expected 1 message in conv2, got: {[t for t, _ in conv2_messages]}"
-    assert conv2_messages[0][0] == "fresh response", f"Conv2 should get fresh response, got: {conv2_messages[0][0]}"
-
-    # The fresh response should NOT arrive instantly (0ms) — that would mean it leaked
-    delay_ms = (conv2_messages[0][1] - t_conv2_start) * 1000
-    assert delay_ms > 100, f"Response arrived in {delay_ms:.0f}ms — too fast, likely a leaked message from conv1"
+    conv2 = emitted[n_before:]
+    assert len(conv2) == 1 and conv2[0][0] == "fresh response", f"Conv 2 got wrong messages: {[t for t, _ in conv2]}"
+    delay_ms = (conv2[0][1] - t0) * 1000
+    assert delay_ms > 100, f"Response at +{delay_ms:.0f}ms — too fast, likely leaked from conv 1"
 
 
 @pytest.mark.anyio
-async def test_message_arrives_without_user_interaction():
+async def test_interrupt_then_response_arrives_without_user_input():
     """Reproduces the exact bug from docker logs: user conversation is interrupted
-    by a notification, notification processing does tool calls and responds — that
-    response must arrive on its own without the user sending another message.
+    by a notification, notification does tool calls then responds — that response
+    must arrive on its own without the user sending another message.
 
-    Timeline from real bug:
+    Real timeline:
       12:28:02 USER: "i did it instantly..."
-      12:28:07 TOOL: Bash (check logs)
-      12:28:21 INTERRUPT (notification arrives)
-      12:28:22 SYSTEM: daemon_died notification processed
+      12:28:21 INTERRUPT (notification)
       12:28:27 TOOL: Bash (restart daemon)
       12:28:30 TOOL: done
-      -- 62 seconds stuck, no ASSISTANT message --
-      12:29:32 USER: "well?" → ASSISTANT appears instantly
-
-    The fix must ensure the notification's response arrives after its tool call
-    without waiting for user input."""
+      -- 62 seconds stuck --
+      12:29:32 USER: "well?" → ASSISTANT appears instantly"""
     import time
 
-    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+    from claude_agent_sdk import TextBlock, ToolUseBlock
     from vesta.core.client import converse
 
-    def _assistant_msg(content):
-        msg = MagicMock(spec=AssistantMessage)
-        msg.content = content
-        return msg
+    state, config, mock_client, emitted, message_queue = _make_converse_harness(use_shared_queue=True)
+    assert message_queue is not None
 
-    def _result_msg():
-        msg = MagicMock(spec=ResultMessage)
-        msg.content = []
-        return msg
-
-    # Shared stream — both converse() calls read from this, like the real SDK.
-    message_queue: asyncio.Queue[tp.Any] = asyncio.Queue()
-
-    async def _receive_response():
-        while True:
-            msg = await message_queue.get()
-            yield msg
-            if isinstance(msg, ResultMessage):
-                return
-
-    emitted: list[tuple[str, float]] = []
-
-    config = vm.VestaConfig(interrupt_timeout=0.5)
-    state = vm.State()
-    state.event_bus = EventBus()
-
-    original_emit = state.event_bus.emit
-
-    def tracking_emit(event):
-        if isinstance(event, dict) and event.get("type") == "assistant":
-            emitted.append((event["text"], time.monotonic()))
-        original_emit(event)
-
-    state.event_bus.emit = tracking_emit  # type: ignore[assignment]
-
-    mock_client = MagicMock()
-    mock_client.query = AsyncMock()
-    mock_client.receive_response = MagicMock(side_effect=lambda: _receive_response())
-    mock_client.interrupt = AsyncMock()
-    state.client = mock_client
-
-    # --- Conv 1: user message, gets interrupted by notification ---
+    # --- Conv 1: user message interrupted by notification ---
     state.interrupt_event = asyncio.Event()
 
-    async def simulate_conv1():
-        # Model does tool call for user's message
+    async def sim_conv1():
         await asyncio.sleep(0.05)
         await message_queue.put(_assistant_msg([ToolUseBlock("1", "Bash", {})]))
         await asyncio.sleep(0.1)
-        # Notification interrupt fires mid-conversation
         assert state.interrupt_event is not None
         state.interrupt_event.set()
-        # Model's response arrives after interrupt (leftover)
         await asyncio.sleep(0.1)
         await message_queue.put(_assistant_msg([TextBlock("checking logs")]))
         await message_queue.put(_result_msg())
 
-    asyncio.create_task(simulate_conv1())
+    asyncio.create_task(sim_conv1())
     await converse("i did it instantly", state=state, config=config, show_output=True)
 
-    # Conv 1's leftover must be emitted (not lost)
-    assert any(t == "checking logs" for t, _ in emitted), f"Conv 1 leftover must be emitted during drain: {[t for t, _ in emitted]}"
+    assert any(t == "checking logs" for t, _ in emitted), f"Conv 1 leftover not emitted: {[t for t, _ in emitted]}"
 
-    # --- Conv 2: notification processing — tool call then response ---
-    # This is the one that got STUCK in the real bug.
+    # --- Conv 2: notification processing (was STUCK in the real bug) ---
     state.interrupt_event = None
-    emitted_before = len(emitted)
-    t_conv2 = time.monotonic()
+    n_before = len(emitted)
+    t0 = time.monotonic()
 
-    async def simulate_conv2():
-        # Model does a tool call (restart daemon)
+    async def sim_conv2():
         await asyncio.sleep(0.05)
         await message_queue.put(_assistant_msg([ToolUseBlock("2", "Bash", {})]))
-        # Tool finishes, model responds
         await asyncio.sleep(0.2)
         await message_queue.put(_assistant_msg([TextBlock("daemon's back up")]))
         await asyncio.sleep(0.05)
         await message_queue.put(_result_msg())
 
-    asyncio.create_task(simulate_conv2())
+    asyncio.create_task(sim_conv2())
     await converse("daemon_died notification", state=state, config=config, show_output=True)
 
-    conv2_texts = [t for t, _ in emitted[emitted_before:]]
+    conv2_texts = [t for t, _ in emitted[n_before:]]
     assert "daemon's back up" in conv2_texts, f"Conv 2 response must arrive without user interaction: {conv2_texts}"
-
-    # Must arrive promptly (within 2s), not stuck for 60+ seconds
-    for text, t in emitted[emitted_before:]:
+    for text, t in emitted[n_before:]:
         if text == "daemon's back up":
-            delay_ms = (t - t_conv2) * 1000
+            delay_ms = (t - t0) * 1000
             assert delay_ms < 2000, f"'{text}' took {delay_ms:.0f}ms — agent was stuck"
+
+
+@pytest.mark.anyio
+async def test_drain_timeout_does_not_block_forever():
+    """If the SDK is slow to send ResultMessage after interrupt, the drain must
+    time out and not block the next conversation forever."""
+    from claude_agent_sdk import ToolUseBlock
+    from vesta.core.client import converse
+
+    state, config, mock_client, _, _ = _make_converse_harness()
+
+    call_count = 0
+
+    async def slow_drain_response():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First call: normal conversation that gets interrupted
+            yield _assistant_msg([ToolUseBlock("1", "Bash", {})])
+            await asyncio.sleep(60)  # Hangs — simulates SDK not sending ResultMessage
+        else:
+            # Drain call: also hangs (SDK is stuck)
+            await asyncio.sleep(60)
+
+    mock_client.receive_response = MagicMock(side_effect=lambda: slow_drain_response())
+    state.client = mock_client
+    state.interrupt_event = asyncio.Event()
+
+    async def trigger():
+        await asyncio.sleep(0.1)
+        assert state.interrupt_event is not None
+        state.interrupt_event.set()
+
+    import time
+
+    asyncio.create_task(trigger())
+    t0 = time.monotonic()
+    await converse("test", state=state, config=config, show_output=True)
+    elapsed = time.monotonic() - t0
+
+    # Must exit within drain timeout (5s) + some margin, not hang for 60s
+    assert elapsed < 8.0, f"converse took {elapsed:.1f}s — drain blocked too long"
 
 
 # --- Nightly restart ---

--- a/agent/tests/test_unit.py
+++ b/agent/tests/test_unit.py
@@ -780,6 +780,85 @@ async def test_interrupt_does_not_leak_or_lose_messages():
     assert delay_ms > 100, f"Response arrived in {delay_ms:.0f}ms — too fast, likely a leaked message from conv1"
 
 
+@pytest.mark.anyio
+async def test_message_arrives_without_user_interaction():
+    """The core bug: model generates a response after tool calls, and it must arrive
+    on its own — without the user needing to send another message to unstick it.
+
+    Simulates: user sends message → agent does tool call → agent responds with text.
+    The text must be emitted promptly after the model generates it."""
+    import time
+
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+    from vesta.core.client import converse
+
+    def _assistant_msg(content):
+        msg = MagicMock(spec=AssistantMessage)
+        msg.content = content
+        return msg
+
+    def _result_msg():
+        msg = MagicMock(spec=ResultMessage)
+        msg.content = []
+        return msg
+
+    message_queue: asyncio.Queue[tp.Any] = asyncio.Queue()
+
+    async def _receive_response():
+        while True:
+            msg = await message_queue.get()
+            yield msg
+            if isinstance(msg, ResultMessage):
+                return
+
+    emitted: list[tuple[str, float]] = []
+
+    config = vm.VestaConfig()
+    state = vm.State()
+    state.event_bus = EventBus()
+
+    original_emit = state.event_bus.emit
+
+    def tracking_emit(event):
+        if isinstance(event, dict) and event.get("type") == "assistant":
+            emitted.append((event["text"], time.monotonic()))
+        original_emit(event)
+
+    state.event_bus.emit = tracking_emit  # type: ignore[assignment]
+
+    mock_client = MagicMock()
+    mock_client.query = AsyncMock()
+    mock_client.receive_response = MagicMock(side_effect=lambda: _receive_response())
+    mock_client.interrupt = AsyncMock()
+    state.client = mock_client
+
+    t_start = time.monotonic()
+
+    async def simulate_model():
+        # Model does a tool call first (text + tool_use, like "let me check")
+        await asyncio.sleep(0.05)
+        await message_queue.put(_assistant_msg([TextBlock("let me check"), ToolUseBlock("1", "Bash", {})]))
+        # Tool runs, then model responds with the answer
+        await asyncio.sleep(0.2)
+        await message_queue.put(_assistant_msg([TextBlock("here are the files in /tmp")]))
+        await asyncio.sleep(0.05)
+        await message_queue.put(_result_msg())
+
+    asyncio.create_task(simulate_model())
+    await converse("list /tmp", state=state, config=config, show_output=True)
+
+    # Both messages must have been emitted
+    texts = [t for t, _ in emitted]
+    assert "let me check" in texts, f"First message not emitted: {texts}"
+    assert "here are the files in /tmp" in texts, f"Second message not emitted: {texts}"
+
+    # Messages must arrive promptly — not stuck waiting for user input.
+    # "let me check" should arrive at ~50ms, "here are the files" at ~250ms.
+    for text, t in emitted:
+        delay_ms = (t - t_start) * 1000
+        assert delay_ms < 2000, f"'{text}' took {delay_ms:.0f}ms — agent was stuck"
+
+
 # --- Nightly restart ---
 
 

--- a/agent/tests/test_unit.py
+++ b/agent/tests/test_unit.py
@@ -782,11 +782,22 @@ async def test_interrupt_does_not_leak_or_lose_messages():
 
 @pytest.mark.anyio
 async def test_message_arrives_without_user_interaction():
-    """The core bug: model generates a response after tool calls, and it must arrive
-    on its own — without the user needing to send another message to unstick it.
+    """Reproduces the exact bug from docker logs: user conversation is interrupted
+    by a notification, notification processing does tool calls and responds — that
+    response must arrive on its own without the user sending another message.
 
-    Simulates: user sends message → agent does tool call → agent responds with text.
-    The text must be emitted promptly after the model generates it."""
+    Timeline from real bug:
+      12:28:02 USER: "i did it instantly..."
+      12:28:07 TOOL: Bash (check logs)
+      12:28:21 INTERRUPT (notification arrives)
+      12:28:22 SYSTEM: daemon_died notification processed
+      12:28:27 TOOL: Bash (restart daemon)
+      12:28:30 TOOL: done
+      -- 62 seconds stuck, no ASSISTANT message --
+      12:29:32 USER: "well?" → ASSISTANT appears instantly
+
+    The fix must ensure the notification's response arrives after its tool call
+    without waiting for user input."""
     import time
 
     from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
@@ -802,6 +813,7 @@ async def test_message_arrives_without_user_interaction():
         msg.content = []
         return msg
 
+    # Shared stream — both converse() calls read from this, like the real SDK.
     message_queue: asyncio.Queue[tp.Any] = asyncio.Queue()
 
     async def _receive_response():
@@ -813,7 +825,7 @@ async def test_message_arrives_without_user_interaction():
 
     emitted: list[tuple[str, float]] = []
 
-    config = vm.VestaConfig()
+    config = vm.VestaConfig(interrupt_timeout=0.5)
     state = vm.State()
     state.event_bus = EventBus()
 
@@ -832,31 +844,55 @@ async def test_message_arrives_without_user_interaction():
     mock_client.interrupt = AsyncMock()
     state.client = mock_client
 
-    t_start = time.monotonic()
+    # --- Conv 1: user message, gets interrupted by notification ---
+    state.interrupt_event = asyncio.Event()
 
-    async def simulate_model():
-        # Model does a tool call first (text + tool_use, like "let me check")
+    async def simulate_conv1():
+        # Model does tool call for user's message
         await asyncio.sleep(0.05)
-        await message_queue.put(_assistant_msg([TextBlock("let me check"), ToolUseBlock("1", "Bash", {})]))
-        # Tool runs, then model responds with the answer
+        await message_queue.put(_assistant_msg([ToolUseBlock("1", "Bash", {})]))
+        await asyncio.sleep(0.1)
+        # Notification interrupt fires mid-conversation
+        assert state.interrupt_event is not None
+        state.interrupt_event.set()
+        # Model's response arrives after interrupt (leftover)
+        await asyncio.sleep(0.1)
+        await message_queue.put(_assistant_msg([TextBlock("checking logs")]))
+        await message_queue.put(_result_msg())
+
+    asyncio.create_task(simulate_conv1())
+    await converse("i did it instantly", state=state, config=config, show_output=True)
+
+    # Conv 1's leftover must be emitted (not lost)
+    assert any(t == "checking logs" for t, _ in emitted), f"Conv 1 leftover must be emitted during drain: {[t for t, _ in emitted]}"
+
+    # --- Conv 2: notification processing — tool call then response ---
+    # This is the one that got STUCK in the real bug.
+    state.interrupt_event = None
+    emitted_before = len(emitted)
+    t_conv2 = time.monotonic()
+
+    async def simulate_conv2():
+        # Model does a tool call (restart daemon)
+        await asyncio.sleep(0.05)
+        await message_queue.put(_assistant_msg([ToolUseBlock("2", "Bash", {})]))
+        # Tool finishes, model responds
         await asyncio.sleep(0.2)
-        await message_queue.put(_assistant_msg([TextBlock("here are the files in /tmp")]))
+        await message_queue.put(_assistant_msg([TextBlock("daemon's back up")]))
         await asyncio.sleep(0.05)
         await message_queue.put(_result_msg())
 
-    asyncio.create_task(simulate_model())
-    await converse("list /tmp", state=state, config=config, show_output=True)
+    asyncio.create_task(simulate_conv2())
+    await converse("daemon_died notification", state=state, config=config, show_output=True)
 
-    # Both messages must have been emitted
-    texts = [t for t, _ in emitted]
-    assert "let me check" in texts, f"First message not emitted: {texts}"
-    assert "here are the files in /tmp" in texts, f"Second message not emitted: {texts}"
+    conv2_texts = [t for t, _ in emitted[emitted_before:]]
+    assert "daemon's back up" in conv2_texts, f"Conv 2 response must arrive without user interaction: {conv2_texts}"
 
-    # Messages must arrive promptly — not stuck waiting for user input.
-    # "let me check" should arrive at ~50ms, "here are the files" at ~250ms.
-    for text, t in emitted:
-        delay_ms = (t - t_start) * 1000
-        assert delay_ms < 2000, f"'{text}' took {delay_ms:.0f}ms — agent was stuck"
+    # Must arrive promptly (within 2s), not stuck for 60+ seconds
+    for text, t in emitted[emitted_before:]:
+        if text == "daemon's back up":
+            delay_ms = (t - t_conv2) * 1000
+            assert delay_ms < 2000, f"'{text}' took {delay_ms:.0f}ms — agent was stuck"
 
 
 # --- Nightly restart ---

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1133,7 +1133,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.101"
+version = "0.1.102"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },


### PR DESCRIPTION
## Summary

Three bugs caused assistant messages to get stuck and only appear when the user sent another message:

1. **`show_output=is_user`** — non-user messages (notifications, greetings) silently collected text instead of emitting it. Fixed: always `show_output=True`
2. **`pending_text` buffering** — text in messages with tool_use blocks was held until a non-tool message arrived or the stream ended. Fixed: removed `pending_text`, emit immediately
3. **SDK stream leak after interrupt** — the model's response sat in the SDK's shared message stream after an interrupt. Cancelling `anext_task` finalized the async generator, so the drain couldn't clean it up. The next `converse()` picked up the stale response instantly. Fixed: drain with a fresh `receive_response()` iterator

## Test plan

6 regression tests added:
- `test_filter_tool_lines` — text isn't silently swallowed
- `test_process_message_always_streams` — AST-level guard that `show_output=True` is never reverted
- `test_converse_emits_text_immediately_with_tool_use` — no pending_text buffering
- `test_interrupt_drains_stream_and_emits_leftovers` — leftover messages emitted, not leaked
- `test_interrupt_then_response_arrives_without_user_input` — reproduces exact bug from docker logs
- `test_drain_timeout_does_not_block_forever` — drain doesn't hang if SDK is slow

Verified fix live: response appeared at +5076ms (fresh model generation) instead of +0ms (stale leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)