### PR TITLE
fix(vestad): make manage_agent_code create-only, preserve mount topology on rebuild

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -272,16 +272,6 @@ impl Client {
         check_response(resp)
     }
 
-    fn patch_json(&self, path: &str, body: &serde_json::Value) -> Result<Response<Body>, String> {
-        let resp = self
-            .agent
-            .patch(&format!("{}{}", self.base_url, path))
-            .header("Authorization", &format!("Bearer {}", self.api_key))
-            .send_json(body)
-            .map_err(map_error)?;
-        check_response(resp)
-    }
-
     fn put_json(&self, path: &str, body: &serde_json::Value) -> Result<Response<Body>, String> {
         let resp = self
             .agent
@@ -331,11 +321,6 @@ impl Client {
 
     pub fn get_agent_settings(&self, name: &str) -> Result<serde_json::Value, String> {
         let resp = self.get(&format!("/agents/{name}/settings"))?;
-        resp.into_body().read_json().map_err(|e| format!("parse error: {e}"))
-    }
-
-    pub fn patch_agent_settings(&self, name: &str, body: &serde_json::Value) -> Result<serde_json::Value, String> {
-        let resp = self.patch_json(&format!("/agents/{name}/settings"), body)?;
         resp.into_body().read_json().map_err(|e| format!("parse error: {e}"))
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -137,16 +137,10 @@ enum Command {
         #[command(subcommand)]
         action: BackupAction,
     },
-    /// View or update agent settings
+    /// View agent settings (manage_agent_code is fixed at create time and read-only here)
     Settings {
         /// Agent name
         name: String,
-        /// Enable vestad-managed core code (mount from host)
-        #[arg(long)]
-        manage_core_code: bool,
-        /// Disable vestad-managed core code (use image's baked-in code)
-        #[arg(long, conflicts_with = "manage_core_code")]
-        no_manage_core_code: bool,
     },
     /// Destroy an agent (irreversible)
     Destroy {
@@ -533,18 +527,11 @@ fn run(cli: Cli) {
             eprintln!("created (run 'vesta auth {name}' to authenticate)");
         }
 
-        Command::Settings { name, manage_core_code, no_manage_core_code } => {
+        Command::Settings { name } => {
             let c = get_client(host_ref, token_ref);
-            if manage_core_code || no_manage_core_code {
-                let body = serde_json::json!({"manage_agent_code": !no_manage_core_code});
-                let result = c.patch_agent_settings(&name, &body).unwrap_or_else(|e| platform::die(&e));
-                let val = result["manage_agent_code"].as_bool().unwrap_or(true);
-                eprintln!("{name}: manage_agent_code = {val}");
-            } else {
-                let result = c.get_agent_settings(&name).unwrap_or_else(|e| platform::die(&e));
-                let val = result["manage_agent_code"].as_bool().unwrap_or(true);
-                eprintln!("manage_agent_code = {val}");
-            }
+            let result = c.get_agent_settings(&name).unwrap_or_else(|e| platform::die(&e));
+            let val = result["manage_agent_code"].as_bool().unwrap_or(true);
+            eprintln!("manage_agent_code = {val}");
         }
 
         Command::Start { name } => {

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -72,7 +72,9 @@ pub const OAUTH_AUTHORIZE_URL: &str = "https://claude.ai/oauth/authorize";
 
 const NETWORK_MODE: &str = "host";
 const RESTART_POLICY: &str = "unless-stopped";
-const MOUNT_DESTS: &[&str] = &["/run/vestad-env", "/root/agent/core", "/root/agent/pyproject.toml", "/root/agent/uv.lock"];
+const ENV_MOUNT_DEST: &str = "/run/vestad-env";
+const CORE_MOUNT_DEST: &str = "/root/agent/core";
+const MOUNT_DESTS: &[&str] = &[ENV_MOUNT_DEST, CORE_MOUNT_DEST, "/root/agent/pyproject.toml", "/root/agent/uv.lock"];
 
 const AGENT_ENTRYPOINT_STEPS: &[&str] = &[
     "export PATH=\"/root/.local/bin:/root/.claude/local/bin:$PATH\"",
@@ -374,32 +376,34 @@ pub fn read_env_value(agents_dir: &std::path::Path, agent_name: &str, key: &str)
     None
 }
 
+pub(crate) fn container_info_from(cname: &str, info: &bollard::models::ContainerInspectResponse, agents_dir: Option<&std::path::Path>) -> ContainerInfo {
+    let status = info.state.as_ref()
+        .and_then(|s| s.status)
+        .map(|s| {
+            let status_str = format!("{:?}", s).to_lowercase();
+            match status_str.as_str() {
+                "running" | "restarting" | "paused" => ContainerStatus::Running,
+                "exited" | "created" => ContainerStatus::Stopped,
+                "dead" | "removing" => ContainerStatus::Dead,
+                _ => ContainerStatus::Stopped,
+            }
+        })
+        .unwrap_or(ContainerStatus::Stopped);
+    let id = info.id.as_ref()
+        .map(|id| id.chars().take(12).collect::<String>());
+    let name = info.config.as_ref()
+        .and_then(|c| c.labels.as_ref())
+        .and_then(|labels| labels.get(LABEL_AGENT_NAME).cloned())
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| name_from_cname(cname));
+    let port = agents_dir.and_then(|dir| read_env_value(dir, &name, "WS_PORT"))
+        .and_then(|v| v.parse().ok());
+    ContainerInfo { status, port, id }
+}
+
 pub(crate) async fn inspect_container(docker: &Docker, cname: &str, agents_dir: Option<&std::path::Path>) -> ContainerInfo {
     match docker.inspect_container(cname, None).await {
-        Ok(info) => {
-            let status = info.state.as_ref()
-                .and_then(|s| s.status)
-                .map(|s| {
-                    let status_str = format!("{:?}", s).to_lowercase();
-                    match status_str.as_str() {
-                        "running" | "restarting" | "paused" => ContainerStatus::Running,
-                        "exited" | "created" => ContainerStatus::Stopped,
-                        "dead" | "removing" => ContainerStatus::Dead,
-                        _ => ContainerStatus::Stopped,
-                    }
-                })
-                .unwrap_or(ContainerStatus::Stopped);
-            let id = info.id.as_ref()
-                .map(|id| id.chars().take(12).collect::<String>());
-            let name = info.config.as_ref()
-                .and_then(|c| c.labels.as_ref())
-                .and_then(|labels| labels.get(LABEL_AGENT_NAME).cloned())
-                .filter(|s| !s.trim().is_empty())
-                .unwrap_or_else(|| name_from_cname(cname));
-            let port = agents_dir.and_then(|dir| read_env_value(dir, &name, "WS_PORT"))
-                .and_then(|v| v.parse().ok());
-            ContainerInfo { status, port, id }
-        }
+        Ok(info) => container_info_from(cname, &info, agents_dir),
         Err(_) => ContainerInfo {
             status: ContainerStatus::NotFound,
             port: None,
@@ -1653,17 +1657,24 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
     // into wiping bind-mounted core code.
     let mut agent_code_ok = false;
     for ManagedAgent { cname, agent_name: name } in &agents {
-        let has_core_mounts = container_has_core_mounts(docker, cname).await;
+        let raw = match docker.inspect_container(cname, None).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(agent = %name, error = %e, "skipping reconcile: inspect failed");
+                continue;
+            }
+        };
+        let has_core_mounts = mounts_have_core_code(raw.mounts.as_deref().unwrap_or(&[]));
         let settings_says = manages_core_code(name);
         if has_core_mounts != settings_says {
             tracing::warn!(
                 agent = %name,
                 settings_says,
                 container_has_core_mounts = has_core_mounts,
-                "settings.manage_agent_code disagrees with container — using container as source of truth. fix by destroying and recreating the agent."
+                "settings.manage_agent_code disagrees with container, using container as source of truth. fix by destroying and recreating the agent."
             );
         }
-        if !needs_rebuild(docker, cname).await {
+        if !needs_rebuild(cname, &raw) {
             tracing::info!(agent = %name, "config ok, no rebuild needed");
             continue;
         }
@@ -1672,7 +1683,7 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
             match crate::agent_code::ensure_agent_code(&env_config.config_dir) {
                 Ok(_) => agent_code_ok = true,
                 Err(e) => {
-                    tracing::error!(error = %e, "failed to ensure agent code — skipping rebuilds");
+                    tracing::error!(error = %e, "failed to ensure agent code, skipping rebuilds");
                     break;
                 }
             }
@@ -1733,33 +1744,26 @@ pub async fn destroy_agent(docker: &Docker, name: &str, agents_dir: &std::path::
     Ok(())
 }
 
-/// Returns whether the container has the core-code bind mount attached. This is the
-/// source of truth for `manage_agent_code` post-creation: settings.json may drift via
-/// hand-edits, but the container's mount config reflects how it was actually created.
-async fn container_has_core_mounts(docker: &Docker, cname: &str) -> bool {
-    match docker.inspect_container(cname, None).await {
-        Ok(info) => info.mounts.as_deref().unwrap_or(&[]).iter()
-            .any(|m| m.destination.as_deref() == Some(MOUNT_DESTS[1])),
-        Err(_) => false,
-    }
+/// Returns whether the container's mount list includes the core-code bind mount. This
+/// is the source of truth for `manage_agent_code` post-creation: settings.json may drift
+/// via hand-edits, but the container's mount config reflects how it was actually created.
+fn mounts_have_core_code(mounts: &[bollard::models::MountPoint]) -> bool {
+    mounts.iter().any(|m| m.destination.as_deref() == Some(CORE_MOUNT_DEST))
 }
 
 /// Check if a container's config diverges from what create_container would produce.
-/// Mount divergence is intentionally NOT a trigger here — it's reported by reconcile
-/// as a warning. See `rebuild_agent` for why mount topology must come from the
-/// container, not from settings.
-async fn needs_rebuild(docker: &Docker, cname: &str) -> bool {
-    let info = match docker.inspect_container(cname, None).await {
-        Ok(i) => i,
-        Err(_) => return true,
-    };
-
+/// Operates on a pre-fetched inspect response so callers can do one Docker round-trip
+/// even when they also need other fields (mount topology, port, status). Mount
+/// divergence is intentionally NOT a trigger here: it's reported by reconcile as a
+/// warning. See `rebuild_agent` for why mount topology must come from the container,
+/// not from settings.
+fn needs_rebuild(cname: &str, info: &bollard::models::ContainerInspectResponse) -> bool {
     let mounts = info.mounts.as_deref().unwrap_or(&[]);
     let mount_dests: Vec<&str> = mounts.iter()
         .filter_map(|m| m.destination.as_deref())
         .collect();
 
-    if !mount_dests.contains(&MOUNT_DESTS[0]) {
+    if !mount_dests.contains(&ENV_MOUNT_DEST) {
         tracing::info!(container = %cname, "rebuild needed: missing env-file mount");
         return true;
     }
@@ -1826,25 +1830,20 @@ async fn needs_rebuild(docker: &Docker, cname: &str) -> bool {
 /// Recreate a container with the latest container config (entrypoint, mounts, env file)
 /// while preserving the filesystem. Snapshots the old container, removes it, and creates
 /// a new one from the snapshot. Mount topology is preserved from the existing container,
-/// not re-derived from settings — `manage_agent_code` is fixed at create time, so the
+/// not re-derived from settings: `manage_agent_code` is fixed at create time, so the
 /// running container is the source of truth for which bind mounts to attach.
 pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvConfig) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
-    let info = inspect_container(docker, &cname, Some(&env_config.agents_dir)).await;
+    let raw = docker.inspect_container(&cname, None).await.map_err(DockerError::from)?;
+    let info = container_info_from(&cname, &raw, Some(&env_config.agents_dir));
     match info.status {
         ContainerStatus::NotFound => return Err(DockerError::NotFound(format!("agent '{}' not found", name))),
         ContainerStatus::Dead => return Err(DockerError::BrokenState(format!("agent '{}' is in a broken state", name))),
         _ => {}
     }
 
-    // Derive mount topology from the existing container so a stale settings.json can never
-    // wipe bind-mounted core code. If the container has the core-code bind mount, keep it.
-    let manage_core_code = match docker.inspect_container(&cname, None).await {
-        Ok(raw) => raw.mounts.as_deref().unwrap_or(&[]).iter()
-            .any(|m| m.destination.as_deref() == Some(MOUNT_DESTS[1])),
-        Err(e) => return Err(DockerError::from(e)),
-    };
+    let manage_core_code = mounts_have_core_code(raw.mounts.as_deref().unwrap_or(&[]));
 
     // Get port: try env file first, then container's baked-in env vars, then allocate new
     let container_port = read_container_env(docker, &cname, "WS_PORT").await
@@ -1852,7 +1851,7 @@ pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvCon
     let port = match info.port.or(container_port) {
         Some(p) => p,
         None => {
-            tracing::warn!(agent = %name, "no port found in env file or container — allocating new port");
+            tracing::warn!(agent = %name, "no port found in env file or container, allocating new port");
             allocate_port(&env_config.agents_dir)?
         }
     };
@@ -2085,6 +2084,11 @@ mod tests {
         connect().expect("failed to connect to docker")
     }
 
+    async fn inspect_then_needs_rebuild(docker: &Docker, cname: &str) -> bool {
+        let info = docker.inspect_container(cname, None).await.expect("inspect");
+        needs_rebuild(cname, &info)
+    }
+
     /// Best-effort cleanup via docker CLI (safe to call from Drop inside tokio).
     fn docker_cleanup(args: &[&str]) {
         std::process::Command::new("docker")
@@ -2233,7 +2237,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(!needs_rebuild(&docker, &tc.name).await, "fresh container should NOT need rebuild");
+        assert!(!inspect_then_needs_rebuild(&docker, &tc.name).await, "fresh container should NOT need rebuild");
     }
 
     #[tokio::test]
@@ -2262,7 +2266,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &mounts, agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(!needs_rebuild(&docker, &tc.name).await, "container with all mounts should NOT need rebuild");
+        assert!(!inspect_then_needs_rebuild(&docker, &tc.name).await, "container with all mounts should NOT need rebuild");
     }
 
     #[tokio::test]
@@ -2276,7 +2280,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], vec!["sh".into(), "-c".into(), "echo wrong".into()], NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(needs_rebuild(&docker, &tc.name).await, "container with wrong cmd SHOULD need rebuild");
+        assert!(inspect_then_needs_rebuild(&docker, &tc.name).await, "container with wrong cmd SHOULD need rebuild");
     }
 
     #[tokio::test]
@@ -2287,16 +2291,12 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(needs_rebuild(&docker, &tc.name).await, "container without env mount SHOULD need rebuild");
+        assert!(inspect_then_needs_rebuild(&docker, &tc.name).await, "container without env mount SHOULD need rebuild");
     }
 
     #[tokio::test]
     #[ignore]
     async fn test_needs_rebuild_false_on_missing_code_mounts() {
-        // After the manage_agent_code-is-create-only refactor, missing core code mounts
-        // are no longer a rebuild trigger — `manage_agent_code` is fixed at create time
-        // and the container's mount topology IS the source of truth. Reconcile only
-        // logs a warning when settings.json drifts via hand-edits.
         let docker = test_docker();
         let tc = TestContainer::new("rebuild-nocode");
         let env_file = tempfile::NamedTempFile::new().expect("tempfile");
@@ -2305,7 +2305,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(!needs_rebuild(&docker, &tc.name).await, "missing core code mounts should NOT trigger rebuild");
+        assert!(!inspect_then_needs_rebuild(&docker, &tc.name).await, "missing core code mounts should NOT trigger rebuild");
     }
 
     #[tokio::test]
@@ -2319,7 +2319,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), "bridge", RESTART_POLICY).await;
 
-        assert!(needs_rebuild(&docker, &tc.name).await, "container with wrong network SHOULD need rebuild");
+        assert!(inspect_then_needs_rebuild(&docker, &tc.name).await, "container with wrong network SHOULD need rebuild");
     }
 
     #[tokio::test]
@@ -2333,7 +2333,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, "no").await;
 
-        assert!(needs_rebuild(&docker, &tc.name).await, "container with wrong restart policy SHOULD need rebuild");
+        assert!(inspect_then_needs_rebuild(&docker, &tc.name).await, "container with wrong restart policy SHOULD need rebuild");
     }
 
     #[tokio::test]
@@ -2348,7 +2348,7 @@ mod tests {
 
         // Create with wrong network to force rebuild
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), "bridge", RESTART_POLICY).await;
-        assert!(needs_rebuild(&docker, &tc.name).await, "precondition: should need rebuild");
+        assert!(inspect_then_needs_rebuild(&docker, &tc.name).await, "precondition: should need rebuild");
 
         // Snapshot
         snapshot_container(&docker, &tc.name, &img.tag, &[]).await.expect("snapshot should succeed");
@@ -2357,6 +2357,6 @@ mod tests {
         remove_container_force(&docker, &tc.name).await.ok();
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(!needs_rebuild(&docker, &tc.name).await, "rebuilt container should NOT need rebuild");
+        assert!(!inspect_then_needs_rebuild(&docker, &tc.name).await, "rebuilt container should NOT need rebuild");
     }
 }

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1648,16 +1648,27 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
         }
     }
 
