### PR TITLE
fix(whatsapp): silent drop detection + actionable error messages

### DIFF
--- a/agent/skills/whatsapp/cli/chat_ops.go
+++ b/agent/skills/whatsapp/cli/chat_ops.go
@@ -72,7 +72,7 @@ func (wac *WhatsAppClient) RequestBackfill(chatIdentifier string, count int) (bo
 
 	msgID, senderJID, isFromMe, ts, err := wac.store.GetOldestMessage(jid.String())
 	if err != nil {
-		return false, fmt.Sprintf("No messages found for this chat to anchor backfill: %v", err)
+		return false, "No local message history for this chat. WhatsApp history sync requires an existing message as an anchor — send a message to this contact first (or ask them to send one), then retry backfill."
 	}
 
 	senderParsed, err := types.ParseJID(senderJID)
@@ -95,7 +95,7 @@ func (wac *WhatsAppClient) RequestBackfill(chatIdentifier string, count int) (bo
 		return false, fmt.Sprintf("Failed to request backfill: %v", err)
 	}
 
-	return true, fmt.Sprintf("Backfill requested for %d messages before %s. Messages will arrive asynchronously.", count, ts.Format(time.RFC3339))
+	return true, fmt.Sprintf("Backfill requested for %d messages before %s. Messages will arrive asynchronously — wait a few seconds then use list-messages to check.", count, ts.Format(time.RFC3339))
 }
 
 // DeleteChat clears all messages in a chat both locally and on the WhatsApp servers

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -403,7 +403,11 @@ func cmdListMessages(args []string, wac *WhatsAppClient) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return map[string]any{"messages": messages}, nil
+	result := map[string]any{"messages": messages}
+	if len(messages) == 0 && to != "" {
+		result["note"] = "No messages found for this chat. If history exists on the phone, run 'backfill --to <contact>' to request it. If the contact is unknown, run 'add-contact' first."
+	}
+	return result, nil
 }
 
 func cmdListChats(args []string, wac *WhatsAppClient) (any, error) {

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -438,7 +438,11 @@ func cmdSendMessage(args []string, wac *WhatsAppClient) (any, error) {
 		return nil, fmt.Errorf("--to and --message are required")
 	}
 	success, msg := wac.SendMessageWithPresence(to, message)
-	return successResult(success, msg), nil
+	result := successResult(success, msg)
+	if success && userAtIPPattern.MatchString(message) {
+		result["delivery_warning"] = "Message contains a user@IP pattern which WhatsApp spam filters may silently drop. Use 'check-delivery' to verify delivery."
+	}
+	return result, nil
 }
 
 func cmdSendFile(args []string, wac *WhatsAppClient) (any, error) {

--- a/agent/skills/whatsapp/cli/client.go
+++ b/agent/skills/whatsapp/cli/client.go
@@ -354,22 +354,12 @@ func (wac *WhatsAppClient) startStaleMessageDetector() {
 					continue
 				}
 				if len(staleIDs) > 0 {
-					wac.logger.Warnf("Detected %d stale outgoing messages (stuck in 'sent' >%v): %v — marking as filtered and writing notification", len(staleIDs), StaleMessageThreshold, staleIDs)
+					wac.logger.Warnf("Detected %d stale outgoing messages (stuck in 'sent' >%v): %v, marking as filtered and writing notification", len(staleIDs), StaleMessageThreshold, staleIDs)
 					if err := wac.store.MarkMessagesFiltered(staleIDs); err != nil {
 						wac.logger.Warnf("Failed to mark stale messages as filtered: %v", err)
 					}
-					if wac.notificationsDir != "" {
-						notif := map[string]any{
-							"source":      "whatsapp",
-							"type":        "delivery_failure",
-							"instance":    wac.instance,
-							"message_ids": staleIDs,
-							"message":     fmt.Sprintf("%d message(s) were never delivered — likely silently dropped by WhatsApp. Check content for user@IP patterns or other spam-triggering strings.", len(staleIDs)),
-							"timestamp":   time.Now().UTC().Format(time.RFC3339),
-						}
-						if err := writeNotificationFile(wac.notificationsDir, notif, "delivery_failure"); err != nil {
-							wac.logger.Warnf("Failed to write delivery failure notification: %v", err)
-						}
+					if err := WriteDeliveryFailureNotification(wac.notificationsDir, wac.instance, staleIDs); err != nil {
+						wac.logger.Warnf("Failed to write delivery failure notification: %v", err)
 					}
 				}
 			}

--- a/agent/skills/whatsapp/cli/client.go
+++ b/agent/skills/whatsapp/cli/client.go
@@ -354,10 +354,22 @@ func (wac *WhatsAppClient) startStaleMessageDetector() {
 					continue
 				}
 				if len(staleIDs) > 0 {
-					wac.logger.Warnf("Detected %d stale outgoing messages (stuck in 'sent' >%v): %v — forcing reconnect", len(staleIDs), StaleMessageThreshold, staleIDs)
-					wac.client.Disconnect()
-					if err := wac.client.Connect(); err != nil {
-						wac.logger.Errorf("Failed to reconnect after stale message detection: %v", err)
+					wac.logger.Warnf("Detected %d stale outgoing messages (stuck in 'sent' >%v): %v — marking as filtered and writing notification", len(staleIDs), StaleMessageThreshold, staleIDs)
+					if err := wac.store.MarkMessagesFiltered(staleIDs); err != nil {
+						wac.logger.Warnf("Failed to mark stale messages as filtered: %v", err)
+					}
+					if wac.notificationsDir != "" {
+						notif := map[string]any{
+							"source":      "whatsapp",
+							"type":        "delivery_failure",
+							"instance":    wac.instance,
+							"message_ids": staleIDs,
+							"message":     fmt.Sprintf("%d message(s) were never delivered — likely silently dropped by WhatsApp. Check content for user@IP patterns or other spam-triggering strings.", len(staleIDs)),
+							"timestamp":   time.Now().UTC().Format(time.RFC3339),
+						}
+						if err := writeNotificationFile(wac.notificationsDir, notif, "delivery_failure"); err != nil {
+							wac.logger.Warnf("Failed to write delivery failure notification: %v", err)
+						}
 					}
 				}
 			}

--- a/agent/skills/whatsapp/cli/constants.go
+++ b/agent/skills/whatsapp/cli/constants.go
@@ -45,6 +45,7 @@ const (
 	DeliveryStatusDelivered = "delivered"
 	DeliveryStatusRead      = "read"
 	DeliveryStatusPlayed    = "played"
+	DeliveryStatusFiltered  = "filtered"
 
 	MediaTypeImage    = "image"
 	MediaTypeVideo    = "video"

--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -31,7 +31,7 @@ func (wac *WhatsAppClient) requireManualContact(jid types.JID) error {
 			phone = "this contact"
 		}
 		return fmt.Errorf(
-			"No saved contact found for %s. Ask the user who this is and run add_contact before sending messages.",
+			"No saved contact found for %s. Ask the user who this is, then run add-contact --name <name> --phone <number>.",
 			phone,
 		)
 	}

--- a/agent/skills/whatsapp/cli/events.go
+++ b/agent/skills/whatsapp/cli/events.go
@@ -224,6 +224,18 @@ func (wac *WhatsAppClient) handleHistorySync(evt *events.HistorySync) {
 
 		name := wac.getChatName(jid)
 
+		// Store chat FIRST so the FTS AFTER INSERT trigger can look up chat name.
+		// Chats with no messages in this sync batch must still be recorded.
+		chatTimestamp := time.Now()
+		if len(conversation.Messages) > 0 {
+			if m0 := conversation.Messages[0]; m0 != nil && m0.Message != nil {
+				chatTimestamp = time.Unix(int64(m0.Message.GetMessageTimestamp()), 0)
+			}
+		}
+		if err := wac.store.StoreChatTx(tx, chatJID, name, chatTimestamp); err != nil {
+			wac.logger.Warnf("Failed to store history chat: %v", err)
+		}
+
 		for _, msg := range conversation.Messages {
 			if msg == nil || msg.Message == nil {
 				continue
@@ -266,16 +278,6 @@ func (wac *WhatsAppClient) handleHistorySync(evt *events.HistorySync) {
 				MediaKey: mediaKey, FileSHA256: fileSHA256, FileEncSHA256: fileEncSHA256, FileLength: fileLength,
 			}); err != nil {
 				wac.logger.Warnf("Failed to store history message: %v", err)
-			}
-		}
-
-		if len(conversation.Messages) > 0 {
-			latestMsg := conversation.Messages[0]
-			if latestMsg != nil && latestMsg.Message != nil {
-				timestamp := time.Unix(int64(latestMsg.Message.GetMessageTimestamp()), 0)
-				if err := wac.store.StoreChatTx(tx, chatJID, name, timestamp); err != nil {
-					wac.logger.Warnf("Failed to store history chat: %v", err)
-				}
 			}
 		}
 	}

--- a/agent/skills/whatsapp/cli/messaging.go
+++ b/agent/skills/whatsapp/cli/messaging.go
@@ -18,7 +18,7 @@ import (
 // mentionPattern matches @word patterns in message text.
 var mentionPattern = regexp.MustCompile(`@(\+?\w+)`)
 
-// userAtIPPattern matches strings like "root@192.168.1.1" which WhatsApp spam filters may silently drop.
+// WhatsApp spam filters silently drop messages containing user@IP patterns.
 var userAtIPPattern = regexp.MustCompile(`\w+@\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
 
 func (wac *WhatsAppClient) SendMessageWithPresence(recipient, message string) (bool, string) {

--- a/agent/skills/whatsapp/cli/messaging.go
+++ b/agent/skills/whatsapp/cli/messaging.go
@@ -18,6 +18,9 @@ import (
 // mentionPattern matches @word patterns in message text.
 var mentionPattern = regexp.MustCompile(`@(\+?\w+)`)
 
+// userAtIPPattern matches strings like "root@192.168.1.1" which WhatsApp spam filters may silently drop.
+var userAtIPPattern = regexp.MustCompile(`\w+@\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
+
 func (wac *WhatsAppClient) SendMessageWithPresence(recipient, message string) (bool, string) {
 	if recipient == "" || message == "" {
 		return false, "Recipient and message are required. Provide a contact name, phone number, or group name plus the message text"

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -97,6 +97,27 @@ func WriteNotification(
 	return writeNotificationFile(ctx.NotifDir, n, "message")
 }
 
+type deliveryFailureNotif struct {
+	Source     string   `json:"source"`
+	Type       string   `json:"type"`
+	Instance   string   `json:"instance,omitempty"`
+	MessageIDs []string `json:"message_ids"`
+	Message    string   `json:"message"`
+	Timestamp  string   `json:"timestamp"`
+}
+
+func WriteDeliveryFailureNotification(notifDir, instance string, messageIDs []string) error {
+	n := deliveryFailureNotif{
+		Source:     "whatsapp",
+		Type:       "delivery_failure",
+		Instance:   instance,
+		MessageIDs: messageIDs,
+		Message:    fmt.Sprintf("%d message(s) were never delivered — likely silently dropped by WhatsApp. Check content for user@IP patterns or other spam-triggering strings.", len(messageIDs)),
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+	}
+	return writeNotificationFile(notifDir, n, "delivery_failure")
+}
+
 func WriteReactionNotification(
 	ctx NotifContext,
 	targetMessageID, emoji string, isRemoved bool,

--- a/agent/skills/whatsapp/cli/storage.go
+++ b/agent/skills/whatsapp/cli/storage.go
@@ -151,6 +151,19 @@ func (ms *MessageStore) rebuildFTS() error {
 		return fmt.Errorf("failed to check FTS index: %v", err)
 	}
 	if count > 0 {
+		// Repair FTS entries where chat_name is NULL — caused by messages being
+		// stored before their chat row existed (fixed in handleHistorySync, but
+		// repairs any entries created by older versions).
+		ms.db.Exec(`DELETE FROM messages_fts WHERE chat_name IS NULL`)
+		ms.db.Exec(`
+			INSERT INTO messages_fts(rowid, content, chat_name, sender)
+			SELECT m.rowid, m.content,
+				(SELECT name FROM chats WHERE jid = m.chat_jid),
+				m.sender
+			FROM messages m
+			WHERE m.content IS NOT NULL AND m.content != ''
+			AND NOT EXISTS (SELECT 1 FROM messages_fts f WHERE f.rowid = m.rowid)
+		`)
 		return nil
 	}
 	var msgCount int

--- a/agent/skills/whatsapp/cli/storage.go
+++ b/agent/skills/whatsapp/cli/storage.go
@@ -825,21 +825,33 @@ func (ms *MessageStore) GetStaleOutgoingMessages(olderThan time.Duration) ([]str
 	return ids, rows.Err()
 }
 
+const sqliteMaxVars = 500
+
 func (ms *MessageStore) MarkMessagesFiltered(ids []string) error {
-	if len(ids) == 0 {
-		return nil
+	for len(ids) > 0 {
+		batch := ids
+		if len(batch) > sqliteMaxVars {
+			batch = ids[:sqliteMaxVars]
+		}
+		ids = ids[len(batch):]
+
+		args := make([]any, 0, len(batch)+2)
+		args = append(args, DeliveryStatusFiltered)
+		for _, id := range batch {
+			args = append(args, id)
+		}
+		args = append(args, DeliveryStatusSent)
+
+		placeholders := strings.Repeat("?,", len(batch))
+		placeholders = placeholders[:len(placeholders)-1]
+		if _, err := ms.db.Exec(
+			"UPDATE messages SET delivery_status = ? WHERE id IN ("+placeholders+") AND delivery_status = ?",
+			args...,
+		); err != nil {
+			return err
+		}
 	}
-	placeholders := strings.Repeat("?,", len(ids))
-	placeholders = placeholders[:len(placeholders)-1]
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
-	_, err := ms.db.Exec(
-		"UPDATE messages SET delivery_status = ? WHERE id IN ("+placeholders+") AND delivery_status = ?",
-		append([]any{DeliveryStatusFiltered}, append(args, DeliveryStatusSent)...)...,
-	)
-	return err
+	return nil
 }
 
 func (ms *MessageStore) ListAllChatJIDs() ([]string, error) {

--- a/agent/skills/whatsapp/cli/storage.go
+++ b/agent/skills/whatsapp/cli/storage.go
@@ -825,6 +825,23 @@ func (ms *MessageStore) GetStaleOutgoingMessages(olderThan time.Duration) ([]str
 	return ids, rows.Err()
 }
 
+func (ms *MessageStore) MarkMessagesFiltered(ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	placeholders := strings.Repeat("?,", len(ids))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	_, err := ms.db.Exec(
+		"UPDATE messages SET delivery_status = ? WHERE id IN ("+placeholders+") AND delivery_status = ?",
+		append([]any{DeliveryStatusFiltered}, append(args, DeliveryStatusSent)...)...,
+	)
+	return err
+}
+
 func (ms *MessageStore) ListAllChatJIDs() ([]string, error) {
 	rows, err := ms.db.Query(`SELECT jid FROM chats ORDER BY last_message_time DESC`)
 	if err != nil {


### PR DESCRIPTION
## Summary

### #285 — Silent message drop detection
- Warns on `user@IP` patterns at send time (`delivery_warning` field in response) — WhatsApp spam filters silently drop these
- Replaces stale message reconnect loop with a `delivery_failure` notification: messages stuck in `"sent"` after 90s get marked `"filtered"` in the DB and a notification is written so the agent can alert the user
- Adds `DeliveryStatusFiltered` constant and `MarkMessagesFiltered()` with SQLite batch cap (500) to stay under `SQLITE_MAX_VARIABLE_NUMBER`

### #282 — Existing chats/contacts disappearing from agent view
Root cause found and fixed: in `handleHistorySync`, messages were stored **before** the chat row existed. The FTS `AFTER INSERT` trigger ran `SELECT name FROM chats WHERE jid = ...` and got NULL, creating broken FTS entries. Additionally, chats with no messages in a sync batch were never stored at all (gated by `if len(messages) > 0`), making them invisible to all queries that JOIN on `chats`.

- Store chat row **before** messages in `handleHistorySync` so FTS triggers get the correct chat name
- Remove the `len(messages) > 0` guard — chats are recorded regardless of whether the current sync batch has messages
- Repair existing NULL `chat_name` FTS entries on startup (fixes data corrupted by older versions)
- Add actionable `note` to `list-messages` when a specific contact returns empty

### #278 — Actionable error messages for contact/backfill flow
- Fix `backfill` no-history error to explain the protocol limitation and tell the agent exactly what to do
- Fix `backfill` success message to tell the agent to wait then use `list-messages`
- Fix `requireManualContact` error to use correct command syntax (`add-contact --name <name> --phone <number>`)

## Test plan

- [ ] Send a message with `root@192.168.1.1` — response includes `delivery_warning`
- [ ] Send a normal message — no `delivery_warning`
- [ ] Messages stuck in `"sent"` past 90s → `delivery_failure` notification written, status → `"filtered"`
- [ ] Fresh history sync: chats with no messages in the batch still appear in `list-chats`
- [ ] `list-messages --to <contact>` returns messages correctly after history sync (not empty)
- [ ] DB with old NULL chat_name FTS entries → repaired on next startup
- [ ] `backfill` on a chat with no local history → clear error explaining the anchor requirement
- [ ] `send-message` to unknown contact → error includes exact `add-contact` syntax

Fixes #285
Fixes #282
Fixes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)