### PR TITLE
feat(cli): GPU passthrough with auto-detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,13 +567,14 @@ jobs:
           cp /tmp/cli-extract/vesta cli/vm/vesta
 
       - name: Build VM Docker image
-        run: docker build --platform linux/${{ matrix.arch }} -t vesta-vm -f cli/vm/Dockerfile cli/vm
+        run: docker build --platform linux/${{ matrix.arch }} --build-arg INCLUDE_KERNEL=true -t vesta-vm -f cli/vm/Dockerfile cli/vm
 
-      - name: Export rootfs and create disk image
+      - name: Export rootfs and create VM disk image
         run: |
           CONTAINER=$(docker create --platform linux/${{ matrix.arch }} vesta-vm)
 
           docker export "$CONTAINER" > /tmp/rootfs.tar
+          docker rm "$CONTAINER" > /dev/null
 
           truncate -s 2G /tmp/vm-disk.raw
           mkfs.ext4 -q /tmp/vm-disk.raw
@@ -586,7 +587,7 @@ jobs:
           INITRD="$MOUNT_DIR/boot/initramfs-virt"
 
           if [ "${{ matrix.arch }}" = "arm64" ]; then
-            # ARM64 Alpine vmlinuz is an EFI stub wrapping a gzip kernel;
+            # ARM64 vmlinuz is an EFI stub wrapping a gzip kernel;
             # vfkit needs the raw uncompressed kernel image
             sudo python3 -c "
           import zlib
@@ -607,7 +608,6 @@ jobs:
           sudo umount "$MOUNT_DIR"
           rmdir "$MOUNT_DIR"
           trap - EXIT
-          docker rm "$CONTAINER" > /dev/null
           sudo chown "$(id -u):$(id -g)" /tmp/vm-kernel /tmp/vm-initrd /tmp/vm-disk.raw
           for f in /tmp/vm-kernel /tmp/vm-initrd /tmp/vm-disk.raw; do
             test -s "$f" || { echo "FATAL: $f is empty"; exit 1; }
@@ -615,9 +615,15 @@ jobs:
 
           cd /tmp
           tar --zstd -cf vesta-vm-${{ matrix.arch }}.tar.zst vm-kernel vm-initrd vm-disk.raw
-          gzip -c /tmp/rootfs.tar > /tmp/vesta-wsl-rootfs.tar.gz
-
           rm -f /tmp/rootfs.tar /tmp/vm-kernel /tmp/vm-initrd /tmp/vm-disk.raw
+
+      - name: Build and export WSL rootfs
+        if: matrix.arch == 'amd64'
+        run: |
+          docker build --build-arg INCLUDE_NVIDIA=true -t vesta-wsl -f cli/vm/Dockerfile cli/vm
+          CONTAINER=$(docker create vesta-wsl)
+          docker export "$CONTAINER" | gzip > /tmp/vesta-wsl-rootfs.tar.gz
+          docker rm "$CONTAINER" > /dev/null
 
       - uses: actions/upload-artifact@v7
         with:

--- a/cli/src/linux.rs
+++ b/cli/src/linux.rs
@@ -321,19 +321,60 @@ fn list_managed_containers() -> Vec<String> {
     .collect()
 }
 
