### PR TITLE
feat(agent): add per-agent constitution prepended to memory

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -21,7 +21,7 @@ from . import models as vm
 from . import state_store
 from . import diagnostics
 from . import sdk_parsing
-from .helpers import get_memory_path
+from .helpers import get_constitution_path, get_memory_path
 from .tools import build_vesta_tools_server
 
 OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
@@ -247,6 +247,15 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
 
     name = config.agent_name
     system_prompt = f"Your name is {name}.\n\n{system_prompt}"
+
+    # Constitution: a user-authored charter set from vestad and bind-mounted read-only,
+    # so the agent cannot edit it. Prepend it ahead of MEMORY.md when non-empty.
+    constitution_path = get_constitution_path(config)
+    if constitution_path.exists():
+        constitution = constitution_path.read_text().strip()
+        if constitution:
+            header = "# Constitution\n\nThe following was set by your user and is immutable. You cannot edit it.\n\n"
+            system_prompt = f"{header}{constitution}\n\n{system_prompt}"
 
     os.environ.setdefault("CLAUDE_STREAM_IDLE_TIMEOUT_MS", str(_STREAM_IDLE_TIMEOUT_MS))
 

--- a/agent/core/helpers.py
+++ b/agent/core/helpers.py
@@ -7,6 +7,10 @@ def get_memory_path(config: vm.VestaConfig) -> pl.Path:
     return config.agent_dir / "MEMORY.md"
 
 
+def get_constitution_path(config: vm.VestaConfig) -> pl.Path:
+    return config.agent_dir / "constitution.md"
+
+
 def load_prompt(name: str, config: vm.VestaConfig) -> str | None:
     path = config.core_prompts_dir / f"{name}.md"
     if path.exists():

--- a/agent/tests/test_constitution.py
+++ b/agent/tests/test_constitution.py
@@ -13,10 +13,16 @@ def _config(tmp_path, **overrides):
     return config
 
 
+def _system_prompt(config, state) -> str:
+    prompt = build_client_options(config, state).system_prompt
+    assert isinstance(prompt, str)
+    return prompt
+
+
 def test_constitution_is_prepended_ahead_of_memory(tmp_path, state):
     config = _config(tmp_path)
     (config.agent_dir / "constitution.md").write_text("Always tell the truth.")
-    prompt = build_client_options(config, state).system_prompt
+    prompt = _system_prompt(config, state)
     assert "Always tell the truth." in prompt
     assert prompt.index("Always tell the truth.") < prompt.index("my memory body")
     assert "immutable" in prompt.lower()
@@ -24,7 +30,7 @@ def test_constitution_is_prepended_ahead_of_memory(tmp_path, state):
 
 def test_no_constitution_file_leaves_prompt_unchanged(tmp_path, state):
     config = _config(tmp_path)
-    prompt = build_client_options(config, state).system_prompt
+    prompt = _system_prompt(config, state)
     assert "Constitution" not in prompt
     assert "my memory body" in prompt
 
@@ -32,6 +38,6 @@ def test_no_constitution_file_leaves_prompt_unchanged(tmp_path, state):
 def test_empty_constitution_is_ignored(tmp_path, state):
     config = _config(tmp_path)
     (config.agent_dir / "constitution.md").write_text("   \n  \n")
-    prompt = build_client_options(config, state).system_prompt
+    prompt = _system_prompt(config, state)
     assert "Constitution" not in prompt
     assert "my memory body" in prompt

