### PR TITLE
feat: add landing page and mobile CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,24 +647,38 @@ jobs:
       )
     runs-on: macos-latest
     steps:
+      - name: Check for Apple signing secrets
+        env:
+          HAS_SECRETS: ${{ secrets.APPLE_CERTIFICATE != '' }}
+        run: |
+          if [ "$HAS_SECRETS" != "true" ]; then
+            echo "::warning::Apple signing secrets not configured — skipping iOS build"
+            echo "SKIP_IOS=true" >> $GITHUB_ENV
+          fi
+
       - uses: actions/checkout@v6
+        if: env.SKIP_IOS != 'true'
 
       - name: Install Rust
+        if: env.SKIP_IOS != 'true'
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-ios
 
       - uses: Swatinem/rust-cache@v2
+        if: env.SKIP_IOS != 'true'
         with:
           workspaces: app/src-tauri
           key: ios
 
       - name: Setup Node
+        if: env.SKIP_IOS != 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 22
 
       - name: Install Apple certificate and provisioning profile
+        if: env.SKIP_IOS != 'true'
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -689,19 +703,22 @@ jobs:
           cp $PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/
 
       - name: Install frontend deps
+        if: env.SKIP_IOS != 'true'
         working-directory: app
         run: npm install
 
       - name: Initialize iOS project
+        if: env.SKIP_IOS != 'true'
         working-directory: app
         run: npx tauri ios init
 
       - name: Build iOS
+        if: env.SKIP_IOS != 'true'
         working-directory: app
         run: npx tauri ios build --export-method app-store-connect
 
       - name: Collect artifacts
-        if: github.event_name != 'pull_request'
+        if: env.SKIP_IOS != 'true' && github.event_name != 'pull_request'
         run: |
           mkdir -p tauri-out
           find app/src-tauri/gen/apple -name '*.ipa' -exec cp {} tauri-out/ \;
@@ -712,7 +729,7 @@ jobs:
           ls -lh tauri-out/
 
       - name: Upload to TestFlight
-        if: github.event_name == 'release'
+        if: env.SKIP_IOS != 'true' && github.event_name == 'release'
         env:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
@@ -727,13 +744,13 @@ jobs:
             --apiIssuer "$APPLE_API_ISSUER_ID"
 
       - uses: actions/upload-artifact@v7
