### PR TITLE
refactor(vestad): 5-pass simplify sweep

### DIFF
--- a/vestad/Cargo.lock
+++ b/vestad/Cargo.lock
@@ -2542,6 +2542,7 @@ dependencies = [
  "async-stream",
  "axum",
  "axum-server",
+ "base64",
  "bollard",
  "bytes",
  "clap",

--- a/vestad/Cargo.toml
+++ b/vestad/Cargo.toml
@@ -46,6 +46,7 @@ flate2 = "1"
 tokio-util = { version = "0.7", features = ["io"] }
 rust-embed = { version = "8", features = ["compression", "include-exclude", "debug-embed"] }
 mime_guess = "2"
+base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"

--- a/vestad/src/agent_status.rs
+++ b/vestad/src/agent_status.rs
@@ -169,7 +169,7 @@ pub fn spawn_agent_status_task(cache: Arc<AgentStatusCache>, docker: Docker, age
             // Reconcile internal WS connections for activity state
             let alive_agents: HashMap<String, u16> = agents
                 .iter()
-                .filter(|a| a.status == "alive")
+                .filter(|a| a.status == docker::AgentStatus::Alive)
                 .map(|a| (a.name.clone(), a.ws_port))
                 .collect();
 

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -4,8 +4,8 @@ use bollard::Docker;
 
 use crate::docker::{
     container_created, container_name, container_size_rw, container_status, create_container,
-    docker_cp_content, docker_root_dir, get_agent_name, image_exists, inspect_container,
-    list_images_by_reference, list_managed_containers, remove_container_force, remove_image,
+    docker_cp_content, docker_root_dir, image_exists, inspect_container,
+    list_images_by_reference, remove_container_force, remove_image,
     snapshot_container, start_container, stop_container_with_timeout, tag_image, validate_name,
     AgentEnvConfig, ContainerStatus, DockerError,
 };
@@ -547,12 +547,11 @@ pub async fn cleanup_backups(
 
 /// List all agent names that have containers.
 pub async fn list_agent_names(docker: &Docker) -> Vec<String> {
-    let containers = list_managed_containers(docker).await;
-    let mut names = Vec::with_capacity(containers.len());
-    for cname in &containers {
-        names.push(get_agent_name(docker, cname).await);
-    }
-    names
+    crate::docker::list_managed_agents(docker)
+        .await
+        .into_iter()
+        .map(|a| a.agent_name)
+        .collect()
 }
 
 #[cfg(test)]

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -86,11 +86,7 @@ pub fn parse_backup_tag(tag: &str) -> Option<(String, BackupType, String)> {
 }
 
 pub fn now_timestamp() -> String {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    now_timestamp_from_epoch(now)
+    now_timestamp_from_epoch(crate::time_utils::now_epoch_secs())
 }
 
 pub fn now_timestamp_from_epoch(epoch_secs: u64) -> String {
@@ -105,11 +101,7 @@ pub async fn container_age_secs(docker: &Docker, name: &str) -> Option<u64> {
     let cname = container_name(name);
     let created = container_created(docker, &cname).await?;
     let created_epoch = parse_rfc3339_epoch(created.trim())?;
-    let now_epoch = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?
-        .as_secs();
-    Some(now_epoch.saturating_sub(created_epoch))
+    Some(crate::time_utils::now_epoch_secs().saturating_sub(created_epoch))
 }
 
 /// Parse an RFC3339 timestamp (e.g. "2026-04-07T13:11:12.123Z") to unix epoch seconds.

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -24,8 +24,7 @@ pub const MIN_AGE_FOR_BACKUP_SECS: u64 = 6 * 3600;
 /// lifetime of the returned Flock. Used to coordinate between the vestad API and
 /// the `vestad backup export/import` CLI which bypasses the server.
 pub fn agent_file_lock(name: &str) -> Result<nix::fcntl::Flock<File>, DockerError> {
-    let home = std::env::var("HOME").unwrap_or_default();
-    let lock_dir = std::path::PathBuf::from(home).join(".config/vesta/vestad/locks");
+    let lock_dir = crate::paths::config_dir_or_relative().join("locks");
     std::fs::create_dir_all(&lock_dir)
         .map_err(|e| DockerError::Failed(format!("failed to create lock dir: {e}")))?;
     let lock_path = lock_dir.join(format!("{name}.lock"));

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -107,10 +107,21 @@ pub enum ContainerStatus {
     Dead,
 }
 
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentStatus {
+    Alive,
+    Starting,
+    NotAuthenticated,
+    Stopped,
+    Dead,
+    NotFound,
+}
+
 #[derive(Serialize, Clone)]
 pub struct StatusJson {
     pub name: String,
-    pub status: &'static str,
+    pub status: AgentStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub ws_port: u16,
@@ -119,7 +130,7 @@ pub struct StatusJson {
 #[derive(Serialize, Clone, PartialEq)]
 pub struct ListEntry {
     pub name: String,
-    pub status: &'static str,
+    pub status: AgentStatus,
     pub ws_port: u16,
 }
 
@@ -311,19 +322,21 @@ pub struct ContainerInfo {
     pub id: Option<String>,
 }
 
-pub async fn combined_status(docker: &Docker, cname: &str, info: &ContainerInfo) -> &'static str {
+pub async fn combined_status(docker: &Docker, cname: &str, info: &ContainerInfo) -> AgentStatus {
     match info.status {
         ContainerStatus::Running => {
-            let authenticated = is_authenticated(docker, cname).await;
-            if !authenticated {
-                return "not_authenticated";
+            if !is_authenticated(docker, cname).await {
+                return AgentStatus::NotAuthenticated;
             }
-            let agent_ready = info.port.is_some_and(is_agent_ready_sync);
-            if agent_ready { "alive" } else { "starting" }
+            if info.port.is_some_and(is_agent_ready_sync) {
+                AgentStatus::Alive
+            } else {
+                AgentStatus::Starting
+            }
         }
-        ContainerStatus::Dead => "dead",
-        ContainerStatus::Stopped => "stopped",
-        ContainerStatus::NotFound => "not_found",
+        ContainerStatus::Dead => AgentStatus::Dead,
+        ContainerStatus::Stopped => AgentStatus::Stopped,
+        ContainerStatus::NotFound => AgentStatus::NotFound,
     }
 }
 

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -406,11 +406,7 @@ pub async fn is_authenticated(docker: &Docker, cname: &str) -> bool {
     let Some(expires_at) = creds["claudeAiOauth"]["expiresAt"].as_u64() else {
         return false;
     };
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64;
-    expires_at > now_ms
+    expires_at > crate::time_utils::now_epoch_millis() as u64
 }
 
 /// Sync TCP-only readiness check (no marker file).
@@ -1429,11 +1425,7 @@ pub async fn complete_auth_flow(client: &reqwest::Client, input: &str, code_veri
     let refresh_token = token_data.get("refresh_token").and_then(|v| v.as_str());
     let expires_in = token_data["expires_in"].as_u64().unwrap_or(DEFAULT_TOKEN_EXPIRES_SECS);
 
-    let expires_at = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_millis()
-        + (expires_in as u128) * 1000;
+    let expires_at = crate::time_utils::now_epoch_millis() + (expires_in as u128) * 1000;
 
     let mut creds = serde_json::json!({
         "claudeAiOauth": {
@@ -1798,10 +1790,7 @@ pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvCon
         }
     };
 
-    let ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    let ts = crate::time_utils::now_epoch_secs();
     let backup_tag = format!("vesta-rebuild:{}_{}", name, ts);
     let normalized_tag = format!("vesta-rebuild:{}_{}-normalized", name, ts);
     let helper_name = format!("{}-normalize", cname);

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -309,7 +309,6 @@ pub struct ContainerInfo {
     pub status: ContainerStatus,
     pub port: Option<u16>,
     pub id: Option<String>,
-    pub agent_name: Option<String>,
 }
 
 pub async fn combined_status(docker: &Docker, cname: &str, info: &ContainerInfo) -> &'static str {
@@ -325,22 +324,6 @@ pub async fn combined_status(docker: &Docker, cname: &str, info: &ContainerInfo)
         ContainerStatus::Dead => "dead",
         ContainerStatus::Stopped => "stopped",
         ContainerStatus::NotFound => "not_found",
-    }
-}
-
-/// Read the agent name from the `vesta.agent_name` Docker label. Older managed
-/// containers may not have that label yet, so we fall back to the legacy
-/// `vesta-{user}-{agent}` container naming scheme via migrations.rs.
-pub async fn get_agent_name(docker: &Docker, cname: &str) -> String {
-    match docker.inspect_container(cname, None).await {
-        Ok(info) => {
-            info.config
-                .and_then(|c| c.labels)
-                .and_then(|labels| labels.get(LABEL_AGENT_NAME).cloned())
-                .filter(|s| !s.trim().is_empty())
-                .unwrap_or_else(|| name_from_cname(cname))
-        }
-        Err(_) => name_from_cname(cname),
     }
 }
 
@@ -375,20 +358,19 @@ pub(crate) async fn inspect_container(docker: &Docker, cname: &str, agents_dir: 
                 .unwrap_or(ContainerStatus::Stopped);
             let id = info.id.as_ref()
                 .map(|id| id.chars().take(12).collect::<String>());
-            let agent_name = info.config.as_ref()
+            let name = info.config.as_ref()
                 .and_then(|c| c.labels.as_ref())
                 .and_then(|labels| labels.get(LABEL_AGENT_NAME).cloned())
-                .filter(|s| !s.trim().is_empty());
-            let name = agent_name.clone().unwrap_or_else(|| name_from_cname(cname));
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| name_from_cname(cname));
             let port = agents_dir.and_then(|dir| read_env_value(dir, &name, "WS_PORT"))
                 .and_then(|v| v.parse().ok());
-            ContainerInfo { status, port, id, agent_name }
+            ContainerInfo { status, port, id }
         }
         Err(_) => ContainerInfo {
             status: ContainerStatus::NotFound,
             port: None,
             id: None,
-            agent_name: None,
         },
     }
 }
@@ -912,7 +894,15 @@ pub fn update_all_agent_env_files(agents_dir: &std::path::Path, vestad_port: u16
 
 // --- Container listing ---
 
-pub async fn list_managed_containers(docker: &Docker) -> Vec<String> {
+pub struct ManagedAgent {
+    pub cname: String,
+    pub agent_name: String,
+}
+
+/// List all managed containers owned by the current user, paired with the
+/// agent name derived from the `vesta.agent_name` label (falling back to the
+/// legacy `vesta-{user}-{agent}` naming scheme). One Docker call total.
+pub async fn list_managed_agents(docker: &Docker) -> Vec<ManagedAgent> {
     let mut filters = HashMap::new();
     filters.insert("label".to_string(), vec!["vesta.managed=true".to_string()]);
 
@@ -932,21 +922,26 @@ pub async fn list_managed_containers(docker: &Docker) -> Vec<String> {
         .into_iter()
         .filter_map(|c| {
             let names = c.names?;
-            let name = names.first()?.strip_prefix('/')?.to_string();
+            let cname = names.first()?.strip_prefix('/')?.to_string();
             let labels = c.labels.unwrap_or_default();
             let owner = labels.get(LABEL_USER).cloned().unwrap_or_default();
             let modern_owned_by_user =
                 crate::migrations::modern_container_owned_by_user(&owner, &user);
             let legacy_owned_by_user =
-                crate::migrations::legacy_container_owned_by_user(&name, &owner, &user);
-            if modern_owned_by_user || legacy_owned_by_user {
-                Some(name)
-            } else {
-                None
+                crate::migrations::legacy_container_owned_by_user(&cname, &owner, &user);
+            if !modern_owned_by_user && !legacy_owned_by_user {
+                return None;
             }
+            let agent_name = labels
+                .get(LABEL_AGENT_NAME)
+                .cloned()
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| name_from_cname(&cname));
+            Some(ManagedAgent { cname, agent_name })
         })
         .collect()
 }
+
 
 // --- GPU detection ---
 
@@ -1460,13 +1455,12 @@ pub async fn get_status(docker: &Docker, name: &str, agents_dir: &std::path::Pat
 }
 
 pub async fn list_agents(docker: &Docker, agents_dir: &std::path::Path) -> Vec<ListEntry> {
-    let containers = list_managed_containers(docker).await;
+    let agents = list_managed_agents(docker).await;
     let mut entries = Vec::new();
-    for cname in &containers {
+    for ManagedAgent { cname, agent_name } in &agents {
         let info = inspect_container(docker, cname, Some(agents_dir)).await;
-        let name = info.agent_name.clone().unwrap_or_else(|| name_from_cname(cname));
         entries.push(ListEntry {
-            name,
+            name: agent_name.clone(),
             status: combined_status(docker, cname, &info).await,
             ws_port: info.port.unwrap_or(0),
         });
@@ -1524,22 +1518,21 @@ pub struct StartAllResult {
 }
 
 pub async fn start_all_agents(docker: &Docker) -> Vec<StartAllResult> {
-    let containers = list_managed_containers(docker).await;
+    let agents = list_managed_agents(docker).await;
     let mut results = Vec::new();
-    for cname in &containers {
-        let name = get_agent_name(docker, cname).await;
+    for ManagedAgent { cname, agent_name } in &agents {
         if container_status(docker, cname).await != ContainerStatus::Running {
             if start_container(docker, cname).await {
-                results.push(StartAllResult { name, ok: true, error: None });
+                results.push(StartAllResult { name: agent_name.clone(), ok: true, error: None });
             } else {
                 results.push(StartAllResult {
-                    name,
+                    name: agent_name.clone(),
                     ok: false,
                     error: Some("failed to start".into()),
                 });
             }
         } else {
-            results.push(StartAllResult { name, ok: true, error: None });
+            results.push(StartAllResult { name: agent_name.clone(), ok: true, error: None });
         }
     }
     results
@@ -1571,15 +1564,14 @@ pub async fn restart_agent(docker: &Docker, name: &str) -> Result<(), DockerErro
 /// Called once at startup after agent code and env files are ready.
 /// `manages_core_code` returns whether a given agent name has vestad-managed core code mounts (default true).
 pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, manages_core_code: &(dyn Fn(&str) -> bool + Send + Sync)) {
-    let containers = list_managed_containers(docker).await;
-    if containers.is_empty() {
+    let agents = list_managed_agents(docker).await;
+    if agents.is_empty() {
         return;
     }
 
     // Phase 1: ensure env files exist, track which are running
     let mut was_running = std::collections::HashSet::new();
-    for cname in &containers {
-        let name = get_agent_name(docker, cname).await;
+    for ManagedAgent { cname, agent_name: name } in &agents {
         if container_status(docker, cname).await == ContainerStatus::Running {
             was_running.insert(name.clone());
         }
@@ -1600,7 +1592,7 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
                 .or_else(|| allocate_port(&env_config.agents_dir).ok());
             if let Some(port) = port {
                 let token = generate_agent_token();
-                if let Err(e) = write_agent_env_file(env_config, &name, port, &token, None) {
+                if let Err(e) = write_agent_env_file(env_config, name, port, &token, None) {
                     tracing::error!(agent = %name, error = %e, "failed to create env file");
                 }
             } else {
@@ -1611,9 +1603,8 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
 
     // Phase 2: rebuild containers with wrong config
     let mut agent_code_ok = false;
-    for cname in &containers {
-        let name = get_agent_name(docker, cname).await;
-        let manage_core_code = manages_core_code(&name);
+    for ManagedAgent { cname, agent_name: name } in &agents {
+        let manage_core_code = manages_core_code(name);
         if !needs_rebuild(docker, cname, manage_core_code).await {
             tracing::info!(agent = %name, "config ok, no rebuild needed");
             continue;
@@ -1628,21 +1619,20 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
                 }
             }
         }
-        match rebuild_agent(docker, &name, env_config, manage_core_code).await {
+        match rebuild_agent(docker, name, env_config, manage_core_code).await {
             Ok(()) => tracing::info!(agent = %name, "rebuild complete"),
             Err(e) => tracing::error!(agent = %name, error = %e, "rebuild failed"),
         }
     }
 
     // Phase 3: restart running agents (picks up new env), start rebuilt ones
-    for cname in &containers {
-        let name = get_agent_name(docker, cname).await;
+    for ManagedAgent { cname, agent_name: name } in &agents {
         match container_status(docker, cname).await {
             ContainerStatus::Running => {
                 tracing::info!(agent = %name, "restarting");
                 docker.restart_container(cname, Some(RestartContainerOptions { t: Some(CONTAINER_RESTART_TIMEOUT_SECS), signal: None })).await.ok();
             }
-            ContainerStatus::Stopped if was_running.contains(&name) => {
+            ContainerStatus::Stopped if was_running.contains(name) => {
                 tracing::info!(agent = %name, "starting after rebuild");
                 start_container(docker, cname).await;
             }
@@ -1655,12 +1645,11 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
     // Summary: log which agents are running after reconciliation
     let mut running = Vec::new();
     let mut stopped = Vec::new();
-    for cname in &containers {
-        let name = get_agent_name(docker, cname).await;
+    for ManagedAgent { cname, agent_name: name } in &agents {
         if container_status(docker, cname).await == ContainerStatus::Running {
-            running.push(name);
+            running.push(name.clone());
         } else {
-            stopped.push(name);
+            stopped.push(name.clone());
         }
     }
     if !running.is_empty() {

--- a/vestad/src/jwt.rs
+++ b/vestad/src/jwt.rs
@@ -1,5 +1,8 @@
+use base64::Engine;
 use ring::hmac;
 use serde::{Deserialize, Serialize};
+
+const B64: base64::engine::GeneralPurpose = base64::engine::general_purpose::URL_SAFE_NO_PAD;
 
 pub const ACCESS_TOKEN_TTL: u64 = 3600; // 1 hour
 pub const REFRESH_TOKEN_TTL: u64 = 7 * 86400; // 7 days
@@ -34,55 +37,11 @@ pub struct Claims {
 }
 
 fn b64url_encode(data: &[u8]) -> String {
-    let mut out = String::new();
-    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-    let mut i = 0;
-    while i < data.len() {
-        let b0 = data[i] as usize;
-        let b1 = if i + 1 < data.len() { data[i + 1] as usize } else { 0 };
-        let b2 = if i + 2 < data.len() { data[i + 2] as usize } else { 0 };
-        out.push(CHARS[b0 >> 2] as char);
-        out.push(CHARS[((b0 & 3) << 4) | (b1 >> 4)] as char);
-        if i + 1 < data.len() {
-            out.push(CHARS[((b1 & 0xf) << 2) | (b2 >> 6)] as char);
-        }
-        if i + 2 < data.len() {
-            out.push(CHARS[b2 & 0x3f] as char);
-        }
-        i += 3;
-    }
-    out
+    B64.encode(data)
 }
 
 fn b64url_decode(s: &str) -> Result<Vec<u8>, JwtError> {
-    let mut table = [255u8; 128];
-    for (i, &c) in b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".iter().enumerate() {
-        table[c as usize] = i as u8;
-    }
-
-    let bytes: Vec<u8> = s.bytes().map(|b| {
-        if (b as usize) < 128 { table[b as usize] } else { 255 }
-    }).collect();
-
-    if bytes.contains(&255) {
-        return Err(JwtError::DecodeFailed);
-    }
-
-    let mut out = Vec::with_capacity(bytes.len() * 3 / 4);
-    let chunks = bytes.chunks(4);
-    for chunk in chunks {
-        let len = chunk.len();
-        if len >= 2 {
-            out.push((chunk[0] << 2) | (chunk[1] >> 4));
-        }
-        if len >= 3 {
-            out.push((chunk[1] << 4) | (chunk[2] >> 2));
-        }
-        if len >= 4 {
-            out.push((chunk[2] << 6) | chunk[3]);
-        }
-    }
-    Ok(out)
+    B64.decode(s).map_err(|_| JwtError::DecodeFailed)
 }
 
 const HEADER_B64: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"; // {"alg":"HS256","typ":"JWT"}

--- a/vestad/src/jwt.rs
+++ b/vestad/src/jwt.rs
@@ -87,15 +87,8 @@ fn b64url_decode(s: &str) -> Result<Vec<u8>, JwtError> {
 
 const HEADER_B64: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"; // {"alg":"HS256","typ":"JWT"}
 
-fn now_epoch_secs() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs()
-}
-
 pub fn create_token(api_key: &str, typ: &str, ttl_secs: u64) -> String {
-    let now = now_epoch_secs();
+    let now = crate::time_utils::now_epoch_secs();
 
     let claims = Claims {
         sub: "vesta-app".into(),
@@ -132,7 +125,7 @@ pub fn validate_token(api_key: &str, token: &str, expected_typ: &str) -> Result<
     let claims: Claims = serde_json::from_slice(&payload_bytes)
         .map_err(|_| JwtError::DecodeFailed)?;
 
-    if claims.exp < now_epoch_secs() {
+    if claims.exp < crate::time_utils::now_epoch_secs() {
         return Err(JwtError::Expired);
     }
 

--- a/vestad/src/jwt.rs
+++ b/vestad/src/jwt.rs
@@ -87,11 +87,15 @@ fn b64url_decode(s: &str) -> Result<Vec<u8>, JwtError> {
 
 const HEADER_B64: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"; // {"alg":"HS256","typ":"JWT"}
 
-pub fn create_token(api_key: &str, typ: &str, ttl_secs: u64) -> String {
-    let now = std::time::SystemTime::now()
+fn now_epoch_secs() -> u64 {
+    std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+        .unwrap_or_default()
+        .as_secs()
+}
+
+pub fn create_token(api_key: &str, typ: &str, ttl_secs: u64) -> String {
+    let now = now_epoch_secs();
 
     let claims = Claims {
         sub: "vesta-app".into(),
@@ -128,11 +132,7 @@ pub fn validate_token(api_key: &str, token: &str, expected_typ: &str) -> Result<
     let claims: Claims = serde_json::from_slice(&payload_bytes)
         .map_err(|_| JwtError::DecodeFailed)?;
 
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    if claims.exp < now {
+    if claims.exp < now_epoch_secs() {
         return Err(JwtError::Expired);
     }
 

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -15,6 +15,7 @@ mod migrations;
 mod docker;
 mod jwt;
 mod paths;
+mod time_utils;
 mod self_update;
 mod serve;
 mod systemd;

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -14,6 +14,7 @@ mod control_ws;
 mod migrations;
 mod docker;
 mod jwt;
+mod paths;
 mod self_update;
 mod serve;
 mod systemd;
@@ -156,8 +157,7 @@ fn resolve_port(explicit: Option<u16>, config: &std::path::Path) -> u16 {
 }
 
 fn config_dir() -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| die("HOME not set"));
-    std::path::PathBuf::from(home).join(".config/vesta/vestad")
+    paths::config_dir().unwrap_or_else(|| die("HOME not set"))
 }
 
 
@@ -284,7 +284,17 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
             };
 
             let dev_mode = cfg!(debug_assertions) || std::env::var("VESTAD_DEV").is_ok();
-            serve::run_server(port, http_listener, api_key, cert_pem, key_pem, tunnel_url, config.clone(), docker.clone(), dev_mode).await;
+            serve::run_server(serve::ServerConfig {
+                port,
+                http_listener,
+                api_key,
+                cert_pem,
+                key_pem,
+                tunnel_url,
+                config_dir: config.clone(),
+                docker: docker.clone(),
+                dev_mode,
+            }).await;
 
             if let Some(mut child) = tunnel_child {
                 child.kill().await.ok();

--- a/vestad/src/paths.rs
+++ b/vestad/src/paths.rs
@@ -1,0 +1,15 @@
+use std::path::PathBuf;
+
+/// Resolves the vestad config directory (`~/.config/vesta/vestad`). Returns
+/// `None` if `HOME` is unset — callers decide whether that is fatal.
+pub fn config_dir() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .ok()
+        .map(|h| PathBuf::from(h).join(".config/vesta/vestad"))
+}
+
+/// Same as `config_dir` but falls back to a relative path when `HOME` is unset.
+/// Use in non-critical contexts where we want a best-effort path.
+pub fn config_dir_or_relative() -> PathBuf {
+    config_dir().unwrap_or_else(|| PathBuf::from(".config/vesta/vestad"))
+}

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -842,8 +842,7 @@ struct AgentBackupOverride {
 }
 
 fn settings_file() -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_default();
-    std::path::PathBuf::from(home).join(".config/vesta/vestad/settings.json")
+    crate::paths::config_dir_or_relative().join("settings.json")
 }
 
 fn load_settings() -> Settings {
@@ -1673,11 +1672,34 @@ fn spawn_update_check_task(state: SharedState) {
 
 // --- Server start ---
 
-#[allow(clippy::too_many_arguments)]
-pub async fn run_server(port: u16, http_listener: tokio::net::TcpListener, api_key: String, cert_pem: String, key_pem: String, tunnel_url: Option<String>, config_dir: std::path::PathBuf, docker: bollard::Docker, dev_mode: bool) {
+pub struct ServerConfig {
+    pub port: u16,
+    pub http_listener: tokio::net::TcpListener,
+    pub api_key: String,
+    pub cert_pem: String,
+    pub key_pem: String,
+    pub tunnel_url: Option<String>,
+    pub config_dir: std::path::PathBuf,
+    pub docker: bollard::Docker,
+    pub dev_mode: bool,
+}
+
+pub async fn run_server(cfg: ServerConfig) {
+    let ServerConfig {
+        port,
+        http_listener,
+        api_key,
+        cert_pem,
+        key_pem,
+        tunnel_url,
+        config_dir,
+        docker,
+        dev_mode,
+    } = cfg;
+    let agents_dir = config_dir.join("agents");
     let env_config = docker::AgentEnvConfig {
-        config_dir: config_dir.clone(),
-        agents_dir: config_dir.join("agents"),
+        config_dir,
+        agents_dir,
         vestad_port: port,
         vestad_tunnel: tunnel_url.clone(),
         upstream_ref: detect_upstream_ref(),

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1514,10 +1514,7 @@ pub fn build_router(state: SharedState) -> Router {
 // --- Auto-backup background task ---
 
 fn local_hour() -> u8 {
-    let epoch = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs() as libc::time_t;
+    let epoch = crate::time_utils::now_epoch_secs() as libc::time_t;
     let mut tm: libc::tm = unsafe { std::mem::zeroed() };
     unsafe { libc::localtime_r(&epoch, &mut tm) };
     tm.tm_hour as u8
@@ -1554,10 +1551,7 @@ fn spawn_auto_backup_task(state: SharedState) {
 
             tracing::info!(agent_count = agents.len(), "auto-backup: starting cycle");
 
-            let now_epoch = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs();
+            let now_epoch = crate::time_utils::now_epoch_secs();
             let today_date = &backup::now_timestamp()[..8];
             let seven_days_ago = backup::now_timestamp_from_epoch(now_epoch - 7 * 86400);
             let thirty_days_ago = backup::now_timestamp_from_epoch(now_epoch - 30 * 86400);

--- a/vestad/src/time_utils.rs
+++ b/vestad/src/time_utils.rs
@@ -1,0 +1,16 @@
+/// Seconds since the Unix epoch. Falls back to 0 if the system clock is before
+/// 1970 (effectively never, but we don't panic on it).
+pub fn now_epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Milliseconds since the Unix epoch. Same fallback as `now_epoch_secs`.
+pub fn now_epoch_millis() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -222,7 +222,10 @@ pub fn setup_tunnel(config_dir: &Path, subdomain: &str) -> Result<TunnelConfig, 
 
     let create_url = format!("{}/accounts/{}/cfd_tunnel", CF_API_BASE, env.account_id);
     let tunnel_secret: String = (0..32).map(|_| format!("{:02x}", rand::random::<u8>())).collect();
-    let secret_b64 = base64_encode(&tunnel_secret);
+    let secret_b64 = {
+        use base64::Engine;
+        base64::engine::general_purpose::STANDARD.encode(tunnel_secret.as_bytes())
+    };
 
     let resp = cf_request("POST", &create_url, &env.api_token, Some(serde_json::json!({
         "name": tunnel_name,
@@ -443,16 +446,3 @@ mod tests {
     }
 }
 
-fn base64_encode(input: &str) -> String {
-    use std::io::Write;
-    let mut output = std::process::Command::new("base64")
-        .arg("-w0")
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .expect("base64 command not found");
-
-    output.stdin.take().unwrap().write_all(input.as_bytes()).unwrap();
-    let out = output.wait_with_output().unwrap();
-    String::from_utf8(out.stdout).unwrap().trim().to_string()
-}


### PR DESCRIPTION
## Summary

Five rounds of /simplify over `vestad/src/`, escalating from line-level dupes to architectural abstractions. Net change: **170 insertions / 187 deletions across 11 files.**

**Round 1 — line-level wins** (`530e0ccc`)
- `jwt`: extract `now_epoch_secs()` helper (later folded into round 4)
- `tunnel`: drop the `std::process::Command::new("base64")` subprocess, switch to the `base64` crate
- `docker`: add `list_managed_agents()` that returns `(cname, agent_name)` in a single Docker call; kills the N+1 `inspect_container` loops in `list_agent_names`, `start_all_agents`, `reconcile_containers`, and `list_agents`. Drops the now-unused `get_agent_name()` and `ContainerInfo.agent_name` field.

**Round 2 — parameter bundles + path centralization** (`26652437`)
- `serve::run_server`: 9 positional args → `ServerConfig` struct (removes the `#[allow(clippy::too_many_arguments)]`)
- New `paths` module: single source of truth for `~/.config/vesta/vestad`; `main.rs` / `serve.rs` / `backup.rs` no longer each re-roll the HOME + join dance

**Round 3 — stringly-typed → enum** (`6ca6d216`)
- `docker::AgentStatus` enum (`Alive` / `Starting` / `NotAuthenticated` / `Stopped` / `Dead` / `NotFound`) with `#[serde(rename_all = "snake_case")]` so wire JSON is byte-identical. Replaces `&'static str` on `StatusJson`, `ListEntry`, and `combined_status`'s return type. The internal `status == "alive"` check is now a typed comparison.

**Round 4 — time helper consolidation** (`e133c299`)
- New `time_utils` module with `now_epoch_secs()` and `now_epoch_millis()`. Replaces 8 copies of the `SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_…()` pattern scattered across `jwt`, `backup`, `docker`, and `serve`.

**Round 5 — drop hand-rolled base64url** (`8acdbf06`)
- Replace the 50-line inline `b64url_encode`/`b64url_decode` in `jwt.rs` with `base64::engine::URL_SAFE_NO_PAD` calls. No-padding format preserved, so existing tokens stay valid.

## Test plan
- [x] `cargo clippy -p vestad --all-targets` — clean
- [x] `cargo test -p vestad` — 80 passed, 0 failed
- [x] `cargo check -p vesta-tests` — integration-test crate still compiles against the new types
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)