### PR TITLE
feat(vestad): ignisinextinctus easter egg

### DIFF
--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1400,8 +1400,9 @@ pub async fn list_agents(docker: &Docker, agents_dir: &std::path::Path) -> Vec<L
 }
 
 pub async fn create_agent(docker: &Docker, name: &str, env_config: &AgentEnvConfig, manage_code: bool) -> Result<String, DockerError> {
+    let name = if name == "ignisinextinctus" { "vesta" } else { name };
     validate_name(name)?;
-    if name.contains("vesta") {
+    if name != "vesta" && name.contains("vesta") {
         return Err(DockerError::InvalidName("agent name must not contain 'vesta'".into()));
     }
     let cname = container_name(name);


### PR DESCRIPTION
## Summary
- Adds an easter egg: passing `ignisinextinctus` as the agent name bypasses the "vesta" name ban and creates an agent called `vesta`
- The name "vesta" remains banned via normal input — only the easter egg phrase works
- *Ignis inextinctus* — the inextinguishable fire tended by the Vestal Virgins for over a thousand years

## Test plan
- [ ] `vesta create ignisinextinctus` creates an agent named `vesta`
- [ ] `vesta create vesta` still rejected
- [ ] `vesta create myvesta` still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)