### PR TITLE
diag(vestad): log reason on agent token auth failure (#317)

### DIFF
--- a/vestad/src/auth.rs
+++ b/vestad/src/auth.rs
@@ -55,22 +55,68 @@ pub async fn auth_middleware_agent_token(
         return next.run(request).await;
     }
 
-    if let Some(agent_name) = extract_agent_name(request.uri().path()) {
-        if let Some(provided) = headers.get("x-agent-token").and_then(|v| v.to_str().ok()) {
-            let (_, expected) = crate::docker::read_agent_port_and_token(&agent_name, &state.env_config.agents_dir);
-            if let Some(expected) = expected {
-                if provided == expected {
-                    return next.run(request).await;
-                }
-            }
-        }
+    let path = request.uri().path().to_string();
+    let Some(agent_name) = extract_agent_name(&path) else {
+        tracing::warn!(path = %path, reason = "path-missing-agent-name", "agent token auth failed");
+        return unauthorized();
+    };
+
+    let provided = headers.get("x-agent-token").and_then(|v| v.to_str().ok());
+    let Some(provided) = provided else {
+        tracing::warn!(
+            path = %path,
+            agent = %agent_name,
+            reason = "header-missing",
+            "agent token auth failed",
+        );
+        return unauthorized();
+    };
+
+    let (_, expected) = crate::docker::read_agent_port_and_token(&agent_name, &state.env_config.agents_dir);
+    let Some(expected) = expected else {
+        tracing::warn!(
+            path = %path,
+            agent = %agent_name,
+            reason = "env-file-missing-or-no-token",
+            agents_dir = %state.env_config.agents_dir.display(),
+            "agent token auth failed",
+        );
+        return unauthorized();
+    };
+
+    if provided == expected {
+        return next.run(request).await;
     }
 
-    let path = request.uri().path().to_string();
-    tracing::warn!(path = %path, "agent token auth failed");
+    tracing::warn!(
+        path = %path,
+        agent = %agent_name,
+        reason = "token-mismatch",
+        provided_fp = %token_fingerprint(provided),
+        expected_fp = %token_fingerprint(&expected),
+        provided_len = provided.len(),
+        expected_len = expected.len(),
+        "agent token auth failed",
+    );
+    unauthorized()
+}
+
+fn unauthorized() -> Response {
     (StatusCode::UNAUTHORIZED, Json(serde_json::json!({
         "error": "unauthorized — pass X-Agent-Token header with the AGENT_TOKEN from the agent's environment"
     }))).into_response()
+}
+
+/// Short, non-reversible fingerprint of a token for diagnostic logs.
+/// Returns the first 6 hex chars of its SHA-256 — enough to tell two tokens
+/// apart without leaking the secret itself.
+fn token_fingerprint(token: &str) -> String {
+    let digest = ring::digest::digest(&ring::digest::SHA256, token.as_bytes());
+    let mut out = String::with_capacity(6);
+    for byte in digest.as_ref().iter().take(3) {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
 }
 
 pub(crate) fn has_valid_api_auth(headers: &HeaderMap, uri: &axum::http::Uri, api_key: &str) -> bool {


### PR DESCRIPTION
## Summary
- Adds structured reason codes to the `auth_middleware_agent_token` warn log so we can tell *why* a request 401s: `path-missing-agent-name`, `header-missing`, `env-file-missing-or-no-token`, or `token-mismatch`.
- On `token-mismatch`, logs a short SHA-256 fingerprint (first 6 hex chars) and the length of both the provided and expected tokens so the two can be compared without leaking the secret to logs.

Context: #317 reports that `POST /agents/:name/services` returns 401 after a container restart even though the caller read `AGENT_TOKEN` from `/run/vestad-env`. The auth path re-reads the env file from disk on every request, so in principle disk and container should always agree — this logging is to capture the actual failure shape the next time it happens and confirm whether the tokens really differ or something else is failing (missing header, unreadable env file, etc.).

Not a fix for #317 — purely diagnostic.

## Test plan
- [ ] Reproduce the #317 restart sequence and confirm the new `reason=...` line appears with a `token-mismatch` (or other) reason.
- [ ] Compare `provided_fp` vs `expected_fp` in the log to confirm whether the disk and in-container tokens diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)