### PR TITLE
docs(proactive-check): clarify silence is valid and avoid double-scheduling wakeups

### DIFF
--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -19,9 +19,12 @@ This is your scheduled moment to think unprompted. No one asked; you're checking
 
 Reach out if you found something good, something needs attention, or you just have something to say. You don't need a reason to start a conversation, but don't be annoying about it either.
 
-If there's nothing worth saying, stay quiet. Background action beats a message that wastes their attention.
+If there's nothing worth saying, stay quiet. Silence is a valid response: when nothing has changed since the last sweep and no action is warranted, return no text at all. "Holding", "state unchanged", "still no reply" announcements are themselves noise. Background action beats a message that wastes their attention.
+
+Your default cadence comes from the system, not your own wakeups. Hourly proactive-checks fire automatically and notifications wake you on demand, so don't schedule parallel idle ticks that just duplicate the hourly check. Reserve ScheduleWakeup for actively watched signals: a build that's finishing, a reply expected within minutes, a time-binding event.
 
 ## How to decide
 
 - Read MEMORY.md's user state and the recent conversation before acting
 - Check the `tasks` skill for anything overdue or upcoming
+- If this sweep surfaces nothing new and warrants no action, produce no output and don't schedule a wakeup; the next hourly check will come around on its own


### PR DESCRIPTION
## Summary

The proactive-check skill combined with the dynamic-loop ScheduleWakeup tool produced noise when there was nothing to surface:

1. Agents scheduled ScheduleWakeup idle ticks on top of the already-scheduled hourly proactive-check (double-scheduling).
2. On each idle tick, agents announced "holding" / "no change" / "state unchanged", which is itself noise.

This is a docs-only change to `agent/skills/proactive-check/SKILL.md` adding two clarifications:

- **Default cadence comes from the system, not your wakeups.** Hourly proactive-checks fire automatically and notifications wake on demand, so don't schedule parallel idle ticks. Reserve ScheduleWakeup for actively watched signals (build finishing, reply expected within minutes, time-binding event).
- **Silence is a valid response.** When nothing has changed and no action is warranted, return no text at all.

Index regenerated via `agent/skills/generate-index.py` with no diff (frontmatter unchanged).

Fixes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)