### PR TITLE
fix(cli): statically link CRT on Windows to fix VCRUNTIME140.dll error

### DIFF
--- a/app/src-tauri/.cargo/config.toml
+++ b/app/src-tauri/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/cli/.cargo/config.toml
+++ b/cli/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
## Summary
- Rust binaries compiled with MSVC dynamically link `VCRUNTIME140.dll` by default, which means Windows users need the Visual C++ Redistributable installed — otherwise they get a "VCRUNTIME140.dll not found" error when running the installer
- This adds `.cargo/config.toml` to both `cli/` and `app/src-tauri/` with `+crt-static` for x86_64 and aarch64 Windows MSVC targets, statically linking the C runtime into the binaries
- Windows users no longer need any external runtime dependencies installed

## Test plan
- [ ] Build CLI on Windows: `cargo build --target x86_64-pc-windows-msvc` and verify the binary runs without VCRUNTIME140.dll in PATH
- [ ] Build Tauri app on Windows and verify the installer/app runs on a clean Windows machine without Visual C++ Redistributable
- [ ] Verify Linux and macOS builds are unaffected (config only targets `*-windows-msvc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)