### PR TITLE
feat(agent): add Telegram skill

### DIFF
--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -36,6 +36,10 @@
     "description": "Discover and install new capabilities from the skill registry. Use this when asked to add a new feature, when you want to explore what you could do, or when a user asks if you can do something you don't have a skill for yet. The registry lives on GitHub \u2014 search it to find skills, then install them to give yourself new abilities."
   },
   {
+    "name": "telegram",
+    "description": "This skill should be used when the user asks about \"telegram\", \"tg\", \"telegram message\", or needs to send/receive messages via Telegram. Requires a background daemon."
+  },
+  {
     "name": "tasks",
     "description": "This skill should be used when the user asks about \"tasks\", \"to-do\", \"todo\", \"task list\", \"reminders\", \"remind me\", \"alert\", \"notify\", or needs to create, manage, track, or organize tasks, to-do items, reminders, and time-based notifications. Everything actionable becomes a task immediately. All work, progress, drafts go in task metadata. Reminders are nudges about when to think about something \u2014 standalone or linked to a task. IMPORTANT \u2014 this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how."
   },

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -36,12 +36,12 @@
     "description": "Discover and install new capabilities from the skill registry. Use this when asked to add a new feature, when you want to explore what you could do, or when a user asks if you can do something you don't have a skill for yet. The registry lives on GitHub \u2014 search it to find skills, then install them to give yourself new abilities."
   },
   {
-    "name": "telegram",
-    "description": "This skill should be used when the user asks about \"telegram\", \"tg\", \"telegram message\", or needs to send/receive messages via Telegram. Requires a background daemon."
-  },
-  {
     "name": "tasks",
     "description": "This skill should be used when the user asks about \"tasks\", \"to-do\", \"todo\", \"task list\", \"reminders\", \"remind me\", \"alert\", \"notify\", or needs to create, manage, track, or organize tasks, to-do items, reminders, and time-based notifications. Everything actionable becomes a task immediately. All work, progress, drafts go in task metadata. Reminders are nudges about when to think about something \u2014 standalone or linked to a task. IMPORTANT \u2014 this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how."
+  },
+  {
+    "name": "telegram",
+    "description": "This skill should be used when the user asks about \"telegram\", \"tg\", \"telegram message\", or needs to send/receive messages via Telegram. Requires a background daemon."
   },
   {
     "name": "upstream",

--- a/agent/skills/telegram/SETUP.md
+++ b/agent/skills/telegram/SETUP.md
@@ -1,0 +1,30 @@
+# Telegram Setup
+
+1. Install dependencies (gcc for CGO and Go from https://go.dev/dl/ — NOT the system package manager):
+   ```bash
+   apt-get install -y gcc
+   ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+   curl -fsSL "https://go.dev/dl/$(curl -fsSL 'https://go.dev/VERSION?m=text' | head -1).linux-${ARCH}.tar.gz" | tar -C /usr/local -xz
+   export PATH="/usr/local/go/bin:$PATH"
+   ```
+2. Build the Telegram CLI (CGO required for SQLite with FTS5):
+   ```bash
+   cd ~/vesta/skills/telegram/cli && CGO_ENABLED=1 CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" CGO_LDFLAGS="-lm" go build -o /usr/local/bin/telegram .
+   ```
+3. Create a Telegram bot and authenticate:
+   - Tell the user to message [@BotFather](https://t.me/BotFather) on Telegram
+   - Send `/newbot` and follow the prompts to create a bot
+   - Copy the bot token (looks like `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`)
+   - Save the token:
+     ```bash
+     telegram authenticate --token "<BOT_TOKEN>"
+     ```
+4. Start the daemon:
+   ```bash
+   screen -dmS telegram telegram serve --notifications-dir ~/vesta/notifications
+   ```
+5. **Important**: The user must `/start` the bot from their Telegram account before Vesta can send them messages. After that first interaction, Vesta can message them anytime (including autonomously, e.g., morning reports).
+6. Add to `~/vesta/prompts/restart.md`:
+   ```
+   screen -dmS telegram telegram serve --notifications-dir ~/vesta/notifications
+   ```

--- a/agent/skills/telegram/SKILL.md
+++ b/agent/skills/telegram/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: telegram
+description: This skill should be used when the user asks about "telegram", "tg", "telegram message", or needs to send/receive messages via Telegram. Requires a background daemon.
+---
+
+# Telegram — CLI: telegram
+
+**Setup**: See [SETUP.md](SETUP.md)
+**Background**: `screen -dmS telegram telegram serve --notifications-dir ~/vesta/notifications`
+
+## Quick Reference
+```bash
+telegram send '<contact_name>' 'Hello!'
+telegram send '<chat_id>' 'Photo' --attachment /path/to/image.jpg
+telegram chats
+telegram contacts
+telegram messages --to "<contact_name>" --limit 20
+telegram groups
+telegram react '<contact_name>' '<message_id>' '👍'
+telegram send-file --to "<contact_name>" --file-path /path/to/document.pdf
+```
+
+## Notes
+- Chat IDs are numeric (e.g., `123456789` for private, `-1001234567890` for groups)
+- Users must `/start` the bot before it can message them
+- Recipients can be resolved by: contact name, @username, or numeric chat ID
+- The binary is installed to `/usr/local/bin/telegram`
+- Auth state is stored in `~/.telegram/`
+- Bot token is stored in `~/.telegram/bot-token`
+
+### Contact Preferences
+[How the user prefers to communicate with different contacts]

--- a/agent/skills/telegram/cli/cli.go
+++ b/agent/skills/telegram/cli/cli.go
@@ -1,0 +1,485 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func extractFlag(name string) string {
+	f := "--" + name
+	prefix := f + "="
+	for i, arg := range os.Args {
+		if arg == f && i+1 < len(os.Args) {
+			return os.Args[i+1]
+		}
+		if strings.HasPrefix(arg, prefix) {
+			return strings.TrimPrefix(arg, prefix)
+		}
+	}
+	return ""
+}
+
+func extractInstance() string        { return extractFlag("instance") }
+func extractNotificationsDir() string { return extractFlag("notifications-dir") }
+
+func isReadOnly() bool {
+	for _, arg := range os.Args {
+		if arg == "--read-only" {
+			return true
+		}
+	}
+	return false
+}
+
+func extractSkipSenders() map[string]bool {
+	val := extractFlag("skip-senders")
+	result := make(map[string]bool)
+	if val != "" {
+		for _, id := range strings.Split(val, ",") {
+			id = strings.TrimSpace(id)
+			if id != "" {
+				result[id] = true
+			}
+		}
+	}
+	return result
+}
+
+func parseStateDir() (dataDir, logDir string) {
+	instance := extractInstance()
+	if instance != "" {
+		dataDir = filepath.Join(os.Getenv("HOME"), ".telegram", instance)
+		logDir = filepath.Join(os.Getenv("HOME"), ".telegram", instance, "logs")
+	} else {
+		dataDir = filepath.Join(os.Getenv("HOME"), ".telegram")
+		logDir = filepath.Join(os.Getenv("HOME"), ".telegram", "logs")
+	}
+	return
+}
+
+func getSocketPath() string {
+	instance := extractInstance()
+	if instance != "" {
+		return filepath.Join(os.Getenv("HOME"), ".telegram", instance, "telegram.sock")
+	}
+	return filepath.Join(os.Getenv("HOME"), ".telegram", "telegram.sock")
+}
+
+func printJSON(v interface{}) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "JSON encoding error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(data))
+}
+
+func writeDeathNotification(notifDir string, sig string) {
+	notif := map[string]string{
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"source":    "telegram",
+		"type":      "daemon_died",
+		"signal":    sig,
+	}
+	data, err := json.Marshal(notif)
+	if err != nil {
+		return
+	}
+	filename := fmt.Sprintf("%d-telegram-daemon_died.json", time.Now().UnixMicro())
+	os.MkdirAll(notifDir, 0755)
+	os.WriteFile(filepath.Join(notifDir, filename), data, 0644)
+}
+
+func readAuthStatus(dataDir string) map[string]string {
+	tokenPath := filepath.Join(dataDir, "bot-token")
+	if _, err := os.Stat(tokenPath); err != nil {
+		return map[string]string{"status": "not_authenticated", "instructions": "Set your bot token with: telegram authenticate --token <BOT_TOKEN>"}
+	}
+	return map[string]string{"status": "authenticated"}
+}
+
+func runAuthenticate() {
+	dataDir, _ := parseStateDir()
+
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	token := extractFlag("token")
+
+	if token == "" {
+		// Check if reading from stdin pipe
+		stat, _ := os.Stdin.Stat()
+		if (stat.Mode() & os.ModeCharDevice) == 0 {
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				token = strings.TrimSpace(scanner.Text())
+			}
+		}
+	}
+
+	if token != "" {
+		tokenPath := filepath.Join(dataDir, "bot-token")
+		if err := os.WriteFile(tokenPath, []byte(token), 0600); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving token: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Write auth status
+		statusData, _ := json.Marshal(map[string]string{"status": "authenticated"})
+		os.WriteFile(filepath.Join(dataDir, "auth-status.json"), statusData, 0644)
+
+		printJSON(map[string]string{"status": "authenticated", "message": "Bot token saved successfully"})
+		return
+	}
+
+	printJSON(readAuthStatus(dataDir))
+}
+
+func runServe() {
+	dataDir, _ := parseStateDir()
+
+	notifDir := extractNotificationsDir()
+	if notifDir == "" {
+		fmt.Fprintln(os.Stderr, "error: --notifications-dir is required for serve")
+		os.Exit(1)
+	}
+
+	var err error
+	if err = os.MkdirAll(dataDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if err = os.MkdirAll(notifDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	tc, err := NewTelegramClient(dataDir, notifDir, extractInstance(), isReadOnly(), extractSkipSenders())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initialize Telegram client: %v\n", err)
+		os.Exit(1)
+	}
+
+	sockPath := filepath.Join(dataDir, "telegram.sock")
+	listener, err := startSocketServer(sockPath, tc)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to start socket server: %v\n", err)
+	}
+
+	instance := extractInstance()
+	if instance != "" {
+		fmt.Fprintf(os.Stderr, "Telegram bot initialized (instance: %s). Data: %s\n", instance, dataDir)
+	} else {
+		fmt.Fprintf(os.Stderr, "Telegram bot initialized. Data: %s\n", dataDir)
+	}
+	fmt.Fprintf(os.Stderr, "Notifications: %s\n", notifDir)
+	if isReadOnly() {
+		fmt.Fprintln(os.Stderr, "Running in READ-ONLY mode (no sending)")
+	}
+
+	tc.writeAuthStatusFile(map[string]string{"status": "authenticated"})
+
+	printJSON(map[string]string{"status": "serving", "bot": "@" + tc.bot.Self.UserName})
+
+	// Start polling in background
+	go tc.StartPolling()
+
+	signal.Ignore(syscall.SIGHUP)
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-sigChan
+
+	fmt.Fprintf(os.Stderr, "Shutting down (signal: %v)...\n", sig)
+	writeDeathNotification(notifDir, sig.String())
+	if listener != nil {
+		stopSocketServer(listener, sockPath)
+	}
+	tc.Stop()
+}
+
+func stripGlobalFlags(args []string) []string {
+	var filtered []string
+	skip := false
+	for _, arg := range args {
+		if skip {
+			skip = false
+			continue
+		}
+		if arg == "--instance" || arg == "--notifications-dir" || arg == "--skip-senders" {
+			skip = true
+			continue
+		}
+		if strings.HasPrefix(arg, "--instance=") || strings.HasPrefix(arg, "--notifications-dir=") || arg == "--read-only" || strings.HasPrefix(arg, "--skip-senders=") {
+			continue
+		}
+		filtered = append(filtered, arg)
+	}
+	return filtered
+}
+
+func runOneShot(command string) {
+	sockPath := getSocketPath()
+	output, exitCode, connected := trySocketCommand(sockPath, command, stripGlobalFlags(os.Args[1:]))
+	if !connected {
+		printJSON(map[string]interface{}{"error": "daemon not running — start with: screen -dmS telegram telegram serve --notifications-dir ~/vesta/notifications"})
+		os.Exit(1)
+	}
+	fmt.Println(string(output))
+	os.Exit(exitCode)
+}
+
+func executeCommand(command string, args []string, tc *TelegramClient) (interface{}, error) {
+	if tc.readOnly {
+		writeCommands := map[string]bool{
+			"send-message": true, "send-file": true, "send-reaction": true,
+		}
+		if writeCommands[command] {
+			return nil, fmt.Errorf("command %q blocked: instance is read-only", command)
+		}
+	}
+
+	switch command {
+	case "list-contacts":
+		var query string
+		var limit int
+		fs := flag.NewFlagSet("list-contacts", flag.ContinueOnError)
+		fs.StringVar(&query, "query", "", "Optional search query")
+		fs.IntVar(&limit, "limit", 50, "Max results")
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		contacts, err := tc.store.SearchContacts(query, limit)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"contacts": contacts}, nil
+
+	case "add-contact":
+		var name, chatIDStr, username string
+		fs := flag.NewFlagSet("add-contact", flag.ContinueOnError)
+		fs.StringVar(&name, "name", "", "Contact name")
+		fs.StringVar(&chatIDStr, "chat-id", "", "Telegram chat ID")
+		fs.StringVar(&username, "username", "", "Telegram @username (optional)")
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		if name == "" || chatIDStr == "" {
+			return nil, fmt.Errorf("--name and --chat-id are required")
+		}
+		chatID, err := strconv.ParseInt(chatIDStr, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid chat ID: %s", chatIDStr)
+		}
+		contact, err := tc.store.SaveManualContact(name, chatID, username)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"contact": contact}, nil
+
+	case "remove-contact":
+		var identifier string
+		fs := flag.NewFlagSet("remove-contact", flag.ContinueOnError)
+		fs.StringVar(&identifier, "identifier", "", "Contact name or username")
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		if identifier == "" {
+			return nil, fmt.Errorf("--identifier is required")
+		}
+		if err := tc.store.DeleteManualContact(identifier); err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"success": true, "message": "Contact removed"}, nil
+
+	case "list-messages":
+		var to, after, before, sender, query string
+		var limit, page int
+		fs := flag.NewFlagSet("list-messages", flag.ContinueOnError)
+		fs.StringVar(&to, "to", "", "Chat filter (contact name, username, or chat ID)")
+		fs.StringVar(&after, "after", "", "ISO-8601 datetime")
+		fs.StringVar(&before, "before", "", "ISO-8601 datetime")
+		fs.StringVar(&sender, "sender", "", "Filter by sender name")
+		fs.StringVar(&query, "query", "", "Search query")
+		fs.IntVar(&limit, "limit", 50, "Max results")
+		fs.IntVar(&page, "page", 0, "Page number")
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+
+		var afterTime, beforeTime *time.Time
+		if after != "" {
+			t, err := time.Parse(time.RFC3339, after)
+			if err != nil {
+				return nil, fmt.Errorf("invalid --after timestamp (expected RFC3339): %v", err)
+			}
+			afterTime = &t
+		}
+		if before != "" {
+			t, err := time.Parse(time.RFC3339, before)
+			if err != nil {
+				return nil, fmt.Errorf("invalid --before timestamp (expected RFC3339): %v", err)
+			}
+			beforeTime = &t
+		}
+
+		var chatID int64
+		if to != "" {
+			resolved, err := tc.store.ResolveRecipient(to)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve chat: %v", err)
+			}
+			chatID = resolved
+		}
+
+		messages, err := tc.store.ListMessages(
+			afterTime, beforeTime,
+			sender, chatID, query,
+			limit, page*limit,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"messages": messages}, nil
+
+	case "list-chats":
+		var query, sortBy string
+		var limit, page int
+		var includeLastMessage bool
+		fs := flag.NewFlagSet("list-chats", flag.ContinueOnError)
+		fs.StringVar(&query, "query", "", "Search query")
+		fs.IntVar(&limit, "limit", 50, "Max results")
+		fs.IntVar(&page, "page", 0, "Page number")
+		fs.BoolVar(&includeLastMessage, "include-last-message", false, "Include last message")
+		fs.StringVar(&sortBy, "sort-by", "last_active", "Sort by (last_active or name)")
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		chats, err := tc.store.ListChats(query, limit, page*limit, includeLastMessage, sortBy)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"chats": chats}, nil
+
+	case "send-message":
+		var to, message string
+		fs := flag.NewFlagSet("send-message", flag.ContinueOnError)
+		fs.StringVar(&to, "to", "", "Recipient (name, username, or chat ID)")
+		fs.StringVar(&message, "message", "", "Message text")
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		if to == "" || message == "" {
+			return nil, fmt.Errorf("--to and --message are required")
+		}
+
+		chatID, err := tc.store.ResolveRecipient(to)
+		if err != nil {
+			return nil, err
+		}
+
+		msgID, err := tc.SendMessage(chatID, message)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"success": true, "message_id": msgID, "message": "Message sent successfully"}, nil
+
+	case "send-file":
+		var to, filePath, caption string
+		fs := flag.NewFlagSet("send-file", flag.ContinueOnError)
+		fs.StringVar(&to, "to", "", "Recipient")
+		fs.StringVar(&filePath, "file-path", "", "Path to file")
+		fs.StringVar(&caption, "caption", "", "Optional caption")
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		if to == "" || filePath == "" {
+			return nil, fmt.Errorf("--to and --file-path are required")
+		}
+
+		chatID, err := tc.store.ResolveRecipient(to)
+		if err != nil {
+			return nil, err
+		}
+
+		msgID, err := tc.SendFile(chatID, filePath, caption)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"success": true, "message_id": msgID, "message": "File sent successfully"}, nil
+
+	case "send-reaction":
+		var to, messageIDStr, emoji string
+		fs := flag.NewFlagSet("send-reaction", flag.ContinueOnError)
+		fs.StringVar(&to, "to", "", "Chat")
+		fs.StringVar(&messageIDStr, "message-id", "", "Message ID")
+		fs.StringVar(&emoji, "emoji", "", "Emoji")
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		if to == "" || messageIDStr == "" || emoji == "" {
+			return nil, fmt.Errorf("--to, --message-id, and --emoji are required")
+		}
+
+		chatID, err := tc.store.ResolveRecipient(to)
+		if err != nil {
+			return nil, err
+		}
+
+		msgID, err := strconv.Atoi(messageIDStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid message ID: %s", messageIDStr)
+		}
+
+		if err := tc.SendReaction(chatID, msgID, emoji); err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"success": true, "message": "Reaction sent"}, nil
+
+	case "download-media":
+		var fileID, downloadPath string
+		fs := flag.NewFlagSet("download-media", flag.ContinueOnError)
+		fs.StringVar(&fileID, "file-id", "", "Telegram file ID")
+		fs.StringVar(&downloadPath, "download-path", "", "Save path")
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		if fileID == "" {
+			return nil, fmt.Errorf("--file-id is required")
+		}
+
+		path, err := tc.DownloadFile(fileID, downloadPath)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"success": true, "file_path": path, "message": "File downloaded"}, nil
+
+	case "list-groups":
+		var limit, page int
+		fs := flag.NewFlagSet("list-groups", flag.ContinueOnError)
+		fs.IntVar(&limit, "limit", 50, "Max results")
+		fs.IntVar(&page, "page", 0, "Page number")
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		groups, err := tc.store.ListGroups(limit, page*limit)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"groups": groups}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown command: %s", command)
+	}
+}

