### PR TITLE
feat(agent): restart container on error instead of resetting SDK session

### DIFF
--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -103,7 +103,14 @@ async def queue_greeting(queue: asyncio.Queue[tuple[str, bool]], *, config: vm.V
         if prompt:
             prompt = f"[System: your name is {config.agent_name}]\n\n{prompt}"
     else:
-        prompt = build_restart_context(reason, config)
+        extras = []
+        today = _now().strftime("%Y-%m-%d")
+        try:
+            summary = (config.dreamer_dir / f"{today}.md").read_text().strip()
+            extras.append(f"[Dreamer Summary]\n{summary}")
+        except FileNotFoundError:
+            pass
+        prompt = build_restart_context(reason, config, extras=extras)
     if not prompt or not prompt.strip():
         return
 
@@ -143,9 +150,10 @@ async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, c
                     persist_session_id(sid, state=state, config=config)
             except (AttributeError, TypeError):
                 pass
-        logger.error(f"Error processing message: {error_msg}")
+        logger.error(f"Error processing message: {error_msg} — triggering restart")
         state.event_bus.emit({"type": "error", "text": error_msg})
-        state.pending_context = f"[System: Previous request failed with error: {error_msg}. Session was reset.]"
+        state.restart_reason = f"error — {error_msg}"
+        state.graceful_shutdown.set()
     finally:
         state.event_bus.set_state("idle")
 
@@ -159,7 +167,7 @@ async def _process_interruptible(
 
     try:
         while pending:
-            if state.pending_context is not None:
+            if state.graceful_shutdown.is_set():
                 for remaining in pending:
                     await queue.put(remaining)
                 break
@@ -192,34 +200,29 @@ async def _process_interruptible(
 
 
 async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.State, config: vm.VestaConfig) -> None:
-    while state.shutdown_event and not state.shutdown_event.is_set():
-        logger.client("Creating new client session...")
-        options = build_client_options(config, state)
-        async with ClaudeSDKClient(options=options) as client:
-            state.client = client
-            logger.client("Client session started")
+    logger.client("Creating new client session...")
+    options = build_client_options(config, state)
+    async with ClaudeSDKClient(options=options) as client:
+        state.client = client
+        logger.client("Client session started")
 
-            try:
-                if state.pending_context:
-                    await queue.put((state.pending_context, False))
-                    state.pending_context = None
+        try:
+            while not state.shutdown_event.is_set():
+                try:
+                    msg, is_user = await asyncio.wait_for(queue.get(), timeout=1.0)
+                except TimeoutError:
+                    continue
 
-                while not state.shutdown_event.is_set() and state.pending_context is None:
-                    try:
-                        msg, is_user = await asyncio.wait_for(queue.get(), timeout=1.0)
-                    except TimeoutError:
-                        continue
+                await _process_interruptible(msg, is_user=is_user, queue=queue, state=state, config=config)
 
-                    await _process_interruptible(msg, is_user=is_user, queue=queue, state=state, config=config)
-
-                    if state.dreamer_active:
-                        state.dreamer_active = False
-                        state.event_bus.clear_history()
-                        _trigger_nightly_restart(state=state, config=config)
-            finally:
-                state.client = None
-                state.interrupt_event = None
-                logger.client("Client session closed")
+                if state.dreamer_active:
+                    state.dreamer_active = False
+                    state.event_bus.clear_history()
+                    _trigger_nightly_restart(state=state, config=config)
+        finally:
+            state.client = None
+            state.interrupt_event = None
+            logger.client("Client session closed")
 
 
 # --- Proactive & dreamer ---
@@ -237,14 +240,8 @@ def _trigger_nightly_restart(*, state: vm.State, config: vm.VestaConfig) -> None
     logger.dreamer("Dreamer complete, triggering nightly restart...")
     state.session_id = None
     config.session_file.unlink(missing_ok=True)
-
-    today = _now().strftime("%Y-%m-%d")
-    summary_path = config.dreamer_dir / f"{today}.md"
-    extras = []
-    if summary_path.exists():
-        extras.append(f"[Dreamer Summary]\n{summary_path.read_text().strip()}")
-
-    state.pending_context = build_restart_context("new day — conversation history reset, nightly dreamer ran", config, extras=extras)
+    state.restart_reason = "nightly — conversation history reset, dreamer ran"
+    state.graceful_shutdown.set()
 
 
 async def process_nightly_memory(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.State, config: vm.VestaConfig) -> None:

--- a/agent/src/vesta/main.py
+++ b/agent/src/vesta/main.py
@@ -61,13 +61,15 @@ def _make_signal_handler(state: vm.State, *, allow_force_exit: bool = False) -> 
     return handler
 
 
-async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: bool = False, crashed: bool = False) -> None:
+CLEAN_RESTART = "restart — clean restart"
+
+
+async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: bool = False, restart_reason: str = CLEAN_RESTART) -> None:
     signal.signal(signal.SIGHUP, signal.SIG_IGN)
     signal.signal(signal.SIGINT, _make_signal_handler(state, allow_force_exit=True))
     signal.signal(signal.SIGTERM, _make_signal_handler(state))
 
     logger.init(f"{config.agent_name.upper()} started")
