### PR TITLE
docs(skills): warn against running multiple browser agents in parallel

### DIFF
--- a/agent/skills/browser/SKILL.md
+++ b/agent/skills/browser/SKILL.md
@@ -115,6 +115,8 @@ browser resize 1920 1080                # Resize viewport
 
 ## Multi-Agent / Concurrent Use
 
+**Memory warning:** Each Chrome instance uses 200 to 400 MB of RAM. On memory-constrained hosts, running 3 or more browser agents in parallel can trigger the OOM killer and crash the container. Prefer sequential browser agents for scraping tasks that span many sites.
+
 Multiple subagents can each run their own Chrome instance concurrently. Port allocation is automatic; each `browser launch` finds a free port starting from 9222, so no conflicts occur.
 
 **Session isolation via `BROWSER_SESSION` env var:**


### PR DESCRIPTION
## Summary

- Adds a memory warning to the top of the Multi-Agent / Concurrent Use section in `agent/skills/browser/SKILL.md`.
- Each Chrome instance uses 200 to 400 MB of RAM; running 3 or more browser agents in parallel can trigger the OOM killer on memory-constrained hosts.
- Recommends sequential browser agents for scraping tasks that span many sites.

Fixes #401

## Test plan

- [ ] Verify the warning renders as the first paragraph under `## Multi-Agent / Concurrent Use` in the rendered markdown.
- [ ] Confirm no other content in `SKILL.md` was modified.
- [ ] CI passes (ruff, ty, clippy, pytest, skills index freshness).