### PR TITLE
fix(web): stop iOS zoom-on-focus in onboarding/connect inputs

### DIFF
--- a/apps/web/src/components/AuthFlow/index.tsx
+++ b/apps/web/src/components/AuthFlow/index.tsx
@@ -113,7 +113,7 @@ export function AuthFlow({
           onChange={(e) => setCode(e.target.value)}
           onKeyDown={handleKeyDown}
           autoFocus
-          className="w-full text-center text-sm"
+          className="w-full text-center"
         />
         <Button
           onClick={handleSubmit}

--- a/apps/web/src/components/Connect/index.tsx
+++ b/apps/web/src/components/Connect/index.tsx
@@ -77,7 +77,7 @@ export function Connect() {
                   autoComplete="url"
                   value={host}
                   onChange={(e) => setHost(e.target.value)}
-                  className="text-center text-sm"
+                  className="text-center"
                 />
               </Field>
             )}
@@ -93,7 +93,7 @@ export function Connect() {
                 autoComplete="current-password"
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}
-                className="text-center text-sm"
+                className="text-center"
               />
             </Field>
           </FieldGroup>

--- a/apps/web/src/components/NewAgent/Steps/NameStep/index.tsx
+++ b/apps/web/src/components/NewAgent/Steps/NameStep/index.tsx
@@ -61,7 +61,7 @@ export function NameStep({
             onChange={(e) => setName(e.target.value)}
             onKeyDown={handleKeyDown}
             autoFocus
-            className="text-center text-sm"
+            className="text-center"
           />
         </Field>
       </FieldGroup>


### PR DESCRIPTION
## what changed

four inputs on the first screens a user sees (connect host, connect key, new-agent name, auth code) overrode the shared `Input` base font size to `text-sm` at all breakpoints. on mobile that renders at 14px, and any input below 16px makes iOS Safari auto-zoom on focus, so the page jumps mid-onboarding.

the fix drops `text-sm` from each of the four `className` strings while keeping `text-center` (and `w-full` on the auth input). the `Input` base already resolves to `text-base` (16px) on mobile and only narrows to `md:text-sm` (15px) at the `md` breakpoint and up, so desktop sizing is unchanged and mobile no longer trips the zoom threshold.

- `apps/web/src/components/Connect/index.tsx` (host input, key input)
- `apps/web/src/components/NewAgent/Steps/NameStep/index.tsx`
- `apps/web/src/components/AuthFlow/index.tsx` (code input)

## design principle

interaction/motion, mobile input ergonomics: form controls should be at least 16px so iOS Safari does not zoom on focus. an unexpected viewport zoom during onboarding is a jarring, trust-eroding motion glitch on the very first screens, and avoiding it is a known mobile-web best practice.

verified with `./check.sh web` (eslint: 0 errors, prettier clean, tsc clean, 53 vitest tests pass). the auth code input was at line 116 (not 119 as the draft cited) and carried `w-full text-center text-sm`; adapted minimally by removing only `text-sm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)