### PR TITLE
feat(dashboard): mock pages, children nav, sidebar improvements

### DIFF
--- a/agent/skills/dashboard/app/src/App.tsx
+++ b/agent/skills/dashboard/app/src/App.tsx
@@ -95,7 +95,7 @@ function DashboardContent() {
           }}
         />
         <SidebarInset>
-          <SiteHeader title={activePage?.title ?? ""} />
+          <SiteHeader title={activePage?.title ?? ""} icon={activePage?.icon} />
           <div className="@container/main overflow-y-auto flex-1 min-h-0 px-4 py-4 lg:px-6">
             {activePage?.component && <activePage.component />}
           </div>

--- a/agent/skills/dashboard/app/src/components/nav-main.tsx
+++ b/agent/skills/dashboard/app/src/components/nav-main.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react"
 import { Reorder } from "motion/react"
 import { ChevronRightIcon } from "lucide-react"
 import {
@@ -11,12 +12,18 @@ import {
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
+  useSidebar,
 } from "@/components/ui/sidebar"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 
 export type NavItem = {
   id: string
   title: string
-  icon?: React.ReactNode
+  icon?: ReactNode
   children?: NavItem[]
 }
 
@@ -88,6 +95,8 @@ function CollapsibleNavItem({
   activeId: string
   onNavigate: (id: string) => void
 }) {
+  const { state, isMobile } = useSidebar()
+  const collapsed = state === "collapsed" && !isMobile
   const hasActiveChild = item.children?.some((c) => c.id === activeId) ?? false
 
   return (
@@ -102,28 +111,47 @@ function CollapsibleNavItem({
       transition={{ duration: 0.15 }}
     >
       <Collapsible defaultOpen={hasActiveChild} className="group/collapsible">
-        <CollapsibleTrigger asChild>
-          <SidebarMenuButton tooltip={item.title}>
-            {item.icon}
-            <span>{item.title}</span>
-            <ChevronRightIcon className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90 group-data-[collapsible=icon]:hidden" />
-          </SidebarMenuButton>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <SidebarMenuSub>
-            {item.children!.map((child) => (
-              <SidebarMenuSubItem key={child.id}>
-                <SidebarMenuSubButton
-                  isActive={child.id === activeId}
-                  onClick={() => onNavigate(child.id)}
-                >
-                  {child.icon}
-                  <span>{child.title}</span>
-                </SidebarMenuSubButton>
-              </SidebarMenuSubItem>
-            ))}
-          </SidebarMenuSub>
-        </CollapsibleContent>
+        <div className="rounded-lg [[data-collapsible=icon]_&]:rounded-xl [[data-collapsible=icon]_&]:group-data-[state=open]/collapsible:ring-1 [[data-collapsible=icon]_&]:group-data-[state=open]/collapsible:ring-sidebar-border [[data-collapsible=icon]_&]:group-data-[state=open]/collapsible:my-1">
+          <CollapsibleTrigger asChild>
+            <SidebarMenuButton tooltip={item.title} className="transition-colors duration-0 group-data-[state=open]/collapsible:duration-200 [[data-collapsible=icon]_&]:group-data-[state=open]/collapsible:bg-primary/40 [[data-collapsible=icon]_&]:group-data-[state=open]/collapsible:hover:bg-primary/45">
+              {item.icon}
+              <span>{item.title}</span>
+              <ChevronRightIcon className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90 group-data-[collapsible=icon]:hidden" />
+            </SidebarMenuButton>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <SidebarMenuSub>
+              {item.children!.map((child) => (
+                <SidebarMenuSubItem key={child.id}>
+                  {collapsed ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <SidebarMenuSubButton
+                          isActive={child.id === activeId}
+                          onClick={() => onNavigate(child.id)}
+                        >
+                          {child.icon}
+                          <span>{child.title}</span>
+                        </SidebarMenuSubButton>
+                      </TooltipTrigger>
+                      <TooltipContent side="right" align="center">
+                        {child.title}
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <SidebarMenuSubButton
+                      isActive={child.id === activeId}
+                      onClick={() => onNavigate(child.id)}
+                    >
+                      {child.icon}
+                      <span>{child.title}</span>
+                    </SidebarMenuSubButton>
+                  )}
+                </SidebarMenuSubItem>
+              ))}
+            </SidebarMenuSub>
+          </CollapsibleContent>
+        </div>
       </Collapsible>
     </Reorder.Item>
   )

--- a/agent/skills/dashboard/app/src/components/shell/index.tsx
+++ b/agent/skills/dashboard/app/src/components/shell/index.tsx
@@ -26,7 +26,7 @@ export function Shell({ className, ...props }: React.ComponentProps<"div">) {
           "bg-card text-card-foreground overflow-hidden contain-paint",
           fullscreen
             ? "h-full w-full"
-            : "m-2 h-[calc(100%-1rem)] w-[calc(100%-1rem)] rounded-4xl shadow-md ring-1 ring-foreground/5 dark:ring-foreground/10",
+            : "m-2 h-[calc(100%-1rem)] w-[calc(100%-1rem)] rounded-squircle-md [corner-shape:squircle] shadow-md ring-1 ring-foreground/5 dark:ring-foreground/10",
           className,
         )}
         {...props}

--- a/agent/skills/dashboard/app/src/components/site-header.tsx
+++ b/agent/skills/dashboard/app/src/components/site-header.tsx
@@ -1,11 +1,19 @@
+import type { ReactNode } from "react"
 import { SidebarTrigger } from "@/components/ui/sidebar"
 
-export function SiteHeader({ title }: { title: string }) {
+export function SiteHeader({ title, icon }: { title: string; icon?: ReactNode }) {
   return (
     <header className="flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
-      <div className="flex w-full items-center gap-2 px-4 lg:px-6">
-        <SidebarTrigger className="-ml-1" />
-        <h1 className="text-base font-medium">{title}</h1>
+      <div className="flex w-full min-w-0 items-center gap-2 px-4 lg:px-6">
+        <SidebarTrigger className="-ml-1 shrink-0" />
+        <div className="flex min-w-0 items-center gap-2">
+          {icon ? (
+            <span className="flex shrink-0 [&_svg]:size-4 [&_svg]:shrink-0">
+              {icon}
+            </span>
+          ) : null}
+          <h1 className="truncate text-base font-medium">{title}</h1>
+        </div>
       </div>
     </header>
   )

--- a/agent/skills/dashboard/app/src/components/ui/sidebar.tsx
+++ b/agent/skills/dashboard/app/src/components/ui/sidebar.tsx
@@ -382,7 +382,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto pb-5 [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden",
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto pb-5 [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-x-hidden group-data-[collapsible=icon]:overflow-y-auto",
         className,
       )}
       {...props}
@@ -478,7 +478,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-xl px-3 py-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-xl px-3 py-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! group-data-[collapsible=icon]:[&>span]:sr-only hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
   {
     variants: {
       variant: {
@@ -678,7 +678,7 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-xl px-3 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:translate-x-0 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-xl px-3 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:translate-x-0 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2! group-data-[collapsible=icon]:[&>span]:sr-only hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
         className,
       )}
       {...props}

--- a/agent/skills/dashboard/app/src/examples/chart-area-interactive.tsx
+++ b/agent/skills/dashboard/app/src/examples/chart-area-interactive.tsx
@@ -1,34 +1,14 @@
-"use client"
-
 import * as React from "react"
 import { Area, AreaChart, CartesianGrid, XAxis } from "recharts"
 
 import { useIsMobile } from "@/hooks/use-mobile"
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
 import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import {
-  ToggleGroup,
-  ToggleGroupItem,
-} from "@/components/ui/toggle-group"
+import { Button } from "@/components/ui/button"
 
 export const description = "An interactive area chart"
 
@@ -165,127 +145,102 @@ export function ChartAreaInteractive() {
   })
 
   return (
-    <Card className="@container/card">
-      <CardHeader>
-        <CardTitle>Total Visitors</CardTitle>
-        <CardDescription>
-          <span className="hidden @[540px]/card:block">
-            Total for the last 3 months
-          </span>
-          <span className="@[540px]/card:hidden">Last 3 months</span>
-        </CardDescription>
-        <CardAction>
-          <ToggleGroup
-            type="single"
-            value={timeRange}
-            onValueChange={setTimeRange}
-            variant="outline"
-            className="hidden *:data-[slot=toggle-group-item]:px-4! @[767px]/card:flex"
-          >
-            <ToggleGroupItem value="90d">Last 3 months</ToggleGroupItem>
-            <ToggleGroupItem value="30d">Last 30 days</ToggleGroupItem>
-            <ToggleGroupItem value="7d">Last 7 days</ToggleGroupItem>
-          </ToggleGroup>
-          <Select value={timeRange} onValueChange={setTimeRange}>
-            <SelectTrigger
-              className="flex w-40 **:data-[slot=select-value]:block **:data-[slot=select-value]:truncate @[767px]/card:hidden"
+    <div className="rounded-2xl bg-secondary p-3 text-sm">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h3 className="font-medium">Total Visitors</h3>
+          <p className="text-xs text-muted-foreground">Total for the last 3 months</p>
+        </div>
+        <div className="flex gap-1">
+          {(["90d", "30d", "7d"] as const).map((range) => (
+            <Button
+              key={range}
               size="sm"
-              aria-label="Select a value"
+              variant={timeRange === range ? "default" : "ghost"}
+              className="h-7 px-2 text-xs"
+              onClick={() => setTimeRange(range)}
             >
-              <SelectValue placeholder="Last 3 months" />
-            </SelectTrigger>
-            <SelectContent className="rounded-xl">
-              <SelectItem value="90d" className="rounded-lg">
-                Last 3 months
-              </SelectItem>
-              <SelectItem value="30d" className="rounded-lg">
-                Last 30 days
-              </SelectItem>
-              <SelectItem value="7d" className="rounded-lg">
-                Last 7 days
-              </SelectItem>
-            </SelectContent>
-          </Select>
-        </CardAction>
-      </CardHeader>
-      <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
-        <ChartContainer
-          config={chartConfig}
-          className="aspect-auto h-[250px] w-full"
-        >
-          <AreaChart data={filteredData}>
-            <defs>
-              <linearGradient id="fillDesktop" x1="0" y1="0" x2="0" y2="1">
-                <stop
-                  offset="5%"
-                  stopColor="var(--color-desktop)"
-                  stopOpacity={1.0}
-                />
-                <stop
-                  offset="95%"
-                  stopColor="var(--color-desktop)"
-                  stopOpacity={0.1}
-                />
-              </linearGradient>
-              <linearGradient id="fillMobile" x1="0" y1="0" x2="0" y2="1">
-                <stop
-                  offset="5%"
-                  stopColor="var(--color-mobile)"
-                  stopOpacity={0.8}
-                />
-                <stop
-                  offset="95%"
-                  stopColor="var(--color-mobile)"
-                  stopOpacity={0.1}
-                />
-              </linearGradient>
-            </defs>
-            <CartesianGrid vertical={false} />
-            <XAxis
-              dataKey="date"
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              minTickGap={32}
-              tickFormatter={(value) => {
-                const date = new Date(value)
-                return date.toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                })
-              }}
-            />
-            <ChartTooltip
-              cursor={false}
-              content={
-                <ChartTooltipContent
-                  labelFormatter={(value) => {
-                    return new Date(value).toLocaleDateString("en-US", {
-                      month: "short",
-                      day: "numeric",
-                    })
-                  }}
-                  indicator="dot"
-                />
-              }
-            />
-            <Area
-              dataKey="mobile"
-              type="natural"
-              fill="url(#fillMobile)"
-              stroke="var(--color-mobile)"
-              stackId="a"
-            />
-            <Area
-              dataKey="desktop"
-              type="natural"
-              fill="url(#fillDesktop)"
-              stroke="var(--color-desktop)"
-              stackId="a"
-            />
-          </AreaChart>
-        </ChartContainer>
-      </CardContent>
-    </Card>
+              {range === "90d" ? "3m" : range === "30d" ? "30d" : "7d"}
+            </Button>
+          ))}
+        </div>
+      </div>
+      <ChartContainer
+        config={chartConfig}
+        className="aspect-auto h-[250px] w-full"
+      >
+        <AreaChart data={filteredData}>
+          <defs>
+            <linearGradient id="fillDesktop" x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="5%"
+                stopColor="var(--color-desktop)"
+                stopOpacity={1.0}
+              />
+              <stop
+                offset="95%"
+                stopColor="var(--color-desktop)"
+                stopOpacity={0.1}
+              />
+            </linearGradient>
+            <linearGradient id="fillMobile" x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="5%"
+                stopColor="var(--color-mobile)"
+                stopOpacity={0.8}
+              />
+              <stop
+                offset="95%"
+                stopColor="var(--color-mobile)"
+                stopOpacity={0.1}
+              />
+            </linearGradient>
+          </defs>
+          <CartesianGrid vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            minTickGap={32}
+            tickFormatter={(value) => {
+              const date = new Date(value)
+              return date.toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+              })
+            }}
+          />
+          <ChartTooltip
+            cursor={false}
+            content={
+              <ChartTooltipContent
+                labelFormatter={(value) => {
+                  return new Date(value).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                  })
+                }}
+                indicator="dot"
+              />
+            }
+          />
+          <Area
+            dataKey="mobile"
+            type="natural"
+            fill="url(#fillMobile)"
+            stroke="var(--color-mobile)"
+            stackId="a"
+          />
+          <Area
+            dataKey="desktop"
+            type="natural"
+            fill="url(#fillDesktop)"
+            stroke="var(--color-desktop)"
+            stackId="a"
+          />
+        </AreaChart>
+      </ChartContainer>
+    </div>
   )
 }

