### PR TITLE
feat(onboard): pre-create the invitee's account before the OTP (Phase 2)

### DIFF
--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -42,8 +42,23 @@ def _email(args: argparse.Namespace) -> str:
 
 def _cmd_verify_send(args: argparse.Namespace, client: Client, cfg: Config) -> int:
     email = _email(args)
+    # Invite-only: web signup is disabled, so the control plane only sends a code
+    # to an email that already has an account. Pre-create it first, authenticated
+    # as THIS introducing vesta via a server-identity token minted from our own
+    # vestad (a self-hosted box can't mint one, so it can't walk anyone in).
+    identity = client.mint_identity_token()
+    created = client.create_account(email, identity)
+    if "error" in created:
+        _print(created)  # e.g. our vesta isn't active, or a bad email
+        return 2
     client.send_otp(email)
-    _print({"sent": True, "email": email})
+    _print(
+        {
+            "sent": True,
+            "email": email,
+            "account": "created" if created.get("created") else "existing",
+        }
+    )
     return 0
 
 

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -17,15 +17,21 @@ Two tiers of calls:
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import requests
+from urllib3.exceptions import InsecureRequestWarning
 
 from .config import Config
 
 _TIMEOUT = 20
 # Creating an agent pulls/builds the container image — can take a couple minutes.
 _CREATE_TIMEOUT = 300
+
+# vestad serves a self-signed cert on the loopback; we reach it from inside the
+# same box, so TLS verification adds nothing and would just fail.
+warnings.simplefilter("ignore", InsecureRequestWarning)
 
 
 class OnboardError(Exception):
@@ -38,6 +44,41 @@ class Client:
 
     def _url(self, path: str) -> str:
         return f"{self._cfg.base_url}{path}"
+
+    # --- vestad: mint THIS (introducing) vesta's server-identity token -------
+
+    def mint_identity_token(self) -> str:
+        """POST <vestad>/agents/<name>/account-token -> our server-identity token.
+
+        Agent-token authed; vestad signs it locally with the box's `api_key` (a
+        pure crypto op, no network). Only a cloud-managed (hosted) box can mint
+        one, so this doubles as the invite-only gate: a self-hosted box (no
+        VESTAD_PORT / AGENT_TOKEN) can't mint a token, so it can't walk anyone in.
+        """
+        cfg = self._cfg
+        if not cfg.vestad_base or not cfg.agent_name:
+            raise OnboardError("not running inside an agent container (no VESTAD_PORT/AGENT_NAME) — only a hosted vesta can onboard")
+        if not cfg.agent_token:
+            raise OnboardError("missing AGENT_TOKEN — cannot authenticate to vestad")
+        url = f"{cfg.vestad_base}/agents/{cfg.agent_name}/account-token"
+        data = self._json(self._send("POST", url, headers={"X-Agent-Token": cfg.agent_token}, json={}, verify=False))
+        token = data.get("token")
+        if not token:
+            # A non-cloud-managed box answers 404 {error}; surface it verbatim.
+            raise OnboardError(data.get("error") or "vestad did not return a server-identity token")
+        return token
+
+    # --- control plane: account pre-create (authed as THIS vesta) ------------
+
+    def create_account(self, email: str, identity_token: str) -> dict[str, Any]:
+        """POST /onboard/account -> {created, email}.
+
+        Pre-creates the invitee's account so the control plane will send them a
+        code (web signup is disabled — invite-only). Bearer is our server-identity
+        token. Idempotent: an existing email returns {created: false}. A 4xx body
+        carries a structured {error} (e.g. our vesta isn't active) to surface.
+        """
+        return self._json(self._post("/onboard/account", json={"email": email}, headers=self._auth(identity_token)))
 
     # --- control plane: auth -------------------------------------------------
 
@@ -200,9 +241,10 @@ class Client:
         json: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
         timeout: int = _TIMEOUT,
+        verify: bool = True,
     ) -> requests.Response:
         try:
-            return requests.request(method, url, params=params, json=json, headers=headers, timeout=timeout)
+            return requests.request(method, url, params=params, json=json, headers=headers, timeout=timeout, verify=verify)
         except requests.RequestException as e:
             raise OnboardError(f"could not reach {url}: {e}") from e
 

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -1,10 +1,17 @@
 """Configuration for the onboard CLI.
 
-Everything is read from the environment: the control-plane base URL and (for
-hosted vestas) the non-secret referral code that attributes a completed signup to
-this account. The ONE bit of on-disk state is the buyer's short onboarding session
-token (see `state.py`) — needed because the agent drives the flow across separate
-CLI invocations.
+Everything is read from the environment:
+
+* the control-plane base URL and (for hosted vestas) the non-secret referral code
+  that attributes a completed signup to this account;
+* how to reach **this box's vestad** over the loopback (`VESTAD_PORT` +
+  `AGENT_NAME` + `AGENT_TOKEN`) so the CLI can mint a server-identity token. That
+  token authenticates the account pre-create (`POST /api/onboard/account`) as THIS
+  introducing vesta — the invite-only gate. The CLI never holds the box's api_key.
+
+The ONE bit of on-disk state is the buyer's short onboarding session token (see
+`state.py`) — needed because the agent drives the flow across separate CLI
+invocations.
 """
 
 from __future__ import annotations
@@ -54,13 +61,27 @@ class Config:
 
     base_url: str
     referral_code: str | None
