### PR TITLE
feat(skills): add ssh skill via bore tunnel

### DIFF
--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -56,6 +56,10 @@
     "description": "This skill should be used when the user asks about \"spotify\", \"music\", \"playlist\", \"playlists\", \"song\", \"songs\", \"track\", \"tracks\", \"now playing\", \"what's playing\", \"play\", \"pause\", \"skip\", \"queue\", or needs to search for music, manage playlists, or control playback."
   },
   {
+    "name": "ssh",
+    "description": "Use when the user wants to allow another computer to SSH into this machine, share remote access, or set up a public SSH tunnel. Creates an internet-accessible SSH endpoint via bore."
+  },
+  {
     "name": "tasks",
     "description": "This skill should be used when the user asks about \"tasks\", \"to-do\", \"todo\", \"task list\", \"reminders\", \"remind me\", \"alert\", \"notify\", or needs to create, manage, track, or organize tasks, to-do items, reminders, and time-based notifications. Everything actionable becomes a task immediately. All work, progress, drafts go in task metadata. Reminders are nudges about when to think about something, standalone or linked to a task. IMPORTANT: this skill requires a background daemon. Before doing anything, immediately make sure the daemon is running. Read this skill to learn how."
   },

--- a/agent/skills/ssh/SKILL.md
+++ b/agent/skills/ssh/SKILL.md
@@ -5,25 +5,78 @@ description: Use when the user wants to allow another computer to SSH into this 
 
 # SSH Access
 
