### PR TITLE
feat(app): tag outgoing messages with input_method

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -76,7 +76,10 @@ async def _recv_loop(ws: web.WebSocketResponse, event_bus: EventBus) -> None:
                 text = data["text"].strip()
                 if text:
                     if msg_type == "message":
-                        event_bus.emit(UserEvent(type="user", text=text))
+                        event: UserEvent = {"type": "user", "text": text}
+                        if "input_method" in data and data["input_method"] in ("voice", "typed"):
+                            event["input_method"] = data["input_method"]
+                        event_bus.emit(event)
                     else:
                         event_bus.emit(ChatEvent(type="chat", text=text))
         elif msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):

--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -46,6 +46,7 @@ class ThinkingEvent(_BaseEvent):
 class UserEvent(_BaseEvent):
     type: tp.Literal["user"]
     text: str
+    input_method: tp.NotRequired[tp.Literal["voice", "typed"]]
 
 
 class ErrorEvent(_BaseEvent):

--- a/agent/tests/test_contract.py
+++ b/agent/tests/test_contract.py
@@ -25,7 +25,7 @@ from core.events import (
 # The single source of truth: every event type and its required fields (excluding base `ts`)
 EVENT_SPEC: dict[str, set[str]] = {
     "status": {"state"},
-    "user": {"text"},
+    "user": {"text", "input_method"},
     "assistant": {"text"},
     "thinking": {"text", "signature"},
     "chat": {"text"},

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -24,11 +24,13 @@ export type AgentActivityState = "idle" | "thinking";
 
 export type OnboardingStep = "name" | "connect" | "creating" | "auth" | "done";
 
+export type InputMethod = "voice" | "typed";
+
 type BaseEvent = { ts?: string };
 
 export type VestaEvent =
   | (BaseEvent & { type: "status"; state: AgentActivityState })
-  | (BaseEvent & { type: "user"; text: string })
+  | (BaseEvent & { type: "user"; text: string; input_method?: InputMethod })
   | (BaseEvent & { type: "assistant"; text: string })
   | (BaseEvent & { type: "thinking"; text: string; signature: string })
   | (BaseEvent & { type: "chat"; text: string })

--- a/apps/web/src/providers/ChatProvider/use-chat.ts
+++ b/apps/web/src/providers/ChatProvider/use-chat.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { VestaEvent, AgentActivityState } from "@/lib/types";
+import type { VestaEvent, AgentActivityState, InputMethod } from "@/lib/types";
 import { wsUrl, fetchHistory } from "@/lib/connection";
 import { useChatPacing } from "@/stores/use-chat-pacing";
 
@@ -237,22 +237,32 @@ export function useChat({
     };
   }, [active, name]);
 
-  const send = useCallback((text: string): boolean => {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return false;
-    ws.send(JSON.stringify({ type: "message", text }));
-    pendingEchoesRef.current.push(text);
-    setMessages((prev) => {
-      const updated: VestaEvent[] = [
-        ...prev,
-        { type: "user", text, ts: new Date().toISOString() },
-      ];
-      return updated.length > MAX_MESSAGES
-        ? updated.slice(-MAX_MESSAGES)
-        : updated;
-    });
-    return true;
-  }, []);
+  const send = useCallback(
+    (text: string, inputMethod: InputMethod = "typed"): boolean => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+      ws.send(
+        JSON.stringify({ type: "message", text, input_method: inputMethod }),
+      );
+      pendingEchoesRef.current.push(text);
+      setMessages((prev) => {
+        const updated: VestaEvent[] = [
+          ...prev,
+          {
+            type: "user",
+            text,
+            input_method: inputMethod,
+            ts: new Date().toISOString(),
+          },
+        ];
+        return updated.length > MAX_MESSAGES
+          ? updated.slice(-MAX_MESSAGES)
+          : updated;
+      });
+      return true;
+    },
+    [],
+  );
 
   const sendEvent = useCallback((event: object): boolean => {
     const ws = wsRef.current;

--- a/apps/web/src/stores/use-voice.ts
+++ b/apps/web/src/stores/use-voice.ts
@@ -8,7 +8,7 @@ import {
   type SttStatus,
   type TtsStatus,
 } from "@/lib/voice";
-import type { ServiceInfo } from "@/lib/types";
+import type { InputMethod, ServiceInfo } from "@/lib/types";
 
 interface VoiceState {
   // Agent context (set by VoiceStoreEffects)
@@ -37,7 +37,7 @@ interface VoiceState {
   speak: (text: string) => void;
   stopSpeech: () => void;
   registerChatCallbacks: (
-    send: (text: string) => void,
+    send: (text: string, inputMethod?: InputMethod) => void,
     draft: (text: string) => void,
   ) => void;
 
@@ -60,7 +60,8 @@ interface VoiceState {
 
 // Mutable refs outside React — safe because the store is a singleton
 let transcriber: Transcriber | null = null;
-let sendCallback: ((text: string) => void) | null = null;
+let sendCallback: ((text: string, inputMethod?: InputMethod) => void) | null =
+  null;
 let draftCallback: ((text: string) => void) | null = null;
 let ttsAbort: AbortController | null = null;
 let ttsQueue: string[] = [];
@@ -156,7 +157,7 @@ export const useVoice = create<VoiceState>((set, get) => {
           if (!get().voiceAutoSend) draftCallback?.(text);
         },
         onTurnEnd: (text) => {
-          if (get().voiceAutoSend) sendCallback?.(text);
+          if (get().voiceAutoSend) sendCallback?.(text, "voice");
           else draftCallback?.(text);
           set({ liveTranscript: "" });
         },


### PR DESCRIPTION
## Summary

- Web app now includes `input_method: "voice" | "typed"` in the outgoing chat-message WebSocket payload, derived from whether the text came from the voice provider's auto-send path or the text composer.
- vestad proxies the WS opaquely and has no typed message body struct, so no server change was needed to forward the field.
- Agent's `UserEvent` TypedDict gets an optional `input_method` field and `api.py`'s WS receiver copies the field through when present; the agent does not yet consume it.

Plumbing only. No response-style adaptation, no analytics, no corpus export.

Fixes #276

## Test plan

- [x] `cd agent && uv run ruff check`
- [x] `cd agent && uv run ty check`
- [x] `cd agent && uv run pytest tests/ --ignore=tests/test_e2e.py`
- [x] `npm -w @vesta/web run check`
- [x] `npm -w @vesta/web run lint` (0 errors, pre-existing warnings only)
- [x] `npm -w @vesta/web run test`