### PR TITLE
ci: harden cargo against transient crates.io download flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   NSIS_VERSION: "3.11"
+  # Harden cargo against transient crates.io registry flakes (sporadic
+  # "curl failed" / partial downloads). Retry network ops well past the
+  # default of 3, and disable HTTP/2 multiplexing, whose connection reuse is
+  # the usual trigger for those mid-download curl errors on CI runners.
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
 
 jobs:
   # ── Detect what changed (for smart PR filtering) ────────────────────────


### PR DESCRIPTION
## Summary

CI intermittently fails with crates.io registry download errors like:

```
error: failed to get `pin-project-lite` as a dependency of package `async-stream v0.3.6`
  download of pi/n-/pin-project-lite failed
  curl failed
```

These are transient runner network flakes, not real build breaks (most recently the `test-integration` job on #765). This adds two global env vars so **every** cargo invocation across all jobs is resilient:

- `CARGO_NET_RETRY=10` — retry network ops 10× (cargo default is 3).
- `CARGO_HTTP_MULTIPLEXING=false` — disable HTTP/2 multiplexing, whose connection reuse is the usual trigger for mid-download `curl failed` errors against the sparse registry.

Set once in the top-level `env:` block, so it's inherited by `check-vesta`, `build-vestad`, `test-integration`, the tauri builds, etc. — no per-job churn.

## Notes

This complements (doesn't replace) the existing `nick-fields/retry` step wrappers, which retry whole job steps; this fixes the failure lower down, at the cargo network layer, so the flake usually never bubbles up to a step retry in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)