### PR TITLE
feat(vestad): add POST /self-update API endpoint

### DIFF
--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.112"
+version = "0.1.113"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 
 mod docker;
 mod jwt;
+mod self_update;
 mod serve;
 mod systemd;
 mod tunnel;
@@ -448,51 +449,7 @@ fn main() {
         }
 
         Command::Update => {
-            let target = match std::env::consts::ARCH {
-                "x86_64" => "x86_64-unknown-linux-gnu",
-                "aarch64" => "aarch64-unknown-linux-gnu",
-                other => die(format!("unsupported architecture: {}", other)),
-            };
-
-            let archive = format!("vestad-{}.tar.gz", target);
-            let url = format!(
-                "https://github.com/elyxlz/vesta/releases/latest/download/{}",
-                archive
-            );
-            let tmp = format!("/tmp/vestad-update-{}", std::process::id());
-            std::fs::create_dir_all(&tmp).ok();
-
-            tracing::info!("downloading update...");
-            let status = std::process::Command::new("curl")
-                .args(["-fsSL", "-o", &format!("{}/{}", tmp, archive), &url])
-                .status();
-            if !status.map(|s| s.success()).unwrap_or(false) {
-                die("failed to download update");
-            }
-
-            let status = std::process::Command::new("tar")
-                .args(["-xzf", &format!("{}/{}", tmp, archive), "-C", &tmp])
-                .status();
-            if !status.map(|s| s.success()).unwrap_or(false) {
-                die("failed to extract update");
-            }
-
-            let new_binary = format!("{}/vestad", tmp);
-            self_replace::self_replace(&new_binary)
-                .unwrap_or_else(|e| die(format!("failed to replace binary: {}", e)));
-
-            std::fs::remove_dir_all(&tmp).ok();
-
-            if let Err(e) = systemd::reinstall_service() {
-                tracing::warn!("failed to update systemd service: {e}");
-            }
-            if systemd::is_active() {
-                tracing::info!("restarting vestad...");
-                systemd::restart().unwrap_or_else(|e| die(&e));
-                tracing::info!("updated and restarted.");
-            } else {
-                tracing::info!("updated. run 'vestad' to start.");
-            }
+            self_update::perform_update().unwrap_or_else(|e| die(e.to_string()));
         }
 
         Command::Uninstall => {

--- a/vestad/src/self_update.rs
+++ b/vestad/src/self_update.rs
@@ -1,0 +1,76 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum UpdateError {
+    UnsupportedArch(String),
+    Download(String),
+    Extract(String),
+    Replace(String),
+}
+
+impl fmt::Display for UpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedArch(arch) => write!(f, "unsupported architecture: {}", arch),
+            Self::Download(msg) => write!(f, "failed to download update: {}", msg),
+            Self::Extract(msg) => write!(f, "failed to extract update: {}", msg),
+            Self::Replace(msg) => write!(f, "failed to replace binary: {}", msg),
+        }
+    }
+}
+
+/// Downloads the latest vestad binary from GitHub, replaces the current binary,
+/// and reinstalls the systemd service. Returns Ok(true) if a restart was triggered.
+pub fn perform_update() -> Result<bool, UpdateError> {
+    let target = match std::env::consts::ARCH {
+        "x86_64" => "x86_64-unknown-linux-gnu",
+        "aarch64" => "aarch64-unknown-linux-gnu",
+        other => return Err(UpdateError::UnsupportedArch(other.to_string())),
+    };
+
+    let archive = format!("vestad-{}.tar.gz", target);
+    let url = format!(
+        "https://github.com/elyxlz/vesta/releases/latest/download/{}",
+        archive
+    );
+    let tmp = format!("/tmp/vestad-update-{}", std::process::id());
+    std::fs::create_dir_all(&tmp).ok();
+
+    tracing::info!("downloading update...");
+    let status = std::process::Command::new("curl")
+        .args(["-fsSL", "-o", &format!("{}/{}", tmp, archive), &url])
+        .status();
+    if !status.map(|s| s.success()).unwrap_or(false) {
+        std::fs::remove_dir_all(&tmp).ok();
+        return Err(UpdateError::Download("curl failed".into()));
+    }
+
+    let status = std::process::Command::new("tar")
+        .args(["-xzf", &format!("{}/{}", tmp, archive), "-C", &tmp])
+        .status();
+    if !status.map(|s| s.success()).unwrap_or(false) {
+        std::fs::remove_dir_all(&tmp).ok();
+        return Err(UpdateError::Extract("tar failed".into()));
+    }
+
+    let new_binary = format!("{}/vestad", tmp);
+    self_replace::self_replace(&new_binary)
+        .map_err(|e| UpdateError::Replace(e.to_string()))?;
+
+    std::fs::remove_dir_all(&tmp).ok();
+
+    if let Err(e) = crate::systemd::reinstall_service() {
+        tracing::warn!("failed to update systemd service: {e}");
+    }
+
+    if crate::systemd::is_active() {
+        tracing::info!("restarting vestad...");
+        if let Err(e) = crate::systemd::restart() {
+            tracing::error!("failed to restart: {e}");
+        }
+        Ok(true)
+    } else {
+        tracing::info!("updated. run 'vestad' to start.");
+        Ok(false)
+    }
+}

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 use tokio::sync::{Mutex, RwLock};
 
-use crate::{docker, jwt, update_check};
+use crate::{docker, jwt, self_update, update_check};
 
 const API_KEY_BYTES: usize = 32;
 const PROXY_MAX_BODY_BYTES: usize = 10 * 1024 * 1024; // 10 MB
@@ -332,6 +332,20 @@ async fn version(State(state): State<SharedState>) -> Json<serde_json::Value> {
         "latest_version": latest,
         "update_available": update_available,
     }))
+}
+
+async fn self_update_handler() -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    tracing::info!("self-update requested via API");
+    let result = tokio::task::spawn_blocking(self_update::perform_update)
+        .await
+        .unwrap();
+    match result {
+        Ok(restarting) => Ok(Json(serde_json::json!({
+            "ok": true,
+            "restarting": restarting,
+        }))),
+        Err(e) => Err(err_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string())),
+    }
 }
 
 async fn tunnel_handler(
@@ -1163,6 +1177,7 @@ pub fn build_router(state: SharedState) -> Router {
 
     let protected = Router::new()
         .route("/version", get(version))
+        .route("/self-update", post(self_update_handler))
         .route("/tunnel", get(tunnel_handler))
         .route("/agents", get(list_agents_handler))
         .route("/agents", post(create_agent_handler))


### PR DESCRIPTION
## Summary
- Extract update logic from `vestad update` CLI command into reusable `self_update` module
- Expose as `POST /self-update` authenticated API endpoint (same auth as all other protected endpoints)
- Enables remote vestad binary updates without SSH — management server calls this over the Cloudflare tunnel
- CLI `vestad update` now calls the same shared function

## Context
Part of the hosted Vesta infrastructure plan (#139). The management server needs to update vestad binaries on user VMs remotely. This endpoint lets it do so using the existing API key auth, without needing SSH access or a separate admin token.

## Test plan
- [ ] `cargo build -p vestad` compiles
- [ ] `cargo clippy -p vestad` passes
- [ ] `POST /self-update` with valid Bearer token downloads latest release, replaces binary, and restarts
- [ ] `POST /self-update` without auth returns 401
- [ ] `vestad update` CLI command still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)