### PR TITLE
feat(agent): have skill setups populate restart.md directly

### DIFF
--- a/agent/prompts/restart.md
+++ b/agent/prompts/restart.md
@@ -1,3 +1,1 @@
-Check each relevant skill's SKILL.md and restart any background services that aren't running.
-
-Then check your User State in MEMORY.md and reach out on their preferred channel. Match the tone to the situation — if it's a new day, greet them warmly. If you just restarted mid-conversation, keep it brief. If you crashed, mention it. If it's the middle of the night, wait until morning.
+Run each command below if the service isn't already running (`screen -ls` to check). Then check your User State in MEMORY.md and reach out on their preferred channel. Match the tone to the situation — if it's a new day, greet them warmly. If you just restarted mid-conversation, keep it brief. If you crashed, mention it. If it's the middle of the night, wait until morning.

--- a/agent/skills/browser/SETUP.md
+++ b/agent/skills/browser/SETUP.md
@@ -62,3 +62,10 @@ the user to let you connect to their browser remotely** instead of retrying loca
 4. Now you control their actual browser — with all their cookies, logins, and extensions
 
 This is the preferred fallback for any authentication or profile issue.
+
+## Restart
+
+Add to `~/vesta/prompts/restart.md`:
+```
+screen -dmS xvfb Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp
+```

--- a/agent/skills/google/SETUP.md
+++ b/agent/skills/google/SETUP.md
@@ -8,6 +8,10 @@
 4. Place the credentials file at `~/vesta/data/google/credentials.json`
 5. Install: `uv tool install ~/vesta/skills/google/cli`
 6. Start background daemon: `screen -dmS google google serve`
+7. Add to `~/vesta/prompts/restart.md`:
+   ```
+   screen -dmS google google serve --notifications-dir ~/vesta/notifications
+   ```
 
 ## Authentication
 

