### PR TITLE
fix(vestad): restore /dev/fuse device and SYS_ADMIN cap for FUSE mounts

### DIFF
--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -2028,6 +2028,12 @@ mod tests {
                 name: Some(restart_policy),
                 ..Default::default()
             }),
+            devices: Some(vec![bollard::models::DeviceMapping {
+                path_on_host: Some("/dev/fuse".to_string()),
+                path_in_container: Some("/dev/fuse".to_string()),
+                cgroup_permissions: Some("rwm".to_string()),
+            }]),
+            cap_add: Some(vec!["SYS_ADMIN".to_string()]),
             ..Default::default()
         };
 

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1146,6 +1146,12 @@ pub async fn create_container(docker: &Docker, cname: &str, image: &str, port: u
             ..Default::default()
         }),
         device_requests,
+        devices: Some(vec![bollard::models::DeviceMapping {
+            path_on_host: Some("/dev/fuse".to_string()),
+            path_in_container: Some("/dev/fuse".to_string()),
+            cgroup_permissions: Some("rwm".to_string()),
+        }]),
+        cap_add: Some(vec!["SYS_ADMIN".to_string()]),
         ..Default::default()
     };
 
@@ -1648,6 +1654,27 @@ async fn needs_rebuild(docker: &Docker, cname: &str, manage_code: bool) -> bool 
         .unwrap_or_default();
     if !restart.contains("unless") {
         tracing::info!(container = %cname, actual = restart, expected = RESTART_POLICY, "rebuild needed: wrong restart policy");
+        return true;
+    }
+
+    // Check /dev/fuse device
+    let devices = info.host_config.as_ref()
+        .and_then(|h| h.devices.as_deref())
+        .unwrap_or(&[]);
+    let has_fuse = devices.iter().any(|d| {
+        d.path_on_host.as_deref() == Some("/dev/fuse")
+    });
+    if !has_fuse {
+        tracing::info!(container = %cname, "rebuild needed: missing /dev/fuse device");
+        return true;
+    }
+
+    // Check SYS_ADMIN capability
+    let caps = info.host_config.as_ref()
+        .and_then(|h| h.cap_add.as_deref())
+        .unwrap_or(&[]);
+    if !caps.iter().any(|c| c == "SYS_ADMIN") {
+        tracing::info!(container = %cname, "rebuild needed: missing SYS_ADMIN capability");
         return true;
     }
 


### PR DESCRIPTION
## Summary

- Adds `/dev/fuse` device mapping and `SYS_ADMIN` capability to container `HostConfig` in `create_container`
- Adds staleness checks in `needs_rebuild` for the device and capability so existing containers auto-rebuild
- These were present in the original Python CLI (`--device /dev/fuse --cap-add SYS_ADMIN`) but lost in the Rust rewrite; required by rclone FUSE mounts (OneDrive)

## Test plan

- [ ] Verify `cargo clippy -p vestad` passes (confirmed locally)
- [ ] Create a new agent and confirm `docker inspect` shows `/dev/fuse` device and `SYS_ADMIN` cap
- [ ] Start an existing agent (created before this fix) and confirm it triggers a rebuild
- [ ] Verify rclone FUSE mount works inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)