### PR TITLE
feat(notifications): desktop OS notifications for agent messages

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -26,8 +26,9 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
 
     Send: all events from the event bus are pushed to connected clients.
     Recv: clients can emit events (e.g. user messages, chat replies).
-    On connect: sends recent history."""
+    On connect: sends recent history unless ?skip_history=1 is passed."""
     event_bus: EventBus = request.app["event_bus"]
+    skip_history = request.query.get("skip_history", "") in ("1", "true")
 
     ws = web.WebSocketResponse()
     await ws.prepare(request)
@@ -36,9 +37,10 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
     recv_task: asyncio.Task[None] | None = None
     send_task: asyncio.Task[None] | None = None
     try:
-        events, cursor = event_bus.recent()
-        if events:
-            await ws.send_json(HistoryEvent(type="history", events=events, state=event_bus.state, cursor=cursor))
+        if not skip_history:
+            events, cursor = event_bus.recent()
+            if events:
+                await ws.send_json(HistoryEvent(type="history", events=events, state=event_bus.state, cursor=cursor))
         recv_task = asyncio.create_task(_recv_loop(ws, event_bus))
         send_task = asyncio.create_task(_send_loop(ws, sub))
         await asyncio.wait([recv_task, send_task], return_when=asyncio.FIRST_COMPLETED)

--- a/agent/tests/test_api.py
+++ b/agent/tests/test_api.py
@@ -1,0 +1,79 @@
+"""Tests for the agent WS server."""
+
+import asyncio
+import json
+import socket
+
+import pytest
+from aiohttp import ClientSession, WSMsgType, web
+
+from core.api import _ws_handler
+from core.events import ChatEvent
+
+
+def _pick_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+async def _start_server(event_bus):
+    app = web.Application()
+    app["event_bus"] = event_bus
+    app.router.add_get("/ws", _ws_handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    port = _pick_port()
+    site = web.TCPSite(runner, "127.0.0.1", port)
+    await site.start()
+    return runner, f"http://127.0.0.1:{port}"
+
+
+async def _drain_until(ws, predicate, timeout=1.0):
+    deadline = asyncio.get_event_loop().time() + timeout
+    received = []
+    while asyncio.get_event_loop().time() < deadline:
+        remaining = max(0.01, deadline - asyncio.get_event_loop().time())
+        try:
+            msg = await asyncio.wait_for(ws.receive(), timeout=remaining)
+        except TimeoutError:
+            break
+        if msg.type != WSMsgType.TEXT:
+            break
+        received.append(json.loads(msg.data))
+        if predicate(received):
+            break
+    return received
+
+
+@pytest.mark.anyio
+async def test_ws_sends_history_by_default(event_bus):
+    event_bus.emit(ChatEvent(type="chat", text="hello"))
+    runner, base = await _start_server(event_bus)
+    try:
+        async with ClientSession() as session:
+            async with session.ws_connect(f"{base}/ws") as ws:
+                msg = await asyncio.wait_for(ws.receive(), timeout=1.0)
+                data = json.loads(msg.data)
+                assert data["type"] == "history"
+                assert any(e["type"] == "chat" and e["text"] == "hello" for e in data["events"])
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.anyio
+async def test_ws_skip_history_omits_history_event(event_bus):
+    event_bus.emit(ChatEvent(type="chat", text="stored"))
+    runner, base = await _start_server(event_bus)
+    try:
+        async with ClientSession() as session:
+            async with session.ws_connect(f"{base}/ws?skip_history=1") as ws:
+                event_bus.emit(ChatEvent(type="chat", text="live"))
+                received = await _drain_until(
+                    ws,
+                    lambda r: any(e.get("type") == "chat" and e.get("text") == "live" for e in r),
+                )
+                assert not any(e.get("type") == "history" for e in received)
+                assert any(e.get("type") == "chat" and e.get("text") == "live" for e in received)
+    finally:
+        await runner.cleanup()

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2061,6 +2061,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,6 +2224,20 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify-rust"
+version = "4.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e551a9f0db223eaf3eb156906f99f46897fd951ee66dd1cb0be14db4d36d2fa"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "num-conv"
@@ -2730,7 +2756,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -2872,6 +2898,15 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -2926,6 +2961,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,6 +2991,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,6 +3016,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4049,6 +4113,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4217,6 +4300,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]
@@ -4752,6 +4847,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-store",
  "tauri-plugin-updater",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-plugin-dialog = "2.7.0"
 tauri-plugin-updater = "2"
 tauri-plugin-opener = "2.5.3"
 tauri-plugin-store = "2"
