### PR TITLE
fix(whatsapp): use temp file hosting for QR code instead of local HTTP server

### DIFF
--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -24,11 +24,11 @@
    **Before showing the QR code**, confirm with the user that they should scan it from a dedicated WhatsApp account for the assistant — NOT their personal WhatsApp. This can be a throwaway phone with a new SIM, a work profile (Android) WhatsApp with an eSIM, or any separate number. Scanning from their personal account would link their own WhatsApp to Vesta and she'd be reading/sending from their personal chats.
 
    If not authenticated, a QR code image is saved to `~/vesta/data/whatsapp/qr-code.png`.
-   Serve it on any available port (host network is shared):
+   Upload it to a temporary hosting service so the user can open it from any device:
    ```bash
-   screen -dmS qr-server bash -c 'cd ~/vesta/data/whatsapp && uv run python3 -m http.server 8888'
+   curl -sF 'reqtype=fileupload' -F 'time=1h' -F 'fileToUpload=@~/vesta/data/whatsapp/qr-code.png' https://litterbox.catbox.moe/resources/internals/api.php
    ```
-   Tell the user to open `http://localhost:8888/qr-code.png` and scan immediately.
+   This returns a URL (e.g. `https://litter.catbox.moe/abc123.png`) that expires in 1 hour. Send the link to the user and tell them to open it and scan immediately.
 
    **QR codes expire in ~20 seconds.** Warn the user to have WhatsApp ready before opening the link.
 
@@ -37,8 +37,6 @@
    sleep 10 && whatsapp authenticate
    ```
    **NEVER restart the daemon after the user has scanned** — restarting invalidates the session. If `authenticate` still says not authenticated, wait longer and check again (up to 30 seconds). Only restart the daemon if the user confirms they didn't scan in time or the QR visually expired.
-
-   Kill the HTTP server once authenticated: `screen -S qr-server -X quit`
 5. Add to `~/vesta/prompts/restart.md`:
    ```
    screen -dmS whatsapp whatsapp serve --notifications-dir ~/vesta/notifications


### PR DESCRIPTION
## Summary
- Replace local `python3 -m http.server` with a `curl` upload to litterbox.catbox.moe for serving the WhatsApp QR code during setup
- The uploaded file gets a public URL that expires in 1 hour, which the agent sends to the user
- Fixes WhatsApp setup when Vesta runs on a remote server where `localhost:8888` isn't accessible to the user

## Test plan
- [ ] Run WhatsApp setup on a remote Vesta instance and verify the litterbox URL is returned and accessible
- [ ] Verify QR code can be scanned from the hosted URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)