-Expose this machine's SSH server publicly over the internet using [bore](https://github.com/ekzhang/bore), a lightweight TCP tunnel. No account required. Standard SSH clients work on the other end — no special tooling needed.
+Exposes this machine over the internet via [bore](https://github.com/ekzhang/bore), a free TCP relay. Runs its own sshd on port 2222 inside the container (independent of the host SSH server) so all auth is fully controlled. No account required. The connecting machine only needs a standard SSH client.
 
-## Usage
+## Before running start.sh — get the client's public key
+
+Ask the user to run this on the machine that will be connecting:
 
 ```bash
-# Start the tunnel (downloads bore if needed, runs in background)
-~/vesta/skills/ssh/scripts/start.sh
+cat ~/.ssh/id_ed25519.pub
+# or if using RSA:
+cat ~/.ssh/id_rsa.pub
+```
 
-# Check status and get the current connection command
+If they don't have a key yet:
+```bash
+ssh-keygen -t ed25519   # press Enter for all prompts
+cat ~/.ssh/id_ed25519.pub
+```
+
+They should paste the full output (one line starting with `ssh-ed25519` or `ssh-rsa`).
+
+## Start the tunnel
+
+```bash
+~/vesta/skills/ssh/scripts/start.sh "ssh-ed25519 AAAA... user@laptop"
+```
+
+This will:
+1. Install `openssh-server` if not already present
+2. Generate SSH host keys if missing
+3. Start sshd on port 2222 with key-only auth (no passwords)
+4. Add the provided public key to `/root/.ssh/authorized_keys`
+5. Download `bore` if not already installed
+6. Open a public bore.pub tunnel and print the connection command
+
+Running `start.sh` again with a different key adds it without removing existing ones (idempotent).
+
+## Connect from the other machine
+
+The script prints the exact command. It will look like:
+
+```bash
+ssh -o StrictHostKeyChecking=accept-new root@bore.pub -p 12345
+```
+
+`StrictHostKeyChecking=accept-new` accepts the host key on first connect and warns if it changes later — safer than `no`. The host key is the container's sshd key and stays stable across bore reconnects.
+
+If the connecting machine has multiple SSH keys and the wrong one is picked:
+```bash
+ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new root@bore.pub -p 12345
+```
+
+## Check status
+
+```bash
 ~/vesta/skills/ssh/scripts/status.sh
+```
 
-# Stop the tunnel
+Shows whether sshd and bore are running, the current connection command, and which keys are authorized.
+
+## Stop
+
+```bash
 ~/vesta/skills/ssh/scripts/stop.sh
 ```
 
+Stops both the bore tunnel and the sshd process. Authorized keys remain in `/root/.ssh/authorized_keys` for the next session.
+
 ## Notes
 
-- The tunnel endpoint changes each time `start.sh` is run (bore assigns a random port)
-- The tunnel connects to port 22 on this machine (the host SSH server, accessible via host networking)
-- The other machine connects with: `ssh <username>@bore.pub -p <port>`
-- Tunnel runs in a `screen` session named `bore-ssh`
-- bore.pub is the default relay; it's a public free service — don't tunnel anything sensitive without considering this
+- Auth is key-only. Password auth and root password login are disabled.
+- The bore port changes each time `start.sh` is run — share the new port with the connecting machine.
+- Tunnel runs in a `screen` session named `bore-ssh`. If bore dies unexpectedly: `screen -r bore-ssh` to inspect, then re-run `start.sh`.
+- bore.pub is a public free service operated by the bore project. Don't use it for long-term persistent access — it's for temporary sessions.
+- To copy files over the tunnel: `scp -P 12345 -o StrictHostKeyChecking=accept-new file root@bore.pub:~/destination/`
+- To use rsync: `rsync -e "ssh -p 12345 -o StrictHostKeyChecking=accept-new" file root@bore.pub:~/destination/`

--- a/agent/skills/ssh/SKILL.md
+++ b/agent/skills/ssh/SKILL.md
@@ -7,7 +7,7 @@ description: Use when the user wants to allow another computer to SSH into this 
 
 Exposes this machine over the internet via [bore](https://github.com/ekzhang/bore), a free TCP relay. Runs its own sshd on port 2222 inside the container (independent of the host SSH server) so all auth is fully controlled. No account required. The connecting machine only needs a standard SSH client.
 
-## Before running start.sh — get the client's public key
+## Before running start.sh: get the client's public key
 
 Ask the user to run this on the machine that will be connecting:
 
@@ -49,7 +49,7 @@ The script prints the exact command. It will look like:
 ssh -o StrictHostKeyChecking=accept-new root@bore.pub -p 12345
 ```
 
-`StrictHostKeyChecking=accept-new` accepts the host key on first connect and warns if it changes later — safer than `no`. The host key is the container's sshd key and stays stable across bore reconnects.
+`StrictHostKeyChecking=accept-new` accepts the host key on first connect and warns if it changes later (safer than `no`). The host key is the container's sshd key and stays stable across bore reconnects.
 
 If the connecting machine has multiple SSH keys and the wrong one is picked:
 ```bash
@@ -75,8 +75,8 @@ Stops both the bore tunnel and the sshd process. Authorized keys remain in `/roo
 ## Notes
 
 - Auth is key-only. Password auth and root password login are disabled.
-- The bore port changes each time `start.sh` is run — share the new port with the connecting machine.
+- The bore port changes each time `start.sh` is run. Share the new port with the connecting machine.
 - Tunnel runs in a `screen` session named `bore-ssh`. If bore dies unexpectedly: `screen -r bore-ssh` to inspect, then re-run `start.sh`.
-- bore.pub is a public free service operated by the bore project. Don't use it for long-term persistent access — it's for temporary sessions.
+- bore.pub is a public free service. Don't use it for long-term persistent access; it's for temporary sessions.
 - To copy files over the tunnel: `scp -P 12345 -o StrictHostKeyChecking=accept-new file root@bore.pub:~/destination/`
 - To use rsync: `rsync -e "ssh -p 12345 -o StrictHostKeyChecking=accept-new" file root@bore.pub:~/destination/`

--- a/agent/skills/ssh/SKILL.md
+++ b/agent/skills/ssh/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: ssh
+description: Use when the user wants to allow another computer to SSH into this machine, share remote access, or set up a public SSH tunnel. Creates an internet-accessible SSH endpoint via bore.
+---
+
+# SSH Access
+
+Expose this machine's SSH server publicly over the internet using [bore](https://github.com/ekzhang/bore), a lightweight TCP tunnel. No account required. Standard SSH clients work on the other end — no special tooling needed.
+
+## Usage
+
+```bash
+# Start the tunnel (downloads bore if needed, runs in background)
+~/vesta/skills/ssh/scripts/start.sh
+
+# Check status and get the current connection command
+~/vesta/skills/ssh/scripts/status.sh
+
+# Stop the tunnel
+~/vesta/skills/ssh/scripts/stop.sh
+```
+
+## Notes
+
+- The tunnel endpoint changes each time `start.sh` is run (bore assigns a random port)
+- The tunnel connects to port 22 on this machine (the host SSH server, accessible via host networking)
+- The other machine connects with: `ssh <username>@bore.pub -p <port>`
+- Tunnel runs in a `screen` session named `bore-ssh`
+- bore.pub is the default relay; it's a public free service — don't tunnel anything sensitive without considering this

--- a/agent/skills/ssh/SKILL.md
+++ b/agent/skills/ssh/SKILL.md
@@ -5,7 +5,7 @@ description: Use when the user wants to allow another computer to SSH into this 
 
 # SSH Access
 
-Exposes this machine over the internet via [bore](https://github.com/ekzhang/bore), a free TCP relay. Runs its own sshd on port 2222 inside the container (independent of the host SSH server) so all auth is fully controlled. No account required. The connecting machine only needs a standard SSH client.
+Exposes this machine over the internet via [bore](https://github.com/ekzhang/bore), a free TCP relay. Runs its own sshd on a dynamically allocated port inside the container (independent of the host SSH server, no port conflicts between containers) so all auth is fully controlled. No account required. The connecting machine only needs a standard SSH client.
 
 ## Before running start.sh: get the client's public key
 
@@ -34,7 +34,7 @@ They should paste the full output (one line starting with `ssh-ed25519` or `ssh-
 This will:
 1. Install `openssh-server` if not already present
 2. Generate SSH host keys if missing
-3. Start sshd on port 2222 with key-only auth (no passwords)
+3. Start sshd on a free port (dynamically allocated, no conflicts between containers)
 4. Add the provided public key to `/root/.ssh/authorized_keys`
 5. Download `bore` if not already installed
 6. Open a public bore.pub tunnel and print the connection command

--- a/agent/skills/ssh/scripts/start.sh
+++ b/agent/skills/ssh/scripts/start.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 BORE_BIN="$HOME/.local/bin/bore"
 BORE_VERSION="0.5.1"
-BORE_LOG="/tmp/bore-ssh.log"
+BORE_LOG="/tmp/vesta-bore-ssh.log"
 BORE_SCREEN="bore-ssh"
-SSHD_PORT=2222
 SSHD_PID="/tmp/vesta-sshd.pid"
+SSHD_PORT_FILE="/tmp/vesta-sshd.port"
 SSHD_CONFIG="/tmp/vesta-sshd.conf"
 
 if [ -z "${1:-}" ]; then
@@ -30,6 +30,9 @@ if ! command -v sshd &>/dev/null; then
 fi
 
 ssh-keygen -A -q 2>/dev/null || true
+
+SSHD_PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); p=s.getsockname()[1]; s.close(); print(p)")
+echo "$SSHD_PORT" > "$SSHD_PORT_FILE"
 
 cat > "$SSHD_CONFIG" <<EOF
 Port $SSHD_PORT

--- a/agent/skills/ssh/scripts/start.sh
+++ b/agent/skills/ssh/scripts/start.sh
@@ -1,12 +1,77 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BORE_BIN="$HOME/.local/bin/bore"
-SCREEN_NAME="bore-ssh"
-LOG_FILE="/tmp/bore-ssh.log"
-BORE_VERSION="0.5.1"
+# Usage: start.sh "<public key string>"
+# Example: start.sh "ssh-ed25519 AAAA... user@laptop"
 
-# Install bore if missing
+BORE_BIN="$HOME/.local/bin/bore"
+BORE_VERSION="0.5.1"
+BORE_LOG="/tmp/bore-ssh.log"
+BORE_SCREEN="bore-ssh"
+SSHD_PORT=2222
+SSHD_PID="/tmp/vesta-sshd.pid"
+SSHD_CONFIG="/tmp/vesta-sshd.conf"
+
+if [ -z "${1:-}" ]; then
+    echo "ERROR: public key required."
+    echo ""
+    echo "On the connecting machine, run:"
+    echo "  cat ~/.ssh/id_ed25519.pub"
+    echo "  # or: cat ~/.ssh/id_rsa.pub"
+    echo "  # no key? generate one: ssh-keygen -t ed25519"
+    echo ""
+    echo "Then pass the output to this script:"
+    echo "  $0 'ssh-ed25519 AAAA... user@host'"
+    exit 1
+fi
+
+PUBLIC_KEY="$1"
+
+# --- sshd setup ---
+
+if ! command -v sshd &>/dev/null; then
+    echo "Installing openssh-server..."
+    apt-get install -y -q openssh-server
+fi
+
+# Generate host keys if missing
+ssh-keygen -A -q 2>/dev/null || true
+
+# Write a self-contained sshd config (doesn't touch system config)
+cat > "$SSHD_CONFIG" <<EOF
+Port $SSHD_PORT
+ListenAddress 0.0.0.0
+PermitRootLogin prohibit-password
+PasswordAuthentication no
+PubkeyAuthentication yes
+AuthorizedKeysFile /root/.ssh/authorized_keys
+HostKey /etc/ssh/ssh_host_ed25519_key
+HostKey /etc/ssh/ssh_host_rsa_key
+PidFile $SSHD_PID
+EOF
+
+# Add the public key to authorized_keys (idempotent)
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+AUTHKEYS="/root/.ssh/authorized_keys"
+if ! grep -qF "$PUBLIC_KEY" "$AUTHKEYS" 2>/dev/null; then
+    echo "$PUBLIC_KEY" >> "$AUTHKEYS"
+    echo "Public key added."
+else
+    echo "Public key already authorized."
+fi
+chmod 600 "$AUTHKEYS"
+
+# Start (or restart) sshd
+if [ -f "$SSHD_PID" ] && kill -0 "$(cat "$SSHD_PID")" 2>/dev/null; then
+    kill "$(cat "$SSHD_PID")"
+    sleep 0.5
+fi
+/usr/sbin/sshd -f "$SSHD_CONFIG"
+echo "sshd running on port $SSHD_PORT."
+
+# --- bore setup ---
+
 if [ ! -x "$BORE_BIN" ]; then
     echo "Installing bore..."
     ARCH=$(uname -m)
@@ -22,29 +87,30 @@ if [ ! -x "$BORE_BIN" ]; then
     echo "bore installed."
 fi
 
-# Stop any existing session
-screen -S "$SCREEN_NAME" -X quit 2>/dev/null || true
+# Stop any existing bore session
+screen -S "$BORE_SCREEN" -X quit 2>/dev/null || true
+rm -f "$BORE_LOG"
 
-# Start bore in background
-screen -dmS "$SCREEN_NAME" bash -c "$BORE_BIN local 22 --to bore.pub > $LOG_FILE 2>&1"
+screen -dmS "$BORE_SCREEN" bash -c "$BORE_BIN local $SSHD_PORT --to bore.pub > $BORE_LOG 2>&1"
 
-# Wait for bore to print the listening port (up to 10s)
+# Wait up to 10s for bore to report the port
+PORT=""
 for i in $(seq 1 20); do
-    PORT=$(grep -oP 'bore\.pub:\K[0-9]+' "$LOG_FILE" 2>/dev/null || true)
-    if [ -n "$PORT" ]; then
-        break
-    fi
+    PORT=$(grep -oP 'bore\.pub:\K[0-9]+' "$BORE_LOG" 2>/dev/null || true)
+    [ -n "$PORT" ] && break
     sleep 0.5
 done
 
 if [ -z "$PORT" ]; then
-    echo "ERROR: bore failed to start. Log:"
-    cat "$LOG_FILE"
+    echo "ERROR: bore failed to get a port. Log:"
+    cat "$BORE_LOG"
     exit 1
 fi
 
-USER=$(whoami)
-echo "SSH tunnel active."
 echo ""
-echo "Connect from another machine:"
-echo "  ssh ${USER}@bore.pub -p ${PORT}"
+echo "SSH tunnel active. On the connecting machine, run:"
+echo ""
+echo "  ssh -o StrictHostKeyChecking=accept-new root@bore.pub -p $PORT"
+echo ""
+echo "If the connecting machine has a different default key, specify it:"
+echo "  ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new root@bore.pub -p $PORT"

--- a/agent/skills/ssh/scripts/start.sh
+++ b/agent/skills/ssh/scripts/start.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BORE_BIN="$HOME/.local/bin/bore"
+SCREEN_NAME="bore-ssh"
+LOG_FILE="/tmp/bore-ssh.log"
+BORE_VERSION="0.5.1"
+
+# Install bore if missing
+if [ ! -x "$BORE_BIN" ]; then
+    echo "Installing bore..."
+    ARCH=$(uname -m)
+    case "$ARCH" in
+        x86_64)  TRIPLE="x86_64-unknown-linux-musl" ;;
+        aarch64) TRIPLE="aarch64-unknown-linux-musl" ;;
+        *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
+    esac
+    URL="https://github.com/ekzhang/bore/releases/download/v${BORE_VERSION}/bore-v${BORE_VERSION}-${TRIPLE}.tar.gz"
+    mkdir -p "$HOME/.local/bin"
+    curl -fsSL "$URL" | tar -xz -C "$HOME/.local/bin" bore
+    chmod +x "$BORE_BIN"
+    echo "bore installed."
+fi
+
+# Stop any existing session
+screen -S "$SCREEN_NAME" -X quit 2>/dev/null || true
+
+# Start bore in background
+screen -dmS "$SCREEN_NAME" bash -c "$BORE_BIN local 22 --to bore.pub > $LOG_FILE 2>&1"
+
+# Wait for bore to print the listening port (up to 10s)
+for i in $(seq 1 20); do
+    PORT=$(grep -oP 'bore\.pub:\K[0-9]+' "$LOG_FILE" 2>/dev/null || true)
+    if [ -n "$PORT" ]; then
+        break
+    fi
+    sleep 0.5
+done
+
+if [ -z "$PORT" ]; then
+    echo "ERROR: bore failed to start. Log:"
+    cat "$LOG_FILE"
+    exit 1
+fi
+
+USER=$(whoami)
+echo "SSH tunnel active."
+echo ""
+echo "Connect from another machine:"
+echo "  ssh ${USER}@bore.pub -p ${PORT}"

