### PR TITLE
fix(app): reveal the agent's Orb on the onboarding done step

### DIFF
--- a/apps/web/src/components/NewAgent/Steps/DoneStep/index.tsx
+++ b/apps/web/src/components/NewAgent/Steps/DoneStep/index.tsx
@@ -1,15 +1,17 @@
 import { useNavigate } from "react-router-dom";
-import { Check } from "lucide-react";
+import { motion } from "motion/react";
 import { Button } from "@/components/ui/button";
+import { Orb } from "@/components/Orb";
+import { fade } from "@/lib/motion";
 
 export function DoneStep({ agentName }: { agentName: string }) {
   const navigate = useNavigate();
 
   return (
     <div className="flex flex-col items-center w-[260px] max-w-full px-4">
-      <div className="size-10 rounded-full bg-primary/20 flex items-center justify-center">
-        <Check size={20} className="text-primary" />
-      </div>
+      <motion.div {...fade}>
+        <Orb state="alive" size={96} />
+      </motion.div>
       <div className="mt-3 flex flex-col items-center gap-1 text-center">
         <h2 className="text-base font-semibold leading-tight">
           {agentName} is ready


### PR DESCRIPTION
## Summary
The NewAgent DoneStep previously closed onboarding with a generic lucide checkmark in a `bg-primary/20` circle, the same affordance any CRUD form uses. This replaces it with the agent's own Orb in its `alive` state, gently fading in above the `{name} is ready` / `say hi.` copy.

This reuses the product's signature element (already used in AgentCard, AgentIsland, LoadingScreen) so the completion moment introduces the actual presence and stays coherent with the `/agent/{name}` dashboard the `continue` button navigates to, whose AgentCard also leads with the Orb.

## Changes
- `apps/web/src/components/NewAgent/Steps/DoneStep/index.tsx`: swap the `Check` icon for `<Orb state="alive" size={96} />` wrapped in a `motion.div` using the existing `fade` variant from `@/lib/motion`. Removed the now-unused `Check` import.

No copy, terminology, or dashes touched.

## Verification
`./check.sh web` passes fully (eslint 0 errors, prettier clean, tsc clean, vitest 53 passed).

Fixes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)