### PR TITLE
refactor(agent): simplify event paging, ws cleanup, dead logger helper

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -50,8 +50,10 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
         send_task = asyncio.create_task(_send_loop(ws, sub))
         await asyncio.wait([recv_task, send_task], return_when=asyncio.FIRST_COMPLETED)
     finally:
-        recv_task and recv_task.cancel()
-        send_task and send_task.cancel()
+        if recv_task:
+            recv_task.cancel()
+        if send_task:
+            send_task.cancel()
         await asyncio.gather(recv_task, send_task, return_exceptions=True)
         event_bus.unsubscribe(sub)
         request.app["websockets"].discard(ws)

--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -182,12 +182,12 @@ class EventBus:
     def tool_finished(self) -> None:
         self._active_tools = max(0, self._active_tools - 1)
 
-    def recent(self, limit: int = PAGE_SIZE) -> tuple[list[StreamEvent], int | None]:
+    def _page(self, where_clause: str, params: tuple[object, ...], limit: int) -> tuple[list[StreamEvent], int | None]:
         if not self._conn or limit <= 0:
             return [], None
         rows = self._conn.execute(
-            "SELECT id, data FROM events ORDER BY id DESC LIMIT ?",
-            (limit + 1,),
+            f"SELECT id, data FROM events {where_clause}ORDER BY id DESC LIMIT ?",
+            (*params, limit + 1),
         ).fetchall()
         if not rows:
             return [], None
@@ -196,19 +196,11 @@ class EventBus:
         events = [json.loads(r[1]) for r in reversed(rows)]
         return events, rows[-1][0] if has_older else None
 
+    def recent(self, limit: int = PAGE_SIZE) -> tuple[list[StreamEvent], int | None]:
+        return self._page("", (), limit)
+
     def before(self, cursor: int, limit: int = PAGE_SIZE) -> tuple[list[StreamEvent], int | None]:
-        if not self._conn or limit <= 0:
-            return [], None
-        rows = self._conn.execute(
-            "SELECT id, data FROM events WHERE id < ? ORDER BY id DESC LIMIT ?",
-            (cursor, limit + 1),
-        ).fetchall()
-        if not rows:
-            return [], None
-        has_older = len(rows) > limit
-        rows = rows[:limit]
-        events = [json.loads(r[1]) for r in reversed(rows)]
-        return events, rows[-1][0] if has_older else None
+        return self._page("WHERE id < ? ", (cursor,), limit)
 
     def search(self, query: str, *, limit: int = 20) -> list[dict[str, str]]:
         if not self._conn:

--- a/agent/core/logger.py
+++ b/agent/core/logger.py
@@ -73,10 +73,6 @@ def _log(msg: str, *, level: int = logging.INFO) -> None:
         _file_handler.emit(clean_record)
 
 
-def _cat(symbol: str, color: str, prefix: str, msg: tp.Any, *, level: int = logging.INFO) -> None:
-    _log(f"{symbol} [{color}][{prefix}][/{color}] {msg}", level=level)
-
-
 def _system_phase(phase: str, msg: tp.Any, *, level: int = logging.INFO) -> None:
     _log(f"* [cyan][SYSTEM][/cyan] - [dim][{phase}][/dim] {msg}", level=level)
 


### PR DESCRIPTION
## What

A `/simplify` pass over `agent/core` (quality-only, no behavior change). Three surgical cleanups:

- **`events.py`** — extract a shared `_page` helper for `EventBus.recent`/`before`. The two methods were ~90% identical, differing only by the `WHERE` clause and params. Removes the duplicated cursor/paging block (-10 net lines).
- **`api.py`** — replace the `recv_task and recv_task.cancel()` boolean short-circuit with explicit `if` guards in the WS handler's `finally`. Same effect, clearer intent.
- **`logger.py`** — remove the unused `_cat` helper (no callers; every log category goes through the `_*_phase` wrappers).

## Why

These were the high-confidence, behavior-preserving findings from a four-angle review (reuse / simplification / efficiency / altitude) of `agent/`. Findings that conflicted with repo conventions (cross-skill code sharing, `.get()`-based rewrites) or that amounted to architectural rewrites (registry/dispatch tables) were intentionally skipped.

## Verification

- `uv run ruff check` — clean
- `uv run ty check` — clean
- `uv run pytest tests/ --ignore=tests/test_e2e.py` — **162 passed, 1 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)