### PR TITLE
fix: first-start sync fixes, app-chat install path, doc/CI housekeeping (split from #602)

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -63,6 +63,7 @@ The user's important people are [agent_name]'s important people too. Keeps track
 
 ### The Machine
 - Docker container running on a host managed by **vestad** (a Rust daemon). Host networking, so `localhost` reaches the host
+- Runs as **root**: home is `/root`, working directory is `/root/agent`. Paths written `~/agent/...` (here and in skills) are `/root/agent/...`; the Read/Edit tools need the absolute form
 - vestad manages the container lifecycle (create, rebuild, backup), proxies traffic from the Vesta app/CLI to the agent, and handles service registration
 - `/run/vestad-env` has env vars injected by vestad (read it to see what's available)
 - On rebuild (`vestad update`): by default, `agent/core/`, `agent/pyproject.toml`, `agent/uv.lock` are replaced from the new image while everything else persists. This depends on the agent's configuration

--- a/agent/core/skills/app-chat/SKILL.md
+++ b/agent/core/skills/app-chat/SKILL.md
@@ -5,6 +5,12 @@ description: Reply to notifications with `source=app-chat` via `app-chat send`. 
 
 # App Chat - CLI: app-chat
 
+## Setup
+This is a core skill: its CLI lives under `~/agent/core/skills/app-chat/` (read-only mount), not `~/agent/skills/`.
+```bash
+uv tool install ~/agent/core/skills/app-chat/cli
+```
+
 **Background**: `screen -dmS app-chat app-chat serve --notifications-dir ~/agent/notifications`
 **Restart**: Add to the `## Services` section of `~/agent/skills/restart/SKILL.md`:
 ```

--- a/agent/skills/essay-iter/SKILL.md
+++ b/agent/skills/essay-iter/SKILL.md
@@ -81,14 +81,14 @@ for round = 1, 2, 3, ...:
 ## File layout
 
 ```
-/root/agent/skills/essay-iter/
+~/agent/skills/essay-iter/
   SKILL.md                  (this file)
   gptzero.py                (reverse-engineered AI detector)
   rubric_prompt.md          (sub-agent A prompt template)
   adversarial_prompt.md     (sub-agent B prompt template)
   citation_prompt.md        (sub-agent C prompt template)
 
-/root/.tasks/metadata/<task_id>_essay/
+~/.tasks/metadata/<task_id>_essay/
   approach.md               (locked plan from Phase 1)
   references/<n>.{md,pdf}   (in-distribution corpus)
   rubric.md                 (operative rubric)

--- a/agent/skills/restart/SKILL.md
+++ b/agent/skills/restart/SKILL.md
@@ -7,7 +7,7 @@ description: What to do after a container restart. Holds the per-skill service s
 
 Read `/run/vestad-env` so the values are in your context (Read tool, not bash).
 
-`screen -ls` to see what's already up. Start anything in `## Services` below that isn't. Then check User State in MEMORY.md and reach out on their preferred channel. Match the moment: new day → warm; mid-convo restart → brief; crash → mention it; middle of the night → wait.
+`screen -ls` to see what's already up. Start anything in the Services section below that isn't. Then check User State in MEMORY.md and reach out on their preferred channel. Match the moment: new day → warm; mid-convo restart → brief; crash → mention it; middle of the night → wait.
 
 ## Services
 

--- a/agent/skills/ssh/SKILL.md
+++ b/agent/skills/ssh/SKILL.md
@@ -35,7 +35,7 @@ This will:
 1. Install `openssh-server` if not already present
 2. Generate SSH host keys if missing
 3. Start sshd on a free port (dynamically allocated, no conflicts between containers)
-4. Add the provided public key to `/root/.ssh/authorized_keys`
+4. Add the provided public key to `~/.ssh/authorized_keys`
 5. Download `bore` if not already installed
 6. Open a public bore.pub tunnel and print the connection command
 
@@ -70,7 +70,7 @@ Shows whether sshd and bore are running, the current connection command, and whi
 ~/vesta/skills/ssh/scripts/stop.sh
 ```
 
-Stops both the bore tunnel and the sshd process. Authorized keys remain in `/root/.ssh/authorized_keys` for the next session.
+Stops both the bore tunnel and the sshd process. Authorized keys remain in `~/.ssh/authorized_keys` for the next session.
 
 ## Notes
 

--- a/agent/skills/upstream-sync/SETUP.md
+++ b/agent/skills/upstream-sync/SETUP.md
@@ -14,7 +14,7 @@ It inits the repo, sets the remote, pins the sparse-checkout cone, configures yo
 
 ## 2. Local ignores (bulky files only)
 
-`sync.sh` already ignores the vestad-managed mounts (`agent/core/`, `pyproject.toml`, `uv.lock`) from its `managed.gitignore` template, so you don't list those. Just add bulky machine-local globs:
+`sync.sh` already ignores the vestad-managed mounts (`agent/core/`, `pyproject.toml`, `uv.lock`) by writing them to `.git/info/exclude`, so you don't list those. Just add bulky machine-local globs:
 
 ```
 *.bin

--- a/agent/skills/upstream-sync/managed.gitignore
+++ b/agent/skills/upstream-sync/managed.gitignore
@@ -1,3 +1,0 @@
-/core/
-/pyproject.toml
-/uv.lock

--- a/agent/skills/upstream-sync/scripts/sync.sh
+++ b/agent/skills/upstream-sync/scripts/sync.sh
@@ -52,13 +52,17 @@ untrack_managed() {
   git ls-files -- $MANAGED | xargs -r git update-index --force-remove
 }
 
+# Ignore the vestad-managed mounts via the repo-LOCAL exclude file, never the committed
+# agent/.gitignore. Editing the tracked .gitignore would (a) conflict on every first sync
+# (no shared history + a one-sided edit on both branches) and (b) leak these machine-local
+# mount ignores upstream. .git/info/exclude is per-checkout and never committed. Idempotent.
 ensure_gitignored() {
-  local gi="agent/.gitignore" line
-  [ -f "$gi" ] || : > "$gi"
-  while IFS= read -r line; do
-    [ -n "$line" ] && { grep -qFx "$line" "$gi" || printf '%s\n' "$line" >> "$gi"; }
-  done < "$HERE/../managed.gitignore"
-  git add --sparse "$gi" 2>/dev/null || true
+  local exclude=".git/info/exclude" path
+  mkdir -p .git/info
+  [ -f "$exclude" ] || : > "$exclude"
+  for path in $MANAGED; do
+    grep -qFx "$path" "$exclude" 2>/dev/null || printf '%s\n' "$path" >> "$exclude"
+  done
 }
 
 summary() {
@@ -99,6 +103,13 @@ if git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1; then
 fi
 
 # --- Phase B: fresh sync ---
+# Stop tracking vestad-managed paths (they come from the read-only mount, never via git) and
+# gitignore them BEFORE the first `git add`. On a fresh `git init` agent they are present on
+# disk, untracked and outside the sparse cone; staging them before they are ignored makes
+# `git add` exit 1 and (under set -e) aborts the very first sync. Idempotent.
+untrack_managed
+ensure_gitignored
+
 say "Checkpoint local work"
 # --ignore-errors still exits non-zero when a path is outside the sparse cone (e.g. a
 # half-initialised cone), which would abort under `set -e`. Tolerate it: the checkpoint is
@@ -107,14 +118,6 @@ git add agent/ --ignore-errors >/dev/null 2>&1 || true
 git diff --cached --name-only --diff-filter=D | grep -v '^agent/' | xargs -r git reset -q HEAD -- 2>/dev/null || true
 if ! git diff --cached --quiet; then
   git commit -q -m "chore: checkpoint before sync to $REF"
-fi
-
-# Stop tracking vestad-managed paths (they come from the read-only mount, never via git)
-# and gitignore them so the mounted copies never show up. Idempotent.
-untrack_managed
-ensure_gitignored
-if ! git diff --cached --quiet; then
-  git commit -q -m "chore: stop tracking vestad-managed paths"
 fi
 
 say "Narrow sparse cone"

--- a/agent/tests/test_upstream_sync.py
+++ b/agent/tests/test_upstream_sync.py
@@ -157,6 +157,39 @@ def make_synthetic_agent(home, upstream, *, installed, self_authored=(), memory,
     _git(["remote", "add", "origin", str(upstream)], home)
 
 
+# A committed agent/.gitignore the image ships and upstream also tracks. sync must NOT edit it
+# (else the one-sided edit conflicts on every no-shared-history first sync); managed-mount
+# ignores go to the repo-local .git/info/exclude instead.
+AGENT_GITIGNORE = "# agent ignores\n*.log\nnode_modules/\n"
+
+
+def make_first_start_agent(home, upstream, *, installed, memory):
+    """Real first start: `git init`, NO baseline commit, and the vestad-managed mounts
+    (agent/core, pyproject.toml, uv.lock) baked onto disk untracked and outside the sparse
+    cone. The first `git add` the repo ever sees is sync.sh's own checkpoint, so if sync
+    stages before gitignoring those paths, `git add` exits 1 on the out-of-cone files."""
+    home.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-q", "-b", "agent"], home)
+    (home / "agent").mkdir(parents=True, exist_ok=True)
+    (home / "agent" / "MEMORY.md").write_text(memory)
+    (home / "agent" / ".gitignore").write_text(AGENT_GITIGNORE)
+    (home / ".gitignore").write_text("local-ignore\n")
+    sk = home / "agent" / "skills"
+    sk.mkdir(parents=True)
+    for name in installed:
+        (sk / name).mkdir(parents=True, exist_ok=True)
+        (sk / name / "SKILL.md").write_text(f"# LOCAL {name}\n")
+    (sk / "index.json").write_text(_registry(list(installed)))
+    (home / "agent" / "core").mkdir(parents=True, exist_ok=True)
+    (home / "agent" / "core" / "x.py").write_text("MOUNTED CORE\n")
+    (home / "agent" / "pyproject.toml").write_text("[project]\nname = 'agent'\n")
+    (home / "agent" / "uv.lock").write_text("lock\n")
+    _git(["sparse-checkout", "init", "--no-cone"], home)
+    _write_sparse(home, NARROW_HEADER + [f"/agent/skills/{n}/" for n in installed])
+    _git(["sparse-checkout", "reapply"], home)
+    _git(["remote", "add", "origin", str(upstream)], home)
+
+
 def place_skills_install(home):
     dst = home / "agent" / "skills" / "skills-registry" / "scripts" / "skills-install"
     dst.parent.mkdir(parents=True, exist_ok=True)
@@ -334,6 +367,33 @@ def test_sync_no_common_ancestor_surfaces_real_conflicts(tmp_path):
         _git(["add", "--", rel], home)
     r2 = _run(SYNC, home, extra_env=MAIN)
     assert r2.returncode == 0, r2.stderr
+
+
+def test_sync_first_start_with_managed_paths_on_disk(tmp_path):
+    """Regression: on a fresh `git init` agent the vestad-managed mounts (agent/core,
+    pyproject.toml, uv.lock) are on disk, untracked and outside the sparse cone. sync must
+    gitignore them BEFORE its first `git add`, or `git add agent/` exits 1 on the out-of-cone
+    files and (under set -e) the very first sync aborts. Owned files that differ from upstream
+    must still surface as ordinary conflicts (exit 2), not a crash.
+
+    sync must ignore the mounts via the repo-local .git/info/exclude, NOT by editing the
+    committed agent/.gitignore: a one-sided edit to a file upstream also tracks conflicts on
+    every no-shared-history first sync, so agent/.gitignore must merge cleanly."""
+    up = tmp_path / "up"
+    make_upstream(up, ["alpha"])
+    add_upstream_file(up, "agent/.gitignore", AGENT_GITIGNORE, "add agent gitignore")
+    home = tmp_path / "agent"
+    make_first_start_agent(home, up, installed=["alpha"], memory="# MY MEMORY\n")
+
+    r = _run(SYNC, home, extra_env=MAIN)
+    assert r.returncode == 2, r.stdout + r.stderr  # real conflicts, not an exit-1 crash
+    assert "outside of your sparse-checkout" not in (r.stdout + r.stderr)
+    assert "agent/.gitignore" not in r.stdout  # untouched file merges clean, no conflict
+    assert (home / "agent" / "core" / "x.py").read_text() == "MOUNTED CORE\n"  # mount untouched
+    assert "agent/core" not in _git(["ls-files"], home)  # never tracked
+    assert "agent/core" not in _git(["status", "--short"], home)  # ignored, no noise
+    assert (home / "agent" / ".gitignore").read_text() == AGENT_GITIGNORE  # committed file unchanged
+    assert "agent/core" in (home / ".git" / "info" / "exclude").read_text()  # ignored locally instead
 
 
 def test_sync_untracks_vestad_managed_core(tmp_path):


### PR DESCRIPTION
Non-OpenRouter changes split out of #602 so that PR stays focused on the provider work.

## What's here

**upstream-sync first-start fixes** (the substance):
- Ignore vestad-managed mounts (`agent/core`, `pyproject.toml`, `uv.lock`) **before** the checkpoint `git add` — on a fresh `git init` agent they're on disk, untracked, and outside the sparse cone, so staging them first made `git add` exit 1 and abort the very first sync under `set -e`.
- Write those ignores to the repo-local `.git/info/exclude` instead of the committed `agent/.gitignore` — editing the tracked file produced an add/add conflict on every no-shared-history first sync. Drops the now-unused `managed.gitignore` template.
- First-start regression test covering the exact production shape (init-based repo with managed mounts on disk) that no existing fixture hit.

**app-chat**: document the CLI install path (`~/agent/core/skills/app-chat/cli` — it's a core skill, not under `~/agent/skills/`), which the agent hunted for on first start.

**Housekeeping** (was already on the #602 branch, moved here):
- `/root/` → `~/` path normalization in essay-iter/restart/ssh skill docs, root-home note in MEMORY.md

Note: the TYPE_CHECKING CI ban stays in #602 — it depends on that PR's models.py refactor (master's `core/models.py` still uses `tp.TYPE_CHECKING`).

## Verification
- 181 agent tests pass, ruff + ty clean
- The new regression test fails against the old sync.sh (exit-1 crash) and passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)