### PR TITLE
fix(app): render newlines in chat messages as line breaks

### DIFF
--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -8769,6 +8769,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -10688,6 +10702,21 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -12518,6 +12547,7 @@
         "react-resizable-panels": "^4",
         "react-router-dom": "^7.13.2",
         "recharts": "3.8.1",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.2.0",
         "sonner": "^2.0.7",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,6 +50,7 @@
     "react-resizable-panels": "^4",
     "react-router-dom": "^7.13.2",
     "recharts": "3.8.1",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.2.0",
     "sonner": "^2.0.7",

--- a/apps/web/src/lib/markdown.tsx
+++ b/apps/web/src/lib/markdown.tsx
@@ -1,10 +1,11 @@
 import ReactMarkdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
 export function Markdown({ children }: { children: string }) {
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={[remarkGfm, remarkBreaks]}
       components={{
         a: ({ node: _n, ...props }) => (
           <a


### PR DESCRIPTION
## Summary

- Chat bubbles render message text through react-markdown with only remark-gfm, which follows CommonMark and turns single newlines into soft breaks (a space). Multi-line agent replies collapsed into one paragraph.
- Added the remark-breaks plugin so a single newline becomes a line break, matching the WhatsApp-style behavior described in the issue.
- Added remark-breaks to apps/web dependencies.

Fixes #218

## Test plan

- [x] npm -w @vesta/web run lint
- [x] npm -w @vesta/web run check
- [x] npm -w @vesta/web run test
- [ ] Manual UI verification in the running app (not performed in this task; please verify that agent replies with embedded newlines now render as multi-line bubbles)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>