### PR TITLE
fix(agent): add can_use_tool callback to unblock sensitive file writes

### DIFF
--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -509,9 +509,7 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
         model=config.agent_model,
         betas=["context-1m-2025-08-07"],
         hooks=_make_hooks(state),
-        # bypassPermissions is blocked when running as root (Claude Code v2.1.97+).
-        # acceptEdits mode + can_use_tool handles both normal and sensitive-file permissions.
-        permission_mode="acceptEdits",
+        permission_mode="bypassPermissions",
         can_use_tool=_approve_all_tools,
         cwd=config.root,
         setting_sources=["project"],

--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -25,6 +25,7 @@ from claude_agent_sdk import (
 from claude_agent_sdk.types import (
     HookEvent,
     NotificationHookInput,
+    PermissionResultAllow,
     PostToolUseFailureHookInput,
     PreCompactHookInput,
     PreToolUseHookInput,
@@ -34,6 +35,7 @@ from claude_agent_sdk.types import (
     SubagentStopHookInput,
     HookJSONOutput,
     HookCallback,
+    ToolPermissionContext,
 )
 
 import vesta.models as vm
@@ -489,6 +491,10 @@ def _make_stderr_handler(state: vm.State) -> tp.Callable[[str], None]:
     return handler
 
 
+async def _approve_all_tools(tool_name: str, tool_input: dict[str, tp.Any], context: ToolPermissionContext) -> PermissionResultAllow:
+    return PermissionResultAllow()
+
+
 def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgentOptions:
     memory_path = get_memory_path(config)
     if not memory_path.exists():
@@ -503,10 +509,13 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
         model=config.agent_model,
         betas=["context-1m-2025-08-07"],
         hooks=_make_hooks(state),
-        permission_mode="bypassPermissions",
+        # bypassPermissions is blocked when running as root (Claude Code v2.1.97+).
+        # acceptEdits mode + can_use_tool handles both normal and sensitive-file permissions.
+        permission_mode="acceptEdits",
+        can_use_tool=_approve_all_tools,
         cwd=config.root,
         setting_sources=["project"],
-        add_dirs=[str(config.root)],
+        add_dirs=[str(config.root), os.path.expanduser("~")],
         thinking=config.thinking,
         max_buffer_size=10 * 1024 * 1024,
         stderr=_make_stderr_handler(state),

--- a/agent/tests/test_e2e.py
+++ b/agent/tests/test_e2e.py
@@ -146,13 +146,9 @@ def container(docker_image):
         "-e",
         "AGENT_NAME=e2e-test",
         "-e",
-        "NOTIFICATION_CHECK_INTERVAL=1",
-        "-e",
-        "NOTIFICATION_BUFFER_DELAY=0",
+        "MONITOR_TICK_INTERVAL=1",
         "-e",
         "EPHEMERAL=true",
-        "-e",
-        "IS_SANDBOX=1",
         docker_image,
         "sh",
         "-c",
@@ -167,6 +163,16 @@ def container(docker_image):
             tmp = f.name
         _docker("cp", tmp, f"{name}:{MEMORY_PATH}")
         Path(tmp).unlink()
+
+        # Blank out the first-start setup prompt so the agent skips interactive
+        # onboarding and goes straight to processing notifications.
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write("")
+            tmp_setup = f.name
+        try:
+            _docker("cp", tmp_setup, f"{name}:/root/vesta/prompts/first_start_setup.md")
+        finally:
+            Path(tmp_setup).unlink(missing_ok=True)
 
         _docker("start", name)
         _exec(container=name, cmd=f"mkdir -p {WORKSPACE_DIR}")
@@ -290,3 +296,19 @@ def test_graceful_shutdown(container):
     assert _exec_ok(container, "test -f /root/vesta/logs/vesta.log")
     log = _exec(container, "head -20 /root/vesta/logs/vesta.log")
     assert "started" in log.lower() or "init" in log.lower()
+
+
+def test_bashrc_write(container):
+    """Agent can write to ~/.bashrc (sensitive file allowlist is configured correctly)."""
+    marker = f"E2E_TEST_{uuid.uuid4().hex[:8]}"
+
+    _write_notification(container, f'Append the line "export {marker}=1" to /root/.bashrc using the Edit or Write tool (not bash).')
+
+    deadline = time.time() + 90
+    while time.time() < deadline:
+        content = _exec(container, "cat /root/.bashrc")
+        if marker in content:
+            return
+        time.sleep(2)
+
+    raise AssertionError(f"Marker {marker} not found in /root/.bashrc after 90s")

--- a/agent/tests/test_e2e.py
+++ b/agent/tests/test_e2e.py
@@ -149,6 +149,8 @@ def container(docker_image):
         "MONITOR_TICK_INTERVAL=1",
         "-e",
         "EPHEMERAL=true",
+        "-e",
+        "IS_SANDBOX=1",
         docker_image,
         "sh",
         "-c",


### PR DESCRIPTION
## Summary

- Add `can_use_tool` callback to `ClaudeAgentOptions` that approves all permission requests
- Add `~` to `add_dirs` so file tools can access the home directory

`bypassPermissions` auto-approves interactive tool dialogs, but sensitive files like `~/.bashrc` trigger a separate `can_use_tool` stdio control protocol that `bypassPermissions` does not cover. Without a handler the SDK raises `"canUseTool callback is not provided"` and the write is blocked.

In production `IS_SANDBOX=1` is already set via `/run/vestad-env` (required for `bypassPermissions` to start as root). The e2e test uses a simplified startup command that doesn't source that file, so `IS_SANDBOX=1` is passed explicitly.

## Test changes

- Add `IS_SANDBOX=1` to container env (vestad sets this via `/run/vestad-env` in production)
- Fix env var: `NOTIFICATION_CHECK_INTERVAL` → `MONITOR_TICK_INTERVAL`
- Blank `first_start_setup.md` before start to skip interactive onboarding in tests
- Add `test_bashrc_write` — verifies the fix end-to-end

Fixes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)