### PR TITLE
fix(app): fall back to normal radius when squircle unsupported

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -47,6 +47,13 @@
     --page-padding-x: 1.5rem;
 }
 
+@supports not (corner-shape: squircle) {
+    :root {
+        --rounded-squircle-lg: calc(var(--radius) * 2.2);
+        --rounded-squircle-md: calc(var(--radius) * 1.8);
+    }
+}
+
 .vibrancy {
     --background: oklch(0.995 0.005 80 / 50%);
     --card: oklch(0.995 0.005 80 / 50%);

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -49,8 +49,8 @@
 
 @supports not (corner-shape: squircle) {
     :root {
-        --rounded-squircle-lg: calc(var(--radius) * 2.2);
-        --rounded-squircle-md: calc(var(--radius) * 1.8);
+        --rounded-squircle-lg: calc(var(--radius) * 3);
+        --rounded-squircle-md: calc(var(--radius) * 2.6);
     }
 }
 


### PR DESCRIPTION
## Summary
- Wrap `--rounded-squircle-lg`/`--rounded-squircle-md` in `@supports not (corner-shape: squircle)` so browsers without squircle support (Safari/WKWebView) collapse back to the normal radius scale (`radius * 2.2` / `radius * 1.8`) instead of rendering the raw 64px/56px pill shapes.

## Test plan
- [ ] Open the app in a squircle-supporting Chromium build → cards keep the squircle shape
- [ ] Open the app in Safari / Tauri WKWebView → cards render with normal rounded corners (not giant pills)