### PR TITLE
fix(agent): coerce legacy THINKING json-dict env into the typed config

### DIFF
--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -59,7 +59,7 @@ class VestaConfig(pyd_settings.BaseSettings):
     @classmethod
     def _parse_thinking(cls, value: object) -> object:
         # The THINKING env var is documented as a plain string (adaptive|enabled|disabled);
-        # coerce it into the SDK's config dict. JSON object values pass through untouched.
+        # coerce it into the SDK's config dict.
         if isinstance(value, str):
             mode = value.strip().lower()
             if mode in ("", "adaptive"):
@@ -69,6 +69,21 @@ class VestaConfig(pyd_settings.BaseSettings):
             if mode == "disabled":
                 return ThinkingConfigDisabled(type="disabled")
             raise ValueError(f"THINKING must be adaptive|enabled|disabled (or a JSON config object), got {value!r}")
+        # Legacy env files set the JSON-dict form (e.g. THINKING='{"type":"adaptive"}'), which
+        # predates the now-required fields (adaptive.display). Fill in the same defaults the
+        # string form uses so an upgrade doesn't fail union validation. Unknown types fall
+        # through to pydantic's normal error.
+        if isinstance(value, dict):
+            data = tp.cast("dict[str, tp.Any]", value)
+            kind = str(data["type"]).strip().lower() if "type" in data else "adaptive"
+            if kind == "adaptive":
+                return ThinkingConfigAdaptive(type="adaptive", display=data["display"] if "display" in data else "summarized")
+            if kind == "enabled":
+                return ThinkingConfigEnabled(
+                    type="enabled", budget_tokens=data["budget_tokens"] if "budget_tokens" in data else _THINKING_ENABLED_BUDGET_TOKENS
+                )
+            if kind == "disabled":
+                return ThinkingConfigDisabled(type="disabled")
         return value
 
     @pyd.field_validator("agent_dir", mode="before")

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -23,18 +23,23 @@ def test_memory_paths(config):
     assert config.skills_dir == config.agent_dir / "skills"
 
 
-def test_thinking_legacy_json_dict_coerces_with_defaults():
+def test_thinking_legacy_json_dict_coerces_with_defaults(monkeypatch):
     """Env files written before adaptive.display was required carry the JSON-dict form
     (e.g. THINKING='{"type":"adaptive"}'); it must coerce, not fail union validation."""
     from core.config import VestaConfig
 
-    assert VestaConfig(thinking={"type": "adaptive"}).thinking == {"type": "adaptive", "display": "summarized"}
-    assert VestaConfig(thinking={"type": "enabled"}).thinking == {"type": "enabled", "budget_tokens": 10000}
-    assert VestaConfig(thinking={"type": "disabled"}).thinking == {"type": "disabled"}
+    monkeypatch.setenv("THINKING", '{"type":"adaptive"}')
+    assert VestaConfig().thinking == {"type": "adaptive", "display": "summarized"}
+    monkeypatch.setenv("THINKING", '{"type":"enabled"}')
+    assert VestaConfig().thinking == {"type": "enabled", "budget_tokens": 10000}
+    monkeypatch.setenv("THINKING", '{"type":"disabled"}')
+    assert VestaConfig().thinking == {"type": "disabled"}
 
 
-def test_thinking_string_form_still_parses():
+def test_thinking_string_form_still_parses(monkeypatch):
     from core.config import VestaConfig
 
-    assert VestaConfig(thinking="adaptive").thinking == {"type": "adaptive", "display": "summarized"}
-    assert VestaConfig(thinking="disabled").thinking == {"type": "disabled"}
+    monkeypatch.setenv("THINKING", "adaptive")
+    assert VestaConfig().thinking == {"type": "adaptive", "display": "summarized"}
+    monkeypatch.setenv("THINKING", "disabled")
+    assert VestaConfig().thinking == {"type": "disabled"}

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -21,3 +21,20 @@ def test_config_default_values():
 def test_memory_paths(config):
     assert get_memory_path(config) == config.agent_dir / "MEMORY.md"
     assert config.skills_dir == config.agent_dir / "skills"
+
+
+def test_thinking_legacy_json_dict_coerces_with_defaults():
+    """Env files written before adaptive.display was required carry the JSON-dict form
+    (e.g. THINKING='{"type":"adaptive"}'); it must coerce, not fail union validation."""
+    from core.config import VestaConfig
+
+    assert VestaConfig(thinking={"type": "adaptive"}).thinking == {"type": "adaptive", "display": "summarized"}
+    assert VestaConfig(thinking={"type": "enabled"}).thinking == {"type": "enabled", "budget_tokens": 10000}
+    assert VestaConfig(thinking={"type": "disabled"}).thinking == {"type": "disabled"}
+
+
+def test_thinking_string_form_still_parses():
+    from core.config import VestaConfig
+
+    assert VestaConfig(thinking="adaptive").thinking == {"type": "adaptive", "display": "summarized"}
+    assert VestaConfig(thinking="disabled").thinking == {"type": "disabled"}


### PR DESCRIPTION
## Problem

Part 2 of #713. The `THINKING` env var is documented as a plain string (`adaptive|enabled|disabled`), but older Vesta versions accepted a JSON object form, e.g. `THINKING='{"type":"adaptive"}'`, back when `ThinkingConfigAdaptive` did not require a `display` field.

`_parse_thinking` only coerced the string form and passed dicts straight through to pydantic union validation. Now that `display` is required, a legacy dict fails against all three branches and the agent dies before it even logs its config:

```
ValidationError: 4 validation errors for VestaConfig
thinking.ThinkingConfigAdaptive.display  Field required [input_value={'type': 'adaptive'}]
thinking.ThinkingConfigEnabled.type      Input should be 'enabled' [input_value='adaptive']
...
```

Only deployments whose env file predates the string form are affected; new installs using `THINKING=adaptive` are fine.

## Fix

Add a dict branch to `_parse_thinking` that fills in the same defaults the string form already uses (`adaptive` → `display="summarized"`, `enabled` → default budget). Unknown `type` values still fall through to pydantic's normal error, so genuinely malformed configs are not silently accepted.

One concern, one validator, no behavior change downstream: `_thinking_env` in cc_sdk already consumes the resulting typed dict regardless of which env form produced it.

## Tests

`test_config.py`:
- `test_thinking_legacy_json_dict_coerces_with_defaults` — the three legacy dict forms coerce to complete typed configs.
- `test_thinking_string_form_still_parses` — the documented string form is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)