### PR TITLE
ci: add retries to integration-test curls

### DIFF
--- a/vestad/tests-integration/src/lib.rs
+++ b/vestad/tests-integration/src/lib.rs
@@ -348,6 +348,11 @@ pub fn download_latest_released_vestad() -> Result<ReleasedVestad, String> {
     let output = Command::new("curl")
         .args([
             "-fsSL",
+            "--retry",
+            "5",
+            "--retry-all-errors",
+            "--retry-delay",
+            "2",
             "-H",
             "Accept: application/vnd.github+json",
             "-H",
@@ -382,7 +387,15 @@ pub fn download_latest_released_vestad() -> Result<ReleasedVestad, String> {
     let tmpdir = tempfile::TempDir::new().map_err(|e| format!("tmpdir: {e}"))?;
     let archive_path = tmpdir.path().join("vestad.tar.gz");
     let output = Command::new("curl")
-        .args(["-fsSL", "-o"])
+        .args([
+            "-fsSL",
+            "--retry",
+            "5",
+            "--retry-all-errors",
+            "--retry-delay",
+            "2",
+            "-o",
+        ])
         .arg(&archive_path)
         .arg(&url)
         .output()

--- a/vestad/tests-integration/src/lib.rs
+++ b/vestad/tests-integration/src/lib.rs
@@ -19,6 +19,9 @@ pub static SERVER: LazyLock<TestServer> = LazyLock::new(|| {
 static TEST_USER_COUNTER: AtomicU32 = AtomicU32::new(0);
 static TEST_AGENT_COUNTER: AtomicU32 = AtomicU32::new(0);
 
+/// curl flags that absorb transient GitHub API/CDN flakes during integration tests.
+const CURL_RETRY_ARGS: &[&str] = &["--retry", "5", "--retry-all-errors", "--retry-delay", "2"];
+
 /// Generate a unique user name for test isolation. Includes PID for cross-run
 /// uniqueness and an atomic counter for intra-run uniqueness. This prevents
 /// tests from seeing each other's Docker containers (vestad scopes by
@@ -346,13 +349,9 @@ pub struct ReleasedVestad {
 
 pub fn download_latest_released_vestad() -> Result<ReleasedVestad, String> {
     let output = Command::new("curl")
+        .arg("-fsSL")
+        .args(CURL_RETRY_ARGS)
         .args([
-            "-fsSL",
-            "--retry",
-            "5",
-            "--retry-all-errors",
-            "--retry-delay",
-            "2",
             "-H",
             "Accept: application/vnd.github+json",
             "-H",
@@ -387,15 +386,9 @@ pub fn download_latest_released_vestad() -> Result<ReleasedVestad, String> {
     let tmpdir = tempfile::TempDir::new().map_err(|e| format!("tmpdir: {e}"))?;
     let archive_path = tmpdir.path().join("vestad.tar.gz");
     let output = Command::new("curl")
-        .args([
-            "-fsSL",
-            "--retry",
-            "5",
-            "--retry-all-errors",
-            "--retry-delay",
-            "2",
-            "-o",
-        ])
+        .arg("-fsSL")
+        .args(CURL_RETRY_ARGS)
+        .arg("-o")
         .arg(&archive_path)
         .arg(&url)
         .output()


### PR DESCRIPTION
## Summary

Master CI flaked on the post-merge run of #470 — `vestad/tests-integration/tests/migrations/upgrade.rs::latest_released_vestad_upgrades_to_current_and_agent_git_state_is_valid` panicked with `failed to fetch latest release metadata` because `curl` to `api.github.com` had a transient failure and there were no retries.

#469 added the same `--retry 5 --retry-all-errors --retry-delay 2` pattern to the cloudflared download in `vestad/build.rs` and to the Tauri jobs, but missed the two curls in `vestad/tests-integration/src/lib.rs`. Patching both:

- `download_latest_released_vestad`: the `api.github.com` release-metadata curl (the one that flaked on master).
- The release-tarball download from `github.com/elyxlz/vesta/releases/download/...` immediately below it (same flake class — github.com release CDN intermittently 502s).

Audited the rest of `vestad/tests-integration/`: the only other external-network calls are the OAuth ureq probes (`platform.claude.com`), which deliberately fail loudly to catch endpoint drift — left alone.

## Test plan

- [ ] CI passes on this branch
- [ ] Migration upgrade test no longer flakes on transient GitHub API blips