### PR TITLE
fix: prevent false crash detection on self-restart

### DIFF
--- a/agent/src/vesta/main.py
+++ b/agent/src/vesta/main.py
@@ -94,6 +94,7 @@ async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: boo
         state.shutdown_event.set()
 
     logger.shutdown("Shutting down...")
+    _write_restart_reason(config, state.restart_reason or CLEAN_RESTART)
 
     for task in tasks:
         task.cancel()
@@ -103,7 +104,6 @@ async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: boo
         logger.shutdown("Shutdown timed out (SDK cleanup hung), forcing exit")
         os._exit(1)
     await ws_runner.cleanup()
-    _write_restart_reason(config, state.restart_reason or CLEAN_RESTART)
     logger.shutdown("sweet dreams!")
 
 

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.109"
+version = "0.1.110"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },


### PR DESCRIPTION
## Summary
- Move `_write_restart_reason()` before task cancellation in the shutdown sequence
- When `restart_vesta` sends SIGTERM, the SDK cleanup hangs (tool call still in-flight), the 5s timeout fires `os._exit(1)`, and the restart reason file is never written — so the next startup sees no file and reports a crash

## Test plan
- [x] Unit tests pass (45/45)
- [ ] Trigger `restart_vesta` tool and verify greeting says "clean restart" not "crash"

🤖 Generated with [Claude Code](https://claude.com/claude-code)