### PR TITLE
feat(agent): add SDK activity watchdog and hang diagnostics

### DIFF
--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -283,7 +283,6 @@ def _make_hooks(state: vm.State) -> dict[HookEvent, list[HookMatcher]]:
 
 
 def _format_hang_diagnostics(state: vm.State) -> str:
-    """Build a diagnostic string for SDK hang events."""
     parts = [f"idle={state.sdk_idle_seconds():.0f}s", f"last_activity={state.last_sdk_activity_label}"]
     longest = state.longest_running_tool()
     if longest:
@@ -302,17 +301,18 @@ async def attempt_interrupt(state: vm.State, *, config: vm.VestaConfig, reason: 
     if not client:
         return False
 
-    diag = _format_hang_diagnostics(state)
     try:
         await asyncio.wait_for(client.interrupt(), timeout=config.interrupt_timeout)
         logger.debug(f"Interrupt sent: {reason}")
         return True
     except TimeoutError:
+        diag = _format_hang_diagnostics(state)
         logger.error(f"SDK unresponsive, sending SIGTERM for graceful shutdown | reason={reason} | {diag}")
         os.kill(os.getpid(), signal.SIGTERM)
         await asyncio.sleep(10)
         os._exit(1)
     except (OSError, RuntimeError) as e:
+        diag = _format_hang_diagnostics(state)
         logger.error(f"Interrupt failed: {e} | {diag}")
         return False
 
@@ -345,13 +345,12 @@ def _check_sdk_subprocess_alive(state: vm.State) -> bool | None:
         process = transport._process  # type: ignore[union-attr]  # ty: ignore[unresolved-attribute]
         if process is None:
             return False
-        return process.returncode is None  # None means still running
+        return process.returncode is None
     except (AttributeError, TypeError):
         return None
 
 
 async def _sdk_watchdog(state: vm.State, *, stop: asyncio.Event) -> None:
-    """Log escalating warnings when no SDK messages arrive for extended periods."""
     warned_at: set[int] = set()
     while not stop.is_set():
         try:

--- a/agent/src/vesta/core/client.py
+++ b/agent/src/vesta/core/client.py
@@ -4,6 +4,7 @@ import datetime as dt
 import json
 import os
 import signal
+import time
 import typing as tp
 from collections.abc import Mapping
 
@@ -225,13 +226,23 @@ def _make_hooks(state: vm.State) -> dict[HookEvent, list[HookMatcher]]:
         prefix, is_sub = _subagent_prefix(input_data)
         logger.tool(f"{prefix}{summary}")
         state.event_bus.emit({"type": "tool_start", "tool": name, "input": summary, "subagent": is_sub})
+        state.touch_activity(f"tool_start:{name}")
+        tool_id = tool_use_id or name
+        state.active_tools[tool_id] = vm.ActiveTool(name=name, summary=summary, started_at=time.monotonic(), is_subagent=is_sub)
         return tp.cast(HookJSONOutput, {})
 
     async def log_tool_finish(input_data: PostToolUseHookInput, tool_use_id: str | None, context: HookContext) -> HookJSONOutput:
         name = input_data["tool_name"]
         prefix, is_sub = _subagent_prefix(input_data)
-        logger.tool(f"{prefix}done: {name}")
+        tool_id = tool_use_id or name
+        elapsed = ""
+        active = state.active_tools.pop(tool_id, None)
+        if active:
+            duration = time.monotonic() - active.started_at
+            elapsed = f" ({duration:.1f}s)"
+        logger.tool(f"{prefix}done: {name}{elapsed}")
         state.event_bus.emit({"type": "tool_end", "tool": name, "subagent": is_sub})
+        state.touch_activity(f"tool_end:{name}")
         return tp.cast(HookJSONOutput, {})
 
     async def log_tool_failure(input_data: PostToolUseFailureHookInput, tool_use_id: str | None, context: HookContext) -> HookJSONOutput:
@@ -239,6 +250,9 @@ def _make_hooks(state: vm.State) -> dict[HookEvent, list[HookMatcher]]:
         error = input_data["error"]
         prefix, _ = _subagent_prefix(input_data)
         logger.warning(f"{prefix}Tool failed: {name}: {error}")
+        tool_id = tool_use_id or name
+        state.active_tools.pop(tool_id, None)
+        state.touch_activity(f"tool_fail:{name}")
         return tp.cast(HookJSONOutput, {})
 
     async def log_compact(input_data: PreCompactHookInput, tool_use_id: str | None, context: HookContext) -> HookJSONOutput:
@@ -268,22 +282,38 @@ def _make_hooks(state: vm.State) -> dict[HookEvent, list[HookMatcher]]:
     }
 
 
