### PR TITLE
fix(agent): robust config loading — coerce legacy THINKING + never crash-loop on invalid env

### DIFF
--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -60,7 +60,7 @@ class VestaConfig(pyd_settings.BaseSettings):
     @classmethod
     def _parse_thinking(cls, value: object) -> object:
         # The THINKING env var is documented as a plain string (adaptive|enabled|disabled);
-        # coerce it into the SDK's config dict. JSON object values pass through untouched.
+        # coerce it into the SDK's config dict.
         if isinstance(value, str):
             mode = value.strip().lower()
             if mode in ("", "adaptive"):
@@ -70,6 +70,21 @@ class VestaConfig(pyd_settings.BaseSettings):
             if mode == "disabled":
                 return ThinkingConfigDisabled(type="disabled")
             raise ValueError(f"THINKING must be adaptive|enabled|disabled (or a JSON config object), got {value!r}")
+        # Legacy env files set the JSON-dict form (e.g. THINKING='{"type":"adaptive"}'), which
+        # predates the now-required fields (adaptive.display). Fill in the same defaults the
+        # string form uses so an upgrade doesn't fail union validation. Unknown types fall
+        # through to pydantic's normal error.
+        if isinstance(value, dict):
+            data = tp.cast("dict[str, tp.Any]", value)
+            kind = str(data["type"]).strip().lower() if "type" in data else "adaptive"
+            if kind == "adaptive":
+                return ThinkingConfigAdaptive(type="adaptive", display=data["display"] if "display" in data else "summarized")
+            if kind == "enabled":
+                return ThinkingConfigEnabled(
+                    type="enabled", budget_tokens=data["budget_tokens"] if "budget_tokens" in data else _THINKING_ENABLED_BUDGET_TOKENS
+                )
+            if kind == "disabled":
+                return ThinkingConfigDisabled(type="disabled")
         return value
 
     @pyd.field_validator("agent_dir", mode="before")

--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -1,3 +1,4 @@
+import os
 import pathlib as pl
 import typing as tp
 
@@ -117,3 +118,37 @@ class VestaConfig(pyd_settings.BaseSettings):
     agent_name: str = "vesta"
     agent_model: str = "opus"
     agent_provider: tp.Literal["claude", "openrouter"] = "claude"