--- a/agent/skills/telegram/cli/go.mod
+++ b/agent/skills/telegram/cli/go.mod
@@ -1,0 +1,9 @@
+module telegram
+
+go 1.24.0
+
+require (
+	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
+	github.com/google/uuid v1.6.0
+	github.com/mattn/go-sqlite3 v1.14.34
+)

--- a/agent/skills/telegram/cli/go.sum
+++ b/agent/skills/telegram/cli/go.sum
@@ -1,0 +1,6 @@
+github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
+github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/mattn/go-sqlite3 v1.14.34 h1:3NtcvcUnFBPsuRcno8pUtupspG/GM+9nZ88zgJcp6Zk=
+github.com/mattn/go-sqlite3 v1.14.34/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/agent/skills/telegram/cli/main.go
+++ b/agent/skills/telegram/cli/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "Usage: telegram <command> [args] [flags]")
+		fmt.Fprintln(os.Stderr, "Commands (short aliases in parentheses):")
+		fmt.Fprintln(os.Stderr, "  send-message (send) [to] [message]   send-file (file) [to] [path]")
+		fmt.Fprintln(os.Stderr, "  list-messages (messages) [to]        send-reaction (react) [to] [id] [emoji]")
+		fmt.Fprintln(os.Stderr, "  list-chats (chats)                   list-contacts (contacts)")
+		fmt.Fprintln(os.Stderr, "  list-groups (groups)                 add-contact [name] [chat-id]")
+		fmt.Fprintln(os.Stderr, "  remove-contact [identifier]")
+		fmt.Fprintln(os.Stderr, "  serve  authenticate")
+		os.Exit(1)
+	}
+
+	command := os.Args[1]
+	os.Args = append(os.Args[:1], os.Args[2:]...)
+
+	aliases := map[string]string{
+		"send":     "send-message",
+		"messages": "list-messages",
+		"chats":    "list-chats",
+		"contacts": "list-contacts",
+		"groups":   "list-groups",
+		"file":     "send-file",
+		"react":    "send-reaction",
+	}
+	if canon, ok := aliases[command]; ok {
+		command = canon
+	}
+
+	for i := range os.Args {
+		os.Args[i] = strings.ReplaceAll(os.Args[i], `\!`, `!`)
+	}
+
+	positionalSpecs := map[string][]string{
+		"send-message":   {"to", "message"},
+		"list-messages":  {"to"},
+		"send-file":      {"to", "file-path"},
+		"send-reaction":  {"to", "message-id", "emoji"},
+		"add-contact":    {"name", "chat-id"},
+		"remove-contact": {"identifier"},
+	}
+	if spec, ok := positionalSpecs[command]; ok {
+		remaining := os.Args[1:]
+		var positionals []string
+		i := 0
+		for i < len(remaining) && i < len(spec) && !strings.HasPrefix(remaining[i], "-") {
+			positionals = append(positionals, remaining[i])
+			i++
+		}
+		if len(positionals) > 0 {
+			var injected []string
+			for j, val := range positionals {
+				injected = append(injected, "--"+spec[j], val)
+			}
+			os.Args = append([]string{os.Args[0]}, append(injected, remaining[i:]...)...)
+		}
+	}
+
+	switch command {
+	case "serve":
+		runServe()
+	case "authenticate":
+		runAuthenticate()
+	default:
+		runOneShot(command)
+	}
+}

