### PR TITLE
fix(agent): detect silent message_processor exits, log WS send errors

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -81,8 +81,10 @@ async def _send_loop(ws: web.WebSocketResponse, sub: asyncio.Queue[VestaEvent]) 
         while True:
             event = await sub.get()
             await ws.send_json(event)
-    except (ConnectionError, RuntimeError, TypeError, asyncio.CancelledError):
+    except asyncio.CancelledError:
         pass
+    except (ConnectionError, RuntimeError, TypeError) as e:
+        logger.info(f"ws send_loop exited: {type(e).__name__}: {e}")
 
 
 async def _history_handler(request: web.Request) -> web.Response:

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -84,14 +84,17 @@ async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: boo
     processor_task = asyncio.create_task(message_processor(message_queue, state=state, config=config))
 
     def _on_processor_done(task: asyncio.Task[None]) -> None:
-        if task.cancelled():
+        if task.cancelled() or state.shutdown_event.is_set() or state.graceful_shutdown.is_set():
             return
         exc = task.exception()
         if exc is not None:
             exit_code, stderr_tail = format_crash_detail(exc, state.stderr_buffer)
             logger.error(f"message_processor crashed: {type(exc).__name__}: {exc} | exit_code={exit_code}\nRecent stderr:\n{stderr_tail}")
             state.restart_reason = f"crash — {type(exc).__name__}: {exc}"
-            state.graceful_shutdown.set()
+        else:
+            logger.error("message_processor exited without error — restarting")
+            state.restart_reason = "crash — processor exited silently"
+        state.graceful_shutdown.set()
 
     processor_task.add_done_callback(_on_processor_done)
 


### PR DESCRIPTION
## Summary
- `_on_processor_done` only triggered a restart when the processor task raised. If `ClaudeSDKClient`'s `async with` block exits cleanly, `message_processor` returns normally — the container stayed alive with nothing draining `message_queue`. Treat any non-cancelled, non-shutdown exit as a crash and restart.
- `_send_loop` silently swallowed `ConnectionError`/`RuntimeError`/`TypeError`. Log them (still swallow `CancelledError`, which is the normal shutdown path) so broken WS clients are visible in the agent logs.

## Why this matters
When the processor silently exits, timed reminders (`proactive_check`, `dreamer`) still log because they log at queue-put time. But WhatsApp and app-chat notifications only log inside `_process_message_safely`, so they vanish from logs — `monitor_loop` keeps ingesting notification files, enqueuing them, and deleting the source files, with no consumer.

## Test plan
- [ ] Restart an agent and verify normal operation unchanged
- [ ] Simulate a processor exit (kill the `claude` subprocess) and confirm `"message_processor exited without error — restarting"` appears and the container restarts
- [ ] Close a WS client and confirm `ws send_loop exited: ...` appears in agent logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)