### PR TITLE
feat(app): notify when an agent loses Claude credentials

### DIFF
--- a/apps/web/src/providers/NotificationProvider/index.tsx
+++ b/apps/web/src/providers/NotificationProvider/index.tsx
@@ -14,7 +14,7 @@ import { setAppBadge } from "@/lib/app-badge";
 import { setFaviconUnseen } from "@/lib/favicon";
 import { useWindowFocus } from "@/hooks/use-window-focus";
 import { router } from "@/router";
-import type { VestaEvent } from "@/lib/types";
+import type { AgentInfo, VestaEvent } from "@/lib/types";
 
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30000;
@@ -89,6 +89,7 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
   const permissionRef = useRef<boolean>(false);
   const tapsRef = useRef<Map<string, TapEntry>>(new Map());
   const chattingAgentRef = useRef<string | null>(null);
+  const prevStatusRef = useRef<Map<string, AgentInfo["status"]>>(new Map());
 
   useEffect(() => {
     const onVisible = () => {
@@ -252,6 +253,28 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
       taps.clear();
     };
   }, []);
+
+  useEffect(() => {
+    for (const agent of agents) {
+      const previous = prevStatusRef.current.get(agent.name);
+      prevStatusRef.current.set(agent.name, agent.status);
+      if (!previous || previous === agent.status) continue;
+      if (agent.status !== "not_authenticated") continue;
+      if (!permissionRef.current) continue;
+      try {
+        const n = new Notification(`${agent.name} needs to sign in again`, {
+          body: "Vesta lost its Claude credentials. Tap to re-authenticate.",
+          tag: `${agent.name}-not-authenticated`,
+        });
+        n.onclick = () => {
+          void focusAndNavigate(agent.name);
+          n.close();
+        };
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [agents]);
 
   const value = useMemo(
     () => ({ notifyAssistant, setChattingAgent }),


### PR DESCRIPTION
Fixes #481

## Problem

When an agent loses its Claude auth, it silently stops processing and the user gets no proactive heads-up.

## Approach

Reuse the machinery that already exists. vestad already computes a `not_authenticated` agent status from the credentials-file expiry check (`is_authenticated` in `vestad/src/docker.rs`), and the app already renders it as the orb's "not signed in" state plus the navbar **reauthenticate** button. The only thing missing was a proactive notification when that status flips.

So this PR is a single, additive web change: `NotificationProvider` watches each agent's status and, on a transition into `not_authenticated`, fires one OS notification (deduped by `tag`) that routes to the agent's chat on tap via the existing `focusAndNavigate`. No new event type, no agent-side detection, no vestad change.

## What this intentionally does NOT do

An earlier draft added agent-side runtime detection (string-matching SDK 401s and deleting the credentials file). That was dropped to keep the change minimal. Consequence: a token **revoked server-side before its `expiresAt`** won't surface as `not_authenticated` until it actually expires, so that narrow case is still covered only on expiry. Normal expiry and wiped/missing credentials are caught immediately by the existing check.

## Verification

- `apps/`: `npm -w @vesta/web run check` pass, `npm -w @vesta/web run lint` -> 0 errors (pre-existing warnings only, none in the changed file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)