### PR TITLE
perf(ci): parallelize Tauri builds across all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
 
   # ── Build Windows CLI (native MSVC) ──────────────────────────────────
   build-windows:
-    needs: [clippy-windows, detect-changes]
+    needs: [version-check, detect-changes]
     if: >-
       !failure() && !cancelled() && (
       needs.detect-changes.outputs.cli == 'true' ||
@@ -463,9 +463,9 @@ jobs:
           name: windows-cli-exe
           path: target/x86_64-pc-windows-msvc/release/vesta.exe
 
-  # ── Build Tauri app (unix) ────────────────────────────────────────────
-  build-tauri-unix:
-    needs: [test-frontend, detect-changes, build-vestad]
+  # ── Build Tauri app (macOS) ───────────────────────────────────────────
+  build-tauri-macos:
+    needs: [test-frontend, detect-changes]
     if: >-
       !failure() && !cancelled() && (
       github.event_name != 'pull_request' ||
@@ -476,12 +476,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            bundles: deb,rpm
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
-            bundles: deb,rpm
           - target: aarch64-apple-darwin
             os: macos-latest
             bundles: dmg
@@ -507,23 +501,92 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install frontend deps
+        working-directory: app
+        run: npm install
+
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: app
+          tauriScript: npx tauri
+          args: --target ${{ matrix.target }} --bundles ${{ matrix.bundles }}
+
+      - name: Collect artifacts
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p tauri-out
+          find app/src-tauri/target/${{ matrix.target }}/release/bundle \
+            -type f \( -name '*.dmg' -o -name '*.tar.gz' -o -name '*.sig' \) \
+            -exec cp {} tauri-out/ \;
+          ARCH_PREFIX=$(echo "${{ matrix.target }}" | cut -d'-' -f1)
+          for f in tauri-out/Vesta.app.tar.gz*; do
+            [ -f "$f" ] && mv "$f" "${f/Vesta.app/Vesta_${ARCH_PREFIX}.app}"
+          done
+          [ "$(ls -A tauri-out)" ] || { echo "No artifacts collected"; exit 1; }
+
+      - uses: actions/upload-artifact@v7
+        if: github.event_name != 'pull_request'
+        with:
+          name: tauri-${{ matrix.target }}
+          path: tauri-out/*
+
+  # ── Build Tauri app (Linux — needs vestad bundled) ──────────────────
+  build-tauri-linux:
+    needs: [test-frontend, detect-changes, build-vestad]
+    if: >-
+      !failure() && !cancelled() && (
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.cli == 'true' ||
+      needs.detect-changes.outputs.app == 'true'
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            bundles: deb,rpm
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            bundles: deb,rpm
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: app/src-tauri
+          key: ${{ matrix.target }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Install Linux deps
-        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             build-essential pkg-config \
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev
 
-      - name: Bundle vestad (Linux)
-        if: runner.os == 'Linux'
+      - name: Bundle vestad
         uses: actions/download-artifact@v8
         with:
           name: vestad-${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-unknown-linux-gnu' || 'x86_64-unknown-linux-gnu' }}
           path: /tmp/vestad-artifact
 
-      - name: Install vestad into resources (Linux)
-        if: runner.os == 'Linux'
+      - name: Install vestad into resources
         run: |
           tar -xzf /tmp/vestad-artifact/vestad-*.tar.gz -C /tmp/vestad-artifact/
           mkdir -p app/src-tauri/resources
@@ -550,13 +613,8 @@ jobs:
         run: |
           mkdir -p tauri-out
           find app/src-tauri/target/${{ matrix.target }}/release/bundle \
-            -type f \( -name '*.deb' -o -name '*.rpm' -o -name '*.dmg' -o -name '*.tar.gz' -o -name '*.sig' \) \
+            -type f \( -name '*.deb' -o -name '*.rpm' -o -name '*.tar.gz' -o -name '*.sig' \) \
             -exec cp {} tauri-out/ \;
-          # Disambiguate macOS updater artifacts by architecture (both builds produce Vesta.app.tar.gz)
-          ARCH_PREFIX=$(echo "${{ matrix.target }}" | cut -d'-' -f1)
-          for f in tauri-out/Vesta.app.tar.gz*; do
-            [ -f "$f" ] && mv "$f" "${f/Vesta.app/Vesta_${ARCH_PREFIX}.app}"
-          done
           [ "$(ls -A tauri-out)" ] || { echo "No artifacts collected"; exit 1; }
 
       - uses: actions/upload-artifact@v7
@@ -567,7 +625,7 @@ jobs:
 
   # ── Build Tauri app (Windows) ─────────────────────────────────────────
   build-tauri-windows:
-    needs: [build-windows, detect-changes]
+    needs: [test-frontend, detect-changes]
     if: >-
       !failure() && !cancelled() && (
       github.event_name != 'pull_request' ||
@@ -838,7 +896,8 @@ jobs:
       - test-linux
       - clippy-windows
       - build-windows
-      - build-tauri-unix
+      - build-tauri-macos
+      - build-tauri-linux
       - build-tauri-windows
       - build-tauri-android
       - build-tauri-ios
@@ -883,7 +942,7 @@ jobs:
 
   # ── Upload artifacts to release and publish ──────────────────────────
   release:
-    needs: [build-vesta, build-vestad, test-frontend, test-integration, test-linux, build-windows, build-tauri-unix, build-tauri-windows, build-tauri-android, build-tauri-ios, push-image]
+    needs: [build-vesta, build-vestad, test-frontend, test-integration, test-linux, build-windows, build-tauri-macos, build-tauri-linux, build-tauri-windows, build-tauri-android, build-tauri-ios, push-image]
     if: ${{ !failure() && !cancelled() && github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Split `build-tauri-unix` into `build-tauri-macos` and `build-tauri-linux` — macOS no longer waits for `build-vestad` (only Linux bundles it)
- Unblock `build-tauri-windows` from `build-windows` — no artifact dependency, was pure serial waste
- Unblock `build-windows` from `clippy-windows` — lint shouldn't gate builds, both run in parallel now

All 5 Tauri platform builds (macOS x2, Windows, Android, iOS) now start as soon as `test-frontend` passes (~1min), instead of waiting 5-8min for vestad/clippy chains.

## Test plan
- [ ] CI passes — all Tauri builds should start earlier and complete in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)