### PR TITLE
fix: remove waitForReady from agent restart

### DIFF
--- a/app/src/providers/SelectedAgentProvider/index.tsx
+++ b/app/src/providers/SelectedAgentProvider/index.tsx
@@ -110,7 +110,6 @@ export function SelectedAgentProvider({ children }: { children: ReactNode }) {
   const restart = useCallback(() => {
     withOp(name, "starting", async () => {
       await restartAgent(name);
-      await waitForReady(name);
       await refreshAgent();
     }, "restart failed");
   }, [name, withOp, refreshAgent]);


### PR DESCRIPTION
## Summary
- Remove redundant `waitForReady` call from the agent restart flow

## Details
The restart flow called `waitForReady` with a 30s timeout after docker restart. Since the ready marker persists across restarts, this was redundant — the existing 5s status polling handles the transition naturally. When the timeout was hit (slow boot, tunnel timeout), the error got stored in the ops zustand store and lingered on the grid view indefinitely since nothing cleared it.

Fix: just don't wait. `restartAgent` already blocks until docker restart completes; the UI polling picks up the rest.

## Test plan
- [ ] Restart an agent from the UI and verify it transitions back to running state without errors
- [ ] Confirm no lingering error banners appear on the grid view after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)