### PR TITLE
ci: retry tauri builds up to 3× to absorb bundle_dmg.sh flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,16 +515,18 @@ jobs:
         working-directory: apps
         run: npm install
 
+      # Retry: bundle_dmg.sh occasionally fails on macos-latest runners when the
+      # window server is unresponsive to the AppleScript-driven Finder layout step.
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: nick-fields/retry@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          projectPath: apps/desktop
-          tauriScript: npx tauri
-          args: --target ${{ matrix.target }} --bundles ${{ matrix.bundles }}
+          timeout_minutes: 30
+          max_attempts: 3
+          command: cd apps/desktop && npx tauri build --target ${{ matrix.target }} --bundles ${{ matrix.bundles }}
 
       - name: Collect artifacts
         if: github.event_name != 'pull_request'
@@ -608,15 +610,15 @@ jobs:
         run: npm install
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: nick-fields/retry@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          projectPath: apps/desktop
-          tauriScript: npx tauri
-          args: --target ${{ matrix.target }} --bundles ${{ matrix.bundles }}
+          timeout_minutes: 30
+          max_attempts: 3
+          command: cd apps/desktop && npx tauri build --target ${{ matrix.target }} --bundles ${{ matrix.bundles }}
 
       - name: Collect artifacts
         if: github.event_name != 'pull_request'
@@ -682,15 +684,16 @@ jobs:
         run: npm install
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: nick-fields/retry@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          projectPath: apps/desktop
-          tauriScript: npx tauri
-          args: --target x86_64-pc-windows-msvc --bundles nsis
+          timeout_minutes: 30
+          max_attempts: 3
+          shell: bash
+          command: cd apps/desktop && npx tauri build --target x86_64-pc-windows-msvc --bundles nsis
 
       - name: Collect artifacts
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

- Wrap each `Build Tauri app` step (macOS, Linux, Windows) with `nick-fields/retry@v3` (3 attempts, 30 min timeout)
- Replace `tauri-apps/tauri-action@v0` with the equivalent `npx tauri build` since nick-fields/retry only retries shell commands and tauri-action was a thin wrapper

## Why

`bundle_dmg.sh` on macos-latest runners occasionally fails at the AppleScript-driven Finder window layout step when the runner's window server is unresponsive (or `hdiutil` is racing with Spotlight). The underlying error is swallowed by tauri-action: only `failed to run` reaches the GitHub log, no `hdiutil` / `osascript` stderr.

Same commit can pass on the PR run (e.g. #459 PR run, 3m13s) and fail on the master push immediately after (3m45s). Pure runner-state flake.

This kills the false-failure class without touching any code logic. Cargo cache is hot on retry so the second attempt mostly skips compilation; cost on a real failure is ~2-3 min extra wall time, which is acceptable.

## Test plan

- [ ] CI on this branch passes all 3 platforms (macOS x2, Linux x2, Windows)
- [ ] No regression in build artifacts (DMG / deb / rpm / nsis still produced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)