### PR TITLE
feat: add uninstall commands to vesta and vestad

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -690,25 +690,23 @@ fn run(cli: Cli) {
 
         Command::Uninstall => {
             eprint!("This will remove the vesta CLI binary and its config. Continue? [y/N] ");
-            io::stdout().flush().ok();
+            io::stderr().flush().ok();
             let mut answer = String::new();
-            io::stdin().read_line(&mut answer).ok();
+            if io::stdin().read_line(&mut answer).is_err() {
+                eprintln!("failed to read input");
+                process::exit(1);
+            }
             if !answer.trim().eq_ignore_ascii_case("y") {
                 eprintln!("Aborted.");
                 process::exit(0);
             }
 
-            // Remove config directory
-            let config = common::config_dir();
-            if config.exists() {
-                if let Err(err) = std::fs::remove_dir_all(&config) {
-                    eprintln!("warning: failed to remove config dir {}: {}", config.display(), err);
-                } else {
-                    eprintln!("  removed {}", config.display());
-                }
+            match std::fs::remove_dir_all(common::config_dir()) {
+                Ok(()) => eprintln!("  removed {}", common::config_dir().display()),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => eprintln!("warning: failed to remove config: {}", err),
             }
 
-            // Remove the binary itself (best-effort self-delete)
             if let Ok(exe) = std::env::current_exe() {
                 if let Err(err) = std::fs::remove_file(&exe) {
                     eprintln!("warning: could not remove binary {}: {}", exe.display(), err);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -161,6 +161,8 @@ enum Command {
     },
     /// Update vesta to the latest version
     Update,
+    /// Uninstall vesta CLI and remove config
+    Uninstall,
 }
 
 #[derive(Subcommand)]
@@ -686,6 +688,38 @@ fn run(cli: Cli) {
             eprintln!("connected to {url}");
         }
 
+        Command::Uninstall => {
+            eprint!("This will remove the vesta CLI binary and its config. Continue? [y/N] ");
+            io::stdout().flush().ok();
+            let mut answer = String::new();
+            io::stdin().read_line(&mut answer).ok();
+            if !answer.trim().eq_ignore_ascii_case("y") {
+                eprintln!("Aborted.");
+                process::exit(0);
+            }
+
+            // Remove config directory
+            let config = common::config_dir();
+            if config.exists() {
+                if let Err(err) = std::fs::remove_dir_all(&config) {
+                    eprintln!("warning: failed to remove config dir {}: {}", config.display(), err);
+                } else {
+                    eprintln!("  removed {}", config.display());
+                }
+            }
+
+            // Remove the binary itself (best-effort self-delete)
+            if let Ok(exe) = std::env::current_exe() {
+                if let Err(err) = std::fs::remove_file(&exe) {
+                    eprintln!("warning: could not remove binary {}: {}", exe.display(), err);
+                    eprintln!("  remove it manually: rm {}", exe.display());
+                } else {
+                    eprintln!("  removed {}", exe.display());
+                }
+            }
+
+            eprintln!("\nvesta has been uninstalled.");
+        }
         Command::Update => {
             #[cfg(target_os = "linux")]
             {

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -67,6 +67,8 @@ enum Command {
     Info,
     /// Update vestad to the latest version
     Update,
+    /// Uninstall vestad: stop service, remove config, and delete binary
+    Uninstall,
 }
 
 #[derive(clap::Subcommand)]
@@ -491,6 +493,59 @@ fn main() {
             } else {
                 tracing::info!("updated. run 'vestad' to start.");
             }
+        }
+
+        Command::Uninstall => {
+            eprint!("This will stop vestad, remove its systemd service, config, and binary. Continue? [y/N] ");
+            use std::io::Write;
+            std::io::stdout().flush().ok();
+            let mut answer = String::new();
+            std::io::stdin().read_line(&mut answer).ok();
+            if !answer.trim().eq_ignore_ascii_case("y") {
+                eprintln!("Aborted.");
+                std::process::exit(0);
+            }
+
+            // Stop and disable systemd service
+            if systemd::is_active() {
+                eprintln!("stopping vestad service...");
+                systemd::stop().unwrap_or_else(|e| eprintln!("warning: {}", e));
+            }
+            systemd::uninstall().unwrap_or_else(|e| eprintln!("warning: {}", e));
+            eprintln!("  removed systemd service");
+
+            // Remove config directory
+            let config = config_dir();
+            if config.exists() {
+                if let Err(err) = std::fs::remove_dir_all(&config) {
+                    eprintln!("warning: failed to remove config dir {}: {}", config.display(), err);
+                } else {
+                    eprintln!("  removed {}", config.display());
+                }
+            }
+
+            // Remove tunnel config/binary if present
+            let tunnel_dir = config.parent().map(|p| p.join("cloudflared"));
+            if let Some(td) = tunnel_dir {
+                if td.exists() {
+                    std::fs::remove_dir_all(&td).ok();
+                    eprintln!("  removed {}", td.display());
+                }
+            }
+
+            // Remove the binary
+            if let Ok(exe) = std::env::current_exe() {
+                if let Err(err) = std::fs::remove_file(&exe) {
+                    eprintln!("warning: could not remove binary {}: {}", exe.display(), err);
+                    eprintln!("  remove it manually: rm {}", exe.display());
+                } else {
+                    eprintln!("  removed {}", exe.display());
+                }
+            }
+
+            eprintln!("\nvestad has been uninstalled.");
+            eprintln!("Note: Docker containers and images for agents are still intact.");
+            eprintln!("To remove them too, run: docker rm -f $(docker ps -aq --filter name=vesta-)");
         }
     }
 }

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -498,42 +498,42 @@ fn main() {
         Command::Uninstall => {
             eprint!("This will stop vestad, remove its systemd service, config, and binary. Continue? [y/N] ");
             use std::io::Write;
-            std::io::stdout().flush().ok();
+            std::io::stderr().flush().ok();
             let mut answer = String::new();
-            std::io::stdin().read_line(&mut answer).ok();
+            if std::io::stdin().read_line(&mut answer).is_err() {
+                eprintln!("failed to read input");
+                std::process::exit(1);
+            }
             if !answer.trim().eq_ignore_ascii_case("y") {
                 eprintln!("Aborted.");
                 std::process::exit(0);
             }
 
-            // Stop and disable systemd service
             if systemd::is_active() {
                 eprintln!("stopping vestad service...");
                 systemd::stop().unwrap_or_else(|e| eprintln!("warning: {}", e));
             }
-            systemd::uninstall().unwrap_or_else(|e| eprintln!("warning: {}", e));
-            eprintln!("  removed systemd service");
+            if let Err(err) = systemd::uninstall() {
+                eprintln!("warning: {}", err);
+            } else {
+                eprintln!("  removed systemd service");
+            }
 
-            // Remove config directory
             let config = config_dir();
-            if config.exists() {
-                if let Err(err) = std::fs::remove_dir_all(&config) {
-                    eprintln!("warning: failed to remove config dir {}: {}", config.display(), err);
-                } else {
-                    eprintln!("  removed {}", config.display());
+            match std::fs::remove_dir_all(&config) {
+                Ok(()) => eprintln!("  removed {}", config.display()),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => eprintln!("warning: failed to remove config: {}", err),
+            }
+
+            if let Some(tunnel_dir) = config.parent().map(|p| p.join("cloudflared")) {
+                match std::fs::remove_dir_all(&tunnel_dir) {
+                    Ok(()) => eprintln!("  removed {}", tunnel_dir.display()),
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(err) => eprintln!("warning: failed to remove cloudflared: {}", err),
                 }
             }
 
-            // Remove tunnel config/binary if present
-            let tunnel_dir = config.parent().map(|p| p.join("cloudflared"));
-            if let Some(td) = tunnel_dir {
-                if td.exists() {
-                    std::fs::remove_dir_all(&td).ok();
-                    eprintln!("  removed {}", td.display());
-                }
-            }
-
-            // Remove the binary
             if let Ok(exe) = std::env::current_exe() {
                 if let Err(err) = std::fs::remove_file(&exe) {
                     eprintln!("warning: could not remove binary {}: {}", exe.display(), err);

--- a/vestad/src/systemd.rs
+++ b/vestad/src/systemd.rs
@@ -94,6 +94,13 @@ pub fn restart() -> Result<(), String> {
     run_systemctl(&["restart", SERVICE_NAME])
 }
 
+pub fn uninstall() -> Result<(), String> {
+    run_systemctl(&["disable", SERVICE_NAME]).ok();
+    let unit_path = unit_file_path()?;
+    std::fs::remove_file(&unit_path).ok();
+    run_systemctl(&["daemon-reload"])
+}
+
 pub fn wait_for_start() -> Result<(), String> {
     let deadline = std::time::Instant::now()
         + std::time::Duration::from_millis(SERVICE_STARTUP_WAIT_MS);


### PR DESCRIPTION
## Summary
- `vesta uninstall` — removes CLI binary and config directory (~/.config/vesta/cli)
- `vestad uninstall` — stops systemd service, removes unit file, config (~/.config/vesta/vestad), and binary. Leaves Docker containers/images intact with instructions to remove them manually.

Both commands prompt for confirmation before proceeding.

## Test plan
- [ ] `vesta uninstall` prompts, then removes binary and config
- [ ] `vestad uninstall` stops service, removes unit file, config, and binary
- [ ] Both abort cleanly on "n" response
- [ ] `vestad uninstall` prints note about Docker containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)