### PR TITLE
feat(vestad): restore systemd integration, make Linux-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,12 +206,22 @@ jobs:
       - name: Clippy
         if: "!matrix.cross"
         working-directory: .
-        run: cargo clippy --workspace --exclude vesta-tests --target ${{ matrix.target }} -- -D warnings
+        run: cargo clippy --workspace --exclude vesta-tests --exclude vestad --target ${{ matrix.target }} -- -D warnings
+
+      - name: Clippy (vestad, Linux only)
+        if: "!matrix.cross && runner.os == 'Linux'"
+        working-directory: .
+        run: cargo clippy -p vestad --target ${{ matrix.target }} -- -D warnings
 
       - name: Test
         if: "!matrix.cross"
         working-directory: .
-        run: cargo test --workspace --exclude vesta-tests --target ${{ matrix.target }}
+        run: cargo test --workspace --exclude vesta-tests --exclude vestad --target ${{ matrix.target }}
+
+      - name: Test (vestad, Linux only)
+        if: "!matrix.cross && runner.os == 'Linux'"
+        working-directory: .
+        run: cargo test -p vestad --target ${{ matrix.target }}
 
       - name: Build vesta
         working-directory: .

--- a/README.md
+++ b/README.md
@@ -34,18 +34,25 @@ curl -fsSL https://raw.githubusercontent.com/elyxlz/vesta/master/install.sh | ba
 irm https://raw.githubusercontent.com/elyxlz/vesta/master/install.ps1 | iex
 ```
 
-## Remote Setup
+## Setup
 
-Run vestad on a remote server and connect from your local machine.
-
-### 1. Server
+### 1. Server (Linux only)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/elyxlz/vesta/master/install.sh | bash
-vestad serve
+vestad
 ```
 
-On startup, vestad prints the host URL and API key. By default it auto-selects an available port and sets up a Cloudflare tunnel. You can pin a specific port with `vestad serve --port 7860` or disable the tunnel with `--no-tunnel`.
+On first run, vestad installs a systemd user service, starts itself, and prints the host URL and API key. It runs persistently via systemd (survives logout).
+
+```bash
+vestad status    # show service status
+vestad logs      # stream service logs
+vestad restart   # restart the service
+vestad stop      # stop the service
+```
+
+By default vestad auto-selects a port and sets up a Cloudflare tunnel. Use `vestad serve --standalone` to run in the foreground without systemd (for CI/development).
 
 ### 2. Client
 

