### PR TITLE
fix(voice): stream TTS through a native audio element instead of MSE

### DIFF
--- a/agent/skills/voice/handlers.py
+++ b/agent/skills/voice/handlers.py
@@ -3,6 +3,7 @@ import logging
 import os
 import pathlib as pl
 import ssl
+import time
 import typing as tp
 
 import aiohttp
@@ -10,10 +11,14 @@ from aiohttp import web
 
 from . import config as voice_config
 from . import providers
+from . import tts_pending
 
 logger = logging.getLogger("voice")
 
 DATA_DIR = pl.Path.home() / ".voice"
+
+# Pending TTS clips awaiting a streamed GET (see tts_pending / issue #466).
+_PENDING_TTS: tts_pending.PendingStore = {}
 
 _VESTAD_PORT = os.environ.get("VESTAD_PORT", "")
 _AGENT_NAME = os.environ.get("AGENT_NAME", "")
@@ -286,6 +291,16 @@ async def set_setting(request: web.Request) -> web.Response:
     return await tts_status(request)
 
 
+async def _synthesize(entry: dict, provider: tp.Any, creds: dict[str, str], text: str, request: web.Request) -> web.StreamResponse:
+    voice_id = entry.get("selected_voice_id")
+    if not voice_id:
+        voices = provider.premade_voices()
+        voice_id = voices[0]["id"] if voices else None
+    if not voice_id:
+        return web.json_response({"error": "no voice selected"}, status=500)
+    return await provider.speak(text, voice_id, creds, request)
+
+
 async def tts_speak(request: web.Request) -> web.StreamResponse:
     resolved = _resolve_domain("tts")
     if isinstance(resolved, web.Response):
@@ -299,11 +314,35 @@ async def tts_speak(request: web.Request) -> web.StreamResponse:
     if not text:
         return web.json_response({"error": "text required"}, status=400)
 
-    voice_id = entry.get("selected_voice_id")
-    if not voice_id:
-        voices = provider.premade_voices()
-        voice_id = voices[0]["id"] if voices else None
-    if not voice_id:
-        return web.json_response({"error": "no voice selected"}, status=500)
+    return await _synthesize(entry, provider, creds, text, request)
 
-    return await provider.speak(text, voice_id, creds, request)
+
+async def tts_prepare(request: web.Request) -> web.Response:
+    """Register text and return a short-lived id the app streams via GET (issue #466)."""
+    resolved = _resolve_domain("tts")
+    if isinstance(resolved, web.Response):
+        return resolved
+
+    body = await _json_body(request)
+    if isinstance(body, web.Response):
+        return body
+    text = body.get("text", "").strip()
+    if not text:
+        return web.json_response({"error": "text required"}, status=400)
+
+    token = tts_pending.register(_PENDING_TTS, text, time.monotonic())
+    return web.json_response({"id": token})
+
+
+async def tts_stream(request: web.Request) -> web.StreamResponse:
+    """Stream the audio for a prepared id so a native <audio> element can play it."""
+    resolved = _resolve_domain("tts")
+    if isinstance(resolved, web.Response):
+        return resolved
+    entry, _name, provider, creds = resolved
+
+    text = tts_pending.resolve(_PENDING_TTS, request.match_info["id"], time.monotonic())
+    if text is None:
+        return web.json_response({"error": "unknown or expired tts id"}, status=404)
+
+    return await _synthesize(entry, provider, creds, text, request)

--- a/agent/skills/voice/server.py
+++ b/agent/skills/voice/server.py
@@ -26,6 +26,8 @@ app.router.add_get("/tts/usage", handlers.tts_usage)
 app.router.add_post("/tts/set-enabled", handlers.tts_set_enabled)
 app.router.add_post("/tts/set-voice", handlers.tts_set_voice)
 app.router.add_post("/tts/speak", handlers.tts_speak)
+app.router.add_post("/tts/prepare", handlers.tts_prepare)
+app.router.add_get("/tts/stream/{id}", handlers.tts_stream)
 
 # Generic setter (works for any provider setting)
 app.router.add_post("/{domain:stt|tts}/set", handlers.set_setting)

--- a/agent/skills/voice/server.py
+++ b/agent/skills/voice/server.py
@@ -10,35 +10,39 @@ from aiohttp import web
 
 from . import handlers
 
-app = web.Application()
 
