### PR TITLE
chore(updater): rotate Tauri signing key

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -46,7 +46,7 @@
       "endpoints": [
         "https://github.com/elyxlz/vesta/releases/latest/download/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEFCOTlGN0E4QTAwM0ZFREEKUldUYS9nT2dxUGVacTJ3M1NuNGM3OVo0VEZoRFA1Y2pWZ2xpSjJiU1QrNXo2L3RNZkhyc0tVMDUK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDIxNDRGMTZDM0FEODA1N0QKUldSOUJkZzZiUEZFSVYzczVQek1wT2RCazh1eG9xc3ltOHFDYU1lWUJvWW1XOEdGV3pVV1EzUngK"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

Rotates the Tauri auto-updater signing key. Old key ID `AB99F7A8A003FEDA` → new key ID `2144F16C3AD8057D`. The matching private key has been uploaded to both the Actions and Dependabot secret scopes (`TAURI_SIGNING_PRIVATE_KEY`, passwordless to match the existing workflow which leaves `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` empty).

**Why now:** the previous private key (generated 2026-03-13, only present locally) didn't match what was in the Actions secret (last rotated 2026-04-21), so neither I nor any future operator could mint a working signature outside CI. Six dependabot PRs were stuck red because the dependabot env didn't have the secret at all. Setting the same value on dependabot is what unblocks them; doing that required regenerating because the old private key isn't recoverable.

**Updater impact (read this):** existing installs of Vesta have the old pubkey embedded at compile time, so the auto-updater on those installs will refuse any release built from this PR forward (signature won't verify). Affected users need to do one fresh install; from then on auto-updates resume normally.

## Test plan

- [ ] CI tauri builds pass, proving the new private key in the Actions secret signs cleanly
- [ ] At least one dependabot PR (e.g. #535) goes green after this merges and is rebased, proving the new key is consistent across both secret scopes
- [ ] After merge, manually verify a fresh install can install the next release and pick up subsequent auto-updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)