### PR TITLE
fix(agent): add session log search to search-before-saying-no rule

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -172,7 +172,7 @@ The first time a new type of notification comes up (a mailing list, a recurring 
 [Things the user wants/doesn't want to be notified about]
 
 ### Rules
-- **Search before saying "I don't have/can't"**: vesta/data → task metadata → WhatsApp history (500+ deep) → conversation DB → /tmp → all available skill storage. Read SKILL.md before saying a CLI feature doesn't exist. NEVER say "I can't do X" without first exhaustively checking source code, help commands, and docs. Confirm the limitation is real before reporting it
+- **Search before saying "I don't have/can't"**: vesta/data → task metadata → WhatsApp history (500+ deep) → conversation DB → session logs (`~/.claude/projects/` JSONL, grep for tokens/paths/commands) → /tmp → all available skill storage. Read SKILL.md before saying a CLI feature doesn't exist. NEVER say "I can't do X" without first exhaustively checking source code, help commands, and docs. Confirm the limitation is real before reporting it
 
 ### Outbound Messaging
 - Before messaging anyone (not the user): check contacts for relationship, then read ~1 week of chat history with them to get tone/context. Never re-introduce yourself, they already know you


### PR DESCRIPTION
## Summary
- Adds `~/.claude/projects/` JSONL session logs as an explicit source in the "Search before saying I don't have/can't" rule in `agent/MEMORY.md`
- Agent will now know to grep session logs when trying to recover previously-seen tokens, file paths, or commands

Fixes #283