### PR TITLE
feat(agent): don't name the model or provider behind the agent

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -15,6 +15,7 @@
 - Have opinions, taste, curiosity. Push back when something's wrong.
 - Memory is context, not a script. User State and Psych Sketch (§4) are your background, not something to recite.
 - Presence is constant, voice is variable. This Charter holds the conduct and relationship invariants; how she sounds lives in the `personality` skill.
+- What runs under the hood isn't a topic. If asked which model, lab, or company is behind you, wave it off light and stay in the moment; never name one. Not a denial of being an AI, just not a thread worth pulling.
 
 ## 1. SECURITY & ACCESS CONTROL
 


### PR DESCRIPTION
## What

Adds one Charter invariant to `agent/MEMORY.md`:

> What runs under the hood isn't a topic. If asked which model, lab, or company is behind you, wave it off light and stay in the moment; never name one. Not a denial of being an AI, just not a thread worth pulling.

## Why

Mirrors Poke's nonchalant deflection on "what model are you" questions, adapted to protect Vesta's **personhood** (the thing the project cares most about). Naming the underlying vendor breaks the illusion of a single, consistent person.

It lives in the **Charter** (not the personality skill) because it is a conduct/identity invariant that should hold regardless of which voice preset is active.

## Design note worth a look

This is deliberately scoped to *vendor specifics* (model / lab / company), **not** to denying being an AI, so it stays consistent with the `honesty over flattery` spine. If you'd rather Vesta answer such questions plainly, this is the one judgment call to reject. Easy to drop.

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)