### PR TITLE
fix(vestad): detect containerd snapshotter and run post-pull image sanity check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,20 +143,22 @@ main() {
     local driver
     driver=$(docker info --format '{{.Driver}}' 2>/dev/null || true)
     if [ "$driver" = "overlayfs" ]; then
-      echo ""
-      echo "WARNING: docker is using the containerd snapshotter (storage driver: overlayfs)."
-      echo "This corrupts multi-layer image extraction on Docker 29+ and will cause vesta to"
-      echo "fail with 'exec format error'."
-      echo ""
-      echo "Fix: add the following to /etc/docker/daemon.json and restart docker:"
-      echo ""
-      echo '  {'
-      echo '    "features": { "containerd-snapshotter": false },'
-      echo '    "storage-driver": "overlay2"'
-      echo '  }'
-      echo ""
-      echo "Then run: sudo systemctl restart docker"
-      echo ""
+      cat <<'EOF'
+
+WARNING: docker is using the containerd snapshotter (storage driver: overlayfs).
+This corrupts multi-layer image extraction on Docker 29+ and will cause vesta to
+fail with 'exec format error'.
+
+Fix: add the following to /etc/docker/daemon.json and restart docker:
+
+  {
+    "features": { "containerd-snapshotter": false },
+    "storage-driver": "overlay2"
+  }
+
+Then run: sudo systemctl restart docker
+
+EOF
     fi
   }
 

--- a/install.sh
+++ b/install.sh
@@ -136,6 +136,30 @@ main() {
     ensure_path
   }
 
+  check_docker_snapshotter() {
+    if ! command -v docker >/dev/null 2>&1; then
+      return
+    fi
+    local driver
+    driver=$(docker info --format '{{.Driver}}' 2>/dev/null || true)
+    if [ "$driver" = "overlayfs" ]; then
+      echo ""
+      echo "WARNING: docker is using the containerd snapshotter (storage driver: overlayfs)."
+      echo "This corrupts multi-layer image extraction on Docker 29+ and will cause vesta to"
+      echo "fail with 'exec format error'."
+      echo ""
+      echo "Fix: add the following to /etc/docker/daemon.json and restart docker:"
+      echo ""
+      echo '  {'
+      echo '    "features": { "containerd-snapshotter": false },'
+      echo '    "storage-driver": "overlay2"'
+      echo '  }'
+      echo ""
+      echo "Then run: sudo systemctl restart docker"
+      echo ""
+    fi
+  }
+
   install_vestad() {
     case "$ARCH" in
       x86_64) local rust_target="x86_64-unknown-linux-gnu" ;;
