### PR TITLE
feat(agent): emit hang and unresponsive-SDK conditions to the event bus

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -69,7 +69,11 @@ async def attempt_interrupt(state: vm.State, *, config: vm.VestaConfig, reason: 
         return True
     except TimeoutError:
         diag = diagnostics.format_hang_diagnostics(state)
-        logger.error(f"SDK unresponsive, sending SIGTERM for graceful shutdown | reason={reason} | {diag}")
+        msg = f"SDK unresponsive, sending SIGTERM for graceful shutdown | reason={reason} | {diag}"
+        logger.error(msg)
+        # emit() is synchronous (queue put_nowait + sqlite commit), so the unresponsive-SDK
+        # condition is persisted and fanned out to subscribers before we SIGTERM/exit.
+        state.event_bus.emit({"type": "error", "text": msg})
         os.kill(os.getpid(), signal.SIGTERM)
         await asyncio.sleep(10)
         os._exit(1)

--- a/agent/core/diagnostics.py
+++ b/agent/core/diagnostics.py
@@ -10,6 +10,7 @@ from . import models as vm
 
 _WATCHDOG_THRESHOLDS_S = (60, 120, 300)
 _CONTEXT_USAGE_TIMEOUT_S = 10.0
+_CONTEXT_USAGE_WARN_PCT = 80.0
 
 
 def touch_activity(state: vm.State, label: str) -> None:
@@ -87,6 +88,9 @@ async def sdk_watchdog(state: vm.State, *, stop: asyncio.Event) -> None:
                 alive_str = f"process_alive={alive}" if alive is not None else "process_alive=unknown"
                 diag = format_hang_diagnostics(state)
                 logger.warning(f"SDK silent for {threshold}s | {alive_str} | {diag}")
+                # One event per threshold crossing (warned_at gates re-emit), so a multi-minute
+                # hang reaches the observability surface without spamming the stream every poll.
+                state.event_bus.emit({"type": "error", "text": f"SDK silent for {threshold}s | {alive_str} | {diag}"})
         if idle < _WATCHDOG_THRESHOLDS_S[0]:
             warned_at.clear()
 
@@ -99,8 +103,14 @@ async def log_context_usage(state: vm.State) -> None:
         pct = usage["percentage"]
         total = usage["totalTokens"]
         max_tok = usage["maxTokens"]
-        log_fn = logger.warning if pct > 80 else logger.usage
-        log_fn(f"Context: {pct:.0f}% ({total:,}/{max_tok:,} tokens)")
+        over_threshold = pct > _CONTEXT_USAGE_WARN_PCT
+        log_fn = logger.warning if over_threshold else logger.usage
+        summary = f"Context: {pct:.0f}% ({total:,}/{max_tok:,} tokens)"
+        log_fn(summary)
+        # Emit once on crossing into the warning band, not on every per-message check.
+        if over_threshold and not state.context_warning_active:
+            state.event_bus.emit({"type": "error", "text": f"Context usage above {_CONTEXT_USAGE_WARN_PCT:.0f}% | {summary}"})
+        state.context_warning_active = over_threshold
     except TimeoutError:
         logger.warning(f"get_context_usage hung for {_CONTEXT_USAGE_TIMEOUT_S}s — skipping")
     except (OSError, RuntimeError, KeyError, TypeError):

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -68,6 +68,9 @@ class State:
     last_sdk_activity: float = dc.field(default_factory=time.monotonic)
     last_sdk_activity_label: str = "init"
     active_tools: dict[str, ActiveTool] = dc.field(default_factory=dict)
+    # True while context usage is above the warning threshold, so log_context_usage emits
+    # the warning event once on crossing rather than on every per-message check.
+    context_warning_active: bool = False
 
 
 class Notification(pyd.BaseModel):

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -342,6 +342,8 @@ async def test_attempt_interrupt_escalates_to_sigterm_then_hard_exit(tmp_path):
 
     config = vm.VestaConfig(agent_dir=tmp_path / "agent", interrupt_timeout=0.01)
     state = vm.State()
+    state.event_bus = vm.EventBus(data_dir=tmp_path)
+    queue = state.event_bus.subscribe()
 
     mock_client = MagicMock()
 
@@ -378,6 +380,15 @@ async def test_attempt_interrupt_escalates_to_sigterm_then_hard_exit(tmp_path):
     assert kills == [(_os.getpid(), _signal.SIGTERM)], f"expected one SIGTERM to our own pid, got {kills}"
     assert exits == [1], f"expected os._exit(1), got {exits}"
     assert 10 in slept, "the 10s grace sleep before hard exit must be awaited (patched, not real)"
+
+    errors: list[str] = []
+    while not queue.empty():
+        event = queue.get_nowait()
+        if event["type"] == "error":
+            errors.append(event["text"])
+    assert len(errors) == 1, f"unresponsive SDK must emit exactly one error event before SIGTERM, got {errors}"
+    assert "SDK unresponsive" in errors[0]
+    state.event_bus.close()
 
 
 # --- Converse interrupt behavior ---

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -406,3 +406,42 @@ async def test_log_context_usage_timeout(tmp_path):
 
     with patch("core.diagnostics._CONTEXT_USAGE_TIMEOUT_S", 0.05):
         await asyncio.wait_for(log_context_usage(state), timeout=0.2)
+
+
+@pytest.mark.anyio
+async def test_log_context_usage_emits_warning_event_once_on_crossing(tmp_path):
+    """Crossing above the context warning threshold emits one error event; staying above does not re-emit."""
+    from core.diagnostics import log_context_usage
+
+    state = vm.State()
+    state.event_bus = vm.EventBus(data_dir=tmp_path)
+    queue = state.event_bus.subscribe()
+    mock_client = MagicMock()
+    pct = 92.0
+
+    async def usage():
+        return {"percentage": pct, "totalTokens": 184_000, "maxTokens": 200_000}
+
+    mock_client.get_context_usage = usage
+    state.client = mock_client
+
+    def error_texts() -> list[str]:
+        out: list[str] = []
+        while not queue.empty():
+            event = queue.get_nowait()
+            if event["type"] == "error":
+                out.append(event["text"])
+        return out
+
+    await log_context_usage(state)  # crosses into the warning band
+    await log_context_usage(state)  # still above: must not re-emit
+
+    errors = error_texts()
+    assert len(errors) == 1, f"expected one context warning event, got {errors}"
+    assert "above 80%" in errors[0]
+
+    pct = 40.0
+    await log_context_usage(state)  # drops back below: clears the flag, still no new event
+    assert state.context_warning_active is False
+    assert error_texts() == [], "dropping below threshold must not emit"
+    state.event_bus.close()

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -222,6 +222,43 @@ async def test_watchdog_stops_cleanly():
     await sdk_watchdog(state, stop=stop)  # Should not hang
 
 
+@pytest.mark.anyio
+async def test_watchdog_emits_error_event_once_per_threshold(tmp_path):
+    """Crossing a watchdog threshold emits exactly one error event to the bus, not one per poll."""
+    from unittest.mock import patch as _patch
+
+    state = vm.State()
+    state.event_bus = vm.EventBus(data_dir=tmp_path)
+    queue = state.event_bus.subscribe()
+    state.last_sdk_activity = time.monotonic() - 65  # Idle past the 60s threshold
+    stop = asyncio.Event()
+    seen: list[tp.Any] = []
+
+    def sixty_events() -> list[str]:
+        while not queue.empty():
+            seen.append(queue.get_nowait())
+        return [e["text"] for e in seen if e["type"] == "error" and "SDK silent for 60s" in e["text"]]
+
+    original_wait_for = asyncio.wait_for
+
+    async def fast_wait_for(coro, *, timeout):  # type: ignore[no-untyped-def]
+        return await original_wait_for(coro, timeout=0.01)
+
+    async def stop_after_some_polls():
+        # Wait until the threshold has fired, then let several more polls run to prove
+        # the event is emitted once per crossing rather than once per poll.
+        await wait_for_condition(lambda: len(sixty_events()) >= 1, message="watchdog never emitted")
+        for _ in range(5):
+            await asyncio.sleep(0.02)
+        stop.set()
+
+    with _patch("core.diagnostics.asyncio.wait_for", fast_wait_for):
+        await asyncio.gather(sdk_watchdog(state, stop=stop), stop_after_some_polls())
+
+    assert len(sixty_events()) == 1, f"expected exactly one 60s error event, got {sixty_events()}"
+    state.event_bus.close()
+
+
 # --- Tool duration tracking via hooks ---
 
 


### PR DESCRIPTION
Fixes #640

## Problem
Operational hang conditions and the unresponsive-SDK SIGTERM escalation were visible only in the container log file no client reads. A silent multi-minute hang or a self-destruct on a wedged SDK is precisely an operationally significant event, yet nothing reached the observability surface (events.db + WS stream).

## Transitions chosen to emit
Each emits exactly once per transition to avoid spamming the stream:

- **Watchdog threshold crossed** (`diagnostics.sdk_watchdog`): one error event per threshold (60/120/300s), gated by the existing `warned_at` set so a hang does not emit on every 15s poll.
- **Context usage above the warning threshold** (`diagnostics.log_context_usage`): one error event on crossing above 80%, tracked via new `State.context_warning_active` so it does not re-emit on every per-message check; the flag clears when usage drops back below.
- **SDK unresponsive before SIGTERM** (`client.attempt_interrupt`): emit the unresponsive-SDK error before the SIGTERM/exit. `emit()` is synchronous (queue `put_nowait` + sqlite commit), so the condition is persisted and fanned out to subscribers before the process exits.

## Event type
Reused the existing `ErrorEvent` rather than adding a new wire event type, so the web/TS contract (`apps/web/src/lib/types.ts`, `agent/tests/test_contract.py`) is untouched. The single-owner layout holds: the event shape stays in `events.py`.

## Tests
Behavioral tests asserting emit-once-per-transition and bus delivery:
- `test_watchdog_emits_error_event_once_per_threshold` — crossing a threshold emits exactly one event even across multiple subsequent polls.
- `test_log_context_usage_emits_warning_event_once_on_crossing` — emits once on crossing, not again while still above, and clears on dropping below.
- Extended `test_attempt_interrupt_escalates_to_sigterm_then_hard_exit` to assert one error event is emitted before SIGTERM.

All hermetic, concrete assertions, no sleeps-to-await. `./check.sh agent` passes (276 tests, ruff/format/ty clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)