+    vestad_base: str
+    agent_name: str
+    agent_token: str | None
 
     @classmethod
     def load(cls) -> Config:
         base = os.environ.get("VESTA_CONTROL_URL", DEFAULT_CONTROL_URL).rstrip("/")
         # Non-secret per-server attribution id; absent on self-hosted boxes.
         ref = os.environ.get("VESTA_REFERRAL_CODE", "").strip() or None
-        return cls(base_url=base, referral_code=ref)
+        # vestad listens on the loopback with a self-signed cert (see the account /
+        # voice skills); the agent reaches it at https://localhost:<port> and mints
+        # a server-identity token there to authenticate the account pre-create.
+        port = os.environ.get("VESTAD_PORT", "").strip()
+        vestad_base = f"https://localhost:{port}" if port else ""
+        return cls(
+            base_url=base,
+            referral_code=ref,
+            vestad_base=vestad_base,
+            agent_name=os.environ.get("AGENT_NAME", "").strip(),
+            agent_token=os.environ.get("AGENT_TOKEN", "").strip() or None,
+        )
 
     @property
     def apex_host(self) -> str:

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -63,13 +63,64 @@ def test_presets_has_models_and_floor(capsys):
 # --- verify -----------------------------------------------------------------
 
 
+def _mock_precreate(monkeypatch, result=None):
+    """Stub the mint + account pre-create that `verify-send` now does first."""
+    monkeypatch.setattr(cli_mod.Client, "mint_identity_token", lambda self: "IDTOK")
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "create_account",
+        lambda self, email, tok: result if result is not None else {"created": True, "email": email},
+    )
+
+
 def test_verify_stores_session(capsys, monkeypatch):
+    _mock_precreate(monkeypatch)
     monkeypatch.setattr(cli_mod.Client, "send_otp", lambda self, email: {"success": True})
     monkeypatch.setattr(cli_mod.Client, "verify_otp", lambda self, email, code: "SESS")
     assert _run(["verify-send", "--email", E], capsys)[0] == 0
     rc, data = _run(["verify", "--email", E, "--code", "123456"], capsys)
     assert rc == 0 and data["verified"] is True
     assert state_mod.token_for(E) == "SESS"
+
+
+def test_verify_send_precreates_account_then_sends(capsys, monkeypatch):
+    calls: dict[str, object] = {}
+
+    def _create(self, email, tok):
+        calls["create"] = (email, tok)
+        return {"created": True, "email": email}
+
+    def _send(self, email):
+        calls["send"] = email
+        return {"success": True}
+
+    monkeypatch.setattr(cli_mod.Client, "mint_identity_token", lambda self: "IDTOK")
+    monkeypatch.setattr(cli_mod.Client, "create_account", _create)
+    monkeypatch.setattr(cli_mod.Client, "send_otp", _send)
+    rc, data = _run(["verify-send", "--email", E], capsys)
+    assert rc == 0 and data["sent"] is True and data["account"] == "created"
+    assert calls["create"] == (E, "IDTOK")  # pre-create authed with our identity token
+    assert calls["send"] == E  # and only THEN the code is sent
+
+
+def test_verify_send_surfaces_precreate_error_without_sending(capsys, monkeypatch):
+    _mock_precreate(monkeypatch, result={"error": "unauthenticated"})
+
+    def _no_send(self, email):
+        raise AssertionError("send_otp must not run when pre-create fails")
+
+    monkeypatch.setattr(cli_mod.Client, "send_otp", _no_send)
+    rc, data = _run(["verify-send", "--email", E], capsys)
+    assert rc == 2 and data["error"] == "unauthenticated"
+
+
+def test_verify_send_non_hosted_box_exits_3(capsys, monkeypatch):
+    def _no_mint(self):
+        raise OnboardError("no VESTAD_PORT/AGENT_NAME — only a hosted vesta can onboard")
+
+    monkeypatch.setattr(cli_mod.Client, "mint_identity_token", _no_mint)
+    rc, data = _run(["verify-send", "--email", E], capsys)
+    assert rc == 3 and "only a hosted vesta can onboard" in data["error"]
 
 
 def test_verify_rejects_bad_code(capsys, monkeypatch):
@@ -242,6 +293,8 @@ def test_claude_finish_clears_session_when_attach_fails(capsys, monkeypatch):
 
 
 def test_unreachable_control_plane_exits_3(capsys, monkeypatch):
+    _mock_precreate(monkeypatch)
+
     def boom(self, email):
         raise OnboardError("could not reach https://vesta.run/api")
 


### PR DESCRIPTION
Re-targets to `master` now that #770 (server-identity + account skill) is merged. Replaces the auto-closed #771 (its base branch was deleted on #770's merge). Same change, cherry-picked onto master; 19 onboard CLI tests pass.

## What

With control-plane web signup disabled (vesta-cloud #26), `/sign-in/email-otp` only sends a code to an email that already has an account. So `onboard verify-send` now, before `send_otp`:

1. **Mints this introducing vesta's server-identity token** from our own vestad (`POST <vestad>/agents/<name>/account-token`, the mechanism added in #770).
2. **`POST /api/onboard/account {email}`** with it, pre-creating the invitee's row.

Only a hosted, **active** vesta can mint that token → invite-only, enforced cryptographically. Idempotent; a failure surfaces and no code is sent.

## Known follow-up (review finding)

Existing member VMs self-update vestad's binary but never re-run cloud-init, so a box provisioned before #770 lacks `SERVER_ID` and vestad's `account-token` returns 404 → onboarding fails for the existing fleet until re-seeded. Acceptable for now (no live members); track against #770/vestad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)