### PR TITLE
fix(google): bound first-run catch-up so re-auth doesn't flood stale notifications

### DIFF
--- a/agent/skills/google/cli/src/google_cli/monitor.py
+++ b/agent/skills/google/cli/src/google_cli/monitor.py
@@ -13,6 +13,15 @@ from .gmail import _get_header
 _INVISIBLE = re.compile(r"[​-‏‪-‮⁠⁦-⁩﻿]")
 _WHITESPACE_RUN = re.compile(r"\s+")
 
+# Cap how far back a first-run catch-up reaches. A long offline gap (e.g. the
+# daemon restarting with a fresh token after the old one expired) otherwise
+# replays weeks of unread email and past calendar events as notifications.
+MAX_CATCHUP_LOOKBACK = timedelta(hours=24)
+
+
+def clamp_catchup_start(last_check_dt: datetime, now: datetime) -> datetime:
+    return max(last_check_dt, now - MAX_CATCHUP_LOOKBACK)
+
 
 def clean_preview(text: str) -> str:
     return _WHITESPACE_RUN.sub(" ", _INVISIBLE.sub("", text)).strip()
@@ -85,12 +94,16 @@ def run(ctx: GoogleContext):
                     catching_up = True
             first_run = False
 
-            logger.info(f"Checking for updates since {last_check_str}")
+            query_since = clamp_catchup_start(last_check_dt, new_check_time)
+            if query_since != last_check_dt:
+                logger.info(f"Clamping catch-up window from {last_check_str} to {query_since.isoformat()}")
+
+            logger.info(f"Checking for updates since {query_since.isoformat()}")
 
             try:
                 gmail = api.gmail_service(config)
 
-                epoch_seconds = int(last_check_dt.timestamp())
+                epoch_seconds = int(query_since.timestamp())
                 query = f"after:{epoch_seconds}"
                 results = gmail.users().messages().list(userId="me", q=query, labelIds=["INBOX"], maxResults=50).execute()
                 messages = results["messages"] if "messages" in results else []
@@ -134,7 +147,7 @@ def run(ctx: GoogleContext):
                     cal.events()
                     .list(
                         calendarId="primary",
-                        timeMin=last_check_dt.isoformat(),
+                        timeMin=query_since.isoformat(),
                         timeMax=window_end.isoformat(),
                         singleEvents=True,
                         orderBy="startTime",
@@ -159,7 +172,7 @@ def run(ctx: GoogleContext):
 
                     for threshold_mins in config.get_calendar_notify_thresholds():
                         trigger_time = event_time - timedelta(minutes=threshold_mins)
-                        if not (last_check_dt <= trigger_time < new_check_time):
+                        if not (query_since <= trigger_time < new_check_time):
                             continue
 
                         label = _format_threshold_label(threshold_mins)

--- a/agent/skills/google/cli/tests/test_monitor.py
+++ b/agent/skills/google/cli/tests/test_monitor.py
@@ -1,0 +1,27 @@
+"""Unit tests for monitor.clamp_catchup_start — bounding the first-run catch-up window."""
+
+from datetime import datetime, timedelta, UTC
+
+from google_cli import monitor
+
+
+def test_recent_last_check_is_left_untouched():
+    now = datetime(2026, 6, 9, 12, 0, tzinfo=UTC)
+    last_check = now - timedelta(seconds=45)
+    assert monitor.clamp_catchup_start(last_check, now) == last_check
+
+
+def test_gap_within_the_window_is_left_untouched():
+    now = datetime(2026, 6, 9, 12, 0, tzinfo=UTC)
+    last_check = now - timedelta(hours=6)
+    assert monitor.clamp_catchup_start(last_check, now) == last_check
+
+
+def test_stale_last_check_is_clamped_to_the_lookback_bound():
+    now = datetime(2026, 6, 9, 12, 0, tzinfo=UTC)
+    last_check = now - timedelta(weeks=6)
+    assert monitor.clamp_catchup_start(last_check, now) == now - monitor.MAX_CATCHUP_LOOKBACK
+
+
+def test_clamp_bound_is_24_hours():
+    assert monitor.MAX_CATCHUP_LOOKBACK == timedelta(hours=24)


### PR DESCRIPTION
## Problem

Fixes #728.

When `google serve` restarts after a long offline gap (token expired, then re-auth), `~/.google/monitor/state.txt` still holds the weeks-old `last_check` from when the daemon last ran. The first-run catch-up then queried Gmail with `after:<weeks ago>` and Calendar with `timeMin=<weeks ago>`, replaying every unread INBOX email and every past calendar event in the window as a notification (the reported 50+ burst, including events with `minutes_until < -20000`).

## Fix

Clamp the catch-up query lower bound to at most `MAX_CATCHUP_LOOKBACK` (24h) via a small pure helper, `clamp_catchup_start(last_check_dt, now)`, applied before the Gmail and Calendar lookups (and the per-event trigger check).

- Normal 45s cycles and short offline gaps are unaffected (`last_check` is always within the window, so the clamp is a no-op).
- Only the stale-state re-auth case is bounded: anything older than 24h is dropped silently rather than surfaced.
- The offline-gap detection log and the `missed` flag on genuinely-missed recent items are unchanged.

This is the daemon-side fix the issue asked for; it supersedes the agent-side memory workaround. No `--backfill` opt-in was added (kept minimal); older state is simply not replayed.

## Tests

Added `agent/skills/google/cli/tests/test_monitor.py` covering the clamp helper: recent/within-window checks pass through untouched, stale checks clamp to the 24h bound, and the bound is asserted to be 24h.

```
$ uv run pytest tests/ -q
....   4 passed
```