### PR TITLE
chore: remove pre-v1.0 backwards-compat shims

### DIFF
--- a/agent/core/state_store.py
+++ b/agent/core/state_store.py
@@ -3,10 +3,6 @@
 All boot-time and cross-restart markers live in `~/agent/data/state.json`. Loaded once
 at boot, mutated in place via the `PersistedState` field on `vm.State`, and saved
 immediately via `save_state` after every mutation. Writes are atomic (tmp + rename).
-
-On first boot under this code path, `load_state` imports any legacy marker files
-(`first_start_done`, `restart_reason`, `last_dreamer_run`, `show_dreamer_summary`,
-`session_id`, `migrations.applied`) into the new schema and removes them.
 """
 
 import datetime as dt
@@ -19,18 +15,6 @@ from . import logger
 from . import config as cfg
 
 STATE_FILENAME = "state.json"
-
-# LEGACY-CLEANUP(#726): drop LEGACY_FILES, _import_legacy, _remove_legacy_files,
-# and their calls in load_state once every agent has booted once on a
-# state.json-aware version (old per-marker files are imported then deleted).
-LEGACY_FILES = (
-    "first_start_done",
-    "restart_reason",
-    "last_dreamer_run",
-    "show_dreamer_summary",
-    "session_id",
-    "migrations.applied",
-)
 
 
 class PersistedState(pyd.BaseModel):
@@ -61,9 +45,8 @@ def load_state(config: cfg.VestaConfig) -> PersistedState:
             # state.json — log and start fresh; first-start will re-run.
             logger.error(f"state.json unparseable ({type(e).__name__}: {e}) — starting fresh")
             return PersistedState()
-    state = _import_legacy(config)
+    state = PersistedState()
     save_state(state, config)
-    _remove_legacy_files(config)
     return state
 
 
@@ -73,51 +56,3 @@ def save_state(state: PersistedState, config: cfg.VestaConfig) -> None:
     tmp = path.with_suffix(".json.tmp")
     tmp.write_text(state.model_dump_json())
     os.replace(tmp, path)
-
-
-def _import_legacy(config: cfg.VestaConfig) -> PersistedState:
-    d = config.data_dir
-    legacy = PersistedState(
-        first_start_done=(d / "first_start_done").exists(),
-        last_restart_reason=_read_text_or_none(d / "restart_reason"),
-        last_dreamer_run=_parse_iso_or_none(d / "last_dreamer_run"),
-        show_dreamer_summary=(d / "show_dreamer_summary").exists(),
-        session_id=_read_text_or_none(d / "session_id"),
-        applied_migrations=_read_lines(d / "migrations.applied"),
-    )
-    if any(
-        [
-            legacy.first_start_done,
-            legacy.last_restart_reason,
-            legacy.last_dreamer_run,
-            legacy.show_dreamer_summary,
-            legacy.session_id,
-            legacy.applied_migrations,
-        ]
-    ):
-        logger.startup("Imported legacy marker files into state.json")
-    return legacy
-
-
-def _read_text_or_none(path: pl.Path) -> str | None:
-    if not path.exists():
-        return None
-    return path.read_text().strip() or None
-
-
-def _parse_iso_or_none(path: pl.Path) -> dt.datetime | None:
-    raw = _read_text_or_none(path)
-    if raw is None:
-        return None
-    return dt.datetime.fromisoformat(raw)
-
-
-def _read_lines(path: pl.Path) -> list[str]:
-    if not path.exists():
-        return []
-    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
-
-
-def _remove_legacy_files(config: cfg.VestaConfig) -> None:
-    for name in LEGACY_FILES:
-        (config.data_dir / name).unlink(missing_ok=True)

--- a/agent/tests/test_state_store.py
+++ b/agent/tests/test_state_store.py
@@ -12,7 +12,7 @@ def _config(tmp_path):
     return config
 
 
-def test_load_returns_defaults_when_no_state_or_legacy(tmp_path):
+def test_load_returns_defaults_when_no_state(tmp_path):
     config = _config(tmp_path)
     state = state_store.load_state(config)
     assert state == vm.PersistedState()
@@ -35,29 +35,6 @@ def test_save_then_load_round_trip(tmp_path):
     assert reloaded == original
 
 
-def test_legacy_files_are_imported_and_removed(tmp_path):
-    config = _config(tmp_path)
-    d = config.data_dir
-    (d / "first_start_done").write_text("1")
-    (d / "restart_reason").write_text("clean restart\n")
-    (d / "last_dreamer_run").write_text("2026-01-02T03:04:05\n")
-    (d / "show_dreamer_summary").write_text("1")
-    (d / "session_id").write_text("legacy-session-id-1234567890\n")
-    (d / "migrations.applied").write_text("mig-1\nmig-2\n\n")
-
-    state = state_store.load_state(config)
-
-    assert state.first_start_done is True
-    assert state.last_restart_reason == "clean restart"
-    assert state.last_dreamer_run == dt.datetime(2026, 1, 2, 3, 4, 5)
-    assert state.show_dreamer_summary is True
-    assert state.session_id == "legacy-session-id-1234567890"
-    assert state.applied_migrations == ["mig-1", "mig-2"]
-
-    for name in state_store.LEGACY_FILES:
-        assert not (d / name).exists(), f"legacy file {name} should be removed"
-
-
 def test_save_is_atomic(tmp_path):
     """tmp + rename: a partial write must never leave the canonical state.json corrupt."""
     config = _config(tmp_path)
@@ -67,15 +44,3 @@ def test_save_is_atomic(tmp_path):
     tmp.write_text("garbage")
     state_store.save_state(vm.PersistedState(session_id="second"), config)
     assert state_store.load_state(config).session_id == "second"
-
-
-def test_load_with_existing_state_ignores_legacy_files(tmp_path):
-    """If state.json already exists, legacy markers are leftover noise — don't merge them."""
-    config = _config(tmp_path)
-    state_store.save_state(vm.PersistedState(session_id="from-state-json"), config)
-    (config.data_dir / "session_id").write_text("legacy-noise")
-
-    state = state_store.load_state(config)
-    assert state.session_id == "from-state-json"
-    # Legacy file is left alone (only removed during the import path, not on every load).
-    assert (config.data_dir / "session_id").exists()

