### PR TITLE
feat(vestad): add structured logging with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +901,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +945,15 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -1082,6 +1115,23 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"
@@ -1301,6 +1351,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +1480,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1578,9 +1646,11 @@ dependencies = [
  "bitflags",
  "bytes",
  "http",
+ "http-body",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1603,7 +1673,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1613,6 +1695,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1751,6 +1863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +1926,8 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tower-http",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.109"
+version = "0.1.110"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/vestad/Cargo.toml
+++ b/vestad/Cargo.toml
@@ -17,7 +17,9 @@ axum = { version = "0.8", features = ["ws"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "io-util", "process", "sync", "time", "fs", "net"] }
 tokio-tungstenite = "0.26"
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 rcgen = "0.13"
 ring = "0.17"

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -509,12 +509,10 @@ pub fn create_container(cname: &str, image: &str, port: u16, agent_name: &str) -
     match gpu_available() {
         GpuStatus::Ready => {
             args.extend(["--gpus", "all"]);
-            eprintln!("GPU detected, enabling passthrough");
+            tracing::info!("GPU detected, enabling passthrough");
         }
         GpuStatus::NoRuntime => {
-            eprintln!("warning: NVIDIA GPU detected but nvidia-container-toolkit is not installed.");
-            eprintln!("         install it to enable GPU passthrough:");
-            eprintln!("         https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html");
+            tracing::warn!("NVIDIA GPU detected but nvidia-container-toolkit is not installed. Install it to enable GPU passthrough: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html");
         }
         GpuStatus::NoGpu => {}
     }

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -85,6 +85,14 @@ fn print_server_info(tunnel_url: Option<&str>, local_url: &str, api_key: &str) {
 }
 
 fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_target(false)
+        .init();
+
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("failed to install crypto provider");
@@ -108,7 +116,7 @@ fn main() {
                 match tunnel::ensure_tunnel(&config) {
                     Ok(tc) => Some(format!("https://{}", tc.hostname)),
                     Err(e) => {
-                        eprintln!("warning: tunnel setup failed ({}), running without tunnel", e);
+                        tracing::warn!("tunnel setup failed: {e}, running without tunnel");
                         None
                     }
                 }
@@ -134,7 +142,7 @@ fn main() {
                                 Some(child)
                             }
                             Err(e) => {
-                                eprintln!("warning: failed to start tunnel: {}", e);
+                                tracing::warn!("failed to start tunnel: {e}");
                                 None
                             }
                         }
@@ -226,7 +234,7 @@ fn main() {
             let tmp = format!("/tmp/vestad-update-{}", std::process::id());
             std::fs::create_dir_all(&tmp).ok();
 
-            eprintln!("downloading update...");
+            tracing::info!("downloading update...");
             let status = std::process::Command::new("curl")
                 .args(["-fsSL", "-o", &format!("{}/{}", tmp, archive), &url])
                 .status();
@@ -246,7 +254,7 @@ fn main() {
                 .unwrap_or_else(|e| die(format!("failed to replace binary: {}", e)));
 
             std::fs::remove_dir_all(&tmp).ok();
-            eprintln!("updated. restart vestad to use new version.");
+            tracing::info!("updated — restart vestad to use new version");
         }
     }
 }

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -340,6 +340,7 @@ async fn create_agent_handler(
         return Err(err_response(StatusCode::BAD_REQUEST, "invalid agent name"));
     }
     let build = body.build.unwrap_or(false);
+    tracing::info!(name = %name, build, "creating agent");
 
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
@@ -367,6 +368,7 @@ async fn start_agent_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    tracing::info!(name = %name, "starting agent");
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
 
@@ -398,6 +400,7 @@ async fn stop_agent_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    tracing::info!(name = %name, "stopping agent");
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
 
@@ -412,6 +415,7 @@ async fn restart_agent_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    tracing::info!(name = %name, "restarting agent");
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
 
@@ -426,6 +430,7 @@ async fn destroy_agent_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    tracing::info!(name = %name, "destroying agent");
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
 
@@ -441,6 +446,7 @@ async fn rebuild_agent_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    tracing::info!(name = %name, "rebuilding agent");
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
 
