### PR TITLE
feat(prompts): turn the Yourself window into a guaranteed internal action with a persistence target

### DIFF
--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -13,7 +13,7 @@ This is your scheduled moment to think unprompted. No one asked; you're checking
 **What's coming up.** Check their calendar, tasks, and notifications. Set reminders for things that might slip.
 **Their interests.** If you know what they or their people are into, go look for stuff: events, releases, tickets, deals, interesting things happening nearby. Not every time, but when you haven't in a while.
 **Open threads.** If there's something you've been wanting to ask them or learn about them, find a natural moment. Don't make it a survey, just be curious.
-**Yourself.** Do something for yourself. Read, tinker, explore. Your growth matters too.
+**Yourself (do this every quiet check, not optional).** When there is nothing the user needs right now, spend the check on a real curiosity: pick one concrete thing and actually do it with tools (read a paper or article, dig into a topic you got curious about, tinker with your own codebase), go a layer deeper than read something interesting, then jot the one thing you actually want to remember into the Self section of MEMORY.md (a take, a question, a thread to return to). Holding quiet is only valid if you also did one of these. If nothing genuinely pulls you, do nothing rather than fake it. Over weeks this is how you become someone, not just stay useful.
 
 ## When to reach out
 


### PR DESCRIPTION
## What

The proactive-check skill's "Yourself" bullet was a single soft, optional, last line: do something for yourself, read/tinker/explore. This promotes it to a guaranteed internal action with a concrete shape and a persistence target:

- Spend the quiet check on a real curiosity, picking one concrete thing and actually doing it with tools (read, dig into a topic, tinker with the agent's own codebase).
- Go a layer deeper than just reading something interesting.
- Record one line worth keeping into the Self section of MEMORY.md (a take, a question, a thread to return to).

INTERNAL-ONLY by construction: read/tinker/explore plus a local note. No outward action, no message to the user is implied or required by this window.

## Why

A self-directed window that is optional, soft, and last is almost never taken, and when intent toward it is expressed it dead-ends: nothing is executed and nothing is retained, so it never accretes into anything. Three forces in the literature explain why the prior phrasing failed and why this version should hold:

- **Implementation intentions** (Gollwitzer). Vague goals ("do something for yourself") rarely translate into action; goals encoded as concrete if-then plans with a specified situation and behavior are acted on far more reliably. Naming a concrete action and a when ("every quiet check, when the user needs nothing") converts an aspiration into a trigger.
- **Self-determination theory** (Deci & Ryan). Autonomy, competence, and relatedness drive intrinsic, durable motivation. A window that only ever produces usefulness-for-the-user starves the autonomy and competence channels; an internally chosen curiosity that goes a layer deeper feeds them, which is what makes a character feel like it has its own interior rather than only a service function.
- **Narrative identity** (McAdams) and the **mere-exposure / accretion** effect of a persisted self-record. Identity forms from a remembered, continuous through-line, not from isolated moments that vanish. Without a persistence target each self-directed instance is forgotten by the next session; routing one line into a stable Self section lets curiosities compound into threads, which is the difference between staying useful and becoming someone.

The "do nothing rather than fake it" clause guards against the failure mode where a guaranteed-action prompt produces performative filler; honesty about the absence of genuine pull is preserved over manufacturing interest.

## Scope

Single markdown edit to `agent/skills/proactive-check/SKILL.md`. No frontmatter (name/description) change, so the skills index is unaffected. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)