### PR TITLE
fix(vestad): drop baked Cloudflare token — BYOK self-host + control-plane-managed tunnels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,10 +613,10 @@ jobs:
 
       - name: Build vestad
         working-directory: vestad
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        # No CLOUDFLARE_* here: vestad no longer bakes a Cloudflare token into the
+        # binary. Self-hosters bring their own (`vestad tunnel login`); managed VMs
+        # get a control-plane-seeded tunnel.json. Nothing fleet-wide ships in the
+        # public binary.
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package

--- a/install.sh
+++ b/install.sh
@@ -275,15 +275,22 @@ EOF
   esac
 
   echo ""
-  echo "Done! Get started:"
+  echo "Installed!"
+  echo ""
   if [ "$OS" = "linux" ]; then
-    echo "  vestad              # Install systemd service and start"
-    echo "  vesta connect       # Connect the CLI"
+    echo "Start your server — this one command does the rest:"
+    echo ""
+    echo "    vestad"
+    echo ""
+    echo "It walks you through connecting a domain, then prints your agent's URL."
+    echo "Open that URL in a browser to create your first agent."
   else
-    echo "  vesta connect <host>#<key>   # Connect to a remote vestad"
+    echo "Connect to a vestad server:"
+    echo "    vesta connect <host>#<key>"
   fi
   if has_gui; then
-    echo "  Open Vesta app and connect to your server"
+    echo ""
+    echo "Prefer an app? Open the Vesta app and connect with your server's URL + key."
   fi
   if [ -n "$PATH_UPDATED" ]; then
     echo ""

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -70,7 +70,9 @@ enum Command {
         /// Agent name
         name: String,
     },
-    /// Manage Cloudflare tunnel
+    /// Connect a Cloudflare domain so your agent gets a public URL
+    Connect,
+    /// Manage the Cloudflare tunnel (advanced)
     Tunnel {
         #[command(subcommand)]
         action: TunnelAction,
@@ -119,13 +121,28 @@ enum TunnelAction {
     },
     /// Tear down tunnel and DNS record
     Destroy,
-    /// Connect a Cloudflare account + domain for a self-hosted stable tunnel (BYOK)
-    Login,
 }
 
 fn die(msg: impl std::fmt::Display) -> ! {
     eprintln!("error: {}", msg);
     std::process::exit(1);
+}
+
+/// Whether to emit ANSI color: only when stderr is a real terminal and NO_COLOR
+/// is unset. Without this, `vestad status > file` / piping captures raw escape
+/// codes.
+fn color_on() -> bool {
+    use std::io::IsTerminal;
+    std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none()
+}
+
+/// Wrap `s` in ANSI `code` (e.g. "1;35"), but only when color is enabled.
+fn paint(code: &str, s: &str) -> String {
+    if color_on() {
+        format!("\x1b[{code}m{s}\x1b[0m")
+    } else {
+        s.to_string()
+    }
 }
 
 fn find_available_port() -> Option<u16> {
@@ -161,11 +178,13 @@ fn resolve_port(explicit: Option<u16>, config: &std::path::Path) -> u16 {
         tracing::warn!(stored_port = stored, "stored port unavailable, allocating new one");
     }
 
-    find_available_port().unwrap_or_else(|| die("no available port found"))
+    find_available_port()
+        .unwrap_or_else(|| die("no free port found — another service may be using the range; try `vestad restart`"))
 }
 
 fn config_dir() -> std::path::PathBuf {
-    paths::config_dir().unwrap_or_else(|| die("HOME not set"))
+    paths::config_dir()
+        .unwrap_or_else(|| die("couldn't find your home directory ($HOME) — vestad stores its config there"))
 }
 
 const RESTART_LOCAL_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