--- a/agent/skills/ssh/scripts/start.sh
+++ b/agent/skills/ssh/scripts/start.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: start.sh "<public key string>"
-# Example: start.sh "ssh-ed25519 AAAA... user@laptop"
-
 BORE_BIN="$HOME/.local/bin/bore"
 BORE_VERSION="0.5.1"
 BORE_LOG="/tmp/bore-ssh.log"
@@ -27,17 +24,13 @@ fi
 
 PUBLIC_KEY="$1"
 
-# --- sshd setup ---
-
 if ! command -v sshd &>/dev/null; then
     echo "Installing openssh-server..."
     apt-get install -y -q openssh-server
 fi
 
-# Generate host keys if missing
 ssh-keygen -A -q 2>/dev/null || true
 
-# Write a self-contained sshd config (doesn't touch system config)
 cat > "$SSHD_CONFIG" <<EOF
 Port $SSHD_PORT
 ListenAddress 0.0.0.0
@@ -50,7 +43,6 @@ HostKey /etc/ssh/ssh_host_rsa_key
 PidFile $SSHD_PID
 EOF
 
-# Add the public key to authorized_keys (idempotent)
 mkdir -p /root/.ssh
 chmod 700 /root/.ssh
 AUTHKEYS="/root/.ssh/authorized_keys"
