### PR TITLE
feat(agent): retry transient API errors with backoff

### DIFF
--- a/agent/src/vesta/config.py
+++ b/agent/src/vesta/config.py
@@ -85,4 +85,3 @@ class VestaConfig(pyd_settings.BaseSettings):
 
     agent_name: str = "vesta"
     agent_model: str = "opus"
-    user_phone: str | None = None

--- a/agent/src/vesta/config.py
+++ b/agent/src/vesta/config.py
@@ -85,3 +85,4 @@ class VestaConfig(pyd_settings.BaseSettings):
 
     agent_name: str = "vesta"
     agent_model: str = "opus"
+    user_phone: str | None = None

--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -152,7 +152,7 @@ async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, c
                 while not state.shutdown_event.is_set() and not state.graceful_shutdown.is_set():
                     try:
                         await asyncio.wait_for(state.shutdown_event.wait(), timeout=_RETRY_INTERVAL)
-                        return  # shutdown fired during sleep
+                        return
                     except TimeoutError:
                         pass
                     if state.graceful_shutdown.is_set():

--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -130,25 +130,6 @@ def _is_transient(error: Exception) -> bool:
     return any(marker in msg for marker in _TRANSIENT_MARKERS)
 
 
-async def _send_outage_notification(message: str, *, config: vm.VestaConfig) -> None:
-    if not config.user_phone:
-        return
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "whatsapp",
-            "send",
-            "--to",
-            config.user_phone,
-            "--message",
-            message,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        await asyncio.wait_for(proc.wait(), timeout=10)
-    except Exception as e:
-        logger.warning(f"Outage notification failed: {e}")
-
-
 async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, config: vm.VestaConfig) -> None:
     try:
         if is_user:
@@ -167,18 +148,13 @@ async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, c
             state.event_bus.emit(ApiOutageEvent(type="api_outage", text=str(e), retry_count=state.api_failures))
 
             if state.api_failures >= _MAX_TRANSIENT_RETRIES:
-                await _send_outage_notification(
-                    "Anthropic API is currently down. "
-                    "Status: https://status.anthropic.com — "
-                    "I'll retry automatically and message you when I'm back.",
-                    config=config,
-                )
+                logger.warning("API outage detected, entering retry loop...")
                 while not state.shutdown_event.is_set() and not state.graceful_shutdown.is_set():
                     await asyncio.sleep(_RETRY_INTERVAL)
                     try:
                         await process_message(msg, state=state, config=config, is_user=is_user)
                         state.api_failures = 0
-                        await _send_outage_notification("API is back online, I'm operational again.", config=config)
+                        logger.startup("API recovered, resuming normal operation")
                         state.event_bus.emit(ApiRecoveredEvent(type="api_recovered"))
                         return
                     except Exception as retry_e:

--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -14,6 +14,7 @@ import vesta.models as vm
 from vesta import logger
 from vesta.core.client import process_message, build_client_options, attempt_interrupt, persist_session_id, _cancel_task
 from vesta.core.init import load_prompt, build_restart_context
+from vesta.events import ApiOutageEvent, ApiRecoveredEvent
 
 
 def _now() -> dt.datetime:
@@ -119,6 +120,29 @@ async def queue_greeting(queue: asyncio.Queue[tuple[str, bool]], *, config: vm.V
 # --- Message processing ---
 
 
+_TRANSIENT_MARKERS = ("500", "502", "503", "529", "overloaded", "internal_error")
+_MAX_TRANSIENT_RETRIES = 3
+_RETRY_INTERVAL = 60  # seconds
+
+
+def _is_transient(error: Exception) -> bool:
+    msg = str(error).lower()
+    return any(marker in msg for marker in _TRANSIENT_MARKERS)
+
+
+async def _send_outage_notification(message: str, *, config: vm.VestaConfig) -> None:
+    if not config.user_phone:
+        return
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "whatsapp", "send", "--to", config.user_phone, "--message", message,
+            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=10)
+    except Exception as e:
+        logger.warning(f"Outage notification failed: {e}")
+
+
 async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, config: vm.VestaConfig) -> None:
     try:
         if is_user:
@@ -129,7 +153,40 @@ async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, c
             logger.system(preview.replace("\n", " "))
         state.event_bus.set_state("thinking")
         await process_message(msg, state=state, config=config, is_user=is_user)
+        state.api_failures = 0
     except (ClaudeSDKError, OSError, RuntimeError, ValueError, TimeoutError) as e:
