### PR TITLE
fix: remove pkill/killall to prevent container crashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN mkdir -p .claude && ln -s ../skills .claude/skills
 RUN git clone --bare --single-branch https://github.com/elyxlz/vesta.git .git && \
     git config core.bare false
 
+RUN rm -f /usr/bin/pkill /usr/bin/killall
+
 ENV HOME=/root
 ENV IS_SANDBOX=1
 ENTRYPOINT ["uv", "run", "--project", "/root/vesta", "python", "-m", "vesta.main"]

--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -69,6 +69,7 @@ Once [agent_name] knows who they're with (name isn't "[Unknown]"), that's it. No
 
 ### Technical
 - **Clean up**: Temp files, stale processes. Don't leave a mess
+- **Never use `pkill`, `killall`, or `kill`** — these can kill the main vesta process and crash the whole container. They've been removed from the system. To stop a specific process, use `screen -S name -X quit` for daemons or manage it through the tool that started it
 - **Daemons use screen sessions** — start background services with `screen -dmS <name> <command>` instead of `<command> &`. This prevents orphaned processes and makes them easy to manage (`screen -ls`, `screen -S name -X quit`)
 - **Sub-agents**: Use freely for anything noisy (browser, research, bulk file work, multi-step CLI). Always spawn in the background — never block the main thread. Run in parallel when independent. The main context is limited, so offload aggressively
 


### PR DESCRIPTION
## Summary

- **Remove `pkill` and `killall` binaries from the Docker image** via `rm -f` in the Dockerfile
- **Add MEMORY.md instruction** telling the agent to never use `pkill`, `killall`, or `kill`, and to use `screen -X quit` instead

## Problem

The agent was using `pkill` (e.g. `pkill -f Xvfb`) to stop processes. `pkill -f` pattern-matches against the command line of *all* running processes, which could match and kill the main vesta process, crashing the entire container.

## Fix

1. **Dockerfile**: Remove `/usr/bin/pkill` and `/usr/bin/killall` so they simply don't exist in the image
2. **agent/MEMORY.md**: Add a clear instruction in the Technical section that these commands must not be used, with the recommended alternative (`screen -S name -X quit` for daemons, or managing processes through the tool that started them)

## Test plan

- [ ] Verify Docker image builds successfully
- [ ] Verify `pkill` and `killall` are not available inside the container
- [ ] Verify existing daemon management via `screen -X quit` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)