@@ -153,6 +177,7 @@ main() {
     install -m 755 "$WORK_DIR/vestad" "$bin_dir/vestad"
     echo "  ✓ vestad server → $bin_dir/vestad"
     ensure_path
+    check_docker_snapshotter
   }
 
   install_app_linux() {

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -121,7 +121,7 @@ pub fn connect() -> Result<Docker, DockerError> {
 pub async fn ensure_docker(docker: &Docker) -> Result<(), DockerError> {
     // First attempt — check for permission errors
     match docker.ping().await {
-        Ok(_) => return Ok(()),
+        Ok(_) => {}
         Err(e) => {
             let msg = e.to_string().to_lowercase();
             if msg.contains("permission denied") {
@@ -131,17 +131,39 @@ pub async fn ensure_docker(docker: &Docker) -> Result<(), DockerError> {
                      then log out and back in (or run: newgrp docker)".to_string()
                 ));
             }
+
+            let mut running = false;
+            for _ in 0..DOCKER_DAEMON_PING_RETRIES {
+                if docker.ping().await.is_ok() {
+                    running = true;
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+            if !running {
+                return Err(DockerError::Failed("docker daemon is not running. start it with: sudo systemctl start docker".into()));
+            }
         }
     }
 
-    for _ in 0..DOCKER_DAEMON_PING_RETRIES {
-        if docker.ping().await.is_ok() {
-            return Ok(());
+    // Detect Docker's containerd snapshotter (Docker 29+), which silently corrupts
+    // multi-layer image extraction and causes "exec format error" on every binary.
+    if let Ok(info) = docker.info().await {
+        if info.driver.as_deref() == Some("overlayfs") {
+            return Err(DockerError::Failed(
+                "docker is using the containerd snapshotter (storage driver: overlayfs), \
+                 which corrupts multi-layer images on Docker 29+.\n\
+                 \n\
+                 Fix: add the following to /etc/docker/daemon.json and restart docker:\n\
+                 \n\
+                 {\n  \"features\": { \"containerd-snapshotter\": false },\n  \"storage-driver\": \"overlay2\"\n}\n\
+                 \n\
+                 Then run: sudo systemctl restart docker".to_string()
+            ));
         }
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
 
-    Err(DockerError::Failed("docker daemon is not running. start it with: sudo systemctl start docker".into()))
+    Ok(())
 }
 
 pub fn ensure_docker_sync(docker: &Docker) -> Result<(), DockerError> {
@@ -628,6 +650,37 @@ fn glob_match(text: &[u8], pattern: &[u8]) -> bool {
     }
 }
 
+async fn verify_image_runnable(image: &str) -> Result<(), DockerError> {
+    let image = image.to_string();
+    let output = tokio::task::spawn_blocking(move || {
+        std::process::Command::new("docker")
+            .args(["run", "--rm", &image, "/bin/true"])
+            .output()
+    })
+    .await
+    .map_err(|e| DockerError::Failed(format!("image sanity check task failed: {e}")))?
+    .map_err(|e| DockerError::Failed(format!("image sanity check failed to run: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+        if stderr.contains("exec format error") {
+            return Err(DockerError::Failed(
+                "image sanity check failed with 'exec format error'. \
+                 docker may be using the containerd snapshotter, which corrupts multi-layer images.\n\
+                 \n\
+                 Check your storage driver: docker info --format '{{.Driver}}'\n\
+                 If it shows 'overlayfs', add to /etc/docker/daemon.json and restart docker:\n\
+                 \n\
+                 {\n  \"features\": { \"containerd-snapshotter\": false },\n  \"storage-driver\": \"overlay2\"\n}".to_string()
+            ));
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(DockerError::Failed(format!("image sanity check failed: {stderr}")));
+    }
+
+    Ok(())
+}
+
 pub async fn resolve_image(docker: &Docker) -> Result<&'static str, DockerError> {
     if let Ok(context) = find_dockerfile() {
         let tar_body = build_context_tar(&context)?;
@@ -648,6 +701,7 @@ pub async fn resolve_image(docker: &Docker) -> Result<&'static str, DockerError>
                 }
             }
         }
+        verify_image_runnable(LOCAL_IMAGE_TAG).await?;
         Ok(LOCAL_IMAGE_TAG)
     } else {
         let opts = CreateImageOptions {
@@ -660,6 +714,7 @@ pub async fn resolve_image(docker: &Docker) -> Result<&'static str, DockerError>
                 return Err(DockerError::Failed(format!("failed to pull image: {e}")));
             }
         }
+        verify_image_runnable(VESTA_IMAGE).await?;
         Ok(VESTA_IMAGE)
     }
 }

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -132,15 +132,13 @@ pub async fn ensure_docker(docker: &Docker) -> Result<(), DockerError> {
                 ));
             }
 
-            let mut running = false;
-            for _ in 0..DOCKER_DAEMON_PING_RETRIES {
-                if docker.ping().await.is_ok() {
-                    running = true;
-                    break;
+            'retry: {
+                for _ in 0..DOCKER_DAEMON_PING_RETRIES {
+                    if docker.ping().await.is_ok() {
+                        break 'retry;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                 }
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            }
-            if !running {
                 return Err(DockerError::Failed("docker daemon is not running. start it with: sudo systemctl start docker".into()));
             }
         }
@@ -662,8 +660,8 @@ async fn verify_image_runnable(image: &str) -> Result<(), DockerError> {
     .map_err(|e| DockerError::Failed(format!("image sanity check failed to run: {e}")))?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
-        if stderr.contains("exec format error") {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.to_lowercase().contains("exec format error") {
             return Err(DockerError::Failed(
                 "image sanity check failed with 'exec format error'. \
                  docker may be using the containerd snapshotter, which corrupts multi-layer images.\n\
@@ -674,7 +672,6 @@ async fn verify_image_runnable(image: &str) -> Result<(), DockerError> {
                  {\n  \"features\": { \"containerd-snapshotter\": false },\n  \"storage-driver\": \"overlay2\"\n}".to_string()
             ));
         }
-        let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(DockerError::Failed(format!("image sanity check failed: {stderr}")));
     }
 


### PR DESCRIPTION
## Summary

Docker 29+ enables the containerd snapshotter by default, which silently corrupts multi-layer image extraction. Every binary in the container becomes 0 bytes and the kernel returns `exec format error` — which looks exactly like an arch mismatch and is very hard to diagnose.

Three-layer defense:
- **`install.sh`**: warns at install time if `docker info` shows storage driver `overlayfs`
- **`ensure_docker`**: hard-fails with a clear fix message before any docker operations can proceed
- **`verify_image_runnable`**: runs `/bin/true` in the image after every pull/build, giving a targeted message on `exec format error` or a generic error for any other unknown breakage

The last layer also catches any future unknown image-level docker issues, not just this specific bug.

## Test plan

- [ ] On a normal system (overlay2 driver): `ensure_docker` passes, `verify_image_runnable` passes, everything works as before
- [ ] On Docker 29+ with containerd snapshotter: `ensure_docker` returns a clear error with the `daemon.json` fix before any image operations run
- [ ] If somehow `ensure_docker` passes but image is corrupted: `verify_image_runnable` after pull returns a targeted `exec format error` message
- [ ] `install.sh --server` on a system with `overlayfs` driver: prints the warning after installing vestad

Fixes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)