-# STT
-app.router.add_get("/stt/status", handlers.stt_status)
-app.router.add_get("/stt/usage", handlers.stt_usage)
-app.router.add_post("/stt/set-enabled", handlers.stt_set_enabled)
-app.router.add_post("/stt/set-auto-send", handlers.stt_set_auto_send)
-app.router.add_post("/stt/set-eot", handlers.stt_set_eot)
-app.router.add_get("/stt/listen", handlers.stt_listen)
+def create_app() -> web.Application:
+    app = web.Application()
 
-# TTS
-app.router.add_get("/tts/status", handlers.tts_status)
-app.router.add_get("/tts/usage", handlers.tts_usage)
-app.router.add_post("/tts/set-enabled", handlers.tts_set_enabled)
-app.router.add_post("/tts/set-voice", handlers.tts_set_voice)
-app.router.add_post("/tts/speak", handlers.tts_speak)
-app.router.add_post("/tts/prepare", handlers.tts_prepare)
-app.router.add_get("/tts/stream/{id}", handlers.tts_stream)
+    # STT
+    app.router.add_get("/stt/status", handlers.stt_status)
+    app.router.add_get("/stt/usage", handlers.stt_usage)
+    app.router.add_post("/stt/set-enabled", handlers.stt_set_enabled)
+    app.router.add_post("/stt/set-auto-send", handlers.stt_set_auto_send)
+    app.router.add_post("/stt/set-eot", handlers.stt_set_eot)
+    app.router.add_get("/stt/listen", handlers.stt_listen)
 
-# Generic setter (works for any provider setting)
-app.router.add_post("/{domain:stt|tts}/set", handlers.set_setting)
+    # TTS
+    app.router.add_get("/tts/status", handlers.tts_status)
+    app.router.add_get("/tts/usage", handlers.tts_usage)
+    app.router.add_post("/tts/set-enabled", handlers.tts_set_enabled)
+    app.router.add_post("/tts/set-voice", handlers.tts_set_voice)
+    app.router.add_post("/tts/speak", handlers.tts_speak)
+    app.router.add_post("/tts/prepare", handlers.tts_prepare)
+    app.router.add_get("/tts/stream/{id}", handlers.tts_stream)
 
-# Health
-app.router.add_get("/health", lambda _: web.Response(text="ok"))
+    # Generic setter (works for any provider setting)
+    app.router.add_post("/{domain:stt|tts}/set", handlers.set_setting)
+
+    # Health
+    app.router.add_get("/health", lambda _: web.Response(text="ok"))
+
+    return app
 
 
 def main() -> None:
     port = int(os.environ["SKILL_PORT"])
-    web.run_app(app, host="0.0.0.0", port=port, print=lambda *_: None)
+    web.run_app(create_app(), host="0.0.0.0", port=port, print=lambda *_: None)
 
 
 if __name__ == "__main__":

--- a/agent/skills/voice/tts_pending.py
+++ b/agent/skills/voice/tts_pending.py
@@ -1,0 +1,38 @@
+"""Short-lived id -> text store backing the native-audio TTS stream route.
+
+The app streams TTS through a native ``<audio>`` element (a GET it can
+authenticate with ``?token=``) instead of feeding a POST body into MediaSource,
+so playback starts at the first byte and streams progressively on every webview
+(Android's System WebView would otherwise fall back to buffering the whole clip
+then dumping it). See issue #466. ``POST /tts/prepare`` registers the text and
+returns an id; ``GET /tts/stream/{id}`` resolves it back and synthesizes.
+
+Entries live until their TTL so a media element that reopens the stream within
+the window still resolves; expired ids are pruned lazily on each access.
+"""
+
+import secrets
+
+DEFAULT_TTL_SECS = 120.0
+
+# id -> (text, expiry_monotonic)
+PendingStore = dict[str, tuple[str, float]]
+
+
+def prune_expired(store: PendingStore, now: float) -> None:
+    for key in [k for k, (_text, expiry) in store.items() if expiry <= now]:
+        del store[key]
+
+
+def register(store: PendingStore, text: str, now: float, ttl: float = DEFAULT_TTL_SECS) -> str:
+    prune_expired(store, now)
+    token = secrets.token_urlsafe(16)
+    store[token] = (text, now + ttl)
+    return token
+
+
+def resolve(store: PendingStore, token: str, now: float) -> str | None:
+    prune_expired(store, now)
+    if token not in store:
+        return None
+    return store[token][0]

