### PR TITLE
fix(app): gateway update survives vestad restart

### DIFF
--- a/app/src/components/VersionMismatchDialog/index.tsx
+++ b/app/src/components/VersionMismatchDialog/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Footer } from "@/components/Footer";
 import { LogoText } from "@/components/Logo/LogoText";
 import { Navbar } from "@/components/Navbar";
@@ -12,11 +12,11 @@ import {
   EmptyTitle,
   EmptyDescription,
 } from "@/components/ui/empty";
-import { apiFetch } from "@/api/client";
 import { isTauri } from "@/lib/env";
 
 interface VersionMismatchDialogProps {
   gatewayVersion: string;
+  onUpdateGateway: () => void;
 }
 
 async function updateApp(gatewayVersion: string) {
@@ -41,21 +41,22 @@ async function updateApp(gatewayVersion: string) {
 
 export function VersionMismatchDialog({
   gatewayVersion,
+  onUpdateGateway,
 }: VersionMismatchDialogProps) {
   const appIsOlder = gatewayVersion > __APP_VERSION__;
   const hint = appIsOlder ? "update your app" : "update your gateway";
   const [updating, setUpdating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleUpdateGateway = async () => {
+  // Reset if gateway version changes (e.g. update failed, vestad restarted with old version)
+  useEffect(() => {
+    setUpdating(false);
+  }, [gatewayVersion]);
+
+  const handleUpdateGateway = () => {
     setUpdating(true);
     setError(null);
-    try {
-      await apiFetch("/self-update", { method: "POST" });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "update failed");
-      setUpdating(false);
-    }
+    onUpdateGateway();
   };
 
   const handleUpdateApp = async () => {

--- a/app/src/providers/GatewayProvider/index.tsx
+++ b/app/src/providers/GatewayProvider/index.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { apiFetch } from "@/api/client";
 import { getConnection, authHeaders } from "@/lib/connection";
 import { ensureFreshToken } from "@/lib/token-refresh";
 import { useAuth } from "@/providers/AuthProvider";
@@ -24,6 +25,7 @@ interface GatewayContextValue {
   agents: AgentInfo[];
   agentsFetched: boolean;
   send: (event: object) => boolean;
+  triggerGatewayUpdate: () => void;
 }
 
 const GatewayContext = createContext<GatewayContextValue | null>(null);
@@ -37,6 +39,7 @@ const disconnectedValue: GatewayContextValue = {
   agents: [],
   agentsFetched: false,
   send: () => false,
+  triggerGatewayUpdate: () => {},
 };
 
 function controlWsUrl(): string {
@@ -52,10 +55,22 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
   const [gatewayVersion, setGatewayVersion] = useState("");
   const [gatewayBranch, setGatewayBranch] = useState<string | null>(null);
   const [gatewayPort, setGatewayPort] = useState(0);
+
   const [versionChecked, setVersionChecked] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   const [agentsFetched, setAgentsFetched] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
+
+  const [connectEpoch, setConnectEpoch] = useState(0);
+  const skipVersionGateRef = useRef(false);
+
+  const triggerGatewayUpdate = () => {
+    apiFetch("/self-update", { method: "POST" }).catch((err) => {
+      console.warn("[gateway] self-update request failed:", err);
+    });
+    skipVersionGateRef.current = true;
+    setConnectEpoch((e) => e + 1);
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -91,8 +106,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
               setGatewayVersion(data.version);
               setGatewayBranch(data.branch || null);
               setVersionChecked(true);
-              // Skip WS if version mismatch — the dialog will render instead
-              if (data.version !== __APP_VERSION__) return;
+              if (data.version !== __APP_VERSION__ && !skipVersionGateRef.current) return;
             }
           }
         }
@@ -121,6 +135,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
             case "hello": {
               setGatewayVersion(msg.version ?? "");
               setGatewayPort(msg.port ?? 0);
+              skipVersionGateRef.current = false;
               break;
             }
             case "agents": {
@@ -158,7 +173,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
       }
       wsRef.current = null;
     };
-  }, []);
+  }, [connectEpoch]);
 
   const send = (event: object): boolean => {
     const ws = wsRef.current;
@@ -181,10 +196,14 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
         agents,
         agentsFetched,
         send,
+        triggerGatewayUpdate,
       }}
     >
       {versionMismatch ? (
-        <VersionMismatchDialog gatewayVersion={gatewayVersion} />
+        <VersionMismatchDialog
+          gatewayVersion={gatewayVersion}
+          onUpdateGateway={triggerGatewayUpdate}
+        />
       ) : (
         children
       )}


### PR DESCRIPTION
## Summary
- Gateway update no longer fails when vestad restarts and drops the HTTP connection
- Fire-and-forget the POST /self-update instead of awaiting the response
- WebSocket auto-reconnects after restart and detects the new version via hello message
- Version mismatch dialog clears naturally when versions match

## Test plan
- [ ] Click "update your gateway" when version mismatch is shown
- [ ] Button shows spinner, vestad restarts
- [ ] After restart, WS reconnects and dialog disappears (versions now match)
- [ ] No error is shown during the process