-    // Phase 2: rebuild containers with wrong config
+    // Phase 2: rebuild containers with wrong config. Uses container-derived mount
+    // topology (not settings) so a stale settings.json can't redirect the rebuild
+    // into wiping bind-mounted core code.
     let mut agent_code_ok = false;
     for ManagedAgent { cname, agent_name: name } in &agents {
-        let manage_core_code = manages_core_code(name);
-        if !needs_rebuild(docker, cname, manage_core_code).await {
+        let has_core_mounts = container_has_core_mounts(docker, cname).await;
+        let settings_says = manages_core_code(name);
+        if has_core_mounts != settings_says {
+            tracing::warn!(
+                agent = %name,
+                settings_says,
+                container_has_core_mounts = has_core_mounts,
+                "settings.manage_agent_code disagrees with container — using container as source of truth. fix by destroying and recreating the agent."
+            );
+        }
+        if !needs_rebuild(docker, cname).await {
             tracing::info!(agent = %name, "config ok, no rebuild needed");
             continue;
         }
         tracing::info!(agent = %name, "rebuild needed");
-        if manage_core_code && !agent_code_ok {
+        if has_core_mounts && !agent_code_ok {
             match crate::agent_code::ensure_agent_code(&env_config.config_dir) {
                 Ok(_) => agent_code_ok = true,
                 Err(e) => {
@@ -1666,7 +1677,7 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
                 }
             }
         }
-        match rebuild_agent(docker, name, env_config, manage_core_code).await {
+        match rebuild_agent(docker, name, env_config).await {
             Ok(()) => tracing::info!(agent = %name, "rebuild complete"),
             Err(e) => tracing::error!(agent = %name, error = %e, "rebuild failed"),
         }
@@ -1722,31 +1733,35 @@ pub async fn destroy_agent(docker: &Docker, name: &str, agents_dir: &std::path::
     Ok(())
 }
 
+/// Returns whether the container has the core-code bind mount attached. This is the
+/// source of truth for `manage_agent_code` post-creation: settings.json may drift via
+/// hand-edits, but the container's mount config reflects how it was actually created.
+async fn container_has_core_mounts(docker: &Docker, cname: &str) -> bool {
+    match docker.inspect_container(cname, None).await {
+        Ok(info) => info.mounts.as_deref().unwrap_or(&[]).iter()
+            .any(|m| m.destination.as_deref() == Some(MOUNT_DESTS[1])),
+        Err(_) => false,
+    }
+}
+
 /// Check if a container's config diverges from what create_container would produce.
-async fn needs_rebuild(docker: &Docker, cname: &str, manage_core_code: bool) -> bool {
+/// Mount divergence is intentionally NOT a trigger here — it's reported by reconcile
+/// as a warning. See `rebuild_agent` for why mount topology must come from the
+/// container, not from settings.
+async fn needs_rebuild(docker: &Docker, cname: &str) -> bool {
     let info = match docker.inspect_container(cname, None).await {
         Ok(i) => i,
         Err(_) => return true,
     };
 
-    // Check mounts
     let mounts = info.mounts.as_deref().unwrap_or(&[]);
     let mount_dests: Vec<&str> = mounts.iter()
         .filter_map(|m| m.destination.as_deref())
         .collect();
 
-    let expected_mounts: &[&str] = if manage_core_code { MOUNT_DESTS } else { &MOUNT_DESTS[..1] };
-    let missing: Vec<_> = expected_mounts.iter().filter(|d| !mount_dests.contains(*d)).collect();
-    if !missing.is_empty() {
-        tracing::info!(container = %cname, missing = ?missing, "rebuild needed: missing mounts");
+    if !mount_dests.contains(&MOUNT_DESTS[0]) {
+        tracing::info!(container = %cname, "rebuild needed: missing env-file mount");
         return true;
-    }
-    if !manage_core_code {
-        let unexpected: Vec<_> = MOUNT_DESTS[1..].iter().filter(|d| mount_dests.contains(*d)).collect();
-        if !unexpected.is_empty() {
-            tracing::info!(container = %cname, unexpected = ?unexpected, "rebuild needed: has core code mounts while manage_core_code is false");
-            return true;
-        }
     }
 
     // Check cmd
@@ -1809,9 +1824,11 @@ async fn needs_rebuild(docker: &Docker, cname: &str, manage_core_code: bool) -> 
 }
 
 /// Recreate a container with the latest container config (entrypoint, mounts, env file)
-/// while preserving the filesystem. Commits the old container, removes it, and creates
-/// a new one from the committed image.
-pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvConfig, manage_core_code: bool) -> Result<(), DockerError> {
+/// while preserving the filesystem. Snapshots the old container, removes it, and creates
+/// a new one from the snapshot. Mount topology is preserved from the existing container,
+/// not re-derived from settings — `manage_agent_code` is fixed at create time, so the
+/// running container is the source of truth for which bind mounts to attach.
+pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvConfig) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
     let info = inspect_container(docker, &cname, Some(&env_config.agents_dir)).await;
@@ -1820,6 +1837,14 @@ pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvCon
         ContainerStatus::Dead => return Err(DockerError::BrokenState(format!("agent '{}' is in a broken state", name))),
         _ => {}
     }
+
+    // Derive mount topology from the existing container so a stale settings.json can never
+    // wipe bind-mounted core code. If the container has the core-code bind mount, keep it.
+    let manage_core_code = match docker.inspect_container(&cname, None).await {
+        Ok(raw) => raw.mounts.as_deref().unwrap_or(&[]).iter()
+            .any(|m| m.destination.as_deref() == Some(MOUNT_DESTS[1])),
+        Err(e) => return Err(DockerError::from(e)),
+    };
 
     // Get port: try env file first, then container's baked-in env vars, then allocate new
     let container_port = read_container_env(docker, &cname, "WS_PORT").await
@@ -2208,7 +2233,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(!needs_rebuild(&docker, &tc.name, false).await, "fresh container should NOT need rebuild");
+        assert!(!needs_rebuild(&docker, &tc.name).await, "fresh container should NOT need rebuild");
     }
 
     #[tokio::test]
@@ -2237,7 +2262,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &mounts, agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(!needs_rebuild(&docker, &tc.name, true).await, "container with all mounts should NOT need rebuild");
+        assert!(!needs_rebuild(&docker, &tc.name).await, "container with all mounts should NOT need rebuild");
     }
 
     #[tokio::test]
@@ -2251,7 +2276,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], vec!["sh".into(), "-c".into(), "echo wrong".into()], NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(needs_rebuild(&docker, &tc.name, false).await, "container with wrong cmd SHOULD need rebuild");
+        assert!(needs_rebuild(&docker, &tc.name).await, "container with wrong cmd SHOULD need rebuild");
     }
 
     #[tokio::test]
