### PR TITLE
fix(ci): sign android release apk from repo secrets (supersedes #392)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -753,11 +753,44 @@ jobs:
         working-directory: apps/mobile
         run: npx tauri android init
 
+      # Set up release signing if the ANDROID_KEYSTORE_BASE64 secret is configured.
+      # If the secret is missing, the next step falls back to a debug-signed APK
+      # so CI doesn't break (debug APKs install on-device but can't be used for
+      # real Play Store updates because Android tracks signing certs per app).
+      - name: Set up release signing
+        id: signing
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::ANDROID_KEYSTORE_BASE64 secret not set — building debug-signed APK (not suitable for Play Store updates)"
+            exit 0
+          fi
+          KEYSTORE_PATH="$RUNNER_TEMP/release.jks"
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_PATH"
+          cat > apps/mobile/src-tauri/gen/android/keystore.properties <<EOF
+          storePassword=$ANDROID_KEYSTORE_PASSWORD
+          keyPassword=$ANDROID_KEY_PASSWORD
+          keyAlias=$ANDROID_KEY_ALIAS
+          storeFile=$KEYSTORE_PATH
+          EOF
+          python3 scripts/android-sign-patch.py apps/mobile/src-tauri/gen/android/app/build.gradle.kts
+          echo "signed=true" >> "$GITHUB_OUTPUT"
+
       - name: Build Android APK
         working-directory: apps/mobile
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/27.0.12077973
-        run: npx tauri android build --apk
+        run: |
+          if [ "${{ steps.signing.outputs.signed }}" = "true" ]; then
+            npx tauri android build --apk
+          else
+            npx tauri android build --apk --debug
+          fi
 
       - name: Collect artifacts
         if: github.event_name != 'pull_request'
@@ -765,8 +798,12 @@ jobs:
           mkdir -p tauri-out
           find apps/mobile/src-tauri/gen/android -name '*.apk' -exec cp {} tauri-out/ \;
           VERSION=$(python3 -c "import json; print(json.load(open('apps/mobile/src-tauri/tauri.conf.json'))['version'])")
+          SUFFIX=""
+          if [ "${{ steps.signing.outputs.signed }}" != "true" ]; then
+            SUFFIX="-debug"
+          fi
           for f in tauri-out/*.apk; do
-            mv "$f" "tauri-out/Vesta_${VERSION}.apk"
+            mv "$f" "tauri-out/Vesta_${VERSION}${SUFFIX}.apk"
           done
           ls -lh tauri-out/
 

--- a/scripts/android-sign-patch.py
+++ b/scripts/android-sign-patch.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Patch Tauri-generated Android build.gradle.kts to add release signing.
+
+Expects a `keystore.properties` file next to `gen/android/` with:
+    storePassword=...
+    keyPassword=...
+    keyAlias=...
+    storeFile=<absolute path to .jks>
+
+Idempotent: running twice is a no-op.
+"""
+
+import pathlib
+import re
+import sys
+
+KEYSTORE_LOAD_BLOCK = """
+val keystorePropertiesFile = rootProject.file("keystore.properties")
+val keystoreProperties = java.util.Properties()
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(java.io.FileInputStream(keystorePropertiesFile))
+}
+
+"""
+
+SIGNING_CONFIGS_BLOCK = """    signingConfigs {
+        create("release") {
+            keyAlias = keystoreProperties["keyAlias"] as String
+            keyPassword = keystoreProperties["keyPassword"] as String
+            storeFile = file(keystoreProperties["storeFile"] as String)
+            storePassword = keystoreProperties["storePassword"] as String
+        }
+    }
+
+"""
+
+RELEASE_SIGNING_LINE = '            signingConfig = signingConfigs.getByName("release")\n'
+
+SENTINEL = "signingConfigs.getByName(\"release\")"
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit("usage: android-sign-patch.py <path to build.gradle.kts>")
+    path = pathlib.Path(sys.argv[1])
+    if not path.exists():
+        sys.exit(f"file not found: {path}")
+
+    text = path.read_text()
+    if SENTINEL in text:
+        print(f"{path}: already patched")
+        return
+
+    # 1. Insert keystore loader before the top-level `android {` block.
+    android_block = re.search(r"(?m)^android\s*\{", text)
+    if not android_block:
+        sys.exit("could not find 'android {' block")
+    text = text[: android_block.start()] + KEYSTORE_LOAD_BLOCK + text[android_block.start() :]
+
+    # 2. Inject signingConfigs as the first child of `android { }`.
+    android_open = re.search(r"(?m)^android\s*\{[ \t]*\n", text)
+    if not android_open:
+        sys.exit("could not re-locate 'android {' after patch step 1")
+    text = text[: android_open.end()] + SIGNING_CONFIGS_BLOCK + text[android_open.end() :]
+
+    # 3. Add signingConfig assignment inside the release buildType.
+    release_block = re.search(r'getByName\("release"\)\s*\{[ \t]*\n', text)
+    if not release_block:
+        sys.exit("could not find 'getByName(\"release\")' block in buildTypes")
+    text = text[: release_block.end()] + RELEASE_SIGNING_LINE + text[release_block.end() :]
+
+    path.write_text(text)
+    print(f"{path}: patched")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Proper fix for the unsigned Android APK issue. Supersedes #392 (which was the tonight-only `--debug` workaround).

## How it works
- After `tauri android init`, if `ANDROID_KEYSTORE_BASE64` secret is set:
  - Decode it to `$RUNNER_TEMP/release.jks`
  - Write `apps/mobile/src-tauri/gen/android/keystore.properties` with the four secret values
  - Run `scripts/android-sign-patch.py` to inject a release `signingConfig` into the Tauri-generated `build.gradle.kts` and wire it to the release buildType
  - Build with `npx tauri android build --apk` → signed release APK, artifact `Vesta_<version>.apk`
- If the secret is missing, emit a CI warning and fall back to `npx tauri android build --apk --debug` → debug-signed APK, artifact `Vesta_<version>-debug.apk`. CI stays green, you can set up secrets whenever.

The patch script is idempotent and tested against a mock Tauri-generated `build.gradle.kts`. Adds `java.util.Properties` loader before the `android {}` block, `signingConfigs.create("release") { ... }` as its first child, and `signingConfig = signingConfigs.getByName("release")` inside the release buildType.

## Required secrets (one-time, you set these)
- `ANDROID_KEYSTORE_BASE64` — `base64 -i vesta-release.jks`
- `ANDROID_KEYSTORE_PASSWORD` — store password set during keytool
- `ANDROID_KEY_ALIAS` — e.g. `vesta`
- `ANDROID_KEY_PASSWORD` — key password (can be same as store)

Safekeep `vesta-release.jks` somewhere offline. Losing it means future users need to uninstall + reinstall on update.

## Test plan
- [ ] Secrets set → next CI push produces `Vesta_<version>.apk`, verify with `jarsigner -verify` or by `unzip -l` looking for `META-INF/*.RSA` and the APK signing block
- [ ] Install on an Android device → succeeds without "package appears to be invalid"
- [ ] Install a newer signed build on top of the first → updates in place (proves cert matches)
- [ ] Secrets NOT set → CI still passes, produces `Vesta_<version>-debug.apk` with a warning annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)