### PR TITLE
fix(web): correctness bugs from frontend code review

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -12,9 +12,10 @@ export async function apiFetch(
     headers: { ...authHeaders(), ...init?.headers },
   });
 
-  // If 401, try one refresh then retry
+  // If 401, force a refresh then retry (the token was rejected even if the
+  // local clock thinks it is still valid, e.g. server-side rotation/revocation)
   if (resp.status === 401) {
-    const refreshed = await ensureFreshToken();
+    const refreshed = await ensureFreshToken(true);
     if (refreshed) {
       resp = await fetch(apiUrl(path), {
         ...init,

--- a/apps/web/src/api/logs.ts
+++ b/apps/web/src/api/logs.ts
@@ -15,6 +15,8 @@ export function streamLogs(
     }
 
     const url = `${conn.url}/agents/${encodeURIComponent(name)}/logs?token=${encodeURIComponent(conn.accessToken)}`;
+    const existing = logSources.get(name);
+    if (existing) existing.close();
     const es = new EventSource(url);
     logSources.set(name, es);
 

--- a/apps/web/src/api/updates.ts
+++ b/apps/web/src/api/updates.ts
@@ -1,13 +1,8 @@
 import { isTauri } from "@/lib/env";
+import { compareVersions } from "@/lib/version";
 
 export function isNewer(latest: string, current: string): boolean {
-  const a = latest.split(".").map(Number);
-  const b = current.split(".").map(Number);
-  for (let i = 0; i < Math.max(a.length, b.length); i++) {
-    if ((a[i] ?? 0) > (b[i] ?? 0)) return true;
-    if ((a[i] ?? 0) < (b[i] ?? 0)) return false;
-  }
-  return false;
+  return compareVersions(latest, current) > 0;
 }
 
 export type UpdateInfo = {

--- a/apps/web/src/components/AgentSettings/FilesTab/FileEditor.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/FileEditor.tsx
@@ -53,9 +53,14 @@ export function FileEditor({
 }: FileEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const onChangeRef = useRef(onChange);
+  // Only the value at editor-creation time matters; tracking it in a ref keeps
+  // it out of the effect deps so a parent re-render (e.g. saving, which updates
+  // the content prop) does not destroy and rebuild the live editor.
+  const initialContentRef = useRef(initialContent);
 
   useEffect(() => {
     onChangeRef.current = onChange;
+    initialContentRef.current = initialContent;
   });
 
   useEffect(() => {
@@ -84,12 +89,12 @@ export function FileEditor({
     if (lang) extensions.push(lang);
 
     const view = new EditorView({
-      state: EditorState.create({ doc: initialContent, extensions }),
+      state: EditorState.create({ doc: initialContentRef.current, extensions }),
       parent: container,
     });
 
     return () => view.destroy();
-  }, [path, initialContent, readonly, encoding]);
+  }, [path, readonly, encoding]);
 
   if (encoding === "base64") {
     return (

--- a/apps/web/src/components/AgentSettings/PlanUsage/index.tsx
+++ b/apps/web/src/components/AgentSettings/PlanUsage/index.tsx
@@ -45,10 +45,12 @@ function UsageBar({ label, limit }: { label: string; limit: RateLimit }) {
 export function PlanUsage() {
   const { name: agentName } = useSelectedAgent();
   const utilizationMap = useSettings((s) => s.utilization);
-  const loading = useSettings((s) => s.usageLoading);
-  const error = useSettings((s) => s.usageError);
+  const loadingMap = useSettings((s) => s.usageLoading);
+  const errorMap = useSettings((s) => s.usageError);
   const refreshUsageAction = useSettings((s) => s.refreshUsage);
   const utilization = agentName ? (utilizationMap[agentName] ?? null) : null;
+  const loading = agentName ? (loadingMap[agentName] ?? false) : false;
+  const error = agentName ? (errorMap[agentName] ?? false) : false;
 
   const refresh = () => {
     if (agentName) refreshUsageAction(agentName);

--- a/apps/web/src/components/AgentSettings/VoiceSection/index.tsx
+++ b/apps/web/src/components/AgentSettings/VoiceSection/index.tsx
@@ -585,7 +585,10 @@ function VoicePicker({
     if (!opt.preview) return;
     const audio = new Audio(opt.preview);
     audio.onended = () => setPlayingId(null);
-    audio.play();
+    audio.play().catch(() => {
+      if (audioRef.current === audio) audioRef.current = null;
+      setPlayingId((current) => (current === opt.value ? null : current));
+    });
     audioRef.current = audio;
     setPlayingId(opt.value);
   };

--- a/apps/web/src/components/Console/index.tsx
+++ b/apps/web/src/components/Console/index.tsx
@@ -137,6 +137,8 @@ export function Console({ name, onClose, fullscreen }: ConsoleProps) {
       streamLogs(name, (event) => {
         switch (event.kind) {
           case "Line": {
+            // A line means the connection is healthy, so reset the backoff.
+            reconnectDelayRef.current = RECONNECT_BASE;
             const stripped = stripAnsi(event.text);
             setLines((prev) => {
               const next = [...prev, stripped];
@@ -158,8 +160,6 @@ export function Console({ name, onClose, fullscreen }: ConsoleProps) {
             }
             break;
         }
-      }).then(() => {
-        reconnectDelayRef.current = RECONNECT_BASE;
       });
     };
   });

--- a/apps/web/src/components/Dashboard/index.tsx
+++ b/apps/web/src/components/Dashboard/index.tsx
@@ -188,7 +188,8 @@ export function Dashboard({ fullscreen }: { fullscreen?: boolean } = {}) {
         if (handshakeRef.current) {
           setLoaded(true);
         } else {
-          if (handshakeTimerRef.current) clearTimeout(handshakeTimerRef.current);
+          if (handshakeTimerRef.current)
+            clearTimeout(handshakeTimerRef.current);
           handshakeTimerRef.current = setTimeout(() => {
             handshakeTimerRef.current = null;
             if (handshakeRef.current) {

--- a/apps/web/src/components/Dashboard/index.tsx
+++ b/apps/web/src/components/Dashboard/index.tsx
@@ -22,6 +22,7 @@ export function Dashboard({ fullscreen }: { fullscreen?: boolean } = {}) {
   const [loaded, setLoaded] = useState(false);
   const [iframeKey, setIframeKey] = useState(0);
   const handshakeRef = useRef(false);
+  const handshakeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const dashboardService = agent.services?.dashboard;
   const hasDashboard = !!dashboardService;
@@ -51,6 +52,9 @@ export function Dashboard({ fullscreen }: { fullscreen?: boolean } = {}) {
 
   useEffect(() => {
     handshakeRef.current = false;
+    return () => {
+      if (handshakeTimerRef.current) clearTimeout(handshakeTimerRef.current);
+    };
   }, [iframeKey]);
 
   const conn = getConnection();
@@ -184,7 +188,9 @@ export function Dashboard({ fullscreen }: { fullscreen?: boolean } = {}) {
         if (handshakeRef.current) {
           setLoaded(true);
         } else {
-          setTimeout(() => {
+          if (handshakeTimerRef.current) clearTimeout(handshakeTimerRef.current);
+          handshakeTimerRef.current = setTimeout(() => {
+            handshakeTimerRef.current = null;
             if (handshakeRef.current) {
               setLoaded(true);
             } else {

--- a/apps/web/src/components/StatusPill/index.tsx
+++ b/apps/web/src/components/StatusPill/index.tsx
@@ -13,9 +13,10 @@ export function StatusPill({ showHostname = true }: StatusPillProps) {
     useGateway();
   const [updating, setUpdating] = useState(false);
 
-  const handleUpdate = () => {
+  const handleUpdate = async () => {
     setUpdating(true);
-    triggerGatewayUpdate();
+    const ok = await triggerGatewayUpdate();
+    if (!ok) setUpdating(false);
   };
 
   const hostname = (() => {

--- a/apps/web/src/components/VersionMismatchDialog/index.tsx
+++ b/apps/web/src/components/VersionMismatchDialog/index.tsx
@@ -13,10 +13,11 @@ import {
   EmptyDescription,
 } from "@/components/ui/empty";
 import { isTauri } from "@/lib/env";
+import { compareVersions } from "@/lib/version";
 
 interface VersionMismatchDialogProps {
   gatewayVersion: string;
-  onUpdateGateway: () => void;
+  onUpdateGateway: () => Promise<boolean>;
 }
 
 async function updateApp(gatewayVersion: string) {
@@ -43,7 +44,7 @@ export function VersionMismatchDialog({
   gatewayVersion,
   onUpdateGateway,
 }: VersionMismatchDialogProps) {
-  const appIsOlder = gatewayVersion > __APP_VERSION__;
+  const appIsOlder = compareVersions(__APP_VERSION__, gatewayVersion) < 0;
   const hint = appIsOlder ? "update your app" : "update your gateway";
   const [updating, setUpdating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -53,10 +54,14 @@ export function VersionMismatchDialog({
     setUpdating(false);
   }, [gatewayVersion]);
 
-  const handleUpdateGateway = () => {
+  const handleUpdateGateway = async () => {
     setUpdating(true);
     setError(null);
-    onUpdateGateway();
+    const ok = await onUpdateGateway();
+    if (!ok) {
+      setError("update failed");
+      setUpdating(false);
+    }
   };
 
   const handleUpdateApp = async () => {

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -17,4 +17,9 @@ describe("isNewer", () => {
     expect(isNewer("0.1.104", "0.1.105")).toBe(false);
     expect(isNewer("0.1.0", "0.2.0")).toBe(false);
   });
+
+  it("handles prerelease suffixes without NaN", () => {
+    expect(isNewer("0.2.0-rc1", "0.1.0")).toBe(true);
+    expect(isNewer("0.1.0", "0.2.0-rc1")).toBe(false);
+  });
 });

--- a/apps/web/src/lib/token-refresh.ts
+++ b/apps/web/src/lib/token-refresh.ts
@@ -2,8 +2,8 @@ import { getConnection, updateTokens, isTokenExpiringSoon } from "./connection";
 
 let refreshPromise: Promise<boolean> | null = null;
 
-export async function ensureFreshToken(): Promise<boolean> {
-  if (!isTokenExpiringSoon()) return true;
+export async function ensureFreshToken(force = false): Promise<boolean> {
+  if (!force && !isTokenExpiringSoon()) return true;
 
   // Deduplicate concurrent refresh calls
   if (refreshPromise) return refreshPromise;

--- a/apps/web/src/lib/version.test.ts
+++ b/apps/web/src/lib/version.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { compareVersions } from "@/lib/version";
+
+describe("compareVersions", () => {
+  it("compares numerically, not lexicographically", () => {
+    expect(compareVersions("0.1.154", "0.1.9")).toBe(1);
+    expect(compareVersions("0.1.9", "0.1.154")).toBe(-1);
+    expect(compareVersions("0.2.10", "0.2.9")).toBe(1);
+  });
+
+  it("returns 0 for equal versions", () => {
+    expect(compareVersions("0.1.0", "0.1.0")).toBe(0);
+  });
+
+  it("treats missing segments as zero", () => {
+    expect(compareVersions("1.2", "1.2.0")).toBe(0);
+    expect(compareVersions("1.2.1", "1.2")).toBe(1);
+  });
+
+  it("parses prerelease suffixes via their leading integer", () => {
+    expect(compareVersions("0.2.0-rc1", "0.1.0")).toBe(1);
+    expect(compareVersions("0.1.0", "0.2.0")).toBe(-1);
+  });
+});

--- a/apps/web/src/lib/version.ts
+++ b/apps/web/src/lib/version.ts
@@ -1,0 +1,21 @@
+/**
+ * Compare two dotted version strings numerically (semver-ish).
+ * Returns -1 if a < b, 1 if a > b, 0 if equal.
+ * Non-numeric segments (e.g. prerelease suffixes like "0-rc1") parse via their
+ * leading integer; a missing segment counts as 0.
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (segment: string) => {
+    const value = Number.parseInt(segment, 10);
+    return Number.isNaN(value) ? 0 : value;
+  };
+  const left = a.split(".");
+  const right = b.split(".");
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const lhs = parse(left[i] ?? "0");
+    const rhs = parse(right[i] ?? "0");
+    if (lhs > rhs) return 1;
+    if (lhs < rhs) return -1;
+  }
+  return 0;
+}

--- a/apps/web/src/lib/voice.ts
+++ b/apps/web/src/lib/voice.ts
@@ -180,14 +180,17 @@ async function playStreamedAudio(
   const audio = new Audio();
   audio.src = URL.createObjectURL(mediaSource);
 
-  if (signal) {
-    signal.addEventListener("abort", () => {
-      audio.pause();
-      URL.revokeObjectURL(audio.src);
-    });
-  }
-
   await new Promise<void>((resolve, reject) => {
+    if (signal) {
+      // Resolve (not reject) on abort so the caller's await completes instead
+      // of hanging forever when playback is cancelled mid-stream.
+      signal.addEventListener("abort", () => {
+        audio.pause();
+        URL.revokeObjectURL(audio.src);
+        resolve();
+      });
+    }
+
     mediaSource.addEventListener(
       "sourceopen",
       async () => {
@@ -229,10 +232,19 @@ async function playStreamedAudio(
               mediaSource.endOfStream();
             return;
           }
-          sourceBuffer.appendBuffer(queue.shift()!.buffer as ArrayBuffer);
+          try {
+            sourceBuffer.appendBuffer(queue.shift()!.buffer as ArrayBuffer);
+          } catch (err) {
+            // Without this the awaited Promise would hang: updateend never
+            // fires after a failed append, so nothing resolves it.
+            reject(err instanceof Error ? err : new Error("appendBuffer failed"));
+          }
         };
 
         sourceBuffer.addEventListener("updateend", appendNext);
+        sourceBuffer.addEventListener("error", () =>
+          reject(new Error("audio decode failed")),
+        );
 
         audio.onended = () => {
           URL.revokeObjectURL(audio.src);

--- a/apps/web/src/lib/voice.ts
+++ b/apps/web/src/lib/voice.ts
@@ -237,7 +237,9 @@ async function playStreamedAudio(
           } catch (err) {
             // Without this the awaited Promise would hang: updateend never
             // fires after a failed append, so nothing resolves it.
-            reject(err instanceof Error ? err : new Error("appendBuffer failed"));
+            reject(
+              err instanceof Error ? err : new Error("appendBuffer failed"),
+            );
           }
         };
 

--- a/apps/web/src/providers/GatewayProvider/index.tsx
+++ b/apps/web/src/providers/GatewayProvider/index.tsx
@@ -44,7 +44,7 @@ interface GatewayContextValue {
   agents: AgentInfo[];
   agentsFetched: boolean;
   send: (event: object) => boolean;
-  triggerGatewayUpdate: () => void;
+  triggerGatewayUpdate: () => Promise<boolean>;
   checkForUpdate: () => Promise<void>;
 }
 
@@ -61,7 +61,7 @@ const disconnectedValue: GatewayContextValue = {
   agents: [],
   agentsFetched: false,
   send: () => false,
-  triggerGatewayUpdate: () => {},
+  triggerGatewayUpdate: async () => false,
   checkForUpdate: async () => {},
 };
 
@@ -89,12 +89,16 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
   const [connectEpoch, setConnectEpoch] = useState(0);
   const skipVersionGateRef = useRef(false);
 
-  const triggerGatewayUpdate = () => {
-    apiFetch("/gateway/update", { method: "POST" }).catch((err) => {
+  const triggerGatewayUpdate = async (): Promise<boolean> => {
+    try {
+      await apiFetch("/gateway/update", { method: "POST" });
+    } catch (err) {
       console.warn("[gateway] update request failed:", err);
-    });
+      return false;
+    }
     skipVersionGateRef.current = true;
     setConnectEpoch((e) => e + 1);
+    return true;
   };
 
   const checkForUpdate = async () => {

--- a/apps/web/src/providers/VoiceProvider/index.tsx
+++ b/apps/web/src/providers/VoiceProvider/index.tsx
@@ -7,6 +7,7 @@ export function VoiceStoreEffects({ children }: { children: ReactNode }) {
   const { name: agentName, agent } = useSelectedAgent();
   const services = agent.services;
   const voiceRev = agent.services?.voice?.rev;
+  const hasVoice = "voice" in (services ?? {});
 
   const _setAgentContext = useVoice((s) => s._setAgentContext);
   const _setSttStatus = useVoice((s) => s._setSttStatus);
@@ -28,7 +29,6 @@ export function VoiceStoreEffects({ children }: { children: ReactNode }) {
       return;
     }
 
-    const hasVoice = "voice" in (services ?? {});
     if (!hasVoice) {
       _setSttStatus(null);
       _setTtsStatus(null);
@@ -48,7 +48,7 @@ export function VoiceStoreEffects({ children }: { children: ReactNode }) {
       .catch(() => {});
 
     return () => ctrl.abort();
-  }, [agentName, services, voiceRev, _setSttStatus, _setTtsStatus]);
+  }, [agentName, hasVoice, voiceRev, _setSttStatus, _setTtsStatus]);
 
   // Preload worklet module when STT is available
   const sttAvailable = useVoice((s) => s.sttAvailable);

--- a/apps/web/src/stores/use-settings.ts
+++ b/apps/web/src/stores/use-settings.ts
@@ -3,27 +3,30 @@ import { fetchUsage, type Utilization } from "@/api/agents";
 
 interface SettingsState {
   utilization: Record<string, Utilization>;
-  usageLoading: boolean;
-  usageError: boolean;
+  usageLoading: Record<string, boolean>;
+  usageError: Record<string, boolean>;
   refreshUsage: (agentName: string) => void;
 }
 
-export const useSettings = create<SettingsState>((set, get) => ({
+export const useSettings = create<SettingsState>((set) => ({
   utilization: {},
-  usageLoading: false,
-  usageError: false,
+  usageLoading: {},
+  usageError: {},
 
   refreshUsage: (agentName: string) => {
-    set({ usageLoading: true, usageError: false });
+    set((s) => ({
+      usageLoading: { ...s.usageLoading, [agentName]: true },
+      usageError: { ...s.usageError, [agentName]: false },
+    }));
     fetchUsage(agentName)
       .then((data) => {
-        set({ utilization: { ...get().utilization, [agentName]: data } });
+        set((s) => ({ utilization: { ...s.utilization, [agentName]: data } }));
       })
       .catch(() => {
-        set({ usageError: true });
+        set((s) => ({ usageError: { ...s.usageError, [agentName]: true } }));
       })
       .finally(() => {
-        set({ usageLoading: false });
+        set((s) => ({ usageLoading: { ...s.usageLoading, [agentName]: false } }));
       });
   },
 }));

--- a/apps/web/src/stores/use-settings.ts
+++ b/apps/web/src/stores/use-settings.ts
@@ -26,7 +26,9 @@ export const useSettings = create<SettingsState>((set) => ({
         set((s) => ({ usageError: { ...s.usageError, [agentName]: true } }));
       })
       .finally(() => {
-        set((s) => ({ usageLoading: { ...s.usageLoading, [agentName]: false } }));
+        set((s) => ({
+          usageLoading: { ...s.usageLoading, [agentName]: false },
+        }));
       });
   },
 }));

--- a/apps/web/src/stores/use-voice.ts
+++ b/apps/web/src/stores/use-voice.ts
@@ -68,6 +68,9 @@ let idleTimer: ReturnType<typeof setTimeout> | null = null;
 let ttsAbort: AbortController | null = null;
 let ttsQueue: string[] = [];
 let ttsProcessing = false;
+// Bumped by stopSpeech to invalidate an in-flight processQueue loop, so a
+// stop-then-speak sequence never leaves two loops draining ttsQueue at once.
+let ttsEpoch = 0;
 const ttsPrefetchCache = new Map<string, Promise<Response>>();
 
 function clearIdleTimer() {
@@ -91,9 +94,10 @@ export const useVoice = create<VoiceState>((set, get) => {
     const { agentName } = get();
     if (ttsProcessing || !agentName) return;
     ttsProcessing = true;
+    const myEpoch = ttsEpoch;
     set({ isSpeaking: true });
 
-    while (ttsQueue.length > 0) {
+    while (ttsQueue.length > 0 && ttsEpoch === myEpoch) {
       const text = ttsQueue.shift()!;
       const controller = new AbortController();
       ttsAbort = controller;
@@ -109,8 +113,12 @@ export const useVoice = create<VoiceState>((set, get) => {
           console.warn("[tts] playback failed:", err);
         }
       }
-      ttsAbort = null;
+      if (ttsAbort === controller) ttsAbort = null;
     }
+
+    // A newer epoch (stopSpeech) superseded this loop; the new loop owns the
+    // shared flags, so exit without resetting them.
+    if (ttsEpoch !== myEpoch) return;
 
     ttsProcessing = false;
 
@@ -237,6 +245,7 @@ export const useVoice = create<VoiceState>((set, get) => {
     stopSpeech: () => {
       ttsQueue = [];
       ttsPrefetchCache.clear();
+      ttsEpoch++;
       ttsAbort?.abort();
       ttsProcessing = false;
       set({ isSpeaking: false });
@@ -309,6 +318,7 @@ export const useVoice = create<VoiceState>((set, get) => {
     _cleanup: () => {
       transcriber?.stop();
       transcriber = null;
+      get().stopSpeech();
       set({ isRecording: false, liveTranscript: "" });
     },
   };


### PR DESCRIPTION
A recall-biased `/code-review` over all of `apps/web` (no diff — the whole frontend was the scope) surfaced these bugs. Each was verified before fixing; two candidates were refuted (GatewayProvider reconnect has a `cancelled` guard at line 146; Transcriber `onclose` clears `active` synchronously) and are not included.

## Fixed

**Correctness**
1. **VersionMismatchDialog** — used raw string `>` (lexicographic), so `"0.1.9" > "0.1.154"` told the user to update the wrong side. New `lib/version.ts#compareVersions` does numeric comparison, reused by the dialog and `isNewer`.
2. **token-refresh / api/client** — `ensureFreshToken()` short-circuited when the clock said "not expiring," so the 401-retry reused the dead token. Added a `force` flag used on retry.
3. **api/updates `isNewer`** — `Number("0-rc1")` → `NaN`, all comparisons false → a newer prerelease was never offered. Fixed via `compareVersions`.
4. **api/logs** — `streamLogs` overwrote the `EventSource` without closing the old one (leak + double-fired events). Now closes the existing one first.
5. **stores/use-voice** — `_cleanup` never stopped TTS, so audio kept playing after an agent switch. Now calls `stopSpeech()`.
6. **stores/use-voice** — `stopSpeech` cleared `ttsProcessing` mid-await, letting a following `speak()` spawn a second concurrent drain loop (overlapping audio). Added an epoch counter so a superseded loop exits cleanly.
7. **components/Console** — reconnect backoff reset to base on every disconnect → never backed off. Now resets only on a healthy line.
8. **StatusPill + VersionMismatchDialog** — gateway-update spinner stuck forever on a failed POST. `triggerGatewayUpdate` now returns success and the spinner resets on failure.
9. **AgentSettings/PlanUsage + use-settings** — `usageLoading`/`usageError` were global while `utilization` was per-agent, so one agent's error suppressed auto-fetch for the rest. Now keyed per agent.
10. **AgentSettings/FilesTab/FileEditor** — editor recreated whenever `initialContent` changed, and saving mutates that prop → cursor/scroll/undo lost on save. `initialContent` is now read via a ref and out of the effect deps.
11. **providers/VoiceProvider** — fetch effect depended on the `services` object identity (fresh each gateway poll) → refetched STT/TTS status every poll. Now depends on a derived `hasVoice` boolean.
12. **components/Dashboard** — 500ms handshake `setTimeout` could `setState` after unmount or onto a superseded iframe. Timer is now tracked in a ref and cleared on key change / unmount.
13. **AgentSettings/VoiceSection** — uncaught `audio.play()` rejection (blocked autoplay / 404) left the play button stuck. Now caught and resets state.
14. **lib/voice `playStreamedAudio`** — a failed final `appendBuffer` / source error left the awaited promise hanging forever. Now rejects on append failure / source error and resolves on abort.

Tests added for `compareVersions` and the prerelease case in `isNewer`.

## Deferred (reported, not fixed here)
- **use-chat `loadMore`** prepends history without the `MAX_MESSAGES` cap — capping would discard the page it just fetched; correct fix is windowing/virtualization, out of scope.
- **use-auto-scroll** single `programmaticScrollRef` flag can misclassify a user scroll landing in the same frame as a programmatic one — reworking it needs interaction testing.
- **Cleanup:** `AgentMenu/AgentActions` dead `showAliveActions`/`onAuthenticate` plumbing and the unreferenced `AgentSettings/MemoryCard` — left in place per "don't delete pre-existing dead code unless asked."

## Verification
- `npm -w @vesta/web run check` — clean
- `npm -w @vesta/web run lint` — 0 errors (pre-existing warnings only)
- `npm -w @vesta/web run test` — 40 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)