--- a/agent/tests/test_constitution.py
+++ b/agent/tests/test_constitution.py
@@ -1,0 +1,37 @@
+"""The constitution is a user-authored charter prepended to the system prompt ahead
+of MEMORY.md. It is bind-mounted read-only into the container, so the agent reads it
+but cannot edit it; these tests cover the prompt-assembly side."""
+
+import core.models as vm
+from core.client import build_client_options
+
+
+def _config(tmp_path, **overrides):
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent", **overrides)
+    config.agent_dir.mkdir(parents=True, exist_ok=True)
+    (config.agent_dir / "MEMORY.md").write_text("my memory body")
+    return config
+
+
+def test_constitution_is_prepended_ahead_of_memory(tmp_path, state):
+    config = _config(tmp_path)
+    (config.agent_dir / "constitution.md").write_text("Always tell the truth.")
+    prompt = build_client_options(config, state).system_prompt
+    assert "Always tell the truth." in prompt
+    assert prompt.index("Always tell the truth.") < prompt.index("my memory body")
+    assert "immutable" in prompt.lower()
+
+
+def test_no_constitution_file_leaves_prompt_unchanged(tmp_path, state):
+    config = _config(tmp_path)
+    prompt = build_client_options(config, state).system_prompt
+    assert "Constitution" not in prompt
+    assert "my memory body" in prompt
+
+
+def test_empty_constitution_is_ignored(tmp_path, state):
+    config = _config(tmp_path)
+    (config.agent_dir / "constitution.md").write_text("   \n  \n")
+    prompt = build_client_options(config, state).system_prompt
+    assert "Constitution" not in prompt
+    assert "my memory body" in prompt

--- a/apps/web/src/api/constitution.ts
+++ b/apps/web/src/api/constitution.ts
@@ -1,0 +1,19 @@
+import { apiJson } from "./client";
+
+export async function fetchConstitution(agentName: string): Promise<string> {
+  const { content } = await apiJson<{ content: string }>(
+    `/agents/${encodeURIComponent(agentName)}/constitution`,
+  );
+  return content;
+}
+
+export async function saveConstitution(
+  agentName: string,
+  content: string,
+): Promise<void> {
+  await apiJson(`/agents/${encodeURIComponent(agentName)}/constitution`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content }),
+  });
+}

--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -13,6 +13,7 @@ export {
   type BackupInfo,
 } from "./agents";
 export { fetchMemory, saveMemory } from "./memory";
+export { fetchConstitution, saveConstitution } from "./constitution";
 export { fetchPersonalities, type Personality } from "./personalities";
 export * as claudeProvider from "./providers/claude";
 export * as openrouterProvider from "./providers/openrouter";

