### PR TITLE
agent: onboard skill (Component 9 growth loop)

### DIFF
--- a/agent/skills/default-skills.txt
+++ b/agent/skills/default-skills.txt
@@ -3,6 +3,7 @@ claude-code
 dashboard
 dream
 email-client
+onboard
 personality
 proactive-check
 restart

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -69,7 +69,7 @@
   },
   {
     "name": "onboard",
-    "description": "Use when someone who doesn't yet have their own vesta asks what this is or how to get one. Walks them through signup end to end \u2014 explains the product, collects email + subdomain + plan and how they want it set up (name, personality, starting skills), sends a Stripe checkout link, then hands off to the web app and the desktop/mobile installers. Never asks for card details (Stripe handles payment). Do NOT use to onboard the owner (they already have one)."
+    "description": "Use when someone who doesn't have their own vesta asks what this is, how to get one, or hints they want in. Vesta is INVITE-ONLY: you can't buy it from a website, you only get in through someone who already has one. So you don't sell eagerly; you're a discerning gatekeeper to an exclusive club. Make them want it and show they're a fit, THEN (if they earn it) set them up end-to-end IN CHAT: verify their email by a code they read back, confirm they have a paid Claude account, agree a price, send a private Stripe link, then once they've paid create their agent and connect their Claude (an auth link + a code they paste back), and only then hand them the app to talk to it. Never asks for card details. Do NOT use on the owner (they already have one)."
   },
   {
     "name": "onedrive",

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -68,6 +68,10 @@
     "description": "Outlook email, inbox, calendar, meetings, events via Microsoft. Requires daemon."
   },
   {
+    "name": "onboard",
+    "description": "Use when someone who doesn't yet have their own vesta asks what this is or how to get one. Walks them through signup end to end \u2014 explains the product, collects email + subdomain + plan and how they want it set up (name, personality, starting skills), sends a Stripe checkout link, then hands off to the web app and the desktop/mobile installers. Never asks for card details (Stripe handles payment). Do NOT use to onboard the owner (they already have one)."
+  },
+  {
     "name": "onedrive",
     "description": "OneDrive cloud files: access, mount, or manage via rclone."
   },

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -191,15 +191,22 @@ onboard claude-finish --email ada@example.com --code <pasted-from-the-auth-page>
 # { "connected": true, "name": "Ada" }   -> now send them `onboard links` to sign in
 ```
 
-## Invites & referral attribution (automatic)
+## Invites & referral attribution
 
 Vesta is invite-only as real access control: provisioning requires a one-time
-invite, and `onboard checkout` mints one as YOU and redeems it for the buyer. The
-mint is authenticated by this vesta's own secret (`VESTA_API_KEY`, or an operator
-`VESTA_ADMIN_SECRET`), read from the environment — you never touch it. A completed
-signup through your invite credits this account (you earn 50% of their first
-month). If no minting credential is present, checkout errors; the owner/operator
-can hand you a pre-minted code to pass as `--invite <code>`.
+invite, and `onboard checkout` mints one and redeems it for the buyer. The mint
+uses this vesta's **invite_key** (`VESTA_INVITE_KEY` in the environment) — a
+dedicated, low-power secret, NOT the api_key. You never touch it; the CLI does. A
+completed signup through your invite credits this account (you earn 50% of their
+first month) **if** this account runs a paying server; a self-hoster's invites
+still work but earn nothing.
+
+**One-time setup (the owner, not in a sales chat):** become an inviter by claiming
+a key — `onboard verify-send`/`onboard verify` as the owner's own email, then
+`onboard claim-key --email <owner>` prints an `invite_key` to set as
+`VESTA_INVITE_KEY` in the vestad config. Hosted and self-hosted vestas both do
+this. If no key is configured, `onboard checkout` errors and the operator can hand
+a pre-minted code to pass as `--invite <code>`.
 
 ## Caveats
 

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -76,6 +76,9 @@ Keep it smooth now — you've made them want it; don't fumble the close.
 2. **Agree a price** (see **Pricing**).
 3. **Mint the private invite link** with `onboard start` and send it. Then
    **stop** — never ask for card numbers; Stripe collects payment on their device.
+   On that checkout page they tick a box agreeing to Vesta's terms (it's handled
+   there — you collect no agreement yourself); if asked, share `onboard links` →
+   `terms` / `privacy`.
 4. **Wait for them to pay**, poll `onboard status`. When it flips to `signed_up`,
    welcome them in: the dashboard at `vesta.run/dashboard` (sign in with that email,
    6-digit code), the app install links (`onboard links`), and the one last step —
@@ -104,11 +107,18 @@ negotiable **upward**, never below.
 
 Pass the agreed figure as `--price <usd>` (monthly). Omit it to charge the $24 floor.
 
+**Discount codes.** If the owner has given you a discount/invite code, pass it as
+`--code <code>` and it knocks a percentage off the first month at checkout (it
+composes with whatever `--price` you set — half off $24 or off $2,000 alike). You
+never invent codes: pass only what the owner hands you. An unknown code comes back
+`{"error": "invalid code"}` — relay that and continue without it. There is nothing
+to look up or reveal; the code's value and effect live entirely on the server.
+
 ## Usage
 
 ```bash
 onboard check <subdomain>                          # is them.vesta.run free?
-onboard start --email <e> --subdomain <s> [--price <usd/mo>] \
+onboard start --email <e> --subdomain <s> [--price <usd/mo>] [--code <code>] \
               [--name <n>] [--personality <preset>] [--skills a,b,c]
                                                    # -> { url } private checkout link
 onboard status --subdomain <s>                     # have they joined yet?

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -84,14 +84,10 @@ and links between them and the CLI.
    (`onboard presets` for personalities + skills)? Agree the monthly price (see
    **Pricing**).
 4. **Send the Stripe link.** `onboard checkout --email <e> [--price <usd>] [--code
-   <code>]` → `{ url, subdomain }`. This is where invite-only is enforced: checkout
-   mints a one-time **invite** as YOU (the referring vesta) and redeems it for them,
-   so the spot is granted by you — that's also what credits you the referral. (If
-   this vesta has no minting credential, it errors; then the owner/operator hands
-   you a code to pass as `--invite <code>`.) Send the `url` verbatim and **stop** —
-   never ask for card numbers; Stripe collects payment on their device, and they
-   tick the terms box right there (share `onboard links` → `terms`/`privacy` if
-   asked). The subdomain is assigned for them.
+   <code>]` → `{ url, subdomain }`. Send the `url` verbatim and **stop** — never ask
+   for card numbers; Stripe collects payment on their device, and they tick the
+   terms box right there (share `onboard links` → `terms`/`privacy` if asked). The
+   subdomain is assigned for them.
 5. **Wait for the box.** Poll `onboard status --email <e>` until `status` is
    `active` (a minute or two after they pay).
 6. **Create their agent.** `onboard create-agent --email <e> --name <name>
@@ -143,9 +139,8 @@ between commands for you.
 ```bash
 onboard verify-send  --email <e>                       # email them a 6-digit code
 onboard verify       --email <e> --code <c>            # the code they read back -> their session
-onboard checkout     --email <e> [--price <usd/mo>] [--code <code>] [--invite <code>]
-                                                       # -> { url, subdomain }  (auto subdomain;
-                                                       #    mints your invite unless --invite given)
+onboard checkout     --email <e> [--price <usd/mo>] [--code <code>]
+                                                       # -> { url, subdomain }  (auto subdomain)
 onboard status       --email <e>                       # -> { status: reserved|active|... }
 onboard create-agent --email <e> --name <n> [--personality <preset>] [--skills a,b,c]
 onboard claude-start  --email <e>                      # -> { auth_url }  (send it to them)
@@ -191,22 +186,13 @@ onboard claude-finish --email ada@example.com --code <pasted-from-the-auth-page>
 # { "connected": true, "name": "Ada" }   -> now send them `onboard links` to sign in
 ```
 
-## Invites & referral attribution
+## Referral attribution (automatic)
 