--- a/agent/skills/telegram/cli/notifications.go
+++ b/agent/skills/telegram/cli/notifications.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type messageNotif struct {
+	Source      string `json:"source"`
+	Type        string `json:"type"`
+	Instance    string `json:"instance,omitempty"`
+	ContactName string `json:"contact_name,omitempty"`
+	Message     string `json:"message"`
+	Sender      string `json:"sender,omitempty"`
+	ChatName    string `json:"chat_name,omitempty"`
+	Username    string `json:"username,omitempty"`
+	MediaType   string `json:"media_type,omitempty"`
+	ReplyToID   int64  `json:"reply_to_id,omitempty"`
+	Timestamp   string `json:"timestamp"`
+	MessageID   int64  `json:"message_id,omitempty"`
+	ContactSaved bool  `json:"contact_saved"`
+	Note        string `json:"note,omitempty"`
+}
+
+type reactionNotif struct {
+	Source      string `json:"source"`
+	Type        string `json:"type"`
+	Instance    string `json:"instance,omitempty"`
+	ContactName string `json:"contact_name,omitempty"`
+	Emoji       string `json:"emoji,omitempty"`
+	Sender      string `json:"sender,omitempty"`
+	ChatName    string `json:"chat_name,omitempty"`
+	Username    string `json:"username,omitempty"`
+	IsRemoved   bool   `json:"is_removed"`
+	Timestamp   string `json:"timestamp"`
+	TargetMessageID int64 `json:"target_message_id"`
+	ContactSaved bool  `json:"contact_saved"`
+	Note        string `json:"note,omitempty"`
+}
+
+func WriteNotification(
+	notifDir string, messageID int64, chatName, contactName, username, instance string,
+	contactSaved, isDirectChat bool,
+	sender, content, mediaType string,
+	replyToID int64,
+) error {
+	if notifDir == "" {
+		return nil
+	}
+
+	if err := os.MkdirAll(notifDir, 0755); err != nil {
+		return fmt.Errorf("failed to create notifications dir: %v", err)
+	}
+
+	notif := messageNotif{
+		Source:       "telegram",
+		Type:         "message",
+		Instance:     instance,
+		ContactName:  contactName,
+		Message:      content,
+		Username:     username,
+		MediaType:    mediaType,
+		ReplyToID:    replyToID,
+		Timestamp:    time.Now().Format(time.RFC3339),
+		MessageID:    messageID,
+		ContactSaved: contactSaved,
+	}
+	if !isDirectChat {
+		notif.Sender = sender
+		notif.ChatName = chatName
+	}
+	if !contactSaved && isDirectChat && instance == "" {
+		notif.Note = "Unknown contact. Ask the user who this is and add them as a contact once you know."
+	}
+
+	data, err := json.MarshalIndent(notif, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal notification: %v", err)
+	}
+
+	filename := fmt.Sprintf("%s-telegram-message.json", uuid.New().String())
+	return os.WriteFile(filepath.Join(notifDir, filename), data, 0644)
+}
+
+func WriteReactionNotification(
+	notifDir string, targetMessageID int64, chatName, contactName, username, instance string,
+	contactSaved, isDirectChat bool,
+	sender, emoji string, isRemoved bool,
+) error {
+	if notifDir == "" {
+		return nil
+	}
+
+	if err := os.MkdirAll(notifDir, 0755); err != nil {
+		return fmt.Errorf("failed to create notifications dir: %v", err)
+	}
+
+	notif := reactionNotif{
+		Source:          "telegram",
+		Type:            "reaction",
+		Instance:        instance,
+		ContactName:     contactName,
+		Emoji:           emoji,
+		Username:        username,
+		IsRemoved:       isRemoved,
+		Timestamp:       time.Now().Format(time.RFC3339),
+		TargetMessageID: targetMessageID,
+		ContactSaved:    contactSaved,
+	}
+	if !isDirectChat {
+		notif.Sender = sender
+		notif.ChatName = chatName
+	}
+	if !contactSaved && isDirectChat && instance == "" {
+		notif.Note = "Unknown contact. Ask the user who this is and add them as a contact once you know."
+	}
+
+	data, err := json.MarshalIndent(notif, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal reaction notification: %v", err)
+	}
+
+	filename := fmt.Sprintf("%s-telegram-reaction.json", uuid.New().String())
+	return os.WriteFile(filepath.Join(notifDir, filename), data, 0644)
+}

