### PR TITLE
feat(diagnostics): surface the claude pane tail when the SDK goes silent

### DIFF
--- a/agent/core/cc_sdk/client.py
+++ b/agent/core/cc_sdk/client.py
@@ -276,6 +276,19 @@ class ClaudeSDKClient:
         percentage = (total / max_tokens * 100) if max_tokens else 0.0
         return {"percentage": percentage, "totalTokens": total, "maxTokens": max_tokens}
 
+    async def snapshot_pane(self) -> str | None:
+        """Raw text of the live claude TUI pane, or None if the session isn't running.
+
+        The silence watchdog uses this to surface what a wedged TUI is actually showing
+        (a frozen prompt, an unsubmitted paste, a modal) instead of only reporting silence.
+        """
+        if self._monitor_task is None or self._exit_code is not None:
+            return None
+        try:
+            return await tmux.capture_pane(self._tmux_socket, self._tmux_session)
+        except (OSError, RuntimeError):
+            return None
+
     async def compact(self, instructions: str = "") -> None:
         """Compact the conversation in place via `/compact` and wait for it to finish.
 

--- a/agent/core/diagnostics.py
+++ b/agent/core/diagnostics.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import collections
+import re
 import time
 import typing as tp
 
@@ -11,6 +12,25 @@ from . import models as vm
 _WATCHDOG_THRESHOLDS_S = (60, 120, 300)
 _CONTEXT_USAGE_TIMEOUT_S = 10.0
 _CONTEXT_USAGE_WARN_PCT = 80.0
+_PANE_CAPTURE_TIMEOUT_S = 5.0
+_PANE_TAIL_LINES = 4
+_PANE_TAIL_MAXLEN = 240
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+
+
+def format_pane_tail(pane: str) -> str:
+    """Condense a raw TUI capture to its last few content lines, ANSI-stripped.
+
+    Keeps the watchdog warning a single readable line: blank lines and pure box-drawing
+    rules are dropped, only the tail (where the prompt and any error live) is kept, and the
+    result is length-capped so a wedged-pane dump never floods the log stream.
+    """
+    lines = []
+    for raw in pane.splitlines():
+        stripped = _ANSI_RE.sub("", raw).strip()
+        if any(ch.isalnum() for ch in stripped):
+            lines.append(stripped)
+    return " | ".join(lines[-_PANE_TAIL_LINES:])[:_PANE_TAIL_MAXLEN]
 
 
 def touch_activity(state: vm.State, label: str) -> None:
@@ -69,6 +89,19 @@ def _check_sdk_subprocess_alive(state: vm.State) -> bool | None:
     return state.client.is_alive()
 
 
+async def _capture_pane_tail(state: vm.State) -> str:
+    """Best-effort, bounded snapshot of the claude TUI tail; empty string if unavailable."""
+    if state.client is None:
+        return ""
+    try:
+        pane = await asyncio.wait_for(state.client.snapshot_pane(), timeout=_PANE_CAPTURE_TIMEOUT_S)
+    except (TimeoutError, OSError, RuntimeError):
+        return ""
+    if not pane:
+        return ""
+    return format_pane_tail(pane)
+
+
 async def sdk_watchdog(state: vm.State, *, stop: asyncio.Event) -> None:
     warned_at: set[int] = set()
     while not stop.is_set():
@@ -91,6 +124,9 @@ async def sdk_watchdog(state: vm.State, *, stop: asyncio.Event) -> None:
                 # turns; log at debug so quiet stretches don't spam the warning stream.
                 turn_in_flight = state.interrupt_event is not None
                 if turn_in_flight or alive is False:
+                    pane_tail = await _capture_pane_tail(state)
+                    if pane_tail:
+                        msg = f"{msg} | pane_tail={pane_tail!r}"
                     logger.warning(msg)
                     # One event per threshold crossing (warned_at gates re-emit), so a multi-minute
                     # hang reaches the observability surface without spamming the stream every poll.

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -14,6 +14,7 @@ from wait_util import wait_for_condition
 from core.diagnostics import (
     _check_sdk_subprocess_alive,
     format_hang_diagnostics,
+    format_pane_tail,
     longest_running_tool,
     sdk_idle_seconds,
     sdk_watchdog,
@@ -91,6 +92,33 @@ def test_format_hang_diagnostics_includes_stderr_tail():
     assert "line 9" in diag
 
 
+# --- format_pane_tail ---
+
+
+def test_format_pane_tail_strips_ansi_and_box_drawing():
+    pane = (
+        "\x1b[2m  Searched for 1 pattern\x1b[0m\n"
+        "\n"
+        "──────────────────────────────\n"
+        "\x1b[34m●\x1b[0m Services back up\n"
+        "❯ yeah run it\n"
+        "  ⏵⏵ bypass permissions on\n"
+    )
+    tail = format_pane_tail(pane)
+    assert "❯ yeah run it" in tail
+    assert "bypass permissions on" in tail
+    assert "\x1b[" not in tail  # ANSI stripped
+    assert "──────" not in tail  # Box-drawing rule dropped
+
+
+def test_format_pane_tail_keeps_only_last_lines_and_caps_length():
+    pane = "\n".join(f"content line number {i} here" for i in range(50))
+    tail = format_pane_tail(pane)
+    assert len(tail) <= 240
+    assert "content line number 49 here" in tail
+    assert "content line number 10 here" not in tail  # Only the tail survives
+
+
 # --- _check_sdk_subprocess_alive ---
 # Liveness is read through the client's public is_alive() accessor. The alive/dead
 # distinction needs a launched claude process and lives in test_e2e_transport.py; the
@@ -150,6 +178,47 @@ async def test_watchdog_warns_at_thresholds():
         diagnostics_mod.logger.warning = original_warning
 
     assert any("SDK silent for 60s" in w for w in warnings), f"Expected 60s warning, got: {warnings}"
+
+
+@pytest.mark.anyio
+async def test_watchdog_warning_includes_pane_tail():
+    """A suspicious silence captures the live claude pane so the warning shows what's wedged."""
+    from unittest.mock import patch as _patch
+
+    import core.diagnostics as diagnostics_mod
+
+    state = vm.State()
+    state.last_sdk_activity = time.monotonic() - 65  # Idle for 65s
+    state.interrupt_event = asyncio.Event()  # Turn in flight, so silence is suspicious
+    client = MagicMock()
+    client.is_alive = MagicMock(return_value=True)
+    client.snapshot_pane = AsyncMock(return_value="\x1b[34m●\x1b[0m wedged\n❯ yeah run it\n  ⏵⏵ bypass permissions on\n")
+    state.client = client  # ty: ignore[invalid-assignment]
+    stop = asyncio.Event()
+    warnings: list[str] = []
+
+    original_warning = diagnostics_mod.logger.warning
+    diagnostics_mod.logger.warning = lambda msg: warnings.append(str(msg))  # ty: ignore[invalid-assignment]
+
+    original_wait_for = asyncio.wait_for
+
+    async def fast_wait_for(coro, *, timeout):  # type: ignore[no-untyped-def]
+        return await original_wait_for(coro, timeout=0.05)
+
+    try:
+
+        async def stop_after_warning():
+            await wait_for_condition(lambda: any("SDK silent for 60s" in w for w in warnings), message="watchdog never warned")
+            stop.set()
+
+        with _patch("core.diagnostics.asyncio.wait_for", fast_wait_for):
+            await asyncio.gather(sdk_watchdog(state, stop=stop), stop_after_warning())
+    finally:
+        diagnostics_mod.logger.warning = original_warning
+
+    silent = next(w for w in warnings if "SDK silent for 60s" in w)
+    assert "pane_tail=" in silent
+    assert "yeah run it" in silent
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Why

