### PR TITLE
fix(tasks): render reminder schedule label in scheduled tz

### DIFF
--- a/agent/skills/tasks/cli/src/tasks_cli/commands.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/commands.py
@@ -38,7 +38,7 @@ def _now_utc() -> datetime:
     return datetime.now(UTC)
 
 
-def _to_utc_dt(datetime_str: str, timezone_str: str) -> datetime:
+def _parse_local_dt(datetime_str: str, timezone_str: str) -> datetime:
     from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
     try:
@@ -46,10 +46,14 @@ def _to_utc_dt(datetime_str: str, timezone_str: str) -> datetime:
     except (ZoneInfoNotFoundError, KeyError):
         raise ValueError(f"Invalid timezone: '{timezone_str}'. Use IANA names like 'Europe/London' or 'America/New_York'.")
 
-    naive = datetime.fromisoformat(datetime_str.replace("Z", "+00:00"))
-    if naive.tzinfo is not None:
-        return naive.astimezone(UTC)
-    return naive.replace(tzinfo=local_tz).astimezone(UTC)
+    parsed = datetime.fromisoformat(datetime_str.replace("Z", "+00:00"))
+    if parsed.tzinfo is not None:
+        return parsed.astimezone(local_tz)
+    return parsed.replace(tzinfo=local_tz)
+
+
+def _to_utc_dt(datetime_str: str, timezone_str: str) -> datetime:
+    return _parse_local_dt(datetime_str, timezone_str).astimezone(UTC)
 
 
 def _to_utc(datetime_str: str, timezone_str: str) -> str:
