### PR TITLE
fix(vestad): always write settings.json to disk on startup

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -93,7 +93,7 @@ jobs:
             echo '❌ app/vite.config.ts has base: "./" — must be "/" for Cloudflare deployments'
             exit 1
           fi
-          echo '✓ vite base path is correct'
+          echo '✅ vite base path is correct'
 
   # ── Merge gate (single required check for branch protection) ─────────
   merge-gate-pr:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -81,10 +81,24 @@ jobs:
       # available in the Docker build environment. Compilation is verified
       # by the container image build in CI.
 
+  vite-base-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Ensure vite base is "/" (required for Cloudflare Pages)
+        run: |
+          if grep -q 'base:\s*"\.\/"' app/vite.config.ts; then
+            echo '❌ app/vite.config.ts has base: "./" — must be "/" for Cloudflare deployments'
+            exit 1
+          fi
+          echo '✓ vite base path is correct'
+
   # ── Merge gate (single required check for branch protection) ─────────
   merge-gate-pr:
     if: always()
-    needs: [lockfile, agent-tests, go-checks]
+    needs: [lockfile, agent-tests, go-checks, vite-base-check]
     runs-on: ubuntu-latest
     steps:
       - name: Check for failures

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -719,7 +719,11 @@ fn load_settings() -> Settings {
     // Try loading unified settings.json
     if let Ok(data) = std::fs::read_to_string(&path) {
         match serde_json::from_str(&data) {
-            Ok(settings) => return settings,
+            Ok(settings) => {
+                // Re-write to persist any new fields added with defaults
+                save_settings(&settings);
+                return settings;
+            }
             Err(err) => {
                 tracing::warn!(path = %path.display(), error = %err, "corrupt settings.json, using defaults");
             }
@@ -732,7 +736,6 @@ fn load_settings() -> Settings {
     if let Ok(data) = std::fs::read_to_string(&old_services) {
         if let Ok(services) = serde_json::from_str(&data) {
             settings.services = services;
-            save_settings(&settings);
             if let Err(err) = std::fs::remove_file(&old_services) {
                 tracing::warn!(error = %err, "failed to remove old services.json after migration");
             } else {
@@ -740,6 +743,9 @@ fn load_settings() -> Settings {
             }
         }
     }
+
+    // Always write settings to disk so users can edit the file
+    save_settings(&settings);
 
     settings
 }


### PR DESCRIPTION
## Summary
- Write default `settings.json` to disk on first vestad startup, so users can stop vestad, edit the config file, and restart with their changes
- Re-write existing settings on load to persist any new fields added with defaults (forward-compatible config)

## Test plan
- [ ] Run vestad for the first time with no existing config — verify `~/.config/vesta/vestad/settings.json` is created with defaults
- [ ] Stop vestad, edit settings.json, restart — verify changes are picked up
- [ ] Upgrade vestad with new settings fields — verify they appear in the file after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)