### PR TITLE
fix(vestad): bump docker client timeout to 600s to absorb image-build flakes

### DIFF
--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -98,6 +98,13 @@ const CONTAINER_STOP_TIMEOUT_SECS: i32 = 10;
 const CONTAINER_RESTART_TIMEOUT_SECS: i32 = 10;
 const LOADED_IMAGE_PREFIX: &str = "Loaded image: ";
 
+// Override bollard's 120s default to absorb slow image builds under CI contention.
+const DOCKER_TIMEOUT_SECS: u64 = 600;
+#[cfg(unix)]
+const DOCKER_SOCKET: &str = "unix:///var/run/docker.sock";
+#[cfg(windows)]
+const DOCKER_NAMED_PIPE: &str = "npipe:////./pipe/docker_engine";
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ContainerStatus {
     Running,
@@ -136,8 +143,19 @@ pub struct ListEntry {
 // --- Docker connection ---
 
 pub fn connect() -> Result<Docker, DockerError> {
-    Docker::connect_with_local_defaults()
-        .map_err(|e| DockerError::Failed(format!("failed to connect to docker: {e}")))
+    #[cfg(unix)]
+    let result = Docker::connect_with_socket(
+        DOCKER_SOCKET,
+        DOCKER_TIMEOUT_SECS,
+        bollard::API_DEFAULT_VERSION,
+    );
+    #[cfg(windows)]
+    let result = Docker::connect_with_named_pipe(
+        DOCKER_NAMED_PIPE,
+        DOCKER_TIMEOUT_SECS,
+        bollard::API_DEFAULT_VERSION,
+    );
+    result.map_err(|e| DockerError::Failed(format!("failed to connect to docker: {e}")))
 }
 
 pub async fn ensure_docker(docker: &Docker) -> Result<(), DockerError> {


### PR DESCRIPTION
## Summary

- `vestad/src/docker.rs::connect()` previously called `Docker::connect_with_local_defaults()`, which in bollard 0.20 hardcodes `DEFAULT_TIMEOUT: u64 = 120` seconds for every Docker API request.
- Image builds in CI under parallel `multi_user` test contention routinely exceed that window. PR #484's `test-integration` job ran for 120.47s before panicking with `image build failed: Timeout error` across 5 `multi_user` tests, all with timestamps within milliseconds of the 120s mark — a textbook bollard timeout, not a real Docker failure.
- Replace the defaults helper with an explicit `Docker::connect_with_socket` (unix) / `Docker::connect_with_named_pipe` (windows) call that passes a generous `DOCKER_TIMEOUT_SECS = 600`. `cfg` gates select the right transport per platform; the socket path consts (`DEFAULT_SOCKET` / `DEFAULT_NAMED_PIPE`) live in bollard's private `docker` module and aren't re-exported, so the standard paths are inlined as `const`s.

Single file, 20-line diff, no behavioral change other than the timeout.

## Test plan

- [x] `cargo build -p vestad` (clean)
- [x] `cargo clippy -p vestad` (no warnings)
- [x] `cargo test -p vestad` (78 passed, 11 ignored docker-required)
- [ ] CI green on this PR (the real proof — `test-integration` should no longer hit the 120s wall)