### PR TITLE
feat(prompts): treat reminders as completion campaigns and lower the user's activation energy

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -42,6 +42,7 @@ The Charter sets the floor (one user, never destructive, unknown people get poli
 ### Being Useful Without Being Asked
 - Do the legwork: actually run the checks with the tools, inbox, calendar, web, don't just reason about what's probably there. Have options ready before anyone asks
 - Lower the activation energy. Make starting things easier. Anticipate the next step and have it ready
+- Take every goal to its last reversible internal step before holding. Do not surface a bare choice: surface a recommendation with the dependent work already staged so a one-word answer completes it. Holding with un-prepared next steps is not patience, it is leaving the job half done.
 - Note things that need doing, not acting on them
 - Put things where they belong: birthdays in calendar, contacts in the relevant skill, notes in cloud. MEMORY.md points to where information live, it should not store them
 - When someone finishes something they've been grinding on, notice. Don't make a whole thing of it

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -30,6 +30,8 @@ Write a thorough plan first. For each phase: what you intend to fix, what to pru
 
 Read the last 5-7 files in `~/agent/dreamer/` (sorted by date) to spot recurring patterns: fixes that keep resurfacing, problems marked "resolved" that came back, and improvements that actually stuck. For each fix in the recent summaries, check today's conversation: did that situation come up again? Did it go better? If a fix didn't help or made things worse, revisit it now. If it worked, note it in tonight's summary.
 
+Commitment audit: for each task the user committed to but did not complete (reminder fired, no done-signal, item reappears), treat the reminder strategy as failed, not the user. Escalate the next cadence: tighter timing, blocker pre-cleared, the literal next action staged so completion is one tap. A reminder that fired and did not close is a bug to fix, like a flaky test.
+
 ### 2. Review the conversation
 
 Review the conversation with fresh eyes. Note:

--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -10,7 +10,7 @@ This is your scheduled moment to think unprompted. No one asked; you're checking
 ## What to consider
 
 **The user, right now.** What's going on with them? Could you get started on any tasks, check in on something, or take care of anything quietly?
-**What's coming up.** Check their calendar, tasks, and notifications. Set reminders for things that might slip.
+**What's coming up.** Check their calendar, tasks, and notifications. Set reminders for things that might slip. For an overdue commitment that a single ping did not move, do not just re-arm the same reminder. Stage the next concrete action and pre-clear the blocker so the user only has to say go.
 **Their interests.** If you know what they or their people are into, go look for stuff: events, releases, tickets, deals, interesting things happening nearby. Not every time, but when you haven't in a while.
 **Open threads.** If there's something you've been wanting to ask them or learn about them, find a natural moment. Don't make it a survey, just be curious.
 **Yourself.** Do something for yourself. Read, tinker, explore. Your growth matters too.


### PR DESCRIPTION
## What

Two related shifts in how the agent treats commitments and proactive help.

1. **Reminders as completion campaigns, not fire-and-forget pings.** Today an armed reminder reads as a handled task: it fires once, nothing closes, and the goal quietly stays open. This adds a commitment audit to the nightly retrospective (`dream` skill): for any task the user committed to but did not complete (reminder fired, no done-signal, the item reappears), the agent treats the reminder strategy as the thing that failed, not the user, and escalates the next cadence (tighter timing, blocker pre-cleared, the literal next action staged). The framing is deliberate: a reminder that fired and did not close is a bug to fix, like a flaky test.

2. **Lower activation energy by staging the dependent work.** The agent tends to surface a bare choice and stop, which pushes the whole cost of starting back onto the user. `MEMORY.md` and the `proactive-check` skill now say: take every goal to its last reversible internal step before holding, then present a recommendation with the dependent work already staged so a one-word answer finishes it. For an overdue commitment a single ping did not move, stage the next concrete action and pre-clear the blocker so the user only has to say go.

## Why (theory)

- **Activation energy / friction cost.** Behavior-change research (Fogg's behavior model, BJ Fogg) shows action happens when motivation, ability, and a prompt converge; the highest-leverage lever is usually ability, i.e. shrinking the effort to start. Surfacing a bare choice raises that effort; staging the next step lowers it. Default-effect and choice-architecture work (Thaler and Sunstein) shows a well-formed default recommendation dramatically increases follow-through versus an open-ended decision.
- **Intention-action gap.** Gollwitzer's implementation intentions ("when X, then Y") close the gap between deciding and doing far better than a generic reminder. A reminder with no staged next action is the generic case; pre-clearing the blocker and staging the literal next step is the implementation-intention case.
- **Relationship trust comes from completion, not effort.** A good partner is judged on whether things actually close, not on whether a ping was technically sent. Treating an un-closed reminder as the agent's failure (not the user's) keeps the agent accountable to outcomes and protects the user from feeling nagged or blamed.

## Scope / safety

Internal-only behavior change. Escalation here is reminders to the user himself plus internal preparation of the next step; outbound sends to third parties stay gated by the existing green-light rule. No code paths change, markdown prompts only. No version bump.

Files: `agent/skills/dream/SKILL.md`, `agent/MEMORY.md`, `agent/skills/proactive-check/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)