--- a/apps/web/src/components/AgentSettings/ConstitutionCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ConstitutionCard/index.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import { ScrollText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Field, FieldContent, FieldLabel } from "@/components/ui/field";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { fetchConstitution, saveConstitution } from "@/api/constitution";
+import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "saving" }
+  | { kind: "saved" }
+  | { kind: "error"; message: string };
+
+// The constitution is host-side config (not stored in the container), so it loads and
+// saves regardless of whether the agent is running. Saving restarts the agent so the new
+// charter is loaded into its system prompt. The agent itself cannot edit it.
+export function ConstitutionCard() {
+  const { name: agentName, restart } = useSelectedAgent();
+
+  const [original, setOriginal] = useState<string | null>(null);
+  const [value, setValue] = useState("");
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  useEffect(() => {
+    if (!agentName) return;
+    setOriginal(null);
+    setLoadError(null);
+    fetchConstitution(agentName)
+      .then((content) => {
+        setOriginal(content);
+        setValue(content);
+      })
+      .catch((e: Error) => setLoadError(e.message));
+  }, [agentName]);
+
+  const dirty = original !== null && value !== original;
+
+  const onSave = async () => {
+    if (!agentName || !dirty) return;
+    setStatus({ kind: "saving" });
+    try {
+      await saveConstitution(agentName, value);
+      setOriginal(value);
+      setStatus({ kind: "saved" });
+      restart();
+    } catch (e) {
+      setStatus({ kind: "error", message: (e as Error).message });
+    }
+  };
+
+  return (
+    <Card size="sm">
+      <CardContent>
+        <Field orientation="vertical" className="gap-3">
+          <Field
+            orientation="horizontal"
+            className="items-center justify-between"
+          >
+            <FieldContent>
+              <FieldLabel className="flex items-center gap-2">
+                <ScrollText className="size-4 text-muted-foreground" />
+                constitution
+              </FieldLabel>
+            </FieldContent>
+          </Field>
+
+          <p className="text-xs text-muted-foreground">
+            a charter prepended to the agent's memory. the agent cannot edit it.
+          </p>
+
+          {loadError ? (
+            <p className="text-xs text-destructive">
+              failed to load: {loadError}
+            </p>
+          ) : original === null ? (
+            <Skeleton className="h-64 w-full rounded-2xl" />
+          ) : (
+            <>
+              <Textarea
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                spellCheck={false}
+                placeholder="empty — set principles, boundaries, or facts the agent must always honor"
+                className="min-h-64 max-h-[60vh] overflow-auto font-mono text-xs"
+              />
+              <div className="flex items-center justify-between">
+                <span
+                  className={`text-[10px] ${
+                    status.kind === "error" || (status.kind === "idle" && dirty)
+                      ? "text-destructive"
+                      : "text-muted-foreground/60"
+                  }`}
+                >
+                  {status.kind === "saving"
+                    ? "saving..."
+                    : status.kind === "saved"
+                      ? "saved, restarting agent"
+                      : status.kind === "error"
+                        ? status.message
+                        : dirty
+                          ? "unsaved changes — save will restart the agent"
+                          : ""}
+                </span>
+                <Button
+                  size="sm"
+                  disabled={!dirty || status.kind === "saving"}
+                  onClick={onSave}
+                >
+                  save
+                </Button>
+              </div>
+            </>
+          )}
+        </Field>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/AgentSettings/index.tsx
+++ b/apps/web/src/components/AgentSettings/index.tsx
@@ -1,5 +1,6 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ActionsCard } from "./ActionsCard";
+import { ConstitutionCard } from "./ConstitutionCard";
 import { FilesTab } from "./FilesTab";
 import { KeybindsCard } from "./KeybindsSection";
 import { PlanUsage } from "./PlanUsage";
@@ -28,6 +29,7 @@ export function AgentSettings() {
             </div>
             <div className="flex min-w-0 flex-col gap-4">
               <PlanUsage />
+              <ConstitutionCard />
               <SttCard />
               <TtsCard />
             </div>

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -584,6 +584,21 @@ impl Client {
         read_json(resp)
     }
 
+    pub fn get_agent_constitution(&self, name: &str) -> Result<String, String> {
+        let resp = self.get(&format!("/agents/{name}/constitution"))?;
+        let body: serde_json::Value = read_json(resp)?;
+        body["content"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| "response missing 'content' field".to_string())
+    }
+
+    pub fn set_agent_constitution(&self, name: &str, content: &str) -> Result<(), String> {
+        let body = serde_json::json!({ "content": content });
+        self.put_json(&format!("/agents/{name}/constitution"), &body)?;
+        Ok(())
+    }
+
     pub fn stream_logs(&self, name: &str, tail: u64) -> Result<(), String> {
         let resp = self.get(&format!("/agents/{name}/logs?tail={tail}"))?;
         consume_sse_log_stream(resp, "agent_stopped", Some("agent stopped"))

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -162,6 +162,21 @@ enum Command {
         /// Agent name
         name: String,
     },
+    /// View or edit an agent's constitution (a charter prepended to its memory; the agent
+    /// cannot edit it). With no flags, prints the current constitution.
+    Constitution {
+        /// Agent name
+        name: String,
+        /// Open the current constitution in $EDITOR and save on exit
+        #[arg(long)]
+        edit: bool,
+        /// Set the constitution from a file ('-' reads stdin)
+        #[arg(long, conflicts_with_all = ["edit", "clear"])]
+        file: Option<PathBuf>,
+        /// Clear the constitution
+        #[arg(long, conflicts_with_all = ["edit", "file"])]
+        clear: bool,
+    },
     /// Destroy an agent (irreversible)
     Destroy {
         /// Agent name
@@ -305,6 +320,40 @@ fn print_agent_backup_settings(result: &serde_json::Value) {
         result["retention"]["weekly"].as_u64().unwrap_or(0),
         result["retention"]["monthly"].as_u64().unwrap_or(0),
     );
+}
+
+fn read_file_or_stdin(path: &std::path::Path) -> String {
+    if path == std::path::Path::new("-") {
+        let mut buf = String::new();
+        io::Read::read_to_string(&mut io::stdin(), &mut buf)
+            .unwrap_or_else(|e| platform::die(&format!("failed to read stdin: {e}")));
+        return buf;
+    }
+    std::fs::read_to_string(path)
+        .unwrap_or_else(|e| platform::die(&format!("failed to read {}: {e}", path.display())))
+}
+
+/// Open `initial` in $EDITOR (falling back to vi) and return the edited contents.
+fn edit_in_editor(initial: &str) -> String {
+    let editor = std::env::var("EDITOR")
+        .or_else(|_| std::env::var("VISUAL"))
+        .unwrap_or_else(|_| "vi".to_string());
+    let mut tmp = std::env::temp_dir();
+    tmp.push(format!("vesta-constitution-{}.md", process::id()));
+    std::fs::write(&tmp, initial)
+        .unwrap_or_else(|e| platform::die(&format!("failed to write temp file: {e}")));
+    let status = process::Command::new(&editor)
+        .arg(&tmp)
+        .status()
+        .unwrap_or_else(|e| platform::die(&format!("failed to launch editor '{editor}': {e}")));
+    if !status.success() {
+        std::fs::remove_file(&tmp).ok();
+        platform::die("editor exited with an error, aborting");
+    }
+    let edited = std::fs::read_to_string(&tmp)
+        .unwrap_or_else(|e| platform::die(&format!("failed to read temp file: {e}")));
+    std::fs::remove_file(&tmp).ok();
+    edited
 }
 
 fn prompt_raw(label: &str) -> String {
@@ -784,6 +833,36 @@ fn run(cli: Cli) {
             let result = c.get_agent_settings(&name).unwrap_or_else(|e| platform::die(&e));
             let val = result["manage_agent_code"].as_bool().unwrap_or(true);
             eprintln!("manage_agent_code = {val}");
+        }
+
+        Command::Constitution { name, edit, file, clear } => {
+            let c = get_client(host_ref, token_ref);
+            let new_content: Option<String> = if clear {
+                Some(String::new())
+            } else if let Some(path) = file {
+                Some(read_file_or_stdin(&path))
+            } else if edit {
+                let current = c.get_agent_constitution(&name).unwrap_or_else(|e| platform::die(&e));
+                Some(edit_in_editor(&current))
+            } else {
+                None
+            };
+
+            match new_content {
+                None => {
+                    let content = c.get_agent_constitution(&name).unwrap_or_else(|e| platform::die(&e));
+                    print!("{content}");
+                    if !content.ends_with('\n') {
+                        println!();
+                    }
+                }
+                Some(content) => {
+                    c.set_agent_constitution(&name, &content).unwrap_or_else(|e| platform::die(&e));
+                    // Restart so the new constitution is loaded into the system prompt.
+                    c.restart_agent(&name).unwrap_or_else(|e| platform::die(&e));
+                    eprintln!("{name}: constitution updated, agent restarting");
+                }
+            }
         }
 
         Command::Start { name } => {

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -79,7 +79,11 @@ const NETWORK_MODE: &str = "host";
 const RESTART_POLICY: &str = "unless-stopped";
 const ENV_MOUNT_DEST: &str = "/run/vestad-env";
 const CORE_MOUNT_DEST: &str = "/root/agent/core";
-pub(crate) const MOUNT_DESTS: &[&str] = &[ENV_MOUNT_DEST, CORE_MOUNT_DEST, "/root/agent/pyproject.toml", "/root/agent/uv.lock"];
+/// User-authored charter, bind-mounted read-only so the agent reads but cannot edit it.
+/// Lives in host config (keyed by agent name), separate from the core-code mount, so
+/// agent-code updates never touch it.
+const CONSTITUTION_MOUNT_DEST: &str = "/root/agent/constitution.md";
+pub(crate) const MOUNT_DESTS: &[&str] = &[ENV_MOUNT_DEST, CORE_MOUNT_DEST, "/root/agent/pyproject.toml", "/root/agent/uv.lock", CONSTITUTION_MOUNT_DEST];
 
 pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
     let steps: [String; 9] = [
@@ -930,6 +934,48 @@ fn delete_agent_env_file(agents_dir: &std::path::Path, agent_name: &str) {
     std::fs::remove_file(&env_path).ok();
 }
 
+/// Host path of an agent's constitution. Per-agent user data, separate from agent code,
+/// so it survives code updates, rebuilds, and container destroy/restore.
+pub fn constitution_host_path(agents_dir: &std::path::Path, agent_name: &str) -> std::path::PathBuf {
+    agents_dir.join(format!("{}.constitution.md", agent_name))
+}
+
+/// Ensure the constitution file exists (empty by default) so it can be bind-mounted as a
+/// file. Bind-mounting a missing host path would make Docker create a directory there.
+fn ensure_constitution_file(agents_dir: &std::path::Path, agent_name: &str) -> Result<std::path::PathBuf, DockerError> {
+    std::fs::create_dir_all(agents_dir)
+        .map_err(|e| DockerError::Failed(format!("failed to create agents dir: {e}")))?;
+    let path = constitution_host_path(agents_dir, agent_name);
+    if !path.exists() {
+        std::fs::write(&path, "")
+            .map_err(|e| DockerError::Failed(format!("failed to create constitution file: {e}")))?;
+    }
+    Ok(path)
+}
+
+/// Read an agent's constitution, returning an empty string when unset.
+pub fn read_constitution(agents_dir: &std::path::Path, agent_name: &str) -> Result<String, DockerError> {
+    let path = constitution_host_path(agents_dir, agent_name);
+    match std::fs::read_to_string(&path) {
+        Ok(content) => Ok(content),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(e) => Err(DockerError::Failed(format!("failed to read constitution: {e}"))),
+    }
+}
+
+/// Overwrite an agent's constitution in place. Writing in place (rather than rename) keeps
+/// the inode stable so the read-only bind mount in a running container sees the new content;
+/// the agent only re-reads it into its system prompt on restart.
+pub fn write_constitution(agents_dir: &std::path::Path, agent_name: &str, content: &str) -> Result<(), DockerError> {
+    let path = ensure_constitution_file(agents_dir, agent_name)?;
+    std::fs::write(&path, content)
+        .map_err(|e| DockerError::Failed(format!("failed to write constitution: {e}")))
+}
+
+fn delete_constitution_file(agents_dir: &std::path::Path, agent_name: &str) {
+    std::fs::remove_file(constitution_host_path(agents_dir, agent_name)).ok();
+}
+
 /// Update VESTAD_PORT, VESTAD_TUNNEL, and VESTA_UPSTREAM_REF in all existing per-agent env files.
 /// Called at vestad startup so running containers pick up the new values on restart.
 pub fn update_all_agent_env_files(agents_dir: &std::path::Path, vestad_port: u16, vestad_tunnel: Option<&str>) {
@@ -1252,7 +1298,10 @@ pub async fn snapshot_container(_docker: &Docker, cname: &str, tag: &str, change
 pub async fn create_container(docker: &Docker, cname: &str, image: &str, port: u16, agent_name: &str, env_config: &AgentEnvConfig, manage_core_code: bool, timezone: Option<&str>, seed_personality: Option<&str>) -> Result<(), DockerError> {
     let agent_token = generate_agent_token();
     let env_path = write_agent_env_file(env_config, agent_name, port, &agent_token, timezone, seed_personality)?;
-    let env_mount = format!("{}:{}:ro,z", env_path.display(), MOUNT_DESTS[0]);
+    let env_mount = format!("{}:{}:ro,z", env_path.display(), ENV_MOUNT_DEST);
+
+    let constitution_path = ensure_constitution_file(&env_config.agents_dir, agent_name)?;
+    let constitution_mount = format!("{}:{}:ro,z", constitution_path.display(), CONSTITUTION_MOUNT_DEST);
 
     let code_dir = crate::agent_code::agent_code_dir(&env_config.config_dir);
     let core_mount = format!("{}:{}:ro,z", code_dir.join("core").display(), MOUNT_DESTS[1]);
@@ -1264,7 +1313,7 @@ pub async fn create_container(docker: &Docker, cname: &str, image: &str, port: u
     labels.insert(LABEL_USER.to_string(), current_user());
     labels.insert(LABEL_AGENT_NAME.to_string(), agent_name.to_string());
 
-    let mut binds = vec![env_mount];
+    let mut binds = vec![env_mount, constitution_mount];
     if manage_core_code {
         binds.extend([core_mount, pyproject_mount, lock_mount]);
     }
@@ -1755,6 +1804,7 @@ pub async fn destroy_agent(docker: &Docker, name: &str, agents_dir: &std::path::
     }
     remove_container_force(docker, &cname).await?;
     delete_agent_env_file(agents_dir, name);
+    delete_constitution_file(agents_dir, name);
     crate::restic::remove_repo(name);
     Ok(())
 }
@@ -1949,7 +1999,14 @@ pub async fn rename_agent(
 
     tracing::info!(agent = %old_name, "[3/4] removing old container and env file...");
     remove_container_force(docker, &old_cname).await.ok();
+    // Carry the constitution across the rename before the new container is created, so its
+    // bind mount resolves to the existing content rather than a fresh empty file.
+    let old_constitution = read_constitution(&env_config.agents_dir, old_name).unwrap_or_default();
+    if !old_constitution.is_empty() {
+        write_constitution(&env_config.agents_dir, new_name, &old_constitution).ok();
+    }
     delete_agent_env_file(&env_config.agents_dir, old_name);
+    delete_constitution_file(&env_config.agents_dir, old_name);
 
     tracing::info!(new = %new_name, "[4/4] creating renamed container from snapshot...");
     create_container(docker, &new_cname, &snapshot_tag, port, new_name, env_config, manage_core_code, None, None).await?;
@@ -1963,6 +2020,47 @@ pub async fn rename_agent(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn constitution_unset_reads_empty() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        assert_eq!(read_constitution(dir.path(), "vesta").expect("read"), "");
+    }
+
+    #[test]
+    fn constitution_write_then_read_round_trips() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        write_constitution(dir.path(), "vesta", "Always tell the truth.").expect("write");
+        assert_eq!(read_constitution(dir.path(), "vesta").expect("read"), "Always tell the truth.");
+    }
+
+    #[test]
+    fn constitution_write_preserves_inode() {
+        // The bind mount in a running container points at this inode; in-place writes keep
+        // it stable so the container sees updates without a mount refresh.
+        use std::os::unix::fs::MetadataExt;
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        write_constitution(dir.path(), "vesta", "first").expect("write");
+        let ino_before = std::fs::metadata(constitution_host_path(dir.path(), "vesta")).expect("stat").ino();
+        write_constitution(dir.path(), "vesta", "second").expect("write");
+        let ino_after = std::fs::metadata(constitution_host_path(dir.path(), "vesta")).expect("stat").ino();
+        assert_eq!(ino_before, ino_after);
+        assert_eq!(read_constitution(dir.path(), "vesta").expect("read"), "second");
+    }
+
+    #[test]
+    fn constitution_delete_removes_file() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        write_constitution(dir.path(), "vesta", "x").expect("write");
+        delete_constitution_file(dir.path(), "vesta");
+        assert!(!constitution_host_path(dir.path(), "vesta").exists());
+    }
+
+    #[test]
+    fn constitution_mount_dest_is_read_only_path() {
+        // Ensures the file API refuses to write the constitution from inside the container.
+        assert!(MOUNT_DESTS.contains(&CONSTITUTION_MOUNT_DEST));
+    }
 
     #[test]
     fn normalize_simple() {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1705,6 +1705,44 @@ async fn delete_agent_backup_settings_handler(
     }))
 }
 
+// --- Constitution ---
+//
+// A user-authored charter prepended to the agent's system prompt ahead of MEMORY.md.
+// It lives in host config and is bind-mounted read-only into the container, so the agent
+// reads it but cannot edit it. These endpoints sit behind the API-key middleware only
+// (never the agent token), so the agent itself cannot reach them. Like the memory editor,
+// PUT only persists; the client restarts the agent so the new system prompt loads.
+
+#[derive(Deserialize)]
+struct SetConstitutionBody {
+    content: String,
+}
+
+async fn get_constitution_handler(
+    State(state): State<SharedState>,
+    Path(name): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    docker::validate_name(&name).map_err(map_docker_err)?;
+    let content = docker::read_constitution(&state.env_config.agents_dir, &name)
+        .map_err(|e| err_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
+    Ok(Json(serde_json::json!({ "content": content })))
+}
+
+async fn set_constitution_handler(
+    State(state): State<SharedState>,
+    Path(name): Path<String>,
+    Json(body): Json<SetConstitutionBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    docker::validate_name(&name).map_err(map_docker_err)?;
+    let lock = state.agent_lock(&name).await;
+    let _guard = lock.write().await;
+
+    docker::write_constitution(&state.env_config.agents_dir, &name, &body.content)
+        .map_err(|e| err_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
+    tracing::info!(agent = %name, "constitution updated");
+    Ok(ok_json())
+}
+
 // --- Port file ---
 
 pub fn write_port_file(config_dir: &std::path::Path, port: u16) {
@@ -1786,6 +1824,8 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/agents/{name}/backups", get(list_backups_handler))
         .route("/agents/{name}/backups/{backup_id}/restore", post(restore_backup_handler))
         .route("/agents/{name}/backups/{backup_id}", axum::routing::delete(delete_backup_handler))
+        .route("/agents/{name}/constitution", get(get_constitution_handler))
+        .route("/agents/{name}/constitution", axum::routing::put(set_constitution_handler))
         .route("/agents/{name}/settings", get(get_agent_settings_handler))
         .route("/agents/{name}/settings/backup", get(get_agent_backup_settings_handler))
         .route("/agents/{name}/settings/backup", axum::routing::put(set_agent_backup_settings_handler))


### PR DESCRIPTION
## What

Adds an optional, user-authored **constitution** per agent: a charter prepended to the agent's system prompt ahead of `MEMORY.md`. It starts empty, is editable only by the user/client (app + CLI), and the **agent itself cannot modify it**.

## Why

`MEMORY.md` is fully agent-owned (the dreamer rewrites it nightly). There was no place for the user to set invariant principles, boundaries, or facts the agent must always honor and can't curate away. The constitution is that place.

## Design

- **Immutable from inside the container.** The constitution lives in host config at `~/.config/vesta/vestad/agents/{name}.constitution.md` and is bind-mounted **read-only** at `/root/agent/constitution.md`. A read-only mount is the only real guarantee, since the agent runs as root in-container (file perms wouldn't help).
- **Separate from core code.** It's per-agent user data keyed by name, not shipped code, so agent-code updates/rebuilds never touch it. It's carried across `rebuild`/`rename` and removed on `destroy`.
- **User/client only.** The `GET`/`PUT /agents/{name}/constitution` endpoints sit behind the **API-key** middleware only, never the agent token, so the agent cannot reach them.
- **Apply on restart.** Like the memory editor, `PUT` only persists; the client restarts the agent so the new charter loads into the system prompt. Writes are in-place (stable inode) so the live bind mount stays consistent.
- Always created (empty) and mounted at agent creation, so enabling it later is just a content change — no container recreate.

## Layers

- **agent** — `build_client_options` prepends `constitution.md` when non-empty, under a header marking it immutable; new `get_constitution_path` helper.
- **vestad** — always create + read-only bind-mount the constitution; `read_constitution`/`write_constitution` host helpers; API-key-only endpoints; cleanup on destroy, carry-over on rename.
- **cli** — `vesta constitution <name>` prints it; `--edit` opens `$EDITOR`, `--file <path>` (`-` = stdin), `--clear`. Restarts the agent after a change.
- **web** — `ConstitutionCard` editor in agent settings (general tab), mirroring the memory editor.

## Deferred

- Setting the constitution in the **create flow** is intentionally left for a follow-up; for now it's created empty and edited from settings.

## Tests

- agent: prepend-when-present / ignore-when-empty / absent (`test_constitution.py`).
- vestad: host-file round-trip, in-place write preserves inode, delete, and constitution path is treated read-only by the file API.
- web layer is a thin mirror of `memory.ts`; endpoint shape is covered by the cross-language contract test, and the real logic is tested in the agent/vestad layers.

## Notes

- The constitution is host-side config, so it is not part of a `docker export` snapshot (consistent with the env file / token). It survives rebuild/rename/restore-over-existing; a `destroy` clears it by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)