### PR TITLE
fix(browser): enable SharedArrayBuffer for COEP-isolated web apps

### DIFF
--- a/agent/skills/browser/SKILL.md
+++ b/agent/skills/browser/SKILL.md
@@ -9,6 +9,10 @@ Raw Chrome DevTools Protocol. Accessibility-tree snapshots with numbered refs (`
 for the ergonomic path, and `click(x, y)` + screenshots for everything accessibility can't see.
 The helpers are Python, short, and agent-editable. When something is missing, write it.
 
+`SharedArrayBuffer` is enabled by default, so web apps that require cross-origin isolation
+(COEP `require-corp` / COOP `same-origin`) load and render normally. No stealth or Xvfb
+workarounds are needed for those apps.
+
 **Setup**: [SETUP.md](SETUP.md)
 
 ## Search first

--- a/agent/skills/browser/cli/src/vesta_browser/launcher.py
+++ b/agent/skills/browser/cli/src/vesta_browser/launcher.py
@@ -77,7 +77,7 @@ STEALTH_ARGS = [
     "--autoplay-policy=user-gesture-required",
     "--disable-offer-store-unmasked-wallet-cards",
     "--disable-component-extensions-with-background-pages",
-    "--enable-features=NetworkService,NetworkServiceInProcess,TrustTokens,TrustTokensAlwaysAllowIssuance",
+    "--enable-features=NetworkService,NetworkServiceInProcess,TrustTokens,TrustTokensAlwaysAllowIssuance,SharedArrayBuffer",
     "--blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4",
     "--disable-features=AudioServiceOutOfProcess,TranslateUI,BlinkGenPropertyTrees",
 ]
@@ -216,6 +216,7 @@ def launch(
         "--disable-background-networking",
         "--disable-component-update",
         "--disable-features=Translate,MediaRouter",
+        "--enable-features=SharedArrayBuffer",
         "--disable-blink-features=AutomationControlled",
         "--disable-session-crashed-bubble",
         "--hide-crash-restore-bubble",


### PR DESCRIPTION
## Problem

The browser skill launches Chromium, which blocks `SharedArrayBuffer` by default. Web apps that require cross-origin isolation (COEP `require-corp` / COOP `same-origin`) therefore only render their own "couldn't load" overlay instead of the actual app.

Fixes #577

## Change

- Add `--enable-features=SharedArrayBuffer` to the default Chromium launch flags in `launcher.py` so cross-origin-isolated apps render by default (always-on, matching the existing default-flag pattern; no new opt-in flag).
- Also append `SharedArrayBuffer` to the stealth `--enable-features` value, since stealth mode dedupes the default `--enable-features` entry by key prefix. This keeps it enabled under `--stealth` as well.
- Add a short note to `SKILL.md` that COEP / SharedArrayBuffer apps are supported, so the agent does not waste turns on stealth/Xvfb workarounds.

## Verification

- `uv run pytest agent/skills/browser/cli/tests/test_launcher.py` — pass (11 passed)
- `uv run ruff check` (from `agent/`) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)