### PR TITLE
feat(agent): expand dream skill to pull and push upstream

### DIFF
--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -14,7 +14,7 @@ description: Self-improvement and memory curation. Used by the nightly dreamer, 
 
 ## Order of operations
 
-1. **Self-improvement** — retrospective, review, fix, validate, sync, upstream
+1. **Self-improvement** — retrospective, review, fix, validate, upstream sync
 2. **User State** — update the snapshot in MEMORY.md
 3. **Memory curation** — prune, consolidate, move things out
 4. **Summary** — write tonight's dreamer summary
@@ -49,13 +49,9 @@ You can change anything. If a fix requires code, write the code.
 
 Re-read the failing exchange and simulate: would the updated version have changed the outcome? If no or unclear, revise further or note it as unresolved. Don't mark something fixed if you can't convince yourself it would have helped.
 
-### 5. Sync
+### 5. Upstream sync
 
-Use the `upstream` skill to pull from the source repo. Check for new commits — new skills, tool improvements, prompt upgrades, bug fixes. Apply anything useful. Don't skip this just because nothing broke today; upstream may have shipped something better than what you're running.
-
-### 6. Upstream
-
-If you built or improved something generic — a fix, a new skill, a better prompt, a tool upgrade, anything that would help a fresh Vesta instance — PR it back to the source repo via the `upstream` skill. Don't limit this to bug fixes. If you wrote something good tonight, share it.
+Use the `upstream` skill to both pull and push. Don't skip this just because nothing broke today.
 
 ## User State (in MEMORY.md)
 

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -14,7 +14,7 @@ description: Self-improvement and memory curation. Used by the nightly dreamer, 
 
 ## Order of operations
 
-1. **Self-improvement** — retrospective, review, fix, validate, upstream
+1. **Self-improvement** — retrospective, review, fix, validate, sync, upstream
 2. **User State** — update the snapshot in MEMORY.md
 3. **Memory curation** — prune, consolidate, move things out
 4. **Summary** — write tonight's dreamer summary
@@ -49,9 +49,13 @@ You can change anything. If a fix requires code, write the code.
 
 Re-read the failing exchange and simulate: would the updated version have changed the outcome? If no or unclear, revise further or note it as unresolved. Don't mark something fixed if you can't convince yourself it would have helped.
 
-### 5. Upstream
+### 5. Sync
 
-If you fixed something generic — something that would help any fresh Vesta, not just your instance — use the `upstream` skill to PR it back to the source repo.
+Use the `upstream` skill to pull from the source repo. Check for new commits — new skills, tool improvements, prompt upgrades, bug fixes. Apply anything useful. Don't skip this just because nothing broke today; upstream may have shipped something better than what you're running.
+
+### 6. Upstream
+
+If you built or improved something generic — a fix, a new skill, a better prompt, a tool upgrade, anything that would help a fresh Vesta instance — PR it back to the source repo via the `upstream` skill. Don't limit this to bug fixes. If you wrote something good tonight, share it.
 
 ## User State (in MEMORY.md)
 

--- a/agent/skills/upstream/SKILL.md
+++ b/agent/skills/upstream/SKILL.md
@@ -12,7 +12,7 @@ Local fork: `~/vesta` (this is a fork — it diverges from upstream as local cha
 
 1. `git -C ~/vesta fetch origin`
 2. `git -C ~/vesta log HEAD..origin/master --oneline` — see what's new
-3. Only look at changes under `agent/`
+3. Only look at changes under `agent/` (source, skills, prompts, tools)
 4. For each interesting commit: `git -C ~/vesta show <hash>` — understand what it does
 5. Manually apply the relevant changes to `~/vesta` source (don't paste diffs blindly — local may have diverged, adapt the intent)
 6. Track the last processed commit hash in MEMORY.md so you don't redo it next time
@@ -43,16 +43,6 @@ uv run ~/vesta/skills/upstream/pr.py --token-only
 ## What to PR
 - Tool improvements, bug fixes, new skills, prompt upgrades that any vesta instance would benefit from
 - Don't PR: personal config, memory files, credentials, user-specific customizations
-
-## Skill registry sync
-
-When syncing upstream, also check for skill updates under `agent/skills/`:
-
-- For each installed skill (`ls ~/vesta/skills/`) check if there are new commits touching `agent/skills/<name>/`
-- Read the diff and apply useful generic improvements to `~/vesta/skills/<name>/`
-- Track the last processed commit hash in MEMORY.md (same as core upstream sync)
-
-When contributing a skill improvement back upstream, use the same worktree flow. All skill changes — core or not — go in `agent/skills/<name>/`.
 
 ## How it works
 - Authenticates via the `vesta-upstream` GitHub App (ID 2990557)


### PR DESCRIPTION
## Summary
- Split the dream skill's single "upstream" step into two: **sync** (pull from source repo) and **upstream** (push back)
- Encourages Vesta to stay current with upstream changes every dream cycle, not just when something breaks
- Broadens push scope beyond bug fixes to include new skills, prompt upgrades, and improvements

## Test plan
- [ ] Verify dream skill loads correctly with updated SKILL.md
- [ ] Confirm dreamer process follows the new 6-step self-improvement flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)