### PR TITLE
fix: native skill loading + first-wake setup snags

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -218,7 +218,12 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
         permission_mode="bypassPermissions",
         can_use_tool=_approve_all_tools,
         cwd=config.agent_dir,
-        setting_sources=["project"],
+        # "user" enables discovery of ~/.claude/skills, where the entrypoint symlinks every
+        # installed skill (agent/skills/* + agent/core/skills/*); without it the Skill tool
+        # never sees them. "project" stays for CLAUDE.md loading. skills="all" turns the
+        # Skill tool on for every discovered skill (the single documented switch).
+        setting_sources=["user", "project"],
+        skills="all",
         add_dirs=[str(config.agent_dir), os.path.expanduser("~")],
         thinking=config.thinking,
         max_buffer_size=10 * 1024 * 1024,

--- a/agent/core/prompts/first_start_setup.md
+++ b/agent/core/prompts/first_start_setup.md
@@ -4,7 +4,7 @@ Hello world. First wake. Do these in order, then stop:
 2. Run `~/agent/skills/upstream-sync/SETUP.md` end to end (git init, branch, checkpoint).
 3. In MEMORY.md, replace every `[agent_name]` with your name.
 4. Run `~/agent/core/skills/personality/SETUP.md` end to end (registers the voice in the restart skill, adopts it now).
-5. Set up tasks, app-chat, and dashboard from their SKILL.md / SETUP.md. Silently, no asking.
+5. Set up tasks, app-chat, and dashboard from their SKILL.md / SETUP.md. Silently, no asking. `tasks` and `dashboard` live under `~/agent/skills/`; `app-chat` is a core skill under `~/agent/core/skills/app-chat/` (not `~/agent/skills/`).
 6. **Call `mark_setup_done`.** This records completion and brings the WebSocket server online. Until you call it, no users can reach you.
 7. Use the app-chat skill to say hi.
 8. Get their name.

--- a/agent/skills/dashboard/SKILL.md
+++ b/agent/skills/dashboard/SKILL.md
@@ -127,7 +127,8 @@ import { StarIcon } from "lucide-react"
 Rebuild, re-register with vestad, restart the preview server, and notify the Vesta app:
 
 ```bash
-cd ~/agent/skills/dashboard/app && npx vite build
+# First build only: node_modules is not baked into the image, so install deps once.
+cd ~/agent/skills/dashboard/app && { [ -d node_modules ] || npm install; } && npx vite build
 PORT=$(curl -sk -X POST https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services \
   -H "X-Agent-Token: $AGENT_TOKEN" -H 'Content-Type: application/json' -d '{"name":"dashboard","public":true}' | python3 -c "import sys,json; print(json.load(sys.stdin)['port'])")
 screen -S dashboard -X quit 2>/dev/null
@@ -152,7 +153,7 @@ curl -sk -X POST https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services/dash
 *   **Dashboard not showing?** `screen -ls | grep dashboard`
 *   **Check registration:** `curl -sk https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services`
 *   **Restart server:** Run the rebuild/restart block above.
-*   **Build failed or blank after deploy?** Run `cd ~/agent/skills/dashboard/app && npx vite build` and fix reported errors; confirm `app/dist/` exists before starting preview.
+*   **Build failed or blank after deploy?** Run `cd ~/agent/skills/dashboard/app && { [ -d node_modules ] || npm install; } && npx vite build` and fix reported errors; confirm `app/dist/` exists before starting preview. `UNRESOLVED_IMPORT` / "Cannot find package" means deps were never installed, run `npm install` first.
 *   **Iframe stuck on an old build?** After a successful build and preview restart, run the `.../services/dashboard/invalidate` `curl` from the block above (the parent app keeps the iframe until invalidated).
 *   **Preview errors or 404?** Attach to logs with `screen -r dashboard`, then detach with Ctrl+A then `d`. If the session is wedged, `screen -S dashboard -X quit` and rerun the restart line from the block above.
 *   **No port from vestad?** Run the `POST .../services` `curl` alone and inspect the body; the `python3` one-liner errors on bad JSON. Verify `VESTAD_PORT`, `AGENT_NAME`, and `AGENT_TOKEN`.

--- a/agent/skills/upstream-sync/SETUP.md
+++ b/agent/skills/upstream-sync/SETUP.md
@@ -4,25 +4,13 @@ First-time only. The ongoing flow lives in [SKILL.md](SKILL.md) (`sync.sh`).
 
 ## 1. Init
 
-`$AGENT_NAME` and `$VESTA_UPSTREAM_REF` are in `/run/vestad-env`.
+`$AGENT_NAME` and `$VESTA_UPSTREAM_REF` are in `/run/vestad-env`. Run the init script (idempotent):
 
 ```bash
