### PR TITLE
fix(vestad): block agents from changing their own settings

### DIFF
--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1102,8 +1102,17 @@ struct PatchAgentSettingsBody {
 async fn patch_agent_settings_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
+    headers: axum::http::HeaderMap,
     Json(body): Json<PatchAgentSettingsBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    // Reject requests from the agent itself — agents must not change their own settings.
+    if let Some(provided) = headers.get("x-agent-token").and_then(|v| v.to_str().ok()) {
+        let (_, expected) = docker::read_agent_port_and_token(&name, &state.env_config.agents_dir);
+        if expected.as_deref() == Some(provided) {
+            return Err(err_response(StatusCode::FORBIDDEN, "agents cannot modify their own settings"));
+        }
+    }
+
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
 


### PR DESCRIPTION
## Summary
- Agents in containers use host networking and have access to `VESTAD_PORT`, so they can reach the settings PATCH endpoint
- Added a check to `patch_agent_settings_handler` that rejects requests carrying a valid `X-Agent-Token` for the target agent, returning 403 Forbidden
- Prevents agents from toggling `manage_agent_code` (or any future settings) on themselves

## Test plan
- [x] `cargo clippy -p vestad` passes
- [x] `cargo test -p vestad` passes (64/64, 1 pre-existing network flake)
- [ ] Deploy and verify agent curl to PATCH `/agents/{name}/settings` with `X-Agent-Token` header returns 403
- [ ] Verify CLI/app can still change settings (no `X-Agent-Token` header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)