### PR TITLE
Reduce update-check polling to 4x/day + on-demand check

### DIFF
--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -5,6 +5,7 @@ import {
   Moon,
   Monitor,
   LogOut,
+  RefreshCw,
 } from "lucide-react";
 import {
   Dialog,
@@ -46,7 +47,18 @@ export function SettingsDialog({
 }: SettingsDialogProps) {
   const { theme, setTheme } = useTheme();
   const { disconnect } = useAuth();
-  const { reachable, gatewayVersion, gatewayBranch } = useGateway();
+  const { reachable, gatewayVersion, gatewayBranch, updateAvailable, checkForUpdate } =
+    useGateway();
+  const [checking, setChecking] = useState(false);
+
+  const onCheckForUpdate = async () => {
+    setChecking(true);
+    try {
+      await checkForUpdate();
+    } finally {
+      setChecking(false);
+    }
+  };
   const { isTauri } = useTauri();
   const naturalPacing = useChatPacing((s) => s.natural);
   const setNaturalPacing = useChatPacing((s) => s.setNatural);
@@ -166,6 +178,24 @@ export function SettingsDialog({
                       {gatewayVersion && gatewayBranch && " "}
                       {gatewayBranch && <>({gatewayBranch})</>}
                     </span>
+                  )}
+                  {reachable && (
+                    <button
+                      type="button"
+                      onClick={onCheckForUpdate}
+                      disabled={checking}
+                      className="mt-1 inline-flex w-fit items-center gap-1 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+                    >
+                      <RefreshCw
+                        data-icon="inline-start"
+                        className={checking ? "animate-spin" : undefined}
+                      />
+                      {updateAvailable
+                        ? "Update available"
+                        : checking
+                          ? "Checking…"
+                          : "Check for updates"}
+                    </button>
                   )}
                 </div>
               </div>

--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -47,8 +47,13 @@ export function SettingsDialog({
 }: SettingsDialogProps) {
   const { theme, setTheme } = useTheme();
   const { disconnect } = useAuth();
-  const { reachable, gatewayVersion, gatewayBranch, updateAvailable, checkForUpdate } =
-    useGateway();
+  const {
+    reachable,
+    gatewayVersion,
+    gatewayBranch,
+    updateAvailable,
+    checkForUpdate,
+  } = useGateway();
   const [checking, setChecking] = useState(false);
 
   const onCheckForUpdate = async () => {

--- a/apps/web/src/providers/GatewayProvider/index.tsx
+++ b/apps/web/src/providers/GatewayProvider/index.tsx
@@ -14,6 +14,9 @@ import { VersionMismatchDialog } from "@/components/VersionMismatchDialog";
 import type { AgentInfo, GatewayVersionInfo } from "@/lib/types";
 
 const VERSION_FETCH_TIMEOUT_MS = 5000;
+// A manual check fetches from GitHub server-side, so allow longer than the
+// cached /version read (vestad's own fetch timeout is 10s).
+const VERSION_CHECK_TIMEOUT_MS = 15000;
 
 async function fetchVersionInfo(): Promise<GatewayVersionInfo | null> {
   try {
@@ -42,6 +45,7 @@ interface GatewayContextValue {
   agentsFetched: boolean;
   send: (event: object) => boolean;
   triggerGatewayUpdate: () => void;
+  checkForUpdate: () => Promise<void>;
 }
 
 const GatewayContext = createContext<GatewayContextValue | null>(null);
@@ -58,6 +62,7 @@ const disconnectedValue: GatewayContextValue = {
   agentsFetched: false,
   send: () => false,
   triggerGatewayUpdate: () => {},
+  checkForUpdate: async () => {},
 };
 
 function controlWsUrl(): string {
@@ -90,6 +95,19 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
     });
     skipVersionGateRef.current = true;
     setConnectEpoch((e) => e + 1);
+  };
+
+  const checkForUpdate = async () => {
+    try {
+      const data = await apiJson<GatewayVersionInfo>("/version/check", {
+        method: "POST",
+        signal: AbortSignal.timeout(VERSION_CHECK_TIMEOUT_MS),
+      });
+      setUpdateAvailable(!!data.update_available);
+      setLatestVersion(data.latest_version ?? null);
+    } catch (err) {
+      console.warn("[gateway] update check request failed:", err);
+    }
   };
 
   useEffect(() => {
@@ -227,6 +245,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
         agentsFetched,
         send,
         triggerGatewayUpdate,
+        checkForUpdate,
       }}
     >
       {versionMismatch ? (

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -215,6 +215,24 @@ async fn health() -> Json<serde_json::Value> {
 }
 
 async fn version(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    Json(version_json(&state).await)
+}
+
+// Force an immediate GitHub release check (instead of waiting for the periodic
+// background task) and return the refreshed version info.
+async fn version_check(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    match tokio::task::spawn_blocking(update_check::check_once).await {
+        Ok(Ok(info)) => {
+            let mut slot = state.update_info.lock().await;
+            *slot = Some(info);
+        }
+        Ok(Err(e)) => tracing::warn!("manual update check failed: {}", e),
+        Err(e) => tracing::error!("manual update check task failed: {}", e),
+    }
+    Json(version_json(&state).await)
+}
+
+async fn version_json(state: &SharedState) -> serde_json::Value {
     let update = state.update_info.lock().await;
     let (latest, update_available) = match update.as_ref() {
         Some(info) => (
@@ -223,13 +241,13 @@ async fn version(State(state): State<SharedState>) -> Json<serde_json::Value> {
         ),
         None => (None, None),
     };
-    Json(serde_json::json!({
+    serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
         "api_compat": "0.2",
         "latest_version": latest,
         "update_available": update_available,
         "dev_mode": state.dev_mode,
-    }))
+    })
 }
 
 #[derive(Deserialize)]
@@ -1680,6 +1698,7 @@ pub fn build_router(state: SharedState) -> Router {
 
     let vestad_protected = Router::new()
         .route("/version", get(version))
+        .route("/version/check", post(version_check))
         .route("/gateway/update", post(gateway_update_handler))
         .route("/gateway/restart", post(restart_gateway_handler))
         .route("/gateway/logs", get(gateway_logs_handler))

--- a/vestad/src/update_check.rs
+++ b/vestad/src/update_check.rs
@@ -1,4 +1,6 @@
-pub const CHECK_INTERVAL_SECS: u64 = 10 * 60;
+// Poll GitHub for new releases 4 times a day (every 6 hours). The desktop app
+// can force an immediate check via POST /version/check.
+pub const CHECK_INTERVAL_SECS: u64 = 6 * 60 * 60;
 const FETCH_TIMEOUT_SECS: u64 = 10;
 const ERROR_SNIPPET_MAX_LEN: usize = 300;
 const HTTP_STATUS_SENTINEL: &str = "\n__VESTA_HTTP_STATUS__:";


### PR DESCRIPTION
## Summary
- Reduce vestad's GitHub release-check poll from every 10 minutes (~144×/day) to every 6 hours (4×/day) in `update_check.rs`.
- Add `POST /version/check` to vestad, which forces an immediate GitHub check, refreshes the cached `update_info`, and returns the same JSON as `GET /version`. Shared response building extracted into `version_json()`.
- Wire it into the app: a `checkForUpdate()` method on `GatewayProvider` and a "Check for updates" button in Settings, so users can force a fresh check rather than waiting up to 6 hours for the background poll.

## Why
The 10-minute poll hits the GitHub API far more often than necessary. Dropping to 4×/day cuts that load; the on-demand endpoint keeps the UX responsive when a user actually wants to check now.

Note: the web app's existing 60s `/version` poll is unchanged — it only reads vestad's cache and never hit GitHub itself, so it doesn't affect polling frequency.

## Testing
- Web: `tsc --noEmit` clean; lint clean (0 errors, pre-existing warnings only).
- vestad is Linux-only and does not build on macOS locally (pre-existing `backup.rs` errors unrelated to this change); relying on CI for the Rust build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)