### PR TITLE
refactor(vestad): harden daemon reliability

### DIFF
--- a/vestad/src/agent_status.rs
+++ b/vestad/src/agent_status.rs
@@ -77,7 +77,7 @@ impl AgentStatusCache {
     /// Bump the monotonic revision for a service, signalling clients to refetch it.
     pub fn invalidate_service(&self, agent: &str, service: &str) {
         {
-            let mut revs = self.revs.lock().unwrap();
+            let mut revs = self.revs.lock().unwrap_or_else(|e| e.into_inner());
             *revs
                 .entry(agent.to_string())
                 .or_default()
@@ -90,7 +90,7 @@ impl AgentStatusCache {
 
     /// Current revision for each agent+service.
     pub fn service_revs(&self) -> HashMap<String, HashMap<String, u64>> {
-        self.revs.lock().unwrap().clone()
+        self.revs.lock().unwrap_or_else(|e| e.into_inner()).clone()
     }
 }
 

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -33,6 +33,8 @@ impl std::fmt::Display for DockerError {
     }
 }
 
+impl std::error::Error for DockerError {}
+
 impl From<bollard::errors::Error> for DockerError {
     fn from(e: bollard::errors::Error) -> Self {
         match &e {
@@ -1112,7 +1114,7 @@ pub async fn import_image_gzip(docker: &Docker, input: &std::path::Path) -> Resu
     let file = tokio::fs::File::open(input).await
         .map_err(|e| DockerError::Failed(format!("failed to open input file: {e}")))?;
     let byte_stream = tokio_util::codec::FramedRead::new(file, tokio_util::codec::BytesCodec::new())
-        .filter_map(|r| async { r.ok().map(|b| Ok::<Bytes, std::io::Error>(b.freeze())) });
+        .map(|r| r.map(|b| b.freeze()));
 
     let opts = ImportImageOptions { ..Default::default() };
     let mut stream = docker.import_image_stream(opts, byte_stream, None);
@@ -1413,7 +1415,7 @@ fn generate_state() -> String {
     base64url_encode(&state_bytes)
 }
 
-/// Start the OAuth PKCE flow. Returns (auth_url, session_id, code_verifier, state).
+/// Start the OAuth PKCE flow. Returns (auth_url, code_verifier, state).
 pub fn start_auth_flow() -> (String, String, String) {
     let (code_verifier, code_challenge) = generate_pkce();
     let state = generate_state();

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1779,6 +1779,9 @@ pub fn acquire_pid_lock(config_dir: &std::path::Path) -> Result<std::fs::File, S
         use std::io::Write;
         use std::os::unix::io::AsRawFd;
         let fd = file.as_raw_fd();
+        // SAFETY: fd comes from file.as_raw_fd() and file is kept alive past this call, so the
+        // descriptor is valid for the duration of flock. flock with these flags has no other
+        // preconditions.
         let ret = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
         if ret != 0 {
             return Err("vestad already running".into());
@@ -1915,7 +1918,10 @@ pub fn build_router(state: SharedState) -> Router {
 
 fn local_hour() -> u8 {
     let epoch = crate::time_utils::now_epoch_secs() as libc::time_t;
+    // SAFETY: libc::tm is a plain-integer C struct for which an all-zero bit pattern is valid.
     let mut tm: libc::tm = unsafe { std::mem::zeroed() };
+    // SAFETY: &epoch and &mut tm are valid, non-overlapping, properly aligned pointers for the
+    // duration of the call.
     unsafe { libc::localtime_r(&epoch, &mut tm) };
     tm.tm_hour as u8
 }


### PR DESCRIPTION
Focused quality pass on the vestad daemon. Surgical, additive changes across three files.

## Changes

- **Implement `std::error::Error` for `DockerError`** (docker.rs): the crate-wide public error type implemented Display + From<bollard::Error> but not the standard Error trait, so callers could not use it with `?` into `Box<dyn Error>` or compose with the standard error ecosystem. One-line additive impl. The default `source()` returning None is correct because every variant carries only a String.
- **Propagate read errors in `import_image_gzip`** (docker.rs): the FramedRead stream was mapped with `filter_map(|r| r.ok()...)`, silently discarding any `std::io::Error` while reading the backup tar.gz, so a truncated file ended the stream and Docker imported a partial image that looked successful. Now mapped with `.map(|r| r.map(|b| b.freeze()))` so the error reaches `import_image_stream` and surfaces as a `DockerError`.
- **Fix stale doc comment on `start_auth_flow`** (docker.rs): the comment claimed a 4-tuple with a nonexistent `session_id`. Corrected to the actual 3-element return `(auth_url, code_verifier, state)`.
- **Document the three unsafe blocks** (serve.rs): added SAFETY comments to the `flock` call, the `zeroed::<libc::tm>()`, and the `localtime_r` call, recording the invariants that make each sound (valid fd kept alive, all-zero bit pattern valid for the plain-integer C struct, valid non-overlapping aligned pointers).
- **Recover from a poisoned mutex** (agent_status.rs): `invalidate_service` and `service_revs` called `.lock().unwrap()`, so a panic while holding the lock would poison it and cascade every later call into a daemon-wide crash. Both now use `.lock().unwrap_or_else(|e| e.into_inner())`, matching the existing pattern in restic.rs. The guarded revision counters remain valid after a poisoning panic.

## Dropped

The proposed constant-time token comparison (auth.rs) was dropped. `ring::constant_time::verify_slices_are_equal` is deprecated in ring 0.17.14 with an explicit note that it makes no promises regarding side channels, and `-D warnings` rejects it. Adopting it cleanly would require either an `#[allow(deprecated)]` hack (which is exactly the kind of check loosening to avoid, and the comparator disclaims the property we want) or pulling in a new direct dependency (`subtle`), which exceeds the surgical scope of this pass. Left auth.rs unchanged.

## Verification

`./check.sh vestad` is green: clippy `-D warnings` clean and all 85 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)