### PR TITLE
a11y(web): accessible names for icon-only controls

### DIFF
--- a/apps/web/src/components/AuthFlow/index.tsx
+++ b/apps/web/src/components/AuthFlow/index.tsx
@@ -98,10 +98,14 @@ export function AuthFlow({
               variant="ghost"
               size="icon-xs"
               className="shrink-0"
+              aria-label={copied ? "copied" : "copy auth link"}
               onClick={copyAuthUrl}
             >
               {copied ? <Check /> : <Copy />}
             </Button>
+            <span className="sr-only" role="status" aria-live="polite">
+              {copied ? "copied" : ""}
+            </span>
           </div>
         )}
         <p className="text-xs text-muted-foreground text-center">

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -111,6 +111,7 @@ export function ChatComposer({
             <InputGroupButton
               size="icon-sm"
               variant="ghost"
+              aria-label="send message"
               disabled={!connected}
               onClick={onSend}
             >

--- a/apps/web/src/components/Console/index.tsx
+++ b/apps/web/src/components/Console/index.tsx
@@ -208,6 +208,7 @@ export function Console({ name, onClose, fullscreen }: ConsoleProps) {
                 variant="ghost"
                 size="icon-sm"
                 className="size-9"
+                aria-label="close logs"
                 onClick={onClose}
               >
                 <X className="size-5" />

--- a/apps/web/src/components/Navbar/AgentNavbar/index.tsx
+++ b/apps/web/src/components/Navbar/AgentNavbar/index.tsx
@@ -63,6 +63,7 @@ export function AgentNavbar({
                 <Button
                   variant="outline"
                   size="icon-lg"
+                  aria-label="dashboard"
                   onClick={() => navigate(`/agent/${encodeURIComponent(name)}`)}
                 >
                   <LayoutDashboard />
@@ -76,6 +77,7 @@ export function AgentNavbar({
                 <Button
                   variant="outline"
                   size="icon-lg"
+                  aria-label="home"
                   onClick={() => navigate("/")}
                 >
                   <Home />

--- a/apps/web/src/components/StatusPill/index.tsx
+++ b/apps/web/src/components/StatusPill/index.tsx
@@ -32,8 +32,16 @@ export function StatusPill({ showHostname = true }: StatusPillProps) {
   return (
     <div className="flex items-center gap-2">
       <div
+        role="img"
+        title={reachable ? "connected" : "can't reach gateway"}
+        aria-label={reachable ? "connected" : "can't reach gateway"}
         className={`size-2 rounded-full shrink-0 ${reachable ? "bg-green-500" : "bg-red-500"}`}
       />
+      {!reachable && (
+        <span className="text-sm text-secondary-foreground truncate">
+          offline
+        </span>
+      )}
       {showHostname && hostname && (
         <span className="text-sm text-secondary-foreground truncate hidden sm:block">
           {hostname}

--- a/apps/web/src/components/ThemeToggle/index.tsx
+++ b/apps/web/src/components/ThemeToggle/index.tsx
@@ -33,7 +33,7 @@ export function ThemeToggle() {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Button variant="ghost" size="icon" onClick={next}>
+        <Button variant="ghost" size="icon" aria-label={label} onClick={next}>
           {icon}
         </Button>
       </TooltipTrigger>


### PR DESCRIPTION
## what changed

Several icon-only buttons announced only as "button" to assistive tech, while sibling controls in the codebase already carry aria-labels. This adds names to match that existing convention (tooltips are kept as visual hints, since they are not exposed to AT reliably):

- **chat composer** send button (`Chat/ChatComposer`): `aria-label="send message"`
- **theme toggle** (`ThemeToggle`): `aria-label={label}` tracks the current theme
- **agent navbar** back buttons (`Navbar/AgentNavbar`): `aria-label="home"` / `aria-label="dashboard"`
- **console** close button (`Console`): `aria-label="close logs"`
- **auth flow** copy button (`AuthFlow`): `aria-label` toggles between `copy auth link` and `copied`, plus a transient `copied` string in an `aria-live="polite"` region so the copy action is announced
- **status pill** dot (`StatusPill`): `title`/`aria-label` for `connected` / `can't reach gateway`, and a visible `offline` text when unreachable so status is not conveyed by color alone

All copy is lowercase with no dashes, per the product voice.

## design principle

WCAG 4.1.2 (Name, Role, Value): interactive controls must expose an accessible name. WCAG 1.4.1 (Use of Color): the connection status must not rely on color alone, hence the visible `offline` text. WCAG 4.1.3 (Status Messages): the copy confirmation is surfaced via a polite live region. These are invisible, identity-safe additions that land on the first screens a user sees.

## checks

`./check.sh web` passes: eslint (0 errors), prettier, tsc, and vitest (53 passed). The remaining eslint warnings are pre-existing and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)