### PR TITLE
feat: add --cli, --server, --app flags to install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,34 @@ curl -fsSL https://raw.githubusercontent.com/elyxlz/vesta/master/install.sh | ba
 irm https://raw.githubusercontent.com/elyxlz/vesta/master/install.ps1 | iex
 ```
 
+### Install specific components
+
+By default, all available components for your platform are installed. Use flags to install only what you need:
+
+```bash
+# CLI only
+curl -fsSL https://raw.githubusercontent.com/elyxlz/vesta/master/install.sh | bash -s -- --cli
+
+# Server only (Linux)
+curl -fsSL https://raw.githubusercontent.com/elyxlz/vesta/master/install.sh | bash -s -- --server
+
+# Desktop app only
+curl -fsSL https://raw.githubusercontent.com/elyxlz/vesta/master/install.sh | bash -s -- --app
+
+# Specific version
+curl -fsSL https://raw.githubusercontent.com/elyxlz/vesta/master/install.sh | bash -s -- --version=0.1.112
+```
+
+Windows (PowerShell):
+
+```powershell
+# CLI only
+irm https://raw.githubusercontent.com/elyxlz/vesta/master/install.ps1 | iex -- --cli
+
+# Desktop app only
+irm https://raw.githubusercontent.com/elyxlz/vesta/master/install.ps1 | iex -- --app
+```
+
 ## Setup
 
 ### 1. Server (Linux only)

--- a/install.ps1
+++ b/install.ps1
@@ -11,6 +11,10 @@ foreach ($arg in $args) {
     }
     elseif ($arg -eq "--cli") { $InstallCli = $true }
     elseif ($arg -eq "--app") { $InstallApp = $true }
+    elseif ($arg -eq "--server") {
+        Write-Host "Error: --server is only available on Linux (use WSL2)"
+        exit 1
+    }
     elseif ($arg -eq "--help" -or $arg -eq "-h") {
         Write-Host "Usage: irm https://raw.githubusercontent.com/elyxlz/vesta/master/install.ps1 | iex"
         Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -2,21 +2,34 @@ $ErrorActionPreference = "Stop"
 
 $Repo = "elyxlz/vesta"
 $Version = ""
+$InstallCli = $false
+$InstallApp = $false
 
 foreach ($arg in $args) {
     if ($arg -match "^--version=(.+)$") {
         $Version = $Matches[1]
     }
+    elseif ($arg -eq "--cli") { $InstallCli = $true }
+    elseif ($arg -eq "--app") { $InstallApp = $true }
     elseif ($arg -eq "--help" -or $arg -eq "-h") {
         Write-Host "Usage: irm https://raw.githubusercontent.com/elyxlz/vesta/master/install.ps1 | iex"
         Write-Host ""
         Write-Host "Installs vesta CLI and desktop app on Windows."
+        Write-Host "By default, both are installed."
         Write-Host ""
         Write-Host "Options:"
+        Write-Host "  --cli              Install only the CLI"
+        Write-Host "  --app              Install only the desktop app"
         Write-Host "  --version=X.Y.Z   Install a specific version"
         Write-Host "  --help             Show this help"
         exit 0
     }
+}
+
+# If no component flags given, install everything
+if (-not $InstallCli -and -not $InstallApp) {
+    $InstallCli = $true
+    $InstallApp = $true
 }
 
 if (-not $Version) {
@@ -31,41 +44,45 @@ $TmpDir = Join-Path $env:TEMP "vesta-install-$(Get-Random)"
 New-Item -ItemType Directory -Path $TmpDir -Force | Out-Null
 
 try {
-    # --- CLI ---
-    $CliArtifact = "vesta-x86_64-pc-windows-msvc.zip"
-    $CliZip = Join-Path $TmpDir "vesta.zip"
-    $CliUrl = "https://github.com/$Repo/releases/download/v$Version/$CliArtifact"
+    if ($InstallCli) {
+        # --- CLI ---
+        $CliArtifact = "vesta-x86_64-pc-windows-msvc.zip"
+        $CliZip = Join-Path $TmpDir "vesta.zip"
+        $CliUrl = "https://github.com/$Repo/releases/download/v$Version/$CliArtifact"
 
-    Write-Host "Downloading vesta CLI..."
-    Invoke-WebRequest -Uri $CliUrl -OutFile $CliZip -UseBasicParsing
+        Write-Host "Downloading vesta CLI..."
+        Invoke-WebRequest -Uri $CliUrl -OutFile $CliZip -UseBasicParsing
 
-    Expand-Archive -Path $CliZip -DestinationPath $TmpDir -Force
+        Expand-Archive -Path $CliZip -DestinationPath $TmpDir -Force
 
-    $BinDir = Join-Path $env:LOCALAPPDATA "vesta\bin"
-    New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
-    Copy-Item (Join-Path $TmpDir "vesta.exe") -Destination (Join-Path $BinDir "vesta.exe") -Force
+        $BinDir = Join-Path $env:LOCALAPPDATA "vesta\bin"
+        New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+        Copy-Item (Join-Path $TmpDir "vesta.exe") -Destination (Join-Path $BinDir "vesta.exe") -Force
 
-    # Add to PATH if not already there
-    $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    if ($UserPath -notlike "*$BinDir*") {
-        [Environment]::SetEnvironmentVariable("Path", "$BinDir;$UserPath", "User")
-        Write-Host "  Added $BinDir to PATH"
+        # Add to PATH if not already there
+        $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+        if ($UserPath -notlike "*$BinDir*") {
+            [Environment]::SetEnvironmentVariable("Path", "$BinDir;$UserPath", "User")
+            Write-Host "  Added $BinDir to PATH"
+        }
+        $env:Path = "$BinDir;$env:Path"
+
+        Write-Host "  ✓ vesta CLI → $BinDir\vesta.exe"
     }
-    $env:Path = "$BinDir;$env:Path"
 
-    Write-Host "  ✓ vesta CLI → $BinDir\vesta.exe"
+    if ($InstallApp) {
+        # --- Desktop app ---
+        $AppArtifact = "Vesta_${Version}_x64-setup.exe"
+        $AppExe = Join-Path $TmpDir $AppArtifact
+        $AppUrl = "https://github.com/$Repo/releases/download/v$Version/$AppArtifact"
 
-    # --- Desktop app ---
-    $AppArtifact = "Vesta_${Version}_x64-setup.exe"
-    $AppExe = Join-Path $TmpDir $AppArtifact
-    $AppUrl = "https://github.com/$Repo/releases/download/v$Version/$AppArtifact"
+        Write-Host "Downloading desktop app..."
+        Invoke-WebRequest -Uri $AppUrl -OutFile $AppExe -UseBasicParsing
 
-    Write-Host "Downloading desktop app..."
-    Invoke-WebRequest -Uri $AppUrl -OutFile $AppExe -UseBasicParsing
-
-    Write-Host "Running installer..."
-    Start-Process -FilePath $AppExe -ArgumentList "/S" -Wait
-    Write-Host "  ✓ Vesta desktop app"
+        Write-Host "Running installer..."
+        Start-Process -FilePath $AppExe -ArgumentList "/S" -Wait
+        Write-Host "  ✓ Vesta desktop app"
+    }
 
     Write-Host ""
     Write-Host "Done! Get started:"

--- a/install.sh
+++ b/install.sh
@@ -4,22 +4,39 @@ set -euo pipefail
 main() {
   REPO="elyxlz/vesta"
   INSTALL_VERSION=""
+  INSTALL_CLI=""
+  INSTALL_SERVER=""
+  INSTALL_APP=""
 
   for arg in "$@"; do
     case "$arg" in
       --version=*) INSTALL_VERSION="${arg#--version=}" ;;
+      --cli) INSTALL_CLI=1 ;;
+      --server) INSTALL_SERVER=1 ;;
+      --app) INSTALL_APP=1 ;;
       --help|-h)
         echo "Usage: curl -fsSL https://raw.githubusercontent.com/elyxlz/vesta/master/install.sh | bash"
         echo ""
         echo "Installs vesta CLI, desktop app (if GUI available), and vestad (Linux only)."
+        echo "By default, all available components for your platform are installed."
         echo ""
         echo "Options:"
+        echo "  --cli              Install only the CLI"
+        echo "  --server           Install only vestad (Linux only)"
+        echo "  --app              Install only the desktop app"
         echo "  --version=X.Y.Z   Install a specific version"
         echo "  --help             Show this help"
         exit 0
         ;;
     esac
   done
+
+  # If no component flags given, install everything
+  if [ -z "$INSTALL_CLI" ] && [ -z "$INSTALL_SERVER" ] && [ -z "$INSTALL_APP" ]; then
+    INSTALL_CLI=1
+    INSTALL_SERVER=1
+    INSTALL_APP=1
+  fi
 
   OS=$(uname -s | tr '[:upper:]' '[:lower:]')
   ARCH=$(uname -m)
@@ -199,15 +216,15 @@ main() {
 
   case "$OS" in
     linux)
-      install_cli
-      install_vestad
-      if has_gui; then
+      [ -n "$INSTALL_CLI" ] && install_cli
+      [ -n "$INSTALL_SERVER" ] && install_vestad
+      if [ -n "$INSTALL_APP" ] && has_gui; then
         install_app_linux
       fi
       ;;
     darwin)
-      install_cli
-      if has_gui; then
+      [ -n "$INSTALL_CLI" ] && install_cli
+      if [ -n "$INSTALL_APP" ] && has_gui; then
         install_app_macos
       fi
       ;;

--- a/install.sh
+++ b/install.sh
@@ -31,14 +31,17 @@ main() {
     esac
   done
 
-  # If no component flags given, install everything
-  if [ -z "$INSTALL_CLI" ] && [ -z "$INSTALL_SERVER" ] && [ -z "$INSTALL_APP" ]; then
+  OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+  EXPLICIT_FLAGS=""
+  [ -n "$INSTALL_CLI" ] || [ -n "$INSTALL_SERVER" ] || [ -n "$INSTALL_APP" ] && EXPLICIT_FLAGS=1
+
+  # If no component flags given, install everything available for this platform
+  if [ -z "$EXPLICIT_FLAGS" ]; then
     INSTALL_CLI=1
-    INSTALL_SERVER=1
+    [ "$OS" = "linux" ] && INSTALL_SERVER=1
     INSTALL_APP=1
   fi
-
-  OS=$(uname -s | tr '[:upper:]' '[:lower:]')
   ARCH=$(uname -m)
 
   case "$ARCH" in
@@ -214,12 +217,14 @@ main() {
 
   echo ""
 
-  # Validate flags for the current platform
-  if [ -n "$INSTALL_SERVER" ] && [ "$OS" != "linux" ]; then
-    echo "Error: --server is only available on Linux"; exit 1
-  fi
-  if [ -n "$INSTALL_APP" ] && ! has_gui; then
-    echo "Error: --app requires a GUI (DISPLAY or WAYLAND_DISPLAY)"; exit 1
+  # Validate explicit flags for the current platform
+  if [ -n "$EXPLICIT_FLAGS" ]; then
+    if [ -n "$INSTALL_SERVER" ] && [ "$OS" != "linux" ]; then
+      echo "Error: --server is only available on Linux"; exit 1
+    fi
+    if [ -n "$INSTALL_APP" ] && ! has_gui; then
+      echo "Error: --app requires a GUI (DISPLAY or WAYLAND_DISPLAY)"; exit 1
+    fi
   fi
 
   case "$OS" in

--- a/install.sh
+++ b/install.sh
@@ -214,19 +214,23 @@ main() {
 
   echo ""
 
+  # Validate flags for the current platform
+  if [ -n "$INSTALL_SERVER" ] && [ "$OS" != "linux" ]; then
+    echo "Error: --server is only available on Linux"; exit 1
+  fi
+  if [ -n "$INSTALL_APP" ] && ! has_gui; then
+    echo "Error: --app requires a GUI (DISPLAY or WAYLAND_DISPLAY)"; exit 1
+  fi
+
   case "$OS" in
     linux)
       [ -n "$INSTALL_CLI" ] && install_cli
       [ -n "$INSTALL_SERVER" ] && install_vestad
-      if [ -n "$INSTALL_APP" ] && has_gui; then
-        install_app_linux
-      fi
+      [ -n "$INSTALL_APP" ] && has_gui && install_app_linux
       ;;
     darwin)
       [ -n "$INSTALL_CLI" ] && install_cli
-      if [ -n "$INSTALL_APP" ] && has_gui; then
-        install_app_macos
-      fi
+      [ -n "$INSTALL_APP" ] && has_gui && install_app_macos
       ;;
     *)
       echo "Unsupported OS: $OS"


### PR DESCRIPTION
## Summary
- Add `--cli`, `--server`, `--app` flags to `install.sh` (macOS/Linux) and `install.ps1` (Windows)
- Default behavior unchanged — installs all components when no flags given
- Update README with selective install examples

## Test plan
- [ ] `install.sh --cli` installs only the CLI
- [ ] `install.sh --server` installs only vestad (Linux)
- [ ] `install.sh --app` installs only the desktop app
- [ ] `install.sh` with no flags installs everything (unchanged)
- [ ] `install.ps1 --cli` / `--app` work on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)