### PR TITLE
fix: correct zip extraction path in Windows install script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -61,7 +61,7 @@ try {
 
         $BinDir = Join-Path $env:LOCALAPPDATA "vesta\bin"
         New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
-        Copy-Item (Join-Path $TmpDir "vesta.exe") -Destination (Join-Path $BinDir "vesta.exe") -Force
+        Copy-Item (Join-Path $TmpDir "vesta-windows" "vesta.exe") -Destination (Join-Path $BinDir "vesta.exe") -Force
 
         # Add to PATH if not already there
         $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")


### PR DESCRIPTION
## Summary
- The CI packages `vesta.exe` inside a `vesta-windows/` subdirectory in the zip artifact, but `install.ps1` expected it at the zip root
- Fixed the `Copy-Item` source path from `$TmpDir/vesta.exe` to `$TmpDir/vesta-windows/vesta.exe`

## Test plan
- [ ] Run `irm https://vesta.run/install.ps1 | iex` on Windows and verify CLI installs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)