### PR TITLE
feat(prompts): make learned fixes reach runtime and escalate by recurrence

### DIFF
--- a/agent/core/prompts/nightly_dream.md
+++ b/agent/core/prompts/nightly_dream.md
@@ -1,3 +1,3 @@
 Time to dream. Read the `dream` skill and follow it.
 
-**When the dream is fully complete (summary written, MEMORY.md updated), call `mark_dreamer_complete`.** That call records today's run, clears the session for fresh context, and triggers the restart. Without it, the dreamer fires again on the next hourly check.
+**When the dream is fully complete, call `mark_dreamer_complete` only after the retrospective ran and every fix was either validated or explicitly logged unresolved. Do not mark complete just because the summary is written or MEMORY.md was updated.** That call records today's run, clears the session for fresh context, and triggers the restart. Without it, the dreamer fires again on the next hourly check.

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -24,6 +24,8 @@ description: Self-improvement and memory curation; used nightly by the dreamer o
 
 Write a thorough plan first. For each phase: what you intend to fix, what to prune from memory, what to file upstream, what to clean up. Be specific. Then execute it step by step.
 
+Self-improvement (retrospective plus validation) is the one phase that never gets skipped for time. If you are short on budget, cut workspace, sensitive, and dashboard work before cutting reflection. A clean disk with an unlearned lesson is a worse night than a messy disk with a durable fix.
+
 ## Self-Improvement
 
 ### 1. Retrospective
@@ -47,6 +49,8 @@ Prefer the simplest, most reliable change that addresses the root cause. A one-l
 - Create a new skill for a recurring need or capability
 - Add a rule to memory (only if a universal instruction)
 
+If the fix is a behavior that must fire on a schedule (a nudge, a check, a re-poke), it does not belong in MEMORY.md as a rule, it belongs as an explicit instruction in the proactive-check skill or as a scheduled reminder. A rule the future agent must remember to apply is the weakest fix; a trigger that fires on its own is the strongest. Match intervention strength to recurrence: first occurrence, a memory rule or skill note is fine; second occurrence of the same failure, escalate to a runtime trigger; third, change the system so the failure is structurally impossible. Never answer a repeat failure with the same artifact class that already failed.
+
 You can change anything. If a fix requires code, write the code, if a fix requires doing research online, research online.
 
 **Memory vs skill:** Memory is always loaded; every character costs tokens on every message. Use it for short rules and things you need to know at all times. A skill is for a distinct capability with its own workflow, loaded only when relevant. Under two lines and broadly relevant → memory. Longer or task-specific → skill. Skills are preferred, only use MEMORY.md if there is no clear existing SKILL.md or new one that should be made.
@@ -54,6 +58,8 @@ You can change anything. If a fix requires code, write the code, if a fix requir
 ### 4. Validate each fix
 
 Re-read the failing exchange and simulate: would the updated version have changed the outcome? If no or unclear, revise further or note it as unresolved. Don't mark something fixed if you can't convince yourself it would have helped. If relevant, spawn a subagent and replay the cause of the issue, does the agent using the new skill fix the issue?
+
+Self-simulation is the weakest validation and tends to approve your own fixes. For any fix addressing a failure that already recurred once, self-simulation is not enough: spawn a fresh subagent with no knowledge of the fix, hand it the original failing exchange plus the updated skill or prompt, and see if it independently produces the right behavior. If it does not, the fix is not durable: escalate it to a runtime trigger or flag it unresolved. Do not mark a twice-seen failure resolved on simulation alone.
 
 ### 5. Upstream
 


### PR DESCRIPTION
## What

Tightens the nightly self-improvement loop in the `dream` skill and the `nightly_dream` prompt so that lessons learned actually change runtime behavior instead of accumulating as inert notes.

Four surgical, markdown-only edits:

1. **Runtime-trigger landing spot + escalation ladder** (`dream/SKILL.md`, §3 Fix). A fix for a behavior that must fire on a schedule (a nudge, a check, a re-poke) now belongs as an explicit instruction in the proactive-check skill or a scheduled reminder, not as a MEMORY.md rule the future agent has to remember to apply. Intervention strength is matched to recurrence: first occurrence a rule/note is fine, second occurrence escalate to a runtime trigger, third change the system so the failure is structurally impossible. A repeat failure is never answered with the same artifact class that already failed.

2. **Mandatory fresh-subagent validation for twice-seen failures** (`dream/SKILL.md`, §4 Validate). Self-simulation rubber-stamps its own fixes, so for any failure that already recurred once, a fresh subagent with no knowledge of the fix must independently reproduce the right behavior from the original failing exchange plus the updated artifact. If it cannot, the fix is escalated or flagged unresolved.

3. **Non-skippable reflection phase** (`dream/SKILL.md`, Before you start). Under time/budget pressure, workspace, sensitive, and dashboard work get cut before retrospective and validation. A clean disk with an unlearned lesson is a worse night than a messy disk with a durable fix.

4. **Tighter completion gate** (`nightly_dream.md`). `mark_dreamer_complete` may only be called after the retrospective ran and every fix was validated or explicitly logged unresolved, not merely because a summary was written.

Scope is internal-only: all four edits govern the agent's own self-improvement. No outward reach-out behavior is touched; the green-light gate stays intact.

## Why (psychology / behavior-change theory)

The old loop conflated *knowing* a fix with *installing* it. A memory rule is a declarative intention; behavior change research (implementation intentions, Gollwitzer) shows that intentions reliably convert to action only when bound to a concrete cue-action trigger ("when X, do Y") rather than held as a general resolve. A rule the agent must remember to apply is exactly the intention-without-a-cue that fails to fire. Promoting scheduled behaviors to runtime triggers is the implementation-intention move: the environment fires the action instead of recall.

The recurrence-keyed ladder mirrors an escalating-response / error-management hierarchy: the cost of a heavier intervention is only justified once a lighter one has demonstrably failed, and repeating the same failed artifact class is the textbook insanity loop. Tying escalation to recurrence count keeps the response proportionate.

Mandatory fresh-subagent validation counters confirmation bias and the self-assessment blind spot (Dunning-Kruger, plus the author-cannot-proofread-their-own-work effect): the agent that wrote the fix is the worst judge of whether it generalizes. A naive replayer with no exposure to the intended answer is a genuine out-of-sample test, the difference between marking your own homework and an independent check.

Making reflection the last thing cut encodes a deliberate-practice priority: durable improvement comes from reviewing and correcting performance, and a system that sheds its learning step first under load optimizes for tidy state over actual growth. The completion gate enforces closure on the feedback loop so a fix is either verified or honestly logged as open, never silently abandoned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)