### PR TITLE
fix(update-check): cut GitHub release-API rate limiting

### DIFF
--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -17,4 +17,4 @@ export { fetchPersonalities, type Personality } from "./personalities";
 export { authenticate, submitAuthCode, type AuthStartResult } from "./auth";
 export { streamLogs, stopLogs } from "./logs";
 export { connectToServer } from "./server";
-export { isNewer, checkAndInstallUpdate, type UpdateInfo } from "./updates";
+export { isNewer } from "./updates";

--- a/apps/web/src/api/updates.ts
+++ b/apps/web/src/api/updates.ts
@@ -1,39 +1,5 @@
-import { isTauri } from "@/lib/env";
 import { compareVersions } from "@/lib/version";
 
 export function isNewer(latest: string, current: string): boolean {
   return compareVersions(latest, current) > 0;
-}
-
-export type UpdateInfo = {
-  version: string;
-  /** Update was downloaded and installed — app needs restart to apply. */
-  installed: boolean;
-};
-
-export async function checkAndInstallUpdate(): Promise<UpdateInfo | null> {
-  if (!isTauri) return null;
-  try {
-    const { getVersion } = await import("@tauri-apps/api/app");
-    const { detectPlatform } = await import("@/lib/platform");
-    if (detectPlatform() === "linux") {
-      const current = await getVersion();
-      const resp = await fetch(
-        "https://api.github.com/repos/elyxlz/vesta/releases/latest",
-      );
-      if (!resp.ok) return null;
-      const data = await resp.json();
-      const latest = (data.tag_name as string).replace(/^v/, "");
-      if (!isNewer(latest, current)) return null;
-      return { version: latest, installed: false };
-    }
-    const { check } = await import("@tauri-apps/plugin-updater");
-    const update = await check();
-    if (!update) return null;
-    await update.downloadAndInstall();
-    return { version: update.version, installed: true };
-  } catch (e) {
-    console.error("Update check failed:", e);
-    return null;
-  }
 }

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -137,6 +137,15 @@ fn extract_server_error(body: &str) -> Option<String> {
     v["error"].as_str().map(|s| s.to_string())
 }
 
+fn extract_latest_version(value: &serde_json::Value) -> Option<String> {
+    let tag = value["latest_version"].as_str()?.trim().trim_start_matches('v');
+    if tag.is_empty() {
+        None
+    } else {
+        Some(tag.to_string())
+    }
+}
+
 fn urlencod(s: &str) -> String {
     percent_encoding::utf8_percent_encode(s, percent_encoding::NON_ALPHANUMERIC).to_string()
 }
@@ -277,6 +286,29 @@ impl Client {
             .map_err(|e| map_error(&self.base_url, e))?;
         check_response(resp)?;
         Ok(())
+    }
+
+    // Read vestad's cached view of the latest release. vestad polls GitHub on
+    // our behalf (with an ETag conditional request), so routing through it keeps
+    // every client on one machine from hitting the GitHub API independently.
+    pub fn latest_release_tag(&self) -> Result<Option<String>, String> {
+        let resp = self.get("/version")?;
+        let value: serde_json::Value = resp
+            .into_body()
+            .read_json()
+            .map_err(|e| format!("parse error: {e}"))?;
+        Ok(extract_latest_version(&value))
+    }
+
+    // Force vestad to refresh from GitHub, then return the latest tag. Used by
+    // the explicit `vesta update` so it does not act on a stale cached value.
+    pub fn check_latest_release_tag(&self) -> Result<Option<String>, String> {
+        let resp = self.post("/version/check")?;
+        let value: serde_json::Value = resp
+            .into_body()
+            .read_json()
+            .map_err(|e| format!("parse error: {e}"))?;
+        Ok(extract_latest_version(&value))
     }
 
     pub fn list_agents(&self) -> Result<Vec<ListEntry>, String> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -324,11 +324,27 @@ fn get_client(host: Option<&str>, token: Option<&str>) -> client::Client {
     client::Client::new(&config)
 }
 
