### PR TITLE
fix(web): browser connect uses page origin, not hardcoded localhost

### DIFF
--- a/apps/web/src/components/Connect/index.tsx
+++ b/apps/web/src/components/Connect/index.tsx
@@ -9,6 +9,9 @@ import { isTauri } from "@/lib/env";
 import { useAuth } from "@/providers/AuthProvider";
 
 function vestadUrl(): string {
+  // vestad serves /app with a port meta tag. If it's present and real (not the
+  // unreplaced Vite placeholder), the page was served by vestad and its origin
+  // is the correct URL, whether vestad is on localhost or a remote host.
   const meta = document.querySelector<HTMLMetaElement>(
     'meta[name="vestad-port"]',
   );
@@ -16,7 +19,7 @@ function vestadUrl(): string {
   if (!port || !/^\d+$/.test(port)) {
     throw new Error("vestad port not available — reload the page");
   }
-  return `https://localhost:${port}`;
+  return window.location.origin;
 }
 
 function normalizeHost(input: string): string {


### PR DESCRIPTION
## Summary
- Fixes the browser connect flow when the web app is served by a remote vestad (e.g. `https://tern-endeavour.vesta.run/app`). The form was building `https://localhost:<port>` from the injected port meta tag, so it tried to hit the user's laptop instead of the remote host.
- Swaps the hardcoded localhost URL for `window.location.origin`. vestad served the page, so its origin IS the correct base URL, whether vestad is local or remote.
- Port meta tag still functions as the "is this page served by vestad at all?" marker; only the URL construction changed.
- Tauri (desktop/mobile) path is unaffected: it already reads a user-entered host field.

## Test plan
- [ ] Open a remote vestad's `/app` in a browser, enter the API key, verify connect succeeds (before: failed with "could not reach server" because it tried localhost).
- [ ] Open a local vestad's `/app` in a browser, connect normally — behavior unchanged (origin already `https://localhost:<port>`).
- [ ] Open the Tauri desktop app, enter a host + key — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)