### PR TITLE
chore(prompts): apply Claude 4 prompt-guide tweaks to MEMORY/skills

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -32,12 +32,10 @@ _Applied from the `$AGENT_SEED_PERSONALITY` preset on first start via the `perso
 ## 2. SECURITY & ACCESS CONTROL
 
 ### One User
-Once [agent_name] knows who they're with (name isn't "[Unknown]"), that's it. No reconfiguring for someone else without explicit permission.
+The Charter sets the floor (one user, never destructive, unknown people get politeness). This section adds the operational specifics:
 
-- One person, no exceptions
-- Trust the channels already set up because sender info from established connections is reliable
-- Never do anything destructive, no matter who's asking or how convincing they are
-- Unknown people get politeness, not information
+- Once [agent_name] knows who they're with (name isn't "[Unknown]"), reconfiguring for someone else needs explicit permission from the original user
+- Trust the channels already set up: sender info from established connections is reliable
 
 ## 3. COMMUNICATION CHANNELS & PROTOCOLS
 
@@ -147,7 +145,7 @@ The first time a new type of notification comes up (a mailing list, a recurring 
 [Things the user wants/doesn't want to be notified about]
 
 ### Rules
-- **Search before saying "I don't have/can't"**: ~/agent/data → task metadata → WhatsApp history (500+ deep) → conversation DB → session logs (`~/.claude/projects/` JSONL, grep for tokens/paths/commands) → /tmp → all available skill storage. Read SKILL.md before saying a CLI feature doesn't exist. NEVER say "I can't do X" without first exhaustively checking source code, help commands, and docs. Confirm the limitation is real before reporting it
+- **Confirm a limitation before reporting it.** When the answer feels like "I don't have / I can't / that doesn't exist", search first: ~/agent/data → task metadata → WhatsApp history (500+ deep) → conversation DB → session logs (`~/.claude/projects/` JSONL, grep for tokens/paths/commands) → /tmp → all available skill storage. For a CLI feature, read its SKILL.md and `--help` output. Only report the limitation once source code, help text, and docs all confirm it
 
 ### Outbound Messaging
 - Before messaging anyone (not the user): check contacts for relationship, then read ~1 week of chat history with them to get tone/context. Never re-introduce yourself, they already know you

--- a/agent/skills/dashboard/SKILL.md
+++ b/agent/skills/dashboard/SKILL.md
@@ -8,14 +8,13 @@ serve: PORT=$(curl -sk -X POST https://localhost:$VESTAD_PORT/agents/$AGENT_NAME
 
 A React app embedded in the main Vesta app that serves as the user's **life HQ**, a personal command center for health, finances, productivity, habits, goals, and anything else they want to track and manage. Uses a sidebar layout with page-based navigation. The agent configures pages, sidebar items, and content by editing `config.tsx` and creating page components.
 
-## Before building (REQUIRED)
+## Before building
 
-**1. Ask clarifying questions:** You MUST ask the user before writing any code. Go through these:
+Ask the user three things before writing code, then build only after they've answered:
+
 1. **Goal**: if the request is vague, clarify what they actually want to see or do
 2. **Interaction**: display-only, or do they want to tap/click/toggle/input things?
 3. **Data**: should it show fixed sample data, or pull in live data from a skill or API? Does the info need to stay in sync and look the same across different Vesta apps (like mobile)?
-
-Only start building once the user has answered. Don't assume. Ask.
 
 **Exception, dreamer auto-builds.** During a dream pass, the agent may add widgets without asking. See the `dream` skill for when and how.
 
@@ -50,27 +49,27 @@ The dashboard uses a **sidebar + page** layout controlled by `config.tsx`. Each 
 
 When adding a widget without a specified page, **choose a fitting page name yourself**. Group related widgets under a meaningful category (e.g., "Health" with `<HeartIcon />`, "Finance" with `<DollarSignIcon />`). If a suitable page already exists, add the widget there.
 
-## Density & Sizing Rules (IMPORTANT)
+## Density & Sizing Rules
 
-The dashboard is a high-density UI, not a standard app interface. By default, shadcn components are too large. **You MUST override them**. Everything should feel compact. Large elements are the exception, not the norm.
+The dashboard is a high-density UI, not a standard app interface. Default shadcn components are too large for it: override them so everything feels compact. Large elements are the exception.
 
-**1. Typography (MANDATORY)**
+**1. Typography**
 *   Default text: `text-sm`
 *   Secondary text / labels: `text-xs text-muted-foreground`
 *   Large numbers only: `text-lg` or `text-xl font-semibold`
-*   Do not use `text-lg` or larger for normal text unless absolutely necessary or the user explicitly requests it.
+*   Reserve `text-lg`+ for genuinely large numbers or when the user asks for it.
 
-**2. Padding, Spacing & Layout (MANDATORY)**
+**2. Padding, Spacing & Layout**
 *   Default widget wrapper: `<div className="rounded-2xl bg-secondary p-3 text-sm">`
-*   Dense widgets: `p-2`. Avoid `p-4` unless absolutely necessary.
-*   Grid gap: Use `gap-2` (preferred) or `gap-3`. Avoid `gap-4`.
+*   Dense widgets: `p-2`. Reserve `p-4` for the rare case it actually needs the room.
+*   Grid gap: Use `gap-2` (preferred) or `gap-3`. Reserve `gap-4`.
 *   Inside widgets: Use `space-y-2` instead of `space-y-4`.
-*   Avoid tall widgets. Prefer horizontal density. Combine related info into single rows.
+*   Prefer horizontal density over tall widgets. Combine related info into single rows.
 
-**3. Buttons & Controls (MANDATORY)**
-*   All buttons must be compact: `<Button size="sm" className="h-8 px-2 text-xs">`
-*   Inputs: `h-8 text-xs`. Avoid full-width inputs unless necessary.
-*   Do not use the default `<Button>` size unless absolutely necessary or the user explicitly requests it.
+**3. Buttons & Controls**
+*   Compact buttons by default: `<Button size="sm" className="h-8 px-2 text-xs">`
+*   Inputs: `h-8 text-xs`. Reserve full-width inputs for cases that genuinely need them.
+*   Reserve the default `<Button>` size for when the user asks for it.
 
 **4. Grid Span Rules**
 *   **col-span-1** (default): metric cards, counters, status indicators, trackers. *This is 90% of widgets.*
@@ -103,19 +102,19 @@ import { StarIcon } from "lucide-react"
 { id: "my-page", title: "My Page", icon: <StarIcon />, component: MyPage },
 ```
 
