### PR TITLE
feat(agent/notifications): inline reply hints + source-aware skill descriptions

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -52,12 +52,37 @@ async def delete_notification_files(notifications: list[vm.Notification]) -> Non
         pl.Path(path_str).unlink(missing_ok=True)
 
 
+def _reply_hint(notif: vm.Notification) -> str:
+    """Inline command hint so the model invokes the reply skill instead of forgetting."""
+    if notif.type != "message":
+        return ""
+    if notif.source == "app-chat":
+        return "\n→ Reply with: `app-chat send --message '...'`"
+    if notif.source in ("whatsapp", "telegram"):
+        data = notif.model_dump(exclude={"file_path", "type", "source", "interrupt", "timestamp"})
+        recipient = None
+        for key in ("chat_name", "contact_name"):
+            if key in data and data[key]:
+                recipient = data[key]
+                break
+        if not recipient:
+            return ""
+        if notif.source == "whatsapp":
+            return f"\n→ Reply with: `whatsapp send --to '{recipient}' --message '...'`"
+        return f"\n→ Reply with: `telegram send '{recipient}' '...'`"
+    return ""
+
+
+def _format_one(notif: vm.Notification) -> str:
+    return notif.format_for_display() + _reply_hint(notif)
+
+
 def format_notification_batch(notifications: list[vm.Notification], *, suffix: str = "") -> str:
     suffix_str = f"\n\n{suffix}" if suffix else ""
     if len(notifications) == 1:
-        return notifications[0].format_for_display() + suffix_str
+        return _format_one(notifications[0]) + suffix_str
 
-    prompts = [n.format_for_display() for n in notifications]
+    prompts = [_format_one(n) for n in notifications]
     return "[NOTIFICATIONS]\n" + "\n".join(prompts) + suffix_str
 
 

--- a/agent/core/skills/app-chat/SKILL.md
+++ b/agent/core/skills/app-chat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: app-chat
-description: This skill handles messages from the Vesta app (desktop/web). When a user sends a message through the Vesta app, it arrives as a notification. Reply using the `app-chat` CLI. Requires a background daemon.
+description: Use this skill to reply to notifications with `source=app-chat` (messages from the Vesta desktop/web app). Always reply via `app-chat send` — never via any other channel. Requires a background daemon.
 ---
 
 # App Chat - CLI: app-chat

