### PR TITLE
fix(agent): suppress proactive-check while agent is busy

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -273,7 +273,11 @@ async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm
                         except TimeoutError:
                             continue
 
-                        await _run_messages_with_interrupts(msg, is_user=is_user, queue=queue, state=state, config=config)
+                        state.processor_busy = True
+                        try:
+                            await _run_messages_with_interrupts(msg, is_user=is_user, queue=queue, state=state, config=config)
+                        finally:
+                            state.processor_busy = False
                 finally:
                     state.client = None
                     state.interrupt_event = None
@@ -367,8 +371,11 @@ async def monitor_loop(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.Stat
                 now = _now()
 
                 if (now - last_proactive).total_seconds() >= config.proactive_check_interval * 60:
-                    check_proactive_task(config=config)
                     last_proactive = now
+                    if state.processor_busy or not queue.empty():
+                        logger.debug("Proactive check skipped: agent is busy — waiting full interval")
+                    else:
+                        check_proactive_task(config=config)
 
                 if (now - last_dreamer_check).total_seconds() >= 3600:
                     process_nightly_memory(state=state, config=config)

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -52,6 +52,7 @@ class State:
     ws_runner: "AppRunner | None" = None
     interrupt_event: asyncio.Event | None = None
     compacting: bool = False
+    processor_busy: bool = False
     event_bus: EventBus = dc.field(default_factory=EventBus)
     stderr_buffer: collections.deque[str] = dc.field(default_factory=lambda: collections.deque(maxlen=50))
 

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -155,6 +155,50 @@ async def test_message_processor_interrupts_on_new_message(tmp_path):
 
 
 @pytest.mark.anyio
+async def test_message_processor_sets_busy_flag_during_turn(tmp_path):
+    """processor_busy is True while a turn runs and False once it finishes (gates the proactive check)."""
+    processing_started = asyncio.Event()
+    busy_during_turn = False
+
+    async def slow_side_effect(msg, *, state, config, is_user):
+        nonlocal busy_during_turn
+        busy_during_turn = state.processor_busy
+        processing_started.set()
+        return (["OK"], state)
+
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent")
+    state = vm.State()
+    state.shutdown_event = asyncio.Event()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    await queue.put(("message", True))
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    async def shutdown_after_turn():
+        await processing_started.wait()
+        await asyncio.sleep(0.1)
+        state.shutdown_event.set()
+
+    from core.loops import message_processor
+
+    with (
+        patch("core.loops.ClaudeSDKClient", return_value=mock_client),
+        patch("core.loops.process_message", slow_side_effect),
+        patch("core.loops.build_client_options", return_value=MagicMock()),
+    ):
+        await asyncio.gather(
+            message_processor(queue, state=state, config=config),
+            shutdown_after_turn(),
+        )
+
+    assert busy_during_turn, "processor_busy should be True while a turn is processing"
+    assert not state.processor_busy, "processor_busy should be cleared once the turn finishes"
+
+
+@pytest.mark.anyio
 async def test_run_messages_with_interrupts_cancels_process_task(tmp_path):
     """Cancelling _run_messages_with_interrupts must cancel its in-flight process_task (no orphaned tasks)."""
     from core.loops import _run_messages_with_interrupts


### PR DESCRIPTION
## Summary

The proactive timer fired on its fixed interval (`PROACTIVE_CHECK_INTERVAL`, default 60 min) regardless of whether the agent was busy. If a tick landed mid-conversation, mid-tool-call, or while a prompt was already queued, the proactive prompt got queued behind the active turn and surfaced afterward, talking to the user about something unrelated to what they were working on.

This gates the tick so it only fires when the agent is idle.

## Changes

- **`State.processor_busy`** — new flag (alongside `compacting`).
- **`message_processor`** — sets `processor_busy = True` around the active turn, cleared in a `finally` so it always resets (interrupt/error included).
- **`monitor_loop`** — when the proactive interval elapses it resets `last_proactive` first, then fires `check_proactive_task` only if `not (processor_busy or queue non-empty)`. A suppressed tick logs at debug level and waits the full interval rather than re-firing on the next monitor tick (the "skip and wait" option from the issue).

Covers both "busy" conditions: a turn mid-processing and a prompt already queued.

## Test

`test_message_processor_sets_busy_flag_during_turn` asserts `processor_busy` is True while a turn runs and False once it finishes.

- `ruff check` ✅ · `ty check` ✅ · unit suite: 163 passed, 1 skipped ✅

## Notes

Left out the issue's optional early-return inside `check_proactive_task` — it'd require threading `state` into that function for no current benefit (single caller). The gate lives only in `monitor_loop`.

Fixes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)