### PR TITLE
chore: mark pre-v1.0 backwards-compat shims for removal

### DIFF
--- a/agent/core/state_store.py
+++ b/agent/core/state_store.py
@@ -20,6 +20,9 @@ from . import config as cfg
 
 STATE_FILENAME = "state.json"
 
+# LEGACY-CLEANUP(#726): drop LEGACY_FILES, _import_legacy, _remove_legacy_files,
+# and their calls in load_state once every agent has booted once on a
+# state.json-aware version (old per-marker files are imported then deleted).
 LEGACY_FILES = (
     "first_start_done",
     "restart_reason",

--- a/apps/web/src/components/Console/index.tsx
+++ b/apps/web/src/components/Console/index.tsx
@@ -62,6 +62,9 @@ const SUBFAMILY_COLOR_CLASS: Record<string, Record<string, string>> = {
   },
 };
 
+// LEGACY-CLEANUP(#726): remove this map (and its use in extractTags / color
+// lookup) once the minimum supported agent emits the hierarchical
+// family/subfamily log format instead of these old flat tags.
 const LEGACY_TAG_TO_FAMILY: Record<string, string> = {
   ASSISTANT: "AGENT",
   THINKING: "AGENT",

--- a/apps/web/src/lib/connection.ts
+++ b/apps/web/src/lib/connection.ts
@@ -51,6 +51,8 @@ function readFromLocalStorage(): ConnectionConfig | null {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw);
+    // LEGACY-CLEANUP(#726): drop this branch once pre-token (apiKey) installs are
+    // assumed cleared; it discards the old auth format so it can't be misread.
     if (parsed.apiKey && !parsed.accessToken) {
       localStorage.removeItem(STORAGE_KEY);
       return null;

--- a/apps/web/src/stores/use-voice-activation.ts
+++ b/apps/web/src/stores/use-voice-activation.ts
@@ -15,6 +15,8 @@ interface VoiceActivationState {
 function loadMode(): VoiceActivationMode {
   if (typeof localStorage === "undefined") return "toggle";
   // Migrate the old key if it's the only one present.
+  // LEGACY-CLEANUP(#726): drop the spacebar-mode fallback once existing installs
+  // have re-saved under STORAGE_KEY (a release or two after this shipped).
   const legacy = localStorage.getItem("spacebar-mode");
   const current = localStorage.getItem(STORAGE_KEY) ?? legacy;
   return current === "hold" ? "hold" : "toggle";

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -369,6 +369,10 @@ pub async fn cleanup_backups(
 /// Reclaim disk from the old docker-image backups: drop an agent's legacy
 /// `vesta-backup:<agent>_*` images once it has a restic snapshot (so a current
 /// backup always exists first). Idempotent; safe to call repeatedly.
+///
+/// LEGACY-CLEANUP(#726): remove this fn, `legacy_backup_images`, and the two
+/// `cleanup_legacy_backups` call sites in serve.rs once all agents have migrated
+/// off the pre-restic docker-image backup model.
 pub async fn cleanup_legacy_backups(docker: &Docker) {
     for name in list_agent_names(docker).await {
         let images = legacy_backup_images(&name).await;


### PR DESCRIPTION
## What

Adds a greppable `LEGACY-CLEANUP(#726)` marker at each of the five backwards-compat shims found in the repo-wide legacy audit. Comment-only, no behavior change.

```
git grep "LEGACY-CLEANUP(#726)"
```

| Site | What |
|------|------|
| `vestad/src/backup.rs` | pre-restic docker-image backup reaper (`cleanup_legacy_backups` + `legacy_backup_images`) |
| `agent/core/state_store.py` | legacy marker-file import (`LEGACY_FILES`, `_import_legacy`, `_remove_legacy_files`) |
| `apps/web/src/components/Console/index.tsx` | old flat log-tag mapping (`LEGACY_TAG_TO_FAMILY`) |
| `apps/web/src/stores/use-voice-activation.ts` | `spacebar-mode` localStorage migration |
| `apps/web/src/lib/connection.ts` | pre-token `apiKey` localStorage discard |

## Why

These shims are correct today (old agents / old installs still rely on them) but become dead code once we set a minimum supported version. Marking them keeps them findable so they can be removed in one batch at the v1.0 cutoff rather than rediscovered piecemeal.

`name_from_cname()` in `docker.rs` was deliberately **not** marked: it's a defensive helper used across ~8 error paths, not a self-contained legacy block. It's noted under "Investigate" in the tracking issue instead.

Tracked in #726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)