### PR TITLE
fix: consolidate agent creation flow server-side

### DIFF
--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.113"
+version = "0.1.114"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/app/src/components/AgentIslandModals/index.tsx
+++ b/app/src/components/AgentIslandModals/index.tsx
@@ -27,7 +27,7 @@ import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { useModals } from "@/providers/ModalsProvider";
 
 export function AgentIslandModals() {
-  const { name, agent, restart } = useSelectedAgent();
+  const { name, agent, refreshAgent } = useSelectedAgent();
   const {
     showAuth,
     authStarting,
@@ -64,7 +64,7 @@ export function AgentIslandModals() {
               onCancel={clearAuthState}
               onComplete={async () => {
                 clearAuthState();
-                await restart();
+                await refreshAgent();
               }}
             />
           ) : authStarting ? (

--- a/app/src/components/AuthFlow/index.tsx
+++ b/app/src/components/AuthFlow/index.tsx
@@ -69,8 +69,8 @@ export function AuthFlow({
     if (authState === "submitting") {
       return (
         <div className="flex min-w-0 w-full max-w-full flex-col items-center gap-3">
-          <p className="text-sm text-muted-foreground">verifying code...</p>
-          <ProgressBar message="verifying..." />
+          <p className="text-sm text-muted-foreground">setting up agent...</p>
+          <ProgressBar message="this may take a couple of mins" />
         </div>
       );
     }

--- a/app/src/components/NewAgent/index.tsx
+++ b/app/src/components/NewAgent/index.tsx
@@ -9,9 +9,6 @@ import { AuthFlow } from "@/components/AuthFlow";
 import {
   createAgent,
   deleteAgent,
-  startAgent,
-  restartAgent,
-  waitForReady,
   authenticate,
   type AuthStartResult,
 } from "@/api";
@@ -23,7 +20,7 @@ import { useAgents } from "@/providers/AgentsProvider";
 import { useNavigate } from "react-router-dom";
 import { friendlyError } from "./errors";
 
-type Step = "platform" | "name" | "creating" | "auth" | "finalizing" | "done";
+type Step = "platform" | "name" | "creating" | "auth" | "done";
 
 const CREATING_MESSAGES = [
   "setting things up...",
@@ -96,10 +93,6 @@ export function NewAgent() {
       await createAgent(normalized);
       created = true;
       await refreshAgents();
-      await startAgent(normalized);
-      await refreshAgents();
-      await waitForReady(normalized, 180);
-      await refreshAgents();
       const nextAuthStart = await authenticate(normalized);
       setAuthStart(nextAuthStart);
       setStep("auth");
@@ -134,15 +127,6 @@ export function NewAgent() {
       );
     }
 
-    if (step === "finalizing") {
-      return (
-        <div className="flex flex-col items-center gap-3 w-[260px] max-w-full px-4">
-          <h2 className="text-base font-semibold">preparing final things</h2>
-          <ProgressBar message="almost ready..." />
-        </div>
-      );
-    }
-
     if (step === "auth") {
       return (
         <div className="flex flex-col items-center gap-3 w-[260px] max-w-full px-4">
@@ -169,9 +153,6 @@ export function NewAgent() {
               }}
               onComplete={async () => {
                 setAuthStart(null);
-                setStep("finalizing");
-                await restartAgent(createdName);
-                await waitForReady(createdName, 30);
                 await refreshAgents();
                 setStep("done");
               }}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -429,10 +429,7 @@ fn run(cli: Cli) {
 
             eprintln!("authenticating claude...");
             authenticate_agent(&c, &name);
-
-            // Start
-            c.start_agent(&name).unwrap_or_else(|e| platform::die(&e));
-            eprintln!("agent '{}' is running.", name);
+            eprintln!("agent '{}' is ready.", name);
 
         }
 
@@ -442,10 +439,7 @@ fn run(cli: Cli) {
                 .map(|name| name.trim().to_string())
                 .unwrap_or_else(prompt_name);
             let name = c.create_agent(&name, build).unwrap_or_else(|e| platform::die(&e));
-            eprintln!(
-                "created (run 'vesta auth {}' to authenticate, then 'vesta start {}')",
-                name, name
-            );
+            eprintln!("created (run 'vesta auth {}' to authenticate)", name);
         }
 
         Command::Start { name } => {

--- a/tests/tests/server.rs
+++ b/tests/tests/server.rs
@@ -370,6 +370,43 @@ fn destroy_nonexistent_error_message() {
 
 // ── WebSocket ──────────────────────────────────────────────────
 
+// ── Creation flow ─────────────────────────────────────────────
+
+#[test]
+fn create_auto_starts() {
+    // POST /agents now auto-starts the agent.
+    let c = SERVER.client();
+    let agent = TestAgent::create(&c, "test-create-autostart").unwrap();
+
+    let st = c.agent_status(&agent.name).unwrap();
+    assert_eq!(st.status, "running");
+}
+
+#[test]
+fn creation_flow() {
+    // Mirrors the app's NewAgent creation flow:
+    //   create (auto-starts) → authenticate → complete_auth (auto-restarts + waits)
+    let c = SERVER.client();
+    let agent = TestAgent::create(&c, "test-creation-flow").unwrap();
+
+    // Agent is auto-started by create, no separate start needed
+    let st = c.agent_status(&agent.name).unwrap();
+    assert_eq!(st.status, "running");
+    assert!(!st.authenticated);
+
+    // Simulate OAuth: inject token then restart + wait (as complete_auth would)
+    inject_fake_token(&c, &agent.name);
+    assert!(c.agent_status(&agent.name).unwrap().authenticated);
+
+    c.restart_agent(&agent.name).unwrap();
+    c.wait_ready(&agent.name, 60).unwrap();
+
+    let st = c.agent_status(&agent.name).unwrap();
+    assert_eq!(st.status, "running");
+    assert!(st.authenticated);
+    assert!(st.agent_ready);
+}
+
 #[tokio::test]
 async fn ws_connect_to_running_agent() {
     let c = SERVER.client();

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -390,6 +390,12 @@ async fn create_agent_handler(
             .unwrap()
             .map_err(map_docker_err)?;
 
+    let start_name = name.clone();
+    tokio::task::spawn_blocking(move || docker::start_agent(&start_name))
+        .await
+        .unwrap()
+        .map_err(map_docker_err)?;
+
     Ok((StatusCode::CREATED, Json(serde_json::json!({"name": name}))))
 }
 
@@ -571,6 +577,8 @@ struct AuthCodeBody {
     code: String,
 }
 
+const AUTH_READY_TIMEOUT_SECS: u64 = 180;
+
 async fn complete_auth_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
@@ -600,6 +608,21 @@ async fn complete_auth_handler(
     tokio::task::spawn_blocking(move || docker::inject_credentials(&cname, &credentials))
         .await
         .unwrap()
+        .map_err(map_docker_err)?;
+
+    // Restart the agent so it picks up the new credentials, then wait for
+    // first-start setup (skills, memory, greeting) to complete.
+    let restart_name = name.clone();
+    let lock = state.agent_lock(&name).await;
+    let _guard = lock.write().await;
+
+    tokio::task::spawn_blocking(move || docker::restart_agent(&restart_name))
+        .await
+        .unwrap()
+        .map_err(map_docker_err)?;
+
+    docker::wait_ready_async(&name, AUTH_READY_TIMEOUT_SECS)
+        .await
         .map_err(map_docker_err)?;
 
     Ok(ok_json())


### PR DESCRIPTION
## Summary
- **Fixes deadlock from #147**: `waitForReady` before auth caused a deadlock because the agent waits for credentials while the app waits for readiness
- **`POST /agents` now auto-starts** the agent after creation — no separate start call needed
- **`POST /agents/{name}/auth/code` now auto-restarts + waits for ready** after injecting credentials — clients get success only when the agent has fully processed its first-start setup
- Simplifies client orchestration from 6 steps (`create → start → waitForReady → auth → restart → waitForReady`) to 3 (`create → auth → complete_auth`)

## Test plan
- [x] `cargo clippy` passes (vestad + cli)
- [x] `uv run pytest tests/test_unit.py` — 48/48 pass
- [x] `cargo test -p vesta-tests` — 33/33 pass (includes 2 new tests: `create_auto_starts`, `creation_flow`)
- [ ] Manual: create a new agent via app, verify the flow completes without timeout
- [ ] Manual: reauthenticate an existing agent, verify it restarts automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)