### PR TITLE
feat(web): connect via injected vestad port + Tauri host field

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4743,7 +4743,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta-app"
-version = "0.1.140"
+version = "0.1.142"
 dependencies = [
  "objc2",
  "objc2-foundation",

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
     <link rel="icon" type="image/png" href="/favicon.png" />
+    <meta name="vestad-port" content="__VESTAD_PORT__" />
     <title>Vesta</title>
   </head>
   <body>

--- a/apps/web/src/components/Connect/index.tsx
+++ b/apps/web/src/components/Connect/index.tsx
@@ -5,11 +5,30 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { FieldGroup, Field, FieldLabel } from "@/components/ui/field";
 import { fadeSlide } from "@/lib/motion";
+import { isTauri } from "@/lib/env";
 import { useAuth } from "@/providers/AuthProvider";
+
+function vestadUrl(): string {
+  const meta = document.querySelector<HTMLMetaElement>(
+    'meta[name="vestad-port"]',
+  );
+  const port = meta?.content;
+  if (!port || !/^\d+$/.test(port)) {
+    throw new Error("vestad port not available — reload the page");
+  }
+  return `https://localhost:${port}`;
+}
+
+function normalizeHost(input: string): string {
+  const trimmed = input.trim().replace(/\/+$/, "");
+  if (!/^https?:\/\//i.test(trimmed)) return `https://${trimmed}`;
+  return trimmed;
+}
 
 export function Connect() {
   const { connected, connect } = useAuth();
   const [apiKey, setApiKey] = useState("");
+  const [host, setHost] = useState("");
   const [error, setError] = useState("");
   const [details, setDetails] = useState("");
   const [showDetails, setShowDetails] = useState(false);
@@ -19,12 +38,14 @@ export function Connect() {
 
   const handleConnect = async () => {
     if (!apiKey.trim() || busy) return;
+    if (isTauri && !host.trim()) return;
     setBusy(true);
     setError("");
     setDetails("");
 
     try {
-      await connect(window.location.origin, apiKey.trim());
+      const url = isTauri ? normalizeHost(host) : vestadUrl();
+      await connect(url, apiKey.trim());
     } catch (e: unknown) {
       const msg = (e as { message?: string })?.message || "connection failed";
       setError("could not reach server");
@@ -50,6 +71,22 @@ export function Connect() {
           </div>
 
           <FieldGroup className="gap-3">
+            {isTauri && (
+              <Field>
+                <FieldLabel htmlFor="host" className="sr-only">
+                  Host
+                </FieldLabel>
+                <Input
+                  id="host"
+                  type="url"
+                  placeholder="https://your-tunnel.example.com"
+                  autoComplete="url"
+                  value={host}
+                  onChange={(e) => setHost(e.target.value)}
+                  className="text-center text-sm"
+                />
+              </Field>
+            )}
             <Field>
               <FieldLabel htmlFor="key" className="sr-only">
                 Key
@@ -69,7 +106,7 @@ export function Connect() {
 
           <Button
             type="submit"
-            disabled={!apiKey.trim() || busy}
+            disabled={!apiKey.trim() || (isTauri && !host.trim()) || busy}
             className="w-full"
           >
             {busy ? "connecting..." : "connect"}

--- a/vestad/src/app_static.rs
+++ b/vestad/src/app_static.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::Body,
-    extract::Path,
+    extract::{Path, State},
     http::{header, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
@@ -8,28 +8,28 @@ use axum::{
 };
 use rust_embed::RustEmbed;
 
+use crate::serve::SharedState;
+
 #[derive(RustEmbed)]
 #[folder = "../apps/web/dist"]
 struct AppAssets;
 
 const IMMUTABLE_CACHE: &str = "public, max-age=31536000, immutable";
 const NO_CACHE: &str = "no-cache";
+const VESTAD_PORT_PLACEHOLDER: &str = "__VESTAD_PORT__";
 
-pub fn router<S>() -> Router<S>
-where
-    S: Clone + Send + Sync + 'static,
-{
+pub fn router() -> Router<SharedState> {
     Router::new()
         .route("/app", get(index))
         .route("/app/", get(index))
         .route("/app/{*path}", get(asset))
 }
 
-async fn index() -> Response {
-    serve_index()
+async fn index(State(state): State<SharedState>) -> Response {
+    serve_index(state.https_port)
 }
 
-async fn asset(Path(path): Path<String>) -> Response {
+async fn asset(State(state): State<SharedState>, Path(path): Path<String>) -> Response {
     if let Some(file) = AppAssets::get(&path) {
         let mime = mime_guess::from_path(&path).first_or_octet_stream();
         let cache = if path.starts_with("assets/") {
@@ -56,17 +56,22 @@ async fn asset(Path(path): Path<String>) -> Response {
         return (StatusCode::NOT_FOUND, "not found").into_response();
     }
 
-    serve_index()
+    serve_index(state.https_port)
 }
 
-fn serve_index() -> Response {
+fn serve_index(https_port: u16) -> Response {
     match AppAssets::get("index.html") {
-        Some(file) => Response::builder()
-            .status(StatusCode::OK)
-            .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
-            .header(header::CACHE_CONTROL, NO_CACHE)
-            .body(Body::from(file.data.into_owned()))
-            .expect("valid index.html response"),
+        Some(file) => {
+            let html = std::str::from_utf8(&file.data)
+                .expect("index.html is valid utf-8")
+                .replace(VESTAD_PORT_PLACEHOLDER, &https_port.to_string());
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+                .header(header::CACHE_CONTROL, NO_CACHE)
+                .body(Body::from(html))
+                .expect("valid index.html response")
+        }
         None => (
             StatusCode::NOT_FOUND,
             "vesta app bundle not built — run `npm --workspace @vesta/web run build`",

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -159,10 +159,11 @@ pub struct AppState {
     pub(crate) settings: RwLock<Settings>,
     dev_mode: bool,
     pub(crate) agent_status_cache: Arc<agent_status::AgentStatusCache>,
+    pub(crate) https_port: u16,
 }
 
 impl AppState {
-    fn new(api_key: String, env_config: docker::AgentEnvConfig, docker: bollard::Docker, tunnel_url: Option<String>, dev_mode: bool) -> Self {
+    fn new(api_key: String, env_config: docker::AgentEnvConfig, docker: bollard::Docker, tunnel_url: Option<String>, dev_mode: bool, https_port: u16) -> Self {
         let settings = load_settings();
         Self {
             api_key,
@@ -177,6 +178,7 @@ impl AppState {
             settings: RwLock::new(settings),
             dev_mode,
             agent_status_cache: Arc::new(agent_status::AgentStatusCache::new()),
+            https_port,
         }
     }
 
@@ -1669,7 +1671,7 @@ pub async fn run_server(port: u16, api_key: String, cert_pem: String, key_pem: S
     docker::reconcile_containers(&docker, &env_config, &|name| {
         agent_settings.get(name).is_none_or(|s| s.manage_agent_code)
     }).await;
-    let state = Arc::new(AppState::new(api_key, env_config, docker.clone(), tunnel_url, dev_mode));
+    let state = Arc::new(AppState::new(api_key, env_config, docker.clone(), tunnel_url, dev_mode, port));
     agent_status::spawn_agent_status_task(
         state.agent_status_cache.clone(),
         docker,


### PR DESCRIPTION
## Summary

- The Connect page previously hardcoded `window.location.origin`, so the Tauri desktop app had no way to aim at a remote vestad, and the web app went through the tunnel even when it was on the same machine.
- **Web**: vestad now templates its HTTPS port into the served `index.html` as a `<meta name="vestad-port">` tag. The Connect page reads it and connects directly to `https://localhost:<port>` — same-protocol preserves secure-context (mic, etc.), and the self-signed cert already includes `localhost` in its SANs.
- **Tauri**: Connect page shows a URL field so the user can enter their tunnel; `https://` is auto-prepended if missing.

## Test plan

- [ ] Load `/app` locally via HTTPS → Connect succeeds against `https://localhost:<port>` (check devtools network tab)
- [ ] Load `/app` via a tunnel → Connect still hits `https://localhost:<port>`, not the tunnel (same-machine only; this is the intended fast path)
- [ ] Desktop Tauri build → Connect page shows the host field; submit is disabled until both host + key are filled
- [ ] Tauri: entering `mytunnel.example.com` (no scheme) is normalized to `https://mytunnel.example.com`
- [ ] Microphone / secure-context APIs still work on the web version

🤖 Generated with [Claude Code](https://claude.com/claude-code)