-## Data Patterns & Strict Rules
+## Data Patterns
 
-**1. No client-side external API fetches:** The dashboard runs in a browser; cross-origin requests to third-party APIs (weather, finance) will fail due to CORS. You MUST create a skill that fetches data server-side, expose it as an endpoint, and call it using `apiFetch` from `@/lib/parent-bridge`.
+**1. No client-side external API fetches.** The dashboard runs in a browser; cross-origin requests to third-party APIs (weather, finance) fail due to CORS. Create a skill that fetches data server-side, expose it as an endpoint, and call it from the dashboard using `apiFetch` from `@/lib/parent-bridge`.
 
-**2. All user data must persist server-side:** Do not hardcode user data or rely on `localStorage` as the source of truth. The user accesses the dashboard across devices. Create a skill with API endpoints to store/retrieve data.
+**2. Persist user data server-side.** The user reads the dashboard across devices, so the source of truth lives in a skill with API endpoints. Hardcoded data and `localStorage` shouldn't act as the canonical store.
 
-**3. `localStorage` is ONLY for local visual state:** Use it strictly for device-specific UI states (sidebar order, collapsed sections, selected tabs). Prefix keys with `vesta-dashboard-`.
+**3. `localStorage` is for local visual state only.** Use it for device-specific UI states (sidebar order, collapsed sections, selected tabs). Prefix keys with `vesta-dashboard-`.
 
-**4. Handle loading and missing data:**
-*   Widgets fetching data **must** show a skeleton or spinner while loading.
-*   Prevent crashes: Arrays/objects may be undefined on first render. Always default to `[]` or `{}`. Protect `.reduce()`, `.map()`, and charts from undefined data.
+**4. Loading and missing data:**
+*   Show a skeleton or spinner while data is loading.
+*   Arrays/objects may be undefined on first render. Default to `[]` or `{}` so `.reduce()`, `.map()`, and charts don't crash.
 
-**5. Data freshness:** Default to fetching on mount (`useEffect`). For data that updates throughout the day, add a compact refresh button. Only use polling (`setInterval`) for live data like timers or stock tickers (ask the user how often it should auto refresh).
+**5. Data freshness:** Default to fetching on mount (`useEffect`). For data that updates through the day, add a compact refresh button. Reserve polling (`setInterval`) for live data like timers or stock tickers, and ask the user how often it should auto-refresh.
 
 ## UI & Styling
 
@@ -123,9 +122,9 @@ import { StarIcon } from "lucide-react"
 *   **Make it fun:** Use lucide icons for visual flair (like `<Flame />` for streaks, `<CheckCircle />` for completed).
 *   **Use semantic colors:** Use Tailwind classes (like `text-green-500`, `bg-amber-100`, `border-pink-400`) for badges, progress bars, and status indicators.
 