--- a/agent/tests/test_voice_tts_handlers.py
+++ b/agent/tests/test_voice_tts_handlers.py
@@ -1,0 +1,73 @@
+"""The prepare/stream HTTP contract behind native-audio TTS playback (issue #466).
+
+Drives the real aiohttp app and routes; the TTS provider and on-disk config are
+faked at the edge so no ElevenLabs call or ~/.voice file is needed.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from voice import handlers, server
+
+CONFIGURED_TTS = {
+    "stt": None,
+    "tts": {"provider": "fake", "selected_voice_id": "v1", "credentials": {"fake": {"api_key": "k"}}},
+}
+
+
+def _fake_provider():
+    provider = MagicMock()
+    provider.premade_voices.return_value = [{"id": "v1"}]
+
+    async def fake_speak(text, voice_id, creds, request):
+        return web.Response(body=text.encode(), headers={"Content-Type": "audio/mpeg"})
+
+    provider.speak = fake_speak
+    return provider
+
+
+@pytest.fixture
+def voice_app(monkeypatch):
+    """A fresh voice app wired to a faked, configured TTS provider with an empty id store."""
+    monkeypatch.setattr("voice.config.load", lambda data_dir: dict(CONFIGURED_TTS))
+    monkeypatch.setattr("voice.providers.get_tts", lambda name: _fake_provider())
+    handlers._PENDING_TTS.clear()
+    return server.create_app()
+
+
+@pytest.mark.anyio
+async def test_prepare_then_stream_returns_the_audio(voice_app):
+    async with TestClient(TestServer(voice_app)) as client:
+        prepared = await client.post("/tts/prepare", json={"text": "hello world"})
+        assert prepared.status == 200
+        tts_id = (await prepared.json())["id"]
+
+        streamed = await client.get(f"/tts/stream/{tts_id}")
+        assert streamed.status == 200
+        assert streamed.headers["Content-Type"] == "audio/mpeg"
+        assert await streamed.text() == "hello world"
+
+
+@pytest.mark.anyio
+async def test_prepare_rejects_empty_text(voice_app):
+    async with TestClient(TestServer(voice_app)) as client:
+        resp = await client.post("/tts/prepare", json={"text": "   "})
+        assert resp.status == 400
+
+
+@pytest.mark.anyio
+async def test_stream_unknown_id_is_404(voice_app):
+    async with TestClient(TestServer(voice_app)) as client:
+        resp = await client.get("/tts/stream/does-not-exist")
+        assert resp.status == 404
+
+
+@pytest.mark.anyio
+async def test_prepare_when_tts_unconfigured_is_503(monkeypatch):
+    monkeypatch.setattr("voice.config.load", lambda data_dir: {"stt": None, "tts": None})
+    async with TestClient(TestServer(server.create_app())) as client:
+        resp = await client.post("/tts/prepare", json={"text": "hello"})
+        assert resp.status == 503

--- a/agent/tests/test_voice_tts_stream.py
+++ b/agent/tests/test_voice_tts_stream.py
@@ -1,0 +1,44 @@
+"""The id-store backing the native-audio TTS stream route (issue #466)."""
+
+from voice import tts_pending
+
+
+def test_register_then_resolve_returns_the_text():
+    store: tts_pending.PendingStore = {}
+    token = tts_pending.register(store, "hello there", now=100.0)
+    assert tts_pending.resolve(store, token, now=100.0) == "hello there"
+
+
+def test_distinct_registrations_get_distinct_ids():
+    store: tts_pending.PendingStore = {}
+    first = tts_pending.register(store, "one", now=0.0)
+    second = tts_pending.register(store, "two", now=0.0)
+    assert first != second
+    assert tts_pending.resolve(store, first, now=0.0) == "one"
+    assert tts_pending.resolve(store, second, now=0.0) == "two"
+
+
+def test_unknown_id_resolves_to_none():
+    store: tts_pending.PendingStore = {}
+    assert tts_pending.resolve(store, "nope", now=0.0) is None
+
+
+def test_id_resolves_repeatedly_within_its_ttl():
+    store: tts_pending.PendingStore = {}
+    token = tts_pending.register(store, "replayable", now=0.0, ttl=10.0)
+    assert tts_pending.resolve(store, token, now=5.0) == "replayable"
+    assert tts_pending.resolve(store, token, now=9.0) == "replayable"
+
+
+def test_expired_id_resolves_to_none():
+    store: tts_pending.PendingStore = {}
+    token = tts_pending.register(store, "stale", now=0.0, ttl=10.0)
+    assert tts_pending.resolve(store, token, now=10.0) is None
+
+
+def test_resolving_prunes_other_expired_entries():
+    store: tts_pending.PendingStore = {}
+    stale = tts_pending.register(store, "stale", now=0.0, ttl=10.0)
+    fresh = tts_pending.register(store, "fresh", now=0.0, ttl=100.0)
+    assert tts_pending.resolve(store, fresh, now=20.0) == "fresh"
+    assert stale not in store

--- a/apps/web/src/lib/voice.test.ts
+++ b/apps/web/src/lib/voice.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { buildTtsStreamUrl } from "@/lib/voice";
+
+describe("buildTtsStreamUrl", () => {
+  it("carries the auth token in the query string (media elements can't send headers)", () => {
+    const url = buildTtsStreamUrl(
+      "https://host:8443",
+      "tok-123",
+      "my-agent",
+      "abc123",
+    );
+    expect(url).toBe(
+      "https://host:8443/agents/my-agent/voice/tts/stream/abc123?token=tok-123",
+    );
+  });
+
+  it("encodes the agent name and id", () => {
+    const url = buildTtsStreamUrl(
+      "https://host:8443",
+      "tok-123",
+      "my agent",
+      "a/b+c",
+    );
+    expect(url).toContain("/agents/my%20agent/voice/tts/stream/a%2Fb%2Bc?");
+  });
+
+  it("encodes a token with url-unsafe characters", () => {
+    const url = buildTtsStreamUrl("https://h", "a b+c", "agent", "id");
+    expect(url).toContain("?token=a+b%2Bc");
+  });
+});

--- a/apps/web/src/lib/voice.ts
+++ b/apps/web/src/lib/voice.ts
@@ -1,4 +1,4 @@
-import { apiFetch, apiJson } from "@/api/client";
+import { apiJson } from "@/api/client";
 import { getConnection } from "@/lib/connection";
 
 const SAMPLE_RATE = 16000;
@@ -123,154 +123,88 @@ export const setTtsVoice = (n: string, voiceId: string) =>
   voicePost(n, "tts/set-voice", { voice_id: voiceId });
 
 // --- TTS playback ---
+//
+// Playback runs through a native <audio> element pointed at a streamed GET
+// rather than fetching bytes in JS and feeding MediaSource. The native media
+// stack streams progressively from the first byte on every webview (Android's
+// System WebView has no reliable MSE support for raw audio/mpeg and would
+// otherwise buffer the whole clip then dump it), and it owns audio routing
+// including Bluetooth A2DP cold-start. See issue #466.
+//
+// Because a media-element request can't carry an Authorization header and uses
+// GET (no body), the text is first registered via POST /tts/prepare, which
+// returns an id; the element then streams GET /tts/stream/{id}?token=...
 
-export function prefetchSpeech(
+export function prepareSpeech(
   text: string,
   agentName: string,
   signal?: AbortSignal,
-): Promise<Response> {
-  return apiFetch(`/agents/${encodeURIComponent(agentName)}/voice/tts/speak`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ text }),
-    signal,
-  });
+): Promise<string> {
+  return apiJson<{ id: string }>(
+    `/agents/${encodeURIComponent(agentName)}/voice/tts/prepare`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+      signal,
+    },
+  ).then((res) => res.id);
+}
+
+// Exported for testing: the token rides the query string because a media
+// element's request cannot carry an Authorization header.
+export function buildTtsStreamUrl(
+  baseUrl: string,
+  accessToken: string,
+  agentName: string,
+  id: string,
+): string {
+  const params = new URLSearchParams({ token: accessToken });
+  return `${baseUrl}/agents/${encodeURIComponent(agentName)}/voice/tts/stream/${encodeURIComponent(id)}?${params.toString()}`;
+}
+
+function ttsStreamUrl(agentName: string, id: string): string {
+  const conn = getConnection();
+  if (!conn) throw new Error("not connected to vestad");
+  return buildTtsStreamUrl(conn.url, conn.accessToken, agentName, id);
 }
 
 export async function streamSpeech(
   text: string,
   agentName: string,
   signal?: AbortSignal,
-  prefetched?: Response,
+  preparedId?: string,
 ): Promise<void> {
-  const res = prefetched ?? (await prefetchSpeech(text, agentName, signal));
+  const id = preparedId ?? (await prepareSpeech(text, agentName, signal));
+  if (signal?.aborted) return;
 
-  const contentType = res.headers.get("content-type") || "";
-  if (contentType.includes("audio/mpeg") || contentType.includes("audio/mp3")) {
-    return playStreamedAudio(res.body!, signal);
-  }
-
-  const blob = await res.blob();
-  const url = URL.createObjectURL(blob);
-  const audio = new Audio(url);
-  if (signal) {
-    signal.addEventListener("abort", () => {
-      audio.pause();
-      URL.revokeObjectURL(url);
-    });
-  }
-  await new Promise<void>((resolve, reject) => {
-    audio.onended = () => {
-      URL.revokeObjectURL(url);
-      resolve();
-    };
-    audio.onerror = () => {
-      URL.revokeObjectURL(url);
-      reject(new Error("Audio playback failed"));
-    };
-    audio.play().catch(reject);
-  });
-}
-
-async function playStreamedAudio(
-  body: ReadableStream<Uint8Array>,
-  signal?: AbortSignal,
-): Promise<void> {
-  const mediaSource = new MediaSource();
-  const audio = new Audio();
-  audio.src = URL.createObjectURL(mediaSource);
+  const audio = new Audio(ttsStreamUrl(agentName, id));
+  audio.preload = "auto";
 
   await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      audio.onended = null;
+      audio.onerror = null;
+    };
     if (signal) {
       // Resolve (not reject) on abort so the caller's await completes instead
-      // of hanging forever when playback is cancelled mid-stream.
+      // of hanging when playback is cancelled mid-stream.
       signal.addEventListener("abort", () => {
+        cleanup();
         audio.pause();
-        URL.revokeObjectURL(audio.src);
+        audio.src = "";
         resolve();
       });
     }