--- a/apps/web/src/components/Console/index.tsx
+++ b/apps/web/src/components/Console/index.tsx
@@ -62,28 +62,6 @@ const SUBFAMILY_COLOR_CLASS: Record<string, Record<string, string>> = {
   },
 };
 
-// LEGACY-CLEANUP(#726): remove this map (and its use in extractTags / color
-// lookup) once the minimum supported agent emits the hierarchical
-// family/subfamily log format instead of these old flat tags.
-const LEGACY_TAG_TO_FAMILY: Record<string, string> = {
-  ASSISTANT: "AGENT",
-  THINKING: "AGENT",
-  "TOOL CALL": "AGENT",
-  TOOL: "AGENT",
-  SUBAGENT: "AGENT",
-  INIT: "SYSTEM",
-  STARTUP: "SYSTEM",
-  SHUTDOWN: "SYSTEM",
-  CLIENT: "SYSTEM",
-  DREAMER: "SYSTEM",
-  INTERRUPT: "SYSTEM",
-  PROACTIVE: "SYSTEM",
-  SDK: "SYSTEM",
-  USAGE: "SYSTEM",
-  USER: "USER",
-  NOTIFICATION: "EVENT",
-};
-
 function extractTags(line: string): string[] {
   return [...line.matchAll(/\[([A-Z ]+)\]/g)]
     .map((match) => match[1])
@@ -104,15 +82,7 @@ function lineColorClass(line: string): string | null {
     );
   }
 
