### PR TITLE
fix: delay agent_ready until first-start setup completes

### DIFF
--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -99,6 +99,8 @@ async def queue_greeting(queue: asyncio.Queue[tuple[str, bool]], *, config: vm.V
             prompt = f"[System: your name is {config.agent_name}]\n\n{prompt}"
             # Mark first start as done so restarts don't re-trigger it
             (config.data_dir / "first_start_done").write_text("1")
+            # Remove ready marker so vestad keeps showing "waking up" until setup completes
+            (config.data_dir / "agent_ready").unlink(missing_ok=True)
     else:
         extras = []
         today = _now().strftime("%Y-%m-%d")
@@ -199,6 +201,7 @@ async def _process_interruptible(
 async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.State, config: vm.VestaConfig) -> None:
     logger.client("Creating new client session...")
     options = build_client_options(config, state)
+    ready_marker = config.data_dir / "agent_ready"
     async with ClaudeSDKClient(options=options) as client:
         state.client = client
         logger.client("Client session started")
@@ -211,6 +214,11 @@ async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm
                     continue
 
                 await _process_interruptible(msg, is_user=is_user, queue=queue, state=state, config=config)
+
+                if not ready_marker.exists():
+                    ready_marker.parent.mkdir(parents=True, exist_ok=True)
+                    ready_marker.write_text("1")
+                    logger.startup("Agent ready")
 
                 if state.dreamer_active:
                     state.dreamer_active = False

--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -99,8 +99,6 @@ async def queue_greeting(queue: asyncio.Queue[tuple[str, bool]], *, config: vm.V
             prompt = f"[System: your name is {config.agent_name}]\n\n{prompt}"
             # Mark first start as done so restarts don't re-trigger it
             (config.data_dir / "first_start_done").write_text("1")
-            # Remove ready marker so vestad keeps showing "waking up" until setup completes
-            (config.data_dir / "agent_ready").unlink(missing_ok=True)
     else:
         extras = []
         today = _now().strftime("%Y-%m-%d")

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.112"
+version = "0.1.113"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -28,6 +28,7 @@ pub const VESTA_LOG_PATH: &str = "/root/vesta/logs/vesta.log";
 pub const LOCAL_IMAGE_TAG: &str = "vesta:local";
 const MAX_DOCKERFILE_SEARCH_DEPTH: usize = 5;
 pub const CREDENTIALS_PATH: &str = "/root/.claude/.credentials.json";
+pub const AGENT_READY_MARKER_PATH: &str = "/root/vesta/data/agent_ready";
 const CLAUDE_JSON_PATH: &str = "/root/.claude.json";
 pub const BASE_WS_PORT: u16 = 7865;
 const NAME_MAX_LEN: usize = 32;
@@ -279,7 +280,7 @@ pub struct AgentDerivedState {
 
 pub fn compute_agent_state(cname: &str, info: &ContainerInfo) -> AgentDerivedState {
     let authenticated = info.status != ContainerStatus::NotFound && is_authenticated(cname);
-    let agent_ready = info.status == ContainerStatus::Running && is_agent_ready(info.port);
+    let agent_ready = info.status == ContainerStatus::Running && is_agent_ready(info.port, cname);
     let alive = info.status == ContainerStatus::Running && authenticated;
     let friendly_status = friendly_status(&info.status, authenticated, agent_ready);
     AgentDerivedState { authenticated, agent_ready, alive, friendly_status }
@@ -406,12 +407,13 @@ pub fn is_authenticated(cname: &str) -> bool {
     expires_at > now_ms
 }
 
-pub fn is_agent_ready(port: u16) -> bool {
-    std::net::TcpStream::connect_timeout(
+pub fn is_agent_ready(port: u16, cname: &str) -> bool {
+    let tcp_ok = std::net::TcpStream::connect_timeout(
         &std::net::SocketAddr::from(([127, 0, 0, 1], port)),
         std::time::Duration::from_millis(AGENT_READY_TIMEOUT_MS),
     )
-    .is_ok()
+    .is_ok();
+    tcp_ok && read_container_file(cname, AGENT_READY_MARKER_PATH).is_some()
 }
 
 pub fn ensure_exists(cname: &str) -> Result<(), DockerError> {
@@ -998,10 +1000,13 @@ pub async fn wait_ready_async(name: &str, timeout_secs: u64) -> Result<(), Docke
         .await
         .unwrap()?
     };
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(timeout_secs);
     loop {
-        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+        let cname_check = cname.clone();
+        let ready = tokio::task::spawn_blocking(move || is_agent_ready(port, &cname_check))
+            .await
+            .unwrap();
+        if ready {
             return Ok(());
         }
         if tokio::time::Instant::now() >= deadline {


### PR DESCRIPTION
## Summary
- On first boot, the app showed "alive" immediately when the WS server started, even though the agent spent ~2 minutes processing its first-start setup
- Agent now writes an `agent_ready` marker file only after its first message (the greeting) is fully processed
- vestad checks for this marker alongside the existing TCP check
- On restarts the marker already exists, so readiness is instant — no behavior change for restarts

## Test plan
- [x] `cargo clippy` passes
- [x] `uv run pytest tests/test_unit.py` — 48/48 pass
- [ ] Manual: create a new agent, verify orb stays in "waking up..." until first-start greeting completes
- [ ] Manual: restart an existing agent, verify it shows "alive" immediately after WS is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)