--- a/agent/skills/dashboard/app/src/examples/layout-example.tsx
+++ b/agent/skills/dashboard/app/src/examples/layout-example.tsx
@@ -4,6 +4,8 @@
  * Each widget is a direct child of the page grid — never wrap widgets
  * in their own sub-grid. Most widgets should be col-span-1 (the default).
  *
+ * Default widget wrapper: <div className="rounded-2xl bg-secondary p-3 text-sm">
+ *
  * - Default (col-span-1): metric cards, counters, small lists, trackers
  * - col-span-2: charts that need horizontal space to be readable
  * - col-span-full: almost never — only wide data tables with many columns
@@ -13,9 +15,9 @@
 
 function MetricCard({ title, value, change }: { title: string; value: string; change: string }) {
   return (
-    <div className="rounded-2xl border border-border bg-muted p-4">
-      <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
-      <p className="mt-2 text-2xl font-bold">{value}</p>
+    <div className="rounded-2xl bg-secondary p-3 text-sm">
+      <h3 className="text-xs text-muted-foreground">{title}</h3>
+      <p className="mt-1 text-xl font-semibold">{value}</p>
       <p className="text-xs text-muted-foreground mt-1">{change}</p>
     </div>
   )
@@ -25,9 +27,9 @@ function MetricCard({ title, value, change }: { title: string; value: string; ch
 
 function WeeklyChart() {
   return (
-    <div className="rounded-2xl border border-border bg-muted p-4 col-span-2">
-      <h3 className="text-sm font-medium text-muted-foreground">Weekly Activity</h3>
-      <div className="mt-4 flex items-end gap-2 h-32">
+    <div className="rounded-2xl bg-secondary p-3 text-sm col-span-2">
+      <h3 className="text-xs text-muted-foreground">Weekly Activity</h3>
+      <div className="mt-3 flex items-end gap-2 h-32">
         {[40, 65, 45, 80, 55, 90, 70].map((h, i) => (
           <div key={i} className="flex-1 rounded-md bg-primary/20" style={{ height: `${h}%` }} />
         ))}
@@ -43,11 +45,11 @@ function WeeklyChart() {
 
 function TaskList() {
   return (
-    <div className="rounded-2xl border border-border bg-muted p-4">
-      <h3 className="text-sm font-medium text-muted-foreground">Tasks</h3>
-      <div className="mt-3 space-y-2">
+    <div className="rounded-2xl bg-secondary p-3 text-sm">
+      <h3 className="text-xs text-muted-foreground">Tasks</h3>
+      <div className="mt-2 space-y-2">
         {["Review PR #42", "Deploy v2.1", "Update docs"].map((t, i) => (
-          <div key={i} className="flex items-center gap-2 text-sm">
+          <div key={i} className="flex items-center gap-2">
             <div className="size-4 rounded border border-muted-foreground/30" />
             <span>{t}</span>
           </div>
@@ -68,16 +70,16 @@ function EventLog() {
   ]
 
   return (
-    <div className="rounded-2xl border border-border bg-muted p-4 col-span-full">
-      <h3 className="text-sm font-medium text-muted-foreground">Recent Events</h3>
-      <div className="mt-3 divide-y">
+    <div className="rounded-2xl bg-secondary p-3 text-sm col-span-full">
+      <h3 className="text-xs text-muted-foreground">Recent Events</h3>
+      <div className="mt-2 divide-y divide-border">
         {events.map((e, i) => (
-          <div key={i} className="flex items-center justify-between py-2 text-sm">
+          <div key={i} className="flex items-center justify-between py-2">
             <div className="flex items-center gap-3">
               <div className={`size-2 rounded-full ${e.status === "success" ? "bg-green-500" : e.status === "warning" ? "bg-yellow-500" : "bg-blue-500"}`} />
               <span>{e.event}</span>
             </div>
-            <span className="text-muted-foreground text-xs">{e.time}</span>
+            <span className="text-xs text-muted-foreground">{e.time}</span>
           </div>
         ))}
       </div>
@@ -89,7 +91,7 @@ function EventLog() {
 
 export function LayoutExamplePage() {
   return (
-    <div className="grid gap-4 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <div className="grid gap-3 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
       <MetricCard title="Users" value="1,234" change="+12% from last month" />
       <MetricCard title="Revenue" value="$5,678" change="+8% from last month" />
       <MetricCard title="Uptime" value="99.9%" change="Last 30 days" />

--- a/agent/skills/dashboard/app/src/examples/section-cards.tsx
+++ b/agent/skills/dashboard/app/src/examples/section-cards.tsx
@@ -1,116 +1,73 @@
-"use client"
-
-import { Badge } from "@/components/ui/badge"
-import {
-  Card,
-  CardAction,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
 import { TrendingUpIcon, TrendingDownIcon } from "lucide-react"
 
 export function RevenueCard() {
   return (
-    <Card className="@container/card">
-      <CardHeader>
-        <CardDescription>Total Revenue</CardDescription>
-        <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-          $1,250.00
-        </CardTitle>
-        <CardAction>
-          <Badge variant="outline">
-            <TrendingUpIcon />
-            +12.5%
-          </Badge>
-        </CardAction>
-      </CardHeader>
-      <CardFooter className="flex-col items-start gap-1.5 text-sm">
-        <div className="line-clamp-1 flex gap-2 font-medium">
-          Trending up this month <TrendingUpIcon className="size-4" />
-        </div>
-        <div className="text-muted-foreground">
-          Visitors for the last 6 months
-        </div>
-      </CardFooter>
-    </Card>
+    <div className="rounded-2xl bg-secondary p-3 text-sm">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">Total Revenue</span>
+        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+          <TrendingUpIcon className="size-3" />
+          +12.5%
+        </span>
+      </div>
+      <p className="mt-1 text-xl font-semibold tabular-nums">$1,250.00</p>
+      <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
+        Trending up this month <TrendingUpIcon className="size-3" />
+      </div>
+    </div>
   )
 }
 
 export function CustomersCard() {
   return (
-    <Card className="@container/card">
-      <CardHeader>
-        <CardDescription>New Customers</CardDescription>
-        <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-          1,234
-        </CardTitle>
-        <CardAction>
-          <Badge variant="outline">
-            <TrendingDownIcon />
-            -20%
-          </Badge>
-        </CardAction>
-      </CardHeader>
-      <CardFooter className="flex-col items-start gap-1.5 text-sm">
-        <div className="line-clamp-1 flex gap-2 font-medium">
-          Down 20% this period <TrendingDownIcon className="size-4" />
-        </div>
-        <div className="text-muted-foreground">
-          Acquisition needs attention
-        </div>
-      </CardFooter>
-    </Card>
+    <div className="rounded-2xl bg-secondary p-3 text-sm">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">New Customers</span>
+        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+          <TrendingDownIcon className="size-3" />
+          -20%
+        </span>
+      </div>
+      <p className="mt-1 text-xl font-semibold tabular-nums">1,234</p>
+      <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
+        Down 20% this period <TrendingDownIcon className="size-3" />
+      </div>
+    </div>
   )
 }
 
 export function ActiveAccountsCard() {
   return (
-    <Card className="@container/card">
-      <CardHeader>
-        <CardDescription>Active Accounts</CardDescription>
-        <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-          45,678
-        </CardTitle>
-        <CardAction>
-          <Badge variant="outline">
-            <TrendingUpIcon />
-            +12.5%
-          </Badge>
-        </CardAction>
-      </CardHeader>
-      <CardFooter className="flex-col items-start gap-1.5 text-sm">
-        <div className="line-clamp-1 flex gap-2 font-medium">
-          Strong user retention <TrendingUpIcon className="size-4" />
-        </div>
-        <div className="text-muted-foreground">Engagement exceed targets</div>
-      </CardFooter>
-    </Card>
+    <div className="rounded-2xl bg-secondary p-3 text-sm">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">Active Accounts</span>
+        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+          <TrendingUpIcon className="size-3" />
+          +12.5%
+        </span>
+      </div>
+      <p className="mt-1 text-xl font-semibold tabular-nums">45,678</p>
+      <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
+        Strong user retention <TrendingUpIcon className="size-3" />
+      </div>
+    </div>
   )
 }
 
 export function GrowthRateCard() {
   return (
-    <Card className="@container/card">
-      <CardHeader>
-        <CardDescription>Growth Rate</CardDescription>
-        <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-          4.5%
-        </CardTitle>
-        <CardAction>
-          <Badge variant="outline">
-            <TrendingUpIcon />
-            +4.5%
-          </Badge>
-        </CardAction>
-      </CardHeader>
-      <CardFooter className="flex-col items-start gap-1.5 text-sm">
-        <div className="line-clamp-1 flex gap-2 font-medium">
-          Steady performance increase <TrendingUpIcon className="size-4" />
-        </div>
-        <div className="text-muted-foreground">Meets growth projections</div>
-      </CardFooter>
-    </Card>
+    <div className="rounded-2xl bg-secondary p-3 text-sm">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">Growth Rate</span>
+        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+          <TrendingUpIcon className="size-3" />
+          +4.5%
+        </span>
+      </div>
+      <p className="mt-1 text-xl font-semibold tabular-nums">4.5%</p>
+      <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
+        Steady performance increase <TrendingUpIcon className="size-3" />
+      </div>
+    </div>
   )
 }

--- a/app/src/components/ui/sidebar.tsx
+++ b/app/src/components/ui/sidebar.tsx
@@ -382,7 +382,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto pb-5 [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden",
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto pb-5 [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-x-hidden group-data-[collapsible=icon]:overflow-y-auto",
         className,
       )}
       {...props}
@@ -478,7 +478,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-xl px-3 py-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-xl px-3 py-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! group-data-[collapsible=icon]:[&>span]:sr-only hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
   {
     variants: {
       variant: {
@@ -678,7 +678,7 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-xl px-3 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:translate-x-0 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-xl px-3 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:translate-x-0 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2! group-data-[collapsible=icon]:[&>span]:sr-only hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Add 12 mock pages with children navigation (overview, analytics/traffic/reports, tasks/board/timeline, notifications/rules, settings/profile/team/api)
- Update all widgets to follow SKILL.md spec (bg-secondary, no borders, compact sizing)
- Collapsible sidebar groups: ring outline + primary bg on parent icon in collapsed mode, tooltips for children
- Sidebar: add sr-only to button spans in icon mode, split overflow for scrollable collapsed sidebar
- Site header icon inherits text color

## Test plan
- [ ] Verify sidebar navigation with collapsible groups in expanded and collapsed modes
- [ ] Check tooltips appear on collapsed child items
- [ ] Confirm widget styling matches SKILL.md spec (bg-secondary, no border/shadow)
- [ ] Test sidebar collapse/expand animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)