-        if: github.event_name != 'pull_request'
+        if: env.SKIP_IOS != 'true' && github.event_name != 'pull_request'
         with:
           name: tauri-ios
           path: tauri-out/*
 
       - name: Clean up keychain
-        if: always()
+        if: env.SKIP_IOS != 'true'
         run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
 
   # ── Merge gate (single required check for branch protection) ─────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,6 +566,176 @@ jobs:
           name: tauri-x86_64-pc-windows-msvc
           path: tauri-out/*
 
+  # ── Build Tauri app (Android APK) ────────────────────────────────────
+  build-tauri-android:
+    needs: [test-frontend, detect-changes]
+    if: >-
+      !failure() && !cancelled() && (
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.app == 'true'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: app/src-tauri
+          key: android
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android NDK
+        run: sdkmanager "ndk;27.0.12077973"
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install frontend deps
+        working-directory: app
+        run: npm install
+
+      - name: Initialize Android project
+        working-directory: app
+        run: npx tauri android init
+
+      - name: Build Android APK
+        working-directory: app
+        env:
+          NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/27.0.12077973
+        run: npx tauri android build --apk
+
+      - name: Collect artifacts
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p tauri-out
+          find app/src-tauri/gen/android -name '*.apk' -exec cp {} tauri-out/ \;
+          # Rename to include version
+          VERSION=$(python3 -c "import json; print(json.load(open('app/src-tauri/tauri.conf.json'))['version'])")
+          for f in tauri-out/*.apk; do
+            mv "$f" "tauri-out/Vesta_${VERSION}.apk"
+          done
+          ls -lh tauri-out/
+
+      - uses: actions/upload-artifact@v7
+        if: github.event_name != 'pull_request'
+        with:
+          name: tauri-android
+          path: tauri-out/*
+
+  # ── Build Tauri app (iOS) ──────────────────────────────────────────
+  build-tauri-ios:
+    needs: [test-frontend, detect-changes]
+    if: >-
+      !failure() && !cancelled() && (
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.app == 'true'
+      )
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: app/src-tauri
+          key: ios
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install Apple certificate and provisioning profile
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
+          KEYCHAIN_PASSWORD: ${{ github.run_id }}
+        run: |
+          CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
+          PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$APPLE_PROVISIONING_PROFILE" | base64 --decode -o $PROFILE_PATH
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security import $CERTIFICATE_PATH -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp $PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/
+
+      - name: Install frontend deps
+        working-directory: app
+        run: npm install
+
+      - name: Initialize iOS project
+        working-directory: app
+        run: npx tauri ios init
+
+      - name: Build iOS
+        working-directory: app
+        run: npx tauri ios build --export-method app-store-connect
+
+      - name: Collect artifacts
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p tauri-out
+          find app/src-tauri/gen/apple -name '*.ipa' -exec cp {} tauri-out/ \;
+          VERSION=$(python3 -c "import json; print(json.load(open('app/src-tauri/tauri.conf.json'))['version'])")
+          for f in tauri-out/*.ipa; do
+            mv "$f" "tauri-out/Vesta_${VERSION}.ipa"
+          done
+          ls -lh tauri-out/
+
+      - name: Upload to TestFlight
+        if: github.event_name == 'release'
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo -n "$APPLE_API_KEY" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8
+          xcrun altool --upload-app \
+            --type ios \
+            --file tauri-out/Vesta_*.ipa \
+            --apiKey "$APPLE_API_KEY_ID" \
+            --apiIssuer "$APPLE_API_ISSUER_ID"
+
+      - uses: actions/upload-artifact@v7
+        if: github.event_name != 'pull_request'
+        with:
+          name: tauri-ios
+          path: tauri-out/*
+
+      - name: Clean up keychain
+        if: always()
+        run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
+
   # ── Merge gate (single required check for branch protection) ─────────
   merge-gate-ci:
     if: always()
@@ -621,7 +791,7 @@ jobs:
 
   # ── Upload artifacts to release and publish ──────────────────────────
   release:
-    needs: [build-vesta, build-vestad, test-frontend, test-integration, test-linux, build-windows, build-tauri, build-tauri-windows, push-image]
+    needs: [build-vesta, build-vestad, test-frontend, test-integration, test-linux, build-windows, build-tauri, build-tauri-windows, build-tauri-android, build-tauri-ios, push-image]
     if: ${{ !failure() && !cancelled() && github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
@@ -640,6 +810,7 @@ jobs:
             -name '*.tar.gz' -o -name '*.zip' -o \
             -name '*.deb' -o -name '*.rpm' -o -name '*.dmg' -o \
             -name '*-setup.exe' -o -name '*_x64-setup.exe' -o \
+            -name '*.apk' -o -name '*.ipa' -o \
             -name '*.sig' \
           \) -exec cp {} release/ \;
           ls -lh release/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,14 +566,10 @@ jobs:
           name: tauri-x86_64-pc-windows-msvc
           path: tauri-out/*
 
-  # ── Build Tauri app (Android APK) ────────────────────────────────────
+  # ── Build Tauri app (Android APK, non-PR only) ──────────────────────
   build-tauri-android:
-    needs: [test-frontend, detect-changes]
-    if: >-
-      !failure() && !cancelled() && (
-      github.event_name != 'pull_request' ||
-      needs.detect-changes.outputs.app == 'true'
-      )
+    needs: [test-frontend]
+    if: ${{ !failure() && !cancelled() && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -620,11 +616,9 @@ jobs:
         run: npx tauri android build --apk
 
       - name: Collect artifacts
-        if: github.event_name != 'pull_request'
         run: |
           mkdir -p tauri-out
           find app/src-tauri/gen/android -name '*.apk' -exec cp {} tauri-out/ \;
-          # Rename to include version
           VERSION=$(python3 -c "import json; print(json.load(open('app/src-tauri/tauri.conf.json'))['version'])")
           for f in tauri-out/*.apk; do
             mv "$f" "tauri-out/Vesta_${VERSION}.apk"
@@ -632,19 +626,14 @@ jobs:
           ls -lh tauri-out/
 
       - uses: actions/upload-artifact@v7
-        if: github.event_name != 'pull_request'
         with:
           name: tauri-android
           path: tauri-out/*
 
-  # ── Build Tauri app (iOS) ──────────────────────────────────────────
+  # ── Build Tauri app (iOS, non-PR only) ──────────────────────────────
   build-tauri-ios:
-    needs: [test-frontend, detect-changes]
-    if: >-
-      !failure() && !cancelled() && (
-      github.event_name != 'pull_request' ||
-      needs.detect-changes.outputs.app == 'true'
-      )
+    needs: [test-frontend]
+    if: ${{ !failure() && !cancelled() && github.event_name != 'pull_request' }}
     runs-on: macos-latest
     steps:
       - name: Check for Apple signing secrets
@@ -718,7 +707,7 @@ jobs:
         run: npx tauri ios build --export-method app-store-connect
 
       - name: Collect artifacts
-        if: env.SKIP_IOS != 'true' && github.event_name != 'pull_request'
+        if: env.SKIP_IOS != 'true'
         run: |
           mkdir -p tauri-out
           find app/src-tauri/gen/apple -name '*.ipa' -exec cp {} tauri-out/ \;
@@ -744,7 +733,7 @@ jobs:
             --apiIssuer "$APPLE_API_ISSUER_ID"
 
       - uses: actions/upload-artifact@v7
-        if: env.SKIP_IOS != 'true' && github.event_name != 'pull_request'
+        if: env.SKIP_IOS != 'true'
         with:
           name: tauri-ios
           path: tauri-out/*

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.112"
+version = "0.1.113"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vesta",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vesta",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-rc.0",

--- a/app/src/components/Connect/index.tsx
+++ b/app/src/components/Connect/index.tsx
@@ -27,7 +27,7 @@ export function Connect() {
     try {
       const url = host.includes("://") ? host.trim() : `https://${host.trim()}`;
       await connect(url, apiKey.trim());
-      navigate("/", { replace: true });
+      navigate("/home", { replace: true });
     } catch (e: unknown) {
       const msg = (e as { message?: string })?.message || "connection failed";
       if (msg === "could not reach server") {

--- a/app/src/components/ErrorBoundary/index.tsx
+++ b/app/src/components/ErrorBoundary/index.tsx
@@ -95,9 +95,9 @@ function ErrorFallback({
 
   const handleGoHome = useCallback(() => {
     if (navigate) {
-      navigate("/");
+      navigate("/home");
     } else {
-      window.location.href = "/";
+      window.location.href = "/home";
     }
   }, [navigate]);
 

--- a/app/src/components/Navbar/index.tsx
+++ b/app/src/components/Navbar/index.tsx
@@ -25,7 +25,7 @@ export function Navbar({ center, trailing }: NavbarProps = {}) {
   const { agents } = useAgents();
   const navigate = useNavigate();
   const location = useLocation();
-  const isHome = location.pathname === "/";
+  const isHome = location.pathname === "/home";
   const setNavbarHeight = useLayout((s) => s.setNavbarHeight);
 
   const measureRef = useCallback((node: HTMLDivElement | null) => {
@@ -66,7 +66,7 @@ export function Navbar({ center, trailing }: NavbarProps = {}) {
                   variant="outline"
                   size="icon-sm"
                   className="md:size-9"
-                  onClick={() => navigate("/")}
+                  onClick={() => navigate("/home")}
                 >
                   <Home />
                 </Button>

--- a/app/src/components/NewAgent/index.tsx
+++ b/app/src/components/NewAgent/index.tsx
@@ -118,7 +118,7 @@ export function NewAgent() {
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter") handleCreate();
-    if (e.key === "Escape" && hasAgents) navigate("/");
+    if (e.key === "Escape" && hasAgents) navigate("/home");
   };
 
   const content = (() => {
@@ -157,7 +157,7 @@ export function NewAgent() {
                 setAuthStart(null);
 
                 if (hasOtherAgents) {
-                  navigate("/");
+                  navigate("/home");
                 } else {
                   setStep("name");
                 }

--- a/app/src/lib/AgentLayout/index.tsx
+++ b/app/src/lib/AgentLayout/index.tsx
@@ -18,7 +18,7 @@ export function AgentLayout() {
   const { agents } = useAgents();
 
   if (!agents.some((a) => a.name === routeName)) {
-    return <Navigate to="/" replace />;
+    return <Navigate to="/home" replace />;
   }
 
   return (

--- a/app/src/lib/platform.ts
+++ b/app/src/lib/platform.ts
@@ -3,6 +3,7 @@ export type Platform = "macos" | "windows" | "linux" | "ios" | "android";
 export function detectPlatform(): Platform {
   const ua = navigator.userAgent;
   if (ua.includes("Android")) return "android";
+  if (ua.includes("iPhone") || ua.includes("iPad")) return "ios";
   if (ua.includes("Mac")) {
     if ("maxTouchPoints" in navigator && navigator.maxTouchPoints > 0) return "ios";
     return "macos";

--- a/app/src/pages/Landing/index.tsx
+++ b/app/src/pages/Landing/index.tsx
@@ -10,7 +10,6 @@ type DownloadInfo = {
   label: string;
   filename: (version: string) => string;
   note?: string;
-  external?: boolean;
   altLinks?: { label: string; filename: (version: string) => string }[];
 };
 
@@ -42,7 +41,7 @@ const DOWNLOAD_MAP: Record<Platform, DownloadInfo> = {
   ios: {
     label: "Get on TestFlight",
     filename: () => "",
-    external: true,
+    note: "Coming soon",
   },
 };
 
@@ -69,11 +68,17 @@ export function Landing() {
     fetch(`${RELEASES}/latest/download/latest.json`, {
       signal: controller.signal,
     })
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error(r.statusText);
+        return r.json();
+      })
       .then((data: { version?: string }) => {
         if (data.version) setVersion(data.version);
       })
-      .catch(() => {});
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        console.error("Failed to fetch latest version:", err);
+      });
     return () => controller.abort();
   }, []);
 

--- a/app/src/pages/Landing/index.tsx
+++ b/app/src/pages/Landing/index.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import { detectPlatform, type Platform } from "@/lib/platform";
+
+const REPO = "https://github.com/elyxlz/vesta";
+const RELEASES = `${REPO}/releases`;
+
+type DownloadInfo = {
+  label: string;
+  filename: (version: string) => string;
+  note?: string;
+  altLinks?: { label: string; filename: (version: string) => string }[];
+};
+
+const DOWNLOAD_MAP: Record<Platform, DownloadInfo> = {
+  macos: {
+    label: "Download for macOS",
+    filename: (v) => `Vesta_${v}_aarch64.dmg`,
+    note: "Apple Silicon",
+    altLinks: [{ label: "Intel Mac", filename: (v) => `Vesta_${v}_x64.dmg` }],
+  },
+  windows: {
+    label: "Download for Windows",
+    filename: (v) => `Vesta_${v}_x64-setup.exe`,
+  },
+  linux: {
+    label: "Download for Linux",
+    filename: (v) => `Vesta_${v}_amd64.deb`,
+    note: ".deb",
+    altLinks: [
+      { label: ".rpm", filename: (v) => `Vesta-${v}-1.x86_64.rpm` },
+      { label: "ARM64 .deb", filename: (v) => `Vesta_${v}_arm64.deb` },
+    ],
+  },
+  android: {
+    label: "Download for Android",
+    filename: (v) => `Vesta_${v}.apk`,
+    note: ".apk",
+  },
+  ios: {
+    label: "Get on TestFlight",
+    filename: () => "",
+    note: "Coming soon",
+  },
+};
+
+const ALL_PLATFORMS: { label: string; platform: Platform }[] = [
+  { label: "macOS", platform: "macos" },
+  { label: "Windows", platform: "windows" },
+  { label: "Linux", platform: "linux" },
+  { label: "Android", platform: "android" },
+  { label: "iOS", platform: "ios" },
+];
+
+function buildUrl(version: string, filename: string): string {
+  return `${RELEASES}/download/v${version}/${filename}`;
+}
+
+export function Landing() {
+  const platform = detectPlatform();
+  const download = DOWNLOAD_MAP[platform];
+  const [version, setVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${RELEASES}/latest/download/latest.json`)
+      .then((r) => r.json())
+      .then((data: { version?: string }) => {
+        if (data.version) setVersion(data.version);
+      })
+      .catch(() => {});
+  }, []);
+
+  const mainUrl = version
+    ? buildUrl(version, download.filename(version))
+    : `${RELEASES}/latest`;
+
+  return (
+    <div className="flex flex-col items-center justify-center flex-1 min-h-0 px-4 gap-8 select-none">
+      <div className="flex flex-col items-center gap-2">
+        <h1 className="text-4xl font-serif font-medium tracking-tight">
+          Vesta
+        </h1>
+        <p className="text-sm text-muted-foreground">Personal AI assistant</p>
+      </div>
+
+      <div className="flex flex-col items-center gap-3">
+        <a
+          href={mainUrl}
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          {download.label}
+          {download.note && (
+            <span className="text-xs opacity-70">({download.note})</span>
+          )}
+        </a>
+
+        {version && download.altLinks && (
+          <div className="flex gap-3">
+            {download.altLinks.map((link) => (
+              <a
+                key={link.label}
+                href={buildUrl(version, link.filename(version))}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2"
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-wrap justify-center gap-3 text-xs text-muted-foreground">
+        {ALL_PLATFORMS.filter((p) => p.platform !== platform).map((p) => {
+          const info = DOWNLOAD_MAP[p.platform];
+          const url = version
+            ? buildUrl(version, info.filename(version))
+            : `${RELEASES}/latest`;
+          return (
+            <a
+              key={p.platform}
+              href={url}
+              className="hover:text-foreground transition-colors underline underline-offset-2"
+            >
+              {p.label}
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/src/pages/Landing/index.tsx
+++ b/app/src/pages/Landing/index.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
 import { detectPlatform, type Platform } from "@/lib/platform";
 
 const REPO = "https://github.com/elyxlz/vesta";
@@ -8,6 +10,7 @@ type DownloadInfo = {
   label: string;
   filename: (version: string) => string;
   note?: string;
+  external?: boolean;
   altLinks?: { label: string; filename: (version: string) => string }[];
 };
 
@@ -39,7 +42,7 @@ const DOWNLOAD_MAP: Record<Platform, DownloadInfo> = {
   ios: {
     label: "Get on TestFlight",
     filename: () => "",
-    note: "Coming soon",
+    external: true,
   },
 };
 
@@ -52,6 +55,7 @@ const ALL_PLATFORMS: { label: string; platform: Platform }[] = [
 ];
 
 function buildUrl(version: string, filename: string): string {
+  if (!filename) return `${RELEASES}/latest`;
   return `${RELEASES}/download/v${version}/${filename}`;
 }
 
@@ -61,12 +65,16 @@ export function Landing() {
   const [version, setVersion] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch(`${RELEASES}/latest/download/latest.json`)
+    const controller = new AbortController();
+    fetch(`${RELEASES}/latest/download/latest.json`, {
+      signal: controller.signal,
+    })
       .then((r) => r.json())
       .then((data: { version?: string }) => {
         if (data.version) setVersion(data.version);
       })
       .catch(() => {});
+    return () => controller.abort();
   }, []);
 
   const mainUrl = version
@@ -82,16 +90,21 @@ export function Landing() {
         <p className="text-sm text-muted-foreground">Personal AI assistant</p>
       </div>
 
-      <div className="flex flex-col items-center gap-3">
-        <a
-          href={mainUrl}
-          className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-        >
-          {download.label}
-          {download.note && (
-            <span className="text-xs opacity-70">({download.note})</span>
-          )}
-        </a>
+      <div className="flex flex-col items-center gap-4">
+        <div className="flex flex-col items-center gap-2">
+          <Button asChild>
+            <a href={mainUrl}>
+              {download.label}
+              {download.note && (
+                <span className="text-xs opacity-70">({download.note})</span>
+              )}
+            </a>
+          </Button>
+
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/connect">Continue in browser</Link>
+          </Button>
+        </div>
 
         {version && download.altLinks && (
           <div className="flex gap-3">

--- a/app/src/pages/index.ts
+++ b/app/src/pages/index.ts
@@ -3,4 +3,5 @@ export { AgentChat } from "./AgentChat";
 export { AgentSettingsPage } from "./AgentSettings";
 export { Connect } from "./Connect";
 export { Home } from "./Home";
+export { Landing } from "./Landing";
 export { NewAgent } from "./NewAgent";

--- a/app/src/providers/ModalsProvider/index.tsx
+++ b/app/src/providers/ModalsProvider/index.tsx
@@ -79,7 +79,7 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
   }, [name, authStarting]);
 
   const handleDelete = useCallback(async () => {
-    navigate("/");
+    navigate("/home");
     await remove();
     await refreshAgents();
   }, [navigate, remove, refreshAgents]);

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -3,12 +3,14 @@ import { RouteErrorBoundary } from "@/components/ErrorBoundary";
 import { AgentLayout } from "@/lib/AgentLayout";
 import { NavigationGuard } from "@/lib/NavigationGuard";
 import { RootLayout } from "@/lib/RootLayout";
+import { isTauri } from "@/lib/env";
 import {
   AgentChat,
   AgentDashboard,
   AgentSettingsPage,
   Connect,
   Home,
+  Landing,
   NewAgent,
 } from "@/pages";
 
@@ -17,12 +19,16 @@ export const router = createBrowserRouter([
     element: <RootLayout />,
     errorElement: <RouteErrorBoundary />,
     children: [
+      {
+        index: true,
+        element: isTauri ? <Navigate to="/connect" replace /> : <Landing />,
+      },
       { path: "/connect", element: <Connect /> },
       {
         element: <NavigationGuard />,
         errorElement: <RouteErrorBoundary />,
         children: [
-          { index: true, element: <Home /> },
+          { path: "home", element: <Home /> },
           { path: "new", element: <NewAgent /> },
           {
             path: "agent/:name",
@@ -34,7 +40,7 @@ export const router = createBrowserRouter([
               { path: "settings", element: <AgentSettingsPage /> },
             ],
           },
-          { path: "*", element: <Navigate to="/" replace /> },
+          { path: "*", element: <Navigate to="/home" replace /> },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- Add minimalist landing page at `/` (vesta.run) with auto-detected platform download buttons
- Move existing app home route from `/` to `/home`; Tauri apps redirect `/` to `/connect`
- Add Android APK build job to CI (unsigned, sideloadable)
- Add iOS IPA build job to CI with TestFlight upload on release

## Details

**Landing page** (`app/src/pages/Landing/`):
- Detects platform via `detectPlatform()` and shows the right download button
- Fetches `latest.json` to resolve current version and construct download URLs
- Shows alt links (e.g. Intel Mac, .rpm) and links to all other platforms
- Only shown on web — Tauri redirects to `/connect`

**Mobile CI** (`.github/workflows/ci.yml`):
- Android: ubuntu-latest, JDK 17, Android SDK + NDK, `tauri android init` + `build --apk`
- iOS: macos-latest, Apple signing via secrets, `tauri ios init` + `build`, TestFlight upload on release
- Both jobs added to release artifact collection (`.apk`, `.ipa`)

**Required secrets for iOS** (need to be configured in repo settings):
- `APPLE_CERTIFICATE` (base64 p12)
- `APPLE_CERTIFICATE_PASSWORD`
- `APPLE_PROVISIONING_PROFILE` (base64 mobileprovision)
- `APPLE_API_KEY_ID`, `APPLE_API_ISSUER_ID`, `APPLE_API_KEY` (for TestFlight upload)

## Test plan
- [ ] `npm run check` and `npm run test` pass
- [ ] `npm run web:build` succeeds
- [ ] Landing page renders at `/` in web preview
- [ ] `/connect` still works as before
- [ ] Desktop Tauri build still works (redirects `/` to `/connect`)
- [ ] Android CI job runs successfully
- [ ] iOS CI job runs successfully (once secrets configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)