### PR TITLE
fix(vestad): self-update systemd crash loop, agent code extraction

### DIFF
--- a/vestad/Cargo.toml
+++ b/vestad/Cargo.toml
@@ -37,3 +37,6 @@ reqwest = { version = "0.12", default-features = false, features = ["stream", "j
 dotenvy = "0.15"
 time = { version = "0.3", features = ["formatting", "parsing", "macros"] }
 
+[dev-dependencies]
+tempfile = "3"
+

--- a/vestad/src/agent_code.rs
+++ b/vestad/src/agent_code.rs
@@ -227,3 +227,20 @@ fn fetch_agent_code_from_github(config: &Path, tag: &str) -> Result<(), AgentCod
     tracing::info!(tag = %tag, "agent code updated successfully");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_agent_code_known_tag() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = tmp.path();
+        // Use a known released tag
+        fetch_agent_code_from_github(config, "0.1.118").unwrap();
+        let dir = agent_code_dir(config);
+        assert!(dir.join("src/vesta/main.py").exists(), "main.py missing");
+        assert!(dir.join("pyproject.toml").exists(), "pyproject.toml missing");
+        assert!(dir.join("uv.lock").exists(), "uv.lock missing");
+    }
+}

--- a/vestad/src/agent_code.rs
+++ b/vestad/src/agent_code.rs
@@ -181,10 +181,9 @@ fn fetch_agent_code_from_github(config: &Path, tag: &str) -> Result<(), AgentCod
         return Err(AgentCodeError::Download(format!("failed to download {archive_url}")));
     }
 
-    // Extract the entire agent/ subtree into a temp staging dir, then move what we need.
-    // GitHub archives have prefix vesta-v{tag}/, so --strip-components=2 turns
-    // vesta-v{tag}/agent/src/vesta/... into src/vesta/...
-    let prefix = format!("vesta-v{tag}/agent");
+    // GitHub archives have prefix vesta-{tag}/ (v is stripped from directory name).
+    // --strip-components=2 turns vesta-{tag}/agent/src/vesta/... into src/vesta/...
+    let prefix = format!("vesta-{tag}/agent");
     let ok = process::Command::new("tar")
         .args([
             "-xzf", &archive_path,

--- a/vestad/src/self_update.rs
+++ b/vestad/src/self_update.rs
@@ -20,7 +20,7 @@ impl fmt::Display for UpdateError {
 }
 
 /// Downloads the latest vestad binary from GitHub, replaces the current binary,
-/// and reinstalls the systemd service. Agent code and container restarts are
+/// and restarts the systemd service. Agent code and container restarts are
 /// handled on the next vestad startup.
 /// Returns Ok(true) if a restart was triggered.
 pub fn perform_update() -> Result<bool, UpdateError> {

--- a/vestad/src/self_update.rs
+++ b/vestad/src/self_update.rs
@@ -31,9 +31,11 @@ pub fn perform_update() -> Result<bool, UpdateError> {
 
     update_binary(&tag)?;
 
-    if let Err(e) = crate::systemd::reinstall_service() {
-        tracing::warn!("failed to update systemd service: {e}");
-    }
+    // Don't reinstall the systemd service here — self-replace puts the new
+    // binary at the same path, so the ExecStart line doesn't change. And
+    // reading /proc/self/exe after self-replace returns the path with
+    // " (deleted)" appended, which would break the service file.
+    // The new binary calls ensure_service_installed() on startup if needed.
 
     if crate::systemd::is_active() {
         tracing::info!("restarting vestad...");

--- a/vestad/src/systemd.rs
+++ b/vestad/src/systemd.rs
@@ -9,11 +9,6 @@ fn unit_file_path() -> Result<String, String> {
     Ok(format!("{}/.config/systemd/user/vestad.service", home))
 }
 
-pub fn reinstall_service() -> Result<(), String> {
-    std::fs::remove_file(&unit_file_path()?).ok();
-    ensure_service_installed()
-}
-
 pub fn ensure_service_installed() -> Result<(), String> {
     let vestad_path = std::env::current_exe()
         .map_err(|e| format!("cannot determine binary path: {}", e))?


### PR DESCRIPTION
## Summary
- Remove `reinstall_service()` from self-update — after `self-replace`, `/proc/self/exe` returns path with `" (deleted)"` suffix which corrupts the systemd service file and causes crash loops
- Fix tar prefix: GitHub strips `v` from archive directory name (`vesta-0.1.121/` not `vesta-v0.1.121/`), so extraction was always failing
- Add unit test that downloads a known release tag and verifies extraction works — catches both URL and prefix bugs that integration tests miss (debug builds copy from local repo, never hit the download path)

## Test plan
- [ ] Self-update vestad, verify systemd restarts cleanly
- [ ] Create new agent, verify agent code downloads and extracts successfully
- [ ] `cargo test -p vestad -- fetch_agent_code_known_tag` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)