### PR TITLE
fix(vestad): show (recommended) on remote URL, update README prerequisites

### DIFF
--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -128,7 +128,7 @@ fn print_server_info(tunnel_url: Option<&str>, local_url: &str, api_key: &str) {
     eprintln!();
     eprintln!("  \x1b[36mhost\x1b[0m  \x1b[2m(enter in the app's host field)\x1b[0m");
     if let Some(url) = tunnel_url {
-        eprintln!("    \x1b[36mremote\x1b[0m  \x1b[1m{}\x1b[0m", url);
+        eprintln!("    \x1b[36mremote\x1b[0m  \x1b[1m{}\x1b[0m  \x1b[32m(recommended)\x1b[0m", url);
     }
     eprintln!("    \x1b[36mlocal\x1b[0m   \x1b[1m{}\x1b[0m  \x1b[2m(same machine only)\x1b[0m", local_url);
     eprintln!("  \x1b[36mkey\x1b[0m   \x1b[33m{}\x1b[0m", api_key);


### PR DESCRIPTION
## Summary
- Show green `(recommended)` next to the remote tunnel URL in vestad server info output
- Update README prerequisites: remove incorrect WSL2 and macOS 13+ requirements, clarify Docker is only needed for the server
- Simplify setup section, document `--no-tunnel` flag

## Test plan
- [ ] `vestad info` / `vestad status` shows `(recommended)` next to remote URL
- [ ] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)