### PR TITLE
fix(web): clearer OAuth handoff and re-auth label consistency

### DIFF
--- a/apps/web/src/components/AuthFlow/index.tsx
+++ b/apps/web/src/components/AuthFlow/index.tsx
@@ -84,29 +84,36 @@ export function AuthFlow({
         >
           <path d="m3.127 10.604 3.135-1.76.053-.153-.053-.085H6.11l-.525-.032-1.791-.048-1.554-.065-1.505-.08-.38-.081L0 7.832l.036-.234.32-.214.455.04 1.009.069 1.513.105 1.097.064 1.626.17h.259l.036-.105-.089-.065-.068-.064-1.566-1.062-1.695-1.121-.887-.646-.48-.327-.243-.306-.104-.67.435-.48.585.04.15.04.593.456 1.267.981 1.654 1.218.242.202.097-.068.012-.049-.109-.181-.9-1.626-.96-1.655-.428-.686-.113-.411a2 2 0 0 1-.068-.484l.496-.674L4.446 0l.662.089.279.242.411.94.666 1.48 1.033 2.014.302.597.162.553.06.17h.105v-.097l.085-1.134.157-1.392.154-1.792.052-.504.25-.605.497-.327.387.186.319.456-.045.294-.19 1.23-.37 1.93-.243 1.29h.142l.161-.16.654-.868 1.097-1.372.484-.545.565-.601.363-.287h.686l.505.751-.226.775-.707.895-.585.759-.839 1.13-.524.904.048.072.125-.012 1.897-.403 1.024-.186 1.223-.21.553.258.06.263-.218.536-1.307.323-1.533.307-2.284.54-.028.02.032.04 1.029.098.44.024h1.077l2.005.15.525.346.315.424-.053.323-.807.411-3.631-.863-.872-.218h-.12v.073l.726.71 1.331 1.202 1.667 1.55.084.383-.214.302-.226-.032-1.464-1.101-.565-.497-1.28-1.077h-.084v.113l.295.432 1.557 2.34.08.718-.112.234-.404.141-.444-.08-.911-1.28-.94-1.44-.759-1.291-.093.053-.448 4.821-.21.246-.484.186-.403-.307-.214-.496.214-.98.258-1.28.21-1.016.19-1.263.112-.42-.008-.028-.092.012-.953 1.307-1.448 1.957-1.146 1.227-.274.109-.477-.247.045-.44.266-.39 1.586-2.018.956-1.25.617-.723-.004-.105h-.036l-4.212 2.736-.75.096-.324-.302.04-.496.154-.162 1.267-.871z" />
         </svg>
+        <h2 className="text-base font-semibold">sign in to claude</h2>
+        <p className="text-xs text-muted-foreground text-center">
+          this signs your agent into your own claude account. open this link,
+          sign in to claude, then paste the code it gives you.
+        </p>
         {authUrl && (
-          <div className="mt-2 flex min-h-0 min-w-0 w-full max-w-full items-center gap-1.5 overflow-hidden">
-            <a
-              href={authUrl}
-              target="_blank"
-              rel="noopener"
-              className="block min-w-0 flex-1 truncate text-xs text-muted-foreground hover:text-foreground"
-            >
-              {authUrl}
-            </a>
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              className="shrink-0"
-              onClick={copyAuthUrl}
-            >
-              {copied ? <Check /> : <Copy />}
-            </Button>
+          <div className="mt-2 flex min-w-0 w-full max-w-full flex-col gap-1">
+            <span className="text-xs font-medium text-muted-foreground">
+              auth link
+            </span>
+            <div className="flex min-h-0 min-w-0 w-full max-w-full items-center gap-1.5 overflow-hidden">
+              <a
+                href={authUrl}
+                target="_blank"
+                rel="noopener"
+                className="block min-w-0 flex-1 truncate text-xs text-muted-foreground hover:text-foreground"
+              >
+                {authUrl}
+              </a>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="shrink-0"
+                onClick={copyAuthUrl}
+              >
+                {copied ? <Check /> : <Copy />}
+              </Button>
+            </div>
           </div>
         )}
-        <p className="text-xs text-muted-foreground text-center">
-          paste the code from the browser below
-        </p>
         <Input
           placeholder="paste code here"
           value={code}

--- a/apps/web/src/components/Navbar/AgentNavbar/index.tsx
+++ b/apps/web/src/components/Navbar/AgentNavbar/index.tsx
@@ -96,7 +96,7 @@ export function AgentNavbar({
                   onClick={() => void handleOpenAuth()}
                 >
                   <KeyRound data-icon="inline-start" />
-                  authenticate
+                  sign in
                 </Button>
               </div>
             )}
@@ -113,7 +113,7 @@ export function AgentNavbar({
                   onClick={() => void handleOpenAuth()}
                 >
                   <KeyRound data-icon="inline-start" />
-                  authenticate
+                  sign in
                 </Button>
               )}
               {showChatButton && (


### PR DESCRIPTION
## what changed

On the claude sign-in step (`AuthFlow`):
- added an `h2` heading (`sign in to claude`) matching the existing `text-base font-semibold` pattern used by the other auth states, so the waiting state has the same framing as every other onboarding step.
- added a one-line ordered instruction ABOVE the url with a short account-linking lead: `this signs your agent into your own claude account. open this link, sign in to claude, then paste the code it gives you.` (this replaces the old `paste the code from the browser below` line, which sat after the url and gave no ordering or linking context).
- gave the url row a visible `auth link` label so the link is self-describing; the copy button stays as a secondary affordance.

In the agent navbar (`AgentNavbar`):
- unified the `not_authenticated` cta label to `sign in` on both mobile and desktop, matching the orb's existing `not signed in` / `signing in...` vocabulary (`Orb/styles.ts`). Both buttons previously read `authenticate`.

All copy is lowercase with no dashes, and "agent" terminology is preserved.

## design principle

Heuristics / agent-ux-trust: recognition over recall and visibility of system status. The OAuth handoff is a first-run decision point that lacked a heading, an ordered instruction, and account-linking context, forcing the user to infer what the link does and what to do next. Naming the step, ordering the instruction above the url, labeling the url, and aligning the re-auth cta vocabulary make the handoff legible and consistent across surfaces.

## verification

`./check.sh web` passes: eslint 0 errors, prettier clean, tsc clean, 53/53 vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)