+// Ask the configured vestad for the latest release tag so the CLI does not hit
+// the GitHub API directly. vestad keeps a cached, ETag-conditional view of the
+// latest release. Returns None when no server is configured or the request
+// fails, letting callers fall back to a direct GitHub check.
+fn fetch_latest_via_gateway(force: bool) -> Option<String> {
+    let config = common::load_server_config()?;
+    let client = client::Client::new(&config);
+    let result = if force {
+        client.check_latest_release_tag()
+    } else {
+        client.latest_release_tag()
+    };
+    result.ok().flatten()
+}
+
 fn check_latest_version() -> Option<String> {
     let current = env!("CARGO_PKG_VERSION");
     eprintln!("current version: v{current}");
 
-    let latest = fetch_latest_release_tag(None)
+    let latest = fetch_latest_via_gateway(true)
+        .or_else(|| fetch_latest_release_tag(None))
         .unwrap_or_else(|| platform::die("failed to check for updates"));
 
     if latest == current {
@@ -430,7 +446,7 @@ fn check_update_cached() -> Option<std::thread::JoinHandle<Option<String>>> {
     }
 
     Some(std::thread::spawn(move || {
-        let latest = fetch_latest_release_tag(Some(5))?;
+        let latest = fetch_latest_via_gateway(false).or_else(|| fetch_latest_release_tag(Some(5)))?;
         let _ = std::fs::create_dir_all(&cache_dir);
         let _ = std::fs::write(&cache_file, &latest);
         if version_less_than(env!("CARGO_PKG_VERSION"), &latest) {

--- a/vestad/src/update_check.rs
+++ b/vestad/src/update_check.rs
@@ -4,6 +4,7 @@ pub const CHECK_INTERVAL_SECS: u64 = 6 * 60 * 60;
 const FETCH_TIMEOUT_SECS: u64 = 10;
 const ERROR_SNIPPET_MAX_LEN: usize = 300;
 const HTTP_STATUS_SENTINEL: &str = "\n__VESTA_HTTP_STATUS__:";
+const CACHE_FILE_NAME: &str = "update-check-cache.json";
 
 const GITHUB_RELEASES_LATEST_URL: &str =
     "https://api.github.com/repos/elyxlz/vesta/releases/latest";
@@ -35,7 +36,50 @@ pub fn fetch_latest_tag() -> Option<String> {
     fetch_latest_release_tag(Some(FETCH_TIMEOUT_SECS)).ok()
 }
 
+// Persisted across restarts so the conditional request below keeps working
+// after vestad bounces. GitHub does not count a 304 response against the
+// unauthenticated rate limit, so a stored ETag makes steady-state polling free.
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+struct CacheEntry {
+    etag: String,
+    tag: String,
+}
+
+fn cache_path() -> Option<std::path::PathBuf> {
+    crate::paths::config_dir().map(|dir| dir.join(CACHE_FILE_NAME))
+}
+
+fn read_cache() -> Option<CacheEntry> {
+    let path = cache_path()?;
+    let contents = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+fn write_cache(etag: &str, tag: &str) {
+    let Some(path) = cache_path() else { return };
+    if let Some(parent) = path.parent() {
+        if std::fs::create_dir_all(parent).is_err() {
+            return;
+        }
+    }
+    let entry = CacheEntry {
+        etag: etag.to_string(),
+        tag: tag.to_string(),
+    };
+    if let Ok(json) = serde_json::to_string(&entry) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
 fn fetch_latest_release_tag(timeout_secs: Option<u64>) -> Result<String, String> {
+    let cache = read_cache();
+
+    // Dump response headers to a temp file (portable across curl versions,
+    // unlike `-w %header{etag}`) so we can read the ETag without parsing it out
+    // of the body, which contains release notes with blank lines.
+    let header_file =
+        std::env::temp_dir().join(format!("vesta-update-headers-{}.txt", std::process::id()));
+
     // Omit curl's `-f` so HTTP errors still return a body. This surfaces
     // GitHub's rate-limit message to the caller instead of collapsing every
     // failure into a generic error.
@@ -45,9 +89,17 @@ fn fetch_latest_release_tag(timeout_secs: Option<u64>) -> Result<String, String>
         "Accept: application/vnd.github+json".into(),
         "-H".into(),
         "User-Agent: vesta-release-check".into(),
+        "-D".into(),
+        header_file.to_string_lossy().into_owned(),
         "-w".into(),
         format!("{HTTP_STATUS_SENTINEL}%{{http_code}}"),
     ];
+    if let Some(entry) = &cache {
+        if !entry.etag.is_empty() {
+            args.push("-H".into());
+            args.push(format!("If-None-Match: {}", entry.etag));
+        }
+    }
     if let Some(t) = timeout_secs {
         args.push("--connect-timeout".into());
         args.push(t.to_string());
@@ -60,6 +112,9 @@ fn fetch_latest_release_tag(timeout_secs: Option<u64>) -> Result<String, String>
         .args(&args)
         .output()
         .map_err(|e| format!("failed to spawn curl: {e}"))?;
+
+    let headers = std::fs::read_to_string(&header_file).unwrap_or_default();
+    let _ = std::fs::remove_file(&header_file);
 
     if !output.status.success() {
         let code = output
@@ -83,6 +138,16 @@ fn fetch_latest_release_tag(timeout_secs: Option<u64>) -> Result<String, String>
     let status_code: u16 = status
         .parse()
         .map_err(|_| format!("unparseable HTTP status {status:?}"))?;
+
+    // 304 Not Modified: the release is unchanged since our last check and this
+    // response did not cost us a rate-limit unit. Reuse the cached tag.
+    if status_code == 304 {
+        match cache {
+            Some(entry) if !entry.tag.is_empty() => return Ok(entry.tag),
+            _ => return Err("received 304 but no cached tag available".into()),
+        }
+    }
+
     if !(200..300).contains(&status_code) {
         return Err(format!(
             "HTTP {status_code}: {}",
@@ -103,7 +168,29 @@ fn fetch_latest_release_tag(timeout_secs: Option<u64>) -> Result<String, String>
     if tag.is_empty() {
         return Err("tag_name is empty".into());
     }
+
+    if let Some(etag) = parse_etag(&headers) {
+        write_cache(&etag, tag);
+    }
+
     Ok(tag.to_string())
+}
+
+fn parse_etag(headers: &str) -> Option<String> {
+    // With `-L`, headers may contain multiple response blocks (one per hop).
+    // Take the last ETag so it matches the final 200 response.
+    headers
+        .lines()
+        .rev()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.trim().eq_ignore_ascii_case("etag") {
+                Some(value.trim().to_string())
+            } else {
+                None
+            }
+        })
+        .filter(|etag| !etag.is_empty())
 }
 
 fn snippet(s: &str) -> String {
@@ -140,5 +227,23 @@ mod tests {
     fn snippet_passes_short_strings_through() {
         assert_eq!(snippet("hi"), "hi");
         assert_eq!(snippet(""), "<empty>");
+    }
+
+    #[test]
+    fn parse_etag_reads_header_case_insensitively() {
+        let headers = "HTTP/2 200\r\ndate: now\r\nETag: \"abc123\"\r\n\r\n";
+        assert_eq!(parse_etag(headers), Some("\"abc123\"".into()));
+    }
+
+    #[test]
+    fn parse_etag_takes_last_block_on_redirect() {
+        let headers =
+            "HTTP/2 301\r\netag: \"old\"\r\n\r\nHTTP/2 200\r\netag: \"new\"\r\n\r\n";
+        assert_eq!(parse_etag(headers), Some("\"new\"".into()));
+    }
+
+    #[test]
+    fn parse_etag_returns_none_when_absent() {
+        assert_eq!(parse_etag("HTTP/2 200\r\ndate: now\r\n\r\n"), None);
     }
 }


### PR DESCRIPTION
## Problem

We poll `https://api.github.com/repos/elyxlz/vesta/releases/latest` for new releases from **multiple independent call sites on the same IP**, which blows through GitHub's **60 requests/hour** unauthenticated limit:

- `apps/web/src/api/updates.ts` fetched GitHub directly with **no caching**.
- `vestad/src/update_check.rs` polls every 6h but cached **in memory only**, so every daemon restart re-hit immediately.
- `cli/src/common.rs` hits GitHub directly (1h disk cache + a background thread on startup).

Three independent cachers (one with none) racing on one IP.

## Fix (solutions #1 and #2)

**1. Consolidate through vestad.** The CLI now asks the configured vestad for the latest release tag instead of calling GitHub:
- passive startup check → `GET /version` (vestad's cached value)
- explicit `vesta update` → `POST /version/check` (forces a fresh, ETag-cheap refresh)
- falls back to a direct GitHub call only when no server is reachable.

The web app already reads update info from vestad via `GatewayProvider` (`/version` + `/version/check`). Its `checkAndInstallUpdate` — dead code, never called, and the only remaining client-side direct-GitHub path — is removed.

**2. ETag conditional requests in vestad.** The release poll persists the ETag + tag to `~/.config/vesta/vestad/update-check-cache.json` and sends `If-None-Match`. GitHub does **not** count a `304 Not Modified` against the rate limit, so steady-state polling (and the web app's manual checks) is now essentially free.

Net effect: one machine makes one upstream GitHub call per interval instead of N, and that call is usually a free 304.

## Testing
- `cargo clippy -p vestad` / `cargo clippy` (cli): clean
- `cargo test -p vestad` (incl. new `parse_etag` tests) and `cargo test` (cli): pass
- web `check` (tsc), `lint` (0 errors), `test` (35 pass): pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)