-    (config.data_dir / "run_marker").touch()
 
     message_queue: asyncio.Queue[tuple[str, bool]] = asyncio.Queue()
 
@@ -80,8 +82,7 @@ async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: boo
         asyncio.create_task(monitor_loop(message_queue, state=state, config=config)),
     ]
 
-    reason = "first_start" if first_start else ("crash — restarted after unexpected exit" if crashed else "restart — clean restart")
-    await queue_greeting(message_queue, config=config, reason=reason)
+    await queue_greeting(message_queue, config=config, reason=restart_reason)
 
     try:
         await state.graceful_shutdown.wait()
@@ -101,15 +102,28 @@ async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: boo
         logger.shutdown("Shutdown timed out (SDK cleanup hung), forcing exit")
         os._exit(1)
     await ws_runner.cleanup()
-    (config.data_dir / "run_marker").unlink(missing_ok=True)
+    _write_restart_reason(config, state.restart_reason or CLEAN_RESTART)
     logger.shutdown("sweet dreams!")
 
 
-def _detect_crash(config: vm.VestaConfig) -> bool:
-    run_marker = config.data_dir / "run_marker"
-    crashed = run_marker.exists()
-    run_marker.unlink(missing_ok=True)
-    return crashed
+def _write_restart_reason(config: vm.VestaConfig, reason: str) -> None:
+    try:
+        (config.data_dir / "restart_reason").write_text(reason)
+    except OSError:
+        logger.warning("Could not write restart_reason file")
+
+
+def _read_restart_reason(config: vm.VestaConfig) -> str:
+    path = config.data_dir / "restart_reason"
+    try:
+        reason = path.read_text().strip()
+        path.unlink(missing_ok=True)
+        return reason
+    except FileNotFoundError:
+        return "crash — restarted after unexpected exit"
+    except (OSError, UnicodeDecodeError):
+        logger.warning("Could not read restart_reason file")
+        return "crash — restarted after unexpected exit"
 
 
 def _read_last_dreamer_run(config: vm.VestaConfig) -> dt.datetime | None:
@@ -122,7 +136,7 @@ def _read_last_dreamer_run(config: vm.VestaConfig) -> dt.datetime | None:
     return None
 
 
-def init_state(*, config: vm.VestaConfig) -> tuple[vm.State, bool]:
+def init_state(*, config: vm.VestaConfig) -> vm.State:
     session_id = None
     try:
         if config.session_file.exists():
@@ -130,15 +144,11 @@ def init_state(*, config: vm.VestaConfig) -> tuple[vm.State, bool]:
     except (OSError, UnicodeDecodeError):
         logger.warning("Could not read session file, starting fresh")
 
-    crashed = _detect_crash(config)
-    if crashed:
-        logger.init("Crash detected")
-
     last_dreamer_run = _read_last_dreamer_run(config)
 
     if session_id:
         logger.init(f"Resuming session {session_id[:16]}...")
-    return vm.State(last_dreamer_run=last_dreamer_run, session_id=session_id), crashed
+    return vm.State(last_dreamer_run=last_dreamer_run, session_id=session_id)
 
 
 async def async_main() -> None:
@@ -154,10 +164,11 @@ async def async_main() -> None:
 
     memory_path = get_memory_path(config)
     first_start = not memory_path.exists() or "[Unknown - need to ask]" in memory_path.read_text()
-    initial_state, crashed = init_state(config=config)
+    restart_reason = _read_restart_reason(config)
+    initial_state = init_state(config=config)
     initial_state.history = open_history(config.history_db)
-    logger.init("Starting main loop...")
-    await run_vesta(config, state=initial_state, first_start=first_start, crashed=crashed)
+    logger.init(f"Starting main loop ({restart_reason})...")
+    await run_vesta(config, state=initial_state, first_start=first_start, restart_reason=restart_reason)
 
 
 def main() -> None:

--- a/agent/src/vesta/models.py
+++ b/agent/src/vesta/models.py
@@ -19,7 +19,7 @@ class State:
     graceful_shutdown: asyncio.Event = dc.field(default_factory=asyncio.Event)
     shutdown_count: int = 0
     session_id: str | None = None
-    pending_context: str | None = None
+    restart_reason: str | None = None
     last_dreamer_run: dt.datetime | None = None
     dreamer_active: bool = False
     interrupt_event: asyncio.Event | None = None

