### PR TITLE
fix(agent): stop notification watcher from silently wedging the agent

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -336,10 +336,24 @@ def _is_new_json(change: Change, path: str) -> bool:
     return change != Change.deleted and path.endswith(".json")
 
 
-async def _notification_watcher(notify: asyncio.Event, *, notifications_dir: pl.Path, stop: asyncio.Event) -> None:
-    """Watch the notifications directory for new .json files and signal the monitor loop."""
-    async for _ in awatch(notifications_dir, stop_event=stop, recursive=False, debounce=100, watch_filter=_is_new_json):
-        notify.set()
+async def _notification_watcher(notify: asyncio.Event, *, notifications_dir: pl.Path, shutdown: asyncio.Event) -> None:
+    """Watch the notifications directory for new .json files and signal the monitor loop.
+
+    watchfiles SETS the stop_event it is handed when its watch thread is torn down, so we never pass the shared
+    shutdown_event directly: any watcher exception would then flip shutdown_event and wedge the whole process
+    silently. We hand awatch a local event and bridge the shared shutdown_event into it instead."""
+    local_stop = asyncio.Event()
+
+    async def _bridge() -> None:
+        await shutdown.wait()
+        local_stop.set()
+
+    bridge_task = asyncio.create_task(_bridge())
+    try:
+        async for _ in awatch(notifications_dir, stop_event=local_stop, recursive=False, debounce=100, watch_filter=_is_new_json):
+            notify.set()
+    finally:
+        bridge_task.cancel()
 
 
 async def monitor_loop(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.State, config: vm.VestaConfig) -> None:
@@ -349,7 +363,7 @@ async def monitor_loop(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.Stat
     pending_passive: list[vm.Notification] = []
     notify = asyncio.Event()
 
-    watcher_task = asyncio.create_task(_notification_watcher(notify, notifications_dir=config.notifications_dir, stop=state.shutdown_event))
+    watcher_task = asyncio.create_task(_notification_watcher(notify, notifications_dir=config.notifications_dir, shutdown=state.shutdown_event))
 
     try:
         while state.shutdown_event and not state.shutdown_event.is_set():

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -76,7 +76,7 @@ def _make_signal_handler(state: vm.State, *, allow_force_exit: bool = False) -> 
 
 def handle_processor_done(task: asyncio.Task[None], *, state: vm.State, config: vm.VestaConfig) -> None:
     """Set restart_reason + graceful_shutdown on unexpected termination so the agent never wedges silently."""
-    if state.shutdown_event.is_set() or state.graceful_shutdown.is_set():
+    if state.graceful_shutdown.is_set():
         return
     if task.cancelled():
         logger.error("message_processor cancelled unexpectedly — restarting")


### PR DESCRIPTION
## Problem

When any exception unwound the notification watcher, the agent process wedged and was restarted with only a generic crash message and no traceback.

Root cause: watchfiles.awatch SETS the stop_event it is handed when its internal watch thread is torn down. `_notification_watcher` passed the shared `state.shutdown_event` straight through as that stop_event. So when the watcher unwound on any exception, watchfiles set `state.shutdown_event`, which made `message_processor` (which loops `while not state.shutdown_event.is_set()`) return cleanly. `handle_processor_done` then saw `shutdown_event` set and short-circuited without logging, so the process exited and was restarted with the real failure never recorded.

## Fix

1. `_notification_watcher` now creates a LOCAL `asyncio.Event` and hands THAT to awatch as the stop_event. A small bridge task awaits the shared `state.shutdown_event` and sets the local event, and the bridge task is cancelled in a finally. A watcher teardown can no longer touch the shared shutdown event.
2. Narrowed the `handle_processor_done` guard so it short-circuits only on the `graceful_shutdown` flag, not on `shutdown_event`. Any other unexpected exit now falls through to the existing diagnostic logging.

## Verification

Run from `agent/`:
- `uv run ruff check`: passed
- `uv run ty check`: passed
- `uv run pytest tests/test_notifications.py`: passed

Fixes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)
