### PR TITLE
fix(agent): address code-review findings across agent/

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -71,7 +71,7 @@ async def _recv_loop(ws: web.WebSocketResponse, event_bus: EventBus) -> None:
                 continue
             msg_type = data["type"]
             if msg_type in ("message", "chat"):
-                if "text" not in data:
+                if "text" not in data or not isinstance(data["text"], str):
                     continue
                 text = data["text"].strip()
                 if text:
@@ -183,10 +183,12 @@ async def _usage_handler(request: web.Request) -> web.Response:
                 headers=headers,
                 timeout=_aiohttp.ClientTimeout(total=10),
             ) as resp:
-                body = await resp.json()
                 if resp.status != 200:
+                    # Read as text first: an upstream error body may not be JSON, and resp.json() would
+                    # raise ContentTypeError, masking the real status behind a generic 502.
+                    body = await resp.text()
                     return web.json_response({"error": f"anthropic returned {resp.status}", "body": body}, status=resp.status)
-                return web.json_response(body)
+                return web.json_response(await resp.json())
     except (TimeoutError, _aiohttp.ClientError) as e:
         logger.error(f"usage fetch failed: {e}")
         return web.json_response({"error": str(e)}, status=502)

--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -7,6 +7,7 @@ from claude_agent_sdk.types import ThinkingConfigAdaptive, ThinkingConfigDisable
 
 
 _DEFAULT_AGENT_DIR = pl.Path.home() / "agent"
+_THINKING_ENABLED_BUDGET_TOKENS = 10000
 
 
 class VestaConfig(pyd_settings.BaseSettings):
@@ -42,6 +43,22 @@ class VestaConfig(pyd_settings.BaseSettings):
     agent_token: str | None = None
 
     agent_dir: pl.Path = pyd.Field(default=_DEFAULT_AGENT_DIR)
+
+    @pyd.field_validator("thinking", mode="before")
+    @classmethod
+    def _parse_thinking(cls, value: object) -> object:
+        # The THINKING env var is documented as a plain string (adaptive|enabled|disabled);
+        # coerce it into the SDK's config dict. JSON object values pass through untouched.
+        if isinstance(value, str):
+            mode = value.strip().lower()
+            if mode in ("", "adaptive"):
+                return ThinkingConfigAdaptive(type="adaptive", display="summarized")
+            if mode == "enabled":
+                return ThinkingConfigEnabled(type="enabled", budget_tokens=_THINKING_ENABLED_BUDGET_TOKENS)
+            if mode == "disabled":
+                return ThinkingConfigDisabled(type="disabled")
+            raise ValueError(f"THINKING must be adaptive|enabled|disabled (or a JSON config object), got {value!r}")
+        return value
 
     @pyd.field_validator("agent_dir", mode="before")
     @classmethod

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -316,9 +316,9 @@ def process_nightly_memory(*, state: vm.State, config: vm.VestaConfig) -> None:
     if config.ephemeral or config.nightly_memory_hour is None:
         return
     now = _now()
-    if now.hour < config.nightly_memory_hour:
-        return
-    if now.hour >= config.nightly_memory_hour + DREAMER_CATCHUP_HOURS:
+    # Circular window so a late hour (e.g. 22:00) still catches up past midnight.
+    hours_since_start = (now.hour - config.nightly_memory_hour) % 24
+    if hours_since_start >= DREAMER_CATCHUP_HOURS:
         return
     last = state.persisted.last_dreamer_run
     if last is not None and last.date() >= now.date():

--- a/agent/core/sdk_parsing.py
+++ b/agent/core/sdk_parsing.py
@@ -93,7 +93,7 @@ def parse_sdk_message(msg: Message, *, sub_agent_context: str | None) -> tuple[l
         try:
             usage_data = msg.usage or {}
             cost = msg.total_cost_usd
-            duration_s = msg.duration_ms / 1000 if msg.duration_ms else None
+            duration_s = msg.duration_ms / 1000 if msg.duration_ms is not None else None
             parts = []
             if usage_data:
                 input_tok = usage_data.get("input_tokens", 0)

--- a/agent/skills/email-client/auth.py
+++ b/agent/skills/email-client/auth.py
@@ -88,6 +88,12 @@ class _RedirectHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):  # noqa: N802
         parsed = urllib.parse.urlparse(self.path)
         params = urllib.parse.parse_qs(parsed.query)
