### PR TITLE
feat(cli,vestad): `vesta gateway restart` + `vesta gateway logs`

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -368,6 +368,20 @@ impl Client {
         Ok(())
     }
 
+    pub fn stream_gateway_logs(&self, tail: u64, follow: bool) -> Result<(), String> {
+        let resp = self.get(&format!("/gateway/logs?tail={}&follow={}", tail, follow))?;
+        let reader = std::io::BufReader::new(resp.into_body().into_reader());
+        for line in std::io::BufRead::lines(reader) {
+            let line = line.map_err(|e| format!("read error: {}", e))?;
+            if let Some(data) = line.strip_prefix("data:") {
+                println!("{}", data.trim_start());
+            } else if line.starts_with("event:gateway_stopped") {
+                break;
+            }
+        }
+        Ok(())
+    }
+
     pub fn destroy_agent(&self, name: &str) -> Result<(), String> {
         self.post(&format!("/agents/{}/destroy", name))?;
         Ok(())

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -370,16 +370,7 @@ impl Client {
 
     pub fn stream_gateway_logs(&self, tail: u64, follow: bool) -> Result<(), String> {
         let resp = self.get(&format!("/gateway/logs?tail={}&follow={}", tail, follow))?;
-        let reader = std::io::BufReader::new(resp.into_body().into_reader());
-        for line in std::io::BufRead::lines(reader) {
-            let line = line.map_err(|e| format!("read error: {}", e))?;
-            if let Some(data) = line.strip_prefix("data:") {
-                println!("{}", data.trim_start());
-            } else if line.starts_with("event:gateway_stopped") {
-                break;
-            }
-        }
-        Ok(())
+        consume_sse_log_stream(resp, "gateway_stopped", None)
     }
 
     pub fn destroy_agent(&self, name: &str) -> Result<(), String> {
@@ -493,18 +484,29 @@ impl Client {
 
     pub fn stream_logs(&self, name: &str, tail: u64) -> Result<(), String> {
         let resp = self.get(&format!("/agents/{}/logs?tail={}", name, tail))?;
-        let reader = std::io::BufReader::new(resp.into_body().into_reader());
-        for line in std::io::BufRead::lines(reader) {
-            let line = line.map_err(|e| format!("read error: {}", e))?;
-            if let Some(data) = line.strip_prefix("data:") {
-                println!("{}", data.trim_start());
-            } else if line.starts_with("event:agent_stopped") {
-                eprintln!("agent stopped");
-                break;
-            }
-        }
-        Ok(())
+        consume_sse_log_stream(resp, "agent_stopped", Some("agent stopped"))
     }
+}
+
+fn consume_sse_log_stream(
+    resp: Response<Body>,
+    stop_event: &str,
+    stop_message: Option<&str>,
+) -> Result<(), String> {
+    let reader = std::io::BufReader::new(resp.into_body().into_reader());
+    let stop_marker = format!("event:{stop_event}");
+    for line in std::io::BufRead::lines(reader) {
+        let line = line.map_err(|e| format!("read error: {}", e))?;
+        if let Some(data) = line.strip_prefix("data:") {
+            println!("{}", data.trim_start());
+        } else if line.starts_with(&stop_marker) {
+            if let Some(msg) = stop_message {
+                eprintln!("{msg}");
+            }
+            break;
+        }
+    }
+    Ok(())
 }
 
 // ── WebSocket chat (CLI-only) ──────────────────────────────────

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -363,6 +363,11 @@ impl Client {
         Ok(())
     }
 
+    pub fn restart_gateway(&self) -> Result<(), String> {
+        self.post("/gateway/restart")?;
+        Ok(())
+    }
+
     pub fn destroy_agent(&self, name: &str) -> Result<(), String> {
         self.post(&format!("/agents/{}/destroy", name))?;
         Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -193,6 +193,15 @@ enum Command {
 enum GatewayAction {
     /// Restart the remote vestad daemon
     Restart,
+    /// Stream vestad logs from the remote gateway
+    Logs {
+        /// Number of lines to show initially
+        #[arg(long, default_value = "500")]
+        tail: u64,
+        /// Follow the log (tail -f)
+        #[arg(long, short)]
+        follow: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -585,6 +594,10 @@ fn run(cli: Cli) {
                 let c = get_client(host_ref, token_ref);
                 c.restart_gateway().unwrap_or_else(|e| platform::die(&e));
                 eprintln!("vestad: restart initiated");
+            }
+            GatewayAction::Logs { tail, follow } => {
+                let c = get_client(host_ref, token_ref);
+                c.stream_gateway_logs(tail, follow).unwrap_or_else(|e| platform::die(&e));
             }
         },
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -102,6 +102,11 @@ enum Command {
         /// Agent name
         name: String,
     },
+    /// Manage the remote vestad gateway daemon
+    Gateway {
+        #[command(subcommand)]
+        action: GatewayAction,
+    },
     /// Authenticate Claude for an agent
     Auth {
         /// Agent name
@@ -182,6 +187,12 @@ enum Command {
     Uninstall,
     /// Print version information
     Version,
+}
+
+#[derive(Subcommand)]
+enum GatewayAction {
+    /// Restart the remote vestad daemon
+    Restart,
 }
 
 #[derive(Subcommand)]
@@ -568,6 +579,14 @@ fn run(cli: Cli) {
             c.restart_agent(&name).unwrap_or_else(|e| platform::die(&e));
             eprintln!("{}: restarted", name);
         }
+
+        Command::Gateway { action } => match action {
+            GatewayAction::Restart => {
+                let c = get_client(host_ref, token_ref);
+                c.restart_gateway().unwrap_or_else(|e| platform::die(&e));
+                eprintln!("vestad: restart initiated");
+            }
+        },
 
         Command::Auth { name, token } => {
             let c = get_client(host_ref, token_ref);

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -14,7 +14,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, atomic::AtomicBool};
 use tokio::sync::{Mutex, RwLock};
 
-use crate::{agent_proxy, agent_status, auth, backup, control_ws, docker, self_update, update_check};
+use crate::{agent_proxy, agent_status, auth, backup, control_ws, docker, self_update, systemd, update_check};
+
+const GATEWAY_RESTART_DELAY_MS: u64 = 200;
 
 const API_KEY_BYTES: usize = 32;
 pub(crate) const PROXY_MAX_BODY_BYTES: usize = 10 * 1024 * 1024; // 10 MB
@@ -245,6 +247,28 @@ async fn version(State(state): State<SharedState>) -> Json<serde_json::Value> {
         "update_available": update_available,
         "dev_mode": state.dev_mode,
     }))
+}
+
+async fn restart_gateway_handler() -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    if !systemd::is_active() {
+        return Err(err_response(
+            StatusCode::PRECONDITION_FAILED,
+            "vestad is not running under systemd — cannot self-restart",
+        ));
+    }
+    tracing::info!("gateway restart requested via API");
+    // Defer the systemctl call so the HTTP response can flush before this
+    // process is killed. systemd::restart is blocking, so hop it onto the
+    // blocking pool.
+    tokio::spawn(async {
+        tokio::time::sleep(tokio::time::Duration::from_millis(GATEWAY_RESTART_DELAY_MS)).await;
+        match tokio::task::spawn_blocking(systemd::restart).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::error!(error = %e, "gateway restart failed"),
+            Err(e) => tracing::error!(error = %e, "gateway restart task panicked"),
+        }
+    });
+    Ok(Json(serde_json::json!({"ok": true, "restarting": true})))
 }
 
 async fn self_update_handler(
@@ -1334,6 +1358,7 @@ pub fn build_router(state: SharedState) -> Router {
     let vestad_protected = Router::new()
         .route("/version", get(version))
         .route("/self-update", post(self_update_handler))
+        .route("/gateway/restart", post(restart_gateway_handler))
         .route("/tunnel", get(tunnel_handler))
         .route("/agents", get(list_agents_handler))
         .route("/agents", post(create_agent_handler))

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -249,6 +249,48 @@ async fn version(State(state): State<SharedState>) -> Json<serde_json::Value> {
     }))
 }
 
+#[derive(Deserialize)]
+struct GatewayLogsQuery {
+    tail: Option<u64>,
+    follow: Option<bool>,
+}
+
+async fn gateway_logs_handler(
+    Query(query): Query<GatewayLogsQuery>,
+) -> Result<Sse<impl futures_core::Stream<Item = Result<Event, std::io::Error>>>, (StatusCode, Json<serde_json::Value>)> {
+    let tail = query.tail.unwrap_or(DEFAULT_LOG_TAIL_LINES) as usize;
+    let follow = query.follow.unwrap_or(false);
+
+    let mut child = systemd::spawn_journal_stream(tail, follow)
+        .map_err(|e| err_response(StatusCode::INTERNAL_SERVER_ERROR, &e))?;
+
+    let stdout = child.stdout.take().ok_or_else(|| {
+        err_response(StatusCode::INTERNAL_SERVER_ERROR, "journalctl stdout not captured")
+    })?;
+
+    let stream = async_stream::stream! {
+        use tokio::io::AsyncBufReadExt;
+        let reader = tokio::io::BufReader::new(stdout);
+        let mut lines = reader.lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => yield Ok(Event::default().data(line)),
+                Ok(None) => break,
+                Err(e) => {
+                    yield Ok(Event::default().data(format!("error: {}", e)));
+                    break;
+                }
+            }
+        }
+        // Reap the child so kill_on_drop's SIGKILL is clean if we got here
+        // via follow-mode exiting on its own.
+        let _ = child.wait().await;
+        yield Ok(Event::default().event("gateway_stopped").data(""));
+    };
+
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
 async fn restart_gateway_handler() -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     if !systemd::is_active() {
         return Err(err_response(
@@ -1359,6 +1401,7 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/version", get(version))
         .route("/self-update", post(self_update_handler))
         .route("/gateway/restart", post(restart_gateway_handler))
+        .route("/gateway/logs", get(gateway_logs_handler))
         .route("/tunnel", get(tunnel_handler))
         .route("/agents", get(list_agents_handler))
         .route("/agents", post(create_agent_handler))

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -252,16 +252,16 @@ async fn version(State(state): State<SharedState>) -> Json<serde_json::Value> {
 #[derive(Deserialize)]
 struct GatewayLogsQuery {
     tail: Option<u64>,
-    follow: Option<bool>,
+    #[serde(default)]
+    follow: bool,
 }
 
 async fn gateway_logs_handler(
     Query(query): Query<GatewayLogsQuery>,
 ) -> Result<Sse<impl futures_core::Stream<Item = Result<Event, std::io::Error>>>, (StatusCode, Json<serde_json::Value>)> {
     let tail = query.tail.unwrap_or(DEFAULT_LOG_TAIL_LINES) as usize;
-    let follow = query.follow.unwrap_or(false);
 
-    let mut child = systemd::spawn_journal_stream(tail, follow)
+    let mut child = systemd::spawn_journal_stream(tail, query.follow)
         .map_err(|e| err_response(StatusCode::INTERNAL_SERVER_ERROR, &e))?;
 
     let stdout = child.stdout.take().ok_or_else(|| {
@@ -282,8 +282,6 @@ async fn gateway_logs_handler(
                 }
             }
         }
-        // Reap the child so kill_on_drop's SIGKILL is clean if we got here
-        // via follow-mode exiting on its own.
         let _ = child.wait().await;
         yield Ok(Event::default().event("gateway_stopped").data(""));
     };
@@ -299,9 +297,7 @@ async fn restart_gateway_handler() -> Result<Json<serde_json::Value>, (StatusCod
         ));
     }
     tracing::info!("gateway restart requested via API");
-    // Defer the systemctl call so the HTTP response can flush before this
-    // process is killed. systemd::restart is blocking, so hop it onto the
-    // blocking pool.
+    // Delay so the HTTP response can flush before systemctl kills this process.
     tokio::spawn(async {
         tokio::time::sleep(tokio::time::Duration::from_millis(GATEWAY_RESTART_DELAY_MS)).await;
         match tokio::task::spawn_blocking(systemd::restart).await {

--- a/vestad/src/systemd.rs
+++ b/vestad/src/systemd.rs
@@ -151,6 +151,22 @@ pub fn exec_journal(lines: usize, follow: bool) -> ! {
     process::exit(1);
 }
 
+/// Spawn `journalctl --user -u vestad -n LINES [-f]` with stdout piped.
+/// Tokio will SIGKILL the child when the returned handle is dropped, so a
+/// client disconnecting (e.g. Ctrl-C) tears the follow down.
+pub fn spawn_journal_stream(lines: usize, follow: bool) -> Result<tokio::process::Child, String> {
+    let mut cmd = tokio::process::Command::new("journalctl");
+    cmd.args(["--user", "-u", SERVICE_NAME, "-n", &lines.to_string(), "--no-hostname", "-o", "cat"]);
+    if follow {
+        cmd.arg("-f");
+    }
+    cmd.stdout(process::Stdio::piped())
+        .stderr(process::Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| format!("failed to spawn journalctl: {}", e))
+}
+
 pub fn main_pid() -> Option<u32> {
     let output = Command::new("systemctl")
         .args(["--user", "show", SERVICE_NAME, "--property=MainPID", "--value"])

--- a/vestad/src/systemd.rs
+++ b/vestad/src/systemd.rs
@@ -136,31 +136,37 @@ pub fn print_status() {
         .status();
 }
 
+fn journal_args(lines: usize, follow: bool) -> Vec<String> {
+    let mut args = vec![
+        "--user".into(),
+        "-u".into(),
+        SERVICE_NAME.into(),
+        "-n".into(),
+        lines.to_string(),
+        "--no-hostname".into(),
+        "-o".into(),
+        "cat".into(),
+    ];
+    if follow {
+        args.push("-f".into());
+    }
+    args
+}
+
 pub fn exec_journal(lines: usize, follow: bool) -> ! {
     use std::os::unix::process::CommandExt;
 
-    let lines_str = lines.to_string();
-    let mut cmd = Command::new("journalctl");
-    cmd.args(["--user", "-u", SERVICE_NAME, "-n", &lines_str, "--no-hostname", "-o", "cat"]);
-    if follow {
-        cmd.arg("-f");
-    }
-
-    let err = cmd.exec();
+    let err = Command::new("journalctl")
+        .args(journal_args(lines, follow))
+        .exec();
     eprintln!("failed to exec journalctl: {}", err);
     process::exit(1);
 }
 
-/// Spawn `journalctl --user -u vestad -n LINES [-f]` with stdout piped.
-/// Tokio will SIGKILL the child when the returned handle is dropped, so a
-/// client disconnecting (e.g. Ctrl-C) tears the follow down.
 pub fn spawn_journal_stream(lines: usize, follow: bool) -> Result<tokio::process::Child, String> {
-    let mut cmd = tokio::process::Command::new("journalctl");
-    cmd.args(["--user", "-u", SERVICE_NAME, "-n", &lines.to_string(), "--no-hostname", "-o", "cat"]);
-    if follow {
-        cmd.arg("-f");
-    }
-    cmd.stdout(process::Stdio::piped())
+    tokio::process::Command::new("journalctl")
+        .args(journal_args(lines, follow))
+        .stdout(process::Stdio::piped())
         .stderr(process::Stdio::null())
         .kill_on_drop(true)
         .spawn()


### PR DESCRIPTION
## Summary
- Adds `POST /gateway/restart` to vestad. The handler schedules `systemctl --user restart vestad` 200ms after replying so the HTTP response flushes before the service goes down. Fails with `412 Precondition Failed` if vestad isn't running under systemd (e.g. `vestad serve --standalone`).
- Adds `GET /gateway/logs?tail=N&follow=BOOL` which spawns `journalctl --user -u vestad -n N [-f]` and streams stdout as SSE. `kill_on_drop(true)` tears the journal tail down when the client disconnects.
- Adds `vesta gateway restart` and `vesta gateway logs [--tail N] [--follow]` to the CLI. "Gateway" matches the terminology already used in `app/src/providers/GatewayProvider/`.
- Works against any connected vestad (local or remote via `vesta connect`), since vestad is Linux-only and always has systemd available in supported deployments.

## Test plan
- [ ] `cargo build -p vesta -p vestad` and `cargo clippy -p vesta -p vestad` clean (verified locally).
- [ ] `vesta gateway --help` lists both `restart` and `logs` subcommands.
- [ ] `vesta gateway logs --tail 50` prints recent vestad log lines and exits.
- [ ] `vesta gateway logs --follow` tails in real time; Ctrl-C exits cleanly and the journalctl child dies on the server.
- [ ] `vesta gateway restart` returns "restart initiated" and `journalctl --user -u vestad` shows the service restarting. Existing agent containers should not be affected (restart policy keeps them up; reconcile runs on vestad re-entry).
- [ ] Against `vestad serve --standalone`: `vesta gateway restart` returns 412 with a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)