### PR TITLE
fix(agent): catch BlockingIOError on stdout flush in logger

### DIFF
--- a/agent/src/vesta/logger.py
+++ b/agent/src/vesta/logger.py
@@ -63,7 +63,10 @@ def _strip_markup(msg: str) -> str:
 def _log(msg: str, *, level: int = logging.INFO) -> None:
     record = _logger.makeRecord(_logger.name, level, "", 0, msg, (), None)
     _console_handler.emit(record)
-    sys.stdout.flush()
+    try:
+        sys.stdout.flush()
+    except BlockingIOError:
+        pass
 
     if _file_handler:
         clean_record = _logger.makeRecord(_logger.name, level, "", 0, _strip_markup(msg), (), None)


### PR DESCRIPTION
## Summary
- Catch `BlockingIOError` on `sys.stdout.flush()` in the logger's `_log()` function
- Docker can set stdout to non-blocking mode; when the pipe buffer is full, `flush()` throws `BlockingIOError: [Errno 11]`, crashing Vesta
- The data is already in Python's write buffer and will flush on the next successful write, so it is safe to catch and ignore

## Test plan
- [x] Verify ruff/ty pass (no new lint issues from a bare `except`/`pass` — this is a specific, named exception)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)