### PR TITLE
fix(ci): build debug-signed android apk so it installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -753,11 +753,16 @@ jobs:
         working-directory: apps/mobile
         run: npx tauri android init
 
+      # Debug build produces a debug-signed APK that installs on-device without a
+      # release keystore. Release signing is a TODO: generate a keystore, store
+      # it as ANDROID_KEYSTORE_BASE64 + password secrets, wire it into
+      # apps/mobile/src-tauri/gen/android/app/build.gradle.kts signingConfigs,
+      # then drop --debug.
       - name: Build Android APK
         working-directory: apps/mobile
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/27.0.12077973
-        run: npx tauri android build --apk
+        run: npx tauri android build --apk --debug
 
       - name: Collect artifacts
         if: github.event_name != 'pull_request'
@@ -766,7 +771,7 @@ jobs:
           find apps/mobile/src-tauri/gen/android -name '*.apk' -exec cp {} tauri-out/ \;
           VERSION=$(python3 -c "import json; print(json.load(open('apps/mobile/src-tauri/tauri.conf.json'))['version'])")
           for f in tauri-out/*.apk; do
-            mv "$f" "tauri-out/Vesta_${VERSION}.apk"
+            mv "$f" "tauri-out/Vesta_${VERSION}-debug.apk"
           done
           ls -lh tauri-out/
 


### PR DESCRIPTION
## Summary
- `npx tauri android build --apk` (no flags) produces an unsigned release APK. Android refuses to install it with `package appears to be invalid` — confirmed by a tester: no `META-INF/*.RSA|SF|DSA` (no v1 sig), no `APK Sig Block 42` (no v2/v3).
- Add `--debug` so the same CI step produces a debug-signed APK that installs on-device. Tonight's testable build.
- Rename artifact to `Vesta_<version>-debug.apk` so the unsuitable-for-production nature is obvious at download time.
- Leaves a comment on the step outlining the proper release-signing TODO.

## Proper release signing (follow-up, out of scope here)
1. Generate a release keystore: `keytool -genkey -v -keystore vesta-release.jks -keyalg RSA -keysize 2048 -validity 10000 -alias vesta`.
2. Base64-encode it and add as GitHub secret `ANDROID_KEYSTORE_BASE64`, plus `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`.
3. In CI, before `tauri android build`, decode the keystore and inject signing env vars; wire them into `apps/mobile/src-tauri/gen/android/app/build.gradle.kts` `signingConfigs`.
4. Drop `--debug` from this step.

## Test plan
- [ ] CI runs on this branch → artifact is `Vesta_<version>-debug.apk`.
- [ ] Tester installs the downloaded APK on a real Android device → install succeeds.
- [ ] App launches; connect flow reaches a remote vestad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)