### PR TITLE
fix(vestad): startup validation, reconciliation logs, tunnel error handling

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -118,6 +118,9 @@ fn check_response(resp: Response<Body>) -> Result<Response<Body>, String> {
         401 => Err("invalid API key".into()),
         404 => Err(error_msg.unwrap_or_else(|| "not found".into())),
         409 => Err(error_msg.unwrap_or_else(|| "conflict".into())),
+        502 | 520..=530 => Err(error_msg.unwrap_or_else(|| format!(
+            "server not reachable via tunnel ({}). is vestad running?", status
+        ))),
         503 => Err(error_msg.unwrap_or_else(|| "agent not running".into())),
         _ => Err(error_msg.unwrap_or_else(|| format!("server error ({})", status))),
     }

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1504,7 +1504,7 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
         }
         let env_path = env_config.agents_dir.join(format!("{name}.env"));
         if env_path.is_file() {
-            tracing::debug!(agent = %name, "env file ok");
+            tracing::info!(agent = %name, "env file ok");
         } else {
             if env_path.exists() {
                 tracing::warn!(agent = %name, path = %env_path.display(), "env path is not a file, removing");
@@ -1534,7 +1534,7 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
         let name = get_agent_name(docker, cname).await;
         let manage_code = manages_code(&name);
         if !needs_rebuild(docker, cname, manage_code).await {
-            tracing::debug!(agent = %name, "config ok, no rebuild needed");
+            tracing::info!(agent = %name, "config ok, no rebuild needed");
             continue;
         }
         tracing::info!(agent = %name, "rebuild needed");
@@ -1566,7 +1566,7 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
                 start_container(docker, cname).await;
             }
             status => {
-                tracing::debug!(agent = %name, ?status, "not restarting");
+                tracing::info!(agent = %name, ?status, "not restarting");
             }
         }
     }

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -281,7 +281,10 @@ pub async fn download_from_container(
     while let Some(chunk) = stream.next().await {
         match chunk {
             Ok(data) => bytes.extend_from_slice(&data),
-            Err(_) => return None,
+            Err(e) => {
+                tracing::debug!(container = %cname, path = %container_path, error = %e, "download_from_container failed");
+                return None;
+            }
         }
     }
 

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -737,6 +737,51 @@ pub struct AgentEnvConfig {
     pub vestad_tunnel: Option<String>,
 }
 
+/// Validate that the config and agents directories exist, are writable, and have
+/// no stale entries (e.g. directories where files should be). Fails fast with a
+/// clear error instead of producing cryptic permission errors later.
+pub fn validate_config_dir(env_config: &AgentEnvConfig) -> Result<(), DockerError> {
+    // Ensure dirs exist
+    std::fs::create_dir_all(&env_config.agents_dir)
+        .map_err(|e| DockerError::Failed(format!(
+            "cannot create agents directory {}: {e} — check ownership (try: sudo chown -R $(whoami) {})",
+            env_config.agents_dir.display(),
+            env_config.config_dir.display(),
+        )))?;
+
+    // Check agents_dir is writable by writing a temp file
+    let probe = env_config.agents_dir.join(".vestad-probe");
+    std::fs::write(&probe, b"")
+        .map_err(|e| DockerError::Failed(format!(
+            "agents directory {} is not writable: {e} — check ownership (try: sudo chown -R $(whoami) {})",
+            env_config.agents_dir.display(),
+            env_config.config_dir.display(),
+        )))?;
+    std::fs::remove_file(&probe).ok();
+
+    // Check for stale entries (directories where .env files should be)
+    if let Ok(entries) = std::fs::read_dir(&env_config.agents_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.ends_with(".env") && path.is_dir() {
+                tracing::warn!(
+                    path = %path.display(),
+                    "removing stale directory where env file should be"
+                );
+                std::fs::remove_dir_all(&path).map_err(|e| DockerError::Failed(format!(
+                    "cannot remove stale directory {}: {e} — check ownership (try: sudo chown -R $(whoami) {})",
+                    path.display(),
+                    env_config.config_dir.display(),
+                )))?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Write a sourceable env file for a single agent. Returns the file path.
 pub fn write_agent_env_file(
     env_config: &AgentEnvConfig,
@@ -1458,18 +1503,24 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
             was_running.insert(name.clone());
         }
         let env_path = env_config.agents_dir.join(format!("{name}.env"));
-        if !env_path.is_file() {
-            // Remove if it exists but isn't a file (e.g. stale directory)
+        if env_path.is_file() {
+            tracing::debug!(agent = %name, "env file ok");
+        } else {
             if env_path.exists() {
-                std::fs::remove_dir_all(&env_path).ok();
+                tracing::warn!(agent = %name, path = %env_path.display(), "env path is not a file, removing");
+                if let Err(e) = std::fs::remove_dir_all(&env_path) {
+                    tracing::error!(agent = %name, error = %e, "failed to remove stale env path");
+                    continue;
+                }
             }
+            tracing::info!(agent = %name, "env file missing, recreating");
             let port = read_container_env(docker, cname, "WS_PORT").await
                 .and_then(|v| v.parse::<u16>().ok())
                 .or_else(|| allocate_port(&env_config.agents_dir).ok().map(|(p, _)| p));
             if let Some(port) = port {
                 let token = generate_agent_token();
                 if let Err(e) = write_agent_env_file(env_config, &name, port, &token) {
-                    tracing::error!(agent = %name, error = %e, "failed to create missing env file");
+                    tracing::error!(agent = %name, error = %e, "failed to create env file");
                 }
             } else {
                 tracing::error!(agent = %name, "could not determine or allocate port for env file");

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -87,7 +87,7 @@ const CONTAINER_STOP_TIMEOUT_SECS: i64 = 10;
 const CONTAINER_RESTART_TIMEOUT_SECS: isize = 10;
 const LOADED_IMAGE_PREFIX: &str = "Loaded image: ";
 
-#[derive(PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ContainerStatus {
     Running,
     Stopped,
@@ -1534,8 +1534,10 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
         let name = get_agent_name(docker, cname).await;
         let manage_code = manages_code(&name);
         if !needs_rebuild(docker, cname, manage_code).await {
+            tracing::debug!(agent = %name, "config ok, no rebuild needed");
             continue;
         }
+        tracing::info!(agent = %name, "rebuild needed");
         if manage_code && !agent_code_ok {
             match crate::agent_code::ensure_agent_code(&env_config.config_dir) {
                 Ok(_) => agent_code_ok = true,
@@ -1563,8 +1565,28 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
                 tracing::info!(agent = %name, "starting after rebuild");
                 start_container(docker, cname).await;
             }
-            _ => {}
+            status => {
+                tracing::debug!(agent = %name, ?status, "not restarting");
+            }
         }
+    }
+
+    // Summary: log which agents are running after reconciliation
+    let mut running = Vec::new();
+    let mut stopped = Vec::new();
+    for cname in &containers {
+        let name = get_agent_name(docker, cname).await;
+        if container_status(docker, cname).await == ContainerStatus::Running {
+            running.push(name);
+        } else {
+            stopped.push(name);
+        }
+    }
+    if !running.is_empty() {
+        tracing::info!(agents = ?running, "running");
+    }
+    if !stopped.is_empty() {
+        tracing::info!(agents = ?stopped, "stopped");
     }
 }
 

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -185,6 +185,13 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
     docker::ensure_docker_sync(&docker).unwrap_or_else(|e| die(&e));
 
     let _pid_lock = serve::acquire_pid_lock(&config).unwrap_or_else(|e| die(&e));
+    // Kill orphaned cloudflared from a previous crash so it doesn't hold the port
+    let cf_config = config.join("cloudflared.yml");
+    if cf_config.exists() {
+        std::process::Command::new("pkill")
+            .args(["-f", &format!("cloudflared.*{}", cf_config.display())])
+            .output().ok();
+    }
     let port = resolve_port(port, &config);
     serve::write_port_file(&config, port);
 

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1873,6 +1873,10 @@ pub async fn run_server(port: u16, api_key: String, cert_pem: String, key_pem: S
         vestad_port: port,
         vestad_tunnel: tunnel_url.clone(),
     };
+    if let Err(e) = docker::validate_config_dir(&env_config) {
+        tracing::error!(error = %e, "config directory validation failed — aborting startup");
+        std::process::exit(1);
+    }
     if let Err(e) = crate::agent_code::ensure_agent_code(&env_config.config_dir) {
         tracing::error!(error = %e, "failed to ensure agent code");
     }


### PR DESCRIPTION
## Summary
- **Config dir validation at startup** — check agents dir is writable, remove stale `.env` directories, crash with actionable `sudo chown -R $(whoami) ...` message on permission errors
- **Reconciliation logging** — per-agent info logs for env file status, rebuild check result, restart/skip decision, and final running/stopped summary
- **CLI tunnel error handling** — status codes 502/520-530 now show "server not reachable via tunnel. is vestad running?" instead of generic "server error (530)"
- **Kill orphaned cloudflared on startup** — after unclean shutdown, cloudflared can hold the stored port causing vestad to allocate a new random port; now killed (matched by config path) before port check
- **Debug on ContainerStatus** + debug log on `download_from_container` failure

## Test plan
- [x] `cargo clippy` clean
- [x] `cargo test` passes (56 tests)
- [x] Manual: verified reconciliation logs show per-agent status on startup
- [x] Manual: verified `[no auth]` correctly reports expired credentials
- [ ] Manual: verify startup crashes cleanly when agents dir is root-owned

🤖 Generated with [Claude Code](https://claude.com/claude-code)