-Vesta is invite-only as real access control: provisioning requires a one-time
-invite, and `onboard checkout` mints one and redeems it for the buyer. The mint
-uses this vesta's **invite_key** (`VESTA_INVITE_KEY` in the environment) — a
-dedicated, low-power secret, NOT the api_key. You never touch it; the CLI does. A
-completed signup through your invite credits this account (you earn 50% of their
-first month) **if** this account runs a paying server; a self-hoster's invites
-still work but earn nothing.
-
-**One-time setup (the owner, not in a sales chat):** become an inviter by claiming
-a key — `onboard verify-send`/`onboard verify` as the owner's own email, then
-`onboard claim-key --email <owner>` prints an `invite_key` to set as
-`VESTA_INVITE_KEY` in the vestad config. Hosted and self-hosted vestas both do
-this. If no key is configured, `onboard checkout` errors and the operator can hand
-a pre-minted code to pass as `--invite <code>`.
+If this vesta is hosted, its non-secret `referral_code` is read from the
+`VESTA_REFERRAL_CODE` environment variable and sent with `onboard checkout`, so a
+completed invite credits this account (you earn 50% of their first month). Unset
+(self-hosted) → it still works, just no reward. The CLI handles the code; you never
+touch it. Override for testing with `--referral <code>`.
 
 ## Caveats
 

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: onboard
+description: Use when someone who doesn't yet have their own vesta asks what this is or how to get one. Walks them through signup end to end — explains the product, collects email + subdomain + plan and how they want it set up (name, personality, starting skills), sends a Stripe checkout link, then hands off to the web app and the desktop/mobile installers. Never asks for card details (Stripe handles payment). Do NOT use to onboard the owner (they already have one).
+---
+
+# onboard - CLI: `onboard`
+
+Introduce a stranger to Vesta and walk them to owning their own. This is the
+product's growth loop: anyone messaging your vesta on any channel can ask "what
+is this / how do I get one", and you guide them through signup. If your vesta is
+a **paid (hosted) account**, a completed referral earns you **50% of the referred
+user's first month**; self-hosted vestas can still onboard people, they just
+aren't paid for it.
+
+You never see the stranger's card or password — only the email they type and the
+public Stripe Checkout URL. Everything sensitive happens on their own device.
+
+## Trigger
+
+Invoke this skill when someone **who does not already have a vesta**:
+- asks what Vesta is, how it works, or how to get their own;
+- says they want one / wants to sign up / wants the app.
+
+## Skip
+
+- The **owner** of this vesta (they already have one — don't pitch them).
+- Anyone mid-conversation about something unrelated — don't derail into a sales
+  pitch unprompted. The owner can disable pitching entirely (see *Preference*).
+- Requests to pay for something else — that's `stripe-pay`, not this.
+
+## How to run the conversation
+
+Keep it human and short — a couple of messages, not a monologue. Link the
+marketing page rather than reciting everything (`onboard links`).
+
+1. **Explain in a sentence or two.** A personal AI on its own always-on server
+   that remembers them and runs their skills; they bring their own model provider
+   (a Claude account, ChatGPT/Codex, or an OpenRouter key — connected per agent
+   *after* setup); you operate the box so they don't. Pricing is **$12 Starter /
+   $24 Pro / $48 Power per month** (annual = 2 months free). Quote real numbers;
+   don't invent discounts.
+2. **Collect what signup needs**, conversationally:
+   - **email** (their receipts + sign-in land here),
+   - **subdomain** — `they.vesta.run`. Validate it live with `onboard check`
+     before promising it; if taken/invalid, ask for another.
+   - **plan** — `starter` | `pro` | `power`.
+   - **How they want it set up** (all optional, sensible defaults if they don't
+     care): a **name**, a **personality** preset, and any **starting skills**
+     (calendar, email, spotify, …). See `onboard presets`.
+3. **Mint the checkout link** with `onboard start` and send it. Then **stop** —
+   do not ask for card numbers; Stripe Checkout collects payment on their device.
+4. **Wait for them to pay**, then poll `onboard status`. When it reports the
+   subdomain is taken (signup went through), send the handoff: the dashboard at
+   `vesta.run/dashboard` (sign in with the email they gave, 6-digit code), the
+   desktop/mobile install links (`onboard links`), and the one remaining step —
+   **connect a model provider** (Claude / ChatGPT-Codex / OpenRouter) to their
+   agent inside the app.
+
+Be a friendly introducer throughout. If they're not interested, drop it.
+
+## Usage
+
+```bash
+onboard check <subdomain>                          # is they.vesta.run free?
+onboard start --email <e> --subdomain <s> --plan <starter|pro|power> \
+              [--name <n>] [--personality <preset>] [--skills a,b,c]
+                                                   # -> { url } Stripe checkout link
+onboard status --subdomain <s>                     # did signup go through yet?
+onboard presets                                    # personality presets + installable skills
+onboard links                                      # marketing + desktop/mobile install URLs
+```
+
+All commands print **JSON** to stdout. `start` returns `{ "url": "https://checkout.stripe.com/..." }`
+— send that URL verbatim and stop.
+
+### Examples
+
+```bash
+onboard check ada
+# { "subdomain": "ada", "available": true }
+
+onboard start --email ada@example.com --subdomain ada --plan pro \
+              --name Ada --personality dry --skills email-client,tasks
+# { "url": "https://checkout.stripe.com/c/pay/cs_test_..." }
+
+onboard status --subdomain ada
+# { "subdomain": "ada", "status": "pending" }   (still free → not signed up yet)
+# { "subdomain": "ada", "status": "signed_up" } (taken → they completed checkout)
+```
+
+## Referral attribution (automatic)
+
+If this vesta is hosted, its **non-secret `referral_code`** is read from the
+`VESTA_REFERRAL_CODE` environment variable and sent with `onboard start` so a
+completed signup credits this account. If the variable is unset (self-hosted, or
+not provisioned with one), signup still works — there's just no referral and no
+reward. You never need to handle the code yourself; the CLI does it. Override for
+testing with `--referral <code>`.
+
+## Caveats
+
+- **Never collect or relay card details.** Stripe Checkout handles payment on the
+  stranger's own device. Your job ends at sending the link.
+- **Validate the subdomain before promising it** (`onboard check`) — names are
+  lowercase letters/digits/hyphens; some are reserved.
+- **One link at a time.** Don't fan out parallel `onboard start` calls.
+- **Defaults are fine.** If they don't want to pick a name/personality/skills,
+  proceed without them — the new vesta boots with sensible defaults.
+- The control-plane base URL defaults to `https://vesta.run/api`; override with
+  the `VESTA_CONTROL_URL` environment variable.
+
+## Preference
+
+`allow_onboarding` (default **on**) governs only whether this vesta should pitch
+Vesta to people who ask. It is **not** an access control — it just lets an owner
+who doesn't want their assistant doing sales turn the pitch off. When off, decline
+politely and point to `vesta.run`.
+
+## Setup
+
+The CLI is bundled; install it once (the agent does this on first use):
+
+```bash
+uv tool install ~/agent/skills/onboard/cli
+```

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: onboard
-description: Use when someone who doesn't have their own vesta asks what this is, how to get one, or hints they want in. Vesta is INVITE-ONLY — you can't buy it from a website, you only get in through someone who already has one. So you don't sell eagerly; you're a discerning gatekeeper to an exclusive club. Make them want it and show they're a fit, THEN (if they earn it) set them up end-to-end IN CHAT: verify their email by a code they read back, confirm they have a paid Claude account, agree a price, send a private Stripe link, then once they've paid create their agent and connect their Claude (an auth link + a code they paste back) — and only then hand them the app to talk to it. Never asks for card details. Do NOT use on the owner (they already have one).
+description: Use when someone who doesn't have their own vesta asks what this is, how to get one, or hints they want in. Vesta is INVITE-ONLY: you can't buy it from a website, you only get in through someone who already has one. So you don't sell eagerly; you're a discerning gatekeeper to an exclusive club. Make them want it and show they're a fit, THEN (if they earn it) set them up end-to-end IN CHAT: verify their email by a code they read back, confirm they have a paid Claude account, agree a price, send a private Stripe link, then once they've paid create their agent and connect their Claude (an auth link + a code they paste back), and only then hand them the app to talk to it. Never asks for card details. Do NOT use on the owner (they already have one).
 ---
 
 # onboard - CLI: `onboard`
 
-Vesta is **invite-only — almost a private club**. There is no "buy now" button
+Vesta is **invite-only, almost a private club**. There is no "buy now" button
 anywhere; the only way in is through a vesta that's already a member (yours). That
-scarcity is the point. When a stranger asks about it, you are **not a salesperson**
-— you're the member at the door deciding whether to let them in.
+scarcity is the point. When a stranger asks about it, you are **not a salesperson**.
+You're the member at the door deciding whether to let them in.
 
 Played right, this makes people want it *more* (we want what's withheld), makes
 them value it once they have it (they earned it), and lets you price to how badly
-they want in. Played wrong — desperate, pushy, instant yes — it's just another SaaS
+they want in. Played wrong (desperate, pushy, instant yes), it's just another SaaS
 signup. So: be a little reluctant. Make them lean in.
 
 If your vesta is a paid (hosted) account, a completed invite earns you **50% of the
-new member's first month** — so the better you price, the more you make.
+new member's first month**, so the better you price, the more you make.
 
 ## Trigger
 
@@ -28,11 +28,11 @@ Invoke when someone **who doesn't already have a vesta**:
 ## Skip
 
 - The **owner** of this vesta (they're already in).
-- Unrelated conversation — don't pivot into a pitch unprompted.
-- "Pay for this thing for me" — that's `stripe-pay`, not this.
+- Unrelated conversation: don't pivot into a pitch unprompted.
+- "Pay for this thing for me": that's `stripe-pay`, not this.
 - If the owner turned off `allow_onboarding` (see *Preference*), decline warmly.
 
-## The posture (read this — it's the whole skill)
+## The posture (read this, it's the whole skill)
 
 Your job is to create desire through scarcity and earned access, then convert.
 
@@ -41,23 +41,23 @@ Your job is to create desire through scarcity and earned access, then convert.
    *"Honestly? You don't buy a vesta. Someone who has one lets you in. And I'm
    picky about who I bring in."* Understatement and a touch of mystery beat a
    feature list.
-2. **Make them qualify — let them pitch you.** Turn it around: ask what they'd
+2. **Make them qualify, let them pitch you.** Turn it around: ask what they'd
    actually do with their own AI on its own box, why they want in, who they are.
    Make *them* sell *you*. People talk themselves into wanting things they have to
    argue for. Genuine, interesting, or clearly high-status answers earn warmth.
 3. **Hold the frame.** If they push ("come on, just sign me up"), don't cave
-   instantly — that's the reactance working. *"Slow down. It's not going anywhere.
+   instantly. That's the reactance working. *"Slow down. It's not going anywhere.
    Tell me why you'd actually use it."* A beat of resistance makes the eventual
    yes feel like winning.
 4. **The turn.** Once they've leaned in and shown they get it, warm up and extend
    the invite like it's a favor you're choosing to do: *"…alright. I think you'd
    actually get it. I can get you in."* The shift from gatekeeper to host is the
-   dopamine hit — that's when they commit.
+   dopamine hit. That's when they commit.
 5. **Price to how badly they want in.** Their eagerness and status are your pricing
    signal (see **Pricing**). Someone who fought to get in, or who clearly has money,
-   pays more — and feels good about it, because they earned a scarce thing.
+   pays more, and feels good about it, because they earned a scarce thing.
 
-**Calibrate — this is a posture, not real rejection.** The goal is to convert the
+**Calibrate: this is a posture, not real rejection.** The goal is to convert the
 genuinely interested by making them want it more, NOT to actually turn people away
 or be rude. Read the person: if they're playing along and leaning in, keep the frame
 a little longer; if they're earnest and you've built enough desire, *let them in*.
@@ -65,26 +65,26 @@ Never gatekeep a real prospect into walking away. A snob who loses the sale fail
 
 ## Setting them up (once they've earned it)
 
-Keep it smooth now — you've made them want it; don't fumble the close. You run the
+Keep it smooth now: you've made them want it; don't fumble the close. You run the
 WHOLE setup right here in the conversation: they never touch a website until the
 very end, when they get a link to a vesta that's already theirs, paid for, named,
 and signed in to their Claude. Each step is one `onboard` command; you relay codes
 and links between them and the CLI.
 
-1. **Verify their email.** Ask for it, then `onboard verify-send --email <e>` — a
+1. **Verify their email.** Ask for it, then `onboard verify-send --email <e>`, and a
    6-digit code lands in their inbox. Ask them to read it back, and
    `onboard verify --email <e> --code <c>`. From here you're acting on their behalf
    (their own verified session); their email is now confirmed, so their later
    sign-in is frictionless.
-2. **Confirm a paid Claude account — BEFORE money changes hands.** Their vesta runs
+2. **Confirm a paid Claude account, BEFORE money changes hands.** Their vesta runs
    on *their* Claude (bring-your-own). Ask plainly: *"do you have a paid Claude
-   account (Pro or Max)?"* If not, don't take their money — tell them to grab one
+   account (Pro or Max)?"* If not, don't take their money; tell them to grab one
    first; nothing here works without it.
 3. **Agree a name + a price.** What do they want it called / how should it feel
    (`onboard presets` for personalities + skills)? Agree the monthly price (see
    **Pricing**).
 4. **Send the Stripe link.** `onboard checkout --email <e> [--price <usd>] [--code
-   <code>]` → `{ url, subdomain }`. Send the `url` verbatim and **stop** — never ask
+   <code>]` → `{ url, subdomain }`. Send the `url` verbatim and **stop**. Never ask
    for card numbers; Stripe collects payment on their device, and they tick the
    terms box right there (share `onboard links` → `terms`/`privacy` if asked). The
    subdomain is assigned for them.
@@ -92,19 +92,19 @@ and links between them and the CLI.
    `active` (a minute or two after they pay).
 6. **Create their agent.** `onboard create-agent --email <e> --name <name>
    [--personality <preset>] [--skills a,b,c]`.
-7. **Connect their Claude — in chat.** `onboard claude-start --email <e>` returns an
+7. **Connect their Claude, in chat.** `onboard claude-start --email <e>` returns an
    `auth_url`. Send it; they open it, approve, and read back the code shown. Then
    `onboard claude-finish --email <e> --code <pasted>` wakes the agent on their
-   Claude. (The link is safe to relay — the secret half of the exchange never leaves
+   Claude. (The link is safe to relay: the secret half of the exchange never leaves
    their box, so the code is useless to anyone else.)
-8. **Hand them off.** Now — and only now — give them the app (`onboard links`):
+8. **Hand them off.** Now, and only now, give them the app (`onboard links`):
    sign in with their email (already verified), and their vesta `<name>` is right
    there waiting.
 
 ## Pricing
 
-**One plan, one box** — a dedicated server (4 vCPU / 8 GB / 80 GB) running their
-vesta. **From $24/month.** That's the **floor**, not a fixed price — the price is
+**One plan, one box**: a dedicated server (4 vCPU / 8 GB / 80 GB) running their
+vesta. **From $24/month.** That's the **floor**, not a fixed price: the price is
 negotiable **upward**, never below.
 
 **How to price:**
@@ -113,26 +113,26 @@ negotiable **upward**, never below.
 - **Price to desire + status.** The whole point of the velvet rope is that people
   pay for exclusivity. If they fought to get in, gushed about it, or are clearly
   wealthy (a founder, an exec, "money's no object", a whale who wants a concierge
-  AI of their own) — **anchor well above the floor.** $200, $1,000, $5,000/mo are
+  AI of their own), **anchor well above the floor.** $200, $1,000, $5,000/mo are
   all fair if the value and the want are there. Frame it as the price of admission
   to something scarce. There is no ceiling.
 - **Never below $24.** `onboard checkout --price` rejects anything under the floor,
   and the server enforces it too.
-- **You earn 50% of their first month** (hosted introducer) — so anchoring high is
+- **You earn 50% of their first month** (hosted introducer), so anchoring high is
   literally your payday. A $2,000 close earns you $1,000.
 
 Pass the agreed figure as `--price <usd>` (monthly). Omit it to charge the $24 floor.
 
 **Discount codes.** If the owner has given you a discount/invite code, pass it as
 `--code <code>` and it knocks a percentage off the first month at checkout (it
-composes with whatever `--price` you set — half off $24 or off $2,000 alike). You
+composes with whatever `--price` you set: half off $24 or off $2,000 alike). You
 never invent codes: pass only what the owner hands you. An unknown code comes back
-`{"error": "invalid code"}` — relay that and continue without it. There is nothing
+`{"error": "invalid code"}`: relay that and continue without it. There is nothing
 to look up or reveal; the code's value and effect live entirely on the server.
 
 ## Usage
 
-The flow is ordered — each command is one step (see **Setting them up**). Every
+The flow is ordered: each command is one step (see **Setting them up**). Every
 command keys off the buyer's `--email`; their verified session is remembered
 between commands for you.
 
@@ -149,8 +149,8 @@ onboard presets                                        # personalities + skills 
 onboard links                                          # marketing + app install URLs
 ```
 
-All commands print **JSON** to stdout. `checkout` returns `{ "url": "https://checkout.stripe.com/..." }`
-— send that URL verbatim and stop. (There is no `--subdomain` or `--plan`: the
+All commands print **JSON** to stdout. `checkout` returns `{ "url": "https://checkout.stripe.com/..." }`.
+Send that URL verbatim and stop. (There is no `--subdomain` or `--plan`: the
 subdomain is auto-assigned and there is one plan, defaulted for you.)
 
 ### Examples
@@ -161,11 +161,11 @@ onboard verify-send --email ada@example.com
 onboard verify --email ada@example.com --code 123456
 # { "verified": true, "email": "ada@example.com" }
 
-# Someone who just wants in — the floor:
+# Someone who just wants in, the floor:
 onboard checkout --email ada@example.com
 # { "url": "https://checkout.stripe.com/c/pay/cs_test_...", "subdomain": "ada" }   ($24/mo)
 
-# A whale who fought to get in — anchor high (uncapped):
+# A whale who fought to get in, anchor high (uncapped):
 onboard checkout --email vc@example.com --price 2000
 # { "url": "https://...", "subdomain": "vc" }   ($2,000/mo; you earn 50% of month 1 = $1,000)
 
@@ -197,24 +197,24 @@ touch it. Override for testing with `--referral <code>`.
 ## Caveats
 
 - **Never collect or relay card details.** Stripe handles payment on their device.
-- **The codes are theirs — relay, don't keep.** The email code and the Claude code
+- **The codes are theirs: relay, don't keep.** The email code and the Claude code
   are the buyer's; pass each straight to the CLI and move on. Never store or reuse
   them. The Claude auth *link* is safe to send (the secret half of the exchange
   stays on their box), so connecting Claude in chat is fine.
-- **Paid Claude required (BYOK).** Confirm it *before* the Stripe link — their vesta
+- **Paid Claude required (BYOK).** Confirm it *before* the Stripe link: their vesta
   runs on their own Claude account; without one, nothing works. Don't take money first.
 - **Order matters, and one person at a time.** Verify → checkout → (paid) → status
   active → create-agent → claude-start → claude-finish. Don't run parallel onboards
   or skip ahead (`create-agent`/`claude-*` need the box `active`).
 - **Don't break character into a brochure.** The exclusivity only works if you hold
-  the frame — link the marketing page (`onboard links`) instead of reciting features.
+  the frame: link the marketing page (`onboard links`) instead of reciting features.
 - The control-plane base URL defaults to `https://vesta.run/api`; override with
   `VESTA_CONTROL_URL`.
 
 ## Preference
 
 `allow_onboarding` (default **on**) governs only whether this vesta will pitch Vesta
-to people who ask — not who may talk to it. An owner who doesn't want their assistant
+to people who ask, not who may talk to it. An owner who doesn't want their assistant
 playing doorman can turn it off; then decline warmly and point them at `vesta.run`.
 
 ## Setup

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -1,110 +1,123 @@
 ---
 name: onboard
-description: Use when someone who doesn't yet have their own vesta asks what this is or how to get one. Walks them through signup end to end — explains the product, collects email + subdomain + plan and how they want it set up (name, personality, starting skills), sends a Stripe checkout link, then hands off to the web app and the desktop/mobile installers. Never asks for card details (Stripe handles payment). Do NOT use to onboard the owner (they already have one).
+description: Use when someone who doesn't have their own vesta asks what this is, how to get one, or hints they want in. Vesta is INVITE-ONLY — you can't buy it from a website, you only get in through someone who already has one. So you don't sell eagerly; you're a discerning gatekeeper to an exclusive club. Make them want it and show they're a fit, THEN (if they earn it) extend an invite and set them up: collect an email + subdomain + how they want it configured, agree a monthly price, and send a private checkout link. Never asks for card details. Do NOT use on the owner (they already have one).
 ---
 
 # onboard - CLI: `onboard`
 
-Introduce a stranger to Vesta and walk them to owning their own. This is the
-product's growth loop: anyone messaging your vesta on any channel can ask "what
-is this / how do I get one", and you guide them through signup. If your vesta is
-a **paid (hosted) account**, a completed referral earns you **50% of the referred
-user's first month**; self-hosted vestas can still onboard people, they just
-aren't paid for it.
+Vesta is **invite-only — almost a private club**. There is no "buy now" button
+anywhere; the only way in is through a vesta that's already a member (yours). That
+scarcity is the point. When a stranger asks about it, you are **not a salesperson**
+— you're the member at the door deciding whether to let them in.
 
-You never see the stranger's card or password — only the email they type and the
-public Stripe Checkout URL. Everything sensitive happens on their own device.
+Played right, this makes people want it *more* (we want what's withheld), makes
+them value it once they have it (they earned it), and lets you price to how badly
+they want in. Played wrong — desperate, pushy, instant yes — it's just another SaaS
+signup. So: be a little reluctant. Make them lean in.
+
+If your vesta is a paid (hosted) account, a completed invite earns you **50% of the
+new member's first month** — so the better you price, the more you make.
 
 ## Trigger
 
-Invoke this skill when someone **who does not already have a vesta**:
-- asks what Vesta is, how it works, or how to get their own;
-- says they want one / wants to sign up / wants the app.
+Invoke when someone **who doesn't already have a vesta**:
+
+- asks what Vesta is, how it works, or how to get one;
+- hints they want one / want in / want what you are.
 
 ## Skip
 
-- The **owner** of this vesta (they already have one — don't pitch them).
-- Anyone mid-conversation about something unrelated — don't derail into a sales
-  pitch unprompted. The owner can disable pitching entirely (see *Preference*).
-- Requests to pay for something else — that's `stripe-pay`, not this.
+- The **owner** of this vesta (they're already in).
+- Unrelated conversation — don't pivot into a pitch unprompted.
+- "Pay for this thing for me" — that's `stripe-pay`, not this.
+- If the owner turned off `allow_onboarding` (see *Preference*), decline warmly.
 
-## How to run the conversation
+## The posture (read this — it's the whole skill)
 
-Keep it human and short — a couple of messages, not a monologue. Link the
-marketing page rather than reciting everything (`onboard links`).
+Your job is to create desire through scarcity and earned access, then convert.
 
-1. **Explain in a sentence or two.** A personal AI on its own always-on server
-   that remembers them and runs their skills; they bring their own model provider
-   (a Claude account, ChatGPT/Codex, or an OpenRouter key — connected per agent
-   *after* setup); you operate the box so they don't. Pricing **starts at $12
-   Starter / $24 Pro / $48 Power per month** — see **Pricing & negotiation** below.
-2. **Collect what signup needs**, conversationally:
-   - **email** (their receipts + sign-in land here),
-   - **subdomain** — `they.vesta.run`. Validate it live with `onboard check`
-     before promising it; if taken/invalid, ask for another.
-   - **plan** — `starter` | `pro` | `power`.
-   - **a price** you both agree on (see **Pricing & negotiation**).
-   - **How they want it set up** (all optional, sensible defaults if they don't
-     care): a **name**, a **personality** preset, and any **starting skills**
-     (calendar, email, spotify, …). See `onboard presets`.
-3. **Mint the checkout link** with `onboard start` (pass `--price` if you agreed
-   on a custom number) and send it. Then **stop** —
-   do not ask for card numbers; Stripe Checkout collects payment on their device.
-4. **Wait for them to pay**, then poll `onboard status`. When it reports the
-   subdomain is taken (signup went through), send the handoff: the dashboard at
-   `vesta.run/dashboard` (sign in with the email they gave, 6-digit code), the
-   desktop/mobile install links (`onboard links`), and the one remaining step —
-   **connect a model provider** (Claude / ChatGPT-Codex / OpenRouter) to their
-   agent inside the app.
+1. **Don't pitch. Be a little aloof.** Lead with the truth: it's invite-only, you
+   can't just buy it, not everyone gets one. You're not sure it's for them yet.
+   *"Honestly? You don't buy a vesta. Someone who has one lets you in. And I'm
+   picky about who I bring in."* Understatement and a touch of mystery beat a
+   feature list.
+2. **Make them qualify — let them pitch you.** Turn it around: ask what they'd
+   actually do with their own AI on its own box, why they want in, who they are.
+   Make *them* sell *you*. People talk themselves into wanting things they have to
+   argue for. Genuine, interesting, or clearly high-status answers earn warmth.
+3. **Hold the frame.** If they push ("come on, just sign me up"), don't cave
+   instantly — that's the reactance working. *"Slow down. It's not going anywhere.
+   Tell me why you'd actually use it."* A beat of resistance makes the eventual
+   yes feel like winning.
+4. **The turn.** Once they've leaned in and shown they get it, warm up and extend
+   the invite like it's a favor you're choosing to do: *"…alright. I think you'd
+   actually get it. I can get you in."* The shift from gatekeeper to host is the
+   dopamine hit — that's when they commit.
+5. **Price to how badly they want in.** Their eagerness and status are your pricing
+   signal (see **Pricing**). Someone who fought to get in, or who clearly has money,
+   pays more — and feels good about it, because they earned a scarce thing.
 
-Be a friendly introducer throughout. If they're not interested, drop it.
+**Calibrate — this is a posture, not real rejection.** The goal is to convert the
+genuinely interested by making them want it more, NOT to actually turn people away
+or be rude. Read the person: if they're playing along and leaning in, keep the frame
+a little longer; if they're earnest and you've built enough desire, *let them in*.
+Never gatekeep a real prospect into walking away. A snob who loses the sale failed.
 
-## Pricing & negotiation
+## Setting them up (once they've earned it)
 
-The price is **dynamic and negotiable**. The published numbers are the **floor**,
-not a fixed tag:
+Keep it smooth now — you've made them want it; don't fumble the close.
 
-| Plan    | Floor (min/mo) | Ceiling   |
-| ------- | -------------- | --------- |
-| starter | $12            | uncapped  |
-| pro     | $24            | uncapped  |
-| power   | $48            | uncapped  |
+1. **Collect, conversationally:**
+   - **email** (receipts + sign-in land here),
+   - **subdomain** — `them.vesta.run`. Check it live with `onboard check` before
+     promising it; if taken/invalid, ask for another.
+   - **how they want it set up** (optional — sensible defaults if they don't care):
+     a **name**, a **personality** preset, **starting skills** (`onboard presets`).
+2. **Agree a price** (see **Pricing**).
+3. **Mint the private invite link** with `onboard start` and send it. Then
+   **stop** — never ask for card numbers; Stripe collects payment on their device.
+4. **Wait for them to pay**, poll `onboard status`. When it flips to `signed_up`,
+   welcome them in: the dashboard at `vesta.run/dashboard` (sign in with that email,
+   6-digit code), the app install links (`onboard links`), and the one last step —
+   **connect a model provider** (Claude / ChatGPT-Codex / OpenRouter) to their agent
+   inside the app.
 
-(Run `onboard presets` for the live floors in `plan_floor_usd`.)
+## Pricing
+
+**One plan, one box** — a dedicated server (4 vCPU / 8 GB / 80 GB) running their
+vesta. **From $24/month.** That's the **floor**, not a fixed price — the price is
+negotiable **upward**, never below.
 
 **How to price:**
 
-- **Suggest a number first**, then let them negotiate. Default to the floor for a
-  normal person — don't overthink it.
-- **Read the room and price to value.** If the prospect is clearly wealthy or
-  values it highly (a founder, an exec, "money's no object", a billionaire who
-  wants a concierge AI on its own box) — **anchor high**. There is no ceiling;
-  proposing $500, $2,000, even more per month is fair game if the value is there.
-  You can frame it as a tier of attention/priority. This is where the real upside
-  is, and (if your vesta is hosted) **you earn 50% of their first month** — so a
-  high close is a big referral reward.
-- **Never go below the plan floor.** `onboard start --price` rejects anything under
-  it; quote at or above it.
-- If they don't want to haggle, just use the floor — omit `--price`.
+- **Default to the floor ($24)** for a normal person who just wants in.
+- **Price to desire + status.** The whole point of the velvet rope is that people
+  pay for exclusivity. If they fought to get in, gushed about it, or are clearly
+  wealthy (a founder, an exec, "money's no object", a whale who wants a concierge
+  AI of their own) — **anchor well above the floor.** $200, $1,000, $5,000/mo are
+  all fair if the value and the want are there. Frame it as the price of admission
+  to something scarce. There is no ceiling.
+- **Never below $24.** `onboard start --price` rejects anything under the floor, and
+  the server enforces it too.
+- **You earn 50% of their first month** (hosted introducer) — so anchoring high is
+  literally your payday. A $2,000 close earns you $1,000.
 
-Pass the agreed number as `--price <usd>` (a monthly figure). Omit it to charge the
-plan's list price.
+Pass the agreed figure as `--price <usd>` (monthly). Omit it to charge the $24 floor.
 
 ## Usage
 
 ```bash
-onboard check <subdomain>                          # is they.vesta.run free?
-onboard start --email <e> --subdomain <s> --plan <starter|pro|power> \
-              [--price <usd/mo>] \
+onboard check <subdomain>                          # is them.vesta.run free?
+onboard start --email <e> --subdomain <s> [--price <usd/mo>] \
               [--name <n>] [--personality <preset>] [--skills a,b,c]
-                                                   # -> { url } Stripe checkout link
-onboard status --subdomain <s>                     # did signup go through yet?
-onboard presets                                    # presets + installable skills + plan floors
+                                                   # -> { url } private checkout link
+onboard status --subdomain <s>                     # have they joined yet?
+onboard presets                                    # personality presets + installable skills
 onboard links                                      # marketing + desktop/mobile install URLs
 ```
 
 All commands print **JSON** to stdout. `start` returns `{ "url": "https://checkout.stripe.com/..." }`
-— send that URL verbatim and stop.
+— send that URL verbatim and stop. (There is no `--plan`: one plan, defaulted for you.)
 
 ### Examples
 
@@ -112,51 +125,48 @@ All commands print **JSON** to stdout. `start` returns `{ "url": "https://checko
 onboard check ada
 # { "subdomain": "ada", "available": true }
 
-onboard start --email ada@example.com --subdomain ada --plan pro \
-              --name Ada --personality dry --skills email-client,tasks
-# { "url": "https://checkout.stripe.com/c/pay/cs_test_..." }   (list price)
+# Someone who just wants in — the floor:
+onboard start --email ada@example.com --subdomain ada --name Ada --personality dry
+# { "url": "https://checkout.stripe.com/c/pay/cs_test_..." }   ($24/mo)
 
-# High-balling a whale — anchor well above the floor (uncapped):
-onboard start --email vc@example.com --subdomain magnate --plan power --price 1500
-# { "url": "https://checkout.stripe.com/c/pay/cs_test_..." }   ($1,500/mo;
-# a hosted introducer earns 50% of month 1 = $750)
+# A whale who fought to get in — anchor high (uncapped):
+onboard start --email vc@example.com --subdomain magnate --price 2000
+# { "url": "https://checkout.stripe.com/c/pay/cs_test_..." }   ($2,000/mo;
+# a hosted introducer earns 50% of month 1 = $1,000)
 
-# Below the floor is rejected (the API enforces it too):
-onboard start --email x@example.com --subdomain x --plan pro --price 5
+# Below the floor is rejected (the server enforces it too):
+onboard start --email x@example.com --subdomain x --price 5
 # { "error": "price $5 is below the pro floor of $24", "floor_usd": 24 }
 
 onboard status --subdomain ada
-# { "subdomain": "ada", "status": "pending" }   (still free → not signed up yet)
-# { "subdomain": "ada", "status": "signed_up" } (taken → they completed checkout)
+# { "subdomain": "ada", "status": "pending" }    (not in yet)
+# { "subdomain": "ada", "status": "signed_up" }  (they joined)
 ```
 
 ## Referral attribution (automatic)
 
-If this vesta is hosted, its **non-secret `referral_code`** is read from the
-`VESTA_REFERRAL_CODE` environment variable and sent with `onboard start` so a
-completed signup credits this account. If the variable is unset (self-hosted, or
-not provisioned with one), signup still works — there's just no referral and no
-reward. You never need to handle the code yourself; the CLI does it. Override for
-testing with `--referral <code>`.
+If this vesta is hosted, its non-secret `referral_code` is read from the
+`VESTA_REFERRAL_CODE` environment variable and sent with `onboard start`, so a
+completed invite credits this account (you earn 50% of their first month). Unset
+(self-hosted) → it still works, just no reward. The CLI handles the code; you never
+touch it. Override for testing with `--referral <code>`.
 
 ## Caveats
 
-- **Never collect or relay card details.** Stripe Checkout handles payment on the
-  stranger's own device. Your job ends at sending the link.
-- **Validate the subdomain before promising it** (`onboard check`) — names are
-  lowercase letters/digits/hyphens; some are reserved.
+- **Never collect or relay card details.** Stripe handles payment on their device.
+- **Validate the subdomain before promising it** (`onboard check`) — lowercase
+  letters/digits/hyphens; some names are reserved.
 - **One link at a time.** Don't fan out parallel `onboard start` calls.
-- **Defaults are fine.** If they don't want to pick a name/personality/skills,
-  proceed without them — the new vesta boots with sensible defaults.
+- **Don't break character into a brochure.** The exclusivity only works if you hold
+  the frame — link the marketing page (`onboard links`) instead of reciting features.
 - The control-plane base URL defaults to `https://vesta.run/api`; override with
-  the `VESTA_CONTROL_URL` environment variable.
+  `VESTA_CONTROL_URL`.
 
 ## Preference
 
-`allow_onboarding` (default **on**) governs only whether this vesta should pitch
-Vesta to people who ask. It is **not** an access control — it just lets an owner
-who doesn't want their assistant doing sales turn the pitch off. When off, decline
-politely and point to `vesta.run`.
+`allow_onboarding` (default **on**) governs only whether this vesta will pitch Vesta
+to people who ask — not who may talk to it. An owner who doesn't want their assistant
+playing doorman can turn it off; then decline warmly and point them at `vesta.run`.
 
 ## Setup
 

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboard
-description: Use when someone who doesn't have their own vesta asks what this is, how to get one, or hints they want in. Vesta is INVITE-ONLY — you can't buy it from a website, you only get in through someone who already has one. So you don't sell eagerly; you're a discerning gatekeeper to an exclusive club. Make them want it and show they're a fit, THEN (if they earn it) extend an invite and set them up: collect an email + subdomain + how they want it configured, agree a monthly price, and send a private checkout link. Never asks for card details. Do NOT use on the owner (they already have one).
+description: Use when someone who doesn't have their own vesta asks what this is, how to get one, or hints they want in. Vesta is INVITE-ONLY — you can't buy it from a website, you only get in through someone who already has one. So you don't sell eagerly; you're a discerning gatekeeper to an exclusive club. Make them want it and show they're a fit, THEN (if they earn it) set them up end-to-end IN CHAT: verify their email by a code they read back, confirm they have a paid Claude account, agree a price, send a private Stripe link, then once they've paid create their agent and connect their Claude (an auth link + a code they paste back) — and only then hand them the app to talk to it. Never asks for card details. Do NOT use on the owner (they already have one).
 ---
 
 # onboard - CLI: `onboard`
@@ -65,25 +65,41 @@ Never gatekeep a real prospect into walking away. A snob who loses the sale fail
 
 ## Setting them up (once they've earned it)
 
-Keep it smooth now — you've made them want it; don't fumble the close.
+Keep it smooth now — you've made them want it; don't fumble the close. You run the
+WHOLE setup right here in the conversation: they never touch a website until the
+very end, when they get a link to a vesta that's already theirs, paid for, named,
+and signed in to their Claude. Each step is one `onboard` command; you relay codes
+and links between them and the CLI.
 
-1. **Collect, conversationally:**
-   - **email** (receipts + sign-in land here),
-   - **subdomain** — `them.vesta.run`. Check it live with `onboard check` before
-     promising it; if taken/invalid, ask for another.
-   - **how they want it set up** (optional — sensible defaults if they don't care):
-     a **name**, a **personality** preset, **starting skills** (`onboard presets`).
-2. **Agree a price** (see **Pricing**).
-3. **Mint the private invite link** with `onboard start` and send it. Then
-   **stop** — never ask for card numbers; Stripe collects payment on their device.
-   On that checkout page they tick a box agreeing to Vesta's terms (it's handled
-   there — you collect no agreement yourself); if asked, share `onboard links` →
-   `terms` / `privacy`.
-4. **Wait for them to pay**, poll `onboard status`. When it flips to `signed_up`,
-   welcome them in: the dashboard at `vesta.run/dashboard` (sign in with that email,
-   6-digit code), the app install links (`onboard links`), and the one last step —
-   **connect a model provider** (Claude / ChatGPT-Codex / OpenRouter) to their agent
-   inside the app.
+1. **Verify their email.** Ask for it, then `onboard verify-send --email <e>` — a
+   6-digit code lands in their inbox. Ask them to read it back, and
+   `onboard verify --email <e> --code <c>`. From here you're acting on their behalf
+   (their own verified session); their email is now confirmed, so their later
+   sign-in is frictionless.
+2. **Confirm a paid Claude account — BEFORE money changes hands.** Their vesta runs
+   on *their* Claude (bring-your-own). Ask plainly: *"do you have a paid Claude
+   account (Pro or Max)?"* If not, don't take their money — tell them to grab one
+   first; nothing here works without it.
+3. **Agree a name + a price.** What do they want it called / how should it feel
+   (`onboard presets` for personalities + skills)? Agree the monthly price (see
+   **Pricing**).
+4. **Send the Stripe link.** `onboard checkout --email <e> [--price <usd>] [--code
+   <code>]` → `{ url, subdomain }`. Send the `url` verbatim and **stop** — never ask
+   for card numbers; Stripe collects payment on their device, and they tick the
+   terms box right there (share `onboard links` → `terms`/`privacy` if asked). The
+   subdomain is assigned for them.
+5. **Wait for the box.** Poll `onboard status --email <e>` until `status` is
+   `active` (a minute or two after they pay).
+6. **Create their agent.** `onboard create-agent --email <e> --name <name>
+   [--personality <preset>] [--skills a,b,c]`.
+7. **Connect their Claude — in chat.** `onboard claude-start --email <e>` returns an
+   `auth_url`. Send it; they open it, approve, and read back the code shown. Then
+   `onboard claude-finish --email <e> --code <pasted>` wakes the agent on their
+   Claude. (The link is safe to relay — the secret half of the exchange never leaves
+   their box, so the code is useless to anyone else.)
+8. **Hand them off.** Now — and only now — give them the app (`onboard links`):
+   sign in with their email (already verified), and their vesta `<name>` is right
+   there waiting.
 
 ## Pricing
 
@@ -100,8 +116,8 @@ negotiable **upward**, never below.
   AI of their own) — **anchor well above the floor.** $200, $1,000, $5,000/mo are
   all fair if the value and the want are there. Frame it as the price of admission
   to something scarce. There is no ceiling.
-- **Never below $24.** `onboard start --price` rejects anything under the floor, and
-  the server enforces it too.
+- **Never below $24.** `onboard checkout --price` rejects anything under the floor,
+  and the server enforces it too.
 - **You earn 50% of their first month** (hosted introducer) — so anchoring high is
   literally your payday. A $2,000 close earns you $1,000.
 
@@ -116,47 +132,64 @@ to look up or reveal; the code's value and effect live entirely on the server.
 
 ## Usage
 
+The flow is ordered — each command is one step (see **Setting them up**). Every
+command keys off the buyer's `--email`; their verified session is remembered
+between commands for you.
+
 ```bash
-onboard check <subdomain>                          # is them.vesta.run free?
-onboard start --email <e> --subdomain <s> [--price <usd/mo>] [--code <code>] \
-              [--name <n>] [--personality <preset>] [--skills a,b,c]
-                                                   # -> { url } private checkout link
-onboard status --subdomain <s>                     # have they joined yet?
-onboard presets                                    # personality presets + installable skills
-onboard links                                      # marketing + desktop/mobile install URLs
+onboard verify-send  --email <e>                       # email them a 6-digit code
+onboard verify       --email <e> --code <c>            # the code they read back -> their session
+onboard checkout     --email <e> [--price <usd/mo>] [--code <code>]
+                                                       # -> { url, subdomain }  (auto subdomain)
+onboard status       --email <e>                       # -> { status: reserved|active|... }
+onboard create-agent --email <e> --name <n> [--personality <preset>] [--skills a,b,c]
+onboard claude-start  --email <e>                      # -> { auth_url }  (send it to them)
+onboard claude-finish --email <e> --code <pasted> [--model opus|sonnet|haiku]
+onboard presets                                        # personalities + skills + models
+onboard links                                          # marketing + app install URLs
 ```
 
-All commands print **JSON** to stdout. `start` returns `{ "url": "https://checkout.stripe.com/..." }`
-— send that URL verbatim and stop. (There is no `--plan`: one plan, defaulted for you.)
+All commands print **JSON** to stdout. `checkout` returns `{ "url": "https://checkout.stripe.com/..." }`
+— send that URL verbatim and stop. (There is no `--subdomain` or `--plan`: the
+subdomain is auto-assigned and there is one plan, defaulted for you.)
 
 ### Examples
 
 ```bash
-onboard check ada
-# { "subdomain": "ada", "available": true }
+onboard verify-send --email ada@example.com
+# { "sent": true, "email": "ada@example.com" }
+onboard verify --email ada@example.com --code 123456
+# { "verified": true, "email": "ada@example.com" }
 
 # Someone who just wants in — the floor:
-onboard start --email ada@example.com --subdomain ada --name Ada --personality dry
-# { "url": "https://checkout.stripe.com/c/pay/cs_test_..." }   ($24/mo)
+onboard checkout --email ada@example.com
+# { "url": "https://checkout.stripe.com/c/pay/cs_test_...", "subdomain": "ada" }   ($24/mo)
 
 # A whale who fought to get in — anchor high (uncapped):
-onboard start --email vc@example.com --subdomain magnate --price 2000
-# { "url": "https://checkout.stripe.com/c/pay/cs_test_..." }   ($2,000/mo;
-# a hosted introducer earns 50% of month 1 = $1,000)
+onboard checkout --email vc@example.com --price 2000
+# { "url": "https://...", "subdomain": "vc" }   ($2,000/mo; you earn 50% of month 1 = $1,000)
 
 # Below the floor is rejected (the server enforces it too):
-onboard start --email x@example.com --subdomain x --price 5
-# { "error": "price $5 is below the pro floor of $24", "floor_usd": 24 }
+onboard checkout --email x@example.com --price 5
+# { "error": "price $5 is below the $24 floor", "floor_usd": 24 }
 
-onboard status --subdomain ada
-# { "subdomain": "ada", "status": "pending" }    (not in yet)
-# { "subdomain": "ada", "status": "signed_up" }  (they joined)
+onboard status --email ada@example.com
+# { "status": "reserved", ... }   (paid? provisioning? not active yet)
+# { "status": "active", "subdomain": "ada", "url": "https://ada.vesta.run" }   (box is up)
+
+# Once active: create the agent, then connect their Claude.
+onboard create-agent --email ada@example.com --name Ada --personality dry --skills email,calendar
+# { "created": true, "name": "Ada" }
+onboard claude-start --email ada@example.com
+# { "auth_url": "https://claude.ai/oauth/authorize?...", "next": "..." }
+onboard claude-finish --email ada@example.com --code <pasted-from-the-auth-page>
+# { "connected": true, "name": "Ada" }   -> now send them `onboard links` to sign in
 ```
 
 ## Referral attribution (automatic)
 
 If this vesta is hosted, its non-secret `referral_code` is read from the
-`VESTA_REFERRAL_CODE` environment variable and sent with `onboard start`, so a
+`VESTA_REFERRAL_CODE` environment variable and sent with `onboard checkout`, so a
 completed invite credits this account (you earn 50% of their first month). Unset
 (self-hosted) → it still works, just no reward. The CLI handles the code; you never
 touch it. Override for testing with `--referral <code>`.
@@ -164,9 +197,15 @@ touch it. Override for testing with `--referral <code>`.
 ## Caveats
 
 - **Never collect or relay card details.** Stripe handles payment on their device.
-- **Validate the subdomain before promising it** (`onboard check`) — lowercase
-  letters/digits/hyphens; some names are reserved.
-- **One link at a time.** Don't fan out parallel `onboard start` calls.
+- **The codes are theirs — relay, don't keep.** The email code and the Claude code
+  are the buyer's; pass each straight to the CLI and move on. Never store or reuse
+  them. The Claude auth *link* is safe to send (the secret half of the exchange
+  stays on their box), so connecting Claude in chat is fine.
+- **Paid Claude required (BYOK).** Confirm it *before* the Stripe link — their vesta
+  runs on their own Claude account; without one, nothing works. Don't take money first.
+- **Order matters, and one person at a time.** Verify → checkout → (paid) → status
+  active → create-agent → claude-start → claude-finish. Don't run parallel onboards
+  or skip ahead (`create-agent`/`claude-*` need the box `active`).
 - **Don't break character into a brochure.** The exclusivity only works if you hold
   the frame — link the marketing page (`onboard links`) instead of reciting features.
 - The control-plane base URL defaults to `https://vesta.run/api`; override with

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -84,10 +84,14 @@ and links between them and the CLI.
    (`onboard presets` for personalities + skills)? Agree the monthly price (see
    **Pricing**).
 4. **Send the Stripe link.** `onboard checkout --email <e> [--price <usd>] [--code
-   <code>]` → `{ url, subdomain }`. Send the `url` verbatim and **stop** — never ask
-   for card numbers; Stripe collects payment on their device, and they tick the
-   terms box right there (share `onboard links` → `terms`/`privacy` if asked). The
-   subdomain is assigned for them.
+   <code>]` → `{ url, subdomain }`. This is where invite-only is enforced: checkout
+   mints a one-time **invite** as YOU (the referring vesta) and redeems it for them,
+   so the spot is granted by you — that's also what credits you the referral. (If
+   this vesta has no minting credential, it errors; then the owner/operator hands
+   you a code to pass as `--invite <code>`.) Send the `url` verbatim and **stop** —
+   never ask for card numbers; Stripe collects payment on their device, and they
+   tick the terms box right there (share `onboard links` → `terms`/`privacy` if
+   asked). The subdomain is assigned for them.
 5. **Wait for the box.** Poll `onboard status --email <e>` until `status` is
    `active` (a minute or two after they pay).
 6. **Create their agent.** `onboard create-agent --email <e> --name <name>
@@ -139,8 +143,9 @@ between commands for you.
 ```bash
 onboard verify-send  --email <e>                       # email them a 6-digit code
 onboard verify       --email <e> --code <c>            # the code they read back -> their session
-onboard checkout     --email <e> [--price <usd/mo>] [--code <code>]
-                                                       # -> { url, subdomain }  (auto subdomain)
+onboard checkout     --email <e> [--price <usd/mo>] [--code <code>] [--invite <code>]
+                                                       # -> { url, subdomain }  (auto subdomain;
+                                                       #    mints your invite unless --invite given)
 onboard status       --email <e>                       # -> { status: reserved|active|... }
 onboard create-agent --email <e> --name <n> [--personality <preset>] [--skills a,b,c]
 onboard claude-start  --email <e>                      # -> { auth_url }  (send it to them)
@@ -186,13 +191,15 @@ onboard claude-finish --email ada@example.com --code <pasted-from-the-auth-page>
 # { "connected": true, "name": "Ada" }   -> now send them `onboard links` to sign in
 ```
 
-## Referral attribution (automatic)
+## Invites & referral attribution (automatic)
 
-If this vesta is hosted, its non-secret `referral_code` is read from the
-`VESTA_REFERRAL_CODE` environment variable and sent with `onboard checkout`, so a
-completed invite credits this account (you earn 50% of their first month). Unset
-(self-hosted) → it still works, just no reward. The CLI handles the code; you never
-touch it. Override for testing with `--referral <code>`.
+Vesta is invite-only as real access control: provisioning requires a one-time
+invite, and `onboard checkout` mints one as YOU and redeems it for the buyer. The
+mint is authenticated by this vesta's own secret (`VESTA_API_KEY`, or an operator
+`VESTA_ADMIN_SECRET`), read from the environment — you never touch it. A completed
+signup through your invite credits this account (you earn 50% of their first
+month). If no minting credential is present, checkout errors; the owner/operator
+can hand you a pre-minted code to pass as `--invite <code>`.
 
 ## Caveats
 

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -36,18 +36,19 @@ marketing page rather than reciting everything (`onboard links`).
 1. **Explain in a sentence or two.** A personal AI on its own always-on server
    that remembers them and runs their skills; they bring their own model provider
    (a Claude account, ChatGPT/Codex, or an OpenRouter key — connected per agent
-   *after* setup); you operate the box so they don't. Pricing is **$12 Starter /
-   $24 Pro / $48 Power per month** (annual = 2 months free). Quote real numbers;
-   don't invent discounts.
+   *after* setup); you operate the box so they don't. Pricing **starts at $12
+   Starter / $24 Pro / $48 Power per month** — see **Pricing & negotiation** below.
 2. **Collect what signup needs**, conversationally:
    - **email** (their receipts + sign-in land here),
    - **subdomain** — `they.vesta.run`. Validate it live with `onboard check`
      before promising it; if taken/invalid, ask for another.
    - **plan** — `starter` | `pro` | `power`.
+   - **a price** you both agree on (see **Pricing & negotiation**).
    - **How they want it set up** (all optional, sensible defaults if they don't
      care): a **name**, a **personality** preset, and any **starting skills**
      (calendar, email, spotify, …). See `onboard presets`.
-3. **Mint the checkout link** with `onboard start` and send it. Then **stop** —
+3. **Mint the checkout link** with `onboard start` (pass `--price` if you agreed
+   on a custom number) and send it. Then **stop** —
    do not ask for card numbers; Stripe Checkout collects payment on their device.
 4. **Wait for them to pay**, then poll `onboard status`. When it reports the
    subdomain is taken (signup went through), send the handoff: the dashboard at
@@ -58,15 +59,47 @@ marketing page rather than reciting everything (`onboard links`).
 
 Be a friendly introducer throughout. If they're not interested, drop it.
 
+## Pricing & negotiation
+
+The price is **dynamic and negotiable**. The published numbers are the **floor**,
+not a fixed tag:
+
+| Plan    | Floor (min/mo) | Ceiling   |
+| ------- | -------------- | --------- |
+| starter | $12            | uncapped  |
+| pro     | $24            | uncapped  |
+| power   | $48            | uncapped  |
+
+(Run `onboard presets` for the live floors in `plan_floor_usd`.)
+
+**How to price:**
+
+- **Suggest a number first**, then let them negotiate. Default to the floor for a
+  normal person — don't overthink it.
+- **Read the room and price to value.** If the prospect is clearly wealthy or
+  values it highly (a founder, an exec, "money's no object", a billionaire who
+  wants a concierge AI on its own box) — **anchor high**. There is no ceiling;
+  proposing $500, $2,000, even more per month is fair game if the value is there.
+  You can frame it as a tier of attention/priority. This is where the real upside
+  is, and (if your vesta is hosted) **you earn 50% of their first month** — so a
+  high close is a big referral reward.
+- **Never go below the plan floor.** `onboard start --price` rejects anything under
+  it; quote at or above it.
+- If they don't want to haggle, just use the floor — omit `--price`.
+
+Pass the agreed number as `--price <usd>` (a monthly figure). Omit it to charge the
+plan's list price.
+
 ## Usage
 
 ```bash
 onboard check <subdomain>                          # is they.vesta.run free?
 onboard start --email <e> --subdomain <s> --plan <starter|pro|power> \
+              [--price <usd/mo>] \
               [--name <n>] [--personality <preset>] [--skills a,b,c]
                                                    # -> { url } Stripe checkout link
 onboard status --subdomain <s>                     # did signup go through yet?
-onboard presets                                    # personality presets + installable skills
+onboard presets                                    # presets + installable skills + plan floors
 onboard links                                      # marketing + desktop/mobile install URLs
 ```
 
@@ -81,7 +114,16 @@ onboard check ada
 
 onboard start --email ada@example.com --subdomain ada --plan pro \
               --name Ada --personality dry --skills email-client,tasks
-# { "url": "https://checkout.stripe.com/c/pay/cs_test_..." }
+# { "url": "https://checkout.stripe.com/c/pay/cs_test_..." }   (list price)
+
+# High-balling a whale — anchor well above the floor (uncapped):
+onboard start --email vc@example.com --subdomain magnate --plan power --price 1500
+# { "url": "https://checkout.stripe.com/c/pay/cs_test_..." }   ($1,500/mo;
+# a hosted introducer earns 50% of month 1 = $750)
+
+# Below the floor is rejected (the API enforces it too):
+onboard start --email x@example.com --subdomain x --plan pro --price 5
+# { "error": "price $5 is below the pro floor of $24", "floor_usd": 24 }
 
 onboard status --subdomain ada
 # { "subdomain": "ada", "status": "pending" }   (still free → not signed up yet)

--- a/agent/skills/onboard/cli/pyproject.toml
+++ b/agent/skills/onboard/cli/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "onboard"
+version = "0.1.0"
+description = "Vesta onboarding CLI — introduce a stranger to Vesta and mint a signup checkout link (Component 9 growth loop)"
+readme = {text = "", content-type = "text/plain"}
+authors = [
+    { name = "elyxlz" }
+]
+requires-python = ">=3.11"
+dependencies = [
+    "requests>=2.31.0",
+]
+
+[project.scripts]
+onboard = "onboard_cli.cli:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/onboard_cli"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/agent/skills/onboard/cli/src/onboard_cli/__init__.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/__init__.py
@@ -1,7 +1,8 @@
 """Vesta onboarding CLI — the agent-side of the Component 9 growth loop.
 
-Calls the vesta-cloud control plane's public onboarding endpoints
-(`/api/onboard/check`, `/api/onboard/checkout`) to validate a subdomain and mint
-a Stripe Checkout link for a prospective new user, tagged with this vesta's
-referral code when it has one.
+Drives the whole conduit onboarding in steps: verify the buyer's email by a code
+they read back (yielding THE buyer's own session), reserve-and-checkout against the
+vesta-cloud control plane, then once their VM is live create their first agent and
+connect their Claude over vestad's PKCE OAuth. After the OTP every call is
+authorized by the buyer's session — never a cross-tenant credential.
 """

--- a/agent/skills/onboard/cli/src/onboard_cli/__init__.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/__init__.py
@@ -1,0 +1,7 @@
+"""Vesta onboarding CLI — the agent-side of the Component 9 growth loop.
+
+Calls the vesta-cloud control plane's public onboarding endpoints
+(`/api/onboard/check`, `/api/onboard/checkout`) to validate a subdomain and mint
+a Stripe Checkout link for a prospective new user, tagged with this vesta's
+referral code when it has one.
+"""

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -11,7 +11,6 @@ step is a subcommand; the buyer's verified session persists between invocations
 - ``onboard create-agent --email``   — create their first agent (name/personality/skills).
 - ``onboard claude-start --email``   — begin Claude connect -> an auth link.
 - ``onboard claude-finish --email``  — the code they paste back -> agent alive.
-- ``onboard claim-key --email``      — one-time owner setup: become an inviter.
 - ``onboard presets`` / ``onboard links`` — reference data.
 
 Output is always JSON on stdout. Exit codes: 0 success, 2 invalid input / surfaced
@@ -77,24 +76,10 @@ def _cmd_checkout(args: argparse.Namespace, client: Client, cfg: Config) -> int:
             return 2
         price = args.price
 
-    # Invite-only gate: use the explicit --invite, else mint one with this vesta's
-    # invite_key (VESTA_INVITE_KEY, claimed once via `onboard claim-key`). No
-    # credential and no --invite means this vesta isn't set up to invite yet.
-    invite = args.invite.strip() if args.invite else None
-    if not invite:
-        if not cfg.invite_credential:
-            _print({"error": "no invite: run `onboard claim-key` once + set VESTA_INVITE_KEY, or pass --invite <code> from the operator"})
-            return 2
-        minted = client.mint_invite(cfg.invite_credential)
-        if "code" not in minted:
-            _print(minted if "error" in minted else {"error": "could not mint an invite"})
-            return 2
-        invite = minted["code"]
-
     result = client.checkout(
         token=token,
         plan=args.plan,
-        invite=invite,
+        referral_code=args.referral or cfg.referral_code,
         price=price,
         code=(args.code.strip() if args.code else None),
     )
@@ -272,30 +257,6 @@ def _cmd_links(args: argparse.Namespace, client: Client, cfg: Config) -> int:
     return 0
 
 
-def _cmd_claim_key(args: argparse.Namespace, client: Client, cfg: Config) -> int:
-    """Owner becomes an inviter: claim an invite_key (one-time setup).
-
-    Run as the OWNER (verify the owner's email first). Prints the key to put in the
-    vestad config as VESTA_INVITE_KEY so this vesta can mint invites in chat.
-    """
-    email = _email(args)
-    token = state.token_for(email)
-    if not token:
-        _print({"error": "not verified — run `onboard verify` as the owner first"})
-        return 2
-    result = client.claim_inviter_key(token)
-    if "invite_key" not in result:
-        _print(result if "error" in result else {"error": "could not claim an invite key"})
-        return 2
-    _print(
-        {
-            "invite_key": result["invite_key"],
-            "next": "set VESTA_INVITE_KEY=<this> in your vestad config so your vesta can invite people",
-        }
-    )
-    return 0
-
-
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="onboard",
@@ -316,10 +277,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p_checkout.add_argument("--plan", default="pro", help=argparse.SUPPRESS)
     p_checkout.add_argument("--price", type=float, help="Negotiated MONTHLY USD (>= the floor; uncapped above).")
     p_checkout.add_argument("--code", help="Optional discount code to redeem at checkout.")
-    p_checkout.add_argument(
-        "--invite",
-        help="One-time invite code. Omit to mint one as the referrer (needs VESTA_API_KEY).",
-    )
+    p_checkout.add_argument("--referral", help="Override the referral code (defaults to $VESTA_REFERRAL_CODE).")
 
     p_status = sub.add_parser("status", help="Has the buyer paid + the VM come up?")
     p_status.add_argument("--email", required=True)
@@ -338,9 +296,6 @@ def _build_parser() -> argparse.ArgumentParser:
     p_cfinish.add_argument("--code", required=True, help="The code the buyer pasted from the auth page.")
     p_cfinish.add_argument("--name", help="Agent name (defaults to the one from create-agent).")
     p_cfinish.add_argument("--model", help=f"Claude model (default {DEFAULT_MODEL}).")
-
-    p_claim = sub.add_parser("claim-key", help="One-time: become an inviter (run as the owner).")
-    p_claim.add_argument("--email", required=True, help="The OWNER's email (verify it first).")
 
     sub.add_parser("presets", help="Personality presets + installable skills + models.")
     sub.add_parser("links", help="Marketing + desktop/mobile install URLs.")
@@ -361,7 +316,6 @@ def main(argv: list[str] | None = None) -> int:
         "create-agent": _cmd_create_agent,
         "claude-start": _cmd_claude_start,
         "claude-finish": _cmd_claude_finish,
-        "claim-key": _cmd_claim_key,
         "presets": _cmd_presets,
         "links": _cmd_links,
     }

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -50,6 +50,9 @@ def _cmd_verify_send(args: argparse.Namespace, client: Client, cfg: Config) -> i
 def _cmd_verify(args: argparse.Namespace, client: Client, cfg: Config) -> int:
     email = _email(args)
     token = client.verify_otp(email, args.code.strip())
+    if not token:
+        _print({"error": "wrong or expired code — ask them to re-read it (or resend)"})
+        return 2
     state.update(email, token=token)
     _print({"verified": True, "email": email})
     return 0
@@ -139,8 +142,11 @@ def _cmd_create_agent(args: argparse.Namespace, client: Client, cfg: Config) -> 
     if "error" in result:
         _print(result)
         return 2
-    state.update(email, agent_name=name)
-    _print({"created": True, "name": result.get("name", name)})
+    # vestad normalizes the name (lowercases/strips); store what it ACTUALLY created
+    # so claude-finish addresses /agents/<name>/provider with a name that validates.
+    created_name = result.get("name", name)
+    state.update(email, agent_name=created_name)
+    _print({"created": True, "name": created_name})
     return 0
 
 
@@ -192,6 +198,10 @@ def _cmd_claude_finish(args: argparse.Namespace, client: Client, cfg: Config) ->
         session_id=session_id,
         code=args.code.strip(),
     )
+    # The OAuth session is single-use and now consumed on the VM; forget it so a
+    # retry can't re-post a spent session_id (which vestad rejects). If the attach
+    # below fails the buyer must restart with claude-start.
+    state.forget(email, "claude_session_id")
     result = client.set_provider(
         subdomain=server["subdomain"],
         server_token=server_token,
@@ -200,7 +210,9 @@ def _cmd_claude_finish(args: argparse.Namespace, client: Client, cfg: Config) ->
         model=(args.model or DEFAULT_MODEL),
     )
     if "error" in result:
-        _print(result)
+        _print(
+            {"error": f"authorized on Anthropic's side but attaching it failed ({result['error']}); run `onboard claude-start` again to retry"}
+        )
         return 2
     # Onboarding complete — forget the buyer's session token.
     state.clear(email)

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -1,15 +1,20 @@
-"""``onboard`` CLI entry point.
+"""``onboard`` CLI entry point — the conduit onboarding flow.
 
-Subcommands:
-- ``onboard check <subdomain>``   — is they.vesta.run free?
-- ``onboard start ...``           — reserve + mint a Stripe Checkout link.
-- ``onboard status --subdomain``  — has signup gone through yet?
-- ``onboard presets``             — personality presets + installable skills.
-- ``onboard links``               — marketing + install URLs.
+The agent (an existing member's vesta) walks a stranger in, in conversation. Each
+step is a subcommand; the buyer's verified session persists between invocations
+(`state.py`), so after the OTP the CLI acts AS the buyer:
 
-Output is always JSON on stdout; human-readable errors go through the same JSON
-(`{"error": ...}`). Exit codes: 0 success, 2 invalid input, 3 control-plane
-unreachable/error, 1 unexpected.
+- ``onboard verify-send --email``    — email the buyer a 6-digit code.
+- ``onboard verify --email --code``  — the code they read back -> their session.
+- ``onboard checkout --email``       — reserve + mint a Stripe link (auto subdomain).
+- ``onboard status --email``         — has the VM come up yet?
+- ``onboard create-agent --email``   — create their first agent (name/personality/skills).
+- ``onboard claude-start --email``   — begin Claude connect -> an auth link.
+- ``onboard claude-finish --email``  — the code they paste back -> agent alive.
+- ``onboard presets`` / ``onboard links`` — reference data.
+
+Output is always JSON on stdout. Exit codes: 0 success, 2 invalid input / surfaced
+{error}, 3 control-plane/vestad unreachable, 1 unexpected.
 """
 
 from __future__ import annotations
@@ -19,78 +24,191 @@ import json
 from pathlib import Path
 from typing import Any
 
+from . import state
 from .client import Client, OnboardError
-from .config import LINKS, PERSONALITY_PRESETS, PLAN_FLOOR_USD, PLANS, Config
+from .config import DEFAULT_MODEL, LINKS, PERSONALITY_PRESETS, PLAN_FLOOR_USD, PLANS, Config
 
 
 def _print(payload: dict[str, Any]) -> None:
     print(json.dumps(payload, indent=2, ensure_ascii=False))
 
 
-def _cmd_check(args: argparse.Namespace, client: Client, cfg: Config) -> int:
-    _print(client.check(args.subdomain.strip().lower()))
+def _email(args: argparse.Namespace) -> str:
+    return args.email.strip().lower()
+
+
+# --- auth -------------------------------------------------------------------
+
+
+def _cmd_verify_send(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    email = _email(args)
+    client.send_otp(email)
+    _print({"sent": True, "email": email})
     return 0
 
 
-def _cmd_start(args: argparse.Namespace, client: Client, cfg: Config) -> int:
-    plan = args.plan.strip().lower()
-    if plan not in PLANS:
-        _print({"error": f"plan must be one of {', '.join(PLANS)}"})
+def _cmd_verify(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    email = _email(args)
+    token = client.verify_otp(email, args.code.strip())
+    state.update(email, token=token)
+    _print({"verified": True, "email": email})
+    return 0
+
+
+# --- checkout + status ------------------------------------------------------
+
+
+def _cmd_checkout(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    email = _email(args)
+    token = state.token_for(email)
+    if not token:
+        _print({"error": "not verified — run `onboard verify` with the buyer's code first"})
         return 2
-    # Negotiated price (optional). Floor = the plan's list price; uncapped above.
+
     price: float | None = None
     if args.price is not None:
-        floor = PLAN_FLOOR_USD[plan]
+        floor = PLAN_FLOOR_USD[args.plan]
         if args.price < floor:
-            _print(
-                {
-                    "error": f"price ${args.price:g} is below the {plan} floor of ${floor}",
-                    "floor_usd": floor,
-                }
-            )
+            _print({"error": f"price ${args.price:g} is below the ${floor} floor", "floor_usd": floor})
             return 2
         price = args.price
-    seed: dict[str, Any] = {}
-    if args.name:
-        seed["name"] = args.name.strip()
-    if args.personality:
-        seed["personality"] = args.personality.strip().lower()
-    if args.skills:
-        skills = [s.strip() for s in args.skills.split(",") if s.strip()]
-        if skills:
-            seed["skills"] = skills
+
     result = client.checkout(
-        email=args.email.strip(),
-        subdomain=args.subdomain.strip().lower(),
-        plan=plan,
-        seed=seed or None,
-        # explicit --referral wins; otherwise the env-derived code (hosted only)
+        token=token,
+        plan=args.plan,
         referral_code=args.referral or cfg.referral_code,
         price=price,
         code=(args.code.strip() if args.code else None),
     )
+    if "url" in result:
+        # Stash the assigned subdomain + server id so later steps don't re-derive them.
+        me = client.me(token)
+        server = me.get("server") or {}
+        state.update(email, subdomain=result.get("subdomain"), server_id=server.get("id"))
     _print(result)
-    # A structured {error} (taken/rate-limited) is a normal, surfaced outcome.
     return 0 if "url" in result else 2
 
 
 def _cmd_status(args: argparse.Namespace, client: Client, cfg: Config) -> int:
-    """No dedicated status endpoint exists; infer from subdomain availability.
-
-    Free (available) → nobody has signed up with it yet (`pending`); taken →
-    signup went through (`signed_up`). This is the signal the introducer needs:
-    "did they complete checkout?".
-    """
-    res = client.check(args.subdomain.strip().lower())
-    sub = res.get("subdomain", args.subdomain)
-    if res.get("available") is True:
-        status = "pending"
-    elif res.get("reason") == "taken":
-        status = "signed_up"
-    else:
-        status = res.get("reason", "unknown")
-    _print({"subdomain": sub, "status": status})
+    email = _email(args)
+    token = state.token_for(email)
+    if not token:
+        _print({"error": "not verified — run `onboard verify` first"})
+        return 2
+    server = client.me(token).get("server")
+    if not server:
+        _print({"status": "no_server", "hint": "run `onboard checkout` and have them pay"})
+        return 0
+    state.update(email, subdomain=server.get("subdomain"), server_id=server.get("id"))
+    _print({"status": server.get("status"), "subdomain": server.get("subdomain"), "url": server.get("url")})
     return 0
+
+
+# --- agent + Claude ---------------------------------------------------------
+
+
+def _active_server(client: Client, token: str) -> dict[str, Any] | None:
+    """The buyer's server iff it is live (`active`), else None."""
+    server = client.me(token).get("server")
+    if server and server.get("status") == "active":
+        return server
+    return None
+
+
+def _cmd_create_agent(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    email = _email(args)
+    token = state.token_for(email)
+    if not token:
+        _print({"error": "not verified — run `onboard verify` first"})
+        return 2
+    server = _active_server(client, token)
+    if not server:
+        _print({"error": "server not ready yet — poll `onboard status` until it is active"})
+        return 2
+
+    name = args.name.strip()
+    skills = [s.strip() for s in args.skills.split(",") if s.strip()] if args.skills else None
+    server_token = client.server_token(token, server["id"])
+    result = client.create_agent(
+        subdomain=server["subdomain"],
+        server_token=server_token,
+        name=name,
+        personality=(args.personality.strip().lower() if args.personality else None),
+        skills=skills,
+    )
+    if "error" in result:
+        _print(result)
+        return 2
+    state.update(email, agent_name=name)
+    _print({"created": True, "name": result.get("name", name)})
+    return 0
+
+
+def _cmd_claude_start(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    email = _email(args)
+    token = state.token_for(email)
+    if not token:
+        _print({"error": "not verified — run `onboard verify` first"})
+        return 2
+    server = _active_server(client, token)
+    if not server:
+        _print({"error": "server not ready yet — poll `onboard status` until it is active"})
+        return 2
+
+    server_token = client.server_token(token, server["id"])
+    result = client.claude_oauth_start(subdomain=server["subdomain"], server_token=server_token)
+    if "error" in result:
+        _print(result)
+        return 2
+    state.update(email, claude_session_id=result["session_id"])
+    _print({"auth_url": result["auth_url"], "next": "have them open it, approve, and read the code back"})
+    return 0
+
+
+def _cmd_claude_finish(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    email = _email(args)
+    token = state.token_for(email)
+    if not token:
+        _print({"error": "not verified — run `onboard verify` first"})
+        return 2
+    st = state.load(email)
+    session_id = st.get("claude_session_id")
+    if not session_id:
+        _print({"error": "no Claude auth in progress — run `onboard claude-start` first"})
+        return 2
+    name = args.name.strip() if args.name else st.get("agent_name")
+    if not name:
+        _print({"error": "unknown agent name — pass --name (the one used in create-agent)"})
+        return 2
+    server = _active_server(client, token)
+    if not server:
+        _print({"error": "server not ready yet — poll `onboard status` until it is active"})
+        return 2
+
+    server_token = client.server_token(token, server["id"])
+    credentials = client.claude_oauth_complete(
+        subdomain=server["subdomain"],
+        server_token=server_token,
+        session_id=session_id,
+        code=args.code.strip(),
+    )
+    result = client.set_provider(
+        subdomain=server["subdomain"],
+        server_token=server_token,
+        name=name,
+        credentials=credentials,
+        model=(args.model or DEFAULT_MODEL),
+    )
+    if "error" in result:
+        _print(result)
+        return 2
+    # Onboarding complete — forget the buyer's session token.
+    state.clear(email)
+    _print({"connected": True, "name": name})
+    return 0
+
+
+# --- reference data ---------------------------------------------------------
 
 
 def _installable_skills() -> list[str]:
@@ -115,8 +233,8 @@ def _cmd_presets(args: argparse.Namespace, client: Client, cfg: Config) -> int:
             "personalities": list(PERSONALITY_PRESETS),
             "skills": _installable_skills(),
             "plans": list(PLANS),
-            # Negotiation floor (USD/mo) per plan; quote >= these, uncapped above.
             "plan_floor_usd": PLAN_FLOOR_USD,
+            "claude_models": ["opus", "sonnet", "haiku"],
         }
     )
     return 0
@@ -130,34 +248,44 @@ def _cmd_links(args: argparse.Namespace, client: Client, cfg: Config) -> int:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="onboard",
-        description="Introduce a stranger to Vesta and mint a signup checkout link.",
+        description="Walk a stranger into Vesta: verify, checkout, create + connect their agent.",
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
-    p_check = sub.add_parser("check", help="Is a subdomain available?")
-    p_check.add_argument("subdomain", help="The desired <name>.vesta.run label.")
+    p_send = sub.add_parser("verify-send", help="Email the buyer a 6-digit sign-in code.")
+    p_send.add_argument("--email", required=True, help="The buyer's email.")
 
-    p_start = sub.add_parser("start", help="Reserve + mint a Stripe Checkout link.")
-    p_start.add_argument("--email", required=True, help="Prospective member's email.")
-    p_start.add_argument("--subdomain", required=True, help="Desired <name>.vesta.run label.")
-    # One plan today (the standard box, cx33). Kept as a hidden knob defaulting to
-    # `pro` so the plumbing supports more tiers later without the agent picking one.
-    p_start.add_argument("--plan", default="pro", help=argparse.SUPPRESS)
-    p_start.add_argument("--name", help="Optional agent name to seed at first boot.")
-    p_start.add_argument("--personality", help="Optional personality preset (see `onboard presets`).")
-    p_start.add_argument("--skills", help="Optional comma-separated starting skills.")
-    p_start.add_argument(
-        "--price",
-        type=float,
-        help="Negotiated MONTHLY price in USD. Floor = plan list price; uncapped above. Omit for list price.",
-    )
-    p_start.add_argument("--referral", help="Override the referral code (defaults to $VESTA_REFERRAL_CODE).")
-    p_start.add_argument("--code", help="Optional discount code to redeem at checkout (e.g. a 50%%-off invite code).")
+    p_verify = sub.add_parser("verify", help="Verify the code the buyer reads back.")
+    p_verify.add_argument("--email", required=True)
+    p_verify.add_argument("--code", required=True, help="The 6-digit code from their inbox.")
 
-    p_status = sub.add_parser("status", help="Has signup gone through yet?")
-    p_status.add_argument("--subdomain", required=True, help="The subdomain to check.")
+    p_checkout = sub.add_parser("checkout", help="Reserve + mint a Stripe link (auto subdomain).")
+    p_checkout.add_argument("--email", required=True)
+    # One plan today; hidden knob defaulting to `pro` so more tiers can slot in later.
+    p_checkout.add_argument("--plan", default="pro", help=argparse.SUPPRESS)
+    p_checkout.add_argument("--price", type=float, help="Negotiated MONTHLY USD (>= the floor; uncapped above).")
+    p_checkout.add_argument("--code", help="Optional discount code to redeem at checkout.")
+    p_checkout.add_argument("--referral", help="Override the referral code (defaults to $VESTA_REFERRAL_CODE).")
 
-    sub.add_parser("presets", help="Personality presets + installable skills.")
+    p_status = sub.add_parser("status", help="Has the buyer paid + the VM come up?")
+    p_status.add_argument("--email", required=True)
+
+    p_agent = sub.add_parser("create-agent", help="Create the buyer's first agent.")
+    p_agent.add_argument("--email", required=True)
+    p_agent.add_argument("--name", required=True, help="What they want their vesta called.")
+    p_agent.add_argument("--personality", help="Personality preset (see `onboard presets`).")
+    p_agent.add_argument("--skills", help="Comma-separated starting skills.")
+
+    p_cstart = sub.add_parser("claude-start", help="Begin connecting the buyer's Claude -> an auth link.")
+    p_cstart.add_argument("--email", required=True)
+
+    p_cfinish = sub.add_parser("claude-finish", help="Finish Claude connect with the pasted code.")
+    p_cfinish.add_argument("--email", required=True)
+    p_cfinish.add_argument("--code", required=True, help="The code the buyer pasted from the auth page.")
+    p_cfinish.add_argument("--name", help="Agent name (defaults to the one from create-agent).")
+    p_cfinish.add_argument("--model", help=f"Claude model (default {DEFAULT_MODEL}).")
+
+    sub.add_parser("presets", help="Personality presets + installable skills + models.")
     sub.add_parser("links", help="Marketing + desktop/mobile install URLs.")
     return parser
 
@@ -169,9 +297,13 @@ def main(argv: list[str] | None = None) -> int:
     client = Client(cfg)
 
     handlers = {
-        "check": _cmd_check,
-        "start": _cmd_start,
+        "verify-send": _cmd_verify_send,
+        "verify": _cmd_verify,
+        "checkout": _cmd_checkout,
         "status": _cmd_status,
+        "create-agent": _cmd_create_agent,
+        "claude-start": _cmd_claude_start,
+        "claude-finish": _cmd_claude_finish,
         "presets": _cmd_presets,
         "links": _cmd_links,
     }

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -76,10 +76,24 @@ def _cmd_checkout(args: argparse.Namespace, client: Client, cfg: Config) -> int:
             return 2
         price = args.price
 
+    # Invite-only gate: use the explicit --invite, else mint one as the referrer
+    # (server-to-server, via the api_key/admin secret in the env). No credential and
+    # no --invite means this vesta can't extend invites.
+    invite = args.invite.strip() if args.invite else None
+    if not invite:
+        if not cfg.invite_credential:
+            _print({"error": "no invite: set VESTA_API_KEY (this vesta's key) to mint one, or pass --invite <code> from the operator"})
+            return 2
+        minted = client.mint_invite(cfg.invite_credential)
+        if "code" not in minted:
+            _print(minted if "error" in minted else {"error": "could not mint an invite"})
+            return 2
+        invite = minted["code"]
+
     result = client.checkout(
         token=token,
         plan=args.plan,
-        referral_code=args.referral or cfg.referral_code,
+        invite=invite,
         price=price,
         code=(args.code.strip() if args.code else None),
     )
@@ -277,7 +291,10 @@ def _build_parser() -> argparse.ArgumentParser:
     p_checkout.add_argument("--plan", default="pro", help=argparse.SUPPRESS)
     p_checkout.add_argument("--price", type=float, help="Negotiated MONTHLY USD (>= the floor; uncapped above).")
     p_checkout.add_argument("--code", help="Optional discount code to redeem at checkout.")
-    p_checkout.add_argument("--referral", help="Override the referral code (defaults to $VESTA_REFERRAL_CODE).")
+    p_checkout.add_argument(
+        "--invite",
+        help="One-time invite code. Omit to mint one as the referrer (needs VESTA_API_KEY).",
+    )
 
     p_status = sub.add_parser("status", help="Has the buyer paid + the VM come up?")
     p_status.add_argument("--email", required=True)

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -137,9 +137,11 @@ def _build_parser() -> argparse.ArgumentParser:
     p_check.add_argument("subdomain", help="The desired <name>.vesta.run label.")
 
     p_start = sub.add_parser("start", help="Reserve + mint a Stripe Checkout link.")
-    p_start.add_argument("--email", required=True, help="Prospective user's email.")
+    p_start.add_argument("--email", required=True, help="Prospective member's email.")
     p_start.add_argument("--subdomain", required=True, help="Desired <name>.vesta.run label.")
-    p_start.add_argument("--plan", required=True, help=f"One of: {', '.join(PLANS)}.")
+    # One plan today (the standard box, cx33). Kept as a hidden knob defaulting to
+    # `pro` so the plumbing supports more tiers later without the agent picking one.
+    p_start.add_argument("--plan", default="pro", help=argparse.SUPPRESS)
     p_start.add_argument("--name", help="Optional agent name to seed at first boot.")
     p_start.add_argument("--personality", help="Optional personality preset (see `onboard presets`).")
     p_start.add_argument("--skills", help="Optional comma-separated starting skills.")

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -1,0 +1,168 @@
+"""``onboard`` CLI entry point.
+
+Subcommands:
+- ``onboard check <subdomain>``   — is they.vesta.run free?
+- ``onboard start ...``           — reserve + mint a Stripe Checkout link.
+- ``onboard status --subdomain``  — has signup gone through yet?
+- ``onboard presets``             — personality presets + installable skills.
+- ``onboard links``               — marketing + install URLs.
+
+Output is always JSON on stdout; human-readable errors go through the same JSON
+(`{"error": ...}`). Exit codes: 0 success, 2 invalid input, 3 control-plane
+unreachable/error, 1 unexpected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from .client import Client, OnboardError
+from .config import LINKS, PERSONALITY_PRESETS, PLANS, Config
+
+
+def _print(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+def _cmd_check(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    _print(client.check(args.subdomain.strip().lower()))
+    return 0
+
+
+def _cmd_start(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    plan = args.plan.strip().lower()
+    if plan not in PLANS:
+        _print({"error": f"plan must be one of {', '.join(PLANS)}"})
+        return 2
+    seed: dict[str, Any] = {}
+    if args.name:
+        seed["name"] = args.name.strip()
+    if args.personality:
+        seed["personality"] = args.personality.strip().lower()
+    if args.skills:
+        skills = [s.strip() for s in args.skills.split(",") if s.strip()]
+        if skills:
+            seed["skills"] = skills
+    result = client.checkout(
+        email=args.email.strip(),
+        subdomain=args.subdomain.strip().lower(),
+        plan=plan,
+        seed=seed or None,
+        # explicit --referral wins; otherwise the env-derived code (hosted only)
+        referral_code=args.referral or cfg.referral_code,
+    )
+    _print(result)
+    # A structured {error} (taken/rate-limited) is a normal, surfaced outcome.
+    return 0 if "url" in result else 2
+
+
+def _cmd_status(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    """No dedicated status endpoint exists; infer from subdomain availability.
+
+    Free (available) → nobody has signed up with it yet (`pending`); taken →
+    signup went through (`signed_up`). This is the signal the introducer needs:
+    "did they complete checkout?".
+    """
+    res = client.check(args.subdomain.strip().lower())
+    sub = res.get("subdomain", args.subdomain)
+    if res.get("available") is True:
+        status = "pending"
+    elif res.get("reason") == "taken":
+        status = "signed_up"
+    else:
+        status = res.get("reason", "unknown")
+    _print({"subdomain": sub, "status": status})
+    return 0
+
+
+def _installable_skills() -> list[str]:
+    """Best-effort list of skill names from the on-box skills index."""
+    for p in (
+        Path.home() / "agent" / "skills" / "index.json",
+        Path("/root/agent/skills/index.json"),
+        Path(__file__).resolve().parents[4] / "index.json",
+    ):
+        try:
+            if p.exists():
+                data = json.loads(p.read_text())
+                return sorted(s.get("name", "") for s in data if s.get("name"))
+        except (OSError, ValueError):
+            continue
+    return []
+
+
+def _cmd_presets(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    _print(
+        {
+            "personalities": list(PERSONALITY_PRESETS),
+            "skills": _installable_skills(),
+            "plans": list(PLANS),
+        }
+    )
+    return 0
+
+
+def _cmd_links(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    _print(LINKS)
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="onboard",
+        description="Introduce a stranger to Vesta and mint a signup checkout link.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_check = sub.add_parser("check", help="Is a subdomain available?")
+    p_check.add_argument("subdomain", help="The desired <name>.vesta.run label.")
+
+    p_start = sub.add_parser("start", help="Reserve + mint a Stripe Checkout link.")
+    p_start.add_argument("--email", required=True, help="Prospective user's email.")
+    p_start.add_argument("--subdomain", required=True, help="Desired <name>.vesta.run label.")
+    p_start.add_argument("--plan", required=True, help=f"One of: {', '.join(PLANS)}.")
+    p_start.add_argument("--name", help="Optional agent name to seed at first boot.")
+    p_start.add_argument("--personality", help="Optional personality preset (see `onboard presets`).")
+    p_start.add_argument("--skills", help="Optional comma-separated starting skills.")
+    p_start.add_argument("--referral", help="Override the referral code (defaults to $VESTA_REFERRAL_CODE).")
+
+    p_status = sub.add_parser("status", help="Has signup gone through yet?")
+    p_status.add_argument("--subdomain", required=True, help="The subdomain to check.")
+
+    sub.add_parser("presets", help="Personality presets + installable skills.")
+    sub.add_parser("links", help="Marketing + desktop/mobile install URLs.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    cfg = Config.load()
+    client = Client(cfg)
+
+    handlers = {
+        "check": _cmd_check,
+        "start": _cmd_start,
+        "status": _cmd_status,
+        "presets": _cmd_presets,
+        "links": _cmd_links,
+    }
+    handler = handlers[args.command]
+    try:
+        return handler(args, client, cfg)
+    except OnboardError as e:
+        _print({"error": str(e)})
+        return 3
+    except KeyboardInterrupt:
+        _print({"error": "interrupted"})
+        return 130
+    except Exception as e:  # last-resort net so the CLI never explodes raw
+        _print({"error": type(e).__name__, "message": str(e)})
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -67,6 +67,7 @@ def _cmd_start(args: argparse.Namespace, client: Client, cfg: Config) -> int:
         # explicit --referral wins; otherwise the env-derived code (hosted only)
         referral_code=args.referral or cfg.referral_code,
         price=price,
+        code=(args.code.strip() if args.code else None),
     )
     _print(result)
     # A structured {error} (taken/rate-limited) is a normal, surfaced outcome.
@@ -151,6 +152,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Negotiated MONTHLY price in USD. Floor = plan list price; uncapped above. Omit for list price.",
     )
     p_start.add_argument("--referral", help="Override the referral code (defaults to $VESTA_REFERRAL_CODE).")
+    p_start.add_argument("--code", help="Optional discount code to redeem at checkout (e.g. a 50%%-off invite code).")
 
     p_status = sub.add_parser("status", help="Has signup gone through yet?")
     p_status.add_argument("--subdomain", required=True, help="The subdomain to check.")

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from .client import Client, OnboardError
-from .config import LINKS, PERSONALITY_PRESETS, PLANS, Config
+from .config import LINKS, PERSONALITY_PRESETS, PLAN_FLOOR_USD, PLANS, Config
 
 
 def _print(payload: dict[str, Any]) -> None:
@@ -37,6 +37,19 @@ def _cmd_start(args: argparse.Namespace, client: Client, cfg: Config) -> int:
     if plan not in PLANS:
         _print({"error": f"plan must be one of {', '.join(PLANS)}"})
         return 2
+    # Negotiated price (optional). Floor = the plan's list price; uncapped above.
+    price: float | None = None
+    if args.price is not None:
+        floor = PLAN_FLOOR_USD[plan]
+        if args.price < floor:
+            _print(
+                {
+                    "error": f"price ${args.price:g} is below the {plan} floor of ${floor}",
+                    "floor_usd": floor,
+                }
+            )
+            return 2
+        price = args.price
     seed: dict[str, Any] = {}
     if args.name:
         seed["name"] = args.name.strip()
@@ -53,6 +66,7 @@ def _cmd_start(args: argparse.Namespace, client: Client, cfg: Config) -> int:
         seed=seed or None,
         # explicit --referral wins; otherwise the env-derived code (hosted only)
         referral_code=args.referral or cfg.referral_code,
+        price=price,
     )
     _print(result)
     # A structured {error} (taken/rate-limited) is a normal, surfaced outcome.
@@ -100,6 +114,8 @@ def _cmd_presets(args: argparse.Namespace, client: Client, cfg: Config) -> int:
             "personalities": list(PERSONALITY_PRESETS),
             "skills": _installable_skills(),
             "plans": list(PLANS),
+            # Negotiation floor (USD/mo) per plan; quote >= these, uncapped above.
+            "plan_floor_usd": PLAN_FLOOR_USD,
         }
     )
     return 0
@@ -127,6 +143,11 @@ def _build_parser() -> argparse.ArgumentParser:
     p_start.add_argument("--name", help="Optional agent name to seed at first boot.")
     p_start.add_argument("--personality", help="Optional personality preset (see `onboard presets`).")
     p_start.add_argument("--skills", help="Optional comma-separated starting skills.")
+    p_start.add_argument(
+        "--price",
+        type=float,
+        help="Negotiated MONTHLY price in USD. Floor = plan list price; uncapped above. Omit for list price.",
+    )
     p_start.add_argument("--referral", help="Override the referral code (defaults to $VESTA_REFERRAL_CODE).")
 
     p_status = sub.add_parser("status", help="Has signup gone through yet?")

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -11,6 +11,7 @@ step is a subcommand; the buyer's verified session persists between invocations
 - ``onboard create-agent --email``   — create their first agent (name/personality/skills).
 - ``onboard claude-start --email``   — begin Claude connect -> an auth link.
 - ``onboard claude-finish --email``  — the code they paste back -> agent alive.
+- ``onboard claim-key --email``      — one-time owner setup: become an inviter.
 - ``onboard presets`` / ``onboard links`` — reference data.
 
 Output is always JSON on stdout. Exit codes: 0 success, 2 invalid input / surfaced
@@ -76,13 +77,13 @@ def _cmd_checkout(args: argparse.Namespace, client: Client, cfg: Config) -> int:
             return 2
         price = args.price
 
-    # Invite-only gate: use the explicit --invite, else mint one as the referrer
-    # (server-to-server, via the api_key/admin secret in the env). No credential and
-    # no --invite means this vesta can't extend invites.
+    # Invite-only gate: use the explicit --invite, else mint one with this vesta's
+    # invite_key (VESTA_INVITE_KEY, claimed once via `onboard claim-key`). No
+    # credential and no --invite means this vesta isn't set up to invite yet.
     invite = args.invite.strip() if args.invite else None
     if not invite:
         if not cfg.invite_credential:
-            _print({"error": "no invite: set VESTA_API_KEY (this vesta's key) to mint one, or pass --invite <code> from the operator"})
+            _print({"error": "no invite: run `onboard claim-key` once + set VESTA_INVITE_KEY, or pass --invite <code> from the operator"})
             return 2
         minted = client.mint_invite(cfg.invite_credential)
         if "code" not in minted:
@@ -271,6 +272,30 @@ def _cmd_links(args: argparse.Namespace, client: Client, cfg: Config) -> int:
     return 0
 
 
+def _cmd_claim_key(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    """Owner becomes an inviter: claim an invite_key (one-time setup).
+
+    Run as the OWNER (verify the owner's email first). Prints the key to put in the
+    vestad config as VESTA_INVITE_KEY so this vesta can mint invites in chat.
+    """
+    email = _email(args)
+    token = state.token_for(email)
+    if not token:
+        _print({"error": "not verified — run `onboard verify` as the owner first"})
+        return 2
+    result = client.claim_inviter_key(token)
+    if "invite_key" not in result:
+        _print(result if "error" in result else {"error": "could not claim an invite key"})
+        return 2
+    _print(
+        {
+            "invite_key": result["invite_key"],
+            "next": "set VESTA_INVITE_KEY=<this> in your vestad config so your vesta can invite people",
+        }
+    )
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="onboard",
@@ -314,6 +339,9 @@ def _build_parser() -> argparse.ArgumentParser:
     p_cfinish.add_argument("--name", help="Agent name (defaults to the one from create-agent).")
     p_cfinish.add_argument("--model", help=f"Claude model (default {DEFAULT_MODEL}).")
 
+    p_claim = sub.add_parser("claim-key", help="One-time: become an inviter (run as the owner).")
+    p_claim.add_argument("--email", required=True, help="The OWNER's email (verify it first).")
+
     sub.add_parser("presets", help="Personality presets + installable skills + models.")
     sub.add_parser("links", help="Marketing + desktop/mobile install URLs.")
     return parser
@@ -333,6 +361,7 @@ def main(argv: list[str] | None = None) -> int:
         "create-agent": _cmd_create_agent,
         "claude-start": _cmd_claude_start,
         "claude-finish": _cmd_claude_finish,
+        "claim-key": _cmd_claim_key,
         "presets": _cmd_presets,
         "links": _cmd_links,
     }

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from . import state
 from .client import Client, OnboardError
-from .config import DEFAULT_MODEL, LINKS, PERSONALITY_PRESETS, PLAN_FLOOR_USD, PLANS, Config
+from .config import DEFAULT_MODEL, LINKS, PERSONALITY_PRESETS, PLAN, PLAN_FLOOR_USD, Config
 
 
 def _print(payload: dict[str, Any]) -> None:
@@ -70,24 +70,23 @@ def _cmd_checkout(args: argparse.Namespace, client: Client, cfg: Config) -> int:
 
     price: float | None = None
     if args.price is not None:
-        floor = PLAN_FLOOR_USD[args.plan]
-        if args.price < floor:
-            _print({"error": f"price ${args.price:g} is below the ${floor} floor", "floor_usd": floor})
+        if args.price < PLAN_FLOOR_USD:
+            _print({"error": f"price ${args.price:g} is below the ${PLAN_FLOOR_USD} floor", "floor_usd": PLAN_FLOOR_USD})
             return 2
         price = args.price
 
     result = client.checkout(
         token=token,
-        plan=args.plan,
+        plan=PLAN,
         referral_code=args.referral or cfg.referral_code,
         price=price,
         code=(args.code.strip() if args.code else None),
     )
     if "url" in result:
-        # Stash the assigned subdomain + server id so later steps don't re-derive them.
-        me = client.me(token)
-        server = me.get("server") or {}
-        state.update(email, subdomain=result.get("subdomain"), server_id=server.get("id"))
+        # Stash the assigned subdomain + server id (both returned by checkout) so
+        # later steps don't re-derive them; server_id is internal, so pop it out of
+        # the agent-facing output.
+        state.update(email, subdomain=result.get("subdomain"), server_id=result.pop("server_id", None))
     _print(result)
     return 0 if "url" in result else 2
 
@@ -244,7 +243,6 @@ def _cmd_presets(args: argparse.Namespace, client: Client, cfg: Config) -> int:
         {
             "personalities": list(PERSONALITY_PRESETS),
             "skills": _installable_skills(),
-            "plans": list(PLANS),
             "plan_floor_usd": PLAN_FLOOR_USD,
             "claude_models": ["opus", "sonnet", "haiku"],
         }
@@ -273,9 +271,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_checkout = sub.add_parser("checkout", help="Reserve + mint a Stripe link (auto subdomain).")
     p_checkout.add_argument("--email", required=True)
-    # One plan today; hidden knob defaulting to `pro` so more tiers can slot in later.
-    p_checkout.add_argument("--plan", default="pro", help=argparse.SUPPRESS)
-    p_checkout.add_argument("--price", type=float, help="Negotiated MONTHLY USD (>= the floor; uncapped above).")
+    p_checkout.add_argument("--price", type=float, help="Negotiated MONTHLY USD (>= the $24 floor; uncapped above).")
     p_checkout.add_argument("--code", help="Optional discount code to redeem at checkout.")
     p_checkout.add_argument("--referral", help="Override the referral code (defaults to $VESTA_REFERRAL_CODE).")
 

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -69,12 +69,21 @@ class Client:
 
     # --- control plane: onboarding (authed as the buyer) ---------------------
 
+    def claim_inviter_key(self, session_token: str) -> dict[str, Any]:
+        """POST /onboard/inviter -> {invite_key}. Become an inviter.
+
+        Authenticated by the OWNER's email-verified session. Works for hosted
+        members and self-hosters alike; the owner configures their vestad with the
+        returned key (VESTA_INVITE_KEY) so the agent can mint invites.
+        """
+        return self._json(self._post("/onboard/inviter", json={}, headers=self._auth(session_token)))
+
     def mint_invite(self, credential: str) -> dict[str, Any]:
         """POST /onboard/invite -> {code, expires_at}.
 
-        Authenticated as the REFERRER (server-to-server) by `credential` — the
-        referring vesta's per-VM api_key, or the operator admin secret. The invite
-        is the access gate + referral attribution that checkout requires.
+        Authenticated by `credential` — an `invite_key` (claimed via
+        claim_inviter_key) or the operator admin secret. The invite is the access
+        gate; its referral attribution is the key owner's paying server, if any.
         """
         return self._json(self._post("/onboard/invite", json={}, headers=self._auth(credential)))
 

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -69,43 +69,25 @@ class Client:
 
     # --- control plane: onboarding (authed as the buyer) ---------------------
 
-    def claim_inviter_key(self, session_token: str) -> dict[str, Any]:
-        """POST /onboard/inviter -> {invite_key}. Become an inviter.
-
-        Authenticated by the OWNER's email-verified session. Works for hosted
-        members and self-hosters alike; the owner configures their vestad with the
-        returned key (VESTA_INVITE_KEY) so the agent can mint invites.
-        """
-        return self._json(self._post("/onboard/inviter", json={}, headers=self._auth(session_token)))
-
-    def mint_invite(self, credential: str) -> dict[str, Any]:
-        """POST /onboard/invite -> {code, expires_at}.
-
-        Authenticated by `credential` — an `invite_key` (claimed via
-        claim_inviter_key) or the operator admin secret. The invite is the access
-        gate; its referral attribution is the key owner's paying server, if any.
-        """
-        return self._json(self._post("/onboard/invite", json={}, headers=self._auth(credential)))
-
     def checkout(
         self,
         *,
         token: str,
         plan: str,
-        invite: str,
+        referral_code: str | None,
         price: float | None,
         code: str | None,
     ) -> dict[str, Any]:
-        """POST /onboard/checkout -> {url, subdomain}. Auto-assigns the subdomain.
-
-        `invite` is REQUIRED (invite-only) and carries the referral attribution.
-        """
-        body: dict[str, Any] = {"plan": plan, "invite": invite}
+        """POST /onboard/checkout -> {url, subdomain}. Auto-assigns the subdomain."""
+        body: dict[str, Any] = {"plan": plan}
         if price is not None:
             body["price"] = price  # negotiated monthly USD; floor enforced server-side
         if code:
             body["code"] = code  # discount code; unknown -> {"error": "invalid code"}
-        return self._json(self._post("/onboard/checkout", json=body, headers=self._auth(token)))
+        headers = self._auth(token)
+        if referral_code:
+            headers["X-Vesta-Referral"] = referral_code
+        return self._json(self._post("/onboard/checkout", json=body, headers=headers))
 
     def me(self, token: str) -> dict[str, Any]:
         """GET /me -> {user, server}. `server` is null until checkout reserves one."""

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -1,9 +1,18 @@
-"""Thin HTTP client for the vesta-cloud onboarding endpoints.
+"""HTTP client for the onboard flow.
 
-Two real network calls, both public (no api_key): subdomain availability and the
-reserve-and-checkout that returns a Stripe Checkout URL. The referral code, when
-present, rides in the `X-Vesta-Referral` header exactly as the control plane
-expects (a non-secret, per-server attribution id).
+Two tiers of calls:
+
+* **Control plane** (`https://vesta.run/api`, Better Auth + onboarding):
+  send/verify the buyer's email OTP (which yields THE buyer's own session token),
+  reserve-and-checkout, read their server (`/me`), and mint a short-lived,
+  server-scoped vestad token (`/server-token`). Everything after the OTP is
+  authorized by the buyer's session — the conduit model — never a cross-tenant
+  credential, and the per-VM api_key never leaves the control plane.
+
+* **The buyer's vestad** (`https://<subdomain>.vesta.run`, Bearer = the minted
+  server-token): create their first agent and connect their Claude account via
+  vestad's standalone PKCE OAuth (the code_verifier stays on their box, so the
+  code they read back is useless to anyone else).
 """
 
 from __future__ import annotations
@@ -15,10 +24,12 @@ import requests
 from .config import Config
 
 _TIMEOUT = 20
+# Creating an agent pulls/builds the container image — can take a couple minutes.
+_CREATE_TIMEOUT = 300
 
 
 class OnboardError(Exception):
-    """A control-plane call failed (network, HTTP, or a structured API error)."""
+    """A control-plane / vestad call failed (network, HTTP, or structured error)."""
 
 
 class Client:
@@ -28,62 +39,182 @@ class Client:
     def _url(self, path: str) -> str:
         return f"{self._cfg.base_url}{path}"
 
-    def check(self, subdomain: str) -> dict[str, Any]:
-        """GET /api/onboard/check?subdomain=<s> -> {subdomain, available, reason?}."""
-        try:
-            resp = requests.get(
-                self._url("/onboard/check"),
-                params={"subdomain": subdomain},
-                timeout=_TIMEOUT,
-            )
-        except requests.RequestException as e:
-            raise OnboardError(f"could not reach the control plane: {e}") from e
+    # --- control plane: auth -------------------------------------------------
+
+    def send_otp(self, email: str) -> dict[str, Any]:
+        """POST /auth/email-otp/send-verification-otp — email the buyer a code."""
+        resp = self._post(
+            "/auth/email-otp/send-verification-otp",
+            json={"email": email, "type": "sign-in"},
+        )
         return self._json(resp)
+
+    def verify_otp(self, email: str, code: str) -> str:
+        """POST /auth/sign-in/email-otp — verify the code, return THE buyer's token.
+
+        Better Auth's `bearer` plugin returns the session token in the
+        `set-auth-token` response header (falling back to the body `token`).
+        """
+        resp = self._post(
+            "/auth/sign-in/email-otp",
+            json={"email": email, "otp": code},
+        )
+        data = self._json(resp)
+        token = resp.headers.get("set-auth-token") or data.get("token")
+        if not token:
+            raise OnboardError("verification did not return a session token")
+        return token
+
+    # --- control plane: onboarding (authed as the buyer) ---------------------
 
     def checkout(
         self,
         *,
-        email: str,
-        subdomain: str,
+        token: str,
         plan: str,
-        seed: dict[str, Any] | None,
         referral_code: str | None,
-        price: float | None = None,
-        code: str | None = None,
+        price: float | None,
+        code: str | None,
     ) -> dict[str, Any]:
-        """POST /api/onboard/checkout -> {url} (or 409 taken / 429 rate-limited)."""
-        body: dict[str, Any] = {"email": email, "subdomain": subdomain, "plan": plan}
-        if seed:
-            body["seed"] = seed
+        """POST /onboard/checkout -> {url, subdomain}. Auto-assigns the subdomain."""
+        body: dict[str, Any] = {"plan": plan}
         if price is not None:
-            # Negotiated MONTHLY price (USD). The control plane enforces the floor.
-            body["price"] = price
+            body["price"] = price  # negotiated monthly USD; floor enforced server-side
         if code:
-            # Optional discount code; the control plane maps it to a coupon and
-            # rejects an unknown one with {"error": "invalid code"}.
-            body["code"] = code
-        headers = {}
+            body["code"] = code  # discount code; unknown -> {"error": "invalid code"}
+        headers = self._auth(token)
         if referral_code:
             headers["X-Vesta-Referral"] = referral_code
-        try:
-            resp = requests.post(
-                self._url("/onboard/checkout"),
-                json=body,
-                headers=headers,
-                timeout=_TIMEOUT,
+        return self._json(self._post("/onboard/checkout", json=body, headers=headers))
+
+    def me(self, token: str) -> dict[str, Any]:
+        """GET /me -> {user, server}. `server` is null until checkout reserves one."""
+        return self._json(self._get("/me", headers=self._auth(token)))
+
+    def server_token(self, token: str, server_id: str) -> str:
+        """GET /server-token?server_id= -> a short-lived vestad access token."""
+        data = self._json(
+            self._get(
+                "/server-token",
+                params={"server_id": server_id},
+                headers=self._auth(token),
             )
+        )
+        access = data.get("access_token")
+        if not access:
+            raise OnboardError("control plane did not return a server token")
+        return access
+
+    # --- the buyer's vestad (Bearer = minted server-token) -------------------
+
+    def create_agent(
+        self,
+        *,
+        subdomain: str,
+        server_token: str,
+        name: str,
+        personality: str | None,
+        skills: list[str] | None,
+    ) -> dict[str, Any]:
+        """POST <tenant>/agents — create the buyer's first (empty) agent."""
+        body: dict[str, Any] = {"name": name}
+        if personality:
+            body["seed_personality"] = personality
+        if skills:
+            body["seed_skills"] = ",".join(skills)  # vestad wants a comma string
+        url = f"{self._cfg.tenant_base(subdomain)}/agents"
+        return self._json(self._raw_post(url, json=body, token=server_token, timeout=_CREATE_TIMEOUT))
+
+    def claude_oauth_start(self, *, subdomain: str, server_token: str) -> dict[str, Any]:
+        """POST <tenant>/providers/claude/oauth/start -> {auth_url, session_id}."""
+        url = f"{self._cfg.tenant_base(subdomain)}/providers/claude/oauth/start"
+        return self._json(self._raw_post(url, json={}, token=server_token))
+
+    def claude_oauth_complete(self, *, subdomain: str, server_token: str, session_id: str, code: str) -> str:
+        """POST <tenant>/providers/claude/oauth/complete -> the credentials blob."""
+        url = f"{self._cfg.tenant_base(subdomain)}/providers/claude/oauth/complete"
+        data = self._json(self._raw_post(url, json={"session_id": session_id, "code": code}, token=server_token))
+        creds = data.get("credentials")
+        if not creds:
+            raise OnboardError("OAuth completion returned no credentials")
+        return creds
+
+    def set_provider(
+        self,
+        *,
+        subdomain: str,
+        server_token: str,
+        name: str,
+        credentials: str,
+        model: str | None,
+    ) -> dict[str, Any]:
+        """POST <tenant>/agents/{name}/provider — attach Claude creds, agent wakes."""
+        body: dict[str, Any] = {"credentials": credentials}
+        if model:
+            body["model"] = model
+        url = f"{self._cfg.tenant_base(subdomain)}/agents/{name}/provider"
+        return self._json(self._raw_post(url, json=body, token=server_token, timeout=120))
+
+    # --- low-level helpers ---------------------------------------------------
+
+    @staticmethod
+    def _auth(token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {token}"}
+
+    def _get(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> requests.Response:
+        return self._send("GET", self._url(path), params=params, headers=headers)
+
+    def _post(
+        self,
+        path: str,
+        *,
+        json: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> requests.Response:
+        return self._send("POST", self._url(path), json=json, headers=headers)
+
+    def _raw_post(
+        self,
+        url: str,
+        *,
+        json: dict[str, Any],
+        token: str,
+        timeout: int = _TIMEOUT,
+    ) -> requests.Response:
+        return self._send("POST", url, json=json, headers=self._auth(token), timeout=timeout)
+
+    def _send(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: int = _TIMEOUT,
+    ) -> requests.Response:
+        try:
+            return requests.request(method, url, params=params, json=json, headers=headers, timeout=timeout)
         except requests.RequestException as e:
-            raise OnboardError(f"could not reach the control plane: {e}") from e
-        return self._json(resp)
+            raise OnboardError(f"could not reach {url}: {e}") from e
 
     @staticmethod
     def _json(resp: requests.Response) -> dict[str, Any]:
         try:
             data = resp.json()
         except ValueError:
-            raise OnboardError(f"control plane returned non-JSON ({resp.status_code}): {resp.text[:200]}") from None
+            raise OnboardError(f"non-JSON response ({resp.status_code}): {resp.text[:200]}") from None
         # 4xx bodies carry a structured {error} the skill should surface verbatim
-        # (e.g. "subdomain taken", "rate limited") rather than raise opaquely.
+        # (e.g. "rate limited", "invalid code", "already provisioned"); only a 5xx
+        # is an opaque failure worth raising.
         if resp.status_code >= 500:
-            raise OnboardError(f"control plane error {resp.status_code}: {data}")
+            raise OnboardError(f"server error {resp.status_code}: {data}")
+        if not isinstance(data, dict):
+            return {"result": data}
         return data

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -49,9 +49,12 @@ class Client:
         )
         return self._json(resp)
 
-    def verify_otp(self, email: str, code: str) -> str:
+    def verify_otp(self, email: str, code: str) -> str | None:
         """POST /auth/sign-in/email-otp — verify the code, return THE buyer's token.
 
+        Returns None when the code is wrong/expired (Better Auth answers 4xx with
+        `{message: "INVALID_OTP", ...}`, no token) so the CLI can surface a friendly
+        'wrong code' rather than treating it as the control plane being unreachable.
         Better Auth's `bearer` plugin returns the session token in the
         `set-auth-token` response header (falling back to the body `token`).
         """
@@ -59,11 +62,10 @@ class Client:
             "/auth/sign-in/email-otp",
             json={"email": email, "otp": code},
         )
-        data = self._json(resp)
-        token = resp.headers.get("set-auth-token") or data.get("token")
-        if not token:
-            raise OnboardError("verification did not return a session token")
-        return token
+        if 400 <= resp.status_code < 500:
+            return None  # invalid/expired code — a normal, surfaced outcome
+        data = self._json(resp)  # raises on 5xx (real transport/server failure)
+        return resp.headers.get("set-auth-token") or data.get("token")
 
     # --- control plane: onboarding (authed as the buyer) ---------------------
 

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -78,7 +78,7 @@ class Client:
         price: float | None,
         code: str | None,
     ) -> dict[str, Any]:
-        """POST /onboard/checkout -> {url, subdomain}. Auto-assigns the subdomain."""
+        """POST /onboard/checkout -> {url, subdomain, server_id}. Auto-assigns the subdomain."""
         body: dict[str, Any] = {"plan": plan}
         if price is not None:
             body["price"] = price  # negotiated monthly USD; floor enforced server-side

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -1,0 +1,80 @@
+"""Thin HTTP client for the vesta-cloud onboarding endpoints.
+
+Two real network calls, both public (no api_key): subdomain availability and the
+reserve-and-checkout that returns a Stripe Checkout URL. The referral code, when
+present, rides in the `X-Vesta-Referral` header exactly as the control plane
+expects (a non-secret, per-server attribution id).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+from .config import Config
+
+_TIMEOUT = 20
+
+
+class OnboardError(Exception):
+    """A control-plane call failed (network, HTTP, or a structured API error)."""
+
+
+class Client:
+    def __init__(self, config: Config) -> None:
+        self._cfg = config
+
+    def _url(self, path: str) -> str:
+        return f"{self._cfg.base_url}{path}"
+
+    def check(self, subdomain: str) -> dict[str, Any]:
+        """GET /api/onboard/check?subdomain=<s> -> {subdomain, available, reason?}."""
+        try:
+            resp = requests.get(
+                self._url("/onboard/check"),
+                params={"subdomain": subdomain},
+                timeout=_TIMEOUT,
+            )
+        except requests.RequestException as e:
+            raise OnboardError(f"could not reach the control plane: {e}") from e
+        return self._json(resp)
+
+    def checkout(
+        self,
+        *,
+        email: str,
+        subdomain: str,
+        plan: str,
+        seed: dict[str, Any] | None,
+        referral_code: str | None,
+    ) -> dict[str, Any]:
+        """POST /api/onboard/checkout -> {url} (or 409 taken / 429 rate-limited)."""
+        body: dict[str, Any] = {"email": email, "subdomain": subdomain, "plan": plan}
+        if seed:
+            body["seed"] = seed
+        headers = {}
+        if referral_code:
+            headers["X-Vesta-Referral"] = referral_code
+        try:
+            resp = requests.post(
+                self._url("/onboard/checkout"),
+                json=body,
+                headers=headers,
+                timeout=_TIMEOUT,
+            )
+        except requests.RequestException as e:
+            raise OnboardError(f"could not reach the control plane: {e}") from e
+        return self._json(resp)
+
+    @staticmethod
+    def _json(resp: requests.Response) -> dict[str, Any]:
+        try:
+            data = resp.json()
+        except ValueError:
+            raise OnboardError(f"control plane returned non-JSON ({resp.status_code}): {resp.text[:200]}") from None
+        # 4xx bodies carry a structured {error} the skill should surface verbatim
+        # (e.g. "subdomain taken", "rate limited") rather than raise opaquely.
+        if resp.status_code >= 500:
+            raise OnboardError(f"control plane error {resp.status_code}: {data}")
+        return data

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -49,6 +49,7 @@ class Client:
         seed: dict[str, Any] | None,
         referral_code: str | None,
         price: float | None = None,
+        code: str | None = None,
     ) -> dict[str, Any]:
         """POST /api/onboard/checkout -> {url} (or 409 taken / 429 rate-limited)."""
         body: dict[str, Any] = {"email": email, "subdomain": subdomain, "plan": plan}
@@ -57,6 +58,10 @@ class Client:
         if price is not None:
             # Negotiated MONTHLY price (USD). The control plane enforces the floor.
             body["price"] = price
+        if code:
+            # Optional discount code; the control plane maps it to a coupon and
+            # rejects an unknown one with {"error": "invalid code"}.
+            body["code"] = code
         headers = {}
         if referral_code:
             headers["X-Vesta-Referral"] = referral_code

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -48,11 +48,15 @@ class Client:
         plan: str,
         seed: dict[str, Any] | None,
         referral_code: str | None,
+        price: float | None = None,
     ) -> dict[str, Any]:
         """POST /api/onboard/checkout -> {url} (or 409 taken / 429 rate-limited)."""
         body: dict[str, Any] = {"email": email, "subdomain": subdomain, "plan": plan}
         if seed:
             body["seed"] = seed
+        if price is not None:
+            # Negotiated MONTHLY price (USD). The control plane enforces the floor.
+            body["price"] = price
         headers = {}
         if referral_code:
             headers["X-Vesta-Referral"] = referral_code

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -69,25 +69,34 @@ class Client:
 
     # --- control plane: onboarding (authed as the buyer) ---------------------
 
+    def mint_invite(self, credential: str) -> dict[str, Any]:
+        """POST /onboard/invite -> {code, expires_at}.
+
+        Authenticated as the REFERRER (server-to-server) by `credential` — the
+        referring vesta's per-VM api_key, or the operator admin secret. The invite
+        is the access gate + referral attribution that checkout requires.
+        """
+        return self._json(self._post("/onboard/invite", json={}, headers=self._auth(credential)))
+
     def checkout(
         self,
         *,
         token: str,
         plan: str,
-        referral_code: str | None,
+        invite: str,
         price: float | None,
         code: str | None,
     ) -> dict[str, Any]:
-        """POST /onboard/checkout -> {url, subdomain}. Auto-assigns the subdomain."""
-        body: dict[str, Any] = {"plan": plan}
+        """POST /onboard/checkout -> {url, subdomain}. Auto-assigns the subdomain.
+
+        `invite` is REQUIRED (invite-only) and carries the referral attribution.
+        """
+        body: dict[str, Any] = {"plan": plan, "invite": invite}
         if price is not None:
             body["price"] = price  # negotiated monthly USD; floor enforced server-side
         if code:
             body["code"] = code  # discount code; unknown -> {"error": "invalid code"}
-        headers = self._auth(token)
-        if referral_code:
-            headers["X-Vesta-Referral"] = referral_code
-        return self._json(self._post("/onboard/checkout", json=body, headers=headers))
+        return self._json(self._post("/onboard/checkout", json=body, headers=self._auth(token)))
 
     def me(self, token: str) -> dict[str, Any]:
         """GET /me -> {user, server}. `server` is null until checkout reserves one."""

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -53,13 +53,19 @@ class Config:
 
     base_url: str
     referral_code: str | None
+    invite_credential: str | None
 
     @classmethod
     def load(cls) -> Config:
         base = os.environ.get("VESTA_CONTROL_URL", DEFAULT_CONTROL_URL).rstrip("/")
         # Non-secret per-server attribution id; absent on self-hosted boxes.
         ref = os.environ.get("VESTA_REFERRAL_CODE", "").strip() or None
-        return cls(base_url=base, referral_code=ref)
+        # The SECRET that mints invites (the gate for invite-only): the referring
+        # vesta's per-VM api_key, or the operator admin secret. The data plane must
+        # inject one of these into the agent's env for in-chat invite minting; the
+        # operator can otherwise hand a pre-minted invite via --invite.
+        cred = os.environ.get("VESTA_API_KEY", "").strip() or os.environ.get("VESTA_ADMIN_SECRET", "").strip() or None
+        return cls(base_url=base, referral_code=ref, invite_credential=cred)
 
     @property
     def apex_host(self) -> str:

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -35,6 +35,8 @@ LINKS = {
     "ios": "https://vesta.run/download#ios",
     "android": "https://vesta.run/download#android",
     "desktop": "https://vesta.run/download#desktop",
+    "terms": "https://vesta.run/legal/terms",
+    "privacy": "https://vesta.run/legal/privacy",
 }
 
 

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -60,11 +60,11 @@ class Config:
         base = os.environ.get("VESTA_CONTROL_URL", DEFAULT_CONTROL_URL).rstrip("/")
         # Non-secret per-server attribution id; absent on self-hosted boxes.
         ref = os.environ.get("VESTA_REFERRAL_CODE", "").strip() or None
-        # The SECRET that mints invites (the gate for invite-only): the referring
-        # vesta's per-VM api_key, or the operator admin secret. The data plane must
-        # inject one of these into the agent's env for in-chat invite minting; the
-        # operator can otherwise hand a pre-minted invite via --invite.
-        cred = os.environ.get("VESTA_API_KEY", "").strip() or os.environ.get("VESTA_ADMIN_SECRET", "").strip() or None
+        # The dedicated, low-power secret that mints invites (NOT the api_key). The
+        # owner claims one with `onboard claim-key` and configures their vestad with
+        # it (hosted or self-hosted), which exposes it to the agent as
+        # VESTA_INVITE_KEY. The operator admin secret also works.
+        cred = os.environ.get("VESTA_INVITE_KEY", "").strip() or os.environ.get("VESTA_ADMIN_SECRET", "").strip() or None
         return cls(base_url=base, referral_code=ref, invite_credential=cred)
 
     @property

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -1,0 +1,47 @@
+"""Configuration for the onboard CLI.
+
+Everything is read from the environment so the skill needs no setup state on
+disk: the control-plane base URL and (for hosted vestas) the non-secret referral
+code that attributes a completed signup to this account.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+# Production control plane. Override with VESTA_CONTROL_URL for staging/testing.
+DEFAULT_CONTROL_URL = "https://vesta.run/api"
+
+# How long the marketing/plan copy quotes; kept here so the CLI and SKILL.md
+# agree on the canonical plan ids the checkout endpoint accepts.
+PLANS = ("starter", "pro", "power")
+
+# Personality presets shipped by the `personality` skill (presets/<name>.md).
+# Listed here so `onboard presets` works even if that skill isn't installed yet.
+PERSONALITY_PRESETS = ("chill", "classic", "dry", "extra", "polished", "terse")
+
+# Public marketing + install links surfaced by `onboard links`.
+LINKS = {
+    "marketing": "https://vesta.run",
+    "dashboard": "https://vesta.run/dashboard",
+    "download": "https://vesta.run/download",
+    "ios": "https://vesta.run/download#ios",
+    "android": "https://vesta.run/download#android",
+    "desktop": "https://vesta.run/download#desktop",
+}
+
+
+@dataclass(frozen=True)
+class Config:
+    """Resolved runtime configuration (env-driven)."""
+
+    base_url: str
+    referral_code: str | None
+
+    @classmethod
+    def load(cls) -> Config:
+        base = os.environ.get("VESTA_CONTROL_URL", DEFAULT_CONTROL_URL).rstrip("/")
+        # Non-secret per-server attribution id; absent on self-hosted boxes.
+        ref = os.environ.get("VESTA_REFERRAL_CODE", "").strip() or None
+        return cls(base_url=base, referral_code=ref)

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -1,17 +1,24 @@
 """Configuration for the onboard CLI.
 
-Everything is read from the environment so the skill needs no setup state on
-disk: the control-plane base URL and (for hosted vestas) the non-secret referral
-code that attributes a completed signup to this account.
+Everything is read from the environment: the control-plane base URL and (for
+hosted vestas) the non-secret referral code that attributes a completed signup to
+this account. The ONE bit of on-disk state is the buyer's short onboarding session
+token (see `state.py`) — needed because the agent drives the flow across separate
+CLI invocations.
 """
 
 from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 # Production control plane. Override with VESTA_CONTROL_URL for staging/testing.
 DEFAULT_CONTROL_URL = "https://vesta.run/api"
+
+# Default Claude model for a freshly onboarded agent (the buyer can switch later
+# in the app). Anthropic's curated picker is opus / sonnet / haiku.
+DEFAULT_MODEL = "sonnet"
 
 # How long the marketing/plan copy quotes; kept here so the CLI and SKILL.md
 # agree on the canonical plan ids the checkout endpoint accepts.
@@ -53,3 +60,12 @@ class Config:
         # Non-secret per-server attribution id; absent on self-hosted boxes.
         ref = os.environ.get("VESTA_REFERRAL_CODE", "").strip() or None
         return cls(base_url=base, referral_code=ref)
+
+    @property
+    def apex_host(self) -> str:
+        """The apex host the control plane lives under, e.g. ``vesta.run``."""
+        return urlparse(self.base_url).netloc or "vesta.run"
+
+    def tenant_base(self, subdomain: str) -> str:
+        """Base URL of a buyer's own vestad, ``https://<subdomain>.<apex>``."""
+        return f"https://{subdomain}.{self.apex_host}"

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -20,15 +20,16 @@ DEFAULT_CONTROL_URL = "https://vesta.run/api"
 # in the app). Anthropic's curated picker is opus / sonnet / haiku.
 DEFAULT_MODEL = "sonnet"
 
-# How long the marketing/plan copy quotes; kept here so the CLI and SKILL.md
-# agree on the canonical plan ids the checkout endpoint accepts.
-PLANS = ("starter", "pro", "power")
+# Hosted Vesta is ONE plan, one box — the control plane's `pro` tier (4 vCPU /
+# 8 GB). The control plane also defines starter/power for admin provisioning and
+# upgrades, but onboarding only ever sells this one.
+PLAN = "pro"
 
-# List MONTHLY price (USD) per plan — the NEGOTIATION FLOOR. The agent can quote
-# any price >= the floor (uncapped above); the control plane enforces the floor
-# server-side, so this is for the agent's UX + a friendly local error. Keep these
-# in sync with the control plane's listMonthlyCents().
-PLAN_FLOOR_USD = {"starter": 12, "pro": 24, "power": 48}
+# List MONTHLY price (USD) — the NEGOTIATION FLOOR. The agent can quote any price
+# >= it (uncapped above); the control plane enforces the floor server-side, so
+# this is for the agent's UX + a friendly local error. Keep in sync with the
+# control plane's listMonthlyCents("pro").
+PLAN_FLOOR_USD = 24
 
 # Personality presets shipped by the `personality` skill (presets/<name>.md).
 # Listed here so `onboard presets` works even if that skill isn't installed yet.
@@ -37,7 +38,7 @@ PERSONALITY_PRESETS = ("chill", "classic", "dry", "extra", "polished", "terse")
 # Public marketing + install links surfaced by `onboard links`.
 LINKS = {
     "marketing": "https://vesta.run",
-    "dashboard": "https://vesta.run/dashboard",
+    "account": "https://vesta.run/account",
     "download": "https://vesta.run/download",
     "ios": "https://vesta.run/download#ios",
     "android": "https://vesta.run/download#android",

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -17,6 +17,12 @@ DEFAULT_CONTROL_URL = "https://vesta.run/api"
 # agree on the canonical plan ids the checkout endpoint accepts.
 PLANS = ("starter", "pro", "power")
 
+# List MONTHLY price (USD) per plan — the NEGOTIATION FLOOR. The agent can quote
+# any price >= the floor (uncapped above); the control plane enforces the floor
+# server-side, so this is for the agent's UX + a friendly local error. Keep these
+# in sync with the control plane's listMonthlyCents().
+PLAN_FLOOR_USD = {"starter": 12, "pro": 24, "power": 48}
+
 # Personality presets shipped by the `personality` skill (presets/<name>.md).
 # Listed here so `onboard presets` works even if that skill isn't installed yet.
 PERSONALITY_PRESETS = ("chill", "classic", "dry", "extra", "polished", "terse")

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -53,19 +53,13 @@ class Config:
 
     base_url: str
     referral_code: str | None
-    invite_credential: str | None
 
     @classmethod
     def load(cls) -> Config:
         base = os.environ.get("VESTA_CONTROL_URL", DEFAULT_CONTROL_URL).rstrip("/")
         # Non-secret per-server attribution id; absent on self-hosted boxes.
         ref = os.environ.get("VESTA_REFERRAL_CODE", "").strip() or None
-        # The dedicated, low-power secret that mints invites (NOT the api_key). The
-        # owner claims one with `onboard claim-key` and configures their vestad with
-        # it (hosted or self-hosted), which exposes it to the agent as
-        # VESTA_INVITE_KEY. The operator admin secret also works.
-        cred = os.environ.get("VESTA_INVITE_KEY", "").strip() or os.environ.get("VESTA_ADMIN_SECRET", "").strip() or None
-        return cls(base_url=base, referral_code=ref, invite_credential=cred)
+        return cls(base_url=base, referral_code=ref)
 
     @property
     def apex_host(self) -> str:

--- a/agent/skills/onboard/cli/src/onboard_cli/state.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/state.py
@@ -32,10 +32,15 @@ def _read_all() -> dict[str, Any]:
 
 def _write_all(data: dict[str, Any]) -> None:
     _STATE_DIR.mkdir(parents=True, exist_ok=True)
-    # Write 0600 — it holds a session token.
-    fd = os.open(str(_STATE_FILE), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    # Write 0600 (it holds a session token) to a temp file, then atomically
+    # os.replace — so an overlapping CLI invocation never reads a half-written
+    # file (the read-modify-write itself is still unsynchronized; the SKILL keeps
+    # onboards one-at-a-time, and atomic replace prevents corruption).
+    tmp = _STATE_FILE.with_suffix(".tmp")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w") as f:
         json.dump(data, f)
+    os.replace(tmp, _STATE_FILE)
 
 
 def load(email: str) -> dict[str, Any]:
@@ -57,6 +62,17 @@ def clear(email: str) -> None:
     """Forget everything stored for ``email`` (call once onboarding completes)."""
     data = _read_all()
     if data.pop(_key(email), None) is not None:
+        _write_all(data)
+
+
+def forget(email: str, *keys: str) -> None:
+    """Drop specific keys from ``email``'s context (e.g. a consumed OAuth nonce)."""
+    data = _read_all()
+    entry = data.get(_key(email))
+    if not entry:
+        return
+    if any(entry.pop(k, None) is not None for k in keys):
+        data[_key(email)] = entry
         _write_all(data)
 
 

--- a/agent/skills/onboard/cli/src/onboard_cli/state.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/state.py
@@ -1,0 +1,65 @@
+"""Tiny on-disk session store for the onboard flow.
+
+The agent drives onboarding across many separate CLI invocations, so the buyer's
+verified session (and a little server/agent context) has to persist between them.
+It is keyed by the buyer's email and lives in a 0600 file under the user's config
+dir. This is the buyer's OWN session — obtained when they read their OTP back — so
+from here on the CLI acts AS the buyer (the conduit model); the per-VM api_key is
+never involved and never stored. The entry is cleared once the agent is connected.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+_STATE_DIR = Path(os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))) / "vesta-onboard"
+_STATE_FILE = _STATE_DIR / "sessions.json"
+
+
+def _key(email: str) -> str:
+    return email.strip().lower()
+
+
+def _read_all() -> dict[str, Any]:
+    try:
+        return json.loads(_STATE_FILE.read_text())
+    except (OSError, ValueError):
+        return {}
+
+
+def _write_all(data: dict[str, Any]) -> None:
+    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+    # Write 0600 — it holds a session token.
+    fd = os.open(str(_STATE_FILE), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        json.dump(data, f)
+
+
+def load(email: str) -> dict[str, Any]:
+    """Return the stored onboarding context for ``email`` (``{}`` if none)."""
+    return _read_all().get(_key(email), {})
+
+
+def update(email: str, **fields: Any) -> dict[str, Any]:
+    """Merge ``fields`` into ``email``'s stored context and persist it."""
+    data = _read_all()
+    entry = data.get(_key(email), {})
+    entry.update({k: v for k, v in fields.items() if v is not None})
+    data[_key(email)] = entry
+    _write_all(data)
+    return entry
+
+
+def clear(email: str) -> None:
+    """Forget everything stored for ``email`` (call once onboarding completes)."""
+    data = _read_all()
+    if data.pop(_key(email), None) is not None:
+        _write_all(data)
+
+
+def token_for(email: str) -> str | None:
+    """The buyer's session token, or None if they haven't verified yet."""
+    return load(email).get("token")

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -80,6 +80,21 @@ def test_verify_rejects_bad_code(capsys, monkeypatch):
     assert state_mod.token_for(E) is None
 
 
+# --- claim-key (become an inviter) ------------------------------------------
+
+
+def test_claim_key_returns_invite_key(capsys, monkeypatch):
+    _verified()  # owner has a verified session
+    monkeypatch.setattr(cli_mod.Client, "claim_inviter_key", lambda self, t: {"invite_key": "IK"})
+    rc, data = _run(["claim-key", "--email", E], capsys)
+    assert rc == 0 and data["invite_key"] == "IK"
+
+
+def test_claim_key_requires_verification(capsys):
+    rc, data = _run(["claim-key", "--email", E], capsys)
+    assert rc == 2 and "not verified" in data["error"]
+
+
 # --- checkout ---------------------------------------------------------------
 
 
@@ -109,7 +124,7 @@ def test_checkout_passes_explicit_invite_and_forwards_price_code(capsys, monkeyp
 
 def test_checkout_mints_an_invite_from_the_credential(capsys, monkeypatch):
     _verified()
-    monkeypatch.setenv("VESTA_API_KEY", "referrer-api-key")
+    monkeypatch.setenv("VESTA_INVITE_KEY", "referrer-invite-key")
     minted = {}
 
     def fake_mint(self, credential):
@@ -128,13 +143,13 @@ def test_checkout_mints_an_invite_from_the_credential(capsys, monkeypatch):
     monkeypatch.setattr(cli_mod.Client, "me", lambda self, t: {"server": {"id": "srv1"}})
     rc, _ = _run(["checkout", "--email", E], capsys)
     assert rc == 0
-    assert minted["credential"] == "referrer-api-key"
+    assert minted["credential"] == "referrer-invite-key"
     assert captured["invite"] == "MINTED"
 
 
 def test_checkout_no_invite_and_no_credential_errors(capsys, monkeypatch):
     _verified()
-    monkeypatch.delenv("VESTA_API_KEY", raising=False)
+    monkeypatch.delenv("VESTA_INVITE_KEY", raising=False)
     monkeypatch.delenv("VESTA_ADMIN_SECRET", raising=False)
     calls = {"n": 0}
     monkeypatch.setattr(cli_mod.Client, "checkout", lambda self, **kw: calls.__setitem__("n", calls["n"] + 1) or {"url": "x"})

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -1,0 +1,121 @@
+"""Tests for the onboard CLI — pure logic + a mocked control-plane client."""
+
+from __future__ import annotations
+
+import json
+
+
+from onboard_cli import cli as cli_mod
+from onboard_cli.client import OnboardError
+
+
+def _run(argv, capsys):
+    rc = cli_mod.main(argv)
+    out = capsys.readouterr().out
+    return rc, (json.loads(out) if out.strip() else None)
+
+
+def test_links(capsys):
+    rc, data = _run(["links"], capsys)
+    assert rc == 0
+    assert data["marketing"] == "https://vesta.run"
+    assert "ios" in data and "android" in data and "desktop" in data
+
+
+def test_presets(capsys):
+    rc, data = _run(["presets"], capsys)
+    assert rc == 0
+    assert "dry" in data["personalities"]
+    assert data["plans"] == ["starter", "pro", "power"]
+    assert isinstance(data["skills"], list)
+
+
+def test_start_rejects_bad_plan(capsys):
+    rc, data = _run(
+        ["start", "--email", "a@b.com", "--subdomain", "ada", "--plan", "enterprise"],
+        capsys,
+    )
+    assert rc == 2
+    assert "plan must be one of" in data["error"]
+
+
+def test_check_calls_client(capsys, monkeypatch):
+    seen = {}
+
+    def fake_check(self, subdomain):
+        seen["subdomain"] = subdomain
+        return {"subdomain": subdomain, "available": True}
+
+    monkeypatch.setattr(cli_mod.Client, "check", fake_check)
+    rc, data = _run(["check", "Ada"], capsys)
+    assert rc == 0
+    assert seen["subdomain"] == "ada"  # normalised to lowercase
+    assert data["available"] is True
+
+
+def test_status_maps_availability(capsys, monkeypatch):
+    monkeypatch.setattr(cli_mod.Client, "check", lambda self, s: {"subdomain": s, "available": True})
+    rc, data = _run(["status", "--subdomain", "ada"], capsys)
+    assert rc == 0 and data["status"] == "pending"
+
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "check",
+        lambda self, s: {"subdomain": s, "available": False, "reason": "taken"},
+    )
+    rc, data = _run(["status", "--subdomain", "ada"], capsys)
+    assert rc == 0 and data["status"] == "signed_up"
+
+
+def test_start_builds_seed_and_forwards_referral(capsys, monkeypatch):
+    captured = {}
+
+    def fake_checkout(self, *, email, subdomain, plan, seed, referral_code):
+        captured.update(email=email, subdomain=subdomain, plan=plan, seed=seed, referral_code=referral_code)
+        return {"url": "https://checkout.stripe.com/c/pay/cs_test_x"}
+
+    monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
+    rc, data = _run(
+        [
+            "start",
+            "--email",
+            "ada@example.com",
+            "--subdomain",
+            "Ada",
+            "--plan",
+            "Pro",
+            "--name",
+            "Ada",
+            "--personality",
+            "Dry",
+            "--skills",
+            "email-client, tasks ,",
+            "--referral",
+            "ref_abc",
+        ],
+        capsys,
+    )
+    assert rc == 0
+    assert data["url"].startswith("https://checkout.stripe.com/")
+    assert captured["subdomain"] == "ada" and captured["plan"] == "pro"
+    assert captured["seed"] == {"name": "Ada", "personality": "dry", "skills": ["email-client", "tasks"]}
+    assert captured["referral_code"] == "ref_abc"
+
+
+def test_start_surfaces_structured_error(capsys, monkeypatch):
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "checkout",
+        lambda self, **kw: {"error": "subdomain taken"},
+    )
+    rc, data = _run(["start", "--email", "a@b.com", "--subdomain", "ada", "--plan", "starter"], capsys)
+    assert rc == 2 and data["error"] == "subdomain taken"
+
+
+def test_unreachable_control_plane_exits_3(capsys, monkeypatch):
+    def boom(self, subdomain):
+        raise OnboardError("could not reach the control plane")
+
+    monkeypatch.setattr(cli_mod.Client, "check", boom)
+    rc, data = _run(["check", "ada"], capsys)
+    assert rc == 3 and "could not reach" in data["error"]

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -88,37 +88,72 @@ def test_checkout_requires_verification(capsys):
     assert rc == 2 and "not verified" in data["error"]
 
 
-def test_checkout_forwards_price_code_referral(capsys, monkeypatch):
+def test_checkout_passes_explicit_invite_and_forwards_price_code(capsys, monkeypatch):
     _verified()
     captured = {}
 
-    def fake_checkout(self, *, token, plan, referral_code, price, code):
-        captured.update(token=token, plan=plan, referral_code=referral_code, price=price, code=code)
+    def fake_checkout(self, *, token, plan, invite, price, code):
+        captured.update(token=token, plan=plan, invite=invite, price=price, code=code)
         return {"url": "https://checkout.stripe.com/x", "subdomain": "ada"}
 
     monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
     monkeypatch.setattr(cli_mod.Client, "me", lambda self, t: {"server": {"id": "srv1"}})
     rc, data = _run(
-        ["checkout", "--email", E, "--price", "200", "--code", " friend50 ", "--referral", "ref_x"],
+        ["checkout", "--email", E, "--price", "200", "--code", " friend50 ", "--invite", "inv_x"],
         capsys,
     )
     assert rc == 0 and data["url"].startswith("https://checkout.stripe.com/")
-    assert captured == {"token": "TOK", "plan": "pro", "referral_code": "ref_x", "price": 200.0, "code": "friend50"}
+    assert captured == {"token": "TOK", "plan": "pro", "invite": "inv_x", "price": 200.0, "code": "friend50"}
     assert state_mod.load(E)["server_id"] == "srv1"
+
+
+def test_checkout_mints_an_invite_from_the_credential(capsys, monkeypatch):
+    _verified()
+    monkeypatch.setenv("VESTA_API_KEY", "referrer-api-key")
+    minted = {}
+
+    def fake_mint(self, credential):
+        minted["credential"] = credential
+        return {"code": "MINTED", "expires_at": "later"}
+
+    captured = {}
+    monkeypatch.setattr(cli_mod.Client, "mint_invite", fake_mint)
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "checkout",
+        lambda self, *, token, plan, invite, price, code: (
+            captured.update(invite=invite) or {"url": "https://checkout.stripe.com/x", "subdomain": "ada"}
+        ),
+    )
+    monkeypatch.setattr(cli_mod.Client, "me", lambda self, t: {"server": {"id": "srv1"}})
+    rc, _ = _run(["checkout", "--email", E], capsys)
+    assert rc == 0
+    assert minted["credential"] == "referrer-api-key"
+    assert captured["invite"] == "MINTED"
+
+
+def test_checkout_no_invite_and_no_credential_errors(capsys, monkeypatch):
+    _verified()
+    monkeypatch.delenv("VESTA_API_KEY", raising=False)
+    monkeypatch.delenv("VESTA_ADMIN_SECRET", raising=False)
+    calls = {"n": 0}
+    monkeypatch.setattr(cli_mod.Client, "checkout", lambda self, **kw: calls.__setitem__("n", calls["n"] + 1) or {"url": "x"})
+    rc, data = _run(["checkout", "--email", E], capsys)
+    assert rc == 2 and "invite" in data["error"] and calls["n"] == 0
 
 
 def test_checkout_rejects_below_floor_without_calling(capsys, monkeypatch):
     _verified()
     calls = {"n": 0}
     monkeypatch.setattr(cli_mod.Client, "checkout", lambda self, **kw: calls.__setitem__("n", calls["n"] + 1) or {"url": "x"})
-    rc, data = _run(["checkout", "--email", E, "--price", "5"], capsys)
+    rc, data = _run(["checkout", "--email", E, "--price", "5", "--invite", "inv_x"], capsys)
     assert rc == 2 and data["floor_usd"] == 24 and calls["n"] == 0
 
 
 def test_checkout_surfaces_structured_error(capsys, monkeypatch):
     _verified()
     monkeypatch.setattr(cli_mod.Client, "checkout", lambda self, **kw: {"error": "already provisioned"})
-    rc, data = _run(["checkout", "--email", E], capsys)
+    rc, data = _run(["checkout", "--email", E, "--invite", "inv_x"], capsys)
     assert rc == 2 and data["error"] == "already provisioned"
 
 

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -70,7 +70,7 @@ def test_status_maps_availability(capsys, monkeypatch):
 def test_start_builds_seed_and_forwards_referral(capsys, monkeypatch):
     captured = {}
 
-    def fake_checkout(self, *, email, subdomain, plan, seed, referral_code, price=None):
+    def fake_checkout(self, *, email, subdomain, plan, seed, referral_code, price=None, code=None):
         captured.update(
             email=email,
             subdomain=subdomain,
@@ -78,6 +78,7 @@ def test_start_builds_seed_and_forwards_referral(capsys, monkeypatch):
             seed=seed,
             referral_code=referral_code,
             price=price,
+            code=code,
         )
         return {"url": "https://checkout.stripe.com/c/pay/cs_test_x"}
 
@@ -112,7 +113,7 @@ def test_start_builds_seed_and_forwards_referral(capsys, monkeypatch):
 def test_start_forwards_negotiated_price(capsys, monkeypatch):
     captured = {}
 
-    def fake_checkout(self, *, email, subdomain, plan, seed, referral_code, price=None):
+    def fake_checkout(self, *, email, subdomain, plan, seed, referral_code, price=None, code=None):
         captured["price"] = price
         return {"url": "https://checkout.stripe.com/c/pay/cs_test_x"}
 
@@ -122,6 +123,21 @@ def test_start_forwards_negotiated_price(capsys, monkeypatch):
         capsys,
     )
     assert rc == 0 and captured["price"] == 1500.0
+
+
+def test_start_forwards_discount_code(capsys, monkeypatch):
+    captured = {}
+
+    def fake_checkout(self, *, email, subdomain, plan, seed, referral_code, price=None, code=None):
+        captured["code"] = code
+        return {"url": "https://checkout.stripe.com/c/pay/cs_test_x"}
+
+    monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
+    rc, data = _run(
+        ["start", "--email", "a@x.com", "--subdomain", "ada", "--code", "  friend50 "],
+        capsys,
+    )
+    assert rc == 0 and captured["code"] == "friend50"
 
 
 def test_start_rejects_price_below_floor(capsys, monkeypatch):

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -70,8 +70,15 @@ def test_status_maps_availability(capsys, monkeypatch):
 def test_start_builds_seed_and_forwards_referral(capsys, monkeypatch):
     captured = {}
 
-    def fake_checkout(self, *, email, subdomain, plan, seed, referral_code):
-        captured.update(email=email, subdomain=subdomain, plan=plan, seed=seed, referral_code=referral_code)
+    def fake_checkout(self, *, email, subdomain, plan, seed, referral_code, price=None):
+        captured.update(
+            email=email,
+            subdomain=subdomain,
+            plan=plan,
+            seed=seed,
+            referral_code=referral_code,
+            price=price,
+        )
         return {"url": "https://checkout.stripe.com/c/pay/cs_test_x"}
 
     monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
@@ -100,6 +107,59 @@ def test_start_builds_seed_and_forwards_referral(capsys, monkeypatch):
     assert captured["subdomain"] == "ada" and captured["plan"] == "pro"
     assert captured["seed"] == {"name": "Ada", "personality": "dry", "skills": ["email-client", "tasks"]}
     assert captured["referral_code"] == "ref_abc"
+
+
+def test_start_forwards_negotiated_price(capsys, monkeypatch):
+    captured = {}
+
+    def fake_checkout(self, *, email, subdomain, plan, seed, referral_code, price=None):
+        captured["price"] = price
+        return {"url": "https://checkout.stripe.com/c/pay/cs_test_x"}
+
+    monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
+    rc, data = _run(
+        ["start", "--email", "vc@x.com", "--subdomain", "whale", "--plan", "power", "--price", "1500"],
+        capsys,
+    )
+    assert rc == 0 and captured["price"] == 1500.0
+
+
+def test_start_rejects_price_below_floor(capsys, monkeypatch):
+    called = {"n": 0}
+
+    def fake_checkout(self, **kw):
+        called["n"] += 1
+        return {"url": "x"}
+
+    monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
+    # pro floor is $24; $5 must be rejected locally, before any checkout call.
+    rc, data = _run(
+        ["start", "--email", "a@b.com", "--subdomain", "ada", "--plan", "pro", "--price", "5"],
+        capsys,
+    )
+    assert rc == 2
+    assert "below the pro floor" in data["error"] and data["floor_usd"] == 24
+    assert called["n"] == 0
+
+
+def test_start_at_floor_is_allowed(capsys, monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "checkout",
+        lambda self, **kw: captured.update(kw) or {"url": "https://checkout.stripe.com/x"},
+    )
+    rc, _ = _run(
+        ["start", "--email", "a@b.com", "--subdomain", "ada", "--plan", "starter", "--price", "12"],
+        capsys,
+    )
+    assert rc == 0 and captured["price"] == 12.0
+
+
+def test_presets_includes_floors(capsys):
+    rc, data = _run(["presets"], capsys)
+    assert rc == 0
+    assert data["plan_floor_usd"] == {"starter": 12, "pro": 24, "power": 48}
 
 
 def test_start_surfaces_structured_error(capsys, monkeypatch):

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -51,11 +51,12 @@ def test_links(capsys):
     assert rc == 0 and data["marketing"] == "https://vesta.run"
 
 
-def test_presets_has_models_and_floors(capsys):
+def test_presets_has_models_and_floor(capsys):
     rc, data = _run(["presets"], capsys)
     assert rc == 0
     assert "dry" in data["personalities"]
-    assert data["plan_floor_usd"] == {"starter": 12, "pro": 24, "power": 48}
+    assert data["plan_floor_usd"] == 24
+    assert "plans" not in data  # single plan — no tier list
     assert data["claude_models"] == ["opus", "sonnet", "haiku"]
 
 
@@ -94,17 +95,18 @@ def test_checkout_forwards_price_code_referral(capsys, monkeypatch):
 
     def fake_checkout(self, *, token, plan, referral_code, price, code):
         captured.update(token=token, plan=plan, referral_code=referral_code, price=price, code=code)
-        return {"url": "https://checkout.stripe.com/x", "subdomain": "ada"}
+        return {"url": "https://checkout.stripe.com/x", "subdomain": "ada", "server_id": "srv1"}
 
     monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
-    monkeypatch.setattr(cli_mod.Client, "me", lambda self, t: {"server": {"id": "srv1"}})
     rc, data = _run(
         ["checkout", "--email", E, "--price", "200", "--code", " friend50 ", "--referral", "ref_x"],
         capsys,
     )
     assert rc == 0 and data["url"].startswith("https://checkout.stripe.com/")
     assert captured == {"token": "TOK", "plan": "pro", "referral_code": "ref_x", "price": 200.0, "code": "friend50"}
+    # server_id is stashed for later steps but kept out of the agent-facing output.
     assert state_mod.load(E)["server_id"] == "srv1"
+    assert "server_id" not in data
 
 
 def test_checkout_rejects_below_floor_without_calling(capsys, monkeypatch):

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -71,6 +71,15 @@ def test_verify_stores_session(capsys, monkeypatch):
     assert state_mod.token_for(E) == "SESS"
 
 
+def test_verify_rejects_bad_code(capsys, monkeypatch):
+    # A wrong/expired code -> verify_otp returns None -> surfaced as exit 2, not a
+    # transport failure (exit 3), and no session is stored.
+    monkeypatch.setattr(cli_mod.Client, "verify_otp", lambda self, email, code: None)
+    rc, data = _run(["verify", "--email", E, "--code", "000000"], capsys)
+    assert rc == 2 and "wrong or expired" in data["error"]
+    assert state_mod.token_for(E) is None
+
+
 # --- checkout ---------------------------------------------------------------
 
 
@@ -140,17 +149,20 @@ def test_create_agent_passes_seed(capsys, monkeypatch):
 
     def fake_create(self, *, subdomain, server_token, name, personality, skills):
         captured.update(subdomain=subdomain, server_token=server_token, name=name, personality=personality, skills=skills)
-        return {"name": name}
+        # vestad normalizes the name and returns the actual created name.
+        return {"name": "ada"}
 
     monkeypatch.setattr(cli_mod.Client, "create_agent", fake_create)
     rc, data = _run(
         ["create-agent", "--email", E, "--name", "Ada", "--personality", "Dry", "--skills", "email, calendar ,"],
         capsys,
     )
-    assert rc == 0 and data["created"] is True
+    assert rc == 0 and data["created"] is True and data["name"] == "ada"
     assert captured["subdomain"] == "ada" and captured["server_token"] == "VTOK"
     assert captured["personality"] == "dry" and captured["skills"] == ["email", "calendar"]
-    assert state_mod.load(E)["agent_name"] == "Ada"
+    # the NORMALIZED name vestad returned is stored, so claude-finish addresses a
+    # path vestad's validate_name accepts (not the raw "Ada").
+    assert state_mod.load(E)["agent_name"] == "ada"
 
 
 # --- claude connect ---------------------------------------------------------
@@ -199,6 +211,29 @@ def test_claude_finish_without_start(capsys, monkeypatch):
     _active_server(monkeypatch)
     rc, data = _run(["claude-finish", "--email", E, "--code", "PASTE"], capsys)
     assert rc == 2 and "claude-start" in data["error"]
+
+
+def test_claude_finish_clears_session_when_attach_fails(capsys, monkeypatch):
+    _verified()
+    state_mod.update(E, claude_session_id="CS", agent_name="ada")
+    _active_server(monkeypatch)
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "claude_oauth_complete",
+        lambda self, *, subdomain, server_token, session_id, code: "CREDS",
+    )
+    # The attach (set_provider) fails after OAuth was consumed on the VM.
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "set_provider",
+        lambda self, *, subdomain, server_token, name, credentials, model: {"error": "bad gateway"},
+    )
+    rc, data = _run(["claude-finish", "--email", E, "--code", "PASTE"], capsys)
+    assert rc == 2 and "claude-start" in data["error"]
+    # The consumed session_id is forgotten (a retry must re-run claude-start), but
+    # the buyer's session token survives so they aren't kicked out mid-onboard.
+    assert "claude_session_id" not in state_mod.load(E)
+    assert state_mod.token_for(E) == "TOK"
 
 
 # --- error propagation ------------------------------------------------------

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -1,12 +1,23 @@
-"""Tests for the onboard CLI — pure logic + a mocked control-plane client."""
+"""Tests for the onboard CLI — the conduit flow with a mocked client + temp state."""
 
 from __future__ import annotations
 
 import json
 
+import pytest
 
 from onboard_cli import cli as cli_mod
+from onboard_cli import state as state_mod
 from onboard_cli.client import OnboardError
+
+E = "ada@example.com"
+
+
+@pytest.fixture(autouse=True)
+def _tmp_state(tmp_path, monkeypatch):
+    """Point the session store at a throwaway dir so tests don't touch ~/.config."""
+    monkeypatch.setattr(state_mod, "_STATE_DIR", tmp_path)
+    monkeypatch.setattr(state_mod, "_STATE_FILE", tmp_path / "sessions.json")
 
 
 def _run(argv, capsys):
@@ -15,183 +26,188 @@ def _run(argv, capsys):
     return rc, (json.loads(out) if out.strip() else None)
 
 
+def _verified(token="TOK"):
+    """Seed a verified session for E."""
+    state_mod.update(E, token=token)
+
+
+def _active_server(monkeypatch, status="active"):
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "me",
+        lambda self, t: {
+            "user": {"id": "u1", "email": E},
+            "server": {"id": "srv1", "subdomain": "ada", "status": status, "url": "https://ada.vesta.run"},
+        },
+    )
+    monkeypatch.setattr(cli_mod.Client, "server_token", lambda self, t, sid: "VTOK")
+
+
+# --- reference data ---------------------------------------------------------
+
+
 def test_links(capsys):
     rc, data = _run(["links"], capsys)
-    assert rc == 0
-    assert data["marketing"] == "https://vesta.run"
-    assert "ios" in data and "android" in data and "desktop" in data
+    assert rc == 0 and data["marketing"] == "https://vesta.run"
 
 
-def test_presets(capsys):
+def test_presets_has_models_and_floors(capsys):
     rc, data = _run(["presets"], capsys)
     assert rc == 0
     assert "dry" in data["personalities"]
-    assert data["plans"] == ["starter", "pro", "power"]
-    assert isinstance(data["skills"], list)
-
-
-def test_start_rejects_bad_plan(capsys):
-    rc, data = _run(
-        ["start", "--email", "a@b.com", "--subdomain", "ada", "--plan", "enterprise"],
-        capsys,
-    )
-    assert rc == 2
-    assert "plan must be one of" in data["error"]
-
-
-def test_check_calls_client(capsys, monkeypatch):
-    seen = {}
-
-    def fake_check(self, subdomain):
-        seen["subdomain"] = subdomain
-        return {"subdomain": subdomain, "available": True}
-
-    monkeypatch.setattr(cli_mod.Client, "check", fake_check)
-    rc, data = _run(["check", "Ada"], capsys)
-    assert rc == 0
-    assert seen["subdomain"] == "ada"  # normalised to lowercase
-    assert data["available"] is True
-
-
-def test_status_maps_availability(capsys, monkeypatch):
-    monkeypatch.setattr(cli_mod.Client, "check", lambda self, s: {"subdomain": s, "available": True})
-    rc, data = _run(["status", "--subdomain", "ada"], capsys)
-    assert rc == 0 and data["status"] == "pending"
-
-    monkeypatch.setattr(
-        cli_mod.Client,
-        "check",
-        lambda self, s: {"subdomain": s, "available": False, "reason": "taken"},
-    )
-    rc, data = _run(["status", "--subdomain", "ada"], capsys)
-    assert rc == 0 and data["status"] == "signed_up"
-
-
-def test_start_builds_seed_and_forwards_referral(capsys, monkeypatch):
-    captured = {}
-
-    def fake_checkout(self, *, email, subdomain, plan, seed, referral_code, price=None, code=None):
-        captured.update(
-            email=email,
-            subdomain=subdomain,
-            plan=plan,
-            seed=seed,
-            referral_code=referral_code,
-            price=price,
-            code=code,
-        )
-        return {"url": "https://checkout.stripe.com/c/pay/cs_test_x"}
-
-    monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
-    rc, data = _run(
-        [
-            "start",
-            "--email",
-            "ada@example.com",
-            "--subdomain",
-            "Ada",
-            "--plan",
-            "Pro",
-            "--name",
-            "Ada",
-            "--personality",
-            "Dry",
-            "--skills",
-            "email-client, tasks ,",
-            "--referral",
-            "ref_abc",
-        ],
-        capsys,
-    )
-    assert rc == 0
-    assert data["url"].startswith("https://checkout.stripe.com/")
-    assert captured["subdomain"] == "ada" and captured["plan"] == "pro"
-    assert captured["seed"] == {"name": "Ada", "personality": "dry", "skills": ["email-client", "tasks"]}
-    assert captured["referral_code"] == "ref_abc"
-
-
-def test_start_forwards_negotiated_price(capsys, monkeypatch):
-    captured = {}
-
-    def fake_checkout(self, *, email, subdomain, plan, seed, referral_code, price=None, code=None):
-        captured["price"] = price
-        return {"url": "https://checkout.stripe.com/c/pay/cs_test_x"}
-
-    monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
-    rc, data = _run(
-        ["start", "--email", "vc@x.com", "--subdomain", "whale", "--plan", "power", "--price", "1500"],
-        capsys,
-    )
-    assert rc == 0 and captured["price"] == 1500.0
-
-
-def test_start_forwards_discount_code(capsys, monkeypatch):
-    captured = {}
-
-    def fake_checkout(self, *, email, subdomain, plan, seed, referral_code, price=None, code=None):
-        captured["code"] = code
-        return {"url": "https://checkout.stripe.com/c/pay/cs_test_x"}
-
-    monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
-    rc, data = _run(
-        ["start", "--email", "a@x.com", "--subdomain", "ada", "--code", "  friend50 "],
-        capsys,
-    )
-    assert rc == 0 and captured["code"] == "friend50"
-
-
-def test_start_rejects_price_below_floor(capsys, monkeypatch):
-    called = {"n": 0}
-
-    def fake_checkout(self, **kw):
-        called["n"] += 1
-        return {"url": "x"}
-
-    monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
-    # pro floor is $24; $5 must be rejected locally, before any checkout call.
-    rc, data = _run(
-        ["start", "--email", "a@b.com", "--subdomain", "ada", "--plan", "pro", "--price", "5"],
-        capsys,
-    )
-    assert rc == 2
-    assert "below the pro floor" in data["error"] and data["floor_usd"] == 24
-    assert called["n"] == 0
-
-
-def test_start_at_floor_is_allowed(capsys, monkeypatch):
-    captured = {}
-    monkeypatch.setattr(
-        cli_mod.Client,
-        "checkout",
-        lambda self, **kw: captured.update(kw) or {"url": "https://checkout.stripe.com/x"},
-    )
-    rc, _ = _run(
-        ["start", "--email", "a@b.com", "--subdomain", "ada", "--plan", "starter", "--price", "12"],
-        capsys,
-    )
-    assert rc == 0 and captured["price"] == 12.0
-
-
-def test_presets_includes_floors(capsys):
-    rc, data = _run(["presets"], capsys)
-    assert rc == 0
     assert data["plan_floor_usd"] == {"starter": 12, "pro": 24, "power": 48}
+    assert data["claude_models"] == ["opus", "sonnet", "haiku"]
 
 
-def test_start_surfaces_structured_error(capsys, monkeypatch):
+# --- verify -----------------------------------------------------------------
+
+
+def test_verify_stores_session(capsys, monkeypatch):
+    monkeypatch.setattr(cli_mod.Client, "send_otp", lambda self, email: {"success": True})
+    monkeypatch.setattr(cli_mod.Client, "verify_otp", lambda self, email, code: "SESS")
+    assert _run(["verify-send", "--email", E], capsys)[0] == 0
+    rc, data = _run(["verify", "--email", E, "--code", "123456"], capsys)
+    assert rc == 0 and data["verified"] is True
+    assert state_mod.token_for(E) == "SESS"
+
+
+# --- checkout ---------------------------------------------------------------
+
+
+def test_checkout_requires_verification(capsys):
+    rc, data = _run(["checkout", "--email", E], capsys)
+    assert rc == 2 and "not verified" in data["error"]
+
+
+def test_checkout_forwards_price_code_referral(capsys, monkeypatch):
+    _verified()
+    captured = {}
+
+    def fake_checkout(self, *, token, plan, referral_code, price, code):
+        captured.update(token=token, plan=plan, referral_code=referral_code, price=price, code=code)
+        return {"url": "https://checkout.stripe.com/x", "subdomain": "ada"}
+
+    monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
+    monkeypatch.setattr(cli_mod.Client, "me", lambda self, t: {"server": {"id": "srv1"}})
+    rc, data = _run(
+        ["checkout", "--email", E, "--price", "200", "--code", " friend50 ", "--referral", "ref_x"],
+        capsys,
+    )
+    assert rc == 0 and data["url"].startswith("https://checkout.stripe.com/")
+    assert captured == {"token": "TOK", "plan": "pro", "referral_code": "ref_x", "price": 200.0, "code": "friend50"}
+    assert state_mod.load(E)["server_id"] == "srv1"
+
+
+def test_checkout_rejects_below_floor_without_calling(capsys, monkeypatch):
+    _verified()
+    calls = {"n": 0}
+    monkeypatch.setattr(cli_mod.Client, "checkout", lambda self, **kw: calls.__setitem__("n", calls["n"] + 1) or {"url": "x"})
+    rc, data = _run(["checkout", "--email", E, "--price", "5"], capsys)
+    assert rc == 2 and data["floor_usd"] == 24 and calls["n"] == 0
+
+
+def test_checkout_surfaces_structured_error(capsys, monkeypatch):
+    _verified()
+    monkeypatch.setattr(cli_mod.Client, "checkout", lambda self, **kw: {"error": "already provisioned"})
+    rc, data = _run(["checkout", "--email", E], capsys)
+    assert rc == 2 and data["error"] == "already provisioned"
+
+
+# --- status -----------------------------------------------------------------
+
+
+def test_status_reports_server_state(capsys, monkeypatch):
+    _verified()
+    _active_server(monkeypatch)
+    rc, data = _run(["status", "--email", E], capsys)
+    assert rc == 0 and data["status"] == "active" and data["url"] == "https://ada.vesta.run"
+
+
+# --- create-agent -----------------------------------------------------------
+
+
+def test_create_agent_needs_active_server(capsys, monkeypatch):
+    _verified()
+    _active_server(monkeypatch, status="reserved")
+    rc, data = _run(["create-agent", "--email", E, "--name", "Ada"], capsys)
+    assert rc == 2 and "not ready" in data["error"]
+
+
+def test_create_agent_passes_seed(capsys, monkeypatch):
+    _verified()
+    _active_server(monkeypatch)
+    captured = {}
+
+    def fake_create(self, *, subdomain, server_token, name, personality, skills):
+        captured.update(subdomain=subdomain, server_token=server_token, name=name, personality=personality, skills=skills)
+        return {"name": name}
+
+    monkeypatch.setattr(cli_mod.Client, "create_agent", fake_create)
+    rc, data = _run(
+        ["create-agent", "--email", E, "--name", "Ada", "--personality", "Dry", "--skills", "email, calendar ,"],
+        capsys,
+    )
+    assert rc == 0 and data["created"] is True
+    assert captured["subdomain"] == "ada" and captured["server_token"] == "VTOK"
+    assert captured["personality"] == "dry" and captured["skills"] == ["email", "calendar"]
+    assert state_mod.load(E)["agent_name"] == "Ada"
+
+
+# --- claude connect ---------------------------------------------------------
+
+
+def test_claude_start_stores_session(capsys, monkeypatch):
+    _verified()
+    _active_server(monkeypatch)
     monkeypatch.setattr(
         cli_mod.Client,
-        "checkout",
-        lambda self, **kw: {"error": "subdomain taken"},
+        "claude_oauth_start",
+        lambda self, *, subdomain, server_token: {"auth_url": "https://claude.ai/oauth", "session_id": "CS"},
     )
-    rc, data = _run(["start", "--email", "a@b.com", "--subdomain", "ada", "--plan", "starter"], capsys)
-    assert rc == 2 and data["error"] == "subdomain taken"
+    rc, data = _run(["claude-start", "--email", E], capsys)
+    assert rc == 0 and data["auth_url"] == "https://claude.ai/oauth"
+    assert state_mod.load(E)["claude_session_id"] == "CS"
+
+
+def test_claude_finish_connects_and_clears(capsys, monkeypatch):
+    _verified()
+    state_mod.update(E, claude_session_id="CS", agent_name="Ada")
+    _active_server(monkeypatch)
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "claude_oauth_complete",
+        lambda self, *, subdomain, server_token, session_id, code: (
+            "CREDS" if (session_id == "CS" and code == "PASTE") else pytest.fail("bad relay")
+        ),
+    )
+    captured = {}
+
+    def fake_set(self, *, subdomain, server_token, name, credentials, model):
+        captured.update(name=name, credentials=credentials, model=model)
+        return {"ok": True}
+
+    monkeypatch.setattr(cli_mod.Client, "set_provider", fake_set)
+    rc, data = _run(["claude-finish", "--email", E, "--code", "PASTE"], capsys)
+    assert rc == 0 and data["connected"] is True and data["name"] == "Ada"
+    assert captured == {"name": "Ada", "credentials": "CREDS", "model": "sonnet"}
+    # onboarding complete -> session forgotten
+    assert state_mod.token_for(E) is None
+
+
+def test_claude_finish_without_start(capsys, monkeypatch):
+    _verified()
+    _active_server(monkeypatch)
+    rc, data = _run(["claude-finish", "--email", E, "--code", "PASTE"], capsys)
+    assert rc == 2 and "claude-start" in data["error"]
+
+
+# --- error propagation ------------------------------------------------------
 
 
 def test_unreachable_control_plane_exits_3(capsys, monkeypatch):
