### PR TITLE
docs: fix stale CLAUDE.md references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,8 @@ Client/server architecture. `vestad` daemon runs on the host (manages Docker con
 - **Agent** (`agent/src/vesta/`): Async Python. Entry point `main.py`. Core loop in `core/loops.py` (message processing, notification monitoring). WebSocket server in `api.py`.
 - **CLI** (`cli/`): Rust `vesta` client binary. Connects to vestad over HTTPS.
 - **Server** (`vestad/`): Rust `vestad` daemon. Manages Docker containers, serves API.
-- **Common** (`vesta-common/`): Shared Rust library (types, config, platform setup).
-- **Desktop App** (`app/`): Tauri + Svelte. Uses `vesta-common` to connect to vestad.
-- **Tools** (`agent/tools/`): Independent CLI tools. **Never share code between CLIs.**
-- **Skills** (`agent/memory/skills/`): Templates also in `agent/src/vesta/templates/skills/`. Each has `SKILL.md` + scripts. No MCP servers.
+- **Desktop App** (`app/`): Tauri + React (TypeScript). Components in `app/src/components/`, providers in `app/src/providers/`.
+- **Skills** (`agent/skills/`): Each skill directory has `SKILL.md` + scripts. No MCP servers.
 
 ## Commands
 
@@ -59,10 +57,8 @@ Triggers a GitHub Actions workflow that bumps version, commits to master, tags, 
 - **No silent exception swallowing** — prefer explicit checks (`if path.exists()`) or log the error
 - Minimize comments — only for truly complex logic
 - Line length: 144 (ruff)
-- `effects.py` exports `get_current_time` as a test seam for time mocking
-- `state_dir` defaults to `Path.home()` — the container's home IS the state dir
 
-### Rust (cli/, vestad/, vesta-common/)
+### Rust (cli/, vestad/)
 - **No panics in library/server code** — return `Result`, never `panic!()` or `.unwrap()` on fallible operations. `.expect()` only where failure is truly impossible.
 - **Named constants for magic numbers** — timeouts, buffer sizes, port numbers, retry counts go in `const` at the top of the file.
 - **Descriptive variable names** — no single-letter vars (`n`, `t`, `c`). Use `name`, `tag`, `client`.
@@ -70,7 +66,7 @@ Triggers a GitHub Actions workflow that bumps version, commits to master, tags, 
 - **Extract repeated patterns** — if 3+ lines appear twice, extract a helper function.
 
 ### Frontend (app/src/)
-- **"Agent" terminology everywhere** — never "box". Types: `AgentInfo`, `AgentConnection`, `AgentActivityState`. Component: `AgentView.svelte`.
+- **"Agent" terminology everywhere** — never "box". Types: `AgentInfo`, `AgentConnection`, `AgentActivityState`.
 - **Tauri invoke() names must match Rust backend** — the invoke command strings are the contract, don't rename them.
 - **Hook placement** — hooks used only by a single provider live in that provider's folder (e.g. `providers/VoiceProvider/use-voice-input.ts`). `hooks/` is reserved for shared hooks used across multiple components/providers.
 - **Components in folders** — each component gets a folder with `index.tsx` and optionally `styles.ts`.


### PR DESCRIPTION
## Summary
- Removed references to non-existent `vesta-common/`, `agent/tools/`, `effects.py`, and `state_dir`
- Fixed frontend framework from Svelte to React (TypeScript)
- Updated skills path from `agent/memory/skills/` to `agent/skills/`
- Removed stale `AgentView.svelte` reference

## Test plan
- [ ] Verify CLAUDE.md matches current codebase structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)