### PR TITLE
feat(vestad): embed agent code in the binary via rust-embed

### DIFF
--- a/vestad/Cargo.lock
+++ b/vestad/Cargo.lock
@@ -302,6 +302,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +747,19 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1731,6 +1754,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
+ "globset",
  "sha2",
  "walkdir",
 ]

--- a/vestad/Cargo.toml
+++ b/vestad/Cargo.toml
@@ -44,7 +44,7 @@ bollard = "0.18"
 tar = "0.4"
 flate2 = "1"
 tokio-util = { version = "0.7", features = ["io"] }
-rust-embed = { version = "8", features = ["compression"] }
+rust-embed = { version = "8", features = ["compression", "include-exclude", "debug-embed"] }
 mime_guess = "2"
 
 [dev-dependencies]

--- a/vestad/build.rs
+++ b/vestad/build.rs
@@ -29,6 +29,15 @@ fn main() {
         println!("cargo:rerun-if-changed={}", root_lock.display());
     }
 
+    // Agent source is embedded into the binary via rust-embed in src/agent_embed.rs.
+    // Rebuild when any embedded input changes so release binaries stay in sync.
+    for rel in ["agent/core", "agent/pyproject.toml", "agent/uv.lock"] {
+        let p = repo_root.join(rel);
+        if p.exists() {
+            println!("cargo:rerun-if-changed={}", p.display());
+        }
+    }
+
     if std::env::var_os("VESTAD_SKIP_APP_BUILD").is_some() {
         std::fs::create_dir_all(web_dir.join("dist")).ok();
         let placeholder = web_dir.join("dist").join("index.html");

--- a/vestad/src/agent_code.rs
+++ b/vestad/src/agent_code.rs
@@ -1,21 +1,21 @@
+use crate::agent_embed::AgentSource;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hasher;
 use std::path::{Path, PathBuf};
-use std::{fmt, fs, process};
+use std::sync::OnceLock;
+use std::{fmt, fs};
 
-const GITHUB_ARCHIVE_URL: &str = "https://github.com/elyxlz/vesta/archive/refs/tags";
-const TEMP_PREFIX: &str = "vesta-agent-code";
+const FINGERPRINT_MARKER: &str = ".vestad-fingerprint";
+const MAIN_PY: &str = "core/main.py";
 
 #[derive(Debug)]
 pub enum AgentCodeError {
-    Download(String),
-    Extract(String),
     Io(String),
 }
 
 impl fmt::Display for AgentCodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Download(msg) => write!(f, "download failed: {msg}"),
-            Self::Extract(msg) => write!(f, "extraction failed: {msg}"),
             Self::Io(msg) => write!(f, "io error: {msg}"),
         }
     }
@@ -25,233 +25,93 @@ pub fn agent_code_dir(config: &Path) -> PathBuf {
     config.join("agent-code")
 }
 