@@ -62,15 +54,12 @@ else
 fi
 chmod 600 "$AUTHKEYS"
 
-# Start (or restart) sshd
-if [ -f "$SSHD_PID" ] && kill -0 "$(cat "$SSHD_PID")" 2>/dev/null; then
-    kill "$(cat "$SSHD_PID")"
+if [ -f "$SSHD_PID" ]; then
+    kill "$(cat "$SSHD_PID")" 2>/dev/null || true
     sleep 0.5
 fi
 /usr/sbin/sshd -f "$SSHD_CONFIG"
 echo "sshd running on port $SSHD_PORT."
-
-# --- bore setup ---
 
 if [ ! -x "$BORE_BIN" ]; then
     echo "Installing bore..."
@@ -87,13 +76,11 @@ if [ ! -x "$BORE_BIN" ]; then
     echo "bore installed."
 fi
 
-# Stop any existing bore session
 screen -S "$BORE_SCREEN" -X quit 2>/dev/null || true
 rm -f "$BORE_LOG"
 
 screen -dmS "$BORE_SCREEN" bash -c "$BORE_BIN local $SSHD_PORT --to bore.pub > $BORE_LOG 2>&1"
 
-# Wait up to 10s for bore to report the port
 PORT=""
 for i in $(seq 1 20); do
     PORT=$(grep -oP 'bore\.pub:\K[0-9]+' "$BORE_LOG" 2>/dev/null || true)

