### PR TITLE
feat(vestad): per-agent manage_agent_code, startup fixes, SSE backups

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -154,6 +154,45 @@ fn urlencod(s: &str) -> String {
     out
 }
 
+/// Read an SSE stream, returning the data from the "done" event or an error.
+/// SSE keepalive comments are silently ignored.
+fn read_sse_result(resp: Response<Body>) -> Result<String, String> {
+    let reader = std::io::BufReader::new(resp.into_body().into_reader());
+    let mut event_type = String::new();
+    let mut data = String::new();
+
+    for line in BufRead::lines(reader) {
+        let line = line.map_err(|e| format!("read error: {}", e))?;
+
+        if let Some(ev) = line.strip_prefix("event:") {
+            event_type = ev.trim().to_string();
+        } else if let Some(d) = line.strip_prefix("data:") {
+            data = d.trim().to_string();
+        } else if line.is_empty() && !event_type.is_empty() {
+            match event_type.as_str() {
+                "done" => return Ok(data),
+                "error" => {
+                    let msg = serde_json::from_str::<serde_json::Value>(&data)
+                        .ok()
+                        .and_then(|v| {
+                            v["error"]["message"]
+                                .as_str()
+                                .or(v["error"].as_str())
+                                .map(|s| s.to_string())
+                        })
+                        .unwrap_or(data);
+                    return Err(msg);
+                }
+                _ => {}
+            }
+            event_type.clear();
+            data.clear();
+        }
+    }
+
+    Err("server closed connection before completing".into())
+}
+
 pub struct Client {
     agent: ureq::Agent,
     base_url: String,
@@ -233,6 +272,16 @@ impl Client {
         check_response(resp)
     }
 
+    fn patch_json(&self, path: &str, body: &serde_json::Value) -> Result<Response<Body>, String> {
+        let resp = self
+            .agent
+            .patch(&format!("{}{}", self.base_url, path))
+            .header("Authorization", &format!("Bearer {}", self.api_key))
+            .send_json(body)
+            .map_err(map_error)?;
+        check_response(resp)
+    }
+
     fn put_json(&self, path: &str, body: &serde_json::Value) -> Result<Response<Body>, String> {
         let resp = self
             .agent
@@ -267,14 +316,24 @@ impl Client {
             .map_err(|e| format!("parse error: {}", e))
     }
 
-    pub fn create_agent(&self, name: &str, build: bool) -> Result<String, String> {
-        let body = serde_json::json!({"name": name, "build": build});
+    pub fn create_agent(&self, name: &str, build: bool, manage_agent_code: bool) -> Result<String, String> {
+        let body = serde_json::json!({"name": name, "build": build, "manage_agent_code": manage_agent_code});
         let resp = self.post_json("/agents", &body)?;
         let v: serde_json::Value = resp
             .into_body()
             .read_json()
             .map_err(|e| format!("parse error: {}", e))?;
         Ok(v["name"].as_str().unwrap_or(name).to_string())
+    }
+
+    pub fn get_agent_settings(&self, name: &str) -> Result<serde_json::Value, String> {
+        let resp = self.get(&format!("/agents/{}/settings", name))?;
+        resp.into_body().read_json().map_err(|e| format!("parse error: {}", e))
+    }
+
+    pub fn patch_agent_settings(&self, name: &str, body: &serde_json::Value) -> Result<serde_json::Value, String> {
+        let resp = self.patch_json(&format!("/agents/{}/settings", name), body)?;
+        resp.into_body().read_json().map_err(|e| format!("parse error: {}", e))
     }
 
     pub fn start_agent(&self, name: &str) -> Result<(), String> {
@@ -342,9 +401,8 @@ impl Client {
 
     pub fn create_backup(&self, name: &str) -> Result<BackupInfo, String> {
         let resp = self.post(&format!("/agents/{}/backups", name))?;
-        resp.into_body()
-            .read_json()
-            .map_err(|e| format!("parse error: {}", e))
+        let data = read_sse_result(resp)?;
+        serde_json::from_str(&data).map_err(|e| format!("parse error: {}", e))
     }
 
     pub fn list_backups(&self, name: &str) -> Result<Vec<BackupInfo>, String> {
@@ -355,11 +413,12 @@ impl Client {
     }
 
     pub fn restore_backup(&self, name: &str, backup_id: &str) -> Result<(), String> {
-        self.post(&format!(
+        let resp = self.post(&format!(
             "/agents/{}/backups/{}/restore",
             name,
             urlencod(backup_id)
         ))?;
+        read_sse_result(resp)?;
         Ok(())
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -71,6 +71,9 @@ enum Command {
         /// Agent name (prompted interactively if omitted)
         #[arg(long)]
         name: Option<String>,
+        /// Use the Docker image's baked-in code instead of vestad-managed code
+        #[arg(long)]
+        no_manage_code: bool,
     },
     /// Create an agent container (without starting or authenticating)
     Create {
@@ -80,6 +83,9 @@ enum Command {
         /// Agent name (prompted interactively if omitted)
         #[arg(long)]
         name: Option<String>,
+        /// Use the Docker image's baked-in code instead of vestad-managed code
+        #[arg(long)]
+        no_manage_code: bool,
     },
     /// Start an agent (or all agents if no name given)
     Start {
@@ -129,6 +135,17 @@ enum Command {
     Backup {
         #[command(subcommand)]
         action: BackupAction,
+    },
+    /// View or update agent settings
+    Settings {
+        /// Agent name
+        name: String,
+        /// Enable vestad-managed code (mount from host)
+        #[arg(long)]
+        manage_code: bool,
+        /// Disable vestad-managed code (use image's baked-in code)
+        #[arg(long, conflicts_with = "manage_code")]
+        no_manage_code: bool,
     },
     /// Destroy an agent (irreversible)
     Destroy {
@@ -442,7 +459,7 @@ fn run(cli: Cli) {
     let token_ref = cli.token.as_deref();
 
     match command {
-        Command::Setup { build, yes, name } => {
+        Command::Setup { build, yes, name, no_manage_code } => {
             let c = get_client(host_ref, token_ref);
 
             let name = name
@@ -450,7 +467,7 @@ fn run(cli: Cli) {
                 .unwrap_or_else(prompt_name);
 
             // Create agent
-            match c.create_agent(&name, build) {
+            match c.create_agent(&name, build, !no_manage_code) {
                 Ok(name) => eprintln!("created agent '{}'", name),
                 Err(e) if e.contains("already exists") && yes => {
                     eprintln!("agent '{}' already exists, continuing...", name);
@@ -467,13 +484,27 @@ fn run(cli: Cli) {
 
         }
 
-        Command::Create { build, name } => {
+        Command::Create { build, name, no_manage_code } => {
             let c = get_client(host_ref, token_ref);
             let name = name
                 .map(|name| name.trim().to_string())
                 .unwrap_or_else(prompt_name);
-            let name = c.create_agent(&name, build).unwrap_or_else(|e| platform::die(&e));
+            let name = c.create_agent(&name, build, !no_manage_code).unwrap_or_else(|e| platform::die(&e));
             eprintln!("created (run 'vesta auth {}' to authenticate)", name);
+        }
+
+        Command::Settings { name, manage_code, no_manage_code } => {
+            let c = get_client(host_ref, token_ref);
+            if manage_code || no_manage_code {
+                let body = serde_json::json!({"manage_agent_code": !no_manage_code});
+                let result = c.patch_agent_settings(&name, &body).unwrap_or_else(|e| platform::die(&e));
+                let val = result["manage_agent_code"].as_bool().unwrap_or(true);
+                eprintln!("{}: manage_agent_code = {}", name, val);
+            } else {
+                let result = c.get_agent_settings(&name).unwrap_or_else(|e| platform::die(&e));
+                let val = result["manage_agent_code"].as_bool().unwrap_or(true);
+                eprintln!("manage_agent_code = {}", val);
+            }
         }
 
         Command::Start { name } => {

--- a/tests/src/client.rs
+++ b/tests/src/client.rs
@@ -1,3 +1,4 @@
+use std::io::BufRead;
 use std::sync::Arc;
 use ureq::http::Response;
 use ureq::Body;
@@ -41,6 +42,44 @@ fn urlencod(s: &str) -> String {
         }
     }
     out
+}
+
+/// Read an SSE stream, returning the data from the "done" event or an error.
+fn read_sse_result(resp: Response<Body>) -> Result<String, String> {
+    let reader = std::io::BufReader::new(resp.into_body().into_reader());
+    let mut event_type = String::new();
+    let mut data = String::new();
+
+    for line in BufRead::lines(reader) {
+        let line = line.map_err(|e| format!("read error: {}", e))?;
+
+        if let Some(ev) = line.strip_prefix("event:") {
+            event_type = ev.trim().to_string();
+        } else if let Some(d) = line.strip_prefix("data:") {
+            data = d.trim().to_string();
+        } else if line.is_empty() && !event_type.is_empty() {
+            match event_type.as_str() {
+                "done" => return Ok(data),
+                "error" => {
+                    let msg = serde_json::from_str::<serde_json::Value>(&data)
+                        .ok()
+                        .and_then(|v| {
+                            v["error"]["message"]
+                                .as_str()
+                                .or(v["error"].as_str())
+                                .map(|s| s.to_string())
+                        })
+                        .unwrap_or(data);
+                    return Err(msg);
+                }
+                _ => {}
+            }
+            event_type.clear();
+            data.clear();
+        }
+    }
+
+    Err("server closed connection before completing".into())
 }
 
 pub struct Client {
@@ -179,7 +218,8 @@ impl Client {
 
     pub fn create_backup(&self, name: &str) -> Result<BackupInfo, String> {
         let resp = self.post(&format!("/agents/{}/backups", name))?;
-        resp.into_body().read_json().map_err(|e| format!("parse error: {}", e))
+        let data = read_sse_result(resp)?;
+        serde_json::from_str(&data).map_err(|e| format!("parse error: {}", e))
     }
 
     pub fn list_backups(&self, name: &str) -> Result<Vec<BackupInfo>, String> {
@@ -188,7 +228,8 @@ impl Client {
     }
 
     pub fn restore_backup(&self, name: &str, backup_id: &str) -> Result<(), String> {
-        self.post(&format!("/agents/{}/backups/{}/restore", name, urlencod(backup_id)))?;
+        let resp = self.post(&format!("/agents/{}/backups/{}/restore", name, urlencod(backup_id)))?;
+        read_sse_result(resp)?;
         Ok(())
     }
 

--- a/vestad/src/agent_code.rs
+++ b/vestad/src/agent_code.rs
@@ -166,7 +166,7 @@ fn fetch_agent_code_from_github(config: &Path, tag: &str) -> Result<(), AgentCod
     let _ = fs::remove_dir_all(&old_dir);
     fs::create_dir_all(&tmp_dir).map_err(|e| AgentCodeError::Io(e.to_string()))?;
 
-    let archive_url = format!("{GITHUB_ARCHIVE_URL}/{tag}.tar.gz");
+    let archive_url = format!("{GITHUB_ARCHIVE_URL}/v{tag}.tar.gz");
     let archive_path = format!("/tmp/{TEMP_PREFIX}-{}.tar.gz", std::process::id());
 
     // Download
@@ -182,9 +182,9 @@ fn fetch_agent_code_from_github(config: &Path, tag: &str) -> Result<(), AgentCod
     }
 
     // Extract the entire agent/ subtree into a temp staging dir, then move what we need.
-    // GitHub archives have prefix vesta-{tag}/, so --strip-components=2 turns
-    // vesta-{tag}/agent/src/vesta/... into src/vesta/..., agent/pyproject.toml into pyproject.toml, etc.
-    let prefix = format!("vesta-{tag}/agent");
+    // GitHub archives have prefix vesta-v{tag}/, so --strip-components=2 turns
+    // vesta-v{tag}/agent/src/vesta/... into src/vesta/...
+    let prefix = format!("vesta-v{tag}/agent");
     let ok = process::Command::new("tar")
         .args([
             "-xzf", &archive_path,

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -432,6 +432,7 @@ pub fn restore_backup(
     name: &str,
     backup_id: &str,
     env_config: &AgentEnvConfig,
+    manage_code: bool,
 ) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
@@ -469,7 +470,7 @@ pub fn restore_backup(
         .port
         .ok_or_else(|| DockerError::Failed("agent has no port in env file".into()))?;
     tracing::debug!(agent = %name, backup_id = %backup_id, "creating container from backup image");
-    create_container(&cname, backup_id, port, name, env_config)?;
+    create_container(&cname, backup_id, port, name, env_config, manage_code)?;
 
     if !docker_ok(&["start", &cname]) {
         return Err(DockerError::Failed(

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -702,7 +702,7 @@ fn gpu_available() -> GpuStatus {
 
 // --- Container creation ---
 
-pub fn create_container(cname: &str, image: &str, port: u16, agent_name: &str, env_config: &AgentEnvConfig) -> Result<(), DockerError> {
+pub fn create_container(cname: &str, image: &str, port: u16, agent_name: &str, env_config: &AgentEnvConfig, manage_code: bool) -> Result<(), DockerError> {
     let agent_token = generate_agent_token();
     let env_path = write_agent_env_file(env_config, agent_name, port, &agent_token)?;
     let env_mount = format!("{}:{}:ro,z", env_path.display(), MOUNT_DESTS[0]);
@@ -721,10 +721,11 @@ pub fn create_container(cname: &str, image: &str, port: u16, agent_name: &str, e
         "--label", &user_label,
         "--label", &agent_name_label,
         "-v", &env_mount,
-        "-v", &src_mount,
-        "-v", &pyproject_mount,
-        "-v", &lock_mount,
     ];
+
+    if manage_code {
+        args.extend(["-v", &src_mount, "-v", &pyproject_mount, "-v", &lock_mount]);
+    }
 
     match gpu_available() {
         GpuStatus::Ready => {
@@ -737,7 +738,7 @@ pub fn create_container(cname: &str, image: &str, port: u16, agent_name: &str, e
         GpuStatus::NoGpu => {}
     }
 
-    tracing::info!(agent = %agent_name, "creating container with read-only mounts for src/vesta, pyproject.toml, uv.lock");
+    tracing::info!(agent = %agent_name, manage_code, "creating container");
     args.push(image);
     args.extend(ENTRYPOINT);
     if !docker_ok(&args) {
@@ -988,7 +989,7 @@ pub fn list_agents(agents_dir: &std::path::Path) -> Vec<ListEntry> {
         .collect()
 }
 
-pub fn create_agent(name: &str, env_config: &AgentEnvConfig) -> Result<String, DockerError> {
+pub fn create_agent(name: &str, env_config: &AgentEnvConfig, manage_code: bool) -> Result<String, DockerError> {
     validate_name(name)?;
     if name.contains("vesta") {
         return Err(DockerError::InvalidName("agent name must not contain 'vesta'".into()));
@@ -1001,11 +1002,13 @@ pub fn create_agent(name: &str, env_config: &AgentEnvConfig) -> Result<String, D
 
     let image = resolve_image()?;
 
-    crate::agent_code::ensure_agent_code(&env_config.config_dir)
-        .map_err(|e| DockerError::Failed(format!("agent code: {e}")))?;
+    if manage_code {
+        crate::agent_code::ensure_agent_code(&env_config.config_dir)
+            .map_err(|e| DockerError::Failed(format!("agent code: {e}")))?;
+    }
 
     let (port, _listener) = allocate_port(&env_config.agents_dir)?;
-    create_container(&cname, image, port, name, env_config)?;
+    create_container(&cname, image, port, name, env_config, manage_code)?;
     Ok(name.to_string())
 }
 
@@ -1083,21 +1086,20 @@ pub fn restart_agent(name: &str) -> Result<(), DockerError> {
 
 /// Ensure all containers match expected config and running agents are restarted.
 /// Called once at startup after agent code and env files are ready.
-pub fn reconcile_containers(env_config: &AgentEnvConfig) {
+/// `manages_code` returns whether a given agent name has managed code (default true).
+pub fn reconcile_containers(env_config: &AgentEnvConfig, manages_code: &dyn Fn(&str) -> bool) {
     let containers = list_managed_containers();
     if containers.is_empty() {
         return;
     }
 
-    // Phase 1: ensure env files exist, rebuild containers with wrong config
+    // Phase 1: ensure env files exist, track which are running
     let mut was_running = std::collections::HashSet::new();
-    let mut any_needs_rebuild = false;
-
     for cname in &containers {
         let name = get_agent_name(cname);
-        let running = container_status(cname) == ContainerStatus::Running;
-
-        // Ensure env file exists
+        if container_status(cname) == ContainerStatus::Running {
+            was_running.insert(name.clone());
+        }
         let env_path = env_config.agents_dir.join(format!("{name}.env"));
         if !env_path.exists() {
             if let Some(port) = read_container_env(cname, "WS_PORT").and_then(|v| v.parse::<u16>().ok()) {
@@ -1107,27 +1109,32 @@ pub fn reconcile_containers(env_config: &AgentEnvConfig) {
                 }
             }
         }
+    }
 
-        if needs_rebuild(cname) {
-            if !any_needs_rebuild {
-                any_needs_rebuild = true;
-                if let Err(e) = crate::agent_code::ensure_agent_code(&env_config.config_dir) {
+    // Phase 2: rebuild containers with wrong config
+    let mut agent_code_ok = false;
+    for cname in &containers {
+        let name = get_agent_name(cname);
+        let manage_code = manages_code(&name);
+        if !needs_rebuild(cname, manage_code) {
+            continue;
+        }
+        if manage_code && !agent_code_ok {
+            match crate::agent_code::ensure_agent_code(&env_config.config_dir) {
+                Ok(_) => agent_code_ok = true,
+                Err(e) => {
                     tracing::error!(error = %e, "failed to ensure agent code — skipping rebuilds");
                     break;
                 }
             }
-            match rebuild_agent(&name, env_config) {
-                Ok(()) => tracing::info!(agent = %name, "rebuild complete"),
-                Err(e) => { tracing::error!(agent = %name, error = %e, "rebuild failed"); continue; }
-            }
         }
-
-        if running {
-            was_running.insert(name);
+        match rebuild_agent(&name, env_config, manage_code) {
+            Ok(()) => tracing::info!(agent = %name, "rebuild complete"),
+            Err(e) => tracing::error!(agent = %name, error = %e, "rebuild failed"),
         }
     }
 
-    // Phase 2: restart running agents (picks up new env), start rebuilt ones
+    // Phase 3: restart running agents (picks up new env), start rebuilt ones
     for cname in &containers {
         let name = name_from_cname(cname);
         match container_status(cname) {
@@ -1162,7 +1169,7 @@ pub fn destroy_agent(name: &str, agents_dir: &std::path::Path) -> Result<(), Doc
 }
 
 /// Check if a container's config diverges from what create_container would produce.
-fn needs_rebuild(cname: &str) -> bool {
+fn needs_rebuild(cname: &str, manage_code: bool) -> bool {
     // docker create puts args after the image into Cmd, not Entrypoint
     let fmt = "{{json .Mounts}}\\n{{json .Config.Cmd}}\\n{{.HostConfig.NetworkMode}}\\n{{.HostConfig.RestartPolicy.Name}}";
     let output = match docker_output(&["inspect", "--format", fmt, cname]) {
@@ -1176,10 +1183,20 @@ fn needs_rebuild(cname: &str) -> bool {
     let network = lines.get(2).map(|s| s.trim()).unwrap_or("");
     let restart = lines.get(3).map(|s| s.trim()).unwrap_or("");
 
-    let missing: Vec<_> = MOUNT_DESTS.iter().filter(|d| !mounts.contains(**d)).collect();
+    // env mount is always required; code mounts depend on manage_code
+    let expected_mounts: &[&str] = if manage_code { MOUNT_DESTS } else { &MOUNT_DESTS[..1] };
+    let missing: Vec<_> = expected_mounts.iter().filter(|d| !mounts.contains(**d)).collect();
     if !missing.is_empty() {
         tracing::info!(container = %cname, missing = ?missing, "rebuild needed: missing mounts");
         return true;
+    }
+    // If not managing code, code mounts should be absent
+    if !manage_code {
+        let unexpected: Vec<_> = MOUNT_DESTS[1..].iter().filter(|d| mounts.contains(**d)).collect();
+        if !unexpected.is_empty() {
+            tracing::info!(container = %cname, unexpected = ?unexpected, "rebuild needed: has code mounts but manage_agent_code=false");
+            return true;
+        }
     }
 
     let cmd_ok = serde_json::from_str::<Vec<String>>(cmd_json)
@@ -1206,7 +1223,7 @@ fn needs_rebuild(cname: &str) -> bool {
 /// Recreate a container with the latest container config (entrypoint, mounts, env file)
 /// while preserving the filesystem. Commits the old container, removes it, and creates
 /// a new one from the committed image.
-pub fn rebuild_agent(name: &str, env_config: &AgentEnvConfig) -> Result<(), DockerError> {
+pub fn rebuild_agent(name: &str, env_config: &AgentEnvConfig, manage_code: bool) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
     let info = inspect_container(&cname, Some(&env_config.agents_dir));
@@ -1234,7 +1251,7 @@ pub fn rebuild_agent(name: &str, env_config: &AgentEnvConfig) -> Result<(), Dock
     docker_ok(&["rm", "-f", &cname]);
 
     tracing::info!(agent = %name, "[3/3] creating container with new config...");
-    create_container(&cname, &backup_tag, port, name, env_config)?;
+    create_container(&cname, &backup_tag, port, name, env_config, manage_code)?;
 
     Ok(())
 }

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -466,7 +466,7 @@ fn main() {
                 agent_code::ensure_agent_code(&config)
                     .unwrap_or_else(|e| die(format!("failed to populate agent code: {e}")));
                 let (port, _listener) = docker::allocate_port(&env_config.agents_dir).unwrap_or_else(|e| die(&e));
-                docker::create_container(&cname, loaded_image, port, &name, &env_config)
+                docker::create_container(&cname, loaded_image, port, &name, &env_config, true)
                     .unwrap_or_else(|e| die(&e));
 
                 if !docker::docker_ok(&["start", &cname]) {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -417,6 +417,7 @@ async fn list_agents_handler(
 #[derive(Deserialize)]
 struct CreateBody {
     name: Option<String>,
+    manage_agent_code: Option<bool>,
 }
 
 async fn create_agent_handler(
@@ -428,13 +429,20 @@ async fn create_agent_handler(
     if name.is_empty() {
         return Err(err_response(StatusCode::BAD_REQUEST, "invalid agent name"));
     }
-    tracing::info!(name = %name, "creating agent");
+    let manage_code = body.manage_agent_code.unwrap_or(true);
+    tracing::info!(name = %name, manage_code, "creating agent");
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
 
+    if !manage_code {
+        let mut settings = state.settings.write().await;
+        settings.agents.entry(name.clone()).or_default().manage_agent_code = false;
+        save_settings(&settings);
+    }
+
     let env_config = state.env_config.clone();
     let name =
-        tokio::task::spawn_blocking(move || docker::create_agent(&name, &env_config))
+        tokio::task::spawn_blocking(move || docker::create_agent(&name, &env_config, manage_code))
             .await
             .unwrap()
             .map_err(map_docker_err)?;
@@ -545,6 +553,7 @@ async fn destroy_agent_handler(
     {
         let mut settings = state.settings.write().await;
         settings.services.remove(&name);
+        settings.agents.remove(&name);
         save_settings(&settings);
     }
 
@@ -559,9 +568,10 @@ async fn rebuild_agent_handler(
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
 
+    let manage_code = state.settings.read().await.manages_code(&name);
     let env_config = state.env_config.clone();
     tokio::task::spawn_blocking(move || {
-        docker::rebuild_agent(&name, &env_config)?;
+        docker::rebuild_agent(&name, &env_config, manage_code)?;
         docker::start_agent(&name)
     })
         .await
@@ -841,6 +851,26 @@ struct Settings {
     services: HashMap<String, HashMap<String, u16>>,
     #[serde(default)]
     backup: BackupGlobalSettings,
+    #[serde(default)]
+    agents: HashMap<String, AgentSettings>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct AgentSettings {
+    #[serde(default = "default_true")]
+    manage_agent_code: bool,
+}
+
+impl Default for AgentSettings {
+    fn default() -> Self {
+        Self { manage_agent_code: true }
+    }
+}
+
+impl Settings {
+    fn manages_code(&self, name: &str) -> bool {
+        self.agents.get(name).is_none_or(|s| s.manage_agent_code)
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -1204,22 +1234,35 @@ async fn forward_http_to_container(
 async fn create_backup_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
-) -> Result<Json<crate::types::BackupInfo>, (StatusCode, Json<serde_json::Value>)> {
+) -> Sse<impl futures_core::Stream<Item = Result<Event, std::convert::Infallible>>> {
     tracing::info!(agent = %name, "creating manual backup");
-    let lock = state.agent_lock(&name).await;
-    let _guard = lock.write().await;
 
-    let name_clone = name.clone();
-    let backup = tokio::task::spawn_blocking(move || {
-        let _file_lock = backup::agent_file_lock(&name_clone)?;
-        backup::create_backup(&name_clone, crate::types::BackupType::Manual)
-    })
-    .await
-    .unwrap()
-    .map_err(map_docker_err)?;
+    let stream = async_stream::stream! {
+        let lock = state.agent_lock(&name).await;
+        let _guard = lock.write().await;
 
-    tracing::info!(agent = %name, backup_id = %backup.id, size = backup.size, "backup created");
-    Ok(Json(backup))
+        let name_clone = name.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let _file_lock = backup::agent_file_lock(&name_clone)?;
+            backup::create_backup(&name_clone, crate::types::BackupType::Manual)
+        })
+        .await
+        .unwrap();
+
+        match result {
+            Ok(info) => {
+                tracing::info!(agent = %name, backup_id = %info.id, size = info.size, "backup created");
+                yield Ok(Event::default().event("done").data(serde_json::to_string(&info).unwrap()));
+            }
+            Err(e) => {
+                let (status, body) = map_docker_err(e);
+                let err = serde_json::json!({"status": status.as_u16(), "error": body.0});
+                yield Ok(Event::default().event("error").data(err.to_string()));
+            }
+        }
+    };
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
 }
 
 async fn list_backups_handler(
@@ -1254,24 +1297,38 @@ struct RestoreBackupPath {
 async fn restore_backup_handler(
     State(state): State<SharedState>,
     Path(path): Path<RestoreBackupPath>,
-) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    let lock = state.agent_lock(&path.name).await;
-    let _guard = lock.write().await;
-
+) -> Sse<impl futures_core::Stream<Item = Result<Event, std::convert::Infallible>>> {
     tracing::info!(agent = %path.name, backup_id = %path.backup_id, "restoring backup");
-    let name = path.name.clone();
-    let backup_id = path.backup_id.clone();
-    let env_config = state.env_config.clone();
-    tokio::task::spawn_blocking(move || {
-        let _file_lock = backup::agent_file_lock(&name)?;
-        backup::restore_backup(&name, &backup_id, &env_config)
-    })
-        .await
-        .unwrap()
-        .map_err(map_docker_err)?;
 
-    tracing::info!(agent = %path.name, backup_id = %path.backup_id, "backup restored");
-    Ok(Json(serde_json::json!({"ok": true})))
+    let stream = async_stream::stream! {
+        let lock = state.agent_lock(&path.name).await;
+        let _guard = lock.write().await;
+
+        let name = path.name.clone();
+        let backup_id = path.backup_id.clone();
+        let env_config = state.env_config.clone();
+        let manage_code = state.settings.read().await.manages_code(&name);
+        let result = tokio::task::spawn_blocking(move || {
+            let _file_lock = backup::agent_file_lock(&name)?;
+            backup::restore_backup(&name, &backup_id, &env_config, manage_code)
+        })
+        .await
+        .unwrap();
+
+        match result {
+            Ok(()) => {
+                tracing::info!(agent = %path.name, backup_id = %path.backup_id, "backup restored");
+                yield Ok(Event::default().event("done").data(r#"{"ok":true}"#));
+            }
+            Err(e) => {
+                let (status, body) = map_docker_err(e);
+                let err = serde_json::json!({"status": status.as_u16(), "error": body.0});
+                yield Ok(Event::default().event("error").data(err.to_string()));
+            }
+        }
+    };
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
 }
 
 #[derive(Deserialize)]
@@ -1383,6 +1440,67 @@ async fn set_auto_backup_handler(
         "enabled": settings.backup.enabled,
         "hour": settings.backup.hour,
         "retention": settings.backup.retention,
+    })))
+}
+
+// --- Per-agent settings ---
+
+async fn get_agent_settings_handler(
+    State(state): State<SharedState>,
+    Path(name): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let settings = state.settings.read().await;
+    let agent = settings.agents.get(&name).cloned().unwrap_or_default();
+    Ok(Json(serde_json::json!({
+        "manage_agent_code": agent.manage_agent_code,
+    })))
+}
+
+#[derive(Deserialize)]
+struct PatchAgentSettingsBody {
+    manage_agent_code: Option<bool>,
+}
+
+async fn patch_agent_settings_handler(
+    State(state): State<SharedState>,
+    Path(name): Path<String>,
+    Json(body): Json<PatchAgentSettingsBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let lock = state.agent_lock(&name).await;
+    let _guard = lock.write().await;
+
+    let (old_manage_code, new_manage_code) = {
+        let mut settings = state.settings.write().await;
+        let old = settings.manages_code(&name);
+        if let Some(val) = body.manage_agent_code {
+            settings.agents.entry(name.clone()).or_default().manage_agent_code = val;
+        }
+        let new = settings.manages_code(&name);
+        save_settings(&settings);
+        (old, new)
+    };
+
+    // Rebuild if the mount config changed
+    if old_manage_code != new_manage_code {
+        let env_config = state.env_config.clone();
+        let rebuild_name = name.clone();
+        tokio::task::spawn_blocking(move || {
+            let was_running = docker::container_status(&docker::container_name(&rebuild_name))
+                == docker::ContainerStatus::Running;
+            if let Err(e) = docker::rebuild_agent(&rebuild_name, &env_config, new_manage_code) {
+                tracing::error!(agent = %rebuild_name, error = %e, "rebuild after settings change failed");
+                return;
+            }
+            if was_running {
+                docker::start_agent(&rebuild_name).ok();
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    Ok(Json(serde_json::json!({
+        "manage_agent_code": new_manage_code,
     })))
 }
 
@@ -1536,6 +1654,8 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/agents/{name}/backups", get(list_backups_handler))
         .route("/agents/{name}/backups/{backup_id}/restore", post(restore_backup_handler))
         .route("/agents/{name}/backups/{backup_id}", axum::routing::delete(delete_backup_handler))
+        .route("/agents/{name}/settings", get(get_agent_settings_handler))
+        .route("/agents/{name}/settings", axum::routing::patch(patch_agent_settings_handler))
         .route("/agents/{name}/settings/backup", get(get_agent_backup_settings_handler))
         .route("/agents/{name}/settings/backup", axum::routing::put(set_agent_backup_settings_handler))
         .route("/agents/{name}/settings/backup", axum::routing::delete(delete_agent_backup_settings_handler))
@@ -1799,7 +1919,12 @@ pub async fn run_server(port: u16, api_key: String, cert_pem: String, key_pem: S
         tracing::error!(error = %e, "failed to ensure agent code");
     }
     let env_config_clone = env_config.clone();
-    tokio::task::spawn_blocking(move || docker::reconcile_containers(&env_config_clone));
+    let agent_settings = load_settings().agents.clone();
+    tokio::task::spawn_blocking(move || {
+        docker::reconcile_containers(&env_config_clone, &|name| {
+            agent_settings.get(name).is_none_or(|s| s.manage_agent_code)
+        });
+    });
     let state = Arc::new(AppState::new(api_key, env_config, tunnel_url, dev_mode));
     let app = build_router(state.clone());
     spawn_auto_backup_task(state.clone());


### PR DESCRIPTION
## Summary

**Per-agent `manage_agent_code` setting:**
- `manage_agent_code: false` disables vestad's code mount management — agent uses its Docker image's baked-in code instead
- Stored in `settings.json`, default `true`, cleaned up on destroy
- Set on create: `POST /agents {"manage_agent_code": false}` / `vesta create --no-manage-code`
- Change later: `PATCH /agents/{name}/settings` (triggers immediate rebuild) / `vesta settings <name> --no-manage-code`
- `GET /agents/{name}/settings` / `vesta settings <name>` to view
- `reconcile_containers` and `needs_rebuild` respect the setting per agent

**Startup fixes (re-applied after revert of direct push):**
- Fix 404: GitHub archive tags need `v` prefix (`v0.1.119` not `0.1.119`)
- Separate reconcile phases so `ensure_agent_code` failure doesn't skip env file creation for other agents

**Backup streaming:**
- `create_backup` and `restore_backup` stream progress via SSE
- CLI reads SSE streams for backup/restore operations

## Test plan
- [ ] Create agent with `--no-manage-code`, verify no code mounts in `docker inspect`
- [ ] `vesta settings <name> --no-manage-code` on existing agent, verify rebuild removes code mounts
- [ ] `vesta settings <name> --manage-code` to re-enable, verify rebuild adds code mounts
- [ ] Restart vestad, verify setting persists and container config is stable
- [ ] Verify agent code download works with `v` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)