-fn is_populated(config: &Path) -> bool {
-    let dir = agent_code_dir(config);
-    dir.join("core/main.py").exists()
-        && dir.join("pyproject.toml").is_file()
-        && dir.join("uv.lock").is_file()
-}
-
-/// Read the version from the on-disk agent pyproject.toml.
-fn on_disk_version(config: &Path) -> Option<String> {
-    let pyproject = fs::read_to_string(agent_code_dir(config).join("pyproject.toml")).ok()?;
-    for line in pyproject.lines() {
-        // Match exactly "version = ..." at the top level, not dependency version fields
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix("version") {
-            let rest = rest.trim_start();
-            if let Some(rest) = rest.strip_prefix('=') {
-                return Some(rest.trim().trim_matches('"').to_string());
+fn embed_fingerprint() -> &'static str {
+    static FINGERPRINT: OnceLock<String> = OnceLock::new();
+    FINGERPRINT.get_or_init(|| {
+        let mut hasher = DefaultHasher::new();
+        hasher.write(env!("CARGO_PKG_VERSION").as_bytes());
+        for name in AgentSource::iter() {
+            hasher.write(name.as_bytes());
+            if let Some(file) = AgentSource::get(&name) {
+                hasher.write(&file.data);
             }
         }
-    }
-    None
+        format!("{:016x}", hasher.finish())
+    })
 }
 
-/// Ensure agent code exists on the host and matches the vestad version.
-/// - Dev (debug builds): copies from the local repo if source is newer
-/// - Prod (release builds): downloads from GitHub if missing or version mismatch
+/// Re-extracts embedded agent code into `agent-code/` whenever the on-disk
+/// fingerprint marker doesn't match the binary's (i.e. after a rebuild).
 pub fn ensure_agent_code(config: &Path) -> Result<PathBuf, AgentCodeError> {
     let dir = agent_code_dir(config);
-    let vestad_version = env!("CARGO_PKG_VERSION");
+    let fingerprint = embed_fingerprint();
 
-    if cfg!(debug_assertions) {
-        copy_from_local_repo(config)?;
-    } else if is_populated(config) && on_disk_version(config).as_deref() == Some(vestad_version) {
+    let marker = dir.join(FINGERPRINT_MARKER);
+    let main_py = dir.join(MAIN_PY);
+    if main_py.exists() && fs::read_to_string(&marker).ok().as_deref() == Some(fingerprint) {
         return Ok(dir);
-    } else {
-        tracing::info!(
-            vestad = vestad_version,
-            agent = on_disk_version(config).as_deref().unwrap_or("missing"),
-            "updating agent code from github"
-        );
-        fetch_agent_code_from_github(config, vestad_version)?;
     }
 
-    if !is_populated(config) {
-        return Err(AgentCodeError::Extract(
-            "agent code population succeeded but validation failed".into(),
-        ));
+    tracing::info!(version = env!("CARGO_PKG_VERSION"), dir = %dir.display(), "writing embedded agent code");
+
+    if dir.exists() {
+        fs::remove_dir_all(&dir).map_err(|e| AgentCodeError::Io(format!("clean {}: {e}", dir.display())))?;
+    }
+    fs::create_dir_all(&dir).map_err(|e| AgentCodeError::Io(e.to_string()))?;
+
+    for name in AgentSource::iter() {
+        let file = AgentSource::get(&name)
+            .ok_or_else(|| AgentCodeError::Io(format!("embedded file {name} missing at extraction time")))?;
+        let dest = dir.join(name.as_ref());
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent).map_err(|e| AgentCodeError::Io(e.to_string()))?;
+        }
+        fs::write(&dest, file.data.as_ref())
+            .map_err(|e| AgentCodeError::Io(format!("write {}: {e}", dest.display())))?;
     }
 
-    tracing::info!("agent code ready at {}", dir.display());
+    // Guards against a broken include filter in agent_embed.rs silently producing
+    // an empty extraction — not a TOCTOU concern, the file was just written.
+    if !main_py.exists() {
+        return Err(AgentCodeError::Io(format!(
+            "extraction completed but {MAIN_PY} is missing — check agent_embed.rs include rules"
+        )));
+    }
+
+    fs::write(&marker, fingerprint).map_err(|e| AgentCodeError::Io(e.to_string()))?;
+
+    tracing::info!(dir = %dir.display(), "agent code ready");
     Ok(dir)
 }
 
-/// Find the repo root by walking up from cwd looking for agent/core/main.py.
-fn find_repo_agent_dir() -> Option<PathBuf> {
-    let mut dir = std::env::current_dir().ok()?;
-    for _ in 0..10 {
-        let candidate = dir.join("agent");
-        if candidate.join("core/main.py").exists() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?.to_path_buf();
-    }
-    None
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-/// Most recent mtime of any file under `dir` (recursive).
-fn newest_mtime(dir: &Path) -> Option<std::time::SystemTime> {
-    fn walk(dir: &Path, newest: &mut Option<std::time::SystemTime>) {
-        let entries = fs::read_dir(dir).ok();
-        for entry in entries.into_iter().flatten().filter_map(|e| e.ok()) {
-            if let Ok(meta) = entry.metadata() {
-                if let Ok(mtime) = meta.modified() {
-                    if newest.is_none_or(|n| mtime > n) {
-                        *newest = Some(mtime);
-                    }
-                }
-                if meta.is_dir() {
-                    walk(&entry.path(), newest);
-                }
-            }
-        }
-    }
-    let mut newest = None;
-    walk(dir, &mut newest);
-    newest
-}
+    #[test]
+    fn ensure_extracts_expected_files_and_is_idempotent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = tmp.path();
 
-/// Copy agent code from the local repo into agent-code/, skipping if unchanged.
-fn copy_from_local_repo(config: &Path) -> Result<(), AgentCodeError> {
-    let agent_dir = find_repo_agent_dir()
-        .ok_or_else(|| AgentCodeError::Extract("cannot find agent/ directory in repo".into()))?;
+        let dir = ensure_agent_code(config).expect("first call");
+        assert_eq!(dir, agent_code_dir(config));
+        assert!(dir.join(MAIN_PY).is_file());
+        assert!(dir.join("pyproject.toml").is_file());
+        assert!(dir.join("uv.lock").is_file());
+        assert_eq!(
+            fs::read_to_string(dir.join(FINGERPRINT_MARKER)).expect("marker"),
+            embed_fingerprint(),
+        );
 
-    let dest = agent_code_dir(config);
+        // Matching-fingerprint second call must not rewrite files.
+        let sentinel = dir.join("pyproject.toml");
+        fs::write(&sentinel, b"SENTINEL").expect("write sentinel");
+        let _ = ensure_agent_code(config).expect("second call");
+        assert_eq!(fs::read(&sentinel).expect("read sentinel"), b"SENTINEL");
 
-    // Skip if dest is already up-to-date
-    if dest.exists() {
-        let src_mtime = newest_mtime(&agent_dir.join("core"));
-        let dest_mtime = newest_mtime(&dest.join("core"));
-        if let (Some(src), Some(dst)) = (src_mtime, dest_mtime) {
-            if dst >= src {
-                return Ok(());
-            }
-        }
-    }
-
-    tracing::info!("dev mode: copying agent code from local repo");
-
-    let _ = fs::remove_dir_all(&dest);
-    fs::create_dir_all(&dest).map_err(|e| AgentCodeError::Io(e.to_string()))?;
-
-    let status = process::Command::new("cp")
-        .args([
-            "-r",
-            &agent_dir.join("core").display().to_string(),
-            &dest.join("core").display().to_string(),
-        ])
-        .status()
-        .map_err(|e| AgentCodeError::Io(e.to_string()))?;
-    if !status.success() {
-        return Err(AgentCodeError::Extract("failed to copy core".into()));
-    }
-
-    for file in ["pyproject.toml", "uv.lock"] {
-        fs::copy(agent_dir.join(file), dest.join(file))
-            .map_err(|e| AgentCodeError::Io(format!("failed to copy {file}: {e}")))?;
-    }
-
-    Ok(())
-}
-
-/// Best-effort recursive removal: try `fs::remove_dir_all` first, then fall back
-/// to `rm -rf` (handles directories with mixed ownership from previous runs).
-fn force_remove_dir(path: &Path) {
-    if !path.exists() {
-        return;
-    }
-    if fs::remove_dir_all(path).is_ok() {
-        return;
-    }
-    tracing::warn!(path = %path.display(), "fs::remove_dir_all failed, trying rm -rf");
-    let ok = process::Command::new("rm")
-        .args(["-rf", &path.display().to_string()])
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-    if !ok {
-        tracing::warn!(path = %path.display(), "rm -rf also failed, will use unique temp name");
+        // Tampered marker triggers re-extraction.
+        fs::write(dir.join(FINGERPRINT_MARKER), "stale").expect("write stale marker");
+        let _ = ensure_agent_code(config).expect("third call");
+        assert_ne!(fs::read(&sentinel).expect("read sentinel"), b"SENTINEL");
     }
 }
-
-/// Download agent code for a specific release tag from GitHub and atomically swap it in.
-fn fetch_agent_code_from_github(config: &Path, tag: &str) -> Result<(), AgentCodeError> {
-    let dir = agent_code_dir(config);
-    let pid = std::process::id();
-    let tmp_dir = config.join(format!("agent-code.new.{pid}"));
-    let old_dir = config.join(format!("agent-code.old.{pid}"));
-
-    // Clean up any stale temp directories (best-effort, non-blocking)
-    force_remove_dir(&tmp_dir);
-    force_remove_dir(&old_dir);
-    // Also try to clean generic names from older versions
-    force_remove_dir(&config.join("agent-code.new"));
-    force_remove_dir(&config.join("agent-code.old"));
-
-    fs::create_dir_all(&tmp_dir).map_err(|e| AgentCodeError::Io(e.to_string()))?;
-
-    let archive_url = format!("{GITHUB_ARCHIVE_URL}/v{tag}.tar.gz");
-    let archive_path = format!("/tmp/{TEMP_PREFIX}-{}.tar.gz", std::process::id());
-
-    // Download
-    let ok = process::Command::new("curl")
-        .args(["-fsSL", "-o", &archive_path, &archive_url])
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-    if !ok {
-        force_remove_dir(&tmp_dir);
-        let _ = fs::remove_file(&archive_path);
-        return Err(AgentCodeError::Download(format!("failed to download {archive_url}")));
-    }
-
-    // GitHub archives have prefix vesta-{tag}/ (v is stripped from directory name).
-    // --strip-components=2 turns vesta-{tag}/agent/core/... into core/...
-    let prefix = format!("vesta-{tag}/agent");
-    let ok = process::Command::new("tar")
-        .args([
-            "-xzf", &archive_path,
-            "-C", &tmp_dir.display().to_string(),
-            "--strip-components=2",
-            &prefix,
-        ])
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-
-    let _ = fs::remove_file(&archive_path);
-
-    if !ok {
-        force_remove_dir(&tmp_dir);
-        return Err(AgentCodeError::Extract("failed to extract agent/ from tarball".into()));
-    }
-
-    // Validate
-    if !tmp_dir.join("core/main.py").exists() || !tmp_dir.join("pyproject.toml").exists() {
-        force_remove_dir(&tmp_dir);
-        return Err(AgentCodeError::Extract("extracted archive missing required files".into()));
-    }
-
-    // Atomic swap
-    if dir.exists() {
-        fs::rename(&dir, &old_dir).map_err(|e| {
-            force_remove_dir(&tmp_dir);
-            AgentCodeError::Io(format!("failed to move old agent-code: {e}"))
-        })?;
-    }
-
-    fs::rename(&tmp_dir, &dir).map_err(|e| {
-        if old_dir.exists() {
-            let _ = fs::rename(&old_dir, &dir);
-        }
-        AgentCodeError::Io(format!("failed to move new agent-code into place: {e}"))
-    })?;
-
-    force_remove_dir(&old_dir);
-    tracing::info!(tag = %tag, "agent code updated successfully");
-    Ok(())
-}
-
-// TODO: re-add fetch_agent_code_known_tag test after first release with agent/core/ layout

--- a/vestad/src/agent_embed.rs
+++ b/vestad/src/agent_embed.rs
@@ -2,7 +2,7 @@ use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
 #[folder = "../agent"]
-#[include = "core/**/*.py"]
+#[include = "core/**/*"]
 #[include = "pyproject.toml"]
 #[include = "uv.lock"]
 #[exclude = "**/__pycache__/*"]

--- a/vestad/src/agent_embed.rs
+++ b/vestad/src/agent_embed.rs
@@ -1,0 +1,10 @@
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "../agent"]
+#[include = "core/**/*.py"]
+#[include = "pyproject.toml"]
+#[include = "uv.lock"]
+#[exclude = "**/__pycache__/*"]
+#[exclude = "**/*.pyc"]
+pub(crate) struct AgentSource;

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1489,8 +1489,7 @@ pub async fn create_agent(docker: &Docker, name: &str, env_config: &AgentEnvConf
     let image = resolve_image(docker).await?;
 
     if manage_core_code {
-        let code_source = if cfg!(debug_assertions) { "local repo" } else { "github" };
-        tracing::info!(agent = %name, source = code_source, "fetching agent code");
+        tracing::info!(agent = %name, "ensuring agent code");
         crate::agent_code::ensure_agent_code(&env_config.config_dir)
             .map_err(|e| DockerError::Failed(format!("agent code: {e}")))?;
     }

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -4,6 +4,7 @@ compile_error!("vestad only supports Linux");
 use clap::Parser;
 
 mod agent_code;
+mod agent_embed;
 mod agent_proxy;
 mod agent_status;
 mod app_static;
@@ -153,12 +154,15 @@ fn config_dir() -> std::path::PathBuf {
 
 fn print_server_info(tunnel_url: Option<&str>, local_url: &str, api_key: &str) {
     eprintln!();
-    eprintln!("  \x1b[36mapp\x1b[0m  \x1b[2m(open in a browser and paste the key)\x1b[0m");
+    if let Some(url) = tunnel_url {
+        eprintln!("  \x1b[36mtunnel\x1b[0m  \x1b[1m{}\x1b[0m", url);
+    }
+    eprintln!("  \x1b[36mkey\x1b[0m     \x1b[33m{}\x1b[0m", api_key);
+    eprintln!("  \x1b[36mapp\x1b[0m     \x1b[2m(open in a browser and paste the key)\x1b[0m");
     if let Some(url) = tunnel_url {
         eprintln!("    \x1b[36mremote\x1b[0m  \x1b[1m{}/app\x1b[0m  \x1b[32m(recommended)\x1b[0m", url);
     }
     eprintln!("    \x1b[36mlocal\x1b[0m   \x1b[1m{}/app\x1b[0m  \x1b[2m(same machine only)\x1b[0m", local_url);
-    eprintln!("  \x1b[36mkey\x1b[0m   \x1b[33m{}\x1b[0m", api_key);
     if tunnel_url.is_none() {
         eprintln!();
         eprintln!("  \x1b[33mtip:\x1b[0m run without --no-tunnel to get a remote URL");

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1684,11 +1684,11 @@ pub async fn run_server(port: u16, api_key: String, cert_pem: String, key_pem: S
         tracing::error!(error = %e, "config directory validation failed — aborting startup");
         std::process::exit(1);
     }
-    if cfg!(debug_assertions) {
-        tracing::info!("mode: dev (debug build, agent code from local repo)");
-    } else {
-        tracing::info!(version = env!("CARGO_PKG_VERSION"), "mode: prod (release build, agent code from github)");
-    }
+    tracing::info!(
+        version = env!("CARGO_PKG_VERSION"),
+        mode = if cfg!(debug_assertions) { "dev" } else { "prod" },
+        "agent code embedded in binary",
+    );
     if let Err(e) = crate::agent_code::ensure_agent_code(&env_config.config_dir) {
         tracing::error!(error = %e, "failed to ensure agent code");
     }


### PR DESCRIPTION
## Summary
- Replace dev-mode local-repo copy + release-mode GitHub tarball fetch with a single `rust_embed`-baked `AgentSource`, mirroring the SPA embed in `app_static.rs`.
- `ensure_agent_code` now extracts to `~/.config/vesta/vestad/agent-code/` whenever the on-disk fingerprint marker doesn't match the binary's; fingerprint = hash of `CARGO_PKG_VERSION` + every embedded file. Memoized with `OnceLock` so it's free to call.
- `vestad/src/agent_code.rs` drops from ~250 LOC to ~100. Deletes `curl`/`tar`/`cp` subprocess dance, temp-dir atomic-rename, mtime walker, and pyproject-version parsing.
- Reorders startup info to show `tunnel` → `key` → `app` links.

## Test plan
- [x] `cargo clippy -p vestad` clean (only pre-existing `tunnel.rs` warning)
- [x] `cargo test -p vestad` — new `ensure_extracts_expected_files_and_is_idempotent` test covers first-call extraction, same-fingerprint no-op, and stale-marker re-extraction
- [x] `cargo build -p vestad --release` succeeds; binary ~7 MB
- [ ] Smoke-test: start vestad offline, confirm `agent-code/` populates without any GitHub fetch
- [ ] Smoke-test: edit `agent/core/*.py`, `cargo build -p vestad`, restart; confirm bytes update

🤖 Generated with [Claude Code](https://claude.com/claude-code)