### PR TITLE
feat: vestad auto-update from app and background task

### DIFF
--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.114"
+version = "0.1.115"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vesta",
-  "version": "0.1.112",
+  "version": "0.1.114",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vesta",
-      "version": "0.1.112",
+      "version": "0.1.114",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-rc.0",

--- a/app/src/providers/AuthProvider/index.tsx
+++ b/app/src/providers/AuthProvider/index.tsx
@@ -5,7 +5,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { connectToServer } from "@/api";
+import { connectToServer, isNewer } from "@/api";
 import { clearConnection, getConnection, initConnection, authHeaders } from "@/lib/connection";
 import { ensureFreshToken } from "@/lib/token-refresh";
 import { isTauri } from "@/lib/env";
@@ -40,6 +40,20 @@ async function fetchVersion(): Promise<string> {
     return typeof data.version === "string" ? data.version : "";
   } catch {
     return "";
+  }
+}
+
+async function triggerVestadUpdateIfNeeded(vestadVersion: string) {
+  if (!vestadVersion || !isNewer(__APP_VERSION__, vestadVersion)) return;
+  const conn = getConnection();
+  if (!conn) return;
+  try {
+    await fetch(`${conn.url}/self-update`, {
+      method: "POST",
+      headers: authHeaders(),
+    });
+  } catch {
+    // vestad will restart — connection loss is expected
   }
 }
 
@@ -115,6 +129,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const loadVersion = async () => {
       const nextVersion = await fetchVersion();
       setVersion(nextVersion);
+      void triggerVestadUpdateIfNeeded(nextVersion);
     };
 
     void loadVersion();
@@ -145,6 +160,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setConnected(true);
     const nextVersion = await fetchVersion();
     setVersion(nextVersion);
