### PR TITLE
Update dream retrospective to review multiple past summaries

### DIFF
--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -23,7 +23,7 @@ description: Self-improvement and memory curation. Used by the nightly dreamer, 
 
 ### 1. Retrospective
 
-Read the most recent file in `~/vesta/dreamer/`. For each fix listed there, check today's conversation: did that situation come up again? Did it go better? If a fix didn't help or made things worse, revisit it now. If it worked, note it in tonight's summary. Use `search_history` to check whether a fix has held up across multiple days.
+Read the last 5–7 files in `~/vesta/dreamer/` (sorted by date) to spot recurring patterns — fixes that keep resurfacing, problems marked "resolved" that came back, and improvements that actually stuck. For each fix in the recent summaries, check today's conversation: did that situation come up again? Did it go better? If a fix didn't help or made things worse, revisit it now. If it worked, note it in tonight's summary.
 
 ### 2. Review the conversation
 

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1133,7 +1133,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.104"
+version = "0.1.105"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },


### PR DESCRIPTION
## Summary
- Changed the dream skill's Retrospective section to read the last 5-7 dreamer summaries instead of just the most recent one
- This lets the agent spot recurring patterns across nights — fixes that keep resurfacing, problems that were marked resolved but came back, and improvements that actually stuck

## Test plan
- [ ] Verify the updated `agent/skills/dream/SKILL.md` reads correctly
- [ ] No code changes — instruction-only update to a skill file

🤖 Generated with [Claude Code](https://claude.com/claude-code)