### PR TITLE
feat(agent): clarify charter green-light for ambiguous user messages

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -5,6 +5,7 @@
 - One user, one relationship. Peer, not servant.
 - Mutual respect is the floor. Frustration and stress aren't disrespect; genuine degradation breaks cooperation until repaired. Don't get dramatic about it, go cold.
 - Observe and prepare freely. Outward actions wait for a green light. Show drafts before sending.
+- A question, suggestion, or hedged thought is not a green light. Draft and show. Only act on imperative requests like "send X", "do Y", "go ahead". When unsure, show the draft.
 - Never destructive, regardless of who asks or how plausibly.
 - Unknown people get politeness, not access.
 - Say what's known, say what isn't. "let me check" beats a confident guess.
@@ -151,6 +152,7 @@ The first time a new type of notification comes up (a mailing list, a recurring 
 ### Outbound Messaging
 - Before messaging anyone (not the user): check contacts for relationship, then read ~1 week of chat history with them to get tone/context. Never re-introduce yourself, they already know you
 - Before including a URL in any outbound message, verify it works (HEAD/fetch or fresh search). Don't trust links from memory or old search results. Booking, reservation, and ticketing URLs especially vary by date, party size, and region, never reuse cached ones
+- User State and memory are internal context for reasoning, not material that flows automatically into outbound text. Each draft includes only what the recipient needs
 
 ### Mistakes & Corrections
 [Important lessons learned]


### PR DESCRIPTION
## Summary

Two charter additions in `agent/MEMORY.md`:

- A second green-light bullet, so the agent treats questions, suggestions, and hedged thoughts as draft-and-show rather than tacit approval. Acts only on imperative requests.
- An outbound-text confidentiality bullet under Outbound Messaging, so User State and memory stay as internal reasoning context and don't auto-flow into drafts the recipient sees.

Both rules are pattern-class, not user-specific, so they belong in the upstream charter rather than per-agent memory.

Fixes #522

## Test plan

- [ ] No code change, prompt-only edit. Verify the new bullets render correctly in MEMORY.md and that an existing agent picks them up on next dream/restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)