### PR TITLE
refactor(agent): add public liveness accessor to cc_sdk

### DIFF
--- a/agent/core/cc_sdk/client.py
+++ b/agent/core/cc_sdk/client.py
@@ -148,6 +148,17 @@ class ClaudeSDKClient:
     def returncode(self) -> int | None:
         return self._exit_code
 
+    def is_alive(self) -> bool | None:
+        """Liveness of the underlying claude process, as a tri-state.
+
+        None  — unknown: the session has not been launched yet (no __aenter__).
+        True  — launched and still running (no exit code observed).
+        False — launched and exited (an exit code was observed).
+        """
+        if self._monitor_task is None:
+            return None
+        return self._exit_code is None
+
     async def __aenter__(self) -> "ClaudeSDKClient":
         try:
             _preseed_config(self._cwd)

--- a/agent/core/diagnostics.py
+++ b/agent/core/diagnostics.py
@@ -62,13 +62,10 @@ def make_stderr_handler(state: vm.State) -> tp.Callable[[str], None]:
 
 
 def _check_sdk_subprocess_alive(state: vm.State) -> bool | None:
-    """Returns None if we can't determine."""
+    """Returns None if we can't determine (no client, or session not yet launched)."""
     if state.client is None:
         return None
-    try:
-        return state.client.returncode is None
-    except (AttributeError, TypeError):
-        return None
+    return state.client.is_alive()
 
 
 async def sdk_watchdog(state: vm.State, *, stop: asyncio.Event) -> None:

--- a/agent/tests/test_e2e_transport.py
+++ b/agent/tests/test_e2e_transport.py
@@ -313,8 +313,9 @@ async def test_crash_surfaces_sdk_error_with_stderr(sandbox: Sandbox) -> None:
     stderr_lines: list[str] = []
     options = ClaudeAgentOptions(cwd=str(sandbox.cwd), stderr=stderr_lines.append)
     async with ClaudeSDKClient(options=options) as client:
-        # While alive, the liveness signal diagnostics.subprocess_alive reads is "no exit code yet".
+        # While alive, the liveness signal diagnostics reads through is_alive() is "running".
         assert client.returncode is None
+        assert client.is_alive() is True
 
         await client.query("crash:7")
         with pytest.raises(ClaudeSDKError) as exc_info:
@@ -322,8 +323,9 @@ async def test_crash_surfaces_sdk_error_with_stderr(sandbox: Sandbox) -> None:
         assert "code 7" in str(exc_info.value)
         assert "crashing on request" in str(exc_info.value), "stderr tail must be included for diagnosis"
 
-        # The crash exit code propagates to the returncode that the watchdog inspects.
+        # The crash exit code propagates to the returncode and is_alive() the watchdog inspects.
         assert client.returncode == 7
+        assert client.is_alive() is False
         # Real stderr reaches the callback; the internal exit marker is consumed, not leaked.
         assert any("crashing on request" in line for line in stderr_lines)
         assert not any("__CC_EXIT__" in line for line in stderr_lines)

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -1,12 +1,14 @@
 """Tests for SDK activity watchdog, tool duration tracking, and hang diagnostics."""
 
 import asyncio
+import tempfile
 import time
 import typing as tp
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import core.models as vm
+from core.cc_sdk import ClaudeAgentOptions, ClaudeSDKClient
 from core.client import converse
 from wait_util import wait_for_condition
 from core.diagnostics import (
@@ -90,22 +92,10 @@ def test_format_hang_diagnostics_includes_stderr_tail():
 
 
 # --- _check_sdk_subprocess_alive ---
-
-
-def test_subprocess_alive_returns_true_when_running():
-    state = vm.State()
-    mock_client = MagicMock()
-    mock_client.returncode = None
-    state.client = mock_client
-    assert _check_sdk_subprocess_alive(state) is True
-
-
-def test_subprocess_alive_returns_false_when_exited():
-    state = vm.State()
-    mock_client = MagicMock()
-    mock_client.returncode = 1
-    state.client = mock_client
-    assert _check_sdk_subprocess_alive(state) is False
+# Liveness is read through the client's public is_alive() accessor. The alive/dead
+# distinction needs a launched claude process and lives in test_e2e_transport.py; the
+# reachable-without-tmux cases (no client, and a constructed-but-unlaunched real client)
+# are covered here.
 
 
 def test_subprocess_alive_returns_none_when_no_client():
@@ -114,10 +104,9 @@ def test_subprocess_alive_returns_none_when_no_client():
     assert _check_sdk_subprocess_alive(state) is None
 
 
-def test_subprocess_alive_returns_none_on_missing_attrs():
+def test_subprocess_alive_returns_none_before_launch():
     state = vm.State()
-    mock_client = MagicMock(spec=[])  # No attributes at all
-    state.client = mock_client
+    state.client = ClaudeSDKClient(options=ClaudeAgentOptions(cwd=tempfile.mkdtemp()))
     assert _check_sdk_subprocess_alive(state) is None
 
 


### PR DESCRIPTION
Fixes #636

`core/diagnostics.py` probed SDK child-process liveness by walking `state.client._transport._process.returncode`, breaking the cc_sdk deep-module boundary and inverting the dependency: any refactor of how cc_sdk tracks process exit would silently break the hang watchdog, and the mock-based test encoded the private path as contract.

## Changes
- Add a public `ClaudeSDKClient.is_alive() -> bool | None` accessor (None = unknown / not launched, True = alive, False = exited) exposing the known exit state.
- `_check_sdk_subprocess_alive` now calls `state.client.is_alive()` instead of reaching through `_transport._process`.
- Drop the `_Proc`/`_Transport` peek shim from `client.py`; the client tracks exit state internally. The public `returncode` property is preserved for its existing e2e-test consumer.
- Rewrite `test_watchdog.py` to drive the public accessor on a real client instead of building MagicMock chains for the private path.

`./check.sh agent` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)