### PR TITLE
fix(vestad): close HTTP port-selection race by binding inside tokio

### DIFF
--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -196,6 +196,36 @@ fn read_server_info(config: &std::path::Path) -> (Option<String>, Option<String>
     (tunnel_url, local_url, api_key)
 }
 
+/// Bind the HTTP listener atomically inside the tokio runtime. If the HTTP port
+/// (N+1) is in use, re-select a new N via find_available_port and retry. This
+/// closes the TOCTOU race where find_available_port's probe was dropped before
+/// serve.rs bound the port, letting a parallel vestad steal it.
+async fn bind_http_atomically(
+    explicit: Option<u16>,
+    config: &std::path::Path,
+) -> (u16, tokio::net::TcpListener) {
+    const MAX_BIND_ATTEMPTS: u8 = 16;
+    let mut port = resolve_port(explicit, config);
+    for attempt in 0..MAX_BIND_ATTEMPTS {
+        let Some(http_port) = port.checked_add(1) else {
+            port = find_available_port().unwrap_or_else(|| die("no available port found"));
+            continue;
+        };
+        match tokio::net::TcpListener::bind(("127.0.0.1", http_port)).await {
+            Ok(listener) => return (port, listener),
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                if attempt + 1 == MAX_BIND_ATTEMPTS {
+                    die(format!("http bind retries exhausted on port {}: {}", http_port, e));
+                }
+                tracing::warn!(port, http_port, "http port raced, reselecting");
+                port = find_available_port().unwrap_or_else(|| die("no available port found"));
+            }
+            Err(e) => die(format!("failed to bind http listener: {}", e)),
+        }
+    }
+    unreachable!()
+}
+
 fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
     let config = config_dir();
 
@@ -210,38 +240,37 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
             .args(["-f", &format!("cloudflared.*{}", cf_config.display())])
             .output().ok();
     }
-    let port = resolve_port(port, &config);
-    serve::write_port_file(&config, port);
 
     let api_key = serve::ensure_api_key(&config);
     let (cert_pem, key_pem, _fingerprint) = serve::ensure_tls(&config);
