### PR TITLE
feat: add version and help subcommands to vesta and vestad

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process;
@@ -165,8 +165,6 @@ enum Command {
     Uninstall,
     /// Print version information
     Version,
-    /// Print help information
-    Help,
 }
 
 #[derive(Subcommand)]
@@ -724,11 +722,6 @@ fn run(cli: Cli) {
         }
         Command::Version => {
             println!("v{}", env!("CARGO_PKG_VERSION"));
-            return;
-        }
-
-        Command::Help => {
-            Cli::command().print_help().unwrap_or_else(|e| platform::die(&format!("failed to print help: {e}")));
             return;
         }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process;
@@ -163,6 +163,10 @@ enum Command {
     Update,
     /// Uninstall vesta CLI and remove config
     Uninstall,
+    /// Print version information
+    Version,
+    /// Print help information
+    Help,
 }
 
 #[derive(Subcommand)]
@@ -718,6 +722,16 @@ fn run(cli: Cli) {
 
             eprintln!("\nvesta has been uninstalled.");
         }
+        Command::Version => {
+            println!("v{}", env!("CARGO_PKG_VERSION"));
+            return;
+        }
+
+        Command::Help => {
+            Cli::command().print_help().unwrap_or_else(|e| platform::die(&format!("failed to print help: {e}")));
+            return;
+        }
+
         Command::Update => {
             #[cfg(target_os = "linux")]
             {

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_os = "linux"))]
 compile_error!("vestad only supports Linux");
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 
 mod docker;
 mod jwt;
@@ -70,6 +70,10 @@ enum Command {
     Update,
     /// Uninstall vestad: stop service, remove config, and delete binary
     Uninstall,
+    /// Print version information
+    Version,
+    /// Print help information
+    Help,
 }
 
 #[derive(clap::Subcommand)]
@@ -450,6 +454,14 @@ fn main() {
 
         Command::Update => {
             self_update::perform_update().unwrap_or_else(|e| die(e.to_string()));
+        }
+
+        Command::Version => {
+            println!("v{}", env!("CARGO_PKG_VERSION"));
+        }
+
+        Command::Help => {
+            Cli::command().print_help().unwrap_or_else(|e| die(format!("failed to print help: {e}")));
         }
 
         Command::Uninstall => {

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_os = "linux"))]
 compile_error!("vestad only supports Linux");
 
-use clap::{CommandFactory, Parser};
+use clap::Parser;
 
 mod docker;
 mod jwt;
@@ -72,8 +72,6 @@ enum Command {
     Uninstall,
     /// Print version information
     Version,
-    /// Print help information
-    Help,
 }
 
 #[derive(clap::Subcommand)]
@@ -458,10 +456,6 @@ fn main() {
 
         Command::Version => {
             println!("v{}", env!("CARGO_PKG_VERSION"));
-        }
-
-        Command::Help => {
-            Cli::command().print_help().unwrap_or_else(|e| die(format!("failed to print help: {e}")));
         }
 
         Command::Uninstall => {


### PR DESCRIPTION
## Summary
- Add `version` and `help` as subcommands to both `vesta` and `vestad` CLIs
- `vesta version` / `vestad version` prints the version (e.g. `v0.5.2`)
- `vesta help` / `vestad help` prints the full help text
- Existing `--version` and `--help` flags continue to work

## Test plan
- [ ] `vesta version` prints version
- [ ] `vesta help` prints help
- [ ] `vestad version` prints version
- [ ] `vestad help` prints help
- [ ] `vesta --version` and `vesta --help` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)