### PR TITLE
feat: adaptive thinking, thinking events, logger refactor, console coloring

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "aioconsole>=0.8.1",
     "aiohttp>=3.11",
-    "claude-agent-sdk>=0.1.53",
+    "claude-agent-sdk>=0.1.56",
     "pydantic>=2.10.4",
     "pydantic-settings>=2.7.0",
     "rich>=14.2.0",

--- a/agent/src/vesta/config.py
+++ b/agent/src/vesta/config.py
@@ -3,6 +3,7 @@ import typing as tp
 
 import pydantic as pyd
 import pydantic_settings as pyd_settings
+from claude_agent_sdk.types import ThinkingConfigAdaptive, ThinkingConfigDisabled, ThinkingConfigEnabled
 
 
 _DEFAULT_ROOT = pl.Path.home() / "vesta"
@@ -19,7 +20,7 @@ class VestaConfig(pyd_settings.BaseSettings):
     response_timeout: int = pyd.Field(default=600, ge=1)
     nightly_memory_hour: int | None = pyd.Field(default=3, ge=0, le=23)
     interrupt_timeout: float = pyd.Field(default=5.0, gt=0)
-    thinking: dict[str, tp.Any] = {"type": "adaptive"}
+    thinking: ThinkingConfigAdaptive | ThinkingConfigEnabled | ThinkingConfigDisabled = ThinkingConfigAdaptive(type="adaptive")
     ws_port: int = 0
     agent_token: str | None = None
 

--- a/agent/src/vesta/config.py
+++ b/agent/src/vesta/config.py
@@ -19,7 +19,7 @@ class VestaConfig(pyd_settings.BaseSettings):
     response_timeout: int = pyd.Field(default=600, ge=1)
     nightly_memory_hour: int | None = pyd.Field(default=3, ge=0, le=23)
     interrupt_timeout: float = pyd.Field(default=5.0, gt=0)
-    max_thinking_tokens: int | None = 10000
+    thinking: dict[str, tp.Any] = {"type": "adaptive"}
     ws_port: int = 0
     agent_token: str | None = None
 

