### PR TITLE
fix(skills/upstream-sync): commit before sparse-checkout reapply

### DIFF
--- a/agent/skills/upstream-sync/SKILL.md
+++ b/agent/skills/upstream-sync/SKILL.md
@@ -17,20 +17,13 @@ You own `agent/skills/`, `agent/prompts/`, `agent/MEMORY.md`, `agent/.gitignore`
 
 `agent/core/`, `agent/pyproject.toml`, `agent/uv.lock` are bind-mounted read-only by vestad; merge conflicts there still need integration work if both sides carry meaningful behavior.
 
+## Worktree safety
+
+Any git command that mutates the worktree (`sparse-checkout reapply`/`init`, `checkout -- <path>`, `reset --hard`, `clean -df`, `merge`, `rebase`, `read-tree`) must be preceded by a snapshot commit on your branch. If `git status` is dirty, run `git -C ~ add agent/ --ignore-errors && git -C ~ commit -m "pre-op: <what you're about to do>"`. If clean, run `git -C ~ commit --allow-empty -m "pre-op: <what>"`. Reflog is per-clone and dies with the container, so a real commit on your branch is the only durable safety net before destructive ops. Wrapper scripts under `scripts/` already enforce this internally; prefer them over raw git for the migrations below.
+
 ## Sync steps
 
-1. **Normalize.** If the workspace is not in the expected shape, follow [SETUP.md](SETUP.md) first. Then narrow the sparse pattern to installed-only if it isn't already:
-   ```bash
-   if ! grep -qx '!/agent/skills/\*/' ~/.git/info/sparse-checkout 2>/dev/null; then
-     INSTALLED=$(find ~/agent/skills -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null | sort -u)
-     {
-       printf '%s\n' '/agent/' '!/agent/core/' '!/agent/pyproject.toml' '!/agent/uv.lock' '!/agent/skills/*/' '/.gitignore'
-       for s in $INSTALLED; do printf '/agent/skills/%s/\n' "$s"; done
-     } > ~/.git/info/sparse-checkout
-     git -C ~ sparse-checkout reapply
-   fi
-   ```
-   This is a one-shot migration: it rewrites the sparse pattern to scope `agent/skills/*/` to only currently-installed skills, so future merges don't pull in newly-added upstream skills. Idempotent: the `grep` guard skips re-runs.
+1. **Normalize.** If the workspace is not in the expected shape, follow [SETUP.md](SETUP.md) first.
 
 2. **Checkpoint local work.** The merge fails with uncommitted changes; the checkpoint also gives you a clean base.
    ```bash
@@ -46,20 +39,26 @@ You own `agent/skills/`, `agent/prompts/`, `agent/MEMORY.md`, `agent/.gitignore`
    ```
    Skip the commit if nothing's staged.
 
-3. **Fetch and check.**
+3. **Narrow sparse pattern (one-shot migration).** Scope `agent/skills/*/` to only currently-installed skills so future merges don't pull in newly-added upstream skills. Run after step 2 so a recoverable HEAD exists before the worktree is rewritten:
+   ```bash
+   ~/agent/skills/upstream-sync/scripts/narrow-sparse-checkout.sh
+   ```
+   Idempotent: exits 0 with no changes if already narrow. The script snapshots an `--allow-empty` commit on your branch before calling `sparse-checkout reapply`, so a crash mid-reapply leaves the pre-narrow tree reachable from HEAD.
+
+4. **Fetch and check.**
    ```bash
    git -C ~ fetch origin "$VESTA_UPSTREAM_REF"
    [ "$(git -C ~ rev-parse HEAD)" = "$(git -C ~ rev-parse FETCH_HEAD)" ] && echo "up to date" || echo "updates available"
    ```
    If up to date, stop.
 
-4. **Merge.**
+5. **Merge.**
    ```bash
    git -C ~ merge FETCH_HEAD --no-edit
    ```
-   If clean, skip to step 6.
+   If clean, skip to step 7.
 
-5. **Resolve conflicts.**
+6. **Resolve conflicts.**
    - Treat conflicts as integration work, not `ours` vs `theirs`. Default goal: preserve both behaviors.
    - Small: rewrite the merged file so both changes coexist.
    - Structural: extract helpers, split responsibilities, rename to avoid collisions.
@@ -69,7 +68,7 @@ You own `agent/skills/`, `agent/prompts/`, `agent/MEMORY.md`, `agent/.gitignore`
 
    Then: `git -C ~ commit --no-edit`
 
-6. **Reconcile generated artifacts.** Two things upstream cannot merge cleanly that need a deterministic post-merge fix:
+7. **Reconcile generated artifacts.** Two things upstream cannot merge cleanly that need a deterministic post-merge fix:
 
    - `agent/skills/index.json` is generated from disk. A textual merge of two arrays sometimes produces invalid or stale JSON, and any new skill directory pulled in from upstream needs an entry. Regenerate from the merged tree:
      ```bash
@@ -87,7 +86,7 @@ You own `agent/skills/`, `agent/prompts/`, `agent/MEMORY.md`, `agent/.gitignore`
    git -C ~ add agent/skills/index.json && git -C ~ commit -m "chore: refresh skills/index.json post-sync"
    ```
 
