### PR TITLE
docs: state cc_sdk drives the CLI because it's simpler than the SDK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Vesta is a personal AI assistant that runs as a persistent daemon in Docker, powered by Claude Code. It monitors notifications, responds to messages, and handles tasks autonomously. Instead of the official Claude Agent SDK, the agent drives the `claude` CLI interactively inside tmux via an in-repo SDK (`agent/core/cc_sdk/`, see its README) that exposes the same client surface.
+Vesta is a personal AI assistant that runs as a persistent daemon in Docker, powered by Claude Code. It monitors notifications, responds to messages, and handles tasks autonomously. The agent drives the `claude` CLI interactively inside tmux via an in-repo SDK (`agent/core/cc_sdk/`, see its README) that exposes the same client surface, because driving the CLI directly is simpler than wiring up the official Claude Agent SDK.
 
 ## Architecture
 

--- a/agent/core/cc_sdk/README.md
+++ b/agent/core/cc_sdk/README.md
@@ -2,7 +2,8 @@
 
 A drop-in replacement for the public surface of the official `claude_agent_sdk`,
 implemented by driving the **interactive `claude` CLI** inside tmux rather than the
-headless control protocol. The rest of the agent (`core/`) imports `cc_sdk` exactly
+headless control protocol, because driving the CLI directly turned out simpler than
+wiring up the official SDK. The rest of the agent (`core/`) imports `cc_sdk` exactly
 as it imported `claude_agent_sdk` before: same message/block types, same hook
 plumbing, same MCP-tool registration, same `ClaudeSDKClient` lifecycle.
 


### PR DESCRIPTION
## What

Corrects the stated rationale for why the agent drives the interactive `claude` CLI via cc_sdk instead of the official Claude Agent SDK.

- `CLAUDE.md`: reworded the Project Overview line so it no longer frames the choice as avoiding the Agent SDK / subscription-vs-API rates. The real reason is that driving the CLI directly is simpler than wiring up the official SDK.
- `agent/core/cc_sdk/README.md`: aligned the opening description with the same rationale.

Docs only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)