+    void triggerVestadUpdateIfNeeded(nextVersion);
   };
 
   const disconnect = () => {

--- a/app/src/providers/AuthProvider/index.tsx
+++ b/app/src/providers/AuthProvider/index.tsx
@@ -5,7 +5,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { connectToServer, isNewer } from "@/api";
+import { apiFetch, connectToServer, isNewer } from "@/api";
 import { clearConnection, getConnection, initConnection, authHeaders } from "@/lib/connection";
 import { ensureFreshToken } from "@/lib/token-refresh";
 import { isTauri } from "@/lib/env";
@@ -45,13 +45,8 @@ async function fetchVersion(): Promise<string> {
 
 async function triggerVestadUpdateIfNeeded(vestadVersion: string) {
   if (!vestadVersion || !isNewer(__APP_VERSION__, vestadVersion)) return;
-  const conn = getConnection();
-  if (!conn) return;
   try {
-    await fetch(`${conn.url}/self-update`, {
-      method: "POST",
-      headers: authHeaders(),
-    });
+    await apiFetch("/self-update", { method: "POST" });
   } catch {
     // vestad will restart — connection loss is expected
   }
@@ -158,9 +153,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const connect = async (url: string, apiKey: string) => {
     await connectToServer(url, apiKey);
     setConnected(true);
-    const nextVersion = await fetchVersion();
-    setVersion(nextVersion);
-    void triggerVestadUpdateIfNeeded(nextVersion);
   };
 
   const disconnect = () => {

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import basicSsl from "@vitejs/plugin-basic-ssl";
 import { defineConfig } from "vite";
 import path from "path";
+import pkg from "./package.json" with { type: "json" };
 
 const host = process.env.TAURI_DEV_HOST;
 const vestad = process.env.VITE_VESTAD_URL || "https://localhost:7860";
@@ -10,6 +11,9 @@ const vestad = process.env.VITE_VESTAD_URL || "https://localhost:7860";
 const isTauri = !!process.env.TAURI_ENV_PLATFORM;
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [
     react({
       babel: {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -136,6 +136,7 @@ pub struct AppState {
     agent_locks: Mutex<HashMap<String, Arc<tokio::sync::RwLock<()>>>>,
     tunnel_url: Mutex<Option<String>>,
     update_info: Mutex<Option<update_check::UpdateInfo>>,
+    updating: AtomicBool,
     auto_backup_enabled: AtomicBool,
     backup_retention: Mutex<crate::types::RetentionPolicy>,
     http_client: reqwest::Client,
@@ -152,6 +153,7 @@ impl AppState {
             agent_locks: Mutex::new(HashMap::new()),
             tunnel_url: Mutex::new(tunnel_url),
             update_info: Mutex::new(None),
+            updating: AtomicBool::new(false),
             auto_backup_enabled: AtomicBool::new(true),
             backup_retention: Mutex::new(crate::types::RetentionPolicy {
                 daily: docker::DEFAULT_RETENTION_DAILY,
@@ -334,11 +336,17 @@ async fn version(State(state): State<SharedState>) -> Json<serde_json::Value> {
     }))
 }
 
-async fn self_update_handler() -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+async fn self_update_handler(
+    State(state): State<SharedState>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    if state.updating.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        return Err(err_response(StatusCode::CONFLICT, "update already in progress"));
+    }
     tracing::info!("self-update requested via API");
     let result = tokio::task::spawn_blocking(self_update::perform_update)
         .await
         .unwrap();
+    state.updating.store(false, std::sync::atomic::Ordering::SeqCst);
     match result {
         Ok(restarting) => Ok(Json(serde_json::json!({
             "ok": true,
@@ -1358,16 +1366,19 @@ fn spawn_update_check_task(state: SharedState) {
             let info_result = tokio::task::spawn_blocking(update_check::check_once).await;
             match info_result {
                 Ok(Ok(info)) => {
-                    if info.update_available && last_attempted.as_ref() != Some(&info.latest) {
+                    let mut slot = state.update_info.lock().await;
+                    *slot = Some(info.clone());
+                    drop(slot);
+
+                    if info.update_available
+                        && last_attempted.as_ref() != Some(&info.latest)
+                        && !state.updating.swap(true, std::sync::atomic::Ordering::SeqCst)
+                    {
                         tracing::info!(
                             "update available: v{} -> v{}, auto-updating...",
                             info.current, info.latest
                         );
                         last_attempted = Some(info.latest.clone());
-
-                        let mut slot = state.update_info.lock().await;
-                        *slot = Some(info);
-                        drop(slot);
 
                         match tokio::task::spawn_blocking(self_update::perform_update).await {
                             Ok(Ok(true)) => {
@@ -1380,9 +1391,7 @@ fn spawn_update_check_task(state: SharedState) {
                             Ok(Err(e)) => tracing::error!("auto-update failed: {}", e),
                             Err(e) => tracing::error!("auto-update task panicked: {}", e),
                         }
-                    } else {
-                        let mut slot = state.update_info.lock().await;
-                        *slot = Some(info);
+                        state.updating.store(false, std::sync::atomic::Ordering::SeqCst);
                     }
                 }
                 Ok(Err(e)) => tracing::warn!("update check failed: {}", e),

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1353,20 +1353,37 @@ fn spawn_auto_backup_task(state: SharedState) {
 
 fn spawn_update_check_task(state: SharedState) {
     tokio::spawn(async move {
-        let mut last_notified: Option<String> = None;
+        let mut last_attempted: Option<String> = None;
         loop {
             let info_result = tokio::task::spawn_blocking(update_check::check_once).await;
             match info_result {
                 Ok(Ok(info)) => {
-                    if info.update_available && last_notified.as_ref() != Some(&info.latest) {
+                    if info.update_available && last_attempted.as_ref() != Some(&info.latest) {
                         tracing::info!(
-                            "update available: v{} -> v{} (run 'vestad update')",
+                            "update available: v{} -> v{}, auto-updating...",
                             info.current, info.latest
                         );
-                        last_notified = Some(info.latest.clone());
+                        last_attempted = Some(info.latest.clone());
+
+                        let mut slot = state.update_info.lock().await;
+                        *slot = Some(info);
+                        drop(slot);
+
+                        match tokio::task::spawn_blocking(self_update::perform_update).await {
+                            Ok(Ok(true)) => {
+                                tracing::info!("auto-update: restarting via systemd");
+                                return;
+                            }
+                            Ok(Ok(false)) => {
+                                tracing::info!("auto-update: binary replaced, awaiting restart");
+                            }
+                            Ok(Err(e)) => tracing::error!("auto-update failed: {}", e),
+                            Err(e) => tracing::error!("auto-update task panicked: {}", e),
+                        }
+                    } else {
+                        let mut slot = state.update_info.lock().await;
+                        *slot = Some(info);
                     }
-                    let mut slot = state.update_info.lock().await;
-                    *slot = Some(info);
                 }
                 Ok(Err(e)) => tracing::warn!("update check failed: {}", e),
                 Err(e) => tracing::error!("update check task failed: {}", e),


### PR DESCRIPTION
## Summary

- **Client-triggered vestad update**: When the app connects and detects vestad is on a lower version, it fires `POST /self-update` to bring vestad up to date automatically
- **Periodic auto-update**: vestad's existing 6-hour update check now actually calls `perform_update()` instead of just logging, so vestad self-updates without any client interaction
- **Update mutex**: `AtomicBool` guard prevents concurrent `perform_update` calls between the API handler and background task

## Test plan

- [ ] Connect app to an older vestad — verify it triggers self-update and vestad restarts with new version
- [ ] Start vestad on an old version with no client — verify background task auto-updates within one check cycle
- [ ] Trigger POST /self-update while background auto-update is running — verify 409 Conflict response
- [ ] Connect app to same-version vestad — verify no update triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)