### PR TITLE
feat(app): block UI with overlay when gateway is unreachable

### DIFF
--- a/apps/web/src/components/DisconnectedOverlay/index.tsx
+++ b/apps/web/src/components/DisconnectedOverlay/index.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { motion } from "motion/react";
+import { getConnection } from "@/lib/connection";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from "@/components/ui/empty";
+
+// How long the gateway must stay unreachable before we surface low-level
+// diagnostics (endpoint, last attempt) instead of just the reconnect spinner.
+const DIAGNOSTICS_DELAY_MS = 10000;
+
+interface DisconnectedOverlayProps {
+  lastAttempt: number | null;
+}
+
+export function DisconnectedOverlay({ lastAttempt }: DisconnectedOverlayProps) {
+  const [showDiagnostics, setShowDiagnostics] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(
+      () => setShowDiagnostics(true),
+      DIAGNOSTICS_DELAY_MS,
+    );
+    return () => clearTimeout(timer);
+  }, []);
+
+  const endpoint = getConnection()?.url ?? null;
+
+  return (
+    <motion.div
+      role="alertdialog"
+      aria-modal="true"
+      aria-label="disconnected from gateway"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="absolute inset-0 z-50 flex items-center justify-center bg-muted/80 backdrop-blur-sm"
+    >
+      <Empty className="border-none">
+        <EmptyHeader>
+          <Spinner className="size-6" />
+          <EmptyTitle>disconnected from gateway</EmptyTitle>
+          <EmptyDescription>attempting to reconnect…</EmptyDescription>
+        </EmptyHeader>
+        {showDiagnostics && (
+          <EmptyContent className="text-xs text-muted-foreground">
+            {endpoint && <p>endpoint {endpoint}</p>}
+            {lastAttempt !== null && (
+              <p>last attempt {new Date(lastAttempt).toLocaleTimeString()}</p>
+            )}
+          </EmptyContent>
+        )}
+      </Empty>
+    </motion.div>
+  );
+}

--- a/apps/web/src/providers/GatewayProvider/index.tsx
+++ b/apps/web/src/providers/GatewayProvider/index.tsx
@@ -11,6 +11,7 @@ import { getConnection } from "@/lib/connection";
 import { ensureFreshToken } from "@/lib/token-refresh";
 import { useAuth } from "@/providers/AuthProvider";
 import { VersionMismatchDialog } from "@/components/VersionMismatchDialog";
+import { DisconnectedOverlay } from "@/components/DisconnectedOverlay";
 import type {
   AgentInfo,
   GatewayVersionInfo,
@@ -52,6 +53,10 @@ const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30000;
 
 const VERSION_POLL_MS = 60000;
+
+// Brief grace before the disconnect overlay appears, so quick WS blips and the
+// gap between the initial version fetch and the first socket open don't flash it.
+const DISCONNECT_GRACE_MS = 750;
 
 interface GatewayContextValue {
   reachable: boolean;
@@ -112,6 +117,10 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   const [agentsFetched, setAgentsFetched] = useState(false);
+  const [lastConnectAttempt, setLastConnectAttempt] = useState<number | null>(
+    null,
+  );
+  const [showDisconnected, setShowDisconnected] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
 
   const [connectEpoch, setConnectEpoch] = useState(0);
@@ -151,6 +160,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
 
     const doConnect = async () => {
       if (cancelled) return;
+      setLastConnectAttempt(Date.now());
 
       await ensureFreshToken();
 
@@ -261,6 +271,22 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
     };
   }, [reachable]);
 
+  // Surface a blocking overlay once the gateway has been unreachable past a
+  // brief grace period, and dismiss it the moment it reconnects. The grace
+  // avoids flashing on quick reconnects and during initial connect, where
+  // `reachable` is false until the first socket opens.
+  useEffect(() => {
+    if (loading || reachable) {
+      setShowDisconnected(false);
+      return;
+    }
+    const timer = setTimeout(
+      () => setShowDisconnected(true),
+      DISCONNECT_GRACE_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [loading, reachable]);
+
   const send = (event: object): boolean => {
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) return false;
@@ -297,6 +323,9 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
         />
       ) : (
         children
+      )}
+      {showDisconnected && (
+        <DisconnectedOverlay lastAttempt={lastConnectAttempt} />
       )}
     </GatewayContext.Provider>
   );


### PR DESCRIPTION
Fixes #475

## Problem

When `useGateway().reachable` is false the app kept rendering the normal UI with every control active. Gateway dependent actions (Update, agent start/stop, settings save) silently failed, indistinguishable from a broken feature.

## Change

A blocking `DisconnectedOverlay` is rendered by `GatewayProvider` whenever the control WebSocket has been down past a brief grace period, mirroring the existing `VersionMismatchDialog` gate:

1. **Full screen modal overlay** (not a toast) explaining "disconnected from gateway / attempting to reconnect", with a spinner.
2. **Blocks all gateway dependent actions** by intercepting pointer events. It overlays the app rather than unmounting it, so chat scroll position and in flight state are preserved underneath.
3. **Auto dismisses** the instant `reachable` flips back to true.
4. After the gateway stays unreachable past a threshold, it surfaces **diagnostics** (endpoint URL and last connect attempt time).

A 750ms grace period before showing the overlay prevents flashing on quick reconnect blips and during initial connect (where `reachable` is false until the first socket opens). `lastConnectAttempt` is stamped on each reconnect attempt and passed to the overlay.

## Notes

- The "link to gateway logs" diagnostic from the issue is deferred, it depends on the in-app gateway logs view landing first (the issue's "#X").
- No component test added: the web suite (`src/**/*.test.ts`) is pure logic only with no component render harness, and the change is presentational wiring over time based effects. Adding jsdom + testing-library for one overlay would be out of scope. `./check.sh web` passes (tsc, eslint, prettier, vitest).

## Where

- `apps/web/src/components/DisconnectedOverlay/index.tsx` (new)
- `apps/web/src/providers/GatewayProvider/index.tsx` (gate + grace period + last attempt timestamp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)