@@ -527,25 +531,28 @@ def remind_set(
     elif recurring in ("daily", "weekly", "monthly", "yearly"):
         if not scheduled_datetime or not tz:
             raise ValueError(f"scheduled_datetime and tz are required for {recurring} reminders")
-        utc_dt = _to_utc_dt(scheduled_datetime, tz)
+        local_dt = _parse_local_dt(scheduled_datetime, tz)
+        utc_dt = local_dt.astimezone(UTC)
         h, m = utc_dt.hour, utc_dt.minute
+        local_h, local_m = local_dt.hour, local_dt.minute
 
         if recurring == "daily":
             trigger = CronTrigger(hour=h, minute=m)
-            schedule_info = f"daily at {h:02d}:{m:02d} UTC"
+            schedule_info = f"daily at {local_h:02d}:{local_m:02d} {tz}"
             trigger_data = {"type": "cron", "hour": h, "minute": m}
         elif recurring == "weekly":
             day_name = utc_dt.strftime("%a").lower()
+            local_day_name = local_dt.strftime("%a").lower()
             trigger = CronTrigger(day_of_week=day_name, hour=h, minute=m)
-            schedule_info = f"weekly on {day_name} at {h:02d}:{m:02d} UTC"
+            schedule_info = f"weekly on {local_day_name} at {local_h:02d}:{local_m:02d} {tz}"
             trigger_data = {"type": "cron", "day_of_week": day_name, "hour": h, "minute": m}
         elif recurring == "monthly":
             trigger = CronTrigger(day=utc_dt.day, hour=h, minute=m)
-            schedule_info = f"monthly on day {utc_dt.day} at {h:02d}:{m:02d} UTC"
+            schedule_info = f"monthly on day {local_dt.day} at {local_h:02d}:{local_m:02d} {tz}"
             trigger_data = {"type": "cron", "day": utc_dt.day, "hour": h, "minute": m}
         else:  # yearly
             trigger = CronTrigger(month=utc_dt.month, day=utc_dt.day, hour=h, minute=m)
-            schedule_info = f"yearly on {utc_dt.month}/{utc_dt.day} at {h:02d}:{m:02d} UTC"
+            schedule_info = f"yearly on {local_dt.month}/{local_dt.day} at {local_h:02d}:{local_m:02d} {tz}"
             trigger_data = {"type": "cron", "month": utc_dt.month, "day": utc_dt.day, "hour": h, "minute": m}
         next_run = trigger.get_next_fire_time(None, _now_utc())
     elif scheduled_datetime:

--- a/agent/skills/tasks/cli/tests/test_remind_schedule.py
+++ b/agent/skills/tasks/cli/tests/test_remind_schedule.py
@@ -1,0 +1,105 @@
+"""Unit tests for remind_set schedule label rendering across timezones."""
+
+import json
+from contextlib import closing
+from datetime import datetime, UTC
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from tasks_cli import commands, db
+from tasks_cli.config import Config
+
+
+@pytest.fixture
+def tmp_config(tmp_path: Path) -> Config:
+    cfg = Config(data_dir=tmp_path / "tasks", log_dir=tmp_path / "tasks" / "logs")
+    cfg.data_dir.mkdir(parents=True, exist_ok=True)
+    db.init_db(cfg.data_dir)
+    return cfg
+
+
+def _trigger_data(config: Config, reminder_id: str) -> dict:
+    with closing(db.get_db(config.data_dir)) as conn:
+        row = conn.execute("SELECT trigger_data FROM reminders WHERE id = ?", (reminder_id,)).fetchone()
+    return json.loads(row["trigger_data"])
+
+
+def _expected_utc(local_iso: str, tz_name: str) -> datetime:
+    return datetime.fromisoformat(local_iso).replace(tzinfo=ZoneInfo(tz_name)).astimezone(UTC)
+
+
+def test_daily_label_uses_local_tz(tmp_config: Config):
+    result = commands.remind_set(
+        tmp_config,
+        message="standup",
+        scheduled_datetime="2026-04-26T10:30:00",
+        tz="Europe/London",
+        recurring="daily",
+    )
+    assert result["schedule"] == "daily at 10:30 Europe/London"
+    expected_utc = _expected_utc("2026-04-26T10:30:00", "Europe/London")
+    data = _trigger_data(tmp_config, result["id"])
+    assert (data["hour"], data["minute"]) == (expected_utc.hour, expected_utc.minute)
+
+
+def test_weekly_label_uses_local_tz_and_day(tmp_config: Config):
+    result = commands.remind_set(
+        tmp_config,
+        message="review",
+        scheduled_datetime="2026-04-26T23:30:00",
+        tz="America/New_York",
+        recurring="weekly",
+    )
+    assert result["schedule"] == "weekly on sun at 23:30 America/New_York"
+    expected_utc = _expected_utc("2026-04-26T23:30:00", "America/New_York")
+    data = _trigger_data(tmp_config, result["id"])
+    assert (data["hour"], data["minute"]) == (expected_utc.hour, expected_utc.minute)
+    assert data["day_of_week"] == expected_utc.strftime("%a").lower()
+
+
+def test_monthly_label_uses_local_tz(tmp_config: Config):
+    result = commands.remind_set(
+        tmp_config,
+        message="bills",
+        scheduled_datetime="2026-04-15T23:30:00",
+        tz="America/New_York",
+        recurring="monthly",
+    )
+    assert result["schedule"] == "monthly on day 15 at 23:30 America/New_York"
+    expected_utc = _expected_utc("2026-04-15T23:30:00", "America/New_York")
+    data = _trigger_data(tmp_config, result["id"])
+    assert (data["day"], data["hour"], data["minute"]) == (expected_utc.day, expected_utc.hour, expected_utc.minute)
+
+
+def test_yearly_label_uses_local_tz(tmp_config: Config):
+    result = commands.remind_set(
+        tmp_config,
+        message="birthday",
+        scheduled_datetime="2026-12-31T23:30:00",
+        tz="America/New_York",
+        recurring="yearly",
+    )
+    assert result["schedule"] == "yearly on 12/31 at 23:30 America/New_York"
+    expected_utc = _expected_utc("2026-12-31T23:30:00", "America/New_York")
+    data = _trigger_data(tmp_config, result["id"])
+    assert (data["month"], data["day"], data["hour"], data["minute"]) == (
+        expected_utc.month,
+        expected_utc.day,
+        expected_utc.hour,
+        expected_utc.minute,
+    )
+
+
+def test_daily_label_utc_tz_unchanged(tmp_config: Config):
+    result = commands.remind_set(
+        tmp_config,
+        message="standup",
+        scheduled_datetime="2026-04-26T10:30:00",
+        tz="UTC",
+        recurring="daily",
+    )
+    assert result["schedule"] == "daily at 10:30 UTC"
+    data = _trigger_data(tmp_config, result["id"])
+    assert (data["hour"], data["minute"]) == (10, 30)


### PR DESCRIPTION
## Summary
- The recurring reminder label rendered in `tasks list` previously used UTC hour/minute/weekday/day/month even when the user scheduled the reminder in a local timezone, causing the label to disagree with what the user typed (e.g. "daily at 09:30 UTC" instead of "daily at 10:30 Europe/London").
- The cron trigger and stored `trigger_data` correctly fire in UTC; only the human-readable label was wrong.
- Render the label from the original local datetime and append the IANA tz name. Cron trigger and `next_run` behavior unchanged.

Fixes #465

## Test plan
- [x] New unit tests in `agent/skills/tasks/cli/tests/test_remind_schedule.py` verify daily / weekly / monthly / yearly labels render in the scheduled tz, and the underlying cron `trigger_data` still resolves to the correct UTC instant
- [x] `uv run pytest skills/tasks/cli/tests/ --ignore=skills/tasks/cli/tests/test_e2e.py` from `agent/` passes (e2e failures pre-exist on master, unrelated)
- [x] `uv run ruff check` passes
- [x] `uv run ty check` passes