--- a/agent/skills/ssh/scripts/status.sh
+++ b/agent/skills/ssh/scripts/status.sh
@@ -1,29 +1,23 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 BORE_LOG="/tmp/bore-ssh.log"
 BORE_SCREEN="bore-ssh"
 SSHD_PID="/tmp/vesta-sshd.pid"
 
-SSHD_RUNNING=false
-BORE_RUNNING=false
+sshd_running() { [ -f "$SSHD_PID" ] && kill -0 "$(cat "$SSHD_PID")" 2>/dev/null; }
+bore_running() { screen -ls 2>/dev/null | grep -q "$BORE_SCREEN"; }
 
-if [ -f "$SSHD_PID" ] && kill -0 "$(cat "$SSHD_PID")" 2>/dev/null; then
-    SSHD_RUNNING=true
-fi
-
-if screen -ls | grep -q "$BORE_SCREEN"; then
-    BORE_RUNNING=true
-fi
-
-if ! $SSHD_RUNNING && ! $BORE_RUNNING; then
+if ! sshd_running && ! bore_running; then
     echo "SSH tunnel is not running. Start it with:"
     echo "  ~/vesta/skills/ssh/scripts/start.sh '<public key>'"
     exit 0
 fi
 
-echo "sshd: $($SSHD_RUNNING && echo running || echo stopped)"
-echo "bore: $($BORE_RUNNING && echo running || echo stopped)"
+echo "sshd: $(sshd_running && echo running || echo stopped)"
+echo "bore: $(bore_running && echo running || echo stopped)"
 
