### PR TITLE
fix(dashboard): use relative base path in vite config

### DIFF
--- a/agent/skills/dashboard/app/vite.config.ts
+++ b/agent/skills/dashboard/app/vite.config.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  base: "/",
+  base: "./",
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- Change vite `base` from `"/"` to `"./"` so dashboard assets resolve correctly regardless of the serving path

## Test plan
- [ ] Verify dashboard loads correctly when served from a non-root path

🤖 Generated with [Claude Code](https://claude.com/claude-code)