### PR TITLE
fix(ci): android sign patch needs kotlin imports (java.util.Properties)

### DIFF
--- a/scripts/android-sign-patch.py
+++ b/scripts/android-sign-patch.py
@@ -14,21 +14,26 @@ import pathlib
 import re
 import sys
 
+IMPORTS_BLOCK = """import java.io.FileInputStream
+import java.util.Properties
+
+"""
+
 KEYSTORE_LOAD_BLOCK = """
 val keystorePropertiesFile = rootProject.file("keystore.properties")
-val keystoreProperties = java.util.Properties()
+val keystoreProperties = Properties()
 if (keystorePropertiesFile.exists()) {
-    keystoreProperties.load(java.io.FileInputStream(keystorePropertiesFile))
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 """
 
 SIGNING_CONFIGS_BLOCK = """    signingConfigs {
         create("release") {
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
-            storeFile = file(keystoreProperties["storeFile"] as String)
-            storePassword = keystoreProperties["storePassword"] as String
+            keyAlias = keystoreProperties.getProperty("keyAlias")
+            keyPassword = keystoreProperties.getProperty("keyPassword")
+            storeFile = file(keystoreProperties.getProperty("storeFile"))
+            storePassword = keystoreProperties.getProperty("storePassword")
         }
     }
 
@@ -51,7 +56,11 @@ def main() -> None:
         print(f"{path}: already patched")
         return
 
-    # 1. Insert keystore loader before the top-level `android {` block.
+    # 1a. Add imports at the very top. Kotlin DSL requires them before `plugins {}`
+    #     and does not auto-qualify java.util.* / java.io.*.
+    text = IMPORTS_BLOCK + text
+
+    # 1b. Insert keystore loader before the top-level `android {` block.
     android_block = re.search(r"(?m)^android\s*\{", text)
     if not android_block:
         sys.exit("could not find 'android {' block")


### PR DESCRIPTION
## Summary
The android signing patch on master failed Gradle compile with:

```
e: build.gradle.kts:18:31: Unresolved reference: util
e: build.gradle.kts:20:34: Unresolved reference: io
```

Kotlin DSL does not auto-qualify `java.util.*` / `java.io.*` the way Groovy does, so the fully-qualified `java.util.Properties()` / `java.io.FileInputStream(...)` references I used in the patcher didn't compile.

## Fix
- Add `import java.io.FileInputStream` and `import java.util.Properties` at the top of `build.gradle.kts`.
- Use bare `Properties()` and `FileInputStream(...)` after importing.
- Switch `keystoreProperties["key"] as String` to `keystoreProperties.getProperty("key")` to drop the redundant-cast warnings.

Caught on master run [24743946490](https://github.com/elyxlz/vesta/actions/runs/24743946490).

## Test plan
- [ ] CI on this branch runs `build-tauri-android` and produces a signed `Vesta_<version>.apk`.
- [ ] Tester installs on Android device — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)