-fn create_container(cname: &str, image: &str, port: u16, agent_name: &str) {
+enum GpuStatus {
+    Ready,
+    NoRuntime,
+    NoGpu,
+}
+
+fn gpu_available() -> GpuStatus {
+    let has_gpu = process::Command::new("nvidia-smi")
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if !has_gpu {
+        return GpuStatus::NoGpu;
+    }
+
+    let has_runtime = docker_output(&["info", "--format", "{{json .Runtimes}}"])
+        .map(|s| s.contains("nvidia"))
+        .unwrap_or(false);
+
+    if has_runtime { GpuStatus::Ready } else { GpuStatus::NoRuntime }
+}
+
+fn create_container(cname: &str, image: &str, port: u16, agent_name: &str, no_gpu: bool) {
     let ws_port_env = format!("WS_PORT={}", port);
     let agent_name_env = format!("AGENT_NAME={}", agent_name);
     let port_label = format!("vesta.ws_port={}", port);
-    let args = vec![
+    let mut args = vec![
         "create", "--name", cname, "-it", "--privileged",
         "--restart", "unless-stopped", "--network", "host",
         "--label", "vesta.managed=true",
         "--label", &port_label,
         "-e", &ws_port_env,
         "-e", &agent_name_env,
-        image,
     ];
+
+    if !no_gpu {
+        match gpu_available() {
+            GpuStatus::Ready => {
+                args.extend(["--gpus", "all"]);
+                eprintln!("GPU detected, enabling passthrough");
+            }
+            GpuStatus::NoRuntime => {
+                eprintln!("warning: NVIDIA GPU detected but nvidia-container-toolkit is not installed.");
+                eprintln!("         install it to enable GPU passthrough:");
+                eprintln!("         https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html");
+            }
+            GpuStatus::NoGpu => {}
+        }
+    }
+
+    args.push(image);
     if !docker_ok(&args) {
         die("failed to create container");
     }
@@ -544,7 +585,7 @@ fn maybe_migrate_legacy() {
 
     docker_ok(&["rm", "-f", "vesta"]);
 
-    create_container(&cname, migrate_tag, BASE_WS_PORT, &name);
+    create_container(&cname, migrate_tag, BASE_WS_PORT, &name, false);
 
     if was_running {
         docker_ok(&["start", &cname]);
@@ -583,7 +624,7 @@ pub fn run(command: Command) {
     maybe_migrate_legacy();
 
     match command {
-        Command::Setup { build, yes, name } => {
+        Command::Setup { build, yes, name, no_gpu } => {
             let name = name.map(|n| normalize_name(&n)).unwrap_or_else(prompt_name);
             validate_name(&name);
             let cname = container_name(&name);
@@ -602,7 +643,7 @@ pub fn run(command: Command) {
             let port = allocate_port();
 
             eprintln!("creating agent '{}'...", name);
-            create_container(&cname, image, port, &name);
+            create_container(&cname, image, port, &name, no_gpu);
             inject_credentials(&cname, &credentials);
 
             if !docker_ok(&["start", &cname]) {
@@ -614,7 +655,7 @@ pub fn run(command: Command) {
             docker_interactive(&["attach", "--detach-keys=ctrl-q", &cname]);
         }
 
-        Command::Create { build, name } => {
+        Command::Create { build, name, no_gpu } => {
             let name = name.map(|n| normalize_name(&n)).unwrap_or_else(prompt_name);
             validate_name(&name);
             let cname = container_name(&name);
@@ -627,7 +668,7 @@ pub fn run(command: Command) {
             let port = allocate_port();
 
             eprintln!("creating agent '{}'...", name);
-            create_container(&cname, image, port, &name);
+            create_container(&cname, image, port, &name, no_gpu);
             eprintln!("created (run 'vesta auth {}' to authenticate, then 'vesta start {}')", name, name);
         }
 
@@ -967,7 +1008,7 @@ pub fn run(command: Command) {
             }
 
             let port = allocate_port();
-            create_container(&cname, &loaded_image, port, &name);
+            create_container(&cname, &loaded_image, port, &name, false);
 
             docker_ok(&["rmi", &loaded_image]);
 
@@ -1041,7 +1082,7 @@ pub fn run(command: Command) {
             docker_ok(&["rm", "-f", &cname]);
 
             eprintln!("recreating from backup...");
-            create_container(&cname, &backup_tag, port, &name);
+            create_container(&cname, &backup_tag, port, &name, false);
 
             if !docker_ok(&["start", &cname]) {
                 die("failed to start");

--- a/cli/src/macos.rs
+++ b/cli/src/macos.rs
@@ -465,7 +465,7 @@ fn download_vm_image() {
 
 pub fn run(command: Command) {
     match command {
-        Command::Setup { build, yes, name } => {
+        Command::Setup { build, yes, name, .. } => {
             if !vm_image_ready() {
                 download_vm_image();
             }
@@ -491,7 +491,7 @@ pub fn run(command: Command) {
             }
         }
 
-        Command::Create { build, name } => {
+        Command::Create { build, name, .. } => {
             ensure_vm();
             let mut args = vec!["vesta", "create"];
             if build { args.push("--build"); }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -102,6 +102,9 @@ enum Command {
         /// Agent name (prompted interactively if omitted)
         #[arg(long)]
         name: Option<String>,
+        /// Disable GPU passthrough (overrides auto-detection)
+        #[arg(long)]
+        no_gpu: bool,
     },
     /// Create an agent container (without starting or authenticating)
     Create {
@@ -111,6 +114,9 @@ enum Command {
         /// Agent name (prompted interactively if omitted)
         #[arg(long)]
         name: Option<String>,
+        /// Disable GPU passthrough (overrides auto-detection)
+        #[arg(long)]
+        no_gpu: bool,
     },
     /// Start an agent (or all agents if no name given)
     Start {

--- a/cli/src/windows.rs
+++ b/cli/src/windows.rs
@@ -465,17 +465,19 @@ fn wslpath(win_path: &std::path::Path) -> String {
 
 fn command_args(command: &Command) -> Vec<String> {
     match command {
-        Command::Setup { build, yes, ref name } => {
+        Command::Setup { build, yes, ref name, no_gpu } => {
             let mut args = vec!["setup".into()];
             if *yes { args.push("-y".into()); }
             if *build { args.push("--build".into()); }
             if let Some(n) = name { args.push("--name".into()); args.push(n.clone()); }
+            if *no_gpu { args.push("--no-gpu".into()); }
             args
         }
-        Command::Create { build, ref name } => {
+        Command::Create { build, ref name, no_gpu } => {
             let mut args = vec!["create".into()];
             if *build { args.push("--build".into()); }
             if let Some(n) = name { args.push("--name".into()); args.push(n.clone()); }
+            if *no_gpu { args.push("--no-gpu".into()); }
             args
         }
         Command::Start { ref name } => {

--- a/cli/vm/Dockerfile
+++ b/cli/vm/Dockerfile
@@ -1,13 +1,41 @@
-FROM alpine:3.21
+FROM debian:bookworm-slim
 
-RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/community" >> /etc/apk/repositories
+ARG INCLUDE_KERNEL=false
+ARG INCLUDE_NVIDIA=false
 
-RUN apk add --no-cache \
-    ca-certificates curl openssh docker containerd iptables gcompat libgcc \
-    socat chrony
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl \
+        openssh-server \
+        docker.io iptables \
+        iproute2 kmod socat chrony \
+        isc-dhcp-client \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+    && rm -rf /usr/share/doc /usr/share/man /usr/share/locale
 
-# Kernel optimized for VMs (virtio drivers built-in, not modules)
-RUN apk add --no-cache linux-virt
+# Linux kernel for VM boot (macOS vfkit only)
+RUN if [ "$INCLUDE_KERNEL" = "true" ]; then \
+        apt-get update \
+        && apt-get install -y --no-install-recommends \
+            linux-image-cloud-$(dpkg --print-architecture) \
+        && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+        && cd /boot \
+        && ln -sf vmlinuz-* vmlinuz-virt \
+        && ln -sf initrd.img-* initramfs-virt; \
+    fi
+
+# NVIDIA Container Toolkit for GPU passthrough (WSL2 / Linux server)
+RUN if [ "$INCLUDE_NVIDIA" = "true" ]; then \
+        mkdir -p /etc/apt/keyrings \
+        && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+            > /etc/apt/keyrings/nvidia-container-toolkit.asc \
+        && curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+            | sed 's#deb https://#deb [signed-by=/etc/apt/keyrings/nvidia-container-toolkit.asc] https://#g' \
+            > /etc/apt/sources.list.d/nvidia-container-toolkit.list \
+        && apt-get update \
+        && apt-get install -y --no-install-recommends nvidia-container-toolkit \
+        && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+        && nvidia-ctk runtime configure --runtime=docker; \
+    fi
 
 # SSH
 RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh \

--- a/cli/vm/build-vm-image.sh
+++ b/cli/vm/build-vm-image.sh
@@ -7,8 +7,8 @@ OUTPUT_DIR="${2:-$SCRIPT_DIR}"
 
 echo "building VM image for $ARCH..."
 
-# Build the Docker image
-docker build --platform "linux/$ARCH" -t vesta-vm -f "$SCRIPT_DIR/Dockerfile" "$SCRIPT_DIR"
+# Build the Docker image (with kernel for VM boot)
+docker build --platform "linux/$ARCH" --build-arg INCLUDE_KERNEL=true -t vesta-vm -f "$SCRIPT_DIR/Dockerfile" "$SCRIPT_DIR"
 
 # Export rootfs
 echo "exporting rootfs..."
@@ -27,7 +27,7 @@ MOUNT_DIR=$(mktemp -d)
 sudo mount "$DISK" "$MOUNT_DIR"
 sudo tar -xf /tmp/vesta-rootfs.tar -C "$MOUNT_DIR"
 
-# Extract kernel + initrd (Alpine linux-virt uses fixed names)
+# Extract kernel + initrd (symlinked to vmlinuz-virt / initramfs-virt in Dockerfile)
 VMLINUZ="$MOUNT_DIR/boot/vmlinuz-virt"
 INITRD="$MOUNT_DIR/boot/initramfs-virt"
 if [ ! -f "$VMLINUZ" ] || [ ! -f "$INITRD" ]; then
@@ -40,7 +40,7 @@ fi
 # ARM64 requires uncompressed kernel for Virtualization.framework
 if [ "$ARCH" = "arm64" ]; then
     echo "decompressing kernel for arm64..."
-    # Alpine ARM64 vmlinuz-virt is a PE32+ EFI stub with gzip-compressed kernel inside.
+    # ARM64 vmlinuz is a PE32+ EFI stub with gzip-compressed kernel inside.
     # Find the gzip magic bytes and decompress to get the raw Image.
     python3 -c "
 import zlib

--- a/cli/vm/build-wsl-rootfs.sh
+++ b/cli/vm/build-wsl-rootfs.sh
@@ -10,13 +10,13 @@ cd "$CLI_DIR"
 cargo build --release --target x86_64-unknown-linux-gnu
 cp target/x86_64-unknown-linux-gnu/release/vesta "$SCRIPT_DIR/vesta"
 
-# Build VM image
-echo "building VM image..."
-docker build -t vesta-vm -f "$SCRIPT_DIR/Dockerfile" "$SCRIPT_DIR"
+# Build WSL image (with NVIDIA toolkit for GPU passthrough)
+echo "building WSL image..."
+docker build --build-arg INCLUDE_NVIDIA=true -t vesta-wsl -f "$SCRIPT_DIR/Dockerfile" "$SCRIPT_DIR"
 
 # Export as rootfs tarball
 echo "exporting rootfs..."
-CONTAINER=$(docker create vesta-vm)
+CONTAINER=$(docker create vesta-wsl)
 docker export "$CONTAINER" | gzip > "$SCRIPT_DIR/vesta-wsl-rootfs.tar.gz"
 docker rm "$CONTAINER" > /dev/null
 

--- a/cli/vm/entrypoint.sh
+++ b/cli/vm/entrypoint.sh
@@ -23,7 +23,7 @@ for iface in /sys/class/net/eth*; do
     [ -e "$iface" ] || continue
     iface_name="$(basename "$iface")"
     ip link set "$iface_name" up 2>/dev/null || true
-    udhcpc -i "$iface_name" -q -n 2>/dev/null || true &
+    dhclient -1 "$iface_name" 2>/dev/null || true &
 done
 
 # Mount cgroup v2 (unified hierarchy)
@@ -58,6 +58,11 @@ fi
 
 # Start NTP (handles clock drift after host sleep/wake)
 chronyd 2>/dev/null || true
+
+# Configure NVIDIA container runtime if toolkit is installed
+if command -v nvidia-ctk >/dev/null 2>&1; then
+    nvidia-ctk runtime configure --runtime=docker 2>/dev/null || true
+fi
 
 # Start Docker
 rm -f /var/run/docker.pid /var/run/containerd/containerd.pid


### PR DESCRIPTION
## Summary
- Auto-detect NVIDIA GPUs at container creation via `nvidia-smi` + Docker runtime check, pass `--gpus all` when ready
- Warn users if GPU is present but `nvidia-container-toolkit` is missing (with install link)
- Add `--no-gpu` flag to `vesta setup` / `vesta create` as escape hatch
- Switch VM/WSL base image from Alpine to `debian:bookworm-slim` for nvidia-container-toolkit apt support
- Use build args (`INCLUDE_KERNEL`, `INCLUDE_NVIDIA`) so macOS VM only gets the kernel and WSL2 only gets the NVIDIA toolkit
- CI builds VM and WSL images separately from the same Dockerfile

## Existing containers
`vesta rebuild <name>` will recreate the container with GPU passthrough auto-detected — no data loss.

## Test plan
- [ ] `vesta setup` on a Linux server with NVIDIA GPU — verify `--gpus all` is added and GPU is accessible inside container
- [ ] `vesta setup` on a machine without GPU — verify no warnings, no `--gpus` flag
- [ ] `vesta setup --no-gpu` on a GPU machine — verify GPU detection is skipped
- [ ] `vesta rebuild` on existing container — verify GPU auto-detected on recreate
- [ ] CI: VM image build succeeds with Debian kernel (`INCLUDE_KERNEL=true`)
- [ ] CI: WSL rootfs build succeeds with nvidia-container-toolkit (`INCLUDE_NVIDIA=true`)
- [ ] macOS VM boots correctly with Debian kernel + initrd symlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)