### PR TITLE
fix(ci): force push production, clean stale agent-code dirs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -949,4 +949,4 @@ jobs:
           gh release edit "${{ github.event.release.tag_name }}" --draft=false --prerelease=false
 
       - name: Push to production
-        run: git push origin HEAD:production
+        run: git push --force origin HEAD:production

--- a/vestad/src/agent_code.rs
+++ b/vestad/src/agent_code.rs
@@ -162,8 +162,14 @@ fn fetch_agent_code_from_github(config: &Path, tag: &str) -> Result<(), AgentCod
     let tmp_dir = config.join("agent-code.new");
     let old_dir = config.join("agent-code.old");
 
-    let _ = fs::remove_dir_all(&tmp_dir);
-    let _ = fs::remove_dir_all(&old_dir);
+    if tmp_dir.exists() {
+        fs::remove_dir_all(&tmp_dir).map_err(|e|
+            AgentCodeError::Io(format!("failed to clean stale {}: {e}", tmp_dir.display())))?;
+    }
+    if old_dir.exists() {
+        fs::remove_dir_all(&old_dir).map_err(|e|
+            AgentCodeError::Io(format!("failed to clean stale {}: {e}", old_dir.display())))?;
+    }
     fs::create_dir_all(&tmp_dir).map_err(|e| AgentCodeError::Io(e.to_string()))?;
 
     let archive_url = format!("{GITHUB_ARCHIVE_URL}/v{tag}.tar.gz");
@@ -208,7 +214,8 @@ fn fetch_agent_code_from_github(config: &Path, tag: &str) -> Result<(), AgentCod
         return Err(AgentCodeError::Extract("extracted archive missing required files".into()));
     }
 
-    // Atomic swap
+    // Atomic swap — remove stale old_dir from a previous interrupted update
+    let _ = fs::remove_dir_all(&old_dir);
     if dir.exists() {
         fs::rename(&dir, &old_dir).map_err(|e| {
             let _ = fs::remove_dir_all(&tmp_dir);


### PR DESCRIPTION
## Summary
- **Force push to production** — `git push --force` in CI release job so diverged production branch doesn't block deployment
- **Clean stale agent-code dirs** — remove leftover `agent-code.old` and `agent-code.new` from interrupted updates with proper error propagation instead of silent swallowing. Fixes `Directory not empty (os error 39)` on agent code update after a crash mid-swap.

## Context
v0.1.125 release job failed at `git push origin HEAD:production` because production was behind master. Also, vestad restarting mid-snapshot left stale `agent-code.old` which blocked the next update.

## Test plan
- [x] `cargo clippy` clean
- [x] `cargo test` passes (56 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)