### PR TITLE
feat(agent): recency-weighted conversation history search

### DIFF
--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -329,7 +329,7 @@ async def process_message(msg: str, *, state: vm.State, config: vm.VestaConfig, 
     return responses, state
 
 
-_SEARCH_HISTORY_DESCRIPTION = (
+_SEARCH_CONVERSATION_HISTORY_DESCRIPTION = (
     "Search past conversation memory using full-text search (SQLite FTS5). "
     "Searches ALL past conversations across sessions and days, not just the current session. "
     "Use this to recall specific past discussions, decisions, or information no longer in context.\n\n"
@@ -339,10 +339,10 @@ _SEARCH_HISTORY_DESCRIPTION = (
     '- OR: "cats OR dogs" finds messages with either word\n'
     '- Prefix: "sched*" matches schedule, scheduled, scheduling, etc.\n'
     '- NOT: "meeting NOT cancelled" excludes matches\n\n'
-    "Returns messages in chronological order with timestamps and roles (user/assistant/system)."
+    "Results are ranked by relevance with a recency boost — recent conversations surface higher."
 )
 
-_SEARCH_HISTORY_SCHEMA = {
+_SEARCH_CONVERSATION_HISTORY_SCHEMA = {
     "type": "object",
     "properties": {
         "query": {"type": "string", "description": "FTS5 search query"},
@@ -363,8 +363,8 @@ def _build_vesta_tools_server(state: vm.State, config: vm.VestaConfig) -> tp.Any
         os.kill(os.getpid(), signal.SIGTERM)
         return {"content": [{"type": "text", "text": "Container restart initiated."}]}
 
-    @tool("search_history", _SEARCH_HISTORY_DESCRIPTION, _SEARCH_HISTORY_SCHEMA)
-    async def search_history(args: dict[str, tp.Any]) -> dict[str, tp.Any]:
+    @tool("search_conversation_history", _SEARCH_CONVERSATION_HISTORY_DESCRIPTION, _SEARCH_CONVERSATION_HISTORY_SCHEMA)
+    async def search_conversation_history(args: dict[str, tp.Any]) -> dict[str, tp.Any]:
         if state.history is None:
             return {"content": [{"type": "text", "text": "History store not available."}]}
         query = str(args["query"])
@@ -375,7 +375,7 @@ def _build_vesta_tools_server(state: vm.State, config: vm.VestaConfig) -> tp.Any
             return {"content": [{"type": "text", "text": f"Search error: {e}"}]}
         return {"content": [{"type": "text", "text": format_results(results)}]}
 
-    return create_sdk_mcp_server("vesta-tools", tools=[restart_vesta, search_history])
+    return create_sdk_mcp_server("vesta-tools", tools=[restart_vesta, search_conversation_history])
 
 
 def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgentOptions:

--- a/agent/src/vesta/core/history.py
+++ b/agent/src/vesta/core/history.py
@@ -56,6 +56,9 @@ def history_save(db: HistoryDB, role: str, content: str, *, session_id: str | No
     db.conn.commit()
 
 
+_RECENCY_DECAY_RATE = 0.01
+
+
 def history_search(db: HistoryDB, query: str, *, limit: int = 20) -> list[dict[str, str]]:
     rows = db.conn.execute(
         """
@@ -63,12 +66,12 @@ def history_search(db: HistoryDB, query: str, *, limit: int = 20) -> list[dict[s
         FROM messages_fts f
         JOIN messages m ON m.id = f.rowid
         WHERE messages_fts MATCH ?
-        ORDER BY m.id DESC
+        ORDER BY f.rank / (1.0 + ? * max(julianday('now') - julianday(m.timestamp), 0)) ASC
         LIMIT ?
         """,
-        (query, limit),
+        (query, _RECENCY_DECAY_RATE, limit),
     ).fetchall()
-    return [{"timestamp": r[0], "role": r[1], "content": r[2]} for r in reversed(rows)]
+    return [{"timestamp": r[0], "role": r[1], "content": r[2]} for r in rows]
 
 
 def history_get_range(

--- a/agent/tests/test_unit.py
+++ b/agent/tests/test_unit.py
@@ -1010,6 +1010,20 @@ def test_history_format_results():
     assert "user" in formatted
 
 
+def test_history_search_recency_ranking(tmp_path):
+    store = open_history(tmp_path / "test.db")
+    old = dt.datetime(2024, 1, 1, 10, 0, 0)
+    recent = dt.datetime(2026, 3, 30, 10, 0, 0)
+    history_save(store, "user", "deploy the backend service", timestamp=old)
+    history_save(store, "user", "deploy the backend service", timestamp=recent)
+
+    results = history_search(store, "deploy", limit=2)
+    assert len(results) == 2
+    # Recent message should rank first (lower combined score)
+    assert results[0]["timestamp"] == recent.isoformat()
+    assert results[1]["timestamp"] == old.isoformat()
+
+
 def test_history_store_session_id(tmp_path):
     store = open_history(tmp_path / "test.db")
     history_save(store, "user", "msg one", session_id="session-abc")

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1133,7 +1133,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.105"
+version = "0.1.106"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },


### PR DESCRIPTION
## Summary
- Rename `search_history` tool to `search_conversation_history`
- Add BM25 + time-decay ranking so older conversations are subtly penalized in search results
- No DB schema changes — uses existing FTS5 `rank` column and `julianday()` on stored timestamps

## Test plan
- [x] All existing history tests pass
- [x] New `test_history_search_recency_ranking` verifies newer messages rank higher than identical older ones
- [ ] CI passes (ruff, ty, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)