### PR TITLE
fix(vestad): health-check cached service port before reusing on re-registration

### DIFF
--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -918,6 +918,13 @@ fn all_registered_ports(registry: &HashMap<String, HashMap<String, ServiceEntry>
 const SERVICE_PORT_ALLOC_RETRIES: usize = 5;
 const CACHED_PORT_CONNECT_TIMEOUT_MS: u64 = 200;
 
+fn no_free_ports_err() -> (StatusCode, Json<serde_json::Value>) {
+    err_response(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no free ports available in range 49152-65535 — too many services registered, or all ports are in use",
+    )
+}
+
 /// Find a free port not used by any registered service or other process.
 /// Uses OS-assigned ports with retries to avoid races with other vestad instances.
 fn allocate_service_port(registry: &HashMap<String, HashMap<String, ServiceEntry>>) -> Option<u16> {
@@ -940,17 +947,13 @@ fn allocate_service_port(registry: &HashMap<String, HashMap<String, ServiceEntry
 /// the port is free to bind (service not started yet but nothing blocks it).
 /// Returns false if the port is stuck in a zombie/TIME_WAIT state — a new
 /// process cannot bind to it and nothing is listening. See issue #371.
-fn is_cached_port_reusable(port: u16) -> bool {
+async fn is_cached_port_reusable(port: u16) -> bool {
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
-    if std::net::TcpStream::connect_timeout(
-        &addr,
-        std::time::Duration::from_millis(CACHED_PORT_CONNECT_TIMEOUT_MS),
-    )
-    .is_ok()
-    {
+    let timeout = std::time::Duration::from_millis(CACHED_PORT_CONNECT_TIMEOUT_MS);
+    if let Ok(Ok(_)) = tokio::time::timeout(timeout, tokio::net::TcpStream::connect(addr)).await {
         return true;
     }
-    std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
+    tokio::net::TcpListener::bind(("127.0.0.1", port)).await.is_ok()
 }
 
 async fn register_service_handler(
@@ -983,14 +986,12 @@ async fn register_service_handler(
     // trap the service in a crash loop with no recovery from inside the container.
     let cached_port = settings.services.get(&name).and_then(|s| s.get(&service_name)).map(|e| e.port);
     let port = match cached_port {
-        Some(p) if is_cached_port_reusable(p) => p,
+        Some(p) if is_cached_port_reusable(p).await => p,
         Some(p) => {
             tracing::warn!(agent = %name, service = %service_name, stale_port = p, "cached service port is stuck (connect+bind both failed), allocating a fresh one");
-            allocate_service_port(&settings.services)
-                .ok_or_else(|| err_response(StatusCode::SERVICE_UNAVAILABLE, "no free ports available in range 49152-65535 — too many services registered, or all ports are in use"))?
+            allocate_service_port(&settings.services).ok_or_else(no_free_ports_err)?
         }
-        None => allocate_service_port(&settings.services)
-            .ok_or_else(|| err_response(StatusCode::SERVICE_UNAVAILABLE, "no free ports available in range 49152-65535 — too many services registered, or all ports are in use"))?,
+        None => allocate_service_port(&settings.services).ok_or_else(no_free_ports_err)?,
     };
 
     let entry = ServiceEntry { port, public: body.public };
@@ -1755,21 +1756,18 @@ pub async fn run_server(port: u16, api_key: String, cert_pem: String, key_pem: S
 mod tests {
     use super::is_cached_port_reusable;
 
-    #[test]
-    fn cached_port_is_reusable_when_free() {
-        // Port with nothing bound to it: bind succeeds, reuse is safe.
+    #[tokio::test]
+    async fn cached_port_is_reusable_when_free() {
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let port = listener.local_addr().unwrap().port();
         drop(listener);
-        assert!(is_cached_port_reusable(port), "a free port must be reusable");
+        assert!(is_cached_port_reusable(port).await, "a free port must be reusable");
     }
 
-    #[test]
-    fn cached_port_is_reusable_when_listening() {
-        // Port with a live listener: TCP connect succeeds, reuse returns the
-        // same port — service is still alive.
+    #[tokio::test]
+    async fn cached_port_is_reusable_when_listening() {
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let port = listener.local_addr().unwrap().port();
-        assert!(is_cached_port_reusable(port), "a listening port must be reusable");
+        assert!(is_cached_port_reusable(port).await, "a listening port must be reusable");
     }
 }

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -916,6 +916,7 @@ fn all_registered_ports(registry: &HashMap<String, HashMap<String, ServiceEntry>
 }
 
 const SERVICE_PORT_ALLOC_RETRIES: usize = 5;
+const CACHED_PORT_CONNECT_TIMEOUT_MS: u64 = 200;
 
 /// Find a free port not used by any registered service or other process.
 /// Uses OS-assigned ports with retries to avoid races with other vestad instances.
@@ -932,6 +933,24 @@ fn allocate_service_port(registry: &HashMap<String, HashMap<String, ServiceEntry
     (SERVICE_PORT_MIN..=SERVICE_PORT_MAX).find(|p| {
         !used.contains(p) && std::net::TcpListener::bind(("127.0.0.1", *p)).is_ok()
     })
+}
+
+/// Check whether a cached service port can still be safely reused.
+/// Returns true if something is listening on the port (service alive) OR
+/// the port is free to bind (service not started yet but nothing blocks it).
+/// Returns false if the port is stuck in a zombie/TIME_WAIT state — a new
+/// process cannot bind to it and nothing is listening. See issue #371.
+fn is_cached_port_reusable(port: u16) -> bool {
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    if std::net::TcpStream::connect_timeout(
+        &addr,
+        std::time::Duration::from_millis(CACHED_PORT_CONNECT_TIMEOUT_MS),
+    )
+    .is_ok()
+    {
+        return true;
+    }
+    std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
 }
 
 async fn register_service_handler(
@@ -959,12 +978,19 @@ async fn register_service_handler(
 
     let mut settings = state.settings.write().await;
 
-    // Reuse existing port if already registered, otherwise allocate a new one
-    let port = if let Some(existing) = settings.services.get(&name).and_then(|s| s.get(&service_name)) {
-        existing.port
-    } else {
-        allocate_service_port(&settings.services)
-            .ok_or_else(|| err_response(StatusCode::SERVICE_UNAVAILABLE, "no free ports available in range 49152-65535 — too many services registered, or all ports are in use"))?
+    // Reuse existing port if already registered AND the cached port is still
+    // reusable. A stuck cached port (zombie process, TIME_WAIT) would otherwise
+    // trap the service in a crash loop with no recovery from inside the container.
+    let cached_port = settings.services.get(&name).and_then(|s| s.get(&service_name)).map(|e| e.port);
+    let port = match cached_port {
+        Some(p) if is_cached_port_reusable(p) => p,
+        Some(p) => {
+            tracing::warn!(agent = %name, service = %service_name, stale_port = p, "cached service port is stuck (connect+bind both failed), allocating a fresh one");
+            allocate_service_port(&settings.services)
+                .ok_or_else(|| err_response(StatusCode::SERVICE_UNAVAILABLE, "no free ports available in range 49152-65535 — too many services registered, or all ports are in use"))?
+        }
+        None => allocate_service_port(&settings.services)
+            .ok_or_else(|| err_response(StatusCode::SERVICE_UNAVAILABLE, "no free ports available in range 49152-65535 — too many services registered, or all ports are in use"))?,
     };
 
     let entry = ServiceEntry { port, public: body.public };
@@ -1722,5 +1748,28 @@ pub async fn run_server(port: u16, api_key: String, cert_pem: String, key_pem: S
     tokio::select! {
         r = http_handle => r.expect("http task panicked"),
         r = https_handle => r.expect("https task panicked"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_cached_port_reusable;
+
+    #[test]
+    fn cached_port_is_reusable_when_free() {
+        // Port with nothing bound to it: bind succeeds, reuse is safe.
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        assert!(is_cached_port_reusable(port), "a free port must be reusable");
+    }
+
+    #[test]
+    fn cached_port_is_reusable_when_listening() {
+        // Port with a live listener: TCP connect succeeds, reuse returns the
+        // same port — service is still alive.
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        assert!(is_cached_port_reusable(port), "a listening port must be reusable");
     }
 }


### PR DESCRIPTION
## Summary
- When a service (e.g. `voice`) crashes mid-startup and its port is held in a stuck state (zombie process, TIME_WAIT), the cached entry in `settings.services` meant `POST /agents/:name/services` would hand the same port back. The new process failed to bind, crashed again, and the only recovery was a full container restart.
- `register_service_handler` now probes the cached port before reusing it:
  - **TCP connect succeeds** → service is alive, return the same port (no-op re-register).
  - **bind succeeds** → port is free, reuse is safe (the normal re-register-before-launch path).
  - **both fail** → port is stuck, allocate a fresh one and log a warning.
- Probe is 200ms TCP connect + bind attempt, matching the style of `docker::is_agent_ready_sync` and PR #411's `wait_for_upstream`.

## Why this is separate from #411
PR #411 added a 5s wait on the **proxy** side so newly-registered services have time to bind. That hid cold-start races but did nothing for the case #371 actually describes: the cached port is stuck and the service process never comes back without manual intervention. Registration-side health check is the piece that makes recovery self-healing.

Fixes #371

## Test plan
- [x] `cd vestad && cargo clippy -p vestad` (clean)
- [x] `cd vestad && cargo test -p vestad` (75 passed — two new `cached_port_is_reusable_*` tests plus existing suite)
- [ ] Manual: crash a registered service leaving the port stuck, re-register, verify the response contains a **new** port and the warn log `cached service port is stuck` is emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)