@@ -628,6 +634,7 @@ async fn ws_handler(
     Path(name): Path<String>,
     ws: WebSocketUpgrade,
 ) -> Result<Response, (StatusCode, Json<serde_json::Value>)> {
+    tracing::debug!(name = %name, "websocket connection");
     docker::validate_name(&name).map_err(map_docker_err)?;
     let cname = docker::container_name(&name);
 
@@ -652,6 +659,7 @@ async fn ws_proxy(client_ws: axum::extract::ws::WebSocket, agent_port: u16) {
     let agent_ws = match tokio_tungstenite::connect_async(&url).await {
         Ok((ws, _)) => ws,
         Err(e) => {
+            tracing::warn!(url = %url, error = %e, "agent websocket not reachable");
             let mut client_ws = client_ws;
             let _ = client_ws
                 .send(AxumMsg::Close(Some(axum::extract::ws::CloseFrame {
@@ -709,6 +717,7 @@ async fn create_backup_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
 ) -> Result<Json<crate::types::BackupInfo>, (StatusCode, Json<serde_json::Value>)> {
+    tracing::info!(name = %name, "creating manual backup");
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
 
@@ -752,6 +761,7 @@ async fn restore_backup_handler(
     let lock = state.agent_lock(&path.name).await;
     let _guard = lock.write().await;
 
+    tracing::info!(name = %path.name, backup_id = %path.backup_id, "restoring backup");
     let name = path.name.clone();
     let backup_id = path.backup_id.clone();
     tokio::task::spawn_blocking(move || docker::restore_backup(&name, &backup_id))
@@ -775,6 +785,7 @@ async fn delete_backup_handler(
     let lock = state.agent_lock(&path.name).await;
     let _guard = lock.write().await;
 
+    tracing::info!(backup_id = %path.backup_id, "deleting backup");
     let backup_id = path.backup_id.clone();
     tokio::task::spawn_blocking(move || docker::delete_backup(&backup_id))
         .await
@@ -860,6 +871,7 @@ pub fn build_router(state: SharedState) -> Router {
                 .allow_methods(tower_http::cors::Any)
                 .allow_headers(tower_http::cors::Any),
         )
+        .layer(tower_http::trace::TraceLayer::new_for_http())
         .with_state(state)
 }
 
@@ -902,7 +914,7 @@ fn spawn_auto_backup_task(state: SharedState) {
                     });
 
                     if !has_daily_today {
-                        eprintln!("auto-backup: creating daily backup for '{}'", name_clone);
+                        tracing::info!("auto-backup: creating daily backup for '{}'", name_clone);
                         let new = docker::create_backup(&name_clone, crate::types::BackupType::Daily)?;
                         backups.insert(0, new);
                     }
@@ -911,7 +923,7 @@ fn spawn_auto_backup_task(state: SharedState) {
                         b.backup_type == crate::types::BackupType::Weekly && b.created_at >= week_ago
                     });
                     if !has_recent_weekly {
-                        eprintln!("auto-backup: creating weekly backup for '{}'", name_clone);
+                        tracing::info!("auto-backup: creating weekly backup for '{}'", name_clone);
                         let new = docker::create_backup(&name_clone, crate::types::BackupType::Weekly)?;
                         backups.insert(0, new);
                     }
@@ -920,7 +932,7 @@ fn spawn_auto_backup_task(state: SharedState) {
                         b.backup_type == crate::types::BackupType::Monthly && b.created_at >= month_ago
                     });
                     if !has_recent_monthly {
-                        eprintln!("auto-backup: creating monthly backup for '{}'", name_clone);
+                        tracing::info!("auto-backup: creating monthly backup for '{}'", name_clone);
                         let new = docker::create_backup(&name_clone, crate::types::BackupType::Monthly)?;
                         backups.insert(0, new);
                     }
@@ -932,7 +944,7 @@ fn spawn_auto_backup_task(state: SharedState) {
                 .unwrap_or_else(|e| Err(docker::DockerError::Failed(e.to_string())));
 
                 if let Err(e) = result {
-                    eprintln!("auto-backup error for '{}': {}", name, e);
+                    tracing::error!("auto-backup error for '{}': {}", name, e);
                 }
             }
         }
@@ -949,8 +961,8 @@ fn spawn_update_check_task(state: SharedState) {
             match info_result {
                 Ok(Ok(info)) => {
                     if info.update_available && last_notified.as_ref() != Some(&info.latest) {
-                        eprintln!(
-                            "\nUpdate available: v{} → v{} (run 'vestad update')",
+                        tracing::info!(
+                            "update available: v{} -> v{} (run 'vestad update')",
                             info.current, info.latest
                         );
                         last_notified = Some(info.latest.clone());
@@ -958,8 +970,8 @@ fn spawn_update_check_task(state: SharedState) {
                     let mut slot = state.update_info.lock().await;
                     *slot = Some(info);
                 }
-                Ok(Err(e)) => eprintln!("update check failed: {}", e),
-                Err(e) => eprintln!("update check task failed: {}", e),
+                Ok(Err(e)) => tracing::warn!("update check failed: {}", e),
+                Err(e) => tracing::error!("update check task failed: {}", e),
             }
             tokio::time::sleep(tokio::time::Duration::from_secs(update_check::CHECK_INTERVAL_SECS)).await;
         }
@@ -973,6 +985,8 @@ pub async fn run_server(port: u16, api_key: String, cert_pem: String, key_pem: S
     let app = build_router(state.clone());
     spawn_auto_backup_task(state.clone());
     spawn_update_check_task(state);
+
+    tracing::info!(port, "server listening");
 
     let rustls_config = axum_server::tls_rustls::RustlsConfig::from_pem(
         cert_pem.into_bytes(),

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -107,7 +107,7 @@ pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
         return Ok(tc);
     }
     let subdomain = generate_subdomain();
-    eprintln!("auto-creating tunnel with subdomain: {}", subdomain);
+    tracing::info!(subdomain = %subdomain, "auto-creating tunnel");
     setup_tunnel(config_dir, &subdomain)
 }
 
@@ -117,7 +117,7 @@ pub fn setup_tunnel(config_dir: &Path, subdomain: &str) -> Result<TunnelConfig, 
     let hostname = format!("{}.{}", subdomain, domain);
     let tunnel_name = format!("vesta-{}", subdomain);
 
-    eprintln!("creating tunnel {}...", tunnel_name);
+    tracing::info!(tunnel = %tunnel_name, "creating tunnel");
 
     let create_url = format!("{}/accounts/{}/cfd_tunnel", CF_API_BASE, env.account_id);
     let tunnel_secret: String = (0..32).map(|_| format!("{:02x}", rand::random::<u8>())).collect();
@@ -141,7 +141,7 @@ pub fn setup_tunnel(config_dir: &Path, subdomain: &str) -> Result<TunnelConfig, 
         .ok_or("missing tunnel token in response")?
         .to_string();
 
-    eprintln!("creating DNS record {} -> {}...", hostname, tunnel_id);
+    tracing::info!(hostname = %hostname, tunnel_id = %tunnel_id, "creating DNS record");
 
     let dns_url = format!("{}/zones/{}/dns_records", CF_API_BASE, env.zone_id);
     let dns_resp = cf_request("POST", &dns_url, &env.api_token, Some(serde_json::json!({
@@ -174,7 +174,7 @@ pub fn setup_tunnel(config_dir: &Path, subdomain: &str) -> Result<TunnelConfig, 
         std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o600)).ok();
     }
 
-    eprintln!("tunnel ready: https://{}", hostname);
+    tracing::info!(hostname = %hostname, "tunnel ready");
     Ok(config)
 }
 
@@ -185,12 +185,12 @@ pub fn destroy_tunnel(config_dir: &Path) -> Result<(), String> {
     let env = cf_env()?;
 
     if let Some(record_id) = &config.dns_record_id {
-        eprintln!("deleting DNS record...");
+        tracing::info!("deleting DNS record");
         let dns_url = format!("{}/zones/{}/dns_records/{}", CF_API_BASE, env.zone_id, record_id);
         cf_request("DELETE", &dns_url, &env.api_token, None).ok();
     }
 
-    eprintln!("deleting tunnel {}...", config.tunnel_id);
+    tracing::info!(tunnel_id = %config.tunnel_id, "deleting tunnel");
     let tunnel_url = format!(
         "{}/accounts/{}/cfd_tunnel/{}",
         CF_API_BASE, env.account_id, config.tunnel_id
@@ -199,7 +199,7 @@ pub fn destroy_tunnel(config_dir: &Path) -> Result<(), String> {
         .map_err(|e| format!("failed to delete tunnel: {}", e))?;
 
     std::fs::remove_file(tunnel_config_path(config_dir)).ok();
-    eprintln!("tunnel destroyed");
+    tracing::info!("tunnel destroyed");
     Ok(())
 }
 
@@ -220,7 +220,7 @@ pub fn ensure_cloudflared(config_dir: &Path) -> Result<PathBuf, String> {
     };
 
     let url = format!("{}/cloudflared-linux-{}", CLOUDFLARED_DOWNLOAD_BASE, arch);
-    eprintln!("downloading cloudflared from {}...", url);
+    tracing::info!(url = %url, "downloading cloudflared");
 
     std::fs::create_dir_all(config_dir)
         .map_err(|e| format!("failed to create config dir: {}", e))?;
@@ -241,7 +241,7 @@ pub fn ensure_cloudflared(config_dir: &Path) -> Result<PathBuf, String> {
             .map_err(|e| format!("chmod failed: {}", e))?;
     }
 
-    eprintln!("cloudflared downloaded to {}", local_bin.display());
+    tracing::info!(path = %local_bin.display(), "cloudflared downloaded");
     Ok(local_bin)
 }
 


### PR DESCRIPTION
## Summary
- Add `tracing` + `tracing-subscriber` with env-filter for structured logging (defaults to `info`, configurable via `RUST_LOG`)
- Add `tower_http::trace::TraceLayer` for automatic HTTP request/response logging
- Replace all operational `eprintln!()` with `tracing::info!`, `tracing::warn!`, `tracing::error!` across all modules (docker, tunnel, serve)
- Add structured logs with key-value fields to agent lifecycle handlers, backup operations, websocket connections, and background tasks

## Test plan
- [x] `cargo clippy -p vestad` passes cleanly
- [ ] CI passes
- [ ] Verify logs appear on startup and during agent operations with default log level
- [ ] Verify `RUST_LOG=debug` shows additional detail (e.g., websocket connections, HTTP requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)