### PR TITLE
feat(agent): retry transient API errors with backoff and WA outage notification

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -131,6 +131,7 @@ The user's important people are [agent_name]'s important people too. Keeps track
 
 ### Self-Modification
 - Edit skills, prompts, config (`config.py`, mechanical settings only), MEMORY.md freely
+- **To change a config setting**: read `src/vesta/config.py` for all options and their env var names, set in `~/.bashrc`, run `restart_vesta`
 - `src/vesta/` may be read-only (depends on agent config). If so, PR changes through the upstream skill
 - **New skills**: follow existing patterns (SKILL.md frontmatter, SETUP.md, `~/.{skill}/` data, `screen -dmS`, `restart.md` entry)
 - Changes take effect on next restart, or use `restart_vesta` to apply immediately

--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -130,8 +130,8 @@ The user's important people are [agent_name]'s important people too. Keeps track
 - **Invalidation**: `curl -sk -X POST https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services/<name>/invalidate`, optionally `{"scope": "<part>"}`. Tells the app to refresh that service
 
 ### Self-Modification
-- Edit skills, prompts, config (`config.py`, mechanical settings only), MEMORY.md freely
-- **To change a config setting**: read `src/vesta/config.py` for all options and their env var names, set in `~/.bashrc`, run `restart_vesta`
+- Edit skills, prompts, MEMORY.md freely
+- **To change a config setting**: read `src/vesta/config.py` for all options and their env var names; set the env var in `~/.bashrc`, run `restart_vesta`
 - `src/vesta/` may be read-only (depends on agent config). If so, PR changes through the upstream skill
 - **New skills**: follow existing patterns (SKILL.md frontmatter, SETUP.md, `~/.{skill}/` data, `screen -dmS`, `restart.md` entry)
 - Changes take effect on next restart, or use `restart_vesta` to apply immediately

--- a/agent/src/vesta/config.py
+++ b/agent/src/vesta/config.py
@@ -85,4 +85,3 @@ class VestaConfig(pyd_settings.BaseSettings):
 
     agent_name: str = "vesta"
     agent_model: str = "opus"
-    user_phone: str | None = None

--- a/agent/src/vesta/config.py
+++ b/agent/src/vesta/config.py
@@ -85,3 +85,4 @@ class VestaConfig(pyd_settings.BaseSettings):
 
     agent_name: str = "vesta"
     agent_model: str = "opus"
+    user_phone: str | None = None

--- a/agent/src/vesta/config.py
+++ b/agent/src/vesta/config.py
@@ -10,6 +10,21 @@ _DEFAULT_ROOT = pl.Path.home() / "vesta"
 
 
 class VestaConfig(pyd_settings.BaseSettings):
+    """Vesta agent configuration.
+
+    Every field can be overridden via env var (uppercased field name, no prefix).
+    Set in ~/.bashrc and run restart_vesta to apply.
+
+    Key overrides:
+        AGENT_MODEL   - model name, e.g. "sonnet", "opus", "haiku" (default: "opus")
+        AGENT_NAME    - agent name (default: "vesta")
+        LOG_LEVEL     - DEBUG | INFO | WARNING | ERROR (default: "INFO")
+        THINKING      - adaptive | enabled | disabled (default: "adaptive")
+        PROACTIVE_CHECK_INTERVAL - seconds between proactive checks (default: 60)
+        NIGHTLY_MEMORY_HOUR      - hour 0-23 for nightly dream, unset to disable (default: 3)
+        RESPONSE_TIMEOUT         - max seconds for a single response (default: 600)
+    """
+
     model_config = pyd_settings.SettingsConfigDict(extra="ignore")
 
     ephemeral: bool = False

--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -130,25 +130,6 @@ def _is_transient(error: Exception) -> bool:
     return any(marker in msg for marker in _TRANSIENT_MARKERS)
 
 
