### PR TITLE
ci: harden against external network flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,13 @@ jobs:
             cli:
               - 'cli/**'
               - 'vestad/**'
+              - '.github/workflows/ci.yml'
             app:
               - 'apps/**'
+              - '.github/workflows/ci.yml'
             agent:
               - 'agent/**'
+              - '.github/workflows/ci.yml'
 
   # ── Version check ──────────────────────────────────────────────────────
   version-check:
@@ -793,16 +796,23 @@ jobs:
           python3 scripts/android-sign-patch.py apps/mobile/src-tauri/gen/android/app/build.gradle.kts
           echo "signed=true" >> "$GITHUB_OUTPUT"
 
+      # Retry: Gradle bootstraps from GitHub on first run; GitHub release CDN
+      # occasionally 502s and there's no built-in retry on the Gradle wrapper.
       - name: Build Android APK
-        working-directory: apps/mobile
+        uses: nick-fields/retry@v3
         env:
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/27.0.12077973
-        run: |
-          if [ "${{ steps.signing.outputs.signed }}" = "true" ]; then
-            npx tauri android build --apk
-          else
-            npx tauri android build --apk --debug
-          fi
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          shell: bash
+          command: |
+            cd apps/mobile
+            if [ "${{ steps.signing.outputs.signed }}" = "true" ]; then
+              npx tauri android build --apk
+            else
+              npx tauri android build --apk --debug
+            fi
 
       - name: Collect artifacts
         if: github.event_name != 'pull_request'
@@ -902,8 +912,12 @@ jobs:
 
       - name: Build iOS
         if: env.SKIP_IOS != 'true'
-        working-directory: apps/mobile
-        run: npx tauri ios build --export-method app-store-connect
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          shell: bash
+          command: cd apps/mobile && npx tauri ios build --export-method app-store-connect
 
       - name: Collect artifacts
         if: env.SKIP_IOS != 'true'

--- a/vestad/build.rs
+++ b/vestad/build.rs
@@ -108,8 +108,16 @@ fn vendor_cloudflared(manifest_dir: &Path) {
         std::fs::create_dir_all(&vendored_dir)
             .expect("failed to create vendored dir");
         let url = format!("{}/cloudflared-linux-{}", CLOUDFLARED_DOWNLOAD_BASE, arch);
+        // GitHub release CDN occasionally 502s; retry on any transient error.
         let status = Command::new("curl")
-            .args(["-fsSL", "-o", dest.to_str().unwrap(), &url])
+            .args([
+                "-fsSL",
+                "--retry", "5",
+                "--retry-all-errors",
+                "--retry-delay", "2",
+                "-o", dest.to_str().unwrap(),
+                &url,
+            ])
             .status()
             .expect("failed to spawn curl while vendoring cloudflared (set VESTAD_SKIP_CLOUDFLARED=1 to skip)");
         if !status.success() {


### PR DESCRIPTION
## Summary

Master CI broke twice today on unrelated transient 502s from external services. Adds retries to the three remaining un-retried fetches.

- **`vestad/build.rs`**: add `--retry 5 --retry-all-errors --retry-delay 2` to the curl that downloads cloudflared. `github.com` release CDN 502s intermittently and the build script panics on first failure.
- **`build-tauri-android`**: wrap with `nick-fields/retry@v3` (3 attempts, 30 min timeout). Gradle bootstraps from `github.com` on first run.
- **`build-tauri-ios`**: same wrapper for symmetry; cocoapods + xcodebuild both hit `github.com` and Apple servers.
- **`detect-changes`**: include `.github/workflows/ci.yml` in `cli` / `app` / `agent` filters so a workflow-only PR can actually validate its own changes (without this, gated builds skip and the PR can't exercise the fix). This was the orphaned commit from #468 that didn't get merged.

## Why

Two failures observed today on master, both on the same commit (`157b6bf`):

1. `build-vesta`: `curl: (22) The requested URL returned error: 502` — cloudflared download from github.com.
2. `build-tauri-android`: `502 for URL: ...gradle-distributions/.../gradle-8.14.3-bin.zip` — Gradle bootstrap.

Neither failure was a code issue. Same code passes minutes later on retry.

## Test plan

- [ ] CI passes on this branch
- [ ] No regression in artifact production (cloudflared still vendored, APK / IPA still built)

🤖 Generated with [Claude Code](https://claude.com/claude-code)