### PR TITLE
fix(agent): recursive merge in old-layout migration

### DIFF
--- a/agent/skills/upstream-sync/SETUP.md
+++ b/agent/skills/upstream-sync/SETUP.md
@@ -77,18 +77,23 @@ If `~/agent` does not exist yet:
 mv ~/vesta/agent ~/agent
 ```
 
-If both exist, merge missing entries from `~/vesta/agent` into `~/agent`:
+If both exist, merge entries from `~/vesta/agent` into `~/agent`. For each item: if the target doesn't exist, move it directly. If both are directories, recurse into them. If the target file already exists, keep the existing one (it's newer).
 
 ```bash
-find ~/vesta/agent -mindepth 1 -maxdepth 1 2>/dev/null | while IFS= read -r item; do
-  name=$(basename "$item")
-  if [ ! -e "$HOME/agent/$name" ]; then
-    mv "$item" ~/agent/
-  fi
-done
+merge_dirs() {
+  local src="$1" dst="$2"
+  find "$src" -mindepth 1 -maxdepth 1 2>/dev/null | while IFS= read -r item; do
+    local name
+    name=$(basename "$item")
+    if [ ! -e "$dst/$name" ]; then
+      mv "$item" "$dst/"
+    elif [ -d "$item" ] && [ -d "$dst/$name" ]; then
+      merge_dirs "$item" "$dst/$name"
+    fi
+  done
+}
+merge_dirs ~/vesta/agent ~/agent
 ```
-
-When both sides contain meaningful content for the same path, inspect both and merge them carefully. Do not overwrite blindly.
 
 ### If agent-owned paths exist at repo root
 


### PR DESCRIPTION
## Summary
- The migration merge logic in `SETUP.md` only moved top-level entries from `~/vesta/agent/` into `~/agent/` when the target didn't exist
- Since `~/agent/prompts/` already exists from the Docker image, nested files (e.g. `custom.md`) were silently skipped during migration
- Replaces the shallow merge with a recursive `merge_dirs` function that descends into matching directories

Fixes the `tree::first_start_migrates_old_layout` e2e test failure.

## Test plan
- [x] Agent unit tests pass (125/125)
- [ ] `cargo test -p tests -- tree::first_start_migrates_old_layout` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)