### PR TITLE
fix(vestad): handle permission-denied on stale agent-code cleanup

### DIFF
--- a/vestad/src/agent_code.rs
+++ b/vestad/src/agent_code.rs
@@ -156,20 +156,40 @@ fn copy_from_local_repo(config: &Path) -> Result<(), AgentCodeError> {
     Ok(())
 }
 
+/// Best-effort recursive removal: try `fs::remove_dir_all` first, then fall back
+/// to `rm -rf` (handles directories with mixed ownership from previous runs).
+fn force_remove_dir(path: &Path) {
+    if !path.exists() {
+        return;
+    }
+    if fs::remove_dir_all(path).is_ok() {
+        return;
+    }
+    tracing::warn!(path = %path.display(), "fs::remove_dir_all failed, trying rm -rf");
+    let ok = process::Command::new("rm")
+        .args(["-rf", &path.display().to_string()])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !ok {
+        tracing::warn!(path = %path.display(), "rm -rf also failed, will use unique temp name");
+    }
+}
+
 /// Download agent code for a specific release tag from GitHub and atomically swap it in.
 fn fetch_agent_code_from_github(config: &Path, tag: &str) -> Result<(), AgentCodeError> {
     let dir = agent_code_dir(config);
-    let tmp_dir = config.join("agent-code.new");
-    let old_dir = config.join("agent-code.old");
+    let pid = std::process::id();
+    let tmp_dir = config.join(format!("agent-code.new.{pid}"));
+    let old_dir = config.join(format!("agent-code.old.{pid}"));
 
-    if tmp_dir.exists() {
-        fs::remove_dir_all(&tmp_dir).map_err(|e|
-            AgentCodeError::Io(format!("failed to clean stale {}: {e}", tmp_dir.display())))?;
-    }
-    if old_dir.exists() {
-        fs::remove_dir_all(&old_dir).map_err(|e|
-            AgentCodeError::Io(format!("failed to clean stale {}: {e}", old_dir.display())))?;
-    }
+    // Clean up any stale temp directories (best-effort, non-blocking)
+    force_remove_dir(&tmp_dir);
+    force_remove_dir(&old_dir);
+    // Also try to clean generic names from older versions
+    force_remove_dir(&config.join("agent-code.new"));
+    force_remove_dir(&config.join("agent-code.old"));
+
     fs::create_dir_all(&tmp_dir).map_err(|e| AgentCodeError::Io(e.to_string()))?;
 
     let archive_url = format!("{GITHUB_ARCHIVE_URL}/v{tag}.tar.gz");
@@ -182,7 +202,7 @@ fn fetch_agent_code_from_github(config: &Path, tag: &str) -> Result<(), AgentCod
         .map(|s| s.success())
         .unwrap_or(false);
     if !ok {
-        let _ = fs::remove_dir_all(&tmp_dir);
+        force_remove_dir(&tmp_dir);
         let _ = fs::remove_file(&archive_path);
         return Err(AgentCodeError::Download(format!("failed to download {archive_url}")));
     }
@@ -204,21 +224,20 @@ fn fetch_agent_code_from_github(config: &Path, tag: &str) -> Result<(), AgentCod
     let _ = fs::remove_file(&archive_path);
 
     if !ok {
-        let _ = fs::remove_dir_all(&tmp_dir);
+        force_remove_dir(&tmp_dir);
         return Err(AgentCodeError::Extract("failed to extract agent/ from tarball".into()));
     }
 
     // Validate
     if !tmp_dir.join("src/vesta/main.py").exists() || !tmp_dir.join("pyproject.toml").exists() {
-        let _ = fs::remove_dir_all(&tmp_dir);
+        force_remove_dir(&tmp_dir);
         return Err(AgentCodeError::Extract("extracted archive missing required files".into()));
     }
 
-    // Atomic swap — remove stale old_dir from a previous interrupted update
-    let _ = fs::remove_dir_all(&old_dir);
+    // Atomic swap
     if dir.exists() {
         fs::rename(&dir, &old_dir).map_err(|e| {
-            let _ = fs::remove_dir_all(&tmp_dir);
+            force_remove_dir(&tmp_dir);
             AgentCodeError::Io(format!("failed to move old agent-code: {e}"))
         })?;
     }
@@ -230,7 +249,7 @@ fn fetch_agent_code_from_github(config: &Path, tag: &str) -> Result<(), AgentCod
         AgentCodeError::Io(format!("failed to move new agent-code into place: {e}"))
     })?;
 
-    let _ = fs::remove_dir_all(&old_dir);
+    force_remove_dir(&old_dir);
     tracing::info!(tag = %tag, "agent code updated successfully");
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add `force_remove_dir()` that tries `fs::remove_dir_all()` first, falls back to `rm -rf` subprocess for dirs with mixed ownership (e.g. root-owned from a previous `sudo` run)
- Use PID-suffixed temp dir names (`agent-code.new.{pid}`, `agent-code.old.{pid}`) to avoid collisions with stale dirs from crashed/interrupted previous runs
- Also best-effort cleans generic names (`agent-code.old`, `agent-code.new`) left by older versions

## Context
After v0.1.126, vestad failed to update agent code because a stale `agent-code.old` directory was owned by root (likely from a previous `sudo` debugging session). The fix in #213 correctly propagated the error instead of silently swallowing it, but was too strict — cleanup of stale dirs should be best-effort, not a hard failure.

## Test plan
- [x] `cargo clippy -p vestad -- -D warnings` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)