### PR TITLE
feat(app): native hosted login (desktop loopback) + vesta-account-first connect

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4239,6 +4239,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-oauth"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda564acdb23185caf700f89dd6e5d4540225d6a991516b2cad0cbcf27e4dcd3"
+dependencies = [
+ "httparse",
+ "log",
+ "serde",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4972,6 +4987,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
+ "tauri-plugin-oauth",
  "tauri-plugin-opener",
  "tauri-plugin-store",
  "tauri-plugin-updater",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -22,6 +22,8 @@ tauri-plugin-updater = "2"
 tauri-plugin-opener = "2.5.4"
 tauri-plugin-store = "2"
 tauri-plugin-notification = "2"
+# Loopback server for the native hosted-login redirect (PKCE, see apps/web/src/lib/pkce.ts).
+tauri-plugin-oauth = "2"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [profile.release]

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -25,6 +25,7 @@
     "notification:default",
     "notification:allow-is-permission-granted",
     "notification:allow-request-permission",
-    "notification:allow-notify"
+    "notification:allow-notify",
+    "oauth:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -135,6 +135,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_oauth::init())
         .setup(|_app| {
             use tauri::Manager;
 

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -1026,6 +1026,15 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@fabianlars/tauri-plugin-oauth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fabianlars/tauri-plugin-oauth/-/tauri-plugin-oauth-2.0.0.tgz",
+      "integrity": "sha512-I1s08ZXrsFuYfNWusAcpLyiCfr5TCvaBrRuKfTG+XQrcaqnAcwjdWH0U5J9QWuMDLwCUMnVxdobtMJzPR8raxQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.0.3"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -11145,6 +11154,7 @@
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.43.0",
+        "@fabianlars/tauri-plugin-oauth": "^2.0.0",
         "@fontsource-variable/outfit": "^5.2.8",
         "@fontsource-variable/public-sans": "^5.2.7",
         "@hookform/resolvers": "^5.4.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "@codemirror/language": "^6.0.0",
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.43.0",
+    "@fabianlars/tauri-plugin-oauth": "^2.0.0",
     "@fontsource-variable/outfit": "^5.2.8",
     "@fontsource-variable/public-sans": "^5.2.7",
     "@hookform/resolvers": "^5.4.0",

--- a/apps/web/src/components/Connect/index.tsx
+++ b/apps/web/src/components/Connect/index.tsx
@@ -12,6 +12,7 @@ import {
 import { fade } from "@/lib/motion";
 import { errorMessage } from "@/lib/utils";
 import { startHostedLogin } from "@/lib/pkce";
+import { isTauri } from "@/lib/env";
 import { useAuth } from "@/providers/AuthProvider";
 
 // VITE_VESTAD_HOSTED=true means the SPA was bundled by vestad itself, so
@@ -34,6 +35,11 @@ export function Connect() {
   const [details, setDetails] = useState("");
   const [showDetails, setShowDetails] = useState(false);
   const [busy, setBusy] = useState(false);
+  // In the native app (and any vesta-account surface) we lead with "continue
+  // with vesta account"; `selfHost` flips to the host+key form for people
+  // running their own box. Only ever set on Tauri (the web bundles know which
+  // form they need from `managed`).
+  const [selfHost, setSelfHost] = useState(false);
   // On a vestad-served bundle we don't yet know if this is a hosted (vesta.run)
   // box. Probe /info.managed: managed boxes log in via the vesta.run handoff
   // (PKCE, issue #19) since the user never gets the api_key; self-hosted boxes
@@ -90,7 +96,9 @@ export function Connect() {
     if (busy) return;
     setBusy(true);
     setError("");
-    // Navigates away to vesta.run/api/authorize; on failure we stay put.
+    // Web: full-navigates to vesta.run/api/authorize. Native: opens the system
+    // browser and waits on a loopback redirect (the promise resolves only after
+    // a successful exchange, which itself navigates). On failure we stay put.
     void startHostedLogin().catch(() => {
       setError("could not start sign-in");
       setBusy(false);
@@ -103,14 +111,16 @@ export function Connect() {
   if (managed === null) {
     return <div className="flex h-full flex-col p-page" />;
   }
-  if (managed) {
+  // Lead with the vesta account on a managed box (web) and in the native app,
+  // unless the native user chose self-hosting.
+  if ((managed || isTauri) && !selfHost) {
     return (
       <div className="flex h-full flex-col p-page">
         <div className="flex flex-1 items-center justify-center">
           <div className="flex flex-col items-center gap-3 w-[240px] max-w-full px-4 text-center">
             <h1 className="text-base font-semibold">sign in</h1>
             <FieldDescription className="text-center">
-              continue with your vesta.run account to access this box
+              continue with your vesta account
             </FieldDescription>
             <Button
               type="button"
@@ -118,7 +128,11 @@ export function Connect() {
               disabled={busy}
               className="w-full"
             >
-              {busy ? "redirecting..." : "continue with vesta.run"}
+              {busy
+                ? isTauri
+                  ? "waiting for browser..."
+                  : "redirecting..."
+                : "continue with vesta account"}
             </Button>
             <AnimatePresence>
               {error && (
@@ -127,6 +141,18 @@ export function Connect() {
                 </motion.p>
               )}
             </AnimatePresence>
+            {isTauri && (
+              <button
+                type="button"
+                onClick={() => {
+                  setError("");
+                  setSelfHost(true);
+                }}
+                className="text-xs text-muted-foreground underline-offset-4 hover:underline"
+              >
+                self-hosting? connect with a key
+              </button>
+            )}
           </div>
         </div>
       </div>
@@ -192,6 +218,20 @@ export function Connect() {
           >
             {busy ? "connecting..." : "connect"}
           </Button>
+
+          {isTauri && selfHost && (
+            <button
+              type="button"
+              onClick={() => {
+                setError("");
+                setDetails("");
+                setSelfHost(false);
+              }}
+              className="text-xs text-muted-foreground underline-offset-4 hover:underline"
+            >
+              use a vesta account instead
+            </button>
+          )}
 
           <AnimatePresence>
             {error && (

--- a/apps/web/src/lib/pkce.ts
+++ b/apps/web/src/lib/pkce.ts
@@ -10,9 +10,25 @@
 //     ← { access_token, expires_in }
 //
 // The token never rides in a URL; only the single-use, PKCE-bound code does.
+//
+// Native (Tauri) apps aren't served by a box, so they can't full-navigate to
+// /cb on their own origin. Desktop instead runs a transient loopback server
+// (tauri-plugin-oauth) and registers `http://127.0.0.1:<port>/cb` as the
+// redirect; the control plane returns the box `url` alongside the token, and we
+// upgrade that token to a rotating refresh at the box's `/auth/exchange`. See
+// `startNativeLogin` and the `vesta-app` native client in the control plane's
+// functions/api/oauth.ts.
+
+import { isTauri, buildPlatform } from "./env";
+import { setConnection } from "./connection";
 
 const VERIFIER_KEY = "vesta-pkce-verifier";
 const STATE_KEY = "vesta-pkce-state";
+
+/** Control-plane apex for native apps (which have no box-derived host). */
+const CONTROL_APEX = "https://vesta.run";
+/** Native OAuth client_id the control plane recognises (functions/api/oauth.ts). */
+const NATIVE_CLIENT_ID = "vesta-app";
 
 function base64url(bytes: Uint8Array): string {
   let bin = "";
@@ -49,6 +65,10 @@ export function tenantIdentity(): { apexOrigin: string; subdomain: string } {
  * browser leaves this page.
  */
 export async function startHostedLogin(): Promise<void> {
+  // Native apps can't redirect to their own origin — hand off to the loopback
+  // flow instead (desktop) or the in-app secure tab (mobile, not yet wired).
+  if (isTauri) return startNativeLogin();
+
   const { apexOrigin, subdomain } = tenantIdentity();
   const verifier = randomBase64url(32);
   const state = randomBase64url(16);
@@ -98,4 +118,132 @@ export async function completeHostedLogin(
   const data = await resp.json();
   if (!data.access_token) throw new Error("no token returned");
   return { accessToken: data.access_token, expiresIn: data.expires_in ?? 600 };
+}
+
+/**
+ * Native (Tauri) hosted login. Desktop spins up a loopback server
+ * (tauri-plugin-oauth), opens the system browser to the control plane's single
+ * sign-in page, and catches the redirect there — no box origin to bounce off.
+ *
+ *   loopback :<port>  →  open https://vesta.run/api/authorize?client_id=vesta-app
+ *                        &redirect_uri=http://127.0.0.1:<port>/cb&...
+ *     ← onUrl: http://127.0.0.1:<port>/cb?code=...&state=...
+ *     → POST https://vesta.run/api/token { code, code_verifier }
+ *     ← { access_token, url }                       (url = this user's box)
+ *     → POST <url>/auth/exchange  (Bearer access_token)
+ *     ← { access_token, refresh_token, expires_in } (rotating, on-box)
+ *
+ * Mobile (ios/android) needs an in-app secure tab (ASWebAuthenticationSession /
+ * Custom Tabs via tauri-plugin-web-auth); not wired yet — fail with a clear note
+ * rather than spawning a loopback server that the OS sandbox would block.
+ */
+export async function startNativeLogin(): Promise<void> {
+  if (buildPlatform === "ios" || buildPlatform === "android") {
+    throw new Error("mobile sign-in is coming soon — use the web app for now");
+  }
+
+  const { start, onUrl, cancel } =
+    await import("@fabianlars/tauri-plugin-oauth");
+  const { openUrl } = await import("@tauri-apps/plugin-opener");
+
+  const verifier = randomBase64url(32);
+  const state = randomBase64url(16);
+  const port = await start();
+  const params = new URLSearchParams({
+    client_id: NATIVE_CLIENT_ID,
+    redirect_uri: `http://127.0.0.1:${port}/cb`,
+    code_challenge: await s256(verifier),
+    code_challenge_method: "S256",
+    state,
+  });
+
+  // Bridge the loopback's onUrl callback (which fires when the browser redirects
+  // back, potentially much later) into this promise, so the caller can surface
+  // errors and reset its busy state. A success ends in a full navigation into the
+  // app. `settled` guards against double-firing — the loopback can see a stray
+  // favicon/preflight hit before the real callback.
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let unlisten: (() => void) | undefined;
+    const teardown = () => {
+      void cancel(port).catch(() => {});
+      unlisten?.();
+    };
+
+    onUrl(async (url: string) => {
+      if (settled) return;
+      const u = new URL(url);
+      const code = u.searchParams.get("code");
+      const returnedState = u.searchParams.get("state");
+      if (!code || !returnedState) return; // stray hit — keep waiting
+      settled = true;
+      try {
+        if (returnedState !== state) {
+          throw new Error("state mismatch, try again");
+        }
+        await completeNativeLogin(code, verifier);
+        teardown();
+        resolve();
+        // Full load so connection-reading providers re-init from storage.
+        window.location.assign("/");
+      } catch (e) {
+        teardown();
+        reject(e);
+      }
+    })
+      .then((fn) => {
+        unlisten = fn;
+      })
+      .catch(reject);
+
+    openUrl(`${CONTROL_APEX}/api/authorize?${params.toString()}`).catch((e) => {
+      if (settled) return;
+      settled = true;
+      teardown();
+      reject(e);
+    });
+  });
+}
+
+/**
+ * Finish a native login: code → control-plane access token + box url, then
+ * upgrade that token to a rotating refresh at the box's /auth/exchange and
+ * persist the connection. Throws on any failure (the caller surfaces it).
+ */
+async function completeNativeLogin(
+  code: string,
+  verifier: string,
+): Promise<void> {
+  const tokenResp = await fetch(`${CONTROL_APEX}/api/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code, code_verifier: verifier }),
+  });
+  if (!tokenResp.ok) throw new Error("could not complete sign-in");
+  const tok = await tokenResp.json();
+  if (!tok.access_token || !tok.url) {
+    throw new Error("sign-in response missing token or box url");
+  }
+
+  const exchangeResp = await fetch(`${tok.url}/auth/exchange`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${tok.access_token}`,
+      "Content-Type": "application/json",
+    },
+    body: "{}",
+  });
+  if (!exchangeResp.ok) {
+    throw new Error("could not finish connecting to your vesta");
+  }
+  const ex = await exchangeResp.json();
+  if (!ex.access_token || !ex.refresh_token) {
+    throw new Error("exchange returned no tokens");
+  }
+  setConnection(
+    tok.url,
+    ex.access_token,
+    ex.refresh_token,
+    ex.expires_in ?? 3600,
+  );
 }


### PR DESCRIPTION
Completes the native-client wave of the hosted-login work (#28), pairing with the already-merged control-plane (`vesta-cloud` #29) and vestad (#778) sides.

## What

- **Connect screen** now leads with **"continue with vesta account"** on a managed box and in the native app. A subtle **"self-hosting? connect with a key"** toggle reveals the existing host+key form (and a "use a vesta account instead" link back). Renames the old "continue with vesta.run" copy to "vesta account".
- **`pkce.ts` `startNativeLogin`** — the native flow:
  - Desktop: a transient **loopback server** (`tauri-plugin-oauth`) registers `http://127.0.0.1:<port>/cb`, opens the **system browser** to `vesta.run/api/authorize?client_id=vesta-app`, and captures the redirect.
  - **Two-step exchange**: control-plane `/api/token` (code → access token + box `url`) → box `/auth/exchange` (access → **rotating** refresh). Persisted via `setConnection`.
  - The `onUrl` callback is bridged into the returned promise, so a failed exchange surfaces to the caller and resets the button's busy state (no stuck "waiting…").
  - **Mobile** (ios/android) throws a clear "coming soon" instead of spawning a loopback the OS sandbox blocks.
- **Tauri desktop**: registers `tauri_plugin_oauth::init()` + `oauth:default` capability + the `@fabianlars/tauri-plugin-oauth` JS dep.

## Verified

`apps/web`: tsc / build / lint / format / check + **72 tests** pass. Desktop: `cargo check` + `cargo clippy` clean (the `oauth:default` capability validates against the plugin manifest at build time).

## ⚠️ Needs on-device testing before merge

The native **transport** (loopback redirect capture, system-browser handoff) only exercises on a built desktop app — it can't run in this environment, and per Tauri's own docs deep-link/loopback flows don't fire under `tauri dev` on macOS. Please build the desktop app and walk a real sign-in before merging.

**Follow-up:** mobile sign-in via `tauri-plugin-web-auth` (ASWebAuthenticationSession / Custom Tabs) — currently stubbed with a "coming soon" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)