--- a/agent/skills/telegram/cli/server.go
+++ b/agent/skills/telegram/cli/server.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+type SocketRequest struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+}
+
+type SocketResponse struct {
+	Result interface{} `json:"result,omitempty"`
+	Error  string      `json:"error,omitempty"`
+}
+
+func startSocketServer(sockPath string, tc *TelegramClient) (net.Listener, error) {
+	os.Remove(sockPath)
+
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %s: %v", sockPath, err)
+	}
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go handleSocketConn(conn, tc)
+		}
+	}()
+
+	return listener, nil
+}
+
+func stopSocketServer(listener net.Listener, sockPath string) {
+	listener.Close()
+	os.Remove(sockPath)
+}
+
+func handleSocketConn(conn net.Conn, tc *TelegramClient) {
+	defer conn.Close()
+	defer func() {
+		if r := recover(); r != nil {
+			json.NewEncoder(conn).Encode(SocketResponse{Error: fmt.Sprintf("internal error: %v", r)})
+		}
+	}()
+
+	conn.SetDeadline(time.Now().Add(5 * time.Minute))
+
+	var req SocketRequest
+	if err := json.NewDecoder(conn).Decode(&req); err != nil {
+		json.NewEncoder(conn).Encode(SocketResponse{Error: fmt.Sprintf("invalid request: %v", err)})
+		return
+	}
+
+	result, err := executeCommand(req.Command, req.Args, tc)
+
+	var resp SocketResponse
+	if err != nil {
+		resp.Error = err.Error()
+	} else {
+		resp.Result = result
+	}
+
+	json.NewEncoder(conn).Encode(resp)
+}
+
+func trySocketCommand(sockPath string, command string, args []string) ([]byte, int, bool) {
+	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
+	if err != nil {
+		return nil, 0, false
+	}
+	defer conn.Close()
+
+	conn.SetDeadline(time.Now().Add(5 * time.Minute))
+
+	if err := json.NewEncoder(conn).Encode(SocketRequest{Command: command, Args: args}); err != nil {
+		return nil, 0, false
+	}
+
+	var resp SocketResponse
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		return nil, 0, false
+	}
+
+	if resp.Error != "" {
+		data, _ := json.MarshalIndent(map[string]interface{}{"error": resp.Error}, "", "  ")
+		return data, 1, true
+	}
+
+	data, _ := json.MarshalIndent(resp.Result, "", "  ")
+	return data, 0, true
+}