+def _format_hang_diagnostics(state: vm.State) -> str:
+    """Build a diagnostic string for SDK hang events."""
+    parts = [f"idle={state.sdk_idle_seconds():.0f}s", f"last_activity={state.last_sdk_activity_label}"]
+    longest = state.longest_running_tool()
+    if longest:
+        duration = time.monotonic() - longest.started_at
+        parts.append(f"longest_tool={longest.name} ({duration:.0f}s, sub={longest.is_subagent})")
+    if state.active_tools:
+        parts.append(f"active_tools={len(state.active_tools)}")
+    stderr_tail = list(state.stderr_buffer)[-5:] if state.stderr_buffer else []
+    if stderr_tail:
+        parts.append(f"stderr_tail={' | '.join(stderr_tail)}")
+    return ", ".join(parts)
+
+
 async def attempt_interrupt(state: vm.State, *, config: vm.VestaConfig, reason: str) -> bool:
     client = state.client
     if not client:
         return False
 
+    diag = _format_hang_diagnostics(state)
     try:
         await asyncio.wait_for(client.interrupt(), timeout=config.interrupt_timeout)
         logger.debug(f"Interrupt sent: {reason}")
         return True
     except TimeoutError:
-        logger.error("SDK unresponsive, sending SIGTERM for graceful shutdown")
+        logger.error(f"SDK unresponsive, sending SIGTERM for graceful shutdown | reason={reason} | {diag}")
         os.kill(os.getpid(), signal.SIGTERM)
         await asyncio.sleep(10)
         os._exit(1)
     except (OSError, RuntimeError) as e:
-        logger.error(f"Interrupt failed: {e}")
+        logger.error(f"Interrupt failed: {e} | {diag}")
         return False
 
 
@@ -305,16 +335,56 @@ async def _cancel_task(task: asyncio.Task[tp.Any]) -> None:
         pass
 
 
+_WATCHDOG_THRESHOLDS_S = (60, 120, 300)
+
+
+def _check_sdk_subprocess_alive(state: vm.State) -> bool | None:
+    """Check if the SDK subprocess is still running. Returns None if we can't determine."""
+    try:
+        transport = state.client._transport  # type: ignore[union-attr]  # ty: ignore[unresolved-attribute]
+        process = transport._process  # type: ignore[union-attr]  # ty: ignore[unresolved-attribute]
+        if process is None:
+            return False
+        return process.returncode is None  # None means still running
+    except (AttributeError, TypeError):
+        return None
+
+
+async def _sdk_watchdog(state: vm.State, *, stop: asyncio.Event) -> None:
+    """Log escalating warnings when no SDK messages arrive for extended periods."""
+    warned_at: set[int] = set()
+    while not stop.is_set():
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=15)
+            break
+        except TimeoutError:
+            pass
+        idle = state.sdk_idle_seconds()
+        for threshold in _WATCHDOG_THRESHOLDS_S:
+            if idle >= threshold and threshold not in warned_at:
+                warned_at.add(threshold)
+                alive = _check_sdk_subprocess_alive(state)
+                alive_str = f"process_alive={alive}" if alive is not None else "process_alive=unknown"
+                diag = _format_hang_diagnostics(state)
+                logger.warning(f"SDK silent for {threshold}s | {alive_str} | {diag}")
+        # Reset warnings when activity resumes
+        if idle < _WATCHDOG_THRESHOLDS_S[0]:
+            warned_at.clear()
+
+
 async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show_output: bool) -> list[str]:
     assert state.client is not None
     client = state.client
 
     query = _build_query(prompt, timestamp=dt.datetime.now())
+    state.touch_activity("query_start")
+    state.active_tools.clear()
     try:
         await asyncio.wait_for(client.query(query), timeout=config.query_timeout)
     except TimeoutError:
         await attempt_interrupt(state, config=config, reason="Query timeout")
         raise
+    state.touch_activity("query_sent")
 
     responses: list[str] = []
     assistant_texts: list[str] = []
