### PR TITLE
vestad: hosted-control-plane support (GET /info, tunnel --json, VESTA_SUBDOMAIN)

### DIFF
--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -112,6 +112,10 @@ enum TunnelAction {
     Setup {
         /// Subdomain name (e.g., "alice" for alice.yourdomain.com)
         subdomain: String,
+        /// Emit a single line of JSON ({"tunnel_id","dns_record_id","hostname"})
+        /// to stdout instead of human-readable output (for cloud-init / jq).
+        #[arg(long)]
+        json: bool,
     },
     /// Tear down tunnel and DNS record
     Destroy,
@@ -617,9 +621,16 @@ fn main() {
         Command::Tunnel { action } => {
             let config = config_dir();
             match action {
-                TunnelAction::Setup { subdomain } => {
-                    tunnel::setup_tunnel(&config, &subdomain)
+                TunnelAction::Setup { subdomain, json } => {
+                    let tc = tunnel::setup_tunnel(&config, &subdomain)
                         .unwrap_or_else(|e| die(e));
+                    if json {
+                        println!("{}", serde_json::json!({
+                            "tunnel_id": tc.tunnel_id,
+                            "dns_record_id": tc.dns_record_id,
+                            "hostname": tc.hostname,
+                        }));
+                    }
                 }
                 TunnelAction::Destroy => {
                     tunnel::destroy_tunnel(&config)

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -251,6 +251,21 @@ async fn health() -> Json<serde_json::Value> {
     Json(serde_json::json!({"ok": true, "user": user}))
 }
 
+// Unauthenticated: lets apps/web tell a hosted (vesta.run) VM from a self-hosted
+// one, since both get `*.vesta.run` tunnels and the URL alone can't distinguish.
+// Sourced from the cloud-init env: VESTA_MANAGED ("1" => managed), plus optional
+// VESTA_SERVER_ID / VESTA_LOGIN_URL.
+async fn info() -> Json<serde_json::Value> {
+    let managed = std::env::var("VESTA_MANAGED").as_deref() == Ok("1");
+    let server_id = std::env::var("VESTA_SERVER_ID").ok();
+    let login_url = std::env::var("VESTA_LOGIN_URL").ok();
+    Json(serde_json::json!({
+        "managed": managed,
+        "server_id": server_id,
+        "login_url": login_url,
+    }))
+}
+
 async fn version(State(state): State<SharedState>) -> Json<serde_json::Value> {
     Json(version_json(&state).await)
 }
@@ -1929,6 +1944,7 @@ pub fn build_router(state: SharedState) -> Router {
 
     let vestad_public = Router::new()
         .route("/health", get(health))
+        .route("/info", get(info))
         .route("/auth/session", post(auth::create_session_handler))
         .route("/auth/refresh", post(auth::refresh_session_handler));
 

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -187,7 +187,15 @@ fn gethostname() -> String {
 }
 
 pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
-    let preferred = generate_subdomain(0);
+    // Managed (vesta.run hosted) deployments pin an exact subdomain via
+    // VESTA_SUBDOMAIN — the control plane guarantees uniqueness, so the
+    // collision-avoidance animal prefix is neither needed nor wanted there.
+    // Self-hosters leave it unset and keep the generated <animal>-<hostname>.
+    let preferred = std::env::var("VESTA_SUBDOMAIN")
+        .ok()
+        .map(|s| sanitize(&s))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| generate_subdomain(0));
 
     // Reuse existing tunnel if it matches our preferred subdomain
     if let Some(tc) = get_tunnel_config(config_dir) {


### PR DESCRIPTION
Single consolidated PR for the data-plane changes that the vesta.run hosted control plane ([vesta-cloud#1](https://github.com/elyxlz/vesta-cloud/issues/1)) needs. All backward-compatible; self-hosters unaffected.

## Changes (3 files)
- **`GET /info`** (unauthenticated, in `vestad_public`) → `{ managed, server_id, login_url }` from `VESTA_MANAGED`/`VESTA_SERVER_ID`/`VESTA_LOGIN_URL`. Lets `apps/web` tell a hosted VM from a self-hosted one.
- **`vestad tunnel setup <subdomain> --json`** → emits `{tunnel_id, dns_record_id, hostname}` for cloud-init to capture; human output unchanged without `--json`.
- **`VESTA_SUBDOMAIN`** → `ensure_tunnel()` (called by `vestad serve`) honors it verbatim so a hosted VM uses its control-plane-assigned subdomain instead of the generated `<animal>-<hostname>`; unset = unchanged for self-hosters.

## Status
`cargo check` clean. These were briefly merged as #711/#712 + prereleased to test the full hosted flow, then **reverted** (#717) and consolidated here so nothing lands on master until reviewed. The end-to-end provisioning flow has been verified on real infra against this exact code (see vesta-cloud#1). **Do not merge/release until you've reviewed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)