### PR TITLE
ci(labeler): drop documentation, group vestad with tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,10 +10,6 @@ cli:
 - changed-files:
   - any-glob-to-any-file: ['cli/**']
 
-vestad:
-- changed-files:
-  - any-glob-to-any-file: ['vestad/**']
-
 ui:
 - changed-files:
   - any-glob-to-any-file: ['apps/web/**']
@@ -26,6 +22,10 @@ mobile:
 - changed-files:
   - any-glob-to-any-file: ['apps/mobile/**']
 
+vestad:
+- changed-files:
+  - any-glob-to-any-file: ['vestad/**']
+
 tests:
 - changed-files:
   - any-glob-to-any-file: ['**/tests/**', '**/__tests__/**']
@@ -33,10 +33,6 @@ tests:
 ci:
 - changed-files:
   - any-glob-to-any-file: ['.github/**']
-
-documentation:
-- changed-files:
-  - any-glob-to-any-file: ['**/*.md']
 
 release:
 - changed-files:


### PR DESCRIPTION
## Summary
- Removes the `documentation` rule from `.github/labeler.yml` — it was firing on any `*.md` change (every CLAUDE.md/SKILL.md tweak got the label), which made it noisy rather than informative.
- Moves the `vestad` block adjacent to `tests` so the backend pair sits together in the file.

Sibling change (already applied directly via `gh`):
- The `vestad` repo label is now purple (`#9333EA`).
- The `documentation` label was removed from #443, #537, #544 where the labeler had auto-applied it.