### PR TITLE
refactor(agent): normalize em-dashes in restart reasons and operator log strings

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -109,8 +109,8 @@ async def _history_handler(request: web.Request) -> web.Response:
     """Paginated event history.
 
     Query params:
-      cursor (int, optional) — fetch events before this id. Omit for most recent.
-      limit  (int, optional) — max events to return (default: EventBus.PAGE_SIZE).
+      cursor (int, optional): fetch events before this id. Omit for most recent.
+      limit  (int, optional): max events to return (default: EventBus.PAGE_SIZE).
     """
     event_bus: EventBus = request.app["event_bus"]
 
@@ -139,8 +139,8 @@ async def _search_handler(request: web.Request) -> web.Response:
     """Full-text search over events.
 
     Query params:
-      q     (str, required)  — FTS5 search query.
-      limit (int, optional)  — max results (default: 20).
+      q     (str, required): FTS5 search query.
+      limit (int, optional): max results (default: 20).
     """
     event_bus: EventBus = request.app["event_bus"]
     query = request.query.get("q", "").strip()
@@ -210,7 +210,7 @@ async def _provider_status_handler(request: web.Request) -> web.Response:
     """Report the agent's LLM-provider authentication state.
 
     Read by vestad on every status poll to surface 'alive' vs 'not_authenticated'
-    to the web UI. Agent is the source of truth — vestad knows nothing about
+    to the web UI. Agent is the source of truth: vestad knows nothing about
     credential file formats."""
     state = request.app["state"]
     if state.provider_status is None:

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -33,7 +33,7 @@ async def resolve_openrouter_max_tokens(config: vm.VestaConfig) -> int | None:
     via CLAUDE_CODE_MAX_CONTEXT_TOKENS must reflect what the model actually supports.
     The caller caps this at config.max_context_tokens before passing it to the SDK
     (cache-read cost scales with context size). Returns None on any failure, so
-    claude-code falls back to its default — same behavior as before."""
+    claude-code falls back to its default, same behavior as before."""
     if config.agent_provider != "openrouter" or "ANTHROPIC_AUTH_TOKEN" not in os.environ:
         return None
     try:
@@ -244,7 +244,7 @@ _STREAM_IDLE_TIMEOUT_MS = 300_000  # 5 minutes: abort stalled API streams
 def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgentOptions:
     memory_path = get_memory_path(config)
     if not memory_path.exists():
-        raise FileNotFoundError(f"MEMORY.md not found at {memory_path} — cannot start agent without it")
+        raise FileNotFoundError(f"MEMORY.md not found at {memory_path}, cannot start agent without it")
     system_prompt = memory_path.read_text()
 
     name = config.agent_name

--- a/agent/core/diagnostics.py
+++ b/agent/core/diagnostics.py
@@ -102,6 +102,6 @@ async def log_context_usage(state: vm.State) -> None:
         log_fn = logger.warning if pct > 80 else logger.usage
         log_fn(f"Context: {pct:.0f}% ({total:,}/{max_tok:,} tokens)")
     except TimeoutError:
-        logger.warning(f"get_context_usage hung for {_CONTEXT_USAGE_TIMEOUT_S}s — skipping")
+        logger.warning(f"get_context_usage hung for {_CONTEXT_USAGE_TIMEOUT_S}s, skipping")
     except (OSError, RuntimeError, KeyError, TypeError):
         pass

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -137,13 +137,13 @@ async def process_batch(
 def drop_greeting_notification(*, config: vm.VestaConfig, state: vm.State, reason: str) -> bool:
     """Drop a greeting notification (first_start_setup interrupting, restart greeting passive). Returns True if a notification was dropped."""
     if config.agent_provider == "claude" and not CREDENTIALS_PATH.exists():
-        logger.startup("No credentials yet — waiting for auth before starting")
+        logger.startup("No credentials yet, waiting for auth before starting")
         return False
 
     if reason == "first_start":
         setup_prompt = load_prompt("first_start_setup", config)
         if not setup_prompt:
-            # No prompt to run — flip the flag so we don't loop into first-start every reboot.
+            # No prompt to run, flip the flag so we don't loop into first-start every reboot.
             state.persisted.first_start_done = True
             state_store.save_state(state.persisted, config)
             return False
@@ -157,7 +157,7 @@ def drop_greeting_notification(*, config: vm.VestaConfig, state: vm.State, reaso
         state.persisted.show_dreamer_summary = False
         state_store.save_state(state.persisted, config)
         for path in sorted(config.dreamer_dir.glob("*.md"), reverse=True)[:3]:
-            extras.append(f"[Dreamer Summary — {path.stem}]\n{path.read_text().strip()}")
+            extras.append(f"[Dreamer Summary: {path.stem}]\n{path.read_text().strip()}")
     prompt = build_restart_context(reason, config, extras=extras)
     if not prompt or not prompt.strip():
         return False
@@ -188,9 +188,9 @@ async def _run_messages_with_interrupts(
         except asyncio.CancelledError:
             if state.shutdown_event.is_set() or state.graceful_shutdown.is_set():
                 raise
-            logger.error("Message processing cancelled unexpectedly — triggering restart")
+            logger.error("Message processing cancelled unexpectedly, triggering restart")
             state.event_bus.emit({"type": "error", "text": "processing cancelled"})
-            state.persisted.last_restart_reason = "error — processing cancelled"
+            state.persisted.last_restart_reason = "error: processing cancelled"
             state_store.save_state(state.persisted, config)
             state.graceful_shutdown.set()
             raise
@@ -204,9 +204,9 @@ async def _run_messages_with_interrupts(
             detail = f"Error processing message: {error_msg} | exit_code={exit_code}"
             if stderr_tail:
                 detail += f"\nRecent stderr:\n{stderr_tail}"
-            logger.error(f"{detail} — triggering restart")
+            logger.error(f"{detail}, triggering restart")
             state.event_bus.emit({"type": "error", "text": error_msg})
-            state.persisted.last_restart_reason = f"error — {error_msg}"
+            state.persisted.last_restart_reason = f"error: {error_msg}"
             state_store.save_state(state.persisted, config)
             state.graceful_shutdown.set()
         finally:
@@ -300,7 +300,7 @@ async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm
             logger.warning(
                 f"Session resume failed ({state.persisted.session_id[:16]}...): {type(exc).__name__}: {exc}"
                 f" | exit_code={exit_code}"
-                f" — starting fresh\nRecent stderr:\n{stderr_tail}"
+                f", starting fresh\nRecent stderr:\n{stderr_tail}"
             )
             state.persisted.session_id = None
             state_store.save_state(state.persisted, config)
@@ -394,7 +394,7 @@ async def monitor_loop(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.Stat
             if (now - last_proactive).total_seconds() >= config.proactive_check_interval * 60:
                 last_proactive = now
                 if state.processor_busy or not queue.empty():
-                    logger.debug("Proactive check skipped: agent is busy — waiting full interval")
+                    logger.debug("Proactive check skipped: agent is busy, waiting full interval")
                 else:
                     check_proactive_task(config=config)
 

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -79,17 +79,17 @@ def handle_processor_done(task: asyncio.Task[None], *, state: vm.State, config: 
     if state.graceful_shutdown.is_set():
         return
     if task.cancelled():
-        logger.error("message_processor cancelled unexpectedly — restarting")
-        state.persisted.last_restart_reason = "crash — processor cancelled unexpectedly"
+        logger.error("message_processor cancelled unexpectedly, restarting")
+        state.persisted.last_restart_reason = "crash: processor cancelled unexpectedly"
     else:
         exc = task.exception()
         if exc is not None:
             exit_code, stderr_tail = format_crash_detail(exc, state.stderr_buffer)
             logger.error(f"message_processor crashed: {type(exc).__name__}: {exc} | exit_code={exit_code}\nRecent stderr:\n{stderr_tail}")
-            state.persisted.last_restart_reason = f"crash — {type(exc).__name__}: {exc}"
+            state.persisted.last_restart_reason = f"crash: {type(exc).__name__}: {exc}"
         else:
-            logger.error("message_processor exited without error — restarting")
-            state.persisted.last_restart_reason = "crash — processor exited silently"
+            logger.error("message_processor exited without error, restarting")
+            state.persisted.last_restart_reason = "crash: processor exited silently"
     state_store.save_state(state.persisted, config)
     state.graceful_shutdown.set()
 

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -25,9 +25,9 @@ TYPE_PROACTIVE_CHECK = "proactive_check"
 TYPE_NIGHTLY_DREAM = "nightly_dream"
 TYPE_MIGRATION = "migration"
 
-CLEAN_RESTART = "restart — clean restart"
-NIGHTLY_RESTART = "nightly — dreamer ran, session cleared for fresh context"
-CRASH_RESTART = "crash — restarted after unexpected exit"
+CLEAN_RESTART = "restart: clean restart"
+NIGHTLY_RESTART = "nightly: dreamer ran, session cleared for fresh context"
+CRASH_RESTART = "crash: restarted after unexpected exit"
 FIRST_START_REASON = "first start"
 
 

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -89,7 +89,7 @@ async def test_restarts_on_error(tmp_path):
         tmp_path, message_side_effect=side_effect, initial_queue=[("first message - will fail", True)]
     )
     assert state.graceful_shutdown.is_set()
-    assert state.persisted.last_restart_reason == "error — Simulated SDK buffer overflow"
+    assert state.persisted.last_restart_reason == "error: Simulated SDK buffer overflow"
 
 
 @pytest.mark.anyio
@@ -111,7 +111,7 @@ async def test_error_path_emits_error_event_and_resets_state_idle(tmp_path):
         initial_queue=[("will crash", True)],
     )
 
-    assert state.persisted.last_restart_reason == "error — kaboom in the SDK"
+    assert state.persisted.last_restart_reason == "error: kaboom in the SDK"
     assert state.event_bus.state == "idle", "bus state must reset to idle after the crash path"
 
     drained = []
@@ -131,7 +131,7 @@ async def test_restarts_on_timeout(tmp_path):
         tmp_path, message_side_effect=side_effect, initial_queue=[("slow request", True)]
     )
     assert state.graceful_shutdown.is_set()
-    assert state.persisted.last_restart_reason == "error — Response timed out"
+    assert state.persisted.last_restart_reason == "error: Response timed out"
 
 
 def test_restart_reason_round_trip(tmp_path):
@@ -143,11 +143,11 @@ def test_restart_reason_round_trip(tmp_path):
     config.data_dir.mkdir(parents=True, exist_ok=True)
 
     state = vm.State()
-    state.persisted.last_restart_reason = "nightly — conversation history reset, dreamer ran"
+    state.persisted.last_restart_reason = "nightly: conversation history reset, dreamer ran"
     state_store.save_state(state.persisted, config)
 
     reloaded = vm.State(persisted=state_store.load_state(config))
-    assert _consume_restart_reason(reloaded, config, first_start=False) == "nightly — conversation history reset, dreamer ran"
+    assert _consume_restart_reason(reloaded, config, first_start=False) == "nightly: conversation history reset, dreamer ran"
 
     # Consumed: a fresh load now reports CRASH_RESTART.
     again = vm.State(persisted=state_store.load_state(config))
@@ -261,7 +261,7 @@ async def test_cancellation_triggers_restart(tmp_path):
             await _run_messages_with_interrupts("msg", is_user=True, queue=queue, state=state, config=config)
 
     assert state.graceful_shutdown.is_set()
-    assert state.persisted.last_restart_reason == "error — processing cancelled"
+    assert state.persisted.last_restart_reason == "error: processing cancelled"
 
 
 @pytest.mark.anyio
@@ -320,7 +320,7 @@ async def test_handle_processor_done_silent_cancel_triggers_restart(tmp_path):
     handle_processor_done(task, state=state, config=config)
 
     assert state.graceful_shutdown.is_set()
-    assert state.persisted.last_restart_reason == "crash — processor cancelled unexpectedly"
+    assert state.persisted.last_restart_reason == "crash: processor cancelled unexpectedly"
 
 
 @pytest.mark.anyio
@@ -364,7 +364,7 @@ async def test_handle_processor_done_silent_exit_triggers_restart(tmp_path):
     handle_processor_done(task, state=state, config=config)
 
     assert state.graceful_shutdown.is_set()
-    assert state.persisted.last_restart_reason == "crash — processor exited silently"
+    assert state.persisted.last_restart_reason == "crash: processor exited silently"
 
 
 @pytest.mark.anyio
@@ -376,7 +376,7 @@ async def test_handle_processor_done_noop_during_shutdown(tmp_path):
     config.data_dir.mkdir(parents=True, exist_ok=True)
     state = vm.State()
     state.graceful_shutdown.set()
-    state.persisted.last_restart_reason = "nightly — dreamer ran, session cleared for fresh context"
+    state.persisted.last_restart_reason = "nightly: dreamer ran, session cleared for fresh context"
 
     async def silent():
         return None
@@ -386,7 +386,7 @@ async def test_handle_processor_done_noop_during_shutdown(tmp_path):
 
     handle_processor_done(task, state=state, config=config)
 
-    assert state.persisted.last_restart_reason == "nightly — dreamer ran, session cleared for fresh context"
+    assert state.persisted.last_restart_reason == "nightly: dreamer ran, session cleared for fresh context"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Fixes #645

The no-dashes prose rule explicitly covers comments and log strings. The restart-reason constants are the strongest case: they are persisted, logged at boot/shutdown, and would land in any future surfaced-reason event, so they are operator-facing prose. Several of these constants and surrounding log strings used the em-dash separator.

## Changes
- Normalize em-dash separators to commas/colons across the persisted restart-reason constants in `core/models.py` and the operator-facing log strings / docstrings in `core/main.py`, `core/loops.py`, `core/diagnostics.py`, `core/client.py`, and `core/api.py`, as one coordinated change.

The restart-reason strings are only persisted and logged, never parsed by splitting on the separator, so the change is purely cosmetic with no behavior impact (a one-time cosmetic mismatch with any old persisted value, as noted in the issue). No lint guard was added to keep the PR low-risk and false-positive-free; it can follow up separately.

`./check.sh agent` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)