### PR TITLE
fix(vestad): make cached service port probe bind-only

### DIFF
--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -975,7 +975,6 @@ fn all_registered_ports(registry: &HashMap<String, HashMap<String, ServiceEntry>
 }
 
 const SERVICE_PORT_ALLOC_RETRIES: usize = 5;
-const CACHED_PORT_CONNECT_TIMEOUT_MS: u64 = 200;
 
 fn no_free_ports_err() -> (StatusCode, Json<serde_json::Value>) {
     err_response(
@@ -1002,16 +1001,15 @@ fn allocate_service_port(registry: &HashMap<String, HashMap<String, ServiceEntry
 }
 
 /// Check whether a cached service port can still be safely reused.
-/// Returns true if something is listening on the port (service alive) OR
-/// the port is free to bind (service not started yet but nothing blocks it).
-/// Returns false if the port is stuck in a zombie/TIME_WAIT state — a new
-/// process cannot bind to it and nothing is listening. See issue #371.
+///
+/// Every caller of `POST /agents/:name/services` follows up by binding a
+/// service process to the returned port (see `agent/skills/*/SKILL.md`), so
+/// the only signal that tells us reuse is safe is whether *we* can bind the
+/// port. "Something is listening" is not enough — it could be an unrelated
+/// squatter (a surviving screen session under host networking, an
+/// ephemeral-range collision with vestad itself, etc.), and the caller's
+/// fresh bind would then fail with `EADDRINUSE`. See issues #371 and #433.
 async fn is_cached_port_reusable(port: u16) -> bool {
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
-    let timeout = std::time::Duration::from_millis(CACHED_PORT_CONNECT_TIMEOUT_MS);
-    if let Ok(Ok(_)) = tokio::time::timeout(timeout, tokio::net::TcpStream::connect(addr)).await {
-        return true;
-    }
     tokio::net::TcpListener::bind(("127.0.0.1", port)).await.is_ok()
 }
 
@@ -1040,14 +1038,14 @@ async fn register_service_handler(
 
     let mut settings = state.settings.write().await;
 
-    // Reuse existing port if already registered AND the cached port is still
-    // reusable. A stuck cached port (zombie process, TIME_WAIT) would otherwise
-    // trap the service in a crash loop with no recovery from inside the container.
+    // Reuse the cached port only if it's still bindable. Anything else (stuck
+    // socket, squatter on the port) would trap the caller's service in a
+    // crash loop with no recovery from inside the container.
     let cached_port = settings.services.get(&name).and_then(|s| s.get(&service_name)).map(|e| e.port);
     let port = match cached_port {
         Some(p) if is_cached_port_reusable(p).await => p,
         Some(p) => {
-            tracing::warn!(agent = %name, service = %service_name, stale_port = p, "cached service port is stuck (connect+bind both failed), allocating a fresh one");
+            tracing::warn!(agent = %name, service = %service_name, stale_port = p, "cached service port is not bindable, allocating a fresh one");
             allocate_service_port(&settings.services).ok_or_else(no_free_ports_err)?
         }
         None => allocate_service_port(&settings.services).ok_or_else(no_free_ports_err)?,
@@ -1837,10 +1835,17 @@ mod tests {
         assert!(is_cached_port_reusable(port).await, "a free port must be reusable");
     }
 
+    // Regression for #433: a port that's being squatted on by something other
+    // than the intended service (here simulated by a live listener) must be
+    // treated as not-reusable, because the caller's next step is always to
+    // bind it — and that bind would fail with EADDRINUSE.
     #[tokio::test]
-    async fn cached_port_is_reusable_when_listening() {
+    async fn cached_port_is_not_reusable_when_squatted() {
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let port = listener.local_addr().unwrap().port();
-        assert!(is_cached_port_reusable(port).await, "a listening port must be reusable");
+        assert!(
+            !is_cached_port_reusable(port).await,
+            "a port held by another listener must not be reported reusable",
+        );
     }
 }

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1000,15 +1000,9 @@ fn allocate_service_port(registry: &HashMap<String, HashMap<String, ServiceEntry
     })
 }
 
-/// Check whether a cached service port can still be safely reused.
-///
-/// Every caller of `POST /agents/:name/services` follows up by binding a
-/// service process to the returned port (see `agent/skills/*/SKILL.md`), so
-/// the only signal that tells us reuse is safe is whether *we* can bind the
-/// port. "Something is listening" is not enough — it could be an unrelated
-/// squatter (a surviving screen session under host networking, an
-/// ephemeral-range collision with vestad itself, etc.), and the caller's
-/// fresh bind would then fail with `EADDRINUSE`. See issues #371 and #433.
+/// Bindable = reusable. A port that merely has a listener isn't enough:
+/// callers always bind the returned port themselves, so a squatter would
+/// trap them in a crash loop. See #371 and #433.
 async fn is_cached_port_reusable(port: u16) -> bool {
     tokio::net::TcpListener::bind(("127.0.0.1", port)).await.is_ok()
 }
@@ -1038,9 +1032,6 @@ async fn register_service_handler(
 
     let mut settings = state.settings.write().await;
 
-    // Reuse the cached port only if it's still bindable. Anything else (stuck
-    // socket, squatter on the port) would trap the caller's service in a
-    // crash loop with no recovery from inside the container.
     let cached_port = settings.services.get(&name).and_then(|s| s.get(&service_name)).map(|e| e.port);
     let port = match cached_port {
         Some(p) if is_cached_port_reusable(p).await => p,
@@ -1835,10 +1826,7 @@ mod tests {
         assert!(is_cached_port_reusable(port).await, "a free port must be reusable");
     }
 
-    // Regression for #433: a port that's being squatted on by something other
-    // than the intended service (here simulated by a live listener) must be
-    // treated as not-reusable, because the caller's next step is always to
-    // bind it — and that bind would fail with EADDRINUSE.
+    // Regression for #433.
     #[tokio::test]
     async fn cached_port_is_not_reusable_when_squatted() {
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();


### PR DESCRIPTION
## Summary
- `is_cached_port_reusable` (added in #417) short-circuits and returns `true` as soon as a 200ms TCP connect to the cached port succeeds. That covers the idempotent "same service already running" re-registration case, but also hands the cached port back whenever *anything* is listening on it, even if that's not our service.
- Every caller in-tree (`agent/skills/{dashboard,voice,tasks}/SKILL.md`, plus `SETUP.md` variants) follows the registration with a bind, e.g.:
  ```bash
  PORT=$(curl ... POST /services -d '{"name":"dashboard"}') \
    && screen -dmS dashboard npx vite preview --port $PORT ...
  ```
  So the signal we actually owe the caller is "this port is bindable", not "this port has a TCP listener". Under host networking a surviving `screen` daemon, or an ephemeral-range collision with vestad's own HTTPS/HTTP listener, can trigger connect-succeeds / bind-fails, which leaves the registered service in an unrecoverable crash loop.
- This change drops the connect probe and uses bind as the sole criterion. Free port → reuse; actively-held port → reallocate and log a warning. The TOCTOU gap between the probe listener being dropped and the caller's own bind is the same one `allocate_service_port` already lives with.

## Test plan
- [x] `cd vestad && cargo clippy -p vestad -- -D warnings` (clean)
- [x] `cd vestad && cargo test -p vestad` (80 passed, 11 ignored — includes the new `cached_port_is_not_reusable_when_squatted` regression for #433, plus the existing `cached_port_is_reusable_when_free`)
- [ ] Manual: bind something to a cached service port from *outside* the container, re-register the service, verify the response contains a **new** port and the warn log `cached service port is not bindable` is emitted.

## Notes for reviewer
Issue #433 was filed by the `app/vesta-upstream` bot ~32h after #417 merged and its stated repro has some details that don't match current code (mentions aiohttp / a 404 response, but vestad is axum and the proxy returns 502 on unreachable upstream). I couldn't confirm a live repro, but the code gap it describes is real and trivially reachable with a unit test — the regression test in this PR is exactly that. Net: a one-line tightening of the probe plus a flipped test, no behavior change for the happy path.

Fixes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)