### PR TITLE
docs(keeper): clarify password reveal commands, note unmask is not a subcommand

### DIFF
--- a/agent/skills/keeper/SKILL.md
+++ b/agent/skills/keeper/SKILL.md
@@ -30,9 +30,18 @@ keeper "get <UID> --format json"         # JSON output
 keeper "get <UID> --format password"     # show only the password
 ```
 
-### Get a Password
+### Reveal a Password
+
+To reveal a stored password, use one of these working commands:
 ```bash
-keeper "find-password <UID>"
+keeper "find-password <UID>"             # print just the password
+keeper "get <UID> --unmask"              # print the full record with passwords in plain text
+```
+
+Note: `unmask` is NOT a subcommand. `keeper "unmask <UID> password"` does not exist and will fail. Unmasking is the `--unmask` flag on `get`, or use `find-password` to get the password on its own.
+
+### Copy to Clipboard
+```bash
 keeper "clipboard-copy <UID>"            # copy password to clipboard
 keeper "clipboard-copy <UID> -l"         # copy username
 keeper "clipboard-copy <UID> -t"         # copy TOTP code


### PR DESCRIPTION
## Summary

A sub-agent tried `keeper unmask <UID> password`, which does not exist in Keeper Commander. This updates the keeper skill docs to make the canonical, working password-reveal commands unmissable and to explicitly warn that `unmask` is not a valid subcommand.

Changes in `agent/skills/keeper/SKILL.md`:
- Renamed the "Get a Password" section to "Reveal a Password" and led with the two working forms:
  - `keeper "find-password <UID>"` to print just the password
  - `keeper "get <UID> --unmask"` to print the full unmasked record
- Added an explicit note that `unmask` is NOT a subcommand and that `keeper "unmask <UID> password"` will fail; unmasking is the `--unmask` flag on `get`.
- Split the clipboard-copy examples into their own "Copy to Clipboard" subsection.

These reconcile with the forms already documented in the skill (the existing `get <UID> --unmask` and `find-password`), so no contradictory invocation was introduced.

Docs-only change. Skills index regenerated with no changes (frontmatter untouched).

Fixes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)