### PR TITLE
fix(vestad): reconcile rebuild detection and systemd binary path

### DIFF
--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1165,7 +1165,8 @@ pub fn destroy_agent(name: &str, agents_dir: &std::path::Path) -> Result<(), Doc
 
 /// Check if a container's config diverges from what create_container would produce.
 fn needs_rebuild(cname: &str) -> bool {
-    let fmt = "{{json .Mounts}}\\n{{json .Config.Entrypoint}}\\n{{.HostConfig.NetworkMode}}\\n{{.HostConfig.RestartPolicy.Name}}";
+    // docker create puts args after the image into Cmd, not Entrypoint
+    let fmt = "{{json .Mounts}}\\n{{json .Config.Cmd}}\\n{{.HostConfig.NetworkMode}}\\n{{.HostConfig.RestartPolicy.Name}}";
     let output = match docker_output(&["inspect", "--format", fmt, cname]) {
         Some(s) => s,
         None => return true,
@@ -1173,32 +1174,31 @@ fn needs_rebuild(cname: &str) -> bool {
 
     let lines: Vec<&str> = output.lines().collect();
     let mounts = lines.first().unwrap_or(&"");
-    let entrypoint = lines.get(1).unwrap_or(&"");
+    let cmd_json = lines.get(1).unwrap_or(&"");
     let network = lines.get(2).map(|s| s.trim()).unwrap_or("");
     let restart = lines.get(3).map(|s| s.trim()).unwrap_or("");
 
-    // Check mounts
-    if MOUNT_DESTS.iter().any(|d| !mounts.contains(d)) {
-        tracing::info!(container = %cname, "rebuild needed: missing mounts");
+    let missing: Vec<_> = MOUNT_DESTS.iter().filter(|d| !mounts.contains(**d)).collect();
+    if !missing.is_empty() {
+        tracing::info!(container = %cname, missing = ?missing, "rebuild needed: missing mounts");
         return true;
     }
 
-    // Check entrypoint (exact match against ENTRYPOINT array)
-    let ep_ok = serde_json::from_str::<Vec<String>>(entrypoint)
+    let cmd_ok = serde_json::from_str::<Vec<String>>(cmd_json)
         .map(|actual| actual.iter().zip(ENTRYPOINT).all(|(a, e)| a == e) && actual.len() == ENTRYPOINT.len())
         .unwrap_or(false);
-    if !ep_ok {
-        tracing::info!(container = %cname, "rebuild needed: entrypoint mismatch");
+    if !cmd_ok {
+        tracing::info!(container = %cname, actual = %cmd_json, "rebuild needed: command mismatch");
         return true;
     }
 
     if network != NETWORK_MODE {
-        tracing::info!(container = %cname, network, "rebuild needed: wrong network mode");
+        tracing::info!(container = %cname, actual = network, expected = NETWORK_MODE, "rebuild needed: wrong network mode");
         return true;
     }
 
     if restart != RESTART_POLICY {
-        tracing::info!(container = %cname, restart, "rebuild needed: wrong restart policy");
+        tracing::info!(container = %cname, actual = restart, expected = RESTART_POLICY, "rebuild needed: wrong restart policy");
         return true;
     }
 

--- a/vestad/src/systemd.rs
+++ b/vestad/src/systemd.rs
@@ -19,6 +19,7 @@ pub fn ensure_service_installed() -> Result<(), String> {
         .map_err(|e| format!("cannot determine binary path: {}", e))?
         .to_str()
         .ok_or("binary path is not valid UTF-8")?
+        .trim_end_matches(" (deleted)")
         .to_string();
 
     let unit_path = unit_file_path()?;


### PR DESCRIPTION
## Summary
- **Fix container rebuild detection**: check `Config.Cmd` instead of `Config.Entrypoint` — `docker create` puts args after the image into `Cmd`, not `Entrypoint`, so the old check always triggered a rebuild
- **Improve reconcile logging**: include actual vs expected values in rebuild-reason logs, and list which specific mounts are missing
- **Fix systemd service crash loop**: strip Linux kernel's ` (deleted)` suffix from `/proc/self/exe` before writing the `ExecStart` path — replacing the binary on disk while vestad is running caused restarts to fail with `unrecognized subcommand '(deleted)'`

## Test plan
- [ ] Deploy vestad update, verify reconcile no longer unnecessarily rebuilds containers
- [ ] Replace vestad binary while running, confirm `vestad restart` still works
- [ ] Check `journalctl` logs show improved rebuild reason messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)