### PR TITLE
feat(vestad): add agent rename endpoint

### DIFF
--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1871,6 +1871,77 @@ pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvCon
     Ok(())
 }
 
+/// Rename an agent: snapshot the existing container, destroy it, then create a fresh
+/// container from the snapshot under the new name. Preserves the in-container filesystem
+/// (events.db, session_id, prompts, ~/.claude auth) but rewrites the env file with the
+/// new AGENT_NAME and a fresh AGENT_TOKEN. Caller updates settings.json keys and starts
+/// the new container.
+pub async fn rename_agent(
+    docker: &Docker,
+    old_name: &str,
+    new_name: &str,
+    env_config: &AgentEnvConfig,
+) -> Result<(), DockerError> {
+    validate_name(old_name)?;
+    validate_name(new_name)?;
+    if old_name == new_name {
+        return Err(DockerError::InvalidName("new name must differ from old name".into()));
+    }
+    if new_name != "vesta" && new_name.contains("vesta") {
+        return Err(DockerError::InvalidName("agent name must not contain 'vesta'".into()));
+    }
+
+    let old_cname = container_name(old_name);
+    let new_cname = container_name(new_name);
+
+    if container_status(docker, &old_cname).await == ContainerStatus::NotFound {
+        return Err(DockerError::NotFound(format!("agent '{}' not found", old_name)));
+    }
+    if container_status(docker, &new_cname).await != ContainerStatus::NotFound {
+        return Err(DockerError::AlreadyExists(format!("agent '{}' already exists", new_name)));
+    }
+
+    let raw = docker.inspect_container(&old_cname, None).await.map_err(DockerError::from)?;
+    let info = container_info_from(&old_cname, &raw, Some(&env_config.agents_dir));
+    if info.status == ContainerStatus::Dead {
+        return Err(DockerError::BrokenState(format!("agent '{}' is in a broken state", old_name)));
+    }
+
+    let manage_core_code = mounts_have_core_code(raw.mounts.as_deref().unwrap_or(&[]));
+
+    let container_port = read_container_env(docker, &old_cname, "WS_PORT").await
+        .and_then(|v| v.parse::<u16>().ok());
+    let port = match info.port.or(container_port) {
+        Some(p) => p,
+        None => {
+            tracing::warn!(agent = %old_name, "no port found in env file or container, allocating new port");
+            allocate_port(&env_config.agents_dir)?
+        }
+    };
+
+    // Stop cleanly so the snapshot captures a quiesced filesystem (SQLite mid-write would
+    // be the main concern). Best-effort — snapshot will still proceed if stop fails.
+    if info.status == ContainerStatus::Running {
+        tracing::info!(agent = %old_name, "[1/4] stopping container...");
+        docker.stop_container(&old_cname, Some(StopContainerOptions { t: Some(CONTAINER_STOP_TIMEOUT_SECS), signal: None })).await.ok();
+    }
+
+    let ts = crate::time_utils::now_epoch_secs();
+    let snapshot_tag = format!("vesta-rename:{}-to-{}_{}", old_name, new_name, ts);
+
+    tracing::info!(old = %old_name, new = %new_name, "[2/4] snapshotting container...");
+    snapshot_container(docker, &old_cname, &snapshot_tag, &[]).await?;
+
+    tracing::info!(agent = %old_name, "[3/4] removing old container and env file...");
+    remove_container_force(docker, &old_cname).await.ok();
+    delete_agent_env_file(&env_config.agents_dir, old_name);
+
+    tracing::info!(new = %new_name, "[4/4] creating renamed container from snapshot...");
+    create_container(docker, &new_cname, &snapshot_tag, port, new_name, env_config, manage_core_code, None, None).await?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -606,11 +606,49 @@ async fn rename_agent_handler(
         save_settings(&settings);
     }
 
+    if let Err(e) = drop_rename_notification(&state.docker, &new_name, &name).await {
+        tracing::warn!(old = %name, new = %new_name, error = %e, "failed to drop rename notification");
+    }
+
     docker::start_agent(&state.docker, &new_name)
         .await
         .map_err(map_docker_err)?;
 
     Ok(Json(serde_json::json!({"name": new_name})))
+}
+
+/// Drop a high-priority notification into the renamed agent so it self-updates
+/// MEMORY.md and any prompts that reference the old name. Best-effort: failure
+/// to write the notification doesn't block the rename.
+async fn drop_rename_notification(
+    docker: &bollard::Docker,
+    new_name: &str,
+    old_name: &str,
+) -> Result<(), String> {
+    let cname = docker::container_name(new_name);
+    let epoch = crate::time_utils::now_epoch_secs();
+    let timestamp = time::OffsetDateTime::from_unix_timestamp(epoch as i64)
+        .map_err(|e| format!("epoch out of range: {e}"))?
+        .format(&time::format_description::well_known::Rfc3339)
+        .map_err(|e| format!("format timestamp: {e}"))?;
+    let payload = serde_json::json!({
+        "timestamp": timestamp,
+        "source": "vestad",
+        "type": "rename",
+        "interrupt": true,
+        "old_name": old_name,
+        "new_name": new_name,
+        "message": format!(
+            "you have been renamed from '{old_name}' to '{new_name}'. \
+             AGENT_NAME is now '{new_name}'. update your MEMORY.md and any prompt files \
+             under ~/agent/prompts/ that reference your old name."
+        ),
+    });
+    let bytes = serde_json::to_vec(&payload).map_err(|e| format!("serialize notification: {e}"))?;
+    let file_name = format!("rename-{epoch}.json");
+    docker::upload_to_container(docker, &cname, "/root/agent/notifications", &file_name, &bytes)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 // --- Auth endpoints ---

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -562,6 +562,57 @@ async fn rebuild_agent_handler(
     Ok(ok_json())
 }
 
+#[derive(Deserialize)]
+struct RenameBody {
+    new_name: String,
+}
+
+async fn rename_agent_handler(
+    State(state): State<SharedState>,
+    Path(name): Path<String>,
+    Json(body): Json<RenameBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let new_name = docker::normalize_name(&body.new_name);
+    if new_name.is_empty() {
+        return Err(err_response(StatusCode::BAD_REQUEST, "invalid new agent name"));
+    }
+    if new_name == name {
+        return Err(err_response(StatusCode::BAD_REQUEST, "new name must differ from old name"));
+    }
+    tracing::info!(old = %name, new = %new_name, "renaming agent");
+
+    // Lock both names in lex order to avoid deadlock between concurrent renames.
+    let (first, second) = if name < new_name { (&name, &new_name) } else { (&new_name, &name) };
+    let lock_first = state.agent_lock(first).await;
+    let lock_second = state.agent_lock(second).await;
+    let _g1 = lock_first.write().await;
+    let _g2 = lock_second.write().await;
+
+    docker::rename_agent(&state.docker, &name, &new_name, &state.env_config)
+        .await
+        .map_err(map_docker_err)?;
+
+    {
+        let mut settings = state.settings.write().await;
+        if let Some(v) = settings.agents.remove(&name) {
+            settings.agents.insert(new_name.clone(), v);
+        }
+        if let Some(v) = settings.services.remove(&name) {
+            settings.services.insert(new_name.clone(), v);
+        }
+        if let Some(v) = settings.backup.agents.remove(&name) {
+            settings.backup.agents.insert(new_name.clone(), v);
+        }
+        save_settings(&settings);
+    }
+
+    docker::start_agent(&state.docker, &new_name)
+        .await
+        .map_err(map_docker_err)?;
+
+    Ok(Json(serde_json::json!({"name": new_name})))
+}
+
 // --- Auth endpoints ---
 
 #[derive(Serialize)]
@@ -1728,6 +1779,7 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/agents/{name}/restart", post(restart_agent_handler))
         .route("/agents/{name}/destroy", post(destroy_agent_handler))
         .route("/agents/{name}/rebuild", post(rebuild_agent_handler))
+        .route("/agents/{name}/rename", post(rename_agent_handler))
         .route("/agents/{name}/auth", post(start_auth_handler))
         .route("/agents/{name}/auth/code", post(complete_auth_handler))
         .route("/agents/{name}/auth/token", post(inject_token_handler))

--- a/vestad/tests-integration/src/client.rs
+++ b/vestad/tests-integration/src/client.rs
@@ -200,6 +200,13 @@ impl Client {
         Ok(())
     }
 
+    pub fn rename_agent(&self, name: &str, new_name: &str) -> Result<String, String> {
+        let body = serde_json::json!({"new_name": new_name});
+        let resp = self.post_json(&format!("/agents/{}/rename", name), &body)?;
+        let v: serde_json::Value = resp.into_body().read_json().map_err(|e| format!("parse error: {}", e))?;
+        Ok(v["name"].as_str().unwrap_or(new_name).to_string())
+    }
+
     pub fn wait_until_alive(&self, name: &str, timeout_secs: u64) -> Result<(), String> {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
         let mut backoff = std::time::Duration::from_millis(200);

--- a/vestad/tests-integration/tests/server/mod.rs
+++ b/vestad/tests-integration/tests/server/mod.rs
@@ -6,3 +6,4 @@ mod websocket;
 mod ports;
 mod agent_code;
 mod layout;
+mod rename;

--- a/vestad/tests-integration/tests/server/rename.rs
+++ b/vestad/tests-integration/tests/server/rename.rs
@@ -80,6 +80,43 @@ fn rename_updates_container_label() {
 }
 
 #[test]
+fn rename_drops_notification() {
+    let c = SERVER.client();
+    let mut agent = TestAgent::create(&c, &unique_agent("rename-notif")).unwrap();
+    let old_name = agent.name.clone();
+    let new_name = unique_agent("rename-notif-target");
+
+    c.rename_agent(&old_name, &new_name).unwrap();
+
+    let new_container = agent_container_name(&new_name);
+    let listing = exec_in_container(&new_container, "ls /root/agent/notifications/").unwrap();
+    let notif_file = listing
+        .lines()
+        .map(str::trim)
+        .find(|f| f.starts_with("rename-") && f.ends_with(".json"))
+        .unwrap_or_else(|| panic!("no rename-*.json notification found in:\n{listing}"))
+        .to_string();
+
+    let body = exec_in_container(
+        &new_container,
+        &format!("cat /root/agent/notifications/{notif_file}"),
+    )
+    .unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed["source"], "vestad");
+    assert_eq!(parsed["type"], "rename");
+    assert_eq!(parsed["interrupt"], true);
+    assert_eq!(parsed["old_name"], old_name);
+    assert_eq!(parsed["new_name"], new_name);
+    let msg = parsed["message"].as_str().unwrap();
+    assert!(msg.contains(&old_name), "message missing old name: {msg}");
+    assert!(msg.contains(&new_name), "message missing new name: {msg}");
+    assert!(parsed["timestamp"].as_str().unwrap().contains('T'));
+
+    agent.name = new_name;
+}
+
+#[test]
 fn rename_to_same_name_fails() {
     let c = SERVER.client();
     let agent = TestAgent::create(&c, &unique_agent("rename-same")).unwrap();

--- a/vestad/tests-integration/tests/server/rename.rs
+++ b/vestad/tests-integration/tests/server/rename.rs
@@ -1,0 +1,135 @@
+use vesta_tests::{
+    SERVER, TestAgent, agent_container_name, docker_cmd, exec_in_container, inject_fake_token,
+    is_up, unique_agent,
+};
+
+fn agents_dir() -> std::path::PathBuf {
+    SERVER.home_path().join(".config/vesta/vestad/agents")
+}
+
+#[test]
+fn rename_basic() {
+    let c = SERVER.client();
+    let mut agent = TestAgent::create(&c, &unique_agent("rename-basic")).unwrap();
+    let old_name = agent.name.clone();
+    let new_name = unique_agent("rename-target");
+
+    let returned = c.rename_agent(&old_name, &new_name).unwrap();
+    assert_eq!(returned, new_name);
+
+    assert_eq!(c.agent_status(&old_name).unwrap().status, "not_found");
+    assert!(is_up(&c.agent_status(&new_name).unwrap().status));
+
+    let list = c.list_agents().unwrap();
+    assert!(list.iter().any(|a| a.name == new_name));
+    assert!(!list.iter().any(|a| a.name == old_name));
+
+    let old_env = agents_dir().join(format!("{old_name}.env"));
+    let new_env = agents_dir().join(format!("{new_name}.env"));
+    assert!(!old_env.exists(), "old env file should be deleted: {}", old_env.display());
+    assert!(new_env.exists(), "new env file should exist: {}", new_env.display());
+    let env_contents = std::fs::read_to_string(&new_env).unwrap();
+    assert!(
+        env_contents.contains(&format!("AGENT_NAME={new_name}")),
+        "AGENT_NAME not updated in {}: {env_contents}",
+        new_env.display()
+    );
+
+    agent.name = new_name; // let Drop clean up the renamed container
+}
+
+#[test]
+fn rename_preserves_in_container_state() {
+    let c = SERVER.client();
+    let mut agent = TestAgent::create(&c, &unique_agent("rename-state")).unwrap();
+    inject_fake_token(&c, &agent.name);
+    c.start_agent(&agent.name).unwrap();
+
+    let old_container = agent_container_name(&agent.name);
+    exec_in_container(&old_container, "echo hello-from-old > /root/marker.txt").unwrap();
+
+    let new_name = unique_agent("rename-state-target");
+    c.rename_agent(&agent.name, &new_name).unwrap();
+
+    let new_container = agent_container_name(&new_name);
+    let marker = exec_in_container(&new_container, "cat /root/marker.txt").unwrap();
+    assert_eq!(marker.trim(), "hello-from-old");
+
+    agent.name = new_name;
+}
+
+#[test]
+fn rename_updates_container_label() {
+    let c = SERVER.client();
+    let mut agent = TestAgent::create(&c, &unique_agent("rename-label")).unwrap();
+    let new_name = unique_agent("rename-label-target");
+
+    c.rename_agent(&agent.name, &new_name).unwrap();
+
+    let new_container = agent_container_name(&new_name);
+    let label = docker_cmd(&[
+        "inspect",
+        "--format",
+        "{{ index .Config.Labels \"vesta.agent_name\" }}",
+        &new_container,
+    ])
+    .unwrap();
+    assert_eq!(label.trim(), new_name);
+
+    agent.name = new_name;
+}
+
+#[test]
+fn rename_to_same_name_fails() {
+    let c = SERVER.client();
+    let agent = TestAgent::create(&c, &unique_agent("rename-same")).unwrap();
+    let err = c.rename_agent(&agent.name, &agent.name).unwrap_err();
+    assert!(err.contains("differ"), "expected 'differ' in error: {err}");
+}
+
+#[test]
+fn rename_to_existing_fails() {
+    let c = SERVER.client();
+    let a = TestAgent::create(&c, &unique_agent("rename-conflict-a")).unwrap();
+    let b = TestAgent::create(&c, &unique_agent("rename-conflict-b")).unwrap();
+
+    let err = c.rename_agent(&a.name, &b.name).unwrap_err();
+    assert!(
+        err.contains("already exists"),
+        "expected conflict error: {err}"
+    );
+
+    // Both should still exist unchanged
+    assert!(is_up(&c.agent_status(&a.name).unwrap().status));
+    assert!(is_up(&c.agent_status(&b.name).unwrap().status));
+}
+
+#[test]
+fn rename_nonexistent_fails() {
+    let c = SERVER.client();
+    let err = c
+        .rename_agent("does-not-exist-xyz", "should-not-be-created")
+        .unwrap_err();
+    assert!(
+        err.contains("not found") || err.contains("not_found"),
+        "expected not-found error: {err}"
+    );
+    assert_eq!(
+        c.agent_status("should-not-be-created").unwrap().status,
+        "not_found"
+    );
+}
+
+#[test]
+fn rename_invalid_new_name_fails() {
+    let c = SERVER.client();
+    let agent = TestAgent::create(&c, &unique_agent("rename-invalid")).unwrap();
+
+    // normalize_name strips invalid chars; "!!!" reduces to "" which 400s
+    let err = c.rename_agent(&agent.name, "!!!").unwrap_err();
+    assert!(
+        err.contains("invalid"),
+        "expected invalid-name error: {err}"
+    );
+    assert!(is_up(&c.agent_status(&agent.name).unwrap().status));
+}


### PR DESCRIPTION
## Summary

- `POST /agents/{name}/rename` with body `{"new_name": "..."}` renames an agent in place.
- Internally: stop → `docker commit` to a `vesta-rename:<old>-to-<new>_<ts>` snapshot → remove old container + env file → recreate from snapshot under the new name (writes fresh env file with new `AGENT_NAME` and a fresh `AGENT_TOKEN`) → migrate `settings.json` keys (`agents`, `services`, `backup.agents`) → drop a self-update notification into the new container → start.
- The in-container filesystem (events.db, session_id, prompts, `~/.claude` auth) is preserved across the rename; only the agent's identity (name, token, container) changes.

## Self-update notification

After a successful rename and before starting the new container, vestad writes a JSON file to `/root/agent/notifications/rename-<epoch>.json` inside the new container:

```json
{
  "timestamp": "<RFC 3339>",
  "source": "vestad",
  "type": "rename",
  "interrupt": true,
  "old_name": "<old>",
  "new_name": "<new>",
  "message": "you have been renamed from '<old>' to '<new>'. AGENT_NAME is now '<new>'. update your MEMORY.md and any prompt files under ~/agent/prompts/ that reference your old name."
}
```

The agent's `monitor_loop` picks this up on first boot under the new name (`interrupt: true` jumps it ahead of any queued passive notifications), and the agent decides which of its own files (MEMORY.md, prompts) need to be edited. Doing this via the existing notification system avoids the false-positive risk of a vestad-side `sed` pass and keeps editorial decisions in the agent. Best-effort: if the upload fails the rename still completes and a warning is logged.

## Errors

- `400` if `new_name` normalizes to empty, equals the old name, or contains `vesta`.
- `404` if the source agent does not exist.
- `409` if an agent with `new_name` already exists.
- `500` if the source agent is in a broken state.

## Test plan

- [x] `cargo build -p vestad` clean
- [x] `cargo clippy -p vestad --tests` clean
- [x] `cargo clippy -p vesta-tests --tests` clean
- [x] New `tests/server/rename.rs` covers: basic rename + env-file rewrite, in-container state preservation (writes a marker file before, reads it after), label update (`vesta.agent_name`), self-update notification dropped into the new container with the expected shape, same-name rejected, conflict with existing agent rejected, nonexistent source rejected, invalid new name rejected. All 8 pass; full server suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