+        if _is_transient(e):
+            state.api_failures += 1
+            logger.warning(f"Transient API error ({state.api_failures}/{_MAX_TRANSIENT_RETRIES}): {e}")
+            state.event_bus.emit(ApiOutageEvent(type="api_outage", text=str(e), retry_count=state.api_failures))
+
+            if state.api_failures >= _MAX_TRANSIENT_RETRIES:
+                await _send_outage_notification(
+                    "Anthropic API is currently down. "
+                    "Status: https://status.anthropic.com — "
+                    "I'll retry automatically and message you when I'm back.",
+                    config=config,
+                )
+                while not state.shutdown_event.is_set() and not state.graceful_shutdown.is_set():
+                    await asyncio.sleep(_RETRY_INTERVAL)
+                    try:
+                        await process_message(msg, state=state, config=config, is_user=is_user)
+                        state.api_failures = 0
+                        await _send_outage_notification("API is back online, I'm operational again.", config=config)
+                        state.event_bus.emit(ApiRecoveredEvent(type="api_recovered"))
+                        return
+                    except Exception as retry_e:
+                        if _is_transient(retry_e):
+                            logger.warning(f"API still down, retrying in {_RETRY_INTERVAL}s...")
+                        else:
+                            error_msg = str(retry_e) or type(retry_e).__name__
+                            logger.error(f"Error processing message: {error_msg} — triggering restart")
+                            state.event_bus.emit({"type": "error", "text": error_msg})
+                            state.restart_reason = f"error — {error_msg}"
+                            state.graceful_shutdown.set()
+                            return
+            return
+
         if isinstance(e, TimeoutError):
             error_msg = "Response timed out"
         else:

--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -135,8 +135,14 @@ async def _send_outage_notification(message: str, *, config: vm.VestaConfig) -> 
         return
     try:
         proc = await asyncio.create_subprocess_exec(
-            "whatsapp", "send", "--to", config.user_phone, "--message", message,
-            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+            "whatsapp",
+            "send",
+            "--to",
+            config.user_phone,
+            "--message",
+            message,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
         )
         await asyncio.wait_for(proc.wait(), timeout=10)
     except Exception as e:

--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -14,7 +14,7 @@ import vesta.models as vm
 from vesta import logger
 from vesta.core.client import process_message, build_client_options, attempt_interrupt, persist_session_id, _cancel_task
 from vesta.core.init import load_prompt, build_restart_context
-from vesta.events import ApiOutageEvent, ApiRecoveredEvent
+from vesta.events import ApiOutageEvent, ApiRecoveredEvent, ErrorEvent
 
 
 def _now() -> dt.datetime:
@@ -150,20 +150,26 @@ async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, c
             if state.api_failures >= _MAX_TRANSIENT_RETRIES:
                 logger.warning("API outage detected, entering retry loop...")
                 while not state.shutdown_event.is_set() and not state.graceful_shutdown.is_set():
-                    await asyncio.sleep(_RETRY_INTERVAL)
+                    try:
+                        await asyncio.wait_for(state.shutdown_event.wait(), timeout=_RETRY_INTERVAL)
+                        return  # shutdown fired during sleep
+                    except TimeoutError:
+                        pass
+                    if state.graceful_shutdown.is_set():
+                        return
                     try:
                         await process_message(msg, state=state, config=config, is_user=is_user)
                         state.api_failures = 0
-                        logger.startup("API recovered, resuming normal operation")
+                        logger.client("API recovered, resuming normal operation")
                         state.event_bus.emit(ApiRecoveredEvent(type="api_recovered"))
                         return
-                    except Exception as retry_e:
+                    except (ClaudeSDKError, OSError, RuntimeError, ValueError, TimeoutError) as retry_e:
                         if _is_transient(retry_e):
                             logger.warning(f"API still down, retrying in {_RETRY_INTERVAL}s...")
                         else:
                             error_msg = str(retry_e) or type(retry_e).__name__
                             logger.error(f"Error processing message: {error_msg} — triggering restart")
-                            state.event_bus.emit({"type": "error", "text": error_msg})
+                            state.event_bus.emit(ErrorEvent(type="error", text=error_msg))
                             state.restart_reason = f"error — {error_msg}"
                             state.graceful_shutdown.set()
                             return

--- a/agent/src/vesta/events.py
+++ b/agent/src/vesta/events.py
@@ -76,6 +76,16 @@ class ChatEvent(_BaseEvent):
     text: str
 
 
