### PR TITLE
fix(vestad): atomic releases + stale config reconciliation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,3 +941,6 @@ jobs:
             gh release upload "${{ github.event.release.tag_name }}" "$f" --clobber
           done
           gh release edit "${{ github.event.release.tag_name }}" --draft=false --prerelease=false
+
+      - name: Push to production
+        run: git push origin HEAD:production

--- a/release.sh
+++ b/release.sh
@@ -50,10 +50,7 @@ TAG="v${NEW}"
 git add -A
 git commit -m "Bump version to ${NEW}"
 git push origin master
-gh release create "$TAG" --title "$TAG" --generate-notes --target master --prerelease
+gh release create "$TAG" --title "$TAG" --generate-notes --target master --draft
 
-# Update production branch
-git push origin master:production
-
-echo "✅ Released ${TAG}"
-echo "CI will build artifacts and publish the release."
+echo "✅ Created draft release ${TAG}"
+echo "CI will build artifacts, publish the release, and push to production."

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -517,6 +517,9 @@ fn env_file_names(agents_dir: &std::path::Path) -> Vec<String> {
     entries
         .flatten()
         .filter_map(|entry| {
+            if !entry.file_type().ok()?.is_file() {
+                return None;
+            }
             let name = entry.file_name().to_str()?.to_string();
             name.strip_suffix(".env").map(|s| s.to_string())
         })
@@ -1101,12 +1104,21 @@ pub fn reconcile_containers(env_config: &AgentEnvConfig, manages_code: &dyn Fn(&
             was_running.insert(name.clone());
         }
         let env_path = env_config.agents_dir.join(format!("{name}.env"));
-        if !env_path.exists() {
-            if let Some(port) = read_container_env(cname, "WS_PORT").and_then(|v| v.parse::<u16>().ok()) {
+        if !env_path.is_file() {
+            // Remove if it exists but isn't a file (e.g. stale directory)
+            if env_path.exists() {
+                std::fs::remove_dir_all(&env_path).ok();
+            }
+            let port = read_container_env(cname, "WS_PORT")
+                .and_then(|v| v.parse::<u16>().ok())
+                .or_else(|| allocate_port(&env_config.agents_dir).ok().map(|(p, _)| p));
+            if let Some(port) = port {
                 let token = generate_agent_token();
                 if let Err(e) = write_agent_env_file(env_config, &name, port, &token) {
                     tracing::error!(agent = %name, error = %e, "failed to create missing env file");
                 }
+            } else {
+                tracing::error!(agent = %name, "could not determine or allocate port for env file");
             }
         }
     }
@@ -1136,7 +1148,7 @@ pub fn reconcile_containers(env_config: &AgentEnvConfig, manages_code: &dyn Fn(&
 
     // Phase 3: restart running agents (picks up new env), start rebuilt ones
     for cname in &containers {
-        let name = name_from_cname(cname);
+        let name = get_agent_name(cname);
         match container_status(cname) {
             ContainerStatus::Running => {
                 tracing::info!(agent = %name, "restarting");
@@ -1203,7 +1215,8 @@ fn needs_rebuild(cname: &str, manage_code: bool) -> bool {
         .map(|actual| actual.iter().zip(ENTRYPOINT).all(|(a, e)| a == e) && actual.len() == ENTRYPOINT.len())
         .unwrap_or(false);
     if !cmd_ok {
-        tracing::info!(container = %cname, actual = %cmd_json, "rebuild needed: command mismatch");
+        let expected: Vec<&str> = ENTRYPOINT.to_vec();
+        tracing::info!(container = %cname, actual = %cmd_json, expected = ?expected, "rebuild needed: command mismatch");
         return true;
     }
 
@@ -1233,10 +1246,17 @@ pub fn rebuild_agent(name: &str, env_config: &AgentEnvConfig, manage_code: bool)
         _ => {}
     }
 
-    // Get port: try env file first, then container's baked-in env vars
-    let port = info.port
+    // Get port: try env file first, then container's baked-in env vars, then allocate new
+    let port = match info.port
         .or_else(|| read_container_env(&cname, "WS_PORT").and_then(|v| v.parse().ok()))
-        .ok_or_else(|| DockerError::Failed("agent has no port".into()))?;
+    {
+        Some(p) => p,
+        None => {
+            tracing::warn!(agent = %name, "no port found in env file or container — allocating new port");
+            let (p, _listener) = allocate_port(&env_config.agents_dir)?;
+            p
+        }
+    };
 
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -242,6 +242,7 @@ fn run_server_systemd(port: Option<u16>, no_tunnel: bool) {
         eprintln!("note: --port and --no-tunnel only apply with --standalone");
     }
 
+    docker::ensure_docker().unwrap_or_else(|e| die(&e));
     systemd::ensure_service_installed().unwrap_or_else(|e| die(&e));
 
     if systemd::is_active() {


### PR DESCRIPTION
## Summary
- **Atomic releases**: draft release until artifacts are ready (existing commit)
- **Reconcile fix**: containers from older vestad versions lack `WS_PORT` in env file and container env, causing rebuild to fail with "agent has no port" — now falls back to allocating a fresh port
- **env_file_names**: skip directories that happen to end in `.env` (e.g. stale `luma.env/` directory)
- **Phase 3 name lookup**: use `get_agent_name` (label-aware) instead of `name_from_cname` so rebuilt agents get restarted correctly
- **Logging**: command mismatch log now shows expected entrypoint alongside actual

## Test plan
- [ ] Start vestad with containers created by older versions (no `WS_PORT` baked in, no `.env` file) — should allocate port and rebuild successfully
- [ ] Verify agents restart after rebuild
- [ ] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)