### PR TITLE
fix(vestad): verify HTTP port+1 is bindable in find_available_port

### DIFF
--- a/vestad/Cargo.lock
+++ b/vestad/Cargo.lock
@@ -2554,7 +2554,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta-tests"
-version = "0.1.141"
+version = "0.1.142"
 dependencies = [
  "ring",
  "rustls",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "vestad"
-version = "0.1.141"
+version = "0.1.142"
 dependencies = [
  "async-stream",
  "axum",

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -120,10 +120,19 @@ fn die(msg: impl std::fmt::Display) -> ! {
 }
 
 fn find_available_port() -> Option<u16> {
-    std::net::TcpListener::bind(("0.0.0.0", 0))
-        .ok()
-        .and_then(|l| l.local_addr().ok())
-        .map(|addr| addr.port())
+    // serve.rs binds HTTPS on 0.0.0.0:N and HTTP on 127.0.0.1:N+1, so both must be free.
+    const MAX_ATTEMPTS: u8 = 16;
+    for _ in 0..MAX_ATTEMPTS {
+        let port = std::net::TcpListener::bind(("0.0.0.0", 0))
+            .ok()
+            .and_then(|l| l.local_addr().ok())
+            .map(|addr| addr.port())?;
+        let Some(http_port) = port.checked_add(1) else { continue };
+        if std::net::TcpListener::bind(("127.0.0.1", http_port)).is_ok() {
+            return Some(port);
+        }
+    }
+    None
 }
 
 fn resolve_port(explicit: Option<u16>, config: &std::path::Path) -> u16 {


### PR DESCRIPTION
## Summary
- `find_available_port` only verified port `N` on `0.0.0.0`, but `serve.rs` also binds `127.0.0.1:N+1` for the HTTP listener
- On busy CI runners (e.g. #354 test-integration), another process grabbed `N+1` between allocation and bind, crashing the server with `AddrInUse`
- Retry up to 16 attempts until both ports are bindable, mirroring the dual check already used for the stored port in `resolve_port` (main.rs:138-139)

## Test plan
- [x] `cargo clippy -p vestad --all-targets` clean
- [x] `cargo test -p vestad` passes
- [ ] CI `test-integration` green (was the observed flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)