--- a/agent/tests/test_e2e.py
+++ b/agent/tests/test_e2e.py
@@ -121,7 +121,7 @@ async def _run_test_scenario(state_dir: Path, test_fn, **config_overrides):
     vmain.input_handler = _noop_input_handler  # type: ignore[assignment]
 
     try:
-        state, _ = vmain.init_state(config=config)
+        state = vmain.init_state(config=config)
 
         async def run_test():
             await asyncio.sleep(2)
@@ -152,7 +152,7 @@ async def _run_test_scenario(state_dir: Path, test_fn, **config_overrides):
 def test_client_lifecycle_with_async_with(state_dir):
     """Client should work correctly with async with context manager."""
     config = _make_config(state_dir)
-    state, _ = vmain.init_state(config=config)
+    state = vmain.init_state(config=config)
 
     async def test_fn():
         options = build_client_options(config, state)
@@ -168,18 +168,18 @@ def test_client_lifecycle_with_async_with(state_dir):
     _run(test_fn())
 
 
-def test_pending_context_flag(state_dir):
-    """Setting pending_context should work correctly."""
+def test_restart_reason_flag(state_dir):
+    """Setting restart_reason should work correctly."""
     config = _make_config(state_dir)
-    state, _ = vmain.init_state(config=config)
+    state = vmain.init_state(config=config)
 
     async def test_fn():
-        assert state.pending_context is None
-        state.pending_context = "[System: test reset]"
+        assert state.restart_reason is None
+        state.restart_reason = "error — test error"
         state.session_id = None
-        assert state.pending_context is not None
-        state.pending_context = None
-        assert state.pending_context is None
+        assert state.restart_reason is not None
+        state.restart_reason = None
+        assert state.restart_reason is None
 
     _run(test_fn())
 
@@ -187,7 +187,7 @@ def test_pending_context_flag(state_dir):
 def test_multiple_client_sessions(state_dir):
     """Should be able to create multiple client sessions sequentially."""
     config = _make_config(state_dir)
-    state, _ = vmain.init_state(config=config)
+    state = vmain.init_state(config=config)
 
     async def test_fn():
         options = build_client_options(config, state)
@@ -215,9 +215,9 @@ def test_multiple_client_sessions(state_dir):
 
 
 def test_full_reset_flow(state_dir):
-    """Full flow: pending_context triggers client recreation."""
+    """Full flow: restart_reason triggers graceful shutdown for container restart."""
     config = _make_config(state_dir)
-    state, _ = vmain.init_state(config=config)
+    state = vmain.init_state(config=config)
 
     async def test_fn():
         options = build_client_options(config, state)
@@ -225,12 +225,10 @@ def test_full_reset_flow(state_dir):
             state.client = client
 
         state.client = None
-        state.pending_context = "[System: Reset needed]"
+        state.restart_reason = "error — Reset needed"
+        assert state.restart_reason is not None
 
-        context = state.pending_context
-        state.pending_context = None
-        assert context is not None
-
+        state.restart_reason = None
         options = build_client_options(config, state)
         async with ClaudeSDKClient(options=options) as client:
             state.client = client

--- a/agent/tests/test_unit.py
+++ b/agent/tests/test_unit.py
@@ -261,62 +261,39 @@ async def _run_processor_test(
 
 
 @pytest.mark.anyio
-async def test_message_processor_resets_on_error(tmp_path):
-    call_count = 0
-
+async def test_message_processor_restarts_on_error(tmp_path):
     async def side_effect(msg, *, state, config, is_user):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            raise RuntimeError("Simulated SDK buffer overflow")
-        return (["OK"], state)
+        raise RuntimeError("Simulated SDK buffer overflow")
 
     state, session_count, messages = await _run_processor_test(
         tmp_path, message_side_effect=side_effect, initial_queue=[("first message - will fail", True)]
     )
-    assert session_count >= 2
-    assert any("Previous request failed" in msg for msg in messages)
+    assert state.graceful_shutdown.is_set()
+    assert state.restart_reason == "error — Simulated SDK buffer overflow"
 
 
 @pytest.mark.anyio
-async def test_message_processor_restart_preserves_session(tmp_path):
-    call_count = 0
-
+async def test_message_processor_restarts_on_timeout(tmp_path):
     async def side_effect(msg, *, state, config, is_user):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            state.session_id = "test-session-123"
-            state.pending_context = "[System: Vesta restarted.]"
-        return (["OK"], state)
+        raise TimeoutError()
 
     state, session_count, messages = await _run_processor_test(
-        tmp_path, message_side_effect=side_effect, initial_queue=[("edit some config", True)]
+        tmp_path, message_side_effect=side_effect, initial_queue=[("slow request", True)]
     )
-    assert state.session_id == "test-session-123"
-    assert session_count >= 2
-    assert any("restarted" in msg.lower() for msg in messages)
+    assert state.graceful_shutdown.is_set()
+    assert state.restart_reason == "error — Response timed out"
 
 
-@pytest.mark.anyio
-async def test_response_timeout_triggers_session_reset(tmp_path):
-    call_count = 0
+def test_restart_reason_round_trip(tmp_path):
+    from vesta.main import _write_restart_reason, _read_restart_reason
 
-    async def side_effect(msg, *, state, config, is_user):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            state.pending_context = "[System: Response timed out. Session was reset to recover.]"
-        return (["OK"], state)
+    config = vm.VestaConfig(root=tmp_path)
+    config.data_dir.mkdir(parents=True, exist_ok=True)
 
-    pre_state = vm.State()
-    pre_state.session_id = "timeout-session"
-    state, session_count, messages = await _run_processor_test(
-        tmp_path, message_side_effect=side_effect, pre_state=pre_state, initial_queue=[("slow request", True)]
-    )
-    assert session_count >= 2
-    assert state.session_id == "timeout-session"
-    assert any("timed out" in msg.lower() for msg in messages)
+    _write_restart_reason(config, "nightly — conversation history reset, dreamer ran")
+    assert _read_restart_reason(config) == "nightly — conversation history reset, dreamer ran"
+    # File is consumed after reading
+    assert _read_restart_reason(config) == "crash — restarted after unexpected exit"
 
 
 @pytest.mark.anyio
@@ -417,8 +394,7 @@ async def test_dreamer_triggers_automatic_restart(tmp_path):
     )
     assert state.session_id is None
     assert state.dreamer_active is False