@@ -2262,12 +2287,16 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(needs_rebuild(&docker, &tc.name, false).await, "container without env mount SHOULD need rebuild");
+        assert!(needs_rebuild(&docker, &tc.name).await, "container without env mount SHOULD need rebuild");
     }
 
     #[tokio::test]
     #[ignore]
-    async fn test_needs_rebuild_true_on_missing_code_mounts() {
+    async fn test_needs_rebuild_false_on_missing_code_mounts() {
+        // After the manage_agent_code-is-create-only refactor, missing core code mounts
+        // are no longer a rebuild trigger — `manage_agent_code` is fixed at create time
+        // and the container's mount topology IS the source of truth. Reconcile only
+        // logs a warning when settings.json drifts via hand-edits.
         let docker = test_docker();
         let tc = TestContainer::new("rebuild-nocode");
         let env_file = tempfile::NamedTempFile::new().expect("tempfile");
@@ -2276,7 +2305,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(needs_rebuild(&docker, &tc.name, true).await, "container missing code mounts SHOULD need rebuild when manage_core_code=true");
+        assert!(!needs_rebuild(&docker, &tc.name).await, "missing core code mounts should NOT trigger rebuild");
     }
 
     #[tokio::test]
@@ -2290,7 +2319,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), "bridge", RESTART_POLICY).await;
 
