### PR TITLE
feat(vestad): add `attach` to watch an agent's live claude session

### DIFF
--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -70,6 +70,14 @@ enum Command {
         /// Agent name
         name: String,
     },
+    /// Attach to the agent's live claude session to watch (read-only) what it's doing
+    Attach {
+        /// Agent name
+        name: String,
+        /// Allow typing into the session. Risky: keystrokes race the agent's own driver
+        #[arg(long)]
+        write: bool,
+    },
     /// Connect a Cloudflare domain so your agent gets a public URL
     Connect,
     /// Manage the Cloudflare tunnel (advanced)
@@ -121,6 +129,21 @@ enum TunnelAction {
     },
     /// Tear down tunnel and DNS record
     Destroy,
+}
+
+/// Shell run inside the agent container to attach to the live claude session.
+///
+/// The claude TUI runs under a cc_sdk-named tmux socket (`ccsdk_<suffix>`) in the default
+/// per-uid socket dir; discover the newest one and attach to its session. Attaches read-only
+/// (`-r`) unless `write` is set: the agent's own driver is writing this same pane, so an
+/// unguarded second writer would inject keystrokes into claude's input and race it.
+fn attach_script(name: &str, write: bool) -> String {
+    let attach_flags = if write { "" } else { "-r" };
+    format!(
+        "sock=$(ls -t /tmp/tmux-0/ccsdk_* 2>/dev/null | head -1); \
+         if [ -z \"$sock\" ]; then echo 'no live claude session found for {name}'; exit 1; fi; \
+         exec tmux -S \"$sock\" attach {attach_flags}"
+    )
 }
 
 fn die(msg: impl std::fmt::Display) -> ! {
@@ -591,6 +614,28 @@ fn main() {
             }
         }
 
+        Command::Attach { name, write } => {
+            docker::validate_name(&name).unwrap_or_else(|e| die(&e));
+            let docker = docker::connect().unwrap_or_else(|e| die(&e));
+            let cname = docker::container_name(&name);
+            let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+            rt.block_on(docker::ensure_running(&docker, &cname)).unwrap_or_else(|e| die(&e));
+
+            let script = attach_script(&name, write);
+            let mode = if write { "read-write" } else { "read-only" };
+            eprintln!("attaching to {name}'s claude session ({mode}; detach with Ctrl-Q)…");
+            let status = std::process::Command::new("docker")
+                .args(["exec", "-it", "--detach-keys=ctrl-q", &cname, "bash", "-lc", &script])
+                .stdin(std::process::Stdio::inherit())
+                .stdout(std::process::Stdio::inherit())
+                .stderr(std::process::Stdio::inherit())
+                .status()
+                .unwrap_or_else(|e| die(format!("docker exec failed: {}", e)));
+            if !status.success() {
+                std::process::exit(status.code().unwrap_or(1));
+            }
+        }
+
         Command::Backup { action } => {
             let docker = docker::connect().unwrap_or_else(|e| die(&e));
             let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
@@ -821,5 +866,20 @@ mod tests {
     fn local_health_url_none_without_port_file() {
         let dir = tempfile::tempdir().expect("tempdir");
         assert_eq!(local_health_url(dir.path()), None);
+    }
+
+    #[test]
+    fn attach_script_is_read_only_by_default() {
+        let script = attach_script("vesta", false);
+        assert!(script.contains("tmux -S \"$sock\" attach -r"));
+        assert!(script.contains("ccsdk_*"));
+        assert!(script.contains("no live claude session found for vesta"));
+    }
+
+    #[test]
+    fn attach_script_drops_read_only_guard_when_write() {
+        let script = attach_script("vesta", true);
+        assert!(script.contains("tmux -S \"$sock\" attach "));
+        assert!(!script.contains("attach -r"));
     }
 }


### PR DESCRIPTION
## Why

While triaging a wedged agent (a pasted prompt the claude TUI never picked up, see #779), there was no way to *watch* the live session. `vestad shell` gives you a container shell but not the claude TUI. This adds `vestad attach <name>`, which discovers the cc_sdk tmux socket (`ccsdk_<suffix>`) and attaches to the running claude session.

## What

- New `vestad attach <name>` subcommand, modeled on `vestad shell` (same `validate_name` / `ensure_running` / `docker exec -it --detach-keys=ctrl-q` path).
- **Read-only by default** (`tmux -r`): the agent's own cc_sdk driver is writing that same pane, so an unguarded second writer would inject keystrokes into claude's input and race the driver, the exact failure mode being debugged. `--write` drops the guard for deliberate manual intervention.
- Socket discovery and the read-only flag are extracted into a pure `attach_script(name, write)` helper so the safety default is unit-tested.

## Test

- `attach_script_is_read_only_by_default` and `attach_script_drops_read_only_guard_when_write` lock the `-r` default and the `--write` opt-out.
- `cargo clippy -p vestad -D warnings` clean; `cargo test -p vestad` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)