-  const legacyTag = tags.find((tag) => tag in LEGACY_TAG_TO_FAMILY);
-  if (!legacyTag) return null;
-
-  const family = LEGACY_TAG_TO_FAMILY[legacyTag];
-  return (
-    SUBFAMILY_COLOR_CLASS[family]?.[legacyTag] ||
-    FAMILY_COLOR_CLASS[family] ||
-    null
-  );
+  return null;
 }
 
 interface ConsoleProps {

--- a/apps/web/src/lib/connection.ts
+++ b/apps/web/src/lib/connection.ts
@@ -51,12 +51,6 @@ function readFromLocalStorage(): ConnectionConfig | null {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw);
-    // LEGACY-CLEANUP(#726): drop this branch once pre-token (apiKey) installs are
-    // assumed cleared; it discards the old auth format so it can't be misread.
-    if (parsed.apiKey && !parsed.accessToken) {
-      localStorage.removeItem(STORAGE_KEY);
-      return null;
-    }
     if (parsed.url && parsed.accessToken && parsed.refreshToken) return parsed;
     return null;
   } catch {

--- a/apps/web/src/stores/use-voice-activation.ts
+++ b/apps/web/src/stores/use-voice-activation.ts
@@ -14,11 +14,7 @@ interface VoiceActivationState {
 
 function loadMode(): VoiceActivationMode {
   if (typeof localStorage === "undefined") return "toggle";
-  // Migrate the old key if it's the only one present.
-  // LEGACY-CLEANUP(#726): drop the spacebar-mode fallback once existing installs
-  // have re-saved under STORAGE_KEY (a release or two after this shipped).
-  const legacy = localStorage.getItem("spacebar-mode");
-  const current = localStorage.getItem(STORAGE_KEY) ?? legacy;
+  const current = localStorage.getItem(STORAGE_KEY);
   return current === "hold" ? "hold" : "toggle";
 }
 

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -366,55 +366,6 @@ pub async fn cleanup_backups(
     }
 }
 
-/// Reclaim disk from the old docker-image backups: drop an agent's legacy
-/// `vesta-backup:<agent>_*` images once it has a restic snapshot (so a current
-/// backup always exists first). Idempotent; safe to call repeatedly.
-///
-/// LEGACY-CLEANUP(#726): remove this fn, `legacy_backup_images`, and the two
-/// `cleanup_legacy_backups` call sites in serve.rs once all agents have migrated
-/// off the pre-restic docker-image backup model.
-pub async fn cleanup_legacy_backups(docker: &Docker) {
-    for name in list_agent_names(docker).await {
-        let images = legacy_backup_images(&name).await;
-        if images.is_empty() {
-            continue;
-        }
-        let have_restic = matches!(crate::restic::list(&name).await, Ok(b) if !b.is_empty());
-        if !have_restic {
-            continue;
-        }
-        for image in &images {
-            tokio::process::Command::new("docker")
-                .args(["rmi", "-f", image])
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .await
-                .ok();
-        }
-        tracing::info!(agent = %name, count = images.len(), "reclaimed legacy backup images");
-    }
-}
-
-/// List this agent's legacy `vesta-backup:<agent>_*` image tags, if any.
-async fn legacy_backup_images(name: &str) -> Vec<String> {
-    match tokio::process::Command::new("docker")
-        .args([
-            "images", "--format", "{{.Repository}}:{{.Tag}}",
-            "--filter", &format!("reference=vesta-backup:{name}_*"),
-        ])
-        .output()
-        .await
-    {
-        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
-            .lines()
-            .map(|l| l.trim().to_string())
-            .filter(|l| !l.is_empty())
-            .collect(),
-        _ => Vec::new(),
-    }
-}
-
 /// List all agent names that have containers.
 pub async fn list_agent_names(docker: &Docker) -> Vec<String> {
     crate::docker::list_managed_agents(docker)

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2262,7 +2262,6 @@ fn spawn_auto_backup_task(state: SharedState) {
                 backup::cleanup_backups(name, &backups, &ret).await;
             }
 
-            backup::cleanup_legacy_backups(&state.docker).await;
             tracing::info!(agent_count = agents.len(), "auto-backup: cycle complete");
         }
     });
@@ -2363,11 +2362,6 @@ pub async fn run_server(cfg: ServerConfig) {
     );
     let app = build_router(state.clone());
     spawn_auto_backup_task(state.clone());
-    {
-        // Reclaim legacy docker-image backups (also runs after each backup cycle).
-        let state = state.clone();
-        tokio::spawn(async move { backup::cleanup_legacy_backups(&state.docker).await; });
-    }
     if dev_mode {
         tracing::info!("dev mode: auto-update disabled");
     } else {


### PR DESCRIPTION
## Summary

Removes the batch of legacy/backwards-compat shims tracked under `LEGACY-CLEANUP(#726)`, as a single cleanup at the minimum-supported-version cutoff. Each was correct-but-dead once no old agents/installs remain in the field.

Removed sites:
1. **Pre-restic docker-image backup reaper** (`vestad/src/backup.rs`): `cleanup_legacy_backups()` + `legacy_backup_images()` and the two call sites in `serve.rs` (startup + post-backup cycle). `list_agent_names()` is kept — it has other callers.
2. **Legacy marker-file import** (`agent/core/state_store.py`): `LEGACY_FILES`, `_import_legacy()`, `_remove_legacy_files()` and the IO helpers; first boot now writes a fresh `state.json`. The two legacy-specific tests are dropped and the defaults test renamed.
3. **Old flat log-tag mapping** (`apps/web/src/components/Console/index.tsx`): `LEGACY_TAG_TO_FAMILY` and its fallback branch in `lineColorClass`.
4. **`spacebar-mode` localStorage migration** (`apps/web/src/stores/use-voice-activation.ts`).
5. **Pre-token `apiKey` localStorage discard** (`apps/web/src/lib/connection.ts`).

`name_from_cname()` in `docker.rs` is intentionally left untouched (defensive fallback, not a self-contained legacy block, per the issue).

## Note on timing

The issue gates this on declaring a minimum supported version (framed as a v1.0 task); current version is 0.1.157. Opening per your request — merge whenever the version-cutoff decision is settled.

## Verification

- `agent`: ruff check + format + ty + `pytest tests/test_state_store.py` (3 passed)
- `vestad`: `cargo clippy -p vestad --all-targets -D warnings` (clean)
- `web`: eslint (0 errors), prettier --check, tsc, vitest (57 passed)

Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)