### PR TITLE
fix(ci): dedupe android sign patch imports (tauri already imports Properties)

### DIFF
--- a/scripts/android-sign-patch.py
+++ b/scripts/android-sign-patch.py
@@ -14,10 +14,10 @@ import pathlib
 import re
 import sys
 
-IMPORTS_BLOCK = """import java.io.FileInputStream
-import java.util.Properties
-
-"""
+REQUIRED_IMPORTS = (
+    "import java.io.FileInputStream",
+    "import java.util.Properties",
+)
 
 KEYSTORE_LOAD_BLOCK = """
 val keystorePropertiesFile = rootProject.file("keystore.properties")
@@ -56,9 +56,12 @@ def main() -> None:
         print(f"{path}: already patched")
         return
 
-    # 1a. Add imports at the very top. Kotlin DSL requires them before `plugins {}`
-    #     and does not auto-qualify java.util.* / java.io.*.
-    text = IMPORTS_BLOCK + text
+    # 1a. Add any missing imports at the top. Tauri's generated file already
+    #     imports Properties, so duplicate imports fail with "Conflicting import,
+    #     imported name 'Properties' is ambiguous". Only add what's missing.
+    missing = [imp for imp in REQUIRED_IMPORTS if imp not in text]
+    if missing:
+        text = "\n".join(missing) + "\n\n" + text
 
     # 1b. Insert keystore loader before the top-level `android {` block.
     android_block = re.search(r"(?m)^android\s*\{", text)


### PR DESCRIPTION
## Summary
Follow-up to #396. That fix made the generated `build.gradle.kts` compile *past* the `java.util` resolution error but then hit:

```
e: build.gradle.kts:2:18: Conflicting import, imported name 'Properties' is ambiguous
e: build.gradle.kts:4:18: Conflicting import, imported name 'Properties' is ambiguous
```

Root cause: Tauri's generated `build.gradle.kts` **already imports `java.util.Properties`**. Unconditionally prepending another `import java.util.Properties` produces a duplicate, and Kotlin flags it as ambiguous.

## Fix
Only add imports that aren't already present in the file:
```python
missing = [imp for imp in REQUIRED_IMPORTS if imp not in text]
if missing:
    text = "\n".join(missing) + "\n\n" + text
```

Tested against three fixtures:
- Fresh Tauri output with no imports → adds both
- Pre-existing `Properties` import → adds only `FileInputStream`
- Both already imported → adds neither

Caught on master run [24744715667](https://github.com/elyxlz/vesta/actions/runs/24744715667).

## Test plan
- [ ] CI produces signed `Vesta_<version>.apk`
- [ ] Install on device works

🤖 Generated with [Claude Code](https://claude.com/claude-code)