### PR TITLE
fix(dashboard): steer widget labels away from washed-out muted opacity

### DIFF
--- a/agent/skills/dashboard/SKILL.md
+++ b/agent/skills/dashboard/SKILL.md
@@ -55,7 +55,7 @@ The dashboard is a high-density UI, not a standard app interface. Default shadcn
 
 **1. Typography**
 *   Default text: `text-sm`
-*   Secondary text / labels: `text-xs text-muted-foreground`
+*   Secondary text / labels: `text-xs text-muted-foreground`. Do NOT lower the opacity (no `text-muted-foreground/70`), especially on tiny labels like `text-[10px]`: it washes out and becomes unreadable on the dark theme.
 *   Large numbers only: `text-lg` or `text-xl font-semibold`
 *   Reserve `text-lg`+ for genuinely large numbers or when the user asks for it.
 


### PR DESCRIPTION
## Problem

Issue #562 reports that dashboard widget section labels use `text-[10px] uppercase tracking-wide text-muted-foreground/70`. On the dark theme the 70% opacity, sitting on an already light `--muted-foreground`, collapses contrast at 10px and the labels become unreadable. On light theme they are fine.

## Investigation

The exact label pattern (and the `pages/overview.tsx` files the issue points at) does not exist anywhere in the tracked repo. Those widget pages are generated by the agent at runtime inside the container, not checked in. So there is no tracked label span to edit directly.

The literal `text-muted-foreground/70` string appears only in `apps/web/src` in unrelated contexts (italic descriptions, a tool-call label, a voice timer), none of which are the `text-[10px] uppercase tracking-wide` section labels described.

## Fix

The durable, in-repo fix is in the dashboard skill guidance the agent follows when generating widgets. Updated the typography rule in `agent/skills/dashboard/SKILL.md` to instruct the agent not to lower the muted opacity for labels (no `text-muted-foreground/70`), especially on tiny `text-[10px]` labels, since that washes out on the dark theme. This prevents new widgets from reproducing the bug at its actual source.

`index.css` and `components/ui/` are marked do-not-modify in the skill (synced from the main app), so the raw `--muted-foreground` lightness was intentionally left untouched.

## Verification

`agent/skills/generate-index.py` was re-run: `index.json` is unchanged (the change is in the SKILL.md body, not its frontmatter description), so the CI index-freshness check passes. No app build was run because the dashboard app has no `node_modules` installed; this change is documentation-only and does not affect the build.

Fixes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)