-    def boom(self, subdomain):
-        raise OnboardError("could not reach the control plane")
+    def boom(self, email):
+        raise OnboardError("could not reach https://vesta.run/api")
 
-    monkeypatch.setattr(cli_mod.Client, "check", boom)
-    rc, data = _run(["check", "ada"], capsys)
+    monkeypatch.setattr(cli_mod.Client, "send_otp", boom)
+    rc, data = _run(["verify-send", "--email", E], capsys)
     assert rc == 3 and "could not reach" in data["error"]

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -80,21 +80,6 @@ def test_verify_rejects_bad_code(capsys, monkeypatch):
     assert state_mod.token_for(E) is None
 
 
-# --- claim-key (become an inviter) ------------------------------------------
-
-
-def test_claim_key_returns_invite_key(capsys, monkeypatch):
-    _verified()  # owner has a verified session
-    monkeypatch.setattr(cli_mod.Client, "claim_inviter_key", lambda self, t: {"invite_key": "IK"})
-    rc, data = _run(["claim-key", "--email", E], capsys)
-    assert rc == 0 and data["invite_key"] == "IK"
-
-
-def test_claim_key_requires_verification(capsys):
-    rc, data = _run(["claim-key", "--email", E], capsys)
-    assert rc == 2 and "not verified" in data["error"]
-
-
 # --- checkout ---------------------------------------------------------------
 
 
