### PR TITLE
chore(agent): bump claude-agent-sdk to 0.1.65 (CLI 2.1.118, post-mortem fix)

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "aioconsole>=0.8.2",
     "aiohttp>=3.13.5",
-    "claude-agent-sdk>=0.1.63",
+    "claude-agent-sdk>=0.1.65",
     "pydantic>=2.13.2",
     "pydantic-settings>=2.14.0",
     "rich>=15.0.0",

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -1161,7 +1161,7 @@ dev = [
 requires-dist = [
     { name = "aioconsole", specifier = ">=0.8.2" },
     { name = "aiohttp", specifier = ">=3.13.5" },
-    { name = "claude-agent-sdk", specifier = ">=0.1.63" },
+    { name = "claude-agent-sdk", specifier = ">=0.1.65" },
     { name = "pydantic", specifier = ">=2.13.2" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "rich", specifier = ">=15.0.0" },


### PR DESCRIPTION
## Why
Anthropic published a post-mortem on Claude Code / Agent SDK quality regressions over the past month, [announced by @ClaudeDevs on Apr 23, 2026](https://x.com/ClaudeDevs/status/2047371123185287223). All issues are fixed in Claude CLI **v2.1.116+**.

Our current floor `claude-agent-sdk>=0.1.63` ships CLI **2.1.114**, which is affected. Bumping to `>=0.1.65` ships CLI **2.1.118**.

| SDK | Bundled Claude CLI | Status |
|---|---|---|
| 0.1.63 (old floor) | 2.1.114 | affected |
| 0.1.64 | 2.1.116 | fix lands |
| 0.1.65 (new floor) | 2.1.118 | post-fix, latest |

The lockfile was already resolved at `0.1.65`; this aligns the spec floor with what we ship so CI tests against the fixed CLI and we don't silently regress if the lock ever moves.

## Release highlights also pulled in (additive, no code changes needed)
- **0.1.64** - SessionStore adapter (5-method protocol, transcript mirroring, 9 store-backed helpers, conformance test harness).
- **0.1.65** - batch session summaries (`list_session_summaries` / `fold_session_summary`), `import_session_to_store` for migrating local sessions, new `display` field on `ThinkingConfig`.

## Test plan
- [x] `scripts/prepare-for-pr.sh` (agent subset): ruff, ruff format, ty, pytest, uv.lock freshness all green
- [ ] Wait for CI