-
-    mediaSource.addEventListener(
-      "sourceopen",
-      async () => {
-        let sourceBuffer: SourceBuffer;
-        try {
-          sourceBuffer = mediaSource.addSourceBuffer("audio/mpeg");
-        } catch {
-          URL.revokeObjectURL(audio.src);
-          const reader = body.getReader();
-          const chunks: Uint8Array[] = [];
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            chunks.push(value);
-          }
-          const blob = new Blob(chunks as BlobPart[], { type: "audio/mpeg" });
-          audio.src = URL.createObjectURL(blob);
-          audio.onended = () => {
-            URL.revokeObjectURL(audio.src);
-            resolve();
-          };
-          audio.onerror = () => {
-            URL.revokeObjectURL(audio.src);
-            reject(new Error("Playback failed"));
-          };
-          audio.play().catch(reject);
-          return;
-        }
-
-        const reader = body.getReader();
-        const queue: Uint8Array[] = [];
-        let ended = false;
-
-        const appendNext = () => {
-          if (sourceBuffer.updating) return;
-          if (queue.length === 0) {
-            if (ended && mediaSource.readyState === "open")
-              mediaSource.endOfStream();
-            return;
-          }
-          try {
-            sourceBuffer.appendBuffer(queue.shift()!.buffer as ArrayBuffer);
-          } catch (err) {
-            // Without this the awaited Promise would hang: updateend never
-            // fires after a failed append, so nothing resolves it.
-            reject(
-              err instanceof Error ? err : new Error("appendBuffer failed"),
-            );
-          }
-        };
-
-        sourceBuffer.addEventListener("updateend", appendNext);
-        sourceBuffer.addEventListener("error", () =>
-          reject(new Error("audio decode failed")),
-        );
-
-        audio.onended = () => {
-          URL.revokeObjectURL(audio.src);
-          resolve();
-        };
-        audio.onerror = () => {
-          URL.revokeObjectURL(audio.src);
-          reject(new Error("Playback failed"));
-        };
-        audio.play().catch(reject);
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (signal?.aborted) break;
-          if (done) {
-            ended = true;
-            appendNext();
-            break;
-          }
-          queue.push(value);
-          appendNext();
-        }
-      },
-      { once: true },
-    );
+    audio.onended = () => {
+      cleanup();
+      resolve();
+    };
+    audio.onerror = () => {
+      cleanup();
+      reject(new Error("Audio playback failed"));
+    };
+    audio.play().catch(reject);
   });
 }
 