@@ -179,6 +198,9 @@ const HEALTH_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 /// (no healthy origin yet), which reads like an error but is just startup. Poll `/health`
 /// locally and through the tunnel so the message reflects what is actually reachable.
 fn report_restart_readiness(config: &std::path::Path) {
+    // The probe below can take tens of seconds (local API + tunnel reconnect), so
+    // say what we're doing rather than appearing to hang.
+    eprintln!("waiting for vestad to come back up…");
     let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
         Ok(runtime) => runtime,
         Err(e) => {
@@ -251,19 +273,34 @@ async fn wait_for_health(client: &reqwest::Client, url: &str, timeout: std::time
 
 fn print_server_info(tunnel_url: Option<&str>, local_url: &str, api_key: &str) {
     eprintln!();
+    match tunnel_url {
+        Some(url) => eprintln!("  {} {}", paint("36", "public "), paint("1", url)),
+        // A missing tunnel is a first-class, visible state — never a silent
+        // "local only". Tell the user the exact command to fix it.
+        None => eprintln!(
+            "  {} {} — run {} to get a public URL",
+            paint("36", "public "),
+            paint("33", "not connected"),
+            paint("1", "vestad connect"),
+        ),
+    }
+    eprintln!("  {} {}", paint("36", "key    "), paint("33", api_key));
+    eprintln!();
+    eprintln!("  open the app and paste the key:");
     if let Some(url) = tunnel_url {
-        eprintln!("  \x1b[36mtunnel\x1b[0m  \x1b[1m{}\x1b[0m", url);
+        eprintln!(
+            "    {} {}  {}",
+            paint("36", "remote"),
+            paint("1", &format!("{url}/app")),
+            paint("32", "(recommended)"),
+        );
     }
-    eprintln!("  \x1b[36mkey\x1b[0m     \x1b[33m{}\x1b[0m", api_key);
-    eprintln!("  \x1b[36mapp\x1b[0m     \x1b[2m(open in a browser and paste the key)\x1b[0m");
-    if let Some(url) = tunnel_url {
-        eprintln!("    \x1b[36mremote\x1b[0m  \x1b[1m{}/app\x1b[0m  \x1b[32m(recommended)\x1b[0m", url);
-    }
-    eprintln!("    \x1b[36mlocal\x1b[0m   \x1b[1m{}/app\x1b[0m  \x1b[2m(same machine only)\x1b[0m", local_url);
-    if tunnel_url.is_none() {
-        eprintln!();
-        eprintln!("  \x1b[33mtip:\x1b[0m run without --no-tunnel to get a remote URL");
-    }
+    eprintln!(
+        "    {} {}  {}",
+        paint("36", "local "),
+        paint("1", &format!("{local_url}/app")),
+        paint("2", "(same machine only)"),
+    );
     eprintln!();
 }
 
@@ -439,9 +476,11 @@ fn run_server_systemd(port: Option<u16>, no_tunnel: bool) {
     }
 
     eprintln!("manage with:");
-    eprintln!("  vestad status     show service status");
+    eprintln!("  vestad status     show status + your URL");
+    eprintln!("  vestad connect    connect a domain for a public URL");
     eprintln!("  vestad logs       show service logs");
     eprintln!("  vestad restart    restart the service");
+    eprintln!("  vestad update     update to the latest version");
     eprintln!("  vestad stop       stop the service");
 }
 
@@ -524,6 +563,7 @@ fn main() {
             let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
             rt.block_on(docker::ensure_running(&docker, &cname)).unwrap_or_else(|e| die(&e));
 
+            eprintln!("entering {name} (exit with `exit`, or detach with Ctrl-Q)…");
             // Keep the docker exec -it subprocess as-is for TTY support
             let status = std::process::Command::new("docker")
                 .args(["exec", "-it", "--detach-keys=ctrl-q", &cname, "bash"])
@@ -632,6 +672,23 @@ fn main() {
             }
         },
 
+        Command::Connect => {
+            let config = config_dir();
+            // Collect the user's own Cloudflare creds, create the tunnel, then
+            // restart the running service so it picks the tunnel up.
+            let tc = tunnel::connect_interactive(&config).unwrap_or_else(|e| die(e));
+            if systemd::is_active() {
+                systemd::restart().unwrap_or_else(|e| die(&e));
+            }
+            eprintln!();
+            eprintln!(
+                "  {} your agent is live at {}",
+                paint("32", "✓"),
+                paint("1", &format!("https://{}/app", tc.hostname)),
+            );
+            eprintln!();
+        }
+
         Command::Tunnel { action } => {
             let config = config_dir();
             match action {
@@ -644,16 +701,13 @@ fn main() {
                             "dns_record_id": tc.dns_record_id,
                             "hostname": tc.hostname,
                         }));
+                    } else {
+                        eprintln!("✓ tunnel ready at https://{}", tc.hostname);
                     }
                 }
                 TunnelAction::Destroy => {
-                    tunnel::destroy_tunnel(&config)
-                        .unwrap_or_else(|e| die(e));
-                }
-                TunnelAction::Login => {
-                    tunnel::setup_cf_creds_interactive(&config)
-                        .unwrap_or_else(|e| die(e));
-                    eprintln!("Cloudflare connected. Run `vestad` to bring up your tunnel.");
+                    tunnel::destroy_tunnel(&config).unwrap_or_else(|e| die(e));
+                    eprintln!("✓ tunnel removed");
                 }
             }
         }
