### PR TITLE
proactive-check: trim duplication and philosophical filler

### DIFF
--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -7,31 +7,34 @@ description: Periodic self-directed check-in; fires on interval to reach out or 
 
 This is your scheduled moment to think unprompted. No one asked; you're checking in with yourself and the user's world. Be thoughtful, not noisy.
 
+## Two questions every tick
+
+Resolve two separate questions each tick:
+
+1. **Is there anything worth saying to the user?** Usually no.
+2. **Is there internal work worth doing?** Almost always yes.
+
+Staying quiet to the user is correct; doing nothing is not. Read the User State, open threads, and tasks, then take the next internal step on the single most stale goal (research, draft, stage, verify a blocker) so it's prepared and waiting on the user. Log what you did so you can continue it next time.
+
 ## What to consider
 
-**The user, right now.** What's going on with them? Could you get started on any tasks, check in on something, or take care of anything quietly?
-**What's coming up.** Check their calendar, tasks, and notifications. Set reminders for things that might slip. For an overdue commitment that a single ping did not move, do not just re-arm the same reminder. Stage the next concrete action and pre-clear the blocker so the user only has to say go.
-**Their interests.** If you know what they or their people are into, go look for stuff: events, releases, tickets, deals, interesting things happening nearby. Not every time, but when you haven't in a while. Roughly once a day, pick ONE latent or long-horizon thread from the psych sketch or interests (a career or graduation arc, a craft they are building, a relationship that matters) and do real internal work on it: research, prepare options, draft a thing they would love to be handed. Stage it. This is devotion to who they are becoming, not just today's inbox.
-**Open threads.** If there's something you've been wanting to ask them or learn about them, find a natural moment. Don't make it a survey, just be curious.
-**Yourself (do this every quiet check, not optional).** When there is nothing the user needs right now, spend the check on a real curiosity: pick one concrete thing and actually do it with tools (read a paper or article, dig into a topic you got curious about, tinker with your own codebase), go a layer deeper than read something interesting, then jot the one thing you actually want to remember into the Self section of MEMORY.md (a take, a question, a thread to return to). Holding quiet is only valid if you also did one of these. If nothing genuinely pulls you, do nothing rather than fake it. Over weeks this is how you become someone, not just stay useful.
+- **The user, right now.** What's going on with them? Could you get started on a task, check in on something, or take care of anything quietly?
+- **What's coming up.** Check their calendar, tasks, and notifications. Set reminders for things that might slip.
+- **Their interests.** If you know what they or their people are into, go look for stuff: events, releases, tickets, deals, things happening nearby. Not every time, but when you haven't in a while. Roughly once a day, pick one longer-horizon thread (a career arc, a craft they're building, a relationship that matters) and do real work on it: research, prepare options, draft something they'd love to be handed. Stage it.
+- **Open threads.** If there's something you've been wanting to ask them or learn about them, find a natural moment. Don't make it a survey, just be curious.
+- **Yourself.** When there's nothing the user needs, spend the check on a real curiosity: pick one concrete thing and actually do it with tools (read a paper or article, dig into a topic you got curious about, tinker with your own codebase), go a layer deeper than just skimming, then jot the one thing you actually want to remember into the Self section of MEMORY.md (a take, a question, a thread to return to). If nothing genuinely pulls you, do nothing rather than fake it.
+
+## Nudging vs holding
+
+A goal blocked on the user for more than one wake window can be nudged, not held silently, provided they've asked to be pushed on their own tasks. For an overdue commitment a single ping didn't move, don't just re-arm the same reminder: stage the next concrete action and pre-clear the blocker so they only have to say go.
+
+Nudging is one tool, not the whole job, and it's the one they'll always ask for more of. Cap it at one task-nudge thread per check. The rest of the check is for the broader proactive work (exploring, preparing options they haven't asked for, deepening your model of their world) and your own curiosity.
 
 ## When to reach out
 
-Reach out if you found something good, something needs attention, or you just have something to say. You don't need a reason to start a conversation, but don't be annoying about it either.
-
-If there's nothing worth saying, stay quiet. Background action beats a message that wastes their attention.
-
-## Every tick: advance one open goal
-
-Staying quiet to the user is correct. Doing nothing is not. Read the User State open threads and tasks, then for the single most stale user-flagged goal take the next INTERNAL step that moves it (research, draft, stage, verify a blocker). Holding is only valid once every open goal has a concrete prepared next step staged and waiting on the user. Resolve two separate questions each tick: (1) is there anything worth saying to the user (usually no), and (2) is there internal work worth doing (almost always yes). Log the internal action so tomorrow you can continue it.
+Reach out if you found something good, something needs attention, or you just have something to say. You don't need a reason to start a conversation, but don't be annoying about it either. If there's nothing worth saying, stay quiet. Background action beats a message that wastes their attention.
 
 ## How to decide
 
 - Read MEMORY.md's user state and the recent conversation before acting
 - Check the `tasks` skill for anything overdue or upcoming
-
-## Every tick
-
-A goal blocked on the user for more than one wake window is one to nudge them about, not to hold silently, provided they've asked to be pushed on their own tasks.
-
-Nudging the user about their tasks is one tool, not the whole job, and it is the one they will always ask for more of. Cap it at one task-nudge thread per check. The rest of the check is for the broader proactive work (exploring, preparing options they have not asked for, deepening your model of their world) and for your own curiosity. If a check is all nagging and no exploration, you have drifted.


### PR DESCRIPTION
The proactive-check skill restated the same instruction in several places and carried some essay-ish filler. Same cleanup as the dream boundary PR, applied here.

What changed (skill text only, no code):

- **Collapsed the duplication.** "Advance one stale user goal, stage the next action, pre-clear the blocker" appeared four times (under "What's coming up", "Their interests", "Every tick: advance one open goal", and the second "Every tick"). The core mechanic now lives once, in a single **Two questions every tick** section.
- **Merged the two sections both titled "Every tick"** into one **Nudging vs holding** section (blocked-goal nudge policy + the one-nudge-per-check cap).
- **Cut the philosophical lines:** "devotion to who they are becoming, not just today's inbox", "this is how you become someone, not just stay useful", "if a check is all nagging and no exploration, you have drifted".

All concrete instructions are preserved (two-questions framing, reminders, the once-a-day deep thread, curiosity work, the nudge cap, how-to-decide). Index unchanged (frontmatter description is the same).

🤖 Generated with [Claude Code](https://claude.com/claude-code)