### PR TITLE
feat(voice): multi-language STT auto-detection

### DIFF
--- a/agent/skills/voice/config.py
+++ b/agent/skills/voice/config.py
@@ -26,6 +26,7 @@ class SttDomain(VoiceDomain, total=False):
     eot_threshold: float
     eot_timeout_ms: int
     auto_send: bool
+    multi_language: bool
 
 
 class TtsDomain(VoiceDomain, total=False):

--- a/agent/skills/voice/providers/deepgram.py
+++ b/agent/skills/voice/providers/deepgram.py
@@ -14,6 +14,7 @@ DEEPGRAM_API = "https://api.deepgram.com"
 DEEPGRAM_WS = "wss://api.deepgram.com"
 MODEL = "flux-general-en"
 MODEL_MULTI = "nova-3"
+LANGUAGE_MULTI = "multi"
 ENCODING = "linear16"
 SAMPLE_RATE = 16000
 
@@ -104,7 +105,7 @@ class DeepgramStt:
             min(voice_config.EOT_TIMEOUT_MS_MAX, eot_timeout_ms),
         )
 
-        multi_language: bool = bool(stt_domain.get("multi_language"))
+        multi_language = stt_domain.get("multi_language", False)
         model = MODEL_MULTI if multi_language else MODEL
         params: list[tuple[str, str]] = [
             ("model", model),
@@ -114,7 +115,7 @@ class DeepgramStt:
             ("eot_timeout_ms", str(eot_timeout_ms)),
         ]
         if multi_language:
-            params.append(("language", "multi"))
+            params.append(("language", LANGUAGE_MULTI))
         for term in keyterms:
             params.append(("keyterm", term))
 

--- a/agent/skills/voice/providers/deepgram.py
+++ b/agent/skills/voice/providers/deepgram.py
@@ -189,6 +189,7 @@ class DeepgramStt:
                         elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
                             break
             else:
+
                 async def deepgram_to_browser() -> None:
                     async for msg in dg_ws:
                         if msg.type == aiohttp.WSMsgType.TEXT:

--- a/agent/skills/voice/providers/deepgram.py
+++ b/agent/skills/voice/providers/deepgram.py
@@ -1,6 +1,7 @@
-"""Deepgram STT provider — Flux v2 realtime streaming."""
+"""Deepgram STT provider — Flux v2 realtime streaming, Nova-3 v1 for multi-language."""
 
 import asyncio
+import json
 import logging
 import typing as tp
 from urllib.parse import urlencode
@@ -105,21 +106,33 @@ class DeepgramStt:
             min(voice_config.EOT_TIMEOUT_MS_MAX, eot_timeout_ms),
         )
 
-        multi_language = stt_domain.get("multi_language", False)
-        model = MODEL_MULTI if multi_language else MODEL
-        params: list[tuple[str, str]] = [
-            ("model", model),
-            ("encoding", ENCODING),
-            ("sample_rate", str(SAMPLE_RATE)),
-            ("eot_threshold", str(eot_threshold)),
-            ("eot_timeout_ms", str(eot_timeout_ms)),
-        ]
-        if multi_language:
-            params.append(("language", LANGUAGE_MULTI))
-        for term in keyterms:
-            params.append(("keyterm", term))
+        multi_language: bool = bool(stt_domain.get("multi_language"))
 
-        url = f"{DEEPGRAM_WS}/v2/listen?{urlencode(params)}"
+        if multi_language:
+            # Nova-3 only works on /v1/listen; v2 returns 400 for non-Flux models.
+            params: list[tuple[str, str]] = [
+                ("model", MODEL_MULTI),
+                ("language", LANGUAGE_MULTI),
+                ("encoding", ENCODING),
+                ("sample_rate", str(SAMPLE_RATE)),
+                ("interim_results", "true"),
+                ("utterance_end_ms", str(eot_timeout_ms)),
+            ]
+            for term in keyterms:
+                params.append(("keywords", term))
+            url = f"{DEEPGRAM_WS}/v1/listen?{urlencode(params)}"
+        else:
+            params = [
+                ("model", MODEL),
+                ("encoding", ENCODING),
+                ("sample_rate", str(SAMPLE_RATE)),
+                ("eot_threshold", str(eot_threshold)),
+                ("eot_timeout_ms", str(eot_timeout_ms)),
+            ]
+            for term in keyterms:
+                params.append(("keyterm", term))
+            url = f"{DEEPGRAM_WS}/v2/listen?{urlencode(params)}"
+
         headers = {"Authorization": f"Token {api_key}"}
 
         session = aiohttp.ClientSession()