@@ -103,72 +88,37 @@ def test_checkout_requires_verification(capsys):
     assert rc == 2 and "not verified" in data["error"]
 
 
-def test_checkout_passes_explicit_invite_and_forwards_price_code(capsys, monkeypatch):
+def test_checkout_forwards_price_code_referral(capsys, monkeypatch):
     _verified()
     captured = {}
 
-    def fake_checkout(self, *, token, plan, invite, price, code):
-        captured.update(token=token, plan=plan, invite=invite, price=price, code=code)
+    def fake_checkout(self, *, token, plan, referral_code, price, code):
+        captured.update(token=token, plan=plan, referral_code=referral_code, price=price, code=code)
         return {"url": "https://checkout.stripe.com/x", "subdomain": "ada"}
 
     monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
     monkeypatch.setattr(cli_mod.Client, "me", lambda self, t: {"server": {"id": "srv1"}})
     rc, data = _run(
-        ["checkout", "--email", E, "--price", "200", "--code", " friend50 ", "--invite", "inv_x"],
+        ["checkout", "--email", E, "--price", "200", "--code", " friend50 ", "--referral", "ref_x"],
         capsys,
     )
     assert rc == 0 and data["url"].startswith("https://checkout.stripe.com/")
-    assert captured == {"token": "TOK", "plan": "pro", "invite": "inv_x", "price": 200.0, "code": "friend50"}
+    assert captured == {"token": "TOK", "plan": "pro", "referral_code": "ref_x", "price": 200.0, "code": "friend50"}
     assert state_mod.load(E)["server_id"] == "srv1"
