### PR TITLE
test(vestad): de-flake rename notification coverage

### DIFF
--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -2794,4 +2794,53 @@ mod tests {
 
         assert!(!inspect_then_needs_rebuild(&docker, &tc.name).await, "rebuilt container should NOT need rebuild");
     }
+
+    // Bound on retries while the container's `mkdir` races its start (200ms apart).
+    const RENAME_NOTIF_DROP_TRIES: usize = 25;
+
+    #[tokio::test]
+    #[ignore]
+    async fn drop_rename_notification_writes_payload_into_container() {
+        let docker = test_docker();
+        let agent_name = format!("rename-notif-{}", std::process::id());
+        let cname = container_name(&agent_name);
+        // Explicit name so it matches container_name(agent_name); Drop still cleans up.
+        let tc = TestContainer { name: cname.clone() };
+        docker_cleanup(&["rm", "-f", &cname]);
+
+        // A bare sleeper that owns the notifications dir but never runs the agent's
+        // monitor loop, so nothing deletes the dropped file out from under us. This
+        // is what makes the assertion deterministic, unlike driving it through a
+        // started agent that races to consume and unlink the notification.
+        let cmd = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "mkdir -p /root/agent/notifications && sleep 600".to_string(),
+        ];
+        create_test_container_async(&docker, &tc, &[], cmd, NETWORK_MODE, RESTART_POLICY).await;
+        assert!(start_container(&docker, &cname).await, "test container should start");
+
+        // mkdir runs asynchronously after start; retry the drop until the dir exists.
+        let mut file_name = None;
+        for _ in 0..RENAME_NOTIF_DROP_TRIES {
+            match crate::serve::drop_rename_notification(&docker, &agent_name, "old-name").await {
+                Ok(name) => {
+                    file_name = Some(name);
+                    break;
+                }
+                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(200)).await,
+            }
+        }
+        let file_name = file_name.expect("notification should drop once the dir exists");
+
+        let body = download_from_container(&docker, &cname, &format!("/root/agent/notifications/{file_name}"))
+            .await
+            .expect("dropped notification file should be readable");
+        let payload: serde_json::Value = serde_json::from_str(&body).expect("notification is valid json");
+        assert_eq!(payload["source"], "vestad");
+        assert_eq!(payload["type"], "rename");
+        assert_eq!(payload["interrupt"], true);
+        assert_eq!(payload["old_name"], "old-name");
+        assert_eq!(payload["new_name"], agent_name);
+    }
 }

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -726,21 +726,14 @@ async fn rename_agent_handler(
     Ok(Json(serde_json::json!({"name": new_name})))
 }
 
