### PR TITLE
fix(web): de-jargon tool-call chips and name DoneStep's CTA for its outcome

### DIFF
--- a/apps/web/src/components/Chat/ToolCallLabel/index.tsx
+++ b/apps/web/src/components/Chat/ToolCallLabel/index.tsx
@@ -3,6 +3,19 @@ import { ChevronRight, Wrench } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { cn } from "@/lib/utils";
 
+const TOOL_LABELS: Record<string, string> = {
+  Bash: "ran a command",
+  Read: "read a file",
+  Write: "wrote a file",
+  Edit: "edited a file",
+  Glob: "searched for files",
+  Grep: "searched the code",
+  WebFetch: "fetched a page",
+  WebSearch: "searched the web",
+  TodoWrite: "updated the todo list",
+  Task: "ran a subtask",
+};
+
 export function ToolCallLabel({
   tool,
   input,
@@ -22,7 +35,9 @@ export function ToolCallLabel({
         className="flex items-center gap-1.5 rounded-full border border-muted-foreground/15 bg-muted/50 px-2.5 py-1 cursor-pointer hover:bg-muted/80 transition-colors"
       >
         <Wrench className="size-3 text-muted-foreground/60" />
-        <span className="text-[11px] text-muted-foreground/70">{tool}</span>
+        <span className="text-[11px] text-muted-foreground/70">
+          {TOOL_LABELS[tool] ?? tool}
+        </span>
         <motion.span
           animate={{ rotate: expanded ? 90 : 0 }}
           transition={{ duration: 0.15 }}

--- a/apps/web/src/components/NewAgent/Steps/DoneStep/index.tsx
+++ b/apps/web/src/components/NewAgent/Steps/DoneStep/index.tsx
@@ -20,7 +20,7 @@ export function DoneStep({ agentName }: { agentName: string }) {
         className="mt-2 w-full"
         onClick={() => navigate(`/agent/${agentName}`)}
       >
-        continue
+        say hi
       </Button>
     </div>
   );


### PR DESCRIPTION
two small transparency and microcopy fixes on the chat and onboarding surfaces.

## what changed

- **chat tool-call chips (`Chat/ToolCallLabel`)**: map known SDK tool names to plain-language lowercase verbs (`Bash` -> `ran a command`, `Read` -> `read a file`, `WebFetch` -> `fetched a page`, etc.). unmapped skill/MCP tools fall back to the raw name, and the raw name still persists in the expandable detail, so nothing is hidden.
- **new-agent done step (`NewAgent/Steps/DoneStep`)**: rename the generic `continue` button to `say hi`, which names the outcome and mirrors the `say hi.` line directly above it.

## design principle

recognition over recall and match between system and the real world (Nielsen heuristics): surface plain-language verbs instead of internal SDK identifiers, and label a control by the result it produces rather than a generic `continue`. copy stays all-lowercase with no dashes, consistent with the product voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)