-        assert!(needs_rebuild(&docker, &tc.name, false).await, "container with wrong network SHOULD need rebuild");
+        assert!(needs_rebuild(&docker, &tc.name).await, "container with wrong network SHOULD need rebuild");
     }
 
     #[tokio::test]
@@ -2304,7 +2333,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, "no").await;
 
-        assert!(needs_rebuild(&docker, &tc.name, false).await, "container with wrong restart policy SHOULD need rebuild");
+        assert!(needs_rebuild(&docker, &tc.name).await, "container with wrong restart policy SHOULD need rebuild");
     }
 
     #[tokio::test]
@@ -2319,7 +2348,7 @@ mod tests {
 
         // Create with wrong network to force rebuild
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), "bridge", RESTART_POLICY).await;
-        assert!(needs_rebuild(&docker, &tc.name, false).await, "precondition: should need rebuild");
+        assert!(needs_rebuild(&docker, &tc.name).await, "precondition: should need rebuild");
 
         // Snapshot
         snapshot_container(&docker, &tc.name, &img.tag, &[]).await.expect("snapshot should succeed");
@@ -2328,6 +2357,6 @@ mod tests {
         remove_container_force(&docker, &tc.name).await.ok();
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(!needs_rebuild(&docker, &tc.name, false).await, "rebuilt container should NOT need rebuild");
+        assert!(!needs_rebuild(&docker, &tc.name).await, "rebuilt container should NOT need rebuild");
     }
 }

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -535,8 +535,7 @@ async fn rebuild_agent_handler(
     let lock = state.agent_lock(&name).await;
     let _guard = lock.write().await;
 
-    let manage_core_code = state.settings.read().await.manages_core_code(&name);
-    docker::rebuild_agent(&state.docker, &name, &state.env_config, manage_core_code)
+    docker::rebuild_agent(&state.docker, &name, &state.env_config)
         .await
         .map_err(map_docker_err)?;
     docker::start_agent(&state.docker, &name)
@@ -1266,46 +1265,6 @@ async fn get_agent_settings_handler(
     })))
 }
 
