### PR TITLE
ci: push master to production branch on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,6 @@ jobs:
           VERSION=$(grep '^version = ' agent/pyproject.toml | cut -d'"' -f2)
           TAG="v${VERSION}"
           gh release create "$TAG" --title "$TAG" --generate-notes --target master --prerelease
+
+      - name: Update production branch
+        run: git push origin master:production


### PR DESCRIPTION
## Summary
- Adds a step to the release workflow that pushes master to the `production` branch after creating a GitHub release
- Ensures the production branch always tracks the latest released version

## Test plan
- [ ] Verify release workflow runs successfully and pushes to production branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)