+tauri-plugin-notification = "2"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [profile.release]

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -16,10 +16,15 @@
     "core:window:allow-center",
     "core:window:allow-current-monitor",
     "core:window:allow-set-focus",
+    "core:window:allow-unminimize",
     "dialog:allow-save",
     "dialog:allow-open",
     "updater:default",
     "opener:default",
-    "store:default"
+    "store:default",
+    "notification:default",
+    "notification:allow-is-permission-granted",
+    "notification:allow-request-permission",
+    "notification:allow-notify"
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,16 @@
 mod fps_unlock;
 
 #[tauri::command]
+fn focus_window(app: tauri::AppHandle) {
+    use tauri::Manager;
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
+#[tauri::command]
 fn set_theme(window: tauri::Window, theme: String) {
     #[cfg(not(any(target_os = "ios", target_os = "android")))]
     {
@@ -106,6 +116,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_notification::init())
         .setup(|_app| {
             #[cfg(not(target_os = "android"))]
             use tauri::Manager;
@@ -189,11 +200,11 @@ pub fn run() {
         .invoke_handler({
             #[cfg(target_os = "linux")]
             {
-                tauri::generate_handler![set_theme, install_update]
+                tauri::generate_handler![set_theme, focus_window, install_update]
             }
             #[cfg(not(target_os = "linux"))]
             {
-                tauri::generate_handler![set_theme]
+                tauri::generate_handler![set_theme, focus_window]
             }
         })
         .build(tauri::generate_context!())

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,12 +3,17 @@ mod fps_unlock;
 
 #[tauri::command]
 fn focus_window(app: tauri::AppHandle) {
-    use tauri::Manager;
-    if let Some(window) = app.get_webview_window("main") {
-        let _ = window.show();
-        let _ = window.unminimize();
-        let _ = window.set_focus();
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    {
+        use tauri::Manager;
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.show();
+            let _ = window.unminimize();
+            let _ = window.set_focus();
+        }
     }
+    #[cfg(any(target_os = "ios", target_os = "android"))]
+    let _ = app;
 }
 
 #[tauri::command]

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -12472,7 +12472,7 @@
     },
     "web": {
       "name": "@vesta/web",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-rc.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { LoadingScreen } from "@/components/LoadingScreen";
 import { AuthProvider, useAuth } from "@/providers/AuthProvider";
 import { GatewayProvider, useGateway } from "@/providers/GatewayProvider";
+import { NotificationProvider } from "@/providers/NotificationProvider";
 import { isTauri } from "@/lib/env";
 import { cn } from "@/lib/utils";
 import { router } from "@/router";
@@ -63,7 +64,9 @@ export default function App() {
             <TooltipProvider delayDuration={300}>
               <AuthProvider>
                 <GatewayProvider>
-                  <AppContent />
+                  <NotificationProvider>
+                    <AppContent />
+                  </NotificationProvider>
                 </GatewayProvider>
               </AuthProvider>
             </TooltipProvider>

--- a/apps/web/src/hooks/use-window-focus.ts
+++ b/apps/web/src/hooks/use-window-focus.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { isTauri } from "@/lib/env";
+
+function initialFocused(): boolean {
+  if (typeof document === "undefined") return true;
+  if (document.visibilityState === "hidden") return false;
+  if (typeof document.hasFocus === "function") return document.hasFocus();
+  return true;
+}
+
+export function useWindowFocus(): boolean {
+  const [focused, setFocused] = useState<boolean>(initialFocused);
+
+  useEffect(() => {
+    let disposed = false;
+    let unlistenTauri: (() => void) | null = null;
+
+    const onFocus = () => setFocused(true);
+    const onBlur = () => setFocused(false);
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") setFocused(document.hasFocus());
+      else setFocused(false);
+    };
+
+    window.addEventListener("focus", onFocus);
+    window.addEventListener("blur", onBlur);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    if (isTauri) {
+      import("@tauri-apps/api/window").then(({ getCurrentWindow }) => {
+        if (disposed) return;
+        const w = getCurrentWindow();
+        w.onFocusChanged(({ payload }) => setFocused(payload)).then((fn) => {
+          if (disposed) fn();
+          else unlistenTauri = fn;
+        });
+      });
+    }
+
+    return () => {
+      disposed = true;
+      window.removeEventListener("focus", onFocus);
+      window.removeEventListener("blur", onBlur);
+      document.removeEventListener("visibilitychange", onVisibility);
+      if (unlistenTauri) unlistenTauri();
+    };
+  }, []);
+
+  return focused;
+}

--- a/apps/web/src/lib/connection.ts
+++ b/apps/web/src/lib/connection.ts
@@ -143,11 +143,17 @@ export function apiUrl(path: string): string {
   return `${conn.url}${path}`;
 }
 
-export function wsUrl(name: string): string {
+export interface WsUrlOptions {
+  skipHistory?: boolean;
+}
+
+export function wsUrl(name: string, opts: WsUrlOptions = {}): string {
   const conn = getConnection();
   if (!conn) throw new Error("not connected to vestad");
   const base = conn.url.replace(/^http/, "ws");
-  return `${base}/agents/${name}/ws?token=${encodeURIComponent(conn.accessToken)}`;
+  const params = new URLSearchParams({ token: conn.accessToken });
+  if (opts.skipHistory) params.set("skip_history", "1");
+  return `${base}/agents/${name}/ws?${params.toString()}`;
 }
 
 export async function fetchHistory(

--- a/apps/web/src/providers/ChatProvider/index.tsx
+++ b/apps/web/src/providers/ChatProvider/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { useChat } from "./use-chat";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
+import { useNotifications } from "@/providers/NotificationProvider";
 import { useVoice } from "@/stores/use-voice";
 
 type ChatContextValue = ReturnType<typeof useChat> & {
@@ -21,10 +22,24 @@ const ChatContext = createContext<ChatContextValue | null>(null);
 export function ChatProvider({ children }: { children: ReactNode }) {
   const { name, agent, setAgentState } = useSelectedAgent();
   const { speak, prefetch } = useVoice();
+  const { notifyAssistant, setChattingAgent } = useNotifications();
   const [showToolCalls, setShowToolCalls] = useState(false);
 
+  useEffect(() => {
+    setChattingAgent(name);
+    return () => setChattingAgent(null);
+  }, [name, setChattingAgent]);
+
   const ready = agent?.status === "alive";
-  const chat = useChat({ name, active: ready, onAssistantMessage: speak, onPrefetch: prefetch });
+  const chat = useChat({
+    name,
+    active: ready,
+    onAssistantMessage: (text) => {
+      speak(text);
+      notifyAssistant(name, text);
+    },
+    onPrefetch: prefetch,
+  });
 
   useEffect(() => {
     setAgentState(chat.agentState);

--- a/apps/web/src/providers/NotificationProvider/index.tsx
+++ b/apps/web/src/providers/NotificationProvider/index.tsx
@@ -45,7 +45,7 @@ async function focusAndNavigate(agentName: string): Promise<void> {
   } else {
     window.focus();
   }
-  router.navigate(`/agent/${encodeURIComponent(agentName)}/chat`);
+  router.navigate(`/agent/${encodeURIComponent(agentName)}`);
 }
 
 interface NotificationContextValue {

--- a/apps/web/src/providers/NotificationProvider/index.tsx
+++ b/apps/web/src/providers/NotificationProvider/index.tsx
@@ -1,0 +1,240 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from "react";
+import { useGateway } from "@/providers/GatewayProvider";
+import { wsUrl } from "@/lib/connection";
+import { isTauri } from "@/lib/env";
+import { useWindowFocus } from "@/hooks/use-window-focus";
+import { router } from "@/router";
+import type { VestaEvent } from "@/lib/types";
+
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 30000;
+const PREVIEW_MAX = 100;
+const NOTIFICATION_AUTO_CLOSE_MS = 6000;
+const ASKED_KEY = "vesta-notifications-asked";
+
+function truncate(text: string): string {
+  return text.length <= PREVIEW_MAX ? text : text.slice(0, PREVIEW_MAX) + "…";
+}
+
+async function ensurePermission(): Promise<boolean> {
+  if (typeof Notification === "undefined") return false;
+  if (Notification.permission === "granted") return true;
+  if (Notification.permission === "denied") return false;
+  if (localStorage.getItem(ASKED_KEY) === "1") return false;
+  localStorage.setItem(ASKED_KEY, "1");
+  const result = await Notification.requestPermission();
+  return result === "granted";
+}
+
+async function focusAndNavigate(agentName: string): Promise<void> {
+  if (isTauri) {
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      await invoke("focus_window");
+    } catch {
+      /* ignore */
+    }
+  } else {
+    window.focus();
+  }
+  router.navigate(`/agent/${encodeURIComponent(agentName)}/chat`);
+}
+
+interface NotificationContextValue {
+  notifyAssistant: (agentName: string, text: string) => void;
+  // The agent whose chat the user is actively viewing. Its tap suppresses
+  // direct firing so that ChatProvider can instead fire after the UI's
+  // typing delay, keeping notification and visible-text in sync.
+  setChattingAgent: (agentName: string | null) => void;
+}
+
+const NotificationContext = createContext<NotificationContextValue | null>(null);
+
+export function useNotifications(): NotificationContextValue {
+  return (
+    useContext(NotificationContext) ?? {
+      notifyAssistant: () => {},
+      setChattingAgent: () => {},
+    }
+  );
+}
+
+interface TapEntry {
+  socket: WebSocket | null;
+  cancelled: boolean;
+  timer: ReturnType<typeof setTimeout> | null;
+  delay: number;
+}
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  const { agents, reachable } = useGateway();
+  const focused = useWindowFocus();
+  const focusedRef = useRef(focused);
+  useEffect(() => {
+    focusedRef.current = focused;
+  }, [focused]);
+
+  const permissionRef = useRef<boolean>(false);
+  const tapsRef = useRef<Map<string, TapEntry>>(new Map());
+  const chattingAgentRef = useRef<string | null>(null);
+
+  const aliveKey = useMemo(
+    () =>
+      agents
+        .filter((a) => a.status === "alive")
+        .map((a) => a.name)
+        .sort()
+        .join("|"),
+    [agents],
+  );
+
+  const notifyAssistant = useCallback((agentName: string, text: string) => {
+    if (focusedRef.current) return;
+    if (!permissionRef.current) return;
+    const body = text.trim();
+    if (!body) return;
+    try {
+      const n = new Notification(agentName, { body: truncate(body), tag: agentName });
+      const autoClose = setTimeout(() => n.close(), NOTIFICATION_AUTO_CLOSE_MS);
+      n.onclick = () => {
+        clearTimeout(autoClose);
+        void focusAndNavigate(agentName);
+        n.close();
+      };
+      n.onclose = () => clearTimeout(autoClose);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const setChattingAgent = useCallback((agentName: string | null) => {
+    chattingAgentRef.current = agentName;
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    ensurePermission().then((granted) => {
+      if (!cancelled) permissionRef.current = granted;
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!reachable) {
+      for (const name of Array.from(tapsRef.current.keys())) closeTap(name);
+      return;
+    }
+    const aliveNames = aliveKey ? aliveKey.split("|") : [];
+    const aliveSet = new Set(aliveNames);
+
+    for (const name of Array.from(tapsRef.current.keys())) {
+      if (!aliveSet.has(name)) closeTap(name);
+    }
+    for (const name of aliveNames) {
+      if (!tapsRef.current.has(name)) openTap(name);
+    }
+
+    function openTap(name: string) {
+      const entry: TapEntry = {
+        socket: null,
+        cancelled: false,
+        timer: null,
+        delay: RECONNECT_BASE_MS,
+      };
+      tapsRef.current.set(name, entry);
+
+      const connect = () => {
+        if (entry.cancelled) return;
+        let url: string;
+        try {
+          url = wsUrl(name, { skipHistory: true });
+        } catch {
+          entry.timer = setTimeout(connect, entry.delay);
+          entry.delay = Math.min(entry.delay * 2, RECONNECT_MAX_MS);
+          return;
+        }
+
+        const socket = new WebSocket(url);
+        entry.socket = socket;
+
+        socket.onopen = () => {
+          entry.delay = RECONNECT_BASE_MS;
+        };
+
+        socket.onmessage = (e) => {
+          if (typeof e.data !== "string") return;
+          let event: VestaEvent;
+          try {
+            event = JSON.parse(e.data) as VestaEvent;
+          } catch {
+            return;
+          }
+          if (event.type !== "chat") return;
+          // Defer to ChatProvider for the agent being actively chatted with —
+          // it fires after the typing delay so notification lines up with UI.
+          if (chattingAgentRef.current === name) return;
+          notifyAssistant(name, event.text);
+        };
+
+        socket.onclose = () => {
+          entry.socket = null;
+          if (entry.cancelled) return;
+          entry.timer = setTimeout(connect, entry.delay);
+          entry.delay = Math.min(entry.delay * 2, RECONNECT_MAX_MS);
+        };
+
+        socket.onerror = () => {};
+      };
+
+      connect();
+    }
+
+    function closeTap(name: string) {
+      const entry = tapsRef.current.get(name);
+      if (!entry) return;
+      entry.cancelled = true;
+      if (entry.timer) clearTimeout(entry.timer);
+      if (entry.socket) {
+        entry.socket.onclose = null;
+        entry.socket.close();
+      }
+      tapsRef.current.delete(name);
+    }
+  }, [aliveKey, reachable, notifyAssistant]);
+
+  useEffect(() => {
+    const taps = tapsRef.current;
+    return () => {
+      for (const entry of taps.values()) {
+        entry.cancelled = true;
+        if (entry.timer) clearTimeout(entry.timer);
+        if (entry.socket) {
+          entry.socket.onclose = null;
+          entry.socket.close();
+        }
+      }
+      taps.clear();
+    };
+  }, []);
+
+  const value = useMemo(
+    () => ({ notifyAssistant, setChattingAgent }),
+    [notifyAssistant, setChattingAgent],
+  );
+
+  return (
+    <NotificationContext.Provider value={value}>
+      {children}
+    </NotificationContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- Per-agent WS taps + `skip_history=1` agent flag so notifications work across every alive agent, not only the selected one.
- New `NotificationProvider` fires OS notifications when the window is unfocused; clicking raises the window (new `focus_window` Tauri command) and routes to that agent's chat.
- For the agent the user is actively chatting with, firing is deferred to `ChatProvider`'s `onAssistantMessage` callback so the notification lines up with the typing delay instead of racing ahead of the UI.

## Test plan
- [ ] Start two agents (A selected, B idle). Background the Vesta window. Send a message to B → OS notification fires with B's name + ~3-line preview.
- [ ] Click the notification → window raises, route switches to `/agent/B/chat`, message is already in history.
- [ ] Send a message to A (the one you're viewing) while window is backgrounded → notification fires at the same moment the text appears in the UI, not before.
- [ ] Window focused → no notification fires.
- [ ] `cd agent && uv run pytest tests/test_api.py` — skip_history flag covered.
- [ ] `cd apps/desktop/src-tauri && cargo clippy`, `npm -w @vesta/web run lint && npm -w @vesta/web run check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)