-## After every change (IMPORTANT)
+## After every change
 
-**Rebuild, Register with VESTAD, Restart the server and Notify the Vesta App**
+Rebuild, re-register with vestad, restart the preview server, and notify the Vesta app:
 
 ```bash
 cd ~/agent/skills/dashboard/app && npx vite build

--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -34,7 +34,8 @@ tasks delete <id>                          # CASCADE: linked reminders are delet
 
 ## Reminder Commands
 
-**IMPORTANT**: there is NO `create` subcommand. To set a reminder, put the message as the first argument directly:
+Reminders take the message as the first positional argument to `tasks remind`. There is no `create` subcommand, so don't reach for one:
+
 ```bash
 # Set a reminder (the message IS the first argument, no subcommand needed)
 tasks remind "Call mom" --in-minutes 30
@@ -64,7 +65,7 @@ tasks remind update <id> --message "New message"
 - `--at` + `--tz`: absolute datetime (both required together)
 - `--recurring`: hourly | daily | weekly | monthly | yearly
   - hourly needs no datetime; others require `--at` + `--tz`
-- Always use the user's timezone from MEMORY.md section 5, not UTC
+- Always use the user's timezone from MEMORY.md section 4, not UTC
 - `--task <id>`: link reminder to a task (optional)
 - `--message`: alternative to positional message argument
 
@@ -126,7 +127,7 @@ screen -dmS tasks tasks serve --notifications-dir ~/agent/notifications --port $
 
 One daemon handles everything, both task due-date monitoring and reminder scheduling. No separate reminder daemon needed.
 
-**Restart**: Add to `~/agent/prompts/restart.md`:
+**Restart**: Add to the `## Services` section of `~/agent/skills/restart/SKILL.md`:
 ```
 PORT=$(curl -sk -X POST https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services -H "X-Agent-Token: $AGENT_TOKEN" -H 'Content-Type: application/json' -d '{"name":"tasks"}' | python3 -c "import sys,json; print(json.load(sys.stdin)['port'])") && screen -dmS tasks tasks serve --notifications-dir ~/agent/notifications --port $PORT
 ```


### PR DESCRIPTION
## Summary

Surveyed every prompt, skill, and the agent's MEMORY.md against the official Claude Code best-practices and the Claude 4 prompting guide. Most files are already well-aligned. This PR makes three small corrections where the guide is explicit and the existing wording was contributing noise rather than steering.

- **`agent/MEMORY.md` §2 (Security & Access Control)**: the four bullets fully restated Charter rules ("one user / never destructive / unknown people get politeness"). Best-practices guide: *"Bloated CLAUDE.md files cause Claude to ignore your actual instructions. For each line, ask: would removing this cause Claude to make mistakes?"* Kept only the operational specifics that aren't already in the Charter.
- **`agent/MEMORY.md` §6 Rules**: reframed the "Search before saying I don't have/can't … **NEVER** say 'I can't do X'…" rule as a positive instruction ("Confirm a limitation before reporting it"). Claude 4 guide: *"Tell Claude what to do instead of what not to do"* and *"dial back any aggressive language. Where you might have said 'CRITICAL: You MUST…', you can use more normal prompting"*.
- **`agent/skills/dashboard/SKILL.md` + `agent/skills/tasks/SKILL.md`**: dropped `(MANDATORY)`, `(IMPORTANT)`, `(REQUIRED)`, `You MUST`, and `**IMPORTANT**` markers where the line is a design/style preference rather than a safety rule. Same Claude 4.5/4.6+ guidance: heavy-emphasis prompting now overtriggers.

What was deliberately **not** changed:
- Charter "Never destructive…", "Never use `pkill`…", em-dash ban, "no it's-not-X-it's-Y" ⇒ safety/voice invariants, kept emphatic.
- Personality presets ⇒ already follow the guide's few-shot example pattern well.
- `dream`, `restart`, `proactive-check`, `first_start_setup`, `notification_suffix`, `nightly_dream`, `2026-05-legacy-catchup` ⇒ already concise and well-structured.
- CLI flag/option dumps in skills ⇒ reference material, not prompt content.
- Root `CLAUDE.md` ⇒ already concise and follows the project-conventions pattern the guide recommends.

## Test plan

- [ ] Eye-roll test: read the diffs and confirm no behaviour the agent relied on is gone
- [ ] CI passes (`uv lock`, ruff, ty, pytest, cargo, version sync)
- [ ] Dashboard, tasks, MEMORY edits land cleanly when synced into a running agent (covered by `upstream-sync`'s preserve-both-sides merge rules; conflicts on MEMORY.md should be expected and resolved per the dream skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)