### PR TITLE
fix(web): honest first-build progress copy and non-freezing message track

### DIFF
--- a/apps/web/src/components/NewAgent/Steps/CreatingStep/index.tsx
+++ b/apps/web/src/components/NewAgent/Steps/CreatingStep/index.tsx
@@ -6,7 +6,7 @@ const MESSAGES = [
   "preparing email &\ncalendar access...",
   "loading browser &\nresearch tools...",
   "setting up reminders & tasks...",
-  "almost there...",
+  "still setting things up...",
 ];
 
 export function CreatingStep() {
@@ -28,7 +28,7 @@ export function CreatingStep() {
     <div className="flex flex-col items-center gap-3 w-[260px] max-w-full px-4">
       <h2 className="text-base font-semibold">setting up</h2>
       <p className="text-xs text-muted-foreground">
-        this may take a couple of mins.
+        first setup can take several minutes.
       </p>
       <ProgressBar message={MESSAGES[msgIdx]} />
     </div>


### PR DESCRIPTION
## what changed

The first-agent build wizard's `CreatingStep` undersold and then froze on a near-completion claim while the real Docker build runs for minutes:

- subtitle `this may take a couple of mins.` -> `first setup can take several minutes.`, tracking the CLI's own wording for the same operation (no invented 5-10 min range).
- the rotating message track's terminal line `almost there...` -> `still setting things up...`, so the screen never claims near-completion while minutes of build remain. The indeterminate progress bar (which is honest) and the `Math.min` clamp are left intact, since the clamp now parks on a neutral, accurate line instead of a misleading one.

Scope: only the two changes from cheap-wins index 3. The unverified "you can close this, it keeps building" clause was never present in the current code, so nothing to drop there.

## design principle

Nielsen heuristic #1, visibility of system status (honest progress): never tell the user "almost there" when minutes of work remain, and keep on-screen estimates consistent with the CLI for the same operation. Vesta's intentional choices respected: all-lowercase copy, no em/en dashes or " - " separators.

## checks

`./check.sh web` passes: eslint 0 errors, prettier clean, tsc clean, 53 vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)