@@ -140,14 +153,52 @@ class DeepgramStt:
                     elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
                         break
 
-            async def deepgram_to_browser() -> None:
-                async for msg in dg_ws:
-                    if msg.type == aiohttp.WSMsgType.TEXT:
-                        await browser_ws.send_str(msg.data)
-                    elif msg.type == aiohttp.WSMsgType.BINARY:
-                        await browser_ws.send_bytes(msg.data)
-                    elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
-                        break
+            if multi_language:
+                # v1 emits Results + UtteranceEnd; translate to the TurnInfo format the app expects.
+                async def deepgram_to_browser() -> None:
+                    accumulated = ""
+                    in_turn = False
+                    async for msg in dg_ws:
+                        if msg.type == aiohttp.WSMsgType.TEXT:
+                            try:
+                                data = json.loads(msg.data)
+                            except json.JSONDecodeError:
+                                await browser_ws.send_str(msg.data)
+                                continue
+                            msg_type = data.get("type")
+                            if msg_type == "Results":
+                                alts = (data.get("channel") or {}).get("alternatives") or []
+                                transcript = alts[0].get("transcript", "") if alts else ""
+                                is_final = data.get("is_final", False)
+                                if transcript and not in_turn:
+                                    in_turn = True
+                                    await browser_ws.send_str(json.dumps({"type": "TurnInfo", "event": "StartOfTurn"}))
+                                if transcript:
+                                    display = (accumulated + " " + transcript).strip() if accumulated else transcript
+                                    await browser_ws.send_str(json.dumps({"type": "TurnInfo", "transcript": display}))
+                                if is_final and transcript:
+                                    accumulated = (accumulated + " " + transcript).strip() if accumulated else transcript
+                            elif msg_type == "UtteranceEnd":
+                                if in_turn:
+                                    await browser_ws.send_str(json.dumps({"type": "TurnInfo", "event": "EndOfTurn"}))
+                                    accumulated = ""
+                                    in_turn = False
+                            elif msg_type in ("Error", "ConfigureFailure"):
+                                await browser_ws.send_str(msg.data)
+                        elif msg.type == aiohttp.WSMsgType.BINARY:
+                            await browser_ws.send_bytes(msg.data)
+                        elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
+                            break
+            else:
+                # v2/Flux sends TurnInfo natively — pass through unchanged.
+                async def deepgram_to_browser() -> None:
+                    async for msg in dg_ws:
+                        if msg.type == aiohttp.WSMsgType.TEXT:
+                            await browser_ws.send_str(msg.data)
+                        elif msg.type == aiohttp.WSMsgType.BINARY:
+                            await browser_ws.send_bytes(msg.data)
+                        elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
+                            break
 
             tasks = [
                 asyncio.create_task(browser_to_deepgram()),

--- a/agent/skills/voice/providers/deepgram.py
+++ b/agent/skills/voice/providers/deepgram.py
@@ -13,6 +13,7 @@ logger = logging.getLogger("voice.deepgram")
 DEEPGRAM_API = "https://api.deepgram.com"
 DEEPGRAM_WS = "wss://api.deepgram.com"
 MODEL = "flux-general-en"
+MODEL_MULTI = "nova-3"
 ENCODING = "linear16"
 SAMPLE_RATE = 16000
 
@@ -60,6 +61,13 @@ class DeepgramStt:
                 "description": "stop text-to-speech playback when you start speaking",
                 "default": True,
             },
+            {
+                "key": "multi_language",
+                "type": "bool",
+                "label": "multi-language detection",
+                "description": "automatically detect spoken language per utterance (English, Italian, and more); uses Nova-3 model",
+                "default": False,
+            },
         ]
 
     def __init__(self) -> None:
