### PR TITLE
fix(vestad): restore startup-style colored output for status

### DIFF
--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -370,66 +370,33 @@ fn main() {
 
         Command::Status => {
             let config = config_dir();
-            let current_version = env!("CARGO_PKG_VERSION");
-            println!("vestad v{}", current_version);
-
             let binary_path = std::env::current_exe()
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|_| "<unknown>".into());
-            println!("binary:   {}", binary_path);
-
-            let port = std::fs::read_to_string(config.join("port"))
-                .ok()
-                .and_then(|s| s.trim().parse::<u16>().ok());
-            match port {
-                Some(port) => {
-                    println!("port:     {}", port);
-                    println!("local:    http://localhost:{}", port + 1);
-                }
-                None => {
-                    println!("port:     <not running>");
-                    println!("local:    <not running>");
-                }
-            }
-
-            match tunnel::get_tunnel_config(&config) {
-                Some(tc) => {
-                    println!("tunnel:   https://{}", tc.hostname);
-                    println!("  hostname: {}", tc.hostname);
-                    println!("  id:       {}", tc.tunnel_id);
-                }
-                None => println!("tunnel:   <not configured>"),
-            }
-
-            match std::fs::read_to_string(config.join("api-key")) {
-                Ok(key) => {
-                    let trimmed = key.trim();
-                    let digest = ring::digest::digest(&ring::digest::SHA256, trimmed.as_bytes());
-                    let hex: String = digest.as_ref().iter().take(6).map(|b| format!("{:02x}", b)).collect();
-                    println!("api key:  sha256:{}", hex);
-                }
-                Err(_) => println!("api key:  <not generated>"),
-            }
-
             let agent_count = std::fs::read_dir(config.join("agents"))
                 .map(|rd| rd.filter_map(Result::ok)
                     .filter(|e| e.file_name().to_string_lossy().ends_with(".env"))
                     .count())
                 .unwrap_or(0);
-            println!("agents:   {}", agent_count);
 
-            match update_check::check_once() {
-                Ok(info) => {
-                    println!("latest:   v{}", info.latest);
-                    println!("update:   {}", if info.update_available { "available" } else { "up to date" });
-                }
-                Err(_) => {
-                    println!("latest:   <unavailable>");
-                    println!("update:   unknown");
-                }
+            eprintln!();
+            eprintln!(
+                "  \x1b[1;35mvestad\x1b[0m v{} \x1b[2m({}, {} agent{})\x1b[0m",
+                env!("CARGO_PKG_VERSION"),
+                binary_path,
+                agent_count,
+                if agent_count == 1 { "" } else { "s" },
+            );
+
+            let (tunnel_url, local_url, api_key) = read_server_info(&config);
+            if let Some(api_key) = &api_key {
+                print_server_info(
+                    tunnel_url.as_deref(),
+                    local_url.as_deref().unwrap_or("http://localhost:?"),
+                    api_key,
+                );
             }
 
-            println!();
             systemd::print_status();
         }
 


### PR DESCRIPTION
## Summary
- Restores the colored `print_server_info` layout (tunnel URL, full API key, remote/local app links) for `vestad status` — same block printed at first startup.
- Drops the synchronous `update_check::check_once()` call that blocked the terminal up to 10s on a GitHub fetch every time you ran `vestad status`. The daemon already tracks `latest_version` in the background and exposes it via the HTTP API, so the standalone command shouldn't re-fetch.
- Shows the full API key again (matches startup logs) instead of the `sha256:...` fingerprint.

This regressed in #484, which restructured the output to plaintext `key: value` lines and added the blocking version check.

## Test plan
- [ ] `vestad status` returns instantly (no network wait)
- [ ] Output matches the colored block printed at first startup, plus systemd status below
- [ ] Full API key is visible (not a fingerprint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)