### PR TITLE
feat(vestad): add client connection logging and use docker buildx

### DIFF
--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.110"
+version = "0.1.111"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -380,7 +380,7 @@ pub fn resolve_image(build: bool) -> Result<&'static str, DockerError> {
     if build {
         let context = find_dockerfile()?;
         let status = process::Command::new("docker")
-            .args(["build", "-t", LOCAL_IMAGE_TAG, "."])
+            .args(["buildx", "build", "-t", LOCAL_IMAGE_TAG, "."])
             .current_dir(&context)
             .stdout(process::Stdio::null())
             .stderr(process::Stdio::inherit())

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -200,6 +200,8 @@ async fn auth_middleware(
     };
 
     if !bearer_ok && !query_ok {
+        let path = request.uri().path().to_string();
+        tracing::warn!(path = %path, "client auth failed");
         return (
             StatusCode::UNAUTHORIZED,
             Json(serde_json::json!({"error": "unauthorized"})),
@@ -240,9 +242,11 @@ async fn create_session_handler(
     Json(body): Json<SessionRequest>,
 ) -> Result<Json<SessionResponse>, (StatusCode, Json<serde_json::Value>)> {
     if body.api_key != state.api_key {
+        tracing::warn!("client session auth failed: invalid API key");
         return Err(err_response(StatusCode::UNAUTHORIZED, "invalid API key"));
     }
 
+    tracing::info!("client connected (new session)");
     Ok(Json(SessionResponse {
         access_token: jwt::create_token(&state.api_key, "access", jwt::ACCESS_TOKEN_TTL),
         refresh_token: jwt::create_token(&state.api_key, "refresh", jwt::REFRESH_TOKEN_TTL),
@@ -649,7 +653,7 @@ async fn ws_handler(
     Path(name): Path<String>,
     ws: WebSocketUpgrade,
 ) -> Result<Response, (StatusCode, Json<serde_json::Value>)> {
-    tracing::debug!(name = %name, "websocket connection");
+    tracing::info!(name = %name, "client websocket connecting");
     docker::validate_name(&name).map_err(map_docker_err)?;
     let cname = docker::container_name(&name);
 
@@ -685,6 +689,8 @@ async fn ws_proxy(client_ws: axum::extract::ws::WebSocket, agent_port: u16) {
             return;
         }
     };
+
+    tracing::info!(port = agent_port, "client websocket connected");
 
     let (mut client_tx, mut client_rx) = client_ws.split();
     let (mut agent_tx, mut agent_rx) = agent_ws.split();
@@ -724,6 +730,8 @@ async fn ws_proxy(client_ws: axum::extract::ws::WebSocket, agent_port: u16) {
         _ = client_to_agent => {},
         _ = agent_to_client => {},
     }
+
+    tracing::info!(port = agent_port, "client websocket disconnected");
 }
 
 // --- Backup/Restore ---


### PR DESCRIPTION
## Summary
- Add info/warn-level logs for client auth failures, session creation, and WebSocket connect/disconnect in vestad
- Switch `docker build` to `docker buildx build` to fix legacy builder deprecation warning

## Test plan
- [ ] Verify vestad logs show client connect/disconnect and auth failures
- [ ] Verify `--build` flag uses buildx without deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)