--- a/agent/skills/telegram/cli/storage.go
+++ b/agent/skills/telegram/cli/storage.go
@@ -1,0 +1,667 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type MessageStore struct {
+	db *sql.DB
+}
+
+func NewMessageStore(dataDir string) (*MessageStore, error) {
+	dbPath := filepath.Join(dataDir, "messages.db")
+
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create data directory: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=on")
+	if err != nil {
+		return nil, fmt.Errorf("failed to open message database: %v", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS chats (
+			id INTEGER PRIMARY KEY,
+			name TEXT,
+			chat_type TEXT DEFAULT 'private',
+			last_message_time TIMESTAMP
+		);
+
+		CREATE TABLE IF NOT EXISTS messages (
+			id INTEGER PRIMARY KEY,
+			chat_id INTEGER,
+			sender TEXT,
+			content TEXT,
+			timestamp TIMESTAMP,
+			is_from_me BOOLEAN,
+			media_type TEXT,
+			filename TEXT,
+			file_id TEXT,
+			reply_to_id INTEGER,
+			FOREIGN KEY (chat_id) REFERENCES chats(id)
+		);
+
+		CREATE TABLE IF NOT EXISTS contacts (
+			chat_id INTEGER PRIMARY KEY,
+			name TEXT,
+			username TEXT,
+			added_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages(timestamp);
+		CREATE INDEX IF NOT EXISTS idx_messages_sender ON messages(sender);
+		CREATE INDEX IF NOT EXISTS idx_messages_chat ON messages(chat_id);
+		CREATE INDEX IF NOT EXISTS idx_contacts_name ON contacts(name);
+		CREATE INDEX IF NOT EXISTS idx_contacts_username ON contacts(username);
+	`)
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to create tables: %v", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+			content, chat_name, sender
+		);
+
+		CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+			INSERT INTO messages_fts(rowid, content, chat_name, sender)
+			VALUES (new.rowid, new.content,
+				(SELECT name FROM chats WHERE id = new.chat_id),
+				new.sender);
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
+			DELETE FROM messages_fts WHERE rowid = old.rowid;
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS chats_au AFTER UPDATE OF name ON chats BEGIN
+			DELETE FROM messages_fts WHERE rowid IN (
+				SELECT rowid FROM messages WHERE chat_id = new.id
+			);
+			INSERT INTO messages_fts(rowid, content, chat_name, sender)
+			SELECT m.rowid, m.content, new.name, m.sender
+			FROM messages m WHERE m.chat_id = new.id;
+		END;
+	`)
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to create FTS index: %v", err)
+	}
+
+	ms := &MessageStore{db: db}
+	if err := ms.rebuildFTS(); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return ms, nil
+}
+
+func (ms *MessageStore) Close() error {
+	return ms.db.Close()
+}
+
+func (ms *MessageStore) rebuildFTS() error {
+	var count int
+	if err := ms.db.QueryRow("SELECT COUNT(*) FROM messages_fts").Scan(&count); err != nil {
+		return fmt.Errorf("failed to check FTS index: %v", err)
+	}
+	if count > 0 {
+		return nil
+	}
+	var msgCount int
+	if err := ms.db.QueryRow("SELECT COUNT(*) FROM messages").Scan(&msgCount); err != nil {
+		return fmt.Errorf("failed to count messages: %v", err)
+	}
+	if msgCount == 0 {
+		return nil
+	}
+	_, err := ms.db.Exec(`
+		INSERT INTO messages_fts(rowid, content, chat_name, sender)
+		SELECT m.rowid, m.content,
+			(SELECT name FROM chats WHERE id = m.chat_id),
+			m.sender
+		FROM messages m
+		WHERE m.content IS NOT NULL AND m.content != ''
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to rebuild FTS index: %v", err)
+	}
+	return nil
+}
+
+func (ms *MessageStore) StoreChat(chatID int64, name, chatType string, lastMessageTime time.Time) error {
+	_, err := ms.db.Exec(`
+		INSERT INTO chats (id, name, chat_type, last_message_time)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			name = COALESCE(excluded.name, chats.name),
+			chat_type = COALESCE(excluded.chat_type, chats.chat_type),
+			last_message_time = CASE
+				WHEN excluded.last_message_time > chats.last_message_time
+				THEN excluded.last_message_time
+				ELSE chats.last_message_time
+			END
+	`, chatID, name, chatType, lastMessageTime)
+	return err
+}
+
+func (ms *MessageStore) StoreMessage(
+	msgID, chatID int64, sender, content string,
+	timestamp time.Time, isFromMe bool,
+	mediaType, filename, fileID string,
+	replyToID int64,
+) error {
+	_, err := ms.db.Exec(`
+		INSERT OR REPLACE INTO messages (
+			id, chat_id, sender, content, timestamp,
+			is_from_me, media_type, filename, file_id, reply_to_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, msgID, chatID, sender, content, timestamp, isFromMe,
+		mediaType, filename, fileID, replyToID)
+	return err
+}
+
+func (ms *MessageStore) GetChatName(chatID int64) (string, error) {
+	var name sql.NullString
+	err := ms.db.QueryRow("SELECT name FROM chats WHERE id = ?", chatID).Scan(&name)
+	if err != nil {
+		return "", err
+	}
+	return name.String, nil
+}
+
+func (ms *MessageStore) SearchContacts(query string, limit int) ([]Contact, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+
+	contacts := make([]Contact, 0, limit)
+	seen := make(map[int64]struct{})
+	lowerQuery := strings.ToLower(query)
+	likeName := "%" + lowerQuery + "%"
+
+	// Manual contacts first
+	rows, err := ms.db.Query(`
+		SELECT chat_id, name, username
+		FROM contacts
+		WHERE LOWER(COALESCE(name, '')) LIKE ? OR LOWER(COALESCE(username, '')) LIKE ?
+		ORDER BY LOWER(COALESCE(name, username))
+		LIMIT ?
+	`, likeName, likeName, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		if len(contacts) >= limit {
+			break
+		}
+		var c Contact
+		var name, username sql.NullString
+		if err := rows.Scan(&c.ChatID, &name, &username); err != nil {
+			continue
+		}
+		c.Name = name.String
+		c.Username = username.String
+		c.IsManual = true
+		contacts = append(contacts, c)
+		seen[c.ChatID] = struct{}{}
+	}
+
+	if len(contacts) >= limit {
+		return contacts, nil
+	}
+
+	// Then chats
+	remaining := limit - len(contacts)
+	chatRows, err := ms.db.Query(`
+		SELECT id, name, chat_type
+		FROM chats
+		WHERE chat_type = 'private'
+		AND LOWER(COALESCE(name, '')) LIKE ?
+		ORDER BY LOWER(COALESCE(name, ''))
+		LIMIT ?
+	`, likeName, remaining*2)
+	if err != nil {
+		return contacts, err
+	}
+	defer chatRows.Close()
+
+	for chatRows.Next() {
+		if len(contacts) >= limit {
+			break
+		}
+		var chatID int64
+		var name sql.NullString
+		var chatType string
+		if err := chatRows.Scan(&chatID, &name, &chatType); err != nil {
+			continue
+		}
+		if _, exists := seen[chatID]; exists {
+			continue
+		}
+		contacts = append(contacts, Contact{
+			ChatID: chatID,
+			Name:   name.String,
+		})
+		seen[chatID] = struct{}{}
+	}
+
+	return contacts, nil
+}
+
+func (ms *MessageStore) SaveManualContact(name string, chatID int64, username string) (Contact, error) {
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" {
+		return Contact{}, fmt.Errorf("contact name cannot be empty")
+	}
+	_, err := ms.db.Exec(`
+		INSERT INTO contacts (chat_id, name, username, added_at, updated_at)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		ON CONFLICT(chat_id) DO UPDATE SET
+			name = excluded.name,
+			username = excluded.username,
+			updated_at = CURRENT_TIMESTAMP
+	`, chatID, trimmedName, username)
+	if err != nil {
+		return Contact{}, fmt.Errorf("failed to save contact: %v", err)
+	}
+	return Contact{
+		ChatID:   chatID,
+		Name:     trimmedName,
+		Username: username,
+		IsManual: true,
+	}, nil
+}
+
+func (ms *MessageStore) GetManualContact(chatID int64) (*Contact, error) {
+	var name, username sql.NullString
+	err := ms.db.QueryRow(`
+		SELECT name, username FROM contacts WHERE chat_id = ?
+	`, chatID).Scan(&name, &username)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &Contact{
+		ChatID:   chatID,
+		Name:     name.String,
+		Username: username.String,
+		IsManual: true,
+	}, nil
+}
+
+func (ms *MessageStore) DeleteManualContact(identifier string) error {
+	result, err := ms.db.Exec(`DELETE FROM contacts WHERE name = ?`, identifier)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check delete result: %v", err)
+	}
+	if rows > 0 {
+		return nil
+	}
+
+	// Try by username
+	result, err = ms.db.Exec(`DELETE FROM contacts WHERE username = ?`, strings.TrimPrefix(identifier, "@"))
+	if err != nil {
+		return err
+	}
+	rows, err = result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check delete result: %v", err)
+	}
+	if rows > 0 {
+		return nil
+	}
+
+	return fmt.Errorf("contact not found: %s", identifier)
+}
+
+func (ms *MessageStore) ListMessages(
+	after, before *time.Time,
+	sender string, chatID int64, query string,
+	limit, offset int,
+) ([]Message, error) {
+	if query != "" {
+		messages, err := ms.listMessagesFTS(after, before, sender, chatID, query, limit, offset)
+		if err == nil {
+			return messages, nil
+		}
+	}
+	return ms.listMessagesLike(after, before, sender, chatID, query, limit, offset)
+}
+
+func (ms *MessageStore) listMessagesFTS(
+	after, before *time.Time,
+	sender string, chatID int64, query string,
+	limit, offset int,
+) ([]Message, error) {
+	qb := strings.Builder{}
+	qb.WriteString(`
+		SELECT
+			m.id, m.chat_id, c.name, m.sender, m.content,
+			m.timestamp, m.is_from_me, m.media_type, m.filename, m.reply_to_id
+		FROM messages m
+		JOIN chats c ON m.chat_id = c.id
+		JOIN messages_fts ON messages_fts.rowid = m.rowid
+		WHERE messages_fts MATCH ?
+	`)
+	args := []interface{}{query}
+
+	if after != nil {
+		qb.WriteString(" AND m.timestamp >= ?")
+		args = append(args, *after)
+	}
+	if before != nil {
+		qb.WriteString(" AND m.timestamp <= ?")
+		args = append(args, *before)
+	}
+	if sender != "" {
+		qb.WriteString(" AND m.sender LIKE ?")
+		args = append(args, "%"+sender+"%")
+	}
+	if chatID != 0 {
+		qb.WriteString(" AND m.chat_id = ?")
+		args = append(args, chatID)
+	}
+
+	qb.WriteString(" ORDER BY m.timestamp DESC LIMIT ? OFFSET ?")
+	args = append(args, limit, offset)
+
+	return ms.scanMessages(ms.db.Query(qb.String(), args...))
+}
+
+func (ms *MessageStore) listMessagesLike(
+	after, before *time.Time,
+	sender string, chatID int64, query string,
+	limit, offset int,
+) ([]Message, error) {
+	qb := strings.Builder{}
+	qb.WriteString(`
+		SELECT
+			m.id, m.chat_id, c.name, m.sender, m.content,
+			m.timestamp, m.is_from_me, m.media_type, m.filename, m.reply_to_id
+		FROM messages m
+		JOIN chats c ON m.chat_id = c.id
+		WHERE 1=1
+	`)
+	args := []interface{}{}
+
+	if after != nil {
+		qb.WriteString(" AND m.timestamp >= ?")
+		args = append(args, *after)
+	}
+	if before != nil {
+		qb.WriteString(" AND m.timestamp <= ?")
+		args = append(args, *before)
+	}
+	if sender != "" {
+		qb.WriteString(" AND m.sender LIKE ?")
+		args = append(args, "%"+sender+"%")
+	}
+	if chatID != 0 {
+		qb.WriteString(" AND m.chat_id = ?")
+		args = append(args, chatID)
+	}
+	if query != "" {
+		qb.WriteString(" AND m.content LIKE ?")
+		args = append(args, "%"+query+"%")
+	}
+
+	qb.WriteString(" ORDER BY m.timestamp DESC LIMIT ? OFFSET ?")
+	args = append(args, limit, offset)
+
+	return ms.scanMessages(ms.db.Query(qb.String(), args...))
+}
+
+func (ms *MessageStore) scanMessages(rows *sql.Rows, err error) ([]Message, error) {
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var messages []Message
+	for rows.Next() {
+		var m Message
+		var chatName, mediaType, filename sql.NullString
+		var replyToID sql.NullInt64
+		if err := rows.Scan(
+			&m.ID, &m.ChatID, &chatName, &m.Sender, &m.Content,
+			&m.Timestamp, &m.IsFromMe, &mediaType, &filename, &replyToID,
+		); err != nil {
+			continue
+		}
+		m.ChatName = chatName.String
+		m.MediaType = mediaType.String
+		m.Filename = filename.String
+		if replyToID.Valid {
+			m.ReplyToID = replyToID.Int64
+		}
+		messages = append(messages, m)
+	}
+	return messages, nil
+}
+
+func (ms *MessageStore) ListChats(
+	query string,
+	limit, offset int,
+	includeLastMessage bool,
+	sortBy string,
+) ([]Chat, error) {
+	qb := strings.Builder{}
+
+	if includeLastMessage {
+		qb.WriteString(`
+			SELECT
+				c.id, c.name, c.chat_type, c.last_message_time,
+				m.content, m.sender, m.is_from_me
+			FROM chats c
+			LEFT JOIN messages m ON c.id = m.chat_id
+				AND c.last_message_time = m.timestamp
+		`)
+	} else {
+		qb.WriteString(`
+			SELECT
+				c.id, c.name, c.chat_type, c.last_message_time,
+				NULL, NULL, NULL
+			FROM chats c
+		`)
+	}
+
+	args := []interface{}{}
+	if query != "" {
+		qb.WriteString(" WHERE c.name LIKE ?")
+		args = append(args, "%"+query+"%")
+	}
+
+	if sortBy == "name" {
+		qb.WriteString(" ORDER BY c.name")
+	} else {
+		qb.WriteString(" ORDER BY c.last_message_time DESC")
+	}
+
+	qb.WriteString(" LIMIT ? OFFSET ?")
+	args = append(args, limit, offset)
+
+	rows, err := ms.db.Query(qb.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var chats []Chat
+	for rows.Next() {
+		var c Chat
+		var name, lastMsg, lastSender sql.NullString
+		var chatType sql.NullString
+		var lastTime sql.NullTime
+		var lastIsFromMe sql.NullBool
+
+		if err := rows.Scan(
+			&c.ID, &name, &chatType, &lastTime,
+			&lastMsg, &lastSender, &lastIsFromMe,
+		); err != nil {
+			continue
+		}
+
+		c.Name = name.String
+		c.ChatType = chatType.String
+		if lastTime.Valid {
+			c.LastMessageTime = lastTime.Time
+		}
+		c.LastMessage = lastMsg.String
+		c.LastSender = lastSender.String
+		c.LastIsFromMe = lastIsFromMe.Bool
+
+		chats = append(chats, c)
+	}
+
+	return chats, nil
+}
+
+func (ms *MessageStore) ListGroups(limit, offset int) ([]Chat, error) {
+	rows, err := ms.db.Query(`
+		SELECT
+			c.id, c.name, c.chat_type, c.last_message_time,
+			m.content, m.sender, m.is_from_me
+		FROM chats c
+		LEFT JOIN messages m ON c.id = m.chat_id
+			AND c.last_message_time = m.timestamp
+		WHERE c.chat_type IN ('group', 'supergroup')
+		ORDER BY c.last_message_time DESC
+		LIMIT ? OFFSET ?
+	`, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var groups []Chat
+	for rows.Next() {
+		var c Chat
+		var name, lastMsg, lastSender sql.NullString
+		var chatType sql.NullString
+		var lastTime sql.NullTime
+		var lastIsFromMe sql.NullBool
+
+		if err := rows.Scan(
+			&c.ID, &name, &chatType, &lastTime,
+			&lastMsg, &lastSender, &lastIsFromMe,
+		); err != nil {
+			continue
+		}
+
+		c.Name = name.String
+		c.ChatType = chatType.String
+		if lastTime.Valid {
+			c.LastMessageTime = lastTime.Time
+		}
+		c.LastMessage = lastMsg.String
+		c.LastSender = lastSender.String
+		c.LastIsFromMe = lastIsFromMe.Bool
+
+		groups = append(groups, c)
+	}
+
+	return groups, nil
+}
+
+// ResolveRecipient resolves a contact identifier to a chat ID.
+// Accepts: numeric chat ID, @username, or contact name.
+func (ms *MessageStore) ResolveRecipient(identifier string) (int64, error) {
+	identifier = strings.TrimSpace(identifier)
+
+	// Try as numeric chat ID
+	if chatID, err := parseInt64(identifier); err == nil {
+		return chatID, nil
+	}
+
+	// Try as @username
+	username := strings.TrimPrefix(identifier, "@")
+	var chatID int64
+	err := ms.db.QueryRow(`SELECT chat_id FROM contacts WHERE LOWER(username) = LOWER(?)`, username).Scan(&chatID)
+	if err == nil {
+		return chatID, nil
+	}
+
+	// Try as contact name (exact match first)
+	err = ms.db.QueryRow(`SELECT chat_id FROM contacts WHERE LOWER(name) = LOWER(?)`, identifier).Scan(&chatID)
+	if err == nil {
+		return chatID, nil
+	}
+
+	// Try as chat name
+	err = ms.db.QueryRow(`SELECT id FROM chats WHERE LOWER(name) = LOWER(?)`, identifier).Scan(&chatID)
+	if err == nil {
+		return chatID, nil
+	}
+
+	// Fuzzy match on contact name
+	var matches []struct {
+		chatID int64
+		name   string
+	}
+	rows, err := ms.db.Query(`
+		SELECT chat_id, name FROM contacts
+		WHERE LOWER(name) LIKE LOWER(?)
+		LIMIT 5
+	`, "%"+identifier+"%")
+	if err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			var m struct {
+				chatID int64
+				name   string
+			}
+			if rows.Scan(&m.chatID, &m.name) == nil {
+				matches = append(matches, m)
+			}
+		}
+	}
+
+	if len(matches) == 1 {
+		return matches[0].chatID, nil
+	}
+	if len(matches) > 1 {
+		var names []string
+		for _, m := range matches {
+			names = append(names, m.name)
+		}
+		return 0, fmt.Errorf("ambiguous recipient %q — matches: %s", identifier, strings.Join(names, ", "))
+	}
+
+	return 0, fmt.Errorf("recipient not found: %s. Add them as a contact first with: telegram add-contact <name> <chat-id>", identifier)
+}
+
+func parseInt64(s string) (int64, error) {
+	var n int64
+	for _, c := range s {
+		if c == '-' && n == 0 {
+			continue
+		}
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("not a number")
+		}
+		n = n*10 + int64(c-'0')
+	}
+	if len(s) > 0 && s[0] == '-' {
+		n = -n
+	}
+	return n, nil
+}

