### PR TITLE
ci: add vite base path check for Cloudflare

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -93,7 +93,7 @@ jobs:
             echo '❌ app/vite.config.ts has base: "./" — must be "/" for Cloudflare deployments'
             exit 1
           fi
-          echo '✓ vite base path is correct'
+          echo '✅ vite base path is correct'
 
   # ── Merge gate (single required check for branch protection) ─────────
   merge-gate-pr:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -81,10 +81,24 @@ jobs:
       # available in the Docker build environment. Compilation is verified
       # by the container image build in CI.
 
+  vite-base-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Ensure vite base is "/" (required for Cloudflare Pages)
+        run: |
+          if grep -q 'base:\s*"\.\/"' app/vite.config.ts; then
+            echo '❌ app/vite.config.ts has base: "./" — must be "/" for Cloudflare deployments'
+            exit 1
+          fi
+          echo '✓ vite base path is correct'
+
   # ── Merge gate (single required check for branch protection) ─────────
   merge-gate-pr:
     if: always()
-    needs: [lockfile, agent-tests, go-checks]
+    needs: [lockfile, agent-tests, go-checks, vite-base-check]
     runs-on: ubuntu-latest
     steps:
       - name: Check for failures


### PR DESCRIPTION
## Summary
- Adds a CI check on PRs that fails if `app/vite.config.ts` has `base: "./"` instead of `base: "/"`
- Relative base path breaks Cloudflare Pages deployments on vesta.run
- Added to the merge gate so PRs can't land with the wrong value

## Test plan
- [ ] Verify the check passes on this PR (base is currently `"/"`)
- [ ] Confirm merge-gate includes the new job

🤖 Generated with [Claude Code](https://claude.com/claude-code)