+class ApiOutageEvent(_BaseEvent):
+    type: tp.Literal["api_outage"]
+    text: str
+    retry_count: int
+
+
+class ApiRecoveredEvent(_BaseEvent):
+    type: tp.Literal["api_recovered"]
+
+
 type StreamEvent = (
     StatusEvent
     | ToolStartEvent
@@ -88,6 +98,8 @@ type StreamEvent = (
     | SubagentStartEvent
     | SubagentStopEvent
     | ChatEvent
+    | ApiOutageEvent
+    | ApiRecoveredEvent
 )
 
 

--- a/agent/src/vesta/models.py
+++ b/agent/src/vesta/models.py
@@ -27,6 +27,7 @@ class State:
     dreamer_active: bool = False
     interrupt_event: asyncio.Event | None = None
     event_bus: EventBus = dc.field(default_factory=EventBus)
+    api_failures: int = 0
 
 
 class Notification(pyd.BaseModel):

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -5,8 +5,11 @@ import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from claude_agent_sdk import ClaudeSDKError
+
 import vesta.models as vm
 from vesta.core.client import process_message
+from vesta.core.loops import _is_transient, _MAX_TRANSIENT_RETRIES
 
 
 async def _run_processor_test(
@@ -193,3 +196,142 @@ async def test_process_message_no_correction_on_empty_response(tmp_path):
         await process_message("hello", state=state, config=config, is_user=True)
 
     assert len(converse_calls) == 1
+
+
+# --- Transient error handling ---
+
+
+@pytest.mark.parametrize(
+    "msg",
+    ["HTTP 500 error", "502 bad gateway", "503 service unavailable", "529 overloaded", "overloaded_error", "internal_error"],
+)
+def test_is_transient_matches(msg):
+    assert _is_transient(RuntimeError(msg))
+
+
+@pytest.mark.parametrize("msg", ["connection refused", "timeout", "invalid request", "401 unauthorized"])
+def test_is_transient_no_match(msg):
+    assert not _is_transient(RuntimeError(msg))
+
+
+@pytest.mark.anyio
+async def test_transient_error_no_restart(tmp_path):
+    from vesta.core.loops import _process_message_safely
+
+    config = vm.VestaConfig(root=tmp_path)
+    state = vm.State()
+    state.shutdown_event = asyncio.Event()
+
+    async def side_effect(msg, *, state, config, is_user):
+        raise ClaudeSDKError("HTTP 500 Internal Server Error")
+
+    with patch("vesta.core.loops.process_message", side_effect=side_effect):
+        await _process_message_safely("hello", is_user=True, state=state, config=config)
+
+    assert not state.graceful_shutdown.is_set()
+    assert state.api_failures == 1
+
+
+@pytest.mark.anyio
+async def test_transient_error_resets_on_success(tmp_path):
+    from vesta.core.loops import _process_message_safely
+
+    config = vm.VestaConfig(root=tmp_path)
+    state = vm.State()
+    state.shutdown_event = asyncio.Event()
+    state.api_failures = 2
+
+    async def side_effect(msg, *, state, config, is_user):
+        return ([], state)
+
+    with patch("vesta.core.loops.process_message", side_effect=side_effect):
+        await _process_message_safely("hello", is_user=True, state=state, config=config)
+
+    assert state.api_failures == 0
+    assert not state.graceful_shutdown.is_set()
+
+
+@pytest.mark.anyio
+async def test_retry_loop_recovers(tmp_path):
+    from vesta.core.loops import _process_message_safely
+
+    config = vm.VestaConfig(root=tmp_path)
+    state = vm.State()
+    state.shutdown_event = asyncio.Event()
+    state.api_failures = _MAX_TRANSIENT_RETRIES - 1
+
+    call_count = 0
+
+    async def side_effect(msg, *, state, config, is_user):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ClaudeSDKError("HTTP 503 Service Unavailable")
+        return ([], state)
+
+    with (
+        patch("vesta.core.loops.process_message", side_effect=side_effect),
+        patch("vesta.core.loops._RETRY_INTERVAL", 0.01),
+    ):
+        await _process_message_safely("hello", is_user=True, state=state, config=config)
+
+    assert not state.graceful_shutdown.is_set()
+    assert state.api_failures == 0
+    assert call_count == 2
+
+
+@pytest.mark.anyio
+async def test_retry_loop_exits_on_shutdown(tmp_path):
+    from vesta.core.loops import _process_message_safely
+
+    config = vm.VestaConfig(root=tmp_path)
+    state = vm.State()
+    state.shutdown_event = asyncio.Event()
+    state.api_failures = _MAX_TRANSIENT_RETRIES - 1
+
+    call_count = 0
+
+    async def side_effect(msg, *, state, config, is_user):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            state.shutdown_event.set()
+        raise ClaudeSDKError("HTTP 503 Service Unavailable")
+
+    with (
+        patch("vesta.core.loops.process_message", side_effect=side_effect),
+        patch("vesta.core.loops._RETRY_INTERVAL", 0.01),
+    ):
+        await _process_message_safely("hello", is_user=True, state=state, config=config)
+
+    assert not state.graceful_shutdown.is_set()
+    assert call_count == 2
+
+
+@pytest.mark.anyio
+async def test_retry_loop_non_transient_triggers_restart(tmp_path):
+    from vesta.core.loops import _process_message_safely
+
+    config = vm.VestaConfig(root=tmp_path)
+    state = vm.State()
+    state.shutdown_event = asyncio.Event()
+    state.api_failures = _MAX_TRANSIENT_RETRIES - 1
+
+    call_count = 0
+
+    async def side_effect(msg, *, state, config, is_user):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ClaudeSDKError("HTTP 503 Service Unavailable")
+        raise RuntimeError("Unexpected buffer overflow")
+
+    with (
+        patch("vesta.core.loops.process_message", side_effect=side_effect),
+        patch("vesta.core.loops._RETRY_INTERVAL", 0.01),
+    ):
+        await _process_message_safely("hello", is_user=True, state=state, config=config)
+
+    assert state.graceful_shutdown.is_set()
+    assert "buffer overflow" in state.restart_reason
+    assert call_count == 2

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -9,7 +9,7 @@ from claude_agent_sdk import ClaudeSDKError
 
 import vesta.models as vm
 from vesta.core.client import process_message
-from vesta.core.loops import _is_transient, _MAX_TRANSIENT_RETRIES
+from vesta.core.loops import _is_transient, _MAX_TRANSIENT_RETRIES, _process_message_safely
 
 
 async def _run_processor_test(
@@ -215,13 +215,7 @@ def test_is_transient_no_match(msg):
 
 
 @pytest.mark.anyio
-async def test_transient_error_no_restart(tmp_path):
-    from vesta.core.loops import _process_message_safely
-
-    config = vm.VestaConfig(root=tmp_path)
-    state = vm.State()
-    state.shutdown_event = asyncio.Event()
-
+async def test_transient_error_no_restart(config, state):
     async def side_effect(msg, *, state, config, is_user):
         raise ClaudeSDKError("HTTP 500 Internal Server Error")
 
@@ -233,12 +227,7 @@ async def test_transient_error_no_restart(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_transient_error_resets_on_success(tmp_path):
-    from vesta.core.loops import _process_message_safely
-
-    config = vm.VestaConfig(root=tmp_path)
-    state = vm.State()
-    state.shutdown_event = asyncio.Event()
+async def test_transient_error_resets_on_success(config, state):
     state.api_failures = 2
 
     async def side_effect(msg, *, state, config, is_user):
@@ -252,14 +241,8 @@ async def test_transient_error_resets_on_success(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_retry_loop_recovers(tmp_path):
-    from vesta.core.loops import _process_message_safely
-
-    config = vm.VestaConfig(root=tmp_path)
-    state = vm.State()
-    state.shutdown_event = asyncio.Event()
+async def test_retry_loop_recovers(config, state):
     state.api_failures = _MAX_TRANSIENT_RETRIES - 1
-
     call_count = 0
 
     async def side_effect(msg, *, state, config, is_user):
@@ -281,14 +264,8 @@ async def test_retry_loop_recovers(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_retry_loop_exits_on_shutdown(tmp_path):
-    from vesta.core.loops import _process_message_safely
-
-    config = vm.VestaConfig(root=tmp_path)
-    state = vm.State()
-    state.shutdown_event = asyncio.Event()
+async def test_retry_loop_exits_on_shutdown(config, state):
     state.api_failures = _MAX_TRANSIENT_RETRIES - 1
-
     call_count = 0
 
     async def side_effect(msg, *, state, config, is_user):
@@ -309,14 +286,8 @@ async def test_retry_loop_exits_on_shutdown(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_retry_loop_non_transient_triggers_restart(tmp_path):
-    from vesta.core.loops import _process_message_safely
-
-    config = vm.VestaConfig(root=tmp_path)
-    state = vm.State()
-    state.shutdown_event = asyncio.Event()
+async def test_retry_loop_non_transient_triggers_restart(config, state):
     state.api_failures = _MAX_TRANSIENT_RETRIES - 1
-
     call_count = 0
 
     async def side_effect(msg, *, state, config, is_user):


### PR DESCRIPTION
## Summary

- Detect transient Anthropic API errors (500, 502, 503, 529/overloaded) in `_process_message_safely` — warn and drop instead of restarting
- After 3 consecutive transient failures, log the outage and enter a 60s retry loop (respects shutdown events)
- On recovery, log and emit `api_recovered` event
- Adds `ApiOutageEvent` and `ApiRecoveredEvent` typed events to the event bus

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)