### PR TITLE
ci: auto-label PRs by changed paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,43 @@
+agent:
+- changed-files:
+  - any-glob-to-any-file: ['agent/**']
+
+skills:
+- changed-files:
+  - any-glob-to-any-file: ['agent/skills/**', 'agent/core/skills/**']
+
+cli:
+- changed-files:
+  - any-glob-to-any-file: ['cli/**']
+
+vestad:
+- changed-files:
+  - any-glob-to-any-file: ['vestad/**']
+
+ui:
+- changed-files:
+  - any-glob-to-any-file: ['apps/web/**']
+
+desktop:
+- changed-files:
+  - any-glob-to-any-file: ['apps/desktop/**']
+
+mobile:
+- changed-files:
+  - any-glob-to-any-file: ['apps/mobile/**']
+
+tests:
+- changed-files:
+  - any-glob-to-any-file: ['**/tests/**', '**/__tests__/**']
+
+ci:
+- changed-files:
+  - any-glob-to-any-file: ['.github/**']
+
+documentation:
+- changed-files:
+  - any-glob-to-any-file: ['**/*.md']
+
+release:
+- changed-files:
+  - any-glob-to-any-file: ['release.sh']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
## Summary
- Adds `actions/labeler@v5` workflow that auto-applies labels to PRs based on which paths the diff touches.
- Mapping in `.github/labeler.yml` covers each monorepo area: `agent`, `skills`, `cli`, `vestad`, `ui` (apps/web), `desktop`, `mobile`, `tests`, `ci`, `documentation`, `release`.
- `sync-labels: true` so labels are removed when subsequent pushes no longer touch the matching paths.
- Labels are pre-created on the repo (existing: `agent`, `skills`, `cli`, `vestad`, `documentation`; new: `ui`, `desktop`, `mobile`, `tests`, `ci`, `release`). The old generic `app` label was removed in favor of `ui`/`desktop`/`mobile`.

Note: the workflow uses `pull_request_target`, which runs from the base branch's checkout — so labeling will only start applying to PRs once this lands on master.

## Test plan
- [ ] After merge, open a small follow-up PR touching one area and confirm a single label is applied.
- [ ] Push a commit that adds a file in another area and confirm the additional label appears.
- [ ] Revert that commit and confirm the extra label is removed (sync-labels behavior).