### PR TITLE
fix: correct misleading 503 fallback error message in CLI

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -118,7 +118,7 @@ fn check_response(resp: Response<Body>) -> Result<Response<Body>, String> {
         401 => Err("invalid API key".into()),
         404 => Err(error_msg.unwrap_or_else(|| "not found".into())),
         409 => Err(error_msg.unwrap_or_else(|| "conflict".into())),
-        503 => Err(error_msg.unwrap_or_else(|| "agent not running".into())),
+        503 => Err(error_msg.unwrap_or_else(|| "vestad is not reachable — is it running?".into())),
         _ => Err(error_msg.unwrap_or_else(|| format!("server error ({})", status))),
     }
 }


### PR DESCRIPTION
## Summary
- When vestad is unreachable (e.g. user runs `vesta settings` without `vesta connect` first), a reverse proxy returns a bare 503 with no JSON body
- The fallback error message was "agent not running", which is misleading — it's vestad that's unreachable, not the agent
- Changed to "vestad is not reachable — is it running?" to correctly identify the issue

## Test plan
- [ ] Run `vesta settings okami --no-manage-code` without connecting to vestad first, verify the new error message appears
- [ ] Verify normal 503 responses from vestad (with a JSON error body) still show the server-provided message

🤖 Generated with [Claude Code](https://claude.com/claude-code)