--- a/install.sh
+++ b/install.sh
@@ -221,7 +221,7 @@ main() {
   echo ""
   echo "Done! Get started:"
   if [ "$OS" = "linux" ]; then
-    echo "  vestad              # Start the server"
+    echo "  vestad              # Install systemd service and start"
     echo "  vesta connect       # Connect the CLI"
   else
     echo "  vesta connect <host>#<key>   # Connect to a remote vestad"

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -37,7 +37,7 @@ impl TestServer {
         let docker_config = format!("{}/.docker", real_home);
 
         let process = Command::new(&vestad)
-            .args(["serve", "--port", &port.to_string()])
+            .args(["serve", "--standalone", "--port", &port.to_string()])
             .env("HOME", &home)
             .env("DOCKER_CONFIG", &docker_config)
             .stdout(Stdio::null())

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -1,8 +1,12 @@
+#[cfg(not(target_os = "linux"))]
+compile_error!("vestad only supports Linux");
+
 use clap::Parser;
 
 mod docker;
 mod jwt;
 mod serve;
+mod systemd;
 mod tunnel;
 mod types;
 mod update_check;
@@ -17,7 +21,7 @@ struct Cli {
 
 #[derive(clap::Subcommand)]
 enum Command {
-    /// Start HTTP+WS server (default)
+    /// Start the server (default). Runs via systemd.
     Serve {
         /// Port to listen on (auto-selected if not specified)
         #[arg(long)]
@@ -25,7 +29,25 @@ enum Command {
         /// Disable Cloudflare tunnel
         #[arg(long)]
         no_tunnel: bool,
+        /// Run in foreground without systemd (for CI/dev)
+        #[arg(long)]
+        standalone: bool,
     },
+    /// Show vestad service status
+    Status,
+    /// Stream vestad service logs
+    Logs {
+        /// Number of lines to show
+        #[arg(short, default_value = "50")]
+        n: usize,
+        /// Don't follow, just print and exit
+        #[arg(long)]
+        no_follow: bool,
+    },
+    /// Stop the vestad service
+    Stop,
+    /// Restart the vestad service
+    Restart,
     /// Open a shell inside an agent container
     Shell {
         /// Agent name
@@ -84,6 +106,119 @@ fn print_server_info(tunnel_url: Option<&str>, local_url: &str, api_key: &str) {
     eprintln!();
 }
 
+fn read_server_info(config: &std::path::Path) -> (Option<String>, Option<String>, Option<String>) {
+    let api_key = std::fs::read_to_string(config.join("api-key"))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    let local_url = std::fs::read_to_string(config.join("port"))
+        .ok()
+        .map(|s| format!("https://0.0.0.0:{}", s.trim()));
+
+    let tunnel_url = tunnel::get_tunnel_config(config)
+        .map(|tc| format!("https://{}", tc.hostname));
+
+    (tunnel_url, local_url, api_key)
+}
+
+fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
+    let config = config_dir();
+
+    docker::ensure_docker().unwrap_or_else(|e| die(&e));
+
+    let port = port.unwrap_or_else(|| find_available_port().unwrap_or_else(|| die("no available port found")));
+
+    let _pid_lock = serve::acquire_pid_lock(&config).unwrap_or_else(|e| die(&e));
+    serve::write_port_file(&config, port);
+
+    let api_key = serve::ensure_api_key(&config);
+    let (cert_pem, key_pem, _fingerprint) = serve::ensure_tls(&config);
+
+    let tunnel_url = if !no_tunnel {
+        match tunnel::ensure_tunnel(&config) {
+            Ok(tc) => Some(format!("https://{}", tc.hostname)),
+            Err(e) => {
+                tracing::warn!("tunnel setup failed: {e}, running without tunnel");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let local_url = format!("https://0.0.0.0:{}", port);
+
+    eprintln!();
+    eprintln!("  \x1b[1;35mvestad\x1b[0m v{}", env!("CARGO_PKG_VERSION"));
+    print_server_info(tunnel_url.as_deref(), &local_url, &api_key);
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let tunnel_child = if tunnel_url.is_some() {
+                match tunnel::start_tunnel(&config, port).await {
+                    Ok((child, _url)) => Some(child),
+                    Err(e) => {
+                        tracing::warn!("failed to start tunnel: {e}");
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
+            serve::run_server(port, api_key, cert_pem, key_pem, tunnel_url).await;
+
+            if let Some(mut child) = tunnel_child {
+                child.kill().await.ok();
+            }
+        });
+}
+
+fn run_server_systemd(port: Option<u16>, no_tunnel: bool) {
+    if port.is_some() || no_tunnel {
+        eprintln!("note: --port and --no-tunnel only apply with --standalone");
+    }
+
+    systemd::ensure_service_installed().unwrap_or_else(|e| die(&e));
+
+    if systemd::is_active() {
+        if let Some(pid) = systemd::main_pid() {
+            eprintln!("vestad is already running (pid {}).", pid);
+        } else {
+            eprintln!("vestad is already running.");
+        }
+        eprintln!("run 'vestad logs' to see output, or 'vestad restart' to restart.");
+        return;
+    }
+
+    systemd::start().unwrap_or_else(|e| die(&e));
+    systemd::wait_for_start().unwrap_or_else(|e| die(&e));
+
+    let config = config_dir();
+    let (tunnel_url, local_url, api_key) = read_server_info(&config);
+
+    eprintln!();
+    eprintln!("  \x1b[1;35mvestad\x1b[0m v{} is now running as a systemd service.", env!("CARGO_PKG_VERSION"));
+
+    if let Some(api_key) = &api_key {
+        print_server_info(
+            tunnel_url.as_deref(),
+            local_url.as_deref().unwrap_or("https://0.0.0.0:?"),
+            api_key,
+        );
+    }
+
+    eprintln!("manage with:");
+    eprintln!("  vestad status     show service status");
+    eprintln!("  vestad logs       show service logs");
+    eprintln!("  vestad restart    restart the service");
+    eprintln!("  vestad stop       stop the service");
+}
+
 fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -99,63 +234,43 @@ fn main() {
 
     let cli = Cli::parse();
 
-    match cli.command.unwrap_or(Command::Serve { port: None, no_tunnel: false }) {
-        Command::Serve { port, no_tunnel } => {
-            let config = config_dir();
-
-            docker::ensure_docker().unwrap_or_else(|e| die(&e));
-
-            let port = port.unwrap_or_else(|| find_available_port().unwrap_or_else(|| die("no available port found")));
-
-            let _pid_lock = serve::acquire_pid_lock(&config).unwrap_or_else(|e| die(&e));
-
-            let api_key = serve::ensure_api_key(&config);
-            let (cert_pem, key_pem, _fingerprint) = serve::ensure_tls(&config);
-
-            let tunnel_url = if !no_tunnel {
-                match tunnel::ensure_tunnel(&config) {
-                    Ok(tc) => Some(format!("https://{}", tc.hostname)),
-                    Err(e) => {
-                        tracing::warn!("tunnel setup failed: {e}, running without tunnel");
-                        None
-                    }
-                }
+    match cli.command.unwrap_or(Command::Serve { port: None, no_tunnel: false, standalone: false }) {
+        Command::Serve { port, no_tunnel, standalone } => {
+            if standalone {
+                run_server_foreground(port, no_tunnel);
             } else {
-                None
-            };
+                run_server_systemd(port, no_tunnel);
+            }
+        }
 
-            let local_url = format!("https://0.0.0.0:{}", port);
-
-            eprintln!();
+        Command::Status => {
+            let config = config_dir();
             eprintln!("  \x1b[1;35mvestad\x1b[0m v{}", env!("CARGO_PKG_VERSION"));
-            print_server_info(tunnel_url.as_deref(), &local_url, &api_key);
 
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(async {
-                    let tunnel_child = if tunnel_url.is_some() {
-                        match tunnel::start_tunnel(&config, port).await {
-                            Ok((child, _url)) => {
+            let (tunnel_url, local_url, api_key) = read_server_info(&config);
+            if let Some(api_key) = &api_key {
+                print_server_info(
+                    tunnel_url.as_deref(),
+                    local_url.as_deref().unwrap_or("https://0.0.0.0:?"),
+                    api_key,
+                );
+            }
 
-                                Some(child)
-                            }
-                            Err(e) => {
-                                tracing::warn!("failed to start tunnel: {e}");
-                                None
-                            }
-                        }
-                    } else {
-                        None
-                    };
+            systemd::print_status();
+        }
 
-                    serve::run_server(port, api_key, cert_pem, key_pem, tunnel_url).await;
+        Command::Logs { n, no_follow } => {
+            systemd::exec_journal(n, !no_follow);
+        }
 
-                    if let Some(mut child) = tunnel_child {
-                        child.kill().await.ok();
-                    }
-                });
+        Command::Stop => {
+            systemd::stop().unwrap_or_else(|e| die(&e));
+            eprintln!("vestad stopped.");
+        }
+
+        Command::Restart => {
+            systemd::restart().unwrap_or_else(|e| die(&e));
+            eprintln!("vestad restarted.");
         }
 
         Command::Shell { name } => {
@@ -202,19 +317,10 @@ fn main() {
 
         Command::Info => {
             let config = config_dir();
+            let (tunnel_url, local_url, api_key) = read_server_info(&config);
 
-            let api_key = match std::fs::read_to_string(config.join("api-key")) {
-                Ok(k) if !k.trim().is_empty() => k.trim().to_string(),
-                _ => die("no API key found — has vestad been started?"),
-            };
-
-            let local_url = match std::fs::read_to_string(config.join("port")) {
-                Ok(p) => format!("https://localhost:{}", p.trim()),
-                _ => die("no port file found — is vestad running?"),
-            };
-
-            let tunnel_url = tunnel::get_tunnel_config(&config)
-                .map(|tc| format!("https://{}", tc.hostname));
+            let api_key = api_key.unwrap_or_else(|| die("no API key found — has vestad been started?"));
+            let local_url = local_url.unwrap_or_else(|| die("no port file found — is vestad running?"));
 
             print_server_info(tunnel_url.as_deref(), &local_url, &api_key);
         }
@@ -254,8 +360,17 @@ fn main() {
                 .unwrap_or_else(|e| die(format!("failed to replace binary: {}", e)));
 
             std::fs::remove_dir_all(&tmp).ok();
-            tracing::info!("updated — restart vestad to use new version");
+
+            if let Err(e) = systemd::reinstall_service() {
+                tracing::warn!("failed to update systemd service: {e}");
+            }
+            if systemd::is_active() {
+                tracing::info!("restarting vestad...");
+                systemd::restart().unwrap_or_else(|e| die(&e));
+                tracing::info!("updated and restarted.");
+            } else {
+                tracing::info!("updated. run 'vestad' to start.");
+            }
         }
     }
 }
-

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -795,6 +795,13 @@ async fn delete_backup_handler(
     Ok(Json(serde_json::json!({"ok": true})))
 }
 
+// --- Port file ---
+
+pub fn write_port_file(config_dir: &std::path::Path, port: u16) {
+    let port_path = config_dir.join("port");
+    std::fs::write(&port_path, port.to_string()).ok();
+}
+
 // --- PID file ---
 
 pub fn acquire_pid_lock(config_dir: &std::path::Path) -> Result<std::fs::File, String> {

--- a/vestad/src/systemd.rs
+++ b/vestad/src/systemd.rs
@@ -1,0 +1,176 @@
+use std::process::{self, Command};
+
+const SERVICE_NAME: &str = "vestad";
+const SERVICE_STARTUP_WAIT_MS: u64 = 2000;
+const SERVICE_POLL_INTERVAL_MS: u64 = 100;
+
+fn unit_file_path() -> Result<String, String> {
+    let home = std::env::var("HOME").map_err(|_| "HOME not set".to_string())?;
+    Ok(format!("{}/.config/systemd/user/vestad.service", home))
+}
+
+pub fn reinstall_service() -> Result<(), String> {
+    std::fs::remove_file(&unit_file_path()?).ok();
+    ensure_service_installed()
+}
+
+pub fn ensure_service_installed() -> Result<(), String> {
+    let vestad_path = std::env::current_exe()
+        .map_err(|e| format!("cannot determine binary path: {}", e))?
+        .to_str()
+        .ok_or("binary path is not valid UTF-8")?
+        .to_string();
+
+    let unit_path = unit_file_path()?;
+
+    if let Ok(existing) = std::fs::read_to_string(&unit_path) {
+        if existing.contains(&vestad_path) {
+            return Ok(());
+        }
+        eprintln!("updating systemd service (binary path changed)...");
+    } else {
+        eprintln!("installing systemd user service...");
+    }
+
+    if let Some(parent) = std::path::Path::new(&unit_path).parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create {}: {}", parent.display(), e))?;
+    }
+
+    let unit_content = format!(
+        r#"[Unit]
+Description=Vesta API Server
+After=docker.service
+
+[Service]
+ExecStart={vestad_path} serve --standalone
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"#
+    );
+
+    std::fs::write(&unit_path, unit_content)
+        .map_err(|e| format!("failed to write systemd service: {}", e))?;
+
+    run_systemctl(&["daemon-reload"])?;
+    run_systemctl(&["enable", SERVICE_NAME])?;
+
+    let user = std::env::var("USER").map_err(|_| "USER not set".to_string())?;
+    let status = Command::new("loginctl")
+        .args(["enable-linger", &user])
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .status()
+        .map_err(|e| format!("failed to run loginctl: {}", e))?;
+    if !status.success() {
+        eprintln!("warning: loginctl enable-linger failed — vestad may stop on logout");
+    }
+
+    Ok(())
+}
+
+pub fn is_active() -> bool {
+    Command::new("systemctl")
+        .args(["--user", "is-active", SERVICE_NAME])
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+pub fn start() -> Result<(), String> {
+    run_systemctl(&["start", SERVICE_NAME])
+}
+
+pub fn stop() -> Result<(), String> {
+    run_systemctl(&["stop", SERVICE_NAME])
+}
+
+pub fn restart() -> Result<(), String> {
+    run_systemctl(&["restart", SERVICE_NAME])
+}
+
+pub fn wait_for_start() -> Result<(), String> {
+    let deadline = std::time::Instant::now()
+        + std::time::Duration::from_millis(SERVICE_STARTUP_WAIT_MS);
+
+    while std::time::Instant::now() < deadline {
+        if is_active() {
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(SERVICE_POLL_INTERVAL_MS));
+    }
+
+    if is_active() {
+        Ok(())
+    } else {
+        Err("vestad failed to start — run 'vestad logs' for details".into())
+    }
+}
+
+pub fn print_status() {
+    let _ = Command::new("systemctl")
+        .args(["--user", "status", SERVICE_NAME, "--no-pager"])
+        .stdin(process::Stdio::null())
+        .status();
+}
+
+pub fn exec_journal(lines: usize, follow: bool) -> ! {
+    use std::os::unix::process::CommandExt;
+
+    let lines_str = lines.to_string();
+    let mut cmd = Command::new("journalctl");
+    cmd.args(["--user", "-u", SERVICE_NAME, "-n", &lines_str, "--no-hostname", "-o", "cat"]);
+    if follow {
+        cmd.arg("-f");
+    }
+
+    let err = cmd.exec();
+    eprintln!("failed to exec journalctl: {}", err);
+    process::exit(1);
+}
+
+pub fn main_pid() -> Option<u32> {
+    let output = Command::new("systemctl")
+        .args(["--user", "show", SERVICE_NAME, "--property=MainPID", "--value"])
+        .output()
+        .ok()?;
+    let pid_str = String::from_utf8_lossy(&output.stdout);
+    let pid: u32 = pid_str.trim().parse().ok()?;
+    if pid == 0 { None } else { Some(pid) }
+}
+
+fn run_systemctl(args: &[&str]) -> Result<(), String> {
+    let mut full_args = vec!["--user"];
+    full_args.extend_from_slice(args);
+
+    let output = Command::new("systemctl")
+        .args(&full_args)
+        .stdout(process::Stdio::null())
+        .output()
+        .map_err(|e| format!("failed to run systemctl: {}", e))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let detail = stderr.trim();
+        if detail.is_empty() {
+            Err(format!(
+                "systemctl {} failed (exit {})",
+                args.join(" "),
+                output.status.code().unwrap_or(-1)
+            ))
+        } else {
+            Err(format!(
+                "systemctl {} failed: {}",
+                args.join(" "),
+                detail
+            ))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Restore systemd integration that was removed in #126 — vestad now auto-installs a systemd user service on first run, starts via systemd, and exits
- New commands: `vestad status`, `vestad logs`, `vestad stop`, `vestad restart`
- `vestad serve --standalone` for foreground mode (CI/dev)
- vestad is now Linux-only (`compile_error!` on other platforms)
- `vestad update` reinstalls service file and restarts automatically
- CI updated to exclude vestad from macOS clippy/test

## Test plan
- [ ] `cargo build -p vestad` and `cargo clippy -p vestad` pass
- [ ] CI passes on all platforms (vestad excluded from macOS/Windows)
- [ ] On Linux: `vestad` installs service, starts it, prints info
- [ ] `vestad status` shows systemd status + connection info
- [ ] `vestad logs` streams journalctl
- [ ] `vestad stop` / `vestad restart` work
- [ ] `vestad serve --standalone` runs in foreground
- [ ] `vestad update` reinstalls service and restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)