--- a/agent/core/skills/app-chat/SKILL.md
+++ b/agent/core/skills/app-chat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: app-chat
-description: Use this skill to reply to notifications with `source=app-chat` (messages from the Vesta desktop/web app). Always reply via `app-chat send` — never via any other channel. Requires a background daemon.
+description: Use this skill to reply to notifications with `source=app-chat` (messages from the Vesta desktop/web app). Always reply via `app-chat send`, never via any other channel. Requires a background daemon.
 ---
 
 # App Chat - CLI: app-chat

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "app-chat",
-    "description": "Use this skill to reply to notifications with `source=app-chat` (messages from the Vesta desktop/web app). Always reply via `app-chat send` \u2014 never via any other channel. Requires a background daemon."
+    "description": "Use this skill to reply to notifications with `source=app-chat` (messages from the Vesta desktop/web app). Always reply via `app-chat send`, never via any other channel. Requires a background daemon."
   },
   {
     "name": "browser",
@@ -65,7 +65,7 @@
   },
   {
     "name": "telegram",
-    "description": "Use this skill to reply to notifications with `source=telegram`, or when the user asks about \"telegram\", \"tg\", \"telegram message\", or needs to send/receive messages via Telegram. Always reply to telegram notifications via `telegram send` \u2014 never via any other channel. Requires a background daemon."
+    "description": "Use this skill to reply to notifications with `source=telegram`, or when the user asks about \"telegram\", \"tg\", \"telegram message\", or needs to send/receive messages via Telegram. Always reply to telegram notifications via `telegram send`, never via any other channel. Requires a background daemon."
   },
   {
     "name": "tv",
@@ -89,7 +89,7 @@
   },
   {
     "name": "whatsapp",
-    "description": "Use this skill to reply to notifications with `source=whatsapp`, or when the user asks about \"whatsapp\", \"message\", \"text\", \"chat\", or needs to send/receive messages via WhatsApp. Always reply to whatsapp notifications via `whatsapp send` \u2014 never via any other channel. Requires a background daemon."
+    "description": "Use this skill to reply to notifications with `source=whatsapp`, or when the user asks about \"whatsapp\", \"message\", \"text\", \"chat\", or needs to send/receive messages via WhatsApp. Always reply to whatsapp notifications via `whatsapp send`, never via any other channel. Requires a background daemon."
   },
   {
     "name": "whisper",

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "app-chat",
-    "description": "This skill handles messages from the Vesta app (desktop/web). When a user sends a message through the Vesta app, it arrives as a notification. Reply using the `app-chat` CLI. Requires a background daemon."
+    "description": "Use this skill to reply to notifications with `source=app-chat` (messages from the Vesta desktop/web app). Always reply via `app-chat send` \u2014 never via any other channel. Requires a background daemon."
   },
   {
     "name": "browser",
@@ -65,7 +65,7 @@
   },
   {
     "name": "telegram",
-    "description": "This skill should be used when the user asks about \"telegram\", \"tg\", \"telegram message\", or needs to send/receive messages via Telegram. Requires a background daemon."
+    "description": "Use this skill to reply to notifications with `source=telegram`, or when the user asks about \"telegram\", \"tg\", \"telegram message\", or needs to send/receive messages via Telegram. Always reply to telegram notifications via `telegram send` \u2014 never via any other channel. Requires a background daemon."
   },
   {
     "name": "tv",
@@ -89,7 +89,7 @@
   },
   {
     "name": "whatsapp",
-    "description": "This skill should be used when the user asks about \"whatsapp\", \"message\", \"text\", \"chat\", or needs to send/receive messages via WhatsApp. Requires a background daemon."
+    "description": "Use this skill to reply to notifications with `source=whatsapp`, or when the user asks about \"whatsapp\", \"message\", \"text\", \"chat\", or needs to send/receive messages via WhatsApp. Always reply to whatsapp notifications via `whatsapp send` \u2014 never via any other channel. Requires a background daemon."
   },
   {
     "name": "whisper",

--- a/agent/skills/telegram/SKILL.md
+++ b/agent/skills/telegram/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram
-description: Use this skill to reply to notifications with `source=telegram`, or when the user asks about "telegram", "tg", "telegram message", or needs to send/receive messages via Telegram. Always reply to telegram notifications via `telegram send` — never via any other channel. Requires a background daemon.
+description: Use this skill to reply to notifications with `source=telegram`, or when the user asks about "telegram", "tg", "telegram message", or needs to send/receive messages via Telegram. Always reply to telegram notifications via `telegram send`, never via any other channel. Requires a background daemon.
 ---
 
 # Telegram - CLI: telegram

--- a/agent/skills/telegram/SKILL.md
+++ b/agent/skills/telegram/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram
-description: This skill should be used when the user asks about "telegram", "tg", "telegram message", or needs to send/receive messages via Telegram. Requires a background daemon.
+description: Use this skill to reply to notifications with `source=telegram`, or when the user asks about "telegram", "tg", "telegram message", or needs to send/receive messages via Telegram. Always reply to telegram notifications via `telegram send` — never via any other channel. Requires a background daemon.
 ---
 
 # Telegram - CLI: telegram

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: whatsapp
-description: This skill should be used when the user asks about "whatsapp", "message", "text", "chat", or needs to send/receive messages via WhatsApp. Requires a background daemon.
+description: Use this skill to reply to notifications with `source=whatsapp`, or when the user asks about "whatsapp", "message", "text", "chat", or needs to send/receive messages via WhatsApp. Always reply to whatsapp notifications via `whatsapp send` — never via any other channel. Requires a background daemon.
 ---
 
 # WhatsApp - CLI: whatsapp

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: whatsapp
-description: Use this skill to reply to notifications with `source=whatsapp`, or when the user asks about "whatsapp", "message", "text", "chat", or needs to send/receive messages via WhatsApp. Always reply to whatsapp notifications via `whatsapp send` — never via any other channel. Requires a background daemon.
+description: Use this skill to reply to notifications with `source=whatsapp`, or when the user asks about "whatsapp", "message", "text", "chat", or needs to send/receive messages via WhatsApp. Always reply to whatsapp notifications via `whatsapp send`, never via any other channel. Requires a background daemon.
 ---
 
 # WhatsApp - CLI: whatsapp

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -183,7 +183,14 @@ def test_notification_format_for_display():
             "whatsapp send --to 'Alice'",
         ),
         (
-            {"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "message", "chat_name": "Group", "sender": "bob", "message": "hi"},
+            {
+                "timestamp": "2025-01-01T00:00:00",
+                "source": "whatsapp",
+                "type": "message",
+                "chat_name": "Group",
+                "sender": "bob",
+                "message": "hi",
+            },
             "whatsapp send --to 'Group'",
         ),
         (
@@ -211,7 +218,9 @@ def test_batch_no_hint_for_unknown_source():
 
 
 def test_batch_no_hint_for_non_message_type():
-    notif = vm.Notification.model_validate({"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "reaction", "contact_name": "Alice", "emoji": "👍"})
+    notif = vm.Notification.model_validate(
+        {"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "reaction", "contact_name": "Alice", "emoji": "👍"}
+    )
     formatted = format_notification_batch([notif])
     assert "→ Reply with:" not in formatted
 

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -175,6 +175,47 @@ def test_notification_format_for_display():
     assert "sender=alice" in display
 
 
+@pytest.mark.parametrize(
+    "payload,expected_substr",
+    [
+        (
+            {"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "message", "contact_name": "Alice", "message": "hi"},
+            "whatsapp send --to 'Alice'",
+        ),
+        (
+            {"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "message", "chat_name": "Group", "sender": "bob", "message": "hi"},
+            "whatsapp send --to 'Group'",
+        ),
+        (
+            {"timestamp": "2025-01-01T00:00:00", "source": "telegram", "type": "message", "contact_name": "Carol", "message": "hi"},
+            "telegram send 'Carol'",
+        ),
+        (
+            {"timestamp": "2025-01-01T00:00:00", "source": "app-chat", "type": "message", "message": "hi"},
+            "app-chat send --message",
+        ),
+    ],
+    ids=["whatsapp-direct", "whatsapp-group", "telegram-direct", "app-chat"],
+)
+def test_batch_includes_reply_hint(payload, expected_substr):
+    notif = vm.Notification.model_validate(payload)
+    formatted = format_notification_batch([notif])
+    assert "→ Reply with:" in formatted
+    assert expected_substr in formatted
+
+
+def test_batch_no_hint_for_unknown_source():
+    notif = vm.Notification.model_validate({"timestamp": "2025-01-01T00:00:00", "source": "email", "type": "message", "sender": "alice"})
+    formatted = format_notification_batch([notif])
+    assert "→ Reply with:" not in formatted
+
+
+def test_batch_no_hint_for_non_message_type():
+    notif = vm.Notification.model_validate({"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "reaction", "contact_name": "Alice", "emoji": "👍"})
+    formatted = format_notification_batch([notif])
+    assert "→ Reply with:" not in formatted
+
+
 # --- load_new_notifications ---
 
 


### PR DESCRIPTION
## Summary
- The agent often forgot to reply to whatsapp/telegram/app-chat notifications. The reply rule lived only in prose (`notification_suffix.md`, `MEMORY.md`); nothing in the prompt or tool descriptions concretely bound a notification's `source` to the skill that should reply.
- `format_notification_batch` now emits an inline `→ Reply with: <command>` line per notification for known channels (whatsapp, telegram, app-chat), pulling `chat_name`/`contact_name` from the notification body so the command is ready to run.
- The whatsapp / telegram / app-chat `SKILL.md` descriptions now explicitly say "Use this skill to reply to notifications with `source=<name>`" and forbid replying via other channels — biasing tool selection at the SDK layer. `agent/skills/index.json` regenerated.

## Test plan
- [x] `uv run pytest agent/tests/test_notifications.py` (33 passed, includes 6 new cases covering whatsapp direct/group, telegram, app-chat, unknown source, and non-message type)
- [x] `uv run ruff check agent/core/loops.py agent/tests/test_notifications.py`
- [x] `uv run ty check agent/core/loops.py`
- [ ] Observe a real whatsapp/app-chat notification in a running agent and confirm reply rate improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)