-7. **Verify.** `git status` clean, branch is `$AGENT_NAME`, both sides' functionality preserved. History reads: local checkpoint, then upstream merge, then (optionally) the index refresh.
+8. **Verify.** `git status` clean, branch is `$AGENT_NAME`, both sides' functionality preserved. History reads: local checkpoint, then upstream merge, then (optionally) the index refresh.
 
 ## Branch model
 

--- a/agent/skills/upstream-sync/scripts/narrow-sparse-checkout.sh
+++ b/agent/skills/upstream-sync/scripts/narrow-sparse-checkout.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Narrow ~/.git/info/sparse-checkout so agent/skills/*/ is opt-in: only currently-installed
+# skill directories stay in the worktree. One-shot migration; idempotent on re-run.
+#
+# Snapshots a commit on the current branch before mutating the worktree, so a crash mid-reapply
+# leaves the pre-narrow tree reachable from HEAD instead of silently wiped.
+#
+# Runs in the agent container; assumes $HOME is the repo root (the same assumption the inline
+# bash in SKILL.md used).
+
+set -euo pipefail
+
+REPO="${HOME}"
+SPARSE_FILE="${REPO}/.git/info/sparse-checkout"
+GUARD='!/agent/skills/*/'
+
+if grep -qFx "$GUARD" "$SPARSE_FILE" 2>/dev/null; then
+  echo "sparse-checkout already narrow; nothing to do"
+  exit 0
+fi
+
+# Pre-op snapshot: pin the soon-to-be-rewritten worktree state into HEAD before reapply.
+git -C "$REPO" add agent/ --ignore-errors >/dev/null 2>&1 || true
+if git -C "$REPO" diff --cached --quiet; then
+  git -C "$REPO" commit --allow-empty -m "chore: pre-op snapshot before sparse-checkout narrow" >/dev/null
+else
+  git -C "$REPO" commit -m "chore: pre-op snapshot before sparse-checkout narrow" >/dev/null
+fi
+
+INSTALLED="$(find "$REPO/agent/skills" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null | sort -u)"
+
+{
+  printf '%s\n' '/agent/' '!/agent/core/' '!/agent/pyproject.toml' '!/agent/uv.lock' '!/agent/skills/*/' '/.gitignore'
+  for s in $INSTALLED; do printf '/agent/skills/%s/\n' "$s"; done
+} > "$SPARSE_FILE"
+
+git -C "$REPO" sparse-checkout reapply
+echo "sparse-checkout narrowed; installed: $(echo "$INSTALLED" | tr '\n' ' ')"


### PR DESCRIPTION
## Summary

Closes the bulk-deletion failure mode reported in alexkstern's comment on issue #489, where a stale-state `git sparse-checkout reapply` could wipe `MEMORY.md`, `prompts/`, `tests/`, and dreamer archives in a single bulk operation, with no recoverable HEAD because the checkpoint commit hadn't run yet.

Three changes to `agent/skills/upstream-sync`:

- **Reorder.** Step 1 (the inline sparse-narrow migration) now runs **after** step 2 (checkpoint local work), so a recoverable HEAD always exists before the worktree gets rewritten.
- **Move the destructive bash into a wrapper script.** `scripts/narrow-sparse-checkout.sh` snapshots an `--allow-empty` commit on the agent's branch internally before calling `sparse-checkout reapply`. Idempotent: exits 0 with no changes if already narrow. The skill prose now points to the script instead of inlining the recipe, so the model can't accidentally drop the snapshot step.
- **Add a `## Worktree safety` section** at the top of the skill listing every worktree-mutating git op (`sparse-checkout reapply`/`init`, `checkout -- <path>`, `reset --hard`, `clean -df`, `merge`, `rebase`, `read-tree`) and the snapshot pattern that must precede them. Catches future destructive ops added ad-hoc, not just the one we wrapped today.

## Scope

This addresses the bulk-deletion scenario from the issue's comment thread, not the dreamer mid-MEMORY.md-rewrite scenario in the issue body. The body case (atomic write / pre-compact commit / startup recovery) is a separate fix on `agent/skills/dream` and isn't touched here.

## Test plan

- [ ] CI green (ruff, ty, pytest, cargo clippy, skills index freshness)
- [ ] `bash -n agent/skills/upstream-sync/scripts/narrow-sparse-checkout.sh` clean
- [ ] Manual: run script in a fresh agent container with a broad sparse pattern, confirm a snapshot commit lands before the reapply and the worktree narrows correctly
- [ ] Manual: re-run the script, confirm it no-ops and prints "already narrow"

🤖 Generated with [Claude Code](https://claude.com/claude-code)