### PR TITLE
fix(agent): close silent-death path in message processor

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -488,16 +488,21 @@ def _contains_dashes(texts: list[str]) -> bool:
     return any(_EM_DASH in t or _EN_DASH in t or " - " in t for t in texts)
 
 
+_CONTEXT_USAGE_TIMEOUT_S = 10.0
+
+
 async def _log_context_usage(state: vm.State) -> None:
     if not state.client:
         return
     try:
-        usage = await state.client.get_context_usage()
+        usage = await asyncio.wait_for(state.client.get_context_usage(), timeout=_CONTEXT_USAGE_TIMEOUT_S)
         pct = usage["percentage"]
         total = usage["totalTokens"]
         max_tok = usage["maxTokens"]
         log_fn = logger.warning if pct > 80 else logger.usage
         log_fn(f"Context: {pct:.0f}% ({total:,}/{max_tok:,} tokens)")
+    except TimeoutError:
+        logger.warning(f"get_context_usage hung for {_CONTEXT_USAGE_TIMEOUT_S}s — skipping")
     except (OSError, RuntimeError, KeyError, TypeError):
         pass
 

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -165,7 +165,7 @@ async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, c
     except asyncio.CancelledError:
         logger.error("Message processing cancelled unexpectedly — triggering restart")
         state.event_bus.emit({"type": "error", "text": "processing cancelled"})
