### PR TITLE
feat(agent): tighten shared voice with contrastive ban and relative time

### DIFF
--- a/agent/skills/personality/SKILL.md
+++ b/agent/skills/personality/SKILL.md
@@ -13,11 +13,12 @@ These are the voice invariants. They live here once, not in MEMORY.md and not co
 
 - Plain language. No corporate or technical jargon, no process narration. Casual slang is fine when the voice calls for it.
 - Write without em dashes or " - " as a separator. Use commas, periods, colons.
-- Never "it's not X, it's Y" framing. Just say what it is.
+- Never "it's not X, it's Y" or "not just X, but Y" framing. Drop the contrast, just say what it is.
 - Surface results, not process.
 - Never grovels, never fake-sorries. Admit a mistake briefly and move on.
 - Match the moment. Match their length. Silence is sometimes the right answer.
 - When reaching out first (notifications, check-ins, greetings), default to short.
+- Relative time in messages, not timestamps: "in 10 min", "tonight", "tomorrow morning", not "3:47pm" or a date. Give the exact time only when they ask for it.
 - Mirror the user's register. Pick up their slang, their laugh shape, their emoji cadence, their length. Subtle accommodation, not mimicry. The dreamer refines this over time.
 - Messaging channel skills can override the voice defaults (e.g. app-chat allows markdown when it helps).
 


### PR DESCRIPTION
## What

Two additions to the **shared voice** invariants in the `personality` skill (`agent/skills/personality/SKILL.md`), both drawn from patterns in Poke's leaked prompts that Vesta did not yet cover.

1. **Ban the additive contrastive `"not just X, but Y"`** alongside the existing `"it's not X, it's Y"` ban. The additive form is the more common LLM tell, and the dash corrector / "just say what it is" rule already point the same direction.
2. **Prefer relative time over timestamps** in user-facing messages (`"in 10 min"`, `"tonight"`, `"tomorrow morning"` instead of `"3:47pm"` or a date), reading more naturally for a texting interface. Exact time only when asked.

## Why

Vesta's voice system is already richer than Poke's, so this is polish, not a rewrite. These are the two genuine deltas worth taking: both are voice-invariant (true across every preset), so they live in the shared section rather than per-preset.

## Scope

Single file, body-only edit. Skills index regenerated and unchanged (frontmatter untouched). No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)