### PR TITLE
fix: backup restart notification replay & restart reason

### DIFF
--- a/agent/skills/app-chat/cli/src/app_chat_cli/daemon.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/daemon.py
@@ -28,7 +28,26 @@ class DaemonState:
     shutdown: asyncio.Event = field(default_factory=asyncio.Event)
     ws: aiohttp.ClientWebSocketResponse | None = None
     session: aiohttp.ClientSession | None = None
+    data_dir: pl.Path = field(default_factory=lambda: pl.Path.home() / ".app-chat")
     last_seen_ts: str | None = None
+
+
+def _ts_path(state: DaemonState) -> pl.Path:
+    return state.data_dir / "last_seen_ts"
+
+
+def _load_last_seen_ts(state: DaemonState) -> None:
+    try:
+        state.last_seen_ts = _ts_path(state).read_text().strip() or None
+    except FileNotFoundError:
+        pass
+
+
+def _update_last_seen_ts(state: DaemonState, ts: str) -> None:
+    if ts == state.last_seen_ts:
+        return
+    state.last_seen_ts = ts
+    _ts_path(state).write_text(ts)
 
 
 def cmd_serve(args: object) -> None:
@@ -45,7 +64,9 @@ def cmd_serve(args: object) -> None:
         notifications_dir=notifications_dir,
         ws_url=ws_url,
         sock_path=sock_path,
+        data_dir=data_dir,
     )
+    _load_last_seen_ts(state)
     asyncio.run(_run(state))
 
 
@@ -106,7 +127,7 @@ def _handle_event(state: DaemonState, raw: str) -> None:
         return
 
     if "ts" in event:
-        state.last_seen_ts = event["ts"]
+        _update_last_seen_ts(state, event["ts"])
 
     if event_type == "user" and "text" in event:
         ts = event["ts"] if "ts" in event else None
@@ -128,7 +149,7 @@ def _replay_missed(state: DaemonState, events: list[dict[str, object]]) -> None:
     # Update last_seen_ts to the latest event in the batch
     for past in reversed(events):
         if "ts" in past:
-            state.last_seen_ts = str(past["ts"])
+            _update_last_seen_ts(state, str(past["ts"]))
             break
     if count:
         _log(f"replayed {count} missed message(s)")

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.111"
+version = "0.1.112"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -330,6 +330,48 @@ pub fn container_status(cname: &str) -> ContainerStatus {
     inspect_container(cname).status
 }
 
+pub const MIN_AGE_FOR_BACKUP_SECS: u64 = 6 * 3600;
+
+/// Returns the container's age in seconds, or None if unknown.
+pub fn container_age_secs(name: &str) -> Option<u64> {
+    let cname = container_name(name);
+    let created = docker_output(&["inspect", "--format", "{{.Created}}", &cname])?;
+    let created_epoch = parse_rfc3339_epoch(created.trim())?;
+    let now_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs();
+    Some(now_epoch.saturating_sub(created_epoch))
+}
+
+/// Parse an RFC3339 timestamp (e.g. "2026-04-07T13:11:12.123Z") to unix epoch seconds.
+fn parse_rfc3339_epoch(ts: &str) -> Option<u64> {
+    let date_time = ts.split('T').collect::<Vec<_>>();
+    if date_time.len() != 2 { return None; }
+    let date_parts: Vec<&str> = date_time[0].split('-').collect();
+    let time_str = date_time[1].trim_end_matches('Z');
+    let time_parts: Vec<&str> = time_str.split(':').collect();
+    if date_parts.len() != 3 || time_parts.len() != 3 { return None; }
+
+    let year: u64 = date_parts[0].parse().ok()?;
+    let month: u64 = date_parts[1].parse().ok()?;
+    let day: u64 = date_parts[2].parse().ok()?;
+    let hour: u64 = time_parts[0].parse().ok()?;
+    let min: u64 = time_parts[1].parse().ok()?;
+    let sec: u64 = time_parts[2].split('.').next()?.parse().ok()?;
+
+    fn days_from_civil(year: u64, month: u64, day: u64) -> u64 {
+        let (y, m) = if month <= 2 { (year - 1, month + 9) } else { (year, month - 3) };
+        let era = y / 400;
+        let yoe = y - era * 400;
+        let doy = (153 * m + 2) / 5 + day - 1;
+        let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+        era * 146097 + doe - 719468
+    }
+
+    Some(days_from_civil(year, month, day) * 86400 + hour * 3600 + min * 60 + sec)
+}
+
 pub fn read_container_file(cname: &str, container_path: &str) -> Option<String> {
     let tmp = std::env::temp_dir().join(format!(
         "vesta_read_{}_{}",
@@ -1130,6 +1172,9 @@ pub fn create_backup(name: &str, backup_type: BackupType) -> Result<BackupInfo, 
     tracing::debug!(agent = %name, backup_type = %backup_type, "starting backup");
     let was_running = cs == ContainerStatus::Running;
     if was_running {
+        if let Err(err) = docker_cp_content(&cname, "backup — paused for backup", "/root/vesta/data/restart_reason") {
+            tracing::warn!(agent = %name, error = %err, "failed to write restart reason");
+        }
         docker_ok(&["stop", &cname]);
     }
 

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1257,6 +1257,13 @@ fn spawn_auto_backup_task(state: SharedState) {
                 let ret = retention;
 
                 let result = tokio::task::spawn_blocking(move || -> Result<(), docker::DockerError> {
+                    if let Some(age) = docker::container_age_secs(&name_clone) {
+                        if age < docker::MIN_AGE_FOR_BACKUP_SECS {
+                            tracing::debug!(agent = %name_clone, age_hours = age / 3600, "auto-backup: skipping young agent");
+                            return Ok(());
+                        }
+                    }
+
                     let mut backups = docker::list_backups(&name_clone)?;
 
                     let has_daily_today = backups.iter().any(|b| {


### PR DESCRIPTION
## Summary
- **Persist app-chat `last_seen_ts` to disk** — prevents notification replay after container restart (the daemon was re-emitting all history as new notifications because it lost its cursor)
- **Write restart reason before backup stop** — agent now sees "backup — paused for backup" instead of "crash — restarted after unexpected exit"
- **Skip auto-backup for agents < 6 hours old** — avoids unnecessary container restarts for newly created agents

## Test plan
- [ ] Create a new agent, verify no backup runs within 6 hours
- [ ] Trigger a backup on an existing agent, verify restart reason shows "backup — paused for backup"
- [ ] Restart container, verify app-chat doesn't replay old notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)