-#[derive(Deserialize)]
-struct PatchAgentSettingsBody {
-    manage_agent_code: Option<bool>,
-}
-
-async fn patch_agent_settings_handler(
-    State(state): State<SharedState>,
-    Path(name): Path<String>,
-    Json(body): Json<PatchAgentSettingsBody>,
-) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    let lock = state.agent_lock(&name).await;
-    let _guard = lock.write().await;
-
-    let (old_manage_core_code, new_manage_core_code) = {
-        let mut settings = state.settings.write().await;
-        let old = settings.manages_core_code(&name);
-        if let Some(val) = body.manage_agent_code {
-            settings.agents.entry(name.clone()).or_default().manage_agent_code = val;
-        }
-        let new = settings.manages_core_code(&name);
-        save_settings(&settings);
-        (old, new)
-    };
-
-    // Rebuild if the mount config changed
-    if old_manage_core_code != new_manage_core_code {
-        let was_running = docker::container_status(&state.docker, &docker::container_name(&name)).await
-            == docker::ContainerStatus::Running;
-        if let Err(e) = docker::rebuild_agent(&state.docker, &name, &state.env_config, new_manage_core_code).await {
-            tracing::error!(agent = %name, error = %e, "rebuild after settings change failed");
-        } else if was_running {
-            docker::start_agent(&state.docker, &name).await.ok();
-        }
-    }
-
-    Ok(Json(serde_json::json!({
-        "manage_agent_code": new_manage_core_code,
-    })))
-}
-
 async fn get_agent_backup_settings_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