+
+
+def load_config() -> tuple[VestaConfig, list[str]]:
+    """Build VestaConfig without ever raising.
+
+    Config is on the container's boot path: an exception here exits the process, and with
+    `--restart=unless-stopped` that becomes a tight crash loop the agent can never escape.
+    So instead of letting a single malformed env override (e.g. a stale THINKING or a
+    non-numeric RESPONSE_TIMEOUT in ~/.bashrc) kill startup, drop each offending var from the
+    environment and rebuild, reverting only that field to its default. Returns the config plus
+    a human-readable message per reverted var so the caller can surface them to the agent.
+    """
+    issues: list[str] = []
+    dropped: set[str] = set()
+    while True:
+        try:
+            return VestaConfig(), issues
+        except pyd.ValidationError as exc:
+            progressed = False
+            for error in exc.errors():
+                loc = error["loc"]
+                if not loc:
+                    continue
+                env_name = str(loc[0]).upper()
+                if env_name in os.environ and env_name not in dropped:
+                    issues.append(f"{env_name}={os.environ[env_name]!r} is invalid ({error['msg']}); reverted to default")
+                    del os.environ[env_name]
+                    dropped.add(env_name)
+                    progressed = True
+            if not progressed:
+                # No offending env var to drop (would mean an invalid field default — a bug, not
+                # bad config). Fall back to pure defaults rather than crash-loop the boot.
+                issues.append(f"configuration could not be validated, using all defaults: {exc}")
+                return VestaConfig.model_construct(), issues

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -16,6 +16,7 @@ from . import state_store
 from .api import start_ws_server
 from .diagnostics import format_crash_detail
 from .loops import (
+    drop_core_notification,
     drop_greeting_notification,
     message_processor,
     monitor_loop,
@@ -152,6 +153,20 @@ async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: boo
     logger.shutdown("sweet dreams!")
 
 
+def _report_config_issues(issues: list[str], *, config: vm.VestaConfig) -> None:
+    """Surface config vars that failed validation: log them and tell the agent via a core
+    notification so it can flag the bad values to the user, since the agent ran with defaults."""
+    if not issues:
+        return
+    for issue in issues:
+        logger.error(f"Invalid config, using default: {issue}")
+    body = (
+        "Some configuration env vars failed to validate and were reverted to their defaults. "
+        "Let the user know so they can fix the values in ~/.bashrc and run restart_vesta:\n" + "\n".join(f"- {issue}" for issue in issues)
+    )
+    drop_core_notification(type_=vm.TYPE_CONFIG_INVALID, body=body, interrupt=False, config=config)
+
+
 def _consume_restart_reason(state: vm.State, config: vm.VestaConfig, *, first_start: bool) -> str:
     """Return the reason to log for this boot and clear it from persisted state. On a never-run agent the absence of a stored reason is innocent; report FIRST_START_REASON instead of a misleading crash label."""
     if first_start:
@@ -176,7 +191,7 @@ def init_state(*, config: vm.VestaConfig) -> vm.State:
 
 
 async def async_main() -> None:
-    config = vm.VestaConfig()
+    config, config_issues = vm.load_config()
     logger.init("Config:")
     print_json(data=config.model_dump(mode="json"))
 
@@ -185,6 +200,7 @@ async def async_main() -> None:
 
     logger.setup(config.logs_dir, log_level=config.log_level)
     logger.init(f"{config.agent_name} starting")
+    _report_config_issues(config_issues, config=config)
 
     initial_state = init_state(config=config)
     first_start = not initial_state.persisted.first_start_done

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -8,12 +8,12 @@ import pydantic as pyd
 from aiohttp.web import AppRunner
 from core.cc_sdk import ClaudeSDKClient
 
-from .config import VestaConfig
+from .config import VestaConfig, load_config
 from .events import EventBus
 from .provider import ProviderStatus
 from .state_store import PersistedState
 
-__all__ = ["State", "Notification", "VestaConfig", "PersistedState"]
+__all__ = ["State", "Notification", "VestaConfig", "PersistedState", "load_config"]
 
 CORE_SOURCE = "core"
 
@@ -24,6 +24,7 @@ TYPE_RESTART_GREETING = "restart_greeting"
 TYPE_PROACTIVE_CHECK = "proactive_check"
 TYPE_NIGHTLY_DREAM = "nightly_dream"
 TYPE_MIGRATION = "migration"
+TYPE_CONFIG_INVALID = "config_invalid"
 
 CLEAN_RESTART = "restart: clean restart"
 NIGHTLY_RESTART = "nightly: dreamer ran, session compacted for continuous context"

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -75,7 +75,8 @@ def test_report_config_issues_notifies_agent(config):
     notifs = asyncio.run(load_notifications(config=config))
     assert len(notifs) == 1
     assert notifs[0].type == vm.TYPE_CONFIG_INVALID
-    assert "THINKING" in notifs[0].body
+    body = notifs[0].body
+    assert body is not None and "THINKING" in body
 
 
 def test_report_config_issues_noop_without_issues(config):

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -26,6 +26,28 @@ def test_memory_paths(config):
     assert config.skills_dir == config.agent_dir / "skills"
 
 
+def test_thinking_legacy_json_dict_coerces_with_defaults(monkeypatch):
+    """Env files written before adaptive.display was required carry the JSON-dict form
+    (e.g. THINKING='{"type":"adaptive"}'); it must coerce, not fail union validation."""
+    from core.config import VestaConfig
+
+    monkeypatch.setenv("THINKING", '{"type":"adaptive"}')
+    assert VestaConfig().thinking == {"type": "adaptive", "display": "summarized"}
+    monkeypatch.setenv("THINKING", '{"type":"enabled"}')
+    assert VestaConfig().thinking == {"type": "enabled", "budget_tokens": 10000}
+    monkeypatch.setenv("THINKING", '{"type":"disabled"}')
+    assert VestaConfig().thinking == {"type": "disabled"}
+
+
+def test_thinking_string_form_still_parses(monkeypatch):
+    from core.config import VestaConfig
+
+    monkeypatch.setenv("THINKING", "adaptive")
+    assert VestaConfig().thinking == {"type": "adaptive", "display": "summarized"}
+    monkeypatch.setenv("THINKING", "disabled")
+    assert VestaConfig().thinking == {"type": "disabled"}
+
+
 def test_load_config_reverts_invalid_env_to_default(monkeypatch):
     """A malformed override must never crash the boot: the bad var drops to its default and is
     reported, instead of raising and crash-looping the container."""

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -1,5 +1,8 @@
 """Tests for VestaConfig and initialization."""
 
+import asyncio
+import os
+
 from core.helpers import get_memory_path
 
 
@@ -21,3 +24,62 @@ def test_config_default_values():
 def test_memory_paths(config):
     assert get_memory_path(config) == config.agent_dir / "MEMORY.md"
     assert config.skills_dir == config.agent_dir / "skills"
+
+
+def test_load_config_reverts_invalid_env_to_default(monkeypatch):
+    """A malformed override must never crash the boot: the bad var drops to its default and is
+    reported, instead of raising and crash-looping the container."""
+    from core.config import load_config
+
+    monkeypatch.setenv("RESPONSE_TIMEOUT", "not-a-number")
+    config, issues = load_config()
+
+    assert config.response_timeout == 600
+    assert len(issues) == 1
+    assert "RESPONSE_TIMEOUT" in issues[0]
+    assert "RESPONSE_TIMEOUT" not in os.environ
+
+
+def test_load_config_keeps_other_valid_overrides(monkeypatch):
+    """Only the offending var is reverted; valid overrides alongside it survive."""
+    from core.config import load_config
+
+    monkeypatch.setenv("AGENT_MODEL", "sonnet")
+    monkeypatch.setenv("NIGHTLY_MEMORY_HOUR", "99")
+    config, issues = load_config()
+
+    assert config.agent_model == "sonnet"
+    assert config.nightly_memory_hour == 3
+    assert len(issues) == 1
+    assert "NIGHTLY_MEMORY_HOUR" in issues[0]
+
+
+def test_load_config_clean_env_has_no_issues(monkeypatch):
+    from core.config import load_config
+
+    monkeypatch.setenv("AGENT_MODEL", "haiku")
+    config, issues = load_config()
+
+    assert config.agent_model == "haiku"
+    assert issues == []
+
+
+def test_report_config_issues_notifies_agent(config):
+    """Config issues reach the agent as a core notification so it can tell the user."""
+    import core.models as vm
+    from core.loops import load_notifications
+    from core.main import _report_config_issues
+
+    _report_config_issues(["THINKING='bogus' is invalid (...); reverted to default"], config=config)
+
+    notifs = asyncio.run(load_notifications(config=config))
+    assert len(notifs) == 1
+    assert notifs[0].type == vm.TYPE_CONFIG_INVALID
+    assert "THINKING" in notifs[0].body
+
+
+def test_report_config_issues_noop_without_issues(config):
+    from core.main import _report_config_issues
+
+    _report_config_issues([], config=config)
+    assert not config.notifications_dir.exists() or list(config.notifications_dir.glob("*.json")) == []


### PR DESCRIPTION
Fixes the two config-layer breaks from #713 (Issues 1 and 2 are split: tmux is #716; both config issues are combined here).

## 1. Legacy `THINKING` JSON-dict env coerces instead of failing

`THINKING` is documented as a plain string (`adaptive|enabled|disabled`), but older Vesta accepted a JSON object form, e.g. `THINKING='{"type":"adaptive"}'`, back when `ThinkingConfigAdaptive` did not require `display`. `_parse_thinking` only coerced strings and passed dicts to union validation, so after `display` became required, a legacy dict failed all three branches.

A dict branch in `_parse_thinking` now fills in the same defaults the string form uses; unknown `type` values still fall through to pydantic's normal error.

## 2. Config can never crash-loop the agent

Config construction is the first thing the agent does on boot, with no error handling and before logging is set up. Any field that fails validation raised `ValidationError`, exited the process, and with `--restart=unless-stopped` became an inescapable crash loop — for the THINKING case above, but also for *any* malformed override in `~/.bashrc` (non-numeric `RESPONSE_TIMEOUT`, out-of-range `NIGHTLY_MEMORY_HOUR`, etc.).

`load_config() -> tuple[VestaConfig, list[str]]` now builds the config without ever raising:
- On `ValidationError`, drop each offending env var (keyed off the error's field location) and rebuild. Only the invalid field reverts to its default; **valid overrides alongside it survive**.
- If a failure can't be attributed to any env var (an invalid field *default* — a bug, not user config), fall back to pure defaults via `model_construct()`.
- `_report_config_issues` logs each reverted var and drops a `source=core` notification (`config_invalid`) so the agent flags the bad values to the user instead of silently running on defaults.

The THINKING coercion keeps that specific legacy value working; the resilient loader is the general safety net so nothing else can brick the agent either.

## Tests (`test_config.py`)

- `test_thinking_legacy_json_dict_coerces_with_defaults` / `test_thinking_string_form_still_parses` — both env forms parse (driven through the real `THINKING` env path).
- `test_load_config_reverts_invalid_env_to_default` — a bad `RESPONSE_TIMEOUT` reverts and is reported; no raise.
- `test_load_config_keeps_other_valid_overrides` — a bad `NIGHTLY_MEMORY_HOUR` reverts while a valid `AGENT_MODEL` survives.
- `test_load_config_clean_env_has_no_issues`, `test_report_config_issues_notifies_agent`, `test_report_config_issues_noop_without_issues`.

Full agent suite: 293 passed.

Companion PR: #716 (tmux self-heal on rebuilt containers). Supersedes #720, now closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)