### PR TITLE
fix(ci): use prerelease instead of draft for atomic releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
   pull_request:
   release:
-    types: [created]
+    types: [created, published]
   workflow_dispatch:
 
 permissions:

--- a/release.sh
+++ b/release.sh
@@ -50,7 +50,7 @@ TAG="v${NEW}"
 git add -A
 git commit -m "Bump version to ${NEW}"
 git push origin master
-gh release create "$TAG" --title "$TAG" --generate-notes --target master --draft
+gh release create "$TAG" --title "$TAG" --generate-notes --target master --prerelease
 
-echo "✅ Created draft release ${TAG}"
+echo "✅ Created prerelease ${TAG}"
 echo "CI will build artifacts, publish the release, and push to production."


### PR DESCRIPTION
## Summary
- `release.sh`: `--draft` → `--prerelease` — drafts don't trigger `release: created`, prereleases do
- `ci.yml`: add `published` to release trigger types so converting a stuck draft also triggers CI
- Prereleases are excluded from `/releases/latest` API, giving the same atomicity as drafts
- The release job already clears the prerelease flag after uploading artifacts

## Context
v0.1.124 release was stuck as a draft because CI never triggered. Deleted the stuck release — re-run `./release.sh` after merging this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)