-if $BORE_RUNNING; then
+if bore_running; then
     PORT=$(grep -oP 'bore\.pub:\K[0-9]+' "$BORE_LOG" 2>/dev/null || true)
     if [ -n "$PORT" ]; then
         echo ""
@@ -34,9 +28,4 @@ fi
 
 echo ""
 echo "Authorized keys:"
-cat /root/.ssh/authorized_keys 2>/dev/null | while read -r line; do
-    # Print just the type and comment (first and last fields), not the key body
-    TYPE=$(echo "$line" | awk '{print $1}')
-    COMMENT=$(echo "$line" | awk '{print $NF}')
-    echo "  $TYPE ... $COMMENT"
-done
+awk '{print "  " $1 " ... " $NF}' /root/.ssh/authorized_keys 2>/dev/null || true

--- a/agent/skills/ssh/scripts/status.sh
+++ b/agent/skills/ssh/scripts/status.sh
@@ -1,20 +1,42 @@
 #!/usr/bin/env bash
-LOG_FILE="/tmp/bore-ssh.log"
-SCREEN_NAME="bore-ssh"
+BORE_LOG="/tmp/bore-ssh.log"
+BORE_SCREEN="bore-ssh"
+SSHD_PID="/tmp/vesta-sshd.pid"
 
-if ! screen -ls | grep -q "$SCREEN_NAME"; then
-    echo "SSH tunnel is not running. Start it with: ~/vesta/skills/ssh/scripts/start.sh"
+SSHD_RUNNING=false
+BORE_RUNNING=false
+
+if [ -f "$SSHD_PID" ] && kill -0 "$(cat "$SSHD_PID")" 2>/dev/null; then
+    SSHD_RUNNING=true
+fi
+
+if screen -ls | grep -q "$BORE_SCREEN"; then
+    BORE_RUNNING=true
+fi
+
+if ! $SSHD_RUNNING && ! $BORE_RUNNING; then
+    echo "SSH tunnel is not running. Start it with:"
+    echo "  ~/vesta/skills/ssh/scripts/start.sh '<public key>'"
     exit 0
 fi
 
