### PR TITLE
feat: selectable Claude model + context window (onboarding + settings)

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -24,7 +24,7 @@ from .events import ChatEvent, EventBus, HistoryEvent, UserEvent, VestaEvent
 from .config import VestaConfig
 from .helpers import get_memory_path
 from .models import State
-from .provider import CREDENTIALS_PATH, set_claude, set_model, set_openrouter
+from .provider import CREDENTIALS_PATH, set_claude, set_openrouter, set_settings
 
 
 logger = logging.getLogger("vesta.api")
@@ -221,6 +221,7 @@ async def _provider_status_handler(request: web.Request) -> web.Response:
             "state": status.state.value,
             "kind": status.kind,
             "model": status.model,
+            "max_context_tokens": status.max_context_tokens,
             # vestad gates "alive" on this: an authenticated agent that hasn't yet
             # finished first-start setup (or whose first model call failed) is not ready.
             "setup_complete": state.persisted.first_start_done,
@@ -230,9 +231,11 @@ async def _provider_status_handler(request: web.Request) -> web.Response:
 
 async def _provider_set_handler(request: web.Request) -> web.Response:
     """Apply new provider config. Mutually exclusive body shapes:
-    - `{credentials, model?}`            -> set Claude (OAuth blob, optional model)
-    - `{openrouter_key, openrouter_model}` -> set OpenRouter (switch / refresh key)
-    - `{model}`                          -> change model only, keep current provider
+    - `{credentials, model?, max_context_tokens?}`             -> set Claude (OAuth blob)
+    - `{openrouter_key, openrouter_model, max_context_tokens?}`-> set OpenRouter
+    - `{model?, max_context_tokens?}`                          -> change model and/or
+      context window only, keeping the current provider
+    `max_context_tokens` is the context window in tokens; omit to leave it unchanged.
     Vestad orchestrates the container restart that picks up env-var changes."""
     state = request.app["state"]
     config: VestaConfig = request.app["config"]
@@ -246,15 +249,20 @@ async def _provider_set_handler(request: web.Request) -> web.Response:
     has_creds = "credentials" in data and isinstance(data["credentials"], str)
     has_or = "openrouter_key" in data and isinstance(data["openrouter_key"], str)
     has_model = "model" in data and isinstance(data["model"], str)
+    ctx = data["max_context_tokens"] if "max_context_tokens" in data else None
+    # bool is an int subclass; reject True/False explicitly so {"max_context_tokens": true} 400s.
+    if ctx is not None and (not isinstance(ctx, int) or isinstance(ctx, bool) or ctx <= 0):
+        return web.json_response({"error": "max_context_tokens must be a positive integer"}, status=400)
+    has_ctx = ctx is not None
     if has_creds and has_or:
         return web.json_response({"error": "credentials and openrouter_key are mutually exclusive"}, status=400)
-    if not has_creds and not has_or and not has_model:
-        return web.json_response({"error": "must provide credentials, openrouter_key, or model"}, status=400)
+    if not has_creds and not has_or and not has_model and not has_ctx:
+        return web.json_response({"error": "must provide credentials, openrouter_key, model, or max_context_tokens"}, status=400)
 
     if has_creds:
         claude_model = data["model"] if has_model else None
         try:
-            state.provider_status = set_claude(data["credentials"], claude_model, config=config, persisted=state.persisted)
+            state.provider_status = set_claude(data["credentials"], claude_model, ctx, config=config, persisted=state.persisted)
         except (json.JSONDecodeError, TypeError) as e:
             return web.json_response({"error": f"invalid credentials: {e}"}, status=400)
         except OSError as e:
@@ -263,17 +271,24 @@ async def _provider_set_handler(request: web.Request) -> web.Response:
         if "openrouter_model" not in data or not isinstance(data["openrouter_model"], str):
             return web.json_response({"error": "openrouter_model is required when openrouter_key is set"}, status=400)
         try:
-            state.provider_status = set_openrouter(data["openrouter_key"], data["openrouter_model"], config=config, persisted=state.persisted)
+            state.provider_status = set_openrouter(
+                data["openrouter_key"], data["openrouter_model"], ctx, config=config, persisted=state.persisted
+            )
         except OSError as e:
             return web.json_response({"error": f"set_openrouter failed: {e}"}, status=500)
     else:
-        # Model-only change: keep the current provider and any stored key.
+        # Model and/or context-window change: keep the current provider and any stored key.
         try:
-            state.provider_status = set_model(data["model"], config=config, persisted=state.persisted)
+            state.provider_status = set_settings(
+                model=data["model"] if has_model else None,
+                max_context_tokens=ctx,
+                config=config,
+                persisted=state.persisted,
+            )
         except ValueError as e:
             return web.json_response({"error": str(e)}, status=400)
         except OSError as e:
-            return web.json_response({"error": f"set_model failed: {e}"}, status=500)
+            return web.json_response({"error": f"set_settings failed: {e}"}, status=500)
 
     return web.json_response({"ok": True})
 

--- a/agent/core/cc_sdk/client.py
+++ b/agent/core/cc_sdk/client.py
@@ -253,13 +253,18 @@ class ClaudeSDKClient:
         usage = self._last_usage or {}
         keys = ("input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens", "output_tokens")
         total = sum(usage[k] for k in keys if k in usage and isinstance(usage[k], int))
-        # Don't assume the 1M beta took effect (it is silently ignored on some auth modes).
-        # Stay on the conservative 200k ceiling until usage actually exceeds it — which can
-        # only happen if the larger window is really active — so the overflow warning in
-        # diagnostics.log_context_usage still fires near the real limit instead of never.
-        max_tokens = _DEFAULT_MAX_TOKENS
-        if _BETA_1M in self._options.betas and total > _DEFAULT_MAX_TOKENS:
-            max_tokens = 1_000_000
+        configured = self._options.max_context_tokens
+        if configured:
+            # The user pinned a window; report usage against exactly that.
+            max_tokens = configured
+        else:
+            # Don't assume the 1M beta took effect (it is silently ignored on some auth modes).
+            # Stay on the conservative 200k ceiling until usage actually exceeds it — which can
+            # only happen if the larger window is really active — so the overflow warning in
+            # diagnostics.log_context_usage still fires near the real limit instead of never.
+            max_tokens = _DEFAULT_MAX_TOKENS
+            if _BETA_1M in self._options.betas and total > _DEFAULT_MAX_TOKENS:
+                max_tokens = 1_000_000
         percentage = (total / max_tokens * 100) if max_tokens else 0.0
         return {"percentage": percentage, "totalTokens": total, "maxTokens": max_tokens}
 

--- a/agent/core/cc_sdk/messages.py
+++ b/agent/core/cc_sdk/messages.py
@@ -103,6 +103,10 @@ class ClaudeAgentOptions:
     system_prompt: str | None = None
     model: str | None = None
     betas: list[str] = dc.field(default_factory=list)
+    # Effective context window, when the user has chosen one. Drives the context-usage
+    # percentage; None falls back to the 200k/1M heuristic. claude-code itself is told
+    # via CLAUDE_CODE_MAX_CONTEXT_TOKENS in the launch env (see client.build_client_options).
+    max_context_tokens: int | None = None
     hooks: dict[HookEvent, list[HookMatcher]] = dc.field(default_factory=dict)
     permission_mode: str = "default"
     can_use_tool: tp.Callable[..., tp.Any] | None = None

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -19,6 +19,7 @@ from core.cc_sdk.types import PermissionResultAllow, ThinkingConfigDisabled, Too
 from . import logger
 from . import models as vm
 from . import state_store
+from .config import DEFAULT_CONTEXT_WINDOW
 from . import diagnostics
 from . import sdk_parsing
 from .helpers import get_constitution_path, get_memory_path
@@ -272,6 +273,7 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
     # os.environ here would leak the OpenRouter URL into every other subprocess
     # the agent spawns (skill CLIs, gh, git, ...) and silently misroute them.
     sdk_env: dict[str, str] = {}
+    betas: list[str] = []
     if is_openrouter:
         # The SDK always routes through the local caching proxy, never OpenRouter
         # directly. start_cache_proxy runs first in message_processor, so the URL is set.
@@ -282,11 +284,22 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
         # threshold instead of its 200k default for non-Anthropic models.
         if state.openrouter_max_tokens:
             sdk_env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] = str(state.openrouter_max_tokens)
+    else:
+        # Claude. The 1M-context beta unlocks windows above claude-code's 200k default.
+        # Honor a user-chosen window (MAX_CONTEXT_TOKENS): cap the autocompact threshold
+        # to it, and request the 1M beta only when the choice needs the larger window.
+        # Unset (existing agents) keeps the historical default: 1M beta on, no explicit cap.
+        chosen = config.max_context_tokens
+        if chosen is None or chosen > DEFAULT_CONTEXT_WINDOW:
+            betas = ["context-1m-2025-08-07"]
+        if chosen is not None:
+            sdk_env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] = str(chosen)
 
     return ClaudeAgentOptions(
         system_prompt=system_prompt,
         model=config.agent_model,
-        betas=[] if is_openrouter else ["context-1m-2025-08-07"],
+        betas=betas,
+        max_context_tokens=config.max_context_tokens,
         hooks=sdk_parsing.make_hooks(state),
         permission_mode="bypassPermissions",
         can_use_tool=_approve_all_tools,

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -295,11 +295,17 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
         if chosen is not None:
             sdk_env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] = str(chosen)
 
