### PR TITLE
fix: Android build + run all Tauri builds on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,10 +565,14 @@ jobs:
           name: tauri-${{ matrix.target }}
           path: tauri-out/*
 
-  # ── Build Tauri app (Windows, non-PR) ────────────────────────────────
+  # ── Build Tauri app (Windows) ─────────────────────────────────────────
   build-tauri-windows:
-    needs: [build-windows]
-    if: ${{ !failure() && !cancelled() && github.event_name != 'pull_request' }}
+    needs: [build-windows, detect-changes]
+    if: >-
+      !failure() && !cancelled() && (
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.app == 'true'
+      )
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -621,6 +625,7 @@ jobs:
           args: --target x86_64-pc-windows-msvc --bundles nsis
 
       - name: Collect artifacts
+        if: github.event_name != 'pull_request'
         shell: bash
         run: |
           mkdir -p tauri-out
@@ -628,14 +633,19 @@ jobs:
           find app/src-tauri/target/x86_64-pc-windows-msvc/release/bundle -name '*.sig' -exec cp {} tauri-out/ \;
 
       - uses: actions/upload-artifact@v7
+        if: github.event_name != 'pull_request'
         with:
           name: tauri-x86_64-pc-windows-msvc
           path: tauri-out/*
 
-  # ── Build Tauri app (Android APK, non-PR only) ──────────────────────
+  # ── Build Tauri app (Android APK) ────────────────────────────────────
   build-tauri-android:
-    needs: [test-frontend]
-    if: ${{ !failure() && !cancelled() && github.event_name != 'pull_request' }}
+    needs: [test-frontend, detect-changes]
+    if: >-
+      !failure() && !cancelled() && (
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.app == 'true'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -682,6 +692,7 @@ jobs:
         run: npx tauri android build --apk
 
       - name: Collect artifacts
+        if: github.event_name != 'pull_request'
         run: |
           mkdir -p tauri-out
           find app/src-tauri/gen/android -name '*.apk' -exec cp {} tauri-out/ \;
@@ -692,14 +703,19 @@ jobs:
           ls -lh tauri-out/
 
       - uses: actions/upload-artifact@v7
+        if: github.event_name != 'pull_request'
         with:
           name: tauri-android
           path: tauri-out/*
 
-  # ── Build Tauri app (iOS, non-PR only) ──────────────────────────────
+  # ── Build Tauri app (iOS) ────────────────────────────────────────────
   build-tauri-ios:
-    needs: [test-frontend]
-    if: ${{ !failure() && !cancelled() && github.event_name != 'pull_request' }}
+    needs: [test-frontend, detect-changes]
+    if: >-
+      !failure() && !cancelled() && (
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.app == 'true'
+      )
     runs-on: macos-latest
     steps:
       - name: Check for Apple signing secrets
@@ -823,6 +839,9 @@ jobs:
       - clippy-windows
       - build-windows
       - build-tauri
+      - build-tauri-windows
+      - build-tauri-android
+      - build-tauri-ios
     runs-on: ubuntu-latest
     steps:
       - name: Check for failures

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh && echo "$HOME/.local/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v6
 
       - name: Check skills index is up to date
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,7 +464,7 @@ jobs:
           path: target/x86_64-pc-windows-msvc/release/vesta.exe
 
   # ── Build Tauri app (unix) ────────────────────────────────────────────
-  build-tauri:
+  build-tauri-unix:
     needs: [test-frontend, detect-changes, build-vestad]
     if: >-
       !failure() && !cancelled() && (
@@ -838,7 +838,7 @@ jobs:
       - test-linux
       - clippy-windows
       - build-windows
-      - build-tauri
+      - build-tauri-unix
       - build-tauri-windows
       - build-tauri-android
       - build-tauri-ios
@@ -883,7 +883,7 @@ jobs:
 
   # ── Upload artifacts to release and publish ──────────────────────────
   release:
-    needs: [build-vesta, build-vestad, test-frontend, test-integration, test-linux, build-windows, build-tauri, build-tauri-windows, build-tauri-android, build-tauri-ios, push-image]
+    needs: [build-vesta, build-vestad, test-frontend, test-integration, test-linux, build-windows, build-tauri-unix, build-tauri-windows, build-tauri-android, build-tauri-ios, push-image]
     if: ${{ !failure() && !cancelled() && github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh && echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Lint
         working-directory: agent

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh && echo "$HOME/.local/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v6
 
       - name: Check lockfile is up to date
         working-directory: agent
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh && echo "$HOME/.local/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v6
 
       - name: Lint
         working-directory: agent

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh && echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Check lockfile is up to date
         working-directory: agent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,7 +2381,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta"
-version = "0.1.128"
+version = "0.1.129"
 dependencies = [
  "clap",
  "dirs",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "vesta-tests"
-version = "0.1.128"
+version = "0.1.129"
 dependencies = [
  "ring",
  "rustls",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "vestad"
-version = "0.1.128"
+version = "0.1.129"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["app/src-tauri"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.128"
+version = "0.1.129"
 license = "MIT"
 repository = "https://github.com/elyxlz/vesta"
 authors = ["elyxlz"]

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vesta"
-version = "0.1.128"
+version = "0.1.129"
 description = "Personal assistant agent that works autonomously on your behalf"
 license = "MIT"
 authors = [

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.128"
+version = "0.1.129"
 source = { editable = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vesta",
   "private": true,
-  "version": "0.1.128",
+  "version": "0.1.129",
   "description": "Vesta app",
   "license": "MIT",
   "repository": {

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4743,7 +4743,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta-app"
-version = "0.1.128"
+version = "0.1.129"
 dependencies = [
  "objc2",
  "objc2-foundation",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vesta-app"
-version = "0.1.128"
+version = "0.1.129"
 description = "Vesta desktop app"
 license = "MIT"
 repository = "https://github.com/elyxlz/vesta"

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ mod fps_unlock;
 
 #[tauri::command]
 fn set_theme(window: tauri::Window, theme: String) {
-    #[cfg(not(target_os = "ios"))]
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     {
         let tauri_theme = match theme.as_str() {
             "dark" => Some(tauri::Theme::Dark),
@@ -12,7 +12,7 @@ fn set_theme(window: tauri::Window, theme: String) {
         };
         let _ = window.set_theme(tauri_theme);
     }
-    #[cfg(target_os = "ios")]
+    #[cfg(any(target_os = "ios", target_os = "android"))]
     let _ = (window, theme);
 }
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -107,7 +107,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|_app| {
-            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            #[cfg(not(target_os = "android"))]
             use tauri::Manager;
 
             #[cfg(any(target_os = "macos", target_os = "windows"))]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -107,6 +107,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|_app| {
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
             use tauri::Manager;
 
             #[cfg(any(target_os = "macos", target_os = "windows"))]

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Vesta",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "identifier": "com.vestarun.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Fix `set_theme` cfg guard in `app/src-tauri/src/lib.rs` to exclude Android (not just iOS) — this caused the Android build to fail on master after merge
- Run Android, iOS, and Windows Tauri builds on PRs when `app/**` changes, so platform-specific compilation errors are caught before merge
- Add all Tauri build jobs to `merge-gate-ci`
- Skip artifact collection/upload on PRs (only need to verify compilation)

## Test plan
- [ ] CI passes — Android, iOS, Windows Tauri builds should now run on this PR since it touches `app/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)