### PR TITLE
a11y(web): announce dynamic status to screen readers (CreatingStep + agent orb)

### DIFF
--- a/apps/web/src/components/AgentIsland/Expanded.tsx
+++ b/apps/web/src/components/AgentIsland/Expanded.tsx
@@ -42,6 +42,7 @@ export function AgentIslandExpanded({
           </CardTitle>
         </motion.div>
         <motion.div
+          aria-live="polite"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ ...agentIslandContentTransition, delay: 0.1 }}

--- a/apps/web/src/components/Orb/index.tsx
+++ b/apps/web/src/components/Orb/index.tsx
@@ -574,6 +574,8 @@ export function Orb({
   return (
     <div
       ref={containerRef}
+      role="img"
+      aria-label={state}
       style={{ width: size, height: size, position: "relative" }}
     >
       <div

--- a/apps/web/src/components/ProgressBar/index.tsx
+++ b/apps/web/src/components/ProgressBar/index.tsx
@@ -24,6 +24,8 @@ export function ProgressBar({ message }: ProgressBarProps) {
         {message && (
           <motion.p
             key={message}
+            role="status"
+            aria-live="polite"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}


### PR DESCRIPTION
## what changed

dynamic status text and agent state were conveyed visually without any live regions or roles, so assistive technology never heard them change. this adds the minimal aria so those transitions are announced. invisible and identity safe.

- `apps/web/src/components/ProgressBar/index.tsx`: the rotating progress message (a `motion.p`) now carries `role="status"` and `aria-live="polite"`, so the onboarding/build progress copy is announced as it rotates.
- `apps/web/src/components/Orb/index.tsx`: the orb container now carries `role="img"` and `aria-label={state}`. the critique suggested `aria-label={statusLabel || orbState}`, but the `Orb` component only receives its `state` prop (an `OrbVisualState`, which is exactly the `orbState` value); labeling with `state` covers every orb instance, including the always-present collapsed orb and not only the conditionally-rendered expanded status region.
- `apps/web/src/components/AgentIsland/Expanded.tsx`: the `statusLabel` region now carries `aria-live="polite"`, so thinking to alive transitions are announced.

## design principle

WCAG 4.1.3 (status messages): status changes that aren't tied to a focus change must be programmatically exposed so they are presented to the user by assistive technology. follows the codebase's existing aria-label convention on icon-only controls.

## notes

the critique referenced an `AgentIsland Expanded.tsx` path; the actual file is `apps/web/src/components/AgentIsland/Expanded.tsx`, edited accordingly.

`./check.sh web` passes (eslint 0 errors, prettier clean, tsc clean, 53 vitest tests pass). no version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)