### PR TITLE
vestad: GET /info (managed flag) + tunnel setup --json (hosted control-plane support)

### DIFF
--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -112,6 +112,10 @@ enum TunnelAction {
     Setup {
         /// Subdomain name (e.g., "alice" for alice.yourdomain.com)
         subdomain: String,
+        /// Emit a single line of JSON ({"tunnel_id","dns_record_id","hostname"})
+        /// to stdout instead of human-readable output (for cloud-init / jq).
+        #[arg(long)]
+        json: bool,
     },
     /// Tear down tunnel and DNS record
     Destroy,
@@ -617,9 +621,16 @@ fn main() {
         Command::Tunnel { action } => {
             let config = config_dir();
             match action {
-                TunnelAction::Setup { subdomain } => {
-                    tunnel::setup_tunnel(&config, &subdomain)
+                TunnelAction::Setup { subdomain, json } => {
+                    let tc = tunnel::setup_tunnel(&config, &subdomain)
                         .unwrap_or_else(|e| die(e));
+                    if json {
+                        println!("{}", serde_json::json!({
+                            "tunnel_id": tc.tunnel_id,
+                            "dns_record_id": tc.dns_record_id,
+                            "hostname": tc.hostname,
+                        }));
+                    }
                 }
                 TunnelAction::Destroy => {
                     tunnel::destroy_tunnel(&config)

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -251,6 +251,21 @@ async fn health() -> Json<serde_json::Value> {
     Json(serde_json::json!({"ok": true, "user": user}))
 }
 
+// Unauthenticated: lets apps/web tell a hosted (vesta.run) VM from a self-hosted
+// one, since both get `*.vesta.run` tunnels and the URL alone can't distinguish.
+// Sourced from the cloud-init env: VESTA_MANAGED ("1" => managed), plus optional
+// VESTA_SERVER_ID / VESTA_LOGIN_URL.
+async fn info() -> Json<serde_json::Value> {
+    let managed = std::env::var("VESTA_MANAGED").as_deref() == Ok("1");
+    let server_id = std::env::var("VESTA_SERVER_ID").ok();
+    let login_url = std::env::var("VESTA_LOGIN_URL").ok();
+    Json(serde_json::json!({
+        "managed": managed,
+        "server_id": server_id,
+        "login_url": login_url,
+    }))
+}
+
 async fn version(State(state): State<SharedState>) -> Json<serde_json::Value> {
     Json(version_json(&state).await)
 }
@@ -1929,6 +1944,7 @@ pub fn build_router(state: SharedState) -> Router {
 
     let vestad_public = Router::new()
         .route("/health", get(health))
+        .route("/info", get(info))
         .route("/auth/session", post(auth::create_session_handler))
         .route("/auth/refresh", post(auth::refresh_session_handler));
 


### PR DESCRIPTION
Small, backward-compatible data-plane additions for the **vesta.run hosted control plane** ([vesta-cloud#1](https://github.com/elyxlz/vesta-cloud/issues/1)). Self-hosters are unaffected.

## Changes
- **`GET /info`** (unauthenticated, in `vestad_public`) → `{ managed, server_id, login_url }`, sourced from `VESTA_MANAGED` / `VESTA_SERVER_ID` / `VESTA_LOGIN_URL` (set by hosted cloud-init). Lets `apps/web` tell a hosted VM from a self-hosted one, since both get `*.vesta.run` tunnels and the URL alone cannot distinguish.
- **`vestad tunnel setup <subdomain> --json`** → emits one line of `{tunnel_id, dns_record_id, hostname}` to stdout (progress logs stay on stderr via `tracing`), so hosted cloud-init can `jq` the handles for later cleanup. Without `--json`, behavior is identical to today.

## Notes
- `setup_tunnel` already returned a `TunnelConfig` carrying these fields — no change to `tunnel.rs`.
- `cargo check -p vestad` is clean.
- The native `vesta://` auth scheme (Tauri) is intentionally **not** in this PR — separate follow-up.

Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)