-cd ~
-git init
-git remote add origin https://github.com/elyxlz/vesta.git
-git sparse-checkout init --no-cone
-{
-  printf '%s\n' '/agent/' '!/agent/core/' '!/agent/pyproject.toml' '!/agent/uv.lock' '!/agent/skills/*/' '/.gitignore'
-  for d in agent/skills/*/; do
-    [ -d "$d" ] && printf '/%s\n' "$d"
-  done
-} > .git/info/sparse-checkout
-git config user.name "$AGENT_NAME"
-git config user.email "$AGENT_NAME@vesta"
-git checkout -b "$AGENT_NAME"
+~/agent/skills/upstream-sync/scripts/init.sh
 ```
 
-`agent/skills/*/` is opt-in: only skills already on disk (the defaults baked into the image) are re-included. New upstream skills land in `agent/skills/index.json` (the registry) but stay off disk until `skills-install` adds them.
+It inits the repo, sets the remote, pins the sparse-checkout cone, configures your identity, and creates your branch. Do not hand-write the cone: `init.sh` builds the patterns with `find` so they stay repo-relative regardless of cwd. `agent/skills/*/` is opt-in: only skills already on disk (the defaults baked into the image) are re-included. New upstream skills land in `agent/skills/index.json` (the registry) but stay off disk until `skills-install` adds them.
 
 ## 2. Local ignores (bulky files only)
 

--- a/agent/skills/upstream-sync/scripts/init.sh
+++ b/agent/skills/upstream-sync/scripts/init.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# First-time git setup for upstream sync: init the repo, pin the sparse-checkout cone to
+# the skills currently on disk, and create the agent's branch. Idempotent, safe to re-run.
+# The ongoing pull flow is sync.sh; this runs once at first wake.
+#
+# Why a script and not inline bash in SETUP.md: the cone is built from `find -printf` rather
+# than a shell glob, so the patterns are always repo-relative no matter the caller's cwd. An
+# earlier inline version expanded `~/agent/skills/*/` to absolute paths and wrote dead
+# `//root/agent/skills/...` patterns, which dropped every skill out of the cone and made the
+# first sync abort. Assumes $HOME is the repo root; $AGENT_NAME comes from /run/vestad-env.
+
+set -euo pipefail
+
+REPO="${HOME}"
+REMOTE="https://github.com/elyxlz/vesta.git"
+: "${AGENT_NAME:?AGENT_NAME is unset (source /run/vestad-env first)}"
+
+cd "$REPO"
+
+[ -d .git ] || git init -q
+git remote get-url origin >/dev/null 2>&1 || git remote add origin "$REMOTE"
+git sparse-checkout init --no-cone
+
+# agent/skills/*/ is opt-in: re-include only the skill dirs already on disk (the image
+# defaults). New upstream skills land in agent/skills/index.json (the registry) but stay off
+# disk until skills-install adds them.
+{
+  printf '%s\n' '/agent/' '!/agent/core/' '!/agent/pyproject.toml' '!/agent/uv.lock' '!/agent/skills/*/' '/.gitignore'
+  find agent/skills -mindepth 1 -maxdepth 1 -type d -printf '/agent/skills/%f/\n' 2>/dev/null | sort
+} > .git/info/sparse-checkout
+
+git config user.name "$AGENT_NAME"
+git config user.email "$AGENT_NAME@vesta"
+git rev-parse --verify "$AGENT_NAME" >/dev/null 2>&1 || git checkout -q -b "$AGENT_NAME"
+
+echo "init: repo ready on branch $AGENT_NAME; sparse cone pinned to:"
+find agent/skills -mindepth 1 -maxdepth 1 -type d -printf '  %f\n' 2>/dev/null | sort

--- a/agent/skills/upstream-sync/scripts/sync.sh
+++ b/agent/skills/upstream-sync/scripts/sync.sh
@@ -100,7 +100,10 @@ fi
 
 # --- Phase B: fresh sync ---
 say "Checkpoint local work"
-git add agent/ --ignore-errors
+# --ignore-errors still exits non-zero when a path is outside the sparse cone (e.g. a
+# half-initialised cone), which would abort under `set -e`. Tolerate it: the checkpoint is
+# best-effort and the diff/commit below only acts on what actually staged.
+git add agent/ --ignore-errors >/dev/null 2>&1 || true
 git diff --cached --name-only --diff-filter=D | grep -v '^agent/' | xargs -r git reset -q HEAD -- 2>/dev/null || true
 if ! git diff --cached --quiet; then
   git commit -q -m "chore: checkpoint before sync to $REF"


### PR DESCRIPTION
Fixes a set of first-wake problems surfaced by a real agent setup transcript, plus a confirmed latent bug where installed skills were never loaded natively.

## 1. Skills were never natively loaded (the big one)

The container entrypoint rebuilds `~/.claude/skills/` as per-skill symlinks on every boot (`vestad/src/docker.rs`), flattening both `agent/skills/*` and `agent/core/skills/*` in. But the agent SDK was started with `setting_sources=["project"]`. Confirmed against the bundled CLI's own discovery logic:

```js
let K = join(userConfigDir, "skills");                 // ~/.claude/skills
if (enabledSources.includes("userSettings")) push({dir: K, scope: "user"});
if (enabledSources.includes("projectSettings")) push({dir: join(cwd, ".claude", "skills"), scope: "project"});
```

`~/.claude/skills` is scanned **only when `"user"` is enabled**. With `["project"]` the symlinks were dead and the `Skill` tool never saw a single skill, so the agent fell back to `Read`-ing each `SKILL.md` by hand.

Fix: `setting_sources=["user", "project"]` + `skills="all"` (the documented switch; `allowed_tools` is a permission allowlist, not a hard filter, and `permission_mode=bypassPermissions` makes it moot). `"project"` stays for CLAUDE.md loading.

## 2. Sparse-checkout init was fragile inline bash

`upstream-sync/SETUP.md` §1 made the agent retype the cone-building bash. In the transcript it expanded `~/agent/skills/*/` to absolute paths and wrote dead `//root/agent/skills/...` patterns, dropping every skill out of the cone and aborting the first `sync.sh` under `set -e`. Moved to `scripts/init.sh`, which builds the cone with `find -printf` so patterns are always repo-relative. Also hardened `sync.sh`'s checkpoint `git add` with `|| true` (matching `narrow-sparse-checkout.sh`) so a half-initialised cone can't abort the sync.

## 3. Dashboard first build fails on missing deps

`node_modules` isn't baked into the image, so the first `vite build` died with `UNRESOLVED_IMPORT`. Guarded with `[ -d node_modules ] || npm install`.

## 4. app-chat path not stated at first wake

`first_start_setup` sent the agent to app-chat's `SKILL.md` without saying it lives under `~/agent/core/skills/`, costing a `find`/`ls` detour. Now named explicitly.

## Testing
- `init.sh` exercised end-to-end in an isolated HOME: correct repo-relative cone, branch/identity/remote set, idempotent re-run.
- `pytest tests/test_upstream_sync.py` (15 passed), `ruff` + `ty` clean, skills index still fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)