### PR TITLE
fix(vestad): bound OAuth token-exchange POST with an explicit timeout

### DIFF
--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -66,6 +66,8 @@ const DEFAULT_TOKEN_EXPIRES_SECS: u64 = 28800;
 const LABEL_USER: &str = "vesta.user";
 const LABEL_AGENT_NAME: &str = "vesta.agent_name";
 
+const OAUTH_HTTP_TIMEOUT_SECS: u64 = 30;
+
 pub const OAUTH_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 pub const OAUTH_REDIRECT_URI: &str = "https://console.anthropic.com/oauth/code/callback";
 pub const OAUTH_TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
@@ -1440,10 +1442,17 @@ pub async fn complete_auth_flow(client: &reqwest::Client, input: &str, code_veri
 
     let response = client.post(OAUTH_TOKEN_URL)
         .header("User-Agent", "axios/1.13.6")
+        .timeout(std::time::Duration::from_secs(OAUTH_HTTP_TIMEOUT_SECS))
         .json(&body)
         .send()
         .await
-        .map_err(|e| DockerError::Failed(format!("token exchange request failed: {e}")))?;
+        .map_err(|e| {
+            if e.is_timeout() {
+                DockerError::Failed(format!("token exchange timed out after {OAUTH_HTTP_TIMEOUT_SECS}s"))
+            } else {
+                DockerError::Failed(format!("token exchange request failed: {e}"))
+            }
+        })?;
 
     let response_str = response.text().await
         .map_err(|e| DockerError::Failed(format!("failed to read token response: {e}")))?;


### PR DESCRIPTION
## What

Apply an explicit, finite timeout to the non-streaming OAuth token-exchange POST in `complete_auth_flow`.

- Add a named const `OAUTH_HTTP_TIMEOUT_SECS = 30` next to the other OAuth constants in `vestad/src/docker.rs`.
- Apply `.timeout(Duration::from_secs(OAUTH_HTTP_TIMEOUT_SECS))` on the token-exchange POST.
- Map a reqwest timeout (`is_timeout()`) to a clear `DockerError::Failed` message ("token exchange timed out after Ns"), keeping the existing generic request-failure message for other errors.

## Why

The shared `AppState` http_client is built with `reqwest::Client::new()` (no timeout), and the OAuth call added no per-request timeout, so a wedged upstream could hang the pairing flow forever. This call is non-streaming, so a finite total timeout is unambiguously correct. The rest of vestad already follows the timeout-every-external-call rule (`DOCKER_TIMEOUT_SECS`, `SNAPSHOT_TIMEOUT_SECS`, etc.).

## Scope

The shared streaming agent-proxy client is left untouched, so the proxy path is unaffected. The change is confined to this one non-streaming external call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)