-PORT=$(grep -oP 'bore\.pub:\K[0-9]+' "$LOG_FILE" 2>/dev/null || true)
-if [ -z "$PORT" ]; then
-    echo "Tunnel is starting up, no port yet."
-    exit 0
+echo "sshd: $($SSHD_RUNNING && echo running || echo stopped)"
+echo "bore: $($BORE_RUNNING && echo running || echo stopped)"
+
+if $BORE_RUNNING; then
+    PORT=$(grep -oP 'bore\.pub:\K[0-9]+' "$BORE_LOG" 2>/dev/null || true)
+    if [ -n "$PORT" ]; then
+        echo ""
+        echo "Connect from another machine:"
+        echo "  ssh -o StrictHostKeyChecking=accept-new root@bore.pub -p $PORT"
+    fi
 fi
 
-USER=$(whoami)
-echo "SSH tunnel is running."
 echo ""
-echo "Connect from another machine:"
-echo "  ssh ${USER}@bore.pub -p ${PORT}"
+echo "Authorized keys:"
+cat /root/.ssh/authorized_keys 2>/dev/null | while read -r line; do
+    # Print just the type and comment (first and last fields), not the key body
+    TYPE=$(echo "$line" | awk '{print $1}')
+    COMMENT=$(echo "$line" | awk '{print $NF}')
+    echo "  $TYPE ... $COMMENT"
+done

--- a/agent/skills/ssh/scripts/status.sh
+++ b/agent/skills/ssh/scripts/status.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BORE_LOG="/tmp/bore-ssh.log"
+BORE_LOG="/tmp/vesta-bore-ssh.log"
 BORE_SCREEN="bore-ssh"
 SSHD_PID="/tmp/vesta-sshd.pid"
+SSHD_PORT_FILE="/tmp/vesta-sshd.port"
 
 sshd_running() { [ -f "$SSHD_PID" ] && kill -0 "$(cat "$SSHD_PID")" 2>/dev/null; }
 bore_running() { screen -ls 2>/dev/null | grep -q "$BORE_SCREEN"; }

--- a/agent/skills/ssh/scripts/status.sh
+++ b/agent/skills/ssh/scripts/status.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+LOG_FILE="/tmp/bore-ssh.log"
+SCREEN_NAME="bore-ssh"
+
+if ! screen -ls | grep -q "$SCREEN_NAME"; then
+    echo "SSH tunnel is not running. Start it with: ~/vesta/skills/ssh/scripts/start.sh"
+    exit 0
+fi
+
+PORT=$(grep -oP 'bore\.pub:\K[0-9]+' "$LOG_FILE" 2>/dev/null || true)
+if [ -z "$PORT" ]; then
+    echo "Tunnel is starting up, no port yet."
+    exit 0
+fi
+
+USER=$(whoami)
+echo "SSH tunnel is running."
+echo ""
+echo "Connect from another machine:"
+echo "  ssh ${USER}@bore.pub -p ${PORT}"

