### PR TITLE
feat(vestad): embed Cloudflare credentials at build time and add info command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,10 @@ jobs:
 
       - name: Build vestad
         working-directory: .
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
         run: |
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build --release -p vestad --target ${{ matrix.target }}

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,6 @@
+[build.env]
+passthrough = [
+    "CLOUDFLARE_API_TOKEN",
+    "CLOUDFLARE_ACCOUNT_ID",
+    "CLOUDFLARE_ZONE_ID",
+]

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.108"
+version = "0.1.109"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -71,6 +71,18 @@ fn config_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(home).join(".config/vesta")
 }
 
+fn print_server_info(tunnel_url: Option<&str>, local_url: &str, api_key: &str) {
+    eprintln!();
+    if let Some(url) = tunnel_url {
+        eprintln!("  \x1b[36mhost\x1b[0m    \x1b[1m{}\x1b[0m", url);
+        eprintln!("  \x1b[36mlocal\x1b[0m   \x1b[2m{}\x1b[0m", local_url);
+    } else {
+        eprintln!("  \x1b[36mhost\x1b[0m    \x1b[1m{}\x1b[0m", local_url);
+    }
+    eprintln!("  \x1b[36mkey\x1b[0m     \x1b[33m{}\x1b[0m", api_key);
+    eprintln!();
+}
+
 fn main() {
     rustls::crypto::ring::default_provider()
         .install_default()
@@ -111,15 +123,7 @@ fn main() {
 
             eprintln!();
             eprintln!("  \x1b[1;35mvestad\x1b[0m v{}", env!("CARGO_PKG_VERSION"));
-            eprintln!();
-            if let Some(ref url) = tunnel_url {
-                eprintln!("  \x1b[36mhost\x1b[0m    \x1b[1m{}\x1b[0m", url);
-                eprintln!("  \x1b[36mlocal\x1b[0m   \x1b[2m{}\x1b[0m", local_url);
-            } else {
-                eprintln!("  \x1b[36mhost\x1b[0m    \x1b[1m{}\x1b[0m", local_url);
-            }
-            eprintln!("  \x1b[36mkey\x1b[0m     \x1b[33m{}\x1b[0m", api_key);
-            eprintln!();
+            print_server_info(tunnel_url.as_deref(), &local_url, &api_key);
 
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -204,15 +208,10 @@ fn main() {
                 _ => die("no port file found — is vestad running?"),
             };
 
-            eprintln!();
-            if let Some(tc) = tunnel::get_tunnel_config(&config) {
-                eprintln!("  \x1b[36mhost\x1b[0m    \x1b[1mhttps://{}\x1b[0m", tc.hostname);
-                eprintln!("  \x1b[36mlocal\x1b[0m   \x1b[2m{}\x1b[0m", local_url);
-            } else {
-                eprintln!("  \x1b[36mhost\x1b[0m    \x1b[1m{}\x1b[0m", local_url);
-            }
-            eprintln!("  \x1b[36mkey\x1b[0m     \x1b[33m{}\x1b[0m", api_key);
-            eprintln!();
+            let tunnel_url = tunnel::get_tunnel_config(&config)
+                .map(|tc| format!("https://{}", tc.hostname));
+
+            print_server_info(tunnel_url.as_deref(), &local_url, &api_key);
         }
 
         Command::Update => {

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -199,19 +199,19 @@ fn main() {
                 _ => die("no API key found — has vestad been started?"),
             };
 
-            let host = if let Some(tc) = tunnel::get_tunnel_config(&config) {
-                format!("https://{}", tc.hostname)
-            } else {
-                let port = match std::fs::read_to_string(config.join("port")) {
-                    Ok(p) => p.trim().to_string(),
-                    _ => die("no port file found — is vestad running?"),
-                };
-                format!("https://localhost:{}", port)
+            let local_url = match std::fs::read_to_string(config.join("port")) {
+                Ok(p) => format!("https://localhost:{}", p.trim()),
+                _ => die("no port file found — is vestad running?"),
             };
 
             eprintln!();
-            eprintln!("  \x1b[36mhost\x1b[0m  \x1b[1m{}\x1b[0m", host);
-            eprintln!("  \x1b[36mkey\x1b[0m   \x1b[33m{}\x1b[0m", api_key);
+            if let Some(tc) = tunnel::get_tunnel_config(&config) {
+                eprintln!("  \x1b[36mhost\x1b[0m    \x1b[1mhttps://{}\x1b[0m", tc.hostname);
+                eprintln!("  \x1b[36mlocal\x1b[0m   \x1b[2m{}\x1b[0m", local_url);
+            } else {
+                eprintln!("  \x1b[36mhost\x1b[0m    \x1b[1m{}\x1b[0m", local_url);
+            }
+            eprintln!("  \x1b[36mkey\x1b[0m     \x1b[33m{}\x1b[0m", api_key);
             eprintln!();
         }
 

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -35,6 +35,8 @@ enum Command {
         #[command(subcommand)]
         action: TunnelAction,
     },
+    /// Print host URL and API key for client connections
+    Info,
     /// Update vestad to the latest version
     Update,
 }
@@ -187,6 +189,30 @@ fn main() {
                         .unwrap_or_else(|e| die(e));
                 }
             }