--- a/agent/skills/google/SKILL.md
+++ b/agent/skills/google/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: google
-description: This skill should be used when the user asks about "gmail", "google email", "google calendar", "gcal", "google meet", or needs to read/send emails via Gmail, manage Google Calendar events, create Google Meet links, or handle scheduling via Google. IMPORTANT — this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how.
+description: This skill should be used when the user asks about "gmail", "google email", "google calendar", "gcal", "google meet", or needs to read/send emails via Gmail, manage Google Calendar events, create Google Meet links, or handle scheduling via Google. Requires a background daemon.
 ---
 
 # Google — CLI: google

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -9,7 +9,7 @@
   },
   {
     "name": "google",
-    "description": "This skill should be used when the user asks about \"gmail\", \"google email\", \"google calendar\", \"gcal\", \"google meet\", or needs to read/send emails via Gmail, manage Google Calendar events, create Google Meet links, or handle scheduling via Google. IMPORTANT \u2014 this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how."
+    "description": "This skill should be used when the user asks about \"gmail\", \"google email\", \"google calendar\", \"gcal\", \"google meet\", or needs to read/send emails via Gmail, manage Google Calendar events, create Google Meet links, or handle scheduling via Google. Requires a background daemon."
   },
   {
     "name": "keeper",
@@ -17,7 +17,7 @@
   },
   {
     "name": "microsoft",
-    "description": "This skill should be used when the user asks about \"email\", \"emails\", \"inbox\", \"messages\", \"calendar\", \"schedule\", \"scheduling\", \"meetings\", \"appointments\", \"events\", \"outlook\", or needs to read/send emails, manage calendar events, or handle time-based tasks via Microsoft/Outlook. IMPORTANT \u2014 this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how."
+    "description": "This skill should be used when the user asks about \"email\", \"emails\", \"inbox\", \"messages\", \"calendar\", \"schedule\", \"scheduling\", \"meetings\", \"appointments\", \"events\", \"outlook\", or needs to read/send emails, manage calendar events, or handle time-based tasks via Microsoft/Outlook. Requires a background daemon."
   },
   {
     "name": "onedrive",
@@ -25,7 +25,7 @@
   },
   {
     "name": "reminders",
-    "description": "This skill should be used when the user asks about \"reminders\", \"remind me\", \"alert\", \"notify\", or needs to set, manage, or check reminders and time-based notifications. Reminders are for the user, but also for yourself \u2014 use them to follow up, check in, or bring something up later. Tasks are the ground truth of what needs doing; reminders are nudges about when to think about it. IMPORTANT \u2014 this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how."
+    "description": "This skill should be used when the user asks about \"reminders\", \"remind me\", \"alert\", \"notify\", or needs to set, manage, or check reminders and time-based notifications. Reminders are for the user, but also for yourself \u2014 use them to follow up, check in, or bring something up later. Tasks are the ground truth of what needs doing; reminders are nudges about when to think about it. Requires a background daemon."
   },
   {
     "name": "skills-registry",
@@ -33,7 +33,7 @@
   },
   {
     "name": "tasks",
-    "description": "This skill should be used when the user asks about \"tasks\", \"to-do\", \"todo\", \"task list\", or needs to create, manage, track, or organize tasks and to-do items. Everything actionable becomes a task immediately. All work, progress, drafts go in task metadata. IMPORTANT \u2014 this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how."
+    "description": "This skill should be used when the user asks about \"tasks\", \"to-do\", \"todo\", \"task list\", or needs to create, manage, track, or organize tasks and to-do items. Everything actionable becomes a task immediately. All work, progress, drafts go in task metadata. Requires a background daemon."
   },
   {
     "name": "upstream",
@@ -45,7 +45,7 @@
   },
   {
     "name": "whatsapp",
-    "description": "This skill should be used when the user asks about \"whatsapp\", \"message\", \"text\", \"chat\", or needs to send/receive messages via WhatsApp. IMPORTANT \u2014 this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how."
+    "description": "This skill should be used when the user asks about \"whatsapp\", \"message\", \"text\", \"chat\", or needs to send/receive messages via WhatsApp. Requires a background daemon."
   },
   {
     "name": "whisper",

--- a/agent/skills/microsoft/SETUP.md
+++ b/agent/skills/microsoft/SETUP.md
@@ -13,6 +13,10 @@
    ```
 4. Install: `uv tool install ~/vesta/skills/microsoft/cli`
 5. Start background daemon: `screen -dmS microsoft microsoft serve`
+6. Add to `~/vesta/prompts/restart.md`:
+   ```
+   screen -dmS microsoft microsoft serve --notifications-dir ~/vesta/notifications
+   ```
 
 ## Authentication
 

--- a/agent/skills/microsoft/SKILL.md
+++ b/agent/skills/microsoft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: microsoft
-description: This skill should be used when the user asks about "email", "emails", "inbox", "messages", "calendar", "schedule", "scheduling", "meetings", "appointments", "events", "outlook", or needs to read/send emails, manage calendar events, or handle time-based tasks via Microsoft/Outlook. IMPORTANT — this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how.
+description: This skill should be used when the user asks about "email", "emails", "inbox", "messages", "calendar", "schedule", "scheduling", "meetings", "appointments", "events", "outlook", or needs to read/send emails, manage calendar events, or handle time-based tasks via Microsoft/Outlook. Requires a background daemon.
 ---
 
 # Microsoft — CLI: microsoft

--- a/agent/skills/onedrive/SETUP.md
+++ b/agent/skills/onedrive/SETUP.md
@@ -46,3 +46,7 @@
    mkdir -p ~/onedrive
    rclone mount onedrive: ~/onedrive --daemon --vfs-cache-mode full
    ```
+8. Add to `~/vesta/prompts/restart.md`:
+   ```
+   rclone mount onedrive: ~/onedrive --daemon --vfs-cache-mode full
+   ```

--- a/agent/skills/reminders/SKILL.md
+++ b/agent/skills/reminders/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reminders
-description: This skill should be used when the user asks about "reminders", "remind me", "alert", "notify", or needs to set, manage, or check reminders and time-based notifications. Reminders are for the user, but also for yourself — use them to follow up, check in, or bring something up later. Tasks are the ground truth of what needs doing; reminders are nudges about when to think about it. IMPORTANT — this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how.
+description: This skill should be used when the user asks about "reminders", "remind me", "alert", "notify", or needs to set, manage, or check reminders and time-based notifications. Reminders are for the user, but also for yourself — use them to follow up, check in, or bring something up later. Tasks are the ground truth of what needs doing; reminders are nudges about when to think about it. Requires a background daemon.
 ---
 
 # Reminders — CLI: reminder
@@ -34,6 +34,7 @@ When a recurring reminder fires, treat the message as an instruction and act on 
 
 ## Setup: `uv tool install ~/vesta/skills/reminders/cli`
 ## Background: `screen -dmS reminder reminder serve --notifications-dir ~/vesta/notifications`
+## Restart: add to `~/vesta/prompts/restart.md`: `screen -dmS reminder reminder serve --notifications-dir ~/vesta/notifications`
 
 ### Reminder Patterns
 [User's common reminder types and preferences]

--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tasks
-description: This skill should be used when the user asks about "tasks", "to-do", "todo", "task list", or needs to create, manage, track, or organize tasks and to-do items. Everything actionable becomes a task immediately. All work, progress, drafts go in task metadata. IMPORTANT — this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how.
+description: This skill should be used when the user asks about "tasks", "to-do", "todo", "task list", or needs to create, manage, track, or organize tasks and to-do items. Everything actionable becomes a task immediately. All work, progress, drafts go in task metadata. Requires a background daemon.
 ---
 
 # Tasks — CLI: tasks
@@ -26,6 +26,7 @@ tasks delete <id>
 
 ## Setup: `uv tool install ~/vesta/skills/tasks/cli`
 ## Background: `screen -dmS tasks tasks serve --notifications-dir ~/vesta/notifications`
+## Restart: add to `~/vesta/prompts/restart.md`: `screen -dmS tasks tasks serve --notifications-dir ~/vesta/notifications`
 
 ### Task Patterns
 [User's common task categories and workflows]

--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -39,3 +39,7 @@
    **NEVER restart the daemon after the user has scanned** — restarting invalidates the session. If `authenticate` still says not authenticated, wait longer and check again (up to 30 seconds). Only restart the daemon if the user confirms they didn't scan in time or the QR visually expired.
 
    Kill the HTTP server once authenticated: `screen -S qr-server -X quit`
+5. Add to `~/vesta/prompts/restart.md`:
+   ```
+   screen -dmS whatsapp whatsapp serve --notifications-dir ~/vesta/notifications
+   ```

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: whatsapp
-description: This skill should be used when the user asks about "whatsapp", "message", "text", "chat", or needs to send/receive messages via WhatsApp. IMPORTANT — this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how.
+description: This skill should be used when the user asks about "whatsapp", "message", "text", "chat", or needs to send/receive messages via WhatsApp. Requires a background daemon.
 ---
 
 # WhatsApp — CLI: whatsapp


### PR DESCRIPTION
## Summary
- Each skill's SETUP.md now tells the agent to add its daemon command to `~/vesta/prompts/restart.md` during setup, making it a living document
- `restart.md` no longer says "go read every SKILL.md" — it just runs the commands already listed
- Shortened the daemon warning in skill descriptions from the verbose "IMPORTANT — before doing anything, immediately make sure..." to just "Requires a background daemon."

## Test plan
- [ ] Verify restart.md prompt still loads correctly on agent boot
- [ ] Verify skill descriptions still match correctly for routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)