### PR TITLE
fix(install): show PATH note on fresh machines

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,8 @@ main() {
     fi
   }
 
+  PATH_UPDATED=""
+
   ensure_path() {
     local bin_dir="$HOME/.local/bin"
     case ":$PATH:" in
@@ -98,6 +100,7 @@ main() {
         echo "# Added by Vesta installer" >> "$rc"
         echo "$line" >> "$rc"
         echo "Added $bin_dir to PATH in $(basename "$rc")"
+        PATH_UPDATED=1
       fi
     done
 
@@ -254,6 +257,10 @@ main() {
   fi
   if has_gui; then
     echo "  Open Vesta app and connect to your server"
+  fi
+  if [ -n "$PATH_UPDATED" ]; then
+    echo ""
+    echo "NOTE: Run 'source ~/.bashrc' or open a new terminal first."
   fi
 }
 


### PR DESCRIPTION
## Summary
- On a fresh machine, `~/.local/bin` isn't in PATH. The installer adds it to `.bashrc` but can't modify the parent shell (Unix limitation), so `vestad`/`vesta` aren't found immediately.
- Track whether PATH was updated and print a note at the end telling the user to `source ~/.bashrc` or open a new terminal.

## Test plan
- [ ] Run install script on a fresh machine with `--server` flag, verify the PATH note appears
- [ ] Run on a machine where `~/.local/bin` is already in PATH, verify no note appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)