### PR TITLE
fix(agent): run migration prompt on restart, not first start

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -93,21 +93,19 @@ async def queue_greeting(queue: asyncio.Queue[tuple[str, bool]], *, config: vm.V
         return
 
     if reason == "first_start":
-        parts = []
-        migration_prompt = load_prompt("migration", config)
-        if migration_prompt:
-            parts.append(migration_prompt.strip())
         setup_prompt = load_prompt("first_start_setup", config)
         if setup_prompt:
-            parts.append(setup_prompt.strip())
-
-        if parts:
-            combined = f"[System: your name is {config.agent_name}]\n\n" + "\n\n---\n\n".join(parts)
+            combined = f"[System: your name is {config.agent_name}]\n\n{setup_prompt.strip()}"
             await queue.put((combined, False))
-            logger.startup("Queued first_start (migration + setup)")
+            logger.startup("Queued first_start setup")
 
         (config.data_dir / "first_start_done").write_text("1")
         return
+
+    migration_prompt = load_prompt("migration", config)
+    if migration_prompt:
+        await queue.put((migration_prompt.strip(), False))
+        logger.startup("Queued migration prompt")
 
     extras = []
     flag = config.data_dir / "show_dreamer_summary"

--- a/agent/prompts/migration.md
+++ b/agent/prompts/migration.md
@@ -17,3 +17,11 @@ git -C ~ diff --quiet && echo "OK: clean tree"
 If ALL checks pass, no migration is needed. Move on immediately.
 
 If any check fails, read `~/agent/skills/upstream-sync/SETUP.md` and follow it to fix the layout.
+
+After fixing the layout, rewrite stale path references in agent config files:
+
+```bash
+grep -rl '/root/vesta\|~/vesta' ~/agent/prompts/ ~/agent/data/ ~/agent/MEMORY.md 2>/dev/null
+```
+
+For each file found, replace `/root/vesta/` with `/root/agent/` and `~/vesta/` with `~/agent/`. Also replace references to the old source path `vesta/` (the Python package) with `core/` where it refers to agent source code (e.g. `vesta/config.py` becomes `core/config.py`). Read each file to understand context before replacing.

--- a/agent/prompts/migration.md
+++ b/agent/prompts/migration.md
@@ -1,44 +1,7 @@
-You just woke up for the first time. Before anything else, you must ensure your workspace is in the correct layout.
-
-## 1. Read environment
+Check your workspace layout is correct. First read your environment, then run the checks:
 
 ```bash
-cat /run/vestad-env
-```
-
-Note your `AGENT_NAME` and `VESTA_UPSTREAM_REF`.
-
-## 2. Inspect workspace
-
-```bash
-ls -la ~/
-ls -la ~/vesta/ 2>/dev/null
-ls -la ~/agent/
-git -C ~ rev-parse --show-toplevel
-git -C ~ branch --show-current
-```
-
-## 3. Migrate
-
-Read `~/agent/skills/upstream-sync/SETUP.md` and follow it fully. The mandatory end state is:
-
-- `git -C ~ rev-parse --show-toplevel` prints `/root`
-- `git -C ~ branch --show-current` prints `$AGENT_NAME`
-- All agent-owned content lives under `~/agent/` (prompts, data, logs, notifications, skills, dreamer)
-- `~/.claude/skills` is a symlink to `../agent/skills`
-- If `~/vesta/` exists, all its content has been **moved** (not copied) into `~/agent/`. After moving, remove `~/vesta/` entirely: `rm -rf ~/vesta`
-- If agent-owned paths exist at `~/` root (data, logs, notifications, etc.), move them under `~/agent/`
-- `~/agent/.gitignore` excludes large local-only files (*.db, *.bin, node_modules/, etc.)
-- Local state is committed on branch `$AGENT_NAME`
-- Upstream `$VESTA_UPSTREAM_REF` is merged
-
-Do not skip any step. Do not assume vestad already migrated anything.
-
-## 4. Verify
-
-Run these checks and confirm every one passes before finishing:
-
-```bash
+source /run/vestad-env
 test "$(git -C ~ rev-parse --show-toplevel)" = "/root" && echo "OK: repo root"
 test "$(git -C ~ branch --show-current)" = "$AGENT_NAME" && echo "OK: branch"
 test -d ~/agent/data && echo "OK: agent/data"
@@ -46,6 +9,11 @@ test -d ~/agent/prompts && echo "OK: agent/prompts"
 test -d ~/agent/skills && echo "OK: agent/skills"
 test -L ~/.claude/skills && echo "OK: skills symlink"
 test ! -d ~/vesta && echo "OK: ~/vesta removed"
+test ! -d ~/data && test ! -d ~/logs && test ! -d ~/notifications && echo "OK: no stale root paths"
+test -f ~/agent/.gitignore && echo "OK: gitignore"
+git -C ~ diff --quiet && echo "OK: clean tree"
 ```
 
-If any check fails, go back and fix it.
+If ALL checks pass, no migration is needed. Move on immediately.
+
+If any check fails, read `~/agent/skills/upstream-sync/SETUP.md` and follow it to fix the layout.

--- a/tests/tests/live/tree.rs
+++ b/tests/tests/live/tree.rs
@@ -2,11 +2,12 @@ use vesta_tests::exec_in_container;
 
 use super::common::setup_live_agent;
 
-/// Create a live agent with an old-style ~/vesta/ layout injected before first
-/// start. The agent's first_start_setup prompt instructs it to migrate ~/vesta/
-/// into ~/agent/ using upstream-sync/SETUP.md. Since wait_ready only returns
-/// after the first-start setup prompt is fully processed, the migration must
-/// be complete by the time we run assertions.
+/// Create a live agent with an old-style ~/vesta/ layout and a pre-existing
+/// first_start_done marker. This simulates a rebuild where vestad normalized
+/// the filesystem but the agent still needs to run its migration prompt
+/// (which fires on non-first-start restarts). Since wait_ready only returns
+/// after the migration prompt is fully processed, the migration must be
+/// complete by the time we run assertions.
 #[test]
 fn first_start_migrates_old_layout() {
     let Some((_agent, container)) = setup_live_agent(
@@ -61,7 +62,8 @@ fn first_start_migrates_old_layout() {
         .expect(".claude/skills should be a symlink after migration");
 }
 
-/// Seed the container with an old-style layout before credentials are injected.
+/// Seed the container with an old-style layout and mark first_start as done
+/// so the agent takes the restart path (which runs the migration prompt).
 fn seed_old_layout(container: &str) {
     exec_in_container(container, r#"
         mkdir -p ~/vesta/agent/prompts ~/vesta/agent/skills ~/vesta/data ~/vesta/notifications
@@ -69,5 +71,7 @@ fn seed_old_layout(container: &str) {
         echo 'old data' > ~/vesta/data/custom.txt
         mkdir -p ~/vesta/random-dir
         echo 'junk' > ~/vesta/random-dir/file.txt
+        mkdir -p ~/agent/data
+        echo '1' > ~/agent/data/first_start_done
     "#).expect("seed old layout");
 }


### PR DESCRIPTION
## Summary
- Migration prompt now fires on every non-first-start boot instead of only on first start
- First start already has correct layout from the Docker image, no migration needed
- Migration prompt starts with a fast verification check - if all checks pass, it's a no-op and moves on immediately
- Only reads SETUP.md and does full migration when a check actually fails (e.g. after vestad rebuild with legacy normalization)
- Updated live e2e test to seed `first_start_done` so migration fires on the restart path

## Test plan
- [x] 125 agent unit tests pass
- [x] Live e2e tests pass locally (3/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)