### PR TITLE
fix(app): add directional wizard step motion and rename misnamed fadeSlide

### DIFF
--- a/apps/web/src/components/AuthFlow/index.tsx
+++ b/apps/web/src/components/AuthFlow/index.tsx
@@ -4,7 +4,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ProgressBar } from "@/components/ProgressBar";
-import { fadeSlide } from "@/lib/motion";
+import { fade } from "@/lib/motion";
 import { errorMessage } from "@/lib/utils";
 
 interface AuthFlowProps {
@@ -152,7 +152,7 @@ export function AuthFlow({
     <AnimatePresence mode="wait">
       <motion.div
         key={authState}
-        {...fadeSlide}
+        {...fade}
         className="min-w-0 w-full max-w-full"
       >
         {content}

--- a/apps/web/src/components/Connect/index.tsx
+++ b/apps/web/src/components/Connect/index.tsx
@@ -9,7 +9,7 @@ import {
   FieldLabel,
   FieldDescription,
 } from "@/components/ui/field";
-import { fadeSlide } from "@/lib/motion";
+import { fade } from "@/lib/motion";
 import { errorMessage } from "@/lib/utils";
 import { useAuth } from "@/providers/AuthProvider";
 
@@ -122,7 +122,7 @@ export function Connect() {
           <AnimatePresence>
             {error && (
               <motion.div
-                {...fadeSlide}
+                {...fade}
                 className="flex flex-col items-center gap-1 text-center"
               >
                 <p className="text-xs">

--- a/apps/web/src/components/NewAgent/index.tsx
+++ b/apps/web/src/components/NewAgent/index.tsx
@@ -8,7 +8,7 @@ import {
   type OpenRouterConfig,
   type ProviderResult,
 } from "@/api/agents";
-import { fadeSlide } from "@/lib/motion";
+import { stepTransition } from "@/lib/motion";
 import { errorMessage } from "@/lib/utils";
 import { useOnboarding } from "@/stores/use-onboarding";
 import { NameStep } from "./Steps/NameStep";
@@ -118,7 +118,7 @@ export function NewAgent() {
     <div className="flex flex-col h-full">
       <div className="flex-1 flex items-center justify-center">
         <AnimatePresence mode="wait">
-          <motion.div key={step} {...fadeSlide}>
+          <motion.div key={step} {...stepTransition}>
             {content}
           </motion.div>
         </AnimatePresence>

--- a/apps/web/src/components/ProviderPicker/index.tsx
+++ b/apps/web/src/components/ProviderPicker/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { ChevronLeftIcon } from "lucide-react";
-import { fadeSlide } from "@/lib/motion";
+import { stepTransition } from "@/lib/motion";
 import { claudeProvider } from "@/api";
 import type { ProviderResult } from "@/api/agents";
 
@@ -96,7 +96,7 @@ export function ProviderPicker({
       )}
 
       <AnimatePresence mode="wait">
-        <motion.div key={step} {...fadeSlide} className="w-full">
+        <motion.div key={step} {...stepTransition} className="w-full">
           {step === "choice" && <ChoiceStep onPick={handleChoice} />}
           {step === "auth" && (
             <AuthStep

--- a/apps/web/src/lib/motion.ts
+++ b/apps/web/src/lib/motion.ts
@@ -6,11 +6,11 @@ export const spring: Transition = {
   damping: 30,
 };
 
-export const fadeSlide = {
-  initial: { opacity: 0 },
-  animate: { opacity: 1 },
-  exit: { opacity: 0 },
-  transition: { duration: 0.15 },
+export const stepTransition = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -8 },
+  transition: spring,
 };
 
 export const fade = {


### PR DESCRIPTION
Fixes #672

`fadeSlide` in `apps/web/src/lib/motion.ts` was pure opacity and byte-for-byte identical to the `fade` export below it, so the name was a genuine misnomer; it drove every onboarding step change, leaving the wizard blinking in place with no directional cue. The `spring` export was unused.

## Changes
- Consolidate the genuinely opacity-only uses (Connect error reveal, AuthFlow in-place fades) onto the correctly named `fade`.
- Add a directional `stepTransition` variant (small `y` offset in/out + the existing `spring` for follow-through, total motion ≤200ms) and use it for the `NewAgent` and `ProviderPicker` step transitions.
- `spring` is now used; no remaining `fadeSlide` references.

A vertical `y` offset is direction-ambiguous, so this is framed as life + a correctly named export rather than "forward momentum". Identity-safe, presentational only.

`./check.sh web` passes (eslint, prettier, tsc, vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)