### PR TITLE
feat(prompts): decouple durable lessons from the always-loaded memory cap

### DIFF
--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -109,6 +109,9 @@ MEMORY.md has a **hard limit of 20,000 characters**. It's injected into every sy
 - If the same fact lives in two places, pick one home and replace the other with a one-line pointer. Two facts in two places drift; one fact and a pointer don't.
 - When a section grows past a few lines and is mostly reference material (contacts, family, recurring bills, addresses), split it into a dedicated file like `~/agent/CONTACTS.md` or `~/agent/FAMILY.md` and leave a one-line pointer in MEMORY.md ("Contacts: ~/agent/CONTACTS.md"). MEMORY.md is for things needed at all times, not the full archive.
 
+**Lessons (never zero-sum):**
+- Lessons are durable, never delete a hard-won lesson to free space. When the Mistakes and Corrections or Rules sections grow past their budget, move the older still-true lessons into `~/agent/LESSONS.md` (a permanent, un-injected archive) and keep only a one-line pointer plus the lessons that must fire on every message. The nightly retrospective greps LESSONS.md too. MEMORY.md is the always-loaded hot set; LESSONS.md is the cold, searchable record so growth is additive, not zero-sum.
+
 **Keep:**
 - Core identity, preferences, relationships, security rules
 - Active user context, open threads


### PR DESCRIPTION
## What

Adds a `~/agent/LESSONS.md` overflow archive to the dream skill's Memory Curation section so durable lessons stop competing for the always-loaded memory budget.

MEMORY.md has a hard 20,000 character cap and is injected into every system prompt. In practice it sits permanently near that cap, which makes lesson retention zero-sum: every newly learned lesson has to evict an older one, and under cap pressure the nightly capture of fresh corrections gets deferred entirely. The thing the agent most needs to remember (what it got wrong, and how it was corrected) is exactly the thing the cap squeezes out first.

The fix reuses the existing CONTACTS.md/FAMILY.md split pattern already documented two lines above: when the Mistakes/Corrections or Rules sections outgrow their budget, the older still-true lessons move into a permanent, un-injected `LESSONS.md` archive, leaving a one-line pointer plus the lessons that must fire on every message. MEMORY.md stays the hot, always-loaded set; LESSONS.md is the cold, greppable record. The nightly retrospective searches it too. Nothing is ever deleted.

This is internal-only and additive: a cold local archive plus an existing nightly grep. No outward behavior changes, no new code, no deletion of any lesson.

## Why (theory)

Two well-established findings motivate the split:

- **Retrieval-induced forgetting / interference under a fixed cap.** When new items must displace old ones from a bounded store, recall of the displaced items degrades even when they remain true and useful (Anderson's work on retrieval-induced forgetting; classic interference theory). A hard-capped, always-injected memory turns every new lesson into an act of forgetting. Decoupling a cold archive from the hot working set removes the forced trade-off.

- **Spacing and durable encoding.** Lessons are precisely the high-value, low-frequency knowledge that benefits from a stable long-term store rather than a volatile, constantly-rewritten one (the testing/spacing literature on durable retention). A growth-additive archive lets hard-won corrections persist and be re-surfaced over time instead of being overwritten in the next cap crunch.

The net effect is reliable growth: the agent accumulates lessons monotonically instead of trading one away for each it learns, which is what a relationship that is supposed to get better over time actually requires.

## Scope

- One markdown block added to `agent/skills/dream/SKILL.md`, matching the surrounding bold-lead-in format.
- No `.py` changes, no frontmatter changes (index unaffected), no version bumps.
- Charter invariants intact: peer framing, green-light gate, no em/en dashes or " - ", "agent" not "box".

🤖 Generated with [Claude Code](https://claude.com/claude-code)