### PR TITLE
Increase macOS vfkit VM memory from 4GB to 8GB

### DIFF
--- a/cli/src/macos.rs
+++ b/cli/src/macos.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 const VFKIT_BIN: &str = "vfkit";
 const VM_CPUS: u32 = 2;
-const VM_MEMORY_MIB: u32 = 4096;
+const VM_MEMORY_MIB: u32 = 8192;
 const VM_MAC: &str = "52:54:00:fe:57:a1";
 const VSOCK_PORT: u32 = 2222;
 const LAUNCH_AGENT_LABEL: &str = "com.vesta.autostart";


### PR DESCRIPTION
## Summary
- Bump `VM_MEMORY_MIB` from 4096 (4GB) to 8192 (8GB) in `cli/src/macos.rs`
- vfkit reserves memory upfront with no dynamic/balloon support, and agent containers need more than 4GB

## Test plan
- [ ] Verify `vesta start` on macOS launches the VM with 8GB
- [ ] Confirm agent container runs without OOM under typical workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)