-
-    let tunnel_url = if !no_tunnel {
-        match tunnel::ensure_tunnel(&config) {
-            Ok(tc) => Some(format!("https://{}", tc.hostname)),
-            Err(e) => {
-                tracing::warn!("tunnel setup failed: {e}, running without tunnel");
-                None
-            }
-        }
-    } else {
-        None
-    };
-
-    serve::update_agent_env_files(&config, port, tunnel_url.as_deref());
-
-    let local_url = format!("http://localhost:{}", port + 1);
-
-    let user = std::env::var("USER").or_else(|_| std::env::var("LOGNAME")).unwrap_or_else(|_| "unknown".into());
-    eprintln!();
-    eprintln!("  \x1b[1;35mvestad\x1b[0m v{} \x1b[2m(user: {}, port: {})\x1b[0m", env!("CARGO_PKG_VERSION"), user, port);
-    print_server_info(tunnel_url.as_deref(), &local_url, &api_key);
 
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .unwrap()
         .block_on(async {
+            let (port, http_listener) = bind_http_atomically(port, &config).await;
+            serve::write_port_file(&config, port);
+
+            let tunnel_url = if !no_tunnel {
+                match tunnel::ensure_tunnel(&config) {
+                    Ok(tc) => Some(format!("https://{}", tc.hostname)),
+                    Err(e) => {
+                        tracing::warn!("tunnel setup failed: {e}, running without tunnel");
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
+            serve::update_agent_env_files(&config, port, tunnel_url.as_deref());
+            let local_url = format!("http://localhost:{}", port + 1);
+            let user = std::env::var("USER").or_else(|_| std::env::var("LOGNAME")).unwrap_or_else(|_| "unknown".into());
+            eprintln!();
+            eprintln!("  \x1b[1;35mvestad\x1b[0m v{} \x1b[2m(user: {}, port: {})\x1b[0m", env!("CARGO_PKG_VERSION"), user, port);
+            print_server_info(tunnel_url.as_deref(), &local_url, &api_key);
+
             let tunnel_child = if tunnel_url.is_some() {
                 match tunnel::start_tunnel(&config, port).await {
                     Ok((child, _url)) => Some(child),
@@ -255,7 +284,7 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
             };
 
             let dev_mode = cfg!(debug_assertions) || std::env::var("VESTAD_DEV").is_ok();
-            serve::run_server(port, api_key, cert_pem, key_pem, tunnel_url, config.clone(), docker.clone(), dev_mode).await;
+            serve::run_server(port, http_listener, api_key, cert_pem, key_pem, tunnel_url, config.clone(), docker.clone(), dev_mode).await;
 
             if let Some(mut child) = tunnel_child {
                 child.kill().await.ok();

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1647,7 +1647,7 @@ fn spawn_update_check_task(state: SharedState) {
 // --- Server start ---
 
 #[allow(clippy::too_many_arguments)]
-pub async fn run_server(port: u16, api_key: String, cert_pem: String, key_pem: String, tunnel_url: Option<String>, config_dir: std::path::PathBuf, docker: bollard::Docker, dev_mode: bool) {
+pub async fn run_server(port: u16, http_listener: tokio::net::TcpListener, api_key: String, cert_pem: String, key_pem: String, tunnel_url: Option<String>, config_dir: std::path::PathBuf, docker: bollard::Docker, dev_mode: bool) {
     let env_config = docker::AgentEnvConfig {
         config_dir: config_dir.clone(),
         agents_dir: config_dir.join("agents"),
@@ -1692,22 +1692,18 @@ pub async fn run_server(port: u16, api_key: String, cert_pem: String, key_pem: S
     .await
     .expect("failed to configure TLS");
 
-    // HTTPS on 0.0.0.0 for remote access
+    // HTTP listener was bound atomically in main.rs before the runtime entered
+    // the async block, closing the TOCTOU race on the HTTP port. HTTPS binds
+    // inside axum_server::bind_rustls below; its window is short and a loss is
+    // loud (the task panics) rather than silent.
     let https_addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
 
-    // HTTP on 127.0.0.1 for local access (avoids self-signed cert issues)
-    let http_port = port + 1;
-    let http_addr = std::net::SocketAddr::from(([127, 0, 0, 1], http_port));
-
     tracing::info!(port, "https listening on 0.0.0.0");
-    tracing::info!(http_port, "http listening on 127.0.0.1");
+    tracing::info!(http_port = port + 1, "http listening on 127.0.0.1");
 
     let http_app = app.clone();
     let http_handle = tokio::spawn(async move {
-        let listener = tokio::net::TcpListener::bind(http_addr)
-            .await
-            .expect("failed to bind http listener");
-        axum::serve(listener, http_app.into_make_service_with_connect_info::<std::net::SocketAddr>())
+        axum::serve(http_listener, http_app.into_make_service_with_connect_info::<std::net::SocketAddr>())
             .await
             .expect("http server failed");
     });


### PR DESCRIPTION
## Summary

Fixes the flaky `failed to bind http listener: AddrInUse` panic that hit `test-integration` on PR #416. The HTTP port (`port + 1`) was the one that raced; the failing job picked port 39682 and crashed at `serve.rs:1709`.

`find_available_port` in `vestad/src/main.rs` would bind a probe socket on `0.0.0.0:0` to discover a free port, drop the listener, then verify `port + 1` was free and drop that too. By the time `serve.rs`'s spawn task called `tokio::net::TcpListener::bind(http_addr)`, another vestad could have already taken `port + 1`.

## Fix

Bind the HTTP listener atomically inside the tokio runtime in `main.rs`, with retry on `AddrInUse`. Each retry calls `find_available_port` for a fresh port pair. The port file and per-agent env files are written **after** the bind succeeds, so clients always read the port that was actually claimed.

`bind_http_atomically` lives in `main.rs`. `run_server` now takes a pre-bound `tokio::net::TcpListener` for HTTP. HTTPS stays on its original `axum_server::bind_rustls(addr, config)` path; its race window is theoretical and a loss panics the spawn task with a clear address error rather than the silent stale port-file we saw before.

## Test plan
- [x] `cargo clippy -p vestad -- -D warnings` clean
- [x] `cargo test -p vestad` (78 passed, 0 failed)
- [x] `cargo test -p vesta-tests --test multi_user -- --test-threads=8` passes 6/6, including the `containers::container_names_include_user` test that originally raced on AddrInUse on #416 CI.
- [ ] Watch CI for several runs to confirm the AddrInUse flake is gone.

## Notes
The first version of this PR handed pre-bound `std::net::TcpListener`s through to tokio via `from_std` / `from_tcp_rustls`. That approach has been replaced because tokio's edge-triggered epoll registration of pre-existing listeners did not reliably wake the accept loop. Binding the listener inside the tokio runtime (so the FD is registered with the reactor at bind time) is the correct path; this PR does that for HTTP, where the original race was observed.