+        }
+
+        Command::Info => {
+            let config = config_dir();
+
+            let api_key = match std::fs::read_to_string(config.join("api-key")) {
+                Ok(k) if !k.trim().is_empty() => k.trim().to_string(),
+                _ => die("no API key found — has vestad been started?"),
+            };
+
+            let host = if let Some(tc) = tunnel::get_tunnel_config(&config) {
+                format!("https://{}", tc.hostname)
+            } else {
+                let port = match std::fs::read_to_string(config.join("port")) {
+                    Ok(p) => p.trim().to_string(),
+                    _ => die("no port file found — is vestad running?"),
+                };
+                format!("https://localhost:{}", port)
+            };
+
+            eprintln!();
+            eprintln!("  \x1b[36mhost\x1b[0m  \x1b[1m{}\x1b[0m", host);
+            eprintln!("  \x1b[36mkey\x1b[0m   \x1b[33m{}\x1b[0m", api_key);
+            eprintln!();
         }
 
         Command::Update => {

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -19,12 +19,18 @@ struct CloudflareEnv {
 }
 
 fn cf_env() -> Result<CloudflareEnv, String> {
-    let api_token = std::env::var("CLOUDFLARE_API_TOKEN")
-        .map_err(|_| "CLOUDFLARE_API_TOKEN env var not set")?;
-    let account_id = std::env::var("CLOUDFLARE_ACCOUNT_ID")
-        .map_err(|_| "CLOUDFLARE_ACCOUNT_ID env var not set")?;
-    let zone_id = std::env::var("CLOUDFLARE_ZONE_ID")
-        .map_err(|_| "CLOUDFLARE_ZONE_ID env var not set")?;
+    let api_token = option_env!("CLOUDFLARE_API_TOKEN")
+        .map(String::from)
+        .or_else(|| std::env::var("CLOUDFLARE_API_TOKEN").ok())
+        .ok_or("CLOUDFLARE_API_TOKEN not set (build-time or env)")?;
+    let account_id = option_env!("CLOUDFLARE_ACCOUNT_ID")
+        .map(String::from)
+        .or_else(|| std::env::var("CLOUDFLARE_ACCOUNT_ID").ok())
+        .ok_or("CLOUDFLARE_ACCOUNT_ID not set (build-time or env)")?;
+    let zone_id = option_env!("CLOUDFLARE_ZONE_ID")
+        .map(String::from)
+        .or_else(|| std::env::var("CLOUDFLARE_ZONE_ID").ok())
+        .ok_or("CLOUDFLARE_ZONE_ID not set (build-time or env)")?;
     Ok(CloudflareEnv { api_token, account_id, zone_id })
 }
 


### PR DESCRIPTION
## Summary
- Use `option_env!()` in `tunnel.rs` to embed Cloudflare API credentials (token, account ID, zone ID) into the vestad binary at compile time, with runtime env var fallback
- Add `vestad info` subcommand that prints the host URL and API key for client connections
- Pass Cloudflare secrets to the CI `Build vestad` step and through cross-compilation via `Cross.toml`

## Test plan
- [x] `cargo build -p vestad` compiles successfully
- [ ] CI passes (clippy, tests, cross-compilation)
- [ ] `vestad info` prints host and key when vestad has been started
- [ ] Release builds embed credentials via CI secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)