### PR TITLE
fix(update-check): surface HTTP status and error body in warnings

### DIFF
--- a/vestad/src/update_check.rs
+++ b/vestad/src/update_check.rs
@@ -34,9 +34,9 @@ pub fn fetch_latest_tag() -> Option<String> {
 }
 
 fn fetch_latest_release_tag(timeout_secs: Option<u64>) -> Result<String, String> {
-    // We intentionally omit curl's `-f` so HTTP errors still return a body —
-    // this lets us surface GitHub's rate-limit message to the caller instead
-    // of collapsing every failure into a generic error.
+    // Omit curl's `-f` so HTTP errors still return a body. This surfaces
+    // GitHub's rate-limit message to the caller instead of collapsing every
+    // failure into a generic error.
     let mut args: Vec<String> = vec![
         "-sSL".into(),
         "-H".into(),
@@ -108,9 +108,8 @@ fn snippet(s: &str) -> String {
     if s.is_empty() {
         return "<empty>".into();
     }
-    let mut it = s.char_indices();
-    match it.nth(ERROR_SNIPPET_MAX_LEN) {
-        Some((idx, _)) => format!("{}…", &s[..idx]),
+    match s.char_indices().nth(ERROR_SNIPPET_MAX_LEN) {
+        Some((end, _)) => format!("{}…", &s[..end]),
         None => s.to_string(),
     }
 }

--- a/vestad/src/update_check.rs
+++ b/vestad/src/update_check.rs
@@ -1,5 +1,7 @@
 pub const CHECK_INTERVAL_SECS: u64 = 10 * 60;
 const FETCH_TIMEOUT_SECS: u64 = 10;
+const ERROR_SNIPPET_MAX_LEN: usize = 300;
+const HTTP_STATUS_SENTINEL: &str = "\n__VESTA_HTTP_STATUS__:";
 
 const GITHUB_RELEASES_LATEST_URL: &str =
     "https://api.github.com/repos/elyxlz/vesta/releases/latest";
@@ -11,8 +13,7 @@ pub struct UpdateInfo {
 }
 
 pub fn check_once() -> Result<UpdateInfo, String> {
-    let latest = fetch_latest_release_tag(Some(FETCH_TIMEOUT_SECS))
-        .ok_or_else(|| "failed to fetch latest release".to_string())?;
+    let latest = fetch_latest_release_tag(Some(FETCH_TIMEOUT_SECS))?;
     let update_available = version_less_than(env!("CARGO_PKG_VERSION"), &latest);
 
     Ok(UpdateInfo {
@@ -29,16 +30,21 @@ fn version_less_than(a: &str, b: &str) -> bool {
 }
 
 pub fn fetch_latest_tag() -> Option<String> {
-    fetch_latest_release_tag(Some(FETCH_TIMEOUT_SECS))
+    fetch_latest_release_tag(Some(FETCH_TIMEOUT_SECS)).ok()
 }
 
-fn fetch_latest_release_tag(timeout_secs: Option<u64>) -> Option<String> {
+fn fetch_latest_release_tag(timeout_secs: Option<u64>) -> Result<String, String> {
+    // We intentionally omit curl's `-f` so HTTP errors still return a body —
+    // this lets us surface GitHub's rate-limit message to the caller instead
+    // of collapsing every failure into a generic error.
     let mut args: Vec<String> = vec![
-        "-fsSL".into(),
+        "-sSL".into(),
         "-H".into(),
         "Accept: application/vnd.github+json".into(),
         "-H".into(),
         "User-Agent: vesta-release-check".into(),
+        "-w".into(),
+        format!("{HTTP_STATUS_SENTINEL}%{{http_code}}"),
     ];
     if let Some(t) = timeout_secs {
         args.push("--connect-timeout".into());
@@ -50,20 +56,88 @@ fn fetch_latest_release_tag(timeout_secs: Option<u64>) -> Option<String> {
 
     let output = std::process::Command::new("curl")
         .args(&args)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
         .output()
-        .ok()?;
+        .map_err(|e| format!("failed to spawn curl: {e}"))?;
+
     if !output.status.success() {
-        return None;
+        let code = output
+            .status
+            .code()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "signal".into());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "curl failed (exit {code}): {}",
+            snippet(stderr.trim())
+        ));
     }
 
-    let body = String::from_utf8_lossy(&output.stdout);
-    let data: serde_json::Value = serde_json::from_str(&body).ok()?;
-    let tag = data.get("tag_name")?.as_str()?.trim().trim_start_matches('v');
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let (body, status) = match stdout.rsplit_once(HTTP_STATUS_SENTINEL) {
+        Some((body, status)) => (body, status.trim()),
+        None => return Err("curl output missing HTTP status sentinel".into()),
+    };
+
+    let status_code: u16 = status
+        .parse()
+        .map_err(|_| format!("unparseable HTTP status {status:?}"))?;
+    if !(200..300).contains(&status_code) {
+        return Err(format!(
+            "HTTP {status_code}: {}",
+            snippet(body.trim())
+        ));
+    }
+
+    let data: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| format!("failed to parse response JSON: {e}"))?;
+    let tag_value = data
+        .get("tag_name")
+        .ok_or_else(|| format!("response missing tag_name: {}", snippet(body.trim())))?;
+    let tag = tag_value
+        .as_str()
+        .ok_or_else(|| format!("tag_name is not a string: {tag_value}"))?
+        .trim()
+        .trim_start_matches('v');
     if tag.is_empty() {
-        None
-    } else {
-        Some(tag.to_string())
+        return Err("tag_name is empty".into());
+    }
+    Ok(tag.to_string())
+}
+
+fn snippet(s: &str) -> String {
+    if s.is_empty() {
+        return "<empty>".into();
+    }
+    let mut it = s.char_indices();
+    match it.nth(ERROR_SNIPPET_MAX_LEN) {
+        Some((idx, _)) => format!("{}…", &s[..idx]),
+        None => s.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_less_than_compares_numerically() {
+        assert!(version_less_than("0.1.132", "0.1.141"));
+        assert!(version_less_than("0.1.9", "0.1.10"));
+        assert!(!version_less_than("0.1.141", "0.1.132"));
+        assert!(!version_less_than("0.1.141", "0.1.141"));
+    }
+
+    #[test]
+    fn snippet_truncates_long_strings() {
+        let long = "a".repeat(1000);
+        let out = snippet(&long);
+        assert!(out.ends_with('…'));
+        assert!(out.len() <= ERROR_SNIPPET_MAX_LEN + 4);
+    }
+
+    #[test]
+    fn snippet_passes_short_strings_through() {
+        assert_eq!(snippet("hi"), "hi");
+        assert_eq!(snippet(""), "<empty>");
     }
 }


### PR DESCRIPTION
## Summary
- Drop curl's `-f` and capture HTTP status via `-w`, so update-check failures no longer collapse to the opaque `failed to fetch latest release` log line.
- Return a specific error at each failure point: curl spawn/exit (with stderr), non-2xx status (with response body snippet, truncated to 300 chars), JSON parse errors, missing/non-string/empty `tag_name`.
- Trust the existing log call in `serve.rs` (`tracing::warn!("update check failed: {}", e)`), which now carries the detail.
- `fetch_latest_tag()` keeps its `Option<String>` signature (used by `self_update.rs`) via `.ok()`.

Example log lines operators will now see:
- `update check failed: HTTP 403: {"message":"API rate limit exceeded for ...","documentation_url":"..."}`
- `update check failed: curl failed (exit 28): curl: (28) Connection timed out after 10001 milliseconds`
- `update check failed: failed to parse response JSON: expected value at line 1 column 1`

Fixes #361

## Test plan
- [x] `cargo clippy -p vestad` clean
- [x] `cargo test -p vestad update_check` passes (3 new unit tests: version comparison + snippet truncation)
- [x] Smoke-tested the curl invocation against the live GitHub releases endpoint — sentinel parses cleanly, 200 path returns the tag
- [ ] Operator verification: confirm rate-limit warnings now include the GitHub response body