### PR TITLE
feat: humanize cc sdk tmux input

### DIFF
--- a/agent/core/cc_sdk/README.md
+++ b/agent/core/cc_sdk/README.md
@@ -12,7 +12,7 @@ plumbing, same MCP-tool registration, same `ClaudeSDKClient` lifecycle.
 ```
               ┌─────────────────────── agent process ───────────────────────┐
               │  ClaudeSDKClient                                             │
-  query() ───▶│   tmux paste + Enter ──────────────┐                        │
+  query() ───▶│   tmux typed chunks + Enter ───────┐                        │
               │                                     ▼                        │
               │                          ┌──────────────────┐               │
               │  receive_response()  ◀── │  tmux: claude TUI │  (own -L srv) │
@@ -28,10 +28,13 @@ plumbing, same MCP-tool registration, same `ClaudeSDKClient` lifecycle.
               └─────────────────────────────────────────────────────────────┘
 ```
 
-- **Prompts** are submitted by bracketed-pasting the text into the tmux pane and
-  sending `Enter` (multi-line stays in the box; a single Enter submits; leading `/`
-  runs as a slash command). **Interrupt** sends a double `Escape`: the TUI's
-  escape-sequence parser buffers a lone ESC waiting for a follow-up byte that never
+- **Prompts** and slash commands are submitted by sending randomized literal
+  `send-keys` bursts inside bracketed-paste guards, then sending `Enter` after a
+  short randomized pause (multi-line stays in the box; a single Enter submits).
+  Long text is pasted via tmux's paste buffer, like a person using Ctrl-V in the
+  TUI, so large prompts stay fast. **Interrupt** sends two
+  `Escape` keypresses with a small randomized gap: the TUI's escape-sequence
+  parser buffers a lone ESC waiting for a follow-up byte that never
   comes (verified against claude v2.1.159), so a second ESC is needed to flush the
   first as a real keypress. An interrupted turn never fires its `Stop` hook (no late
   Stop arrives either), so `interrupt()` credits the abandoned turn's Stop itself —

--- a/agent/core/cc_sdk/client.py
+++ b/agent/core/cc_sdk/client.py
@@ -4,7 +4,7 @@ Drop-in replacement for the official SDK client. Instead of speaking the control
 protocol to a headless subprocess, it:
 
   * launches `claude` (the real TUI) in a dedicated tmux server,
-  * submits prompts by bracketed-pasting them into the input box and pressing Enter,
+  * submits prompts by typing randomized bracketed-paste chunks and pressing Enter,
   * streams the assistant's reply by tailing the session transcript JSONL,
   * receives tool/subagent/compaction events as native command hooks routed through
     a unix-socket bridge, and exposes the agent's MCP tools via a stdio proxy,
@@ -223,9 +223,7 @@ class ClaudeSDKClient:
             self._offset = 0
         self._turn_index += 1
         self._turn_started = time.monotonic()
-        await tmux.paste_text(self._tmux_socket, self._tmux_session, prompt)
-        await asyncio.sleep(0.1)
-        await tmux.send_keys(self._tmux_socket, self._tmux_session, "Enter")
+        await tmux.submit_text(self._tmux_socket, self._tmux_session, prompt)
 
     async def receive_response(self) -> tp.AsyncIterator[tp.Any]:
         if self._transcript_path is None:
@@ -252,7 +250,7 @@ class ClaudeSDKClient:
         # waiting for a follow-up byte that never comes (verified against claude v2.1.159,
         # where a lone Escape let generation run to completion). Sending Escape twice
         # flushes the first as a real Escape keypress and reliably interrupts.
-        await tmux.send_keys(self._tmux_socket, self._tmux_session, "Escape", "Escape")
+        await tmux.send_double_escape(self._tmux_socket, self._tmux_session)
         # An interrupted turn never fires its Stop hook (verified: no late Stop arrives
         # either), so account for the abandoned turn here. Without this, every turn after
         # an interrupt waits for a Stop count that can never be reached and hangs.
@@ -291,9 +289,7 @@ class ClaudeSDKClient:
         cursor = self._transcript_path.stat().st_size if self._transcript_path and self._transcript_path.exists() else 0
         command = f"/compact {instructions}".strip()
         self._compaction_started.clear()
-        await tmux.paste_text(self._tmux_socket, self._tmux_session, command)
-        await asyncio.sleep(0.1)
-        await tmux.send_keys(self._tmux_socket, self._tmux_session, "Enter")
+        await tmux.submit_text(self._tmux_socket, self._tmux_session, command)
         try:
             await asyncio.wait_for(self._compaction_started.wait(), _COMPACT_START_TIMEOUT_S)
         except TimeoutError:

--- a/agent/core/cc_sdk/tmux.py
+++ b/agent/core/cc_sdk/tmux.py
@@ -6,8 +6,28 @@ agent process environment.
 """
 
 import asyncio
+import random
 
 _TMUX = "tmux"
+_BRACKETED_PASTE_START = "\x1b[200~"
+_BRACKETED_PASTE_END = "\x1b[201~"
+_SHORT_TEXT_CHARS = 240
+_LONG_TEXT_CHARS = 1000
+_PASTE_TEXT_CHARS = 1000
+_TYPE_SHORT_CHUNK_MIN = 8
+_TYPE_SHORT_CHUNK_MAX = 32
+_TYPE_MEDIUM_CHUNK_MIN = 32
+_TYPE_MEDIUM_CHUNK_MAX = 96
+_TYPE_LONG_CHUNK_MIN = 96
+_TYPE_LONG_CHUNK_MAX = 256
+_TYPE_DELAY_MIN_S = 0.0005
+_TYPE_DELAY_MAX_S = 0.003
+_TYPE_PUNCTUATION_DELAY_MAX_S = 0.008
+_SUBMIT_DELAY_MIN_S = 0.015
+_SUBMIT_DELAY_MAX_S = 0.055
+_DOUBLE_ESCAPE_DELAY_MIN_S = 0.015
+_DOUBLE_ESCAPE_DELAY_MAX_S = 0.045
+_TYPE_PAUSE_AFTER = frozenset(".!?,;:\n")
 
 
 async def _run(socket: str, *args: str, stdin: bytes | None = None) -> tuple[int, str, str]:
@@ -33,6 +53,52 @@ async def start_session(socket: str, name: str, *, cwd: str, command: str, width
 
 async def send_keys(socket: str, name: str, *keys: str) -> None:
     await _run(socket, "send-keys", "-t", name, *keys)
+
+
+async def send_literal(socket: str, name: str, text: str) -> None:
+    await _run(socket, "send-keys", "-t", name, "-l", "--", text)
+
+
+def _chunk_bounds(text_len: int) -> tuple[int, int]:
+    if text_len > _LONG_TEXT_CHARS:
+        return _TYPE_LONG_CHUNK_MIN, _TYPE_LONG_CHUNK_MAX
+    if text_len > _SHORT_TEXT_CHARS:
+        return _TYPE_MEDIUM_CHUNK_MIN, _TYPE_MEDIUM_CHUNK_MAX
+    return _TYPE_SHORT_CHUNK_MIN, _TYPE_SHORT_CHUNK_MAX
+
+
+async def type_text(socket: str, name: str, text: str) -> None:
+    """Type `text` into the pane in randomized literal bursts without submitting."""
+    await send_literal(socket, name, _BRACKETED_PASTE_START)
+    index = 0
+    chunk_min, chunk_max = _chunk_bounds(len(text))
+    while index < len(text):
+        remaining = len(text) - index
+        chunk_len = random.randint(min(chunk_min, remaining), min(chunk_max, remaining))
+        chunk = text[index : index + chunk_len]
+        await send_literal(socket, name, chunk)
+        index += chunk_len
+        if index < len(text):
+            delay = random.uniform(_TYPE_DELAY_MIN_S, _TYPE_DELAY_MAX_S)
+            if chunk[-1] in _TYPE_PAUSE_AFTER:
+                delay += random.uniform(0.0, _TYPE_PUNCTUATION_DELAY_MAX_S)
+            await asyncio.sleep(delay)
+    await send_literal(socket, name, _BRACKETED_PASTE_END)
+
+
+async def submit_text(socket: str, name: str, text: str) -> None:
+    if len(text) > _PASTE_TEXT_CHARS:
+        await paste_text(socket, name, text)
+    else:
+        await type_text(socket, name, text)
+    await asyncio.sleep(random.uniform(_SUBMIT_DELAY_MIN_S, _SUBMIT_DELAY_MAX_S))
+    await send_keys(socket, name, "Enter")
+
+
+async def send_double_escape(socket: str, name: str) -> None:
+    await send_keys(socket, name, "Escape")
+    await asyncio.sleep(random.uniform(_DOUBLE_ESCAPE_DELAY_MIN_S, _DOUBLE_ESCAPE_DELAY_MAX_S))
+    await send_keys(socket, name, "Escape")
 
 
 async def paste_text(socket: str, name: str, text: str) -> None:

--- a/agent/tests/test_cc_sdk.py
+++ b/agent/tests/test_cc_sdk.py
@@ -7,6 +7,7 @@ import sys
 import pytest
 
 from core import cc_sdk
+from core.cc_sdk import tmux as cc_tmux
 from core.cc_sdk.client import ClaudeSDKClient, _FORWARD, _MCP_STDIO
 from core.cc_sdk.messages import ClaudeAgentOptions
 from core.cc_sdk.transcript import assistant_message_from, read_new_objects
@@ -98,6 +99,111 @@ def test_mcp_config_carries_safepath_env(tmp_path):
 
 
 @pytest.mark.anyio
+async def test_tmux_type_text_sends_random_literal_chunks(monkeypatch):
+    calls: list[tuple[tuple[str, ...], bytes | None]] = []
+    sleeps: list[float] = []
+    chunk_sizes = [8, 12]
+
+    async def record_run(socket: str, *args: str, stdin: bytes | None = None) -> tuple[int, str, str]:
+        calls.append((args, stdin))
+        return 0, "", ""
+
+    async def record_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    def randint(start: int, stop: int) -> int:
+        return min(chunk_sizes.pop(0), stop)
+
+    def uniform(start: float, stop: float) -> float:
+        return start
+
+    monkeypatch.setattr(cc_tmux, "_run", record_run)
+    monkeypatch.setattr(cc_tmux.asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(cc_tmux.random, "randint", randint)
+    monkeypatch.setattr(cc_tmux.random, "uniform", uniform)
+
+    await cc_tmux.type_text("sock", "session", "abcdefghijklmnop")
+
+    assert calls == [
+        (("send-keys", "-t", "session", "-l", "--", "\x1b[200~"), None),
+        (("send-keys", "-t", "session", "-l", "--", "abcdefgh"), None),
+        (("send-keys", "-t", "session", "-l", "--", "ijklmnop"), None),
+        (("send-keys", "-t", "session", "-l", "--", "\x1b[201~"), None),
+    ]
+    assert sleeps == [0.0005]
+
+
+@pytest.mark.anyio
+async def test_tmux_submit_text_types_then_enters(monkeypatch):
+    sent: list[tuple[str, str]] = []
+    sleeps: list[float] = []
+
+    async def record_type_text(socket: str, name: str, text: str) -> None:
+        sent.append(("type", text))
+
+    async def record_send_keys(socket: str, name: str, *keys: str) -> None:
+        sent.append(("keys", " ".join(keys)))
+
+    async def record_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(cc_tmux, "type_text", record_type_text)
+    monkeypatch.setattr(cc_tmux, "send_keys", record_send_keys)
+    monkeypatch.setattr(cc_tmux.asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(cc_tmux.random, "uniform", lambda start, stop: start)
+
+    await cc_tmux.submit_text("sock", "session", "hello")
+
+    assert sent == [("type", "hello"), ("keys", "Enter")]
+    assert sleeps == [0.015]
+
+
+@pytest.mark.anyio
+async def test_tmux_submit_text_pastes_long_text_then_enters(monkeypatch):
+    sent: list[tuple[str, str]] = []
+    sleeps: list[float] = []
+    text = "x" * (cc_tmux._PASTE_TEXT_CHARS + 1)
+
+    async def record_type_text(socket: str, name: str, value: str) -> None:
+        sent.append(("type", value))
+
+    async def record_paste_text(socket: str, name: str, value: str) -> None:
+        sent.append(("paste", value))
+
+    async def record_send_keys(socket: str, name: str, *keys: str) -> None:
+        sent.append(("keys", " ".join(keys)))
+
+    async def record_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(cc_tmux, "type_text", record_type_text)
+    monkeypatch.setattr(cc_tmux, "paste_text", record_paste_text)
+    monkeypatch.setattr(cc_tmux, "send_keys", record_send_keys)
+    monkeypatch.setattr(cc_tmux.asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(cc_tmux.random, "uniform", lambda start, stop: start)
+
+    await cc_tmux.submit_text("sock", "session", text)
+
+    assert sent == [("paste", text), ("keys", "Enter")]
+    assert sleeps == [0.015]
+
+
+@pytest.mark.anyio
+async def test_query_submits_prompt(tmp_path, monkeypatch):
+    sent: list[str] = []
+
+    async def record_submit_text(socket: str, name: str, text: str) -> None:
+        sent.append(text)
+
+    monkeypatch.setattr("core.cc_sdk.client.tmux.submit_text", record_submit_text)
+    client = _new_client(tmp_path)
+
+    await client.query("hello")
+
+    assert sent == ["hello"]
+
+
+@pytest.mark.anyio
 async def test_late_stop_does_not_complete_next_turn(tmp_path):
     """The Nth Stop completes the Nth turn. A leftover Stop from an abandoned turn only
     advances the count toward the current turn's threshold, never ending it prematurely."""
@@ -139,7 +245,7 @@ async def test_interrupt_credits_missing_stop_and_double_escapes(tmp_path, monke
     client._stops_received = 2  # turns 1-2 completed, turn 3 in flight
 
     await client.interrupt()
-    assert sent == [("Escape", "Escape")]
+    assert sent == [("Escape",), ("Escape",)]
     assert client._stops_received == 3
 
 


### PR DESCRIPTION
## Summary
- submit short and normal prompts through randomized tmux literal-key bursts instead of bulk paste
- paste long prompts via tmux paste buffer, like Ctrl-V in the TUI, so large payloads stay fast
- add jittered submit and double-Escape timing while preserving bracketed-paste multiline behavior
- document the transport behavior and cover typed/pasted submit paths in cc_sdk tests

## Tests
- ./check.sh agent
