### PR TITLE
fix(ci): atomic releases — draft until artifacts ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,3 +941,6 @@ jobs:
             gh release upload "${{ github.event.release.tag_name }}" "$f" --clobber
           done
           gh release edit "${{ github.event.release.tag_name }}" --draft=false --prerelease=false
+
+      - name: Push to production
+        run: git push origin HEAD:production

--- a/release.sh
+++ b/release.sh
@@ -50,10 +50,7 @@ TAG="v${NEW}"
 git add -A
 git commit -m "Bump version to ${NEW}"
 git push origin master
-gh release create "$TAG" --title "$TAG" --generate-notes --target master --prerelease
+gh release create "$TAG" --title "$TAG" --generate-notes --target master --draft
 
-# Update production branch
-git push origin master:production
-
-echo "✅ Released ${TAG}"
-echo "CI will build artifacts and publish the release."
+echo "✅ Created draft release ${TAG}"
+echo "CI will build artifacts, publish the release, and push to production."


### PR DESCRIPTION
## Summary
- `release.sh` now creates a **draft** release instead of a prerelease
- CI builds artifacts, uploads them, publishes the release, **then** pushes to production
- Fixes race where Cloudflare Pages deployed (showing "update available") before vestad binaries were uploaded, causing failed self-updates

**Before:** release.sh creates release + pushes production → Cloudflare deploys fast, binaries build slow → users see update but can't download it

**After:** release.sh creates draft → CI builds everything → CI publishes release + pushes production → everything available at once

## Test plan
- [ ] Run `./release.sh`, verify draft release is created on GitHub
- [ ] Verify CI builds, uploads assets, publishes release, and pushes to production
- [ ] Verify `/releases/latest` API doesn't return the draft during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)