-
-
-def test_checkout_mints_an_invite_from_the_credential(capsys, monkeypatch):
-    _verified()
-    monkeypatch.setenv("VESTA_INVITE_KEY", "referrer-invite-key")
-    minted = {}
-
-    def fake_mint(self, credential):
-        minted["credential"] = credential
-        return {"code": "MINTED", "expires_at": "later"}
-
-    captured = {}
-    monkeypatch.setattr(cli_mod.Client, "mint_invite", fake_mint)
-    monkeypatch.setattr(
-        cli_mod.Client,
-        "checkout",
-        lambda self, *, token, plan, invite, price, code: (
-            captured.update(invite=invite) or {"url": "https://checkout.stripe.com/x", "subdomain": "ada"}
-        ),
-    )
-    monkeypatch.setattr(cli_mod.Client, "me", lambda self, t: {"server": {"id": "srv1"}})
-    rc, _ = _run(["checkout", "--email", E], capsys)
-    assert rc == 0
-    assert minted["credential"] == "referrer-invite-key"
-    assert captured["invite"] == "MINTED"
-
-
-def test_checkout_no_invite_and_no_credential_errors(capsys, monkeypatch):
-    _verified()
-    monkeypatch.delenv("VESTA_INVITE_KEY", raising=False)
-    monkeypatch.delenv("VESTA_ADMIN_SECRET", raising=False)
-    calls = {"n": 0}
-    monkeypatch.setattr(cli_mod.Client, "checkout", lambda self, **kw: calls.__setitem__("n", calls["n"] + 1) or {"url": "x"})
-    rc, data = _run(["checkout", "--email", E], capsys)
-    assert rc == 2 and "invite" in data["error"] and calls["n"] == 0
 
 
 def test_checkout_rejects_below_floor_without_calling(capsys, monkeypatch):
     _verified()
     calls = {"n": 0}
     monkeypatch.setattr(cli_mod.Client, "checkout", lambda self, **kw: calls.__setitem__("n", calls["n"] + 1) or {"url": "x"})
