### PR TITLE
fix: PowerShell 5.1 compatibility in Windows install script

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -95,10 +95,44 @@ jobs:
           fi
           echo '✅ vite base path is correct'
 
+  install-script-check:
+    if: github.event_name == 'pull_request'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Syntax-check install.ps1 (PowerShell 5.1)
+        shell: powershell
+        run: |
+          $errors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            "$PWD\install.ps1", [ref]$null, [ref]$errors
+          )
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Host "❌ $_" }
+            exit 1
+          }
+          Write-Host "✅ install.ps1 has no syntax errors"
+
+      - name: Check for PowerShell 5.1 incompatibilities
+        shell: powershell
+        run: |
+          $content = Get-Content install.ps1 -Raw
+          $issues = @()
+          # Join-Path with 3+ args requires PowerShell 6+
+          if ($content -match 'Join-Path\s+\S+\s+"[^"]+"\s+"[^"]+"') {
+            $issues += "Join-Path with 3+ arguments is not supported in PowerShell 5.1"
+          }
+          if ($issues.Count -gt 0) {
+            $issues | ForEach-Object { Write-Host "❌ $_" }
+            exit 1
+          }
+          Write-Host "✅ No PowerShell 5.1 compatibility issues found"
+
   # ── Merge gate (single required check for branch protection) ─────────
   merge-gate-pr:
     if: always()
-    needs: [lockfile, agent-tests, go-checks, vite-base-check]
+    needs: [lockfile, agent-tests, go-checks, vite-base-check, install-script-check]
     runs-on: ubuntu-latest
     steps:
       - name: Check for failures

--- a/install.ps1
+++ b/install.ps1
@@ -61,7 +61,7 @@ try {
 
         $BinDir = Join-Path $env:LOCALAPPDATA "vesta\bin"
         New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
-        Copy-Item (Join-Path $TmpDir "vesta-windows" "vesta.exe") -Destination (Join-Path $BinDir "vesta.exe") -Force
+        Copy-Item (Join-Path (Join-Path $TmpDir "vesta-windows") "vesta.exe") -Destination (Join-Path $BinDir "vesta.exe") -Force
 
         # Add to PATH if not already there
         $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")

--- a/install.ps1
+++ b/install.ps1
@@ -71,7 +71,7 @@ try {
         }
         $env:Path = "$BinDir;$env:Path"
 
-        Write-Host "  ✓ vesta CLI → $BinDir\vesta.exe"
+        Write-Host "  OK: vesta CLI -> $BinDir\vesta.exe"
     }
 
     if ($InstallApp) {
@@ -85,7 +85,7 @@ try {
 
         Write-Host "Running installer..."
         Start-Process -FilePath $AppExe -ArgumentList "/S" -Wait
-        Write-Host "  ✓ Vesta desktop app"
+        Write-Host "  OK: Vesta desktop app"
     }
 
     Write-Host ""


### PR DESCRIPTION
## Summary
- Fix `Join-Path` with 3 arguments in `install.ps1` — this syntax requires PowerShell 6+, but Windows ships with PowerShell 5.1 by default, causing `A positional parameter cannot be found that accepts argument 'vesta.exe'`
- Add CI check (`install-script-check`) that runs on Windows with `shell: powershell` (5.1) to syntax-check the script and detect known 5.1 incompatibilities

## Test plan
- [ ] CI `install-script-check` job passes on the PR
- [ ] Verify `irm .../install.ps1 | iex` works on a Windows machine with PowerShell 5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)