### PR TITLE
Add Karpathy guidelines and vesta-prompt-guide skill

### DIFF
--- a/.claude/skills/vesta-prompt-guide/SKILL.md
+++ b/.claude/skills/vesta-prompt-guide/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: vesta-prompt-guide
+description: >
+  Use when the user mentions changing, updating, writing, or reviewing Vesta's prompts, system prompts,
+  CLAUDE.md files, skills, skill definitions, agent instructions, or any prompt engineering work for the
+  Vesta project. TRIGGER when: user says "prompt", "system prompt", "skill", "CLAUDE.md", "instructions",
+  "agent behavior", "prompt engineering", or similar in the context of Vesta configuration.
+---
+
+# Vesta Prompt Engineering Guide
+
+Before making any changes to Vesta's prompts, system prompts, skills, CLAUDE.md files, or agent
+instructions, you MUST first fetch and review the official Claude Code prompting guides to ensure
+best practices are followed.
+
+## Required Reading Before Any Prompt Change
+
+Use the WebFetch tool to retrieve the following pages and review them for relevant guidance:
+
+1. **Claude Code Best Practices**: `https://www.anthropic.com/engineering/claude-code-best-practices`
+2. **Claude 4 Prompting Best Practices**: `https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices`
+3. **General Prompting Overview**: `https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview`
+4. **System Prompts for Claude Code SDK**: `https://docs.anthropic.com/en/docs/claude-code/sdk/modifying-system-prompts`
+
+Fetch at minimum guides #1 and #2 before proceeding. Fetch #3 and #4 if the task involves
+SDK-level system prompts or deeper prompt engineering.
+
+## Workflow
+
+1. **Fetch the guides** listed above using WebFetch
+2. **Identify relevant best practices** from the guides that apply to the current task
+3. **Review the existing prompt/skill/CLAUDE.md** that needs to change
+4. **Apply changes** following the official best practices
+5. **Explain** which best practices informed your changes and why
+
+## Key Principles to Watch For
+
+- Clear, explicit instructions over vague guidance
+- Structured prompts with proper XML tags and sections
+- Placing long context at the top, queries at the bottom
+- Using examples (multishot) where appropriate
+- Avoiding conflicting or redundant instructions
+- Testing prompt changes against expected behavior

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,4 @@ app/src-tauri/target/
 app/src-tauri/binaries/vesta-*
 app/src-tauri/resources/*.tar.gz
 app/src-tauri/resources/vestad
-.claude/settings.json
-.claude/settings.local.json
 ROADMAP.md

--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,6 @@ app/src-tauri/target/
 app/src-tauri/binaries/vesta-*
 app/src-tauri/resources/*.tar.gz
 app/src-tauri/resources/vestad
-.claude/
+.claude/settings.json
+.claude/settings.local.json
 ROADMAP.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,66 @@ Run locally on master. Bumps versions, updates lockfiles, commits, pushes, and c
 ## CI
 
 Runs on push to `master` and PRs. Checks: version sync across 5 sources (`agent/pyproject.toml`, `Cargo.toml`, `app/src-tauri/Cargo.toml`, `app/src-tauri/tauri.conf.json`, `app/package.json`), ruff, ty, cargo clippy, pytest, `uv.lock` freshness. Releases are triggered by `gh release create` (via `./release.sh`).
+
+## Karpathy Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.


### PR DESCRIPTION
## Summary
- Adds Andrej Karpathy's behavioral guidelines for LLM coding to CLAUDE.md (think before coding, simplicity first, surgical changes, goal-driven execution)
- Adds `vesta-prompt-guide` skill that auto-triggers when working on Vesta's prompts/skills, fetching official Claude Code prompting guides before making changes
- Updates `.gitignore` to track `.claude/skills/` while keeping settings files ignored

## Test plan
- [x] Guidelines appended to existing CLAUDE.md without modifying prior sections
- [x] Skill file added at `.claude/skills/vesta-prompt-guide/SKILL.md`
- [x] `.gitignore` only ignores `.claude/settings.json` and `.claude/settings.local.json`
- [ ] Verify Claude Code picks up the new guidelines and skill in future sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)