### PR TITLE
fix(ci): make version-bump push skip cascade to Tauri/Windows build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,10 @@ jobs:
 
   # ── Version check ──────────────────────────────────────────────────────
   # Same skip as detect-changes; version-check has no `needs:` so the gate
-  # has to be explicit here. All build-* and check-* jobs `needs:` either
-  # detect-changes or version-check, so the skip cascades to them.
+  # has to be explicit here. Jobs with a plain `if:` skip automatically when
+  # their needs are skipped. Jobs using `!failure() && !cancelled()` opt out
+  # of that cascade, so they must also gate on
+  # `needs.detect-changes.result == 'success'` explicitly.
   version-check:
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'Bump version to ')
     runs-on: ubuntu-latest
@@ -451,7 +453,8 @@ jobs:
   build-windows:
     needs: [version-check, detect-changes]
     if: >-
-      !failure() && !cancelled() && (
+      !failure() && !cancelled() &&
+      needs.detect-changes.result == 'success' && (
       needs.detect-changes.outputs.cli == 'true' ||
       github.event_name != 'pull_request'
       )
@@ -502,7 +505,8 @@ jobs:
   build-tauri-macos:
     needs: [test-frontend, detect-changes]
     if: >-
-      !failure() && !cancelled() && (
+      !failure() && !cancelled() &&
+      needs.detect-changes.result == 'success' && (
       github.event_name != 'pull_request' ||
       needs.detect-changes.outputs.cli == 'true' ||
       needs.detect-changes.outputs.app == 'true'
@@ -576,7 +580,8 @@ jobs:
   build-tauri-linux:
     needs: [test-frontend, detect-changes, build-vestad]
     if: >-
-      !failure() && !cancelled() && (
+      !failure() && !cancelled() &&
+      needs.detect-changes.result == 'success' && (
       github.event_name != 'pull_request' ||
       needs.detect-changes.outputs.cli == 'true' ||
       needs.detect-changes.outputs.app == 'true'
@@ -664,7 +669,8 @@ jobs:
   build-tauri-windows:
     needs: [test-frontend, detect-changes]
     if: >-
-      !failure() && !cancelled() && (
+      !failure() && !cancelled() &&
+      needs.detect-changes.result == 'success' && (
       github.event_name != 'pull_request' ||
       needs.detect-changes.outputs.app == 'true'
       )
@@ -742,7 +748,8 @@ jobs:
   build-tauri-android:
     needs: [test-frontend, detect-changes]
     if: >-
-      !failure() && !cancelled() && (
+      !failure() && !cancelled() &&
+      needs.detect-changes.result == 'success' && (
       github.event_name != 'pull_request' ||
       needs.detect-changes.outputs.app == 'true'
       )
@@ -864,7 +871,8 @@ jobs:
   build-tauri-ios:
     needs: [test-frontend, detect-changes]
     if: >-
-      !failure() && !cancelled() && (
+      !failure() && !cancelled() &&
+      needs.detect-changes.result == 'success' && (
       github.event_name != 'pull_request' ||
       needs.detect-changes.outputs.app == 'true'
       )


### PR DESCRIPTION
## Problem

Every release since 0.1.150 shows a red ❌ on master: the push-event CI run for the "Bump version to X" commit fails with

```
Unable to download artifact(s): Artifact not found for name: vestad-x86_64-unknown-linux-gnu
```

#495 intended that run to be fully skipped: `detect-changes` and `version-check` skip themselves on bump commits, and the skip is supposed to cascade to every job that `needs:` them.

## Root cause

The cascade only applies to jobs with a plain `if:`. Six build jobs (`build-windows`, `build-tauri-{macos,linux,windows,android,ios}`) use `!failure() && !cancelled()`, which overrides the implicit `success()` check on `needs:`, so they run even when their dependencies were skipped. `build-tauri-linux` then tries to download the vestad artifact from the skipped `build-vestad` job and fails, which fails `merge-gate-ci`.

Evidence: bump push runs for 0.1.150 through 0.1.155 all failed identically; 0.1.149 (the last release before #495) passed. The actual release-event runs were always green, so published releases were never affected.

## Fix

Gate those six jobs on `needs.detect-changes.result == 'success'` in addition to the existing conditions:

- **Bump push**: detect-changes skipped → builds skip → whole run skips (intended behavior from #495)
- **Release event**: detect-changes runs → unchanged
- **PR / normal push**: detect-changes runs → unchanged (the `!failure() && !cancelled()` override still lets builds run when only `test-frontend` is path-skipped on PRs, which is why it exists)

Also updates the comment that documented the incorrect cascade assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)