### PR TITLE
feat(agent): compact context after nightly dream

### DIFF
--- a/agent/prompts/dream.md
+++ b/agent/prompts/dream.md
@@ -1,1 +1,1 @@
-Time to dream. Read the `dream` skill and follow it. When this is done, the system restarts you with fresh memory.
+Time to dream. Read the `dream` skill and follow it. When you finish, your context will be compacted and the system will restart — your session is preserved, so conversation continuity remains.

--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -34,6 +34,8 @@ from vesta.events import SubagentStartEvent, SubagentStopEvent, StreamEvent
 
 
 def _build_query(prompt: str, *, timestamp: dt.datetime) -> str:
+    if prompt.startswith("/"):
+        return prompt
     timestamp_str = timestamp.strftime("%A, %B %d, %Y at %I:%M:%S %p %Z")
     return f"[Current time: {timestamp_str}]\n{prompt}"
 

--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -217,8 +217,11 @@ async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm
 
                 if state.dreamer_active:
                     state.dreamer_active = False
-                    state.event_bus.clear_history()
-                    _trigger_nightly_restart(state=state, config=config)
+                    logger.dreamer("Dreamer complete, running /compact...")
+                    await _process_interruptible("/compact", is_user=False, queue=queue, state=state, config=config)
+                    logger.dreamer("Compact complete, triggering nightly restart (session preserved)...")
+                    state.restart_reason = "nightly — dreamer ran, context compacted"
+                    state.graceful_shutdown.set()
         finally:
             state.client = None
             state.interrupt_event = None
@@ -234,14 +237,6 @@ async def check_proactive_task(queue: asyncio.Queue[tuple[str, bool]], *, config
         return
     logger.proactive(f"Running {config.proactive_check_interval}-minute check...")
     await queue.put((prompt, False))
-
-
-def _trigger_nightly_restart(*, state: vm.State, config: vm.VestaConfig) -> None:
-    logger.dreamer("Dreamer complete, triggering nightly restart...")
-    state.session_id = None
-    config.session_file.unlink(missing_ok=True)
-    state.restart_reason = "nightly — conversation history reset, dreamer ran"
-    state.graceful_shutdown.set()
 
 
 async def process_nightly_memory(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.State, config: vm.VestaConfig) -> None:

--- a/agent/tests/test_unit.py
+++ b/agent/tests/test_unit.py
@@ -376,7 +376,7 @@ async def test_dreamer_skips_when_already_run_today(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_dreamer_triggers_automatic_restart(tmp_path):
+async def test_dreamer_compacts_and_restarts(tmp_path):
     async def side_effect(msg, *, state, config, is_user):
         return (["OK"], state)
 
@@ -392,9 +392,25 @@ async def test_dreamer_triggers_automatic_restart(tmp_path):
         initial_queue=[("dreamer prompt content", False)],
         extra_patches={"vesta.core.loops._now": lambda: fake_now},
     )
-    assert state.session_id is None
+    assert state.session_id == "pre-dreamer-session"
     assert state.dreamer_active is False
     assert state.graceful_shutdown.is_set()
+    assert state.restart_reason == "nightly — dreamer ran, context compacted"
+    assert messages == ["dreamer prompt content", "/compact"]
+
+
+def test_build_query_passes_slash_commands_through():
+    from vesta.core.client import _build_query
+
+    result = _build_query("/compact", timestamp=dt.datetime(2025, 6, 15, 12, 0, 0))
+    assert result == "/compact"
+
+    result = _build_query("/clear some args", timestamp=dt.datetime(2025, 6, 15, 12, 0, 0))
+    assert result == "/clear some args"
+
+    result = _build_query("hello world", timestamp=dt.datetime(2025, 6, 15, 12, 0, 0))
+    assert "[Current time:" in result
+    assert "hello world" in result
 
 
 # --- Interrupt tests ---
@@ -884,23 +900,6 @@ async def test_drain_timeout_does_not_block_forever():
 
     # Must exit within drain timeout (5s) + some margin, not hang for 60s
     assert elapsed < 8.0, f"converse took {elapsed:.1f}s — drain blocked too long"
-
-
-# --- Nightly restart ---
-
-
-def test_nightly_restart(tmp_path):
-    from vesta.core.loops import _trigger_nightly_restart
-
-    config = vm.VestaConfig(root=tmp_path)
-    config.data_dir.mkdir(parents=True, exist_ok=True)
-
-    state = vm.State(session_id="old-session")
-    _trigger_nightly_restart(state=state, config=config)
-
-    assert state.session_id is None
-    assert state.restart_reason == "nightly — conversation history reset, dreamer ran"
-    assert state.graceful_shutdown.is_set()
 
 
 # --- History store ---


### PR DESCRIPTION
## Summary
- After the nightly dreamer runs, send `/compact` to compress the conversation history instead of wiping the session
- Preserve `session_id` and `session_file` so the agent resumes with compacted context on restart
- Skip timestamp prefix in `_build_query` for slash commands so `/compact` is recognized by the CLI
- Remove `_trigger_nightly_restart` helper and `event_bus.clear_history()` call

## Test plan
- [x] `test_dreamer_compacts_and_restarts` — verifies dream → `/compact` → graceful shutdown with session preserved
- [x] `test_build_query_passes_slash_commands_through` — verifies slash commands bypass timestamp prefix
- [x] Full test suite passes (45/45)

🤖 Generated with [Claude Code](https://claude.com/claude-code)