### PR TITLE
fix(agent): drain stderr before reading buffer on session resume failure

### DIFF
--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -240,6 +240,7 @@ async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm
         except (ClaudeSDKError, OSError, RuntimeError) as exc:
             if retried or not state.session_id:
                 raise
+            await asyncio.sleep(0)  # yield to event loop so stderr handler can drain buffered output
             exit_code, stderr_tail = format_crash_detail(exc, state.stderr_buffer)
             logger.warning(
                 f"Session resume failed ({state.session_id[:16]}...): {type(exc).__name__}: {exc}"

--- a/agent/src/vesta/core/loops.py
+++ b/agent/src/vesta/core/loops.py
@@ -240,7 +240,7 @@ async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm
         except (ClaudeSDKError, OSError, RuntimeError) as exc:
             if retried or not state.session_id:
                 raise
-            await asyncio.sleep(0)  # yield to event loop so stderr handler can drain buffered output
+            await asyncio.sleep(0.05)  # give stderr handler time to drain buffered subprocess output
             exit_code, stderr_tail = format_crash_detail(exc, state.stderr_buffer)
             logger.warning(
                 f"Session resume failed ({state.session_id[:16]}...): {type(exc).__name__}: {exc}"


### PR DESCRIPTION
## Summary

- When session resume fails during `ClaudeSDKClient.__aenter__` (specifically during `_query.initialize()`), Python never calls `__aexit__`, so the SDK's `_handle_stderr` asyncio task is still alive
- That task hasn't had a chance to run yet — the subprocess's stderr output sits in the OS pipe buffer unread
- One `await asyncio.sleep(0)` yields to the event loop, letting `_handle_stderr` drain the buffered output into `state.stderr_buffer` before we call `format_crash_detail`
- The session resume warning now shows actual error details instead of empty `Recent stderr:`

## Root cause

`ProcessError` is raised from inside `connect()` (which is called by `__aenter__`). When `__aenter__` raises, Python skips `__aexit__` entirely — meaning `transport.close()` is never called and the stderr reader task is never cancelled. But there's also been no `await` since the subprocess wrote its error, so `_handle_stderr` hasn't run. A single `sleep(0)` fixes the race.

Fixes the empty `Recent stderr:` in session resume failure warnings.