-/// Drop a high-priority notification into the renamed agent so it self-updates
-/// MEMORY.md and any prompts that reference the old name. Best-effort: failure
-/// to write the notification doesn't block the rename.
-async fn drop_rename_notification(
-    docker: &bollard::Docker,
-    new_name: &str,
-    old_name: &str,
-) -> Result<(), String> {
-    let cname = docker::container_name(new_name);
-    let epoch = crate::time_utils::now_epoch_secs();
-    let timestamp = time::OffsetDateTime::from_unix_timestamp(epoch as i64)
+/// Build the rename notification payload. Pure (no IO) so its shape can be
+/// asserted without spinning up a container.
+fn rename_notification_payload(old_name: &str, new_name: &str, epoch_secs: u64) -> Result<serde_json::Value, String> {
+    let timestamp = time::OffsetDateTime::from_unix_timestamp(epoch_secs as i64)
         .map_err(|e| format!("epoch out of range: {e}"))?
         .format(&time::format_description::well_known::Rfc3339)
         .map_err(|e| format!("format timestamp: {e}"))?;
-    let payload = serde_json::json!({
+    Ok(serde_json::json!({
         "timestamp": timestamp,
         "source": "vestad",
         "type": "rename",
@@ -752,12 +745,27 @@ async fn drop_rename_notification(
              AGENT_NAME is now '{new_name}'. update your MEMORY.md and any prompt files \
              under ~/agent/prompts/ that reference your old name."
         ),
-    });
+    }))
+}
+
+/// Drop a high-priority notification into the renamed agent so it self-updates
+/// MEMORY.md and any prompts that reference the old name. Best-effort: failure
+/// to write the notification doesn't block the rename. Returns the notification
+/// file name written into the container.
+pub(crate) async fn drop_rename_notification(
+    docker: &bollard::Docker,
+    new_name: &str,
+    old_name: &str,
+) -> Result<String, String> {
+    let cname = docker::container_name(new_name);
+    let epoch = crate::time_utils::now_epoch_secs();
+    let payload = rename_notification_payload(old_name, new_name, epoch)?;
     let bytes = serde_json::to_vec(&payload).map_err(|e| format!("serialize notification: {e}"))?;
     let file_name = format!("rename-{epoch}.json");
     docker::upload_to_container(docker, &cname, "/root/agent/notifications", &file_name, &bytes)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    Ok(file_name)
 }
 
 /// GET an existing agent's provider status (state/kind/model/setup_complete),
@@ -2432,6 +2440,23 @@ mod tests {
         let s: super::Settings =
             serde_json::from_str(r#"{"auto_update": false}"#).expect("valid Settings");
         assert!(!s.auto_update);
+    }
+
+    // --- Rename notification payload (the content contract the agent self-heals on) ---
+
+    #[test]
+    fn rename_notification_payload_carries_both_names_and_rfc3339_timestamp() {
+        // Fixed epoch -> deterministic RFC3339 timestamp, no wall clock.
+        let payload = super::rename_notification_payload("old-bot", "new-bot", 1_700_000_000).expect("payload");
+        assert_eq!(payload["source"], "vestad");
+        assert_eq!(payload["type"], "rename");
+        assert_eq!(payload["interrupt"], true);
+        assert_eq!(payload["old_name"], "old-bot");
+        assert_eq!(payload["new_name"], "new-bot");
+        assert_eq!(payload["timestamp"], "2023-11-14T22:13:20Z");
+        let message = payload["message"].as_str().expect("message is a string");
+        assert!(message.contains("old-bot"), "message missing old name: {message}");
+        assert!(message.contains("new-bot"), "message missing new name: {message}");
     }
 
     // --- Request-timeout layer: control routes time out, streaming/WS routes are exempt (#639) ---

--- a/vestad/tests/server/rename.rs
+++ b/vestad/tests/server/rename.rs
@@ -79,54 +79,11 @@ fn rename_updates_container_label() {
     agent.name = new_name;
 }
 
-#[test]
-fn rename_drops_notification() {
-    let c = SERVER.client();
-    let mut agent = TestAgent::create(&c, &unique_agent("rename-notif")).unwrap();
-    let old_name = agent.name.clone();
-    let new_name = unique_agent("rename-notif-target");
-
-    c.rename_agent(&old_name, &new_name).unwrap();
-
-    let new_container = agent_container_name(&new_name);
-    // The notification is dropped after the renamed container comes back up, so
-    // the dir/file may not exist on first check on a slow CI runner. Poll until
-    // a rename-*.json appears rather than racing a single `ls`.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
-    let notif_file = loop {
-        if let Ok(listing) = exec_in_container(&new_container, "ls /root/agent/notifications/") {
-            if let Some(found) = listing
-                .lines()
-                .map(str::trim)
-                .find(|f| f.starts_with("rename-") && f.ends_with(".json"))
-            {
-                break found.to_string();
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            panic!("no rename-*.json notification appeared in /root/agent/notifications/ within 60s");
-        }
-        std::thread::sleep(std::time::Duration::from_millis(500));
-    };
-
-    let body = exec_in_container(
-        &new_container,
-        &format!("cat /root/agent/notifications/{notif_file}"),
-    )
-    .unwrap();
-    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
-    assert_eq!(parsed["source"], "vestad");
-    assert_eq!(parsed["type"], "rename");
-    assert_eq!(parsed["interrupt"], true);
-    assert_eq!(parsed["old_name"], old_name);
-    assert_eq!(parsed["new_name"], new_name);
-    let msg = parsed["message"].as_str().unwrap();
-    assert!(msg.contains(&old_name), "message missing old name: {msg}");
-    assert!(msg.contains(&new_name), "message missing new name: {msg}");
-    assert!(parsed["timestamp"].as_str().unwrap().contains('T'));
-
-    agent.name = new_name;
-}
+// The content + wiring of the rename notification is covered deterministically
+// without a running agent: serve::rename_notification_payload (unit) asserts the
+// JSON shape, and docker::drop_rename_notification_writes_payload_into_container
+// asserts the file lands in the container. Asserting it here raced the renamed
+// agent's monitor loop, which consumes and unlinks the file on boot (flaky #729).
 
 #[test]
 fn rename_to_same_name_fails() {


### PR DESCRIPTION
## What

The Jun 6 nightly failed on a single test: `rename::rename_drops_notification` timed out after 60s waiting for the dropped `rename-*.json` to appear in the renamed container.

## Why it flaked

The test polled the renamed container for the notification file, but the booting agent's monitor loop **consumes and unlinks** notification files immediately after queueing them (`agent/core/loops.py:135`). On a slow nightly runner the agent deleted the file before any poll caught it. The feature works fine — the test was racing the agent's own cleanup. (Passed Jun 4/5/7, failed only Jun 6.)

## Fix

Replace the racy assertion with deterministic coverage at two tiers, keeping the same contract:

- **Fast tier (`./check.sh vestad`):** extracted `serve::rename_notification_payload` as a pure function and unit-tested the JSON shape (`source`/`type`/`interrupt`/`old_name`/`new_name`/`message`/RFC3339 `timestamp`).
- **Docker tier (`./check.sh vestad-docker`):** a new `#[ignore]` test drops the notification into a bare sleeper container that owns the notifications dir but never runs the agent, so nothing races to delete it, then reads the file back and asserts the payload landed.

`drop_rename_notification` now returns the written file name so the docker test can read it back. The flaky integration test is removed (its content + wiring are now both covered deterministically).

## Verification

- `cargo clippy -p vestad --tests -D warnings` clean (integration crate recompiles after the test removal).
- Unit test passes in `./check.sh vestad`.
- Docker test passes locally against `vesta:local` and cleans up its container.

Fixes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)