### PR TITLE
test: add multi-user integration tests

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -14,6 +14,26 @@ pub static SERVER: LazyLock<TestServer> = LazyLock::new(|| {
     TestServer::start().unwrap_or_else(|e| panic!("failed to start test server: {e}"))
 });
 
+#[derive(Default)]
+pub struct TestServerBuilder {
+    user: Option<String>,
+}
+
+impl TestServerBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn user(mut self, user: &str) -> Self {
+        self.user = Some(user.to_string());
+        self
+    }
+
+    pub fn start(self) -> Result<TestServer, String> {
+        TestServer::start_with_user(self.user)
+    }
+}
+
 /// Kill vestad processes left behind by previous test runs (those whose HOME is a
 /// temp directory). Ignores the user's real vestad instance.
 fn kill_orphan_vestads() {
@@ -53,6 +73,10 @@ pub struct TestServer {
 
 impl TestServer {
     pub fn start() -> Result<Self, String> {
+        Self::start_with_user(None)
+    }
+
+    fn start_with_user(user: Option<String>) -> Result<Self, String> {
         rustls::crypto::ring::default_provider()
             .install_default()
             .ok();
@@ -64,19 +88,24 @@ impl TestServer {
         let real_home = std::env::var("HOME").unwrap_or_default();
         let docker_config = format!("{}/.docker", real_home);
 
-        let process = Command::new(&vestad)
-            .args(["serve", "--standalone", "--no-tunnel"])
+        let mut cmd = Command::new(&vestad);
+        cmd.args(["serve", "--standalone", "--no-tunnel"])
             .env("HOME", &home)
             .env("DOCKER_CONFIG", &docker_config)
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .map_err(|e| format!("spawn vestad: {e}"))?;
+            .stderr(Stdio::null());
+
+        if let Some(ref user_name) = user {
+            cmd.env("USER", user_name);
+        }
+
+        let process = cmd.spawn().map_err(|e| format!("spawn vestad: {e}"))?;
 
         let config_dir = home.join(".config/vesta/vestad");
         let port_path = config_dir.join("port");
 
-        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        let startup_timeout = Duration::from_secs(30);
+        let deadline = std::time::Instant::now() + startup_timeout;
         let port = loop {
             if let Ok(content) = std::fs::read_to_string(&port_path) {
                 if let Ok(p) = content.trim().parse::<u16>() {

--- a/tests/tests/multi_user.rs
+++ b/tests/tests/multi_user.rs
@@ -1,0 +1,155 @@
+use std::collections::HashSet;
+
+use vesta_tests::{TestAgent, TestServerBuilder};
+
+fn start_pair() -> (vesta_tests::TestServer, vesta_tests::TestServer) {
+    let alice = TestServerBuilder::new()
+        .user("alice")
+        .start()
+        .expect("failed to start alice's server");
+    let bob = TestServerBuilder::new()
+        .user("bob")
+        .start()
+        .expect("failed to start bob's server");
+    (alice, bob)
+}
+
+// ── Two servers on different ports ────────────────────────────
+
+#[test]
+fn two_servers_start_different_ports() {
+    let (alice, bob) = start_pair();
+
+    assert_ne!(alice.port, bob.port, "servers should bind to different ports");
+
+    alice.client().health().expect("alice health check failed");
+    bob.client().health().expect("bob health check failed");
+}
+
+// ── Agent isolation between users ─────────────────────────────
+
+#[test]
+fn agents_isolated_between_users() {
+    let (alice, bob) = start_pair();
+    let alice_client = alice.client();
+    let bob_client = bob.client();
+
+    let _alice_agent = TestAgent::create(&alice_client, "shared-name").unwrap();
+    let _bob_agent = TestAgent::create(&bob_client, "shared-name").unwrap();
+
+    let alice_list = alice_client.list_agents().unwrap();
+    let bob_list = bob_client.list_agents().unwrap();
+
+    assert_eq!(alice_list.len(), 1, "alice should see exactly one agent");
+    assert_eq!(bob_list.len(), 1, "bob should see exactly one agent");
+    assert_eq!(alice_list[0].name, "shared-name");
+    assert_eq!(bob_list[0].name, "shared-name");
+
+    let alice_status = alice_client.agent_status("shared-name").unwrap();
+    let bob_status = bob_client.agent_status("shared-name").unwrap();
+    assert_ne!(alice_status.status, "not_found");
+    assert_ne!(bob_status.status, "not_found");
+}
+
+// ── Container names include user prefix ───────────────────────
+
+#[test]
+fn container_names_include_user() {
+    let (alice, bob) = start_pair();
+    let alice_client = alice.client();
+    let bob_client = bob.client();
+
+    let _alice_agent = TestAgent::create(&alice_client, "prefix-test").unwrap();
+    let _bob_agent = TestAgent::create(&bob_client, "prefix-test").unwrap();
+
+    let output = std::process::Command::new("docker")
+        .args(["ps", "-a", "--format", "{{.Names}}"])
+        .output()
+        .expect("docker ps should work");
+    let container_names = String::from_utf8_lossy(&output.stdout);
+
+    let has_alice_container = container_names
+        .lines()
+        .any(|name| name.contains("alice") && name.contains("prefix-test"));
+    let has_bob_container = container_names
+        .lines()
+        .any(|name| name.contains("bob") && name.contains("prefix-test"));
+
+    assert!(has_alice_container, "expected a container with 'alice' and 'prefix-test' in name, got:\n{container_names}");
+    assert!(has_bob_container, "expected a container with 'bob' and 'prefix-test' in name, got:\n{container_names}");
+}
+
+// ── Agent WS ports don't collide across users ─────────────────
+
+#[test]
+fn agent_ports_dont_collide() {
+    let (alice, bob) = start_pair();
+    let alice_client = alice.client();
+    let bob_client = bob.client();
+
+    let _alice_a1 = TestAgent::create(&alice_client, "port-test-1").unwrap();
+    let _alice_a2 = TestAgent::create(&alice_client, "port-test-2").unwrap();
+    let _bob_a1 = TestAgent::create(&bob_client, "port-test-1").unwrap();
+    let _bob_a2 = TestAgent::create(&bob_client, "port-test-2").unwrap();
+
+    let alice_agents = alice_client.list_agents().unwrap();
+    let bob_agents = bob_client.list_agents().unwrap();
+
+    let mut all_ports: Vec<u16> = alice_agents.iter().map(|a| a.ws_port).collect();
+    all_ports.extend(bob_agents.iter().map(|a| a.ws_port));
+
+    let unique_ports: HashSet<u16> = all_ports.iter().copied().collect();
+    assert_eq!(
+        all_ports.len(),
+        unique_ports.len(),
+        "all WS ports should be unique across both servers: {all_ports:?}"
+    );
+}
+
+// ── Destroy on one server doesn't affect the other ────────────
+
+#[test]
+fn destroy_on_one_doesnt_affect_other() {
+    let (alice, bob) = start_pair();
+    let alice_client = alice.client();
+    let bob_client = bob.client();
+
+    let alice_agent_name = alice_client.create_agent("cross-destroy", false).unwrap();
+    let _bob_agent = TestAgent::create(&bob_client, "cross-destroy").unwrap();
+
+    alice_client.destroy_agent(&alice_agent_name).unwrap();
+
+    let alice_status = alice_client.agent_status("cross-destroy").unwrap();
+    assert_eq!(alice_status.status, "not_found", "alice's agent should be gone");
+
+    let bob_status = bob_client.agent_status("cross-destroy").unwrap();
+    assert_ne!(bob_status.status, "not_found", "bob's agent should still exist");
+}
+
+// ── Stop on one server doesn't affect the other ───────────────
+
+#[test]
+fn stop_start_independent() {
+    let (alice, bob) = start_pair();
+    let alice_client = alice.client();
+    let bob_client = bob.client();
+
+    let _alice_agent = TestAgent::create(&alice_client, "independence").unwrap();
+    let _bob_agent = TestAgent::create(&bob_client, "independence").unwrap();
+
+    alice_client.start_agent("independence").unwrap();
+    bob_client.start_agent("independence").unwrap();
+
+    let alice_running = alice_client.agent_status("independence").unwrap();
+    let bob_running = bob_client.agent_status("independence").unwrap();
+    assert_eq!(alice_running.status, "running");
+    assert_eq!(bob_running.status, "running");
+
+    alice_client.stop_agent("independence").unwrap();
+
+    let alice_stopped = alice_client.agent_status("independence").unwrap();
+    assert_ne!(alice_stopped.status, "running", "alice's agent should be stopped");
+
+    let bob_still_running = bob_client.agent_status("independence").unwrap();
+    assert_eq!(bob_still_running.status, "running", "bob's agent should still be running");
+}


### PR DESCRIPTION
## Summary
- Adds 6 integration tests verifying two vestad instances on the same server (simulating users `alice` and `bob` via different `HOME`/`USER` env vars) don't interfere with each other
- Adds `TestServerBuilder` to the test harness for spawning servers with custom `USER` env vars
- Tests cover: port isolation, container name prefixing, agent listing isolation, cross-user destroy safety, independent stop/start lifecycle

## Test cases
- `two_servers_start_different_ports` — both servers start on distinct ports
- `agents_isolated_between_users` — same agent name on both servers, each only sees its own
- `container_names_include_user` — Docker containers have correct user prefix
- `agent_ports_dont_collide` — WS ports unique across all agents on both servers
- `destroy_on_one_doesnt_affect_other` — destroying alice's agent leaves bob's intact
- `stop_start_independent` — stopping alice's agent doesn't affect bob's running agent

## Test plan
- [x] All 6 multi-user tests pass locally (`cargo test -p vesta-tests --test multi_user -- --test-threads=1`)
- [x] Existing server tests unaffected (39/40 pass, 1 pre-existing flake)
- [x] `cargo clippy -p vesta-tests` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)