### PR TITLE
chore(web): tidy footer, connect placeholder, and agent island tap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Format check
         working-directory: apps
-        run: npm -w @vesta/web run format -- --check
+        run: npm -w @vesta/web run format:check
 
       - name: Type check
         working-directory: apps

--- a/agent/skills/dashboard/app/src/components/ui/sidebar.tsx
+++ b/agent/skills/dashboard/app/src/components/ui/sidebar.tsx
@@ -124,7 +124,16 @@ function SidebarProvider({
       toggleSidebar,
       container,
     }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar, container],
+    [
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+      container,
+    ],
   );
 
   return (
@@ -163,7 +172,8 @@ function Sidebar({
   variant?: "sidebar" | "floating" | "inset";
   collapsible?: "offcanvas" | "icon" | "none";
 }) {
-  const { isMobile, state, openMobile, setOpenMobile, container } = useSidebar();
+  const { isMobile, state, openMobile, setOpenMobile, container } =
+    useSidebar();
 
   if (collapsible === "none") {
     return (
@@ -202,7 +212,9 @@ function Sidebar({
             className="flex flex-col gap-2 overflow-y-auto px-1 sm:px-2 md:px-4 [&_[data-sidebar=header]]:p-0"
             onClick={(e) => {
               const target = e.target as HTMLElement;
-              const button = target.closest("[data-sidebar=menu-button]:not([data-slot=collapsible-trigger]), [data-sidebar=menu-sub-button]");
+              const button = target.closest(
+                "[data-sidebar=menu-button]:not([data-slot=collapsible-trigger]), [data-sidebar=menu-sub-button]",
+              );
               if (button) setOpenMobile(false);
             }}
           >

--- a/agent/skills/dashboard/app/src/index.css
+++ b/agent/skills/dashboard/app/src/index.css
@@ -10,193 +10,192 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-    --safe-area-pt: max(0.5rem, calc(1rem - env(safe-area-inset-top, 0px)));
-    --safe-area-pb: max(0rem, calc(1rem - env(safe-area-inset-bottom, 0px)));
-    --background: oklch(0.995 0.005 80);
-    --foreground: oklch(0.147 0.005 80);
-    --card: oklch(0.995 0.005 80);
-    --card-foreground: oklch(0.147 0.005 80);
-    --popover: oklch(0.995 0.005 80);
-    --popover-foreground: oklch(0.147 0.005 80);
-    --primary: oklch(0.70 0.06 75);
-    --primary-foreground: oklch(0.99 0.005 80);
-    --secondary: oklch(0.97 0.006 80);
-    --secondary-foreground: oklch(0.216 0.006 80);
-    --muted: oklch(0.97 0.006 80);
-    --muted-foreground: oklch(0.553 0.015 80);
-    --accent: oklch(0.97 0.006 80);
-    --accent-foreground: oklch(0.216 0.006 80);
-    --destructive: oklch(0.577 0.245 27.325);
-    --warning: oklch(0.666 0.179 58.318);
-    --border: oklch(0.923 0.01 80);
-    --input: oklch(0.923 0.01 80);
-    --ring: oklch(0.709 0.02 80);
-    --chart-1: oklch(0.869 0.01 80);
-    --chart-2: oklch(0.553 0.015 80);
-    --chart-3: oklch(0.444 0.015 80);
-    --chart-4: oklch(0.374 0.012 80);
-    --chart-5: oklch(0.268 0.008 80);
-    --radius: 0.625rem;
-    --rounded-squircle-lg: 64px;
-    --rounded-squircle-md: 56px;
-    --sidebar: oklch(0.985 0.006 80);
-    --sidebar-foreground: oklch(0.147 0.005 80);
-    --sidebar-primary: oklch(0.216 0.006 80);
-    --sidebar-primary-foreground: oklch(0.985 0.006 80);
-    --sidebar-accent: oklch(0.97 0.006 80);
-    --sidebar-accent-foreground: oklch(0.216 0.006 80);
-    --sidebar-border: oklch(0.923 0.01 80);
-    --sidebar-ring: oklch(0.709 0.02 80);
-    --page-padding-x: 1.5rem;
+  --safe-area-pt: max(0.5rem, calc(1rem - env(safe-area-inset-top, 0px)));
+  --safe-area-pb: max(0rem, calc(1rem - env(safe-area-inset-bottom, 0px)));
+  --background: oklch(0.995 0.005 80);
+  --foreground: oklch(0.147 0.005 80);
+  --card: oklch(0.995 0.005 80);
+  --card-foreground: oklch(0.147 0.005 80);
+  --popover: oklch(0.995 0.005 80);
+  --popover-foreground: oklch(0.147 0.005 80);
+  --primary: oklch(0.7 0.06 75);
+  --primary-foreground: oklch(0.99 0.005 80);
+  --secondary: oklch(0.97 0.006 80);
+  --secondary-foreground: oklch(0.216 0.006 80);
+  --muted: oklch(0.97 0.006 80);
+  --muted-foreground: oklch(0.553 0.015 80);
+  --accent: oklch(0.97 0.006 80);
+  --accent-foreground: oklch(0.216 0.006 80);
+  --destructive: oklch(0.577 0.245 27.325);
+  --warning: oklch(0.666 0.179 58.318);
+  --border: oklch(0.923 0.01 80);
+  --input: oklch(0.923 0.01 80);
+  --ring: oklch(0.709 0.02 80);
+  --chart-1: oklch(0.869 0.01 80);
+  --chart-2: oklch(0.553 0.015 80);
+  --chart-3: oklch(0.444 0.015 80);
+  --chart-4: oklch(0.374 0.012 80);
+  --chart-5: oklch(0.268 0.008 80);
+  --radius: 0.625rem;
+  --rounded-squircle-lg: 64px;
+  --rounded-squircle-md: 56px;
+  --sidebar: oklch(0.985 0.006 80);
+  --sidebar-foreground: oklch(0.147 0.005 80);
+  --sidebar-primary: oklch(0.216 0.006 80);
+  --sidebar-primary-foreground: oklch(0.985 0.006 80);
+  --sidebar-accent: oklch(0.97 0.006 80);
+  --sidebar-accent-foreground: oklch(0.216 0.006 80);
+  --sidebar-border: oklch(0.923 0.01 80);
+  --sidebar-ring: oklch(0.709 0.02 80);
+  --page-padding-x: 1.5rem;
 }
 
 @supports not (corner-shape: squircle) {
-    :root {
-        --rounded-squircle-lg: calc(var(--radius) * 3);
-        --rounded-squircle-md: calc(var(--radius) * 2.6);
-    }
+  :root {
+    --rounded-squircle-lg: calc(var(--radius) * 3);
+    --rounded-squircle-md: calc(var(--radius) * 2.6);
+  }
 }
 
 .vibrancy {
-    --background: oklch(0.995 0.005 80 / 50%);
-    --card: oklch(0.995 0.005 80 / 50%);
-    --muted: oklch(0.97 0.006 80 / 60%);
-    --accent: oklch(0.97 0.006 80 / 50%);
-    --sidebar: oklch(0.985 0.006 80 / 50%);
-    --sidebar-accent: oklch(0.97 0.006 80 / 50%);
+  --background: oklch(0.995 0.005 80 / 50%);
+  --card: oklch(0.995 0.005 80 / 50%);
+  --muted: oklch(0.97 0.006 80 / 60%);
+  --accent: oklch(0.97 0.006 80 / 50%);
+  --sidebar: oklch(0.985 0.006 80 / 50%);
+  --sidebar-accent: oklch(0.97 0.006 80 / 50%);
 }
 
 .vibrancy.dark {
-    --background: oklch(0.147 0.005 80 / 50%);
-    --card: oklch(0.216 0.007 80 / 50%);
-    --muted: oklch(0.19 0.007 80 / 60%);
-    --accent: oklch(0.268 0.008 80 / 50%);
-    --sidebar: oklch(0.216 0.007 80 / 50%);
-    --sidebar-accent: oklch(0.268 0.008 80 / 50%);
+  --background: oklch(0.147 0.005 80 / 50%);
+  --card: oklch(0.216 0.007 80 / 50%);
+  --muted: oklch(0.19 0.007 80 / 60%);
+  --accent: oklch(0.268 0.008 80 / 50%);
+  --sidebar: oklch(0.216 0.007 80 / 50%);
+  --sidebar-accent: oklch(0.268 0.008 80 / 50%);
 }
 
 [data-platform="linux"].vibrancy {
-    --background: oklch(0.995 0.005 80 / 85%);
-    --card: oklch(0.995 0.005 80 / 85%);
-    --muted: oklch(0.97 0.006 80 / 90%);
-    --accent: oklch(0.97 0.006 80 / 85%);
-    --sidebar: oklch(0.985 0.006 80 / 85%);
-    --sidebar-accent: oklch(0.97 0.006 80 / 85%);
+  --background: oklch(0.995 0.005 80 / 85%);
+  --card: oklch(0.995 0.005 80 / 85%);
+  --muted: oklch(0.97 0.006 80 / 90%);
+  --accent: oklch(0.97 0.006 80 / 85%);
+  --sidebar: oklch(0.985 0.006 80 / 85%);
+  --sidebar-accent: oklch(0.97 0.006 80 / 85%);
 }
 
 [data-platform="linux"].vibrancy.dark {
-    --background: oklch(0.147 0.005 80 / 85%);
-    --card: oklch(0.216 0.007 80 / 85%);
-    --muted: oklch(0.19 0.007 80 / 90%);
-    --accent: oklch(0.268 0.008 80 / 85%);
-    --sidebar: oklch(0.216 0.007 80 / 85%);
-    --sidebar-accent: oklch(0.268 0.008 80 / 85%);
+  --background: oklch(0.147 0.005 80 / 85%);
+  --card: oklch(0.216 0.007 80 / 85%);
+  --muted: oklch(0.19 0.007 80 / 90%);
+  --accent: oklch(0.268 0.008 80 / 85%);
+  --sidebar: oklch(0.216 0.007 80 / 85%);
+  --sidebar-accent: oklch(0.268 0.008 80 / 85%);
 }
 
 .dark {
-    --background: oklch(0.147 0.005 80);
-    --foreground: oklch(0.985 0.006 80);
-    --card: oklch(0.216 0.007 80);
-    --card-foreground: oklch(0.985 0.006 80);
-    --popover: oklch(0.216 0.007 80);
-    --popover-foreground: oklch(0.985 0.006 80);
-    --primary: oklch(0.80 0.06 75);
-    --primary-foreground: oklch(0.25 0.015 75);
-    --secondary: oklch(0.268 0.008 80);
-    --secondary-foreground: oklch(0.985 0.006 80);
-    --muted: oklch(0.19 0.007 80);
-    --muted-foreground: oklch(0.709 0.02 80);
-    --accent: oklch(0.268 0.008 80);
-    --accent-foreground: oklch(0.985 0.006 80);
-    --destructive: oklch(0.704 0.191 22.216);
-    --warning: oklch(0.828 0.189 84.429);
-    --border: oklch(1 0.01 80 / 10%);
-    --input: oklch(1 0.01 80 / 15%);
-    --ring: oklch(0.553 0.015 80);
-    --chart-1: oklch(0.869 0.01 80);
-    --chart-2: oklch(0.553 0.015 80);
-    --chart-3: oklch(0.444 0.015 80);
-    --chart-4: oklch(0.374 0.012 80);
-    --chart-5: oklch(0.268 0.008 80);
-    --sidebar: oklch(0.216 0.007 80);
-    --sidebar-foreground: oklch(0.985 0.006 80);
-    --sidebar-primary: oklch(0.75 0.06 75);
-    --sidebar-primary-foreground: oklch(0.985 0.006 80);
-    --sidebar-accent: oklch(0.268 0.008 80);
-    --sidebar-accent-foreground: oklch(0.985 0.006 80);
-    --sidebar-border: oklch(1 0.01 80 / 10%);
-    --sidebar-ring: oklch(0.553 0.015 80);
+  --background: oklch(0.147 0.005 80);
+  --foreground: oklch(0.985 0.006 80);
+  --card: oklch(0.216 0.007 80);
+  --card-foreground: oklch(0.985 0.006 80);
+  --popover: oklch(0.216 0.007 80);
+  --popover-foreground: oklch(0.985 0.006 80);
+  --primary: oklch(0.8 0.06 75);
+  --primary-foreground: oklch(0.25 0.015 75);
+  --secondary: oklch(0.268 0.008 80);
+  --secondary-foreground: oklch(0.985 0.006 80);
+  --muted: oklch(0.19 0.007 80);
+  --muted-foreground: oklch(0.709 0.02 80);
+  --accent: oklch(0.268 0.008 80);
+  --accent-foreground: oklch(0.985 0.006 80);
+  --destructive: oklch(0.704 0.191 22.216);
+  --warning: oklch(0.828 0.189 84.429);
+  --border: oklch(1 0.01 80 / 10%);
+  --input: oklch(1 0.01 80 / 15%);
+  --ring: oklch(0.553 0.015 80);
+  --chart-1: oklch(0.869 0.01 80);
+  --chart-2: oklch(0.553 0.015 80);
+  --chart-3: oklch(0.444 0.015 80);
+  --chart-4: oklch(0.374 0.012 80);
+  --chart-5: oklch(0.268 0.008 80);
+  --sidebar: oklch(0.216 0.007 80);
+  --sidebar-foreground: oklch(0.985 0.006 80);
+  --sidebar-primary: oklch(0.75 0.06 75);
+  --sidebar-primary-foreground: oklch(0.985 0.006 80);
+  --sidebar-accent: oklch(0.268 0.008 80);
+  --sidebar-accent-foreground: oklch(0.985 0.006 80);
+  --sidebar-border: oklch(1 0.01 80 / 10%);
+  --sidebar-ring: oklch(0.553 0.015 80);
 }
 
 @theme inline {
-    --font-sans: 'Public Sans Variable', sans-serif;
-    --font-heading: 'Outfit Variable', sans-serif;
-    --text-sm: 0.9375rem;
-    --color-sidebar-ring: var(--sidebar-ring);
-    --color-sidebar-border: var(--sidebar-border);
-    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-    --color-sidebar-accent: var(--sidebar-accent);
-    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-    --color-sidebar-primary: var(--sidebar-primary);
-    --color-sidebar-foreground: var(--sidebar-foreground);
-    --color-sidebar: var(--sidebar);
-    --color-chart-5: var(--chart-5);
-    --color-chart-4: var(--chart-4);
-    --color-chart-3: var(--chart-3);
-    --color-chart-2: var(--chart-2);
-    --color-chart-1: var(--chart-1);
-    --color-ring: var(--ring);
-    --color-input: var(--input);
-    --color-border: var(--border);
-    --color-destructive: var(--destructive);
-    --color-warning: var(--warning);
-    --color-accent-foreground: var(--accent-foreground);
-    --color-accent: var(--accent);
-    --color-muted-foreground: var(--muted-foreground);
-    --color-muted: var(--muted);
-    --color-secondary-foreground: var(--secondary-foreground);
-    --color-secondary: var(--secondary);
-    --color-primary-foreground: var(--primary-foreground);
-    --color-primary: var(--primary);
-    --color-popover-foreground: var(--popover-foreground);
-    --color-popover: var(--popover);
-    --color-card-foreground: var(--card-foreground);
-    --color-card: var(--card);
-    --color-foreground: var(--foreground);
-    --color-background: var(--background);
-    --radius-sm: calc(var(--radius) * 0.6);
-    --radius-md: calc(var(--radius) * 0.8);
-    --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) * 1.4);
-    --radius-2xl: calc(var(--radius) * 1.8);
-    --radius-3xl: calc(var(--radius) * 2.2);
-    --radius-4xl: calc(var(--radius) * 2.6);
-    --radius-squircle-lg: var(--rounded-squircle-lg);
-    --radius-squircle-md: var(--rounded-squircle-md);
+  --font-sans: "Public Sans Variable", sans-serif;
+  --font-heading: "Outfit Variable", sans-serif;
+  --text-sm: 0.9375rem;
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-border: var(--border);
+  --color-destructive: var(--destructive);
+  --color-warning: var(--warning);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --color-foreground: var(--foreground);
+  --color-background: var(--background);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
+  --radius-squircle-lg: var(--rounded-squircle-lg);
+  --radius-squircle-md: var(--rounded-squircle-md);
 }
 
 @layer base {
   * {
     @apply border-border outline-ring/50;
-    }
+  }
   html {
-    @apply box-border flex h-dvh flex-col font-sans overscroll-none;
     background: transparent;
-    }
+    @apply box-border flex h-dvh flex-col font-sans overscroll-none;
+  }
   .vibrancy {
     background: transparent;
-    }
+  }
   body {
-    @apply flex min-h-0 flex-1 flex-col text-foreground overscroll-none;
     background: transparent;
-    }
+    @apply flex min-h-0 flex-1 flex-col text-foreground overscroll-none;
+  }
   .vibrancy body {
     background: transparent;
-    background: transparent;
-    }
+  }
   #root {
     @apply flex min-h-0 flex-1 flex-col;
-    }
+  }
 }
 
 @utility px-page {
@@ -206,7 +205,6 @@
 @utility p-page {
   padding: var(--page-padding-x);
 }
-
 
 @utility py-page {
   padding-block: var(--page-padding-x);

--- a/apps/web/.agents/skills/app-frontend/SKILL.md
+++ b/apps/web/.agents/skills/app-frontend/SKILL.md
@@ -59,6 +59,7 @@ Providers read the agent name from `useSelectedAgent()` internally — don't pas
 ## Hooks
 
 `hooks/` is **only** for hooks shared across multiple unrelated consumers:
+
 - `use-mobile.ts` — responsive breakpoint detection
 - `use-auto-scroll.ts` — scroll-to-bottom behavior
 - `use-optimistic-toggle.ts` — optimistic boolean toggle
@@ -85,6 +86,7 @@ RootLayout
 `AgentLayout` renders the shared Navbar (with AgentIsland + AgentMenu) once above the `<Outlet />`, so these components persist across route changes without remounting.
 
 Provider stack in `AgentLayout`:
+
 ```
 SelectedAgentProvider → VoiceProvider → ChatProvider → ModalsProvider
 ```

--- a/apps/web/.agents/skills/shadcn/customization.md
+++ b/apps/web/.agents/skills/shadcn/customization.md
@@ -52,11 +52,11 @@ Colors use OKLCH: `--primary: oklch(0.205 0 0)` where values are lightness (0, 1
 Class-based toggle via `.dark` on the root element. In Next.js, use `next-themes`:
 
 ```tsx
-import { ThemeProvider } from "next-themes"
+import { ThemeProvider } from "next-themes";
 
 <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
   {children}
-</ThemeProvider>
+</ThemeProvider>;
 ```
 
 ---
@@ -117,7 +117,7 @@ module.exports = {
       },
     },
   },
-}
+};
 ```
 
 ```tsx
@@ -142,7 +142,9 @@ Prefer these approaches in order:
 ### 1. Built-in variants
 
 ```tsx
-<Button variant="outline" size="sm">Click</Button>
+<Button variant="outline" size="sm">
+  Click
+</Button>
 ```
 
 ### 2. Tailwind classes via `className`
@@ -180,7 +182,7 @@ export function ConfirmDialog({ title, description, onConfirm, children }) {
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
-  )
+  );
 }
 ```
 

--- a/apps/web/.agents/skills/shadcn/mcp.md
+++ b/apps/web/.agents/skills/shadcn/mcp.md
@@ -13,13 +13,13 @@ shadcn mcp init   # write config for your editor
 
 Editor config files:
 
-| Editor | Config file |
-|--------|------------|
-| Claude Code | `.mcp.json` |
-| Cursor | `.cursor/mcp.json` |
-| VS Code | `.vscode/mcp.json` |
-| OpenCode | `opencode.json` |
-| Codex | `~/.codex/config.toml` (manual) |
+| Editor      | Config file                     |
+| ----------- | ------------------------------- |
+| Claude Code | `.mcp.json`                     |
+| Cursor      | `.cursor/mcp.json`              |
+| VS Code     | `.vscode/mcp.json`              |
+| OpenCode    | `opencode.json`                 |
+| Codex       | `~/.codex/config.toml` (manual) |
 
 ---
 

--- a/apps/web/.agents/skills/shadcn/rules/base-vs-radix.md
+++ b/apps/web/.agents/skills/shadcn/rules/base-vs-radix.md
@@ -90,7 +90,9 @@ Same for triggers whose `render` is not a `Button`:
 
 ```tsx
 <Select>
-  <SelectTrigger><SelectValue placeholder="Select a fruit" /></SelectTrigger>
+  <SelectTrigger>
+    <SelectValue placeholder="Select a fruit" />
+  </SelectTrigger>
 </Select>
 ```
 
@@ -157,7 +159,9 @@ Base supports `multiple`, render-function children on `SelectValue`, and object 
 <Select items={items} multiple defaultValue={[]}>
   <SelectTrigger>
     <SelectValue>
-      {(value: string[]) => value.length === 0 ? "Select fruits" : `${value.length} selected`}
+      {(value: string[]) =>
+        value.length === 0 ? "Select fruits" : `${value.length} selected`
+      }
     </SelectValue>
   </SelectTrigger>
   ...

--- a/apps/web/.agents/skills/shadcn/rules/composition.md
+++ b/apps/web/.agents/skills/shadcn/rules/composition.md
@@ -44,13 +44,13 @@ Never render items directly inside the content container.
 
 This applies to all group-based components:
 
-| Item | Group |
-|------|-------|
-| `SelectItem`, `SelectLabel` | `SelectGroup` |
+| Item                                                       | Group               |
+| ---------------------------------------------------------- | ------------------- |
+| `SelectItem`, `SelectLabel`                                | `SelectGroup`       |
 | `DropdownMenuItem`, `DropdownMenuLabel`, `DropdownMenuSub` | `DropdownMenuGroup` |
-| `MenubarItem` | `MenubarGroup` |
-| `ContextMenuItem` | `ContextMenuGroup` |
-| `CommandItem` | `CommandGroup` |
+| `MenubarItem`                                              | `MenubarGroup`      |
+| `ContextMenuItem`                                          | `ContextMenuGroup`  |
+| `CommandItem`                                              | `CommandGroup`      |
 
 ---
 
@@ -70,7 +70,9 @@ This applies to all group-based components:
 ```tsx
 <Empty>
   <EmptyHeader>
-    <EmptyMedia variant="icon"><FolderIcon /></EmptyMedia>
+    <EmptyMedia variant="icon">
+      <FolderIcon />
+    </EmptyMedia>
     <EmptyTitle>No projects yet</EmptyTitle>
     <EmptyDescription>Get started by creating a new project.</EmptyDescription>
   </EmptyHeader>
@@ -85,27 +87,27 @@ This applies to all group-based components:
 ## Toast notifications use sonner
 
 ```tsx
-import { toast } from "sonner"
+import { toast } from "sonner";
 
-toast.success("Changes saved.")
-toast.error("Something went wrong.")
+toast.success("Changes saved.");
+toast.error("Something went wrong.");
 toast("File deleted.", {
   action: { label: "Undo", onClick: () => undoDelete() },
-})
+});
 ```
 
 ---
 
 ## Choosing between overlay components
 