-    assert session_count >= 2
-    assert any("new day" in msg for msg in messages)
+    assert state.graceful_shutdown.is_set()
 
 
 # --- Interrupt tests ---
@@ -917,32 +893,14 @@ def test_nightly_restart(tmp_path):
     from vesta.core.loops import _trigger_nightly_restart
 
     config = vm.VestaConfig(root=tmp_path)
-    fake_now = dt.datetime(2025, 6, 15, 4, 5, 0)
+    config.data_dir.mkdir(parents=True, exist_ok=True)
 
-    # With summary
     state = vm.State(session_id="old-session")
-    config.dreamer_dir.mkdir(parents=True, exist_ok=True)
-    (config.dreamer_dir / "2025-06-15.md").write_text("Updated MEMORY.md, pruned stale entries.")
-
-    with patch("vesta.core.loops._now", return_value=fake_now):
-        _trigger_nightly_restart(state=state, config=config)
+    _trigger_nightly_restart(state=state, config=config)
 
     assert state.session_id is None
-    assert state.pending_context is not None
-    assert "new day" in state.pending_context
-    assert "Updated MEMORY.md" in state.pending_context
-
-    # Without summary
-    state2 = vm.State(session_id="other-session")
-    (config.dreamer_dir / "2025-06-15.md").unlink()
-
-    with patch("vesta.core.loops._now", return_value=fake_now):
-        _trigger_nightly_restart(state=state2, config=config)
-
-    assert state2.session_id is None
-    assert state2.pending_context is not None
-    assert "new day" in state2.pending_context
-    assert "Dreamer Summary" not in state2.pending_context
+    assert state.restart_reason == "nightly — conversation history reset, dreamer ran"
+    assert state.graceful_shutdown.is_set()
 
 
 # --- History store ---

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1133,7 +1133,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.105"
+version = "0.1.106"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },


### PR DESCRIPTION
## Summary

- **Replace in-process session resets with container restarts**: errors (SDK crashes, timeouts) now trigger graceful shutdown instead of resetting the client session in-place, letting Docker's `--restart unless-stopped` policy bring the whole process back fresh — fixing infrastructure issues like dead Xvfb or crashed Chrome that session resets couldn't recover from
- **Simplify message processor**: collapsed the double loop (outer restart + inner message) into a single loop since session resets no longer happen in-process
- **Persist restart reason across boots**: new `restart_reason` file replaces the old `run_marker` crash detection, giving the greeting context about *why* the restart happened (error, nightly, clean, or crash)

## Test plan
- [ ] Unit tests pass (`uv run pytest tests/test_unit.py`)
- [ ] `test_message_processor_restarts_on_error` — verifies error sets `graceful_shutdown` + `restart_reason`
- [ ] `test_message_processor_restarts_on_timeout` — verifies timeout triggers restart
- [ ] `test_restart_reason_round_trip` — verifies file write/read/consume cycle
- [ ] `test_nightly_restart` — verifies nightly sets shutdown + reason
- [ ] `test_dreamer_triggers_automatic_restart` — verifies dreamer flow triggers shutdown
- [ ] CI passes (ruff, ty, clippy, all tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)