--- a/apps/web/src/stores/use-voice.ts
+++ b/apps/web/src/stores/use-voice.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import {
   Transcriber,
-  prefetchSpeech,
+  prepareSpeech,
   streamSpeech,
   fetchSttStatus,
   fetchTtsStatus,
@@ -71,7 +71,9 @@ let ttsProcessing = false;
 // Bumped by stopSpeech to invalidate an in-flight processQueue loop, so a
 // stop-then-speak sequence never leaves two loops draining ttsQueue at once.
 let ttsEpoch = 0;
-const ttsPrefetchCache = new Map<string, Promise<Response>>();
+// Prepared TTS ids, warmed during the typing-pacing delay so playback can
+// start the streamed GET immediately when the message is shown.
+const ttsPrefetchCache = new Map<string, Promise<string>>();
 
 function clearIdleTimer() {
   if (idleTimer) {
@@ -104,10 +106,10 @@ export const useVoice = create<VoiceState>((set, get) => {
       try {
         const cached = ttsPrefetchCache.get(text);
         ttsPrefetchCache.delete(text);
-        const prefetched = cached
+        const preparedId = cached
           ? await cached.catch(() => undefined)
           : undefined;
-        await streamSpeech(text, agentName, controller.signal, prefetched);
+        await streamSpeech(text, agentName, controller.signal, preparedId);
       } catch (err) {
         if (!controller.signal.aborted) {
           console.warn("[tts] playback failed:", err);
@@ -232,7 +234,7 @@ export const useVoice = create<VoiceState>((set, get) => {
       if (!speechEnabled || !agentName) return;
       if (ttsPrefetchCache.has(text)) return;
       console.debug("[tts] prefetching:", text.slice(0, 60));
-      ttsPrefetchCache.set(text, prefetchSpeech(text, agentName));
+      ttsPrefetchCache.set(text, prepareSpeech(text, agentName));
     },
 
     speak: (text: string) => {


### PR DESCRIPTION
## Problem

Android Vesta buffers TTS audio and dumps it on mic release instead of streaming live (#466). The reported lead — PR #416 (`input_method`) — is **not** the cause: that diff is plumbing-only and never touches the TTS queue or gates playback on the user-event echo. And `#358`'s "play on chat, not idle" ask is already satisfied (`speak()` fires from `onAssistantMessage` on `type:'chat'` receive, not on `status:'idle'`).

The actual mechanism is in `playStreamedAudio` (`apps/web/src/lib/voice.ts`): it fed the streamed MP3 into `MediaSource` via `addSourceBuffer("audio/mpeg")`. Raw `audio/mpeg` is unsupported in Android's System WebView, so it fell into the `catch` fallback that reads the **entire** response into one Blob before `play()` — buffer-everything-then-dump. Desktop Chrome supports it and streamed fine, which masked the bug.

## Fix

Stop using MSE here and let the native media stack do progressive playback, which it does from the first byte on every webview and which owns audio routing including Bluetooth A2DP cold-start. MSE is the wrong tool for "play one clip as it arrives."

Because a media-element request can't carry an `Authorization` header and is a bodyless GET, TTS is now a two-step:

- **`POST /agents/{name}/voice/tts/prepare`** registers the text, returns a short-lived `id`.
- **`GET /agents/{name}/voice/tts/stream/{id}?token=...`** streams the same `audio/mpeg` the provider already produces; `<audio src>` plays it.

The vestad agent-proxy already accepts `?token=` query auth (`agent_proxy.rs` → `has_valid_api_auth` checks the URI) and forwards the agent token upstream, so no server-auth changes are needed. The existing `POST /tts/speak` endpoint is kept (now sharing a `_synthesize` helper). This **deletes** the MSE/Blob path rather than guarding it, and as a bonus removes the JS round-trip latency from the playback start.

## Changes

- `agent/skills/voice/tts_pending.py` (new): dependency-free short-lived id→text store (TTL-pruned, replayable within the window so a media element that reopens the stream still resolves).
- `agent/skills/voice/handlers.py` / `server.py`: `tts_prepare` + `tts_stream` handlers and routes; `tts_speak` refactored to share `_synthesize`.
- `apps/web/src/lib/voice.ts`: replace `prefetchSpeech`/`streamSpeech`/`playStreamedAudio` (MSE + Blob) with `prepareSpeech` + native-element `streamSpeech`; `buildTtsStreamUrl` exported for testing.
- `apps/web/src/stores/use-voice.ts`: the prefetch cache now warms prepared ids; queue/epoch logic unchanged.

## Tests

- `agent/tests/test_voice_tts_stream.py`: id-store register/resolve, distinct ids, expiry, lazy prune of expired entries.
- `apps/web/src/lib/voice.test.ts`: stream URL carries the token in the query and url-encodes agent name / id / token.

`./check.sh agent` (ruff/format/ty + new pytest) and `./check.sh web` (eslint/prettier/tsc/vitest) pass.

## Verification note

The buffer-then-dump mechanism is confirmed from the code, but the Android A2DP behavior itself can't be reproduced on CI — this needs one on-device check (hold mic, speak, release; confirm the reply streams live to a car/BT speaker) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)