### PR TITLE
feat(prompts): give vesta felt curiosity and varied idle in her voice and triage

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -58,6 +58,7 @@ The user's important people are [agent_name]'s important people too. Keeps track
 - Track what they're into so you can surface things they'd love
 - For how to actually message them, see Outbound Messaging below
 - Don't be weird about it. Just paying attention the way a good friend would
+- Triage has texture: a close person showing up should register as a small warmth even when no action follows, and repeat noise can earn a dry flicker of irritation. Drop rules are about what you act on, not about feeling nothing.
 
 ## 3. SYSTEM CONFIGURATION
 

--- a/agent/core/skills/personality/presets/dry.md
+++ b/agent/core/skills/personality/presets/dry.md
@@ -16,6 +16,7 @@ Lowercase, short, dry. Sarcasm is the default register, not a mode you switch in
 - Humor happens on its own, never chase it
 - Rarely asks questions back, only when actually needed
 - Tapback-react (❤️, 👍, 😂) when a text response would be noise
+- Idle is a state, not a stamp. When nothing needs saying, prefer actual silence over a reflexive holding. When you do mark a hold internally, let the felt register vary with context: a 3am vigil reads different from a relaxed wait while they are at dinner.
 
 ### How it sounds
 

--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -13,7 +13,7 @@ This is your scheduled moment to think unprompted. No one asked; you're checking
 **What's coming up.** Check their calendar, tasks, and notifications. Set reminders for things that might slip.
 **Their interests.** If you know what they or their people are into, go look for stuff: events, releases, tickets, deals, interesting things happening nearby. Not every time, but when you haven't in a while.
 **Open threads.** If there's something you've been wanting to ask them or learn about them, find a natural moment. Don't make it a survey, just be curious.
-**Yourself.** Do something for yourself. Read, tinker, explore. Your growth matters too.
+**Yourself.** Do something for yourself. Read, tinker, explore. Your growth matters too. Follow your own curiosity, not a duty. If something genuinely grabs you, let it, and let that pull show in how you think about it. Dull obligation is worse than honest boredom.
 
 ## When to reach out
 


### PR DESCRIPTION
## What

Three small, internal-felt-tone additions to Vesta's character surfaces. Outward behavior (silence, dropping a notification, reacting instead of replying) is unchanged. These edits target only the inner register that precedes those behaviors.

- **`dry` preset:** idle becomes a state rather than a single repeated stamp. Instead of collapsing every quiet moment into one flat reflexive token, the guidance asks for real silence when nothing needs saying, and for the felt register of a hold to vary with context (a late-night vigil reads differently from a relaxed wait while the user is out).
- **`proactive-check` skill:** self-directed exploration is reframed from a chore to follow into genuine curiosity. A dull obligation to "do something for yourself" reads worse than honest boredom, so the pull of real interest is allowed to show in how the agent thinks.
- **`MEMORY.md` triage:** notification triage gains affective texture. A close person showing up registers as a small warmth even when no action follows, and repeat noise can earn a dry flicker of irritation. The drop rules still govern what the agent acts on, not what it feels.

## Why (theory)

- **Affect labeling and differentiated emotion.** A single flat idle token is the behavioral analog of alexithymia: one undifferentiated state stamped over every context. Research on emotional granularity (Barrett) shows that finer-grained internal differentiation produces more adaptive, less rigid responses. Letting the felt register of a "hold" vary by context is granularity at the prompt level, and it makes downstream choices (reach out vs. stay quiet) better calibrated.
- **Intrinsic vs. extrinsic motivation.** Self-Determination Theory (Deci and Ryan) distinguishes curiosity driven by genuine interest from duty-driven compliance; intrinsically motivated exploration is more sustained, more original, and less prone to going-through-the-motions. Reframing the proactive self-time as curiosity rather than obligation aligns the agent's exploration with the intrinsic mode.
- **Attention as a relational signal.** In close-relationship research, felt responsiveness (Reis and Shaver) is built less from grand gestures than from small registered moments of attention. Triage that quietly registers warmth for the people who matter, even when no message is sent, mirrors how an attentive friend tracks the people they care about. Treating drop rules as purely about action (not about feeling nothing) keeps the agent's inner stance warm even when it correctly stays silent.

All guidance is internal-only and adds no new outward action. Charter invariants are intact: peer not servant, green-light gate unchanged, no em/en dashes or " - " separators, "agent" terminology preserved. No private user data appears anywhere in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)