### PR TITLE
refactor(agent): reference reply skill by name instead of copying CLI syntax

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -70,25 +70,14 @@ async def delete_notification_files(notifications: list[vm.Notification]) -> Non
         pl.Path(path_str).unlink(missing_ok=True)
 
 
+_REPLY_SKILLS = frozenset({"app-chat", "whatsapp", "telegram"})
+
+
 def _reply_hint(notif: vm.Notification) -> str:
-    """Inline command hint so the model invokes the reply skill instead of forgetting."""
-    if notif.type != "message":
+    """Point the model at the originating channel's reply skill instead of copying its CLI syntax."""
+    if notif.type != "message" or notif.source not in _REPLY_SKILLS:
         return ""
-    if notif.source == "app-chat":
-        return "\n→ Reply with: `app-chat send --message '...'`"
-    if notif.source in ("whatsapp", "telegram"):
-        data = notif.model_dump(exclude={"file_path", "type", "source", "interrupt", "timestamp"})
-        recipient = None
-        for key in ("chat_name", "contact_name"):
-            if key in data and data[key]:
-                recipient = data[key]
-                break
-        if not recipient:
-            return ""
-        if notif.source == "whatsapp":
-            return f"\n→ Reply with: `whatsapp send --to '{recipient}' --message '...'`"
-        return f"\n→ Reply with: `telegram send '{recipient}' '...'`"
-    return ""
+    return f"\n→ Reply using the `{notif.source}` skill."
 
 
 def _format_one(notif: vm.Notification) -> str:

--- a/agent/core/prompts/notification_suffix.md
+++ b/agent/core/prompts/notification_suffix.md
@@ -1,1 +1,1 @@
-Reply on the originating channel if a user message (whatsapp→`whatsapp send`, telegram→`telegram send`, app-chat→`app-chat send`). Check MEMORY.md Learned Patterns before responding.
+Reply on the originating channel if a user message, using that channel's skill (whatsapp, telegram, or app-chat). Check MEMORY.md Learned Patterns before responding.

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -244,7 +244,7 @@ def test_format_for_display_strips_timestamp_microseconds():
     [
         (
             {"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "message", "contact_name": "Alice", "message": "hi"},
-            "whatsapp send --to 'Alice'",
+            "Reply using the `whatsapp` skill",
         ),
         (
             {
@@ -255,15 +255,15 @@ def test_format_for_display_strips_timestamp_microseconds():
                 "sender": "bob",
                 "message": "hi",
             },
-            "whatsapp send --to 'Group'",
+            "Reply using the `whatsapp` skill",
         ),
         (
             {"timestamp": "2025-01-01T00:00:00", "source": "telegram", "type": "message", "contact_name": "Carol", "message": "hi"},
-            "telegram send 'Carol'",
+            "Reply using the `telegram` skill",
         ),
         (
             {"timestamp": "2025-01-01T00:00:00", "source": "app-chat", "type": "message", "message": "hi"},
-            "app-chat send --message",
+            "Reply using the `app-chat` skill",
         ),
     ],
     ids=["whatsapp-direct", "whatsapp-group", "telegram-direct", "app-chat"],
@@ -271,14 +271,14 @@ def test_format_for_display_strips_timestamp_microseconds():
 def test_batch_includes_reply_hint(payload, expected_substr):
     notif = vm.Notification.model_validate(payload)
     formatted = format_notification_batch([notif])
-    assert "→ Reply with:" in formatted
+    assert "→ Reply using" in formatted
     assert expected_substr in formatted
 
 
 def test_batch_no_hint_for_unknown_source():
     notif = vm.Notification.model_validate({"timestamp": "2025-01-01T00:00:00", "source": "email", "type": "message", "sender": "alice"})
     formatted = format_notification_batch([notif])
-    assert "→ Reply with:" not in formatted
+    assert "→ Reply using" not in formatted
 
 
 def test_batch_no_hint_for_non_message_type():
@@ -286,7 +286,7 @@ def test_batch_no_hint_for_non_message_type():
         {"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "reaction", "contact_name": "Alice", "emoji": "👍"}
     )
     formatted = format_notification_batch([notif])
-    assert "→ Reply with:" not in formatted
+    assert "→ Reply using" not in formatted
 
 
 # --- load_new_notifications ---


### PR DESCRIPTION
## Problem
The inline reply hint added to incoming-message notifications hardcoded each channel's exact send command (`whatsapp send --to ... --message`, `telegram send`, `app-chat send --message`) plus the recipient field names (`chat_name`/`contact_name`). That CLI contract is owned by the skills, so the hint was a free-floating copy: a skill renaming a flag (e.g. `--to` → `--recipient`) would silently desync the hint with no test catching it. See #642.

## Change
Drop the per-channel argv from `_reply_hint`. For any user message from a channel with a reply skill, the hint now just names the skill, derived directly from `notif.source`:

> → Reply using the `whatsapp` skill.

- `agent/core/loops.py` — `_reply_hint` no longer mentions flags or recipient fields; a small `_REPLY_SKILLS` whitelist keeps sources without a skill (e.g. `email`) from getting a bogus hint.
- `agent/core/prompts/notification_suffix.md` — say "use that channel's skill" instead of repeating the send commands.
- `agent/tests/test_notifications.py` — assert the skill-reference hint; the no-skill and non-message cases still get no hint.

Core no longer copies the skills' CLI surface, so flag renames can't desync the hint.

Fixes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)