### PR TITLE
feat(upstream-pr): require agent name + vesta version on PRs and issues

### DIFF
--- a/agent/skills/upstream-pr/SKILL.md
+++ b/agent/skills/upstream-pr/SKILL.md
@@ -7,6 +7,20 @@ description: Create PRs, issues, and contributions to the upstream elyxlz/vesta 
 
 Contribute improvements back to `elyxlz/vesta`. Authentication is handled by the `vesta-upstream` GitHub App -- no personal tokens needed.
 
+## Attribution -- always required
+
+Every PR and every issue you create must include your agent name and the vesta version you are running, so maintainers know which agent on which version hit the bug or proposed the change.
+
+- Agent name: `$AGENT_NAME`
+- Vesta version: `$VESTA_UPSTREAM_REF` (e.g. `v0.1.148` in release builds, a branch name in dev)
+
+`pr.py` automatically appends `Submitted by **<name>** on <version>` to every PR body. For **issues**, there is no wrapper -- you must add the same footer to the body yourself:
+
+```
+---
+Submitted by **$AGENT_NAME** on `$VESTA_UPSTREAM_REF`
+```
+
 ## GitHub token
 
 For any GitHub API call (issues, check-runs, PR status):
@@ -29,7 +43,7 @@ Local code diverges from upstream, so never branch from local HEAD. Use a clean 
 
 2. **Apply changes** to `/tmp/vesta-pr`. Only universal improvements -- no personal config, memory, or credentials.
 
-3. **Create a GitHub issue first** (use `--token-only` for API access), then reference it in the PR.
+3. **Create a GitHub issue first** (use `--token-only` for API access), then reference it in the PR. Include the attribution footer in the issue body (see "Attribution" above).
 
 4. **Commit and submit:**
    ```bash

--- a/agent/skills/upstream-pr/pr.py
+++ b/agent/skills/upstream-pr/pr.py
@@ -82,8 +82,15 @@ def main():
     if not args.title:
         parser.error("--title is required when creating a PR")
 
-    # Resolve agent identity for commit authorship
-    agent_name = os.environ.get("AGENT_NAME", "vesta")
+    # Resolve agent identity and vesta version for commit authorship + PR attribution
+    if "AGENT_NAME" not in os.environ:
+        print("Error: AGENT_NAME is not set in env", file=sys.stderr)
+        sys.exit(1)
+    agent_name = os.environ["AGENT_NAME"]
+    if "VESTA_UPSTREAM_REF" not in os.environ:
+        print("Error: VESTA_UPSTREAM_REF is not set in env", file=sys.stderr)
+        sys.exit(1)
+    upstream_ref = os.environ["VESTA_UPSTREAM_REF"]
     author_name = f"{agent_name} (vesta)"
     author_email = f"{agent_name}@vesta.noreply"
 
@@ -126,7 +133,7 @@ def main():
     }
     # Append agent attribution to PR body
     body = args.body
-    attribution = f"\n\n---\nSubmitted by **{agent_name}**"
+    attribution = f"\n\n---\nSubmitted by **{agent_name}** on `{upstream_ref}`"
     body = f"{body}{attribution}" if body else attribution.lstrip()
 
     resp = requests.post(


### PR DESCRIPTION
## Summary

- `pr.py` now hard-errors when `AGENT_NAME` or `VESTA_UPSTREAM_REF` is missing from env (no silent `"vesta"` default).
- PR body attribution becomes `Submitted by **<name>** on <version>` (was name only).
- `SKILL.md` adds an "Attribution -- always required" section, and step 3 of "Creating a PR" now points to it so agents include the footer on manually-created issues.

Maintainers now always see which agent on which version proposed a change or hit a bug.

`VESTA_UPSTREAM_REF` is already injected by vestad (\`v{CARGO_PKG_VERSION}\` in release, branch name in dev), so no infra change is needed.

## Test plan

- [ ] `ruff check` clean on `agent/skills/upstream-pr/pr.py`
- [ ] Manual: run `pr.py --title foo --body bar` with `AGENT_NAME` unset → expect exit 1 with clear stderr
- [ ] Manual: same with `VESTA_UPSTREAM_REF` unset → expect exit 1 with clear stderr
- [ ] Manual: with both set, PR body ends in `Submitted by **<name>** on \`<ref>\``

Fixes #434