### PR TITLE
feat(vestad,app): drive first-build progress from a real backend phase signal

### DIFF
--- a/apps/web/src/api/agents.test.ts
+++ b/apps/web/src/api/agents.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildPhaseMessage, type BuildPhase } from "./agents";
+
+describe("buildPhaseMessage", () => {
+  it("maps each build phase to a distinct lowercase status line", () => {
+    const phases: BuildPhase[] = [
+      "pulling",
+      "building",
+      "preparing",
+      "creating",
+      "starting",
+    ];
+    const messages = phases.map((phase) => buildPhaseMessage(phase));
+    expect(messages).toEqual([
+      "downloading the agent image...",
+      "building the agent image...",
+      "preparing agent code...",
+      "creating the container...",
+      "starting up...",
+    ]);
+    expect(new Set(messages).size).toBe(phases.length);
+    for (const message of messages) {
+      expect(message).toBe(message.toLowerCase());
+      expect(message).not.toContain("-");
+    }
+  });
+
+  it("falls back to a neutral line when no phase is reported", () => {
+    expect(buildPhaseMessage(null)).toBe("setting things up...");
+  });
+});

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -68,6 +68,40 @@ export async function createAgent(
   });
 }
 
+/// Coarse, ordered stages of first-time agent creation reported by vestad while
+/// the create POST is in flight. The image step (`pulling` on a release build,
+/// `building` from a local checkout) is the dominant wait.
+export type BuildPhase =
+  | "pulling"
+  | "building"
+  | "preparing"
+  | "creating"
+  | "starting";
+
+const BUILD_PHASE_MESSAGES: Record<BuildPhase, string> = {
+  pulling: "downloading the agent image...",
+  building: "building the agent image...",
+  preparing: "preparing agent code...",
+  creating: "creating the container...",
+  starting: "starting up...",
+};
+
+/// Map a build phase to an honest, lowercase status line. A null phase (the
+/// create has not reported yet, or has already settled) falls back to a neutral
+/// line rather than a fabricated near-done claim.
+export function buildPhaseMessage(phase: BuildPhase | null): string {
+  return phase === null ? "setting things up..." : BUILD_PHASE_MESSAGES[phase];
+}
+
+/// Read the current in-flight build phase for an agent, or null when none is
+/// recorded. Best-effort status only; the create flow owns success and failure.
+export async function getBuildPhase(name: string): Promise<BuildPhase | null> {
+  const resp = await apiJson<{ phase: BuildPhase | null }>(
+    `/agents/${encodeURIComponent(name)}/build-phase`,
+  );
+  return resp.phase;
+}
+
 /// Poll /agents/{name} until it reports "alive" or "not_authenticated".
 /// A brand-new empty agent boots into not_authenticated until provisioned.
 export async function waitUntilRunning(

--- a/apps/web/src/components/NewAgent/Steps/CreatingStep/index.tsx
+++ b/apps/web/src/components/NewAgent/Steps/CreatingStep/index.tsx
@@ -1,28 +1,36 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { ProgressBar } from "@/components/ProgressBar";
+import {
+  buildPhaseMessage,
+  getBuildPhase,
+  type BuildPhase,
+} from "@/api/agents";
 
-const MESSAGES = [
-  "setting things up...",
-  "preparing email &\ncalendar access...",
-  "loading browser &\nresearch tools...",
-  "setting up reminders & tasks...",
-  "still setting things up...",
-];
+const BUILD_PHASE_POLL_MS = 1000;
 
-export function CreatingStep() {
-  const [msgIdx, setMsgIdx] = useState(0);
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+export function CreatingStep({ agentName }: { agentName: string }) {
+  // Track the latest reported phase so the status line follows the real build
+  // and never walks backwards once a phase has been seen. The indeterminate bar
+  // stays honest about not knowing the remaining time.
+  const [phase, setPhase] = useState<BuildPhase | null>(null);
 
   useEffect(() => {
-    let idx = 0;
-    timerRef.current = setInterval(() => {
-      idx = Math.min(idx + 1, MESSAGES.length - 1);
-      setMsgIdx(idx);
-    }, 3000);
-    return () => {
-      if (timerRef.current) clearInterval(timerRef.current);
+    let active = true;
+    const poll = async () => {
+      try {
+        const next = await getBuildPhase(agentName);
+        if (active && next !== null) setPhase(next);
+      } catch {
+        // best-effort status only; the create flow owns success and failure.
+      }
     };
-  }, []);
+    void poll();
+    const id = setInterval(() => void poll(), BUILD_PHASE_POLL_MS);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, [agentName]);
 
   return (
     <div className="flex flex-col items-center gap-3 w-[260px] max-w-full px-4">
@@ -30,7 +38,7 @@ export function CreatingStep() {
       <p className="text-xs text-muted-foreground">
         first setup can take several minutes.
       </p>
-      <ProgressBar message={MESSAGES[msgIdx]} />
+      <ProgressBar message={buildPhaseMessage(phase)} />
     </div>
   );
 }

--- a/apps/web/src/components/NewAgent/index.tsx
+++ b/apps/web/src/components/NewAgent/index.tsx
@@ -100,7 +100,7 @@ export function NewAgent() {
           }}
         />
       );
-    if (step === "creating") return <CreatingStep />;
+    if (step === "creating") return <CreatingStep agentName={agentName} />;
     if (step === "done") return <DoneStep agentName={agentName} />;
     return (
       <NameStep

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -700,13 +700,15 @@ async fn verify_image_runnable(image: &str) -> Result<(), DockerError> {
     Ok(())
 }
 
-pub async fn resolve_image(docker: &Docker) -> Result<String, DockerError> {
+pub async fn resolve_image(docker: &Docker, progress: &BuildProgress) -> Result<String, DockerError> {
     if let Ok(image) = std::env::var(AGENT_IMAGE_ENV) {
         tracing::info!(image = %image, "using agent image from {AGENT_IMAGE_ENV}");
+        progress.set(BuildPhase::Pulling);
         verify_image_runnable(&image).await?;
         return Ok(image);
     }
     if let Ok(context) = find_dockerfile() {
+        progress.set(BuildPhase::Building);
         let tar_body = build_context_tar(&context)?;
         let opts = BuildImageOptions {
             t: Some(LOCAL_IMAGE_TAG.to_string()),
@@ -729,6 +731,7 @@ pub async fn resolve_image(docker: &Docker) -> Result<String, DockerError> {
         verify_image_runnable(LOCAL_IMAGE_TAG).await?;
         Ok(LOCAL_IMAGE_TAG.to_string())
     } else {
+        progress.set(BuildPhase::Pulling);
         let opts = CreateImageOptions {
             from_image: Some(VESTA_IMAGE.to_string()),
             ..Default::default()
@@ -1582,7 +1585,43 @@ pub async fn list_agents(
     entries
 }
 
-pub async fn create_agent(docker: &Docker, name: &str, env_config: &AgentEnvConfig, manage_core_code: bool, timezone: Option<&str>, seed_personality: Option<&str>) -> Result<String, DockerError> {
+/// Coarse, user-facing stage of first-time agent creation, emitted in order so the
+/// onboarding UI can show honest status instead of a decorative loop. The dominant
+/// wait is the image step (`Pulling` on a release, `Building` from a local checkout).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildPhase {
+    Pulling,
+    Building,
+    Preparing,
+    Creating,
+    Starting,
+}
+
+/// A cheap, clonable sink for `BuildPhase` updates. The create handler wires one
+/// that records into shared state for the build-phase endpoint.
+#[derive(Clone)]
+pub struct BuildProgress {
+    sink: std::sync::Arc<dyn Fn(BuildPhase) + Send + Sync>,
+}
+
+impl BuildProgress {
+    pub fn new(sink: std::sync::Arc<dyn Fn(BuildPhase) + Send + Sync>) -> Self {
+        Self { sink }
+    }
+
+    pub fn set(&self, phase: BuildPhase) {
+        (self.sink)(phase);
+    }
+}
+
+impl std::fmt::Debug for BuildProgress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BuildProgress").finish_non_exhaustive()
+    }
+}
+
+pub async fn create_agent(docker: &Docker, name: &str, env_config: &AgentEnvConfig, manage_core_code: bool, timezone: Option<&str>, seed_personality: Option<&str>, progress: &BuildProgress) -> Result<String, DockerError> {
     let name = if name == "ignisinextinctus" { "vesta" } else { name };
     validate_name(name)?;
     if name != "vesta" && name.contains("vesta") {
@@ -1594,14 +1633,16 @@ pub async fn create_agent(docker: &Docker, name: &str, env_config: &AgentEnvConf
         return Err(DockerError::AlreadyExists(format!("agent '{}' already exists", name)));
     }
 
-    let image = resolve_image(docker).await?;
+    let image = resolve_image(docker, progress).await?;
 
+    progress.set(BuildPhase::Preparing);
     if manage_core_code {
         tracing::info!(agent = %name, "ensuring agent code");
         crate::agent_code::ensure_agent_code(&env_config.config_dir)
             .map_err(|e| DockerError::Failed(format!("agent code: {e}")))?;
     }
 
+    progress.set(BuildPhase::Creating);
     let port = allocate_port(&env_config.agents_dir)?;
     create_container(docker, &cname, &image, port, name, env_config, manage_core_code, timezone, seed_personality).await?;
     Ok(name.to_string())
@@ -2020,6 +2061,29 @@ pub async fn rename_agent(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_phase_serializes_to_snake_case() {
+        let to_str = |phase: BuildPhase| serde_json::to_value(phase).expect("serialize").as_str().expect("string").to_string();
+        assert_eq!(to_str(BuildPhase::Pulling), "pulling");
+        assert_eq!(to_str(BuildPhase::Building), "building");
+        assert_eq!(to_str(BuildPhase::Preparing), "preparing");
+        assert_eq!(to_str(BuildPhase::Creating), "creating");
+        assert_eq!(to_str(BuildPhase::Starting), "starting");
+    }
+
+    #[test]
+    fn build_progress_forwards_phases_to_sink() {
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = seen.clone();
+        let progress = BuildProgress::new(std::sync::Arc::new(move |phase| {
+            recorder.lock().expect("lock").push(phase);
+        }));
+        progress.set(BuildPhase::Building);
+        progress.set(BuildPhase::Preparing);
+        progress.set(BuildPhase::Creating);
+        assert_eq!(*seen.lock().expect("lock"), vec![BuildPhase::Building, BuildPhase::Preparing, BuildPhase::Creating]);
+    }
 
     #[test]
     fn constitution_unset_reads_empty() {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -141,6 +141,11 @@ pub struct AppState {
     dev_mode: bool,
     pub(crate) agent_status_cache: Arc<agent_status::AgentStatusCache>,
     pub(crate) https_port: u16,
+    /// Coarse, in-flight build phase per agent, keyed by normalized name. Written
+    /// by the create handler as `create_agent` progresses and read by the
+    /// build-phase endpoint so onboarding shows honest status. Entries exist only
+    /// for the duration of a create and are removed when it settles.
+    build_phases: Arc<std::sync::Mutex<HashMap<String, docker::BuildPhase>>>,
 }
 
 impl AppState {
@@ -160,7 +165,33 @@ impl AppState {
             dev_mode,
             agent_status_cache: Arc::new(agent_status::AgentStatusCache::new()),
             https_port,
+            build_phases: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Record the current build phase for `name` (normalized). Lock poisoning is
+    /// recovered in place: a panic mid-build must not wedge later creates.
+    fn set_build_phase(&self, name: &str, phase: docker::BuildPhase) {
+        self.build_phases
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(name.to_string(), phase);
+    }
+
+    /// Drop the build-phase entry for `name` once a create settles (success or error).
+    fn clear_build_phase(&self, name: &str) {
+        self.build_phases
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(name);
+    }
+
+    fn build_phase(&self, name: &str) -> Option<docker::BuildPhase> {
+        self.build_phases
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(name)
+            .copied()
     }
 
     pub(crate) async fn agent_lock(&self, name: &str) -> Arc<tokio::sync::RwLock<()>> {
@@ -424,7 +455,7 @@ async fn create_agent_handler(
     State(state): State<SharedState>,
     Json(body): Json<CreateBody>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
-    let raw_name = body.name.unwrap_or_else(|| "default".to_string());
+    let raw_name = body.name.clone().unwrap_or_else(|| "default".to_string());
     let name = docker::normalize_name(&raw_name);
     if name.is_empty() {
         return Err(err_response(StatusCode::BAD_REQUEST, "invalid agent name"));
@@ -443,17 +474,49 @@ async fn create_agent_handler(
 
     // Create + start an empty agent. Provider config arrives via a separate
     // POST /agents/{name}/provider once the agent is up — the agent owns its
-    // own credential files now, vestad only orchestrates.
-    let name =
-        docker::create_agent(&state.docker, &name, &state.env_config, manage_core_code, body.timezone.as_deref(), body.seed_personality.as_deref())
-            .await
-            .map_err(map_docker_err)?;
+    // own credential files now, vestad only orchestrates. `create_agent` reports
+    // coarse phases into shared state so GET /agents/{name}/build-phase can drive
+    // honest onboarding status while this synchronous call is in flight.
+    let phases = state.clone();
+    let progress_name = name.clone();
+    let progress = docker::BuildProgress::new(Arc::new(move |phase| {
+        phases.set_build_phase(&progress_name, phase);
+    }));
 
+    let result = create_and_start(&state, &name, manage_core_code, &body, &progress).await;
+    state.clear_build_phase(&name);
+    let name = result?;
+
+    Ok((StatusCode::CREATED, Json(serde_json::json!({"name": name}))))
+}
+
+/// Run the create then the start, reporting `Starting` between them. Split out so
+/// the caller can clear the build-phase entry on either outcome before returning.
+async fn create_and_start(
+    state: &SharedState,
+    name: &str,
+    manage_core_code: bool,
+    body: &CreateBody,
+    progress: &docker::BuildProgress,
+) -> Result<String, (StatusCode, Json<serde_json::Value>)> {
+    let name = docker::create_agent(&state.docker, name, &state.env_config, manage_core_code, body.timezone.as_deref(), body.seed_personality.as_deref(), progress)
+        .await
+        .map_err(map_docker_err)?;
+
+    progress.set(docker::BuildPhase::Starting);
     docker::start_agent(&state.docker, &name)
         .await
         .map_err(map_docker_err)?;
 
-    Ok((StatusCode::CREATED, Json(serde_json::json!({"name": name}))))
+    Ok(name)
+}
+
+async fn build_phase_handler(
+    State(state): State<SharedState>,
+    Path(name): Path<String>,
+) -> Json<serde_json::Value> {
+    let phase = state.build_phase(&docker::normalize_name(&name));
+    Json(serde_json::json!({ "phase": phase }))
 }
 
 async fn agent_status_handler(
@@ -1808,6 +1871,7 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/agents", post(create_agent_handler))
         .route("/agents/start", post(start_all_handler))
         .route("/agents/{name}", get(agent_status_handler))
+        .route("/agents/{name}/build-phase", get(build_phase_handler))
         .route("/agents/{name}/start", post(start_agent_handler))
         .route("/agents/{name}/stop", post(stop_agent_handler))
         .route("/agents/{name}/restart", post(restart_agent_handler))


### PR DESCRIPTION
## What

The first-agent onboarding step showed a decorative, time-based message rotation that was decoupled from the real Docker build, the highest drop-off moment of onboarding. This drives it from vestad's actual create progress instead.

**vestad**
- `create_agent` now reports a coarse, ordered `BuildPhase` through a cheap clonable `BuildProgress` sink: `pulling` / `building` the image (the dominant wait, pull on a release vs build from a local checkout), then `preparing` agent code, `creating` the container, and `starting`.
- The create handler wires a `BuildProgress` that records the live phase into per-agent shared state (`build_phases`), cleared when the create settles (success or error). A new `GET /agents/{name}/build-phase` returns `{ "phase": <phase> | null }`.
- `POST /agents` keeps its synchronous `201 + {"name"}` contract, so the CLI and integration tests are untouched. The phase endpoint reads a separate lock and never contends with the per-agent create lock, so polling works while the create is in flight.

**web**
- `CreatingStep` polls `getBuildPhase` and renders an honest, lowercase status line via a pure `buildPhaseMessage`, tracking the latest reported phase so the line never walks backwards once a phase is seen.
- The indeterminate progress bar is left as an honest indeterminate spinner, exactly as the issue asks.

## Why

Nielsen #1 / Apple HIG: an indeterminate task should not present a fabricated determinate-feeling track. The slow path is the image build/pull, so the status now names that instead of a canned timer. Copy stays all-lowercase with no dashes, "agent" terminology preserved.

## Tests
- vestad: `BuildPhase` serializes to snake_case; `BuildProgress` forwards phases to its sink in order.
- web: `buildPhaseMessage` maps every phase to a distinct lowercase line and falls back to a neutral line when no phase is reported.

`./check.sh vestad` green (clippy `-D warnings`, 94 tests). `./check.sh web` green (eslint 0 errors, prettier, tsc, 55 vitest tests).

Fixes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)