### PR TITLE
fix(vestad): remove overlayfs hard-fail, rely on image sanity check

### DIFF
--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -144,23 +144,6 @@ pub async fn ensure_docker(docker: &Docker) -> Result<(), DockerError> {
         }
     }
 
-    // Detect Docker's containerd snapshotter (Docker 29+), which silently corrupts
-    // multi-layer image extraction and causes "exec format error" on every binary.
-    if let Ok(info) = docker.info().await {
-        if info.driver.as_deref() == Some("overlayfs") {
-            return Err(DockerError::Failed(
-                "docker is using the containerd snapshotter (storage driver: overlayfs), \
-                 which corrupts multi-layer images on Docker 29+.\n\
-                 \n\
-                 Fix: add the following to /etc/docker/daemon.json and restart docker:\n\
-                 \n\
-                 {\n  \"features\": { \"containerd-snapshotter\": false },\n  \"storage-driver\": \"overlay2\"\n}\n\
-                 \n\
-                 Then run: sudo systemctl restart docker".to_string()
-            ));
-        }
-    }
-
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Removes the hard-fail in `ensure_docker` that blocked ALL users with Docker 29+'s containerd snapshotter (overlayfs driver)
- The containerd snapshotter only corrupts certain multi-layer images, not all of them. Users whose setup works fine were being blocked unnecessarily
- `verify_image_runnable` (runs `/bin/true` after every pull/build) already catches actual exec format errors with a targeted message suggesting the driver fix
- This was the original cause of agents "disappearing" when users followed the fix instructions: switching storage drivers makes all existing containers invisible to Docker

Closes #273's remaining side-effect.

## Test plan

- [ ] On Docker 29+ with containerd snapshotter: vestad starts normally (no hard error)
- [ ] If the image is actually corrupted: `verify_image_runnable` catches it after pull/build with the driver fix suggestion
- [ ] `cargo build -p vestad`, `cargo clippy -p vestad`, `cargo test -p vestad` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)