### PR TITLE
feat(docker): use inclusion list for default skills

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,13 +9,6 @@ __pycache__/
 agent/tests/
 agent/skills/generate-index.py
 agent/skills/index.json
-agent/skills/google
-agent/skills/keeper
-agent/skills/microsoft
-agent/skills/onedrive
-agent/skills/whatsapp
-agent/skills/whisper
-agent/skills/zoom
 app/
 cli/
 vestad/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,14 @@ COPY agent/src ./src
 COPY agent/prompts ./prompts
 RUN uv sync --frozen
 
-# Everything else (non-core skills excluded via .dockerignore)
+# Everything else
 COPY agent/ .
+
+# Remove non-default skills (keep only those listed in default-skills.txt)
+RUN for d in skills/*/; do \
+      name="$(basename "$d")"; \
+      grep -qx "$name" skills/default-skills.txt || rm -rf "$d"; \
+    done && rm -f skills/default-skills.txt
 
 # SDK discovers skills from .claude/skills/ relative to cwd
 RUN mkdir -p .claude && ln -s ../skills .claude/skills

--- a/agent/skills/default-skills.txt
+++ b/agent/skills/default-skills.txt
@@ -1,0 +1,9 @@
+banking
+browser
+dream
+flights
+reminders
+skills-registry
+tasks
+upstream
+what-day


### PR DESCRIPTION
## Summary
- Replace per-skill `.dockerignore` exclusions with a `default-skills.txt` inclusion list in `agent/skills/`
- Add a Dockerfile `RUN` step that removes any skill directory not listed in `default-skills.txt`, then deletes the list file itself
- New skills added to the repo are excluded from the Docker image by default — no `.dockerignore` update needed, just add to `default-skills.txt` when ready

## Test plan
- [ ] Build Docker image and verify only the listed skills are present
- [ ] Add a new skill directory and confirm it is excluded without any config change
- [ ] Confirm existing default skills (banking, browser, dream, flights, reminders, skills-registry, tasks, upstream, what-day) are present in the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)