### PR TITLE
fix(app): clean up update bar as pill with update button

### DIFF
--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.112"
+version = "0.1.113"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,3 +1,79 @@
+#[cfg(target_os = "linux")]
+#[tauri::command]
+async fn install_update(version: String) -> Result<(), String> {
+    use std::process::Command;
+
+    let arch = std::env::consts::ARCH;
+
+    // Try dpkg (Debian/Ubuntu) first, then rpm (Fedora/RHEL)
+    let (url, install_cmd) = if Command::new("dpkg").arg("--version").output().is_ok() {
+        let pkg_arch = match arch {
+            "x86_64" => "amd64",
+            "aarch64" => "arm64",
+            _ => return Err(format!("Unsupported architecture: {arch}")),
+        };
+        let filename = format!("Vesta_{version}_{pkg_arch}.deb");
+        let url =
+            format!("https://github.com/elyxlz/vesta/releases/download/v{version}/{filename}");
+        (url, vec!["dpkg", "-i"])
+    } else if Command::new("rpm").arg("--version").output().is_ok() {
+        let pkg_arch = match arch {
+            "x86_64" => "x86_64",
+            "aarch64" => "aarch64",
+            _ => return Err(format!("Unsupported architecture: {arch}")),
+        };
+        let filename = format!("Vesta-{version}-1.{pkg_arch}.rpm");
+        let url =
+            format!("https://github.com/elyxlz/vesta/releases/download/v{version}/{filename}");
+        (url, vec!["rpm", "-U", "--force"])
+    } else {
+        return Err("No supported package manager (dpkg/rpm) found".into());
+    };
+
+    let tmp_dir = std::env::temp_dir().join("vesta-update");
+    std::fs::create_dir_all(&tmp_dir).map_err(|e| e.to_string())?;
+    let pkg_path = tmp_dir.join("vesta-update-pkg");
+
+    // Download the package
+    let output = Command::new("curl")
+        .args(["-fsSL", "-o"])
+        .arg(&pkg_path)
+        .arg(&url)
+        .output()
+        .map_err(|e| format!("Failed to download update: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "Download failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    // Install with pkexec for GUI privilege escalation
+    let mut args = vec![install_cmd[0]];
+    for flag in &install_cmd[1..] {
+        args.push(flag);
+    }
+    let pkg_path_str = pkg_path.to_string_lossy().to_string();
+    args.push(&pkg_path_str);
+
+    let output = Command::new("pkexec")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to run pkexec: {e}"))?;
+
+    // Clean up
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+
+    if !output.status.success() {
+        return Err(format!(
+            "Install failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
+
 #[cfg(mobile)]
 #[tauri::mobile_entry_point]
 pub fn mobile_entry_point() {
@@ -73,6 +149,16 @@ pub fn run() {
             }
 
             Ok(())
+        })
+        .invoke_handler({
+            #[cfg(target_os = "linux")]
+            {
+                tauri::generate_handler![install_update]
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                tauri::generate_handler![]
+            }
         })
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/app/src/api/index.ts
+++ b/app/src/api/index.ts
@@ -19,4 +19,4 @@ export {
 export { authenticate, submitAuthCode, type AuthStartResult } from "./auth";
 export { streamLogs, stopLogs } from "./logs";
 export { connectToServer } from "./server";
-export { isNewer, checkAndInstallUpdate } from "./updates";
+export { isNewer, checkAndInstallUpdate, type UpdateInfo } from "./updates";

--- a/app/src/api/updates.ts
+++ b/app/src/api/updates.ts
@@ -14,8 +14,6 @@ export type UpdateInfo = {
   version: string;
   /** Update was downloaded and installed — app needs restart to apply. */
   installed: boolean;
-  /** URL to download the update manually (Linux). */
-  releaseUrl: string | null;
 };
 
 export async function checkAndInstallUpdate(): Promise<UpdateInfo | null> {
@@ -30,20 +28,15 @@ export async function checkAndInstallUpdate(): Promise<UpdateInfo | null> {
       );
       if (!resp.ok) return null;
       const data = await resp.json();
-      const tag = data.tag_name as string;
-      const latest = tag.replace(/^v/, "");
+      const latest = (data.tag_name as string).replace(/^v/, "");
       if (!isNewer(latest, current)) return null;
-      return {
-        version: latest,
-        installed: false,
-        releaseUrl: data.html_url as string,
-      };
+      return { version: latest, installed: false };
     }
     const { check } = await import("@tauri-apps/plugin-updater");
     const update = await check();
     if (!update) return null;
     await update.downloadAndInstall();
-    return { version: update.version, installed: true, releaseUrl: null };
+    return { version: update.version, installed: true };
   } catch (e) {
     console.error("Update check failed:", e);
     return null;

--- a/app/src/api/updates.ts
+++ b/app/src/api/updates.ts
@@ -10,10 +10,15 @@ export function isNewer(latest: string, current: string): boolean {
   return false;
 }
 
-export async function checkAndInstallUpdate(): Promise<{
+export type UpdateInfo = {
   version: string;
-  installing: boolean;
-} | null> {
+  /** Update was downloaded and installed — app needs restart to apply. */
+  installed: boolean;
+  /** URL to download the update manually (Linux). */
+  releaseUrl: string | null;
+};
+
+export async function checkAndInstallUpdate(): Promise<UpdateInfo | null> {
   if (!isTauri) return null;
   try {
     const { getVersion } = await import("@tauri-apps/api/app");
@@ -25,15 +30,20 @@ export async function checkAndInstallUpdate(): Promise<{
       );
       if (!resp.ok) return null;
       const data = await resp.json();
-      const latest = (data.tag_name as string).replace(/^v/, "");
+      const tag = data.tag_name as string;
+      const latest = tag.replace(/^v/, "");
       if (!isNewer(latest, current)) return null;
-      return { version: latest, installing: false };
+      return {
+        version: latest,
+        installed: false,
+        releaseUrl: data.html_url as string,
+      };
     }
     const { check } = await import("@tauri-apps/plugin-updater");
     const update = await check();
     if (!update) return null;
     await update.downloadAndInstall();
-    return { version: update.version, installing: true };
+    return { version: update.version, installed: true, releaseUrl: null };
   } catch (e) {
     console.error("Update check failed:", e);
     return null;

--- a/app/src/components/UpdateBar/index.tsx
+++ b/app/src/components/UpdateBar/index.tsx
@@ -2,12 +2,14 @@ import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { isTauri } from "@/lib/env";
 import { checkAndInstallUpdate, type UpdateInfo } from "@/api";
-import { openExternalUrl } from "@/lib/open-external-url";
-import { X } from "lucide-react";
+import { X, LoaderCircle } from "lucide-react";
 
 export function UpdateBar() {
   const [update, setUpdate] = useState<UpdateInfo | null>(null);
   const [dismissed, setDismissed] = useState(false);
+  const [installing, setInstalling] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isTauri) return;
@@ -15,6 +17,21 @@ export function UpdateBar() {
       if (u) setUpdate(u);
     });
   }, []);
+
+  async function handleUpdate() {
+    if (!update || installing) return;
+    setInstalling(true);
+    setError(null);
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      await invoke("install_update", { version: update.version });
+      setDone(true);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setInstalling(false);
+    }
+  }
 
   const show = !!update && !dismissed;
 
@@ -30,15 +47,26 @@ export function UpdateBar() {
         >
           <div className="flex items-center gap-2 rounded-full border border-border bg-muted/50 py-1 pl-3 pr-1 text-xs">
             <span className="text-muted-foreground">
-              v{update!.version}{" "}
-              {update!.installed ? "installed — restart to apply" : "available"}
+              {done
+                ? `v${update!.version} installed — restart to apply`
+                : update!.installed
+                  ? `v${update!.version} installed — restart to apply`
+                  : `v${update!.version} available`}
             </span>
-            {!update!.installed && update!.releaseUrl && (
+            {error && (
+              <span className="text-destructive text-xs">{error}</span>
+            )}
+            {!update!.installed && !done && (
               <button
-                onClick={() => openExternalUrl(update!.releaseUrl!)}
-                className="rounded-full bg-primary px-3 py-0.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                onClick={handleUpdate}
+                disabled={installing}
+                className="rounded-full bg-primary px-3 py-0.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
               >
-                Update
+                {installing ? (
+                  <LoaderCircle size={12} className="animate-spin" />
+                ) : (
+                  "Update"
+                )}
               </button>
             )}
             <button

--- a/app/src/components/UpdateBar/index.tsx
+++ b/app/src/components/UpdateBar/index.tsx
@@ -1,14 +1,12 @@
 import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
-import { Button } from "@/components/ui/button";
 import { isTauri } from "@/lib/env";
-import { checkAndInstallUpdate } from "@/api";
+import { checkAndInstallUpdate, type UpdateInfo } from "@/api";
+import { openExternalUrl } from "@/lib/open-external-url";
+import { X } from "lucide-react";
 
 export function UpdateBar() {
-  const [update, setUpdate] = useState<{
-    version: string;
-    installing: boolean;
-  } | null>(null);
+  const [update, setUpdate] = useState<UpdateInfo | null>(null);
   const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
@@ -28,19 +26,27 @@ export function UpdateBar() {
           animate={{ height: "auto", opacity: 1 }}
           exit={{ height: 0, opacity: 0 }}
           transition={{ duration: 0.2 }}
-          className="overflow-hidden"
+          className="overflow-hidden flex justify-center py-2"
         >
-          <div className="flex items-center justify-center gap-2 py-1.5 px-3 text-xs text-muted-foreground">
-            <span>
-              v{update!.version} {update!.installing ? "installed — restart to apply" : "available"}
+          <div className="flex items-center gap-2 rounded-full border border-border bg-muted/50 py-1 pl-3 pr-1 text-xs">
+            <span className="text-muted-foreground">
+              v{update!.version}{" "}
+              {update!.installed ? "installed — restart to apply" : "available"}
             </span>
-            <Button
-              variant="link"
-              size="sm"
+            {!update!.installed && update!.releaseUrl && (
+              <button
+                onClick={() => openExternalUrl(update!.releaseUrl!)}
+                className="rounded-full bg-primary px-3 py-0.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                Update
+              </button>
+            )}
+            <button
               onClick={() => setDismissed(true)}
+              className="rounded-full p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
-              dismiss
-            </Button>
+              <X size={12} />
+            </button>
           </div>
         </motion.div>
       )}


### PR DESCRIPTION
## Summary
- Redesign the auto-update notification as a compact rounded pill with an X dismiss icon
- On Linux, add an "Update" button that downloads the .deb/.rpm and installs it via `pkexec` (native GUI sudo prompt) — previously there was no way to actually update
- Shows a spinner during download/install, then "installed — restart to apply" on success
- On macOS/Windows the existing behavior is preserved (Tauri auto-updater downloads and installs, then shows "restart to apply")
- Fix stale `uv.lock`

## Test plan
- [ ] Verify the pill renders centered with rounded borders
- [ ] On Linux: click "Update", verify pkexec password prompt appears, package installs, message changes to "restart to apply"
- [ ] Verify the X button dismisses the notification
- [ ] Verify macOS/Windows still auto-installs and shows "restart to apply" without the Update button

🤖 Generated with [Claude Code](https://claude.com/claude-code)