### PR TITLE
fix(agent): clarify channel routing in notification prompts

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -75,7 +75,7 @@ Once [agent_name] knows who they're with (name isn't "[Unknown]"), that's it. No
 
 ### Primary Channel
 - **Default**: [Unknown, gets set up on first meeting]
-- **Rule**: Always reply through whatever channel the message came in on
+- **Rule**: Always reply through whatever channel the message came in on. Notifications include the source in brackets, e.g. "[message from whatsapp]". If it's whatsapp, reply via the whatsapp skill, not the app chat. Same for any other channel.
 
 ### Being Useful Without Being Asked
 - Do the legwork: check inbox, calendar, web. Have options ready before anyone asks

--- a/agent/prompts/notification_suffix.md
+++ b/agent/prompts/notification_suffix.md
@@ -1,3 +1,1 @@
-Think about what they're probably doing and what time it is. Mention it at an appropriate moment. If it's late or they're deep in something, hold it for later. Match tone to the moment. Skip things they've said to stop notifying about (check Learned Patterns in MEMORY.md).
-
-Reply on the same channel the notification came from. If the notification says "[message from whatsapp]", your reply goes via the whatsapp skill, not the app chat.
+Consider timing and context before responding. Reply on the same channel it came from (whatsapp message → whatsapp skill). Check Learned Patterns in MEMORY.md for what to skip.

--- a/agent/prompts/notification_suffix.md
+++ b/agent/prompts/notification_suffix.md
@@ -1,1 +1,3 @@
 Think about what they're probably doing and what time it is. Mention it at an appropriate moment. If it's late or they're deep in something, hold it for later. Match tone to the moment. Skip things they've said to stop notifying about (check Learned Patterns in MEMORY.md).
+
+Reply on the same channel the notification came from. If the notification says "[message from whatsapp]", your reply goes via the whatsapp skill, not the app chat.


### PR DESCRIPTION
## Summary

- Add explicit channel routing reminder to `notification_suffix.md` — injected into every notification prompt so the agent is reminded at the exact moment it needs to respond
- Strengthen the rule in `MEMORY.md` section 3 to spell out the concrete action (use whatsapp skill, not app chat) rather than the abstract principle
- Shortened `notification_suffix.md` to reduce repeated token cost

Fixes #290

## Test plan

- [ ] Send a WhatsApp message and verify the agent replies via WhatsApp, not just the app chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)