### PR TITLE
feat: make vestad updates manual; show update button in StatusPill

### DIFF
--- a/apps/web/src/components/StatusPill/index.tsx
+++ b/apps/web/src/components/StatusPill/index.tsx
@@ -1,12 +1,14 @@
 import { getConnection } from "@/lib/connection";
 import { useGateway } from "@/providers/GatewayProvider";
+import { Button } from "@/components/ui/button";
 
 interface StatusPillProps {
   showHostname?: boolean;
 }
 
 export function StatusPill({ showHostname = true }: StatusPillProps) {
-  const { reachable } = useGateway();
+  const { reachable, updateAvailable, latestVersion, triggerGatewayUpdate } =
+    useGateway();
 
   const hostname = (() => {
     const conn = getConnection();
@@ -27,6 +29,16 @@ export function StatusPill({ showHostname = true }: StatusPillProps) {
         <span className="text-sm text-secondary-foreground truncate hidden sm:block">
           {hostname}
         </span>
+      )}
+      {updateAvailable && (
+        <Button
+          size="xs"
+          variant="outline"
+          onClick={triggerGatewayUpdate}
+          title={latestVersion ? `Update to v${latestVersion}` : "Update available"}
+        >
+          update
+        </Button>
       )}
     </div>
   );

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -49,3 +49,12 @@ export type LogEvent =
   | { kind: "Line"; text: string }
   | { kind: "End" }
   | { kind: "Error"; message: string };
+
+export interface GatewayVersionInfo {
+  version: string;
+  api_compat: string;
+  dev_mode: boolean;
+  latest_version: string | null;
+  update_available: boolean | null;
+  branch?: string | null;
+}

--- a/apps/web/src/providers/GatewayProvider/index.tsx
+++ b/apps/web/src/providers/GatewayProvider/index.tsx
@@ -6,15 +6,29 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { apiFetch } from "@/api/client";
-import { getConnection, authHeaders } from "@/lib/connection";
+import { apiFetch, apiJson } from "@/api/client";
+import { getConnection } from "@/lib/connection";
 import { ensureFreshToken } from "@/lib/token-refresh";
 import { useAuth } from "@/providers/AuthProvider";
 import { VersionMismatchDialog } from "@/components/VersionMismatchDialog";
-import type { AgentInfo } from "@/lib/types";
+import type { AgentInfo, GatewayVersionInfo } from "@/lib/types";
+
+const VERSION_FETCH_TIMEOUT_MS = 5000;
+
+async function fetchVersionInfo(): Promise<GatewayVersionInfo | null> {
+  try {
+    return await apiJson<GatewayVersionInfo>("/version", {
+      signal: AbortSignal.timeout(VERSION_FETCH_TIMEOUT_MS),
+    });
+  } catch {
+    return null;
+  }
+}
 
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30000;
+
+const VERSION_POLL_MS = 60000;
 
 interface GatewayContextValue {
   reachable: boolean;
@@ -22,6 +36,8 @@ interface GatewayContextValue {
   gatewayBranch: string | null;
   gatewayPort: number;
   versionChecked: boolean;
+  updateAvailable: boolean;
+  latestVersion: string | null;
   agents: AgentInfo[];
   agentsFetched: boolean;
   send: (event: object) => boolean;
@@ -36,6 +52,8 @@ const disconnectedValue: GatewayContextValue = {
   gatewayBranch: null,
   gatewayPort: 0,
   versionChecked: true,
+  updateAvailable: false,
+  latestVersion: null,
   agents: [],
   agentsFetched: false,
   send: () => false,
@@ -57,6 +75,8 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
   const [gatewayPort, setGatewayPort] = useState(0);
 
   const [versionChecked, setVersionChecked] = useState(false);
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  const [latestVersion, setLatestVersion] = useState<string | null>(null);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   const [agentsFetched, setAgentsFetched] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
@@ -65,8 +85,8 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
   const skipVersionGateRef = useRef(false);
 
   const triggerGatewayUpdate = () => {
-    apiFetch("/self-update", { method: "POST" }).catch((err) => {
-      console.warn("[gateway] self-update request failed:", err);
+    apiFetch("/gateway/update", { method: "POST" }).catch((err) => {
+      console.warn("[gateway] update request failed:", err);
     });
     skipVersionGateRef.current = true;
     setConnectEpoch((e) => e + 1);
@@ -93,25 +113,14 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
       }
 
       // Fetch version early via HTTP before WS connects
-      try {
-        const conn = getConnection();
-        if (conn) {
-          const resp = await fetch(`${conn.url}/version`, {
-            headers: authHeaders(),
-            signal: AbortSignal.timeout(5000),
-          });
-          if (!cancelled && resp.ok) {
-            const data = await resp.json();
-            if (data.version) {
-              setGatewayVersion(data.version);
-              setGatewayBranch(data.branch || null);
-              setVersionChecked(true);
-              if (data.version !== __APP_VERSION__ && !skipVersionGateRef.current) return;
-            }
-          }
-        }
-      } catch {
-        /* version check failed, proceed with WS */
+      const data = await fetchVersionInfo();
+      if (!cancelled && data?.version) {
+        setGatewayVersion(data.version);
+        setGatewayBranch(data.branch ?? null);
+        setUpdateAvailable(!!data.update_available);
+        setLatestVersion(data.latest_version ?? null);
+        setVersionChecked(true);
+        if (data.version !== __APP_VERSION__ && !skipVersionGateRef.current) return;
       }
       if (!cancelled) setVersionChecked(true);
 
@@ -175,6 +184,24 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
     };
   }, [connectEpoch]);
 
+  useEffect(() => {
+    if (!reachable) return;
+    let cancelled = false;
+
+    const pollVersion = async () => {
+      const data = await fetchVersionInfo();
+      if (cancelled || !data) return;
+      setUpdateAvailable(!!data.update_available);
+      setLatestVersion(data.latest_version ?? null);
+    };
+
+    const timer = setInterval(pollVersion, VERSION_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [reachable]);
+
   const send = (event: object): boolean => {
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) return false;
@@ -193,6 +220,8 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
         gatewayBranch,
         gatewayPort,
         versionChecked,
+        updateAvailable,
+        latestVersion,
         agents,
         agentsFetched,
         send,

--- a/vestad/src/agent_code.rs
+++ b/vestad/src/agent_code.rs
@@ -98,6 +98,10 @@ mod tests {
         assert!(dir.join(MAIN_PY).is_file());
         assert!(dir.join("pyproject.toml").is_file());
         assert!(dir.join("uv.lock").is_file());
+        // Non-.py files under core/ (prompts, skill manifests) must also be embedded
+        // — the agent's prompt loader depends on them at runtime.
+        assert!(dir.join("core/prompts/nightly_dream.md").is_file());
+        assert!(dir.join("core/prompts/notification_suffix.md").is_file());
         assert_eq!(
             fs::read_to_string(dir.join(FINGERPRINT_MARKER)).expect("marker"),
             embed_fingerprint(),

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -309,7 +309,7 @@ async fn restart_gateway_handler() -> Result<Json<serde_json::Value>, (StatusCod
     Ok(Json(serde_json::json!({"ok": true, "restarting": true})))
 }
 
-async fn self_update_handler(
+async fn gateway_update_handler(
     State(state): State<SharedState>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     if state.dev_mode {
@@ -318,7 +318,7 @@ async fn self_update_handler(
     if state.updating.swap(true, std::sync::atomic::Ordering::SeqCst) {
         return Err(err_response(StatusCode::CONFLICT, "update already in progress"));
     }
-    tracing::info!("self-update requested via API");
+    tracing::info!("gateway update requested via API");
     let result = tokio::task::spawn_blocking(self_update::perform_update)
         .await
         .unwrap();
@@ -1395,7 +1395,7 @@ pub fn build_router(state: SharedState) -> Router {
 
     let vestad_protected = Router::new()
         .route("/version", get(version))
-        .route("/self-update", post(self_update_handler))
+        .route("/gateway/update", post(gateway_update_handler))
         .route("/gateway/restart", post(restart_gateway_handler))
         .route("/gateway/logs", get(gateway_logs_handler))
         .route("/tunnel", get(tunnel_handler))
@@ -1628,38 +1628,11 @@ fn spawn_auto_backup_task(state: SharedState) {
 
 fn spawn_update_check_task(state: SharedState) {
     tokio::spawn(async move {
-        let mut last_attempted: Option<String> = None;
         loop {
-            let info_result = tokio::task::spawn_blocking(update_check::check_once).await;
-            match info_result {
+            match tokio::task::spawn_blocking(update_check::check_once).await {
                 Ok(Ok(info)) => {
                     let mut slot = state.update_info.lock().await;
-                    *slot = Some(info.clone());
-                    drop(slot);
-
-                    if info.update_available
-                        && last_attempted.as_ref() != Some(&info.latest)
-                        && !state.updating.swap(true, std::sync::atomic::Ordering::SeqCst)
-                    {
-                        tracing::info!(
-                            "update available: v{} -> v{}, auto-updating...",
-                            info.current, info.latest
-                        );
-                        last_attempted = Some(info.latest.clone());
-
-                        match tokio::task::spawn_blocking(self_update::perform_update).await {
-                            Ok(Ok(true)) => {
-                                tracing::info!("auto-update: restarting via systemd");
-                                return;
-                            }
-                            Ok(Ok(false)) => {
-                                tracing::info!("auto-update: binary replaced, awaiting restart");
-                            }
-                            Ok(Err(e)) => tracing::error!("auto-update failed: {}", e),
-                            Err(e) => tracing::error!("auto-update task panicked: {}", e),
-                        }
-                        state.updating.store(false, std::sync::atomic::Ordering::SeqCst);
-                    }
+                    *slot = Some(info);
                 }
                 Ok(Err(e)) => tracing::warn!("update check failed: {}", e),
                 Err(e) => tracing::error!("update check task failed: {}", e),

--- a/vestad/src/update_check.rs
+++ b/vestad/src/update_check.rs
@@ -1,4 +1,4 @@
-pub const CHECK_INTERVAL_SECS: u64 = 6 * 60 * 60;
+pub const CHECK_INTERVAL_SECS: u64 = 10 * 60;
 const FETCH_TIMEOUT_SECS: u64 = 10;
 
 const GITHUB_RELEASES_LATEST_URL: &str =
@@ -6,7 +6,6 @@ const GITHUB_RELEASES_LATEST_URL: &str =
 
 #[derive(Clone, Debug)]
 pub struct UpdateInfo {
-    pub current: String,
     pub latest: String,
     pub update_available: bool,
 }
@@ -14,11 +13,9 @@ pub struct UpdateInfo {
 pub fn check_once() -> Result<UpdateInfo, String> {
     let latest = fetch_latest_release_tag(Some(FETCH_TIMEOUT_SECS))
         .ok_or_else(|| "failed to fetch latest release".to_string())?;
-    let current = env!("CARGO_PKG_VERSION").to_string();
-    let update_available = version_less_than(&current, &latest);
+    let update_available = version_less_than(env!("CARGO_PKG_VERSION"), &latest);
 
     Ok(UpdateInfo {
-        current,
         latest,
         update_available,
     })


### PR DESCRIPTION
## Summary

- `vestad` no longer silently auto-updates. The background update-check task now only polls GitHub (every **10 min** instead of 6 h) and caches `latest_version` / `update_available` for clients. Applying the update is explicit — via `POST /gateway/update` or `vestad update` / `vesta update`.
- Renamed the client-triggered endpoint `POST /self-update` → `POST /gateway/update` so it groups with the other daemon-control routes (`/gateway/restart`, `/gateway/logs`). Handler renamed `self_update_handler` → `gateway_update_handler`.
- Web app surfaces updates proactively: reads `update_available` / `latest_version` from `/version`, polls `/version` every 60 s while connected, and renders an inline `update` button in `StatusPill` (navbar) that calls `/gateway/update`.
- Both `/version` fetches now go through the typed `apiJson` helper with a shared `GatewayVersionInfo` type; removed the hand-rolled `fetch + authHeaders + AbortSignal` duplicates and the dead `UpdateInfo.current` field in Rust.

## Test plan

- [x] `cargo clippy -p vestad` clean
- [x] `cargo test -p vestad` — 62 passed
- [x] `npm -w @vesta/web run check` (tsc) clean
- [x] `eslint` clean on the touched web files
- [ ] Manual: start vestad; within ~10 min a `/version` check fires, no auto-update / restart lines in the log
- [ ] Manual: `curl -k https://localhost:<port>/version` → includes `latest_version` + `update_available`
- [ ] Manual: `POST /gateway/update` (with auth) triggers the update; `POST /self-update` now returns 404
- [ ] Manual: in the web app, the StatusPill renders an "update" button when `update_available` is true; clicking it runs the update and reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)