### PR TITLE
ci: harden release reliability (auto-revert failed releases + tolerate cache flakes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1420,3 +1420,23 @@ jobs:
           done
           echo "Uploaded assets to prerelease ${{ github.event.release.tag_name }}."
           echo "Run ./promote.sh ${{ github.event.release.tag_name }} to release it to stable."
+
+  # ── Revert a failed release ───────────────────────────────────────────
+  # release.sh creates the GitHub release BEFORE CI runs, so a failure (e.g.
+  # test-live) leaves a published-but-asset-less release. Updaters that follow
+  # prereleases then pick it up and 404 on the missing binary. Delete the
+  # release and its tag so the version vanishes cleanly; re-run ./release.sh
+  # after fixing to retry the same version.
+  revert-failed-release:
+    needs: [build-vesta, build-vestad, test-frontend, test-integration, test-live, test-linux, build-windows, build-tauri-macos, build-tauri-linux, build-tauri-windows, build-tauri-android, build-tauri-ios, push-image, release]
+    if: ${{ failure() && github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Delete the failed release and its tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          echo "::warning::release CI failed for ${TAG} — deleting the release and its tag so updaters cannot pick up an asset-less release. Re-run ./release.sh after fixing to retry ${TAG}."
+          gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        # Caching is best-effort: a transient cache-service outage must not fail the
+        # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
+        continue-on-error: true
 
       # Hermetic: the agent image is built from THIS checkout (GHA layer cache keeps it
       # fast), so integration tests exercise the PR's agent code and Dockerfile — never
@@ -417,6 +420,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        # Caching is best-effort: a transient cache-service outage must not fail the
+        # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
+        continue-on-error: true
 
       # Live tests must exercise the image being released, not the PREVIOUS release's
       # :latest — build it from this checkout (shares the GHA layer cache with
@@ -504,6 +510,9 @@ jobs:
           components: clippy
 
       - uses: Swatinem/rust-cache@v2
+        # Caching is best-effort: a transient cache-service outage must not fail the
+        # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
+        continue-on-error: true
         with:
           workspaces: |
             cli
@@ -574,6 +583,9 @@ jobs:
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
+        # Caching is best-effort: a transient cache-service outage must not fail the
+        # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
+        continue-on-error: true
         with:
           workspaces: |
             cli
@@ -630,6 +642,9 @@ jobs:
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
+        # Caching is best-effort: a transient cache-service outage must not fail the
+        # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
+        continue-on-error: true
         with:
           workspaces: vestad
           key: vestad-${{ matrix.target }}
@@ -697,6 +712,9 @@ jobs:
           components: clippy
 
       - uses: Swatinem/rust-cache@v2
+        # Caching is best-effort: a transient cache-service outage must not fail the
+        # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
+        continue-on-error: true
         with:
           workspaces: cli
           key: x86_64-pc-windows-msvc
@@ -725,6 +743,9 @@ jobs:
           targets: x86_64-pc-windows-msvc
 
       - uses: Swatinem/rust-cache@v2
+        # Caching is best-effort: a transient cache-service outage must not fail the
+        # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
+        continue-on-error: true
         with:
           workspaces: cli
           key: x86_64-pc-windows-msvc
@@ -788,6 +809,9 @@ jobs:
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
+        # Caching is best-effort: a transient cache-service outage must not fail the
+        # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
+        continue-on-error: true
         with:
           workspaces: apps/desktop/src-tauri
           key: ${{ matrix.target }}
@@ -864,6 +888,9 @@ jobs:
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
+        # Caching is best-effort: a transient cache-service outage must not fail the
+        # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
+        continue-on-error: true
         with:
           workspaces: apps/desktop/src-tauri
           key: ${{ matrix.target }}
@@ -941,6 +968,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        # Caching is best-effort: a transient cache-service outage must not fail the
+        # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
+        continue-on-error: true
         with:
           workspaces: apps/desktop/src-tauri
           key: x86_64-pc-windows-msvc
@@ -1023,6 +1053,9 @@ jobs:
           targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
 
       - uses: Swatinem/rust-cache@v2
+        # Caching is best-effort: a transient cache-service outage must not fail the
+        # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
+        continue-on-error: true
         with:
           workspaces: apps/mobile/src-tauri
           key: android
@@ -1158,6 +1191,9 @@ jobs:
           targets: aarch64-apple-ios
 
       - uses: Swatinem/rust-cache@v2
+        # Caching is best-effort: a transient cache-service outage must not fail the
+        # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
+        continue-on-error: true
         if: env.SKIP_IOS != 'true'
         with:
           workspaces: apps/mobile/src-tauri


### PR DESCRIPTION
Two CI-reliability fixes prompted by the v0.1.158 release, where `test-live` failed (stale `CLAUDE_CREDENTIALS` → 401 → `setting_up` timeout) and a `rust-cache` step also flaked.

## 1. Auto-revert a failed release
`release.sh` creates the GitHub release *before* CI runs, so a failing release-blocking job leaves a **published-but-asset-less release** that updaters following prereleases pick up and 404 on (this is what broke `vestad update` for v0.1.158). New `revert-failed-release` job (release event + `failure()` only) deletes the release **and its tag** via `gh release delete --cleanup-tag`, so the version vanishes cleanly; re-run `./release.sh` to retry the same version. Uses the existing `GITHUB_TOKEN` (`contents: write` already set workflow-wide).

## 2. Tolerate transient rust-cache failures
A `Swatinem/rust-cache@v2` step failed during the release run (cache-service hiccup), failing the whole job over a best-effort optimization. Every rust-cache step is now `continue-on-error: true`, so a cache outage just rebuilds uncached instead of failing the build.

## Notes
- The revert job is gated on `github.event_name == 'release'`, so it never runs on PRs/pushes (including this PR's CI).
- Agent-log surfacing on live-test failure is handled in the test harness (PR #776), not as a CI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)