### PR TITLE
fix(install): parse DMG mount point containing spaces

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -198,7 +198,7 @@ main() {
     verify_checksum "$dmg_path" "$artifact"
 
     local mount_point
-    mount_point=$(hdiutil attach "$dmg_path" -nobrowse -noautoopen 2>/dev/null | grep '/Volumes/' | awk '{print $NF}')
+    mount_point=$(hdiutil attach "$dmg_path" -nobrowse -noautoopen 2>/dev/null | grep -o '/Volumes/.*' | head -1)
     if [ -d "$mount_point/Vesta.app" ]; then
       rm -rf /Applications/Vesta.app
       cp -R "$mount_point/Vesta.app" /Applications/


### PR DESCRIPTION
## Summary
- `install.sh` parsed the hdiutil mount point with `awk '{print $NF}'`, which breaks when macOS appends a numeric suffix to an already-mounted volume (e.g. `/Volumes/Vesta 2`) — only `2` was captured, so `Vesta.app` was never found and the install silently skipped the app.
- Switched to `grep -o '/Volumes/.*'` so the full path is preserved regardless of spaces.

Fixes #243

## Test plan
- [x] Reproduced on macOS with a stale `/Volumes/Vesta` mount — old parser returned `2`, new parser returns the full path.
- [x] Clean mount still resolves to `/Volumes/Vesta` and `Vesta.app` is found.
- [ ] Re-run `curl -fsSL .../install.sh | bash -s -- --app` on a fresh machine.