### PR TITLE
fix(cli): lowercase the vesta welcome to match the product voice

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -649,11 +649,11 @@ fn detect_timezone() -> Option<String> {
 fn print_welcome() {
     println!("vesta — your personal AI assistant");
     println!();
-    println!("Quick start:");
-    println!("  vesta setup        Create an agent, authenticate, and start");
-    println!("  vesta list         List all agents");
+    println!("quick start:");
+    println!("  vesta setup        create an agent, authenticate, and start");
+    println!("  vesta list         list all agents");
     println!();
-    println!("Run 'vesta --help' for all commands.");
+    println!("run 'vesta --help' for all commands.");
 }
 
 fn run(cli: Cli) {


### PR DESCRIPTION
## what changed

`print_welcome` in `cli/src/main.rs` used Title Case while the rest of the CLI and every web surface is all-lowercase. Lowercased the welcome copy to match Vesta's intentional all-lowercase voice:

- `Quick start:` -> `quick start:`
- `Create an agent, authenticate, and start` -> `create an agent, authenticate, and start`
- `List all agents` -> `list all agents`
- `Run 'vesta --help' for all commands.` -> `run 'vesta --help' for all commands.`

The `vesta` headline line was left untouched (this change introduces no new style violations).

Note: the headline still contains an em dash (`vesta — your personal AI assistant`), which is itself a separate STYLE_GUARD violation. Flagging it here, but fixing it is out of scope for this surgical copy change.

## design principle

Consistency and standards (Nielsen heuristic 4) plus Vesta's intentional all-lowercase product voice: onboarding/CLI copy should read in one consistent register, not mix Title Case into an otherwise lowercase surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)