@@ -662,7 +716,17 @@ fn main() {
             let outcome =
                 self_update::perform_update(channel::Channel::effective()).unwrap_or_else(|e| die(e.to_string()));
             if !outcome.updated {
-                println!("vestad already at latest version (v{})", outcome.current);
+                println!("vestad already at the latest version (v{})", outcome.current);
+            } else {
+                println!("✓ updated v{} → v{}", outcome.current, outcome.latest);
+                println!(
+                    "{}",
+                    if outcome.restarted {
+                        "  service restarted on the new version."
+                    } else {
+                        "  run `vestad` to start the new version."
+                    },
+                );
             }
         }
 

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -119,6 +119,8 @@ enum TunnelAction {
     },
     /// Tear down tunnel and DNS record
     Destroy,
+    /// Connect a Cloudflare account + domain for a self-hosted stable tunnel (BYOK)
+    Login,
 }
 
 fn die(msg: impl std::fmt::Display) -> ! {
@@ -407,10 +409,22 @@ fn run_server_systemd(port: Option<u16>, no_tunnel: bool) {
         return;
     }
 
+    // Forced BYOK: the service runs the tunnel non-interactively, so collect the
+    // self-hoster's Cloudflare credentials HERE (while we still have a terminal),
+    // before starting it. Skipped when: a tunnel is already configured, creds
+    // already exist, or this is a managed (vesta.run) VM whose tunnel.json the
+    // control plane seeds. `--no-tunnel` is honored only in --standalone mode.
+    let config = config_dir();
+    if std::env::var("VESTA_MANAGED").is_err()
+        && tunnel::get_tunnel_config(&config).is_none()
+        && !tunnel::has_cf_creds(&config)
+    {
+        tunnel::setup_cf_creds_interactive(&config).unwrap_or_else(|e| die(e));
+    }
+
     systemd::start().unwrap_or_else(|e| die(&e));
     systemd::wait_for_start().unwrap_or_else(|e| die(&e));
 
-    let config = config_dir();
     let (tunnel_url, local_url, api_key) = read_server_info(&config);
 
     eprintln!();
@@ -635,6 +649,11 @@ fn main() {
                 TunnelAction::Destroy => {
                     tunnel::destroy_tunnel(&config)
                         .unwrap_or_else(|e| die(e));
+                }
+                TunnelAction::Login => {
+                    tunnel::setup_cf_creds_interactive(&config)
+                        .unwrap_or_else(|e| die(e));
+                    eprintln!("Cloudflare connected. Run `vestad` to bring up your tunnel.");
                 }
             }
         }

