### PR TITLE
vestad: honor VESTA_SUBDOMAIN for exact hosted tunnel subdomain

### DIFF
--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -187,7 +187,15 @@ fn gethostname() -> String {
 }
 
 pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
-    let preferred = generate_subdomain(0);
+    // Managed (vesta.run hosted) deployments pin an exact subdomain via
+    // VESTA_SUBDOMAIN — the control plane guarantees uniqueness, so the
+    // collision-avoidance animal prefix is neither needed nor wanted there.
+    // Self-hosters leave it unset and keep the generated <animal>-<hostname>.
+    let preferred = std::env::var("VESTA_SUBDOMAIN")
+        .ok()
+        .map(|s| sanitize(&s))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| generate_subdomain(0));
 
     // Reuse existing tunnel if it matches our preferred subdomain
     if let Some(tc) = get_tunnel_config(config_dir) {


### PR DESCRIPTION
Lets a vesta.run-hosted VM use the control-plane-assigned subdomain.

`ensure_tunnel()` (called on every `vestad serve`) regenerated an `<animal>-<hostname>` subdomain and **destroyed any tunnel that did not match** — so the subdomain set by `vestad tunnel setup <name>` was overridden and the hosted VM was unreachable at its assigned URL. With `VESTA_SUBDOMAIN` set (managed mode), `ensure_tunnel` uses it verbatim (sanitized); self-hosters leave it unset and keep the generated collision-avoidance name. `cargo check` clean. Pairs with [vesta-cloud#1](https://github.com/elyxlz/vesta-cloud/issues/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)