@@ -1453,7 +1412,6 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/agents/{name}/backups/{backup_id}/restore", post(restore_backup_handler))
         .route("/agents/{name}/backups/{backup_id}", axum::routing::delete(delete_backup_handler))
         .route("/agents/{name}/settings", get(get_agent_settings_handler))
-        .route("/agents/{name}/settings", axum::routing::patch(patch_agent_settings_handler))
         .route("/agents/{name}/settings/backup", get(get_agent_backup_settings_handler))
         .route("/agents/{name}/settings/backup", axum::routing::put(set_agent_backup_settings_handler))
         .route("/agents/{name}/settings/backup", axum::routing::delete(delete_agent_backup_settings_handler))


### PR DESCRIPTION
## Problem

A container created with `manage_agent_code=true` (host bind mounts on `/root/agent/core`, `pyproject.toml`, `uv.lock`) plus a stale `settings.json` saying `false` could be silently bricked by any reconciliation rebuild — most recently triggered by the entrypoint change in #459, which forces every existing container through the cmd-mismatch path.

Chain:
1. `needs_rebuild` returns true (cmd-mismatch).
2. `rebuild_agent` calls `snapshot_container` (`docker export | docker import`); export does not capture bind-mounted content.
3. `create_container` is called with `manage_core_code=false` (read from settings) — no bind mounts re-attached.
4. New container starts with empty `/root/agent/core` → restart loop.

