### PR TITLE
fix(web): keyboardable error disclosure and actionable home empty state

### DIFF
--- a/apps/web/src/components/Connect/index.tsx
+++ b/apps/web/src/components/Connect/index.tsx
@@ -112,18 +112,20 @@ export function Connect() {
                 {...fadeSlide}
                 className="flex flex-col items-center gap-1 text-center"
               >
-                <p
-                  className={`text-xs ${details ? "cursor-pointer" : ""}`}
-                  onClick={
-                    details ? () => setShowDetails(!showDetails) : undefined
-                  }
-                >
+                <p className="text-xs">
                   <span className="text-destructive">{error}</span>
                   {details && (
-                    <span className="text-foreground">
-                      {" "}
-                      · {showDetails ? "hide details" : "show details"}
-                    </span>
+                    <>
+                      <span className="text-foreground"> · </span>
+                      <button
+                        type="button"
+                        aria-expanded={showDetails}
+                        onClick={() => setShowDetails(!showDetails)}
+                        className="text-foreground underline-offset-4 hover:underline"
+                      >
+                        {showDetails ? "hide details" : "show details"}
+                      </button>
+                    </>
                   )}
                 </p>
                 {showDetails && details && (

--- a/apps/web/src/components/Home/EmptyState/index.tsx
+++ b/apps/web/src/components/Home/EmptyState/index.tsx
@@ -1,15 +1,27 @@
+import { useNavigate } from "react-router-dom";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import {
+  EmptyContent,
   EmptyDescription,
   EmptyHeader,
   EmptyTitle,
 } from "@/components/ui/empty";
 
 export function EmptyState() {
+  const navigate = useNavigate();
+
   return (
     <div className="flex h-full w-full items-center justify-center">
       <EmptyHeader>
         <EmptyTitle>no agents found</EmptyTitle>
         <EmptyDescription>create an agent to get started</EmptyDescription>
+        <EmptyContent>
+          <Button onClick={() => navigate("/new")}>
+            <Plus data-icon="inline-start" />
+            new agent
+          </Button>
+        </EmptyContent>
       </EmptyHeader>
     </div>
   );


### PR DESCRIPTION
two first-run decision points where the copy pointed at an action the markup could not perform.

## what changed

- **connect error disclosure** (`apps/web/src/components/Connect/index.tsx`): the "show details" toggle was a clickable `<span>` with an `onClick`, so it was invisible to keyboard and assistive tech and announced nothing about its expanded state. it is now a real `<button type="button">` with `aria-expanded={showDetails}`. the destructive error text stays static and the `·` separator is preserved.
- **home empty state** (`apps/web/src/components/Home/EmptyState/index.tsx`): "create an agent to get started" had no inline affordance. added a primary `new agent` button inside `EmptyContent` that navigates to `/new`, mirroring the navbar's existing wording and `Plus` icon for consistency.

## design principle

heuristic match between system and the real world plus accessibility (WCAG 2.1.1 keyboard, 4.1.2 name/role/value): an interactive control must be reachable by keyboard and expose its state, and a primary call to action should be present where the copy promises one rather than left to the user to find.

all copy stays lowercase, no dashes, "agent" wording. `./check.sh web` passes (eslint 0 errors, prettier, tsc, 53 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)