### PR TITLE
feat(app): add stop control to chat composer while agent thinks

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -37,6 +37,7 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
     Recv: clients can emit events (e.g. user messages, chat replies).
     On connect: sends recent history unless ?skip_history=1 is passed."""
     event_bus: EventBus = request.app["event_bus"]
+    state: State | None = request.app["state"]
     skip_history = request.query.get("skip_history", "") in ("1", "true")
 
     ws = web.WebSocketResponse()
@@ -51,7 +52,7 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
             events, cursor = event_bus.recent()
             if events:
                 await ws.send_json(HistoryEvent(type="history", events=events, state=event_bus.state, cursor=cursor))
-        recv_task = asyncio.create_task(_recv_loop(ws, event_bus))
+        recv_task = asyncio.create_task(_recv_loop(ws, event_bus, state))
         send_task = asyncio.create_task(_send_loop(ws, sub))
         await asyncio.wait([recv_task, send_task], return_when=asyncio.FIRST_COMPLETED)
     finally:
@@ -66,7 +67,7 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
     return ws
 
 
-async def _recv_loop(ws: web.WebSocketResponse, event_bus: EventBus) -> None:
+async def _recv_loop(ws: web.WebSocketResponse, event_bus: EventBus, state: State | None) -> None:
     """Receive events from clients and emit to event bus."""
     async for msg in ws:
         if msg.type == web.WSMsgType.TEXT:
@@ -89,6 +90,14 @@ async def _recv_loop(ws: web.WebSocketResponse, event_bus: EventBus) -> None:
                         event_bus.emit(event)
                     else:
                         event_bus.emit(ChatEvent(type="chat", text=text))
+            elif msg_type == "interrupt":
+                # Pure stop: halt the in-flight turn without queueing a new message.
+                # The message processor owns the interrupt sequence (drain + return to
+                # idle) by waiting on state.interrupt_event; setting it here is a no-op
+                # when the agent is idle (interrupt_event is None between turns).
+                if state is not None and state.interrupt_event is not None and not state.interrupt_event.is_set():
+                    state.interrupt_event.set()
+                    logger.info("client interrupt received")
         elif msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):
             break
 

--- a/agent/tests/test_api.py
+++ b/agent/tests/test_api.py
@@ -21,9 +21,10 @@ def _pick_port() -> int:
         return s.getsockname()[1]
 
 
-async def _start_server(event_bus):
+async def _start_server(event_bus, state=None):
     app = web.Application()
     app["event_bus"] = event_bus
+    app["state"] = state
     app["websockets"] = weakref.WeakSet()
     app.router.add_get("/ws", _ws_handler)
     runner = web.AppRunner(app)
@@ -80,6 +81,40 @@ async def test_ws_skip_history_omits_history_event(event_bus):
                 )
                 assert not any(e.get("type") == "history" for e in received)
                 assert any(e.get("type") == "chat" and e.get("text") == "live" for e in received)
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.anyio
+async def test_ws_interrupt_sets_interrupt_event(event_bus):
+    """A {type: interrupt} message halts the in-flight turn by setting state.interrupt_event."""
+    state = vm.State()
+    interrupt_event = asyncio.Event()
+    state.interrupt_event = interrupt_event
+    runner, base = await _start_server(event_bus, state)
+    try:
+        async with ClientSession() as session:
+            async with session.ws_connect(f"{base}/ws?skip_history=1") as ws:
+                await ws.send_json({"type": "interrupt"})
+                await wait_for_condition(interrupt_event.is_set, message="interrupt_event never set")
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.anyio
+async def test_ws_interrupt_is_noop_when_idle(event_bus):
+    """With no turn in flight (interrupt_event is None) the interrupt is ignored and the socket stays healthy."""
+    state = vm.State()
+    assert state.interrupt_event is None
+    runner, base = await _start_server(event_bus, state)
+    try:
+        async with ClientSession() as session:
+            async with session.ws_connect(f"{base}/ws?skip_history=1") as ws:
+                await ws.send_json({"type": "interrupt"})
+                event_bus.emit(ChatEvent(type="chat", text="alive"))
+                received = await _drain_until(ws, lambda r: any(e.get("text") == "alive" for e in r))
+                assert any(e.get("type") == "chat" and e.get("text") == "alive" for e in received)
+        assert state.interrupt_event is None
     finally:
         await runner.cleanup()
 

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -32,6 +32,8 @@ interface ChatComposerProps {
   onInputChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
   onKeyDown: (e: KeyboardEvent) => void;
   onSend: () => void;
+  isBusy: boolean;
+  onStop: () => void;
   textareaRef: RefObject<HTMLTextAreaElement | null>;
 }
 
@@ -49,6 +51,8 @@ export function ChatComposer({
   onInputChange,
   onKeyDown,
   onSend,
+  isBusy,
+  onStop,
   textareaRef,
 }: ChatComposerProps) {
   const activation = useVoiceActivation((s) => s.mode);
@@ -111,11 +115,11 @@ export function ChatComposer({
             <InputGroupButton
               size="icon-sm"
               variant="ghost"
-              aria-label="send message"
+              aria-label={isBusy ? "stop agent" : "send message"}
               disabled={!connected}
-              onClick={onSend}
+              onClick={isBusy ? onStop : onSend}
             >
-              <SendHorizontal />
+              {isBusy ? <Square fill="currentColor" /> : <SendHorizontal />}
             </InputGroupButton>
           </InputGroupAddon>
         )}

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -49,6 +49,8 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     loadingMore,
     loadMore,
     send,
+    sendEvent,
+    agentState,
     showToolCalls,
   } = useChatContext();
 
@@ -148,6 +150,10 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     }
   };
 
+  const handleStop = () => {
+    sendEvent({ type: "interrupt" });
+  };
+
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
@@ -225,6 +231,8 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
             onInputChange={handleInput}
             onKeyDown={handleKeyDown}
             onSend={handleSend}
+            isBusy={agentState === "thinking"}
+            onStop={handleStop}
             textareaRef={textareaRef}
           />
         </div>


### PR DESCRIPTION
## What

Adds a stop affordance to the chat composer. While the agent is working, the send arrow becomes a stop button (the `Square` icon already imported in `ChatComposer`). Pressing it interrupts the agent and returns the composer to send state once the agent goes idle.

Closes #668.

## Why

Per the issue (HAX G17 "Provide global controls" + PAIR Feedback & Control): the composer's only action while the agent worked was the send arrow, and the frontend had no interrupt path at all. The only way to halt a long tool chain was to type and send a new message, which conflates "stop" with "issue a new instruction" and is a control/trust failure for an autonomous agent.

## How

A real interrupt verb was added to the protocol rather than just swapping an icon:

- **Frontend** (`Chat`, `ChatComposer`): the stop button sends `{type: "interrupt"}` over the existing chat WebSocket via the provider's `sendEvent`. It is shown when `agentState === "thinking"` (the actual "agent is working" signal). Note: the issue suggested keying off `isTyping`, but that flag is the frontend reply-pacing animation (the agent is already idle by then); `agentState === "thinking"` is the meaningful interrupt window, so clicking is never a no-op.
- **Agent** (`api.py` `_recv_loop`): handles `type: "interrupt"` by setting `state.interrupt_event` — the same signal the message processor already uses for mid-turn interrupts. `converse()` then interrupts the SDK, drains leftover output, and returns to idle **without** queueing a new message. When the agent is idle (`interrupt_event is None` between turns) the message is a no-op, and the socket stays healthy.

The vestad WS proxy forwards arbitrary text frames transparently, so no proxy changes were needed.

## Tests

- `test_ws_interrupt_sets_interrupt_event` — an interrupt frame sets `state.interrupt_event`.
- `test_ws_interrupt_is_noop_when_idle` — with no turn in flight the interrupt is ignored and the socket keeps streaming.

Checks run green locally: `ruff`/`ty`/`pytest` (agent), `eslint`/`prettier`/`tsc`/`vitest` (web). No component DOM test was added because the web suite is logic-only (`*.test.ts`, no jsdom/testing-library); the icon-swap is a thin wiring change and the meaningful new behavior (the interrupt protocol) is covered agent-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)