This bricked at least one production agent (okami) when it ran reconciliation against a bumped vestad.

## Fix

Two structural changes, both targeting "container is the source of truth, settings is informational":

**1. `manage_agent_code` becomes a create-time flag only.**
- Drop `PATCH /agents/{name}/settings` and the matching `--manage-core-code` / `--no-manage-core-code` flags on `vesta settings`.
- `GET /agents/{name}/settings` stays for read-only inspection.
- Switching modes after creation now requires `destroy + create` — which is what it always amounted to operationally anyway, since toggle-time rebuilds were already destructive.

**2. `rebuild_agent` derives mount topology from the running container, not settings.**
- New helper `container_has_core_mounts(docker, cname)` — single source of truth.
- `needs_rebuild` no longer triggers on mount divergence; reconcile logs a warning if `settings.json` disagrees with the container but never acts on it.
- A future cmd-mismatch reconcile preserves whatever mounts the container had → bind mounts get re-attached → no FS damage even in the drift case.

## Test plan
- [ ] `cargo clippy -- -D warnings` clean for `vestad` and `vesta` (CLI) — verified locally
- [ ] `cargo test -p vestad` passes (78 tests) — verified locally
- [ ] Existing integration tests in `vestad/tests-integration/tests/server/agent_code.rs` still cover create-time flag both true/false and rebuild
- [ ] CI green

## Migration notes
- No version bump (per repo convention, `release.sh` handles that).
- Users who relied on toggling `manage_agent_code` post-create now use `vesta destroy <agent>` + `vesta create <agent> [--no-manage-core-code]`.
- Agents currently in the drift state (settings says false, container has bind mounts) are no longer at risk of being nuked by a reconcile pass; they'll get a warning log and continue running with their existing mount topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)