### PR TITLE
chore(skills): drop flights from default skills

### DIFF
--- a/agent/skills/default-skills.txt
+++ b/agent/skills/default-skills.txt
@@ -4,7 +4,6 @@ claude-code
 dashboard
 dream
 email-client
-flights
 restart
 skills-registry
 tasks


### PR DESCRIPTION
## What

Removes `flights` from `agent/skills/default-skills.txt`, so it's no longer installed by default.

The `flights` skill directory and its entry in `index.json` are untouched — it remains available to install on demand via the skills registry, just not part of the default set.

## Verification

`test_skills_index_valid` requires any on-disk skill that isn't in `default-skills.txt` to be present in `index.json`; `flights` already is, so the invariant holds. `uv run pytest tests/test_deployment.py` passes (6 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)