### PR TITLE
feat(microsoft): add email delete subcommand for spam/phishing cleanup

### DIFF
--- a/agent/skills/microsoft/SKILL.md
+++ b/agent/skills/microsoft/SKILL.md
@@ -28,6 +28,16 @@ microsoft email unblock --account user@example.com --sender spam@example.com
 microsoft email block --account user@example.com --list  # show blocked senders
 ```
 
+After blocking a phishing/spam sender, clean up messages that already arrived:
+
+```bash
+microsoft email delete --account user@example.com --id <email_id>            # delete one message
+microsoft email delete --account user@example.com --sender spam@example.com  # delete all from a sender
+microsoft email delete --account user@example.com --sender spam@example.com --permanent  # hard delete
+```
+
+Delete soft-deletes to Deleted Items by default (moves to `deleteditems`); `--permanent` hard-deletes. `--id` and `--sender` are mutually exclusive and exactly one is required.
+
 If block returns 403, re-authorize:
 ```bash
 microsoft auth add --account user@example.com

--- a/agent/skills/microsoft/cli/src/microsoft_cli/cli.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/cli.py
@@ -124,6 +124,13 @@ def main():
     p_update.add_argument("--is-read", type=lambda x: x.lower() == "true", default=None)
     p_update.add_argument("--categories", nargs="+", default=None)
 
+    p_delete = email_sub.add_parser("delete")
+    p_delete.add_argument("--account", required=True)
+    p_delete_group = p_delete.add_mutually_exclusive_group(required=True)
+    p_delete_group.add_argument("--id", default=None, dest="email_id", help="ID of a single message to delete")
+    p_delete_group.add_argument("--sender", default=None, help="Delete all messages from this sender address")
+    p_delete.add_argument("--permanent", action="store_true", help="Hard delete instead of moving to Deleted Items")
+
     p_block = email_sub.add_parser("block")
     p_block.add_argument("--account", required=True)
     p_block_group = p_block.add_mutually_exclusive_group(required=True)
@@ -314,6 +321,10 @@ def _dispatch_email(args, config, client):
     elif args.command == "update":
         return email.update_email(
             config, client, account_email=args.account, email_id=args.email_id, is_read=args.is_read, categories=args.categories
+        )
+    elif args.command == "delete":
+        return email.delete_email(
+            config, client, account_email=args.account, email_id=args.email_id, sender=args.sender, permanent=args.permanent
         )
     elif args.command == "block":
         if args.list:

