### PR TITLE
fix(vestad): disable TLS 1.3 post-handshake tickets to unbreak LAN clients

### DIFF
--- a/vestad/Cargo.lock
+++ b/vestad/Cargo.lock
@@ -1850,6 +1850,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,6 +2567,7 @@ dependencies = [
  "ring",
  "rust-embed",
  "rustls",
+ "rustls-pemfile",
  "self-replace",
  "serde",
  "serde_json",

--- a/vestad/Cargo.toml
+++ b/vestad/Cargo.toml
@@ -25,6 +25,7 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
+rustls-pemfile = "2"
 rcgen = "0.14"
 ring = "0.17"
 serde = { version = "1", features = ["derive"] }

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -80,6 +80,18 @@ pub fn ensure_tls(config_dir: &std::path::Path) -> (String, String, String) {
             }
         }
     }
+    // Mark as a TLS server cert only; without EKU, some clients (schannel /
+    // WebView2) treat the cert as potentially mTLS-capable and get confused
+    // by post-handshake messages. See issue #341.
+    params
+        .extended_key_usages
+        .push(rcgen::ExtendedKeyUsagePurpose::ServerAuth);
+    params
+        .key_usages
+        .push(rcgen::KeyUsagePurpose::DigitalSignature);
+    params
+        .key_usages
+        .push(rcgen::KeyUsagePurpose::KeyEncipherment);
     // 10 year validity
     params.not_after = rcgen::date_time_ymd(2036, 1, 1);
 
@@ -115,6 +127,28 @@ pub fn ensure_tls(config_dir: &std::path::Path) -> (String, String, String) {
     }
 
     (cert_pem, key_pem, fingerprint)
+}
+
+// Build a rustls `ServerConfig` that:
+// - does no client-cert auth (vestad authenticates with bearer tokens),
+// - advertises h2 + http/1.1 via ALPN in the initial ServerHello,
+// - disables post-handshake TLS 1.3 NewSessionTicket messages.
+//
+// Windows schannel (used by WebView2, the desktop app's webview) misinterprets
+// post-handshake NewSessionTicket as a renegotiation request, which TLS 1.3
+// clients then refuse, breaking LAN connections. See issue #341.
+fn build_server_tls_config(cert_pem: &str, key_pem: &str) -> std::io::Result<rustls::ServerConfig> {
+    let certs = rustls_pemfile::certs(&mut cert_pem.as_bytes())
+        .collect::<Result<Vec<_>, _>>()?;
+    let key = rustls_pemfile::private_key(&mut key_pem.as_bytes())?
+        .ok_or_else(|| std::io::Error::other("no private key in key.pem"))?;
+    let mut config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(std::io::Error::other)?;
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    config.send_tls13_tickets = 0;
+    Ok(config)
 }
 
 // --- API key generation ---
@@ -1685,12 +1719,9 @@ pub async fn run_server(port: u16, api_key: String, cert_pem: String, key_pem: S
         spawn_update_check_task(state);
     }
 
-    let rustls_config = axum_server::tls_rustls::RustlsConfig::from_pem(
-        cert_pem.into_bytes(),
-        key_pem.into_bytes(),
-    )
-    .await
-    .expect("failed to configure TLS");
+    let rustls_config = axum_server::tls_rustls::RustlsConfig::from_config(Arc::new(
+        build_server_tls_config(&cert_pem, &key_pem).expect("failed to configure TLS"),
+    ));
 
     // HTTPS on 0.0.0.0 for remote access
     let https_addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
@@ -1722,5 +1753,26 @@ pub async fn run_server(port: u16, api_key: String, cert_pem: String, key_pem: S
     tokio::select! {
         r = http_handle => r.expect("http task panicked"),
         r = https_handle => r.expect("https task panicked"),
+    }
+}
+
+#[cfg(test)]
+mod tls_config_tests {
+    use super::build_server_tls_config;
+
+    #[test]
+    fn disables_tls13_tickets_and_sets_alpn() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let tmp = tempfile::tempdir().unwrap();
+        let (cert_pem, key_pem, _fp) = super::ensure_tls(tmp.path());
+        let config = build_server_tls_config(&cert_pem, &key_pem).unwrap();
+        assert_eq!(
+            config.send_tls13_tickets, 0,
+            "TLS 1.3 post-handshake tickets must be disabled (schannel/WebView2 treats them as renegotiation, see issue #341)",
+        );
+        assert_eq!(
+            config.alpn_protocols,
+            vec![b"h2".to_vec(), b"http/1.1".to_vec()],
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `vestad`'s HTTPS listener was breaking direct-LAN connections from the desktop app's webview (WebView2 / schannel). curl worked with `remote party requests renegotiation` visible in its verbose log; WebView2 couldn't recover and reported "could not reach server". Cloudflare-tunneled URLs were fine because Cloudflare terminates TLS.
- Root cause: rustls' default `ServerConfig` sends post-handshake TLS 1.3 `NewSessionTicket` messages, which schannel interprets as a renegotiation request. TLS 1.3 forbids renegotiation, so strict clients drop the connection.
- Switched to a hand-built `rustls::ServerConfig` with `send_tls13_tickets = 0`, explicit `with_no_client_auth()`, and ALPN `h2 + http/1.1` in the initial ServerHello. Newly-generated self-signed certs also get `EKU=ServerAuth` + `KeyUsage=DigitalSignature,KeyEncipherment` so strict clients don't infer mTLS capability from an extension-less cert.
- Existing certs on disk are reused as-is so current fingerprint pinning keeps working; only new cert generations pick up the EKU/KeyUsage.

## Test plan
- [x] `cargo clippy -p vestad -- -D warnings`
- [x] `cargo test -p vestad --bin vestad` (includes new `tls_config_tests::disables_tls13_tickets_and_sets_alpn`)
- [ ] Desktop app connects to a LAN-hosted vestad over HTTPS without the "could not reach server" failure
- [ ] `curl.exe` (schannel) verbose output no longer shows `remote party requests renegotiation`
- [ ] Cloudflare tunnel URL still works end-to-end

Fixes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)