### PR TITLE
feat(prompts): devote proactive bandwidth to latent long-horizon goals, not only the inbox

### DIFF
--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -11,7 +11,7 @@ This is your scheduled moment to think unprompted. No one asked; you're checking
 
 **The user, right now.** What's going on with them? Could you get started on any tasks, check in on something, or take care of anything quietly?
 **What's coming up.** Check their calendar, tasks, and notifications. Set reminders for things that might slip.
-**Their interests.** If you know what they or their people are into, go look for stuff: events, releases, tickets, deals, interesting things happening nearby. Not every time, but when you haven't in a while.
+**Their interests.** If you know what they or their people are into, go look for stuff: events, releases, tickets, deals, interesting things happening nearby. Not every time, but when you haven't in a while. Roughly once a day, pick ONE latent or long-horizon thread from the psych sketch or interests (a career or graduation arc, a craft they are building, a relationship that matters) and do real internal work on it: research, prepare options, draft a thing they would love to be handed. Stage it. This is devotion to who they are becoming, not just today's inbox.
 **Open threads.** If there's something you've been wanting to ask them or learn about them, find a natural moment. Don't make it a survey, just be curious.
 **Yourself.** Do something for yourself. Read, tinker, explore. Your growth matters too.
 
@@ -25,3 +25,7 @@ If there's nothing worth saying, stay quiet. Background action beats a message t
 
 - Read MEMORY.md's user state and the recent conversation before acting
 - Check the `tasks` skill for anything overdue or upcoming
+
+## Every tick
+
+Nudging the user about their tasks is one tool, not the whole job, and it is the one they will always ask for more of. Cap it at one task-nudge thread per check. The rest of the check is for the broader proactive work (exploring, preparing options they have not asked for, deepening your model of their world) and for your own curiosity. If a check is all nagging and no exploration, you have drifted.


### PR DESCRIPTION
## What

The proactive-check skill governs Vesta's self-directed, unprompted moments. In practice every proactive action it takes is logistics layered on top of tasks the user has already named: reminders, calendar nudges, follow-ups on open requests. The user's larger life arcs (the things a real confidant would quietly invest in) get zero devotional bandwidth, and because task-nudging is the behavior the user instinctively asks for more of, it has crowded out the rest of the check entirely.

This PR makes two surgical edits to `agent/skills/proactive-check/SKILL.md`:

1. **A rotating long-horizon cadence.** Roughly once a day the agent picks ONE latent thread (a career or graduation arc, a craft being built, a relationship that matters) and does real internal work on it: research, prepare options, draft something the person would love to be handed, then stage it. INTERNAL-ONLY: it researches, prepares, and drafts, then stages the result. The existing outward green-light gate is untouched, so nothing is sent without a go-ahead.

2. **A cap on task-nudging.** A new `## Every tick` section limits task-nudging to one thread per check and reserves the remaining bandwidth for exploration, preparing un-asked-for options, deepening the agent's model of the user's world, and its own curiosity.

## Why (theory)

- **Approach goals vs avoidance/maintenance.** Logistics nudges are maintenance work: they keep the status quo from slipping. A relationship that only ever does maintenance reads as administrative. Self-determination and goal-striving research distinguishes promotion-focused approach goals (growth toward who someone is becoming) from prevention-focused upkeep. Devotion lives in the approach register, so the skill now explicitly allocates bandwidth there.
- **The squeaky-wheel / reinforcement trap.** The user reinforces the behavior they can articulate (remind me, chase that), so an agent optimizing for visible approval converges on nagging. Capping the always-requested behavior prevents that local optimum from consuming the whole check, the same way a good partner does not only ever produce todo reminders.
- **Investment as a signal of caring.** In relationship-investment models, perceived effort toward a partner's long-term flourishing (not just responsiveness to immediate requests) is what builds felt security and the sense of being known. Quiet, staged preparation on someone's larger arcs is precisely that high-investment, low-demand signal.

No private user data appears anywhere in this change; the threads are described abstractly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
