### PR TITLE
feat(skills): add claude-code skill for delegating coding tasks

### DIFF
--- a/agent/skills/claude-code/SKILL.md
+++ b/agent/skills/claude-code/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: claude-code
+description: Delegate coding tasks to Claude Code (Anthropic's autonomous coding CLI). Use for writing, refactoring, debugging, multi-file edits, code review, and anything else that touches code.
+---
+
+# Claude Code - CLI: `claude`
+
+The `claude` CLI is a separate autonomous coding agent. Shell out to it in **print mode** (`-p`) for coding work. It has a coding-tuned system prompt, the right default tools, and runs to completion in one call. Vesta's own context stays clean: only the final result comes back.
+
+## When to use
+
+- Anything that touches code: writing, editing, refactoring, debugging, building features
+- Multi-file changes or "do this across the repo"
+- Code review, security review, "look at this diff"
+- Tasks that would otherwise burn many turns of Vesta's own loop reading/editing files
+
+For trivial one-line edits, just use Edit/Write directly. This tool exists for tasks where Claude Code's coding system prompt and tooling pay off.
+
+## Basic call
+
+```bash
+claude -p "<task>" \
+  --output-format json \
+  --max-turns 20 \
+  --permission-mode bypassPermissions \
+  --allowedTools "Read,Edit,Write,Bash,Grep,Glob"
+```
+
+JSON response shape:
+```json
+{
+  "result": "<final text Claude Code returned>",
+  "session_id": "75e2167f-...",
+  "total_cost_usd": 0.078,
+  "num_turns": 7,
+  "subtype": "success"
+}
+```
+
+Parse `result` and report it. Capture `session_id` for follow-ups.
+
+## Multi-turn (follow-ups)
+
+Sessions live on Claude Code's side. No Vesta storage needed: the `session_id` is just a string you hold in conversation context and pass back.
+
+```bash
+# Turn 1: get session_id from the JSON
+claude -p "Refactor auth module to use JWT" --output-format json --max-turns 20 ...
+
+# Turn 2: continue the same session
+claude -p "Now add tests" --resume <session_id> --output-format json --max-turns 10 ...
+
+# Or continue the most-recent session in this cwd
+claude -p "Anything you missed?" --continue --output-format json --max-turns 5 ...
+
+# Fork: new id, keeps history
+claude -p "Try a different approach" --resume <session_id> --fork-session ...
+```
+
+When the user follows up ("now also fix X"), reuse the previous `session_id` so Claude Code keeps full context. For an unrelated coding task, start fresh.
+
+## Worktrees
+
+For non-trivial coding work, run inside a git worktree. The user always wants new work isolated on its own branch.
+
+```bash
+cd /path/to/repo
+git worktree add .claude/worktrees/<slug> -b <branch-name>
+cd .claude/worktrees/<slug>
+claude -p "<task>" --output-format json --max-turns 20 ...
+```
+
+Report the worktree path and branch back to the user along with the result.
+
+## Useful flags
+
+- `--allowedTools <list>` - comma-separated whitelist (`"Read,Edit,Bash"`). Scope to what the task needs.
+- `--max-turns <n>` - cost cap. 5-10 for small tasks, 20-30 for refactors.
+- `--max-budget-usd <n>` - dollar cap. Minimum ~$0.05.
+- `--permission-mode bypassPermissions` - skip permission prompts. Required for non-interactive use.
+- `--output-format json` - single result blob with metadata. Always use this.
+- `--model sonnet | opus | haiku` - override default. `haiku` for cheap one-shots, `opus` for hard reasoning.
+- `--add-dir <path>` - grant access to additional directories beyond `cwd`.
+- `--append-system-prompt-file <path>` - add extra instructions on top of Claude Code's default prompt.
+- `--continue` / `--resume <id>` - resume sessions (see above).
+- `--fork-session` - branch off a session with a new id.
+
+## Rules
+
+- **Always use `--permission-mode bypassPermissions`.** Without it the CLI prompts for permission and hangs forever in non-interactive mode.
+- **Always set `--max-turns`.** A confused subagent can otherwise loop indefinitely on your dollar.
+- **Always use `--output-format json`.** You need `session_id` for follow-ups and `result` to report back. Plain-text mode loses both.
+- **Use a generous bash timeout** when invoking this tool. Coding work can take minutes. Set 5+ minute timeouts for non-trivial tasks.
+- **Pass the user's exact intent, not your paraphrase.** Claude Code's prompt is tuned for natural-language coding tasks; don't pre-digest.
+- **Worktree for anything beyond a one-line fix.** The user wants isolated branches for new work.
+- **Don't nest claude calls inside the task string.** If the task itself involves running `claude`, you've over-decomposed - just describe the goal.

--- a/agent/skills/claude-code/SKILL.md
+++ b/agent/skills/claude-code/SKILL.md
@@ -1,24 +1,35 @@
 ---
 name: claude-code
-description: Delegate any serious coding task to Claude Code (Anthropic's autonomous coding CLI). Always use this for writing, refactoring, debugging, multi-file edits, building features, and code review. Only skip it for trivial one-line edits.
+description: Delegate heavy coding tasks to Claude Code (Anthropic's autonomous coding CLI). Use for large multi-file refactors, building entire features or modules, complex debugging that needs extensive exploration, and substantial code reviews. For small edits, single-file changes, and quick fixes, use Vesta's own Read/Edit/Bash tools directly.
 ---
 
 # Claude Code - CLI: `claude`
 
-The `claude` CLI is a separate autonomous coding agent with a coding-tuned system prompt and the right default tools. **Default to this whenever the user asks for coding work.** Shell out to it in print mode (`-p`); it runs to completion in one call and only the final result comes back, so Vesta's own context stays clean.
+The `claude` CLI is a separate autonomous coding agent with a coding-tuned system prompt and the right default tools. Reserve it for **heavy** coding work where its specialized prompt and extended autonomous behavior pay off. For everyday small edits, just use Vesta's own Read/Edit/Bash tools.
 
-## When to use
+When you do invoke it, shell out in print mode (`-p`). It runs to completion in one call and only the final result comes back, so Vesta's own context stays clean.
 
-**Use this for any serious coding task.** That includes:
+## When to use this skill
 
-- Writing new code, features, or whole modules
-- Refactoring or restructuring existing code
-- Debugging, investigating failures, fixing bugs
-- Multi-file changes or "do this across the repo"
-- Code review, security review, "look at this diff"
+Reach for `claude` when the task is genuinely big:
+
+- Building a whole feature or new module
+- Multi-file refactors or "do this across the repo"
+- Complex debugging that needs extensive exploration before a fix
+- Substantial code reviews or security reviews of large diffs
 - Anything that would otherwise burn many turns of Vesta's own loop reading and editing files
 
-The only time to skip this skill is for a trivial one-line edit where shelling out is more overhead than the change itself. When in doubt, prefer this skill.
+## When NOT to use this skill
+
+For everything smaller, do it yourself with Read/Edit/Bash:
+
+- Single-file edits and small tweaks
+- Adding or changing a handful of lines
+- Quick fixes, typos, renames
+- Reading and explaining code
+- Small additions to existing functions
+
+Shelling out has its own overhead (subprocess, JSON parsing, the agent's autonomous turns). For modest work, that overhead exceeds the value of Claude Code's specialized prompt.
 
 ## Basic call
 

--- a/agent/skills/claude-code/SKILL.md
+++ b/agent/skills/claude-code/SKILL.md
@@ -108,4 +108,4 @@ Report the worktree path and branch back to the user along with the result.
 - **Use a generous bash timeout** when invoking this tool. Coding work can take minutes. Set 5+ minute timeouts for non-trivial tasks.
 - **Pass the user's exact intent, not your paraphrase.** Claude Code's prompt is tuned for natural-language coding tasks; don't pre-digest.
 - **Worktree for anything beyond a one-line fix.** The user wants isolated branches for new work.
-- **Don't nest claude calls inside the task string.** If the task itself involves running `claude`, you've over-decomposed - just describe the goal.
+- **Don't nest claude calls inside the task string.** If the task itself involves running `claude`, you've over-decomposed: just describe the goal.

--- a/agent/skills/claude-code/SKILL.md
+++ b/agent/skills/claude-code/SKILL.md
@@ -1,20 +1,24 @@
 ---
 name: claude-code
-description: Delegate coding tasks to Claude Code (Anthropic's autonomous coding CLI). Use for writing, refactoring, debugging, multi-file edits, code review, and anything else that touches code.
+description: Delegate any serious coding task to Claude Code (Anthropic's autonomous coding CLI). Always use this for writing, refactoring, debugging, multi-file edits, building features, and code review. Only skip it for trivial one-line edits.
 ---
 
 # Claude Code - CLI: `claude`
 
-The `claude` CLI is a separate autonomous coding agent. Shell out to it in **print mode** (`-p`) for coding work. It has a coding-tuned system prompt, the right default tools, and runs to completion in one call. Vesta's own context stays clean: only the final result comes back.
+The `claude` CLI is a separate autonomous coding agent with a coding-tuned system prompt and the right default tools. **Default to this whenever the user asks for coding work.** Shell out to it in print mode (`-p`); it runs to completion in one call and only the final result comes back, so Vesta's own context stays clean.
 
 ## When to use
 
-- Anything that touches code: writing, editing, refactoring, debugging, building features
+**Use this for any serious coding task.** That includes:
+
+- Writing new code, features, or whole modules
+- Refactoring or restructuring existing code
+- Debugging, investigating failures, fixing bugs
 - Multi-file changes or "do this across the repo"
 - Code review, security review, "look at this diff"
-- Tasks that would otherwise burn many turns of Vesta's own loop reading/editing files
+- Anything that would otherwise burn many turns of Vesta's own loop reading and editing files
 
-For trivial one-line edits, just use Edit/Write directly. This tool exists for tasks where Claude Code's coding system prompt and tooling pay off.
+The only time to skip this skill is for a trivial one-line edit where shelling out is more overhead than the change itself. When in doubt, prefer this skill.
 
 ## Basic call
 

--- a/agent/skills/default-skills.txt
+++ b/agent/skills/default-skills.txt
@@ -1,5 +1,6 @@
 banking
 browser
+claude-code
 dashboard
 dream
 flights

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -13,7 +13,7 @@
   },
   {
     "name": "claude-code",
-    "description": "Delegate coding tasks to Claude Code (Anthropic's autonomous coding CLI). Use for writing, refactoring, debugging, multi-file edits, code review, and anything else that touches code."
+    "description": "Delegate any serious coding task to Claude Code (Anthropic's autonomous coding CLI). Always use this for writing, refactoring, debugging, multi-file edits, building features, and code review. Only skip it for trivial one-line edits."
   },
   {
     "name": "dashboard",

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -12,6 +12,10 @@
     "description": "Browse, navigate, click, fill forms, screenshot, or scrape web pages via CDP."
   },
   {
+    "name": "claude-code",
+    "description": "Delegate coding tasks to Claude Code (Anthropic's autonomous coding CLI). Use for writing, refactoring, debugging, multi-file edits, code review, and anything else that touches code."
+  },
+  {
     "name": "dashboard",
     "description": "Build or modify the user's dashboard: widgets, pages, layouts, or custom UI."
   },

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -13,7 +13,7 @@
   },
   {
     "name": "claude-code",
-    "description": "Delegate any serious coding task to Claude Code (Anthropic's autonomous coding CLI). Always use this for writing, refactoring, debugging, multi-file edits, building features, and code review. Only skip it for trivial one-line edits."
+    "description": "Delegate heavy coding tasks to Claude Code (Anthropic's autonomous coding CLI). Use for large multi-file refactors, building entire features or modules, complex debugging that needs extensive exploration, and substantial code reviews. For small edits, single-file changes, and quick fixes, use Vesta's own Read/Edit/Bash tools directly."
   },
   {
     "name": "dashboard",


### PR DESCRIPTION
## Summary
- Adds `agent/skills/claude-code/` — a skill that teaches Vesta to shell out to the `claude` CLI in print mode (`-p`) for coding work
- Keeps Claude Code's coding system prompt isolated to the subprocess, so it never enters Vesta's main context
- Multi-turn follow-ups handled via `--resume <session_id>` / `--continue` — Claude Code stores session state itself, no Vesta-side bookkeeping
- No tmux / interactive mode (deliberately omitted)
- The `claude` binary is already installed in the agent container via the existing Dockerfile install line, so no Dockerfile changes

## Why
Claude Code ships with a coding-tuned system prompt and tool conventions that Vesta's general-assistant prompt doesn't have. Instead of bloating the main prompt, this skill lets the agent delegate coding tasks to a fresh `claude` subprocess and just hold the resulting `session_id` in conversation context for follow-ups.

Approach inspired by [Hermes Agent's claude-code skill](https://github.com/NousResearch/hermes-agent/blob/main/skills/autonomous-ai-agents/claude-code/SKILL.md), trimmed to print-mode only.

## Test plan
- [ ] CI green
- [ ] Manual: invoke a small coding task in a Vesta session, confirm `claude -p` is reachable on PATH and returns a JSON result
- [ ] Manual: follow-up with `--resume <session_id>`, confirm context carries over