-async def _send_outage_notification(message: str, *, config: vm.VestaConfig) -> None:
-    if not config.user_phone:
-        return
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "whatsapp",
-            "send",
-            "--to",
-            config.user_phone,
-            "--message",
-            message,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        await asyncio.wait_for(proc.wait(), timeout=10)
-    except Exception as e:
-        logger.warning(f"Outage notification failed: {e}")
-
-
 async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, config: vm.VestaConfig) -> None:
     try:
         if is_user:
@@ -167,18 +148,13 @@ async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, c
             state.event_bus.emit(ApiOutageEvent(type="api_outage", text=str(e), retry_count=state.api_failures))
 
             if state.api_failures >= _MAX_TRANSIENT_RETRIES:
-                await _send_outage_notification(
-                    "Anthropic API is currently down. "
-                    "Status: https://status.anthropic.com — "
-                    "I'll retry automatically and message you when I'm back.",
-                    config=config,
-                )
+                logger.warning("API outage detected, entering retry loop...")
                 while not state.shutdown_event.is_set() and not state.graceful_shutdown.is_set():
                     await asyncio.sleep(_RETRY_INTERVAL)
                     try:
                         await process_message(msg, state=state, config=config, is_user=is_user)
                         state.api_failures = 0
-                        await _send_outage_notification("API is back online, I'm operational again.", config=config)
+                        logger.startup("API recovered, resuming normal operation")
                         state.event_bus.emit(ApiRecoveredEvent(type="api_recovered"))
                         return
                     except Exception as retry_e:

--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -14,6 +14,7 @@ import vesta.models as vm
 from vesta import logger
 from vesta.core.client import process_message, build_client_options, attempt_interrupt, persist_session_id, _cancel_task
 from vesta.core.init import load_prompt, build_restart_context
+from vesta.events import ApiOutageEvent, ApiRecoveredEvent
 
 
 def _now() -> dt.datetime:
@@ -119,6 +120,29 @@ async def queue_greeting(queue: asyncio.Queue[tuple[str, bool]], *, config: vm.V
 # --- Message processing ---
 
 
+_TRANSIENT_MARKERS = ("500", "502", "503", "529", "overloaded", "internal_error")
+_MAX_TRANSIENT_RETRIES = 3
+_RETRY_INTERVAL = 60  # seconds
+
+
+def _is_transient(error: Exception) -> bool:
+    msg = str(error).lower()
+    return any(marker in msg for marker in _TRANSIENT_MARKERS)
+
+
+async def _send_outage_notification(message: str, *, config: vm.VestaConfig) -> None:
+    if not config.user_phone:
+        return
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "whatsapp", "send", "--to", config.user_phone, "--message", message,
+            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=10)
+    except Exception as e:
+        logger.warning(f"Outage notification failed: {e}")
+
+
 async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, config: vm.VestaConfig) -> None:
     try:
         if is_user:
@@ -129,7 +153,40 @@ async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, c
             logger.system(preview.replace("\n", " "))
         state.event_bus.set_state("thinking")
         await process_message(msg, state=state, config=config, is_user=is_user)
+        state.api_failures = 0
     except (ClaudeSDKError, OSError, RuntimeError, ValueError, TimeoutError) as e:
+        if _is_transient(e):
+            state.api_failures += 1
+            logger.warning(f"Transient API error ({state.api_failures}/{_MAX_TRANSIENT_RETRIES}): {e}")
+            state.event_bus.emit(ApiOutageEvent(type="api_outage", text=str(e), retry_count=state.api_failures))
+
+            if state.api_failures >= _MAX_TRANSIENT_RETRIES:
+                await _send_outage_notification(
+                    "Anthropic API is currently down. "
+                    "Status: https://status.anthropic.com — "
+                    "I'll retry automatically and message you when I'm back.",
+                    config=config,
+                )
+                while not state.shutdown_event.is_set() and not state.graceful_shutdown.is_set():
+                    await asyncio.sleep(_RETRY_INTERVAL)
+                    try:
+                        await process_message(msg, state=state, config=config, is_user=is_user)
+                        state.api_failures = 0
+                        await _send_outage_notification("API is back online, I'm operational again.", config=config)
+                        state.event_bus.emit(ApiRecoveredEvent(type="api_recovered"))
+                        return
+                    except Exception as retry_e:
+                        if _is_transient(retry_e):
+                            logger.warning(f"API still down, retrying in {_RETRY_INTERVAL}s...")
+                        else:
+                            error_msg = str(retry_e) or type(retry_e).__name__
+                            logger.error(f"Error processing message: {error_msg} — triggering restart")
+                            state.event_bus.emit({"type": "error", "text": error_msg})
+                            state.restart_reason = f"error — {error_msg}"
+                            state.graceful_shutdown.set()
+                            return
+            return
+
         if isinstance(e, TimeoutError):
             error_msg = "Response timed out"
         else:

