### PR TITLE
fix(agent): timeout SDK client cleanup to avoid slow shutdown

### DIFF
--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -194,11 +194,16 @@ async def _process_interruptible(
         raise
 
 
+SDK_CLEANUP_TIMEOUT = 5
+
+
 async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.State, config: vm.VestaConfig) -> None:
     logger.client("Creating new client session...")
     options = build_client_options(config, state)
     ready_marker = config.data_dir / "agent_ready"
-    async with ClaudeSDKClient(options=options) as client:
+    client = ClaudeSDKClient(options=options)
+    await client.__aenter__()
+    try:
         state.client = client
         logger.client("Client session started")
 
@@ -233,6 +238,12 @@ async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm
             state.client = None
             state.interrupt_event = None
             logger.client("Client session closed")
+    finally:
+        try:
+            async with asyncio.timeout(SDK_CLEANUP_TIMEOUT):
+                await client.__aexit__(None, None, None)
+        except (TimeoutError, Exception):
+            logger.client("SDK cleanup timed out, abandoning")
 
 
 # --- Proactive & dreamer ---


### PR DESCRIPTION
## Summary
- ClaudeSDKClient's `__aexit__` waits for full TCP teardown, causing a ~2 minute delay on every agent shutdown
- Replaced `async with` context manager with manual `__aenter__`/`__aexit__` calls, wrapping the exit in a 5-second `asyncio.timeout`
- Session resume works regardless, and the container restarts after shutdown, so the cleanup is unnecessary

## Test plan
- [x] `ruff check` passes
- [x] All 50 unit tests pass
- [ ] Verify agent shutdown completes in ~5s instead of ~2min

🤖 Generated with [Claude Code](https://claude.com/claude-code)