### PR TITLE
feat(finance): make Enable Banking redirect URL configurable via env var

### DIFF
--- a/agent/skills/finance/SETUP.md
+++ b/agent/skills/finance/SETUP.md
@@ -27,6 +27,26 @@ finance auth login
 # Authorize at the URL → callback caught on localhost:7866
 ```
 
+### Production redirect URL
+
+Enable Banking's production app registration form rejects every form of `localhost`
+(`http://`, `https://`, `127.0.0.1`) with "unsupported scheme" / "invalid url" errors,
+so the localhost default only works for the sandbox / local dev path.
+
+For a real registered app, override the redirect with the `FINANCE_REDIRECT_URL`
+env var (set it in the agent env so the CLI inside the container picks it up):
+
+```bash
+export FINANCE_REDIRECT_URL="https://<your-public-host>/callback"
+```
+
+The natural fit on Vesta is a vestad public service tunnel: register a public
+service for the agent, point Enable Banking at
+`https://<vestad-tunnel>/agents/$AGENT_NAME/<service-name>/callback`, and run a
+small handler on the assigned port that pipes the captured `?code=...` URL
+through `finance auth callback --url <full-url>`. The handler itself is not
+shipped yet, see issue #464 for the followup.
+
 ## 5. Seed and start watcher
 
 ```bash

--- a/agent/skills/finance/cli/src/finance_cli/enablebanking.py
+++ b/agent/skills/finance/cli/src/finance_cli/enablebanking.py
@@ -1,6 +1,7 @@
 """Enable Banking API client with RS256 JWT auth."""
 
 import json
+import os
 import sys
 import uuid
 from datetime import datetime, UTC, timedelta
@@ -13,7 +14,7 @@ import jwt as pyjwt
 BASE_URL = "https://api.enablebanking.com"
 CALLBACK_PORT = 7866
 CALLBACK_PATH = "/callback"
-REDIRECT_URL = f"https://localhost:{CALLBACK_PORT}{CALLBACK_PATH}"
+REDIRECT_URL = os.environ.get("FINANCE_REDIRECT_URL", f"https://localhost:{CALLBACK_PORT}{CALLBACK_PATH}")
 
 # Consent valid for 90 days by default
 CONSENT_DAYS = 90


### PR DESCRIPTION
## Summary
- Read `REDIRECT_URL` from the `FINANCE_REDIRECT_URL` env var in `agent/skills/finance/cli/src/finance_cli/enablebanking.py`, falling back to the existing `https://localhost:7866/callback` default.
- Document the override and the production-redirect rationale in `agent/skills/finance/SETUP.md`, pointing at vestad public services as the natural fit (full handler is left as a followup).

This is the small, easy half of #464: the public-tunnel callback handler is intentionally NOT included here.

Fixes #464

## Test plan
- [x] `uv run ruff check` (agent/) passes
- [x] `uv run ty check` (agent/) passes
- [ ] Manual: with `FINANCE_REDIRECT_URL` unset, `finance auth login` still uses the localhost callback as before
- [ ] Manual: with `FINANCE_REDIRECT_URL=https://example/callback`, the auth URL contains the override