--- a/agent/skills/ssh/scripts/stop.sh
+++ b/agent/skills/ssh/scripts/stop.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+SCREEN_NAME="bore-ssh"
+
+if screen -S "$SCREEN_NAME" -X quit 2>/dev/null; then
+    echo "SSH tunnel stopped."
+else
+    echo "No active SSH tunnel found."
+fi

--- a/agent/skills/ssh/scripts/stop.sh
+++ b/agent/skills/ssh/scripts/stop.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 BORE_SCREEN="bore-ssh"
 SSHD_PID="/tmp/vesta-sshd.pid"
+SSHD_PORT_FILE="/tmp/vesta-sshd.port"
 
 if screen -S "$BORE_SCREEN" -X quit 2>/dev/null; then
     echo "Bore tunnel stopped."
@@ -12,7 +13,7 @@ fi
 
 if [ -f "$SSHD_PID" ]; then
     kill "$(cat "$SSHD_PID")" 2>/dev/null && echo "sshd stopped." || echo "No active sshd found."
-    rm -f "$SSHD_PID"
+    rm -f "$SSHD_PID" "$SSHD_PORT_FILE"
 else
     echo "No active sshd found."
 fi

--- a/agent/skills/ssh/scripts/stop.sh
+++ b/agent/skills/ssh/scripts/stop.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 BORE_SCREEN="bore-ssh"
 SSHD_PID="/tmp/vesta-sshd.pid"
 
@@ -8,9 +10,9 @@ else
     echo "No active bore tunnel found."
 fi
 
-if [ -f "$SSHD_PID" ] && kill -0 "$(cat "$SSHD_PID")" 2>/dev/null; then
-    kill "$(cat "$SSHD_PID")"
-    echo "sshd stopped."
+if [ -f "$SSHD_PID" ]; then
+    kill "$(cat "$SSHD_PID")" 2>/dev/null && echo "sshd stopped." || echo "No active sshd found."
+    rm -f "$SSHD_PID"
 else
     echo "No active sshd found."
 fi

--- a/agent/skills/ssh/scripts/stop.sh
+++ b/agent/skills/ssh/scripts/stop.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
-SCREEN_NAME="bore-ssh"
+BORE_SCREEN="bore-ssh"
+SSHD_PID="/tmp/vesta-sshd.pid"
 
-if screen -S "$SCREEN_NAME" -X quit 2>/dev/null; then
-    echo "SSH tunnel stopped."
+if screen -S "$BORE_SCREEN" -X quit 2>/dev/null; then
+    echo "Bore tunnel stopped."
 else
-    echo "No active SSH tunnel found."
+    echo "No active bore tunnel found."
+fi
+
+if [ -f "$SSHD_PID" ] && kill -0 "$(cat "$SSHD_PID")" 2>/dev/null; then
+    kill "$(cat "$SSHD_PID")"
+    echo "sshd stopped."
+else
+    echo "No active sshd found."
 fi


### PR DESCRIPTION
## Summary

- Adds a new `ssh` skill that exposes this machine publicly over the internet via [bore](https://github.com/ekzhang/bore), a free TCP relay
- Runs its own sshd on port 2222 inside the container (independent of the host SSH server on port 22), giving full control over auth config
- Key-only auth: `start.sh` requires the connecting machine's public key as an argument, no passwords
- Three scripts: `start.sh` (installs deps if needed, configures sshd, adds key, starts tunnel), `status.sh`, `stop.sh`
- Connecting machine needs no special tooling: `ssh -o StrictHostKeyChecking=accept-new root@bore.pub -p <port>`
- SKILL.md covers the full client workflow: getting/generating a key, connecting, scp/rsync commands

## Test plan

- [ ] `start.sh` without args prints helpful key instructions
- [ ] `start.sh "<pubkey>"` installs bore + sshd on first run, prints connection command
- [ ] Re-running `start.sh` with a second key adds it without removing the first
- [ ] `status.sh` shows sshd/bore state, current endpoint, and authorized key summaries
- [ ] `stop.sh` kills bore and sshd, cleans up PID file
- [ ] SSH from another machine to the printed endpoint works

Fixes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)