### PR TITLE
Revert vesta.run hosting changes from master (move to a single open PR)

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vesta"
-version = "0.1.158"
+version = "0.1.157"
 description = "Personal assistant agent that works autonomously on your behalf"
 license = "MIT"
 authors = [

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vesta"
-version = "0.1.157"
+version = "0.1.156"
 description = "Personal assistant agent that works autonomously on your behalf"
 license = "MIT"
 authors = [

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.157"
+version = "0.1.156"
 source = { virtual = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.158"
+version = "0.1.157"
 source = { virtual = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vesta/desktop",
   "private": true,
-  "version": "0.1.157",
+  "version": "0.1.156",
   "description": "Vesta desktop app (Tauri wrapper around @vesta/web)",
   "license": "MIT",
   "repository": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vesta/desktop",
   "private": true,
-  "version": "0.1.158",
+  "version": "0.1.157",
   "description": "Vesta desktop app (Tauri wrapper around @vesta/web)",
   "license": "MIT",
   "repository": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4962,7 +4962,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta-app"
-version = "0.1.158"
+version = "0.1.157"
 dependencies = [
  "objc2",
  "objc2-foundation",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4962,7 +4962,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta-app"
-version = "0.1.157"
+version = "0.1.156"
 dependencies = [
  "objc2",
  "objc2-foundation",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vesta-app"
-version = "0.1.158"
+version = "0.1.157"
 description = "Vesta desktop app"
 license = "MIT"
 repository = "https://github.com/elyxlz/vesta"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vesta-app"
-version = "0.1.157"
+version = "0.1.156"
 description = "Vesta desktop app"
 license = "MIT"
 repository = "https://github.com/elyxlz/vesta"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Vesta",
-  "version": "0.1.158",
+  "version": "0.1.157",
   "identifier": "com.vestarun.app",
   "build": {
     "beforeDevCommand": "npm --workspace @vesta/web run dev",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Vesta",
-  "version": "0.1.157",
+  "version": "0.1.156",
   "identifier": "com.vestarun.app",
   "build": {
     "beforeDevCommand": "npm --workspace @vesta/web run dev",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vesta/mobile",
   "private": true,
-  "version": "0.1.157",
+  "version": "0.1.156",
   "description": "Vesta mobile app (Tauri wrapper around @vesta/web for iOS/Android)",
   "license": "MIT",
   "repository": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vesta/mobile",
   "private": true,
-  "version": "0.1.158",
+  "version": "0.1.157",
   "description": "Vesta mobile app (Tauri wrapper around @vesta/web for iOS/Android)",
   "license": "MIT",
   "repository": {

--- a/apps/mobile/src-tauri/Cargo.lock
+++ b/apps/mobile/src-tauri/Cargo.lock
@@ -4669,7 +4669,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta-mobile"
-version = "0.1.157"
+version = "0.1.156"
 dependencies = [
  "objc2",
  "serde_json",

--- a/apps/mobile/src-tauri/Cargo.lock
+++ b/apps/mobile/src-tauri/Cargo.lock
@@ -4669,7 +4669,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta-mobile"
-version = "0.1.158"
+version = "0.1.157"
 dependencies = [
  "objc2",
  "serde_json",

--- a/apps/mobile/src-tauri/Cargo.toml
+++ b/apps/mobile/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vesta-mobile"
-version = "0.1.157"
+version = "0.1.156"
 description = "Vesta mobile app"
 license = "MIT"
 repository = "https://github.com/elyxlz/vesta"

--- a/apps/mobile/src-tauri/Cargo.toml
+++ b/apps/mobile/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vesta-mobile"
-version = "0.1.158"
+version = "0.1.157"
 description = "Vesta mobile app"
 license = "MIT"
 repository = "https://github.com/elyxlz/vesta"

--- a/apps/mobile/src-tauri/tauri.conf.json
+++ b/apps/mobile/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Vesta",
-  "version": "0.1.158",
+  "version": "0.1.157",
   "identifier": "com.vestarun.mobile",
   "build": {
     "beforeDevCommand": "npm --workspace @vesta/web run dev",

--- a/apps/mobile/src-tauri/tauri.conf.json
+++ b/apps/mobile/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Vesta",
-  "version": "0.1.157",
+  "version": "0.1.156",
   "identifier": "com.vestarun.mobile",
   "build": {
     "beforeDevCommand": "npm --workspace @vesta/web run dev",

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -13,7 +13,7 @@
     },
     "desktop": {
       "name": "@vesta/desktop",
-      "version": "0.1.157",
+      "version": "0.1.156",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2.11.2"
@@ -21,7 +21,7 @@
     },
     "mobile": {
       "name": "@vesta/mobile",
-      "version": "0.1.157",
+      "version": "0.1.156",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2.11.2"
@@ -12679,7 +12679,7 @@
     },
     "web": {
       "name": "@vesta/web",
-      "version": "0.1.157",
+      "version": "0.1.156",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-rc.0",

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -13,7 +13,7 @@
     },
     "desktop": {
       "name": "@vesta/desktop",
-      "version": "0.1.158",
+      "version": "0.1.157",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2.11.2"
@@ -21,7 +21,7 @@
     },
     "mobile": {
       "name": "@vesta/mobile",
-      "version": "0.1.158",
+      "version": "0.1.157",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2.11.2"
@@ -12679,7 +12679,7 @@
     },
     "web": {
       "name": "@vesta/web",
-      "version": "0.1.158",
+      "version": "0.1.157",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-rc.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vesta/web",
   "private": true,
-  "version": "0.1.158",
+  "version": "0.1.157",
   "description": "Vesta web app (served by vestad at /app)",
   "license": "MIT",
   "repository": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vesta/web",
   "private": true,
-  "version": "0.1.157",
+  "version": "0.1.156",
   "description": "Vesta web app (served by vestad at /app)",
   "license": "MIT",
   "repository": {

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1335,7 +1335,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta"
-version = "0.1.157"
+version = "0.1.156"
 dependencies = [
  "clap",
  "dirs",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1335,7 +1335,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta"
-version = "0.1.158"
+version = "0.1.157"
 dependencies = [
  "clap",
  "dirs",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vesta"
-version = "0.1.158"
+version = "0.1.157"
 license = "MIT"
 repository = "https://github.com/elyxlz/vesta"
 authors = ["elyxlz"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vesta"
-version = "0.1.157"
+version = "0.1.156"
 license = "MIT"
 repository = "https://github.com/elyxlz/vesta"
 authors = ["elyxlz"]

--- a/vestad/Cargo.lock
+++ b/vestad/Cargo.lock
@@ -3025,7 +3025,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta-tests"
-version = "0.1.157"
+version = "0.1.156"
 dependencies = [
  "ring",
  "rustls",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "vestad"
-version = "0.1.157"
+version = "0.1.156"
 dependencies = [
  "async-stream",
  "axum",

--- a/vestad/Cargo.lock
+++ b/vestad/Cargo.lock
@@ -3025,7 +3025,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta-tests"
-version = "0.1.158"
+version = "0.1.157"
 dependencies = [
  "ring",
  "rustls",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "vestad"
-version = "0.1.158"
+version = "0.1.157"
 dependencies = [
  "async-stream",
  "axum",

--- a/vestad/Cargo.toml
+++ b/vestad/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "vestad"
-version = "0.1.158"
+version = "0.1.157"
 license = "MIT"
 repository = "https://github.com/elyxlz/vesta"
 authors = ["elyxlz"]

--- a/vestad/Cargo.toml
+++ b/vestad/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "vestad"
-version = "0.1.157"
+version = "0.1.156"
 license = "MIT"
 repository = "https://github.com/elyxlz/vesta"
 authors = ["elyxlz"]

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -112,10 +112,6 @@ enum TunnelAction {
     Setup {
         /// Subdomain name (e.g., "alice" for alice.yourdomain.com)
         subdomain: String,
-        /// Emit a single line of JSON ({"tunnel_id","dns_record_id","hostname"})
-        /// to stdout instead of human-readable output (for cloud-init / jq).
-        #[arg(long)]
-        json: bool,
     },
     /// Tear down tunnel and DNS record
     Destroy,
@@ -621,16 +617,9 @@ fn main() {
         Command::Tunnel { action } => {
             let config = config_dir();
             match action {
-                TunnelAction::Setup { subdomain, json } => {
-                    let tc = tunnel::setup_tunnel(&config, &subdomain)
+                TunnelAction::Setup { subdomain } => {
+                    tunnel::setup_tunnel(&config, &subdomain)
                         .unwrap_or_else(|e| die(e));
-                    if json {
-                        println!("{}", serde_json::json!({
-                            "tunnel_id": tc.tunnel_id,
-                            "dns_record_id": tc.dns_record_id,
-                            "hostname": tc.hostname,
-                        }));
-                    }
                 }
                 TunnelAction::Destroy => {
                     tunnel::destroy_tunnel(&config)

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -251,21 +251,6 @@ async fn health() -> Json<serde_json::Value> {
     Json(serde_json::json!({"ok": true, "user": user}))
 }
 
-// Unauthenticated: lets apps/web tell a hosted (vesta.run) VM from a self-hosted
-// one, since both get `*.vesta.run` tunnels and the URL alone can't distinguish.
-// Sourced from the cloud-init env: VESTA_MANAGED ("1" => managed), plus optional
-// VESTA_SERVER_ID / VESTA_LOGIN_URL.
-async fn info() -> Json<serde_json::Value> {
-    let managed = std::env::var("VESTA_MANAGED").as_deref() == Ok("1");
-    let server_id = std::env::var("VESTA_SERVER_ID").ok();
-    let login_url = std::env::var("VESTA_LOGIN_URL").ok();
-    Json(serde_json::json!({
-        "managed": managed,
-        "server_id": server_id,
-        "login_url": login_url,
-    }))
-}
-
 async fn version(State(state): State<SharedState>) -> Json<serde_json::Value> {
     Json(version_json(&state).await)
 }
@@ -1944,7 +1929,6 @@ pub fn build_router(state: SharedState) -> Router {
 
     let vestad_public = Router::new()
         .route("/health", get(health))
-        .route("/info", get(info))
         .route("/auth/session", post(auth::create_session_handler))
         .route("/auth/refresh", post(auth::refresh_session_handler));
 

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -187,15 +187,7 @@ fn gethostname() -> String {
 }
 
 pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
-    // Managed (vesta.run hosted) deployments pin an exact subdomain via
-    // VESTA_SUBDOMAIN — the control plane guarantees uniqueness, so the
-    // collision-avoidance animal prefix is neither needed nor wanted there.
-    // Self-hosters leave it unset and keep the generated <animal>-<hostname>.
-    let preferred = std::env::var("VESTA_SUBDOMAIN")
-        .ok()
-        .map(|s| sanitize(&s))
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| generate_subdomain(0));
+    let preferred = generate_subdomain(0);
 
     // Reuse existing tunnel if it matches our preferred subdomain
     if let Some(tc) = get_tunnel_config(config_dir) {

--- a/vestad/tests-integration/Cargo.toml
+++ b/vestad/tests-integration/Cargo.toml
@@ -3,7 +3,7 @@
 # them (CARGO_BIN_EXE_vestad); vestad dev-depends on this crate for the harness.
 [package]
 name = "vesta-tests"
-version = "0.1.157"
+version = "0.1.156"
 edition = "2021"
 publish = false
 

--- a/vestad/tests-integration/Cargo.toml
+++ b/vestad/tests-integration/Cargo.toml
@@ -3,7 +3,7 @@
 # them (CARGO_BIN_EXE_vestad); vestad dev-depends on this crate for the harness.
 [package]
 name = "vesta-tests"
-version = "0.1.158"
+version = "0.1.157"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Backs out the hosting-support changes that were merged as #711 + #712 (and their version bumps), returning master to the pre-change tree (version 0.1.156). The changes are re-proposed as one reviewable PR — nothing hosting-related stays merged until reviewed + proven. The two deleted prereleases (v0.1.157/v0.1.158) were never promoted to stable.