### PR TITLE
fix: multi-user isolation — dynamic ports, unique tunnels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,6 +2035,7 @@ dependencies = [
  "axum-server",
  "bytes",
  "clap",
+ "dotenvy",
  "futures-core",
  "futures-util",
  "libc",

--- a/agent/skills/app-chat/cli/src/app_chat_cli/cli.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/cli.py
@@ -15,12 +15,18 @@ from app_chat_cli.daemon import cmd_serve
 
 
 def _default_ws_url() -> str:
-    port = os.environ.get("WS_PORT", "7865")
+    port = os.environ.get("WS_PORT")
+    if not port:
+        print("error: WS_PORT environment variable is not set", file=sys.stderr)
+        sys.exit(1)
     return f"ws://localhost:{port}/ws"
 
 
 def _default_http_url() -> str:
-    port = os.environ.get("WS_PORT", "7865")
+    port = os.environ.get("WS_PORT")
+    if not port:
+        print("error: WS_PORT environment variable is not set", file=sys.stderr)
+        sys.exit(1)
     return f"http://localhost:{port}"
 
 

--- a/agent/skills/app-chat/cli/src/app_chat_cli/commands.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/commands.py
@@ -11,7 +11,10 @@ import urllib.parse
 
 
 def _default_agent_url() -> str:
-    port = os.environ.get("WS_PORT", "7865")
+    port = os.environ.get("WS_PORT")
+    if not port:
+        print("error: WS_PORT environment variable is not set", file=sys.stderr)
+        sys.exit(1)
     return f"http://localhost:{port}"
 
 
@@ -44,6 +47,9 @@ async def _send_via_socket(sock_path: pl.Path, message: str) -> dict[str, object
 
 
 def _api_get(base_url: str, path: str, params: dict[str, str]) -> dict[str, object]:
+    agent_token = os.environ.get("AGENT_TOKEN")
+    if agent_token:
+        params = {**params, "agent_token": agent_token}
     qs = urllib.parse.urlencode({k: v for k, v in params.items() if v is not None})
     url = f"{base_url}{path}?{qs}" if qs else f"{base_url}{path}"
     try:

--- a/agent/skills/app-chat/cli/src/app_chat_cli/daemon.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/daemon.py
@@ -95,7 +95,12 @@ async def _ws_loop(state: DaemonState) -> None:
         try:
             if state.session is None:
                 break
-            async with state.session.ws_connect(state.ws_url) as ws:
+            url = state.ws_url
+            agent_token = os.environ.get("AGENT_TOKEN")
+            if agent_token:
+                sep = "&" if "?" in url else "?"
+                url = f"{url}{sep}agent_token={agent_token}"
+            async with state.session.ws_connect(url) as ws:
                 state.ws = ws
                 _log(f"connected to {state.ws_url}")
                 async for msg in ws:

--- a/agent/skills/dashboard/SKILL.md
+++ b/agent/skills/dashboard/SKILL.md
@@ -77,7 +77,7 @@ screen -S dashboard -X quit 2>/dev/null
 screen -dmS dashboard sh -c "cd ~/vesta/skills/dashboard/app && npx vite preview --port $PORT --host 0.0.0.0"
 # Wait for the server to be ready before notifying the app
 for i in $(seq 1 20); do curl -s -o /dev/null http://localhost:$PORT && break; sleep 0.5; done
-curl -s -X POST http://localhost:$WS_PORT/events/service-update \
+curl -s -X POST "http://localhost:$WS_PORT/events/service-update?agent_token=$AGENT_TOKEN" \
   -H 'Content-Type: application/json' -d '{"service":"dashboard","action":"updated"}'
 ```
 

--- a/agent/skills/voice/SKILL.md
+++ b/agent/skills/voice/SKILL.md
@@ -30,7 +30,7 @@ Once configured, the user can manage voice settings directly from the **agent se
    ```
 5. **Notify the app** so it picks up the new voice config:
    ```bash
-   curl -s -X POST http://localhost:$WS_PORT/events/service-update \
+   curl -s -X POST "http://localhost:$WS_PORT/events/service-update?agent_token=$AGENT_TOKEN" \
      -H 'Content-Type: application/json' -d '{"service":"voice","action":"updated"}'
    ```
 6. **Confirm** — e.g. "Voice is ready! You can use the mic button now. You can also change voices, listen to previews, and tweak settings from the settings page in the app."

--- a/agent/skills/voice/SKILL.md
+++ b/agent/skills/voice/SKILL.md
@@ -28,12 +28,17 @@ Once configured, the user can manage voice settings directly from the **agent se
    ```bash
    uv run ~/vesta/skills/voice/scripts/voice_keys.py set-key --domain stt --provider deepgram --key <key>
    ```
-5. **Notify the app** so it picks up the new voice config:
+5. **Ensure the voice server is running** — the app fetches config from it. Check with `screen -ls | grep voice`. If it's not running, start it:
+   ```bash
+   PORT=$(curl -sk -X POST https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services -H 'Content-Type: application/json' -d '{"name":"voice"}' | python3 -c "import sys,json; print(json.load(sys.stdin)['port'])")
+   SKILL_PORT=$PORT PYTHONPATH=~/vesta/skills screen -dmS voice uv run python -m voice.server
+   ```
+6. **Notify the app** so it picks up the new voice config:
    ```bash
    curl -s -X POST "http://localhost:$WS_PORT/events/service-update?agent_token=$AGENT_TOKEN" \
      -H 'Content-Type: application/json' -d '{"service":"voice","action":"updated"}'
    ```
-6. **Confirm** — e.g. "Voice is ready! You can use the mic button now. You can also change voices, listen to previews, and tweak settings from the settings page in the app."
+7. **Confirm** — e.g. "Voice is ready! You can use the mic button now. You can also change voices, listen to previews, and tweak settings from the settings page in the app."
 
 ## Commands
 

--- a/agent/src/vesta/api.py
+++ b/agent/src/vesta/api.py
@@ -201,8 +201,8 @@ async def _service_update_handler(request: web.Request) -> web.Response:
 
 @web.middleware
 async def _auth_middleware(request: web.Request, handler):
-    expected = request.app.get("agent_token", "")
-    if not expected:
+    expected = request.app.get("agent_token")
+    if expected is None:
         return await handler(request)
     token = request.headers.get("X-Agent-Token") or request.query.get("agent_token")
     if token != expected:

--- a/agent/src/vesta/api.py
+++ b/agent/src/vesta/api.py
@@ -204,10 +204,7 @@ async def _auth_middleware(request: web.Request, handler):
     expected = request.app.get("agent_token", "")
     if not expected:
         return await handler(request)
-    token = (
-        request.headers.get("X-Agent-Token")
-        or request.query.get("agent_token")
-    )
+    token = request.headers.get("X-Agent-Token") or request.query.get("agent_token")
     if token != expected:
         return web.json_response({"error": "unauthorized"}, status=401)
     return await handler(request)

--- a/agent/src/vesta/api.py
+++ b/agent/src/vesta/api.py
@@ -199,14 +199,29 @@ async def _service_update_handler(request: web.Request) -> web.Response:
     return web.json_response({"ok": True})
 
 
+@web.middleware
+async def _auth_middleware(request: web.Request, handler):
+    expected = request.app.get("agent_token", "")
+    if not expected:
+        return await handler(request)
+    token = (
+        request.headers.get("X-Agent-Token")
+        or request.query.get("agent_token")
+    )
+    if token != expected:
+        return web.json_response({"error": "unauthorized"}, status=401)
+    return await handler(request)
+
+
 async def start_ws_server(
     event_bus: EventBus,
     config: VestaConfig,
     *,
     host: str = "0.0.0.0",
 ) -> web.AppRunner:
-    app = web.Application()
+    app = web.Application(middlewares=[_auth_middleware])
     app["event_bus"] = event_bus
+    app["agent_token"] = config.agent_token
     app.router.add_get("/ws", _ws_handler)
     app.router.add_get("/history", _history_handler)
     app.router.add_get("/search", _search_handler)

--- a/agent/src/vesta/config.py
+++ b/agent/src/vesta/config.py
@@ -21,7 +21,7 @@ class VestaConfig(pyd_settings.BaseSettings):
     interrupt_timeout: float = pyd.Field(default=5.0, gt=0)
     max_thinking_tokens: int | None = 10000
     ws_port: int = 0
-    agent_token: str = ""
+    agent_token: str | None = None
 
     root: pl.Path = pyd.Field(default=_DEFAULT_ROOT)
 

--- a/agent/src/vesta/config.py
+++ b/agent/src/vesta/config.py
@@ -20,7 +20,7 @@ class VestaConfig(pyd_settings.BaseSettings):
     nightly_memory_hour: int | None = pyd.Field(default=3, ge=0, le=23)
     interrupt_timeout: float = pyd.Field(default=5.0, gt=0)
     max_thinking_tokens: int | None = 10000
-    ws_port: int
+    ws_port: int = 0
     agent_token: str = ""
 
     root: pl.Path = pyd.Field(default=_DEFAULT_ROOT)

--- a/agent/src/vesta/config.py
+++ b/agent/src/vesta/config.py
@@ -20,7 +20,8 @@ class VestaConfig(pyd_settings.BaseSettings):
     nightly_memory_hour: int | None = pyd.Field(default=3, ge=0, le=23)
     interrupt_timeout: float = pyd.Field(default=5.0, gt=0)
     max_thinking_tokens: int | None = 10000
-    ws_port: int = 7865
+    ws_port: int
+    agent_token: str = ""
 
     root: pl.Path = pyd.Field(default=_DEFAULT_ROOT)
 

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -1,3 +1,4 @@
 import os
 
 os.environ.pop("CLAUDECODE", None)
+os.environ.setdefault("WS_PORT", "17865")

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.115"
+version = "0.1.116"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/tests/src/client.rs
+++ b/tests/src/client.rs
@@ -98,6 +98,12 @@ impl Client {
         Ok(())
     }
 
+    pub fn health_json(&self) -> Result<serde_json::Value, String> {
+        let resp = self.agent.get(&format!("{}/health", self.base_url)).call().map_err(map_error)?;
+        let resp = check_response(resp)?;
+        resp.into_body().read_json().map_err(|e| format!("parse error: {}", e))
+    }
+
     pub fn list_agents(&self) -> Result<Vec<ListEntry>, String> {
         let resp = self.get("/agents")?;
         resp.into_body().read_json().map_err(|e| format!("parse error: {}", e))

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod client;
 pub mod types;
 
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::LazyLock;
@@ -18,7 +17,6 @@ pub struct TestServer {
     process: Option<Child>,
     _tmpdir: tempfile::TempDir,
     pub config: ServerConfig,
-    #[allow(dead_code)]
     pub port: u16,
 }
 
@@ -30,14 +28,13 @@ impl TestServer {
 
         let tmpdir = tempfile::TempDir::new().map_err(|e| format!("tmpdir: {e}"))?;
         let home = tmpdir.path().to_path_buf();
-        let port = free_port()?;
         let vestad = find_vestad()?;
 
         let real_home = std::env::var("HOME").unwrap_or_default();
         let docker_config = format!("{}/.docker", real_home);
 
         let process = Command::new(&vestad)
-            .args(["serve", "--standalone", "--port", &port.to_string()])
+            .args(["serve", "--standalone", "--no-tunnel"])
             .env("HOME", &home)
             .env("DOCKER_CONFIG", &docker_config)
             .stdout(Stdio::null())
@@ -45,19 +42,25 @@ impl TestServer {
             .spawn()
             .map_err(|e| format!("spawn vestad: {e}"))?;
 
-        let addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
+        let config_dir = home.join(".config/vesta/vestad");
+        let port_path = config_dir.join("port");
+
         let deadline = std::time::Instant::now() + Duration::from_secs(30);
-        loop {
-            if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok() {
-                break;
+        let port = loop {
+            if let Ok(content) = std::fs::read_to_string(&port_path) {
+                if let Ok(p) = content.trim().parse::<u16>() {
+                    let addr: std::net::SocketAddr = ([127, 0, 0, 1], p).into();
+                    if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok() {
+                        break p;
+                    }
+                }
             }
             if std::time::Instant::now() > deadline {
                 return Err("vestad did not start within 30s".into());
             }
             std::thread::sleep(Duration::from_millis(100));
-        }
+        };
 
-        let config_dir = home.join(".config/vesta/vestad");
         let api_key = std::fs::read_to_string(config_dir.join("api-key"))
             .map_err(|e| format!("read api-key: {e}"))?
             .trim()
@@ -82,6 +85,10 @@ impl TestServer {
 
     pub fn client(&self) -> Client {
         Client::new(&self.config)
+    }
+
+    pub fn _tmpdir_path(&self) -> &std::path::Path {
+        self._tmpdir.path()
     }
 }
 
@@ -113,11 +120,6 @@ impl Drop for TestAgent<'_> {
         let _ = self.client.stop_agent(&self.name);
         let _ = self.client.destroy_agent(&self.name);
     }
-}
-
-fn free_port() -> Result<u16, String> {
-    let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| format!("bind: {e}"))?;
-    Ok(listener.local_addr().map_err(|e| format!("addr: {e}"))?.port())
 }
 
 pub fn find_vestad() -> Result<PathBuf, String> {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -10,8 +10,39 @@ use client::Client;
 use types::ServerConfig;
 
 pub static SERVER: LazyLock<TestServer> = LazyLock::new(|| {
+    kill_orphan_vestads();
     TestServer::start().unwrap_or_else(|e| panic!("failed to start test server: {e}"))
 });
+
+/// Kill vestad processes left behind by previous test runs (those whose HOME is a
+/// temp directory). Ignores the user's real vestad instance.
+fn kill_orphan_vestads() {
+    let Ok(output) = Command::new("sh")
+        .args(["-c", "ps -eo pid,args | grep '[v]estad serve'"])
+        .output()
+    else {
+        return;
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        let Some(pid_str) = parts.first() else { continue };
+        let Ok(pid) = pid_str.parse::<u32>() else { continue };
+
+        // Check if the process's HOME is a temp directory
+        let environ_path = format!("/proc/{pid}/environ");
+        let Ok(environ) = std::fs::read(&environ_path) else { continue };
+        let is_tmp_home = environ
+            .split(|&b| b == 0)
+            .filter_map(|entry| std::str::from_utf8(entry).ok())
+            .any(|entry| {
+                entry.starts_with("HOME=") && (entry.contains("/tmp/") || entry.contains("/tmp."))
+            });
+        if is_tmp_home {
+            let _ = Command::new("kill").arg("-9").arg(pid_str).output();
+        }
+    }
+}
 
 pub struct TestServer {
     process: Option<Child>,

--- a/tests/tests/server.rs
+++ b/tests/tests/server.rs
@@ -501,19 +501,35 @@ fn api_key_file_exists_and_nonempty() {
 }
 
 #[test]
-fn container_env_includes_vestad_port() {
-    let env_path = SERVER._tmpdir_path().join(".config/vesta/vestad/container.env");
+fn agent_env_file_includes_vestad_port() {
+    let c = SERVER.client();
+    let agent = TestAgent::create(&c, "test-env-port").unwrap();
+
+    let env_path = SERVER._tmpdir_path()
+        .join(format!(".config/vesta/vestad/agents/{}.env", agent.name));
     let content = std::fs::read_to_string(&env_path)
-        .expect("container.env should exist");
+        .expect("per-agent env file should exist");
     let expected = format!("export VESTAD_PORT={}", SERVER.port);
-    assert!(content.contains(&expected), "container.env should contain VESTAD_PORT: {content}");
+    assert!(content.contains(&expected), "agent env file should contain VESTAD_PORT: {content}");
 }
 
 #[test]
-fn agent_has_token_label() {
+fn agent_has_env_file_with_token() {
     let c = SERVER.client();
-    let agent = TestAgent::create(&c, "test-token-label").unwrap();
+    let agent = TestAgent::create(&c, "test-token-env").unwrap();
 
+    let agents_dir = SERVER._tmpdir_path().join(".config/vesta/vestad/agents");
+    let env_path = agents_dir.join(format!("{}.env", agent.name));
+    assert!(env_path.exists(), "per-agent env file should exist at {:?}", env_path);
+
+    let content = std::fs::read_to_string(&env_path).expect("should be able to read env file");
+    let token_line = content.lines()
+        .find(|l| l.contains("AGENT_TOKEN="))
+        .expect("env file should contain AGENT_TOKEN");
+    let token = token_line.strip_prefix("export AGENT_TOKEN=").expect("should have export prefix");
+    assert_eq!(token.len(), 64, "token should be 32 bytes hex-encoded (64 chars)");
+
+    // Token should NOT be in Docker labels
     let output = std::process::Command::new("docker")
         .args([
             "inspect", "--format",
@@ -522,10 +538,8 @@ fn agent_has_token_label() {
         ])
         .output()
         .expect("docker inspect should work");
-
-    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    assert!(!token.is_empty() && token != "<no value>", "agent should have a non-empty token label");
-    assert_eq!(token.len(), 64, "token should be 32 bytes hex-encoded (64 chars)");
+    let label = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert!(label.is_empty() || label == "<no value>", "token should NOT be in Docker labels");
 }
 
 #[test]

--- a/tests/tests/server.rs
+++ b/tests/tests/server.rs
@@ -1,4 +1,4 @@
-use vesta_tests::{TestAgent, SERVER};
+use vesta_tests::{TestAgent, SERVER, find_vestad};
 use vesta_tests::client::Client;
 use vesta_tests::types::{BackupType, ServerConfig};
 
@@ -440,6 +440,117 @@ async fn ws_connect_to_running_agent() {
             );
         }
     }
+}
+
+// ── Multi-user rework ─────────────────────────────────────────
+
+#[test]
+fn health_includes_user() {
+    let body = SERVER.client().health_json().unwrap();
+    assert!(body["ok"].as_bool().unwrap());
+    let user = body["user"].as_str().expect("health should include 'user' field");
+    assert!(!user.is_empty());
+}
+
+#[test]
+fn stopped_agent_port_not_stolen() {
+    let c = SERVER.client();
+    let a1 = TestAgent::create(&c, "test-port-theft-1").unwrap();
+    c.start_agent(&a1.name).unwrap();
+    let port1 = c.agent_status(&a1.name).unwrap().ws_port;
+    assert!(port1 > 0, "agent should have a non-zero port");
+
+    c.stop_agent(&a1.name).unwrap();
+
+    let mut other_ports = Vec::new();
+    let mut agents = Vec::new();
+    for i in 2..=5 {
+        let name = format!("test-port-theft-{i}");
+        let agent = TestAgent::create(&c, &name).unwrap();
+        let port = c.agent_status(&agent.name).unwrap().ws_port;
+        other_ports.push(port);
+        agents.push(agent);
+    }
+
+    assert!(
+        !other_ports.contains(&port1),
+        "stopped agent's port {port1} was stolen by a new agent: {other_ports:?}"
+    );
+}
+
+#[test]
+fn port_file_contains_server_port() {
+    let port_path = SERVER._tmpdir_path().join(".config/vesta/vestad/port");
+    let stored = std::fs::read_to_string(&port_path)
+        .expect("port file should exist")
+        .trim()
+        .parse::<u16>()
+        .expect("port file should contain a valid u16");
+    assert_eq!(stored, SERVER.port, "port file should match the running server port");
+}
+
+#[test]
+fn api_key_file_exists_and_nonempty() {
+    let key_path = SERVER._tmpdir_path().join(".config/vesta/vestad/api-key");
+    let key = std::fs::read_to_string(&key_path)
+        .expect("api-key file should exist")
+        .trim()
+        .to_string();
+    assert!(!key.is_empty());
+    assert_eq!(key, SERVER.config.api_key);
+}
+
+#[test]
+fn container_env_includes_vestad_port() {
+    let env_path = SERVER._tmpdir_path().join(".config/vesta/vestad/container.env");
+    let content = std::fs::read_to_string(&env_path)
+        .expect("container.env should exist");
+    let expected = format!("export VESTAD_PORT={}", SERVER.port);
+    assert!(content.contains(&expected), "container.env should contain VESTAD_PORT: {content}");
+}
+
+#[test]
+fn agent_has_token_label() {
+    let c = SERVER.client();
+    let agent = TestAgent::create(&c, "test-token-label").unwrap();
+
+    let output = std::process::Command::new("docker")
+        .args([
+            "inspect", "--format",
+            "{{index .Config.Labels \"vesta.agent_token\"}}",
+            &format!("vesta-{}-{}", std::env::var("USER").unwrap_or_default(), agent.name),
+        ])
+        .output()
+        .expect("docker inspect should work");
+
+    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert!(!token.is_empty() && token != "<no value>", "agent should have a non-empty token label");
+    assert_eq!(token.len(), 64, "token should be 32 bytes hex-encoded (64 chars)");
+}
+
+#[test]
+fn second_vestad_same_home_rejected() {
+    let _ = &*SERVER;
+
+    let vestad = find_vestad().unwrap();
+    let output = std::process::Command::new(&vestad)
+        .args(["serve", "--standalone", "--no-tunnel"])
+        .env("HOME", SERVER._tmpdir_path())
+        .env("DOCKER_CONFIG", format!("{}/.docker", std::env::var("HOME").unwrap_or_default()))
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .expect("failed to run vestad");
+
+    assert!(
+        !output.status.success(),
+        "second vestad with same HOME should fail"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("already running"),
+        "error should mention 'already running', got: {stderr}"
+    );
 }
 
 #[tokio::test]

--- a/vestad/Cargo.toml
+++ b/vestad/Cargo.toml
@@ -34,4 +34,5 @@ futures-util = "0.3"
 async-stream = "0.3"
 bytes = "1"
 reqwest = { version = "0.12", default-features = false, features = ["stream", "json"] }
+dotenvy = "0.15"
 

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -291,9 +291,23 @@ pub fn compute_agent_state(cname: &str, info: &ContainerInfo) -> AgentDerivedSta
     AgentDerivedState { authenticated, agent_ready, alive, friendly_status }
 }
 
-fn inspect_container(cname: &str) -> ContainerInfo {
+/// Read a value from a per-agent env file by key (e.g. "WS_PORT").
+fn read_env_value(agents_dir: &std::path::Path, agent_name: &str, key: &str) -> Option<String> {
+    let env_path = agents_dir.join(format!("{}.env", agent_name));
+    let content = std::fs::read_to_string(&env_path).ok()?;
+    let prefix = format!("{key}=");
+    for line in content.lines() {
+        let line = line.strip_prefix("export ").unwrap_or(line);
+        if let Some(val) = line.strip_prefix(&prefix) {
+            return Some(val.to_string());
+        }
+    }
+    None
+}
+
+fn inspect_container(cname: &str, agents_dir: Option<&std::path::Path>) -> ContainerInfo {
     let format_str = format!(
-        "{{{{.State.Status}}}}|{{{{index .Config.Labels \"vesta.ws_port\"}}}}|{{{{.Id}}}}|{{{{index .Config.Labels \"{}\"}}}}",
+        "{{{{.State.Status}}}}|{{{{.Id}}}}|{{{{index .Config.Labels \"{}\"}}}}",
         LABEL_AGENT_NAME
     );
     match docker_output(&[
@@ -303,23 +317,23 @@ fn inspect_container(cname: &str) -> ContainerInfo {
         cname,
     ]) {
         Some(s) => {
-            let parts: Vec<&str> = s.splitn(4, '|').collect();
+            let parts: Vec<&str> = s.splitn(3, '|').collect();
             let status = match parts.first().map(|p| p.trim()) {
                 Some("running" | "restarting" | "paused") => ContainerStatus::Running,
                 Some("exited" | "created") => ContainerStatus::Stopped,
                 Some("dead" | "removing") => ContainerStatus::Dead,
                 _ => ContainerStatus::Stopped,
             };
-            let port = parts
-                .get(1)
-                .and_then(|p| p.trim().parse().ok());
             let id = parts
-                .get(2)
+                .get(1)
                 .map(|p| p.trim().chars().take(12).collect::<String>());
             let agent_name = parts
-                .get(3)
+                .get(2)
                 .map(|p| p.trim().to_string())
                 .filter(|s| !s.is_empty() && s != "<no value>");
+            let name = agent_name.clone().unwrap_or_else(|| name_from_cname(cname));
+            let port = agents_dir.and_then(|dir| read_env_value(dir, &name, "WS_PORT"))
+                .and_then(|v| v.parse().ok());
             ContainerInfo { status, port, id, agent_name }
         }
         None => ContainerInfo {
@@ -332,7 +346,7 @@ fn inspect_container(cname: &str) -> ContainerInfo {
 }
 
 pub fn container_status(cname: &str) -> ContainerStatus {
-    inspect_container(cname).status
+    inspect_container(cname, None).status
 }
 
 pub const MIN_AGE_FOR_BACKUP_SECS: u64 = 6 * 3600;
@@ -485,20 +499,30 @@ pub fn resolve_image() -> Result<&'static str, DockerError> {
     }
 }
 
-fn all_vesta_container_ports() -> HashSet<u16> {
-    docker_output(&[
-        "ps", "-a",
-        "--filter", "label=vesta.managed=true",
-        "--format", "{{.Label \"vesta.ws_port\"}}",
-    ])
-    .unwrap_or_default()
-    .lines()
-    .filter_map(|s| s.trim().parse().ok())
-    .collect()
+fn all_agent_ports(agents_dir: &std::path::Path) -> HashSet<u16> {
+    env_file_names(agents_dir)
+        .iter()
+        .filter_map(|name| read_env_value(agents_dir, name, "WS_PORT")?.parse().ok())
+        .collect()
 }
 
-pub fn allocate_port() -> Result<(u16, std::net::TcpListener), DockerError> {
-    let reserved = all_vesta_container_ports();
+/// List agent names that have env files in the agents directory.
+fn env_file_names(agents_dir: &std::path::Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(agents_dir) else { return Vec::new() };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("env") {
+                return None;
+            }
+            path.file_stem().and_then(|s| s.to_str()).map(|s| s.to_string())
+        })
+        .collect()
+}
+
+pub fn allocate_port(agents_dir: &std::path::Path) -> Result<(u16, std::net::TcpListener), DockerError> {
+    let reserved = all_agent_ports(agents_dir);
     for _ in 0..PORT_ALLOC_RETRIES {
         let listener = std::net::TcpListener::bind("127.0.0.1:0")
             .map_err(|e| DockerError::Failed(format!("failed to bind port: {e}")))?;
@@ -512,25 +536,24 @@ pub fn allocate_port() -> Result<(u16, std::net::TcpListener), DockerError> {
     Err(DockerError::Failed("could not allocate a free port after retries".into()))
 }
 
-pub fn get_container_port(cname: &str) -> Option<u16> {
-    docker_output(&[
-        "inspect",
-        "--format",
-        "{{index .Config.Labels \"vesta.ws_port\"}}",
-        cname,
-    ])
-    .and_then(|s| s.trim().parse().ok())
-}
-
-pub fn get_container_agent_token(cname: &str) -> Option<String> {
-    docker_output(&[
-        "inspect",
-        "--format",
-        "{{index .Config.Labels \"vesta.agent_token\"}}",
-        cname,
-    ])
-    .map(|s| s.trim().to_string())
-    .filter(|s| !s.is_empty() && s != "<no value>")
+/// Read the agent's port and token from the per-agent env file in a single read.
+pub fn read_agent_port_and_token(agent_name: &str, agents_dir: &std::path::Path) -> (Option<u16>, Option<String>) {
+    let env_path = agents_dir.join(format!("{}.env", agent_name));
+    let content = match std::fs::read_to_string(&env_path) {
+        Ok(content) => content,
+        Err(_) => return (None, None),
+    };
+    let mut port = None;
+    let mut token = None;
+    for line in content.lines() {
+        let line = line.strip_prefix("export ").unwrap_or(line);
+        if let Some(val) = line.strip_prefix("WS_PORT=") {
+            port = val.parse().ok();
+        } else if let Some(val) = line.strip_prefix("AGENT_TOKEN=") {
+            token = Some(val.to_string());
+        }
+    }
+    (port, token)
 }
 
 pub fn generate_agent_token() -> String {
@@ -538,6 +561,75 @@ pub fn generate_agent_token() -> String {
         .map(|_| format!("{:02x}", rand::random::<u8>()))
         .collect()
 }
+
+// --- Per-agent env file ---
+
+#[derive(Clone)]
+pub struct AgentEnvConfig {
+    pub agents_dir: std::path::PathBuf,
+    pub vestad_port: u16,
+    pub vestad_tunnel: Option<String>,
+}
+
+/// Write a sourceable env file for a single agent. Returns the file path.
+fn write_agent_env_file(
+    env_config: &AgentEnvConfig,
+    agent_name: &str,
+    ws_port: u16,
+    agent_token: &str,
+) -> Result<std::path::PathBuf, DockerError> {
+    std::fs::create_dir_all(&env_config.agents_dir)
+        .map_err(|e| DockerError::Failed(format!("failed to create agents dir: {e}")))?;
+    let env_path = env_config.agents_dir.join(format!("{}.env", agent_name));
+    let mut content = format!(
+        "export WS_PORT={ws_port}\n\
+         export AGENT_NAME={agent_name}\n\
+         export AGENT_TOKEN={agent_token}\n\
+         export IS_SANDBOX=1\n\
+         export VESTAD_PORT={}\n",
+        env_config.vestad_port,
+    );
+    if let Some(url) = &env_config.vestad_tunnel {
+        content.push_str(&format!("export VESTAD_TUNNEL={url}\n"));
+    }
+    std::fs::write(&env_path, &content)
+        .map_err(|e| DockerError::Failed(format!("failed to write agent env file: {e}")))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&env_path, std::fs::Permissions::from_mode(0o600)).ok();
+    }
+    Ok(env_path)
+}
+
+fn delete_agent_env_file(agents_dir: &std::path::Path, agent_name: &str) {
+    let env_path = agents_dir.join(format!("{}.env", agent_name));
+    std::fs::remove_file(&env_path).ok();
+}
+
+/// Update VESTAD_PORT and VESTAD_TUNNEL in all existing per-agent env files.
+/// Called at vestad startup so running containers pick up the new values on restart.
+pub fn update_all_agent_env_files(agents_dir: &std::path::Path, vestad_port: u16, vestad_tunnel: Option<&str>) {
+    for name in env_file_names(agents_dir) {
+        let path = agents_dir.join(format!("{name}.env"));
+        let Ok(content) = std::fs::read_to_string(&path) else { continue };
+        let mut new_lines: Vec<String> = content
+            .lines()
+            .filter(|line| {
+                let stripped = line.strip_prefix("export ").unwrap_or(line);
+                !stripped.starts_with("VESTAD_PORT=") && !stripped.starts_with("VESTAD_TUNNEL=")
+            })
+            .map(|l| l.to_string())
+            .collect();
+        new_lines.push(format!("export VESTAD_PORT={vestad_port}"));
+        if let Some(url) = vestad_tunnel {
+            new_lines.push(format!("export VESTAD_TUNNEL={url}"));
+        }
+        new_lines.push(String::new());
+        std::fs::write(&path, new_lines.join("\n")).ok();
+    }
+}
+
 
 pub fn list_managed_containers() -> Vec<String> {
     // Get all vesta-managed containers with their user label
@@ -597,29 +689,19 @@ fn gpu_available() -> GpuStatus {
 
 // --- Container creation ---
 
-pub fn create_container(cname: &str, image: &str, port: u16, agent_name: &str, env_file: &std::path::Path) -> Result<(), DockerError> {
+pub fn create_container(cname: &str, image: &str, port: u16, agent_name: &str, env_config: &AgentEnvConfig) -> Result<(), DockerError> {
     let agent_token = generate_agent_token();
-    let ws_port_env = format!("WS_PORT={}", port);
-    let agent_name_env = format!("AGENT_NAME={}", agent_name);
-    let agent_token_env = format!("AGENT_TOKEN={}", agent_token);
-    let env_mount = format!("{}:/run/vestad-env:ro", env_file.display());
-    let port_label = format!("vesta.ws_port={}", port);
-    let token_label = format!("vesta.agent_token={}", agent_token);
+    let env_path = write_agent_env_file(env_config, agent_name, port, &agent_token)?;
+    let env_mount = format!("{}:/run/vestad-env:ro", env_path.display());
     let user_label = format!("{}={}", LABEL_USER, current_user());
     let agent_name_label = format!("{}={}", LABEL_AGENT_NAME, agent_name);
     let mut args = vec![
         "create", "--name", cname, "-t",
         "--restart", "unless-stopped", "--network", "host",
         "--label", "vesta.managed=true",
-        "--label", &port_label,
-        "--label", &token_label,
         "--label", &user_label,
         "--label", &agent_name_label,
         "-v", &env_mount,
-        "-e", &ws_port_env,
-        "-e", &agent_name_env,
-        "-e", &agent_token_env,
-        "-e", "IS_SANDBOX=1",
     ];
 
     match gpu_available() {
@@ -636,6 +718,7 @@ pub fn create_container(cname: &str, image: &str, port: u16, agent_name: &str, e
     args.push(image);
     args.extend(ENTRYPOINT);
     if !docker_ok(&args) {
+        delete_agent_env_file(&env_config.agents_dir, agent_name);
         return Err(DockerError::Failed("failed to create container".into()));
     }
     Ok(())
@@ -843,10 +926,10 @@ pub fn friendly_status(
 
 // --- High-level operations (used by serve.rs handlers) ---
 
-pub fn get_status(name: &str) -> Result<StatusJson, DockerError> {
+pub fn get_status(name: &str, agents_dir: &std::path::Path) -> Result<StatusJson, DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
-    let info = inspect_container(&cname);
+    let info = inspect_container(&cname, Some(agents_dir));
     let derived = compute_agent_state(&cname, &info);
 
     Ok(StatusJson {
@@ -861,12 +944,12 @@ pub fn get_status(name: &str) -> Result<StatusJson, DockerError> {
     })
 }
 
-pub fn list_agents() -> Vec<ListEntry> {
+pub fn list_agents(agents_dir: &std::path::Path) -> Vec<ListEntry> {
     let containers = list_managed_containers();
     containers
         .iter()
         .map(|cname| {
-            let info = inspect_container(cname);
+            let info = inspect_container(cname, Some(agents_dir));
             let derived = compute_agent_state(cname, &info);
             let name = info.agent_name.clone().unwrap_or_else(|| name_from_cname(cname));
             ListEntry {
@@ -882,7 +965,7 @@ pub fn list_agents() -> Vec<ListEntry> {
         .collect()
 }
 
-pub fn create_agent(name: &str, env_file: &std::path::Path) -> Result<String, DockerError> {
+pub fn create_agent(name: &str, env_config: &AgentEnvConfig) -> Result<String, DockerError> {
     validate_name(name)?;
     if name.contains("vesta") {
         return Err(DockerError::InvalidName("agent name must not contain 'vesta'".into()));
@@ -894,8 +977,8 @@ pub fn create_agent(name: &str, env_file: &std::path::Path) -> Result<String, Do
     }
 
     let image = resolve_image()?;
-    let (port, _listener) = allocate_port()?;
-    create_container(&cname, image, port, name, env_file)?;
+    let (port, _listener) = allocate_port(&env_config.agents_dir)?;
+    create_container(&cname, image, port, name, env_config)?;
     Ok(name.to_string())
 }
 
@@ -971,7 +1054,7 @@ pub fn restart_agent(name: &str) -> Result<(), DockerError> {
     Ok(())
 }
 
-pub fn destroy_agent(name: &str) -> Result<(), DockerError> {
+pub fn destroy_agent(name: &str, agents_dir: &std::path::Path) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
     let cs = container_status(&cname);
@@ -984,19 +1067,20 @@ pub fn destroy_agent(name: &str) -> Result<(), DockerError> {
     if !docker_ok(&["rm", "-f", &cname]) {
         return Err(DockerError::Failed("failed to destroy".into()));
     }
+    delete_agent_env_file(agents_dir, name);
     Ok(())
 }
 
-pub fn rebuild_agent(name: &str, env_file: &std::path::Path) -> Result<(), DockerError> {
+pub fn rebuild_agent(name: &str, env_config: &AgentEnvConfig) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
-    let info = inspect_container(&cname);
+    let info = inspect_container(&cname, Some(&env_config.agents_dir));
     match info.status {
         ContainerStatus::NotFound => return Err(DockerError::NotFound(format!("agent '{}' not found", name))),
         ContainerStatus::Dead => return Err(DockerError::BrokenState(format!("agent '{}' is in a broken state", name))),
         _ => {}
     }
-    let port = info.port.ok_or_else(|| DockerError::Failed("container has no port label".into()))?;
+    let port = info.port.ok_or_else(|| DockerError::Failed("agent has no port in env file".into()))?;
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -1011,7 +1095,7 @@ pub fn rebuild_agent(name: &str, env_file: &std::path::Path) -> Result<(), Docke
 
     docker_ok(&["rm", "-f", &cname]);
 
-    create_container(&cname, &backup_tag, port, name, env_file)?;
+    create_container(&cname, &backup_tag, port, name, env_config)?;
 
     if !docker_ok(&["start", &cname]) {
         return Err(DockerError::Failed("failed to start".into()));
@@ -1020,15 +1104,18 @@ pub fn rebuild_agent(name: &str, env_file: &std::path::Path) -> Result<(), Docke
     Ok(())
 }
 
-pub async fn wait_ready_async(name: &str, timeout_secs: u64) -> Result<(), DockerError> {
+pub async fn wait_ready_async(name: &str, timeout_secs: u64, agents_dir: &std::path::Path) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
     let port = {
         let cname = cname.clone();
+        let agents_dir = agents_dir.to_path_buf();
+        let agent_name = name.to_string();
         tokio::task::spawn_blocking(move || {
             ensure_running(&cname)?;
-            get_container_port(&cname)
-                .ok_or_else(|| DockerError::Failed("container has no port label".into()))
+            read_env_value(&agents_dir, &agent_name, "WS_PORT")
+                .and_then(|v| v.parse().ok())
+                .ok_or_else(|| DockerError::Failed("agent has no port".into()))
         })
         .await
         .unwrap()?
@@ -1294,7 +1381,7 @@ fn parse_docker_size(s: &str) -> u64 {
 
 /// Restore an agent from a backup image.
 /// Creates a pre-restore safety backup first, then replaces the container.
-pub fn restore_backup(name: &str, backup_id: &str, env_file: &std::path::Path) -> Result<(), DockerError> {
+pub fn restore_backup(name: &str, backup_id: &str, env_config: &AgentEnvConfig) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
 
@@ -1302,7 +1389,7 @@ pub fn restore_backup(name: &str, backup_id: &str, env_file: &std::path::Path) -
         return Err(DockerError::NotFound(format!("backup '{}' not found", backup_id)));
     }
 
-    let info = inspect_container(&cname);
+    let info = inspect_container(&cname, Some(&env_config.agents_dir));
     if info.status == ContainerStatus::NotFound {
         return Err(DockerError::NotFound(format!("agent '{}' not found", name)));
     }
@@ -1315,9 +1402,9 @@ pub fn restore_backup(name: &str, backup_id: &str, env_file: &std::path::Path) -
     commit_backup(&cname, name, &BackupType::PreRestore)?;
     docker_ok(&["rm", "-f", &cname]);
 
-    let port = info.port.ok_or_else(|| DockerError::Failed("container has no port label".into()))?;
+    let port = info.port.ok_or_else(|| DockerError::Failed("agent has no port in env file".into()))?;
     tracing::debug!(agent = %name, backup_id = %backup_id, "creating container from backup image");
-    create_container(&cname, backup_id, port, name, env_file)?;
+    create_container(&cname, backup_id, port, name, env_config)?;
 
     if !docker_ok(&["start", &cname]) {
         return Err(DockerError::Failed("failed to start restored agent".into()));

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::collections::HashSet;
 use std::process;
 use crate::types::{BackupInfo, BackupType, RetentionPolicy};
 
@@ -30,7 +31,8 @@ const MAX_DOCKERFILE_SEARCH_DEPTH: usize = 5;
 pub const CREDENTIALS_PATH: &str = "/root/.claude/.credentials.json";
 pub const AGENT_READY_MARKER_PATH: &str = "/root/vesta/data/agent_ready";
 const CLAUDE_JSON_PATH: &str = "/root/.claude.json";
-const FALLBACK_WS_PORT: u16 = 7865;
+const AGENT_TOKEN_BYTES: usize = 32;
+const PORT_ALLOC_RETRIES: usize = 10;
 const NAME_MAX_LEN: usize = 32;
 const DOCKER_DAEMON_WAIT_RETRIES: usize = 10;
 const AGENT_READY_TIMEOUT_MS: u64 = 200;
@@ -268,7 +270,7 @@ fn check_docker_permission() -> Option<DockerError> {
 
 pub struct ContainerInfo {
     pub status: ContainerStatus,
-    pub port: u16,
+    pub port: Option<u16>,
     pub id: Option<String>,
     pub agent_name: Option<String>,
 }
@@ -282,7 +284,8 @@ pub struct AgentDerivedState {
 
 pub fn compute_agent_state(cname: &str, info: &ContainerInfo) -> AgentDerivedState {
     let authenticated = info.status != ContainerStatus::NotFound && is_authenticated(cname);
-    let agent_ready = info.status == ContainerStatus::Running && is_agent_ready(info.port, cname);
+    let agent_ready = info.status == ContainerStatus::Running
+        && info.port.is_some_and(|p| is_agent_ready(p, cname));
     let alive = info.status == ContainerStatus::Running && authenticated;
     let friendly_status = friendly_status(&info.status, authenticated, agent_ready);
     AgentDerivedState { authenticated, agent_ready, alive, friendly_status }
@@ -309,8 +312,7 @@ fn inspect_container(cname: &str) -> ContainerInfo {
             };
             let port = parts
                 .get(1)
-                .and_then(|p| p.trim().parse().ok())
-                .unwrap_or(FALLBACK_WS_PORT);
+                .and_then(|p| p.trim().parse().ok());
             let id = parts
                 .get(2)
                 .map(|p| p.trim().chars().take(12).collect::<String>());
@@ -322,7 +324,7 @@ fn inspect_container(cname: &str) -> ContainerInfo {
         }
         None => ContainerInfo {
             status: ContainerStatus::NotFound,
-            port: FALLBACK_WS_PORT,
+            port: None,
             id: None,
             agent_name: None,
         },
@@ -483,25 +485,58 @@ pub fn resolve_image() -> Result<&'static str, DockerError> {
     }
 }
 
-pub fn allocate_port() -> u16 {
-    match std::net::TcpListener::bind("127.0.0.1:0") {
-        Ok(listener) => match listener.local_addr() {
-            Ok(addr) => addr.port(),
-            Err(_) => FALLBACK_WS_PORT,
-        },
-        Err(_) => FALLBACK_WS_PORT,
-    }
+fn all_vesta_container_ports() -> HashSet<u16> {
+    docker_output(&[
+        "ps", "-a",
+        "--filter", "label=vesta.managed=true",
+        "--format", "{{.Label \"vesta.ws_port\"}}",
+    ])
+    .unwrap_or_default()
+    .lines()
+    .filter_map(|s| s.trim().parse().ok())
+    .collect()
 }
 
-pub fn get_container_port(cname: &str) -> u16 {
+pub fn allocate_port() -> Result<(u16, std::net::TcpListener), DockerError> {
+    let reserved = all_vesta_container_ports();
+    for _ in 0..PORT_ALLOC_RETRIES {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")
+            .map_err(|e| DockerError::Failed(format!("failed to bind port: {e}")))?;
+        let port = listener.local_addr()
+            .map_err(|e| DockerError::Failed(format!("failed to get port: {e}")))?
+            .port();
+        if !reserved.contains(&port) {
+            return Ok((port, listener));
+        }
+    }
+    Err(DockerError::Failed("could not allocate a free port after retries".into()))
+}
+
+pub fn get_container_port(cname: &str) -> Option<u16> {
     docker_output(&[
         "inspect",
         "--format",
         "{{index .Config.Labels \"vesta.ws_port\"}}",
         cname,
     ])
-    .and_then(|s| s.parse().ok())
-    .unwrap_or(FALLBACK_WS_PORT)
+    .and_then(|s| s.trim().parse().ok())
+}
+
+pub fn get_container_agent_token(cname: &str) -> Option<String> {
+    docker_output(&[
+        "inspect",
+        "--format",
+        "{{index .Config.Labels \"vesta.agent_token\"}}",
+        cname,
+    ])
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty() && s != "<no value>")
+}
+
+pub fn generate_agent_token() -> String {
+    (0..AGENT_TOKEN_BYTES)
+        .map(|_| format!("{:02x}", rand::random::<u8>()))
+        .collect()
 }
 
 pub fn list_managed_containers() -> Vec<String> {
@@ -563,10 +598,13 @@ fn gpu_available() -> GpuStatus {
 // --- Container creation ---
 
 pub fn create_container(cname: &str, image: &str, port: u16, agent_name: &str, env_file: &std::path::Path) -> Result<(), DockerError> {
+    let agent_token = generate_agent_token();
     let ws_port_env = format!("WS_PORT={}", port);
     let agent_name_env = format!("AGENT_NAME={}", agent_name);
+    let agent_token_env = format!("AGENT_TOKEN={}", agent_token);
     let env_mount = format!("{}:/run/vestad-env:ro", env_file.display());
     let port_label = format!("vesta.ws_port={}", port);
+    let token_label = format!("vesta.agent_token={}", agent_token);
     let user_label = format!("{}={}", LABEL_USER, current_user());
     let agent_name_label = format!("{}={}", LABEL_AGENT_NAME, agent_name);
     let mut args = vec![
@@ -574,11 +612,13 @@ pub fn create_container(cname: &str, image: &str, port: u16, agent_name: &str, e
         "--restart", "unless-stopped", "--network", "host",
         "--label", "vesta.managed=true",
         "--label", &port_label,
+        "--label", &token_label,
         "--label", &user_label,
         "--label", &agent_name_label,
         "-v", &env_mount,
         "-e", &ws_port_env,
         "-e", &agent_name_env,
+        "-e", &agent_token_env,
         "-e", "IS_SANDBOX=1",
     ];
 
@@ -815,7 +855,7 @@ pub fn get_status(name: &str) -> Result<StatusJson, DockerError> {
         id: info.id,
         authenticated: derived.authenticated,
         agent_ready: derived.agent_ready,
-        ws_port: info.port,
+        ws_port: info.port.unwrap_or(0),
         alive: derived.alive,
         friendly_status: derived.friendly_status,
     })
@@ -834,7 +874,7 @@ pub fn list_agents() -> Vec<ListEntry> {
                 status: status_label(&info.status),
                 authenticated: derived.authenticated,
                 agent_ready: derived.agent_ready,
-                ws_port: info.port,
+                ws_port: info.port.unwrap_or(0),
                 alive: derived.alive,
                 friendly_status: derived.friendly_status,
             }
@@ -854,7 +894,7 @@ pub fn create_agent(name: &str, env_file: &std::path::Path) -> Result<String, Do
     }
 
     let image = resolve_image()?;
-    let port = allocate_port();
+    let (port, _listener) = allocate_port()?;
     create_container(&cname, image, port, name, env_file)?;
     Ok(name.to_string())
 }
@@ -956,13 +996,13 @@ pub fn rebuild_agent(name: &str, env_file: &std::path::Path) -> Result<(), Docke
         ContainerStatus::Dead => return Err(DockerError::BrokenState(format!("agent '{}' is in a broken state", name))),
         _ => {}
     }
+    let port = info.port.ok_or_else(|| DockerError::Failed("container has no port label".into()))?;
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_secs();
     let backup_tag = format!("vesta-rebuild:{}_{}", name, ts);
 
-    // Ensure base image layers are present so commit succeeds
     docker_ok(&["pull", VESTA_IMAGE]);
 
     if !docker_ok(&["commit", &cname, &backup_tag]) {
@@ -971,7 +1011,7 @@ pub fn rebuild_agent(name: &str, env_file: &std::path::Path) -> Result<(), Docke
 
     docker_ok(&["rm", "-f", &cname]);
 
-    create_container(&cname, &backup_tag, info.port, name, env_file)?;
+    create_container(&cname, &backup_tag, port, name, env_file)?;
 
     if !docker_ok(&["start", &cname]) {
         return Err(DockerError::Failed("failed to start".into()));
@@ -987,7 +1027,8 @@ pub async fn wait_ready_async(name: &str, timeout_secs: u64) -> Result<(), Docke
         let cname = cname.clone();
         tokio::task::spawn_blocking(move || {
             ensure_running(&cname)?;
-            Ok::<_, DockerError>(get_container_port(&cname))
+            get_container_port(&cname)
+                .ok_or_else(|| DockerError::Failed("container has no port label".into()))
         })
         .await
         .unwrap()?
@@ -1274,9 +1315,9 @@ pub fn restore_backup(name: &str, backup_id: &str, env_file: &std::path::Path) -
     commit_backup(&cname, name, &BackupType::PreRestore)?;
     docker_ok(&["rm", "-f", &cname]);
 
-    // Create new container from backup image, reusing the port
+    let port = info.port.ok_or_else(|| DockerError::Failed("container has no port label".into()))?;
     tracing::debug!(agent = %name, backup_id = %backup_id, "creating container from backup image");
-    create_container(&cname, backup_id, info.port, name, env_file)?;
+    create_container(&cname, backup_id, port, name, env_file)?;
 
     if !docker_ok(&["start", &cname]) {
         return Err(DockerError::Failed("failed to start restored agent".into()));
@@ -1643,5 +1684,18 @@ mod tests {
     #[test]
     fn name_from_cname_no_prefix() {
         assert_eq!(name_from_cname("random"), "random");
+    }
+
+    #[test]
+    fn agent_token_length() {
+        let token = generate_agent_token();
+        assert_eq!(token.len(), AGENT_TOKEN_BYTES * 2);
+    }
+
+    #[test]
+    fn agent_tokens_are_unique() {
+        let t1 = generate_agent_token();
+        let t2 = generate_agent_token();
+        assert_ne!(t1, t2);
     }
 }

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -30,7 +30,7 @@ const MAX_DOCKERFILE_SEARCH_DEPTH: usize = 5;
 pub const CREDENTIALS_PATH: &str = "/root/.claude/.credentials.json";
 pub const AGENT_READY_MARKER_PATH: &str = "/root/vesta/data/agent_ready";
 const CLAUDE_JSON_PATH: &str = "/root/.claude.json";
-pub const BASE_WS_PORT: u16 = 7865;
+const FALLBACK_WS_PORT: u16 = 7865;
 const NAME_MAX_LEN: usize = 32;
 const DOCKER_DAEMON_WAIT_RETRIES: usize = 10;
 const AGENT_READY_TIMEOUT_MS: u64 = 200;
@@ -310,7 +310,7 @@ fn inspect_container(cname: &str) -> ContainerInfo {
             let port = parts
                 .get(1)
                 .and_then(|p| p.trim().parse().ok())
-                .unwrap_or(BASE_WS_PORT);
+                .unwrap_or(FALLBACK_WS_PORT);
             let id = parts
                 .get(2)
                 .map(|p| p.trim().chars().take(12).collect::<String>());
@@ -322,7 +322,7 @@ fn inspect_container(cname: &str) -> ContainerInfo {
         }
         None => ContainerInfo {
             status: ContainerStatus::NotFound,
-            port: BASE_WS_PORT,
+            port: FALLBACK_WS_PORT,
             id: None,
             agent_name: None,
         },
@@ -484,26 +484,13 @@ pub fn resolve_image() -> Result<&'static str, DockerError> {
 }
 
 pub fn allocate_port() -> u16 {
-    let containers = list_managed_containers();
-    let used: Vec<u16> = if containers.is_empty() {
-        vec![]
-    } else {
-        let args: Vec<&str> = ["inspect", "--format", "{{index .Config.Labels \"vesta.ws_port\"}}"]
-            .iter()
-            .copied()
-            .chain(containers.iter().map(|s| s.as_str()))
-            .collect();
-        docker_output(&args)
-            .unwrap_or_default()
-            .lines()
-            .filter_map(|s| s.trim().parse().ok())
-            .collect()
-    };
-    let mut port = BASE_WS_PORT;
-    while used.contains(&port) {
-        port += 1;
+    match std::net::TcpListener::bind("127.0.0.1:0") {
+        Ok(listener) => match listener.local_addr() {
+            Ok(addr) => addr.port(),
+            Err(_) => FALLBACK_WS_PORT,
+        },
+        Err(_) => FALLBACK_WS_PORT,
     }
-    port
 }
 
 pub fn get_container_port(cname: &str) -> u16 {
@@ -514,7 +501,7 @@ pub fn get_container_port(cname: &str) -> u16 {
         cname,
     ])
     .and_then(|s| s.parse().ok())
-    .unwrap_or(BASE_WS_PORT)
+    .unwrap_or(FALLBACK_WS_PORT)
 }
 
 pub fn list_managed_containers() -> Vec<String> {

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -118,6 +118,26 @@ fn find_available_port() -> Option<u16> {
         .map(|addr| addr.port())
 }
 
+fn resolve_port(explicit: Option<u16>, config: &std::path::Path) -> u16 {
+    if let Some(port) = explicit {
+        return port;
+    }
+
+    if let Some(stored) = std::fs::read_to_string(config.join("port"))
+        .ok()
+        .and_then(|s| s.trim().parse::<u16>().ok())
+    {
+        if std::net::TcpListener::bind(("0.0.0.0", stored)).is_ok()
+            && std::net::TcpListener::bind(("127.0.0.1", stored + 1)).is_ok()
+        {
+            return stored;
+        }
+        tracing::warn!(stored_port = stored, "stored port unavailable, allocating new one");
+    }
+
+    find_available_port().unwrap_or_else(|| die("no available port found"))
+}
+
 fn config_dir() -> std::path::PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| die("HOME not set"));
     std::path::PathBuf::from(home).join(".config/vesta/vestad")
@@ -161,11 +181,9 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
 
     docker::ensure_docker().unwrap_or_else(|e| die(&e));
 
-    let port = port.unwrap_or_else(|| find_available_port().unwrap_or_else(|| die("no available port found")));
-
     let _pid_lock = serve::acquire_pid_lock(&config).unwrap_or_else(|e| die(&e));
+    let port = resolve_port(port, &config);
     serve::write_port_file(&config, port);
-    serve::write_env_file(&config, port);
 
     let api_key = serve::ensure_api_key(&config);
     let (cert_pem, key_pem, _fingerprint) = serve::ensure_tls(&config);
@@ -182,10 +200,13 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
         None
     };
 
+    serve::write_env_file(&config, port, tunnel_url.as_deref());
+
     let local_url = format!("http://localhost:{}", port + 1);
 
+    let user = std::env::var("USER").or_else(|_| std::env::var("LOGNAME")).unwrap_or_else(|_| "unknown".into());
     eprintln!();
-    eprintln!("  \x1b[1;35mvestad\x1b[0m v{}", env!("CARGO_PKG_VERSION"));
+    eprintln!("  \x1b[1;35mvestad\x1b[0m v{} \x1b[2m(user: {}, port: {})\x1b[0m", env!("CARGO_PKG_VERSION"), user, port);
     print_server_info(tunnel_url.as_deref(), &local_url, &api_key);
 
     tokio::runtime::Builder::new_multi_thread()
@@ -255,6 +276,8 @@ fn run_server_systemd(port: Option<u16>, no_tunnel: bool) {
 }
 
 fn main() {
+    dotenvy::dotenv().ok();
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -399,7 +422,7 @@ fn main() {
                     .unwrap_or_else(|| die("could not determine loaded image from docker load output"));
 
                 eprintln!("creating agent '{}'...", name);
-                let port = find_available_port().unwrap_or_else(|| die("no available port"));
+                let (port, _listener) = docker::allocate_port().unwrap_or_else(|e| die(&e));
                 let env_file = config_dir().join("container.env");
                 docker::create_container(&cname, loaded_image, port, &name, &env_file)
                     .unwrap_or_else(|e| die(&e));

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -200,7 +200,7 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
         None
     };
 
-    serve::write_env_file(&config, port, tunnel_url.as_deref());
+    serve::update_agent_env_files(&config, port, tunnel_url.as_deref());
 
     let local_url = format!("http://localhost:{}", port + 1);
 
@@ -422,9 +422,20 @@ fn main() {
                     .unwrap_or_else(|| die("could not determine loaded image from docker load output"));
 
                 eprintln!("creating agent '{}'...", name);
-                let (port, _listener) = docker::allocate_port().unwrap_or_else(|e| die(&e));
-                let env_file = config_dir().join("container.env");
-                docker::create_container(&cname, loaded_image, port, &name, &env_file)
+                let config = config_dir();
+                let vestad_port = std::fs::read_to_string(config.join("port"))
+                    .ok()
+                    .and_then(|s| s.trim().parse::<u16>().ok())
+                    .unwrap_or(0);
+                let vestad_tunnel = tunnel::get_tunnel_config(&config)
+                    .map(|tc| format!("https://{}", tc.hostname));
+                let env_config = docker::AgentEnvConfig {
+                    agents_dir: config.join("agents"),
+                    vestad_port,
+                    vestad_tunnel,
+                };
+                let (port, _listener) = docker::allocate_port(&env_config.agents_dir).unwrap_or_else(|e| die(&e));
+                docker::create_container(&cname, loaded_image, port, &name, &env_config)
                     .unwrap_or_else(|e| die(&e));
 
                 if !docker::docker_ok(&["start", &cname]) {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -131,7 +131,7 @@ struct AuthSession {
 
 pub struct AppState {
     api_key: String,
-    env_file: std::path::PathBuf,
+    env_config: docker::AgentEnvConfig,
     auth_sessions: Mutex<HashMap<String, AuthSession>>,
     agent_locks: Mutex<HashMap<String, Arc<tokio::sync::RwLock<()>>>>,
     tunnel_url: Mutex<Option<String>>,
@@ -144,11 +144,11 @@ pub struct AppState {
 }
 
 impl AppState {
-    fn new(api_key: String, env_file: std::path::PathBuf, tunnel_url: Option<String>) -> Self {
+    fn new(api_key: String, env_config: docker::AgentEnvConfig, tunnel_url: Option<String>) -> Self {
         let service_registry = load_service_registry();
         Self {
             api_key,
-            env_file,
+            env_config,
             auth_sessions: Mutex::new(HashMap::new()),
             agent_locks: Mutex::new(HashMap::new()),
             tunnel_url: Mutex::new(tunnel_url),
@@ -403,8 +403,11 @@ async fn tunnel_handler(
     }
 }
 
-async fn list_agents_handler() -> impl IntoResponse {
-    let agents = tokio::task::spawn_blocking(docker::list_agents)
+async fn list_agents_handler(
+    State(state): State<SharedState>,
+) -> impl IntoResponse {
+    let agents_dir = state.env_config.agents_dir.clone();
+    let agents = tokio::task::spawn_blocking(move || docker::list_agents(&agents_dir))
         .await
         .unwrap();
     Json(agents)
@@ -428,9 +431,9 @@ async fn create_agent_handler(
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
 
-    let env_file = state.env_file.clone();
+    let env_config = state.env_config.clone();
     let name =
-        tokio::task::spawn_blocking(move || docker::create_agent(&name, &env_file))
+        tokio::task::spawn_blocking(move || docker::create_agent(&name, &env_config))
             .await
             .unwrap()
             .map_err(map_docker_err)?;
@@ -445,9 +448,11 @@ async fn create_agent_handler(
 }
 
 async fn agent_status_handler(
+    State(state): State<SharedState>,
     Path(name): Path<String>,
 ) -> Result<Json<docker::StatusJson>, (StatusCode, Json<serde_json::Value>)> {
-    let status = tokio::task::spawn_blocking(move || docker::get_status(&name))
+    let agents_dir = state.env_config.agents_dir.clone();
+    let status = tokio::task::spawn_blocking(move || docker::get_status(&name, &agents_dir))
         .await
         .unwrap()
         .map_err(map_docker_err)?;
@@ -531,7 +536,8 @@ async fn destroy_agent_handler(
     let _guard = lock.write().await;
 
     let docker_name = name.clone();
-    tokio::task::spawn_blocking(move || docker::destroy_agent(&docker_name))
+    let agents_dir = state.env_config.agents_dir.clone();
+    tokio::task::spawn_blocking(move || docker::destroy_agent(&docker_name, &agents_dir))
         .await
         .unwrap()
         .map_err(map_docker_err)?;
@@ -552,8 +558,8 @@ async fn rebuild_agent_handler(
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
 
-    let env_file = state.env_file.clone();
-    tokio::task::spawn_blocking(move || docker::rebuild_agent(&name, &env_file))
+    let env_config = state.env_config.clone();
+    tokio::task::spawn_blocking(move || docker::rebuild_agent(&name, &env_config))
         .await
         .unwrap()
         .map_err(map_docker_err)?;
@@ -566,11 +572,12 @@ struct WaitReadyQuery {
 }
 
 async fn wait_ready_handler(
+    State(state): State<SharedState>,
     Path(name): Path<String>,
     Query(query): Query<WaitReadyQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     let timeout = query.timeout.unwrap_or(30);
-    docker::wait_ready_async(&name, timeout)
+    docker::wait_ready_async(&name, timeout, &state.env_config.agents_dir)
         .await
         .map_err(|e| err_response(StatusCode::SERVICE_UNAVAILABLE, &e.to_string()))?;
     Ok(ok_json())
@@ -990,16 +997,13 @@ async fn agent_proxy_handler(
         .await
         .map_err(map_join_err)?
         .map_err(map_docker_err)?;
-    let cname_clone = cname.clone();
-    let agent_port = tokio::task::spawn_blocking(move || docker::get_container_port(&cname_clone))
-        .await
-        .map_err(map_join_err)?
-        .ok_or_else(|| err_response(StatusCode::INTERNAL_SERVER_ERROR, "agent has no port"))?;
-
-    let cname_clone = cname.clone();
-    let agent_token = tokio::task::spawn_blocking(move || docker::get_container_agent_token(&cname_clone))
+    let agents_dir = state.env_config.agents_dir.clone();
+    let agent_name = name.clone();
+    let (agent_port, agent_token) = tokio::task::spawn_blocking(move || docker::read_agent_port_and_token(&agent_name, &agents_dir))
         .await
         .map_err(map_join_err)?;
+    let agent_port = agent_port
+        .ok_or_else(|| err_response(StatusCode::INTERNAL_SERVER_ERROR, "agent has no port"))?;
 
     // Check if the first path segment matches a registered service.
     // If so, route directly to that service's port with the prefix stripped.
@@ -1175,8 +1179,8 @@ async fn restore_backup_handler(
     tracing::info!(agent = %path.name, backup_id = %path.backup_id, "restoring backup");
     let name = path.name.clone();
     let backup_id = path.backup_id.clone();
-    let env_file = state.env_file.clone();
-    tokio::task::spawn_blocking(move || docker::restore_backup(&name, &backup_id, &env_file))
+    let env_config = state.env_config.clone();
+    tokio::task::spawn_blocking(move || docker::restore_backup(&name, &backup_id, &env_config))
         .await
         .unwrap()
         .map_err(map_docker_err)?;
@@ -1259,15 +1263,11 @@ pub fn write_port_file(config_dir: &std::path::Path, port: u16) {
     std::fs::write(&port_path, port.to_string()).ok();
 }
 
-/// Write a sourceable env file that containers read via bind mount.
-/// Adding new vars here makes them available to all containers without rebuild.
-pub fn write_env_file(config_dir: &std::path::Path, port: u16, tunnel_url: Option<&str>) {
-    let env_path = config_dir.join("container.env");
-    let mut content = format!("export VESTAD_PORT={port}\n");
-    if let Some(url) = tunnel_url {
-        content.push_str(&format!("export VESTAD_TUNNEL={url}\n"));
-    }
-    std::fs::write(&env_path, content).ok();
+/// Update VESTAD_PORT and VESTAD_TUNNEL in all existing per-agent env files.
+/// Called at vestad startup so containers pick up the new values on restart.
+pub fn update_agent_env_files(config_dir: &std::path::Path, port: u16, tunnel_url: Option<&str>) {
+    let agents_dir = config_dir.join("agents");
+    docker::update_all_agent_env_files(&agents_dir, port, tunnel_url);
 }
 
 // --- PID file ---
@@ -1514,8 +1514,12 @@ fn spawn_update_check_task(state: SharedState) {
 // --- Server start ---
 
 pub async fn run_server(port: u16, api_key: String, cert_pem: String, key_pem: String, tunnel_url: Option<String>, config_dir: std::path::PathBuf) {
-    let env_file = config_dir.join("container.env");
-    let state = Arc::new(AppState::new(api_key, env_file, tunnel_url));
+    let env_config = docker::AgentEnvConfig {
+        agents_dir: config_dir.join("agents"),
+        vestad_port: port,
+        vestad_tunnel: tunnel_url.clone(),
+    };
+    let state = Arc::new(AppState::new(api_key, env_config, tunnel_url));
     let app = build_router(state.clone());
     spawn_auto_backup_task(state.clone());
     spawn_update_check_task(state);

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -350,7 +350,10 @@ fn map_docker_err(e: docker::DockerError) -> (StatusCode, Json<serde_json::Value
 // --- Handlers ---
 
 async fn health() -> Json<serde_json::Value> {
-    Json(serde_json::json!({"ok": true}))
+    let user = std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "unknown".into());
+    Json(serde_json::json!({"ok": true, "user": user}))
 }
 
 async fn version(State(state): State<SharedState>) -> Json<serde_json::Value> {
@@ -747,12 +750,17 @@ async fn logs_handler(
 
 // --- WebSocket proxy (used by agent wildcard) ---
 
-async fn ws_proxy(client_ws: axum::extract::ws::WebSocket, agent_port: u16, path: &str) {
+async fn ws_proxy(client_ws: axum::extract::ws::WebSocket, agent_port: u16, path: &str, agent_token: Option<&str>) {
     use axum::extract::ws::Message as AxumMsg;
     use futures_util::{SinkExt, StreamExt};
     use tokio_tungstenite::tungstenite::Message as TungMsg;
 
-    let url = format!("ws://localhost:{}{}", agent_port, path);
+    let url = if let Some(token) = agent_token {
+        let sep = if path.contains('?') { "&" } else { "?" };
+        format!("ws://localhost:{}{}{}agent_token={}", agent_port, path, sep, token)
+    } else {
+        format!("ws://localhost:{}{}", agent_port, path)
+    };
     let agent_ws = match tokio_tungstenite::connect_async(&url).await {
         Ok((ws, _)) => ws,
         Err(e) => {
@@ -880,10 +888,23 @@ fn all_registered_ports(registry: &HashMap<String, HashMap<String, u16>>) -> Vec
     registry.values().flat_map(|services| services.values().copied()).collect()
 }
 
-/// Find a free port not used by any registered service.
+const SERVICE_PORT_ALLOC_RETRIES: usize = 5;
+
+/// Find a free port not used by any registered service or other process.
+/// Uses OS-assigned ports with retries to avoid races with other vestad instances.
 fn allocate_service_port(registry: &HashMap<String, HashMap<String, u16>>) -> Option<u16> {
     let used = all_registered_ports(registry);
-    (SERVICE_PORT_MIN..=SERVICE_PORT_MAX).find(|p| !used.contains(p))
+    for _ in 0..SERVICE_PORT_ALLOC_RETRIES {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).ok()?;
+        let port = listener.local_addr().ok()?.port();
+        if port >= SERVICE_PORT_MIN && !used.contains(&port) {
+            return Some(port);
+        }
+    }
+    // Fallback: linear scan (slower but guaranteed if ports exist)
+    (SERVICE_PORT_MIN..=SERVICE_PORT_MAX).find(|p| {
+        !used.contains(p) && std::net::TcpListener::bind(("127.0.0.1", *p)).is_ok()
+    })
 }
 
 async fn register_service_handler(
@@ -972,6 +993,12 @@ async fn agent_proxy_handler(
     let cname_clone = cname.clone();
     let agent_port = tokio::task::spawn_blocking(move || docker::get_container_port(&cname_clone))
         .await
+        .map_err(map_join_err)?
+        .ok_or_else(|| err_response(StatusCode::INTERNAL_SERVER_ERROR, "agent has no port"))?;
+
+    let cname_clone = cname.clone();
+    let agent_token = tokio::task::spawn_blocking(move || docker::get_container_agent_token(&cname_clone))
+        .await
         .map_err(map_join_err)?;
 
     // Check if the first path segment matches a registered service.
@@ -1013,15 +1040,13 @@ async fn agent_proxy_handler(
                 ));
             }
         };
+        let ws_token = agent_token.clone();
         Ok(ws.on_upgrade(move |socket| async move {
             drop(guard);
-            ws_proxy(socket, target_port, &target_path).await;
+            ws_proxy(socket, target_port, &target_path, ws_token.as_deref()).await;
         }))
     } else {
         drop(guard);
-        // For service root HTML (e.g. /agents/{name}/dashboard/), rewrite
-        // relative asset URLs to carry the auth token so sub-resource loads
-        // pass through auth.
         let is_service_root = is_service
             && path.strip_suffix('/').unwrap_or(&path) == first_segment;
         let token = if is_service_root {
@@ -1030,7 +1055,7 @@ async fn agent_proxy_handler(
             None
         };
         let resp =
-            forward_http_to_container(&state.http_client, target_port, &target_path, request)
+            forward_http_to_container(&state.http_client, target_port, &target_path, request, agent_token.as_deref())
                 .await?;
         match token {
             Some(token) => crate::service_proxy::rewrite_asset_urls(resp, &token).await,
@@ -1044,6 +1069,7 @@ async fn forward_http_to_container(
     port: u16,
     target_path: &str,
     request: Request,
+    agent_token: Option<&str>,
 ) -> Result<Response, (StatusCode, Json<serde_json::Value>)> {
     let (parts, body) = request.into_parts();
     let url = format!("http://localhost:{}{}", port, target_path);
@@ -1057,12 +1083,14 @@ async fn forward_http_to_container(
 
     let mut req_builder = client.request(method, &url);
     for (name, value) in parts.headers.iter() {
-        // Skip hop-by-hop headers — reqwest sets host/transfer-encoding itself.
         let n = name.as_str().to_ascii_lowercase();
         if matches!(n.as_str(), "host" | "connection" | "transfer-encoding" | "content-length") {
             continue;
         }
         req_builder = req_builder.header(name.as_str(), value.as_bytes());
+    }
+    if let Some(token) = agent_token {
+        req_builder = req_builder.header("X-Agent-Token", token);
     }
     if !body_bytes.is_empty() {
         req_builder = req_builder.body(body_bytes.to_vec());
@@ -1233,9 +1261,12 @@ pub fn write_port_file(config_dir: &std::path::Path, port: u16) {
 
 /// Write a sourceable env file that containers read via bind mount.
 /// Adding new vars here makes them available to all containers without rebuild.
-pub fn write_env_file(config_dir: &std::path::Path, port: u16) {
+pub fn write_env_file(config_dir: &std::path::Path, port: u16, tunnel_url: Option<&str>) {
     let env_path = config_dir.join("container.env");
-    let content = format!("export VESTAD_PORT={port}\n");
+    let mut content = format!("export VESTAD_PORT={port}\n");
+    if let Some(url) = tunnel_url {
+        content.push_str(&format!("export VESTAD_TUNNEL={url}\n"));
+    }
     std::fs::write(&env_path, content).ok();
 }
 

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -76,6 +76,53 @@ fn get_zone_domain(env: &CloudflareEnv) -> Result<String, String> {
         .ok_or_else(|| "failed to get domain name from zone".to_string())
 }
 
+fn delete_tunnel_if_exists(env: &CloudflareEnv, tunnel_name: &str) {
+    let list_url = format!(
+        "{}/accounts/{}/cfd_tunnel?name={}",
+        CF_API_BASE, env.account_id, tunnel_name
+    );
+    let resp = match cf_request("GET", &list_url, &env.api_token, None) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    if let Some(tunnels) = resp["result"].as_array() {
+        for tunnel in tunnels {
+            if tunnel["deleted_at"].is_null() {
+                if let Some(id) = tunnel["id"].as_str() {
+                    let del_url = format!("{}/accounts/{}/cfd_tunnel/{}", CF_API_BASE, env.account_id, id);
+                    tracing::info!(tunnel_id = %id, "deleting stale tunnel");
+                    cf_request("DELETE", &del_url, &env.api_token, None).ok();
+                }
+            }
+        }
+    }
+}
+
+fn delete_dns_record_if_exists(env: &CloudflareEnv, subdomain: &str) {
+    let domain = match get_zone_domain(env) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    let fqdn = format!("{}.{}", subdomain, domain);
+    let list_url = format!(
+        "{}/zones/{}/dns_records?type=CNAME&name={}",
+        CF_API_BASE, env.zone_id, fqdn
+    );
+    let resp = match cf_request("GET", &list_url, &env.api_token, None) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    if let Some(records) = resp["result"].as_array() {
+        for record in records {
+            if let Some(id) = record["id"].as_str() {
+                let del_url = format!("{}/zones/{}/dns_records/{}", CF_API_BASE, env.zone_id, id);
+                tracing::info!(record_id = %id, "deleting stale DNS record");
+                cf_request("DELETE", &del_url, &env.api_token, None).ok();
+            }
+        }
+    }
+}
+
 fn tunnel_config_path(config_dir: &Path) -> PathBuf {
     config_dir.join("tunnel.json")
 }
@@ -86,12 +133,49 @@ pub fn get_tunnel_config(config_dir: &Path) -> Option<TunnelConfig> {
     serde_json::from_str(&data).ok()
 }
 
-pub fn generate_subdomain() -> String {
-    let hostname = gethostname().to_lowercase().replace(|c: char| !c.is_alphanumeric(), "-");
-    let hostname = hostname.trim_matches('-');
-    let short = if hostname.len() > 20 { &hostname[..20] } else { hostname };
-    let suffix: String = (0..4).map(|_| format!("{:x}", rand::random::<u8>() & 0xf)).collect();
-    format!("{}-{}", short, suffix)
+const ANIMALS: &[&str] = &[
+    "alpaca", "badger", "beaver", "bison", "bobcat", "camel", "capybara", "cardinal",
+    "caribou", "chameleon", "cheetah", "chinchilla", "chipmunk", "cobra", "condor",
+    "cougar", "coyote", "crane", "cricket", "crow", "dingo", "dolphin", "donkey",
+    "eagle", "egret", "elk", "falcon", "ferret", "finch", "flamingo", "fox",
+    "gazelle", "gecko", "gopher", "grizzly", "grouse", "gull", "hamster", "hawk",
+    "hedgehog", "heron", "hornet", "hyena", "ibex", "iguana", "impala", "jackal",
+    "jaguar", "jay", "kestrel", "kingfisher", "kiwi", "koala", "komodo", "lark",
+    "lemur", "leopard", "lion", "llama", "lobster", "lynx", "macaw", "mamba",
+    "manatee", "mantis", "marmot", "marten", "merlin", "mink", "mongoose", "moose",
+    "narwhal", "newt", "ocelot", "okapi", "opossum", "osprey", "otter", "owl",
+    "panda", "panther", "parrot", "pelican", "penguin", "phoenix", "pika", "piranha",
+    "puma", "python", "quail", "raven", "robin", "salmon", "scorpion", "shark",
+    "shrike", "sparrow", "squid", "stork", "swift", "tapir", "tern", "tiger",
+    "toucan", "turtle", "viper", "vulture", "walrus", "weasel", "whale", "wolf",
+    "wolverine", "wombat", "wren", "yak", "zebra",
+];
+
+fn animal_for_user(username: &str, offset: usize) -> &'static str {
+    let mut hash: u64 = 5381;
+    for byte in username.bytes() {
+        hash = hash.wrapping_mul(33).wrapping_add(byte as u64);
+    }
+    ANIMALS[(hash as usize + offset) % ANIMALS.len()]
+}
+
+fn current_user() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "unknown".into())
+}
+
+/// Sanitize a string to only contain lowercase alphanumeric characters and hyphens.
+fn sanitize(s: &str) -> String {
+    let cleaned: String = s.to_lowercase().replace(|c: char| !c.is_alphanumeric(), "-");
+    cleaned.trim_matches('-').to_string()
+}
+
+fn generate_subdomain(offset: usize) -> String {
+    let animal = animal_for_user(&current_user(), offset);
+    let hostname = sanitize(&gethostname());
+    let short = if hostname.len() > 20 { &hostname[..20] } else { &hostname };
+    format!("{}-{}", animal, short.trim_end_matches('-'))
 }
 
 fn gethostname() -> String {
@@ -102,13 +186,58 @@ fn gethostname() -> String {
     if output.is_empty() { "vesta".to_string() } else { output }
 }
 
+const SUBDOMAIN_MAX_ATTEMPTS: usize = 10;
+
 pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
+    let preferred = generate_subdomain(0);
+
+    // Reuse existing tunnel if it uses any of our candidate animals
     if let Some(tc) = get_tunnel_config(config_dir) {
-        return Ok(tc);
+        let current = tc.hostname.split('.').next().unwrap_or("");
+        if is_our_subdomain(current) {
+            return Ok(tc);
+        }
+        tracing::info!(old = %current, new = %preferred, "tunnel subdomain changed, recreating");
+        if let Err(e) = destroy_tunnel(config_dir) {
+            tracing::warn!("failed to destroy old tunnel: {e}");
+            std::fs::remove_file(tunnel_config_path(config_dir)).ok();
+        }
     }
-    let subdomain = generate_subdomain();
-    tracing::info!(subdomain = %subdomain, "auto-creating tunnel");
-    setup_tunnel(config_dir, &subdomain)
+
+    let env = cf_env()?;
+
+    for attempt in 0..SUBDOMAIN_MAX_ATTEMPTS {
+        let subdomain = generate_subdomain(attempt);
+        let tunnel_name = format!("vesta-{}", subdomain);
+
+        if tunnel_exists(&env, &tunnel_name) {
+            tracing::info!(subdomain = %subdomain, "tunnel name already taken, trying next");
+            continue;
+        }
+
+        tracing::info!(subdomain = %subdomain, "creating tunnel");
+        return setup_tunnel(config_dir, &subdomain);
+    }
+
+    Err(format!("could not find available tunnel subdomain after {SUBDOMAIN_MAX_ATTEMPTS} attempts"))
+}
+
+/// Check if a subdomain matches any of our candidate animal-hostname combos.
+fn is_our_subdomain(subdomain: &str) -> bool {
+    (0..SUBDOMAIN_MAX_ATTEMPTS).any(|offset| generate_subdomain(offset) == subdomain)
+}
+
+/// Check if an active (non-deleted) tunnel with this name already exists.
+fn tunnel_exists(env: &CloudflareEnv, tunnel_name: &str) -> bool {
+    let url = format!(
+        "{}/accounts/{}/cfd_tunnel?name={}&is_deleted=false",
+        CF_API_BASE, env.account_id, tunnel_name
+    );
+    let resp = match cf_request("GET", &url, &env.api_token, None) {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    resp["result"].as_array().is_some_and(|arr| !arr.is_empty())
 }
 
 pub fn setup_tunnel(config_dir: &Path, subdomain: &str) -> Result<TunnelConfig, String> {
@@ -118,6 +247,8 @@ pub fn setup_tunnel(config_dir: &Path, subdomain: &str) -> Result<TunnelConfig, 
     let tunnel_name = format!("vesta-{}", subdomain);
 
     tracing::info!(tunnel = %tunnel_name, "creating tunnel");
+
+    delete_tunnel_if_exists(&env, &tunnel_name);
 
     let create_url = format!("{}/accounts/{}/cfd_tunnel", CF_API_BASE, env.account_id);
     let tunnel_secret: String = (0..32).map(|_| format!("{:02x}", rand::random::<u8>())).collect();
@@ -142,6 +273,8 @@ pub fn setup_tunnel(config_dir: &Path, subdomain: &str) -> Result<TunnelConfig, 
         .to_string();
 
     tracing::info!(hostname = %hostname, tunnel_id = %tunnel_id, "creating DNS record");
+
+    delete_dns_record_if_exists(&env, subdomain);
 
     let dns_url = format!("{}/zones/{}/dns_records", CF_API_BASE, env.zone_id);
     let dns_resp = cf_request("POST", &dns_url, &env.api_token, Some(serde_json::json!({
@@ -296,6 +429,48 @@ fn which(name: &str) -> Result<PathBuf, ()> {
         }
     }
     Err(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn animal_for_user_is_deterministic() {
+        let a1 = animal_for_user("alice", 0);
+        let a2 = animal_for_user("alice", 0);
+        assert_eq!(a1, a2);
+    }
+
+    #[test]
+    fn animal_offset_changes_result() {
+        let a = animal_for_user("alice", 0);
+        let b = animal_for_user("alice", 1);
+        assert_ne!(a, b, "different offsets should give different animals");
+    }
+
+    #[test]
+    fn animal_is_from_list() {
+        for name in ["alice", "bob", "root", "deploy", "test-user", "x"] {
+            let animal = animal_for_user(name, 0);
+            assert!(ANIMALS.contains(&animal), "{name} mapped to '{animal}' which is not in ANIMALS");
+        }
+    }
+
+    #[test]
+    fn subdomain_format_is_animal_dash_hostname() {
+        let sub = generate_subdomain(0);
+        assert!(sub.contains('-'), "subdomain should contain a dash: {sub}");
+        let animal_part = sub.split('-').next().unwrap();
+        assert!(ANIMALS.contains(&animal_part), "first part should be an animal: {sub}");
+    }
+
+    #[test]
+    fn sanitize_strips_special_chars() {
+        assert_eq!(sanitize("Alice.Bob"), "alice-bob");
+        assert_eq!(sanitize("--test--"), "test");
+        assert_eq!(sanitize("a_b@c"), "a-b-c");
+    }
 }
 
 fn base64_encode(input: &str) -> String {


### PR DESCRIPTION
## Summary

- Replace fragile label-scanning port allocation (`BASE_WS_PORT + increment`) with OS-level allocation via `TcpListener::bind("127.0.0.1:0")`, eliminating race conditions and collisions with non-Vesta processes
- Tunnel subdomains now use deterministic animal-hostname format with collision avoidance — cycles through different animals if the preferred name is taken
- Service port allocation (skills, dashboard, voice) also uses OS-assigned ports with retries to avoid races between multiple `vestad` instances

## Problem

1. **Port collisions**: WS port allocation started at a hardcoded `BASE_WS_PORT = 7865` and incremented by scanning Docker labels. Multiple `vestad` instances could race and pick the same port, and non-Vesta processes in that range went undetected.
2. **Tunnel collisions**: Multiple users on the same host would get identical tunnel subdomains, causing routing conflicts.
3. **Service port conflicts**: Skills hardcoded ports (e.g. dashboard on 8050, voice on 8060), colliding when multiple agents ran simultaneously.

## Solution

- **WS ports**: Use the OS ephemeral port allocator (`TcpListener::bind("127.0.0.1:0")`) for a guaranteed-free port. Passed to the container via `WS_PORT` env var and stored in the `vesta.ws_port` label.
- **Tunnels**: Generate deterministic animal-based subdomains with collision avoidance — if the preferred name is taken, cycle through alternatives before failing.
- **Service ports**: Skills use OS-assigned ports instead of hardcoded values, with retry logic for robustness.

## Test plan

- [ ] `cargo build` and `cargo clippy` pass
- [ ] Create two agents concurrently — verify different WS ports and tunnel subdomains
- [ ] Verify agent status/list commands still show correct ports
- [ ] Verify WebSocket proxy still works
- [ ] Verify skill services (dashboard, voice) start on unique ports per agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)