--- a/agent/skills/telegram/cli/telegram.go
+++ b/agent/skills/telegram/cli/telegram.go
@@ -1,0 +1,417 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+const (
+	MaxFileSizeBytes = 50 * 1024 * 1024 // 50 MB (Telegram bot limit)
+	MaxMessageLength = 4096
+)
+
+type TelegramClient struct {
+	bot              *tgbotapi.BotAPI
+	store            *MessageStore
+	dataDir          string
+	notificationsDir string
+	instance         string
+	readOnly         bool
+	skipSenders      map[string]bool
+	botUserID        int64
+	token            string
+	mu               sync.RWMutex
+}
+
+func NewTelegramClient(dataDir, notificationsDir, instance string, readOnly bool, skipSenders map[string]bool) (*TelegramClient, error) {
+	store, err := NewMessageStore(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize message store: %v", err)
+	}
+
+	tokenPath := filepath.Join(dataDir, "bot-token")
+	tokenBytes, err := os.ReadFile(tokenPath)
+	if err != nil {
+		store.Close()
+		return nil, fmt.Errorf("bot token not found at %s — run 'telegram authenticate' first", tokenPath)
+	}
+	token := strings.TrimSpace(string(tokenBytes))
+	if token == "" {
+		store.Close()
+		return nil, fmt.Errorf("bot token is empty — run 'telegram authenticate' to set it")
+	}
+
+	bot, err := tgbotapi.NewBotAPI(token)
+	if err != nil {
+		store.Close()
+		return nil, fmt.Errorf("failed to authenticate with Telegram: %v", err)
+	}
+
+	tc := &TelegramClient{
+		bot:              bot,
+		store:            store,
+		dataDir:          dataDir,
+		notificationsDir: notificationsDir,
+		instance:         instance,
+		readOnly:         readOnly,
+		skipSenders:      skipSenders,
+		botUserID:        int64(bot.Self.ID),
+		token:            token,
+	}
+
+	return tc, nil
+}
+
+func (tc *TelegramClient) StartPolling() {
+	updateConfig := tgbotapi.NewUpdate(0)
+	updateConfig.Timeout = 30
+	// Note: message_reaction requires Bot API 7.0+; the library will pass it through
+	// even if it doesn't have native struct support
+	updateConfig.AllowedUpdates = []string{"message"}
+
+	updates := tc.bot.GetUpdatesChan(updateConfig)
+
+	log.Printf("Bot @%s started polling for updates", tc.bot.Self.UserName)
+
+	for update := range updates {
+		if update.Message != nil {
+			tc.handleMessage(update.Message)
+		}
+	}
+}
+
+func (tc *TelegramClient) Stop() {
+	tc.bot.StopReceivingUpdates()
+	tc.store.Close()
+}
+
+func (tc *TelegramClient) handleMessage(msg *tgbotapi.Message) {
+	content := msg.Text
+	if content == "" {
+		content = msg.Caption
+	}
+
+	mediaType := ""
+	filename := ""
+	fileID := ""
+
+	if msg.Photo != nil && len(msg.Photo) > 0 {
+		mediaType = "photo"
+		fileID = msg.Photo[len(msg.Photo)-1].FileID
+	} else if msg.Document != nil {
+		mediaType = "document"
+		filename = msg.Document.FileName
+		fileID = msg.Document.FileID
+	} else if msg.Audio != nil {
+		mediaType = "audio"
+		filename = msg.Audio.FileName
+		fileID = msg.Audio.FileID
+	} else if msg.Voice != nil {
+		mediaType = "voice"
+		fileID = msg.Voice.FileID
+	} else if msg.Video != nil {
+		mediaType = "video"
+		filename = msg.Video.FileName
+		fileID = msg.Video.FileID
+	} else if msg.VideoNote != nil {
+		mediaType = "video_note"
+		fileID = msg.VideoNote.FileID
+	} else if msg.Sticker != nil {
+		mediaType = "sticker"
+		fileID = msg.Sticker.FileID
+		if content == "" {
+			content = msg.Sticker.Emoji
+		}
+	} else if msg.Location != nil {
+		mediaType = "location"
+		content = fmt.Sprintf("Location: %.6f, %.6f", msg.Location.Latitude, msg.Location.Longitude)
+	} else if msg.Contact != nil {
+		mediaType = "contact"
+		content = fmt.Sprintf("Contact: %s %s (%s)", msg.Contact.FirstName, msg.Contact.LastName, msg.Contact.PhoneNumber)
+	}
+
+	// Store file ID for later download
+	_ = fileID
+
+	if content == "" && mediaType == "" {
+		return
+	}
+
+	senderName := formatSenderName(msg.From)
+	username := ""
+	if msg.From != nil {
+		username = msg.From.UserName
+	}
+
+	chatName := msg.Chat.Title
+	if chatName == "" && msg.Chat.FirstName != "" {
+		chatName = strings.TrimSpace(msg.Chat.FirstName + " " + msg.Chat.LastName)
+	}
+
+	chatType := string(msg.Chat.Type)
+	isFromMe := msg.From != nil && int64(msg.From.ID) == tc.botUserID
+	isDirectChat := msg.Chat.Type == "private"
+	timestamp := msg.Time()
+
+	var replyToID int64
+	if msg.ReplyToMessage != nil {
+		replyToID = int64(msg.ReplyToMessage.MessageID)
+	}
+
+	// Store chat
+	if err := tc.store.StoreChat(msg.Chat.ID, chatName, chatType, timestamp); err != nil {
+		log.Printf("Failed to store chat: %v", err)
+	}
+
+	// Store message
+	if err := tc.store.StoreMessage(
+		int64(msg.MessageID), msg.Chat.ID, senderName, content,
+		timestamp, isFromMe, mediaType, filename, fileID, replyToID,
+	); err != nil {
+		log.Printf("Failed to store message: %v", err)
+	}
+
+	// Write notification for incoming messages
+	if tc.notificationsDir != "" && !isFromMe {
+		contactName := ""
+		contactSaved := false
+		if contact, _ := tc.store.GetManualContact(msg.Chat.ID); contact != nil {
+			contactName = contact.Name
+			contactSaved = true
+		}
+		if contactName == "" {
+			contactName = senderName
+		}
+
+		senderPhone := ""
+		if msg.From != nil {
+			senderPhone = strconv.FormatInt(int64(msg.From.ID), 10)
+		}
+
+		if !tc.skipSenders[senderPhone] && !tc.skipSenders[username] {
+			WriteNotification(
+				tc.notificationsDir,
+				int64(msg.MessageID),
+				chatName,
+				contactName,
+				username,
+				tc.instance,
+				contactSaved,
+				isDirectChat,
+				senderName,
+				content,
+				mediaType,
+				replyToID,
+			)
+		}
+	}
+}
+
+func (tc *TelegramClient) SendMessage(recipientID int64, text string) (int64, error) {
+	// Split long messages
+	if len(text) > MaxMessageLength {
+		chunks := splitMessage(text, MaxMessageLength)
+		var lastID int64
+		for i, chunk := range chunks {
+			prefix := ""
+			if len(chunks) > 1 {
+				prefix = fmt.Sprintf("(%d/%d) ", i+1, len(chunks))
+			}
+			msg := tgbotapi.NewMessage(recipientID, prefix+chunk)
+			msg.ParseMode = "Markdown"
+			sent, err := tc.bot.Send(msg)
+			if err != nil {
+				// Retry without parse mode
+				msg.ParseMode = ""
+				sent, err = tc.bot.Send(msg)
+				if err != nil {
+					return 0, fmt.Errorf("failed to send message: %v", err)
+				}
+			}
+			lastID = int64(sent.MessageID)
+
+			// Record outgoing
+			chatName, _ := tc.store.GetChatName(recipientID)
+			tc.store.StoreChat(recipientID, chatName, "private", time.Now())
+			tc.store.StoreMessage(lastID, recipientID, tc.bot.Self.UserName, prefix+chunk, time.Now(), true, "", "", "", 0)
+		}
+		return lastID, nil
+	}
+
+	msg := tgbotapi.NewMessage(recipientID, text)
+	msg.ParseMode = "Markdown"
+	sent, err := tc.bot.Send(msg)
+	if err != nil {
+		// Retry without parse mode
+		msg.ParseMode = ""
+		sent, err = tc.bot.Send(msg)
+		if err != nil {
+			return 0, fmt.Errorf("failed to send message: %v", err)
+		}
+	}
+
+	msgID := int64(sent.MessageID)
+	chatName, _ := tc.store.GetChatName(recipientID)
+	tc.store.StoreChat(recipientID, chatName, "private", time.Now())
+	tc.store.StoreMessage(msgID, recipientID, tc.bot.Self.UserName, text, time.Now(), true, "", "", "", 0)
+
+	return msgID, nil
+}
+
+func (tc *TelegramClient) SendFile(recipientID int64, filePath, caption string) (int64, error) {
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return 0, fmt.Errorf("file not found: %s", filePath)
+	}
+	if fileInfo.Size() > MaxFileSizeBytes {
+		return 0, fmt.Errorf("file too large: %d MB (max %d MB)",
+			fileInfo.Size()/(1024*1024), MaxFileSizeBytes/(1024*1024))
+	}
+
+	file := tgbotapi.FilePath(filePath)
+	doc := tgbotapi.NewDocument(recipientID, file)
+	if caption != "" {
+		doc.Caption = caption
+	}
+
+	sent, err := tc.bot.Send(doc)
+	if err != nil {
+		return 0, fmt.Errorf("failed to send file: %v", err)
+	}
+
+	msgID := int64(sent.MessageID)
+	chatName, _ := tc.store.GetChatName(recipientID)
+	tc.store.StoreChat(recipientID, chatName, "private", time.Now())
+	tc.store.StoreMessage(msgID, recipientID, tc.bot.Self.UserName, caption, time.Now(), true, "document", filepath.Base(filePath), "", 0)
+
+	return msgID, nil
+}
+
+// SendReaction sends an emoji reaction to a message via raw Bot API call.
+func (tc *TelegramClient) SendReaction(chatID int64, messageID int, emoji string) error {
+	payload := map[string]interface{}{
+		"chat_id":    chatID,
+		"message_id": messageID,
+		"reaction": []map[string]string{
+			{"type": "emoji", "emoji": emoji},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal reaction: %v", err)
+	}
+
+	url := fmt.Sprintf("https://api.telegram.org/bot%s/setMessageReaction", tc.token)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to send reaction: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		OK          bool   `json:"ok"`
+		Description string `json:"description"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("failed to decode response: %v", err)
+	}
+	if !result.OK {
+		return fmt.Errorf("telegram API error: %s", result.Description)
+	}
+	return nil
+}
+
+// DownloadFile downloads a file from Telegram by its file_id.
+func (tc *TelegramClient) DownloadFile(fileID, downloadPath string) (string, error) {
+	file, err := tc.bot.GetFile(tgbotapi.FileConfig{FileID: fileID})
+	if err != nil {
+		return "", fmt.Errorf("failed to get file info: %v", err)
+	}
+
+	link := file.Link(tc.token)
+
+	if downloadPath == "" {
+		downloadPath = filepath.Join(os.TempDir(), filepath.Base(file.FilePath))
+	}
+
+	resp, err := http.Get(link)
+	if err != nil {
+		return "", fmt.Errorf("failed to download file: %v", err)
+	}
+	defer resp.Body.Close()
+
+	outFile, err := os.Create(downloadPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create output file: %v", err)
+	}
+	defer outFile.Close()
+
+	if _, err := io.Copy(outFile, resp.Body); err != nil {
+		return "", fmt.Errorf("failed to write file: %v", err)
+	}
+
+	return downloadPath, nil
+}
+
+func (tc *TelegramClient) writeAuthStatusFile(data map[string]string) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		log.Printf("Failed to marshal auth status: %v", err)
+		return
+	}
+	if err := os.WriteFile(filepath.Join(tc.dataDir, "auth-status.json"), b, 0644); err != nil {
+		log.Printf("Failed to write auth status file: %v", err)
+	}
+}
+
+func formatSenderName(user *tgbotapi.User) string {
+	if user == nil {
+		return "Unknown"
+	}
+	name := strings.TrimSpace(user.FirstName + " " + user.LastName)
+	if name == "" {
+		if user.UserName != "" {
+			return "@" + user.UserName
+		}
+		return "Unknown"
+	}
+	return name
+}
+
+func splitMessage(text string, maxLen int) []string {
+	if len(text) <= maxLen {
+		return []string{text}
+	}
+
+	var chunks []string
+	for len(text) > 0 {
+		if len(text) <= maxLen {
+			chunks = append(chunks, text)
+			break
+		}
+		// Try to split at newline
+		splitAt := strings.LastIndex(text[:maxLen], "\n")
+		if splitAt < maxLen/2 {
+			// Try space
+			splitAt = strings.LastIndex(text[:maxLen], " ")
+		}
+		if splitAt < maxLen/4 {
+			splitAt = maxLen
+		}
+		chunks = append(chunks, text[:splitAt])
+		text = text[splitAt:]
+	}
+	return chunks
+}

--- a/agent/skills/telegram/cli/types.go
+++ b/agent/skills/telegram/cli/types.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"time"
+)
+
+type Message struct {
+	ID        int64     `json:"id"`
+	ChatID    int64     `json:"-"`
+	ChatName  string    `json:"chat_name,omitempty"`
+	Sender    string    `json:"sender"`
+	Content   string    `json:"content"`
+	Timestamp time.Time `json:"timestamp"`
+	IsFromMe  bool      `json:"is_from_me"`
+	MediaType string    `json:"media_type,omitempty"`
+	Filename  string    `json:"filename,omitempty"`
+	ReplyToID int64     `json:"reply_to_id,omitempty"`
+}
+
+type Chat struct {
+	ID              int64     `json:"id"`
+	Name            string    `json:"name,omitempty"`
+	ChatType        string    `json:"chat_type"` // "private", "group", "supergroup", "channel"
+	LastMessageTime time.Time `json:"last_message_time,omitempty"`
+	LastMessage     string    `json:"last_message,omitempty"`
+	LastSender      string    `json:"last_sender,omitempty"`
+	LastIsFromMe    bool      `json:"last_is_from_me,omitempty"`
+}
+
+type Contact struct {
+	ChatID   int64  `json:"chat_id"`
+	Name     string `json:"name,omitempty"`
+	Username string `json:"username,omitempty"`
+	IsManual bool   `json:"is_manual,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Adds Telegram skill with Go daemon mirroring WhatsApp architecture (Unix socket IPC, SQLite+FTS5 storage, JSON notification files)
- Uses Telegram Bot API via `go-telegram-bot-api/v5` with long polling
- Auth is trivial: paste a bot token from @BotFather (no QR/phone needed)
- Full CLI: `send`, `chats`, `messages`, `contacts`, `groups`, `send-file`, `react`, `download-media`

## Test plan
- [ ] Build: `cd agent/skills/telegram/cli && CGO_ENABLED=1 CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" CGO_LDFLAGS="-lm" go build -o telegram .`
- [ ] Authenticate: `telegram authenticate --token <token>`
- [ ] Start daemon: `telegram serve --notifications-dir /tmp/notifs`
- [ ] Send message: `telegram send <chat_id> "test"`
- [ ] Verify notifications written to dir on incoming message

🤖 Generated with [Claude Code](https://claude.com/claude-code)