+        # Ignore unrelated requests (e.g. the browser's /favicon.ico) so they
+        # don't prematurely end the wait loop with an empty capture.
+        if "code" not in params and "error" not in params:
+            self.send_response(204)
+            self.end_headers()
+            return
         type(self).captured = {
             "code": params.get("code", [None])[0],
             "state": params.get("state", [None])[0],

--- a/agent/skills/stripe-pay/cli/src/stripe_pay/charge.py
+++ b/agent/skills/stripe-pay/cli/src/stripe_pay/charge.py
@@ -31,6 +31,20 @@ from .auth import AuthError, load_active_token
 from .config import Config
 
 
+# Stripe zero-decimal currencies: the smallest unit equals the major unit, so the
+# amount must NOT be multiplied by 100. https://stripe.com/docs/currencies#zero-decimal
+ZERO_DECIMAL_CURRENCIES = frozenset(
+    {"bif", "clp", "djf", "gnf", "jpy", "kmf", "krw", "mga", "pyg", "rwf", "ugx", "vnd", "vuv", "xaf", "xof", "xpf"}
+)
+
+
+def _to_minor_units(amount: float, currency: str) -> int:
+    """Convert a major-unit amount to Stripe minor units, respecting zero-decimal currencies."""
+    if currency.lower() in ZERO_DECIMAL_CURRENCIES:
+        return int(round(amount))
+    return int(round(amount * 100))
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -188,7 +202,7 @@ def _spend_request_requires_link_approval(
         # in-app prompt.
         preview = stripe.SpendRequest.preview(  # type: ignore[attr-defined]
             access_token=access_token,
-            amount=int(round(amount * 100)),
+            amount=_to_minor_units(amount, currency),
             currency=currency.lower(),
             merchant=merchant,
         )
@@ -218,7 +232,7 @@ def _create_single_use_card(
     # if the SDK renames it the patch is one line.
     card_obj = stripe.Issuing.AgentCard.create(  # type: ignore[attr-defined]
         access_token=access_token,
-        amount=int(round(amount * 100)),
+        amount=_to_minor_units(amount, currency),
         currency=currency.lower(),
         merchant=merchant,
         metadata={"reason": reason[:500], "skill": "vesta-stripe-pay"},

--- a/agent/skills/twitter/monitor.py
+++ b/agent/skills/twitter/monitor.py
@@ -199,7 +199,12 @@ def _parse_pub_date(pub_date: str) -> "datetime | None":
     try:
         from email.utils import parsedate_to_datetime
 
-        return parsedate_to_datetime(pub_date)
+        parsed = parsedate_to_datetime(pub_date)
+        # Normalize naive datetimes (pubDate without a timezone) to UTC so comparisons
+        # against the tz-aware min_pub_dt don't raise TypeError and silently drop the tweet.
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed
     except (ValueError, TypeError) as e:
         logger.debug(f"Failed to parse pubDate '{pub_date}': {e}")
         return None

--- a/agent/skills/voice/providers/deepgram.py
+++ b/agent/skills/voice/providers/deepgram.py
@@ -118,7 +118,7 @@ class DeepgramStt:
                 ("utterance_end_ms", str(eot_timeout_ms)),
             ]
             keyterm_param = "keywords"
-            url = f"{DEEPGRAM_WS}/v1/listen?{urlencode(params)}"
+            listen_path = "/v1/listen"
         else:
             params = [
                 ("model", MODEL),
@@ -128,9 +128,11 @@ class DeepgramStt:
                 ("eot_timeout_ms", str(eot_timeout_ms)),
             ]
             keyterm_param = "keyterm"
-            url = f"{DEEPGRAM_WS}/v2/listen?{urlencode(params)}"
+            listen_path = "/v2/listen"
         for term in keyterms:
             params.append((keyterm_param, term))
+        # Build the URL only after keyterms are appended, otherwise they are dropped.
+        url = f"{DEEPGRAM_WS}{listen_path}?{urlencode(params)}"
 
         headers = {"Authorization": f"Token {api_key}"}
 

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -89,6 +89,46 @@ def test_retries_after_dream_hour_when_not_done_today(tmp_path):
     assert len(list(config.notifications_dir.glob("nightly_dream-*.json"))) == 1
 
 
+def test_catches_up_past_midnight_for_late_dreamer_hour(tmp_path):
+    """A late dreamer_hour (e.g. 22:00) must still catch up after midnight.
+
+    Protects against a regression where the window `hour < dreamer_hour + CATCHUP` had no
+    modulo-24 wraparound, so post-midnight hours (0-3) silently fell through and the dream
+    was dropped for the day.
+    """
+    from core.loops import process_nightly_memory
+
+    config = _setup(tmp_path, dreamer_hour=22)
+    state = vm.State()
+    state.persisted.last_dreamer_run = dt.datetime(2025, 6, 14, 22, 0, 0)  # prior day
+    after_midnight = dt.datetime(2025, 6, 15, 1, 0, 0)  # within 22:00 + 6h window
+
+    with (
+        patch("core.loops._now", return_value=after_midnight),
+        patch("core.loops.load_prompt", return_value="dreamer prompt"),
+    ):
+        process_nightly_memory(state=state, config=config)
+
+    assert len(list(config.notifications_dir.glob("nightly_dream-*.json"))) == 1
+
+
+def test_skips_outside_catchup_window_for_late_dreamer_hour(tmp_path):
+    """With dreamer_hour=22, an afternoon hour (14:00) is outside the circular window and must not fire."""
+    from core.loops import process_nightly_memory
+
+    config = _setup(tmp_path, dreamer_hour=22)
+    state = vm.State()
+    afternoon = dt.datetime(2025, 6, 15, 14, 0, 0)
+
+    with (
+        patch("core.loops._now", return_value=afternoon),
+        patch("core.loops.load_prompt", return_value="dreamer prompt"),
+    ):
+        process_nightly_memory(state=state, config=config)
+
+    assert list(config.notifications_dir.glob("nightly_dream-*.json")) == []
+
+
 def test_drop_does_not_persist_last_dreamer_run(tmp_path):
     """Dropping the notification must not advance persisted.last_dreamer_run — only the agent's mark_dreamer_complete call does that.
 


### PR DESCRIPTION
Recall-biased `/code-review` over the entire `agent/` subtree (162 Python files, ~30k LOC), fanned out across correctness, cleanup, and altitude finder angles, then verified. This PR fixes the **9 CONFIRMED correctness bugs** that have clear, low-risk fixes.

## Fixes

| # | File | Bug |
|---|------|-----|
| 1 | `core/loops.py` | **Dreamer catchup window doesn't wrap past midnight.** `hour < nightly_memory_hour + DREAMER_CATCHUP_HOURS` has no `% 24`, so a late `NIGHTLY_MEMORY_HOUR` (e.g. 22) drops the nightly dream for the whole day if it's missed before midnight (hours 0-3 fall through the early `return`). Fixed with a circular window; added 2 regression tests. |
| 2 | `core/api.py` | **`_recv_loop` crashes on non-string `text`.** A valid-JSON message like `{"type":"message","text":123}` raised `AttributeError` on `.strip()` outside the try/except, tearing down the WS connection. Now type-checked. |
| 3 | `core/api.py` | **`_usage_handler` parses body before status check.** A non-JSON upstream error body raised `ContentTypeError`, masking the real status (429/500) behind a generic 502. Now reads text first on the error path. |
| 4 | `core/config.py` | **`THINKING` env var never worked.** Documented as `adaptive\|enabled\|disabled` but the bare string failed to coerce into the SDK `ThinkingConfig` union → `ValidationError` at startup. Added a `mode="before"` validator (verified for all values). |
| 5 | `core/sdk_parsing.py` | **`duration_ms == 0` treated as missing** (falsy-zero) — `is not None` now. |
| 6 | `skills/stripe-pay/.../charge.py` | **100x overcharge on zero-decimal currencies.** `int(round(amount * 100))` was unconditional; for JPY/KRW/etc. the minor unit *is* the major unit. Added a zero-decimal currency set + `_to_minor_units` helper, applied at both call sites. |
| 7 | `skills/voice/providers/deepgram.py` | **STT keyterms silently dropped.** The URL was built via `urlencode(params)` *before* keyterms were appended. Now built after. |
| 8 | `skills/email-client/auth.py` | **Loopback OAuth aborts on favicon.** The redirect handler captured the first GET of any path; a browser `/favicon.ico` set an empty capture → false "state mismatch". Now ignores requests without `code`/`error`. |
| 9 | `skills/twitter/monitor.py` | **Naive RSS pubDate permanently suppresses tweets.** A tz-naive `pubDate` raised `TypeError` against the tz-aware cutoff, caught by the broad except — but the GUID was already recorded as seen, so the tweet was never notified. Now normalizes naive datetimes to UTC. |

## Verification
- `uv run pytest tests/ --ignore=tests/test_e2e.py` → **164 passed, 1 skipped** (incl. 2 new dreamer tests)
- `uv run ruff check` → clean
- `uv run ty check` → clean

## Reviewed but intentionally NOT changed
- **Dash-correction round-trip** (`core/client.py`) — a deliberate design choice enforcing the no-dashes style preference, not a bug.
- **`state_store.load_state` resets on corrupt `state.json`** — documented intentional tradeoff (don't crash-loop the container). Worth a follow-up to back up the corrupt file, but behavior-changing.
- **`_spend_request_requires_link_approval` swallows all exceptions** — intentional per its docstring ("Returns False on any error").
- **`main.py` SIGTERM never force-exits** — low severity (Docker SIGKILLs on stop timeout); left to avoid changing shutdown semantics.
- **`upstream-pr/pr.py` existing-PR `head` filter** — low-confidence (GitHub's `owner:branch` format is valid for same-repo too) and only affects a convenience log line.

Findings REFUTED during verification (no change): `tools.py len(None)` (FTS trigger only indexes text-bearing event types), events.py recency ranking (ordering is correct), migrations.py lexicographic sort (only date-prefixed names exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)