### PR TITLE
feat(vestad): wait for readiness on restart and log tunnel lifecycle

### DIFF
--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -162,6 +162,86 @@ fn config_dir() -> std::path::PathBuf {
     paths::config_dir().unwrap_or_else(|| die("HOME not set"))
 }
 
+const RESTART_LOCAL_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+const RESTART_TUNNEL_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(25);
+const RESTART_READY_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+const HEALTH_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// After `vestad restart`, systemd marks the unit "active" the instant the process is
+/// spawned — but the HTTP server is still binding and the Cloudflare tunnel needs several
+/// seconds to re-establish its edge connections. In that window the tunnel returns 502
+/// (no healthy origin yet), which reads like an error but is just startup. Poll `/health`
+/// locally and through the tunnel so the message reflects what is actually reachable.
+fn report_restart_readiness(config: &std::path::Path) {
+    let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            eprintln!("vestad restarted (could not probe readiness: {e}).");
+            return;
+        }
+    };
+    runtime.block_on(async {
+        let client = match reqwest::Client::builder().timeout(HEALTH_PROBE_TIMEOUT).build() {
+            Ok(client) => client,
+            Err(e) => {
+                eprintln!("vestad restarted (could not probe readiness: {e}).");
+                return;
+            }
+        };
+
+        let local_ready = match local_health_url(config) {
+            Some(url) => wait_for_health(&client, &url, RESTART_LOCAL_READY_TIMEOUT).await,
+            None => false,
+        };
+        if !local_ready {
+            eprintln!("vestad restarted, but its local API did not come up in time — check 'vestad logs'.");
+            return;
+        }
+
+        match tunnel::get_tunnel_config(config) {
+            None => eprintln!("vestad restarted and serving (no tunnel configured)."),
+            Some(tc) => {
+                let tunnel_health = format!("https://{}/health", tc.hostname);
+                if wait_for_health(&client, &tunnel_health, RESTART_TUNNEL_READY_TIMEOUT).await {
+                    eprintln!("vestad restarted and reachable at https://{}", tc.hostname);
+                } else {
+                    eprintln!(
+                        "vestad restarted and serving locally; the tunnel (https://{}) is still \
+                         reconnecting — a 502 for a few seconds is expected, not an error.",
+                        tc.hostname
+                    );
+                }
+            }
+        }
+    });
+}
+
+/// `http://127.0.0.1:<https_port + 1>/health` — the unauthenticated local HTTP API
+/// (serve.rs binds HTTPS on the stored port and plain HTTP on port + 1).
+fn local_health_url(config: &std::path::Path) -> Option<String> {
+    let https_port = std::fs::read_to_string(config.join("port"))
+        .ok()
+        .and_then(|stored| stored.trim().parse::<u16>().ok())?;
+    let http_port = https_port.checked_add(1)?;
+    Some(format!("http://127.0.0.1:{http_port}/health"))
+}
+
+/// Poll `url` until it answers 2xx or `timeout` elapses. A connection refused / 5xx
+/// just means "not ready yet", so keep retrying until the deadline.
+async fn wait_for_health(client: &reqwest::Client, url: &str, timeout: std::time::Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Ok(resp) = client.get(url).send().await {
+            if resp.status().is_success() {
+                return true;
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(RESTART_READY_POLL_INTERVAL).await;
+    }
+}
 
 fn print_server_info(tunnel_url: Option<&str>, local_url: &str, api_key: &str) {
     eprintln!();
@@ -416,7 +496,7 @@ fn main() {
 
         Command::Restart => {
             systemd::restart().unwrap_or_else(|e| die(&e));
-            eprintln!("vestad restarted.");
+            report_restart_readiness(&config_dir());
         }
 
         Command::Shell { name } => {
@@ -612,5 +692,26 @@ fn main() {
             eprintln!("Note: Docker containers and images for agents are still intact.");
             eprintln!("To remove them too, run: docker rm -f $(docker ps -aq --filter name=vesta-)");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_health_url_targets_http_port_plus_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("port"), "39565").expect("write port");
+        assert_eq!(
+            local_health_url(dir.path()).as_deref(),
+            Some("http://127.0.0.1:39566/health"),
+        );
+    }
+
+    #[test]
+    fn local_health_url_none_without_port_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(local_health_url(dir.path()), None);
     }
 }

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -413,7 +413,7 @@ pub async fn start_tunnel(
     // devices aggressively time out idle UDP flows, which silently drops the
     // tunnel and yields error 1033 on the next request (e.g. the first file
     // share after an idle period). TCP keeps the connection alive far longer.
-    let child = tokio::process::Command::new(cloudflared)
+    let mut child = tokio::process::Command::new(cloudflared)
         .args([
             "tunnel", "--protocol", "http2", "--config", cf_config_path.to_str().unwrap(),
             "run", "--token", &tc.tunnel_token,
@@ -422,6 +422,23 @@ pub async fn start_tunnel(
         .stderr(std::process::Stdio::piped())
         .spawn()
         .map_err(|e| format!("failed to start cloudflared: {}", e))?;
+
+    // cloudflared logs its connection lifecycle (registering/registered/lost connections)
+    // to stderr. Forward it into vestad's tracing so `vestad logs` shows tunnel state —
+    // otherwise a reconnecting tunnel looks like silence and a transient 502 has no trail.
+    // This also drains the piped stderr, which would otherwise fill and stall cloudflared.
+    if let Some(stderr) = child.stderr.take() {
+        tokio::spawn(async move {
+            use tokio::io::AsyncBufReadExt;
+            let mut lines = tokio::io::BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let line = line.trim();
+                if !line.is_empty() {
+                    tracing::info!(target: "tunnel", "{line}");
+                }
+            }
+        });
+    }
 
     let url = format!("https://{}", tc.hostname);
     Ok((child, url))


### PR DESCRIPTION
## Problem

`vestad restart` printed `vestad restarted.` the instant systemd spawned the process — but the HTTP server is still binding and the Cloudflare tunnel needs several seconds to re-establish its edge connections. During that window the tunnel returns **502 Bad Gateway** (no healthy origin yet), so a `vesta list` right after a restart looks like a failure when it's just startup. There were also no tunnel logs to diagnose it (cloudflared's stderr was piped but never read).

## Changes

- **`vestad restart` now waits for real readiness.** After restarting, it polls `/health` locally (`http://127.0.0.1:<port+1>`) and through the tunnel, then prints what is actually reachable:
  - `vestad restarted and reachable at https://<host>` — fully up
  - `vestad restarted and serving locally; the tunnel (…) is still reconnecting — a 502 for a few seconds is expected, not an error.`
  - `vestad restarted, but its local API did not come up in time — check 'vestad logs'.` — genuine failure
- **Tunnel lifecycle is now logged.** cloudflared's stderr (registering / registered / lost connections) is forwarded into vestad tracing, so `vestad logs` shows tunnel state instead of silence. This also drains a piped stderr that was previously never read.

## Tests

- Two hermetic unit tests for the local health-URL helper.
- `cargo clippy --all-targets -- -D warnings` clean; `cargo test --bin vestad` green.

## Note (not in this PR)

The 120s wall on long control-plane requests is `CONTROL_REQUEST_TIMEOUT_SECS = 120` in `serve.rs` — the `TimeoutLayer` on the control router that `rebuild`/`backup` sit behind. For large agents, `vesta rebuild` can't finish a multi-GB snapshot within that window; worth a separate change (exempt long ops or stream progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)