### PR TITLE
fix(tunnel): force HTTP/2 protocol to prevent intermittent 1033 errors

### DIFF
--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -409,9 +409,13 @@ pub async fn start_tunnel(
     std::fs::write(&cf_config_path, &cf_config)
         .map_err(|e| format!("failed to write cloudflared config: {}", e))?;
 
+    // Force HTTP/2 over TCP instead of the QUIC/UDP default. Home and laptop NAT
+    // devices aggressively time out idle UDP flows, which silently drops the
+    // tunnel and yields error 1033 on the next request (e.g. the first file
+    // share after an idle period). TCP keeps the connection alive far longer.
     let child = tokio::process::Command::new(cloudflared)
         .args([
-            "tunnel", "--config", cf_config_path.to_str().unwrap(),
+            "tunnel", "--protocol", "http2", "--config", cf_config_path.to_str().unwrap(),
             "run", "--token", &tc.tunnel_token,
         ])
         .stdout(std::process::Stdio::null())


### PR DESCRIPTION
## Problem

Sharing a file via the Cloudflare tunnel sometimes returns **error 1033** ("Cloudflare is currently unable to resolve it"), then works again a few minutes later.

1033 means Cloudflare's edge can't find a healthy `cloudflared` connection at that instant. The DNS/URL is correct; the origin connection on the host just isn't up right then.

## Root cause

`cloudflared` defaults to **QUIC over UDP port 7844**. Home and laptop NAT/firewall devices aggressively time out idle UDP flows. After an idle period the flow gets reaped, the tunnel goes silently dead, and the **next** request (almost always the first file share after idle) hits the reconnect window and returns 1033. It recovers once `cloudflared` re-establishes.

This is a [documented QUIC sensitivity](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/troubleshoot-tunnels/common-errors/); Cloudflare's own recommendation for the symptom is to switch to `protocol: http2`.

## Fix

Pass `--protocol http2` when launching `cloudflared` in `start_tunnel`. HTTP/2 runs over a normal TCP connection that NAT keeps alive far longer than idle UDP, eliminating the idle-disconnect window.

**Tradeoff:** gives up QUIC's marginal throughput/latency edge. For a personal file-share tunnel on a laptop behind NAT, reliability through NAT clearly outweighs that.

## Scope

One-line change to the spawn args (plus an explanatory comment). No new state, no process supervision. A follow-up could add a supervisor to respawn `cloudflared` if the process actually exits (a rarer, separate case), but that's intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)