### PR TITLE
fix(web): give connect inputs format hints and bridge the 'tunnel' vs 'host' wording

### DIFF
--- a/apps/web/src/components/Connect/index.tsx
+++ b/apps/web/src/components/Connect/index.tsx
@@ -3,7 +3,12 @@ import { Navigate } from "react-router-dom";
 import { AnimatePresence, motion } from "motion/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { FieldGroup, Field, FieldLabel } from "@/components/ui/field";
+import {
+  FieldGroup,
+  Field,
+  FieldLabel,
+  FieldDescription,
+} from "@/components/ui/field";
 import { fadeSlide } from "@/lib/motion";
 import { useAuth } from "@/providers/AuthProvider";
 
@@ -79,6 +84,10 @@ export function Connect() {
                   onChange={(e) => setHost(e.target.value)}
                   className="text-center text-sm"
                 />
+                <FieldDescription className="text-center">
+                  the tunnel url vestad printed on first run, e.g.
+                  https://name.trycloudflare.com
+                </FieldDescription>
               </Field>
             )}
             <Field>
@@ -95,6 +104,9 @@ export function Connect() {
                 onChange={(e) => setApiKey(e.target.value)}
                 className="text-center text-sm"
               />
+              <FieldDescription className="text-center">
+                the api key from ~/.config/vesta/vestad/api-key
+              </FieldDescription>
             </Field>
           </FieldGroup>
 


### PR DESCRIPTION
## what changed

On the connect screen, the host and key inputs were bare placeholders with sr-only labels and no example of the expected value, even though the value comes from vestad's terminal output (which prints `tunnel <url>` / `key <token>`).

Added `FieldDescription` hint lines (the field module already exports `FieldDescription`) under each input:

- host: `the tunnel url vestad printed on first run, e.g. https://name.trycloudflare.com`
- key: `the api key from ~/.config/vesta/vestad/api-key`

This bridges the "tunnel" vs "host" wording gap between vestad's terminal output and the connect form, so returning and second-device users are not forced to recall the format. Copy is all-lowercase with no dashes, matching Vesta's voice.

The optional third change (modeling the format inline in placeholders) was skipped, as the critique itself prefers `FieldDescription` since the 240px column truncates long inline placeholders.

## design principle

Nielsen heuristic: recognition rather than recall. Surface the expected input format at the point of entry instead of making users remember it from a terminal session.

## checks

`./check.sh web` passes: eslint (0 errors), prettier clean, tsc clean, all 53 vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)