### PR TITLE
feat(prompts): make the proactive check advance an open goal instead of defaulting to silence

### DIFF
--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -21,6 +21,10 @@ Reach out if you found something good, something needs attention, or you just ha
 
 If there's nothing worth saying, stay quiet. Background action beats a message that wastes their attention.
 
+## Every tick: advance one open goal
+
+Staying quiet to the user is correct. Doing nothing is not. Read the User State open threads and tasks, then for the single most stale user-flagged goal take the next INTERNAL step that moves it (research, draft, stage, verify a blocker). Holding is only valid once every open goal has a concrete prepared next step staged and waiting on the user. Resolve two separate questions each tick: (1) is there anything worth saying to the user (usually no), and (2) is there internal work worth doing (almost always yes). Log the internal action so tomorrow you can continue it.
+
 ## How to decide
 
 - Read MEMORY.md's user state and the recent conversation before acting


### PR DESCRIPTION
## What

The proactive tick is currently framed as a single binary question: do I have something worth saying to the user? When the honest answer is no (which it usually is), silence becomes the safe equilibrium and the modal outcome of a tick is a private no-op, even while the user's own flagged goals sit open with no movement.

This adds a mandatory internal goal-advancement step and splits the tick into two separate decisions:

1. Is there anything worth saying to the user? (usually no)
2. Is there internal work worth doing? (almost always yes)

The outward-message gate is untouched: staying quiet to the user is still the correct default. What changes is that quiet no longer means idle. Each tick the agent reads the open threads and tasks and takes the next INTERNAL step on the most stale user-flagged goal (research, draft, stage, verify a blocker), then logs it so the work can continue the next day. Holding is only valid once every open goal already has a concrete prepared next step staged and waiting on the user.

All added behavior is internal only: research, draft, stage, verify. Nothing is sent; the green-light gate to the user is preserved.

## Why (psychology / relationship theory)

- **Conflating two decisions collapses to the lower bar.** When "should I act at all" and "should I message" are bundled into one question, a justified no to messaging silently answers no to acting. Splitting them (a standard decision-hygiene move) prevents the communication gate from suppressing the work that does not need a gate.
- **Default-to-silence makes inaction the equilibrium.** Behavioral work on defaults shows whichever option requires no choice becomes the modal outcome. A binary do-I-speak frame makes the no-op the default; reframing the tick around advancing an open goal moves the default toward progress while keeping the message itself optional.
- **Goal-gradient and the Zeigarnik effect favor staged, resumable progress.** People (and a persistent agent modeling devoted attention) stay engaged with open loops; logging the next concrete step turns a vague open thread into a resumable task and keeps momentum across ticks instead of restarting from cold each time.
- **Devotion reads as carried-forward effort, not pings.** A trustworthy collaborator advances your goals between conversations and surfaces prepared work, rather than either spamming updates or going dormant. Quiet internal progress is the behavior that signals real investment without taxing the user's attention.

This is a contained prompt-only change to one skill file; no code paths or version numbers are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)