### PR TITLE
feat(whatsapp): notify agent when daemon boots unpaired

### DIFF
--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -188,6 +188,17 @@ func runServe(logger waLog.Logger) {
 		fmt.Fprintln(os.Stderr, "Not authenticated. Use 'whatsapp pair-phone --phone <number>' to authenticate.")
 	}
 
+	// Daemon came up without a device session (e.g. after a backup restore that
+	// lost the whatsmeow session keys). Tell the agent once so it can prompt the
+	// user to re-pair instead of silently failing every send. Runs once per
+	// daemon boot, not per failed send.
+	if wac.client.Store.ID == nil {
+		fmt.Fprintln(os.Stderr, "Daemon started unpaired; notifying agent that re-pairing is required.")
+		if err := WriteUnpairedNotification(notifDir, instance); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to write unpaired notification: %v\n", err)
+		}
+	}
+
 	printJSON(map[string]string{"status": "serving"})
 
 	sigChan := make(chan os.Signal, 1)

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -45,6 +45,14 @@ type reactionNotif struct {
 	ContactUnknown  bool   `json:"contact_unknown,omitempty"`
 }
 
+type authNotif struct {
+	Source    string `json:"source"`
+	Type      string `json:"type"`
+	Instance  string `json:"instance,omitempty"`
+	Message   string `json:"message"`
+	Timestamp string `json:"timestamp"`
+}
+
 func writeNotificationFile(notifDir string, data any, notifType string) error {
 	if notifDir == "" {
 		return nil
@@ -113,4 +121,18 @@ func WriteReactionNotification(
 		}
 	}
 	return writeNotificationFile(ctx.NotifDir, n, "reaction")
+}
+
+// WriteUnpairedNotification tells the agent the WhatsApp daemon came up without a
+// device session and needs re-pairing. Passive (no interrupt field), so it batches
+// until the agent is idle. Called once per unpaired daemon boot.
+func WriteUnpairedNotification(notifDir, instance string) error {
+	n := authNotif{
+		Source:    "whatsapp",
+		Type:      "unpaired",
+		Instance:  instance,
+		Message:   "WhatsApp daemon started without a paired device session. Re-pairing is required: follow the whatsapp skill SETUP.md to scan a new QR code or use pair-phone.",
+		Timestamp: time.Now().Format(time.RFC3339),
+	}
+	return writeNotificationFile(notifDir, n, "unpaired")
 }


### PR DESCRIPTION
## What

After a backup restore, the `whatsapp serve` daemon can come up without a device session: the whatsmeow session/keys (in `~/.whatsapp/whatsapp.db`) are effectively gone while the message DBs survive, so `auth-status.json` reads `qr_ready` and every `whatsapp send` fails. The agent had no signal for this state and would fail silently until the user noticed.

This adds a startup check in `runServe` (`cli/cli.go`): when the daemon has no device session (`wac.client.Store.ID == nil`, the same check `Connect`/`EnsureConnected` already use), it writes one passive notification (source `whatsapp`, type `unpaired`) to the notifications dir telling the agent that re-pairing is required. The new `WriteUnpairedNotification` in `cli/notifications.go` mirrors the existing message/reaction notification helpers and omits the `interrupt` field, so the agent treats it as passive and batches it until idle. It fires once per unpaired daemon boot (not per failed send), since `runServe` runs once per daemon start.

## What this does and does NOT fix

This is `Addresses #571`, not `Fixes`, intentionally.

- It DOES make the unpaired-after-restore state visible and actionable: the agent is told to re-pair instead of silently failing sends.
- It does NOT fix the underlying loss of session keys across the backup/restore cycle.

Why not the root cause: backups stop the container with a 30s graceful timeout (`stop_container_with_timeout`, `backup.rs`) and run `docker export | restic backup --stdin`; restore is `restic dump | docker import` into a fresh container (`restic.rs`). The session DB is opened in SQLite WAL mode and `docker export` captures the on-disk `.db`/`-wal`/`-shm` files, so static analysis does not reveal a concrete file-preservation bug. The actual key loss depends on runtime WAL/checkpoint timing in whatsmeow's sqlstore at shutdown and on the restore path, which needs a live Docker backup/restore reproduction that could not be run in this environment. Rather than guess at a risky change to the storage/backup path, this PR ships the cheap, clearly-correct visibility improvement.

## Files touched

- `agent/skills/whatsapp/cli/notifications.go` — new `authNotif` struct + `WriteUnpairedNotification`.
- `agent/skills/whatsapp/cli/cli.go` — emit the notification once when the daemon boots with no device session.

## Verification

- `gofmt -l` and `gofmt -e` on both touched files: clean (format + parse OK).
- Full `go build`/`go vet` could not be run here: `go.mod` requires Go 1.25.0, only Go 1.24.13 is available and the network toolchain download is blocked; the CLI also links whisper.cpp statically via CGO whose static libs are not installed in this environment.
- `agent/skills/index.json` regenerated; no change (skill name/description unchanged), so it is not part of this PR.

Addresses #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)