@@ -334,6 +404,9 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
     interrupt_task: asyncio.Task[tp.Any] | None = None
     if state.interrupt_event and not state.interrupt_event.is_set():
         interrupt_task = asyncio.create_task(state.interrupt_event.wait())
+
+    watchdog_stop = asyncio.Event()
+    watchdog_task = asyncio.create_task(_sdk_watchdog(state, stop=watchdog_stop))
 
     try:
         while True:
@@ -375,6 +448,7 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
             if result is _STOP:
                 break
 
+            state.touch_activity("sdk_message")
             msg = tp.cast(Message, result)
             texts, thinking_blocks, sub_agent_context, session_id, _ = _parse_sdk_message(msg, sub_agent_context=sub_agent_context)
             if session_id and session_id != state.session_id:
@@ -394,6 +468,8 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
             if filtered:
                 _emit(filtered)
     finally:
+        watchdog_stop.set()
+        await _cancel_task(watchdog_task)
         if interrupt_task and not interrupt_task.done():
             await _cancel_task(interrupt_task)
 
@@ -495,6 +571,9 @@ async def _approve_all_tools(tool_name: str, tool_input: dict[str, tp.Any], cont
     return PermissionResultAllow()
 
 
+_STREAM_IDLE_TIMEOUT_MS = 300_000  # 5 minutes: abort stalled API streams
+
+
 def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgentOptions:
     memory_path = get_memory_path(config)
     if not memory_path.exists():
@@ -503,6 +582,9 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
 
     name = config.agent_name
     system_prompt = f"Your name is {name}.\n\n{system_prompt}"
+
+    # Tell the underlying CLI to abort stalled API streams rather than hanging indefinitely
+    os.environ.setdefault("CLAUDE_STREAM_IDLE_TIMEOUT_MS", str(_STREAM_IDLE_TIMEOUT_MS))
 
     return ClaudeAgentOptions(
         system_prompt=system_prompt,

--- a/agent/src/vesta/models.py
+++ b/agent/src/vesta/models.py
@@ -2,6 +2,7 @@ import asyncio
 import collections
 import dataclasses as dc
 import datetime as dt
+import time
 
 import pydantic as pyd
 from claude_agent_sdk import ClaudeSDKClient
@@ -17,6 +18,14 @@ CRASH_RESTART = "crash — restarted after unexpected exit"
 
 
 @dc.dataclass
+class ActiveTool:
+    name: str
+    summary: str
+    started_at: float
+    is_subagent: bool = False
+
+
+@dc.dataclass
 class State:
     client: ClaudeSDKClient | None = None
     shutdown_event: asyncio.Event = dc.field(default_factory=asyncio.Event)
@@ -29,6 +38,23 @@ class State:
     interrupt_event: asyncio.Event | None = None
     event_bus: EventBus = dc.field(default_factory=EventBus)
     stderr_buffer: collections.deque[str] = dc.field(default_factory=lambda: collections.deque(maxlen=50))
+
+    # SDK activity tracking for hang detection
+    last_sdk_activity: float = dc.field(default_factory=time.monotonic)
+    last_sdk_activity_label: str = "init"
+    active_tools: dict[str, ActiveTool] = dc.field(default_factory=dict)
+
+    def touch_activity(self, label: str) -> None:
+        self.last_sdk_activity = time.monotonic()
+        self.last_sdk_activity_label = label
+
+    def sdk_idle_seconds(self) -> float:
+        return time.monotonic() - self.last_sdk_activity
+
+    def longest_running_tool(self) -> ActiveTool | None:
+        if not self.active_tools:
+            return None
+        return min(self.active_tools.values(), key=lambda t: t.started_at)
 
 
 class Notification(pyd.BaseModel):

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -1,0 +1,319 @@
+"""Tests for SDK activity watchdog, tool duration tracking, and hang diagnostics."""
+
+import asyncio
+import time
+import typing as tp
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import vesta.models as vm
+from vesta.core.client import (
+    _check_sdk_subprocess_alive,
+    _format_hang_diagnostics,
+    _sdk_watchdog,
+    converse,
+)
+
+
+# --- ActiveTool and State activity tracking ---
+
+
+def test_touch_activity_updates_timestamp_and_label():
+    state = vm.State()
+    before = state.last_sdk_activity
+    time.sleep(0.01)
+    state.touch_activity("tool_start:Read")
+    assert state.last_sdk_activity > before
+    assert state.last_sdk_activity_label == "tool_start:Read"
+
+
+def test_sdk_idle_seconds_increases_over_time():
+    state = vm.State()
+    state.last_sdk_activity = time.monotonic() - 42.0
+    idle = state.sdk_idle_seconds()
+    assert 41.5 < idle < 43.0
+
+
+def test_longest_running_tool_returns_oldest():
+    state = vm.State()
+    now = time.monotonic()
+    state.active_tools["a"] = vm.ActiveTool(name="Bash", summary="ls", started_at=now - 10)
+    state.active_tools["b"] = vm.ActiveTool(name="Read", summary="/tmp/x", started_at=now - 30)
+    state.active_tools["c"] = vm.ActiveTool(name="Grep", summary="foo", started_at=now - 5)
+    longest = state.longest_running_tool()
+    assert longest is not None
+    assert longest.name == "Read"
+
+
+def test_longest_running_tool_returns_none_when_empty():
+    state = vm.State()
+    assert state.longest_running_tool() is None
+
+
+# --- _format_hang_diagnostics ---
+
+
+def test_format_hang_diagnostics_minimal():
+    state = vm.State()
+    state.touch_activity("query_sent")
+    diag = _format_hang_diagnostics(state)
+    assert "idle=" in diag
+    assert "last_activity=query_sent" in diag
+    assert "longest_tool" not in diag
+    assert "active_tools" not in diag
+
+
+def test_format_hang_diagnostics_with_active_tools():
+    state = vm.State()
+    state.touch_activity("tool_start:Agent")
+    now = time.monotonic()
+    state.active_tools["t1"] = vm.ActiveTool(name="Agent", summary="research", started_at=now - 120, is_subagent=True)
+    state.active_tools["t2"] = vm.ActiveTool(name="Read", summary="/tmp/x", started_at=now - 5)
+    diag = _format_hang_diagnostics(state)
+    assert "longest_tool=Agent" in diag
+    assert "sub=True" in diag
+    assert "active_tools=2" in diag
+
+
+def test_format_hang_diagnostics_includes_stderr_tail():
+    state = vm.State()
+    for i in range(10):
+        state.stderr_buffer.append(f"line {i}")
+    diag = _format_hang_diagnostics(state)
+    assert "stderr_tail=" in diag
+    assert "line 4" not in diag  # Only last 5
+    assert "line 9" in diag
+
+
+# --- _check_sdk_subprocess_alive ---
+
+
+def test_subprocess_alive_returns_true_when_running():
+    state = vm.State()
+    mock_client = MagicMock()
+    mock_transport = MagicMock()
+    mock_process = MagicMock()
+    mock_process.returncode = None
+    mock_transport._process = mock_process
+    mock_client._transport = mock_transport
+    state.client = mock_client
+    assert _check_sdk_subprocess_alive(state) is True
+
+
+def test_subprocess_alive_returns_false_when_exited():
+    state = vm.State()
+    mock_client = MagicMock()
+    mock_transport = MagicMock()
+    mock_process = MagicMock()
+    mock_process.returncode = 1
+    mock_transport._process = mock_process
+    mock_client._transport = mock_transport
+    state.client = mock_client
+    assert _check_sdk_subprocess_alive(state) is False
+
+
+def test_subprocess_alive_returns_none_when_no_client():
+    state = vm.State()
+    state.client = None
+    assert _check_sdk_subprocess_alive(state) is None
+
+
+def test_subprocess_alive_returns_none_on_missing_attrs():
+    state = vm.State()
+    mock_client = MagicMock(spec=[])  # No attributes at all
+    state.client = mock_client
+    assert _check_sdk_subprocess_alive(state) is None
+
+
+# --- _sdk_watchdog ---
+
+
+@pytest.mark.anyio
+async def test_watchdog_warns_at_thresholds():
+    """Patch the sleep to 0 so the watchdog ticks immediately."""
+    from unittest.mock import patch as _patch
+
+    import vesta.core.client as client_mod
+
+    state = vm.State()
+    state.last_sdk_activity = time.monotonic() - 65  # Idle for 65s
+    stop = asyncio.Event()
+    warnings: list[str] = []
+
+    original_warning = client_mod.logger.warning
+
+    def capture_warning(msg):
+        warnings.append(str(msg))
+
+    client_mod.logger.warning = capture_warning  # ty: ignore[invalid-assignment]
+
+    original_wait_for = asyncio.wait_for
+
+    async def fast_wait_for(coro, *, timeout):  # type: ignore[no-untyped-def]
+        return await original_wait_for(coro, timeout=0.01)
+
+    try:
+        async def stop_after_tick():
+            await asyncio.sleep(0.05)
+            stop.set()
+
+        with _patch("vesta.core.client.asyncio.wait_for", fast_wait_for):
+            await asyncio.gather(_sdk_watchdog(state, stop=stop), stop_after_tick())
+    finally:
+        client_mod.logger.warning = original_warning
+
+    assert any("SDK silent for 60s" in w for w in warnings), f"Expected 60s warning, got: {warnings}"
+
+
+@pytest.mark.anyio
+async def test_watchdog_resets_after_activity_resumes():
+    from unittest.mock import patch as _patch
+
+    import vesta.core.client as client_mod
+
+    state = vm.State()
+    state.last_sdk_activity = time.monotonic() - 65  # Idle
+    stop = asyncio.Event()
+    warnings: list[str] = []
+
+    original_warning = client_mod.logger.warning
+
+    def capture_warning(msg):
+        warnings.append(str(msg))
+
+    client_mod.logger.warning = capture_warning  # ty: ignore[invalid-assignment]
+
+    original_wait_for = asyncio.wait_for
+
+    async def fast_wait_for(coro, *, timeout):  # type: ignore[no-untyped-def]
+        return await original_wait_for(coro, timeout=0.01)
+
+    try:
+        async def resume_then_idle_again():
+            await asyncio.sleep(0.05)
+            state.touch_activity("sdk_message")
+            await asyncio.sleep(0.05)
+            state.last_sdk_activity = time.monotonic() - 65
+            await asyncio.sleep(0.05)
+            stop.set()
+
+        with _patch("vesta.core.client.asyncio.wait_for", fast_wait_for):
+            await asyncio.gather(_sdk_watchdog(state, stop=stop), resume_then_idle_again())
+    finally:
+        client_mod.logger.warning = original_warning
+
+    sixty_warnings = [w for w in warnings if "SDK silent for 60s" in w]
+    assert len(sixty_warnings) >= 2, f"Expected 60s warning to fire again after reset, got {len(sixty_warnings)}: {warnings}"
+
+
+@pytest.mark.anyio
+async def test_watchdog_stops_cleanly():
+    state = vm.State()
+    stop = asyncio.Event()
+    stop.set()  # Stop immediately
+    await _sdk_watchdog(state, stop=stop)  # Should not hang
+
+
+# --- Tool duration tracking via hooks ---
+
+
+@pytest.mark.anyio
+async def test_tool_hooks_track_active_tools():
+    """PreToolUse adds to active_tools, PostToolUse removes and logs duration."""
+    from claude_agent_sdk import HookContext
+    from claude_agent_sdk.types import PostToolUseHookInput, PreToolUseHookInput
+
+    import vesta.core.client as client_mod
+
+    state = vm.State()
+    hooks = client_mod._make_hooks(state)
+
+    pre_hook = hooks["PreToolUse"][0].hooks[0]
+    post_hook = hooks["PostToolUse"][0].hooks[0]
+
+    pre_input = tp.cast(PreToolUseHookInput, {"tool_name": "Read", "tool_input": {"file_path": "/tmp/test.py"}})
+    ctx = tp.cast(HookContext, MagicMock())
+
+    await pre_hook(pre_input, "tool-123", ctx)
+    assert "tool-123" in state.active_tools
+    assert state.active_tools["tool-123"].name == "Read"
+    assert state.last_sdk_activity_label == "tool_start:Read"
+
+    post_input = tp.cast(PostToolUseHookInput, {"tool_name": "Read", "tool_input": {"file_path": "/tmp/test.py"}})
+    await post_hook(post_input, "tool-123", ctx)
+    assert "tool-123" not in state.active_tools
+    assert state.last_sdk_activity_label == "tool_end:Read"
+
+
+@pytest.mark.anyio
+async def test_tool_failure_hook_cleans_up():
+    from claude_agent_sdk import HookContext
+    from claude_agent_sdk.types import PostToolUseFailureHookInput, PreToolUseHookInput
+
+    import vesta.core.client as client_mod
+
+    state = vm.State()
+    hooks = client_mod._make_hooks(state)
+
+    pre_hook = hooks["PreToolUse"][0].hooks[0]
+    fail_hook = hooks["PostToolUseFailure"][0].hooks[0]
+    ctx = tp.cast(HookContext, MagicMock())
+
+    pre_input = tp.cast(PreToolUseHookInput, {"tool_name": "Bash", "tool_input": {"command": "exit 1"}})
+    await pre_hook(pre_input, "tool-456", ctx)
+    assert "tool-456" in state.active_tools
+
+    fail_input = tp.cast(PostToolUseFailureHookInput, {"tool_name": "Bash", "error": "command failed"})
+    await fail_hook(fail_input, "tool-456", ctx)
+    assert "tool-456" not in state.active_tools
+    assert state.last_sdk_activity_label == "tool_fail:Bash"
+
+
+# --- converse() watchdog integration ---
+
+
+@pytest.mark.anyio
+async def test_converse_touches_activity_on_messages():
+    """converse updates last_sdk_activity when SDK messages arrive."""
+    state = vm.State()
+    config = vm.VestaConfig(interrupt_timeout=0.5)
+
+    mock_client = MagicMock()
+    mock_client.query = AsyncMock()
+    mock_client.interrupt = AsyncMock()
+    state.client = mock_client
+
+    async def three_messages():
+        for _ in range(3):
+            msg = MagicMock()
+            msg.content = []
+            yield msg
+
+    mock_client.receive_response = MagicMock(return_value=three_messages())
+
+    await converse("test", state=state, config=config, show_output=False)
+
+    assert state.last_sdk_activity_label == "sdk_message"
+
+
+@pytest.mark.anyio
+async def test_converse_clears_active_tools_on_start():
+    """converse clears stale active_tools from prior calls."""
+    state = vm.State()
+    config = vm.VestaConfig(interrupt_timeout=0.5)
+    state.active_tools["stale"] = vm.ActiveTool(name="Old", summary="leftover", started_at=0)
+
+    mock_client = MagicMock()
+    mock_client.query = AsyncMock()
+    mock_client.interrupt = AsyncMock()
+    state.client = mock_client
+
+    async def empty_response():
+        return
+        yield  # Make it an async generator
+
+    mock_client.receive_response = MagicMock(return_value=empty_response())
+
+    await converse("test", state=state, config=config, show_output=False)
+
+    assert "stale" not in state.active_tools

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -153,6 +153,7 @@ async def test_watchdog_warns_at_thresholds():
         return await original_wait_for(coro, timeout=0.01)
 
     try:
+
         async def stop_after_tick():
             await asyncio.sleep(0.05)
             stop.set()
@@ -189,6 +190,7 @@ async def test_watchdog_resets_after_activity_resumes():
         return await original_wait_for(coro, timeout=0.01)
 
     try:
+
         async def resume_then_idle_again():
             await asyncio.sleep(0.05)
             state.touch_activity("sdk_message")


### PR DESCRIPTION
## Summary

- Adds an SDK activity watchdog that logs escalating warnings at 60s, 120s, and 300s of silence during response processing, including subprocess liveness checks
- Tracks per-tool-call duration via hooks, logging elapsed time on tool completion (e.g. `done: Read (2.3s)`)
- Enriches the "SDK unresponsive" error with full diagnostics: idle duration, last activity label, longest running tool, active tool count, and stderr tail
- Sets `CLAUDE_STREAM_IDLE_TIMEOUT_MS=300000` to tell the underlying Claude CLI to abort stalled API streams after 5 minutes instead of hanging indefinitely

**Context:** The agent frequently hangs when the Claude SDK becomes unresponsive during tool execution (known SDK issues: synthesis hang after tool calls, message queue backpressure with sub-agents, stalled API streams). Previously the only detection was the 600s response timeout with no intermediate warnings and no context about what was happening when the hang occurred.

## Test plan

- [x] `uv run ruff check` passes
- [x] `uv run ty check` passes
- [x] `uv run pytest tests/ --ignore=tests/test_e2e.py` passes (107 tests)
- [ ] CI passes
- [ ] Deploy and observe watchdog warnings in logs during normal operation
- [ ] Verify hang diagnostics appear in logs on next SDK unresponsive event

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)