### PR TITLE
chore(agent): trim log noise, surface queue pile-ups

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -142,12 +142,17 @@ def _parse_sdk_message(msg: Message, *, sub_agent_context: str | None) -> tuple[
 
     if isinstance(msg, RateLimitEvent):
         info = msg.rate_limit_info
-        logger.warning(f"Rate limit {info.status} (utilization={info.utilization}, type={info.rate_limit_type})")
+        log_fn = logger.debug if info.status == "allowed" else logger.warning
+        log_fn(f"Rate limit {info.status} (utilization={info.utilization}, type={info.rate_limit_type})")
         return ([], [], sub_agent_context, None, False)
 
     if isinstance(msg, SystemMessage):
-        raw = json.dumps(msg.data, default=str)
-        logger.system(f"[{msg.subtype}] {raw[:500]}")
+        if msg.subtype == "init":
+            sid = msg.data["session_id"][:16] if isinstance(msg.data, dict) and "session_id" in msg.data else "?"
+            logger.debug(f"[init] session_id={sid}")
+        else:
+            raw = json.dumps(msg.data, default=str)
+            logger.system(f"[{msg.subtype}] {raw[:500]}")
         return ([], [], sub_agent_context, None, False)
 
     if not isinstance(msg, AssistantMessage):
@@ -395,6 +400,8 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
         assistant_texts.append(t)
 
     def _emit_thinking(block: ThinkingBlock) -> None:
+        if not block.thinking.strip():
+            return
         logger.thinking(block.thinking)
         state.event_bus.emit({"type": "thinking", "text": block.thinking, "signature": block.signature})
 

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -299,7 +299,9 @@ async def check_proactive_task(queue: asyncio.Queue[tuple[str, bool]], *, config
     prompt = load_prompt("proactive_check", config)
     if not prompt:
         return
-    logger.proactive(f"Running {config.proactive_check_interval}-minute check...")
+    pending = queue.qsize()
+    suffix = f" (queue={pending} pending — processor may be stuck)" if pending > 0 else ""
+    logger.proactive(f"Running {config.proactive_check_interval}-minute check...{suffix}")
     await queue.put((prompt, False))
 
 


### PR DESCRIPTION
## Summary

Cuts ~1,500 lines of recurring noise per day and adds one signal that would have made last night's silent processor death visible immediately.

- **SDK `[init]` dump → session_id only.** Every new SDK message logged the full `{cwd, session_id, tools: [Task, AskUserQuestion, Bash, ... 30 names]}` blob. In the current log that's ~1,200 occurrences, ~15 lines each. Now just `[init] session_id=abc1234567890abc` at DEBUG.
- **`Rate limit allowed` → DEBUG.** "Allowed" means the limit passed. It's not a warning. 60+ false alarms removed.
- **Empty `[THINKING]` blocks skipped.** Was printing 42 lines of pure whitespace.
- **Queue depth on proactive check.** When the processor wedged last night, four proactive checks + the dreamer queued invisibly. Now a non-empty queue prints: `Running 60-minute check... (queue=3 pending — processor may be stuck)`.

13 lines of change total.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/test_e2e.py` — 132 passed
- [x] `uv run ruff check` — clean
- [x] `uv run ty check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)