### PR TITLE
docs: drop stale migrations test-suite refs from tests-integration README

### DIFF
--- a/vestad/tests-integration/README.md
+++ b/vestad/tests-integration/README.md
@@ -43,10 +43,6 @@ vestad/tests/                   (the actual suites — run via `cargo test -p ve
     common.rs       endpoint checker, constants
     endpoints.rs    authorize, token, callback endpoints
     token_exchange.rs  token exchange format validation
-
-  migrations/     filesystem/skill layout migrations (3 tests)
-    normalize.rs        legacy ~/vesta/ layout normalization (mirrors LEGACY_LAYOUT_NORMALIZE_SCRIPT)
-    sparse_checkout.rs  installed-skills sparse-checkout pattern (mirrors upstream-sync SETUP.md)
 ```
 
 ## Running


### PR DESCRIPTION
## What

Removes a dangling block from `vestad/tests-integration/README.md` that documented a `migrations/` test suite which does not exist:

```
migrations/     filesystem/skill layout migrations (3 tests)
  normalize.rs        legacy ~/vesta/ layout normalization (mirrors LEGACY_LAYOUT_NORMALIZE_SCRIPT)
  sparse_checkout.rs  installed-skills sparse-checkout pattern (mirrors upstream-sync SETUP.md)
```

## Why

Found during a repo-wide legacy/backwards-compat audit. The block is doc drift:

- No `vestad/tests/migrations/` directory exists on `master`.
- `check.sh integration` (and `check_integration`) build only `server`, `multi_user`, and `oauth`.
- `LEGACY_LAYOUT_NORMALIZE_SCRIPT` is referenced nowhere in `vestad/src/`.

Removing the block makes the Layout section match the actual test tree. Docs-only change, no code or test behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)