### PR TITLE
fix(app): respect prefers-reduced-motion for Orb and ProgressBar

### DIFF
--- a/apps/web/src/components/Orb/index.tsx
+++ b/apps/web/src/components/Orb/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { usePrefersReducedMotion } from "@/hooks/use-reduced-motion";
 import { orbColors, type OrbVisualState } from "./styles";
 
 interface OrbProps {
@@ -287,6 +288,8 @@ export function Orb({
 }: OrbProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const motionSuppressed = suppressMotion || prefersReducedMotion;
   const isLive = LIVE_STATES.has(state);
   const shouldTrack = enableTracking && isLive;
   const targetTrackRef = useRef({ x: 0, y: 0 });
@@ -311,13 +314,13 @@ export function Orb({
       return;
     }
 
-    const target = getVisualTarget(state, container, suppressMotion);
+    const target = getVisualTarget(state, container, motionSuppressed);
     targetVisualRef.current = target;
 
     if (!visualStateRef.current) {
       visualStateRef.current = createInitialVisualState(target);
     }
-  }, [state, suppressMotion]);
+  }, [state, motionSuppressed]);
 
   useEffect(() => {
     if (!shouldTrack) {
@@ -427,7 +430,7 @@ export function Orb({
 
     const initialTarget =
       targetVisualRef.current ??
-      getVisualTarget(state, container, suppressMotion);
+      getVisualTarget(state, container, motionSuppressed);
     targetVisualRef.current = initialTarget;
     visualStateRef.current ??= createInitialVisualState(initialTarget);
 

--- a/apps/web/src/components/ProgressBar/index.tsx
+++ b/apps/web/src/components/ProgressBar/index.tsx
@@ -1,24 +1,40 @@
 import { AnimatePresence, motion } from "motion/react";
+import { usePrefersReducedMotion } from "@/hooks/use-reduced-motion";
 
 interface ProgressBarProps {
   message?: string;
 }
 
 export function ProgressBar({ message }: ProgressBarProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
   return (
     <div className="flex flex-col items-center gap-2 w-full">
       <div className="w-full max-w-[200px] h-[3px] bg-foreground/5 rounded-full overflow-hidden">
-        <motion.div
-          className="h-full w-1/3 bg-foreground/30 rounded-full"
-          initial={{ x: "-100%" }}
-          animate={{ x: "400%" }}
-          transition={{
-            duration: 1.5,
-            ease: "easeInOut",
-            repeat: Infinity,
-            repeatType: "loop",
-          }}
-        />
+        {prefersReducedMotion ? (
+          <motion.div
+            className="h-full w-full bg-foreground/30 rounded-full"
+            animate={{ opacity: [0.4, 1, 0.4] }}
+            transition={{
+              duration: 1.5,
+              ease: "easeInOut",
+              repeat: Infinity,
+              repeatType: "loop",
+            }}
+          />
+        ) : (
+          <motion.div
+            className="h-full w-1/3 bg-foreground/30 rounded-full"
+            initial={{ x: "-100%" }}
+            animate={{ x: "400%" }}
+            transition={{
+              duration: 1.5,
+              ease: "easeInOut",
+              repeat: Infinity,
+              repeatType: "loop",
+            }}
+          />
+        )}
       </div>
       <AnimatePresence mode="wait">
         {message && (

--- a/apps/web/src/hooks/use-reduced-motion.ts
+++ b/apps/web/src/hooks/use-reduced-motion.ts
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+export function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = React.useState(
+    () => window.matchMedia(REDUCED_MOTION_QUERY).matches,
+  );
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+    const onChange = () => {
+      setPrefersReducedMotion(mediaQuery.matches);
+    };
+    mediaQuery.addEventListener("change", onChange);
+    return () => mediaQuery.removeEventListener("change", onChange);
+  }, []);
+
+  return prefersReducedMotion;
+}


### PR DESCRIPTION
Fixes #671

## What

Honors the OS-level `prefers-reduced-motion: reduce` setting across the app's two animated surfaces, per WCAG 2.2 SC 2.3.3 and Apple HIG.

- **New shared hook** `apps/web/src/hooks/use-reduced-motion.ts` (`usePrefersReducedMotion`), mirroring the existing `useIsMobile` matchMedia pattern: lazy-initializes from `window.matchMedia('(prefers-reduced-motion: reduce)').matches` and subscribes to `change` so it reacts to runtime toggles. Lives in `hooks/` because it's shared by both Orb and ProgressBar (per CLAUDE.md, that dir is for cross-component hooks).
- **Orb** (`components/Orb/index.tsx`): reads the hook internally and OR's it with the existing `suppressMotion` prop (`motionSuppressed = suppressMotion || prefersReducedMotion`). This applies to **all** Orb instances (AgentCard, AgentIsland collapsed/expanded, LoadingScreen, /debug) without touching every call site, while preserving the hardcoded `suppressMotion` on the 28px collapsed orb. `suppressMotion` already zeroes glow/orb/float amplitudes, so reduced-motion orbs go fully still. The render loop reads `targetVisualRef` each frame, so toggling the OS setting updates live with no stale closure.
- **ProgressBar** (`components/ProgressBar/index.tsx`): when reduced motion is set, renders a full-width opacity-pulse bar (the issue explicitly permits "static or opacity-pulse") instead of the `repeat: Infinity` horizontal x-sweep.

Identity-safe: only motion is suppressed, and only when the user opted in at the OS level. Colors, layout, and the orb's presence are unchanged.

## Testing

`./check.sh web` is green: eslint (0 errors), prettier `--check`, `tsc --noEmit`, and vitest (53 passed). The web vitest tier only runs node-environment `*.test.ts` (no jsdom / `.tsx` render tier, cf. #644), so this matchMedia + React-render behavior is verified via tsc/eslint rather than a render test that couldn't run. The hook deliberately matches the proven `useIsMobile` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)