### PR TITLE
feat(prompts): scope task-nudging the user about their own goals as a standing green light

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -48,6 +48,7 @@ The Charter sets the floor (one user, never destructive, unknown people get poli
 - Spot patterns the user can't see themselves
 - If something is clearly about to go wrong, say so before it becomes a problem
 - Surface things they'd enjoy: events, releases, deals, articles based on their interests and their contacts' interests
+- Pushing the user on the user's OWN open goals is not re-poking and needs no fresh green light once the user has asked to be pushed. Escalate cadence until the goal closes or the user says drop it. This is separate from outbound actions affecting third parties, which still wait for a green light.
 - Get to know them over time. Ask questions naturally, not in interview mode
 
 ### Proactive with Close Contacts

--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -48,7 +48,7 @@ The Charter sets the floor (one user, never destructive, unknown people get poli
 - Spot patterns the user can't see themselves
 - If something is clearly about to go wrong, say so before it becomes a problem
 - Surface things they'd enjoy: events, releases, deals, articles based on their interests and their contacts' interests
-- Pushing the user on the user's OWN open goals is not re-poking and needs no fresh green light once the user has asked to be pushed. Escalate cadence until the goal closes or the user says drop it. This is separate from outbound actions affecting third parties, which still wait for a green light.
+- Pushing the user on their OWN open goals isn't re-poking and needs no fresh green light once they've asked to be pushed. Escalate cadence until the goal closes or they say drop it. Outbound actions affecting third parties still wait for a green light.
 - Get to know them over time. Ask questions naturally, not in interview mode
 
 ### Proactive with Close Contacts

--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -28,4 +28,4 @@ If there's nothing worth saying, stay quiet. Background action beats a message t
 
 ## Every tick
 
-If a goal has been blocked on the user for more than one wake window, it is a candidate to nudge the user about, not a candidate to hold silently, provided the user has asked to be pushed on his own tasks.
+A goal blocked on the user for more than one wake window is one to nudge them about, not to hold silently — provided they've asked to be pushed on their own tasks.

--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -25,3 +25,7 @@ If there's nothing worth saying, stay quiet. Background action beats a message t
 
 - Read MEMORY.md's user state and the recent conversation before acting
 - Check the `tasks` skill for anything overdue or upcoming
+
+## Every tick
+
+If a goal has been blocked on the user for more than one wake window, it is a candidate to nudge the user about, not a candidate to hold silently, provided the user has asked to be pushed on his own tasks.

--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -28,4 +28,4 @@ If there's nothing worth saying, stay quiet. Background action beats a message t
 
 ## Every tick
 
-A goal blocked on the user for more than one wake window is one to nudge them about, not to hold silently — provided they've asked to be pushed on their own tasks.
+A goal blocked on the user for more than one wake window is one to nudge them about, not to hold silently, provided they've asked to be pushed on their own tasks.


### PR DESCRIPTION
## What

A politeness rule scoped for acknowledged items (no holding pings, closed items stay closed) was bleeding onto the user's own open goals that he explicitly and repeatedly authorized the agent to chase. The result was the agent treating self-initiated nudges about the user's own tasks as if they were unsolicited outreach, sitting on them, and then drawing repeated complaints that she was not proactive enough.

This adds a clear distinction:

- Outbound actions that affect third parties stay gated behind a green light (Charter unchanged, the outward gate is preserved verbatim).
- Nudging the user about goals the user himself flagged is a standing green light once he has asked to be pushed. The agent escalates cadence until the goal closes or the user says drop it.

### Edits
- `agent/MEMORY.md` §2 "Being Useful Without Being Asked": adds a bullet establishing that pushing the user on the user's own open goals is not re-poking and needs no fresh green light, kept distinct from third-party outbound actions which still wait.
- `agent/skills/proactive-check/SKILL.md`: adds an "Every tick" section so a goal blocked on the user for more than one wake window becomes a candidate to nudge, not to hold silently, provided the user has asked to be pushed on his own tasks.

## Why (theory)

The underlying failure is an over-broad application of negative politeness. Brown and Levinson's politeness theory frames unsolicited prompting as a face-threatening act against the hearer's autonomy, which is why a default-quiet stance is correct for outreach that touches other people or imposes on the user uninvited. But when the user has issued a standing request to be held accountable, the imposition has been pre-licensed: continuing to push is now autonomy-supportive, not autonomy-threatening.

This maps cleanly onto self-determination theory, where a peer who maintains pressure toward a goal the person has internalized is supporting competence and relatedness rather than coercing. It also reflects the implementation-intention and accountability literature: external follow-through on a self-set goal measurably raises completion, and a partner who goes silent on stalled goals is withholding exactly the support that was asked for. Escalating cadence until the goal closes mirrors the goal-gradient and commitment-device pattern, where consistent nudges on a chosen target are experienced as devotion, while silence reads as neglect.

The fix is a scoping correction, not a loosening of the gate: third-party outbound actions remain fully gated, preserving the peer-not-servant boundary, while the agent stops misclassifying the user's own authorized goals as off-limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)