-| Use case | Component |
-|----------|-----------|
-| Focused task that requires input | `Dialog` |
-| Destructive action confirmation | `AlertDialog` |
-| Side panel with details or filters | `Sheet` |
-| Mobile-first bottom panel | `Drawer` |
-| Quick info on hover | `HoverCard` |
-| Small contextual content on click | `Popover` |
+| Use case                           | Component     |
+| ---------------------------------- | ------------- |
+| Focused task that requires input   | `Dialog`      |
+| Destructive action confirmation    | `AlertDialog` |
+| Side panel with details or filters | `Sheet`       |
+| Mobile-first bottom panel          | `Drawer`      |
+| Quick info on hover                | `HoverCard`   |
+| Small contextual content on click  | `Popover`     |
 
 ---
 
@@ -188,8 +190,8 @@ Always include `AvatarFallback` for when the image fails to load:
 
 ## Use existing components instead of custom markup
 
-| Instead of | Use |
-|---|---|
-| `<hr>` or `<div className="border-t">` | `<Separator />` |
+| Instead of                                         | Use                                  |
+| -------------------------------------------------- | ------------------------------------ |
+| `<hr>` or `<div className="border-t">`             | `<Separator />`                      |
 | `<div className="animate-pulse">` with styled divs | `<Skeleton className="h-4 w-3/4" />` |
-| `<span className="rounded-full bg-green-100 ...">` | `<Badge variant="secondary">` |
+| `<span className="rounded-full bg-green-100 ...">` | `<Badge variant="secondary">`        |

--- a/apps/web/.agents/skills/shadcn/rules/forms.md
+++ b/apps/web/.agents/skills/shadcn/rules/forms.md
@@ -59,11 +59,11 @@ Never use raw `Input` or `Textarea` inside an `InputGroup`.
 **Correct:**
 
 ```tsx
-import { InputGroup, InputGroupInput } from "@/components/ui/input-group"
+import { InputGroup, InputGroupInput } from "@/components/ui/input-group";
 
 <InputGroup>
   <InputGroupInput placeholder="Search..." />
-</InputGroup>
+</InputGroup>;
 ```
 
 ---
@@ -86,7 +86,11 @@ Never place a `Button` directly inside or adjacent to an `Input` with custom pos
 **Correct:**
 
 ```tsx
-import { InputGroup, InputGroupInput, InputGroupAddon } from "@/components/ui/input-group"
+import {
+  InputGroup,
+  InputGroupInput,
+  InputGroupAddon,
+} from "@/components/ui/input-group";
 
 <InputGroup>
   <InputGroupInput placeholder="Search..." />
@@ -95,7 +99,7 @@ import { InputGroup, InputGroupInput, InputGroupAddon } from "@/components/ui/in
       <SearchIcon data-icon="inline-start" />
     </Button>
   </InputGroupAddon>
-</InputGroup>
+</InputGroup>;
 ```
 
 ---
@@ -125,13 +129,13 @@ const [selected, setSelected] = useState("daily")
 **Correct:**
 
 ```tsx
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
 <ToggleGroup spacing={2}>
   <ToggleGroupItem value="daily">Daily</ToggleGroupItem>
   <ToggleGroupItem value="weekly">Weekly</ToggleGroupItem>
   <ToggleGroupItem value="monthly">Monthly</ToggleGroupItem>
-</ToggleGroup>
+</ToggleGroup>;
 ```
 
 Combine with `Field` for labelled toggle groups:
@@ -162,7 +166,9 @@ Use `FieldSet` + `FieldLegend` for related checkboxes, radios, or switches — n
   <FieldGroup className="gap-3">
     <Field orientation="horizontal">
       <Checkbox id="dark" />
-      <FieldLabel htmlFor="dark" className="font-normal">Dark mode</FieldLabel>
+      <FieldLabel htmlFor="dark" className="font-normal">
+        Dark mode
+      </FieldLabel>
     </Field>
   </FieldGroup>
 </FieldSet>

--- a/apps/web/.agents/skills/shadcn/rules/icons.md
+++ b/apps/web/.agents/skills/shadcn/rules/icons.md
@@ -77,25 +77,25 @@ Use `icon={CheckIcon}`, not a string key to a lookup map.
 const iconMap = {
   check: CheckIcon,
   alert: AlertIcon,
-}
+};
 
 function StatusBadge({ icon }: { icon: string }) {
-  const Icon = iconMap[icon]
-  return <Icon />
+  const Icon = iconMap[icon];
+  return <Icon />;
 }
 
-<StatusBadge icon="check" />
+<StatusBadge icon="check" />;
 ```
 
 **Correct:**
 
 ```tsx
 // Import from the project's configured iconLibrary (e.g. lucide-react, @tabler/icons-react).
-import { CheckIcon } from "lucide-react"
+import { CheckIcon } from "lucide-react";
 
 function StatusBadge({ icon: Icon }: { icon: React.ComponentType }) {
-  return <Icon />
+  return <Icon />;
 }
 
-<StatusBadge icon={CheckIcon} />
+<StatusBadge icon={CheckIcon} />;
 ```

--- a/apps/web/.agents/skills/shadcn/rules/styling.md
+++ b/apps/web/.agents/skills/shadcn/rules/styling.md
@@ -7,8 +7,8 @@ See [customization.md](../customization.md) for theming, CSS variables, and addi
 - Semantic colors
 - Built-in variants first
 - className for layout only
-- No space-x-* / space-y-*
-- Prefer size-* over w-* h-* when equal
+- No space-x-_ / space-y-_
+- Prefer size-_ over w-_ h-\* when equal
 - Prefer truncate shorthand
 - No manual dark: color overrides
 - Use cn() for conditional classes
@@ -99,13 +99,14 @@ Use `className` for layout (e.g. `max-w-md`, `mx-auto`, `mt-4`), **not** for ove
 ```
 
 To customize a component's appearance, prefer these approaches in order:
+
 1. **Built-in variants**. `variant="outline"`, `variant="destructive"`, etc.
 2. **Semantic color tokens**. `bg-primary`, `text-muted-foreground`.
 3. **CSS variables**. define custom colors in the global CSS file (see [customization.md](../customization.md)).
 
 ---
 
-## No space-x-* / space-y-*
+## No space-x-_ / space-y-_
 
 Use `gap-*` instead. `space-y-4` → `flex flex-col gap-4`. `space-x-2` → `flex gap-2`.
 