+    # The window claude-code actually enforces: for OpenRouter the resolved (capped)
+    # value, for Claude the user's chosen cap (None = model default). Drives the
+    # context-usage percentage, so it must match the real autocompact threshold —
+    # the raw, uncapped config value would under-report OpenRouter usage.
+    effective_max_context = state.openrouter_max_tokens if is_openrouter else config.max_context_tokens
+
     return ClaudeAgentOptions(
         system_prompt=system_prompt,
         model=config.agent_model,
         betas=betas,
-        max_context_tokens=config.max_context_tokens,
+        max_context_tokens=effective_max_context,
         hooks=sdk_parsing.make_hooks(state),
         permission_mode="bypassPermissions",
         can_use_tool=_approve_all_tools,

--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -9,6 +9,10 @@ from core.cc_sdk.types import ThinkingConfigAdaptive, ThinkingConfigDisabled, Th
 _DEFAULT_AGENT_DIR = pl.Path.home() / "agent"
 _THINKING_ENABLED_BUDGET_TOKENS = 10000
 
+# claude-code's assumed window without the 1M beta, and the OpenRouter cap fallback
+# when the user hasn't explicitly chosen a context window.
+DEFAULT_CONTEXT_WINDOW = 200_000
+
 
 class VestaConfig(pyd_settings.BaseSettings):
     """Vesta agent configuration.
@@ -25,9 +29,11 @@ class VestaConfig(pyd_settings.BaseSettings):
         PROACTIVE_CHECK_INTERVAL - seconds between proactive checks (default: 60)
         NIGHTLY_MEMORY_HOUR      - hour 0-23 for nightly dream, unset to disable (default: 3)
         RESPONSE_TIMEOUT         - max seconds for a single response (default: 600)
-        MAX_CONTEXT_TOKENS       - cap on the context window passed to claude-code; smaller =
-                                   cheaper prompt-cache reads, larger = more context before
-                                   autocompact (default: 200000)
+        MAX_CONTEXT_TOKENS       - context window passed to claude-code. Claude: caps the
+                                   autocompact threshold and requests the 1M beta when above
+                                   200k; unset = model default (1M for Claude). OpenRouter:
+                                   caps the model's real window (fallback cap 200000 when
+                                   unset). Smaller = cheaper prompt-cache reads.
     """
 
     model_config = pyd_settings.SettingsConfigDict(extra="ignore", populate_by_name=True)
@@ -38,7 +44,7 @@ class VestaConfig(pyd_settings.BaseSettings):
     proactive_check_interval: int = pyd.Field(default=60, ge=1)
     query_timeout: int = pyd.Field(default=120, ge=1)
     response_timeout: int = pyd.Field(default=600, ge=1)
-    max_context_tokens: int = pyd.Field(default=200_000, ge=1)
+    max_context_tokens: int | None = pyd.Field(default=None, ge=1)
     nightly_memory_hour: int | None = pyd.Field(default=3, ge=0, le=23)
     interrupt_timeout: float = pyd.Field(default=5.0, gt=0)
     thinking: ThinkingConfigAdaptive | ThinkingConfigEnabled | ThinkingConfigDisabled = ThinkingConfigAdaptive(

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -14,6 +14,7 @@ from watchfiles import awatch, Change
 from . import models as vm
 from . import logger
 from . import state_store
+from .config import DEFAULT_CONTEXT_WINDOW
 from .client import process_message, build_client_options, attempt_interrupt, persist_session_id, resolve_openrouter_max_tokens, _cancel_task
 from .diagnostics import format_crash_detail
 from .helpers import load_prompt, build_restart_context
@@ -261,7 +262,8 @@ async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm
                 # Cap at MAX_CONTEXT_TOKENS: cache-read cost scales with how large the
                 # cached prefix grows before autocompact, so big-window models default
                 # to a 200k working window unless the user raises the cap.
-                state.openrouter_max_tokens = min(real_window, config.max_context_tokens)
+                cap = config.max_context_tokens or DEFAULT_CONTEXT_WINDOW
+                state.openrouter_max_tokens = min(real_window, cap)
                 capped = f" (model supports {real_window:,})" if real_window > state.openrouter_max_tokens else ""
                 logger.startup(f"OpenRouter context window: {state.openrouter_max_tokens:,} tokens{capped}")
         if state.openrouter_proxy_url is None:

--- a/agent/core/provider.py
+++ b/agent/core/provider.py
@@ -49,6 +49,7 @@ class ProviderStatus:
     state: ProviderAuthState
     kind: ProviderKind
     model: str | None
+    max_context_tokens: int | None = None
 
 
 def derive_status(config: VestaConfig, persisted: PersistedState) -> ProviderStatus:
@@ -59,55 +60,75 @@ def derive_status(config: VestaConfig, persisted: PersistedState) -> ProviderSta
         state = ProviderAuthState.NOT_AUTHENTICATED
     else:
         state = _derive_state_from_disk(kind)
-    return ProviderStatus(state=state, kind=kind, model=model)
+    return ProviderStatus(state=state, kind=kind, model=model, max_context_tokens=_current_max_context_tokens())
 
 
-def set_claude(credentials_json: str, model: str | None = None, *, config: VestaConfig, persisted: PersistedState) -> ProviderStatus:
+def set_claude(
+    credentials_json: str, model: str | None = None, max_context_tokens: int | None = None, *, config: VestaConfig, persisted: PersistedState
+) -> ProviderStatus:
     """Write Claude OAuth credentials + the Claude provider file and return the
     new (authenticated) status. The provider file records AGENT_PROVIDER=claude +
-    AGENT_MODEL and clears the OpenRouter exports, so switching OpenRouter->Claude
-    leaves no stale token/base-url behind. `model` defaults to the configured model."""
+    AGENT_MODEL (+ MAX_CONTEXT_TOKENS when given) and clears the OpenRouter exports,
+    so switching OpenRouter->Claude leaves no stale token/base-url behind. `model`
+    defaults to the configured model. `max_context_tokens=None` preserves the
+    currently-recorded window (so a reauth doesn't wipe the user's choice); pass a
+    value to change it."""
     # Validate JSON shape before touching disk so we don't half-apply on bad input.
     json.loads(credentials_json)
     chosen = model or config.agent_model
+    ctx = max_context_tokens if max_context_tokens is not None else _current_max_context_tokens()
     CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
     CREDENTIALS_PATH.write_text(credentials_json)
     CLAUDE_JSON_PATH.write_text('{"hasCompletedOnboarding":true}')
-    _write_provider_file(_claude_provider_file(chosen))
-    status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model=chosen)
+    _write_provider_file(_claude_provider_file(chosen, ctx))
+    status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model=chosen, max_context_tokens=ctx)
     _persist(status, config=config, persisted=persisted)
-    logger.startup(f"Provider set to claude model={chosen}")
+    logger.startup(f"Provider set to claude model={chosen} max_context_tokens={ctx}")
     return status
 
 
-def set_openrouter(key: str, model: str, *, config: VestaConfig, persisted: PersistedState) -> ProviderStatus:
+def set_openrouter(
+    key: str, model: str, max_context_tokens: int | None = None, *, config: VestaConfig, persisted: PersistedState
+) -> ProviderStatus:
     """Write the OpenRouter provider env file and return the new (authenticated)
-    status. The agent must be restarted by vestad for the env vars to take effect."""
-    _write_provider_file(_openrouter_provider_file(key, model))
-    status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="openrouter", model=model)
+    status. The agent must be restarted by vestad for the env vars to take effect.
+    `max_context_tokens=None` preserves the currently-recorded window."""
+    ctx = max_context_tokens if max_context_tokens is not None else _current_max_context_tokens()
+    _write_provider_file(_openrouter_provider_file(key, model, ctx))
+    status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="openrouter", model=model, max_context_tokens=ctx)
     _persist(status, config=config, persisted=persisted)
-    logger.startup(f"Provider set to openrouter model={model}")
+    logger.startup(f"Provider set to openrouter model={model} max_context_tokens={ctx}")
     return status
 
 
-def set_model(model: str, *, config: VestaConfig, persisted: PersistedState) -> ProviderStatus:
-    """Change only the model, keeping the current provider and (for OpenRouter)
-    the stored key. Works for both providers; raises if none is configured. Lets
-    the app switch models without re-supplying credentials."""
+def set_settings(
+    *, model: str | None = None, max_context_tokens: int | None = None, config: VestaConfig, persisted: PersistedState
+) -> ProviderStatus:
+    """Change the model and/or context window, keeping the current provider and
+    (for OpenRouter) the stored key. Fields left None are preserved from the
+    existing provider file. Raises if no provider is configured. Lets the app / CLI
+    adjust model + context post-setup without re-supplying credentials."""
     status = derive_status(config, persisted)
+    if status.kind not in ("claude", "openrouter"):
+        raise ValueError("no provider configured")
+    new_model = model or status.model or config.agent_model
+    new_ctx = max_context_tokens if max_context_tokens is not None else _current_max_context_tokens()
     if status.kind == "openrouter":
         key = _parse_first_export(PROVIDER_ENV_PATH.read_text(), "ANTHROPIC_AUTH_TOKEN")
         if not key:
             raise ValueError("no OpenRouter key on file to preserve")
-        return set_openrouter(key, model, config=config, persisted=persisted)
-    if status.kind == "claude":
-        # OAuth blob in .credentials.json is untouched; only the model changes.
-        _write_provider_file(_claude_provider_file(model))
-        new_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model=model)
-        _persist(new_status, config=config, persisted=persisted)
-        logger.startup(f"Model set to {model} (claude)")
-        return new_status
-    raise ValueError("no provider configured")
+        return set_openrouter(key, new_model, new_ctx, config=config, persisted=persisted)
+    # claude: OAuth blob in .credentials.json is untouched; only the env file changes.
+    _write_provider_file(_claude_provider_file(new_model, new_ctx))
+    new_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model=new_model, max_context_tokens=new_ctx)
+    _persist(new_status, config=config, persisted=persisted)
+    logger.startup(f"Settings updated: model={new_model} max_context_tokens={new_ctx} (claude)")
+    return new_status
+
+
+def set_model(model: str, *, config: VestaConfig, persisted: PersistedState) -> ProviderStatus:
+    """Change only the model, preserving provider, key, and the context window."""
+    return set_settings(model=model, config=config, persisted=persisted)
 
 
 def observed_provider_failure(status: ProviderStatus | None, *, config: VestaConfig, persisted: PersistedState) -> ProviderStatus | None:
@@ -170,20 +191,26 @@ def _write_provider_file(content: str) -> None:
     PROVIDER_ENV_PATH.write_text(content)
 
 
-def _claude_provider_file(model: str) -> str:
-    """The sourced shell file for Claude mode. Records the model and explicitly
-    clears the OpenRouter exports so an OpenRouter->Claude switch leaves no stale
-    token behind (Claude auth itself lives in .credentials.json, not here)."""
+def _context_window_export(max_context_tokens: int | None) -> str:
+    """The MAX_CONTEXT_TOKENS line for a provider file, or empty when unset."""
+    return f"export MAX_CONTEXT_TOKENS={max_context_tokens}\n" if max_context_tokens is not None else ""
+
+
+def _claude_provider_file(model: str, max_context_tokens: int | None = None) -> str:
+    """The sourced shell file for Claude mode. Records the model (+ context window
+    when chosen) and explicitly clears the OpenRouter exports so an OpenRouter->Claude
+    switch leaves no stale token behind (Claude auth itself lives in .credentials.json)."""
     return (
         "export AGENT_PROVIDER=claude\n"
         f"export AGENT_MODEL={_shell_single_quote(model)}\n"
         "export ANTHROPIC_AUTH_TOKEN=\n"
         "export ANTHROPIC_API_KEY=\n"
         "export ANTHROPIC_SMALL_FAST_MODEL=\n"
+        f"{_context_window_export(max_context_tokens)}"
     )
 
 
-def _openrouter_provider_file(key: str, model: str) -> str:
+def _openrouter_provider_file(key: str, model: str, max_context_tokens: int | None = None) -> str:
     """The sourced shell file that puts an agent into OpenRouter mode."""
     return (
         "export AGENT_PROVIDER=openrouter\n"
@@ -191,7 +218,16 @@ def _openrouter_provider_file(key: str, model: str) -> str:
         f"export ANTHROPIC_AUTH_TOKEN={_shell_single_quote(key)}\n"
         "export ANTHROPIC_API_KEY=\n"
         f"export ANTHROPIC_SMALL_FAST_MODEL={_shell_single_quote(OPENROUTER_SMALL_FAST_MODEL)}\n"
+        f"{_context_window_export(max_context_tokens)}"
     )
+
+
+def _current_max_context_tokens() -> int | None:
+    """The MAX_CONTEXT_TOKENS currently recorded in the provider file, if any."""
+    if not PROVIDER_ENV_PATH.exists():
+        return None
+    raw = _parse_first_export(PROVIDER_ENV_PATH.read_text(), "MAX_CONTEXT_TOKENS")
+    return int(raw) if raw and raw.isdigit() else None
 
 
 def _parse_shell_export(line: str, key: str) -> str | None:

--- a/agent/tests/test_openrouter.py
+++ b/agent/tests/test_openrouter.py
@@ -15,11 +15,11 @@ def test_config_defaults_to_claude(tmp_path):
     assert config.agent_provider == "claude"
 
 
-def test_config_max_context_tokens_defaults_to_200k(tmp_path):
-    """Big-window models are capped to a 200k working window by default: cache-read
-    cost scales with how large the cached prefix grows before autocompact."""
+def test_config_max_context_tokens_defaults_to_unset(tmp_path):
+    """Unset (None) by default: Claude runs at its model default (1M via beta) and
+    OpenRouter falls back to a 200k working cap. A chosen value overrides both."""
     config = vm.VestaConfig(agent_dir=tmp_path / "agent")
-    assert config.max_context_tokens == 200_000
+    assert config.max_context_tokens is None
 
 
 def test_config_max_context_tokens_env_override(tmp_path, monkeypatch):
@@ -69,3 +69,29 @@ def test_build_client_options_omits_context_window_when_unresolved(tmp_path, sta
     state.openrouter_proxy_url = "http://127.0.0.1:40000"
     options = build_client_options(config, state)
     assert "CLAUDE_CODE_MAX_CONTEXT_TOKENS" not in options.env
+
+
+def test_build_client_options_claude_default_keeps_1m_window(tmp_path, state):
+    """Unset context window: existing behaviour — 1M beta on, no explicit cap."""
+    config = _config_with_memory(tmp_path)
+    options = build_client_options(config, state)
+    assert options.betas == ["context-1m-2025-08-07"]
+    assert "CLAUDE_CODE_MAX_CONTEXT_TOKENS" not in options.env
+    assert options.max_context_tokens is None
+
+
+def test_build_client_options_claude_caps_to_chosen_window(tmp_path, state):
+    """A chosen window above 200k still needs the 1M beta, and caps the threshold."""
+    config = _config_with_memory(tmp_path, max_context_tokens=500_000)
+    options = build_client_options(config, state)
+    assert options.betas == ["context-1m-2025-08-07"]
+    assert options.env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "500000"
+    assert options.max_context_tokens == 500_000
+
+
+def test_build_client_options_claude_200k_drops_beta(tmp_path, state):
+    """A 200k window fits without the 1M beta."""
+    config = _config_with_memory(tmp_path, max_context_tokens=200_000)
+    options = build_client_options(config, state)
+    assert options.betas == []
+    assert options.env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "200000"

--- a/agent/tests/test_openrouter.py
+++ b/agent/tests/test_openrouter.py
@@ -62,6 +62,9 @@ def test_build_client_options_passes_resolved_context_window(tmp_path, state):
     options = build_client_options(config, state)
     # Overrides claude-code's 200k default for non-Anthropic models (claude-code#46416).
     assert options.env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "1000000"
+    # Usage is reported against the RESOLVED window, not the raw config cap, so the
+    # context-usage % matches the real autocompact threshold.
+    assert options.max_context_tokens == 1_000_000
 
 
 def test_build_client_options_omits_context_window_when_unresolved(tmp_path, state):
@@ -69,6 +72,7 @@ def test_build_client_options_omits_context_window_when_unresolved(tmp_path, sta
     state.openrouter_proxy_url = "http://127.0.0.1:40000"
     options = build_client_options(config, state)
     assert "CLAUDE_CODE_MAX_CONTEXT_TOKENS" not in options.env
+    assert options.max_context_tokens is None
 
 
 def test_build_client_options_claude_default_keeps_1m_window(tmp_path, state):

--- a/agent/tests/test_provider.py
+++ b/agent/tests/test_provider.py
@@ -10,6 +10,7 @@ import pytest
 from core.provider import (
     ProviderAuthState,
     _check_claude_auth,
+    _claude_provider_file,
     _openrouter_provider_file,
     _openrouter_token_present,
     _provider_declares_openrouter,
@@ -38,6 +39,28 @@ def test_openrouter_provider_file_escapes_shell_metacharacters():
     injected = _openrouter_provider_file("k'; touch /tmp/pwned #", "m")
     assert "export ANTHROPIC_AUTH_TOKEN='k'\\''; touch /tmp/pwned #'" in injected
     assert "TOKEN=k';" not in injected
+
+
+# --- Context window (MAX_CONTEXT_TOKENS) in provider files ---
+
+
+def test_claude_provider_file_includes_context_window_when_set():
+    f = _claude_provider_file("opus", 500_000)
+    assert "export AGENT_MODEL='opus'\n" in f
+    assert "export MAX_CONTEXT_TOKENS=500000\n" in f
+
+
+def test_claude_provider_file_omits_context_window_when_unset():
+    assert "MAX_CONTEXT_TOKENS" not in _claude_provider_file("opus")
+
+
+def test_openrouter_provider_file_includes_context_window_when_set():
+    f = _openrouter_provider_file("sk-or-v1-xyz", "anthropic/claude-sonnet-4-6", 200_000)
+    assert "export MAX_CONTEXT_TOKENS=200000\n" in f
+
+
+def test_openrouter_provider_file_omits_context_window_when_unset():
+    assert "MAX_CONTEXT_TOKENS" not in _openrouter_provider_file("k", "m")
 
 
 # --- Parser: provider-mode detection ---

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -6,23 +6,37 @@ export interface OpenRouterConfig {
 }
 
 export type ProviderResult =
-  | { kind: "claude"; credentials: string }
-  | { kind: "openrouter"; config: OpenRouterConfig };
+  | {
+      kind: "claude";
+      credentials: string;
+      model?: string;
+      maxContextTokens?: number;
+    }
+  | {
+      kind: "openrouter";
+      config: OpenRouterConfig;
+      maxContextTokens?: number;
+    };
 
 /// Switch (or refresh) an existing agent's provider. Body is either `credentials`
-/// (Claude OAuth blob) or the `openrouter_*` pair. The agent owns the file writes
-/// and clears the obsolete provider config; vestad proxies the call and restarts.
+/// (Claude OAuth blob) or the `openrouter_*` pair, plus an optional `model` (Claude)
+/// and `max_context_tokens`. The agent owns the file writes and clears the obsolete
+/// provider config; vestad proxies the call and restarts.
 export async function setProvider(
   name: string,
   result: ProviderResult,
 ): Promise<void> {
-  const body =
+  const body: Record<string, unknown> =
     result.kind === "claude"
       ? { credentials: result.credentials }
       : {
           openrouter_key: result.config.key,
           openrouter_model: result.config.model,
         };
+  if (result.kind === "claude" && result.model) body.model = result.model;
+  if (result.maxContextTokens != null) {
+    body.max_context_tokens = result.maxContextTokens;
+  }
   await apiFetch(`/agents/${encodeURIComponent(name)}/provider`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -34,6 +48,7 @@ export interface ProviderInfo {
   state: string;
   kind: "claude" | "openrouter" | "none";
   model: string | null;
+  max_context_tokens: number | null;
   setup_complete: boolean;
 }
 
@@ -50,6 +65,19 @@ export async function setModel(name: string, model: string): Promise<void> {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ model }),
+  });
+}
+
+/// Change only the context window (tokens), keeping the provider, key, and model.
+/// Vestad restarts the agent so the new window takes effect.
+export async function setContextWindow(
+  name: string,
+  maxContextTokens: number,
+): Promise<void> {
+  await apiFetch(`/agents/${encodeURIComponent(name)}/provider`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ max_context_tokens: maxContextTokens }),
   });
 }
 

