### PR TITLE
ci: ban TYPE_CHECKING in agent/core

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -171,6 +171,14 @@ jobs:
         working-directory: agent
         run: uv run ruff check
 
+      - name: Ban TYPE_CHECKING
+        working-directory: agent
+        run: |
+          if grep -rn "TYPE_CHECKING" core/; then
+            echo "::error::TYPE_CHECKING is banned in agent/core — it papers over circular imports / bad file structure. Use direct imports and restructure the modules instead."
+            exit 1
+          fi
+
       - name: Format check
         working-directory: agent
         run: uv run ruff format --check

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -3,17 +3,15 @@ import collections
 import dataclasses as dc
 import datetime as dt
 import time
-import typing as tp
 
 import pydantic as pyd
 from claude_agent_sdk import ClaudeSDKClient
 
+from aiohttp.web import AppRunner
+
 from .config import VestaConfig
 from .events import EventBus
 from .state_store import PersistedState
-
-if tp.TYPE_CHECKING:
-    from aiohttp.web import AppRunner
 
 __all__ = ["State", "Notification", "VestaConfig", "PersistedState"]
 
@@ -49,7 +47,7 @@ class State:
     shutdown_count: int = 0
     persisted: PersistedState = dc.field(default_factory=PersistedState)
     # Set by `mark_setup_done` (or by run_vesta on a non-first-start boot). Acts as the readiness signal vestad polls.
-    ws_runner: "AppRunner | None" = None
+    ws_runner: AppRunner | None = None
     interrupt_event: asyncio.Event | None = None
     compacting: bool = False
     processor_busy: bool = False


### PR DESCRIPTION
Split out of #602 (and previously #624) into its own PR.

Adds a CI check banning `TYPE_CHECKING` in `agent/core` — it papers over circular imports / bad file structure; direct imports and module restructuring are the right fix.

Also fixes the one existing usage so the ban passes on this PR itself: `models.py` imported aiohttp's `AppRunner` under `TYPE_CHECKING` with a quoted annotation. Import it directly and unquote (same change #602 makes, so the two PRs merge cleanly in either order).

## Verification
- The ban check passes against this branch's `agent/core/`
- 180 agent tests pass, ruff + ty clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)