### PR TITLE
feat(app): typing indicator with TTS prefetch for chat

### DIFF
--- a/app/src/components/Chat/ChatMessageArea/index.tsx
+++ b/app/src/components/Chat/ChatMessageArea/index.tsx
@@ -20,7 +20,7 @@ interface ChatMessageAreaProps {
   chatMessages: VestaEvent[];
   connected: boolean;
   agentName: string;
-  isThinking: boolean;
+  isTyping: boolean;
 }
 
 export function ChatMessageArea({
@@ -34,7 +34,7 @@ export function ChatMessageArea({
   chatMessages,
   connected,
   agentName,
-  isThinking,
+  isTyping,
 }: ChatMessageAreaProps) {
   return (
     <CardContent className="flex-1 min-h-0 overflow-hidden p-0 relative">
@@ -66,7 +66,7 @@ export function ChatMessageArea({
         }}
       >
         <div ref={bottomRef} className="h-px shrink-0" />
-        {isThinking && (
+        {isTyping && (
           <div className="flex justify-start mt-2">
             <div className="flex items-center gap-1 bg-muted rounded-2xl rounded-bl-sm px-3.5 py-2.5">
               <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:0ms]" />

--- a/app/src/components/Chat/index.tsx
+++ b/app/src/components/Chat/index.tsx
@@ -142,7 +142,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
       setInput("");
       const ta = textareaRef.current;
       if (ta) ta.style.height = "auto";
-      scrollToBottom();
+      requestAnimationFrame(scrollToBottom);
     }
   };
 

--- a/app/src/components/Chat/index.tsx
+++ b/app/src/components/Chat/index.tsx
@@ -41,7 +41,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
 
   const {
     messages,
-    agentState,
+    isTyping,
     connected,
     hasMore,
     loadingMore,
@@ -98,7 +98,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     [messages, showToolCalls],
   );
 
-  const isThinking = agentState === "thinking";
   const lastMsgRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -198,7 +197,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
           chatMessages={chatMessages}
           connected={connected}
           agentName={name}
-          isThinking={isThinking}
+          isTyping={isTyping}
         />
 
         <div className="relative">

--- a/app/src/lib/voice.ts
+++ b/app/src/lib/voice.ts
@@ -124,12 +124,12 @@ export const setTtsVoice = (n: string, voiceId: string) =>
 
 // --- TTS playback ---
 
-export async function streamSpeech(
+export function prefetchSpeech(
   text: string,
   agentName: string,
   signal?: AbortSignal,
-): Promise<void> {
-  const res = await apiFetch(
+): Promise<Response> {
+  return apiFetch(
     `/agents/${encodeURIComponent(agentName)}/voice/tts/speak`,
     {
       method: "POST",
@@ -138,6 +138,15 @@ export async function streamSpeech(
       signal,
     },
   );
+}
+
+export async function streamSpeech(
+  text: string,
+  agentName: string,
+  signal?: AbortSignal,
+  prefetched?: Response,
+): Promise<void> {
+  const res = prefetched ?? await prefetchSpeech(text, agentName, signal);
 
   const contentType = res.headers.get("content-type") || "";
   if (contentType.includes("audio/mpeg") || contentType.includes("audio/mp3")) {

--- a/app/src/providers/ChatProvider/index.tsx
+++ b/app/src/providers/ChatProvider/index.tsx
@@ -20,11 +20,11 @@ const ChatContext = createContext<ChatContextValue | null>(null);
 
 export function ChatProvider({ children }: { children: ReactNode }) {
   const { name, agent, setAgentState } = useSelectedAgent();
-  const { speak } = useVoice();
+  const { speak, prefetch } = useVoice();
   const [showToolCalls, setShowToolCalls] = useState(false);
 
   const ready = agent?.status === "alive";
-  const chat = useChat({ name, active: ready, onAssistantMessage: speak });
+  const chat = useChat({ name, active: ready, onAssistantMessage: speak, onPrefetch: prefetch });
 
   useEffect(() => {
     setAgentState(chat.agentState);

--- a/app/src/providers/ChatProvider/use-chat.ts
+++ b/app/src/providers/ChatProvider/use-chat.ts
@@ -6,6 +6,17 @@ const RECONNECT_BASE = 1000;
 const RECONNECT_MAX = 30000;
 const MAX_MESSAGES = 5000;
 
+const TYPING_DELAY_PER_CHAR = 25;
+const TYPING_DELAY_MIN = 1500;
+const TYPING_DELAY_MAX = 6000;
+const TYPING_VARIANCE = 0.2;
+
+function typingDelay(charCount: number): number {
+  const raw = Math.min(TYPING_DELAY_MIN + TYPING_DELAY_PER_CHAR * charCount, TYPING_DELAY_MAX);
+  const variance = Math.floor(raw * TYPING_VARIANCE);
+  return raw + Math.floor(Math.random() * variance * 2) - variance;
+}
+
 // Module-level sender so non-descendant components (Settings, etc.) can push
 // typed events over the already-open chat WebSocket without opening their
 // own connection.
@@ -23,6 +34,7 @@ interface UseChatOptions {
 export function useChat({ name, active, onAssistantMessage }: UseChatOptions) {
   const [messages, setMessages] = useState<VestaEvent[]>([]);
   const [agentState, setAgentState] = useState<AgentActivityState>("idle");
+  const [isTyping, setIsTyping] = useState(false);
   const [connected, setConnected] = useState(false);
   const [historyLoaded, setHistoryLoaded] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -33,6 +45,38 @@ export function useChat({ name, active, onAssistantMessage }: UseChatOptions) {
   const cursorRef = useRef<number | null>(null);
   const onAssistantMessageRef = useRef(onAssistantMessage);
   onAssistantMessageRef.current = onAssistantMessage;
+  const chatQueueRef = useRef<VestaEvent[]>([]);
+  const drainingRef = useRef(false);
+  const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const drainQueue = useCallback(() => {
+    if (drainingRef.current) return;
+    const next = chatQueueRef.current[0];
+    if (!next) {
+      setIsTyping(false);
+      return;
+    }
+    drainingRef.current = true;
+    setIsTyping(true);
+    const delay = typingDelay((next as { text?: string }).text?.length ?? 0);
+    typingTimerRef.current = setTimeout(() => {
+      chatQueueRef.current.shift();
+      setMessages((prev) => {
+        const updated = [...prev, next];
+        return updated.length > MAX_MESSAGES ? updated.slice(-MAX_MESSAGES) : updated;
+      });
+      if ((next as { text?: string }).text) {
+        onAssistantMessageRef.current?.((next as { text: string }).text);
+      }
+      drainingRef.current = false;
+      drainQueue();
+    }, delay);
+  }, []);
+
+  const enqueueChatMessage = useCallback((event: VestaEvent) => {
+    chatQueueRef.current.push(event);
+    drainQueue();
+  }, [drainQueue]);
 
   useEffect(() => {
     if (!active || !name) return;
@@ -46,6 +90,10 @@ export function useChat({ name, active, onAssistantMessage }: UseChatOptions) {
     setHistoryLoaded(false);
     cursorRef.current = null;
     pendingEchoesRef.current = [];
+    if (typingTimerRef.current) clearTimeout(typingTimerRef.current);
+    chatQueueRef.current = [];
+    drainingRef.current = false;
+    setIsTyping(false);
 
     const doConnect = () => {
       if (cancelled) return;
@@ -94,14 +142,15 @@ export function useChat({ name, active, onAssistantMessage }: UseChatOptions) {
               return;
             }
           }
-          setMessages((prev) => {
-            const updated = [...prev, event];
-            return updated.length > MAX_MESSAGES
-              ? updated.slice(-MAX_MESSAGES)
-              : updated;
-          });
-          if (event.type === "chat" && event.text) {
-            onAssistantMessageRef.current?.(event.text);
+          if (event.type === "chat") {
+            enqueueChatMessage(event);
+          } else {
+            setMessages((prev) => {
+              const updated = [...prev, event];
+              return updated.length > MAX_MESSAGES
+                ? updated.slice(-MAX_MESSAGES)
+                : updated;
+            });
           }
           if (event.type === "status") {
             setAgentState(event.state);
@@ -136,6 +185,10 @@ export function useChat({ name, active, onAssistantMessage }: UseChatOptions) {
       }
       wsRef.current = null;
       setConnected(false);
+      if (typingTimerRef.current) clearTimeout(typingTimerRef.current);
+      chatQueueRef.current = [];
+      drainingRef.current = false;
+      setIsTyping(false);
     };
   }, [active, name]);
 
@@ -192,6 +245,7 @@ export function useChat({ name, active, onAssistantMessage }: UseChatOptions) {
   return {
     messages,
     agentState,
+    isTyping,
     connected,
     historyLoaded,
     hasMore,

--- a/app/src/providers/ChatProvider/use-chat.ts
+++ b/app/src/providers/ChatProvider/use-chat.ts
@@ -49,29 +49,50 @@ export function useChat({ name, active, onAssistantMessage }: UseChatOptions) {
   const drainingRef = useRef(false);
   const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const flushQueue = useCallback(() => {
+    for (const event of chatQueueRef.current) {
+      setMessages((prev) => {
+        const updated = [...prev, event];
+        return updated.length > MAX_MESSAGES ? updated.slice(-MAX_MESSAGES) : updated;
+      });
+      if (event.type === "chat") {
+        onAssistantMessageRef.current?.(event.text);
+      }
+    }
+    chatQueueRef.current = [];
+    drainingRef.current = false;
+    setIsTyping(false);
+  }, []);
+
   const drainQueue = useCallback(() => {
     if (drainingRef.current) return;
-    const next = chatQueueRef.current[0];
-    if (!next) {
+    const queue = chatQueueRef.current;
+    if (queue.length === 0) {
       setIsTyping(false);
       return;
     }
+    if (queue.length > 3) {
+      flushQueue();
+      return;
+    }
+    const next = queue[0];
     drainingRef.current = true;
     setIsTyping(true);
-    const delay = typingDelay((next as { text?: string }).text?.length ?? 0);
+    const text = next.type === "chat" ? next.text : undefined;
+    const delay = typingDelay(text?.length ?? 0);
     typingTimerRef.current = setTimeout(() => {
-      chatQueueRef.current.shift();
+      queue.shift();
       setMessages((prev) => {
         const updated = [...prev, next];
         return updated.length > MAX_MESSAGES ? updated.slice(-MAX_MESSAGES) : updated;
       });
-      if ((next as { text?: string }).text) {
-        onAssistantMessageRef.current?.((next as { text: string }).text);
+      if (text) {
+        onAssistantMessageRef.current?.(text);
       }
       drainingRef.current = false;
       drainQueue();
     }, delay);
-  }, []);
+  }, [flushQueue]);
 
   const enqueueChatMessage = useCallback((event: VestaEvent) => {
     chatQueueRef.current.push(event);
@@ -118,6 +139,10 @@ export function useChat({ name, active, onAssistantMessage }: UseChatOptions) {
         setMessages([]);
         cursorRef.current = null;
         pendingEchoesRef.current = [];
+        if (typingTimerRef.current) clearTimeout(typingTimerRef.current);
+        chatQueueRef.current = [];
+        drainingRef.current = false;
+        setIsTyping(false);
       };
 
       socket.onmessage = (e) => {

--- a/app/src/providers/ChatProvider/use-chat.ts
+++ b/app/src/providers/ChatProvider/use-chat.ts
@@ -29,9 +29,10 @@ interface UseChatOptions {
   name: string | null;
   active: boolean;
   onAssistantMessage?: (text: string) => void;
+  onPrefetch?: (text: string) => void;
 }
 
-export function useChat({ name, active, onAssistantMessage }: UseChatOptions) {
+export function useChat({ name, active, onAssistantMessage, onPrefetch }: UseChatOptions) {
   const [messages, setMessages] = useState<VestaEvent[]>([]);
   const [agentState, setAgentState] = useState<AgentActivityState>("idle");
   const [isTyping, setIsTyping] = useState(false);
@@ -45,6 +46,8 @@ export function useChat({ name, active, onAssistantMessage }: UseChatOptions) {
   const cursorRef = useRef<number | null>(null);
   const onAssistantMessageRef = useRef(onAssistantMessage);
   onAssistantMessageRef.current = onAssistantMessage;
+  const onPrefetchRef = useRef(onPrefetch);
+  onPrefetchRef.current = onPrefetch;
   const chatQueueRef = useRef<VestaEvent[]>([]);
   const drainingRef = useRef(false);
   const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -79,6 +82,7 @@ export function useChat({ name, active, onAssistantMessage }: UseChatOptions) {
     drainingRef.current = true;
     setIsTyping(true);
     const text = next.type === "chat" ? next.text : undefined;
+    if (text) onPrefetchRef.current?.(text);
     const delay = typingDelay(text?.length ?? 0);
     typingTimerRef.current = setTimeout(() => {
       queue.shift();

--- a/app/src/stores/use-voice.ts
+++ b/app/src/stores/use-voice.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import {
   Transcriber,
+  prefetchSpeech,
   streamSpeech,
   fetchSttStatus,
   fetchTtsStatus,
@@ -32,6 +33,7 @@ interface VoiceState {
 
   // Actions
   toggleVoice: () => void;
+  prefetch: (text: string) => void;
   speak: (text: string) => void;
   stopSpeech: () => void;
   registerChatCallbacks: (
@@ -63,6 +65,7 @@ let draftCallback: ((text: string) => void) | null = null;
 let ttsAbort: AbortController | null = null;
 let ttsQueue: string[] = [];
 let ttsProcessing = false;
+const ttsPrefetchCache = new Map<string, Promise<Response>>();
 
 function deriveStatus(stt: SttStatus | null, tts: TtsStatus | null) {
   const sttAvailable = (stt?.configured && stt?.enabled) ?? false;
@@ -85,7 +88,10 @@ export const useVoice = create<VoiceState>((set, get) => {
       const controller = new AbortController();
       ttsAbort = controller;
       try {
-        await streamSpeech(text, agentName, controller.signal);
+        const cached = ttsPrefetchCache.get(text);
+        ttsPrefetchCache.delete(text);
+        const prefetched = cached ? await cached.catch(() => undefined) : undefined;
+        await streamSpeech(text, agentName, controller.signal, prefetched);
       } catch (err) {
         if (!controller.signal.aborted) {
           console.warn("[tts] playback failed:", err);
@@ -180,6 +186,14 @@ export const useVoice = create<VoiceState>((set, get) => {
         });
     },
 
+    prefetch: (text: string) => {
+      const { speechEnabled, agentName } = get();
+      if (!speechEnabled || !agentName) return;
+      if (ttsPrefetchCache.has(text)) return;
+      console.debug("[tts] prefetching:", text.slice(0, 60));
+      ttsPrefetchCache.set(text, prefetchSpeech(text, agentName));
+    },
+
     speak: (text: string) => {
       const { speechEnabled, agentName } = get();
       if (!speechEnabled || !agentName) return;
@@ -190,6 +204,7 @@ export const useVoice = create<VoiceState>((set, get) => {
 
     stopSpeech: () => {
       ttsQueue = [];
+      ttsPrefetchCache.clear();
       ttsAbort?.abort();
       ttsProcessing = false;
       set({ isSpeaking: false });


### PR DESCRIPTION
## Summary
- Adds a typing indicator (bouncing dots) with a randomized delay before chat messages render, simulating the agent "typing"
- Delay is based on message length (25ms/char, 1.5–6s range, ±20% variance)
- Prefetches TTS audio during the typing delay so playback starts instantly when the bubble appears
- Queue overflow guard: if 3+ messages back up, they flush immediately

## Changes
- **use-chat.ts**: Queue-based message delivery with typing delay, prefetch callback
- **voice.ts**: New `prefetchSpeech()` extracts the fetch from `streamSpeech()` for early invocation
- **use-voice.ts**: Prefetch cache + `prefetch` action, `processQueue` uses cached responses
- **ChatProvider**: Wires `prefetch` from voice store into `useChat`
- **ChatMessageArea**: `isThinking` → `isTyping` (driven by queue state)

## Test plan
- [ ] Send a message and verify typing dots appear before the response bubble
- [ ] Verify delay feels natural and varies between messages
- [ ] With TTS enabled, confirm audio starts immediately when the bubble renders (no extra wait)
- [ ] Send rapid messages and verify queue overflow flushes correctly (3+ queued)
- [ ] Disconnect/reconnect and verify no stale typing state

🤖 Generated with [Claude Code](https://claude.com/claude-code)