### PR TITLE
feat(vestad): move entrypoint and env from Dockerfile to docker run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,3 @@ RUN git clone --bare --single-branch https://github.com/elyxlz/vesta.git .git &&
 RUN rm -f /usr/bin/pkill /usr/bin/killall
 
 ENV HOME=/root
-ENV IS_SANDBOX=1
-ENTRYPOINT ["uv", "run", "--project", "/root/vesta", "python", "-m", "vesta.main"]

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -42,6 +42,8 @@ pub const OAUTH_REDIRECT_URI: &str = "https://console.anthropic.com/oauth/code/c
 pub const OAUTH_TOKEN_URL: &str = "https://api.anthropic.com/v1/oauth/token";
 pub const OAUTH_AUTHORIZE_URL: &str = "https://claude.ai/oauth/authorize";
 
+const ENTRYPOINT: &[&str] = &["uv", "run", "--project", "/root/vesta", "python", "-m", "vesta.main"];
+
 #[derive(PartialEq, Clone, Copy)]
 pub enum ContainerStatus {
     Running,
@@ -497,6 +499,7 @@ pub fn create_container(cname: &str, image: &str, port: u16, agent_name: &str) -
         "--label", &user_label,
         "-e", &ws_port_env,
         "-e", &agent_name_env,
+        "-e", "IS_SANDBOX=1",
     ];
 
     match gpu_available() {
@@ -513,6 +516,7 @@ pub fn create_container(cname: &str, image: &str, port: u16, agent_name: &str) -
     }
 
     args.push(image);
+    args.extend(ENTRYPOINT);
     if !docker_ok(&args) {
         return Err(DockerError::Failed("failed to create container".into()));
     }


### PR DESCRIPTION
## Summary
- Removes `ENTRYPOINT` and `ENV IS_SANDBOX=1` from `Dockerfile` — the image is now a plain build artifact with no runtime config
- `create_container` in vestad now passes `IS_SANDBOX=1` as `-e` and appends the entrypoint command after the image
- Updating vestad + `vesta rebuild` now picks up any changes to env vars or entrypoint without rebuilding the Docker image

## Test plan
- [x] `cargo clippy` clean
- [x] `cargo test -p vestad` — 19/19 unit tests pass
- [ ] Create agent, verify it starts with the entrypoint passed via docker run
- [ ] Rebuild existing agent, verify IS_SANDBOX=1 is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)