Triaged a live agent (`vesta-elio-vesta`) that "kept timing out with the SDK going silent." The transcript showed a 13-minute gap with **zero** entries after a `query_sent`: a pasted prompt was never picked up by the `claude` TUI, so the agent looked stalled. The only signal was `SDK silent for 300s | last_activity=query_sent`, which says nothing about *why*. Ruled out rate limits (the `429`/`529` I first saw were UUID hex, not API errors), OOM (23Gi free), and long thinking (no thinking blocks).

The watchdog already knew the SDK was silent; it just never looked at what `claude` had on screen.

## What

- **`ClaudeSDKClient.snapshot_pane()`** (cc_sdk): bounded best-effort `capture-pane` of the live TUI, `None` when the session isn't running.
- **`format_pane_tail()`** (diagnostics): condenses a raw capture to its last few content lines, ANSI stripped, blank/box-drawing rules dropped, length-capped to 240 chars.
- The silence watchdog appends `pane_tail=...` to the warning **only on the escalation path** (turn in flight or verified-dead), behind a 5s timeout so the watchdog itself never blocks.

Deliberately **not** a raw TUI dump: the warning stays one readable line, so a wedged pane is visible without flooding the log stream.

## Test

- `format_pane_tail` unit tests: ANSI/box-drawing stripping, last-N + length cap.
- `test_watchdog_warning_includes_pane_tail`: a suspicious silence captures the pane and the `pane_tail=` field reaches the warning.
- `./check.sh agent` equivalent locally: ruff + ty clean, `tests/test_watchdog.py` 21 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)