### PR TITLE
fix(agent): bound EventBus subscriber queues with backpressure policy

### DIFF
--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -3,9 +3,19 @@
 import asyncio
 import datetime as dt
 import json
+import logging
 import pathlib as pl
 import sqlite3
 import typing as tp
+
+logger = logging.getLogger("vesta.events")
+
+# Upper bound on events buffered per subscriber. A slow-but-alive WS client (phone
+# on a weak link, wedged webview) whose send loop stalls would otherwise grow its
+# queue without limit. 1000 events covers a long burst of streamed text/tool blocks
+# while capping memory; on overflow we drop the oldest event (see emit) so the
+# stream stays current rather than replaying a stale backlog.
+SUBSCRIBER_QUEUE_MAXSIZE = 1000
 
 type AgentState = tp.Literal["idle", "thinking"]
 
@@ -144,7 +154,7 @@ class EventBus:
             self._conn.executescript(_EVENTS_SCHEMA)
 
     def subscribe(self) -> asyncio.Queue[VestaEvent]:
-        q: asyncio.Queue[VestaEvent] = asyncio.Queue()
+        q: asyncio.Queue[VestaEvent] = asyncio.Queue(maxsize=SUBSCRIBER_QUEUE_MAXSIZE)
         self._subscribers.add(q)
         return q
 
@@ -160,6 +170,22 @@ class EventBus:
             )
             self._conn.commit()
         for q in self._subscribers:
+            self._offer(q, event)
+
+    def _offer(self, q: asyncio.Queue[VestaEvent], event: StreamEvent) -> None:
+        """Enqueue for one subscriber, dropping its oldest event on overflow.
+
+        A stalled send loop must not pin memory: when the queue is full we evict
+        the oldest buffered event to make room for the newest, keeping the live
+        stream current. History replay is delivered out-of-band on connect (api.py),
+        never through this queue, so it is unaffected."""
+        try:
+            q.put_nowait(event)
+        except asyncio.QueueFull:
+            # emit runs on the loop thread, so no other coroutine drains between
+            # full and get_nowait: the queue is non-empty here by construction.
+            dropped = q.get_nowait()
+            logger.warning("subscriber queue full, dropped oldest event type=%s", dropped["type"])
             q.put_nowait(event)
 
     @property

--- a/agent/tests/test_eventbus.py
+++ b/agent/tests/test_eventbus.py
@@ -2,7 +2,7 @@
 
 import typing as tp
 
-from core.events import ChatEvent, EventBus, SubagentStartEvent, UserEvent
+from core.events import SUBSCRIBER_QUEUE_MAXSIZE, ChatEvent, EventBus, SubagentStartEvent, UserEvent
 
 
 # --- Emit & persist ---
@@ -68,6 +68,40 @@ def test_persists_across_instances(tmp_path):
     assert "before restart" in texts
     assert "reply" in texts
     bus2.close()
+
+
+# --- Backpressure ---
+
+
+def test_slow_subscriber_queue_is_bounded(event_bus):
+    """A subscriber that never drains stays bounded; the oldest events are dropped."""
+    q = event_bus.subscribe()
+    overflow = 50
+    total = SUBSCRIBER_QUEUE_MAXSIZE + overflow
+    for i in range(total):
+        event_bus.emit(UserEvent(type="user", text=f"msg {i}"))
+
+    assert q.qsize() == SUBSCRIBER_QUEUE_MAXSIZE
+
+    drained = [q.get_nowait() for _ in range(q.qsize())]
+    texts = [tp.cast(tp.Any, e)["text"] for e in drained]
+    # Oldest `overflow` events were evicted; the queue holds the most recent window.
+    assert texts[0] == f"msg {overflow}"
+    assert texts[-1] == f"msg {total - 1}"
+
+
+def test_drop_does_not_affect_other_subscribers(event_bus):
+    """Overflowing one subscriber must not drop events for a healthy one."""
+    slow = event_bus.subscribe()
+    fast = event_bus.subscribe()
+    total = SUBSCRIBER_QUEUE_MAXSIZE + 10
+    for i in range(total):
+        event = UserEvent(type="user", text=f"msg {i}")
+        event_bus.emit(event)
+        fast.get_nowait()  # fast subscriber keeps draining, never overflows
+
+    assert slow.qsize() == SUBSCRIBER_QUEUE_MAXSIZE
+    assert fast.qsize() == 0
 
 
 # --- Pagination ---


### PR DESCRIPTION
Fixes #637

## Problem
Each WebSocket connection subscribed to the EventBus via an unbounded `asyncio.Queue`, and `emit()` pushed every event with `put_nowait`. A slow-but-alive client (phone on a weak link, wedged Tauri webview) whose send loop stalls never drained its queue, so events accumulated without limit for the life of the connection.

## Policy chosen: drop-oldest
- `subscribe()` now returns `asyncio.Queue(maxsize=SUBSCRIBER_QUEUE_MAXSIZE)` (1000, a named module-level constant documenting the rationale).
- On `QueueFull`, `emit()` evicts that subscriber's **oldest** buffered event to make room for the newest, logging the drop at warning with %-style placeholders. This caps memory while keeping the live stream current, and keeps the connection alive (no disconnect), so a transient slowdown self-heals once the client catches up.
- History replay is delivered out-of-band on connect (`api.py` sends `HistoryEvent` directly before the send loop starts), never through this queue, so replay semantics are unaffected. `_send_loop` needs no change: it keeps draining via `sub.get()`.
- Status-event coalescing (latest-wins) was considered but skipped to keep the change simple; possible follow-up.

## Test
Added behavioral tests in `agent/tests/test_eventbus.py`: filling a subscriber past the bound asserts the queue stays at `SUBSCRIBER_QUEUE_MAXSIZE` with the oldest events evicted (not unbounded growth), and that overflowing one subscriber does not drop events for a healthy one. Hermetic, concrete assertions, no sleeps.

`./check.sh agent` passes (ruff, ruff format, ty, pytest: 276 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)