--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -13,6 +13,7 @@ from claude_agent_sdk import (
     Message,
     ResultMessage,
     TextBlock,
+    ThinkingBlock,
     ToolUseBlock,
     tool,
     create_sdk_mcp_server,
@@ -86,7 +87,7 @@ def filter_tool_lines(text: str) -> str:
     return "\n".join(s for line in text.split("\n") if (s := line.strip()) and not s.startswith("[TOOL]") and not s.startswith("[TASK]"))
 
 
-def _parse_sdk_message(msg: Message, *, sub_agent_context: str | None) -> tuple[list[str], str | None, str | None, bool]:
+def _parse_sdk_message(msg: Message, *, sub_agent_context: str | None) -> tuple[list[str], list[ThinkingBlock], str | None, str | None, bool]:
     if isinstance(msg, ResultMessage):
         session_id: str | None = None
         try:
@@ -113,25 +114,28 @@ def _parse_sdk_message(msg: Message, *, sub_agent_context: str | None) -> tuple[
                 logger.usage(" | ".join(parts))
         except (AttributeError, TypeError, KeyError):
             pass
-        return ([], sub_agent_context, session_id, False)
+        return ([], [], sub_agent_context, session_id, False)
 
     if not isinstance(msg, AssistantMessage):
-        return ([msg] if isinstance(msg, str) else [], sub_agent_context, None, False)
+        return ([msg] if isinstance(msg, str) else [], [], sub_agent_context, None, False)
 
     texts = []
+    thinking_blocks = []
     has_tool_use = False
     current_context = sub_agent_context
 
     for block in msg.content:
         if isinstance(block, TextBlock):
             texts.append(block.text)
+        elif isinstance(block, ThinkingBlock):
+            thinking_blocks.append(block)
         elif isinstance(block, ToolUseBlock):
             has_tool_use = True
             _, new_context = _format_tool_call(block.name, input_data=block.input, sub_agent_context=current_context)
             if new_context:
                 current_context = new_context
 
-    return texts, current_context, None, has_tool_use
+    return texts, thinking_blocks, current_context, None, has_tool_use
 
 
 _TOOL_KEYS: dict[str, str] = {
@@ -267,6 +271,10 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
         state.event_bus.emit({"type": "assistant", "text": t})
         assistant_texts.append(t)
 
+    def _emit_thinking(block: ThinkingBlock) -> None:
+        logger.thinking(block.thinking)
+        state.event_bus.emit({"type": "thinking", "text": block.thinking, "signature": block.signature})
+
     response_iter = client.receive_response().__aiter__()
 
     interrupt_task: asyncio.Task[tp.Any] | None = None
@@ -297,7 +305,10 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 try:
                     drain = client.receive_response().__aiter__()
                     while (leftover := await asyncio.wait_for(anext(drain, None), timeout=5.0)) is not None:
-                        texts, _, _, _ = _parse_sdk_message(tp.cast(Message, leftover), sub_agent_context=sub_agent_context)
+                        texts, thinking_blocks, _, _, _ = _parse_sdk_message(tp.cast(Message, leftover), sub_agent_context=sub_agent_context)
+                        if show_output:
+                            for block in thinking_blocks:
+                                _emit_thinking(block)
                         text = "\n".join(texts) if texts else None
                         if text and show_output:
                             filtered = filter_tool_lines(text)
@@ -312,11 +323,14 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 break
 
             msg = tp.cast(Message, result)
-            texts, sub_agent_context, session_id, _ = _parse_sdk_message(msg, sub_agent_context=sub_agent_context)
+            texts, thinking_blocks, sub_agent_context, session_id, _ = _parse_sdk_message(msg, sub_agent_context=sub_agent_context)
             if session_id and session_id != state.session_id:
                 if state.session_id:
                     logger.warning(f"Session ID changed: {state.session_id[:16]} -> {session_id[:16]} (resume may have failed)")
                 persist_session_id(session_id, state=state, config=config)
+            if show_output:
+                for block in thinking_blocks:
+                    _emit_thinking(block)
             text = "\n".join(texts) if texts else None
             if not text:
                 continue
@@ -410,7 +424,7 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
         cwd=config.root,
         setting_sources=["project"],
         add_dirs=[str(config.root)],
-        max_thinking_tokens=config.max_thinking_tokens,
+        thinking=config.thinking,
         max_buffer_size=10 * 1024 * 1024,
         stderr=lambda line: logger.sdk(line),
         mcp_servers={"vesta": _build_vesta_tools_server(state, config)},

--- a/agent/src/vesta/events.py
+++ b/agent/src/vesta/events.py
@@ -37,6 +37,12 @@ class AssistantEvent(_BaseEvent):
     text: str
 
 
+class ThinkingEvent(_BaseEvent):
+    type: tp.Literal["thinking"]
+    text: str
+    signature: str
+
+
 class UserEvent(_BaseEvent):
     type: tp.Literal["user"]
     text: str
@@ -81,6 +87,7 @@ type StreamEvent = (
     | ToolStartEvent
     | ToolEndEvent
     | AssistantEvent
+    | ThinkingEvent
     | UserEvent
     | ErrorEvent
     | NotificationEvent

--- a/agent/src/vesta/logger.py
+++ b/agent/src/vesta/logger.py
@@ -77,65 +77,88 @@ def _cat(symbol: str, color: str, prefix: str, msg: tp.Any, *, level: int = logg
     _log(f"{symbol} [{color}][{prefix}][/{color}] {msg}", level=level)
 
 
+def _system_phase(phase: str, msg: tp.Any, *, level: int = logging.INFO) -> None:
+    _log(f"* [cyan][SYSTEM][/cyan] - [dim][{phase}][/dim] {msg}", level=level)
+
+
+def _agent_phase(phase: str, msg: tp.Any, *, level: int = logging.INFO) -> None:
+    _log(f"< [magenta][AGENT][/magenta] - [blue][{phase}][/blue] {msg}", level=level)
+
+
+def _user_phase(phase: str, msg: tp.Any, *, level: int = logging.INFO) -> None:
+    _log(f"> [white][USER][/white] - [dim][{phase}][/dim] {msg}", level=level)
+
+
+def _event_phase(phase: str, msg: tp.Any, *, level: int = logging.INFO) -> None:
+    _log(f"! [yellow][EVENT][/yellow] - [dim][{phase}][/dim] {msg}", level=level)
+
+
 # Category loggers
 def init(msg: tp.Any) -> None:
-    _cat("*", "yellow", "INIT", msg)
+    _system_phase("INIT", msg)
 
 
 def shutdown(msg: tp.Any) -> None:
-    _cat("*", "red", "SHUTDOWN", msg)
+    _system_phase("SHUTDOWN", msg)
 
 
 def client(msg: tp.Any) -> None:
-    _cat("*", "dim", "CLIENT", msg)
+    _system_phase("CLIENT", msg)
 
 
 def dreamer(msg: tp.Any) -> None:
-    _cat("*", "magenta", "DREAMER", msg)
+    _system_phase("DREAMER", msg)
 
 
 def interrupt(msg: tp.Any) -> None:
-    _cat("*", "yellow", "INTERRUPT", msg, level=logging.DEBUG)
+    _system_phase("INTERRUPT", msg, level=logging.DEBUG)
 
 
 def proactive(msg: tp.Any) -> None:
-    _cat("*", "yellow", "PROACTIVE", msg)
+    _system_phase("PROACTIVE", msg)
 
 
 def startup(msg: tp.Any) -> None:
-    _cat("*", "dim", "STARTUP", msg)
+    _system_phase("STARTUP", msg)
 
 
 def user(msg: tp.Any) -> None:
-    _cat(">", "white", "USER", msg)
+    _user_phase("MESSAGE", msg)
 
 
 def assistant(msg: tp.Any) -> None:
-    _cat("<", "magenta", "ASSISTANT", msg)
+    _agent_phase("ASSISTANT", msg)
+
+
+def thinking(msg: tp.Any) -> None:
+    text = str(msg)
+    lines = text.splitlines() or [text]
+    for line in lines:
+        _agent_phase("THINKING", line)
 
 
 def tool(msg: tp.Any) -> None:
-    _cat("~", "dim", "TOOL", msg)
+    _agent_phase("TOOL CALL", msg)
 
 
 def notification(msg: tp.Any) -> None:
-    _cat("!", "yellow", "NOTIFICATION", msg)
+    _event_phase("NOTIFICATION", msg)
 
 
 def system(msg: tp.Any) -> None:
-    _cat(">", "cyan", "SYSTEM", msg)
+    _system_phase("MESSAGE", msg)
 
 
 def subagent(msg: tp.Any) -> None:
-    _cat("@", "blue", "SUBAGENT", msg)
+    _agent_phase("SUBAGENT", msg)
 
 
 def sdk(msg: tp.Any) -> None:
-    _cat("~", "dim", "SDK", msg, level=logging.DEBUG)
+    _system_phase("SDK", msg, level=logging.DEBUG)
 
 
 def usage(msg: tp.Any) -> None:
-    _cat("$", "green", "USAGE", msg)
+    _system_phase("USAGE", msg)
 
 
 def debug(msg: tp.Any) -> None:

--- a/agent/tests/test_unit.py
+++ b/agent/tests/test_unit.py
@@ -11,7 +11,7 @@ import pytest
 import vesta.models as vm
 from claude_agent_sdk import HookContext
 from claude_agent_sdk.types import SubagentStartHookInput
-from vesta.core.client import _format_tool_call, _format_search_results, _parse_agent_input, _tool_summary, _subagent_hook
+from vesta.core.client import _format_tool_call, _format_search_results, _parse_agent_input, _parse_sdk_message, _tool_summary, _subagent_hook
 from vesta.events import ChatEvent, EventBus, SubagentStartEvent, SubagentStopEvent, UserEvent
 from vesta.core.init import get_memory_path
 from vesta.core.loops import format_notification_batch
@@ -811,6 +811,23 @@ def test_filter_tool_lines():
     assert filter_tool_lines("") == ""
 
 
+def test_parse_sdk_message_extracts_thinking_blocks():
+    from claude_agent_sdk import TextBlock, ThinkingBlock
+
+    texts, thinking_blocks, context, session_id, has_tool_use = _parse_sdk_message(
+        _assistant_msg([ThinkingBlock("step one\nstep two", "sig-123"), TextBlock("done")]),
+        sub_agent_context=None,
+    )
+
+    assert texts == ["done"]
+    assert len(thinking_blocks) == 1
+    assert thinking_blocks[0].thinking == "step one\nstep two"
+    assert thinking_blocks[0].signature == "sig-123"
+    assert context is None
+    assert session_id is None
+    assert has_tool_use is False
+
+
 def test_process_message_always_streams():
     """process_message must always pass show_output=True — regression guard."""
     import ast
@@ -847,6 +864,34 @@ async def test_converse_emits_text_immediately_with_tool_use():
 
     texts = [t for t, _ in emitted]
     assert texts == ["restarting daemon", "checking status", "all done"], f"All text must be emitted immediately, got: {texts}"
+
+
+@pytest.mark.anyio
+async def test_converse_emits_thinking_events():
+    from claude_agent_sdk import TextBlock, ThinkingBlock
+    from vesta.core.client import converse
+
+    state, config, mock_client, emitted, _ = _make_converse_harness()
+    thinking_events: list[tuple[str, str]] = []
+    original_emit = state.event_bus.emit
+
+    def tracking_emit(event):
+        if isinstance(event, dict) and event.get("type") == "thinking":
+            thinking_events.append((event["text"], event["signature"]))
+        original_emit(event)
+
+    state.event_bus.emit = tracking_emit  # type: ignore[assignment]
+
+    async def response_with_thinking():
+        yield _assistant_msg([ThinkingBlock("step one\nstep two", "sig-123"), TextBlock("done")])
+        yield _result_msg()
+
+    mock_client.receive_response = MagicMock(return_value=response_with_thinking())
+
+    await converse("test", state=state, config=config, show_output=True)
+
+    assert thinking_events == [("step one\nstep two", "sig-123")]
+    assert [t for t, _ in emitted] == ["done"]
 
 
 @pytest.mark.anyio

--- a/agent/tests/test_unit.py
+++ b/agent/tests/test_unit.py
@@ -880,7 +880,7 @@ async def test_converse_emits_thinking_events():
             thinking_events.append((event["text"], event["signature"]))
         original_emit(event)
 
-    state.event_bus.emit = tracking_emit  # type: ignore[assignment]
+    state.event_bus.emit = tracking_emit
 
     async def response_with_thinking():
         yield _assistant_msg([ThinkingBlock("step one\nstep two", "sig-123"), TextBlock("done")])

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1157,7 +1157,7 @@ dev = [
 requires-dist = [
     { name = "aioconsole", specifier = ">=0.8.1" },
     { name = "aiohttp", specifier = ">=3.11" },
-    { name = "claude-agent-sdk", specifier = ">=0.1.53" },
+    { name = "claude-agent-sdk", specifier = ">=0.1.56" },
     { name = "pydantic", specifier = ">=2.10.4" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "rich", specifier = ">=14.2.0" },

--- a/app/src/components/Console/index.tsx
+++ b/app/src/components/Console/index.tsx
@@ -17,6 +17,85 @@ const MAX_LINES = 5000;
 const RECONNECT_BASE = 1000;
 const RECONNECT_MAX = 30000;
 
+const LOG_LEVEL_TAGS = new Set(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]);
+const FAMILY_TAGS = new Set(["AGENT", "SYSTEM", "USER", "EVENT"]);
+
+const FAMILY_COLOR_CLASS: Record<string, string> = {
+  AGENT: "text-fuchsia-300/90",
+  SYSTEM: "text-green-300/90",
+  USER: "text-white/90",
+  EVENT: "text-yellow-300/90",
+};
+
+const SUBFAMILY_COLOR_CLASS: Record<string, Record<string, string>> = {
+  AGENT: {
+    ASSISTANT: "text-fuchsia-200/90",
+    THINKING: "text-fuchsia-300/90",
+    "TOOL CALL": "text-fuchsia-400/90",
+    SUBAGENT: "text-fuchsia-500/90",
+  },
+  SYSTEM: {
+    INIT: "text-green-200/90",
+    STARTUP: "text-green-300/90",
+    SHUTDOWN: "text-green-500/90",
+    CLIENT: "text-green-400/90",
+    DREAMER: "text-green-200/90",
+    INTERRUPT: "text-green-500/90",
+    PROACTIVE: "text-green-200/90",
+    MESSAGE: "text-green-300/90",
+    SDK: "text-green-500/90",
+    USAGE: "text-green-400/90",
+  },
+  USER: {
+    MESSAGE: "text-white/90",
+  },
+  EVENT: {
+    NOTIFICATION: "text-yellow-200/90",
+  },
+};
+
+const LEGACY_TAG_TO_FAMILY: Record<string, string> = {
+  ASSISTANT: "AGENT",
+  THINKING: "AGENT",
+  "TOOL CALL": "AGENT",
+  TOOL: "AGENT",
+  SUBAGENT: "AGENT",
+  INIT: "SYSTEM",
+  STARTUP: "SYSTEM",
+  SHUTDOWN: "SYSTEM",
+  CLIENT: "SYSTEM",
+  DREAMER: "SYSTEM",
+  INTERRUPT: "SYSTEM",
+  PROACTIVE: "SYSTEM",
+  SDK: "SYSTEM",
+  USAGE: "SYSTEM",
+  USER: "USER",
+  NOTIFICATION: "EVENT",
+};
+
+function extractTags(line: string): string[] {
+  return [...line.matchAll(/\[([A-Z ]+)\]/g)]
+    .map((match) => match[1])
+    .filter((tag) => !LOG_LEVEL_TAGS.has(tag));
+}
+
+function lineColorClass(line: string): string | null {
+  const tags = extractTags(line);
+  const familyIndex = tags.findIndex((tag) => FAMILY_TAGS.has(tag));
+
+  if (familyIndex !== -1) {
+    const family = tags[familyIndex];
+    const subfamily = tags[familyIndex + 1];
+    return (subfamily && SUBFAMILY_COLOR_CLASS[family]?.[subfamily]) || FAMILY_COLOR_CLASS[family] || null;
+  }
+
+  const legacyTag = tags.find((tag) => tag in LEGACY_TAG_TO_FAMILY);
+  if (!legacyTag) return null;
+
+  const family = LEGACY_TAG_TO_FAMILY[legacyTag];
+  return SUBFAMILY_COLOR_CLASS[family]?.[legacyTag] || FAMILY_COLOR_CLASS[family] || null;
+}
+
 interface ConsoleProps {
   name: string;
   onClose?: () => void;
@@ -148,7 +227,10 @@ export function Console({ name, onClose, fullscreen }: ConsoleProps) {
             {lines.map((line, i) => (
               <div
                 key={i}
-                className="break-all"
+                className={cn(
+                  "break-words whitespace-pre-wrap",
+                  lineColorClass(line),
+                )}
                 dangerouslySetInnerHTML={{ __html: linkify(line) }}
               />
             ))}

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -38,6 +38,7 @@ export type VestaEvent =
   | (BaseEvent & { type: "status"; state: AgentActivityState })
   | (BaseEvent & { type: "user"; text: string })
   | (BaseEvent & { type: "assistant"; text: string })
+  | (BaseEvent & { type: "thinking"; text: string; signature: string })
   | (BaseEvent & { type: "chat"; text: string })
   | (BaseEvent & { type: "tool_start"; tool: string; input: string })
   | (BaseEvent & { type: "tool_end"; tool: string })


### PR DESCRIPTION
## Summary
- Switch from deprecated `max_thinking_tokens` to `thinking: {"type": "adaptive"}` config for Claude Agent SDK
- Bump `claude-agent-sdk` to `>=0.1.56`
- Add `ThinkingBlock` parsing and `ThinkingEvent` emission through the event bus
- Refactor logger to family/phase format (`SYSTEM`, `AGENT`, `USER`, `EVENT`)
- Add colorized log line rendering in the desktop app console

## Test plan
- [ ] Verify agent starts with adaptive thinking enabled
- [ ] Confirm thinking events appear in console with correct coloring
- [ ] Check logger output format matches new family/phase structure
- [ ] Run `uv run pytest tests/test_unit.py` for new thinking block tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)