### PR TITLE
feat(vestad): block 'vesta' from agent names

### DIFF
--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -138,6 +138,9 @@ pub fn validate_name(name: &str) -> Result<(), DockerError> {
     if !valid {
         return Err(DockerError::InvalidName("agent name must match [a-z0-9][a-z0-9-]*[a-z0-9]".into()));
     }
+    if name.contains("vesta") {
+        return Err(DockerError::InvalidName("agent name must not contain 'vesta'".into()));
+    }
     Ok(())
 }
 
@@ -1358,6 +1361,13 @@ mod tests {
     fn validate_rejects_special_chars() {
         assert!(validate_name("hello world").is_err());
         assert!(validate_name("hello_world").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_vesta() {
+        assert!(validate_name("vesta").is_err());
+        assert!(validate_name("my-vesta").is_err());
+        assert!(validate_name("vesta-agent").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Reject any agent name containing the substring "vesta" in `validate_name()` to prevent confusion between the system itself and its agents
- Returns `400 Bad Request` with message `"agent name must not contain 'vesta'"`
- Adds unit test covering exact match, prefix, and suffix cases

## Test plan
- [x] `cargo test -p vestad` — all 36 tests pass (including new `validate_rejects_vesta`)
- [x] `cargo clippy -p vestad` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)