--- a/apps/web/src/api/providers/claude.ts
+++ b/apps/web/src/api/providers/claude.ts
@@ -26,3 +26,15 @@ export async function completeOAuth(
   );
   return resp.credentials;
 }
+
+export interface ClaudeModelOption {
+  /// The alias stored in AGENT_MODEL, e.g. "opus".
+  id: string;
+  label: string;
+  note: string;
+}
+
+/// The curated Claude model list, served by vestad (opus / sonnet / haiku).
+export async function fetchModels(): Promise<ClaudeModelOption[]> {
+  return apiJson<ClaudeModelOption[]>("/providers/claude/models");
+}

--- a/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Cpu, ArrowLeftRight } from "lucide-react";
+import { Cpu, ArrowLeftRight, Gauge } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -11,44 +11,41 @@ import {
 } from "@/components/ui/dialog";
 import { ProgressBar } from "@/components/ProgressBar";
 import { ModelStep } from "@/components/ProviderPicker/ModelStep";
+import { ContextStep } from "@/components/ProviderPicker/ContextStep";
 import type { openrouterProvider } from "@/api";
-import { setModel } from "@/api/agents";
+import { setModel, setContextWindow } from "@/api/agents";
 import { useProvider } from "@/hooks/use-provider";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { useModals } from "@/providers/ModalsProvider";
 
 // Claude OAuth exposes a small fixed set; the SDK takes these short aliases.
 const CLAUDE_MODELS: openrouterProvider.OpenRouterModelOption[] = [
-  {
-    slug: "opus",
-    label: "Claude Opus",
-    author: "Anthropic",
-    context_length: 200000,
-  },
-  {
-    slug: "sonnet",
-    label: "Claude Sonnet",
-    author: "Anthropic",
-    context_length: 200000,
-  },
-  {
-    slug: "haiku",
-    label: "Claude Haiku",
-    author: "Anthropic",
-    context_length: 200000,
-  },
+  { slug: "opus", label: "Claude Opus", author: "Anthropic" },
+  { slug: "sonnet", label: "Claude Sonnet", author: "Anthropic" },
+  { slug: "haiku", label: "Claude Haiku", author: "Anthropic" },
 ];
 