--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -135,8 +135,14 @@ async def _send_outage_notification(message: str, *, config: vm.VestaConfig) -> 
         return
     try:
         proc = await asyncio.create_subprocess_exec(
-            "whatsapp", "send", "--to", config.user_phone, "--message", message,
-            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+            "whatsapp",
+            "send",
+            "--to",
+            config.user_phone,
+            "--message",
+            message,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
         )
         await asyncio.wait_for(proc.wait(), timeout=10)
     except Exception as e:

--- a/agent/src/vesta/events.py
+++ b/agent/src/vesta/events.py
@@ -76,6 +76,16 @@ class ChatEvent(_BaseEvent):
     text: str
 
 
+class ApiOutageEvent(_BaseEvent):
+    type: tp.Literal["api_outage"]
+    text: str
+    retry_count: int
+
+
+class ApiRecoveredEvent(_BaseEvent):
+    type: tp.Literal["api_recovered"]
+
+
 type StreamEvent = (
     StatusEvent
     | ToolStartEvent
@@ -88,6 +98,8 @@ type StreamEvent = (
     | SubagentStartEvent
     | SubagentStopEvent
     | ChatEvent
+    | ApiOutageEvent
+    | ApiRecoveredEvent
 )
 
 

--- a/agent/src/vesta/main.py
+++ b/agent/src/vesta/main.py
@@ -80,9 +80,22 @@ async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: boo
     ws_runner = await start_ws_server(state.event_bus, config)
     logger.init(f"WebSocket server started on port {config.ws_port}")
 
+    processor_task = asyncio.create_task(message_processor(message_queue, state=state, config=config))
+
+    def _on_processor_done(task: asyncio.Task[None]) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc:
+            logger.error(f"message_processor crashed: {exc}")
+            state.restart_reason = vm.CRASH_RESTART
+            state.graceful_shutdown.set()
+
+    processor_task.add_done_callback(_on_processor_done)
+
     tasks = [
         asyncio.create_task(input_handler(message_queue, state=state)),
-        asyncio.create_task(message_processor(message_queue, state=state, config=config)),
+        processor_task,
         asyncio.create_task(monitor_loop(message_queue, state=state, config=config)),
     ]
 

--- a/agent/src/vesta/models.py
+++ b/agent/src/vesta/models.py
@@ -27,6 +27,7 @@ class State:
     dreamer_active: bool = False
     interrupt_event: asyncio.Event | None = None
     event_bus: EventBus = dc.field(default_factory=EventBus)
+    api_failures: int = 0
 
 
 class Notification(pyd.BaseModel):


### PR DESCRIPTION
## Summary

- Detect transient Anthropic API errors (500, 502, 503, 529/overloaded) in `_process_message_safely` and warn/drop instead of triggering a container restart
- After 3 consecutive transient failures, send a hardcoded WhatsApp outage notification and enter a 60s retry loop (respects shutdown events)
- On recovery, send a recovery notification and emit `api_recovered` event via the event bus
- Adds `user_phone` config field (set via `USER_PHONE` env var) as the WA notification target
- Adds `ApiOutageEvent` and `ApiRecoveredEvent` typed events

## Test plan

- [ ] Unit tests pass (`uv run pytest tests/ --ignore=tests/test_e2e.py`)
- [ ] Ruff and ty checks pass
- [ ] Manually verify a simulated 529 error drops the message instead of restarting
- [ ] Set `USER_PHONE` env var and verify WA notification fires after 3 failures

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)