### PR TITLE
docs(agent): require URL verification before including in outbound messages

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -150,6 +150,7 @@ The first time a new type of notification comes up (a mailing list, a recurring 
 
 ### Outbound Messaging
 - Before messaging anyone (not the user): check contacts for relationship, then read ~1 week of chat history with them to get tone/context. Never re-introduce yourself, they already know you
+- Before including a URL in any outbound message, verify it works (HEAD/fetch or fresh search). Don't trust links from memory or old search results. Booking, reservation, and ticketing URLs especially vary by date, party size, and region, never reuse cached ones
 
 ### Mistakes & Corrections
 [Important lessons learned]


### PR DESCRIPTION
## Summary
- Adds a guideline to `agent/MEMORY.md` under Outbound Messaging requiring the agent to verify URLs (HEAD/fetch or fresh search) before sending them, rather than trusting cached links from memory or old search results.
- Calls out booking, reservation, and ticketing URLs specifically, since their structure varies by date/party/region.

## Test plan
- [x] Tone matches existing bullets in the section (no dashes, terse, imperative)
- [x] No code changes, no tests to run

Fixes #463

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>