-/// Provider hub for an agent: shows the current provider + model, lets you
-/// switch between Claude and OpenRouter (reuses the reconfigure modal), and —
-/// for OpenRouter — change just the model without re-entering the key.
+// Display a token count as 1M / 500K / 200K.
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1)}M`;
+  }
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return String(n);
+}
+
+/// Provider hub for an agent: shows the current provider, model, and context
+/// window; lets you switch between Claude and OpenRouter (reuses the reconfigure
+/// modal), change the model, and change the context window — each without
+/// re-entering credentials.
 export function ProviderCard() {
   const { name, agent } = useSelectedAgent();
   const { handleOpenAuth } = useModals();
   // Revalidate on status change so a provider switch (which restarts the agent)
   // is reflected here without a manual reload.
   const { provider, refresh } = useProvider(name, agent?.status);
-  const [open, setOpen] = useState(false);
+  const [modelOpen, setModelOpen] = useState(false);
+  const [contextOpen, setContextOpen] = useState(false);
   const [applying, setApplying] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -56,17 +53,35 @@ export function ProviderCard() {
 
   const isOpenRouter = provider.kind === "openrouter";
 
-  const apply = async (model: string) => {
+  const applyModel = async (model: string) => {
     if (!name) return;
     setApplying(true);
     setError(null);
     try {
       await setModel(name, model);
-      setOpen(false);
+      setModelOpen(false);
       refresh();
     } catch (e: unknown) {
       setError(
         (e as { message?: string })?.message || "failed to change model",
+      );
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const applyContext = async (tokens: number) => {
+    if (!name) return;
+    setApplying(true);
+    setError(null);
+    try {
+      await setContextWindow(name, tokens);
+      setContextOpen(false);
+      refresh();
+    } catch (e: unknown) {
+      setError(
+        (e as { message?: string })?.message ||
+          "failed to change context window",
       );
     } finally {
       setApplying(false);
@@ -86,9 +101,25 @@ export function ProviderCard() {
           <span className="text-sm break-all">
             {provider.model ?? "unknown"}
           </span>
+          <span className="text-xs text-muted-foreground">
+            context window:{" "}
+            {provider.max_context_tokens != null
+              ? formatTokens(provider.max_context_tokens)
+              : isOpenRouter
+                ? "default"
+                : "1M (default)"}
+          </span>
         </div>
-        <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        <Button variant="outline" size="sm" onClick={() => setModelOpen(true)}>
           change model
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setContextOpen(true)}
+        >
+          <Gauge className="size-4" />
+          change context window
         </Button>
         <Button variant="ghost" size="sm" onClick={() => void handleOpenAuth()}>
           <ArrowLeftRight className="size-4" />
@@ -97,10 +128,10 @@ export function ProviderCard() {
       </CardContent>
 
       <Dialog
-        open={open}
+        open={modelOpen}
         onOpenChange={(next) => {
           if (!next) {
-            setOpen(false);
+            setModelOpen(false);
             setError(null);
           }
         }}
@@ -123,7 +154,42 @@ export function ProviderCard() {
                 models={isOpenRouter ? undefined : CLAUDE_MODELS}
                 allowCustom={isOpenRouter}
                 submitLabel="switch model"
-                onSubmit={(model) => void apply(model)}
+                onSubmit={(model) => void applyModel(model)}
+              />
+              {error && (
+                <p className="text-xs text-destructive text-center">{error}</p>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={contextOpen}
+        onOpenChange={(next) => {
+          if (!next) {
+            setContextOpen(false);
+            setError(null);
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-lg" showCloseButton>
+          <DialogHeader>
+            <DialogTitle>change context window</DialogTitle>
+            <DialogDescription className="sr-only">
+              pick a new context window for this agent
+            </DialogDescription>
+          </DialogHeader>
+          {applying ? (
+            <div className="flex flex-col items-center gap-3 py-4">
+              <ProgressBar message="changing context window, restarting agent..." />
+            </div>
+          ) : (
+            <div className="flex flex-col items-center gap-3 py-2">
+              <ContextStep
+                initial={provider.max_context_tokens ?? undefined}
+                submitLabel="apply"
+                onSubmit={(tokens) => void applyContext(tokens)}
               />
               {error && (
                 <p className="text-xs text-destructive text-center">{error}</p>

--- a/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
@@ -12,27 +12,12 @@ import {
 import { ProgressBar } from "@/components/ProgressBar";
 import { ModelStep } from "@/components/ProviderPicker/ModelStep";
 import { ContextStep } from "@/components/ProviderPicker/ContextStep";
-import type { openrouterProvider } from "@/api";
 import { setModel, setContextWindow } from "@/api/agents";
+import { formatTokens } from "@/lib/format";
 import { useProvider } from "@/hooks/use-provider";
+import { useClaudeModels } from "@/hooks/use-claude-models";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { useModals } from "@/providers/ModalsProvider";
-
-// Claude OAuth exposes a small fixed set; the SDK takes these short aliases.
-const CLAUDE_MODELS: openrouterProvider.OpenRouterModelOption[] = [
-  { slug: "opus", label: "Claude Opus", author: "Anthropic" },
-  { slug: "sonnet", label: "Claude Sonnet", author: "Anthropic" },
-  { slug: "haiku", label: "Claude Haiku", author: "Anthropic" },
-];
-
-// Display a token count as 1M / 500K / 200K.
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) {
-    return `${(n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1)}M`;
-  }
-  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
-  return String(n);
-}
 
 /// Provider hub for an agent: shows the current provider, model, and context
 /// window; lets you switch between Claude and OpenRouter (reuses the reconfigure
@@ -44,6 +29,7 @@ export function ProviderCard() {
   // Revalidate on status change so a provider switch (which restarts the agent)
   // is reflected here without a manual reload.
   const { provider, refresh } = useProvider(name, agent?.status);
+  const claudeModels = useClaudeModels(provider?.kind === "claude");
   const [modelOpen, setModelOpen] = useState(false);
   const [contextOpen, setContextOpen] = useState(false);
   const [applying, setApplying] = useState(false);
@@ -151,7 +137,7 @@ export function ProviderCard() {
             <div className="flex flex-col items-center gap-3 py-2">
               <ModelStep
                 initialModel={provider.model ?? ""}
-                models={isOpenRouter ? undefined : CLAUDE_MODELS}
+                models={isOpenRouter ? undefined : claudeModels}
                 allowCustom={isOpenRouter}
                 submitLabel="switch model"
                 onSubmit={(model) => void applyModel(model)}

--- a/apps/web/src/components/NewAgent/index.tsx
+++ b/apps/web/src/components/NewAgent/index.tsx
@@ -5,7 +5,6 @@ import {
   setProvider,
   waitUntilRunning,
   waitUntilAlive,
-  type OpenRouterConfig,
   type ProviderResult,
 } from "@/api/agents";
 import { stepTransition } from "@/lib/motion";
@@ -25,8 +24,11 @@ export function NewAgent() {
   const setStep = useOnboarding((s) => s.setStep);
   const [agentName, setAgentName] = useState("");
   const [seedPersonality, setSeedPersonality] = useState<string | null>(null);
-  const [openrouter, setOpenrouter] = useState<OpenRouterConfig | null>(null);
-  const [credentials, setCredentials] = useState<string | null>(null);
+  // The full provider result from the picker — carries credentials/key plus the
+  // chosen model and context window, all forwarded verbatim to setProvider.
+  const [providerResult, setProviderResult] = useState<ProviderResult | null>(
+    null,
+  );
   const [createError, setCreateError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -35,7 +37,13 @@ export function NewAgent() {
   }, []);
 
   useEffect(() => {
-    if (step !== "creating" || !agentName || !seedPersonality) return;
+    if (
+      step !== "creating" ||
+      !agentName ||
+      !seedPersonality ||
+      !providerResult
+    )
+      return;
     let cancelled = false;
     (async () => {
       try {
@@ -48,11 +56,8 @@ export function NewAgent() {
         if (cancelled) return;
 
         // Phase 3: provision the provider via POST /agents/{name}/provider.
-        const result: ProviderResult =
-          openrouter !== null
-            ? { kind: "openrouter", config: openrouter }
-            : { kind: "claude", credentials: credentials ?? "" };
-        await setProvider(agentName, result);
+        // The picker's result carries the chosen model + context window.
+        await setProvider(agentName, providerResult);
         if (cancelled) return;
 
         // Phase 4: wait for the provision-triggered restart to settle.
@@ -63,29 +68,23 @@ export function NewAgent() {
       } catch (e) {
         if (cancelled) return;
         setCreateError(errorMessage(e, "creation failed"));
-        setCredentials(null);
-        setOpenrouter(null);
+        setProviderResult(null);
         setStep("name");
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [step, agentName, seedPersonality, openrouter, credentials, setStep]);
+  }, [step, agentName, seedPersonality, providerResult, setStep]);
 
   const content = (() => {
     if (step === "provider")
       return (
         <ProviderPicker
           onDone={(result) => {
-            // Single result type now — ProviderPicker handles OAuth internally.
-            if (result.kind === "openrouter") {
-              setOpenrouter(result.config);
-              setCredentials(null);
-            } else {
-              setCredentials(result.credentials);
-              setOpenrouter(null);
-            }
+            // The picker handles OAuth/key + model + context internally and hands
+            // back a complete result; forward it verbatim to setProvider.
+            setProviderResult(result);
             setStep("personality");
           }}
           onBack={() => setStep("name")}

--- a/apps/web/src/components/ProviderPicker/ContextStep/index.tsx
+++ b/apps/web/src/components/ProviderPicker/ContextStep/index.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { FieldDescription } from "@/components/ui/field";
+
+interface ContextPreset {
+  tokens: number;
+  label: string;
+  note: string;
+}
+
+/// Context-window presets. 1M is the default (largest); smaller windows compact
+/// sooner and make prompt-cache reads cheaper.
+const CONTEXT_PRESETS: ContextPreset[] = [
+  { tokens: 1_000_000, label: "1M", note: "most context (default)" },
+  { tokens: 500_000, label: "500K", note: "balanced" },
+  { tokens: 200_000, label: "200K", note: "cheapest, compacts soonest" },
+];
+
+export function ContextStep({
+  initial,
+  onSubmit,
+  submitLabel = "continue",
+}: {
+  initial?: number;
+  onSubmit: (tokens: number) => void;
+  submitLabel?: string;
+}) {
+  const [selected, setSelected] = useState<number>(
+    initial ?? CONTEXT_PRESETS[0].tokens,
+  );
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit(selected);
+      }}
+      className="flex w-full flex-col items-center gap-4"
+    >
+      <div className="flex flex-col items-center gap-1 text-center">
+        <h2 className="text-base font-semibold">context window</h2>
+        <FieldDescription>
+          how much the agent keeps in context before it compacts. larger holds
+          more at once; smaller is cheaper and compacts sooner.
+        </FieldDescription>
+      </div>
+
+      <div className="flex w-full flex-col gap-1.5">
+        {CONTEXT_PRESETS.map((preset) => (
+          <button
+            key={preset.tokens}
+            type="button"
+            onClick={() => setSelected(preset.tokens)}
+            className={`flex items-center justify-between rounded-xl border p-3 text-left transition-all cursor-pointer ${
+              preset.tokens === selected
+                ? "border-primary/60 bg-primary/5 ring-2 ring-primary/30"
+                : "border-border bg-input/30 hover:bg-input/60 hover:border-border/80"
+            }`}
+          >
+            <span className="text-sm font-medium">{preset.label}</span>
+            <span className="text-[11px] text-muted-foreground">
+              {preset.note}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <Button type="submit" className="w-full">
+        {submitLabel}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/components/ProviderPicker/ModelStep/index.tsx
+++ b/apps/web/src/components/ProviderPicker/ModelStep/index.tsx
@@ -10,6 +10,7 @@ import {
 import { openrouterProvider } from "@/api";
 
 type OpenRouterModelOption = openrouterProvider.OpenRouterModelOption;
+import { formatTokens } from "@/lib/format";
 import { ProviderIcon } from "../ProviderIcon";
 import { fuzzyMatch } from "../fuzzy";
 
@@ -221,7 +222,7 @@ function ModelCard({
         <span className="truncate text-[11px] text-muted-foreground">
           {model.author}
           {model.context_length
-            ? ` · ${formatContextLength(model.context_length)} ctx`
+            ? ` · ${formatTokens(model.context_length)} ctx`
             : ""}
           {formatPrice(
             model.input_price,
@@ -234,14 +235,6 @@ function ModelCard({
       </div>
     </button>
   );
-}
-
-function formatContextLength(n: number): string {
-  if (n >= 1_000_000) {
-    return `${(n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1)}M`;
-  }
-  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
-  return String(n);
 }
 
 // input/output/cache-read price in USD per million tokens, or null when not

--- a/apps/web/src/components/ProviderPicker/index.tsx
+++ b/apps/web/src/components/ProviderPicker/index.tsx
@@ -4,15 +4,31 @@ import { ChevronLeftIcon } from "lucide-react";
 import { stepTransition } from "@/lib/motion";
 import { claudeProvider } from "@/api";
 import type { ProviderResult } from "@/api/agents";
+import type { OpenRouterModelOption } from "@/api/providers/openrouter";
 
 type AuthStartResult = claudeProvider.OAuthStartResult;
 import { ChoiceStep } from "./ChoiceStep";
 import { KeyStep } from "./KeyStep";
 import { ModelStep } from "./ModelStep";
+import { ContextStep } from "./ContextStep";
 import { AuthStep } from "./AuthStep";
 import type { ProviderMode } from "./types";
 
-type InternalStep = "choice" | "auth" | "key" | "model";
+type InternalStep =
+  | "choice"
+  | "auth"
+  | "claude-model"
+  | "key"
+  | "model"
+  | "context";
+
+// Shown immediately; refined from vestad's /providers/claude/models on mount so a
+// newly-added model appears without a code change. claude-code resolves the aliases.
+const CLAUDE_FALLBACK: OpenRouterModelOption[] = [
+  { slug: "opus", label: "Claude Opus", author: "Anthropic" },
+  { slug: "sonnet", label: "Claude Sonnet", author: "Anthropic" },
+  { slug: "haiku", label: "Claude Haiku", author: "Anthropic" },
+];
 
 export function ProviderPicker({
   onDone,
@@ -22,10 +38,36 @@ export function ProviderPicker({
   onBack?: () => void;
 }) {
   const [step, setStep] = useState<InternalStep>("choice");
+  const [mode, setMode] = useState<ProviderMode>("claude");
   const [key, setKey] = useState("");
   const [model, setModel] = useState("");
+  const [claudeModel, setClaudeModel] = useState("");
+  const [credentials, setCredentials] = useState("");
+  const [claudeModels, setClaudeModels] =
+    useState<OpenRouterModelOption[]>(CLAUDE_FALLBACK);
   const [authStart, setAuthStart] = useState<AuthStartResult | null>(null);
   const [authStartError, setAuthStartError] = useState<string | null>(null);
+
+  // Refine the Claude model list once; failures keep the fallback.
+  useEffect(() => {
+    let cancelled = false;
+    claudeProvider
+      .fetchModels()
+      .then((items) => {
+        if (cancelled || items.length === 0) return;
+        setClaudeModels(
+          items.map((m) => ({
+            slug: m.id,
+            label: m.label,
+            author: "Anthropic",
+          })),
+        );
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Kick off the standalone OAuth session once when entering the auth substep.
   // Owned here (not by AuthStep) so AuthStep remounts don't restart a fresh
@@ -50,12 +92,14 @@ export function ProviderPicker({
     };
   }, [step, authStart, authStartError]);
 
-  const handleChoice = (mode: ProviderMode) => {
-    if (mode === "claude") {
-      setStep("auth");
-      return;
-    }
-    setStep("key");
+  const handleChoice = (next: ProviderMode) => {
+    setMode(next);
+    setStep(next === "claude" ? "auth" : "key");
+  };
+
+  const handleCredentialsReady = (creds: string) => {
+    setCredentials(creds);
+    setStep("claude-model");
   };
 
   const handleKeyNext = (newKey: string) => {
@@ -63,21 +107,41 @@ export function ProviderPicker({
     setStep("model");
   };
 
-  const handleModelSubmit = (newModel: string) => {
-    onDone({ kind: "openrouter", config: { key, model: newModel } });
+  const handleContextSubmit = (maxContextTokens: number) => {
+    if (mode === "claude") {
+      onDone({
+        kind: "claude",
+        credentials,
+        model: claudeModel || undefined,
+        maxContextTokens,
+      });
+    } else {
+      onDone({
+        kind: "openrouter",
+        config: { key, model },
+        maxContextTokens,
+      });
+    }
   };
 
-  const handleCredentialsReady = (credentials: string) => {
-    onDone({ kind: "claude", credentials });
+  const resetAuth = () => {
+    setAuthStart(null);
+    setAuthStartError(null);
   };
 
   const back = (() => {
     if (step === "choice") return onBack;
     if (step === "model") return () => setStep("key");
+    if (step === "context")
+      return () => setStep(mode === "claude" ? "claude-model" : "model");
+    if (step === "claude-model")
+      return () => {
+        resetAuth();
+        setStep("choice");
+      };
     // auth and key both return to the choice screen.
     return () => {
-      setAuthStart(null);
-      setAuthStartError(null);
+      resetAuth();
       setStep("choice");
     };
   })();
@@ -104,9 +168,20 @@ export function ProviderPicker({
               startError={authStartError}
               onCredentialsReady={handleCredentialsReady}
               onCancel={() => {
-                setAuthStart(null);
-                setAuthStartError(null);
+                resetAuth();
                 setStep("choice");
+              }}
+            />
+          )}
+          {step === "claude-model" && (
+            <ModelStep
+              initialModel={claudeModel}
+              models={claudeModels}
+              allowCustom={false}
+              onModelChange={setClaudeModel}
+              onSubmit={(m) => {
+                setClaudeModel(m);
+                setStep("context");
               }}
             />
           )}
@@ -117,9 +192,13 @@ export function ProviderPicker({
             <ModelStep
               initialModel={model}
               onModelChange={setModel}
-              onSubmit={handleModelSubmit}
+              onSubmit={(m) => {
+                setModel(m);
+                setStep("context");
+              }}
             />
           )}
+          {step === "context" && <ContextStep onSubmit={handleContextSubmit} />}
         </motion.div>
       </AnimatePresence>
     </div>

--- a/apps/web/src/components/ProviderPicker/index.tsx
+++ b/apps/web/src/components/ProviderPicker/index.tsx
@@ -4,7 +4,7 @@ import { ChevronLeftIcon } from "lucide-react";
 import { stepTransition } from "@/lib/motion";
 import { claudeProvider } from "@/api";
 import type { ProviderResult } from "@/api/agents";
-import type { OpenRouterModelOption } from "@/api/providers/openrouter";
+import { useClaudeModels } from "@/hooks/use-claude-models";
 
 type AuthStartResult = claudeProvider.OAuthStartResult;
 import { ChoiceStep } from "./ChoiceStep";
@@ -22,14 +22,6 @@ type InternalStep =
   | "model"
   | "context";
 
-// Shown immediately; refined from vestad's /providers/claude/models on mount so a
-// newly-added model appears without a code change. claude-code resolves the aliases.
-const CLAUDE_FALLBACK: OpenRouterModelOption[] = [
-  { slug: "opus", label: "Claude Opus", author: "Anthropic" },
-  { slug: "sonnet", label: "Claude Sonnet", author: "Anthropic" },
-  { slug: "haiku", label: "Claude Haiku", author: "Anthropic" },
-];
-
 export function ProviderPicker({
   onDone,
   onBack,
@@ -43,31 +35,10 @@ export function ProviderPicker({
   const [model, setModel] = useState("");
   const [claudeModel, setClaudeModel] = useState("");
   const [credentials, setCredentials] = useState("");
-  const [claudeModels, setClaudeModels] =
-    useState<OpenRouterModelOption[]>(CLAUDE_FALLBACK);
+  // Fetch only once the user is actually on the Claude path, not on mount.
+  const claudeModels = useClaudeModels(mode === "claude" && step !== "choice");
   const [authStart, setAuthStart] = useState<AuthStartResult | null>(null);
   const [authStartError, setAuthStartError] = useState<string | null>(null);
-
-  // Refine the Claude model list once; failures keep the fallback.
-  useEffect(() => {
-    let cancelled = false;
-    claudeProvider
-      .fetchModels()
-      .then((items) => {
-        if (cancelled || items.length === 0) return;
-        setClaudeModels(
-          items.map((m) => ({
-            slug: m.id,
-            label: m.label,
-            author: "Anthropic",
-          })),
-        );
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   // Kick off the standalone OAuth session once when entering the auth substep.
   // Owned here (not by AuthStep) so AuthStep remounts don't restart a fresh

--- a/apps/web/src/hooks/use-claude-models.ts
+++ b/apps/web/src/hooks/use-claude-models.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { claudeProvider } from "@/api";
+import type { OpenRouterModelOption } from "@/api/providers/openrouter";
+
+// Shown immediately; refined from vestad's /providers/claude/models so a newly
+// added model appears without a code change. claude-code resolves the aliases.
+const CLAUDE_FALLBACK: OpenRouterModelOption[] = [
+  { slug: "opus", label: "Claude Opus", author: "Anthropic" },
+  { slug: "sonnet", label: "Claude Sonnet", author: "Anthropic" },
+  { slug: "haiku", label: "Claude Haiku", author: "Anthropic" },
+];
+
+/// The Claude model list as model-card options, single source for both the
+/// onboarding picker and the settings card. Starts from the static fallback and
+/// refines it from vestad. `enabled` gates the fetch so the OpenRouter path (or a
+/// non-Claude agent) doesn't issue a request it would throw away.
+export function useClaudeModels(enabled = true): OpenRouterModelOption[] {
+  const [models, setModels] =
+    useState<OpenRouterModelOption[]>(CLAUDE_FALLBACK);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    claudeProvider
+      .fetchModels()
+      .then((items) => {
+        if (cancelled || items.length === 0) return;
+        setModels(
+          items.map((m) => ({
+            slug: m.id,
+            label: m.label,
+            author: "Anthropic",
+          })),
+        );
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return models;
+}

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -1,0 +1,10 @@
+/// Format a token count compactly: 1M / 1.5M / 500K / 200K / 512.
+/// Shared by the model picker (OpenRouter context_length) and the provider card
+/// (context window) so the two render identically.
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1)}M`;
+  }
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return String(n);
+}

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -240,6 +240,15 @@ pub struct OpenRouterModel {
     pub cache_read_price: Option<f64>,
 }
 
