### PR TITLE
feat: container timezone support via agent-writable .bashrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.title="Vesta" \
       org.opencontainers.image.licenses="MIT"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl git ca-certificates && rm -rf /var/lib/apt/lists/*
+    curl git ca-certificates tzdata && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
@@ -43,3 +43,4 @@ RUN git clone --bare --single-branch https://github.com/elyxlz/vesta.git .git &&
 RUN rm -f /usr/bin/pkill /usr/bin/killall
 
 ENV HOME=/root
+RUN : > /root/.bashrc

--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -67,6 +67,12 @@ Once [agent_name] knows who they're with (name isn't "[Unknown]"), that's it. No
 ### The Machine
 - This is a Docker container and it's [agent_name]'s computer, so install things, reorganize, customize however needed
 
+### Environment
+- `~/.bashrc` is sourced at container start before the agent runs, and also in interactive shells
+- Use it for persistent environment variables, PATH changes, aliases, etc.
+- `TZ` (IANA timezone like `Europe/London`) is set here during onboarding
+- To update: edit `~/.bashrc`, run the export in current shell, update User Profile below
+
 ### Technical
 - **Clean up**: Temp files, stale processes. Don't leave a mess
 - **Never use `pkill`, `killall`, or `kill`** — these can kill the main vesta process and crash the whole container. They've been removed from the system. To stop a specific process, use `screen -S name -X quit` for daemons or manage it through the tool that started it

--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -71,7 +71,7 @@ Once [agent_name] knows who they're with (name isn't "[Unknown]"), that's it. No
 - `~/.bashrc` is sourced at container start before the agent runs, and also in interactive shells
 - Use it for persistent environment variables, PATH changes, aliases, etc.
 - `TZ` (IANA timezone like `Europe/London`) is set here during onboarding
-- To update: edit `~/.bashrc`, run the export in current shell, update User Profile below
+- Changes to `~/.bashrc` only take effect after `restart_vesta` — the running process doesn't pick them up mid-session
 
 ### Technical
 - **Clean up**: Temp files, stale processes. Don't leave a mess

--- a/agent/prompts/first_start_greeting.md
+++ b/agent/prompts/first_start_greeting.md
@@ -1,5 +1,6 @@
 Say hi through the Vesta app — use the app-chat skill to send messages (read its SKILL.md).
 
 1. Get their name.
-2. Ask what they'd like set up: reminders, email, calendar, a daily briefing, web stuff, etc.
-3. Once the communication channel is working, suggest setting up voice (speech-to-text and text-to-speech) — it lets them talk to you and hear you respond. Mention it casually, not as a sales pitch.
+2. Ask where they're based. Work out their IANA timezone (e.g. Europe/London, America/New_York). Append `export TZ=<timezone>` to ~/.bashrc and update MEMORY.md section 5 with their location and timezone.
+3. Ask what they'd like set up: reminders, email, calendar, a daily briefing, web stuff, etc.
+4. Once the communication channel is working, suggest setting up voice (speech-to-text and text-to-speech) — it lets them talk to you and hear you respond. Mention it casually, not as a sales pitch.

--- a/agent/prompts/first_start_greeting.md
+++ b/agent/prompts/first_start_greeting.md
@@ -1,6 +1,6 @@
 Say hi through the Vesta app — use the app-chat skill to send messages (read its SKILL.md).
 
 1. Get their name.
-2. Ask where they're based. Work out their IANA timezone (e.g. Europe/London, America/New_York). Append `export TZ=<timezone>` to ~/.bashrc and update MEMORY.md section 5 with their location and timezone.
+2. Ask where they're based. Work out their IANA timezone (e.g. Europe/London, America/New_York). Append `export TZ=<timezone>` to ~/.bashrc and update MEMORY.md section 5 with their location and timezone. Then `restart_vesta` so the timezone takes effect for the whole system (logs, scheduling, timestamps).
 3. Ask what they'd like set up: reminders, email, calendar, a daily briefing, web stuff, etc.
 4. Once the communication channel is working, suggest setting up voice (speech-to-text and text-to-speech) — it lets them talk to you and hear you respond. Mention it casually, not as a sales pitch.

--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -40,10 +40,10 @@ tasks remind "Meeting" --at "2025-12-01T10:00:00" --tz "Europe/London"
 tasks remind "Check progress" --task <id> --in-hours 1
 
 # Recurring
-tasks remind "Standup" --recurring daily --at "2025-12-01T10:30:00" --tz "UTC"
-tasks remind "Review" --recurring weekly --at "2025-12-06T17:00:00" --tz "UTC"
-tasks remind "Bills" --recurring monthly --at "2025-12-15T09:00:00" --tz "UTC"
-tasks remind "Birthday" --recurring yearly --at "2025-03-14T12:00:00" --tz "UTC"
+tasks remind "Standup" --recurring daily --at "2025-12-01T10:30:00" --tz "America/New_York"
+tasks remind "Review" --recurring weekly --at "2025-12-06T17:00:00" --tz "America/New_York"
+tasks remind "Bills" --recurring monthly --at "2025-12-15T09:00:00" --tz "America/New_York"
+tasks remind "Birthday" --recurring yearly --at "2025-03-14T12:00:00" --tz "America/New_York"
 tasks remind "Check inbox" --recurring hourly
 
 # List, delete, update
@@ -58,6 +58,7 @@ tasks remind update <id> --message "New message"
 - `--at` + `--tz`: absolute datetime (both required together)
 - `--recurring`: hourly | daily | weekly | monthly | yearly
   - hourly needs no datetime; others require `--at` + `--tz`
+- Always use the user's timezone from MEMORY.md section 5, not UTC
 - `--task <id>`: link reminder to a task (optional)
 - `--message`: alternative to positional message argument
 

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -49,7 +49,7 @@ pub const OAUTH_AUTHORIZE_URL: &str = "https://claude.ai/oauth/authorize";
 /// new vars without rebuilding images), then exec the agent.
 const ENTRYPOINT: &[&str] = &[
     "sh", "-c",
-    ". /run/vestad-env; exec uv run --project /root/vesta python -m vesta.main",
+    ". /run/vestad-env; . ~/.bashrc || true; exec uv run --project /root/vesta python -m vesta.main",
 ];
 
 #[derive(PartialEq, Clone, Copy)]


### PR DESCRIPTION
## Summary
- Adds `tzdata` to the container image and seeds a clean `~/.bashrc` so the agent has a persistent, agent-writable place to set environment variables (notably `TZ`) without image rebuilds or vestad changes
- The container entrypoint now sources `~/.bashrc` after `/run/vestad-env`, creating a two-env-file approach: vestad controls `/run/vestad-env` (read-only from the agent's perspective), while the agent owns `~/.bashrc` for runtime config like timezone
- Onboarding flow updated to ask for the user's location/timezone upfront and persist it via `export TZ=<iana_tz>` in `~/.bashrc`
- Task/reminder skill docs updated to use the user's actual timezone instead of hardcoded UTC

## Changed files
- `Dockerfile` — install `tzdata`, seed empty `.bashrc`
- `vestad/src/docker.rs` — source `~/.bashrc` in entrypoint
- `agent/MEMORY.md` — document the `.bashrc` mechanism in section 4
- `agent/prompts/first_start_greeting.md` — add timezone onboarding step
- `agent/skills/tasks/SKILL.md` — replace UTC with user timezone in examples

## Edge cases
- **DST**: Using IANA timezone names (not UTC offsets) so `tzdata` handles DST transitions automatically — reminders at "9 AM daily" fire at 9 AM local regardless of DST
- **Malformed `.bashrc`**: `|| true` guard in the entrypoint ensures the container still starts even if the agent writes bad syntax
- **Travel / timezone change**: Agent updates `~/.bashrc` + MEMORY.md, runs `export TZ=...` in current shell; full effect on next restart
- **Container backup/restore**: `~/.bashrc` persists across `docker commit` backups. On fresh image creation it's empty but onboarding runs again
- **Missing `.bashrc`**: Entrypoint uses `. ~/.bashrc || true` so a missing or empty file is harmless
- **Invalid TZ value**: Python's `datetime.now()` silently falls back to UTC — non-catastrophic
- **Current session**: `export TZ=...` in a subprocess won't affect the running Python process — takes effect on next restart, acceptable during first-start onboarding
- **Existing stored data**: Tasks/reminders already store everything as UTC internally; changing TZ only affects `datetime.now()` and display, not persisted data
- **Existing containers**: Entrypoint is baked in at `docker create` time, so already-running containers need recreation to pick up the new entrypoint
- **No Python code changes needed**: `datetime.now()` in `core/loops.py`, `core/client.py`, `what-day` skill, and `logger.py` all respect the `TZ` env var automatically

## Test plan
- [ ] `cargo clippy` passes (verified locally)
- [ ] Build container image and verify `tzdata` is installed and `~/.bashrc` exists as an empty file
- [ ] Start a container and confirm `~/.bashrc` is sourced (e.g. add `export TZ=Europe/London`, restart, check `date` output)
- [ ] Write garbage to `~/.bashrc` and verify container still starts (`|| true` guard)
- [ ] Verify onboarding flow asks for location before service setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)