--- a/agent/skills/microsoft/cli/src/microsoft_cli/email.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/email.py
@@ -657,6 +657,85 @@ def search_emails(
     return _search_mailbox_messages(config, client, account_id, endpoint, query, limit)
 
 
+def _delete_message(
+    config: Config,
+    client: httpx.Client,
+    account_id: str,
+    settings: MicrosoftSettings,
+    email_id: str,
+    permanent: bool,
+) -> None:
+    if permanent:
+        graph.request(
+            client,
+            config.cache_file,
+            config.scopes,
+            settings,
+            config.base_url,
+            "DELETE",
+            f"/me/messages/{email_id}",
+            account_id,
+        )
+    else:
+        graph.request(
+            client,
+            config.cache_file,
+            config.scopes,
+            settings,
+            config.base_url,
+            "POST",
+            f"/me/messages/{email_id}/move",
+            account_id,
+            json={"destinationId": "deleteditems"},
+        )
+
+
+def delete_email(
+    config: Config,
+    client: httpx.Client,
+    *,
+    account_email: str,
+    email_id: str | None = None,
+    sender: str | None = None,
+    permanent: bool = False,
+) -> dict[str, Any]:
+    if (email_id is None) == (sender is None):
+        raise ValueError("Specify exactly one of --id or --sender")
+
+    settings = _get_settings()
+    account_id = auth.get_account_id_by_email(account_email, config.cache_file, settings=settings)
+    mode = "permanent" if permanent else "soft"
+
+    if email_id is not None:
+        _delete_message(config, client, account_id, settings, email_id, permanent)
+        return {"status": "deleted", "mode": mode, "email_id": email_id}
+
+    params = {
+        "$filter": f"from/emailAddress/address eq '{sender}'",
+        "$top": 100,
+        "$select": "id",
+    }
+    messages = list(
+        graph.request_paginated(
+            client,
+            config.cache_file,
+            config.scopes,
+            settings,
+            config.base_url,
+            "/me/messages",
+            account_id,
+            params=params,
+        )
+    )
+
+    deleted_ids = []
+    for message in messages:
+        _delete_message(config, client, account_id, settings, message["id"], permanent)
+        deleted_ids.append(message["id"])
+
+    return {"status": "deleted", "mode": mode, "sender": sender, "deleted_count": len(deleted_ids), "deleted_ids": deleted_ids}
+
+
 def update_email(
     config: Config,
     client: httpx.Client,

--- a/agent/skills/microsoft/cli/tests/test_delete.py
+++ b/agent/skills/microsoft/cli/tests/test_delete.py
@@ -1,0 +1,71 @@
+"""Unit tests for microsoft_cli.email.delete_email (mocked Graph calls)."""
+
+import pytest
+
+from microsoft_cli import email
+from microsoft_cli.config import Config
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_account_id(account_email, cache_file, *, settings):
+        return "acct-123"
+
+    def fake_request(client, cache_file, scopes, settings, base_url, method, path, account_id=None, **kwargs):
+        calls.append({"method": method, "path": path, "json": kwargs["json"] if "json" in kwargs else None})
+        if method == "GET":
+            return {"value": calls_state["messages"]}
+        return None
+
+    calls_state = {"messages": []}
+
+    monkeypatch.setattr(email, "_get_settings", lambda: object())
+    monkeypatch.setattr(email.auth, "get_account_id_by_email", fake_account_id)
+    monkeypatch.setattr(email.graph, "request", fake_request)
+    return calls, calls_state
+
+
+def test_delete_by_id_soft(patched):
+    calls, _ = patched
+    result = email.delete_email(Config(), None, account_email="me@example.com", email_id="msg-1")
+    assert result == {"status": "deleted", "mode": "soft", "email_id": "msg-1"}
+    assert len(calls) == 1
+    assert calls[0]["method"] == "POST"
+    assert calls[0]["path"] == "/me/messages/msg-1/move"
+    assert calls[0]["json"] == {"destinationId": "deleteditems"}
+
+
+def test_delete_by_id_permanent(patched):
+    calls, _ = patched
+    result = email.delete_email(Config(), None, account_email="me@example.com", email_id="msg-1", permanent=True)
+    assert result == {"status": "deleted", "mode": "permanent", "email_id": "msg-1"}
+    assert len(calls) == 1
+    assert calls[0]["method"] == "DELETE"
+    assert calls[0]["path"] == "/me/messages/msg-1"
+    assert calls[0]["json"] is None
+
+
+def test_delete_by_sender_multiple(patched):
+    calls, calls_state = patched
+    calls_state["messages"] = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+    result = email.delete_email(Config(), None, account_email="me@example.com", sender="spam@bad.com")
+    assert result["status"] == "deleted"
+    assert result["mode"] == "soft"
+    assert result["sender"] == "spam@bad.com"
+    assert result["deleted_count"] == 3
+    assert result["deleted_ids"] == ["a", "b", "c"]
+
+    get_calls = [c for c in calls if c["method"] == "GET"]
+    move_calls = [c for c in calls if c["path"].endswith("/move")]
+    assert len(get_calls) == 1
+    assert len(move_calls) == 3
+    assert {c["path"] for c in move_calls} == {"/me/messages/a/move", "/me/messages/b/move", "/me/messages/c/move"}
+
+
+def test_delete_requires_exactly_one_arg(patched):
+    with pytest.raises(ValueError, match="exactly one of --id or --sender"):
+        email.delete_email(Config(), None, account_email="me@example.com")
+    with pytest.raises(ValueError, match="exactly one of --id or --sender"):
+        email.delete_email(Config(), None, account_email="me@example.com", email_id="x", sender="y@z.com")


### PR DESCRIPTION
## Summary

Adds a `delete` subcommand to `microsoft email`, closing the gap after `block`: once a phishing/spam sender is blocked, the agent can now delete the messages that already landed.

```bash
microsoft email delete --account user@example.com --id <email_id>            # delete one message
microsoft email delete --account user@example.com --sender spam@example.com  # delete all from a sender
microsoft email delete --account user@example.com --sender spam@example.com --permanent  # hard delete
```

- `--id` and `--sender` are mutually exclusive; exactly one is required.
- Default is soft delete (move to Deleted Items); `--permanent` hard-deletes.
- `--sender` lists all matching messages, then deletes each.

## Graph calls used

- Soft delete: `POST /me/messages/{id}/move` with body `{"destinationId": "deleteditems"}`
- Hard delete: `DELETE /me/messages/{id}`
- Sender lookup: `GET /me/messages?$filter=from/emailAddress/address eq '<sender>'&$select=id` (paginated, `$top=100`)

All within the existing `Mail.ReadWrite` scope already used by `send`/`update`, so no new permissions are required.

## Tests / lint

- Added `tests/test_delete.py` (mocked Graph): delete by id (soft), delete by id (`--permanent`), delete by sender (multiple messages), and mutually-exclusive/required-arg validation. All 4 pass.
- `uv run ruff check` on the microsoft CLI: clean.
- `uv run ty check`: no new diagnostics introduced (the 9 reported are pre-existing in the attachment-upload code, confirmed against baseline).

Fixes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)