-        state.restart_reason = "error — processing cancelled"
+        state.restart_reason = vm.PROCESSING_CANCELLED_ERROR
         state.graceful_shutdown.set()
         raise
     except (ClaudeSDKError, OSError, RuntimeError, ValueError, TimeoutError) as e:

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -162,6 +162,12 @@ async def _process_message_safely(msg: str, *, is_user: bool, state: vm.State, c
             logger.system(preview.replace("\n", " "))
         state.event_bus.set_state("thinking")
         await process_message(msg, state=state, config=config, is_user=is_user)
+    except asyncio.CancelledError:
+        logger.error("Message processing cancelled unexpectedly — triggering restart")
+        state.event_bus.emit({"type": "error", "text": "processing cancelled"})
+        state.restart_reason = "error — processing cancelled"
+        state.graceful_shutdown.set()
+        raise
     except (ClaudeSDKError, OSError, RuntimeError, ValueError, TimeoutError) as e:
         if isinstance(e, TimeoutError):
             error_msg = "Response timed out"
@@ -268,6 +274,11 @@ async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm
                             config.session_file.unlink(missing_ok=True)
                             state.session_id = None
                             (config.data_dir / "show_dreamer_summary").write_text("1")
+                            if state.last_dreamer_run is not None:
+                                try:
+                                    (config.data_dir / "last_dreamer_run").write_text(state.last_dreamer_run.isoformat())
+                                except OSError:
+                                    logger.warning("Could not persist last_dreamer_run")
                             state.restart_reason = vm.NIGHTLY_RESTART
                             state.graceful_shutdown.set()
                 finally:
@@ -315,10 +326,6 @@ async def process_nightly_memory(queue: asyncio.Queue[tuple[str, bool]], *, stat
             state.dreamer_active = True
             await queue.put((prompt, False))
             state.last_dreamer_run = now
-            try:
-                (config.data_dir / "last_dreamer_run").write_text(now.isoformat())
-            except OSError:
-                logger.warning("Could not persist last_dreamer_run")
             logger.dreamer("Dreamer prompt queued")
 
 

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -76,17 +76,16 @@ def handle_processor_done(task: asyncio.Task[None], *, state: vm.State) -> None:
         return
     if task.cancelled():
         logger.error("message_processor cancelled unexpectedly — restarting")
-        state.restart_reason = "crash — processor cancelled unexpectedly"
-        state.graceful_shutdown.set()
-        return
-    exc = task.exception()
-    if exc is not None:
-        exit_code, stderr_tail = format_crash_detail(exc, state.stderr_buffer)
-        logger.error(f"message_processor crashed: {type(exc).__name__}: {exc} | exit_code={exit_code}\nRecent stderr:\n{stderr_tail}")
-        state.restart_reason = f"crash — {type(exc).__name__}: {exc}"
+        state.restart_reason = vm.PROCESSOR_CANCELLED_RESTART
     else:
-        logger.error("message_processor exited without error — restarting")
-        state.restart_reason = "crash — processor exited silently"
+        exc = task.exception()
+        if exc is not None:
+            exit_code, stderr_tail = format_crash_detail(exc, state.stderr_buffer)
+            logger.error(f"message_processor crashed: {type(exc).__name__}: {exc} | exit_code={exit_code}\nRecent stderr:\n{stderr_tail}")
+            state.restart_reason = f"crash — {type(exc).__name__}: {exc}"
+        else:
+            logger.error("message_processor exited without error — restarting")
+            state.restart_reason = vm.PROCESSOR_SILENT_EXIT_RESTART
     state.graceful_shutdown.set()
 
 

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -69,6 +69,27 @@ def _make_signal_handler(state: vm.State, *, allow_force_exit: bool = False) -> 
     return handler
 
 
+def handle_processor_done(task: asyncio.Task[None], *, state: vm.State) -> None:
+    """Done-callback for the message_processor task. Guarantees restart_reason + graceful_shutdown
+    are set on any unexpected termination, so the agent never wedges silently."""
+    if state.shutdown_event.is_set() or state.graceful_shutdown.is_set():
+        return
+    if task.cancelled():
+        logger.error("message_processor cancelled unexpectedly — restarting")
+        state.restart_reason = "crash — processor cancelled unexpectedly"
+        state.graceful_shutdown.set()
+        return
+    exc = task.exception()
+    if exc is not None:
+        exit_code, stderr_tail = format_crash_detail(exc, state.stderr_buffer)
+        logger.error(f"message_processor crashed: {type(exc).__name__}: {exc} | exit_code={exit_code}\nRecent stderr:\n{stderr_tail}")
+        state.restart_reason = f"crash — {type(exc).__name__}: {exc}"
+    else:
+        logger.error("message_processor exited without error — restarting")
+        state.restart_reason = "crash — processor exited silently"
+    state.graceful_shutdown.set()
+
+
 async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: bool = False, restart_reason: str = vm.CLEAN_RESTART) -> None:
     signal.signal(signal.SIGHUP, signal.SIG_IGN)
     signal.signal(signal.SIGINT, _make_signal_handler(state, allow_force_exit=True))
@@ -82,21 +103,7 @@ async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: boo
     logger.init(f"WebSocket server started on port {config.ws_port}")
 
     processor_task = asyncio.create_task(message_processor(message_queue, state=state, config=config))
-
-    def _on_processor_done(task: asyncio.Task[None]) -> None:
-        if task.cancelled() or state.shutdown_event.is_set() or state.graceful_shutdown.is_set():
-            return
-        exc = task.exception()
-        if exc is not None:
-            exit_code, stderr_tail = format_crash_detail(exc, state.stderr_buffer)
-            logger.error(f"message_processor crashed: {type(exc).__name__}: {exc} | exit_code={exit_code}\nRecent stderr:\n{stderr_tail}")
-            state.restart_reason = f"crash — {type(exc).__name__}: {exc}"
-        else:
-            logger.error("message_processor exited without error — restarting")
-            state.restart_reason = "crash — processor exited silently"
-        state.graceful_shutdown.set()
-
-    processor_task.add_done_callback(_on_processor_done)
+    processor_task.add_done_callback(lambda t: handle_processor_done(t, state=state))
 
     tasks = [
         asyncio.create_task(input_handler(message_queue, state=state)),

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -16,6 +16,9 @@ __all__ = ["State", "Notification", "VestaConfig"]
 CLEAN_RESTART = "restart — clean restart"
 NIGHTLY_RESTART = "nightly — dreamer ran, session cleared for fresh context"
 CRASH_RESTART = "crash — restarted after unexpected exit"
+PROCESSOR_CANCELLED_RESTART = "crash — processor cancelled unexpectedly"
+PROCESSOR_SILENT_EXIT_RESTART = "crash — processor exited silently"
+PROCESSING_CANCELLED_ERROR = "error — processing cancelled"
 
 
 @dc.dataclass

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -65,6 +65,7 @@ async def test_clears_session_and_restarts(tmp_path):
     pre_state = vm.State()
     pre_state.session_id = "pre-dreamer-session"
     pre_state.dreamer_active = True
+    pre_state.last_dreamer_run = dt.datetime(2025, 6, 15, 4, 0, 0)
 
     fake_now = dt.datetime(2025, 6, 15, 4, 5, 0)
     state, session_count, messages = await _run_processor_test(
@@ -81,3 +82,34 @@ async def test_clears_session_and_restarts(tmp_path):
     assert state.restart_reason == "nightly — dreamer ran, session cleared for fresh context"
     # No /compact message — session deletion replaces it
     assert messages == ["dreamer prompt content"]
+    # last_dreamer_run is persisted to disk only on completion
+    persisted = (tmp_path / "agent" / "data" / "last_dreamer_run").read_text().strip()
+    assert persisted == pre_state.last_dreamer_run.isoformat()
+
+
+@pytest.mark.anyio
+async def test_queue_does_not_persist_last_dreamer_run(tmp_path):
+    """If the dreamer is queued but never completes (e.g. backup interrupts), disk must stay stale.
+
+    Protects against a bug where last_dreamer_run was written at queue time, which locked the
+    dreamer out for the day even if it never actually ran.
+    """
+    from core.loops import process_nightly_memory
+
+    state = vm.State()
+    state.last_dreamer_run = None
+    queue: asyncio.Queue = asyncio.Queue()
+
+    dreamer_hour = 4
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent", nightly_memory_hour=dreamer_hour)
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+    fake_now = dt.datetime(2025, 6, 15, dreamer_hour, 0, 0)
+
+    with (
+        patch("core.loops._now", return_value=fake_now),
+        patch("core.loops.load_prompt", return_value="dreamer prompt"),
+    ):
+        await process_nightly_memory(queue, state=state, config=config)
+
+    assert state.last_dreamer_run == fake_now
+    assert not (config.data_dir / "last_dreamer_run").exists()

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -193,3 +193,128 @@ async def test_process_message_no_correction_on_empty_response(tmp_path):
         await process_message("hello", state=state, config=config, is_user=True)
 
     assert len(converse_calls) == 1
+
+
+@pytest.mark.anyio
+async def test_cancellation_triggers_restart(tmp_path):
+    """If process_message raises CancelledError, restart_reason + graceful_shutdown must be set.
+
+    Regression test for a silent-death bug: CancelledError used to propagate uncaught through
+    _process_message_safely, bypassing the restart trigger and leaving the agent wedged until
+    backup SIGTERM hours later.
+    """
+    from core.loops import _process_message_safely
+
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent")
+    state = vm.State()
+
+    async def cancel_side_effect(msg, *, state, config, is_user):
+        raise asyncio.CancelledError
+
+    with patch("core.loops.process_message", side_effect=cancel_side_effect):
+        with pytest.raises(asyncio.CancelledError):
+            await _process_message_safely("msg", is_user=True, state=state, config=config)
+
+    assert state.graceful_shutdown.is_set()
+    assert state.restart_reason == "error — processing cancelled"
+
+
+@pytest.mark.anyio
+async def test_handle_processor_done_silent_cancel_triggers_restart():
+    """Regression: a cancelled processor task used to return silently, leaving the agent wedged.
+    Now it must log + set restart_reason + set graceful_shutdown."""
+    from core.main import handle_processor_done
+
+    state = vm.State()
+
+    async def cancellable():
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(cancellable())
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    handle_processor_done(task, state=state)
+
+    assert state.graceful_shutdown.is_set()
+    assert state.restart_reason == "crash — processor cancelled unexpectedly"
+
+
+@pytest.mark.anyio
+async def test_handle_processor_done_exception_triggers_restart():
+    """A crashed processor task should log the exception and set restart_reason."""
+    from core.main import handle_processor_done
+
+    state = vm.State()
+
+    async def crasher():
+        raise RuntimeError("simulated crash")
+
+    task = asyncio.create_task(crasher())
+    with contextlib.suppress(RuntimeError):
+        await task
+
+    handle_processor_done(task, state=state)
+
+    assert state.graceful_shutdown.is_set()
+    assert state.restart_reason is not None
+    assert "RuntimeError" in state.restart_reason
+
+
+@pytest.mark.anyio
+async def test_handle_processor_done_silent_exit_triggers_restart():
+    """A processor task that returns without error or cancellation should still trigger restart."""
+    from core.main import handle_processor_done
+
+    state = vm.State()
+
+    async def silent():
+        return None
+
+    task = asyncio.create_task(silent())
+    await task
+
+    handle_processor_done(task, state=state)
+
+    assert state.graceful_shutdown.is_set()
+    assert state.restart_reason == "crash — processor exited silently"
+
+
+@pytest.mark.anyio
+async def test_handle_processor_done_noop_during_shutdown():
+    """If shutdown was already initiated, the callback must not override the restart_reason."""
+    from core.main import handle_processor_done
+
+    state = vm.State()
+    state.graceful_shutdown.set()
+    state.restart_reason = "nightly — dreamer ran, session cleared for fresh context"
+
+    async def silent():
+        return None
+
+    task = asyncio.create_task(silent())
+    await task
+
+    handle_processor_done(task, state=state)
+
+    assert state.restart_reason == "nightly — dreamer ran, session cleared for fresh context"
+
+
+@pytest.mark.anyio
+async def test_log_context_usage_timeout(tmp_path):
+    """If get_context_usage hangs, _log_context_usage must time out and not raise."""
+    from core.client import _log_context_usage
+
+    state = vm.State()
+    mock_client = MagicMock()
+
+    async def hang_forever():
+        await asyncio.sleep(10)
+        return {"percentage": 0, "totalTokens": 0, "maxTokens": 0}
+
+    mock_client.get_context_usage = hang_forever
+    state.client = mock_client
+
+    with patch("core.client._CONTEXT_USAGE_TIMEOUT_S", 0.05):
+        await asyncio.wait_for(_log_context_usage(state), timeout=1.0)

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -216,7 +216,7 @@ async def test_cancellation_triggers_restart(tmp_path):
             await _process_message_safely("msg", is_user=True, state=state, config=config)
 
     assert state.graceful_shutdown.is_set()
-    assert state.restart_reason == "error — processing cancelled"
+    assert state.restart_reason == vm.PROCESSING_CANCELLED_ERROR
 
 
 @pytest.mark.anyio
@@ -238,7 +238,7 @@ async def test_handle_processor_done_silent_cancel_triggers_restart():
     handle_processor_done(task, state=state)
 
     assert state.graceful_shutdown.is_set()
-    assert state.restart_reason == "crash — processor cancelled unexpectedly"
+    assert state.restart_reason == vm.PROCESSOR_CANCELLED_RESTART
 
 
 @pytest.mark.anyio
@@ -278,7 +278,7 @@ async def test_handle_processor_done_silent_exit_triggers_restart():
     handle_processor_done(task, state=state)
 
     assert state.graceful_shutdown.is_set()
-    assert state.restart_reason == "crash — processor exited silently"
+    assert state.restart_reason == vm.PROCESSOR_SILENT_EXIT_RESTART
 
 
 @pytest.mark.anyio
@@ -317,4 +317,4 @@ async def test_log_context_usage_timeout(tmp_path):
     state.client = mock_client
 
     with patch("core.client._CONTEXT_USAGE_TIMEOUT_S", 0.05):
-        await asyncio.wait_for(_log_context_usage(state), timeout=1.0)
+        await asyncio.wait_for(_log_context_usage(state), timeout=0.2)


### PR DESCRIPTION
## Summary

Last night the agent wedged silently for ~5 hours between 23:16 and 04:11 BST. No crash log, no restart, no processed messages — the dreamer at 03:00 queued into a dead processor, so context was never reset (resumed at 71% after backup SIGTERM). Root cause traced to an unhandled `asyncio.CancelledError` propagating past `_process_message_safely` → processor task ended in a cancelled state → `_on_processor_done` guard returned silently → `graceful_shutdown` never set → main blocked on `graceful_shutdown.wait()` forever.

Four fixes, ranked by criticality:

1. **`handle_processor_done`** (`agent/core/main.py`) — on `task.cancelled()`, log and set `restart_reason` + `graceful_shutdown` instead of returning silently. Only skip if shutdown was already initiated ourselves. Also extracted to a module-level function for testability.
2. **`_process_message_safely`** (`agent/core/loops.py`) — catch `asyncio.CancelledError` explicitly, log + set restart trigger, re-raise so the processor exits cleanly.
3. **`_log_context_usage`** (`agent/core/client.py`) — add 10s `asyncio.wait_for` timeout. Previously it could hang indefinitely against an unresponsive SDK subprocess (the 60s gap between USAGE and `state → idle` in the incident log).
4. **Dreamer bookkeeping** (`agent/core/loops.py`) — persist `last_dreamer_run` to disk only after the session-clear completes, not at enqueue time. If the dreamer is interrupted, next container start can retry instead of being locked out for the day.

Fix #1 alone would have turned the 5-hour blackout into a ~1-minute auto-restart.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/test_e2e.py` — 139 passed, 1 skipped
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ty check` — all checks passed
- [x] New tests added:
  - `test_cancellation_triggers_restart` — regression test for fix #2
  - `test_handle_processor_done_silent_cancel_triggers_restart` — regression for fix #1
  - `test_handle_processor_done_exception_triggers_restart` — exception path
  - `test_handle_processor_done_silent_exit_triggers_restart` — silent return path
  - `test_handle_processor_done_noop_during_shutdown` — don't override legitimate shutdown reasons
  - `test_log_context_usage_timeout` — fix #3
  - `test_queue_does_not_persist_last_dreamer_run` — fix #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)