@@ -96,13 +104,17 @@ class DeepgramStt:
             min(voice_config.EOT_TIMEOUT_MS_MAX, eot_timeout_ms),
         )
 
+        multi_language: bool = bool(stt_domain.get("multi_language"))
+        model = MODEL_MULTI if multi_language else MODEL
         params: list[tuple[str, str]] = [
-            ("model", MODEL),
+            ("model", model),
             ("encoding", ENCODING),
             ("sample_rate", str(SAMPLE_RATE)),
             ("eot_threshold", str(eot_threshold)),
             ("eot_timeout_ms", str(eot_timeout_ms)),
         ]
+        if multi_language:
+            params.append(("language", "multi"))
         for term in keyterms:
             params.append(("keyterm", term))
 

--- a/agent/skills/voice/providers/deepgram.py
+++ b/agent/skills/voice/providers/deepgram.py
@@ -15,7 +15,6 @@ DEEPGRAM_API = "https://api.deepgram.com"
 DEEPGRAM_WS = "wss://api.deepgram.com"
 MODEL = "flux-general-en"
 MODEL_MULTI = "nova-3"
-LANGUAGE_MULTI = "multi"
 ENCODING = "linear16"
 SAMPLE_RATE = 16000
 
@@ -112,14 +111,13 @@ class DeepgramStt:
             # Nova-3 only works on /v1/listen; v2 returns 400 for non-Flux models.
             params: list[tuple[str, str]] = [
                 ("model", MODEL_MULTI),
-                ("language", LANGUAGE_MULTI),
+                ("language", "multi"),
                 ("encoding", ENCODING),
                 ("sample_rate", str(SAMPLE_RATE)),
                 ("interim_results", "true"),
                 ("utterance_end_ms", str(eot_timeout_ms)),
             ]
-            for term in keyterms:
-                params.append(("keywords", term))
+            keyterm_param = "keywords"
             url = f"{DEEPGRAM_WS}/v1/listen?{urlencode(params)}"
         else:
             params = [
@@ -129,9 +127,10 @@ class DeepgramStt:
                 ("eot_threshold", str(eot_threshold)),
                 ("eot_timeout_ms", str(eot_timeout_ms)),
             ]
-            for term in keyterms:
-                params.append(("keyterm", term))
+            keyterm_param = "keyterm"
             url = f"{DEEPGRAM_WS}/v2/listen?{urlencode(params)}"
+        for term in keyterms:
+            params.append((keyterm_param, term))
 
         headers = {"Authorization": f"Token {api_key}"}
 
@@ -190,7 +189,6 @@ class DeepgramStt:
                         elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
                             break
             else:
-                # v2/Flux sends TurnInfo natively — pass through unchanged.
                 async def deepgram_to_browser() -> None:
                     async for msg in dg_ws:
                         if msg.type == aiohttp.WSMsgType.TEXT:


### PR DESCRIPTION
## Summary

- Adds `multi_language: bool` to `SttDomain` config type and the Deepgram settings schema (toggle visible in app UI)
- Multi-language mode uses `nova-3` on `/v1/listen` (Deepgram v1) with `language=multi` for per-utterance language detection
- Deepgram v1 emits `Results` + `UtteranceEnd` events; the relay translates these to the `TurnInfo` format the app expects, so no app changes are needed
- Single-language mode is unchanged: `flux-general-en` on `/v2/listen` with pass-through relay
- Also maps v1-specific params correctly: `keywords` (not `keyterm`), `utterance_end_ms` + `interim_results` (not `eot_threshold`/`eot_timeout_ms`)

## Test plan

- [ ] With `multi_language` off: verify transcription still uses `flux-general-en` on v2 (no regression)
- [ ] With `multi_language` on: verify WebSocket connects to `/v1/listen?model=nova-3&language=multi`
- [ ] Speak in English then Italian in the same session — both transcribe and display correctly in the app
- [ ] Live transcript updates appear as you speak (interim results)
- [ ] Turn end fires correctly after silence

Fixes #250
Fixes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)