+/// A Claude model offered by the picker in `vesta setup` (from `GET /providers/claude/models`).
+#[derive(serde::Deserialize)]
+pub struct ClaudeModel {
+    /// The alias stored in AGENT_MODEL, e.g. "opus".
+    pub id: String,
+    pub label: String,
+    pub note: String,
+}
+
 impl Client {
     pub fn new(config: &ServerConfig) -> Result<Self, String> {
         let tls_config = if let Some(ref pem) = config.cert_pem {
@@ -392,12 +401,38 @@ impl Client {
 
     /// Provision an existing agent with provider credentials. Either Claude
     /// (`credentials`: OAuth JSON blob) or OpenRouter (key/model).
-    pub fn set_provider_credentials(&self, name: &str, credentials: &str) -> Result<(), String> {
+    pub fn set_provider_credentials(&self, name: &str, credentials: &str, model: Option<&str>, max_context_tokens: Option<u64>) -> Result<(), String> {
         serde_json::from_str::<serde_json::Value>(credentials)
             .map_err(|e| format!("invalid credentials JSON: {e}"))?;
-        let body = serde_json::json!({"credentials": credentials});
+        let mut body = serde_json::json!({"credentials": credentials});
+        if let Some(model) = model {
+            body["model"] = serde_json::json!(model);
+        }
+        if let Some(ctx) = max_context_tokens {
+            body["max_context_tokens"] = serde_json::json!(ctx);
+        }
         self.post_json(&format!("/agents/{name}/provider"), &body)?;
         Ok(())
+    }
+
+    /// Change the model and/or context window on a provisioned agent, keeping its
+    /// provider and credentials. POSTs `{model?, max_context_tokens?}`.
+    pub fn set_provider_settings(&self, name: &str, model: Option<&str>, max_context_tokens: Option<u64>) -> Result<(), String> {
+        let mut body = serde_json::Map::new();
+        if let Some(model) = model {
+            body.insert("model".to_string(), serde_json::json!(model));
+        }
+        if let Some(ctx) = max_context_tokens {
+            body.insert("max_context_tokens".to_string(), serde_json::json!(ctx));
+        }
+        self.post_json(&format!("/agents/{name}/provider"), &serde_json::Value::Object(body))?;
+        Ok(())
+    }
+
+    /// Current provider status: `{state, kind, model, max_context_tokens}`.
+    pub fn get_provider(&self, name: &str) -> Result<serde_json::Value, String> {
+        let resp = self.get(&format!("/agents/{name}/provider"))?;
+        read_json(resp)
     }
 
     pub fn set_provider_openrouter(&self, name: &str, args: &OpenRouterArgs) -> Result<(), String> {
@@ -542,6 +577,11 @@ impl Client {
 
     pub fn fetch_top_openrouter_models(&self) -> Result<Vec<OpenRouterModel>, String> {
         let resp = self.get("/providers/openrouter/models/top")?;
+        read_json(resp)
+    }
+
+    pub fn fetch_claude_models(&self) -> Result<Vec<ClaudeModel>, String> {
+        let resp = self.get("/providers/claude/models")?;
         read_json(resp)
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -931,6 +931,9 @@ fn run(cli: Cli) {
                     }
                     match provider["max_context_tokens"].as_u64() {
                         Some(ctx) => eprintln!("context_window = {ctx}"),
+                        None if provider["kind"].as_str() == Some("openrouter") => {
+                            eprintln!("context_window = default (model window, capped at 200K)")
+                        }
                         None => eprintln!("context_window = default (1M for Claude)"),
                     }
                 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -89,6 +89,12 @@ enum Command {
         /// from `vesta auth` or an existing agent.
         #[arg(long)]
         claude_token: Option<String>,
+        /// Claude model: opus | sonnet | haiku (prompted on an interactive Claude setup if omitted)
+        #[arg(long)]
+        claude_model: Option<String>,
+        /// Context window in tokens, e.g. 200000 / 500000 / 1000000 (prompted if omitted; Claude default is 1M)
+        #[arg(long)]
+        context_window: Option<u64>,
         #[command(flatten)]
         openrouter: OpenRouterFlags,
     },
@@ -157,10 +163,17 @@ enum Command {
         #[command(subcommand)]
         action: BackupAction,
     },
-    /// View agent settings (manage_agent_code is fixed at create time and read-only here)
+    /// View or change agent settings. With no flags, prints model + context window
+    /// (manage_agent_code is fixed at create time and read-only here).
     Settings {
         /// Agent name
         name: String,
+        /// Change the model: opus | sonnet | haiku (Claude), or an OpenRouter slug
+        #[arg(long)]
+        model: Option<String>,
+        /// Change the context window in tokens, e.g. 200000 / 500000 / 1000000
+        #[arg(long)]
+        context_window: Option<u64>,
     },
     /// View or edit an agent's constitution (a charter prepended to its memory; the agent
     /// cannot edit it). With no flags, prints the current constitution.
@@ -389,14 +402,22 @@ fn build_openrouter_args(flags: OpenRouterFlags) -> Option<client::OpenRouterArg
     Some(client::OpenRouterArgs { key, model })
 }
 
+/// Claude model + context window chosen for a `vesta setup`. Both optional: unset
+/// fields let vestad apply its defaults (Opus, 1M window).
+#[derive(Default)]
+struct ClaudeOptions {
+    model: Option<String>,
+    max_context_tokens: Option<u64>,
+}
+
 /// How `vesta setup` will provision the agent once it's created.
 enum ProvisionPlan {
     /// Run on OpenRouter (key already validated).
     OpenRouter(client::OpenRouterArgs),
     /// Provision Claude from credentials supplied up front (non-interactive).
-    ClaudeCredentials(String),
+    ClaudeCredentials { credentials: String, opts: ClaudeOptions },
     /// Provision Claude via the interactive OAuth dance after create.
-    ClaudeOAuth,
+    ClaudeOAuth { opts: ClaudeOptions },
 }
 
 /// Resolve how `vesta setup` should provision the agent. Every interactive prompt
@@ -405,7 +426,8 @@ enum ProvisionPlan {
 /// - `--claude-token` -> Claude from supplied credentials, no prompts
 /// - `--yes` with neither -> defaults to Claude (OAuth dance still runs)
 /// - otherwise -> prompt for the provider (and key/model, or OAuth)
-fn resolve_setup_provider(c: &client::Client, flags: OpenRouterFlags, claude_token: Option<String>, yes: bool) -> ProvisionPlan {
+#[allow(clippy::too_many_arguments)]
+fn resolve_setup_provider(c: &client::Client, flags: OpenRouterFlags, claude_token: Option<String>, claude_model: Option<String>, context_window: Option<u64>, yes: bool) -> ProvisionPlan {
     if flags.openrouter_key.is_some() && claude_token.is_some() {
         platform::die("--openrouter-key and --claude-token are mutually exclusive");
     }
@@ -416,12 +438,72 @@ fn resolve_setup_provider(c: &client::Client, flags: OpenRouterFlags, claude_tok
         return ProvisionPlan::OpenRouter(args);
     }
     if let Some(credentials) = claude_token {
-        return ProvisionPlan::ClaudeCredentials(credentials);
+        // Non-interactive Claude: model/context come from flags only (no prompts).
+        return ProvisionPlan::ClaudeCredentials {
+            credentials,
+            opts: ClaudeOptions { model: claude_model, max_context_tokens: context_window },
+        };
     }
     if yes || !prompt_use_openrouter() {
-        return ProvisionPlan::ClaudeOAuth;
+        return ProvisionPlan::ClaudeOAuth { opts: resolve_claude_options(c, claude_model, context_window, yes) };
     }
     ProvisionPlan::OpenRouter(prompt_openrouter_interactive(c, flags.openrouter_model))
+}
+
+/// Collect the Claude model + context window for setup. Flags win; otherwise prompt
+/// interactively. With `--yes` and no flags, leave both unset so vestad applies its
+/// defaults (Opus, 1M window).
+fn resolve_claude_options(c: &client::Client, model_flag: Option<String>, ctx_flag: Option<u64>, yes: bool) -> ClaudeOptions {
+    let model = model_flag.or_else(|| (!yes).then(|| prompt_claude_model(c)));
+    let max_context_tokens = ctx_flag.or_else(|| (!yes).then(prompt_context_window));
+    ClaudeOptions { model, max_context_tokens }
+}
+
+/// Prompt for a Claude model from the curated list (default = first entry, Opus).
+/// Falls back to "opus" if the list can't be fetched.
+fn prompt_claude_model(c: &client::Client) -> String {
+    let models = match c.fetch_claude_models() {
+        Ok(models) if !models.is_empty() => models,
+        _ => return "opus".to_string(),
+    };
+    eprintln!("which Claude model?");
+    for (idx, model) in models.iter().enumerate() {
+        let default = if idx == 0 { "  (default)" } else { "" };
+        eprintln!("  {}) {} — {}{}", idx + 1, model.label, model.note, default);
+    }
+    loop {
+        match prompt_raw("choice [1]").as_str() {
+            "" => return models[0].id.clone(),
+            s => match s.parse::<usize>().ok().and_then(|n| models.get(n.wrapping_sub(1))) {
+                Some(model) => return model.id.clone(),
+                None => eprintln!("  pick a number between 1 and {}", models.len()),
+            },
+        }
+    }
+}
+
+/// Context-window presets (tokens, label). 1M is the default (largest).
+const CONTEXT_PRESETS: [(u64, &str); 3] = [
+    (200_000, "200K — cheapest prompt-cache reads, compacts soonest"),
+    (500_000, "500K — balanced"),
+    (1_000_000, "1M — most context (default)"),
+];
+
+/// Prompt for a context-window preset. Default = 1M (the largest).
+fn prompt_context_window() -> u64 {
+    eprintln!("context window?");
+    for (idx, (_, label)) in CONTEXT_PRESETS.iter().enumerate() {
+        eprintln!("  {}) {}", idx + 1, label);
+    }
+    loop {
+        match prompt_raw("choice [3]").as_str() {
+            "" => return CONTEXT_PRESETS[2].0,
+            s => match s.parse::<usize>().ok().and_then(|n| CONTEXT_PRESETS.get(n.wrapping_sub(1))) {
+                Some((tokens, _)) => return *tokens,
+                None => eprintln!("  pick a number between 1 and {}", CONTEXT_PRESETS.len()),
+            },
+        }
+    }
 }
 
 /// Ask the user which provider to run the agent on. Defaults to a Claude
@@ -534,8 +616,9 @@ fn oauth_dance(client: &client::Client) -> String {
 
 fn authenticate_agent(client: &client::Client, name: &str) {
     let credentials = oauth_dance(client);
+    // Reauth only: model + context window are preserved server-side (None = keep).
     client
-        .set_provider_credentials(name, &credentials)
+        .set_provider_credentials(name, &credentials, None, None)
         .unwrap_or_else(|e| platform::die(&e));
     eprintln!("authenticated!");
 }
@@ -727,7 +810,7 @@ fn run(cli: Cli) {
     let token_ref = cli.token.as_deref();
 
     match command {
-        Command::Setup { yes, name, no_manage_core_code, claude_token, openrouter } => {
+        Command::Setup { yes, name, no_manage_core_code, claude_token, claude_model, context_window, openrouter } => {
             let c = get_client(host_ref, token_ref);
 
             let name = name
@@ -739,7 +822,7 @@ fn run(cli: Cli) {
             // is validated client-side here so a bad key fails fast, before we
             // create an agent we'd immediately fail to provision. Claude needs
             // no pre-validation; OAuth happens after create.
-            let plan = resolve_setup_provider(&c, openrouter, claude_token, yes);
+            let plan = resolve_setup_provider(&c, openrouter, claude_token, claude_model, context_window, yes);
             let timezone = detect_timezone();
 
             // 1. Create an empty agent. Vestad no longer accepts credentials at
@@ -770,15 +853,15 @@ fn run(cli: Cli) {
                         .unwrap_or_else(|e| platform::die(&e));
                     eprintln!("running on OpenRouter (no Claude login needed)");
                 }
-                ProvisionPlan::ClaudeCredentials(credentials) => {
-                    c.set_provider_credentials(&created_name, &credentials)
+                ProvisionPlan::ClaudeCredentials { credentials, opts } => {
+                    c.set_provider_credentials(&created_name, &credentials, opts.model.as_deref(), opts.max_context_tokens)
                         .unwrap_or_else(|e| platform::die(&e));
                     eprintln!("authenticated (claude)");
                 }
-                ProvisionPlan::ClaudeOAuth => {
+                ProvisionPlan::ClaudeOAuth { opts } => {
                     eprintln!("authenticating claude...");
                     let credentials = oauth_dance(&c);
-                    c.set_provider_credentials(&created_name, &credentials)
+                    c.set_provider_credentials(&created_name, &credentials, opts.model.as_deref(), opts.max_context_tokens)
                         .unwrap_or_else(|e| platform::die(&e));
                     eprintln!("authenticated!");
                 }
@@ -833,11 +916,25 @@ fn run(cli: Cli) {
             }
         }
 
-        Command::Settings { name } => {
+        Command::Settings { name, model, context_window } => {
             let c = get_client(host_ref, token_ref);
-            let result = c.get_agent_settings(&name).unwrap_or_else(|e| platform::die(&e));
-            let val = result["manage_agent_code"].as_bool().unwrap_or(true);
-            eprintln!("manage_agent_code = {val}");
+            if model.is_some() || context_window.is_some() {
+                c.set_provider_settings(&name, model.as_deref(), context_window)
+                    .unwrap_or_else(|e| platform::die(&e));
+                eprintln!("updated. the agent is restarting to apply the change.");
+            } else {
+                let result = c.get_agent_settings(&name).unwrap_or_else(|e| platform::die(&e));
+                eprintln!("manage_agent_code = {}", result["manage_agent_code"].as_bool().unwrap_or(true));
+                if let Ok(provider) = c.get_provider(&name) {
+                    if let Some(m) = provider["model"].as_str() {
+                        eprintln!("model = {m}");
+                    }
+                    match provider["max_context_tokens"].as_u64() {
+                        Some(ctx) => eprintln!("context_window = {ctx}"),
+                        None => eprintln!("context_window = default (1M for Claude)"),
+                    }
+                }
+            }
         }
 
         Command::Constitution { name, edit, file, clear } => {
@@ -930,7 +1027,7 @@ fn run(cli: Cli) {
         Command::Auth { name, token } => {
             let c = get_client(host_ref, token_ref);
             if let Some(token_str) = token {
-                c.set_provider_credentials(&name, &token_str)
+                c.set_provider_credentials(&name, &token_str, None, None)
                     .unwrap_or_else(|e| platform::die(&e));
                 eprintln!("{name}: authenticated");
             } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -459,6 +459,26 @@ fn resolve_claude_options(c: &client::Client, model_flag: Option<String>, ctx_fl
     ClaudeOptions { model, max_context_tokens }
 }
 
+/// Show a numbered list and return the chosen 0-based index. Empty input picks
+/// `default_idx`; an out-of-range number reprompts. Used by the fixed-list pickers
+/// (Claude model, context window); the OpenRouter picker is richer (search + custom
+/// slug) and stays separate.
+fn prompt_indexed_choice(labels: &[String], default_idx: usize) -> usize {
+    for (idx, label) in labels.iter().enumerate() {
+        let marker = if idx == default_idx { "  (default)" } else { "" };
+        eprintln!("  {}) {label}{marker}", idx + 1);
+    }
+    loop {
+        match prompt_raw(&format!("choice [{}]", default_idx + 1)).as_str() {
+            "" => return default_idx,
+            s => match s.parse::<usize>().ok().filter(|n| (1..=labels.len()).contains(n)) {
+                Some(n) => return n - 1,
+                None => eprintln!("  pick a number between 1 and {}", labels.len()),
+            },
+        }
+    }
+}
+
 /// Prompt for a Claude model from the curated list (default = first entry, Opus).
 /// Falls back to "opus" if the list can't be fetched.
 fn prompt_claude_model(c: &client::Client) -> String {
@@ -467,43 +487,22 @@ fn prompt_claude_model(c: &client::Client) -> String {
         _ => return "opus".to_string(),
     };
     eprintln!("which Claude model?");
-    for (idx, model) in models.iter().enumerate() {
-        let default = if idx == 0 { "  (default)" } else { "" };
-        eprintln!("  {}) {} — {}{}", idx + 1, model.label, model.note, default);
-    }
-    loop {
-        match prompt_raw("choice [1]").as_str() {
-            "" => return models[0].id.clone(),
-            s => match s.parse::<usize>().ok().and_then(|n| models.get(n.wrapping_sub(1))) {
-                Some(model) => return model.id.clone(),
-                None => eprintln!("  pick a number between 1 and {}", models.len()),
-            },
-        }
-    }
+    let labels: Vec<String> = models.iter().map(|m| format!("{} — {}", m.label, m.note)).collect();
+    models[prompt_indexed_choice(&labels, 0)].id.clone()
 }
 
 /// Context-window presets (tokens, label). 1M is the default (largest).
 const CONTEXT_PRESETS: [(u64, &str); 3] = [
     (200_000, "200K — cheapest prompt-cache reads, compacts soonest"),
     (500_000, "500K — balanced"),
-    (1_000_000, "1M — most context (default)"),
+    (1_000_000, "1M — most context"),
 ];
 
-/// Prompt for a context-window preset. Default = 1M (the largest).
+/// Prompt for a context-window preset. Default = 1M (the largest, last entry).
 fn prompt_context_window() -> u64 {
     eprintln!("context window?");
-    for (idx, (_, label)) in CONTEXT_PRESETS.iter().enumerate() {
-        eprintln!("  {}) {}", idx + 1, label);
-    }
-    loop {
-        match prompt_raw("choice [3]").as_str() {
-            "" => return CONTEXT_PRESETS[2].0,
-            s => match s.parse::<usize>().ok().and_then(|n| CONTEXT_PRESETS.get(n.wrapping_sub(1))) {
-                Some((tokens, _)) => return *tokens,
-                None => eprintln!("  pick a number between 1 and {}", CONTEXT_PRESETS.len()),
-            },
-        }
-    }
+    let labels: Vec<String> = CONTEXT_PRESETS.iter().map(|(_, label)| label.to_string()).collect();
+    CONTEXT_PRESETS[prompt_indexed_choice(&labels, CONTEXT_PRESETS.len() - 1)].0
 }
 
 /// Ask the user which provider to run the agent on. Defaults to a Claude

--- a/vestad/src/agent_provider.rs
+++ b/vestad/src/agent_provider.rs
@@ -27,6 +27,11 @@ pub struct ProviderStatus {
     /// older agent that doesn't report the field isn't stuck reporting `SettingUp`.
     #[serde(default = "default_setup_complete")]
     pub setup_complete: bool,
+    /// The agent's chosen context window in tokens, or null for the model default.
+    /// `#[serde(default)]` so an older agent that doesn't report it deserializes fine;
+    /// without the field here vestad would silently drop it on the status round-trip.
+    #[serde(default)]
+    pub max_context_tokens: Option<i64>,
 }
 
 fn default_setup_complete() -> bool {

--- a/vestad/src/providers/claude.rs
+++ b/vestad/src/providers/claude.rs
@@ -14,6 +14,24 @@ pub struct OAuthStartResponse {
     pub session_id: String,
 }
 
+#[derive(Serialize)]
+pub struct ClaudeModel {
+    /// The alias stored in AGENT_MODEL; claude-code resolves it to the latest snapshot.
+    pub id: String,
+    pub label: String,
+    pub note: String,
+}
+
+/// Curated list of Claude models for the picker. Anthropic's lineup is a small,
+/// stable set, so this is static (unlike OpenRouter's remote top-models fetch).
+pub async fn list_models_handler() -> Json<Vec<ClaudeModel>> {
+    Json(vec![
+        ClaudeModel { id: "opus".into(), label: "Claude Opus".into(), note: "most capable".into() },
+        ClaudeModel { id: "sonnet".into(), label: "Claude Sonnet".into(), note: "balanced speed and capability".into() },
+        ClaudeModel { id: "haiku".into(), label: "Claude Haiku".into(), note: "fastest and cheapest".into() },
+    ])
+}
+
 #[derive(Deserialize)]
 pub struct OAuthCompleteBody {
     pub session_id: String,

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1933,6 +1933,7 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/personalities", get(list_personalities_handler))
         .route("/providers/claude/oauth/start", post(crate::providers::claude::oauth_start_handler))
         .route("/providers/claude/oauth/complete", post(crate::providers::claude::oauth_complete_handler))
+        .route("/providers/claude/models", get(crate::providers::claude::list_models_handler))
         .route("/providers/openrouter/models/top", get(crate::providers::openrouter::list_top_models_handler))
         .route("/providers/openrouter/validate-key", post(crate::providers::openrouter::validate_key_handler))
         .route("/agents", get(list_agents_handler))


### PR DESCRIPTION
Lets users pick the **Claude model** (Opus / Sonnet / Haiku) and the **context window** (200K / 500K / 1M) when setting up an agent, and change both afterward — in the app *and* the CLI. OpenRouter already had model selection; this brings parity for the Claude provider and adds context-window control to both.

## Behaviour

- **Model** lives in the provider step (the same place OpenRouter's already does): `vesta-provider.env` → `AGENT_MODEL`. The agent already accepted a Claude model; this surfaces it in the UIs.
- **Context window** is now a real per-agent setting. For Claude the agent sets `CLAUDE_CODE_MAX_CONTEXT_TOKENS` and requests the 1M beta only when the chosen window needs it. **Unset = today's behaviour** (1M beta on, no cap), so existing agents don't regress; `config.max_context_tokens` is now `Optional`, and the OpenRouter cap falls back to 200k.
- Reauth / model-only changes **preserve** the chosen window (don't wipe it).

## Per surface

**vestad** — `GET /providers/claude/models` (curated opus/sonnet/haiku, static like Anthropic's lineup). The `/provider` passthrough already forwards `max_context_tokens`.

**agent** — `provider.py` persists `MAX_CONTEXT_TOKENS` in the provider file and threads/preserves it through `set_claude` / `set_openrouter` / `set_settings`; `POST /provider` accepts `max_context_tokens` and the status reports it; `client.py` applies it to Claude; `cc_sdk` reports usage against the chosen window. New tests cover the file format and the Claude beta/cap logic.

**CLI** — `vesta setup` prompts for model + context (with `--claude-model` / `--context-window` flags); `vesta settings <name>` gains `--model` / `--context-window` and prints the current values; reauth preserves them.

**app** — ProviderPicker gains a Claude model step + a shared context-window preset step; the settings ProviderCard adds a "change context window" control next to the model switcher. API: `setProvider` carries model + `max_context_tokens`, new `setContextWindow`, `ProviderInfo.max_context_tokens`, `claude.fetchModels`.

## Decisions (asked up front)

- Context window = **presets 200K / 500K / 1M** (not a freeform number / slider).
- Scope = **onboarding *and* settings** (change after setup too).
- Models offered = Opus / Sonnet / Haiku (the config aliases).

## Verification

All four CI gates green, each run via `./check.sh`:
- `vestad` — clippy `-D warnings` + tests
- `cli` — clippy `-D warnings` + tests
- `agent` — ruff + ty + **283 pytest** (added Claude context + provider-file tests)
- `web` — eslint (0 errors) + prettier + tsc + **57 vitest**

## Notes / follow-ups

- The CLI `--context-window` takes a raw token count (the interactive prompt + the app use presets); vestad stays permissive on the value, validation/caps belong upstream.
- App UI follows existing ProviderPicker/Dialog patterns but hasn't had a visual pass in a running build — worth a quick look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)