### PR TITLE
fix(agent): fix e2e test container startup

### DIFF
--- a/agent/tests/test_e2e.py
+++ b/agent/tests/test_e2e.py
@@ -154,7 +154,9 @@ def container(docker_image):
         "-e",
         "IS_SANDBOX=1",
         docker_image,
-        "sh", "-c", ". ~/.bashrc || true; exec uv run --frozen --project /root/vesta python -m vesta.main",
+        "sh",
+        "-c",
+        ". ~/.bashrc || true; exec uv run --frozen --project /root/vesta python -m vesta.main",
     )
 
     try:

--- a/agent/tests/test_e2e.py
+++ b/agent/tests/test_e2e.py
@@ -151,7 +151,10 @@ def container(docker_image):
         "NOTIFICATION_BUFFER_DELAY=0",
         "-e",
         "EPHEMERAL=true",
+        "-e",
+        "IS_SANDBOX=1",
         docker_image,
+        "sh", "-c", ". ~/.bashrc || true; exec uv run --frozen --project /root/vesta python -m vesta.main",
     )
 
     try:


### PR DESCRIPTION
## Summary
- The Dockerfile no longer has an `ENTRYPOINT` (moved to vestad at runtime in #111), so the e2e test container was just starting `bash` and never launching the agent
- Add the entrypoint command (`uv run ... python -m vesta.main`) to `docker create` in the test fixture
- Add `IS_SANDBOX=1` env var that vestad normally injects via `/run/vestad-env`, required for `bypassPermissions` mode as root

Closes #288

## Test plan
- [x] `test_interrupt_notification_interrupts_agent` passes (verifies agent remains responsive to interrupt notifications while busy)
- [x] All other e2e tests should pass with the fixed container startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)