### PR TITLE
fix(vestad): reclaim stale tunnel instead of skipping to different subdomain

### DIFF
--- a/vestad/src/systemd.rs
+++ b/vestad/src/systemd.rs
@@ -19,20 +19,6 @@ pub fn ensure_service_installed() -> Result<(), String> {
 
     let unit_path = unit_file_path()?;
 
-    if let Ok(existing) = std::fs::read_to_string(&unit_path) {
-        if existing.contains(&vestad_path) {
-            return Ok(());
-        }
-        eprintln!("updating systemd service (binary path changed)...");
-    } else {
-        eprintln!("installing systemd user service...");
-    }
-
-    if let Some(parent) = std::path::Path::new(&unit_path).parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("failed to create {}: {}", parent.display(), e))?;
-    }
-
     let unit_content = format!(
         r#"[Unit]
 Description=Vesta API Server
@@ -49,7 +35,21 @@ WantedBy=default.target
 "#
     );
 
-    std::fs::write(&unit_path, unit_content)
+    if let Ok(existing) = std::fs::read_to_string(&unit_path) {
+        if existing == unit_content {
+            return Ok(());
+        }
+        eprintln!("updating systemd service...");
+    } else {
+        eprintln!("installing systemd user service...");
+    }
+
+    if let Some(parent) = std::path::Path::new(&unit_path).parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create {}: {}", parent.display(), e))?;
+    }
+
+    std::fs::write(&unit_path, &unit_content)
         .map_err(|e| format!("failed to write systemd service: {}", e))?;
 
     run_systemctl(&["daemon-reload"])?;

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -186,15 +186,13 @@ fn gethostname() -> String {
     if output.is_empty() { "vesta".to_string() } else { output }
 }
 
-const SUBDOMAIN_MAX_ATTEMPTS: usize = 10;
-
 pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
     let preferred = generate_subdomain(0);
 
-    // Reuse existing tunnel if it uses any of our candidate animals
+    // Reuse existing tunnel if it matches our preferred subdomain
     if let Some(tc) = get_tunnel_config(config_dir) {
         let current = tc.hostname.split('.').next().unwrap_or("");
-        if is_our_subdomain(current) {
+        if current == preferred {
             return Ok(tc);
         }
         tracing::info!(old = %current, new = %preferred, "tunnel subdomain changed, recreating");
@@ -204,41 +202,13 @@ pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
         }
     }
 
-    let env = cf_env()?;
-
-    for attempt in 0..SUBDOMAIN_MAX_ATTEMPTS {
-        let subdomain = generate_subdomain(attempt);
-        let tunnel_name = format!("vesta-{}", subdomain);
-
-        if tunnel_exists(&env, &tunnel_name) {
-            tracing::info!(subdomain = %subdomain, "tunnel name already taken, trying next");
-            continue;
-        }
-
-        tracing::info!(subdomain = %subdomain, "creating tunnel");
-        return setup_tunnel(config_dir, &subdomain);
-    }
-
-    Err(format!("could not find available tunnel subdomain after {SUBDOMAIN_MAX_ATTEMPTS} attempts"))
+    // setup_tunnel calls delete_tunnel_if_exists, so stale tunnels with our
+    // preferred name are cleaned up automatically — no need to skip to a
+    // different animal.
+    tracing::info!(subdomain = %preferred, "creating tunnel");
+    setup_tunnel(config_dir, &preferred)
 }
 
-/// Check if a subdomain matches any of our candidate animal-hostname combos.
-fn is_our_subdomain(subdomain: &str) -> bool {
-    (0..SUBDOMAIN_MAX_ATTEMPTS).any(|offset| generate_subdomain(offset) == subdomain)
-}
-
-/// Check if an active (non-deleted) tunnel with this name already exists.
-fn tunnel_exists(env: &CloudflareEnv, tunnel_name: &str) -> bool {
-    let url = format!(
-        "{}/accounts/{}/cfd_tunnel?name={}&is_deleted=false",
-        CF_API_BASE, env.account_id, tunnel_name
-    );
-    let resp = match cf_request("GET", &url, &env.api_token, None) {
-        Ok(r) => r,
-        Err(_) => return false,
-    };
-    resp["result"].as_array().is_some_and(|arr| !arr.is_empty())
-}
 
 pub fn setup_tunnel(config_dir: &Path, subdomain: &str) -> Result<TunnelConfig, String> {
     let env = cf_env()?;


### PR DESCRIPTION
## Summary
- When Cloudflare was unreachable during shutdown, the old tunnel wasn't destroyed
- On restart, `ensure_tunnel` found the tunnel name "already taken" and fell through to a different animal, giving the user a different URL
- Fix: always use the preferred subdomain — `setup_tunnel` already calls `delete_tunnel_if_exists` before creating, so stale tunnels are cleaned up automatically
- Removes `tunnel_exists`, `is_our_subdomain`, `SUBDOMAIN_MAX_ATTEMPTS` and the offset loop (all dead code after this change)

## Test plan
- [x] `cargo clippy -p vestad` clean
- [x] `cargo build -p vestad` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)