### PR TITLE
fix(vestad,agent): self-heal missing tmux on rebuilt containers

### DIFF
--- a/agent/core/cc_sdk/client.py
+++ b/agent/core/cc_sdk/client.py
@@ -20,6 +20,7 @@ import json
 import os
 import pathlib as pl
 import shlex
+import shutil
 import sys
 import tempfile
 import time
@@ -375,6 +376,11 @@ class ClaudeSDKClient:
             (self._workdir / "mcp.json").write_text(json.dumps(mcp))
 
     async def _launch(self) -> None:
+        # tmux is a hard dependency: the session runs the claude TUI inside a private tmux
+        # server. Fail loudly with the fix instead of a bare FileNotFoundError raised deep in
+        # tmux.py when the binary is missing (e.g. a container rebuilt from a pre-tmux snapshot).
+        if shutil.which("tmux") is None:
+            raise RuntimeError("cc_sdk requires tmux on $PATH; install it (e.g. `apt-get install -y tmux`)")
         sysprompt_file = self._workdir / "system_prompt.txt"
         settings_file = self._workdir / "settings.json"
         mcp_file = self._workdir / "mcp.json" if self._bridge.tools else None

--- a/agent/tests/test_cc_sdk.py
+++ b/agent/tests/test_cc_sdk.py
@@ -67,6 +67,16 @@ def _new_client(tmp_path, **opts):
     return ClaudeSDKClient(options=ClaudeAgentOptions(cwd=str(tmp_path), **opts))
 
 
+@pytest.mark.anyio
+async def test_launch_raises_actionable_error_when_tmux_missing(tmp_path, monkeypatch):
+    """A container rebuilt from a pre-tmux snapshot has no tmux on PATH; surface the fix
+    instead of a bare FileNotFoundError raised deep in tmux.py."""
+    monkeypatch.setattr("core.cc_sdk.client.shutil.which", lambda name: None)
+    client = _new_client(tmp_path)
+    with pytest.raises(RuntimeError, match="cc_sdk requires tmux"):
+        await client._launch()
+
+
 def test_hook_commands_carry_safepath_guard(tmp_path):
     client = _new_client(tmp_path, hooks={})
     client._write_config_files()

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -98,7 +98,7 @@ const CONSTITUTION_MOUNT_DEST: &str = "/root/agent/constitution.md";
 pub(crate) const MOUNT_DESTS: &[&str] = &[ENV_MOUNT_DEST, CORE_MOUNT_DEST, "/root/agent/pyproject.toml", "/root/agent/uv.lock", CONSTITUTION_MOUNT_DEST];
 
 pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
-    let steps: [String; 9] = [
+    let steps: [String; 10] = [
         "export PATH=\"/root/.local/bin:/root/.claude/local/bin:$PATH\"".into(),
         ". /run/vestad-env".into(),
         ". ~/.bashrc || true".into(),
@@ -107,6 +107,14 @@ pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
         // built-in, so sourcing a missing file makes dash exit the whole script (and
         // `|| true` does NOT catch it), which would crash-loop every Claude agent.
         "[ -f /root/.claude/vesta-provider.env ] && . /root/.claude/vesta-provider.env".into(),
+        // tmux is a hard runtime dependency of cc_sdk (it drives the real claude TUI in a
+        // private tmux server). Fresh images bake it in via the Dockerfile, but `rebuild`
+        // recreates a container from a `docker export|import` snapshot and never re-runs the
+        // Dockerfile, so an agent snapshotted before tmux was added boots without it and
+        // crash-loops on FileNotFoundError deep in cc_sdk. Self-heal at boot: a no-op (no
+        // network) once tmux is on PATH, and the next snapshot captures the install so it
+        // persists across future rebuilds. `|| true` so a failed install never aborts boot.
+        "command -v tmux >/dev/null 2>&1 || (apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq tmux) || true".into(),
         "uv sync --frozen --project /root/agent".into(),
         // ~/.claude/skills is a real directory of per-skill symlinks. Both
         // /root/agent/skills/ and /root/agent/core/skills/ are flattened in;
@@ -2151,6 +2159,20 @@ mod tests {
         progress.set(BuildPhase::Preparing);
         progress.set(BuildPhase::Creating);
         assert_eq!(*seen.lock().expect("lock"), vec![BuildPhase::Building, BuildPhase::Preparing, BuildPhase::Creating]);
+    }
+
+    #[test]
+    fn entrypoint_self_heals_missing_tmux() {
+        // cc_sdk hard-depends on tmux; the entrypoint must install it at boot when missing so
+        // containers rebuilt from a pre-tmux snapshot self-heal instead of crash-looping.
+        let cmd = agent_container_entrypoint_cmd();
+        let script = cmd.last().expect("entrypoint script");
+        assert!(script.contains("command -v tmux"), "entrypoint must guard on tmux presence: {script}");
+        assert!(script.contains("apt-get install -y -qq tmux"), "entrypoint must install tmux when absent: {script}");
+        // The install runs before the agent process so cc_sdk finds tmux on first launch.
+        let tmux_at = script.find("command -v tmux").expect("tmux step present");
+        let main_at = script.find("python -m core.main").expect("main step present");
+        assert!(tmux_at < main_at, "tmux install must precede launching core.main");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Part 1 of #713. v0.1.156 made `tmux` a hard runtime dependency of `core/cc_sdk` (it drives the real `claude` TUI inside a private tmux server). tmux is baked into `vestad/Dockerfile`, so **fresh** builds/pulls are fine.

But `vestad rebuild` recreates a container from a `docker export | docker import` snapshot and **never re-runs the Dockerfile**. An agent whose snapshot predates tmux therefore boots without it and crash-loops on a bare `FileNotFoundError` deep in `cc_sdk/tmux.py`, with `--restart=unless-stopped` turning it into a tight loop:

```
ERROR x message_processor crashed: FileNotFoundError: [Errno 2] No such file or directory: 'tmux'
[SHUTDOWN] Shutting down (crash: FileNotFoundError ...)
```

A Dockerfile-only fix cannot reach these containers, since rebuild bypasses the image build entirely.

## Fix

**Self-heal at boot.** `agent_container_entrypoint_cmd()` (the single source of truth for the container command) gains a guarded step:

```sh
command -v tmux >/dev/null 2>&1 || (apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq tmux) || true
```

- On fresh images tmux is already on PATH, so this is an instant no-op with no network.
- On a pre-tmux snapshot it installs tmux into the writable overlay on first boot (~30-60s once). The **next** snapshot captures the install, so it persists across future rebuilds.
- `|| true` so a failed install never aborts boot.

It also propagates automatically: changing the entrypoint string is a command mismatch in `needs_rebuild()`, so on vestad's next update every existing agent rebuilds onto the self-healing entrypoint with no per-agent intervention.

**Clearer error (defense in depth).** `ClaudeSDKClient._launch()` now checks `shutil.which("tmux")` and raises `RuntimeError("cc_sdk requires tmux on $PATH; install it ...")` instead of letting the opaque `FileNotFoundError` surface from the tmux driver.

## Tests

- `entrypoint_self_heals_missing_tmux` (vestad): the entrypoint guards on tmux presence, installs it when absent, and does so before launching `core.main`.
- `test_launch_raises_actionable_error_when_tmux_missing` (agent): `_launch` raises the actionable `RuntimeError` when tmux is off PATH.

## Scope

Issue #713 also reports a second, independent break: the `THINKING` env validator rejects the legacy `{"type":"adaptive"}` JSON-dict form (`config.py`). That is a separate concern and will be a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)