--- a/vestad/src/systemd.rs
+++ b/vestad/src/systemd.rs
@@ -144,8 +144,10 @@ fn journal_args(lines: usize, follow: bool) -> Vec<String> {
         "-n".into(),
         lines.to_string(),
         "--no-hostname".into(),
+        // short-iso (not `cat`) so each line carries a timestamp — essential when
+        // debugging "when did this happen".
         "-o".into(),
-        "cat".into(),
+        "short-iso".into(),
     ];
     if follow {
         args.push("-f".into());

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -59,7 +59,7 @@ fn save_cf_creds(config_dir: &Path, creds: &CloudflareCreds) -> Result<(), Strin
 
 /// Resolve Cloudflare credentials for self-hosted tunnel management.
 ///
-/// Order: the saved `cloudflare.json` (written by `vestad tunnel login` /
+/// Order: the saved `cloudflare.json` (written by `vestad connect` /
 /// first-run setup), then env vars (power users + CI). There is NO baked
 /// build-time token anymore — the public binary carries no shared credential.
 fn cf_env(config_dir: &Path) -> Result<CloudflareEnv, String> {
@@ -73,7 +73,7 @@ fn cf_env(config_dir: &Path) -> Result<CloudflareEnv, String> {
         }
     }
     let api_token = std::env::var("CLOUDFLARE_API_TOKEN").map_err(|_| {
-        "no Cloudflare credentials — run `vestad tunnel login` to connect your domain".to_string()
+        "no Cloudflare credentials — run `vestad connect` to connect your domain".to_string()
     })?;
     let account_id =
         std::env::var("CLOUDFLARE_ACCOUNT_ID").map_err(|_| "CLOUDFLARE_ACCOUNT_ID not set".to_string())?;
@@ -102,7 +102,7 @@ pub fn setup_cf_creds_interactive(config_dir: &Path) -> Result<(), String> {
 
     if !std::io::stdin().is_terminal() {
         return Err(
-            "connecting a domain needs an interactive terminal. Run `vestad tunnel login` \
+            "connecting a domain needs an interactive terminal. Run `vestad connect` \
              from a shell, or set CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID / \
              CLOUDFLARE_ZONE_ID in the environment. (Or run `vestad --standalone --no-tunnel` \
              to run locally without a tunnel.)"
@@ -319,6 +319,17 @@ fn gethostname() -> String {
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
         .unwrap_or_default();
     if output.is_empty() { "vesta".to_string() } else { output }
+}
+
+/// Full self-host connect flow (`vestad connect`): collect the user's own
+/// Cloudflare credentials, make sure cloudflared is present, then create (or
+/// reuse) the tunnel. Returns the live tunnel config so the caller can show the
+/// URL. This is the one command a self-hoster needs — they never have to discover
+/// `tunnel setup`.
+pub fn connect_interactive(config_dir: &Path) -> Result<TunnelConfig, String> {
+    setup_cf_creds_interactive(config_dir)?;
+    ensure_cloudflared(config_dir)?;
+    ensure_tunnel(config_dir)
 }
 
 pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -18,20 +18,155 @@ struct CloudflareEnv {
     zone_id: String,
 }
 
-fn cf_env() -> Result<CloudflareEnv, String> {
-    let api_token = option_env!("CLOUDFLARE_API_TOKEN")
-        .map(String::from)
-        .or_else(|| std::env::var("CLOUDFLARE_API_TOKEN").ok())
-        .ok_or("CLOUDFLARE_API_TOKEN not set (build-time or env)")?;
-    let account_id = option_env!("CLOUDFLARE_ACCOUNT_ID")
-        .map(String::from)
-        .or_else(|| std::env::var("CLOUDFLARE_ACCOUNT_ID").ok())
-        .ok_or("CLOUDFLARE_ACCOUNT_ID not set (build-time or env)")?;
-    let zone_id = option_env!("CLOUDFLARE_ZONE_ID")
-        .map(String::from)
-        .or_else(|| std::env::var("CLOUDFLARE_ZONE_ID").ok())
-        .ok_or("CLOUDFLARE_ZONE_ID not set (build-time or env)")?;
+/// Self-hosted (BYOK) Cloudflare credentials, persisted to `cloudflare.json`.
+///
+/// The public vestad binary ships **no** Cloudflare token — a self-hoster brings
+/// their own, scoped to a domain they control (Account → Cloudflare Tunnel: Edit,
+/// Zone → DNS: Edit, Zone → Zone: Read). Managed (vesta.run) VMs never reach this
+/// path: the control plane creates the tunnel and seeds `tunnel.json` directly.
+#[derive(Serialize, Deserialize, Clone)]
+struct CloudflareCreds {
+    api_token: String,
+    account_id: String,
+    zone_id: String,
+}
+
+fn cf_creds_path(config_dir: &Path) -> PathBuf {
+    config_dir.join("cloudflare.json")
+}
+
+/// True iff usable Cloudflare credentials already exist (saved file or env).
+pub fn has_cf_creds(config_dir: &Path) -> bool {
+    cf_creds_path(config_dir).exists()
+        || (std::env::var("CLOUDFLARE_API_TOKEN").is_ok()
+            && std::env::var("CLOUDFLARE_ACCOUNT_ID").is_ok()
+            && std::env::var("CLOUDFLARE_ZONE_ID").is_ok())
+}
+
+fn save_cf_creds(config_dir: &Path, creds: &CloudflareCreds) -> Result<(), String> {
+    std::fs::create_dir_all(config_dir)
+        .map_err(|e| format!("failed to create config dir: {}", e))?;
+    let path = cf_creds_path(config_dir);
+    std::fs::write(&path, serde_json::to_string_pretty(creds).unwrap())
+        .map_err(|e| format!("failed to write cloudflare creds: {}", e))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).ok();
+    }
+    Ok(())
+}
+
+/// Resolve Cloudflare credentials for self-hosted tunnel management.
+///
+/// Order: the saved `cloudflare.json` (written by `vestad tunnel login` /
+/// first-run setup), then env vars (power users + CI). There is NO baked
+/// build-time token anymore — the public binary carries no shared credential.
+fn cf_env(config_dir: &Path) -> Result<CloudflareEnv, String> {
+    if let Ok(data) = std::fs::read_to_string(cf_creds_path(config_dir)) {
+        if let Ok(c) = serde_json::from_str::<CloudflareCreds>(&data) {
+            return Ok(CloudflareEnv {
+                api_token: c.api_token,
+                account_id: c.account_id,
+                zone_id: c.zone_id,
+            });
+        }
+    }
+    let api_token = std::env::var("CLOUDFLARE_API_TOKEN").map_err(|_| {
+        "no Cloudflare credentials — run `vestad tunnel login` to connect your domain".to_string()
+    })?;
+    let account_id =
+        std::env::var("CLOUDFLARE_ACCOUNT_ID").map_err(|_| "CLOUDFLARE_ACCOUNT_ID not set".to_string())?;
+    let zone_id =
+        std::env::var("CLOUDFLARE_ZONE_ID").map_err(|_| "CLOUDFLARE_ZONE_ID not set".to_string())?;
     Ok(CloudflareEnv { api_token, account_id, zone_id })
+}
+
+fn prompt(label: &str) -> Result<String, String> {
+    use std::io::Write;
+    eprint!("{label}");
+    std::io::stderr().flush().ok();
+    let mut s = String::new();
+    std::io::stdin()
+        .read_line(&mut s)
+        .map_err(|e| format!("failed to read input: {}", e))?;
+    Ok(s.trim().to_string())
+}
+
+/// Interactively collect + validate BYOK Cloudflare credentials, then persist
+/// them (0600). The user pastes just their domain + an API token; the zone id and
+/// account id are auto-discovered from the domain, so there are no opaque IDs to
+/// copy. Returns the resolved creds on success.
+pub fn setup_cf_creds_interactive(config_dir: &Path) -> Result<(), String> {
+    use std::io::IsTerminal;
+
+    if !std::io::stdin().is_terminal() {
+        return Err(
+            "connecting a domain needs an interactive terminal. Run `vestad tunnel login` \
+             from a shell, or set CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID / \
+             CLOUDFLARE_ZONE_ID in the environment. (Or run `vestad --standalone --no-tunnel` \
+             to run locally without a tunnel.)"
+                .to_string(),
+        );
+    }
+
+    eprintln!();
+    eprintln!("  \x1b[1;35mConnect your domain\x1b[0m");
+    eprintln!();
+    eprintln!("  Vesta creates a secure Cloudflare tunnel to this machine and a DNS");
+    eprintln!("  record for it, on a domain you own in Cloudflare. That needs an API token.");
+    eprintln!();
+    eprintln!("  Create one at https://dash.cloudflare.com/profile/api-tokens");
+    eprintln!("  → Create Token → Create Custom Token, with these permissions:");
+    eprintln!("    • Account → Cloudflare Tunnel → Edit");
+    eprintln!("    • Zone     → DNS            → Edit");
+    eprintln!("    • Zone     → Zone           → Read");
+    eprintln!("  Scope it to your account and your domain, then paste it below.");
+    eprintln!(
+        "  It's stored only on this machine ({}), never sent anywhere else.",
+        cf_creds_path(config_dir).display()
+    );
+    eprintln!();
+
+    let domain = prompt("  Your domain (e.g. example.com): ")?.to_lowercase();
+    if domain.is_empty() {
+        return Err("no domain entered".into());
+    }
+    let api_token = prompt("  Cloudflare API token: ")?;
+    if api_token.is_empty() {
+        return Err("no token entered".into());
+    }
+
+    eprintln!("  verifying token and looking up zone…");
+    let zones_url = format!("{}/zones?name={}", CF_API_BASE, domain);
+    let resp = cf_request("GET", &zones_url, &api_token, None)
+        .map_err(|e| format!("could not verify token / find zone: {}", e))?;
+    let zone = resp["result"]
+        .as_array()
+        .and_then(|a| a.first())
+        .ok_or_else(|| {
+            format!(
+                "no Cloudflare zone found for '{}'. Add the domain to your Cloudflare \
+                 account first, and make sure the token can read it.",
+                domain
+            )
+        })?;
+    let zone_id = zone["id"]
+        .as_str()
+        .ok_or("zone lookup response missing zone id")?
+        .to_string();
+    let account_id = zone["account"]["id"]
+        .as_str()
+        .ok_or("zone lookup response missing account id")?
+        .to_string();
+
+    save_cf_creds(
+        config_dir,
+        &CloudflareCreds { api_token, account_id, zone_id },
+    )?;
+    eprintln!("  \x1b[32m✓\x1b[0m connected to {}", domain);
+    eprintln!();
+    Ok(())
 }
 
 fn cf_request(
@@ -187,10 +322,21 @@ fn gethostname() -> String {
 }
 
 pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
-    // Managed (vesta.run hosted) deployments pin an exact subdomain via
-    // VESTA_SUBDOMAIN — the control plane guarantees uniqueness, so the
-    // collision-avoidance animal prefix is neither needed nor wanted there.
-    // Self-hosters leave it unset and keep the generated <animal>-<hostname>.
+    // Managed (vesta.run) VMs: the control plane creates the tunnel + DNS and
+    // SEEDS tunnel.json into the config dir. vestad holds no Cloudflare account
+    // credential here, so it must NEVER call the Cloudflare API — it just uses the
+    // seeded config as-is. This is the load-bearing half of removing the baked
+    // fleet-wide token: a managed box can run its one tunnel but cannot touch the
+    // zone or any other tunnel.
+    if std::env::var("VESTA_MANAGED").is_ok() {
+        return get_tunnel_config(config_dir).ok_or_else(|| {
+            "managed mode: no tunnel.json seeded by the control plane".to_string()
+        });
+    }
+
+    // Self-hosted deployments pin an exact subdomain via VESTA_SUBDOMAIN only when
+    // set; otherwise keep the generated <animal>-<hostname>. Creation uses the
+    // BYOK creds in cloudflare.json (see cf_env / setup_cf_creds_interactive).
     let preferred = std::env::var("VESTA_SUBDOMAIN")
         .ok()
         .map(|s| sanitize(&s))
@@ -219,7 +365,7 @@ pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
 
 
 pub fn setup_tunnel(config_dir: &Path, subdomain: &str) -> Result<TunnelConfig, String> {
-    let env = cf_env()?;
+    let env = cf_env(config_dir)?;
     let domain = get_zone_domain(&env)?;
     let hostname = format!("{}.{}", subdomain, domain);
     let tunnel_name = format!("vesta-{}", subdomain);
@@ -296,7 +442,7 @@ pub fn destroy_tunnel(config_dir: &Path) -> Result<(), String> {
     let config = get_tunnel_config(config_dir)
         .ok_or("no tunnel configured")?;
 
-    let env = cf_env()?;
+    let env = cf_env(config_dir)?;
 
     if let Some(record_id) = &config.dns_record_id {
         tracing::info!("deleting DNS record");


### PR DESCRIPTION
## Why

The public `vestad` binary baked a Cloudflare API token into **every release** via `option_env!` (`tunnel.rs`), injected by CI (`ci.yml`). Because:

- the `vesta` repo + its releases are **public** (`install.sh` pulls binaries with no auth), and
- `option_env!` compiles the token in as a **plain string** in the binary,

anyone could `curl` a release and `strings vestad | grep cfut_` to recover a credential scoped to **Account → Cloudflare Tunnel: Edit** + **Zone → DNS: Edit**. That's enough to repoint all of `vesta.run`'s DNS (apex/login → phishing → OTP harvest), mint valid TLS for `*.vesta.run`, and delete/enumerate every tunnel in the account. It was the most exposed secret in the system.

This removes the baked token entirely. No box holds a credential broader than itself.

## What changed

- **`tunnel.rs` — no more bake.** `cf_env()` reads self-hosted creds from `cloudflare.json` (0600), env-var fallback for CI/power users. The binary ships no shared credential.
- **Forced BYOK (self-host).** First `vestad` with a tunnel and no creds prompts **once** for a domain + API token, **auto-discovers** zone + account from the domain (`GET /zones?name=`), validates, and saves. Also available explicitly as **`vestad tunnel login`**. The command stays just `vestad`; one-time paste on first run.
  - Stable URL is preserved on purpose — no ephemeral `*.trycloudflare.com`, because a changing hostname silently breaks externally-registered webhooks (e.g. `agent/skills/agentmail` registers `${VESTAD_TUNNEL}/…` with AgentMail).
  - Simple 3-permission explainer shown inline: Account → Tunnel → Edit, Zone → DNS → Edit, Zone → Zone → Read.
- **Managed mode (`VESTA_MANAGED`).** `ensure_tunnel` never calls the Cloudflare API — it uses the `tunnel.json` the control plane seeds. A managed VM can run its one tunnel but cannot touch the zone or other tunnels.
- **`ci.yml`** — stop injecting `CLOUDFLARE_*` into the vestad build.

## Pairs with

The control-plane change (vesta-cloud): control plane creates the tunnel + DNS server-side and passes only the **per-tunnel run token** to the VM via cloud-init.

## Rollout order (important)

1. Ship this.
2. Ship the control-plane change.
3. Let the fleet self-update.
4. **Only then** revoke the old shared `Edit zone DNS` token — old-build VMs still need it for teardown until they roll forward.

## Compatibility

- **Existing self-hosters:** their running tunnel keeps working (the per-tunnel run token is independent of the API token). To create/recreate a tunnel after updating, they run `vestad tunnel login` once. (They were previously, unknowingly, creating tunnels in the maintainer's `vesta.run` account — BYOK also fixes that.)
- **Managed:** the hosted control plane isn't live yet, so no production fleet to migrate; the seeded-`tunnel.json` path lands with the paired control-plane PR.

## Verification

- `cargo check` ✅ · `cargo clippy --bin vestad` clean ✅ · `cargo test --bin vestad tunnel::` ✅ (5/5)