### PR TITLE
test(live): speed up the live suite (merge tests, deterministic interrupt, 2-agent pool, fail-fast on auth)

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -94,7 +94,10 @@ check_integration() {
 check_live() {
   (
     cd vestad
-    cargo test -p vestad --test live -- --test-threads=2
+    # The live tests use a 2-agent pool (see tests/live/common.rs); run enough threads that
+    # every test starts and self-organizes onto its pool's mutex, so the two agents run in
+    # parallel instead of serializing on one.
+    cargo test -p vestad --test live -- --test-threads=8
   )
 }
 

--- a/vestad/tests/live/common.rs
+++ b/vestad/tests/live/common.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
-use vesta_tests::{SERVER, TestAgent, docker_cmd, exec_in_container};
+use vesta_tests::{SERVER, TestAgent, docker_cmd, dump_agent_diagnostics, exec_in_container};
 
 type SharedAgent = Option<(TestAgent<'static>, String)>;
 
@@ -118,6 +118,13 @@ fn wait_for_container_running(container: &str, timeout: Duration) -> Result<(), 
 /// first goes idle. First-start is several minutes; this only has to not be hit in practice.
 const FIRST_START_SETTLE_TIMEOUT: Duration = Duration::from_secs(600);
 const READY_MARKER: &str = "/root/agent/e2e-test/ready.txt";
+const FIRST_START_ALIVE_POLL: Duration = Duration::from_secs(2);
+
+/// Agent-log markers meaning the injected credentials are being rejected by the API (a dead or
+/// expired CLAUDE_CREDENTIALS). When this happens the agent idles in `setting_up` until the full
+/// timeout, so first-start setup bails fast and prints the agent's own diagnostics on sight of one
+/// rather than hanging for ten minutes on a generic timeout.
+const FIRST_START_AUTH_FAILURE_MARKERS: &[&str] = &["Invalid authentication credentials", "Please run /login"];
 
 /// Block until the agent has fully finished first-start and is idle, using the product's own
 /// idle signal rather than a timer.
@@ -173,10 +180,32 @@ fn setup_shared_live_agent() -> Option<(TestAgent<'static>, String)> {
     // already-running agent picks up the credentials but keeps the default (opus)
     // model for the whole first-start conversation.
     client.restart_agent(&agent.name).expect("restart agent to apply model + credentials");
-    client.wait_until_alive(&agent.name, 600).expect("wait until alive");
+
+    // wait_until_alive would block for the full timeout if the injected credentials are rejected.
+    // Poll the agent's own log alongside its status and fail fast with diagnostics the moment an
+    // auth error appears (a dead/expired CLAUDE_CREDENTIALS is the usual cause).
+    let alive_deadline = std::time::Instant::now() + FIRST_START_SETTLE_TIMEOUT;
+    loop {
+        if std::time::Instant::now() >= alive_deadline {
+            dump_agent_diagnostics(&agent.name);
+            panic!("timeout waiting for first-start to go alive");
+        }
+        if client.agent_status(&agent.name).map(|s| s.status).unwrap_or_default() == "alive" {
+            break;
+        }
+        let agent_log = exec_in_container(&container, "cat /root/agent/logs/vesta.log 2>/dev/null || true").unwrap_or_default();
+        if FIRST_START_AUTH_FAILURE_MARKERS.iter().any(|marker| agent_log.contains(marker)) {
+            dump_agent_diagnostics(&agent.name);
+            panic!("first-start hit an auth error — CLAUDE_CREDENTIALS is invalid/expired; re-seed the secret (agent diagnostics above)");
+        }
+        thread::sleep(FIRST_START_ALIVE_POLL);
+    }
 
     // First-start keeps going after the agent reports alive; wait (via the agent's own idle
     // signal) until it has fully settled before any test sends notifications.
-    wait_for_first_start_settled(&container).expect("agent settled after first-start");
+    if let Err(e) = wait_for_first_start_settled(&container) {
+        dump_agent_diagnostics(&agent.name);
+        panic!("agent did not settle after first-start: {e}");
+    }
     Some((agent, container))
 }

--- a/vestad/tests/live/common.rs
+++ b/vestad/tests/live/common.rs
@@ -9,24 +9,37 @@ use vesta_tests::{SERVER, TestAgent, docker_cmd, dump_agent_diagnostics, exec_in
 
 type SharedAgent = Option<(TestAgent<'static>, String)>;
 
-/// Shared live agent: ONE real first-start for the whole live suite. First-start is by far
-/// the most expensive part of every live test (a multi-minute real-Claude setup conversation),
-/// and the tests only need an agent that is awake, settled, and processing notifications.
-/// Tests lock this agent and run serially against it, isolating themselves with unique
-/// file paths.
+/// The live suite runs against a POOL of two shared agents rather than one, so independent tests
+/// run in parallel. Each agent pays its own one-time first-start (the expensive multi-minute
+/// real-Claude setup), but the two first-starts run concurrently, so the pool's setup wall-clock
+/// stays ~= a single first-start while the test bodies overlap.
 ///
-/// Like SHARED_RO_AGENT in the server suite, the static never drops; the container is cleaned
-/// up on the next run (TestAgent::create destroys leftovers by name).
-static SHARED_LIVE_AGENT: LazyLock<Mutex<SharedAgent>> = LazyLock::new(|| Mutex::new(setup_shared_live_agent()));
+/// Tests are partitioned by agent and must NOT mix pools mid-test: notifications and interrupts
+/// are global to an agent's conversation, so two tests sharing one agent would corrupt each
+/// other. Each pool's Mutex serializes its own tests. The dreamer (which restarts and compacts
+/// its agent) gets pool B to itself; everything else shares pool A. The suite must run with
+/// enough `--test-threads` that both pools have a runner at once (see check.sh `live`).
+///
+/// Like SHARED_RO_AGENT in the server suite, the statics never drop; containers are cleaned up
+/// on the next run (TestAgent::create destroys leftovers by name).
+static LIVE_AGENT_A: LazyLock<Mutex<SharedAgent>> = LazyLock::new(|| Mutex::new(setup_live_agent("test-e2e-a")));
+static LIVE_AGENT_B: LazyLock<Mutex<SharedAgent>> = LazyLock::new(|| Mutex::new(setup_live_agent("test-e2e-b")));
 
-/// Lock the shared live agent for the duration of a test. Returns None (test skips) when
-/// Claude credentials are unavailable. Holding the guard serializes tests: notifications,
-/// and especially interrupts, are global to the agent's conversation, so concurrent tests
-/// would corrupt each other.
-pub fn lock_shared_live_agent() -> Option<(MutexGuard<'static, SharedAgent>, String)> {
-    let guard = SHARED_LIVE_AGENT.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+fn lock_pool(pool: &'static LazyLock<Mutex<SharedAgent>>) -> Option<(MutexGuard<'static, SharedAgent>, String)> {
+    let guard = pool.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
     let container = guard.as_ref()?.1.clone();
     Some((guard, container))
+}
+
+/// Lock pool A (general tests: file ops, mcp tools, interrupt). Returns None (test skips) when
+/// Claude credentials are unavailable.
+pub fn lock_live_agent_a() -> Option<(MutexGuard<'static, SharedAgent>, String)> {
+    lock_pool(&LIVE_AGENT_A)
+}
+
+/// Lock pool B (the dreamer's dedicated agent — it restarts and compacts, so it runs alone).
+pub fn lock_live_agent_b() -> Option<(MutexGuard<'static, SharedAgent>, String)> {
+    lock_pool(&LIVE_AGENT_B)
 }
 
 const MEMORY_PATH: &str = "/root/agent/MEMORY.md";
@@ -144,7 +157,7 @@ fn wait_for_first_start_settled(container: &str) -> Result<(), String> {
     wait_for_file_contains(container, READY_MARKER, "READY", FIRST_START_SETTLE_TIMEOUT).map(|_| ())
 }
 
-fn setup_shared_live_agent() -> Option<(TestAgent<'static>, String)> {
+fn setup_live_agent(name: &str) -> Option<(TestAgent<'static>, String)> {
     let Some(credentials_path) = host_credentials_path() else {
         eprintln!("skipping live e2e: ~/.claude/.credentials.json not found");
         return None;
@@ -156,7 +169,7 @@ fn setup_shared_live_agent() -> Option<(TestAgent<'static>, String)> {
     // Follow the real user creation path: build the image, then discover
     // the container via the API (not by hardcoding the naming convention).
     let client = Box::leak(Box::new(SERVER.client()));
-    let agent = TestAgent::create(client, "test-e2e-shared").unwrap();
+    let agent = TestAgent::create(client, name).unwrap();
 
     let status = client.agent_status(&agent.name).unwrap();
     let container = status.id.unwrap_or_else(|| panic!("agent {} has no container id", agent.name));

--- a/vestad/tests/live/dreamer.rs
+++ b/vestad/tests/live/dreamer.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use vesta_tests::exec_in_container;
 
-use super::common::{lock_shared_live_agent, wait_for_file_contains, write_notification, E2E_FILES_DIR};
+use super::common::{lock_live_agent_b, wait_for_file_contains, write_notification, E2E_FILES_DIR};
 
 /// Poll a container shell command until its stdout contains `needle`, or time out.
 fn wait_for_exec_contains(container: &str, script: &str, needle: &str, timeout: Duration) -> Result<String, String> {
@@ -41,7 +41,7 @@ fn read_session_id(container: &str) -> String {
 /// than waking up on a blank slate. This is the behavior that replaced the old hard session reset.
 #[test]
 fn dreamer_complete_compacts_in_place_and_restart_resumes_the_session() {
-    let Some((_shared, container)) = lock_shared_live_agent() else {
+    let Some((_shared, container)) = lock_live_agent_b() else {
         return;
     };
 

--- a/vestad/tests/live/file_ops.rs
+++ b/vestad/tests/live/file_ops.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use super::common::{lock_shared_live_agent, wait_for_file_contains, write_notification, E2E_FILES_DIR};
+use super::common::{lock_live_agent_a, wait_for_file_contains, write_notification, E2E_FILES_DIR};
 
 /// Basic file operations end to end against real claude. Create and modify share the same
 /// notification -> file mechanism, so one conversation exercises both: the agent creates a file
@@ -8,7 +8,7 @@ use super::common::{lock_shared_live_agent, wait_for_file_contains, write_notifi
 /// notification without losing the original content.
 #[test]
 fn agent_notification_e2e_creates_then_modifies_file_via_vestad() {
-    let Some((_shared, container)) = lock_shared_live_agent() else {
+    let Some((_shared, container)) = lock_live_agent_a() else {
         return;
     };
 

--- a/vestad/tests/live/file_ops.rs
+++ b/vestad/tests/live/file_ops.rs
@@ -1,11 +1,13 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use vesta_tests::exec_in_container;
+use super::common::{lock_shared_live_agent, wait_for_file_contains, write_notification, E2E_FILES_DIR};
 
-use super::common::{lock_shared_live_agent, write_notification, wait_for_file_contains, E2E_FILES_DIR};
-
+/// Basic file operations end to end against real claude. Create and modify share the same
+/// notification -> file mechanism, so one conversation exercises both: the agent creates a file
+/// with exact content from one notification, then appends to that same file from a second
+/// notification without losing the original content.
 #[test]
-fn agent_notification_e2e_creates_file_via_vestad() {
+fn agent_notification_e2e_creates_then_modifies_file_via_vestad() {
     let Some((_shared, container)) = lock_shared_live_agent() else {
         return;
     };
@@ -17,47 +19,27 @@ fn agent_notification_e2e_creates_file_via_vestad() {
             .unwrap()
             .as_secs()
     );
-    let created = format!("{E2E_FILES_DIR}/single-{uid}.txt");
+    let file = format!("{E2E_FILES_DIR}/file-{uid}.txt");
     let expected = format!("E2E content {uid}");
 
     write_notification(
         &container,
-        &format!("Create the file \"{created}\" containing only:\n{expected}"),
+        &format!("Create the file \"{file}\" containing only:\n{expected}"),
         true,
     )
     .expect("write create notification");
-
-    let created_content = wait_for_file_contains(&container, &created, &expected, Duration::from_secs(180))
+    let created_content = wait_for_file_contains(&container, &file, &expected, Duration::from_secs(180))
         .expect("wait for created file");
     assert!(created_content.contains(&expected));
-}
 
-#[test]
-fn agent_notification_e2e_modifies_file_via_vestad() {
-    let Some((_shared, container)) = lock_shared_live_agent() else {
-        return;
-    };
-
-    let uid = format!(
-        "{}",
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-    );
-    let modified = format!("{E2E_FILES_DIR}/modify-{uid}.txt");
-
-    exec_in_container(&container, &format!("printf '%s\n' 'original content' > {modified}"))
-        .expect("seed file");
     write_notification(
         &container,
-        &format!("Append the text \"--- APPENDED ---\" to the file \"{modified}\""),
+        &format!("Append the text \"--- APPENDED ---\" to the file \"{file}\""),
         true,
     )
     .expect("write modify notification");
-
-    let modified_content = wait_for_file_contains(&container, &modified, "APPENDED", Duration::from_secs(180))
+    let modified_content = wait_for_file_contains(&container, &file, "APPENDED", Duration::from_secs(180))
         .expect("wait for modified file");
-    assert!(modified_content.contains("original content"));
+    assert!(modified_content.contains(&expected), "append must preserve the original content");
     assert!(modified_content.contains("APPENDED"));
 }

--- a/vestad/tests/live/interrupt.rs
+++ b/vestad/tests/live/interrupt.rs
@@ -1,5 +1,5 @@
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use vesta_tests::exec_in_container;
 
@@ -8,11 +8,39 @@ use super::common::{lock_shared_live_agent, wait_for_file_contains, write_notifi
 /// Per-step timeout for the agent to make observable progress.
 const TASK_TIMEOUT: Duration = Duration::from_secs(240);
 
-/// How long the count must keep NOT reaching 10 after the redirect task completed.
-/// The counting task appends a number every ~5s, so if the interrupt failed (the counting
-/// turn survived, or an orphaned tool process kept running) it would reach 10 well inside
-/// this window.
-const POST_REDIRECT_GRACE: Duration = Duration::from_secs(45);
+/// Proving the count is dead: the counting task appends a number roughly every 5s, so once the
+/// file is unchanged for COUNT_STABLE_WINDOW (comfortably longer than that cadence) nothing is
+/// appending anymore. We poll at COUNT_POLL_INTERVAL, fail fast the instant the count reaches 10
+/// (the interrupt did not abort), and cap the whole check at COUNT_DEATH_TIMEOUT.
+const COUNT_POLL_INTERVAL: Duration = Duration::from_secs(3);
+const COUNT_STABLE_WINDOW: Duration = Duration::from_secs(15);
+const COUNT_DEATH_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Prove the negative: after the redirect ran, the counting task is dead. It must never reach 10
+/// (a surviving turn or an orphaned `sleep && echo` appender would get there), and its file must
+/// stop growing. Returns as soon as the file has been stable for COUNT_STABLE_WINDOW rather than
+/// always blocking for a fixed grace period.
+fn assert_counting_is_dead(container: &str, counting_file: &str) {
+    let read = || exec_in_container(container, &format!("cat {counting_file} 2>/dev/null || true")).unwrap_or_default();
+    let overall_deadline = Instant::now() + COUNT_DEATH_TIMEOUT;
+    let mut last = read();
+    let mut last_changed = Instant::now();
+    loop {
+        assert!(
+            !last.contains("10"),
+            "count reached 10 — the interrupt did not abort the counting task:\n{last}"
+        );
+        if last_changed.elapsed() >= COUNT_STABLE_WINDOW || Instant::now() >= overall_deadline {
+            return;
+        }
+        thread::sleep(COUNT_POLL_INTERVAL);
+        let current = read();
+        if current != last {
+            last = current;
+            last_changed = Instant::now();
+        }
+    }
+}
 
 /// The real interrupt path, end to end with real Claude:
 /// a slow multi-step task (count to 10 via file appends) is interrupted mid-flight by an
@@ -65,13 +93,6 @@ fn interrupt_aborts_counting_and_runs_redirect_task() {
     // The redirect task must complete.
     wait_for_file_contains(&container, &redirect_file, "interrupted", TASK_TIMEOUT).expect("redirect file written");
 
-    // Prove the negative: counting stays dead. If the interrupted turn (or an orphaned
-    // `sleep && echo` process) were still appending, it would hit 10 within this window.
-    thread::sleep(POST_REDIRECT_GRACE);
-
-    let count_content = exec_in_container(&container, &format!("cat {counting_file} 2>/dev/null || true")).unwrap_or_default();
-    assert!(
-        !count_content.contains("10"),
-        "count reached 10 — the interrupt did not abort the counting task:\n{count_content}"
-    );
+    // The counting task must stay dead: never reach 10, and stop growing.
+    assert_counting_is_dead(&container, &counting_file);
 }

--- a/vestad/tests/live/interrupt.rs
+++ b/vestad/tests/live/interrupt.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use vesta_tests::exec_in_container;
 
-use super::common::{lock_shared_live_agent, wait_for_file_contains, write_notification, E2E_FILES_DIR};
+use super::common::{lock_live_agent_a, wait_for_file_contains, write_notification, E2E_FILES_DIR};
 
 /// Per-step timeout for the agent to make observable progress.
 const TASK_TIMEOUT: Duration = Duration::from_secs(240);
@@ -48,7 +48,7 @@ fn assert_counting_is_dead(container: &str, counting_file: &str) {
 /// task must be abandoned (count never reaches 10) and the new task must complete.
 #[test]
 fn interrupt_aborts_counting_and_runs_redirect_task() {
-    let Some((_shared, container)) = lock_shared_live_agent() else {
+    let Some((_shared, container)) = lock_live_agent_a() else {
         return;
     };
 

--- a/vestad/tests/live/mcp_tools.rs
+++ b/vestad/tests/live/mcp_tools.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use vesta_tests::exec_in_container;
 
-use super::common::{lock_shared_live_agent, wait_for_file_contains, write_notification, E2E_FILES_DIR};
+use super::common::{lock_live_agent_a, wait_for_file_contains, write_notification, E2E_FILES_DIR};
 
 /// The agent must invoke one of its in-process MCP tools mid-conversation. This
 /// exercises the full cc_sdk MCP path against real claude: claude -> _mcp_stdio.py
@@ -11,7 +11,7 @@ use super::common::{lock_shared_live_agent, wait_for_file_contains, write_notifi
 /// but this verifies tools keep working in the middle of a normal conversation turn.
 #[test]
 fn agent_uses_mcp_tool_in_conversation() {
-    let Some((_shared, container)) = lock_shared_live_agent() else {
+    let Some((_shared, container)) = lock_live_agent_a() else {
         return;
     };
 
@@ -60,7 +60,7 @@ fn agent_uses_mcp_tool_in_conversation() {
 /// finding it proves the model actually had, and called, the MCP control tool during first-start.
 #[test]
 fn agent_called_mark_setup_done_as_real_mcp_tool() {
-    let Some((_shared, container)) = lock_shared_live_agent() else {
+    let Some((_shared, container)) = lock_live_agent_a() else {
         return;
     };
 


### PR DESCRIPTION
Speed + reliability improvements to the live e2e suite (the slowest, release-gating tier). All verified locally against a real agent.

## Speed
- **2-agent pool** (biggest win): the suite ran every test serially against one shared agent. Now pool A runs the file-ops/MCP/interrupt tests and pool B runs the dreamer alone (it restarts+compacts its agent, so it's isolated). Each pool's Mutex serializes its own tests, but the two pools — and their two first-starts — run in parallel. `check.sh live` uses `--test-threads=8` so every test starts and self-organizes onto its pool. **Full suite: 4m59s, down from ~16 min serial.**
- **Merged the file-ops create+modify tests** into one conversation (removes a notification round-trip).
- **Deterministic interrupt check**: replaced the blind 45s `POST_REDIRECT_GRACE` sleep with `assert_counting_is_dead` — fails fast if the count reaches 10, returns as soon as the file is stable for 15s.

## Reliability / debuggability
- **Fail fast on first-start auth errors**: a dead/expired `CLAUDE_CREDENTIALS` made the agent 401 and idle in `setting_up` until the full 600s timeout (this wasted ~25 min on v0.1.158). The harness now polls the agent's `vesta.log` while waiting to go alive and, on `Invalid authentication credentials` / `Please run /login`, dumps diagnostics and fails immediately telling you to re-seed the secret. Also dumps diagnostics if the settle step times out.

## Verification (local, real Claude)
- Full pooled suite: **all 5 tests pass in 4m59s**.
- Individual: merged file-ops 153s, interrupt 176s, happy-path first-start settles with no false auth trigger.
- `cargo clippy -p vestad --tests -- -D warnings` clean.

Note: `test-live` only runs on release, so PR CI validates compile/clippy here; live behavior verified locally as above. The 2 first-starts run concurrently on one Claude account — fine in practice, flagged in case of rate-limit sensitivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)