### PR TITLE
ci+test: harden flaky CI jobs (retry backoff + poll for rename notification)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,9 +195,19 @@ jobs:
         working-directory: vestad
         run: cargo build
 
+      # These exercise a real Docker daemon, which occasionally hiccups on
+      # transient container/image operations. Retry once so a single flaky op
+      # doesn't fail the whole job (the build above is already cached).
       - name: Run integration tests (excludes live tests)
-        working-directory: vestad
-        run: cargo test -p vesta-tests --test server --test multi_user --test oauth --test migrations -- --test-threads=8
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 18
+          max_attempts: 2
+          retry_wait_seconds: 15
+          shell: bash
+          command: |
+            cd vestad
+            cargo test -p vesta-tests --test server --test multi_user --test oauth --test migrations -- --test-threads=8
 
   # ── Check vesta (clippy + tests, PRs only) ────────────────────────────
   check-vesta:
@@ -808,8 +818,10 @@ jobs:
           python3 scripts/android-sign-patch.py apps/mobile/src-tauri/gen/android/app/build.gradle.kts
           echo "signed=true" >> "$GITHUB_OUTPUT"
 
-      # Retry: Gradle bootstraps from GitHub on first run; GitHub release CDN
-      # occasionally 502s and there's no built-in retry on the Gradle wrapper.
+      # Retry: Gradle bootstraps from GitHub on first run, and resolves Kotlin/
+      # Android deps from Maven Central + plugins.gradle.org, which intermittently
+      # 403/502. retry_wait_seconds backs off so a transient block clears between
+      # attempts instead of all 3 retries hitting it back-to-back.
       - name: Build Android APK
         uses: nick-fields/retry@v4
         env:
@@ -817,6 +829,7 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
+          retry_wait_seconds: 30
           shell: bash
           command: |
             cd apps/mobile

--- a/vestad/tests-integration/tests/server/rename.rs
+++ b/vestad/tests-integration/tests/server/rename.rs
@@ -89,13 +89,25 @@ fn rename_drops_notification() {
     c.rename_agent(&old_name, &new_name).unwrap();
 
     let new_container = agent_container_name(&new_name);
-    let listing = exec_in_container(&new_container, "ls /root/agent/notifications/").unwrap();
-    let notif_file = listing
-        .lines()
-        .map(str::trim)
-        .find(|f| f.starts_with("rename-") && f.ends_with(".json"))
-        .unwrap_or_else(|| panic!("no rename-*.json notification found in:\n{listing}"))
-        .to_string();
+    // The notification is dropped after the renamed container comes back up, so
+    // the dir/file may not exist on first check on a slow CI runner. Poll until
+    // a rename-*.json appears rather than racing a single `ls`.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    let notif_file = loop {
+        if let Ok(listing) = exec_in_container(&new_container, "ls /root/agent/notifications/") {
+            if let Some(found) = listing
+                .lines()
+                .map(str::trim)
+                .find(|f| f.starts_with("rename-") && f.ends_with(".json"))
+            {
+                break found.to_string();
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no rename-*.json notification appeared in /root/agent/notifications/ within 60s");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    };
 
     let body = exec_in_container(
         &new_container,


### PR DESCRIPTION
## Problem

Several CI jobs failed PR runs on flaky, non-deterministic conditions (all confirmed flaky — passed on other runs / re-runs):

- **build-tauri-android**: `Received status code 403` resolving Kotlin/Android deps from Maven Central + plugins.gradle.org. The existing `max_attempts: 3` retry had **no wait between attempts**, so all 3 hit the same transient block within seconds.
- **test-integration / docker import**: `docker import failed: ...unexpected EOF` — transient daemon hiccup (also fixed in code in #614).
- **test-integration / rename_drops_notification**: `ls /root/agent/notifications/: No such file or directory` — the test execed a single `ls` immediately after rename, racing the async notification drop on slow runners.

## Fix

Workflow (`.github/workflows/ci.yml`):
- Android: add `retry_wait_seconds: 30` so a transient registry block clears between attempts.
- test-integration: wrap in a 2-attempt retry (`retry_wait_seconds: 15`) as a backstop for transient daemon ops.

Test (`tests-integration`):
- `rename_drops_notification` now polls for a `rename-*.json` to appear (60s timeout, 500ms interval) instead of racing a single `ls`, mirroring `layout.rs::wait_for_path`.

## Validation
- `ci.yml` parses as valid YAML; `vesta-tests` compiles.
- This PR's own run exercises all three changed paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)