### PR TITLE
fix(agent): bind WS server before processing restart greeting

### DIFF
--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -100,7 +100,10 @@ async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: boo
 
     greeting_reason = "first_start" if first_start else restart_reason
     setup_queued = await queue_greeting(message_queue, config=config, state=state, reason=greeting_reason)
-    if not setup_queued:
+    # Only defer the WS bind when the queued prompt is the first_start setup.
+    # Regular restart greetings often poll the WS port themselves, which would
+    # deadlock if WS were gated on the greeting completing.
+    if not (first_start and setup_queued):
         state.first_setup_complete.set()
 
     processor_task = asyncio.create_task(message_processor(message_queue, state=state, config=config))


### PR DESCRIPTION
## Summary
- Restart greetings deadlocked the agent: the WS server bind was gated on `state.first_setup_complete`, which only fires once the first queued prompt finishes — so when the restart greeting polled the WS port itself (`until curl http://localhost:$WS_PORT/`), WS waited for the greeting and the greeting waited for WS.
- Fix: only defer the WS bind on actual first-start. On every other restart, the WS server binds immediately, before the greeting starts processing.

## Root cause
`agent/core/main.py:103` used `if not setup_queued` to decide whether to skip the deferral. But `queue_greeting()` returns `True` for both first-start setup and regular restart greetings, so the gate triggered on every restart that queued a greeting. The intent (per the existing comment two blocks below: *"WS bind is the readiness signal; first-start defers it until setup is processed"*) was first-start only.

The deadlock surfaced reliably in the screen-restart flow because the prompt's tail bash polls `$WS_PORT` until any HTTP response arrives — which never happens while the WS server is gated on the same prompt completing. Symptom in the UI: chat stays on "connecting" forever; logs look healthy.

## Test plan
- [x] `uv run pytest agent/tests/ --ignore=agent/tests/test_e2e.py` — 146 passed
- [x] Manually unstuck a stuck container (`vesta-emi-giuseppe`) by patching the bind-mounted mirror at `~/.config/vesta/vestad/agent-code/core/main.py` and `docker restart`. Logs now show `WebSocket server started on port …` immediately, before the restart greeting starts processing tools.
- [ ] Confirm a fresh first-start still defers WS until the `first_start_setup` prompt completes (deferral path preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)