### PR TITLE
fix(cli): fix chat command panic and broken WebSocket messaging

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -44,7 +44,7 @@ pub fn chat(client: &Client, name: &str) -> Result<(), String> {
 
     loop {
         if let Ok(input) = rx.try_recv() {
-            let msg = serde_json::json!({"type": "message", "content": input});
+            let msg = serde_json::json!({"type": "message", "text": input});
             if socket
                 .send(tungstenite::Message::Text(msg.to_string().into()))
                 .is_err()
@@ -56,7 +56,7 @@ pub fn chat(client: &Client, name: &str) -> Result<(), String> {
         match socket.read() {
             Ok(tungstenite::Message::Text(text)) => {
                 if let Ok(msg) = serde_json::from_str::<serde_json::Value>(text.as_ref()) {
-                    if let Some(content) = msg["content"].as_str() {
+                    if let Some(content) = msg["text"].as_str() {
                         print!("{}", content);
                         std::io::stdout().flush().ok();
                     }

--- a/vesta-common/src/client.rs
+++ b/vesta-common/src/client.rs
@@ -7,6 +7,7 @@ use crate::{AuthFlowResponse, ListEntry, ServerConfig, StartAllResult, StatusJso
 // ── TLS fingerprint verification ────────────────────────────────
 
 fn make_rustls_config(fingerprint: Option<String>) -> Arc<rustls::ClientConfig> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
     Arc::new(
         rustls::ClientConfig::builder()
             .dangerous()


### PR DESCRIPTION
## Summary
- Fix panic in `vesta chat` caused by missing rustls `CryptoProvider` — `install_default()` before building TLS config
- Fix send/receive field name mismatch: CLI used `"content"` but server expects/sends `"text"`

## Test plan
- [x] `vesta chat <name>` no longer panics
- [x] WebSocket connects successfully through vestad proxy
- [x] Message field names match server protocol (`"text"`)
- [x] `cargo build` / `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)