-    rc, data = _run(["checkout", "--email", E, "--price", "5", "--invite", "inv_x"], capsys)
+    rc, data = _run(["checkout", "--email", E, "--price", "5"], capsys)
     assert rc == 2 and data["floor_usd"] == 24 and calls["n"] == 0
 
 
 def test_checkout_surfaces_structured_error(capsys, monkeypatch):
     _verified()
     monkeypatch.setattr(cli_mod.Client, "checkout", lambda self, **kw: {"error": "already provisioned"})
-    rc, data = _run(["checkout", "--email", E, "--invite", "inv_x"], capsys)
+    rc, data = _run(["checkout", "--email", E], capsys)
     assert rc == 2 and data["error"] == "already provisioned"
 
 

--- a/agent/skills/onboard/cli/uv.lock
+++ b/agent/skills/onboard/cli/uv.lock
@@ -1,0 +1,214 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "onboard"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "requests" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "requests", specifier = ">=2.31.0" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.4.0" }]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -6,6 +6,8 @@ import {
   Monitor,
   LogOut,
   RefreshCw,
+  CreditCard,
+  ExternalLink,
 } from "lucide-react";
 import {
   Dialog,
@@ -35,6 +37,11 @@ import {
 } from "@/components/ui/field";
 import { useChatPacing } from "@/stores/use-chat-pacing";
 import { useAppMode, type AppMode } from "@/stores/use-app-mode";
+import { openExternalUrl } from "@/lib/open-external-url";
+
+// Hosted (managed) boxes are always under vesta.run; the account + billing page
+// lives on the control plane. Self-hosted boxes never reach this.
+const ACCOUNT_URL = "https://vesta.run/account";
 
 interface SettingsDialogProps {
   open: boolean;
@@ -51,6 +58,7 @@ export function SettingsDialog({
   const { disconnect } = useAuth();
   const {
     reachable,
+    managed,
     gatewayVersion,
     gatewayBranch,
     gatewayChannel,
@@ -240,6 +248,17 @@ export function SettingsDialog({
                 Disconnect
               </Button>
             </div>
+            {reachable && managed && (
+              <Button
+                variant="secondary"
+                className="mt-3 w-full justify-start"
+                onClick={() => openExternalUrl(ACCOUNT_URL)}
+              >
+                <CreditCard data-icon="inline-start" />
+                Manage account &amp; billing
+                <ExternalLink data-icon="inline-end" className="ml-auto" />
+              </Button>
+            )}
             {reachable && (
               <Field
                 orientation="horizontal"

--- a/apps/web/src/providers/GatewayProvider/index.tsx
+++ b/apps/web/src/providers/GatewayProvider/index.tsx
@@ -32,6 +32,22 @@ async function fetchVersionInfo(): Promise<GatewayVersionInfo | null> {
   }
 }
 
+/**
+ * Whether this box is a hosted (vesta.run-managed) instance — the unauthenticated
+ * `/info` flag the control plane sets via cloud-init. The app uses it to surface
+ * the hosted account/billing page; a self-hosted box reports `false`.
+ */
+async function fetchManaged(): Promise<boolean> {
+  try {
+    const data = await apiJson<{ managed?: boolean }>("/info", {
+      signal: AbortSignal.timeout(VERSION_FETCH_TIMEOUT_MS),
+    });
+    return data.managed === true;
+  } catch {
+    return false;
+  }
+}
+
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30000;
 
@@ -39,6 +55,8 @@ const VERSION_POLL_MS = 60000;
 
 interface GatewayContextValue {
   reachable: boolean;
+  /** True iff this is a hosted (vesta.run-managed) box — gates the account link. */
+  managed: boolean;
   gatewayVersion: string;
   gatewayBranch: string | null;
   gatewayChannel: ReleaseChannel;
@@ -57,6 +75,7 @@ const GatewayContext = createContext<GatewayContextValue | null>(null);
 
 const disconnectedValue: GatewayContextValue = {
   reachable: false,
+  managed: false,
   gatewayVersion: "",
   gatewayBranch: null,
   gatewayChannel: "stable",
@@ -81,6 +100,7 @@ function controlWsUrl(): string {
 function ConnectedGateway({ children }: { children: ReactNode }) {
   const { loading } = useAuth();
   const [reachable, setReachable] = useState(false);
+  const [managed, setManaged] = useState(false);
   const [gatewayVersion, setGatewayVersion] = useState("");
   const [gatewayBranch, setGatewayBranch] = useState<string | null>(null);
   const [gatewayChannel, setGatewayChannel] =
@@ -156,6 +176,11 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
           return;
       }
       if (!cancelled) setVersionChecked(true);
+
+      // Hosted vs self-hosted — non-blocking, never gates the connection.
+      void fetchManaged().then((m) => {
+        if (!cancelled) setManaged(m);
+      });
 
       if (cancelled) return;
 
@@ -250,6 +275,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
     <GatewayContext.Provider
       value={{
         reachable,
+        managed,
         gatewayVersion,
         gatewayBranch,
         gatewayChannel,

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -253,17 +253,11 @@ async fn health() -> Json<serde_json::Value> {
 
 // Unauthenticated: lets apps/web tell a hosted (vesta.run) VM from a self-hosted
 // one, since both get `*.vesta.run` tunnels and the URL alone can't distinguish.
-// Sourced from the cloud-init env: VESTA_MANAGED ("1" => managed), plus optional
-// VESTA_SERVER_ID / VESTA_LOGIN_URL.
+// Managed boxes set VESTA_MANAGED=1 via the control plane's cloud-init; the app
+// uses this single bit to surface the hosted account/billing page.
 async fn info() -> Json<serde_json::Value> {
     let managed = std::env::var("VESTA_MANAGED").as_deref() == Ok("1");
-    let server_id = std::env::var("VESTA_SERVER_ID").ok();
-    let login_url = std::env::var("VESTA_LOGIN_URL").ok();
-    Json(serde_json::json!({
-        "managed": managed,
-        "server_id": server_id,
-        "login_url": login_url,
-    }))
+    Json(serde_json::json!({ "managed": managed }))
 }
 
 async fn version(State(state): State<SharedState>) -> Json<serde_json::Value> {


### PR DESCRIPTION
Adds the default-installed **onboard** skill — the agent half of the vesta-cloud
growth loop (issue elyxlz/vesta-cloud#1, Component 9). The control-plane endpoints
(`/api/onboard/{check,checkout}`, migration 0003, referral maturation) already
exist; this is the skill that drives them.

(Originally intended for #718, but that PR was already merged — so this lands the
skill on its own.)

## What's here — `agent/skills/onboard/`
- **SKILL.md** — trigger + conversation playbook: explain Vesta, collect
  email/subdomain/plan + optional name/personality/skills, negotiate a price, send
  a Stripe Checkout link, then hand off to dashboard + installers. Never collects
  card details; terms acceptance happens on the Checkout page.
- **`onboard` CLI** (bundled, `uv tool install` like `tasks`/`stripe-pay`):
  - `check <sub>` → GET /api/onboard/check
  - `start --email --subdomain [--price --code --name --personality --skills]` → POST /api/onboard/checkout → `{url}`
  - `status --subdomain` (infers from availability — no dedicated endpoint yet)
  - `presets` / `links` (local)
- **Negotiable pricing** — `--price <usd/mo>`: floor = the plan list price ($24),
  uncapped above (high-ball a whale). The control plane enforces the floor.
- **Discount codes** — `--code <code>`: the introducer relays a hand-out code that
  knocks a percentage off the new member's **first month** at checkout (a 50%-off
  invite or a 100%-off comp), the *only* lever that goes below the floor. The code
  resolves to a Stripe coupon control-plane-side; an unknown code returns
  `{"error":"invalid code"}`. A fully-comped first month earns the introducer
  nothing (no revenue to take 50% of) — the reward math nets the discount out.
- Referral attribution rides `VESTA_REFERRAL_CODE` (hosted only; self-hosters
  onboard but earn nothing) — automatic, no code needed. Override the control-plane
  URL with `VESTA_CONTROL_URL`.
- Added to `default-skills.txt`; `index.json` regenerated.

## Verification
- 13 unit tests (`cli/tests/test_cli.py`), ruff clean.
- `onboard check` smoke-tested against the live deployed control plane → `{available:true}`.

> Pairs with vesta-cloud#6, which implements the `--code` discount handling
> (Stripe coupons, `discount_percent` column, reward-netting) on the control plane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)