### PR TITLE
fix(vestad): make self-update a no-op when already at latest version

### DIFF
--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -553,7 +553,10 @@ fn main() {
         }
 
         Command::Update => {
-            self_update::perform_update().unwrap_or_else(|e| die(e.to_string()));
+            let outcome = self_update::perform_update().unwrap_or_else(|e| die(e.to_string()));
+            if !outcome.updated {
+                println!("vestad already at latest version (v{})", outcome.current);
+            }
         }
 
         Command::Version => {

--- a/vestad/src/self_update.rs
+++ b/vestad/src/self_update.rs
@@ -19,17 +19,35 @@ impl fmt::Display for UpdateError {
     }
 }
 
+pub struct UpdateOutcome {
+    pub updated: bool,
+    pub restarted: bool,
+    pub current: String,
+    pub latest: String,
+}
+
 /// Downloads the latest vestad binary from GitHub, replaces the current binary,
 /// and restarts the systemd service. Agent code and container restarts are
 /// handled on the next vestad startup.
-/// Returns Ok(true) if a restart was triggered.
-pub fn perform_update() -> Result<bool, UpdateError> {
-    let tag = crate::update_check::fetch_latest_tag()
+/// No-op when the running version is already at or above the latest release.
+pub fn perform_update() -> Result<UpdateOutcome, UpdateError> {
+    let current = env!("CARGO_PKG_VERSION").to_string();
+    let latest = crate::update_check::fetch_latest_tag()
         .ok_or_else(|| UpdateError::Download("cannot determine latest version".into()))?;
 
-    tracing::info!(tag = %tag, "starting update");
+    if !crate::update_check::version_less_than(&current, &latest) {
+        tracing::info!(current = %current, latest = %latest, "already up to date, skipping");
+        return Ok(UpdateOutcome {
+            updated: false,
+            restarted: false,
+            current,
+            latest,
+        });
+    }
 
-    update_binary(&tag)?;
+    tracing::info!(tag = %latest, "starting update");
+
+    update_binary(&latest)?;
 
     // Don't reinstall the systemd service here — self-replace puts the new
     // binary at the same path, so the ExecStart line doesn't change. And
@@ -37,16 +55,23 @@ pub fn perform_update() -> Result<bool, UpdateError> {
     // " (deleted)" appended, which would break the service file.
     // The new binary calls ensure_service_installed() on startup if needed.
 
-    if crate::systemd::is_active() {
+    let restarted = if crate::systemd::is_active() {
         tracing::info!("restarting vestad...");
         if let Err(e) = crate::systemd::restart() {
             tracing::error!("failed to restart: {e}");
         }
-        Ok(true)
+        true
     } else {
         tracing::info!("updated. run 'vestad' to start.");
-        Ok(false)
-    }
+        false
+    };
+
+    Ok(UpdateOutcome {
+        updated: true,
+        restarted,
+        current,
+        latest,
+    })
 }
 
 fn update_binary(tag: &str) -> Result<(), UpdateError> {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -307,9 +307,12 @@ async fn gateway_update_handler(
         .unwrap();
     state.updating.store(false, std::sync::atomic::Ordering::SeqCst);
     match result {
-        Ok(restarting) => Ok(Json(serde_json::json!({
+        Ok(outcome) => Ok(Json(serde_json::json!({
             "ok": true,
-            "restarting": restarting,
+            "updated": outcome.updated,
+            "restarting": outcome.restarted,
+            "current": outcome.current,
+            "latest": outcome.latest,
         }))),
         Err(e) => Err(err_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string())),
     }

--- a/vestad/src/update_check.rs
+++ b/vestad/src/update_check.rs
@@ -22,7 +22,7 @@ pub fn check_once() -> Result<UpdateInfo, String> {
     })
 }
 
-fn version_less_than(a: &str, b: &str) -> bool {
+pub(crate) fn version_less_than(a: &str, b: &str) -> bool {
     let parse = |v: &str| -> Vec<u64> {
         v.split('.').filter_map(|s| s.parse().ok()).collect()
     };


### PR DESCRIPTION
## Summary
- `perform_update` now fetches the latest tag, compares against `env!("CARGO_PKG_VERSION")` via the existing `version_less_than` helper, and short-circuits when the running vestad is not older — no download, no `self_replace`, no systemd bounce.
- `perform_update` returns a structured `UpdateOutcome { updated, restarted, current, latest }`. The `POST /self-update` handler exposes `{ updated, restarting, current, latest }` so the app can show an "already up to date" toast instead of a confusing silent restart-or-not.
- The `vestad update` CLI now prints `vestad already at latest version (vX.Y.Z)` when no-op instead of being silent.

Fixes #477

## Test plan
- [x] `cargo clippy -p vestad` clean
- [x] `cargo test -p vestad` (78 passed, 11 ignored docker tests)
- [ ] Manual: hit `POST /self-update` against a vestad already on latest, verify response shows `updated: false` and the service does not bounce.