@@ -119,7 +120,7 @@ Use `gap-*` instead. `space-y-4` → `flex flex-col gap-4`. `space-x-2` → `fle
 
 ---
 
-## Prefer size-* over w-* h-* when equal
+## Prefer size-_ over w-_ h-\* when equal
 
 `size-10` not `w-10 h-10`. Applies to icons, avatars, skeletons, etc.
 

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,14 +1,14 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { defineConfig, globalIgnores } from 'eslint/config'
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(["dist"]),
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     extends: [
       js.configs.recommended,
       tseslint.configs.recommended,
@@ -21,29 +21,32 @@ export default defineConfig([
     },
     rules: {
       // Allow _prefixed unused vars (destructuring rest patterns, intentional omissions)
-      '@typescript-eslint/no-unused-vars': ['error', {
-        argsIgnorePattern: '^_',
-        varsIgnorePattern: '^_',
-        destructuredArrayIgnorePattern: '^_',
-      }],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+        },
+      ],
       // React compiler rules (new in react-hooks v7) — too strict for our codebase
-      'react-hooks/refs': 'warn',
-      'react-hooks/set-state-in-effect': 'warn',
-      'react-hooks/purity': 'warn',
-      'react-hooks/immutability': 'warn',
+      "react-hooks/refs": "warn",
+      "react-hooks/set-state-in-effect": "warn",
+      "react-hooks/purity": "warn",
+      "react-hooks/immutability": "warn",
     },
   },
   // Files that legitimately export non-components alongside components/hooks
   {
     files: [
-      'src/components/ui/**/*.{ts,tsx}',
-      'src/providers/**/*.{ts,tsx}',
-      'src/hooks/**/*.{ts,tsx}',
-      'src/stores/**/*.{ts,tsx}',
-      'src/lib/**/*.{ts,tsx}',
+      "src/components/ui/**/*.{ts,tsx}",
+      "src/providers/**/*.{ts,tsx}",
+      "src/hooks/**/*.{ts,tsx}",
+      "src/stores/**/*.{ts,tsx}",
+      "src/lib/**/*.{ts,tsx}",
     ],
     rules: {
-      'react-refresh/only-export-components': 'off',
+      "react-refresh/only-export-components": "off",
     },
   },
-])
+]);

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
     <meta name="color-scheme" content="light dark" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="vestad-port" content="__VESTAD_PORT__" />

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "preview": "vite preview",
     "lint": "eslint .",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "check": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/apps/web/src/components/AgentIsland/Collapsed.tsx
+++ b/apps/web/src/components/AgentIsland/Collapsed.tsx
@@ -1,4 +1,5 @@
 import { motion } from "motion/react";
+import { useNavigate } from "react-router-dom";
 import { Orb } from "@/components/Orb";
 import type { OrbVisualState } from "@/components/Orb/styles";
 import { agentIslandContentTransition } from "./transitions";
@@ -6,20 +7,19 @@ import { agentIslandContentTransition } from "./transitions";
 type AgentIslandCollapsedProps = {
   name: string;
   orbState: OrbVisualState;
-  onExpand: () => void;
 };
 
 export function AgentIslandCollapsed({
   name,
   orbState,
-  onExpand,
 }: AgentIslandCollapsedProps) {
+  const navigate = useNavigate();
   return (
     <div
       className="flex h-8 w-full min-w-0 cursor-pointer touch-manipulation items-center gap-1.5 will-change-transform"
       onPointerDown={(event) => {
         if (event.pointerType === "touch") {
-          onExpand();
+          navigate("/");
         }
       }}
     >

--- a/apps/web/src/components/AgentIsland/index.tsx
+++ b/apps/web/src/components/AgentIsland/index.tsx
@@ -74,11 +74,7 @@ export function AgentIsland() {
                   error={error}
                 />
               ) : (
-                <AgentIslandCollapsed
-                  name={name}
-                  orbState={orbState}
-                  onExpand={() => setExpanded(true)}
-                />
+                <AgentIslandCollapsed name={name} orbState={orbState} />
               )}
             </div>
           </LayoutGroup>

--- a/apps/web/src/components/AgentMenu/index.tsx
+++ b/apps/web/src/components/AgentMenu/index.tsx
@@ -144,7 +144,12 @@ export function AgentMenu() {
           <Tabs defaultValue="socket">
             <TabsList>
               <TabsTrigger value="socket">control socket</TabsTrigger>
-              <TabsTrigger value="tree" onClick={() => { if (!treeLines && !treeLoading) fetchTree(); }}>
+              <TabsTrigger
+                value="tree"
+                onClick={() => {
+                  if (!treeLines && !treeLoading) fetchTree();
+                }}
+              >
                 file tree
               </TabsTrigger>
             </TabsList>

--- a/apps/web/src/components/AgentSettings/PlanUsage/index.tsx
+++ b/apps/web/src/components/AgentSettings/PlanUsage/index.tsx
@@ -1,10 +1,6 @@
 import { useEffect } from "react";
 import { Activity, RefreshCw } from "lucide-react";
-import {
-  Field,
-  FieldContent,
-  FieldLabel,
-} from "@/components/ui/field";
+import { Field, FieldContent, FieldLabel } from "@/components/ui/field";
 import { Card, CardContent } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/apps/web/src/components/AgentSettings/VoiceSection/index.tsx
+++ b/apps/web/src/components/AgentSettings/VoiceSection/index.tsx
@@ -150,8 +150,8 @@ export function TtsCard() {
                 </span>
                 <span className="text-foreground tabular-nums">
                   {chars &&
-                    typeof chars.character_count === "number" &&
-                    typeof chars.character_limit === "number"
+                  typeof chars.character_count === "number" &&
+                  typeof chars.character_limit === "number"
                     ? `${chars.character_count.toLocaleString()} / ${chars.character_limit.toLocaleString()}`
                     : "—"}
                 </span>
@@ -174,7 +174,11 @@ function UsageCollapsible({
   children: React.ReactNode;
 }) {
   return (
-    <Collapsible onOpenChange={(isOpen) => { if (isOpen) onOpen(); }}>
+    <Collapsible
+      onOpenChange={(isOpen) => {
+        if (isOpen) onOpen();
+      }}
+    >
       <CollapsibleTrigger asChild>
         <Button
           variant="ghost"
@@ -451,7 +455,10 @@ function SelectSetting({
     return (
       <>
         <VoicePicker setting={setting} onChange={onChange} />
-        <SubSettingsCollapsible setting={setting} updateSetting={updateSetting} />
+        <SubSettingsCollapsible
+          setting={setting}
+          updateSetting={updateSetting}
+        />
       </>
     );
   }
@@ -468,7 +475,8 @@ function SelectSetting({
             <ChevronDown className="size-4 transition-transform [[data-state=closed]_&]:-rotate-90" />
             {setting.label}:{" "}
             <span className="text-foreground font-medium">
-              {options.find((o) => o.value === setting.value)?.label ?? "Unknown"}
+              {options.find((o) => o.value === setting.value)?.label ??
+                "Unknown"}
             </span>
           </Button>
         </CollapsibleTrigger>
@@ -561,17 +569,19 @@ function VoicePicker({
             return (
               <button
                 key={opt.value}
-                className={`group relative flex flex-col items-center gap-1.5 rounded-lg p-2 transition-colors cursor-pointer ${selected
+                className={`group relative flex flex-col items-center gap-1.5 rounded-lg p-2 transition-colors cursor-pointer ${
+                  selected
                     ? "bg-primary/10 ring-1 ring-primary/30"
                     : "hover:bg-muted"
-                  }`}
+                }`}
                 onClick={() => select(opt)}
               >
                 <div
-                  className={`relative size-9 rounded-full flex items-center justify-center text-xs font-medium ${selected
+                  className={`relative size-9 rounded-full flex items-center justify-center text-xs font-medium ${
+                    selected
                       ? "bg-primary text-primary-foreground"
                       : "bg-muted text-muted-foreground"
-                    }`}
+                  }`}
                 >
                   {opt.label[0]}
                   {opt.preview && (
@@ -594,10 +604,11 @@ function VoicePicker({
                   )}
                 </div>
                 <span
-                  className={`text-[10px] leading-tight text-center truncate max-w-full ${selected
+                  className={`text-[10px] leading-tight text-center truncate max-w-full ${
+                    selected
                       ? "text-primary font-medium"
                       : "text-muted-foreground"
-                    }`}
+                  }`}
                 >
                   {opt.label}
                 </span>

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -68,10 +68,7 @@ export function ChatComposer({
           enterKeyHint="send"
           className="max-h-[120px] md:text-base"
         />
-        {(sttAvailable ||
-          !isRecording ||
-          !voiceAutoSend ||
-          isSpeaking) && (
+        {(sttAvailable || !isRecording || !voiceAutoSend || isSpeaking) && (
           <InputGroupAddon align="inline-end" className="gap-0">
             {isSpeaking && (
               <InputGroupButton

--- a/apps/web/src/components/Chat/ChatMessageArea/index.tsx
+++ b/apps/web/src/components/Chat/ChatMessageArea/index.tsx
@@ -1,10 +1,7 @@
 import type { RefObject } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { CardContent } from "@/components/ui/card";
-import {
-  calendarDayKey,
-  formatChatDayStampLabel,
-} from "@/lib/chat-day-stamp";
+import { calendarDayKey, formatChatDayStampLabel } from "@/lib/chat-day-stamp";
 import type { VestaEvent } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { ChatBubble } from "../ChatBubble";
@@ -92,8 +89,7 @@ export function ChatMessageArea({
                   const prev = chatMessages[i - 1];
                   const dayKey = calendarDayKey(msg.ts);
                   const showDayStamp = Boolean(
-                    dayKey &&
-                      (lastDayKey === null || dayKey !== lastDayKey),
+                    dayKey && (lastDayKey === null || dayKey !== lastDayKey),
                   );
                   if (dayKey) lastDayKey = dayKey;
                   const isTool = msg.type === "tool_start";

--- a/apps/web/src/components/Connect/index.tsx
+++ b/apps/web/src/components/Connect/index.tsx
@@ -79,7 +79,7 @@ export function Connect() {
                 <Input
                   id="host"
                   type="url"
-                  placeholder="https://your-tunnel.example.com"
+                  placeholder="host"
                   autoComplete="url"
                   value={host}
                   onChange={(e) => setHost(e.target.value)}

--- a/apps/web/src/components/Dashboard/index.tsx
+++ b/apps/web/src/components/Dashboard/index.tsx
@@ -67,7 +67,14 @@ export function Dashboard({ fullscreen }: { fullscreen?: boolean } = {}) {
     );
     frame.postMessage({ type: "vesta-layout", fullscreen: !!fullscreen }, "*");
     frame.postMessage(
-      { type: "vesta-platform", isTauri, platform, isDesktop, isMobile, vibrancy },
+      {
+        type: "vesta-platform",
+        isTauri,
+        platform,
+        isDesktop,
+        isMobile,
+        vibrancy,
+      },
       "*",
     );
     if (conn)
@@ -80,7 +87,17 @@ export function Dashboard({ fullscreen }: { fullscreen?: boolean } = {}) {
         },
         "*",
       );
-  }, [resolvedTheme, fullscreen, isTauri, platform, isDesktop, isMobile, vibrancy, conn, name]);
+  }, [
+    resolvedTheme,
+    fullscreen,
+    isTauri,
+    platform,
+    isDesktop,
+    isMobile,
+    vibrancy,
+    conn,
+    name,
+  ]);
 
   useEffect(() => {
     const handler = (e: MessageEvent) => {
@@ -106,7 +123,10 @@ export function Dashboard({ fullscreen }: { fullscreen?: boolean } = {}) {
     return (
       <Empty className="flex-1 h-full w-full border-0">
         <EmptyHeader>
-          <EmptyMedia variant="icon" className="size-12 rounded-full bg-sidebar-primary text-sidebar-primary-foreground [&_svg:not([class*='size-'])]:size-6">
+          <EmptyMedia
+            variant="icon"
+            className="size-12 rounded-full bg-sidebar-primary text-sidebar-primary-foreground [&_svg:not([class*='size-'])]:size-6"
+          >
             <LayoutDashboard />
           </EmptyMedia>
           <EmptyTitle>your dashboard</EmptyTitle>
@@ -122,7 +142,10 @@ export function Dashboard({ fullscreen }: { fullscreen?: boolean } = {}) {
     return (
       <Empty className="flex-1 h-full w-full border-0">
         <EmptyHeader>
-          <EmptyMedia variant="icon" className="size-12 rounded-full bg-sidebar-primary text-sidebar-primary-foreground [&_svg:not([class*='size-'])]:size-6">
+          <EmptyMedia
+            variant="icon"
+            className="size-12 rounded-full bg-sidebar-primary text-sidebar-primary-foreground [&_svg:not([class*='size-'])]:size-6"
+          >
             <AlertCircle />
           </EmptyMedia>
           <EmptyTitle>dashboard unavailable</EmptyTitle>

--- a/apps/web/src/components/Footer/index.tsx
+++ b/apps/web/src/components/Footer/index.tsx
@@ -1,9 +1,3 @@
 export function Footer() {
-  return (
-    <div className="flex items-center justify-center shrink-0 select-none absolute bottom-3 left-0 right-0">
-      <span className="pointer-events-none rounded px-1 py-px text-[9px] leading-none text-muted-foreground">
-        v{__APP_VERSION__}
-      </span>
-    </div>
-  );
+  return null;
 }

--- a/apps/web/src/components/Home/AgentsCarousel/index.tsx
+++ b/apps/web/src/components/Home/AgentsCarousel/index.tsx
@@ -52,7 +52,11 @@ function CarouselCard({ agent }: { agent: AgentInfo }) {
   return (
     <motion.div
       className="flex h-full items-center justify-center"
-      style={{ width: `${AGENT_CAROUSEL_CARD_WIDTH}px`, aspectRatio: "1/1", scale }}
+      style={{
+        width: `${AGENT_CAROUSEL_CARD_WIDTH}px`,
+        aspectRatio: "1/1",
+        scale,
+      }}
     >
       <AgentCard agent={agent} enableTracking={isCentered} />
     </motion.div>

--- a/apps/web/src/components/Home/index.tsx
+++ b/apps/web/src/components/Home/index.tsx
@@ -11,16 +11,8 @@ import {
 } from "./AgentsCarousel/constants";
 import { EmptyState } from "./EmptyState";
 
-function SkeletonCard({
-  index,
-  opacity,
-}: {
-  index: number;
-  opacity: number;
-}) {
-  const scale = scaleForCarouselItemOffset(
-    index * AGENT_CAROUSEL_ITEM_STRIDE,
-  );
+function SkeletonCard({ index, opacity }: { index: number; opacity: number }) {
+  const scale = scaleForCarouselItemOffset(index * AGENT_CAROUSEL_ITEM_STRIDE);
   return (
     <motion.div
       className="flex shrink-0 items-center justify-center"
@@ -60,11 +52,7 @@ function SkeletonList() {
       transition={{ duration: 0.3 }}
     >
       {Array.from({ length: SKELETON_COUNT }, (_, i) => (
-        <SkeletonCard
-          key={i}
-          index={i}
-          opacity={1 - i / SKELETON_COUNT}
-        />
+        <SkeletonCard key={i} index={i} opacity={1 - i / SKELETON_COUNT} />
       ))}
       <p className="absolute bottom-12 left-0 right-0 text-center text-sm text-muted-foreground">
         loading agents…

--- a/apps/web/src/components/Navbar/AgentNavbar/index.tsx
+++ b/apps/web/src/components/Navbar/AgentNavbar/index.tsx
@@ -1,12 +1,7 @@
 import { type Dispatch, type SetStateAction } from "react";
 import { type MotionValue } from "motion/react";
 import { useMatch, useNavigate } from "react-router-dom";
-import {
-  Home,
-  KeyRound,
-  LayoutDashboard,
-  MessageSquare,
-} from "lucide-react";
+import { Home, KeyRound, LayoutDashboard, MessageSquare } from "lucide-react";
 import { AgentIsland } from "@/components/AgentIsland";
 import { AgentMenu } from "@/components/AgentMenu";
 import { MobileNavbar } from "@/components/MobileNavbar";
@@ -68,9 +63,7 @@ export function AgentNavbar({
                 <Button
                   variant="outline"
                   size="icon-lg"
-                  onClick={() =>
-                    navigate(`/agent/${encodeURIComponent(name)}`)
-                  }
+                  onClick={() => navigate(`/agent/${encodeURIComponent(name)}`)}
                 >
                   <LayoutDashboard />
                 </Button>

--- a/apps/web/src/components/Navbar/HomeNavbar/index.tsx
+++ b/apps/web/src/components/Navbar/HomeNavbar/index.tsx
@@ -75,9 +75,7 @@ export function HomeNavbar() {
   return (
     <Navbar
       leading={<Leading />}
-      center={
-        <LogoText />
-      }
+      center={<LogoText />}
       trailing={
         <>
           <StatusPill />

--- a/apps/web/src/components/Navbar/index.tsx
+++ b/apps/web/src/components/Navbar/index.tsx
@@ -26,7 +26,10 @@ export function Navbar({ leading, center, trailing }: NavbarProps) {
         data-tauri-drag-region
         className="grid grid-cols-[1fr_auto_1fr] items-center"
       >
-        <div data-tauri-drag-region className="flex items-center gap-2 justify-self-start">
+        <div
+          data-tauri-drag-region
+          className="flex items-center gap-2 justify-self-start"
+        >
           {leading}
         </div>
 
@@ -38,7 +41,10 @@ export function Navbar({ leading, center, trailing }: NavbarProps) {
           {center}
         </div>
 
-        <div data-tauri-drag-region className="flex items-center gap-2 justify-self-end">
+        <div
+          data-tauri-drag-region
+          className="flex items-center gap-2 justify-self-end"
+        >
           {trailing}
           <WindowControls />
         </div>

--- a/apps/web/src/components/NewAgent/Steps/NameStep/index.tsx
+++ b/apps/web/src/components/NewAgent/Steps/NameStep/index.tsx
@@ -8,11 +8,7 @@ import {
   FieldLabel,
   FieldDescription,
 } from "@/components/ui/field";
-import {
-  createAgent,
-  authenticate,
-  type AuthStartResult,
-} from "@/api";
+import { createAgent, authenticate, type AuthStartResult } from "@/api";
 import { useGateway } from "@/providers/GatewayProvider";
 import { useOnboarding } from "@/stores/use-onboarding";
 
@@ -91,9 +87,7 @@ export function NameStep({
         create
       </Button>
 
-      {error && (
-        <p className="text-xs text-destructive text-center">{error}</p>
-      )}
+      {error && <p className="text-xs text-destructive text-center">{error}</p>}
     </div>
   );
 }

--- a/apps/web/src/components/StatusPill/index.tsx
+++ b/apps/web/src/components/StatusPill/index.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import { getConnection } from "@/lib/connection";
 import { useGateway } from "@/providers/GatewayProvider";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 
 interface StatusPillProps {
   showHostname?: boolean;
@@ -9,6 +11,12 @@ interface StatusPillProps {
 export function StatusPill({ showHostname = true }: StatusPillProps) {
   const { reachable, updateAvailable, latestVersion, triggerGatewayUpdate } =
     useGateway();
+  const [updating, setUpdating] = useState(false);
+
+  const handleUpdate = () => {
+    setUpdating(true);
+    triggerGatewayUpdate();
+  };
 
   const hostname = (() => {
     const conn = getConnection();
@@ -33,12 +41,13 @@ export function StatusPill({ showHostname = true }: StatusPillProps) {
       {updateAvailable && (
         <Button
           size="xs"
-          variant="outline"
-          onClick={triggerGatewayUpdate}
+          onClick={handleUpdate}
+          disabled={updating}
           title={
             latestVersion ? `Update to v${latestVersion}` : "Update available"
           }
         >
+          {updating && <Spinner className="size-3" />}
           update
         </Button>
       )}

--- a/apps/web/src/components/StatusPill/index.tsx
+++ b/apps/web/src/components/StatusPill/index.tsx
@@ -35,7 +35,9 @@ export function StatusPill({ showHostname = true }: StatusPillProps) {
           size="xs"
           variant="outline"
           onClick={triggerGatewayUpdate}
-          title={latestVersion ? `Update to v${latestVersion}` : "Update available"}
+          title={
+            latestVersion ? `Update to v${latestVersion}` : "Update available"
+          }
         >
           update
         </Button>

--- a/apps/web/src/components/VersionMismatchDialog/index.tsx
+++ b/apps/web/src/components/VersionMismatchDialog/index.tsx
@@ -73,9 +73,7 @@ export function VersionMismatchDialog({
   return (
     <>
       <Navbar
-        center={
-          <LogoText />
-        }
+        center={<LogoText />}
         trailing={
           <>
             <StatusPill />

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -124,7 +124,16 @@ function SidebarProvider({
       toggleSidebar,
       container,
     }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar, container],
+    [
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+      container,
+    ],
   );
 
   return (
@@ -163,7 +172,8 @@ function Sidebar({
   variant?: "sidebar" | "floating" | "inset";
   collapsible?: "offcanvas" | "icon" | "none";
 }) {
-  const { isMobile, state, openMobile, setOpenMobile, container } = useSidebar();
+  const { isMobile, state, openMobile, setOpenMobile, container } =
+    useSidebar();
 
   if (collapsible === "none") {
     return (
@@ -202,7 +212,9 @@ function Sidebar({
             className="flex flex-col gap-2 overflow-y-auto px-1 sm:px-2 md:px-4 [&_[data-sidebar=header]]:p-0"
             onClick={(e) => {
               const target = e.target as HTMLElement;
-              const button = target.closest("[data-sidebar=menu-button]:not([data-slot=collapsible-trigger]), [data-sidebar=menu-sub-button]");
+              const button = target.closest(
+                "[data-sidebar=menu-button]:not([data-slot=collapsible-trigger]), [data-sidebar=menu-sub-button]",
+              );
               if (button) setOpenMobile(false);
             }}
           >

--- a/apps/web/src/hooks/use-window-focus.ts
+++ b/apps/web/src/hooks/use-window-focus.ts
@@ -18,7 +18,8 @@ export function useWindowFocus(): boolean {
     const onFocus = () => setFocused(true);
     const onBlur = () => setFocused(false);
     const onVisibility = () => {
-      if (document.visibilityState === "visible") setFocused(document.hasFocus());
+      if (document.visibilityState === "visible")
+        setFocused(document.hasFocus());
       else setFocused(false);
     };
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7,190 +7,190 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-    --safe-area-pt: max(0.5rem, calc(1rem - env(safe-area-inset-top, 0px)));
-    --safe-area-pb: max(0rem, calc(1rem - env(safe-area-inset-bottom, 0px)));
-    --background: oklch(0.995 0.005 80);
-    --foreground: oklch(0.147 0.005 80);
-    --card: oklch(0.995 0.005 80);
-    --card-foreground: oklch(0.147 0.005 80);
-    --popover: oklch(0.995 0.005 80);
-    --popover-foreground: oklch(0.147 0.005 80);
-    --primary: oklch(0.70 0.06 75);
-    --primary-foreground: oklch(0.99 0.005 80);
-    --secondary: oklch(0.97 0.006 80);
-    --secondary-foreground: oklch(0.216 0.006 80);
-    --muted: oklch(0.97 0.006 80);
-    --muted-foreground: oklch(0.553 0.015 80);
-    --accent: oklch(0.97 0.006 80);
-    --accent-foreground: oklch(0.216 0.006 80);
-    --destructive: oklch(0.577 0.245 27.325);
-    --warning: oklch(0.666 0.179 58.318);
-    --border: oklch(0.923 0.01 80);
-    --input: oklch(0.923 0.01 80);
-    --ring: oklch(0.709 0.02 80);
-    --chart-1: oklch(0.869 0.01 80);
-    --chart-2: oklch(0.553 0.015 80);
-    --chart-3: oklch(0.444 0.015 80);
-    --chart-4: oklch(0.374 0.012 80);
-    --chart-5: oklch(0.268 0.008 80);
-    --radius: 0.625rem;
-    --rounded-squircle-lg: 64px;
-    --rounded-squircle-md: 56px;
-    --sidebar: oklch(0.985 0.006 80);
-    --sidebar-foreground: oklch(0.147 0.005 80);
-    --sidebar-primary: oklch(0.216 0.006 80);
-    --sidebar-primary-foreground: oklch(0.985 0.006 80);
-    --sidebar-accent: oklch(0.97 0.006 80);
-    --sidebar-accent-foreground: oklch(0.216 0.006 80);
-    --sidebar-border: oklch(0.923 0.01 80);
-    --sidebar-ring: oklch(0.709 0.02 80);
-    --page-padding-x: 1.5rem;
+  --safe-area-pt: max(0.5rem, calc(1rem - env(safe-area-inset-top, 0px)));
+  --safe-area-pb: max(0rem, calc(1rem - env(safe-area-inset-bottom, 0px)));
+  --background: oklch(0.995 0.005 80);
+  --foreground: oklch(0.147 0.005 80);
+  --card: oklch(0.995 0.005 80);
+  --card-foreground: oklch(0.147 0.005 80);
+  --popover: oklch(0.995 0.005 80);
+  --popover-foreground: oklch(0.147 0.005 80);
+  --primary: oklch(0.7 0.06 75);
+  --primary-foreground: oklch(0.99 0.005 80);
+  --secondary: oklch(0.97 0.006 80);
+  --secondary-foreground: oklch(0.216 0.006 80);
+  --muted: oklch(0.97 0.006 80);
+  --muted-foreground: oklch(0.553 0.015 80);
+  --accent: oklch(0.97 0.006 80);
+  --accent-foreground: oklch(0.216 0.006 80);
+  --destructive: oklch(0.577 0.245 27.325);
+  --warning: oklch(0.666 0.179 58.318);
+  --border: oklch(0.923 0.01 80);
+  --input: oklch(0.923 0.01 80);
+  --ring: oklch(0.709 0.02 80);
+  --chart-1: oklch(0.869 0.01 80);
+  --chart-2: oklch(0.553 0.015 80);
+  --chart-3: oklch(0.444 0.015 80);
+  --chart-4: oklch(0.374 0.012 80);
+  --chart-5: oklch(0.268 0.008 80);
+  --radius: 0.625rem;
+  --rounded-squircle-lg: 64px;
+  --rounded-squircle-md: 56px;
+  --sidebar: oklch(0.985 0.006 80);
+  --sidebar-foreground: oklch(0.147 0.005 80);
+  --sidebar-primary: oklch(0.216 0.006 80);
+  --sidebar-primary-foreground: oklch(0.985 0.006 80);
+  --sidebar-accent: oklch(0.97 0.006 80);
+  --sidebar-accent-foreground: oklch(0.216 0.006 80);
+  --sidebar-border: oklch(0.923 0.01 80);
+  --sidebar-ring: oklch(0.709 0.02 80);
+  --page-padding-x: 1.5rem;
 }
 
 @supports not (corner-shape: squircle) {
-    :root {
-        --rounded-squircle-lg: calc(var(--radius) * 3);
-        --rounded-squircle-md: calc(var(--radius) * 2.6);
-    }
+  :root {
+    --rounded-squircle-lg: calc(var(--radius) * 3);
+    --rounded-squircle-md: calc(var(--radius) * 2.6);
+  }
 }
 
 .vibrancy {
-    --background: oklch(0.995 0.005 80 / 50%);
-    --card: oklch(0.995 0.005 80 / 50%);
-    --muted: oklch(0.97 0.006 80 / 60%);
-    --accent: oklch(0.97 0.006 80 / 50%);
-    --sidebar: oklch(0.985 0.006 80 / 50%);
-    --sidebar-accent: oklch(0.97 0.006 80 / 50%);
+  --background: oklch(0.995 0.005 80 / 50%);
+  --card: oklch(0.995 0.005 80 / 50%);
+  --muted: oklch(0.97 0.006 80 / 60%);
+  --accent: oklch(0.97 0.006 80 / 50%);
+  --sidebar: oklch(0.985 0.006 80 / 50%);
+  --sidebar-accent: oklch(0.97 0.006 80 / 50%);
 }
 
 .vibrancy.dark {
-    --background: oklch(0.147 0.005 80 / 50%);
-    --card: oklch(0.216 0.007 80 / 50%);
-    --muted: oklch(0.19 0.007 80 / 60%);
-    --accent: oklch(0.268 0.008 80 / 50%);
-    --sidebar: oklch(0.216 0.007 80 / 50%);
-    --sidebar-accent: oklch(0.268 0.008 80 / 50%);
+  --background: oklch(0.147 0.005 80 / 50%);
+  --card: oklch(0.216 0.007 80 / 50%);
+  --muted: oklch(0.19 0.007 80 / 60%);
+  --accent: oklch(0.268 0.008 80 / 50%);
+  --sidebar: oklch(0.216 0.007 80 / 50%);
+  --sidebar-accent: oklch(0.268 0.008 80 / 50%);
 }
 
 [data-platform="linux"].vibrancy {
-    --background: oklch(0.995 0.005 80 / 85%);
-    --card: oklch(0.995 0.005 80 / 85%);
-    --muted: oklch(0.97 0.006 80 / 90%);
-    --accent: oklch(0.97 0.006 80 / 85%);
-    --sidebar: oklch(0.985 0.006 80 / 85%);
-    --sidebar-accent: oklch(0.97 0.006 80 / 85%);
+  --background: oklch(0.995 0.005 80 / 85%);
+  --card: oklch(0.995 0.005 80 / 85%);
+  --muted: oklch(0.97 0.006 80 / 90%);
+  --accent: oklch(0.97 0.006 80 / 85%);
+  --sidebar: oklch(0.985 0.006 80 / 85%);
+  --sidebar-accent: oklch(0.97 0.006 80 / 85%);
 }
 
 [data-platform="linux"].vibrancy.dark {
-    --background: oklch(0.147 0.005 80 / 85%);
-    --card: oklch(0.216 0.007 80 / 85%);
-    --muted: oklch(0.19 0.007 80 / 90%);
-    --accent: oklch(0.268 0.008 80 / 85%);
-    --sidebar: oklch(0.216 0.007 80 / 85%);
-    --sidebar-accent: oklch(0.268 0.008 80 / 85%);
+  --background: oklch(0.147 0.005 80 / 85%);
+  --card: oklch(0.216 0.007 80 / 85%);
+  --muted: oklch(0.19 0.007 80 / 90%);
+  --accent: oklch(0.268 0.008 80 / 85%);
+  --sidebar: oklch(0.216 0.007 80 / 85%);
+  --sidebar-accent: oklch(0.268 0.008 80 / 85%);
 }
 
 .dark {
-    --background: oklch(0.147 0.005 80);
-    --foreground: oklch(0.985 0.006 80);
-    --card: oklch(0.216 0.007 80);
-    --card-foreground: oklch(0.985 0.006 80);
-    --popover: oklch(0.216 0.007 80);
-    --popover-foreground: oklch(0.985 0.006 80);
-    --primary: oklch(0.80 0.06 75);
-    --primary-foreground: oklch(0.25 0.015 75);
-    --secondary: oklch(0.268 0.008 80);
-    --secondary-foreground: oklch(0.985 0.006 80);
-    --muted: oklch(0.19 0.007 80);
-    --muted-foreground: oklch(0.709 0.02 80);
-    --accent: oklch(0.268 0.008 80);
-    --accent-foreground: oklch(0.985 0.006 80);
-    --destructive: oklch(0.704 0.191 22.216);
-    --warning: oklch(0.828 0.189 84.429);
-    --border: oklch(1 0.01 80 / 10%);
-    --input: oklch(1 0.01 80 / 15%);
-    --ring: oklch(0.553 0.015 80);
-    --chart-1: oklch(0.869 0.01 80);
-    --chart-2: oklch(0.553 0.015 80);
-    --chart-3: oklch(0.444 0.015 80);
-    --chart-4: oklch(0.374 0.012 80);
-    --chart-5: oklch(0.268 0.008 80);
-    --sidebar: oklch(0.216 0.007 80);
-    --sidebar-foreground: oklch(0.985 0.006 80);
-    --sidebar-primary: oklch(0.75 0.06 75);
-    --sidebar-primary-foreground: oklch(0.985 0.006 80);
-    --sidebar-accent: oklch(0.268 0.008 80);
-    --sidebar-accent-foreground: oklch(0.985 0.006 80);
-    --sidebar-border: oklch(1 0.01 80 / 10%);
-    --sidebar-ring: oklch(0.553 0.015 80);
+  --background: oklch(0.147 0.005 80);
+  --foreground: oklch(0.985 0.006 80);
+  --card: oklch(0.216 0.007 80);
+  --card-foreground: oklch(0.985 0.006 80);
+  --popover: oklch(0.216 0.007 80);
+  --popover-foreground: oklch(0.985 0.006 80);
+  --primary: oklch(0.8 0.06 75);
+  --primary-foreground: oklch(0.25 0.015 75);
+  --secondary: oklch(0.268 0.008 80);
+  --secondary-foreground: oklch(0.985 0.006 80);
+  --muted: oklch(0.19 0.007 80);
+  --muted-foreground: oklch(0.709 0.02 80);
+  --accent: oklch(0.268 0.008 80);
+  --accent-foreground: oklch(0.985 0.006 80);
+  --destructive: oklch(0.704 0.191 22.216);
+  --warning: oklch(0.828 0.189 84.429);
+  --border: oklch(1 0.01 80 / 10%);
+  --input: oklch(1 0.01 80 / 15%);
+  --ring: oklch(0.553 0.015 80);
+  --chart-1: oklch(0.869 0.01 80);
+  --chart-2: oklch(0.553 0.015 80);
+  --chart-3: oklch(0.444 0.015 80);
+  --chart-4: oklch(0.374 0.012 80);
+  --chart-5: oklch(0.268 0.008 80);
+  --sidebar: oklch(0.216 0.007 80);
+  --sidebar-foreground: oklch(0.985 0.006 80);
+  --sidebar-primary: oklch(0.75 0.06 75);
+  --sidebar-primary-foreground: oklch(0.985 0.006 80);
+  --sidebar-accent: oklch(0.268 0.008 80);
+  --sidebar-accent-foreground: oklch(0.985 0.006 80);
+  --sidebar-border: oklch(1 0.01 80 / 10%);
+  --sidebar-ring: oklch(0.553 0.015 80);
 }
 
 @theme inline {
-    --font-sans: 'Public Sans Variable', sans-serif;
-    --font-heading: 'Outfit Variable', sans-serif;
-    --text-sm: 0.9375rem;
-    --color-sidebar-ring: var(--sidebar-ring);
-    --color-sidebar-border: var(--sidebar-border);
-    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-    --color-sidebar-accent: var(--sidebar-accent);
-    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-    --color-sidebar-primary: var(--sidebar-primary);
-    --color-sidebar-foreground: var(--sidebar-foreground);
-    --color-sidebar: var(--sidebar);
-    --color-chart-5: var(--chart-5);
-    --color-chart-4: var(--chart-4);
-    --color-chart-3: var(--chart-3);
-    --color-chart-2: var(--chart-2);
-    --color-chart-1: var(--chart-1);
-    --color-ring: var(--ring);
-    --color-input: var(--input);
-    --color-border: var(--border);
-    --color-destructive: var(--destructive);
-    --color-warning: var(--warning);
-    --color-accent-foreground: var(--accent-foreground);
-    --color-accent: var(--accent);
-    --color-muted-foreground: var(--muted-foreground);
-    --color-muted: var(--muted);
-    --color-secondary-foreground: var(--secondary-foreground);
-    --color-secondary: var(--secondary);
-    --color-primary-foreground: var(--primary-foreground);
-    --color-primary: var(--primary);
-    --color-popover-foreground: var(--popover-foreground);
-    --color-popover: var(--popover);
-    --color-card-foreground: var(--card-foreground);
-    --color-card: var(--card);
-    --color-foreground: var(--foreground);
-    --color-background: var(--background);
-    --radius-sm: calc(var(--radius) * 0.6);
-    --radius-md: calc(var(--radius) * 0.8);
-    --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) * 1.4);
-    --radius-2xl: calc(var(--radius) * 1.8);
-    --radius-3xl: calc(var(--radius) * 2.2);
-    --radius-4xl: calc(var(--radius) * 2.6);
-    --radius-squircle-lg: var(--rounded-squircle-lg);
-    --radius-squircle-md: var(--rounded-squircle-md);
+  --font-sans: "Public Sans Variable", sans-serif;
+  --font-heading: "Outfit Variable", sans-serif;
+  --text-sm: 0.9375rem;
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-border: var(--border);
+  --color-destructive: var(--destructive);
+  --color-warning: var(--warning);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --color-foreground: var(--foreground);
+  --color-background: var(--background);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
+  --radius-squircle-lg: var(--rounded-squircle-lg);
+  --radius-squircle-md: var(--rounded-squircle-md);
 }
 
 @layer base {
   * {
     @apply border-border outline-ring/50;
-    }
+  }
   html {
     @apply box-border flex h-dvh flex-col bg-background font-sans overscroll-none;
-    }
+  }
   .vibrancy {
     background: transparent;
-    }
+  }
   body {
     @apply flex min-h-0 flex-1 flex-col bg-background text-foreground overscroll-none;
-    }
+  }
   .vibrancy body {
     background: transparent;
-    }
+  }
   #root {
     @apply flex min-h-0 flex-1 flex-col;
-    }
+  }
 }
 
 @utility px-page {
@@ -200,7 +200,6 @@
 @utility p-page {
   padding: var(--page-padding-x);
 }
-
 
 @utility py-page {
   padding-block: var(--page-padding-x);

--- a/apps/web/src/lib/Carousel/context.mjs
+++ b/apps/web/src/lib/Carousel/context.mjs
@@ -1,12 +1,14 @@
-import { invariant } from 'motion-utils';
-import { useContext, createContext } from 'react';
+import { invariant } from "motion-utils";
+import { useContext, createContext } from "react";
 
-const CarouselContext = 
-/** @__PURE__ */ createContext(null);
+const CarouselContext = /** @__PURE__ */ createContext(null);
 function useCarousel() {
-    const context = useContext(CarouselContext);
-    invariant(Boolean(context), "useCarousel must be used within a Carousel component");
-    return context;
+  const context = useContext(CarouselContext);
+  invariant(
+    Boolean(context),
+    "useCarousel must be used within a Carousel component",
+  );
+  return context;
 }
 
 export { CarouselContext, useCarousel };

--- a/apps/web/src/lib/Carousel/index.mjs
+++ b/apps/web/src/lib/Carousel/index.mjs
@@ -1,238 +1,308 @@
 "use client";
-import { jsx } from 'react/jsx-runtime';
-import { wheel } from 'motion-plus-dom';
-import { useMotionValue, useTransform, useMotionValueEvent, JSAnimation, clamp, animate } from 'motion/react';
-import { useRef, useState, useEffect } from 'react';
-import { Ticker } from '../Ticker/index.mjs';
-import { useTicker } from '../Ticker/context.mjs';
-import { getLayoutStrategy } from '../Ticker/utils/layout-strategy.mjs';
-import { CarouselContext } from './context.mjs';
-import { calcCurrentPage } from './utils/calc-current-page.mjs';
-import { calcPageInsets } from './utils/calc-page-insets.mjs';
-import { findNextPageInset } from './utils/find-next-page.mjs';
-import { findPrevPageInset } from './utils/find-prev-page.mjs';
+import { jsx } from "react/jsx-runtime";
+import { wheel } from "motion-plus-dom";
+import {
+  useMotionValue,
+  useTransform,
+  useMotionValueEvent,
+  JSAnimation,
+  clamp,
+  animate,
+} from "motion/react";
+import { useRef, useState, useEffect } from "react";
+import { Ticker } from "../Ticker/index.mjs";
+import { useTicker } from "../Ticker/context.mjs";
+import { getLayoutStrategy } from "../Ticker/utils/layout-strategy.mjs";
+import { CarouselContext } from "./context.mjs";
+import { calcCurrentPage } from "./utils/calc-current-page.mjs";
+import { calcPageInsets } from "./utils/calc-page-insets.mjs";
+import { findNextPageInset } from "./utils/find-next-page.mjs";
+import { findPrevPageInset } from "./utils/find-prev-page.mjs";
 
-function CarouselView({ children, offset, targetOffset, tugOffset, loop = true, transition, tickerRef, axis = "x", snap = "page", }) {
-    /**
-     * When this boolean is true, the rendered offset will be "attached" to
-     * the target offset, allowing for direct manipulation. When it's false,
-     * we're animating the offset to the target offset. This allows things
-     * like pagination and pagination progress to be optionally coupled to
-     * the target offset.
-     */
-    const isOffsetAttachedToTarget = useRef(true);
-    /**
-     * Calculate pagination and inset limits based on the measured
-     * ticker and item dimensions.
-     */
-    const { clampOffset, totalItemLength, itemPositions, containerLength, gap, maxInset, direction, } = useTicker();
-    const wrapInset = totalItemLength + gap;
-    const pagination = snap === "item"
-        ? { insets: itemPositions.map(p => p.start), visibleLength: containerLength }
-        : calcPageInsets(itemPositions, containerLength, maxInset);
-    const totalPages = pagination.insets.length;
-    const { sign } = getLayoutStrategy(axis, direction);
-    /**
-     * Helper function to calculate pagination state based on target offset
-     */
-    const calculatePaginationState = (targetOffsetValue) => {
-        const current = calcCurrentPage(targetOffsetValue * sign, pagination.insets, wrapInset, maxInset);
-        const isNextActive = loop ? true : targetOffsetValue * -sign < maxInset;
-        const isPrevActive = loop ? true : targetOffsetValue * -sign > 0;
-        return { current, isNextActive, isPrevActive };
-    };
-    // Initialize pagination state with current target offset
-    const [paginationState, setPaginationState] = useState(() => calculatePaginationState(targetOffset.get()));
-    // Update the pagination state when the measured ticker dimensions change
-    useEffect(() => {
-        updatePaginationState();
-    }, [containerLength, totalItemLength]);
-    const updatePaginationState = () => {
-        /**
-         * We derive the current page from the target offset, not the currently-rendered
-         * offset. This ensures that if we're paginating discretely, the page indicator
-         * updates immediately, and if we're jumping many pages that any indicator like a dots
-         * indicator doesn't appear to animate through many dots as the carousel animates.
-         */
-        const newPaginationState = calculatePaginationState(targetOffset.get());
-        // Only update state if something has changed
-        if (newPaginationState.current !== paginationState.current ||
-            newPaginationState.isNextActive !== paginationState.isNextActive ||
-            newPaginationState.isPrevActive !== paginationState.isPrevActive) {
-            setPaginationState(newPaginationState);
+function CarouselView({
+  children,
+  offset,
+  targetOffset,
+  tugOffset,
+  loop = true,
+  transition,
+  tickerRef,
+  axis = "x",
+  snap = "page",
+}) {
+  /**
+   * When this boolean is true, the rendered offset will be "attached" to
+   * the target offset, allowing for direct manipulation. When it's false,
+   * we're animating the offset to the target offset. This allows things
+   * like pagination and pagination progress to be optionally coupled to
+   * the target offset.
+   */
+  const isOffsetAttachedToTarget = useRef(true);
+  /**
+   * Calculate pagination and inset limits based on the measured
+   * ticker and item dimensions.
+   */
+  const {
+    clampOffset,
+    totalItemLength,
+    itemPositions,
+    containerLength,
+    gap,
+    maxInset,
+    direction,
+  } = useTicker();
+  const wrapInset = totalItemLength + gap;
+  const pagination =
+    snap === "item"
+      ? {
+          insets: itemPositions.map((p) => p.start),
+          visibleLength: containerLength,
         }
-    };
+      : calcPageInsets(itemPositions, containerLength, maxInset);
+  const totalPages = pagination.insets.length;
+  const { sign } = getLayoutStrategy(axis, direction);
+  /**
+   * Helper function to calculate pagination state based on target offset
+   */
+  const calculatePaginationState = (targetOffsetValue) => {
+    const current = calcCurrentPage(
+      targetOffsetValue * sign,
+      pagination.insets,
+      wrapInset,
+      maxInset,
+    );
+    const isNextActive = loop ? true : targetOffsetValue * -sign < maxInset;
+    const isPrevActive = loop ? true : targetOffsetValue * -sign > 0;
+    return { current, isNextActive, isPrevActive };
+  };
+  // Initialize pagination state with current target offset
+  const [paginationState, setPaginationState] = useState(() =>
+    calculatePaginationState(targetOffset.get()),
+  );
+  // Update the pagination state when the measured ticker dimensions change
+  useEffect(() => {
+    updatePaginationState();
+  }, [containerLength, totalItemLength]);
+  const updatePaginationState = () => {
     /**
-     * Handle changes to the target offset.
-     * - Update the rendered offset.
-     * - Update pagination state.
+     * We derive the current page from the target offset, not the currently-rendered
+     * offset. This ensures that if we're paginating discretely, the page indicator
+     * updates immediately, and if we're jumping many pages that any indicator like a dots
+     * indicator doesn't appear to animate through many dots as the carousel animates.
      */
-    useMotionValueEvent(targetOffset, "change", (latest) => {
-        offset.set(latest);
-        updatePaginationState();
-    });
-    /**
-     * Attach the rendered offset to the target offset.
-     */
-    const currentAnimation = useRef(null);
-    const stopOffsetAnimation = () => {
-        if (!currentAnimation.current)
-            return;
-        currentAnimation.current.stop();
-        currentAnimation.current = null;
-    };
-    /**
-     * Add a custom handler to the offset motion value. We link offset to targetOffset
-     * and only update targetOffset from pagination/gestures. When offset is attached
-     * to targetOffset, changes are passed straight through to offset. When it's not
-     * attached, we animate offset to the latest targetOffset value.
-     */
-    useEffect(() => {
-        offset.attach((v, onUpdate) => {
-            stopOffsetAnimation();
-            if (isOffsetAttachedToTarget.current) {
-                onUpdate(v);
-            }
-            else {
-                currentAnimation.current = new JSAnimation({
-                    keyframes: [offset.get(), v],
-                    velocity: clamp(-2e3, 2000, offset.getVelocity()),
-                    ...transition,
-                    onUpdate,
-                    onComplete: () => {
-                        currentAnimation.current = null;
-                    },
-                });
-            }
-            isOffsetAttachedToTarget.current = true;
-        }, stopOffsetAnimation);
-    }, []);
-    /**
-     * Discrete pagination. Support (and pass via context) next/prev/goto
-     * functions.
-     */
-    const stepOffset = (newOffset) => {
-        const clampedOffset = clampOffset(newOffset);
-        targetOffset.stop();
-        isOffsetAttachedToTarget.current = false;
-        targetOffset.set(clampedOffset * sign);
-    };
-    const paginate = (findPageInset, direction) => {
-        const offset = -findPageInset(-targetOffset.get() * sign, pagination.visibleLength, itemPositions, gap);
-        const clamped = clampOffset(offset);
-        if (clamped * sign === targetOffset.get()) {
-            animate(tugOffset, 0, {
-                velocity: direction * sign * 400,
-                ...limitSpring,
-            });
-        }
-        else {
-            stepOffset(clamped);
-        }
-    };
-    const nextPage = () => {
-        if (snap === "item") {
-            const next = Math.min(paginationState.current + 1, totalPages - 1);
-            if (next !== paginationState.current) gotoPage(next);
-            return;
-        }
-        paginate(findNextPageInset, -1);
-    };
-    const prevPage = () => {
-        if (snap === "item") {
-            const prev = Math.max(paginationState.current - 1, 0);
-            if (prev !== paginationState.current) gotoPage(prev);
-            return;
-        }
-        paginate(findPrevPageInset, 1);
-    };
-    const gotoPage = (i) => {
-        const iteration = loop
-            ? Math.floor((-targetOffset.get() * sign) / wrapInset)
-            : 0;
-        const transformOffset = iteration * -wrapInset;
-        stepOffset(-pagination.insets[i] + transformOffset);
-    };
-    const snapToNearest = () => {
-        const current = -targetOffset.get() * sign;
-        let closestInset = pagination.insets[0];
-        let closestDist = Math.abs(current - closestInset);
-        for (let i = 1; i < pagination.insets.length; i++) {
-            const dist = Math.abs(current - pagination.insets[i]);
-            if (dist < closestDist) {
-                closestDist = dist;
-                closestInset = pagination.insets[i];
-            }
-        }
-        stepOffset(-closestInset);
-    };
-    const wheelCallbacks = useRef({
-        snapToNearest,
-        maxInset,
-    });
-    useEffect(() => {
-        wheelCallbacks.current = {
-            snapToNearest,
-            maxInset,
-        };
-    }, [snapToNearest, maxInset]);
-    useEffect(() => {
-        const element = tickerRef.current;
-        if (!element)
-            return;
-        let snapTimeoutId = null;
-        const wheelCleanup = wheel(element, {
-            axis,
-            onWheel: (delta) => {
-                const { maxInset: mi } = wheelCallbacks.current;
-                let newOffset = offset.get() + delta;
-                if (mi !== null)
-                    newOffset = clamp(-mi, 0, newOffset);
-                targetOffset.jump(newOffset);
-                if (snap) {
-                    if (snapTimeoutId)
-                        clearTimeout(snapTimeoutId);
-                    snapTimeoutId = setTimeout(() => {
-                        wheelCallbacks.current.snapToNearest();
-                        snapTimeoutId = null;
-                    }, 150);
-                }
-            },
+    const newPaginationState = calculatePaginationState(targetOffset.get());
+    // Only update state if something has changed
+    if (
+      newPaginationState.current !== paginationState.current ||
+      newPaginationState.isNextActive !== paginationState.isNextActive ||
+      newPaginationState.isPrevActive !== paginationState.isPrevActive
+    ) {
+      setPaginationState(newPaginationState);
+    }
+  };
+  /**
+   * Handle changes to the target offset.
+   * - Update the rendered offset.
+   * - Update pagination state.
+   */
+  useMotionValueEvent(targetOffset, "change", (latest) => {
+    offset.set(latest);
+    updatePaginationState();
+  });
+  /**
+   * Attach the rendered offset to the target offset.
+   */
+  const currentAnimation = useRef(null);
+  const stopOffsetAnimation = () => {
+    if (!currentAnimation.current) return;
+    currentAnimation.current.stop();
+    currentAnimation.current = null;
+  };
+  /**
+   * Add a custom handler to the offset motion value. We link offset to targetOffset
+   * and only update targetOffset from pagination/gestures. When offset is attached
+   * to targetOffset, changes are passed straight through to offset. When it's not
+   * attached, we animate offset to the latest targetOffset value.
+   */
+  useEffect(() => {
+    offset.attach((v, onUpdate) => {
+      stopOffsetAnimation();
+      if (isOffsetAttachedToTarget.current) {
+        onUpdate(v);
+      } else {
+        currentAnimation.current = new JSAnimation({
+          keyframes: [offset.get(), v],
+          velocity: clamp(-2e3, 2000, offset.getVelocity()),
+          ...transition,
+          onUpdate,
+          onComplete: () => {
+            currentAnimation.current = null;
+          },
         });
-        return () => {
-            if (snapTimeoutId)
-                clearTimeout(snapTimeoutId);
-            wheelCleanup();
-        };
-    }, [axis, snap, offset, sign]);
-    return (jsx(CarouselContext.Provider, { value: {
-            currentPage: paginationState.current,
-            isNextActive: paginationState.isNextActive,
-            isPrevActive: paginationState.isPrevActive,
-            totalPages,
-            nextPage,
-            prevPage,
-            gotoPage,
-            targetOffset,
-        }, children: children }));
+      }
+      isOffsetAttachedToTarget.current = true;
+    }, stopOffsetAnimation);
+  }, []);
+  /**
+   * Discrete pagination. Support (and pass via context) next/prev/goto
+   * functions.
+   */
+  const stepOffset = (newOffset) => {
+    const clampedOffset = clampOffset(newOffset);
+    targetOffset.stop();
+    isOffsetAttachedToTarget.current = false;
+    targetOffset.set(clampedOffset * sign);
+  };
+  const paginate = (findPageInset, direction) => {
+    const offset = -findPageInset(
+      -targetOffset.get() * sign,
+      pagination.visibleLength,
+      itemPositions,
+      gap,
+    );
+    const clamped = clampOffset(offset);
+    if (clamped * sign === targetOffset.get()) {
+      animate(tugOffset, 0, {
+        velocity: direction * sign * 400,
+        ...limitSpring,
+      });
+    } else {
+      stepOffset(clamped);
+    }
+  };
+  const nextPage = () => {
+    if (snap === "item") {
+      const next = Math.min(paginationState.current + 1, totalPages - 1);
+      if (next !== paginationState.current) gotoPage(next);
+      return;
+    }
+    paginate(findNextPageInset, -1);
+  };
+  const prevPage = () => {
+    if (snap === "item") {
+      const prev = Math.max(paginationState.current - 1, 0);
+      if (prev !== paginationState.current) gotoPage(prev);
+      return;
+    }
+    paginate(findPrevPageInset, 1);
+  };
+  const gotoPage = (i) => {
+    const iteration = loop
+      ? Math.floor((-targetOffset.get() * sign) / wrapInset)
+      : 0;
+    const transformOffset = iteration * -wrapInset;
+    stepOffset(-pagination.insets[i] + transformOffset);
+  };
+  const snapToNearest = () => {
+    const current = -targetOffset.get() * sign;
+    let closestInset = pagination.insets[0];
+    let closestDist = Math.abs(current - closestInset);
+    for (let i = 1; i < pagination.insets.length; i++) {
+      const dist = Math.abs(current - pagination.insets[i]);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closestInset = pagination.insets[i];
+      }
+    }
+    stepOffset(-closestInset);
+  };
+  const wheelCallbacks = useRef({
+    snapToNearest,
+    maxInset,
+  });
+  useEffect(() => {
+    wheelCallbacks.current = {
+      snapToNearest,
+      maxInset,
+    };
+  }, [snapToNearest, maxInset]);
+  useEffect(() => {
+    const element = tickerRef.current;
+    if (!element) return;
+    let snapTimeoutId = null;
+    const wheelCleanup = wheel(element, {
+      axis,
+      onWheel: (delta) => {
+        const { maxInset: mi } = wheelCallbacks.current;
+        let newOffset = offset.get() + delta;
+        if (mi !== null) newOffset = clamp(-mi, 0, newOffset);
+        targetOffset.jump(newOffset);
+        if (snap) {
+          if (snapTimeoutId) clearTimeout(snapTimeoutId);
+          snapTimeoutId = setTimeout(() => {
+            wheelCallbacks.current.snapToNearest();
+            snapTimeoutId = null;
+          }, 150);
+        }
+      },
+    });
+    return () => {
+      if (snapTimeoutId) clearTimeout(snapTimeoutId);
+      wheelCleanup();
+    };
+  }, [axis, snap, offset, sign]);
+  return jsx(CarouselContext.Provider, {
+    value: {
+      currentPage: paginationState.current,
+      isNextActive: paginationState.isNextActive,
+      isPrevActive: paginationState.isPrevActive,
+      totalPages,
+      nextPage,
+      prevPage,
+      gotoPage,
+      targetOffset,
+    },
+    children: children,
+  });
 }
-function Carousel({ children, loop = true, transition = defaultTransition, axis = "x", snap = "page", ...props }) {
-    const ref = useRef(null);
-    const targetOffset = useMotionValue(0);
-    const offset = useMotionValue(0);
-    const tugOffset = useMotionValue(0);
-    const renderedOffset = useTransform(() => tugOffset.get() + offset.get());
-    return (jsx(Ticker, { role: "region", "aria-roledescription": "carousel", offset: renderedOffset, loop: loop, ref: ref, axis: axis, drag: axis, _dragX: axis === "x" ? targetOffset : false, _dragY: axis === "y" ? targetOffset : false, snap: snap, pageTransition: transition, ...props, children: jsx(CarouselView, { tickerRef: ref, loop: loop, offset: offset, tugOffset: tugOffset, targetOffset: targetOffset, transition: transition, snap: snap, axis: axis, children: children }) }));
+function Carousel({
+  children,
+  loop = true,
+  transition = defaultTransition,
+  axis = "x",
+  snap = "page",
+  ...props
+}) {
+  const ref = useRef(null);
+  const targetOffset = useMotionValue(0);
+  const offset = useMotionValue(0);
+  const tugOffset = useMotionValue(0);
+  const renderedOffset = useTransform(() => tugOffset.get() + offset.get());
+  return jsx(Ticker, {
+    role: "region",
+    "aria-roledescription": "carousel",
+    offset: renderedOffset,
+    loop: loop,
+    ref: ref,
+    axis: axis,
+    drag: axis,
+    _dragX: axis === "x" ? targetOffset : false,
+    _dragY: axis === "y" ? targetOffset : false,
+    snap: snap,
+    pageTransition: transition,
+    ...props,
+    children: jsx(CarouselView, {
+      tickerRef: ref,
+      loop: loop,
+      offset: offset,
+      tugOffset: tugOffset,
+      targetOffset: targetOffset,
+      transition: transition,
+      snap: snap,
+      axis: axis,
+      children: children,
+    }),
+  });
 }
 const defaultTransition = {
-    type: "spring",
-    stiffness: 200,
-    damping: 40,
+  type: "spring",
+  stiffness: 200,
+  damping: 40,
 };
 const limitSpring = {
-    type: "spring",
-    stiffness: 80,
-    damping: 10,
+  type: "spring",
+  stiffness: 80,
+  damping: 10,
 };
 
 export { Carousel };

--- a/apps/web/src/lib/Carousel/utils/calc-current-page.mjs
+++ b/apps/web/src/lib/Carousel/utils/calc-current-page.mjs
@@ -1,27 +1,30 @@
-import { wrap } from 'motion';
+import { wrap } from "motion";
 
 function calcCurrentPage(targetOffset, pageInsets, wrapInset, maxInset) {
-    const targetInset = -targetOffset;
-    const iteration = maxInset === null ? Math.floor(targetInset / wrapInset) : 0;
-    const transformInset = iteration * wrapInset;
-    for (let i = pageInsets.length - 1; i >= 0; i--) {
-        const inset = pageInsets[i] + transformInset;
-        const prevIndex = wrap(0, pageInsets.length, i - 1);
-        const prevIteration = i === 0 ? iteration - 1 : iteration;
-        const prevTransformInset = prevIteration * wrapInset;
-        const prevInset = pageInsets[prevIndex] + prevTransformInset;
-        const halfDistanceToPrev = (inset - prevInset) / 2;
-        const nextIndex = wrap(0, pageInsets.length, i + 1);
-        const nextIteration = i === pageInsets.length - 1 ? iteration + 1 : iteration;
-        const nextTransformInset = nextIteration * wrapInset;
-        const nextInset = pageInsets[nextIndex] + nextTransformInset;
-        const halfDistanceToNext = (nextInset - inset) / 2;
-        if (targetInset < nextInset - halfDistanceToNext &&
-            targetInset >= prevInset + halfDistanceToPrev) {
-            return i;
-        }
+  const targetInset = -targetOffset;
+  const iteration = maxInset === null ? Math.floor(targetInset / wrapInset) : 0;
+  const transformInset = iteration * wrapInset;
+  for (let i = pageInsets.length - 1; i >= 0; i--) {
+    const inset = pageInsets[i] + transformInset;
+    const prevIndex = wrap(0, pageInsets.length, i - 1);
+    const prevIteration = i === 0 ? iteration - 1 : iteration;
+    const prevTransformInset = prevIteration * wrapInset;
+    const prevInset = pageInsets[prevIndex] + prevTransformInset;
+    const halfDistanceToPrev = (inset - prevInset) / 2;
+    const nextIndex = wrap(0, pageInsets.length, i + 1);
+    const nextIteration =
+      i === pageInsets.length - 1 ? iteration + 1 : iteration;
+    const nextTransformInset = nextIteration * wrapInset;
+    const nextInset = pageInsets[nextIndex] + nextTransformInset;
+    const halfDistanceToNext = (nextInset - inset) / 2;
+    if (
+      targetInset < nextInset - halfDistanceToNext &&
+      targetInset >= prevInset + halfDistanceToPrev
+    ) {
+      return i;
     }
-    return 0;
+  }
+  return 0;
 }
 
 export { calcCurrentPage };

--- a/apps/web/src/lib/Carousel/utils/calc-page-insets.mjs
+++ b/apps/web/src/lib/Carousel/utils/calc-page-insets.mjs
@@ -1,70 +1,79 @@
-function calcPageInsets(itemPositions, containerLength, maxInset, allowRescale = true) {
-    const pageInsetData = { insets: [], visibleLength: containerLength };
-    if (itemPositions.length === 0) {
-        return pageInsetData;
-    }
-    const insets = [itemPositions[0].start];
+function calcPageInsets(
+  itemPositions,
+  containerLength,
+  maxInset,
+  allowRescale = true,
+) {
+  const pageInsetData = { insets: [], visibleLength: containerLength };
+  if (itemPositions.length === 0) {
+    return pageInsetData;
+  }
+  const insets = [itemPositions[0].start];
+  /**
+   * Loop through items and decide whether they've passed the
+   * threshold of a new page.
+   */
+  for (let i = 1; i < itemPositions.length; i++) {
+    const { start, end } = itemPositions[i];
     /**
-     * Loop through items and decide whether they've passed the
-     * threshold of a new page.
+     * If the end of this item is greater than the last
+     * page inset plus the container length, we need to
+     * add a new page inset.
      */
-    for (let i = 1; i < itemPositions.length; i++) {
-        const { start, end } = itemPositions[i];
-        /**
-         * If the end of this item is greater than the last
-         * page inset plus the container length, we need to
-         * add a new page inset.
-         */
-        if (insets[insets.length - 1] + containerLength < end) {
-            /**
-             * If we have a maxInset, it means looping is disabled and
-             * therefore we need bail if the we're beyond the maxInset
-             * (as this will align the final item with the end of the container)
-             */
-            if (maxInset !== null) {
-                if (start <= maxInset) {
-                    insets.push(start);
-                }
-                else {
-                    // If start > maxInset, add maxInset as the final offset
-                    insets.push(maxInset);
-                    break; // Don't add any more insets
-                }
-            }
-            else {
-                insets.push(start);
-            }
+    if (insets[insets.length - 1] + containerLength < end) {
+      /**
+       * If we have a maxInset, it means looping is disabled and
+       * therefore we need bail if the we're beyond the maxInset
+       * (as this will align the final item with the end of the container)
+       */
+      if (maxInset !== null) {
+        if (start <= maxInset) {
+          insets.push(start);
+        } else {
+          // If start > maxInset, add maxInset as the final offset
+          insets.push(maxInset);
+          break; // Don't add any more insets
         }
+      } else {
+        insets.push(start);
+      }
     }
-    /**
-     * If we're not looping, we want to check the size of the final page vs
-     * the average page size. If the final page is less than half the average,
-     * we attempt to redistribute by using a shorter container length.
-     */
-    if (allowRescale && maxInset !== null && insets.length > 1) {
-        // Store the original insets before adding maxInset
-        const originalLastInset = insets[insets.length - 1];
-        // Calculate average page size (using actual page breaks, not including potential maxInset)
-        const pageSizes = [];
-        for (let i = 0; i < insets.length - 1; i++) {
-            pageSizes.push(insets[i + 1] - insets[i]);
-        }
-        const averagePageSize = pageSizes.reduce((sum, size) => sum + size, 0) / pageSizes.length;
-        // Calculate the size of the final page (from last actual page break to maxInset)
-        const finalPageSize = maxInset - originalLastInset;
-        // If final page is less than half the average, try to redistribute
-        if (finalPageSize < averagePageSize * 0.5) {
-            const scaledPagination = calcPageInsets(itemPositions, containerLength * 0.75, maxInset, false);
-            // If we still get the same number of actual page breaks, use the redistributed version
-            if (scaledPagination.insets.length === insets.length) {
-                return scaledPagination;
-            }
-        }
+  }
+  /**
+   * If we're not looping, we want to check the size of the final page vs
+   * the average page size. If the final page is less than half the average,
+   * we attempt to redistribute by using a shorter container length.
+   */
+  if (allowRescale && maxInset !== null && insets.length > 1) {
+    // Store the original insets before adding maxInset
+    const originalLastInset = insets[insets.length - 1];
+    // Calculate average page size (using actual page breaks, not including potential maxInset)
+    const pageSizes = [];
+    for (let i = 0; i < insets.length - 1; i++) {
+      pageSizes.push(insets[i + 1] - insets[i]);
     }
-    return {
-        insets,
-        visibleLength: containerLength,
-    };
+    const averagePageSize =
+      pageSizes.reduce((sum, size) => sum + size, 0) / pageSizes.length;
+    // Calculate the size of the final page (from last actual page break to maxInset)
+    const finalPageSize = maxInset - originalLastInset;
+    // If final page is less than half the average, try to redistribute
+    if (finalPageSize < averagePageSize * 0.5) {
+      const scaledPagination = calcPageInsets(
+        itemPositions,
+        containerLength * 0.75,
+        maxInset,
+        false,
+      );
+      // If we still get the same number of actual page breaks, use the redistributed version
+      if (scaledPagination.insets.length === insets.length) {
+        return scaledPagination;
+      }
+    }
+  }
+  return {
+    insets,
+    visibleLength: containerLength,
+  };
 }
 
 export { calcPageInsets };

--- a/apps/web/src/lib/Carousel/utils/find-current-index.mjs
+++ b/apps/web/src/lib/Carousel/utils/find-current-index.mjs
@@ -1,16 +1,16 @@
 function findCurrentIndexFromInset(currentInset, itemPositions, wrapInset) {
-    const iteration = Math.floor(currentInset / wrapInset);
-    const transform = iteration * wrapInset;
-    let itemIndex = 0;
-    for (let i = 0; i < itemPositions.length; i++) {
-        const { end } = itemPositions[i];
-        itemIndex = i;
-        if (end + transform > currentInset) {
-            break;
-        }
+  const iteration = Math.floor(currentInset / wrapInset);
+  const transform = iteration * wrapInset;
+  let itemIndex = 0;
+  for (let i = 0; i < itemPositions.length; i++) {
+    const { end } = itemPositions[i];
+    itemIndex = i;
+    if (end + transform > currentInset) {
+      break;
     }
-    // Return the iteration-adjusted index
-    return itemIndex + iteration * itemPositions.length;
+  }
+  // Return the iteration-adjusted index
+  return itemIndex + iteration * itemPositions.length;
 }
 
 export { findCurrentIndexFromInset };

--- a/apps/web/src/lib/Carousel/utils/find-next-page.mjs
+++ b/apps/web/src/lib/Carousel/utils/find-next-page.mjs
@@ -1,40 +1,42 @@
-import { wrap } from 'motion/react';
-import { findCurrentIndexFromInset } from './find-current-index.mjs';
+import { wrap } from "motion/react";
+import { findCurrentIndexFromInset } from "./find-current-index.mjs";
 
 function findNextItemInset(currentInset, itemPositions, gap, targetInset) {
-    if (itemPositions.length === 0)
-        return 0;
-    const totalItemLength = itemPositions[itemPositions.length - 1].end;
-    const wrapInset = totalItemLength + gap;
-    const idealInset = targetInset ?? currentInset + (itemPositions[0]?.end ?? 0);
-    /**
-     * First, find the index of the item closest to the current
-     * inset. We do this to ensure we paginate by at least one
-     * item in the event that the items are larger than the
-     * viewable container.
-     */
-    const currentItemIndex = findCurrentIndexFromInset(currentInset, itemPositions, wrapInset);
-    let index = currentItemIndex + 1;
-    let nextItemInset = 0;
-    let hasFoundNextInset = false;
-    while (!hasFoundNextInset) {
-        const { start, end } = itemPositions[wrap(0, itemPositions.length, index)];
-        const iteration = Math.floor(index / itemPositions.length);
-        const transformInset = iteration * wrapInset;
-        const transformedStart = start + transformInset;
-        nextItemInset = transformedStart;
-        if (end + transformInset > idealInset) {
-            hasFoundNextInset = true;
-        }
-        else {
-            index++;
-        }
+  if (itemPositions.length === 0) return 0;
+  const totalItemLength = itemPositions[itemPositions.length - 1].end;
+  const wrapInset = totalItemLength + gap;
+  const idealInset = targetInset ?? currentInset + (itemPositions[0]?.end ?? 0);
+  /**
+   * First, find the index of the item closest to the current
+   * inset. We do this to ensure we paginate by at least one
+   * item in the event that the items are larger than the
+   * viewable container.
+   */
+  const currentItemIndex = findCurrentIndexFromInset(
+    currentInset,
+    itemPositions,
+    wrapInset,
+  );
+  let index = currentItemIndex + 1;
+  let nextItemInset = 0;
+  let hasFoundNextInset = false;
+  while (!hasFoundNextInset) {
+    const { start, end } = itemPositions[wrap(0, itemPositions.length, index)];
+    const iteration = Math.floor(index / itemPositions.length);
+    const transformInset = iteration * wrapInset;
+    const transformedStart = start + transformInset;
+    nextItemInset = transformedStart;
+    if (end + transformInset > idealInset) {
+      hasFoundNextInset = true;
+    } else {
+      index++;
     }
-    return nextItemInset;
+  }
+  return nextItemInset;
 }
 function findNextPageInset(currentInset, containerLength, itemPositions, gap) {
-    const idealInset = currentInset + containerLength;
-    return findNextItemInset(currentInset, itemPositions, gap, idealInset);
+  const idealInset = currentInset + containerLength;
+  return findNextItemInset(currentInset, itemPositions, gap, idealInset);
 }
 
 export { findNextItemInset, findNextPageInset };

--- a/apps/web/src/lib/Carousel/utils/find-prev-page.mjs
+++ b/apps/web/src/lib/Carousel/utils/find-prev-page.mjs
@@ -1,51 +1,67 @@
-import { wrap } from 'motion/react';
-import { findCurrentIndexFromInset } from './find-current-index.mjs';
+import { wrap } from "motion/react";
+import { findCurrentIndexFromInset } from "./find-current-index.mjs";
 
-function findPrevItemInset(currentInset, itemPositions, gap, targetInset, containerLength) {
-    if (itemPositions.length === 0)
-        return 0;
-    const totalItemLength = itemPositions[itemPositions.length - 1].end;
-    const wrapInset = totalItemLength + gap;
-    const idealInset = targetInset ?? currentInset - (containerLength ?? 0);
-    /**
-     * First, find the index of the item closest to the current
-     * inset. We do this to ensure we paginate by at least one
-     * item in the event that the items are larger than the
-     * viewable container.
-     */
-    const currentItemIndex = findCurrentIndexFromInset(currentInset, itemPositions, wrapInset);
-    let index = currentItemIndex;
-    let prevItemInset = currentInset;
-    let hasFoundPrevInset = false;
-    while (!hasFoundPrevInset) {
-        const { start, end } = itemPositions[wrap(0, itemPositions.length, index)];
-        const itemSize = end - start;
-        const iteration = Math.floor(index / itemPositions.length);
-        const transformInset = iteration * wrapInset;
-        const transformedStart = start + transformInset;
-        if (idealInset <= transformedStart + gap ||
-            transformedStart >= currentInset) {
-            prevItemInset = transformedStart;
-            index--;
-        }
-        else if (idealInset <= transformedStart) {
-            prevItemInset = transformedStart;
-            hasFoundPrevInset = true;
-        }
-        else {
-            if ((containerLength && itemSize > containerLength) ||
-                (prevItemInset === currentInset &&
-                    idealInset >= transformedStart)) {
-                prevItemInset = transformedStart;
-            }
-            hasFoundPrevInset = true;
-        }
+function findPrevItemInset(
+  currentInset,
+  itemPositions,
+  gap,
+  targetInset,
+  containerLength,
+) {
+  if (itemPositions.length === 0) return 0;
+  const totalItemLength = itemPositions[itemPositions.length - 1].end;
+  const wrapInset = totalItemLength + gap;
+  const idealInset = targetInset ?? currentInset - (containerLength ?? 0);
+  /**
+   * First, find the index of the item closest to the current
+   * inset. We do this to ensure we paginate by at least one
+   * item in the event that the items are larger than the
+   * viewable container.
+   */
+  const currentItemIndex = findCurrentIndexFromInset(
+    currentInset,
+    itemPositions,
+    wrapInset,
+  );
+  let index = currentItemIndex;
+  let prevItemInset = currentInset;
+  let hasFoundPrevInset = false;
+  while (!hasFoundPrevInset) {
+    const { start, end } = itemPositions[wrap(0, itemPositions.length, index)];
+    const itemSize = end - start;
+    const iteration = Math.floor(index / itemPositions.length);
+    const transformInset = iteration * wrapInset;
+    const transformedStart = start + transformInset;
+    if (
+      idealInset <= transformedStart + gap ||
+      transformedStart >= currentInset
+    ) {
+      prevItemInset = transformedStart;
+      index--;
+    } else if (idealInset <= transformedStart) {
+      prevItemInset = transformedStart;
+      hasFoundPrevInset = true;
+    } else {
+      if (
+        (containerLength && itemSize > containerLength) ||
+        (prevItemInset === currentInset && idealInset >= transformedStart)
+      ) {
+        prevItemInset = transformedStart;
+      }
+      hasFoundPrevInset = true;
     }
-    return prevItemInset;
+  }
+  return prevItemInset;
 }
 function findPrevPageInset(currentInset, containerLength, itemPositions, gap) {
-    const idealInset = currentInset - containerLength;
-    return findPrevItemInset(currentInset, itemPositions, gap, idealInset, containerLength);
+  const idealInset = currentInset - containerLength;
+  return findPrevItemInset(
+    currentInset,
+    itemPositions,
+    gap,
+    idealInset,
+    containerLength,
+  );
 }
 
 export { findPrevItemInset, findPrevPageInset };

--- a/apps/web/src/lib/Ticker/TickerItem.mjs
+++ b/apps/web/src/lib/Ticker/TickerItem.mjs
@@ -1,10 +1,10 @@
 "use client";
-import { jsx } from 'react/jsx-runtime';
-import { useTransform, motion } from 'motion/react';
-import { useTicker } from './context.mjs';
-import { TickerItemContext } from './TickerItemContext.mjs';
-import { useTickerItem } from './use-ticker-item.mjs';
-import { getLayoutStrategy } from './utils/layout-strategy.mjs';
+import { jsx } from "react/jsx-runtime";
+import { useTransform, motion } from "motion/react";
+import { useTicker } from "./context.mjs";
+import { TickerItemContext } from "./TickerItemContext.mjs";
+import { useTickerItem } from "./use-ticker-item.mjs";
+import { getLayoutStrategy } from "./utils/layout-strategy.mjs";
 
 /**
  * Represents an individual item within the Ticker.
@@ -19,82 +19,99 @@ import { getLayoutStrategy } from './utils/layout-strategy.mjs';
  * @param props - HTML attributes to pass to the list item li element.
  * @returns A ListItem React component.
  */
-function TickerItemWrapper({ children, offset, axis, listSize = 0, numItems = 0, itemIndex, cloneIndex, bounds, alignItems, reproject = true, size = "auto", safeMargin, }) {
-    const { start, end } = bounds;
-    const { visibleLength, direction, inset } = useTicker();
-    const { sign } = getLayoutStrategy(axis, direction);
-    const projection = useTransform(() => {
-        if (!reproject)
-            return 0;
-        const currentOffset = offset.get();
-        if ((!start && !end) || !listSize)
-            return 0;
-        if (currentOffset * sign + bounds.end <= -inset - safeMargin) {
-            return listSize * sign;
+function TickerItemWrapper({
+  children,
+  offset,
+  axis,
+  listSize = 0,
+  numItems = 0,
+  itemIndex,
+  cloneIndex,
+  bounds,
+  alignItems,
+  reproject = true,
+  size = "auto",
+  safeMargin,
+}) {
+  const { start, end } = bounds;
+  const { visibleLength, direction, inset } = useTicker();
+  const { sign } = getLayoutStrategy(axis, direction);
+  const projection = useTransform(() => {
+    if (!reproject) return 0;
+    const currentOffset = offset.get();
+    if ((!start && !end) || !listSize) return 0;
+    if (currentOffset * sign + bounds.end <= -inset - safeMargin) {
+      return listSize * sign;
+    }
+    /**
+     * If we've defined a safeMargin, also project items backwards if they
+     * fall outside the right boundary (+ margin). This fills-in the start area
+     * without affecting the alignment of items.
+     */
+    if (safeMargin > 0) {
+      const rightBoundary = visibleLength - safeMargin - inset;
+      if (currentOffset * sign + bounds.start >= rightBoundary) {
+        return -listSize * sign;
+      }
+    }
+    return 0;
+  });
+  const itemOffset = useTransform(() => {
+    const currentOffset = offset.get();
+    const currentTransform = projection.get();
+    if ((!start && !end) || !listSize) return 0;
+    return currentOffset * sign + start + currentTransform * sign;
+  });
+  const ariaProps =
+    cloneIndex === undefined
+      ? {
+          ["aria-hidden"]: false,
+          ["aria-posinset"]: itemIndex + 1,
+          ["aria-setsize"]: numItems,
         }
-        /**
-         * If we've defined a safeMargin, also project items backwards if they
-         * fall outside the right boundary (+ margin). This fills-in the start area
-         * without affecting the alignment of items.
-         */
-        if (safeMargin > 0) {
-            const rightBoundary = visibleLength - safeMargin - inset;
-            if (currentOffset * sign + bounds.start >= rightBoundary) {
-                return -listSize * sign;
-            }
-        }
-        return 0;
-    });
-    const itemOffset = useTransform(() => {
-        const currentOffset = offset.get();
-        const currentTransform = projection.get();
-        if ((!start && !end) || !listSize)
-            return 0;
-        return currentOffset * sign + start + currentTransform * sign;
-    });
-    const ariaProps = cloneIndex === undefined
-        ? {
-            ["aria-hidden"]: false,
-            ["aria-posinset"]: itemIndex + 1,
-            ["aria-setsize"]: numItems,
-        }
-        : {
-            ["aria-hidden"]: true,
+      : {
+          ["aria-hidden"]: true,
         };
-    const isFill = size === "fill";
-    const offAxisSize = alignItems === "stretch" ? "100%" : "fit-content";
-    const props = {
-        className: cloneIndex === undefined ? "ticker-item" : "clone-item",
-        style: {
-            flexGrow: 0,
-            flexShrink: 0,
-            position: "relative",
-            flexBasis: size === "fill" ? "100%" : undefined,
-            display: isFill ? "grid" : undefined,
-            gridTemplateColumns: isFill ? "1fr" : undefined,
-            gridTemplateRows: isFill ? "1fr" : undefined,
-            minWidth: isFill ? 0 : undefined,
-            minHeight: isFill ? 0 : undefined,
-            height: axis === "x" ? offAxisSize : undefined,
-            width: axis === "y" ? offAxisSize : undefined,
-            x: axis === "x" ? projection : 0,
-            y: axis === "y" ? projection : 0,
-        },
-        ...ariaProps,
-    };
-    return (jsx(TickerItemContext.Provider, { value: {
-            start,
-            end,
-            offset: itemOffset,
-            projection,
-            itemIndex,
-            cloneIndex,
-            props,
-        }, children: size === "manual" ? (children) : (jsx(DefaultTickerItem, { children: children })) }));
+  const isFill = size === "fill";
+  const offAxisSize = alignItems === "stretch" ? "100%" : "fit-content";
+  const props = {
+    className: cloneIndex === undefined ? "ticker-item" : "clone-item",
+    style: {
+      flexGrow: 0,
+      flexShrink: 0,
+      position: "relative",
+      flexBasis: size === "fill" ? "100%" : undefined,
+      display: isFill ? "grid" : undefined,
+      gridTemplateColumns: isFill ? "1fr" : undefined,
+      gridTemplateRows: isFill ? "1fr" : undefined,
+      minWidth: isFill ? 0 : undefined,
+      minHeight: isFill ? 0 : undefined,
+      height: axis === "x" ? offAxisSize : undefined,
+      width: axis === "y" ? offAxisSize : undefined,
+      x: axis === "x" ? projection : 0,
+      y: axis === "y" ? projection : 0,
+    },
+    ...ariaProps,
+  };
+  return jsx(TickerItemContext.Provider, {
+    value: {
+      start,
+      end,
+      offset: itemOffset,
+      projection,
+      itemIndex,
+      cloneIndex,
+      props,
+    },
+    children:
+      size === "manual"
+        ? children
+        : jsx(DefaultTickerItem, { children: children }),
+  });
 }
 function DefaultTickerItem({ children }) {
-    const { props } = useTickerItem();
-    return jsx(motion.li, { ...props, children: children });
+  const { props } = useTickerItem();
+  return jsx(motion.li, { ...props, children: children });
 }
 
 export { DefaultTickerItem, TickerItemWrapper };

--- a/apps/web/src/lib/Ticker/TickerItemContext.mjs
+++ b/apps/web/src/lib/Ticker/TickerItemContext.mjs
@@ -1,4 +1,4 @@
-import { createContext } from 'react';
+import { createContext } from "react";
 
 const TickerItemContext = /** @__PURE__ */ createContext(undefined);
 

--- a/apps/web/src/lib/Ticker/context.mjs
+++ b/apps/web/src/lib/Ticker/context.mjs
@@ -1,11 +1,14 @@
-import { invariant } from 'motion-utils';
-import { useContext, createContext } from 'react';
+import { invariant } from "motion-utils";
+import { useContext, createContext } from "react";
 
 const TickerContext = /** @__PURE__ */ createContext(null);
 function useTicker() {
-    const context = useContext(TickerContext);
-    invariant(Boolean(context), "useTicker must be used within a Ticker component");
-    return context;
+  const context = useContext(TickerContext);
+  invariant(
+    Boolean(context),
+    "useTicker must be used within a Ticker component",
+  );
+  return context;
 }
 
 export { TickerContext, useTicker };

--- a/apps/web/src/lib/Ticker/index.mjs
+++ b/apps/web/src/lib/Ticker/index.mjs
@@ -1,354 +1,601 @@
 "use client";
-import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
-import { useComposedRefs, useMotionValue, noop, useTransform, wrap, useInView, usePageInView, useReducedMotion, useIsomorphicLayoutEffect, resize, useAnimationFrame, LayoutGroup, clamp, animate, motion, frame, useMotionValueEvent } from 'motion/react';
-import { forwardRef, useRef, useState, useMemo, useCallback } from 'react';
-import { findNextItemInset } from '../Carousel/utils/find-next-page.mjs';
-import { findPrevItemInset } from '../Carousel/utils/find-prev-page.mjs';
-import { TickerContext } from './context.mjs';
-import { TickerItemWrapper } from './TickerItem.mjs';
-import { useFocusNavigation } from './use-focus-navigation.mjs';
-import { calcNumClones } from './utils/calc-num-clones.mjs';
-import { calcTotalItemLength } from './utils/calc-total-item-length.mjs';
-import { getLayoutStrategy } from './utils/layout-strategy.mjs';
+import { jsx, jsxs, Fragment } from "react/jsx-runtime";
+import {
+  useComposedRefs,
+  useMotionValue,
+  noop,
+  useTransform,
+  wrap,
+  useInView,
+  usePageInView,
+  useReducedMotion,
+  useIsomorphicLayoutEffect,
+  resize,
+  useAnimationFrame,
+  LayoutGroup,
+  clamp,
+  animate,
+  motion,
+  frame,
+  useMotionValueEvent,
+} from "motion/react";
+import { forwardRef, useRef, useState, useMemo, useCallback } from "react";
+import { findNextItemInset } from "../Carousel/utils/find-next-page.mjs";
+import { findPrevItemInset } from "../Carousel/utils/find-prev-page.mjs";
+import { TickerContext } from "./context.mjs";
+import { TickerItemWrapper } from "./TickerItem.mjs";
+import { useFocusNavigation } from "./use-focus-navigation.mjs";
+import { calcNumClones } from "./utils/calc-num-clones.mjs";
+import { calcTotalItemLength } from "./utils/calc-total-item-length.mjs";
+import { getLayoutStrategy } from "./utils/layout-strategy.mjs";
 
 const alignAlias = {
-    start: "flex-start",
-    end: "flex-end",
+  start: "flex-start",
+  end: "flex-end",
 };
 /**
  * A performant, accessible, and infinitely scrolling ticker component.
  */
-function TickerComponent({ items, velocity = 50, hoverFactor = 1, gap = 10, axis = "x", align = "center", offset, isStatic = false, itemSize = "auto", overflow = false, loop = true, children, as = "div", snap, safeMargin = 0, fade = 0, fadeTransition, pageTransition, ...props }, ref) {
-    const internalContainerRef = useRef(null);
-    const containerRef = useComposedRefs(ref, internalContainerRef);
-    const listRef = useRef(null);
-    const [state, setState] = useState({
-        direction: "ltr",
-        visibleLength: 0,
-        inset: 0,
-        totalItemLength: 0,
-        containerLength: 0,
-        itemPositions: [],
-        isMeasured: false,
-        maxInset: null,
+function TickerComponent(
+  {
+    items,
+    velocity = 50,
+    hoverFactor = 1,
+    gap = 10,
+    axis = "x",
+    align = "center",
+    offset,
+    isStatic = false,
+    itemSize = "auto",
+    overflow = false,
+    loop = true,
+    children,
+    as = "div",
+    snap,
+    safeMargin = 0,
+    fade = 0,
+    fadeTransition,
+    pageTransition,
+    ...props
+  },
+  ref,
+) {
+  const internalContainerRef = useRef(null);
+  const containerRef = useComposedRefs(ref, internalContainerRef);
+  const listRef = useRef(null);
+  const [state, setState] = useState({
+    direction: "ltr",
+    visibleLength: 0,
+    inset: 0,
+    totalItemLength: 0,
+    containerLength: 0,
+    itemPositions: [],
+    isMeasured: false,
+    maxInset: null,
+  });
+  const alignItems = alignAlias[align] || align;
+  const { sign } = getLayoutStrategy(axis, state.direction);
+  if (isStatic) {
+    const renderedOffset = useMotionValue(0);
+    return jsx(TickerContext.Provider, {
+      value: { ...state, gap, clampOffset: noop, renderedOffset },
+      children: jsx(ListView, {
+        containerProps: props,
+        containerRef: containerRef,
+        children: children,
+        gap: gap,
+        axis: axis,
+        alignItems: alignItems,
+        offset: renderedOffset,
+        renderedOffset: renderedOffset,
+        items: items,
+        itemSize: itemSize,
+        state: state,
+        overflow: overflow,
+        safeMargin: safeMargin,
+        isStatic: true,
+        as: as,
+        fade: fade,
+        sign: sign,
+      }),
     });
-    const alignItems = alignAlias[align] || align;
-    const { sign } = getLayoutStrategy(axis, state.direction);
-    if (isStatic) {
-        const renderedOffset = useMotionValue(0);
-        return (jsx(TickerContext.Provider, { value: { ...state, gap, clampOffset: noop, renderedOffset }, children: jsx(ListView, { containerProps: props, containerRef: containerRef, children: children, gap: gap, axis: axis, alignItems: alignItems, offset: renderedOffset, renderedOffset: renderedOffset, items: items, itemSize: itemSize, state: state, overflow: overflow, safeMargin: safeMargin, isStatic: true, as: as, fade: fade, sign: sign }) }));
+  }
+  const [hasFocus, setHasFocus] = useState(false);
+  const velocityFactor = useMotionValue(1);
+  const defaultOffset = useMotionValue(0);
+  offset ?? (offset = defaultOffset);
+  const wrappedOffset = useTransform(() => {
+    // TODO: Move to strategy
+    if (state.direction === "rtl") {
+      return wrap(
+        state.totalItemLength + gap + state.inset,
+        state.inset,
+        offset.get(),
+      );
     }
-    const [hasFocus, setHasFocus] = useState(false);
-    const velocityFactor = useMotionValue(1);
-    const defaultOffset = useMotionValue(0);
-    offset ?? (offset = defaultOffset);
-    const wrappedOffset = useTransform(() => {
-        // TODO: Move to strategy
-        if (state.direction === "rtl") {
-            return wrap(state.totalItemLength + gap + state.inset, state.inset, offset.get());
-        }
-        return wrap(-state.totalItemLength - gap - state.inset, -state.inset, offset.get());
-    });
-    const focusOffset = useMotionValue(0);
-    const renderedOffset = hasFocus
-        ? focusOffset
-        : loop
-            ? wrappedOffset
-            : offset;
-    const isInViewport = useInView(internalContainerRef, { margin: "100px" });
-    const isPageInView = usePageInView();
-    const isInView = isInViewport && isPageInView;
-    const isReducedMotion = useReducedMotion();
-    const updateMeasurements = () => {
-        if (!internalContainerRef.current || !listRef.current)
-            return;
-        const direction = window.getComputedStyle(internalContainerRef.current)
-            .direction;
-        const { measureItem, lengthProp, viewportLengthProp, getCumulativeInset, } = getLayoutStrategy(axis, direction);
-        const paddingStartProp = axis === "x" ? "paddingLeft" : "paddingTop";
-        const paddingEndProp = axis === "x" ? "paddingRight" : "paddingBottom";
-        const container = internalContainerRef.current;
-        const list = listRef.current;
-        const allItems = list.querySelectorAll(".ticker-item");
-        if (!allItems.length)
-            return;
-        let hasItemSizeChanged = false;
-        const itemPositions = [];
-        for (let i = 0; i < allItems.length; i++) {
-            const size = measureItem(allItems[i], container);
-            itemPositions.push(size);
-            const prevSize = state.itemPositions[i];
-            if (!prevSize ||
-                size.start !== prevSize.start ||
-                size.end !== prevSize.end) {
-                hasItemSizeChanged = true;
-            }
-        }
-        /**
-         * Cap to viewport size to prevent infinite or wasteful cloning in the event that the
-         * container width is reactive to the number of children rendered within it.
-         */
-        const containerLength = Math.min(container[lengthProp], window[viewportLengthProp]);
-        let visibleLength = overflow
-            ? window[viewportLengthProp]
-            : containerLength;
-        if (safeMargin > 0) {
-            visibleLength += safeMargin * 2;
-        }
-        const totalItemLength = calcTotalItemLength(itemPositions);
-        const computedContainerStyle = window.getComputedStyle(container);
-        const containerPaddingStart = parseInt(computedContainerStyle[paddingStartProp] ?? 0);
-        const containerPaddingEnd = parseInt(computedContainerStyle[paddingEndProp] ?? 0);
-        const inset = overflow
-            ? getCumulativeInset(allItems[0])
-            : containerPaddingStart;
-        const maxInset = loop === false
-            ? Math.max(0, totalItemLength -
-                containerLength +
-                containerPaddingStart +
-                containerPaddingEnd)
-            : null;
-        if (visibleLength !== state.visibleLength ||
-            totalItemLength !== state.totalItemLength ||
-            inset !== state.inset ||
-            state.itemPositions.length !== itemPositions.length ||
-            hasItemSizeChanged) {
-            setState({
-                direction,
-                visibleLength,
-                itemPositions,
-                totalItemLength,
-                inset,
-                containerLength,
-                maxInset,
-                isMeasured: true,
-            });
-        }
+    return wrap(
+      -state.totalItemLength - gap - state.inset,
+      -state.inset,
+      offset.get(),
+    );
+  });
+  const focusOffset = useMotionValue(0);
+  const renderedOffset = hasFocus ? focusOffset : loop ? wrappedOffset : offset;
+  const isInViewport = useInView(internalContainerRef, { margin: "100px" });
+  const isPageInView = usePageInView();
+  const isInView = isInViewport && isPageInView;
+  const isReducedMotion = useReducedMotion();
+  const updateMeasurements = () => {
+    if (!internalContainerRef.current || !listRef.current) return;
+    const direction = window.getComputedStyle(
+      internalContainerRef.current,
+    ).direction;
+    const { measureItem, lengthProp, viewportLengthProp, getCumulativeInset } =
+      getLayoutStrategy(axis, direction);
+    const paddingStartProp = axis === "x" ? "paddingLeft" : "paddingTop";
+    const paddingEndProp = axis === "x" ? "paddingRight" : "paddingBottom";
+    const container = internalContainerRef.current;
+    const list = listRef.current;
+    const allItems = list.querySelectorAll(".ticker-item");
+    if (!allItems.length) return;
+    let hasItemSizeChanged = false;
+    const itemPositions = [];
+    for (let i = 0; i < allItems.length; i++) {
+      const size = measureItem(allItems[i], container);
+      itemPositions.push(size);
+      const prevSize = state.itemPositions[i];
+      if (
+        !prevSize ||
+        size.start !== prevSize.start ||
+        size.end !== prevSize.end
+      ) {
+        hasItemSizeChanged = true;
+      }
+    }
+    /**
+     * Cap to viewport size to prevent infinite or wasteful cloning in the event that the
+     * container width is reactive to the number of children rendered within it.
+     */
+    const containerLength = Math.min(
+      container[lengthProp],
+      window[viewportLengthProp],
+    );
+    let visibleLength = overflow ? window[viewportLengthProp] : containerLength;
+    if (safeMargin > 0) {
+      visibleLength += safeMargin * 2;
+    }
+    const totalItemLength = calcTotalItemLength(itemPositions);
+    const computedContainerStyle = window.getComputedStyle(container);
+    const containerPaddingStart = parseInt(
+      computedContainerStyle[paddingStartProp] ?? 0,
+    );
+    const containerPaddingEnd = parseInt(
+      computedContainerStyle[paddingEndProp] ?? 0,
+    );
+    const inset = overflow
+      ? getCumulativeInset(allItems[0])
+      : containerPaddingStart;
+    const maxInset =
+      loop === false
+        ? Math.max(
+            0,
+            totalItemLength -
+              containerLength +
+              containerPaddingStart +
+              containerPaddingEnd,
+          )
+        : null;
+    if (
+      visibleLength !== state.visibleLength ||
+      totalItemLength !== state.totalItemLength ||
+      inset !== state.inset ||
+      state.itemPositions.length !== itemPositions.length ||
+      hasItemSizeChanged
+    ) {
+      setState({
+        direction,
+        visibleLength,
+        itemPositions,
+        totalItemLength,
+        inset,
+        containerLength,
+        maxInset,
+        isMeasured: true,
+      });
+    }
+  };
+  useIsomorphicLayoutEffect(() => {
+    if (!isInView || !internalContainerRef.current) return;
+    updateMeasurements();
+    const trackViewport = overflow ? resize(updateMeasurements) : undefined;
+    const trackContainer = resize(
+      internalContainerRef.current,
+      updateMeasurements,
+    );
+    return () => {
+      trackViewport?.();
+      trackContainer();
     };
-    useIsomorphicLayoutEffect(() => {
-        if (!isInView || !internalContainerRef.current)
-            return;
-        updateMeasurements();
-        const trackViewport = overflow ? resize(updateMeasurements) : undefined;
-        const trackContainer = resize(internalContainerRef.current, updateMeasurements);
-        return () => {
-            trackViewport?.();
-            trackContainer();
-        };
-    }, [items, isInView, overflow]);
-    const isMeasured = state.totalItemLength > 0;
-    useAnimationFrame(isMeasured && isInView && offset === defaultOffset && !isReducedMotion
-        ? (_, delta) => {
-            const frameOffset = (delta / 1000) * (velocity * sign * velocityFactor.get());
-            offset.set(offset.get() - frameOffset);
+  }, [items, isInView, overflow]);
+  const isMeasured = state.totalItemLength > 0;
+  useAnimationFrame(
+    isMeasured && isInView && offset === defaultOffset && !isReducedMotion
+      ? (_, delta) => {
+          const frameOffset =
+            (delta / 1000) * (velocity * sign * velocityFactor.get());
+          offset.set(offset.get() - frameOffset);
         }
-        : noop);
-    const cloneCount = useMemo(() => {
-        if (!isMeasured || !state.visibleLength)
-            return 0;
-        return calcNumClones(state.visibleLength, state.itemPositions, gap);
-    }, [isMeasured, state]);
-    const totalListSize = state.totalItemLength === 0
-        ? 0
-        : (state.totalItemLength + gap) * (cloneCount + 1);
-    const clonedItemGroups = [];
-    if (loop) {
-        for (let i = 0; i < cloneCount; i++) {
-            const clonedItems = [];
-            items.forEach((item, itemIndex) => {
-                const originalBounds = state.itemPositions[itemIndex];
-                const cloneOffset = (state.totalItemLength + gap) * (i + 1);
-                const cloneBounds = originalBounds
-                    ? {
-                        start: originalBounds.start + cloneOffset,
-                        end: originalBounds.end + cloneOffset,
-                    }
-                    : defaultBounds;
-                clonedItems.push(jsx(TickerItemWrapper, { offset: renderedOffset, axis: axis, listSize: totalListSize, itemIndex: itemIndex, cloneIndex: itemIndex, bounds: cloneBounds, alignItems: alignItems, size: itemSize, safeMargin: safeMargin, numItems: items.length, children: item }, `clone-${i}-${itemIndex}`));
-            });
-            const id = `ticker-group-${i}`;
-            clonedItemGroups.push(jsx(LayoutGroup, { id: id, children: clonedItems }, id));
-        }
+      : noop,
+  );
+  const cloneCount = useMemo(() => {
+    if (!isMeasured || !state.visibleLength) return 0;
+    return calcNumClones(state.visibleLength, state.itemPositions, gap);
+  }, [isMeasured, state]);
+  const totalListSize =
+    state.totalItemLength === 0
+      ? 0
+      : (state.totalItemLength + gap) * (cloneCount + 1);
+  const clonedItemGroups = [];
+  if (loop) {
+    for (let i = 0; i < cloneCount; i++) {
+      const clonedItems = [];
+      items.forEach((item, itemIndex) => {
+        const originalBounds = state.itemPositions[itemIndex];
+        const cloneOffset = (state.totalItemLength + gap) * (i + 1);
+        const cloneBounds = originalBounds
+          ? {
+              start: originalBounds.start + cloneOffset,
+              end: originalBounds.end + cloneOffset,
+            }
+          : defaultBounds;
+        clonedItems.push(
+          jsx(
+            TickerItemWrapper,
+            {
+              offset: renderedOffset,
+              axis: axis,
+              listSize: totalListSize,
+              itemIndex: itemIndex,
+              cloneIndex: itemIndex,
+              bounds: cloneBounds,
+              alignItems: alignItems,
+              size: itemSize,
+              safeMargin: safeMargin,
+              numItems: items.length,
+              children: item,
+            },
+            `clone-${i}-${itemIndex}`,
+          ),
+        );
+      });
+      const id = `ticker-group-${i}`;
+      clonedItemGroups.push(
+        jsx(LayoutGroup, { id: id, children: clonedItems }, id),
+      );
     }
-    useFocusNavigation(internalContainerRef, axis, focusOffset, offset, setHasFocus);
-    const clampOffset = useCallback((offset) => {
-        return state.maxInset !== null
-            ? clamp(-state.maxInset, 0, offset)
-            : offset;
-    }, [state.maxInset]);
-    return (jsx(TickerContext.Provider, { value: { ...state, gap, clampOffset, renderedOffset }, children: jsx(ListView, { containerProps: props, children: children, containerRef: containerRef, listRef: listRef, gap: gap, axis: axis, alignItems: alignItems, isMeasured: isMeasured, isInView: isInView, offset: offset, renderedOffset: renderedOffset, items: items, itemSize: itemSize, clonedItems: clonedItemGroups, clampOffset: clampOffset, snap: snap, safeMargin: safeMargin, onPointerEnter: () => {
-                animate(velocityFactor, hoverFactor);
-            }, onPointerLeave: () => {
-                animate(velocityFactor, 1);
-            }, totalListSize: totalListSize, state: state, overflow: overflow, loop: loop, as: as, fade: fade, sign: sign, fadeTransition: fadeTransition, pageTransition: pageTransition }) }));
+  }
+  useFocusNavigation(
+    internalContainerRef,
+    axis,
+    focusOffset,
+    offset,
+    setHasFocus,
+  );
+  const clampOffset = useCallback(
+    (offset) => {
+      return state.maxInset !== null
+        ? clamp(-state.maxInset, 0, offset)
+        : offset;
+    },
+    [state.maxInset],
+  );
+  return jsx(TickerContext.Provider, {
+    value: { ...state, gap, clampOffset, renderedOffset },
+    children: jsx(ListView, {
+      containerProps: props,
+      children: children,
+      containerRef: containerRef,
+      listRef: listRef,
+      gap: gap,
+      axis: axis,
+      alignItems: alignItems,
+      isMeasured: isMeasured,
+      isInView: isInView,
+      offset: offset,
+      renderedOffset: renderedOffset,
+      items: items,
+      itemSize: itemSize,
+      clonedItems: clonedItemGroups,
+      clampOffset: clampOffset,
+      snap: snap,
+      safeMargin: safeMargin,
+      onPointerEnter: () => {
+        animate(velocityFactor, hoverFactor);
+      },
+      onPointerLeave: () => {
+        animate(velocityFactor, 1);
+      },
+      totalListSize: totalListSize,
+      state: state,
+      overflow: overflow,
+      loop: loop,
+      as: as,
+      fade: fade,
+      sign: sign,
+      fadeTransition: fadeTransition,
+      pageTransition: pageTransition,
+    }),
+  });
 }
 const Ticker = /** @__PURE__ */ forwardRef(TickerComponent);
-function ListView({ children, containerProps, containerRef, listRef, gap, axis, alignItems, isMeasured, isInView, isStatic, items, offset, clonedItems, clampOffset, renderedOffset, onPointerEnter, onPointerLeave, totalListSize, itemSize, overflow, state, safeMargin, snap, loop, as, fade, sign, fadeTransition = defaultFadeTransition, pageTransition, }) {
-    const MotionComponent = useMemo(() => motion.create(as), [as]);
-    /**
-     * Derive drag constraints based on measurements.
-     */
-    let dragConstraints = {};
-    const { maxInset } = state;
-    if (maxInset !== null) {
-        if (axis === "x") {
-            dragConstraints =
-                sign > 0
-                    ? { left: maxInset * -1, right: 0 }
-                    : { right: maxInset, left: 0 };
-        }
-        else {
-            dragConstraints = { top: maxInset * -1, bottom: 0 };
-        }
+function ListView({
+  children,
+  containerProps,
+  containerRef,
+  listRef,
+  gap,
+  axis,
+  alignItems,
+  isMeasured,
+  isInView,
+  isStatic,
+  items,
+  offset,
+  clonedItems,
+  clampOffset,
+  renderedOffset,
+  onPointerEnter,
+  onPointerLeave,
+  totalListSize,
+  itemSize,
+  overflow,
+  state,
+  safeMargin,
+  snap,
+  loop,
+  as,
+  fade,
+  sign,
+  fadeTransition = defaultFadeTransition,
+  pageTransition,
+}) {
+  const MotionComponent = useMemo(() => motion.create(as), [as]);
+  /**
+   * Derive drag constraints based on measurements.
+   */
+  let dragConstraints = {};
+  const { maxInset } = state;
+  if (maxInset !== null) {
+    if (axis === "x") {
+      dragConstraints =
+        sign > 0
+          ? { left: maxInset * -1, right: 0 }
+          : { right: maxInset, left: 0 };
+    } else {
+      dragConstraints = { top: maxInset * -1, bottom: 0 };
     }
-    let { drag, _dragX, _dragY, dragMomentum = false, onDragEnd, onPointerDown, ...remainingProps } = containerProps;
-    const dragMotionValue = axis === "x" ? _dragX : _dragY;
-    const dragMomentumAnimation = useRef(null);
-    /**
-     * TODO: This should probably be accomplished with dragMotionValue.jump()
-     * in the onPointerDown handler but investigate why this isn't working.
-     */
-    const stopDragMomentumAnimation = () => {
-        if (!dragMomentumAnimation.current)
-            return;
-        dragMomentumAnimation.current.stop();
-        dragMomentumAnimation.current = null;
+  }
+  let {
+    drag,
+    _dragX,
+    _dragY,
+    dragMomentum = false,
+    onDragEnd,
+    onPointerDown,
+    ...remainingProps
+  } = containerProps;
+  const dragMotionValue = axis === "x" ? _dragX : _dragY;
+  const dragMomentumAnimation = useRef(null);
+  /**
+   * TODO: This should probably be accomplished with dragMotionValue.jump()
+   * in the onPointerDown handler but investigate why this isn't working.
+   */
+  const stopDragMomentumAnimation = () => {
+    if (!dragMomentumAnimation.current) return;
+    dragMomentumAnimation.current.stop();
+    dragMomentumAnimation.current = null;
+  };
+  if (!onDragEnd && drag && dragMotionValue) {
+    onPointerDown = () => {
+      dragMotionValue.jump(offset.get());
+      stopDragMomentumAnimation();
     };
-    if (!onDragEnd && drag && dragMotionValue) {
-        onPointerDown = () => {
-            dragMotionValue.jump(offset.get());
-            stopDragMomentumAnimation();
-        };
-        onDragEnd = (_e, { velocity }) => {
-            const current = offset.get();
-            stopDragMomentumAnimation();
-            frame.postRender(() => {
-                let target = current + velocity[axis] * (snap ? 0.3 : 0.8);
-                if (snap) {
-                    if (velocity[axis] < 0) {
-                        target = -findNextItemInset(-current, state.itemPositions, gap, -target);
-                    }
-                    else if (velocity[axis] > 0) {
-                        target = -findPrevItemInset(-current, state.itemPositions, gap, -target, state.containerLength);
-                    }
-                    else {
-                        const closestNext = -findNextItemInset(-current, state.itemPositions, gap, -current);
-                        const closestPrev = -findPrevItemInset(-current, state.itemPositions, gap, -current, state.containerLength);
-                        target =
-                            Math.abs(current - closestNext) <
-                                Math.abs(current - closestPrev)
-                                ? closestNext
-                                : closestPrev;
-                    }
-                }
-                const constraints = loop
-                    ? {}
-                    : sign > 0
-                        ? {
-                            max: 0,
-                            min: dragConstraints[axis === "x" ? "left" : "top"],
-                        }
-                        : {
-                            min: 0,
-                            max: dragConstraints.right,
-                        };
-                dragMomentumAnimation.current = animate(dragMotionValue, clampOffset(target * sign) * sign, snap
-                    ? pageTransition
-                    : {
-                        type: "inertia",
-                        velocity: velocity[axis],
-                        modifyTarget: () => target,
-                        bounceDamping: 40,
-                        bounceStiffness: 400,
-                        ...constraints,
-                    });
-            });
-        };
+    onDragEnd = (_e, { velocity }) => {
+      const current = offset.get();
+      stopDragMomentumAnimation();
+      frame.postRender(() => {
+        let target = current + velocity[axis] * (snap ? 0.3 : 0.8);
+        if (snap) {
+          if (velocity[axis] < 0) {
+            target = -findNextItemInset(
+              -current,
+              state.itemPositions,
+              gap,
+              -target,
+            );
+          } else if (velocity[axis] > 0) {
+            target = -findPrevItemInset(
+              -current,
+              state.itemPositions,
+              gap,
+              -target,
+              state.containerLength,
+            );
+          } else {
+            const closestNext = -findNextItemInset(
+              -current,
+              state.itemPositions,
+              gap,
+              -current,
+            );
+            const closestPrev = -findPrevItemInset(
+              -current,
+              state.itemPositions,
+              gap,
+              -current,
+              state.containerLength,
+            );
+            target =
+              Math.abs(current - closestNext) < Math.abs(current - closestPrev)
+                ? closestNext
+                : closestPrev;
+          }
+        }
+        const constraints = loop
+          ? {}
+          : sign > 0
+            ? {
+                max: 0,
+                min: dragConstraints[axis === "x" ? "left" : "top"],
+              }
+            : {
+                min: 0,
+                max: dragConstraints.right,
+              };
+        dragMomentumAnimation.current = animate(
+          dragMotionValue,
+          clampOffset(target * sign) * sign,
+          snap
+            ? pageTransition
+            : {
+                type: "inertia",
+                velocity: velocity[axis],
+                modifyTarget: () => target,
+                bounceDamping: 40,
+                bounceStiffness: 400,
+                ...constraints,
+              },
+        );
+      });
+    };
+  }
+  /**
+   * Create mask image to fade edges out
+   */
+  const fadeStartOpacity = useMotionValue(loop ? 0 : 1);
+  const fadeEndOpacity = useMotionValue(0);
+  const strategy = getLayoutStrategy(axis, state.direction);
+  const unit = typeof fade === "number" ? "px" : "";
+  const maskImage = useTransform(() => {
+    return `linear-gradient(to ${strategy.direction}, rgba(0,0,0,${fadeStartOpacity.get()}) 0px, black ${fade}${unit}, black calc(100% - ${fade}${unit}), rgba(0,0,0,${fadeEndOpacity.get()}) 100%)`;
+  });
+  const fadeStyles = fade ? { maskImage, WebkitMaskImage: maskImage } : {};
+  const isAtLimits = useRef({ start: true, end: false });
+  useMotionValueEvent(renderedOffset, "change", (value) => {
+    if (maxInset === null) return;
+    const maxOffset = maxInset * -1;
+    value *= sign;
+    // Start edge
+    if (value < 0) {
+      // If it's currently at the limits, and moves, fade mask out
+      if (isAtLimits.current.start) {
+        animate(fadeStartOpacity, 0, fadeTransition);
+        isAtLimits.current.start = false;
+      }
+    } else {
+      if (!isAtLimits.current.start) {
+        animate(fadeStartOpacity, 1, fadeTransition);
+        isAtLimits.current.start = true;
+      }
     }
-    /**
-     * Create mask image to fade edges out
-     */
-    const fadeStartOpacity = useMotionValue(loop ? 0 : 1);
-    const fadeEndOpacity = useMotionValue(0);
-    const strategy = getLayoutStrategy(axis, state.direction);
-    const unit = typeof fade === "number" ? "px" : "";
-    const maskImage = useTransform(() => {
-        return `linear-gradient(to ${strategy.direction}, rgba(0,0,0,${fadeStartOpacity.get()}) 0px, black ${fade}${unit}, black calc(100% - ${fade}${unit}), rgba(0,0,0,${fadeEndOpacity.get()}) 100%)`;
-    });
-    const fadeStyles = fade ? { maskImage, WebkitMaskImage: maskImage } : {};
-    const isAtLimits = useRef({ start: true, end: false });
-    useMotionValueEvent(renderedOffset, "change", (value) => {
-        if (maxInset === null)
-            return;
-        const maxOffset = maxInset * -1;
-        value *= sign;
-        // Start edge
-        if (value < 0) {
-            // If it's currently at the limits, and moves, fade mask out
-            if (isAtLimits.current.start) {
-                animate(fadeStartOpacity, 0, fadeTransition);
-                isAtLimits.current.start = false;
-            }
-        }
-        else {
-            if (!isAtLimits.current.start) {
-                animate(fadeStartOpacity, 1, fadeTransition);
-                isAtLimits.current.start = true;
-            }
-        }
-        // End edge
-        if (value > maxOffset) {
-            // If it's currently at the limits, and moves, fade mask out
-            if (isAtLimits.current.end) {
-                animate(fadeEndOpacity, 0, fadeTransition);
-                isAtLimits.current.end = false;
-            }
-        }
-        else {
-            if (!isAtLimits.current.end) {
-                animate(fadeEndOpacity, 1, fadeTransition);
-                isAtLimits.current.end = true;
-            }
-        }
-    });
-    return (jsxs(Fragment, { children: [jsx(MotionComponent, { ...remainingProps, ref: containerRef, style: {
-                    overflowX: !overflow && axis === "x" ? "clip" : undefined,
-                    overflowY: !overflow && axis === "y" ? "clip" : undefined,
-                    ...containerStyle,
-                    ...containerProps.style,
-                    ...fadeStyles,
-                }, onPointerEnter: onPointerEnter, onPointerLeave: onPointerLeave, drag: drag, _dragX: _dragX, _dragY: _dragY, dragConstraints: dragConstraints, dragMomentum: dragMomentum, onPointerDown: onPointerDown, onDragEnd: onDragEnd, children: jsxs(motion.ul, { ref: listRef, role: "group", style: {
-                        ...listStyle,
-                        flexDirection: axis === "x" ? "row" : "column",
-                        gap: `${gap}px`,
-                        x: axis === "x" ? renderedOffset : 0,
-                        y: axis === "y" ? renderedOffset : 0,
-                        opacity: isMeasured || isStatic ? 1 : 0,
-                        alignItems,
-                        willChange: isMeasured && isInView ? "transform" : undefined,
-                        width: "100%",
-                        height: "100%",
-                        maxHeight: "100%",
-                        maxWidth: "100%",
-                    }, children: [items.map((item, index) => (jsx(TickerItemWrapper, { axis: axis, offset: renderedOffset, listSize: totalListSize, itemIndex: index, bounds: state.itemPositions[index] ?? defaultBounds, alignItems: alignItems, size: itemSize, reproject: loop, safeMargin: safeMargin, numItems: items.length, children: item }, "original-" + index))), clonedItems || null] }) }), " ", children] }));
+    // End edge
+    if (value > maxOffset) {
+      // If it's currently at the limits, and moves, fade mask out
+      if (isAtLimits.current.end) {
+        animate(fadeEndOpacity, 0, fadeTransition);
+        isAtLimits.current.end = false;
+      }
+    } else {
+      if (!isAtLimits.current.end) {
+        animate(fadeEndOpacity, 1, fadeTransition);
+        isAtLimits.current.end = true;
+      }
+    }
+  });
+  return jsxs(Fragment, {
+    children: [
+      jsx(MotionComponent, {
+        ...remainingProps,
+        ref: containerRef,
+        style: {
+          overflowX: !overflow && axis === "x" ? "clip" : undefined,
+          overflowY: !overflow && axis === "y" ? "clip" : undefined,
+          ...containerStyle,
+          ...containerProps.style,
+          ...fadeStyles,
+        },
+        onPointerEnter: onPointerEnter,
+        onPointerLeave: onPointerLeave,
+        drag: drag,
+        _dragX: _dragX,
+        _dragY: _dragY,
+        dragConstraints: dragConstraints,
+        dragMomentum: dragMomentum,
+        onPointerDown: onPointerDown,
+        onDragEnd: onDragEnd,
+        children: jsxs(motion.ul, {
+          ref: listRef,
+          role: "group",
+          style: {
+            ...listStyle,
+            flexDirection: axis === "x" ? "row" : "column",
+            gap: `${gap}px`,
+            x: axis === "x" ? renderedOffset : 0,
+            y: axis === "y" ? renderedOffset : 0,
+            opacity: isMeasured || isStatic ? 1 : 0,
+            alignItems,
+            willChange: isMeasured && isInView ? "transform" : undefined,
+            width: "100%",
+            height: "100%",
+            maxHeight: "100%",
+            maxWidth: "100%",
+          },
+          children: [
+            items.map((item, index) =>
+              jsx(
+                TickerItemWrapper,
+                {
+                  axis: axis,
+                  offset: renderedOffset,
+                  listSize: totalListSize,
+                  itemIndex: index,
+                  bounds: state.itemPositions[index] ?? defaultBounds,
+                  alignItems: alignItems,
+                  size: itemSize,
+                  reproject: loop,
+                  safeMargin: safeMargin,
+                  numItems: items.length,
+                  children: item,
+                },
+                "original-" + index,
+              ),
+            ),
+            clonedItems || null,
+          ],
+        }),
+      }),
+      " ",
+      children,
+    ],
+  });
 }
 const defaultBounds = { start: 0, end: 0 };
 const containerStyle = {
-    display: "flex",
-    position: "relative",
+  display: "flex",
+  position: "relative",
 };
 const listStyle = {
-    display: "flex",
-    position: "relative",
-    willChange: "transform",
-    listStyleType: "none",
-    padding: 0,
-    margin: 0,
-    justifyContent: "flex-start",
+  display: "flex",
+  position: "relative",
+  willChange: "transform",
+  listStyleType: "none",
+  padding: 0,
+  margin: 0,
+  justifyContent: "flex-start",
 };
 const defaultFadeTransition = {
-    duration: 0.2,
-    ease: "linear",
+  duration: 0.2,
+  ease: "linear",
 };
 
 export { Ticker };

--- a/apps/web/src/lib/Ticker/use-focus-navigation.mjs
+++ b/apps/web/src/lib/Ticker/use-focus-navigation.mjs
@@ -1,168 +1,194 @@
-import { isHTMLElement, wrap, frame } from 'motion/react';
-import { useRef, useEffect } from 'react';
+import { isHTMLElement, wrap, frame } from "motion/react";
+import { useRef, useEffect } from "react";
 
-function useFocusNavigation(containerRef, axis, focusOffset, offset, setHasFocus) {
-    const isFocusTrapped = useRef(false);
-    useEffect(() => {
-        const container = containerRef.current;
-        if (!container)
-            return;
-        let detectionEnabled = false;
-        const abortController = new AbortController();
-        const eventOptions = {
-            signal: abortController.signal,
-        };
-        const eventOptionsWithCapture = {
-            ...eventOptions,
-            capture: true,
-        };
-        const scrollProp = axis === "x" ? "scrollLeft" : "scrollTop";
-        const offsetProp = axis === "x" ? "offsetLeft" : "offsetTop";
-        const leftKey = axis === "x" ? "ArrowLeft" : "ArrowUp";
-        const rightKey = axis === "x" ? "ArrowRight" : "ArrowDown";
-        let focusableElements = [];
-        let focusIndex = 0;
-        const applyFocusOffset = () => {
-            const nextFocusableElement = focusableElements[focusIndex];
-            if (!nextFocusableElement)
-                return;
-            nextFocusableElement.focus();
-            // Move the ticker offset to the focused item
-            focusOffset.set(-nextFocusableElement[offsetProp]);
-            // Override the default browser scroll into view behaviour
-            container[scrollProp] = 0;
-            frame.render(() => {
-                container[scrollProp] = 0;
-            });
-        };
-        const handleFocusNavigation = (event) => {
-            if (event.key === "Tab") {
-                event.preventDefault();
-                // Focus the next selectable element in the DOM outside the container
-                endFocusTrap();
-                // Find the next focusable element after the container
-                const allFocusableElements = Array.from(document.querySelectorAll('a, button, input, textarea, select, [tabindex]:not([tabindex="-1"]), [contenteditable="true"]')).filter(isHTMLElement);
-                // Sort the focusable elements by their tabIndex
-                allFocusableElements.sort(compareTabIndexes);
-                const lastFocusableElement = allFocusableElements[event.shiftKey ? 0 : allFocusableElements.length - 1];
-                const initialIndex = event.shiftKey
-                    ? allFocusableElements.length - 1
-                    : 0;
-                /**
-                 * If the last focusable element in the DOM is inside the container
-                 * then we want to set focus on the first DOM element
-                 */
-                if (container.contains(lastFocusableElement)) {
-                    allFocusableElements[initialIndex].focus();
-                    return;
-                }
-                else {
-                    const indexOfCurrentElement = allFocusableElements.indexOf(focusableElements[focusIndex]);
-                    const delta = event.shiftKey ? -1 : 1;
-                    for (let i = indexOfCurrentElement; i < allFocusableElements.length && i >= 0; i += delta) {
-                        const element = allFocusableElements[i];
-                        if (!container.contains(element)) {
-                            element.focus();
-                            return;
-                        }
-                    }
-                }
-                return;
+function useFocusNavigation(
+  containerRef,
+  axis,
+  focusOffset,
+  offset,
+  setHasFocus,
+) {
+  const isFocusTrapped = useRef(false);
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    let detectionEnabled = false;
+    const abortController = new AbortController();
+    const eventOptions = {
+      signal: abortController.signal,
+    };
+    const eventOptionsWithCapture = {
+      ...eventOptions,
+      capture: true,
+    };
+    const scrollProp = axis === "x" ? "scrollLeft" : "scrollTop";
+    const offsetProp = axis === "x" ? "offsetLeft" : "offsetTop";
+    const leftKey = axis === "x" ? "ArrowLeft" : "ArrowUp";
+    const rightKey = axis === "x" ? "ArrowRight" : "ArrowDown";
+    let focusableElements = [];
+    let focusIndex = 0;
+    const applyFocusOffset = () => {
+      const nextFocusableElement = focusableElements[focusIndex];
+      if (!nextFocusableElement) return;
+      nextFocusableElement.focus();
+      // Move the ticker offset to the focused item
+      focusOffset.set(-nextFocusableElement[offsetProp]);
+      // Override the default browser scroll into view behaviour
+      container[scrollProp] = 0;
+      frame.render(() => {
+        container[scrollProp] = 0;
+      });
+    };
+    const handleFocusNavigation = (event) => {
+      if (event.key === "Tab") {
+        event.preventDefault();
+        // Focus the next selectable element in the DOM outside the container
+        endFocusTrap();
+        // Find the next focusable element after the container
+        const allFocusableElements = Array.from(
+          document.querySelectorAll(
+            'a, button, input, textarea, select, [tabindex]:not([tabindex="-1"]), [contenteditable="true"]',
+          ),
+        ).filter(isHTMLElement);
+        // Sort the focusable elements by their tabIndex
+        allFocusableElements.sort(compareTabIndexes);
+        const lastFocusableElement =
+          allFocusableElements[
+            event.shiftKey ? 0 : allFocusableElements.length - 1
+          ];
+        const initialIndex = event.shiftKey
+          ? allFocusableElements.length - 1
+          : 0;
+        /**
+         * If the last focusable element in the DOM is inside the container
+         * then we want to set focus on the first DOM element
+         */
+        if (container.contains(lastFocusableElement)) {
+          allFocusableElements[initialIndex].focus();
+          return;
+        } else {
+          const indexOfCurrentElement = allFocusableElements.indexOf(
+            focusableElements[focusIndex],
+          );
+          const delta = event.shiftKey ? -1 : 1;
+          for (
+            let i = indexOfCurrentElement;
+            i < allFocusableElements.length && i >= 0;
+            i += delta
+          ) {
+            const element = allFocusableElements[i];
+            if (!container.contains(element)) {
+              element.focus();
+              return;
             }
-            else if (event.key === leftKey) {
-                focusIndex--;
-            }
-            else if (event.key === rightKey) {
-                focusIndex++;
-            }
-            focusIndex = wrap(0, focusableElements.length, focusIndex);
-            applyFocusOffset();
-        };
-        const startFocusTrap = () => {
-            if (isFocusTrapped.current)
-                return;
-            // Get all focusable elements within .ticker-item elements
-            focusableElements = Array.from(container.querySelectorAll('.ticker-item a, .ticker-item button, .ticker-item input, .ticker-item textarea, .ticker-item select, .ticker-item [tabindex]:not([tabindex="-1"]), .ticker-item [contenteditable="true"]')).filter(isHTMLElement);
-            focusIndex = 0;
-            if (!focusableElements.length)
-                return;
-            setHasFocus(true);
-            isFocusTrapped.current = true;
-            applyFocusOffset();
-            window.addEventListener("focus", detectTrapEnd, eventOptionsWithCapture);
-            window.addEventListener("blur", detectTrapEnd, eventOptionsWithCapture);
-            container.addEventListener("keydown", handleFocusNavigation, eventOptions);
-        };
-        const detectTrapEnd = (event) => {
-            if (!event.target ||
-                !(event.target instanceof HTMLElement) ||
-                !container.contains(event.target)) {
-                endFocusTrap();
-            }
-        };
-        const endFocusTrap = () => {
-            if (!isFocusTrapped.current)
-                return;
-            isFocusTrapped.current = false;
-            setHasFocus(false);
-            offset.set(focusOffset.get());
-            window.removeEventListener("focus", detectTrapEnd);
-            window.removeEventListener("blur", detectTrapEnd);
-            container.removeEventListener("keydown", handleFocusNavigation);
-        };
-        const handleFocus = (event) => {
-            const { target } = event;
-            if (!isHTMLElement(target))
-                return;
-            if (!isFocusTrapped.current) {
-                startFocusTrap();
-            }
-        };
-        const detectFocusTrapEnable = () => {
-            if (detectionEnabled)
-                return;
-            detectionEnabled = true;
-            container.addEventListener("focus", handleFocus, eventOptionsWithCapture);
-            window.addEventListener("pointermove", handlePointerMove, eventOptions);
-        };
-        const handlePointerMove = () => {
-            if (!detectionEnabled)
-                return;
-            detectionEnabled = false;
-            container.removeEventListener("focus", handleFocus, true);
-            window.removeEventListener("pointermove", handlePointerMove, eventOptions);
-        };
-        const handleAriaHiddenClicks = (event) => {
-            const target = event.target;
-            // Check if target is a descendant of an element with aria-hidden="true"
-            let ariaHiddenAncestor = target.closest('[aria-hidden="true"]');
-            if (ariaHiddenAncestor) {
-                ariaHiddenAncestor.removeAttribute("aria-hidden");
-            }
-        };
-        window.addEventListener("keydown", detectFocusTrapEnable, eventOptions);
-        container.addEventListener("pointerdown", handleAriaHiddenClicks, eventOptions);
-        return () => {
-            abortController.abort();
-            endFocusTrap();
-        };
-    }, []);
+          }
+        }
+        return;
+      } else if (event.key === leftKey) {
+        focusIndex--;
+      } else if (event.key === rightKey) {
+        focusIndex++;
+      }
+      focusIndex = wrap(0, focusableElements.length, focusIndex);
+      applyFocusOffset();
+    };
+    const startFocusTrap = () => {
+      if (isFocusTrapped.current) return;
+      // Get all focusable elements within .ticker-item elements
+      focusableElements = Array.from(
+        container.querySelectorAll(
+          '.ticker-item a, .ticker-item button, .ticker-item input, .ticker-item textarea, .ticker-item select, .ticker-item [tabindex]:not([tabindex="-1"]), .ticker-item [contenteditable="true"]',
+        ),
+      ).filter(isHTMLElement);
+      focusIndex = 0;
+      if (!focusableElements.length) return;
+      setHasFocus(true);
+      isFocusTrapped.current = true;
+      applyFocusOffset();
+      window.addEventListener("focus", detectTrapEnd, eventOptionsWithCapture);
+      window.addEventListener("blur", detectTrapEnd, eventOptionsWithCapture);
+      container.addEventListener(
+        "keydown",
+        handleFocusNavigation,
+        eventOptions,
+      );
+    };
+    const detectTrapEnd = (event) => {
+      if (
+        !event.target ||
+        !(event.target instanceof HTMLElement) ||
+        !container.contains(event.target)
+      ) {
+        endFocusTrap();
+      }
+    };
+    const endFocusTrap = () => {
+      if (!isFocusTrapped.current) return;
+      isFocusTrapped.current = false;
+      setHasFocus(false);
+      offset.set(focusOffset.get());
+      window.removeEventListener("focus", detectTrapEnd);
+      window.removeEventListener("blur", detectTrapEnd);
+      container.removeEventListener("keydown", handleFocusNavigation);
+    };
+    const handleFocus = (event) => {
+      const { target } = event;
+      if (!isHTMLElement(target)) return;
+      if (!isFocusTrapped.current) {
+        startFocusTrap();
+      }
+    };
+    const detectFocusTrapEnable = () => {
+      if (detectionEnabled) return;
+      detectionEnabled = true;
+      container.addEventListener("focus", handleFocus, eventOptionsWithCapture);
+      window.addEventListener("pointermove", handlePointerMove, eventOptions);
+    };
+    const handlePointerMove = () => {
+      if (!detectionEnabled) return;
+      detectionEnabled = false;
+      container.removeEventListener("focus", handleFocus, true);
+      window.removeEventListener(
+        "pointermove",
+        handlePointerMove,
+        eventOptions,
+      );
+    };
+    const handleAriaHiddenClicks = (event) => {
+      const target = event.target;
+      // Check if target is a descendant of an element with aria-hidden="true"
+      let ariaHiddenAncestor = target.closest('[aria-hidden="true"]');
+      if (ariaHiddenAncestor) {
+        ariaHiddenAncestor.removeAttribute("aria-hidden");
+      }
+    };
+    window.addEventListener("keydown", detectFocusTrapEnable, eventOptions);
+    container.addEventListener(
+      "pointerdown",
+      handleAriaHiddenClicks,
+      eventOptions,
+    );
+    return () => {
+      abortController.abort();
+      endFocusTrap();
+    };
+  }, []);
 }
 function compareTabIndexes(a, b) {
-    // Elements with tabIndex >= 1 come first, ordered by tabIndex value
-    if (a.tabIndex >= 1 && b.tabIndex >= 1) {
-        return a.tabIndex - b.tabIndex;
-    }
-    // Elements with tabIndex >= 1 come before tabIndex 0 or -1
-    if (a.tabIndex >= 1 && b.tabIndex <= 0) {
-        return -1;
-    }
-    if (b.tabIndex >= 1 && a.tabIndex <= 0) {
-        return 1;
-    }
-    // Both have tabIndex 0 or -1, maintain document order (return 0)
-    // tabIndex -1 elements are focusable programmatically but not via tab navigation
-    return 0;
+  // Elements with tabIndex >= 1 come first, ordered by tabIndex value
+  if (a.tabIndex >= 1 && b.tabIndex >= 1) {
+    return a.tabIndex - b.tabIndex;
+  }
+  // Elements with tabIndex >= 1 come before tabIndex 0 or -1
+  if (a.tabIndex >= 1 && b.tabIndex <= 0) {
+    return -1;
+  }
+  if (b.tabIndex >= 1 && a.tabIndex <= 0) {
+    return 1;
+  }
+  // Both have tabIndex 0 or -1, maintain document order (return 0)
+  // tabIndex -1 elements are focusable programmatically but not via tab navigation
+  return 0;
 }
 
 export { useFocusNavigation };

--- a/apps/web/src/lib/Ticker/use-ticker-item.mjs
+++ b/apps/web/src/lib/Ticker/use-ticker-item.mjs
@@ -1,11 +1,14 @@
-import { invariant } from 'motion-utils';
-import { useContext } from 'react';
-import { TickerItemContext } from './TickerItemContext.mjs';
+import { invariant } from "motion-utils";
+import { useContext } from "react";
+import { TickerItemContext } from "./TickerItemContext.mjs";
 
 function useTickerItem() {
-    const itemContext = useContext(TickerItemContext);
-    invariant(Boolean(itemContext), "useTickerItem must be used within a TickerItem");
-    return itemContext;
+  const itemContext = useContext(TickerItemContext);
+  invariant(
+    Boolean(itemContext),
+    "useTickerItem must be used within a TickerItem",
+  );
+  return itemContext;
 }
 
 export { useTickerItem };

--- a/apps/web/src/lib/Ticker/utils/calc-num-clones.mjs
+++ b/apps/web/src/lib/Ticker/utils/calc-num-clones.mjs
@@ -1,18 +1,21 @@
-import { calcTotalItemLength, calcItemLength } from './calc-total-item-length.mjs';
+import {
+  calcTotalItemLength,
+  calcItemLength,
+} from "./calc-total-item-length.mjs";
 
 function calcNumClones(visibleLength, itemPositions, gap) {
-    const totalItemLength = calcTotalItemLength(itemPositions);
-    const maxItemLength = Math.max(...itemPositions.map(calcItemLength));
-    let count = 0;
-    /**
-     * A length where the largest item is out of the visible area.
-     */
-    let safeFillLength = 0;
-    while (safeFillLength < visibleLength) {
-        safeFillLength = (totalItemLength + gap) * (count + 1) - maxItemLength;
-        count++;
-    }
-    return Math.max(count - 1, 0);
+  const totalItemLength = calcTotalItemLength(itemPositions);
+  const maxItemLength = Math.max(...itemPositions.map(calcItemLength));
+  let count = 0;
+  /**
+   * A length where the largest item is out of the visible area.
+   */
+  let safeFillLength = 0;
+  while (safeFillLength < visibleLength) {
+    safeFillLength = (totalItemLength + gap) * (count + 1) - maxItemLength;
+    count++;
+  }
+  return Math.max(count - 1, 0);
 }
 
 export { calcNumClones };

--- a/apps/web/src/lib/Ticker/utils/calc-total-item-length.mjs
+++ b/apps/web/src/lib/Ticker/utils/calc-total-item-length.mjs
@@ -1,8 +1,8 @@
 function calcItemLength(itemPosition) {
-    return itemPosition.end - itemPosition.start;
+  return itemPosition.end - itemPosition.start;
 }
 function calcTotalItemLength(itemPositions) {
-    return itemPositions[itemPositions.length - 1].end - itemPositions[0].start;
+  return itemPositions[itemPositions.length - 1].end - itemPositions[0].start;
 }
 
 export { calcItemLength, calcTotalItemLength };

--- a/apps/web/src/lib/Ticker/utils/layout-strategy.mjs
+++ b/apps/web/src/lib/Ticker/utils/layout-strategy.mjs
@@ -1,59 +1,77 @@
-const ltrStrategy = (insetProp, lengthProp, viewportLengthProp, paddingStartProp, direction) => {
-    return {
-        sign: 1,
-        direction,
-        lengthProp,
-        viewportLengthProp,
-        paddingStartProp,
-        measureItem: (item) => {
-            return {
-                start: item[insetProp],
-                end: item[insetProp] + item[lengthProp],
-            };
-        },
-        getCumulativeInset: (element) => {
-            let offset = 0;
-            let el = element;
-            while (el) {
-                offset += el[insetProp];
-                el = el.offsetParent;
-            }
-            return offset;
-        },
-    };
-};
-const xStrategy = ltrStrategy("offsetLeft", "offsetWidth", "innerWidth", "paddingLeft", "right");
-const yStrategy = ltrStrategy("offsetTop", "offsetHeight", "innerHeight", "paddingTop", "bottom");
-function offsetRight(element, container) {
-    const containerWidth = container?.offsetWidth ?? window.innerWidth;
-    return containerWidth - (element.offsetLeft + element.offsetWidth);
-}
-const xRtlStrategy = {
-    ...xStrategy,
-    sign: -1,
-    direction: "left",
-    paddingStartProp: "paddingRight",
-    measureItem: (item, container) => {
-        const length = item.offsetWidth;
-        const start = offsetRight(item, container);
-        return { start, end: start + length };
+const ltrStrategy = (
+  insetProp,
+  lengthProp,
+  viewportLengthProp,
+  paddingStartProp,
+  direction,
+) => {
+  return {
+    sign: 1,
+    direction,
+    lengthProp,
+    viewportLengthProp,
+    paddingStartProp,
+    measureItem: (item) => {
+      return {
+        start: item[insetProp],
+        end: item[insetProp] + item[lengthProp],
+      };
     },
     getCumulativeInset: (element) => {
-        let offset = 0;
-        let el = element;
-        while (el) {
-            offset += offsetRight(el, el.offsetParent);
-            el = el.offsetParent;
-        }
-        return offset;
+      let offset = 0;
+      let el = element;
+      while (el) {
+        offset += el[insetProp];
+        el = el.offsetParent;
+      }
+      return offset;
     },
+  };
+};
+const xStrategy = ltrStrategy(
+  "offsetLeft",
+  "offsetWidth",
+  "innerWidth",
+  "paddingLeft",
+  "right",
+);
+const yStrategy = ltrStrategy(
+  "offsetTop",
+  "offsetHeight",
+  "innerHeight",
+  "paddingTop",
+  "bottom",
+);
+function offsetRight(element, container) {
+  const containerWidth = container?.offsetWidth ?? window.innerWidth;
+  return containerWidth - (element.offsetLeft + element.offsetWidth);
+}
+const xRtlStrategy = {
+  ...xStrategy,
+  sign: -1,
+  direction: "left",
+  paddingStartProp: "paddingRight",
+  measureItem: (item, container) => {
+    const length = item.offsetWidth;
+    const start = offsetRight(item, container);
+    return { start, end: start + length };
+  },
+  getCumulativeInset: (element) => {
+    let offset = 0;
+    let el = element;
+    while (el) {
+      offset += offsetRight(el, el.offsetParent);
+      el = el.offsetParent;
+    }
+    return offset;
+  },
 };
 function getLayoutStrategy(axis, direction) {
-    return axis === "y"
-        ? yStrategy
-        : direction === "ltr"
-            ? xStrategy
-            : xRtlStrategy;
+  return axis === "y"
+    ? yStrategy
+    : direction === "ltr"
+      ? xStrategy
+      : xRtlStrategy;
 }
 
 export { getLayoutStrategy };

--- a/apps/web/src/lib/types.test.ts
+++ b/apps/web/src/lib/types.test.ts
@@ -3,9 +3,18 @@ import type { VestaEvent } from "./types";
 
 describe("VestaEvent contract", () => {
   const EXPECTED_TYPES = [
-    "status", "user", "assistant", "thinking", "chat",
-    "tool_start", "tool_end", "error", "notification",
-    "subagent_start", "subagent_stop", "history",
+    "status",
+    "user",
+    "assistant",
+    "thinking",
+    "chat",
+    "tool_start",
+    "tool_end",
+    "error",
+    "notification",
+    "subagent_start",
+    "subagent_stop",
+    "history",
   ] as const;
 
   it("covers all expected event types", () => {
@@ -15,22 +24,39 @@ describe("VestaEvent contract", () => {
   });
 
   it("tool_start includes subagent field", () => {
-    const event: VestaEvent = { type: "tool_start", tool: "Bash", input: "ls", subagent: false };
+    const event: VestaEvent = {
+      type: "tool_start",
+      tool: "Bash",
+      input: "ls",
+      subagent: false,
+    };
     expect(event.type).toBe("tool_start");
   });
 
   it("tool_end includes subagent field", () => {
-    const event: VestaEvent = { type: "tool_end", tool: "Bash", subagent: true };
+    const event: VestaEvent = {
+      type: "tool_end",
+      tool: "Bash",
+      subagent: true,
+    };
     expect(event.type).toBe("tool_end");
   });
 
   it("subagent_start has required fields", () => {
-    const event: VestaEvent = { type: "subagent_start", agent_id: "abc", agent_type: "browser" };
+    const event: VestaEvent = {
+      type: "subagent_start",
+      agent_id: "abc",
+      agent_type: "browser",
+    };
     expect(event.type).toBe("subagent_start");
   });
 
   it("subagent_stop has required fields", () => {
-    const event: VestaEvent = { type: "subagent_stop", agent_id: "abc", agent_type: "browser" };
+    const event: VestaEvent = {
+      type: "subagent_stop",
+      agent_id: "abc",
+      agent_type: "browser",
+    };
     expect(event.type).toBe("subagent_stop");
   });
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -32,12 +32,25 @@ export type VestaEvent =
   | (BaseEvent & { type: "assistant"; text: string })
   | (BaseEvent & { type: "thinking"; text: string; signature: string })
   | (BaseEvent & { type: "chat"; text: string })
-  | (BaseEvent & { type: "tool_start"; tool: string; input: string; subagent?: boolean })
+  | (BaseEvent & {
+      type: "tool_start";
+      tool: string;
+      input: string;
+      subagent?: boolean;
+    })
   | (BaseEvent & { type: "tool_end"; tool: string; subagent?: boolean })
   | (BaseEvent & { type: "error"; text: string })
   | (BaseEvent & { type: "notification"; source: string; summary: string })
-  | (BaseEvent & { type: "subagent_start"; agent_id: string; agent_type: string })
-  | (BaseEvent & { type: "subagent_stop"; agent_id: string; agent_type: string })
+  | (BaseEvent & {
+      type: "subagent_start";
+      agent_id: string;
+      agent_type: string;
+    })
+  | (BaseEvent & {
+      type: "subagent_stop";
+      agent_id: string;
+      agent_type: string;
+    })
   | (BaseEvent & {
       type: "history";
       events: VestaEvent[];

--- a/apps/web/src/lib/voice.ts
+++ b/apps/web/src/lib/voice.ts
@@ -129,15 +129,12 @@ export function prefetchSpeech(
   agentName: string,
   signal?: AbortSignal,
 ): Promise<Response> {
-  return apiFetch(
-    `/agents/${encodeURIComponent(agentName)}/voice/tts/speak`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text }),
-      signal,
-    },
-  );
+  return apiFetch(`/agents/${encodeURIComponent(agentName)}/voice/tts/speak`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+    signal,
+  });
 }
 
 export async function streamSpeech(
@@ -146,7 +143,7 @@ export async function streamSpeech(
   signal?: AbortSignal,
   prefetched?: Response,
 ): Promise<void> {
-  const res = prefetched ?? await prefetchSpeech(text, agentName, signal);
+  const res = prefetched ?? (await prefetchSpeech(text, agentName, signal));
 
   const contentType = res.headers.get("content-type") || "";
   if (contentType.includes("audio/mpeg") || contentType.includes("audio/mp3")) {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,7 +11,6 @@ const platform = detectPlatform();
 const d = document.documentElement;
 d.dataset.platform = platform;
 
-
 if (isTauri) {
   d.classList.add("tauri");
   if (platform === "macos" || platform === "windows" || platform === "linux") {

--- a/apps/web/src/providers/ChatProvider/use-chat.ts
+++ b/apps/web/src/providers/ChatProvider/use-chat.ts
@@ -13,7 +13,10 @@ const TYPING_DELAY_MAX = 6000;
 const TYPING_VARIANCE = 0.2;
 
 function typingDelay(charCount: number): number {
-  const raw = Math.min(TYPING_DELAY_MIN + TYPING_DELAY_PER_CHAR * charCount, TYPING_DELAY_MAX);
+  const raw = Math.min(
+    TYPING_DELAY_MIN + TYPING_DELAY_PER_CHAR * charCount,
+    TYPING_DELAY_MAX,
+  );
   const variance = Math.floor(raw * TYPING_VARIANCE);
   return raw + Math.floor(Math.random() * variance * 2) - variance;
 }
@@ -33,7 +36,12 @@ interface UseChatOptions {
   onPrefetch?: (text: string) => void;
 }
 
-export function useChat({ name, active, onAssistantMessage, onPrefetch }: UseChatOptions) {
+export function useChat({
+  name,
+  active,
+  onAssistantMessage,
+  onPrefetch,
+}: UseChatOptions) {
   const [messages, setMessages] = useState<VestaEvent[]>([]);
   const [agentState, setAgentState] = useState<AgentActivityState>("idle");
   const [isTyping, setIsTyping] = useState(false);
@@ -57,7 +65,9 @@ export function useChat({ name, active, onAssistantMessage, onPrefetch }: UseCha
     for (const event of chatQueueRef.current) {
       setMessages((prev) => {
         const updated = [...prev, event];
-        return updated.length > MAX_MESSAGES ? updated.slice(-MAX_MESSAGES) : updated;
+        return updated.length > MAX_MESSAGES
+          ? updated.slice(-MAX_MESSAGES)
+          : updated;
       });
       if (event.type === "chat") {
         onAssistantMessageRef.current?.(event.text);
@@ -89,7 +99,9 @@ export function useChat({ name, active, onAssistantMessage, onPrefetch }: UseCha
       queue.shift();
       setMessages((prev) => {
         const updated = [...prev, next];
-        return updated.length > MAX_MESSAGES ? updated.slice(-MAX_MESSAGES) : updated;
+        return updated.length > MAX_MESSAGES
+          ? updated.slice(-MAX_MESSAGES)
+          : updated;
       });
       if (text) {
         onAssistantMessageRef.current?.(text);
@@ -99,10 +111,13 @@ export function useChat({ name, active, onAssistantMessage, onPrefetch }: UseCha
     }, delay);
   }, [flushQueue]);
 
-  const enqueueChatMessage = useCallback((event: VestaEvent) => {
-    chatQueueRef.current.push(event);
-    drainQueue();
-  }, [drainQueue]);
+  const enqueueChatMessage = useCallback(
+    (event: VestaEvent) => {
+      chatQueueRef.current.push(event);
+      drainQueue();
+    },
+    [drainQueue],
+  );
 
   useEffect(() => {
     if (!active || !name) return;

--- a/apps/web/src/providers/GatewayProvider/index.tsx
+++ b/apps/web/src/providers/GatewayProvider/index.tsx
@@ -120,7 +120,8 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
         setUpdateAvailable(!!data.update_available);
         setLatestVersion(data.latest_version ?? null);
         setVersionChecked(true);
-        if (data.version !== __APP_VERSION__ && !skipVersionGateRef.current) return;
+        if (data.version !== __APP_VERSION__ && !skipVersionGateRef.current)
+          return;
       }
       if (!cancelled) setVersionChecked(true);
 

--- a/apps/web/src/providers/KeybindProvider/index.tsx
+++ b/apps/web/src/providers/KeybindProvider/index.tsx
@@ -13,7 +13,9 @@ interface SpacebarModeState {
 }
 
 export const useSpacebarMode = create<SpacebarModeState>((set) => ({
-  mode: (localStorage.getItem(STORAGE_KEY) === "hold" ? "hold" : "toggle") as SpacebarMode,
+  mode: (localStorage.getItem(STORAGE_KEY) === "hold"
+    ? "hold"
+    : "toggle") as SpacebarMode,
   setMode: (mode) => {
     localStorage.setItem(STORAGE_KEY, mode);
     set({ mode });

--- a/apps/web/src/providers/NotificationProvider/index.tsx
+++ b/apps/web/src/providers/NotificationProvider/index.tsx
@@ -56,7 +56,9 @@ interface NotificationContextValue {
   setChattingAgent: (agentName: string | null) => void;
 }
 
-const NotificationContext = createContext<NotificationContextValue | null>(null);
+const NotificationContext = createContext<NotificationContextValue | null>(
+  null,
+);
 
 export function useNotifications(): NotificationContextValue {
   return (
@@ -102,7 +104,10 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
     const body = text.trim();
     if (!body) return;
     try {
-      const n = new Notification(agentName, { body: truncate(body), tag: agentName });
+      const n = new Notification(agentName, {
+        body: truncate(body),
+        tag: agentName,
+      });
       const autoClose = setTimeout(() => n.close(), NOTIFICATION_AUTO_CLOSE_MS);
       n.onclick = () => {
         clearTimeout(autoClose);

--- a/apps/web/src/providers/TauriProvider/index.tsx
+++ b/apps/web/src/providers/TauriProvider/index.tsx
@@ -29,7 +29,9 @@ const info: TauriInfo = {
   isLinux: platform === "linux",
   isIOS: platform === "ios",
   isAndroid: platform === "android",
-  vibrancy: isTauri && (platform === "macos" || platform === "windows" || platform === "linux"),
+  vibrancy:
+    isTauri &&
+    (platform === "macos" || platform === "windows" || platform === "linux"),
 };
 
 export function TauriProvider({ children }: { children: ReactNode }) {

--- a/apps/web/src/stores/use-voice.ts
+++ b/apps/web/src/stores/use-voice.ts
@@ -90,7 +90,9 @@ export const useVoice = create<VoiceState>((set, get) => {
       try {
         const cached = ttsPrefetchCache.get(text);
         ttsPrefetchCache.delete(text);
-        const prefetched = cached ? await cached.catch(() => undefined) : undefined;
+        const prefetched = cached
+          ? await cached.catch(() => undefined)
+          : undefined;
         await streamSpeech(text, agentName, controller.signal, prefetched);
       } catch (err) {
         if (!controller.signal.aborted) {
@@ -137,8 +139,7 @@ export const useVoice = create<VoiceState>((set, get) => {
       const { sttAvailable, agentName } = get();
       if (!sttAvailable || !agentName) {
         set({
-          voiceError:
-            "Voice input not configured — ask the agent to set it up",
+          voiceError: "Voice input not configured — ask the agent to set it up",
         });
         return;
       }

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -3,15 +3,9 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": [
-      "ES2022",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": [
-      "vite/client"
-    ],
+    "types": ["vite/client"],
     "skipLibCheck": true,
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -28,12 +22,8 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -10,9 +10,7 @@
   ],
   "compilerOptions": {
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   }
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -12,7 +12,9 @@ function resolveInNodeModules(pkgRelPath: string): string {
     if (existsSync(candidate)) return candidate;
     const parent = path.dirname(dir);
     if (parent === dir) {
-      throw new Error(`could not find node_modules/${pkgRelPath} walking up from ${__dirname}`);
+      throw new Error(
+        `could not find node_modules/${pkgRelPath} walking up from ${__dirname}`,
+      );
     }
     dir = parent;
   }
@@ -35,7 +37,9 @@ const versionMatch = cargoToml.match(
   /\[package\][^[]*?\nversion\s*=\s*"([^"]+)"/,
 );
 if (!versionMatch) {
-  throw new Error("could not read [package] version from ../../vestad/Cargo.toml");
+  throw new Error(
+    "could not read [package] version from ../../vestad/Cargo.toml",
+  );
 }
 const version = versionMatch[1];
 
@@ -87,7 +91,9 @@ export default defineConfig({
     port: isTauri ? 1420 : 1430,
     strictPort: true,
     host: host || "0.0.0.0",
-    hmr: host ? { protocol: "ws", host, port: isTauri ? 1421 : 1431 } : undefined,
+    hmr: host
+      ? { protocol: "ws", host, port: isTauri ? 1421 : 1431 }
+      : undefined,
     proxy: host
       ? undefined
       : {

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -1,5 +1,5 @@
 {
   "name": "vesta",
   "pages_build_output_dir": "dist",
-  "compatibility_date": "2026-04-04"
+  "compatibility_date": "2026-04-04",
 }

--- a/scripts/prepare-for-pr.sh
+++ b/scripts/prepare-for-pr.sh
@@ -141,7 +141,7 @@ else
     run_in apps "npm install" npm install
   fi
   run_in apps "web lint"         npm -w @vesta/web run lint
-  run_in apps "web format check" npm -w @vesta/web run format -- --check
+  run_in apps "web format check" npm -w @vesta/web run format:check
   run_in apps "web type check"   npm -w @vesta/web run check
   run_in apps "web tests"        npm -w @vesta/web run test
 fi

--- a/scripts/sync-dashboard.sh
+++ b/scripts/sync-dashboard.sh
@@ -17,9 +17,9 @@ cp "$APP_SRC/hooks/use-mobile.ts" "$DASHBOARD_SRC/hooks/use-mobile.ts"
 cp "$APP_SRC/components/ui/"*.tsx "$DASHBOARD_SRC/components/ui/"
 
 # Patch index.css for iframe embedding (transparent background, tailwind sources)
-sed -i 's/bg-background //g; s/ bg-background//g; s/bg-background//g' "$DASHBOARD_SRC/index.css"
-sed -i '/html {/{n;s|$|\n    background: transparent;|}' "$DASHBOARD_SRC/index.css"
-sed -i '/body {/{n;s|$|\n    background: transparent;|}' "$DASHBOARD_SRC/index.css"
-sed -i '1s|^|@source "./components/ui";\n@source "./lib";\n@source "./hooks";\n|' "$DASHBOARD_SRC/index.css"
+# Use perl for portable in-place editing (BSD/macOS sed differs from GNU sed).
+perl -i -pe 's/bg-background ?//g; s/ bg-background//g' "$DASHBOARD_SRC/index.css"
+perl -i -pe 's|^(\s*html \{)$|$1\n    background: transparent;|; s|^(\s*body \{)$|$1\n    background: transparent;|' "$DASHBOARD_SRC/index.css"
+perl -i -pe 'print "\@source \"./components/ui\";\n\@source \"./lib\";\n\@source \"./hooks\";\n" if $. == 1' "$DASHBOARD_SRC/index.css"
 
 echo "Synced $(ls "$DASHBOARD_SRC/components/ui/" | wc -l) UI components"

--- a/vestad/tests-integration/tests/server/layout.rs
+++ b/vestad/tests-integration/tests/server/layout.rs
@@ -5,20 +5,41 @@ fn container_id(agent_name: &str) -> String {
     status.id.unwrap_or_else(|| panic!("agent {agent_name} has no container id"))
 }
 
+const ENTRYPOINT_POLL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const ENTRYPOINT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Poll a `test -<flag> <path>` check until it succeeds or the timeout elapses.
+/// CI runners are slow under contention — a single post-sleep check races with
+/// the entrypoint's filesystem setup.
+fn wait_for_path(cid: &str, flag: char, path: &str) {
+    let deadline = std::time::Instant::now() + ENTRYPOINT_POLL_TIMEOUT;
+    let script = format!("test -{flag} {path}");
+    loop {
+        if exec_in_container(cid, &script).is_ok() {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "expected {} {path} to exist within {}s",
+                if flag == 'd' { "directory" } else { "file" },
+                ENTRYPOINT_POLL_TIMEOUT.as_secs()
+            );
+        }
+        std::thread::sleep(ENTRYPOINT_POLL_INTERVAL);
+    }
+}
+
 #[test]
 fn fresh_agent_has_expected_directory_structure() {
     let c = SERVER.client();
     let agent = TestAgent::create_built(&c, &unique_agent("layout")).unwrap();
     let cid = container_id(&agent.name);
 
-    // Wait for entrypoint to finish setting up the filesystem
     c.wait_ready(&agent.name, 10).ok(); // may not become ready without auth, that's fine
-    std::thread::sleep(std::time::Duration::from_secs(5));
 
     // Root-level directories created by Dockerfile + entrypoint
     for dir in ["/root/.git", "/root/.claude", "/root/agent"] {
-        exec_in_container(&cid, &format!("test -d {dir}"))
-            .unwrap_or_else(|_| panic!("expected directory {dir} to exist"));
+        wait_for_path(&cid, 'd', dir);
     }
 
     // .claude/skills symlink points to agent skills
@@ -37,14 +58,12 @@ fn fresh_agent_has_expected_directory_structure() {
         "/root/agent/skills",
         "/root/agent/core",
     ] {
-        exec_in_container(&cid, &format!("test -d {dir}"))
-            .unwrap_or_else(|_| panic!("expected directory {dir} to exist"));
+        wait_for_path(&cid, 'd', dir);
     }
 
     // Key files exist
     for file in ["/root/agent/MEMORY.md", "/root/agent/pyproject.toml", "/root/.gitignore"] {
-        exec_in_container(&cid, &format!("test -f {file}"))
-            .unwrap_or_else(|_| panic!("expected file {file} to exist"));
+        wait_for_path(&cid, 'f', file);
     }
 
     // Git state: repo root is /root, on the agent's branch


### PR DESCRIPTION
## Summary
- Hide version label in footer (component kept for future use)
- Shorten Connect host input placeholder to "host"
- Tapping the collapsed agent island on touch devices navigates to home

## Test plan
- [ ] Verify no version label appears at the bottom of the app
- [ ] Verify the Connect host input shows "host" as placeholder
- [ ] On mobile/touch, tap collapsed agent island and confirm navigation to /
- [ ] On desktop, hover over agent island still expands it

🤖 Generated with [Claude Code](https://claude.com/claude-code)