### PR TITLE
chore: track .claude workflows and skills in git

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: issue-triage
+description: >
+  Use when the user asks to triage, tag, label, categorize, rename, or de-duplicate GitHub issues
+  and PRs in the Vesta repo ("triage open issues", "tag all issues", "label this issue",
+  "add labels", "standardize issue titles", "rename PR titles", "normalize titles", "find
+  duplicate issues", "merge duplicates"). Applies the standardized Vesta label taxonomy
+  (type + priority + area), the conventional-commits title format, and a duplicate-merging policy
+  so labeling, naming, and the open-issue set stay consistent across sessions.
+---
+
+# Vesta Issue & PR Triage
+
+Three jobs:
+
+1. **Labels** — every triaged issue gets exactly **one type label**, exactly **one priority
+   label**, and **one or more area labels**.
+2. **Title** — every issue and PR title follows the conventional-commits format
+   `type(scope): description`, lowercase, imperative, no trailing period.
+3. **Duplicates** — for every cluster of issues that report the same broken behavior or feature
+   ask, keep one canonical and close the rest as duplicates, preserving any non-overlapping
+   information into the canonical.
+
+If the user asks to "tag" or "triage", do all three. If they ask only to "label", do labels only.
+If they ask only to "rename" / "standardize titles", do titles only. If they ask only to
+"de-dup" / "find duplicates" / "merge duplicates", do duplicates only.
+
+## Workflow
+
+1. List candidates:
+   ```
+   gh issue list --limit 100 --state open --json number,title,labels
+   gh pr list   --limit 100 --state open --json number,title       # only when normalizing PR titles too
+   ```
+2. For each item, read the title. If the title alone is ambiguous, `gh issue view <N>` (or
+   `gh pr view <N>`) to read the body before deciding labels, renaming, or judging duplicates.
+3. **Duplicate pass first** (if in scope) — see "Duplicate Detection & Merging" below. Resolve
+   duplicates before labeling/renaming so you don't waste edits on issues you're about to close.
+4. Decide labels from the taxonomy below. Apply with `gh issue edit <N> --add-label "a,b,c"`.
+5. Decide the canonical title from the rules below. If the current title already matches, leave it
+   alone. Otherwise rename with `gh issue edit <N> --title "..."` or `gh pr edit <N> --title "..."`.
+6. Items that already have a complete label set (type + priority + area) **and** a conformant title
+   should be left alone unless the user asked for a re-triage.
+
+Run the `gh issue edit` / `gh pr edit` calls in parallel when processing many items at once.
+
+## Duplicate Detection & Merging
+
+**Goal:** for every set of open issues that describe the same underlying broken behavior or
+feature ask, keep one canonical and close the rest as duplicates without losing information.
+
+### How to find candidates
+
+1. Read titles + bodies for all open issues. Group by area label first — duplicates almost never
+   cross areas.
+2. Within each area, look for clusters that share at least two of:
+   - Same observed symptom (e.g. "TTS audio buffered then dumped on mic release").
+   - Same proposed remediation (e.g. "stream chunks immediately instead of buffering").
+   - Same triggering scenario (e.g. "after upgrading to v0.1.148 on Android").
+3. Sub-issues that are fully covered by a parent's acceptance criteria count as duplicates of the
+   parent.
+4. PRs are not deduped — only issues. A PR that fixes an open issue is not a duplicate; that's a
+   normal "Fixes #N" relationship.
+
+### Pick the canonical
+
+Within a cluster, the canonical is the issue you keep open. Prefer (in order):
+
+1. The issue with the most concrete acceptance criteria or repro.
+2. The issue with the lowest number (older, usually more cross-referenced).
+3. If both are equally well-written, keep the lower number.
+
+### Decide what to merge
+
+Diff the duplicate's body against the canonical's body. Identify content in the duplicate that is
+**not** present in the canonical:
+
+- Distinct repro steps or environments (e.g. "also reproduces on Android 14, not just iOS").
+- Additional log snippets, stack traces, or error messages.
+- Acceptance criteria the canonical didn't cover.
+- Linked PRs, related issues, or external references.
+- Reactions/upvote counts are signal but not content; don't merge them.
+
+If the duplicate is a strict subset of the canonical (no new info), skip the merge step and just
+close.
+
+### Apply the merge
+
+For each duplicate `D` of canonical `C`:
+
+1. **Preserve unique info** (only if `D` has any). Post a comment on `C`:
+   ```
+   gh issue comment <C> --body "Merged from #<D>:
+
+   <quoted unique content from D's body, as a markdown blockquote>"
+   ```
+2. **Cross-reference + close `D`.** Use `not planned` as the reason (gh CLI doesn't expose a
+   `duplicate` reason; the cross-reference + label do the rest):
+   ```
+   gh issue close <D> --reason "not planned" --comment "Duplicate of #<C>. Unique details merged into the canonical issue."
+   gh issue edit  <D> --add-label "duplicate"
+   ```
+3. **Do not** rename or add taxonomy labels to `D` — it's about to be closed.
+
+Run the comment + close + label calls for one duplicate sequentially (the close depends on the
+comment landing). Across multiple unrelated clusters, run them in parallel.
+
+### Surface ambiguous candidates instead of closing
+
+Closing issues is visible to others and reverses poorly. Auto-merge only when the cluster is
+unambiguous (≥2 of the cluster signals above plus matching area). For borderline pairs, list them
+in your end-of-run report and ask the user to confirm before closing — don't guess.
+
+Borderline indicators that should bump you to "ask the user":
+
+- Same area but different observed symptoms ("UI flashes" vs "UI freezes").
+- Same component but different root-cause hypotheses.
+- One is a P0/P1 incident report and the other is a long-form design proposal — they may both be
+  legitimate (the incident gets fixed; the proposal is the longer-term redesign).
+- Either issue has multiple participants in the comments — closing erases context for them.
+
+### Don'ts (duplicates)
+
+- Don't close as duplicate without leaving a comment that names the canonical issue.
+- Don't merge information that is identical or near-identical — only the genuinely unique parts.
+- Don't paraphrase the duplicate's content when merging; quote it verbatim so the author's wording
+  is preserved.
+- Don't merge across `bug` ↔ `enhancement` boundaries even if the topic is similar — those are
+  separate problems by definition.
+- Don't dedupe PRs.
+- Don't reopen previously-closed duplicates to "re-merge" them. If the canonical was closed, leave
+  the duplicate alone and surface it.
+
+## Title Standardization
+
+### Format
+
+```
+type(scope): short imperative description
+```
+
+- **type** — required. One of: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `ci`, `chore`,
+  `style`, `build`. Map from the issue/PR's intent (see "Type → label mapping" below).
+- **scope** — required when a clear single area applies; omit `()` when the change spans many
+  areas (rare). Use the lowercase area name or a finer-grained sub-system: `agent`, `app`,
+  `vestad`, `cli`, `skills`, `dream`, `tasks`, `whatsapp`, `voice`, `finance`, `agentmail`,
+  `integration`, `tls`, `security`, `infra`, or a specific skill name (`onedrive`, `media-server`,
+  `home-assistant`, `agentmail`, etc.) when the work lives inside that skill.
+- **description** — imperative present tense ("add", "fix", "remove" — not "added" / "adds" /
+  "fixed"), lowercase first word (proper nouns/acronyms keep their case), no trailing period,
+  ≤72 chars when feasible. Don't repeat the type or scope in the description.
+
+### Type → label mapping
+
+| Title type | Implies label |
+| --- | --- |
+| `feat` | `enhancement` |
+| `fix` | `bug` |
+| `docs` | `documentation` |
+| `refactor`, `perf`, `test`, `ci`, `chore`, `style`, `build` | no required type label; pick from taxonomy if the work also fits one |
+
+If the title type and the chosen label disagree (e.g. title `feat(...)` but you labeled it `bug`),
+one of them is wrong. Re-read the body and reconcile before saving.
+
+### Issue vs PR titles
+
+PRs almost always describe a single change → use the strict `type(scope): description` form.
+Issues sometimes describe a problem without a fix in mind. Still prefer `type(scope): description`,
+where the type reflects the *intended outcome*:
+
+- A reported breakage → `fix(scope): <what is broken>`
+- A feature request → `feat(scope): <what to add>`
+- A docs gap → `docs(scope): <what to document>`
+- An open investigation with no committed direction → drop the type and use `scope: <question>`
+  (and add the `research` or `question` label).
+
+### Normalization examples
+
+| Before | After |
+| --- | --- |
+| `app: chat UI becomes very slow once tool calls are rendered` | `fix(app): chat UI slows once tool calls are rendered` |
+| `app: v0.1.148 Android TTS audio buffered, dumped on mic release instead of streaming live (regression from 0.1.147, likely PR #416)` | `fix(voice): android TTS buffers audio instead of streaming (v0.1.148 regression)` |
+| `Add VPN and media-server skills` | `feat(skills): add VPN and media-server skills` |
+| `whatsapp: spurious delivery_failure notifications and misleading filtered status` | `fix(whatsapp): stop firing spurious delivery_failure notifications` |
+| `OneDrive setup: pin rclone to v1.73+ to fix personal-OneDrive content fetches` | `fix(onedrive): pin rclone to v1.73+ to fix personal-account fetches` |
+| `bug: nightly dreamer crash mid-execution leaves MEMORY.md wiped with no recovery` | `fix(dream): preserve MEMORY.md when nightly dreamer crashes mid-run` |
+| `vestad: \`perform_update\` should be a no-op when already at the latest version` | `fix(vestad): make perform_update a no-op when already at latest` |
+| `skill: cloudflare-email for agent send/receive via Cloudflare Email Service` | `feat(skills): add cloudflare-email skill` |
+
+### Don'ts (titles)
+
+- Don't include issue/PR numbers, version tags (`v0.1.148`), or commit hashes in the title unless
+  load-bearing for the bug report; prefer to put that detail in the body.
+- Don't include trailing parentheticals describing the cause ("(regression from PR #416)") unless
+  the cause is the headline.
+- Don't capitalize the description after the colon.
+- Don't add a period at the end.
+- Don't double-tag (`fix(bug): ...`, `feat(enhancement): ...`) — the type already conveys this.
+- Don't change the title of a merged PR; only rename open PRs and issues.
+
+## Taxonomy (labels)
+
+### Type — pick exactly one
+
+| Label | When to apply |
+| --- | --- |
+| `bug` | Something is broken, regressed, crashes, hangs, produces wrong output, or violates a documented invariant. Title cues: "fix", "broken", "regression", "race condition", "hangs", "blocks", "flashes". |
+| `enhancement` | New feature, new capability, or a meaningful UX/quality improvement on existing behavior. Title cues: "feat:", "feat(...)", "add", "support", "make ... first-class". |
+| `documentation` | Docs, README, CLAUDE.md, SKILL.md, or comments only. No behavior change. |
+| `question` | Open question or request for information, no concrete deliverable yet. |
+| `research` | Investigation / spike where the outcome is a decision or a writeup, not a shipped change. Title cues: "investigate", "explore", "evaluate". |
+
+A single issue should not get both `bug` and `enhancement`. If a regression is reported alongside a feature ask, prefer `bug` and note the feature in a follow-up.
+
+### Priority — pick exactly one
+
+| Label | When to apply |
+| --- | --- |
+| `P0-critical` | Blocks normal operation right now: data loss risk, can't start the agent, broken backup, security incident, prod outage. Use sparingly. |
+| `P1-important` | Significant impact but not a stop-the-world: major UX regressions, perf cliffs that make a flow unusable, auth/notification reliability bugs. |
+| `P2-normal` | Default for most feature requests and non-blocking bugs. When unsure between P1 and P2, choose P2. |
+| `P3-low` | Nice to have, polish, niche tooling, low-traffic CI/infra ergonomics. |
+
+### Area — pick one or more
+
+Apply every area that the issue genuinely touches. Most issues need 1–2 area labels.
+
+| Label | Scope |
+| --- | --- |
+| `agent` | Python agent core: `agent/core/` loops, message processing, notifications, memory, dreamer, EventBus. |
+| `app` | Desktop or mobile Tauri app, including `apps/web/`, `apps/desktop/`, `apps/mobile/`. UI bugs, app-side connection logic, auth UX. |
+| `voice` | TTS / STT / voice pipeline (any platform). |
+| `whatsapp` | WhatsApp integration / CLI / skill. |
+| `cli` | `vesta` CLI client (`cli/` Rust crate). |
+| `vestad` | `vestad` daemon (`vestad/` Rust crate): Docker management, HTTP/WS gateway, agent lifecycle. |
+| `skills` | Anything under `agent/skills/` or `agent/core/skills/` (skill content, scripts, index). |
+| `infra` | Docker, CI, GitHub Actions, release pipeline, hosting, signing certs. |
+| `security` | Auth, tokens, credential handling, access control, supply chain. |
+| `tls` | TLS / cert pinning / self-signed cert handling specifically. Pair with `security` when about trust. |
+
+Note: `app` and `vestad` can co-occur (e.g. "view gateway logs from inside the app"). Apply both when the issue spans the boundary.
+
+## Heuristics & Examples
+
+- **"feat(app): X"** → `enhancement` + `app` + priority based on user impact (default `P2-normal`).
+- **"app: <thing> is slow / flashes / blocks"** → `bug` + `app` + priority by severity. Hard freezes or unusable flows = `P1-important`; cosmetic flicker = `P3-low`.
+- **"backup ... urgently"** or anything risking data loss → `bug` + `vestad` + `infra` + `P0-critical`.
+- **TTS regressions on a specific app version** → `bug` + `app` + `voice` + `P1-important` (audio regressions are high-impact).
+- **Auth / credential / cert issues** → add `security`. If specifically about TLS trust, also add `tls`.
+- **"feat(skills): ..."** → `enhancement` + `skills`. Add a second area if the skill is tied to one (e.g. `whatsapp`).
+- **Compaction / loop / message-processing bugs** → `bug` + `agent`.
+
+## Don'ts
+
+- Don't invent labels. If something doesn't fit, surface it to the user and let them decide whether to add a new label to the repo (`gh label create ...`).
+- Don't relabel issues that already have a complete (type + priority + area) set unless the user asked.
+- Don't use `bug` for missing features. Missing != broken.
+- Don't apply `P0-critical` to feature requests. P0 is reserved for things that are currently breaking the user.
+- Don't add the dependency-update / language-tag labels (`dependencies`, `rust`, `python`, `javascript`, `github_actions`) by hand — those are for Dependabot PRs.
+- Don't rewrite a title beyond format normalization. Preserve the author's intent and key technical
+  details; if the body says something the title omits, leave the body alone.
+
+## Verification
+
+After labeling and renaming, re-run:
+```
+gh issue list --limit 100 --state open --json number,title,labels
+gh pr list   --limit 100 --state open --json number,title         # if PRs were in scope
+```
+Confirm every open issue has at least one type label, one priority label, and one area label, and
+that every title matches `type(scope): description` (or `scope: description` for open
+investigations). Report any item you intentionally skipped and why.

--- a/.claude/workflows/bug-hunt.js
+++ b/.claude/workflows/bug-hunt.js
@@ -1,0 +1,164 @@
+export const meta = {
+  name: 'bug-hunt',
+  description: 'Hunt real bugs with diverse finder lenses; a bug survives only if a failing test proves it; fix PRs ship the regression test',
+  whenToUse: 'Recurring correctness pass across agent, cli, vestad, web. Complements repo-quality (style/elegance) and repo-architecture (design) with proven-by-test bug fixing.',
+  phases: [
+    { title: 'Hunt', detail: 'parallel finder lenses, rounds until dry' },
+    { title: 'Prove', detail: 'write a failing test or kill the claim' },
+    { title: 'Curate', detail: 'dedup proven bugs, rank, cap' },
+    { title: 'Fix', detail: 'one worktree PR per bug, regression test included' },
+  ],
+}
+
+// fable to find subtle bugs (a missed bug is never recovered downstream); sonnet for proof and fixes (the failing test is the gate).
+const deep = (prompt, opts) => agent(prompt, { model: 'fable', ...opts })
+const run = (prompt, opts) => agent(prompt, { model: 'sonnet', ...opts })
+
+const MAX_ROUNDS = 3
+const MAX_FIXES = 6
+
+const NORTH_STAR = `NORTH STAR: a proven bug, not a plausible one. Every claim must survive a failing test or die. Fixes are minimal and elegant: the smallest change that makes the test pass without weakening anything else.`
+
+const TESTS_HOWTO = `Where tests live and the house rules:
+- agent: agent/tests/ (pytest, run 'cd agent && uv run pytest tests/<file> -x'). Use the high-fidelity fakes (tests/fake_claude.py) and poll with tests/wait_util.py; NEVER sleep to await a condition. Hermetic: own tmpdir db/dirs, no running agent, no Docker.
+- cli: cargo test in cli/. vestad: cargo test -p vestad in vestad/ (do not add Docker-gated tests; if proof needs Docker, the claim is unprovable here).
+- web: vitest in apps/web (npm -w @vesta/web run test).
+Tests must be deterministic: run twice, same failure both times.`
+
+const PR_RULES = `Branch from origin/master (git fetch origin master, git checkout -b <branch> origin/master). Never weaken or delete a test to pass. Commit ending with the Co-Authored-By trailer for Claude, push -u origin, gh pr create --base master. Body: no dashes, ending with the Generated with Claude Code trailer.`
+
+const CHECKS = { agent: './check.sh agent', cli: './check.sh cli', vestad: './check.sh vestad', web: './check.sh web' }
+
+const LENSES = [
+  { key: 'concurrency', focus: 'races, deadlocks, lost wakeups, cancellation bugs: asyncio task lifecycle in agent/core (loops.py, api.py, cc_sdk), the interrupt and compaction paths, tokio tasks and WS lifecycle in vestad' },
+  { key: 'error-paths', focus: 'failure handling: partial failures, swallowed errors, missing timeouts, retry bugs, resource leaks (files, sockets, tmux sessions, docker handles), cleanup skipped on early return' },
+  { key: 'boundaries', focus: 'parsing and contracts: the env config contract, notification JSON, cc_sdk transcript tailing, HTTP/WS DTOs between cli/app and vestad, edge inputs (empty, huge, unicode, concurrent writers)' },
+  { key: 'state-integrity', focus: 'persistence: events.db migrations and FTS, state.json atomic writes, session resume, crash recovery, backup/restore (restic, docker import metadata), boot markers' },
+  { key: 'security', focus: 'auth and injection: API key and AGENT_TOKEN handling, TLS fingerprint verification, path traversal in file-serving endpoints, command and tmux-paste injection, secrets leaking into logs' },
+]
+
+const BUGS_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: { findings: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
+    title: { type: 'string' },
+    area: { type: 'string', enum: ['agent', 'cli', 'vestad', 'web'] },
+    file: { type: 'string' }, line: { type: 'number' },
+    severity: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },
+    bug: { type: 'string', description: 'what goes wrong and why, per the actual code' },
+    trigger: { type: 'string', description: 'the concrete sequence that hits it' },
+  }, required: ['title', 'area', 'file', 'severity', 'bug', 'trigger'] } } },
+  required: ['findings'],
+}
+
+const PROOF_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    proven: { type: 'boolean' },
+    testPath: { type: 'string' },
+    testCode: { type: 'string', description: 'the full failing test source' },
+    testCommand: { type: 'string' },
+    observedFailure: { type: 'string', description: 'the actual failure output, abridged' },
+    reason: { type: 'string' },
+  }, required: ['proven', 'reason'],
+}
+
+const PLAN_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    bugs: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
+      title: { type: 'string' }, area: { type: 'string', enum: ['agent', 'cli', 'vestad', 'web'] },
+      file: { type: 'string' }, severity: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },
+      bug: { type: 'string' }, trigger: { type: 'string' },
+      testPath: { type: 'string' }, testCode: { type: 'string' }, testCommand: { type: 'string' },
+      fixHint: { type: 'string', description: 'the minimal fix direction' },
+    }, required: ['title', 'area', 'file', 'severity', 'bug', 'trigger', 'testPath', 'testCode', 'testCommand', 'fixHint'] } },
+    droppedCount: { type: 'number' },
+  }, required: ['bugs', 'droppedCount'],
+}
+
+const PR_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    label: { type: 'string' }, prUrl: { type: ['string', 'null'] },
+    checksPassed: { type: 'boolean' }, note: { type: 'string' },
+  }, required: ['label', 'checksPassed', 'note'],
+}
+
+// ---- Hunt: rounds of diverse finders until a round adds nothing new ----
+phase('Hunt')
+const seen = new Set()
+const claims = []
+let round = 0
+while (round < MAX_ROUNDS) {
+  round++
+  const prior = claims.map((c) => c.title).join('; ')
+  const found = (await parallel(LENSES.map((lens) => () =>
+    deep(
+      `Hunt for REAL bugs in this repo through one lens: ${lens.focus}.
+${round > 1 ? `Round ${round}. Already claimed (hunt ELSEWHERE): ${prior}` : ''}
+${NORTH_STAR}
+Read CLAUDE.md first; its Architecture section describes intentional design, do not flag it. Then read the relevant code deeply. A bug is a concrete defect with a trigger sequence, not a smell or a hypothetical. Report only claims you believe would survive a reproducing test: exact file:line, what goes wrong and why per the code, the concrete trigger. No style notes. Do not edit anything. An empty findings list is a fine answer.`,
+      { phase: 'Hunt', label: `hunt:${lens.key}:r${round}`, schema: BUGS_SCHEMA },
+    )))).filter(Boolean).flatMap((r) => r.findings)
+  const fresh = found.filter((f) => !seen.has(`${f.file}|${f.title}`))
+  fresh.forEach((f) => seen.add(`${f.file}|${f.title}`))
+  claims.push(...fresh)
+  log(`round ${round}: ${fresh.length} new claims (${claims.length} total)`)
+  if (fresh.length === 0) break
+}
+
+if (claims.length === 0) {
+  log('no bug claims survived the hunt')
+  return { bugsProven: 0, prs: [] }
+}
+
+// ---- Prove: a failing test or death ----
+phase('Prove')
+const proofs = await parallel(claims.map((claim) => () =>
+  run(
+    `Prove or kill this bug claim by writing a failing test in your isolated worktree.
+Claim: ${JSON.stringify(claim)}
+${TESTS_HOWTO}
+Write the MINIMAL test that reproduces the bug, run it, confirm it fails for the claimed reason (not a setup error), then run it again: same failure twice or it does not count. If you cannot make it fail honestly (the bug is not real, needs Docker or a live agent, or is flaky), proven=false with the reason. Never return proven=true without the observed failing output.`,
+    { phase: 'Prove', label: `prove:${claim.title.slice(0, 28)}`, schema: PROOF_SCHEMA, isolation: 'worktree' },
+  ).then((p) => (p && p.proven ? { ...claim, ...p } : null)),
+))
+const proven = proofs.filter(Boolean)
+log(`${proven.length}/${claims.length} claims proven by a failing test`)
+
+if (proven.length === 0) return { claims: claims.length, bugsProven: 0, prs: [] }
+
+// ---- Curate: dedup same-root-cause, rank, cap (needs all proofs together) ----
+phase('Curate')
+const plan = (await deep(
+  `Curate proven bugs into fix PRs. Dedup claims sharing one root cause (keep the best test), rank by severity, cap at ${MAX_FIXES} (count the rest in droppedCount). Run \`gh pr list --state open\`: drop bugs a PR already fixes in flight; closed-unmerged fix PRs from prior runs are rejected taste, do not re-propose. For each kept bug add fixHint: the minimal fix direction, per the north star.
+${NORTH_STAR}
+Proven bugs: ${JSON.stringify(proven)}`,
+  { phase: 'Curate', label: 'curate', schema: PLAN_SCHEMA },
+)) || { bugs: [], droppedCount: 0 }
+log(`${plan.bugs.length} fix PRs planned, ${plan.droppedCount} dropped`)
+
+// ---- Fix: one PR per bug, regression test included ----
+phase('Fix')
+const prs = await parallel(plan.bugs.map((bug, i) => () =>
+  run(
+    `Fix ONE proven bug in your isolated worktree. Branch fix/bug-${i}.
+Bug + proof: ${JSON.stringify(bug)}
+${NORTH_STAR}
+1. Recreate the regression test exactly (testPath, testCode), run ${bug.testCommand}, confirm it FAILS.
+2. Implement the minimal fix (start from fixHint, trust the code over the hint). Honor repo conventions: read CLAUDE.md + CONTRIBUTING.md (functional Python, Result-returning Rust, no dashes in prose).
+3. The test now passes; run ${CHECKS[bug.area]} until fully green.
+4. ${PR_RULES} Title 'fix(${bug.area}): ${bug.title}'. Body: the bug, root cause, trigger, how the shipped test guards it.
+If the honest fix requires a structural redesign, abort with a clear note instead of hacking around it.`,
+    { phase: 'Fix', label: `fix:${bug.area}-${i}`, schema: PR_SCHEMA, isolation: 'worktree' },
+  )))
+
+const opened = prs.filter(Boolean).filter((r) => r.prUrl)
+log(`Done: ${opened.length} fix PR(s) opened`)
+return {
+  claims: claims.length,
+  bugsProven: proven.length,
+  prs: opened.map((r) => ({ label: r.label, url: r.prUrl })),
+  noPr: prs.filter(Boolean).filter((r) => !r.prUrl).map((r) => ({ label: r.label, note: r.note })),
+  dropped: plan.droppedCount,
+}

--- a/.claude/workflows/gtm.js
+++ b/.claude/workflows/gtm.js
@@ -1,0 +1,264 @@
+export const meta = {
+  name: "gtm",
+  description:
+    "Audit the entire stranger-to-paying-user funnel (positioning, landing, pricing, onboarding, emails, referral) across vesta + vesta-cloud against exemplar GTM; copy/design fixes -> PRs in the right repo, strategy forks -> issues + a strategy doc.",
+  whenToUse:
+    "Recurring go-to-market pass. Needs ../vesta-cloud checked out locally. Default emit=draft writes .critique/gtm/ for review; args {emit:'live'} opens PRs and issues.",
+  phases: [
+    { title: "Audit", detail: "5 funnel stages, walked as a skeptical buyer" },
+    { title: "Verify", detail: "refute each finding" },
+    { title: "Synthesize", detail: "positioning, route PRs/issues, strategy doc" },
+    { title: "Emit", detail: "drafts or live cross-repo PRs + issues" },
+  ],
+};
+
+// fable for buyer-judgment and positioning; sonnet for refutation and check-verified copy PRs; haiku for I/O chores.
+const deep = (prompt, opts) => agent(prompt, { model: "fable", ...opts });
+const run = (prompt, opts) => agent(prompt, { model: "sonnet", ...opts });
+const fast = (prompt, opts) => agent(prompt, { model: "haiku", ...opts });
+
+const EMIT = (args && args.emit) || "draft";
+const CLOUD = "/home/elyx/Repos/vesta-cloud";
+
+const BUSINESS = `The business: vesta.run sells a hosted personal AI agent. Open-core: the data plane (this repo, elyxlz/vesta: vestad daemon + CLI + apps) is open source; the control plane (${CLOUD}, elyxlz/vesta-cloud: marketing SPA + dashboard + Stripe billing + per-user Hetzner VM provisioning + referral rewards) is closed. The buyer is a consumer/prosumer who wants a personal AI living in their life (WhatsApp, Telegram, email, calendar), not a dev tool. Indie income, not venture scale; the moat is doing what the labs cannot.`;
+
+const VOICE = `Brand voice (intentional, never "fix"): lowercase, terse, human; no em/en dashes or " - " separators (CI enforces this in both repos; use commas/colons); "agent" never "box".`;
+
+const NORTH_STAR = `NORTH STAR: elegance. 90% of the value for 10% of the effort. The best GTM fix usually removes: a step, a claim, a paragraph, a decision. One sharp sentence beats three feature lists. Sweat the details: a stranger decides in seconds. A busier page or longer funnel is failure, not ambition.`;
+
+const FUNNEL = [
+  {
+    key: "discover",
+    stage: "Discover: first impression and positioning",
+    surfaces: `vesta.run landing + marketing pages (${CLOUD}/src/pages, ${CLOUD}/index.html), elyxlz/vesta README.md, the one-liner wherever it appears (repo description, app copy)`,
+    mandate: "Does a stranger get what Vesta is, who it is for, and why it beats ChatGPT-in-a-tab within 10 seconds? Is the one-liner sharp and consistent everywhere? Does the page sell the feeling (a personal presence in your life) or list features?",
+  },
+  {
+    key: "evaluate",
+    stage: "Evaluate: trust, pricing, objections",
+    surfaces: `pricing page + plan copy (${CLOUD}/src), legal pages (${CLOUD}/legal), the privacy/open-source story, FAQ or its absence, README architecture/trust sections`,
+    mandate: "Walk the buyer's objections: price vs value framing, what happens to my data, why a dedicated VM matters, can I leave (export/self-host), is this maintained? Each objection answered where it arises, or the buyer leaves silently.",
+  },
+  {
+    key: "convert",
+    stage: "Convert: signup to provisioned",
+    surfaces: `signup/checkout/onboarding flow (${CLOUD}/functions/api, ${CLOUD}/functions/auth, ${CLOUD}/src dashboard states), transactional emails (${CLOUD}/functions/lib/email.ts), the provisioning wait, the self-host alternative (install.sh + vestad first run in this repo)`,
+    mandate: "Count every field, click, paste, wait, and decision between intent and a live agent. Where does momentum die? Is the provisioning wait honest and warm or a silent spinner? Do the emails arrive at the right moments and sound like the brand?",
+  },
+  {
+    key: "activate",
+    stage: "Activate: first session to aha",
+    surfaces: `first chat and channel setup (apps/web onboarding wizard in this repo, the connect flows, WhatsApp/Telegram pairing skills), the first-wake experience, time-to-first-value`,
+    mandate: "The aha is Vesta acting in YOUR life (messages, calendar, memory), not answering a test prompt. How fast does a new user reach it? What is the designed emotional peak of day one, and the ending (Peak-End)?",
+  },
+  {
+    key: "retain-refer",
+    stage: "Retain and refer",
+    surfaces: `referral program presentation (${CLOUD}), grace-period/dunning emails (${CLOUD}/functions/lib/email.ts, crons), release notes and update communication, the reasons to stay after week one`,
+    mandate: "Why does month two feel worth it? Does the product communicate growth (what Vesta learned, did, prevented)? Is the referral ask placed at a moment of delight? Are the churn-moment emails graceful and human?",
+  },
+];
+
+const FINDINGS_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["stage", "findings"],
+  properties: {
+    stage: { type: "string" },
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "surface", "repo", "problem", "proposal", "kind", "impact", "effort"],
+        properties: {
+          title: { type: "string" },
+          surface: { type: "string" },
+          repo: { type: "string", enum: ["vesta", "vesta-cloud"] },
+          file: { type: "string", description: "file:line where known" },
+          problem: { type: "string", description: "the funnel leak, as the buyer experiences it" },
+          before: { type: "string", description: "current copy/behavior" },
+          proposal: { type: "string", description: "concrete change; for copy, the exact new words" },
+          kind: { type: "string", enum: ["copy", "design", "strategy"] },
+          impact: { type: "string", enum: ["low", "medium", "high"] },
+          effort: { type: "string", enum: ["trivial", "small", "medium", "large"] },
+        },
+      },
+    },
+  },
+};
+
+const VERDICT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["keep", "isReal", "fixIsBetter", "reason"],
+  properties: {
+    keep: { type: "boolean" },
+    isReal: { type: "boolean", description: "a genuine funnel leak, not marketer taste" },
+    fixIsBetter: { type: "boolean", description: "sharper and simpler, not just different; respects the brand voice" },
+    reason: { type: "string" },
+  },
+};
+
+const SYNTH_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["positioning", "top10", "prGroups", "issues", "strategyMarkdown", "reportMarkdown"],
+  properties: {
+    positioning: { type: "string", description: "the one-liner + a 3-sentence narrative" },
+    top10: {
+      type: "array",
+      items: {
+        type: "object", additionalProperties: false, required: ["title", "why"],
+        properties: { title: { type: "string" }, why: { type: "string" } },
+      },
+    },
+    prGroups: {
+      type: "array",
+      description: "one PR each, in the right repo; copy/design fixes fully specified",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "repo", "summary", "changes"],
+        properties: {
+          title: { type: "string", description: "conventional-commit style" },
+          repo: { type: "string", enum: ["vesta", "vesta-cloud"] },
+          summary: { type: "string" },
+          changes: { type: "array", items: { type: "string", description: "file -> before -> after" } },
+        },
+      },
+    },
+    issues: {
+      type: "array",
+      description: "strategy forks the user must decide (pricing, naming, channels)",
+      items: {
+        type: "object", additionalProperties: false, required: ["title", "repo", "labels", "body"],
+        properties: {
+          title: { type: "string" },
+          repo: { type: "string", enum: ["vesta", "vesta-cloud"] },
+          labels: { type: "array", items: { type: "string" } },
+          body: { type: "string" },
+        },
+      },
+    },
+    strategyMarkdown: { type: "string", description: "the GTM strategy doc: positioning, funnel diagnosis, channel/pricing recommendations with reasoning" },
+    reportMarkdown: { type: "string", description: "the full findings report" },
+  },
+};
+
+// ── Audit ────────────────────────────────────────────────────────────────────
+const verified = await pipeline(
+  FUNNEL,
+  (f) =>
+    deep(
+      `You are a world-class GTM critic walking ONE funnel stage as a skeptical prospective buyer.
+Stage: ${f.stage}
+Surfaces to walk (read the real files): ${f.surfaces}
+Mandate: ${f.mandate}
+${BUSINESS}
+${VOICE}
+${NORTH_STAR}
+Ground in exemplars: fetch how Linear, Raycast, Tailscale, and Superhuman handle this stage if useful, but judge against what fits an indie personal-AI product, not a venture SaaS. File 5-10 high-signal findings: the leak as the buyer feels it, exact file where known, concrete proposal (for copy: the exact new words, in the brand voice). kind: copy = words/strings; design = layout/flow needing visual judgment; strategy = a fork the user must decide (pricing, naming, channels).`,
+      { label: `audit:${f.key}`, phase: "Audit", schema: FINDINGS_SCHEMA },
+    ),
+  (result, f) => {
+    if (!result || !result.findings || !result.findings.length) return [];
+    return parallel(
+      result.findings.map((finding) => () =>
+        run(
+          `Refute this GTM finding; most marketing notes are taste, not leaks.
+${JSON.stringify(finding)}
+${VOICE}
+${NORTH_STAR}
+keep=true only if it is a real funnel leak a buyer would actually hit AND the proposal is sharper and simpler (not louder, longer, or busier) AND it respects the brand voice. Verify the cited file exists where given. Unsure -> keep=false.`,
+          { label: `verify:${f.key}:${finding.title.slice(0, 22)}`, phase: "Verify", schema: VERDICT_SCHEMA },
+        ).then((v) => ({ ...finding, stage: f.key, verdict: v })),
+      ),
+    );
+  },
+);
+
+const kept = verified.flat().filter(Boolean).filter((f) => f.verdict && f.verdict.keep);
+log(`${kept.length} findings survived refutation`);
+
+// ── Synthesize ───────────────────────────────────────────────────────────────
+phase("Synthesize");
+const synth = await deep(
+  `Synthesize the GTM report from these verified findings.
+${JSON.stringify(kept, null, 2)}
+${BUSINESS}
+${VOICE}
+${NORTH_STAR}
+1. Write positioning: the one-liner + 3-sentence narrative everything else should align to.
+2. Dedup/cluster. Run \`gh pr list --state open\` and \`gh pr list -R elyxlz/vesta-cloud --state open\`: drop what is in flight. Route: copy and well-specified design fixes -> prGroups (one coherent PR each, exact file -> before -> after, tagged with the right repo). Strategy forks (pricing, naming, channel bets) -> issues in the right repo; these need the user.
+3. top10 highest-leverage moves.
+4. strategyMarkdown: the GTM strategy doc (positioning, funnel diagnosis per stage, channel and pricing recommendations with reasoning, what NOT to do).
+5. reportMarkdown: the findings report.`,
+  { label: "synthesize", phase: "Synthesize", schema: SYNTH_SCHEMA },
+);
+
+// ── Emit ─────────────────────────────────────────────────────────────────────
+phase("Emit");
+await fast(
+  `Write with the Write tool and confirm paths:
+- .critique/gtm/STRATEGY.md = exactly:\n---\n${synth.strategyMarkdown}\n---
+- .critique/gtm/REPORT.md = exactly:\n---\n${synth.reportMarkdown}\n---
+- .critique/gtm/prs.json = ${JSON.stringify(synth.prGroups)}
+- .critique/gtm/issues.json = ${JSON.stringify(synth.issues)}`,
+  { label: "write-drafts", phase: "Emit" },
+);
+
+if (EMIT !== "live") {
+  return {
+    mode: "draft",
+    positioning: synth.positioning,
+    findings: kept.length,
+    prGroups: synth.prGroups.length,
+    issues: synth.issues.length,
+    strategy: ".critique/gtm/STRATEGY.md",
+  };
+}
+
+log(`live emit: ${synth.prGroups.length} PRs, ${synth.issues.length} issues`);
+
+const prs = await parallel(
+  synth.prGroups.map((group, i) => () =>
+    run(
+      `Open ONE GTM PR for repo ${group.repo}.
+Group: ${JSON.stringify(group)}
+${VOICE}
+${NORTH_STAR}
+${group.repo === "vesta-cloud"
+        ? `This targets vesta-cloud, manage your own worktree there:
+1. git -C ${CLOUD} fetch origin master && git -C ${CLOUD} worktree add /tmp/gtm-${i} -b gtm/${i} origin/master
+2. Work in /tmp/gtm-${i}: npm install, apply ONLY the listed changes (adapt minimally where the spec misses current code), run ./check.sh all until green.
+3. Commit (Co-Authored-By trailer), git push -u origin gtm/${i}, gh pr create --base master (run gh from /tmp/gtm-${i}).
+4. Cleanup: git -C ${CLOUD} worktree remove --force /tmp/gtm-${i}.`
+        : `This targets this repo (you are in an isolated worktree):
+1. git fetch origin master && git checkout -b gtm/${i} origin/master
+2. Apply ONLY the listed changes. Run the check.sh suite for whatever you touched (web/cli/agent); markdown-only edits rely on CI.
+3. Commit (Co-Authored-By trailer), push -u, gh pr create --base master.`}
+No version bumps. PR title "${group.title}"; body: the funnel leak and the rationale, ending with the Generated with Claude Code line.
+Return the PR url or an error string.`,
+      { label: `pr:${group.repo}-${i}`, phase: "Emit", isolation: group.repo === "vesta" ? "worktree" : undefined },
+    ),
+  ),
+);
+
+const issues = await parallel(
+  synth.issues.map((issue, i) => () =>
+    fast(
+      `Open a GitHub issue on elyxlz/${issue.repo}: \`gh issue create -R elyxlz/${issue.repo} --title ${JSON.stringify(issue.title)} --body <body>\`, applying only labels that already exist there (gh label list -R elyxlz/${issue.repo}). Body:\n${issue.body}\nReturn the issue url.`,
+      { label: `issue:${issue.repo}-${i}`, phase: "Emit" },
+    ),
+  ),
+);
+
+return {
+  mode: "live",
+  positioning: synth.positioning,
+  findings: kept.length,
+  prs: prs.filter(Boolean),
+  issues: issues.filter(Boolean),
+  strategy: ".critique/gtm/STRATEGY.md",
+};

--- a/.claude/workflows/product-critique.js
+++ b/.claude/workflows/product-critique.js
@@ -1,0 +1,361 @@
+export const meta = {
+  name: "product-critique",
+  description:
+    "Frontier product/design critique of the Vesta app (visuals, interaction, onboarding, copy, a11y). Every truly-needed fix -> PR drafts (cheap or ambitious); only genuine design forks -> issue drafts. Vesta's voice/personality is out of scope.",
+  whenToUse:
+    "Holistic design/UX pass on the Vesta app and onboarding journey. Run after capturing screenshots with tools/critique/capture-ui.mjs.",
+  phases: [
+    { title: "Brief", detail: "list captured shots" },
+    { title: "Critique", detail: "9 authority-grounded lenses, parallel" },
+    { title: "Verify", detail: "adversarially refute each finding" },
+    { title: "Synthesize", detail: "dedupe, rank, route" },
+    { title: "Emit", detail: "drafts or live PRs/issues" },
+  ],
+};
+
+// fable for judgment nothing downstream can recover; sonnet where gates/checks catch mistakes; haiku for I/O chores.
+const deep = (prompt, opts) => agent(prompt, { model: "fable", ...opts });
+const run = (prompt, opts) => agent(prompt, { model: "sonnet", ...opts });
+const fast = (prompt, opts) => agent(prompt, { model: "haiku", ...opts });
+
+const SHOTS_DIR = (args && args.shotsDir) || ".critique/shots";
+const EMIT = (args && args.emit) || "draft"; // "draft" | "live"
+const REPO = (args && args.repo) || "elyxlz/vesta";
+
+// ── shared context baked in so lenses stay grounded, never generic ──────────
+
+const SURFACE_MAP = `
+Vesta web app: apps/web/src (React + Tailwind + shadcn/base-ui + Framer Motion).
+Tokens: apps/web/src/index.css (oklch colors, --rounded-squircle-*, Public Sans body / Outfit headings, --page-padding-x). Copy is INLINE in components, no i18n file.
+
+Screens (route -> code):
+- /connect            components/Connect/index.tsx            host + api key form, error details toggle
+- /                   components/Home/index.tsx               AgentsCarousel or EmptyState ("no agents found")
+- /new                components/NewAgent/                    wizard: NameStep -> PersonalityStep -> CreatingStep (fake rotating progress) -> AuthStep (OAuth copy/paste) -> DoneStep ("{name} is ready / say hi.")
+- /agent/:name        components/Dashboard + Chat            desktop split-pane vs mobile swipe; AgentIsland + Orb (alive/thinking/booting/dead...)
+- /agent/:name/chat   components/Chat/                       ChatBubble, ChatComposer, BottomBanner, ToolCallLabel
+- /agent/:name/logs   components/Console/                    live log stream
+- /agent/:name/settings components/AgentSettings/            actions, files+editor, keybinds, voice, memory, plan usage
+- Settings dialog     components/Settings/index.tsx           theme, chat pacing, mode, gateway status, logout
+- /debug              pages/Debug/index.tsx                  showcase: all orb states + every chat-bubble/markdown variant (backend-free)
+
+Journey beyond the app (terminal copy worth critiquing):
+- install.sh                          one-line installer output
+- vestad first run (vestad/src/serve.rs, systemd.rs)  prints tunnel url + key + manage commands
+- cli/src/main.rs                     "vesta" welcome, "vesta setup", "vesta connect", OAuth paste-code prompts
+- first build wait: 5-10 min on first agent create (git clone + npm + vite build)
+`;
+
+// Vesta's deliberate choices. Findings that "correct" these are INVALID.
+const STYLE_GUARD = `
+INTENTIONAL, DO NOT FLAG AS BUGS:
+- UI + agent copy is intentionally all-lowercase, texting-feel, terse.
+- No em dashes, en dashes, or " - " as a separator anywhere. Use commas/periods/colons. (A finding that adds dashes is wrong.)
+- Terminology is "agent", never "box".
+- oklch palette, squircle radii, Public Sans + Outfit are the chosen design language.
+OUT OF SCOPE (separate workflow): Vesta's personality, voice, prompt content, proactivity tuning, the 6 personality presets. Do not critique what Vesta *says* as a character; only how the *app* presents, formats, and supports it.
+`;
+
+const NORTH_STAR = `
+NORTH STAR: elegance. 90% of the value for 10% of the effort. Be bold in scope, ruthless in the result: redesign freely, but the surface must END SIMPLER (fewer steps, states, strings, concepts). Subtraction beats addition. Sweat the last 1%: alignment, easing, copy rhythm, error tone. A busier final design is failure, not ambition.
+`;
+
+const LENSES = [
+  {
+    key: "visual-craft",
+    title: "Visual craft & hierarchy",
+    authority: "Apple Human Interface Guidelines + Refactoring UI (Wathan/Schoger)",
+    url: "https://developer.apple.com/design/human-interface-guidelines/layout",
+    mandate:
+      "Spacing rhythm, type scale & weight, color usage, contrast, depth/elevation, alignment, density, optical balance, the orb/squircle treatment, empty states. Judge the rendered pixels in the shots first, then trace to tokens in index.css / className.",
+  },
+  {
+    key: "interaction-motion",
+    title: "Interaction & motion",
+    authority: "Rauno Freiberg Web Interface Guidelines + Emil Kowalski + Laws of UX",
+    url: "https://interfaces.rauno.me/",
+    mandate:
+      "Hover/focus/active/disabled states, focus rings, keyboard paths, touch-target size, easing & duration, anticipation/follow-through, optimistic UI, perceived latency (Doherty threshold), loading vs skeleton, the CreatingStep's fake rotating progress vs honest status, transitions between dashboard/chat.",
+  },
+  {
+    key: "heuristics",
+    title: "Usability heuristics",
+    authority: "Nielsen's 10 Heuristics + Norman (DOET)",
+    url: "https://www.nngroup.com/articles/ten-usability-heuristics/",
+    mandate:
+      "Cite the specific heuristic per finding. Visibility of system status, match to mental model, user control/undo, consistency, error prevention, recognition over recall, flexibility, minimalist design, error recovery, help. The OAuth copy-paste and the long first-build wait are prime targets.",
+  },
+  {
+    key: "onboarding-friction",
+    title: "Onboarding & friction (time-to-value)",
+    authority: "Fogg B=MAP + Growth.Design + Kathy Sierra (Badass) + Peak-End rule",
+    url: "https://www.nngroup.com/articles/onboarding-tutorials/",
+    mandate:
+      "Walk install -> vestad run -> connect -> create agent -> auth -> first chat as a new user. Every paste, wait, decision, and dead-end. Reduce activation energy, shorten time-to-first-value, design the emotional peak and the ending. Include the CLI/vestad terminal copy in SURFACE_MAP.",
+  },
+  {
+    key: "agent-ux-trust",
+    title: "Agent UX in the app: status, trust, errors",
+    authority: "Google PAIR People+AI Guidebook + Microsoft HAX guidelines",
+    url: "https://pair.withgoogle.com/guidebook/",
+    mandate:
+      "How the APP (not Vesta's voice) sets expectations, shows what the agent is doing (orb/island states, tool calls, thinking), calibrates trust, handles agent errors/offline/auth-expired, and lets the user steer/interrupt. Mental model of what an 'agent' is on first contact.",
+  },
+  {
+    key: "copy-writing",
+    title: "Copy / UX writing",
+    authority: "Mailchimp Content Style Guide + Apple Style Guide + Microcopy (Yifrah)",
+    url: "https://www.nngroup.com/articles/ux-writing-study-guide/",
+    mandate:
+      "Every on-screen + CLI string: buttons (verbs), empty states, errors, placeholders, toasts, the wizard, vestad terminal output. Clarity, concreteness, consistency, helpful errors. Respect the intentional lowercase/no-dashes/texting voice (STYLE_GUARD): improve within it, never against it.",
+  },
+  {
+    key: "accessibility",
+    title: "Accessibility",
+    authority: "WCAG 2.2 AA + Apple accessibility HIG",
+    url: "https://www.w3.org/WAI/WCAG22/quickref/",
+    mandate:
+      "Color contrast (check oklch tokens in both themes), focus visibility & order, keyboard operability, touch-target minimums, semantic roles/labels for icon buttons, reduced-motion, screen-reader names for the orb/island/status. Cite the WCAG SC number.",
+  },
+  {
+    key: "elegance-reduction",
+    title: "Elegance & reduction",
+    authority: "Dieter Rams (less, but better) + Tufte (data-ink ratio) + Tesler's law + the Jobs/Ive subtraction ethos",
+    url: "https://www.interaction-design.org/literature/article/dieter-rams-10-timeless-commandments-for-good-design",
+    mandate:
+      "Hunt for what to REMOVE: steps in the wizard, decisions, states, settings, copy, chrome, concepts the user must hold. Where does the app make the user carry complexity the product could absorb or delete? 'Delete this' is a complete proposal when justified.",
+  },
+  {
+    key: "holistic-northstar",
+    title: "Holistic north-star",
+    authority: "Apple design ethos + Linear/Raycast/Vercel as exemplars",
+    url: "https://developer.apple.com/design/human-interface-guidelines/designing-for-ios",
+    mandate:
+      "Step back: what is Vesta trying to FEEL like (a calm, trustworthy, personal presence), and where does the whole fall short of that ideal? Coherence across screens, the 5 highest-leverage moves, what one exemplar product would do differently here.",
+  },
+];
+
+const FINDINGS_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["lens", "findings"],
+  properties: {
+    lens: { type: "string" },
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "surface", "principle", "whatWrong", "after", "fixKind", "severity", "impact", "effort"],
+        properties: {
+          title: { type: "string" },
+          surface: { type: "string", description: "screen/element, e.g. 'CreatingStep progress'" },
+          fileRef: { type: "string", description: "file:line or path, empty if shot-only" },
+          shotRef: { type: "string", description: "screenshot filename it's visible in, if any" },
+          principle: { type: "string", description: "the specific cited principle/heuristic/SC" },
+          whatWrong: { type: "string" },
+          before: { type: "string", description: "current copy/value/behavior" },
+          after: { type: "string", description: "concrete proposed change" },
+          fixKind: { type: "string", enum: ["cheap", "design", "behavior"] },
+          severity: { type: "string", enum: ["low", "medium", "high"] },
+          impact: { type: "string", enum: ["low", "medium", "high"] },
+          effort: { type: "string", enum: ["trivial", "small", "medium", "large"] },
+        },
+      },
+    },
+  },
+};
+
+const VERDICT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["keep", "isReal", "violatesIdentity", "fixIsBetter", "reason"],
+  properties: {
+    keep: { type: "boolean" },
+    isReal: { type: "boolean", description: "a genuine problem, not designer preference" },
+    violatesIdentity: { type: "boolean", description: "true if it fights an intentional STYLE_GUARD choice" },
+    fixIsBetter: { type: "boolean", description: "the proposed 'after' is actually better, not just different" },
+    adjustedSeverity: { type: "string", enum: ["low", "medium", "high"] },
+    reason: { type: "string" },
+  },
+};
+
+const SYNTH_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["northStar", "top10", "prGroups", "issues", "reportMarkdown"],
+  properties: {
+    northStar: { type: "string" },
+    top10: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "why"],
+        properties: { title: { type: "string" }, why: { type: "string" } },
+      },
+    },
+    prGroups: {
+      type: "array",
+      description: "batches of fixes, one PR each; tier cheap = trivial/small tweaks batched by theme, tier ambitious = one truly-needed redesign of one surface, fully specified",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "area", "tier", "summary", "changes"],
+        properties: {
+          title: { type: "string", description: "conventional-commit style, e.g. 'fix(web): honest setup progress copy'" },
+          area: { type: "string" },
+          tier: { type: "string", enum: ["cheap", "ambitious"] },
+          summary: { type: "string", description: "for ambitious: the design rationale, what the surface becomes, what gets removed" },
+          changes: { type: "array", items: { type: "string", description: "file:line -> before -> after (for ambitious, may describe new/removed components precisely)" } },
+        },
+      },
+    },
+    issues: {
+      type: "array",
+      description: "only genuine design forks that need the user's decision",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "severity", "labels", "body"],
+        properties: {
+          title: { type: "string" },
+          severity: { type: "string", enum: ["low", "medium", "high"] },
+          labels: { type: "array", items: { type: "string" } },
+          body: { type: "string" },
+        },
+      },
+    },
+    reportMarkdown: { type: "string", description: "the full human-readable report" },
+  },
+};
+
+// ── Brief ───────────────────────────────────────────────────────────────────
+phase("Brief");
+const shotList = await fast(
+  `List the screenshots available for the critique. Run: \`ls -R ${SHOTS_DIR} 2>/dev/null; echo '---'; cat ${SHOTS_DIR}/manifest.json 2>/dev/null\`. Return a plain newline list of every PNG path plus a one-line note on covered/missing screens. If the directory is empty or missing, say exactly: "NO SHOTS".`,
+  { label: "list-shots", phase: "Brief" },
+);
+const haveShots = !shotList.includes("NO SHOTS");
+log(haveShots ? "screenshots available, visual lenses enabled" : "no screenshots, lenses fall back to code-only (lower fidelity)");
+
+// ── Critique -> Verify (pipeline: each lens flows to verification independently)
+const verified = await pipeline(
+  LENSES,
+  (lens) =>
+    deep(
+      `Critique Vesta through ONE lens: ${lens.title}. Ground every finding in ${lens.authority} (fetch ${lens.url} if useful).
+Mandate: ${lens.mandate}
+${SURFACE_MAP}
+${STYLE_GUARD}
+${NORTH_STAR}
+Screenshots (Read the PNGs to judge real pixels):
+${haveShots ? shotList : "NONE. Critique from source under apps/web/src and the terminal copy above; mark pixel-dependent findings fixKind 'design'."}
+
+File 5-12 high-signal findings. Each: the cited principle, a real surface, file:line (grep apps/web/src) and/or shotRef, and an exact before -> after. If you cannot spec the change, do not file it. fixKind: cheap = string/spacing/token/state tweak; design = needs visual judgment; behavior = changes flow/logic.`,
+      { label: `lens:${lens.key}`, phase: "Critique", schema: FINDINGS_SCHEMA },
+    ),
+  (result, lens) => {
+    if (!result || !result.findings || !result.findings.length) return [];
+    return parallel(
+      result.findings.map((f) => () =>
+        run(
+          `Adversarially refute this ${lens.title} finding; most plausible design notes are preference, not problems.
+${JSON.stringify(f)}
+${STYLE_GUARD}
+${NORTH_STAR}
+- isReal: a genuine problem per the cited principle? Small details count.
+- violatesIdentity: fights an intentional choice above? Then keep=false.
+- fixIsBetter: actually superior, not just different. Superior usually means simpler; a fix adding UI/steps/concepts where a subtraction would do is not better.
+Unsure it is real -> keep=false. Never kill a real problem for having an ambitious fix. Verify any fileRef exists (grep it).`,
+          { label: `verify:${lens.key}:${f.title.slice(0, 24)}`, phase: "Verify", schema: VERDICT_SCHEMA },
+        ).then((v) => ({ ...f, lens: lens.key, verdict: v })),
+      ),
+    );
+  },
+);
+
+const kept = verified
+  .flat()
+  .filter(Boolean)
+  .filter((f) => f.verdict && f.verdict.keep && !f.verdict.violatesIdentity);
+log(`${kept.length} findings survived adversarial verification`);
+
+// ── Synthesize (barrier: needs ALL kept findings to dedupe/cluster/rank) ──────
+phase("Synthesize");
+const synth = await deep(
+  `Synthesize the product critique report from these verified findings.
+${JSON.stringify(kept, null, 2)}
+${STYLE_GUARD}
+${NORTH_STAR}
+1. Dedupe and cluster across lenses. Also run \`gh pr list --state open\` and \`gh issue list --state open\`: drop what an open PR/issue already covers; closed-unmerged critique PRs are rejected taste, do not re-propose them.
+2. Route, PR by default: tier "cheap" = trivial/small tweaks batched by theme; tier "ambitious" = one truly-needed redesign per surface, exact files and behavior, reviewable diff, prefer subtraction. An issue ONLY for a genuine design fork the user must decide.
+3. northStar: 2-3 sentences on what Vesta should FEEL like and the gap.
+4. top10 highest-leverage moves.
+5. reportMarkdown: north-star, top-10, PR groups, issues; each finding shows surface, principle, before -> after.
+Issue labels where apt: type:enhancement, type:bug, area:web, area:onboarding, area:cli, priority:high|medium|low, design.`,
+  { label: "synthesize", phase: "Synthesize", schema: SYNTH_SCHEMA },
+);
+
+// ── Emit ──────────────────────────────────────────────────────────────────
+phase("Emit");
+
+if (EMIT !== "live") {
+  await fast(
+    `Write the critique outputs with the Write tool and confirm the paths:
+- .critique/out/REPORT.md = exactly:
+---
+${synth.reportMarkdown}
+---
+- .critique/out/prs.json = ${JSON.stringify(synth.prGroups)}
+- .critique/out/issues.json = ${JSON.stringify(synth.issues)}`,
+    { label: "emit-drafts", phase: "Emit" },
+  );
+  return {
+    mode: "draft",
+    northStar: synth.northStar,
+    findings: kept.length,
+    prGroups: synth.prGroups.length,
+    issues: synth.issues.length,
+    report: ".critique/out/REPORT.md",
+  };
+}
+
+// live: every PR group (cheap or ambitious) -> PR branch, design forks -> issues
+log(`live emit: ${synth.prGroups.length} PRs, ${synth.issues.length} issues`);
+
+const prs = await parallel(
+  synth.prGroups.map((group, i) => () =>
+    (group.tier === "ambitious" ? deep : run)(
+      `Implement this ${group.tier} product PR and open it against ${REPO}.
+Group: ${JSON.stringify(group)}
+${STYLE_GUARD}
+${NORTH_STAR}
+1. \`git fetch origin master && git checkout -b critique/${group.area}-${i} origin/master\`.
+2. ${group.tier === "ambitious"
+        ? "Implement the redesign: read every touched component fully, match codebase patterns (Tailwind + shadcn/base-ui, folders with index.tsx), one surface only, adapt minimally where the spec misses current code. Sweat spacing, easing, focus states, reduced-motion, both themes."
+        : "Apply ONLY the listed changes, surgically; skip (and note in the PR body) any change that no longer matches the code."} No version bumps.
+3. \`cd apps && npm install\` (once), then \`./check.sh web\` from repo root until green; drop a change that cannot pass rather than the PR.${group.tier === "ambitious" ? " Then re-read the full diff: if the surface did not end simpler, abort with a note instead of opening the PR (a good outcome)." : ""}
+4. Commit (Co-Authored-By trailer), push -u, \`gh pr create --base master\` with title "${group.title}" and a body giving the rationale + cited principle${group.tier === "ambitious" ? " + what the journey loses (steps, decisions, waiting)" : ""}, ending with the Generated with Claude Code line.
+Return the PR url, or an error string.`,
+      { label: `pr:${group.tier}:${group.area}-${i}`, phase: "Emit", isolation: "worktree" },
+    ),
+  ),
+);
+
+const issues = await parallel(
+  synth.issues.map((issue, i) => () =>
+    fast(
+      `Open a GitHub issue on ${REPO}: \`gh issue create --title ${JSON.stringify(issue.title)} --body <body> ${issue.labels.map((l) => `--label ${JSON.stringify(l)}`).join(" ")}\`. Body:\n${issue.body}\nCreate any missing labels first with \`gh label create\`. Return the issue url.`,
+      { label: `issue:${i}`, phase: "Emit" },
+    ),
+  ),
+);
+
+return {
+  mode: "live",
+  northStar: synth.northStar,
+  findings: kept.length,
+  prs: prs.filter(Boolean),
+  issues: issues.filter(Boolean),
+};

--- a/.claude/workflows/product-emit.js
+++ b/.claude/workflows/product-emit.js
@@ -1,0 +1,72 @@
+export const meta = {
+  name: "product-emit",
+  description: "Emit the product-critique PRs from the saved draft (.critique/out/prs.json): cheap wins and ambitious redesigns, one PR per group, branched off master with web checks.",
+  phases: [
+    { title: "Load", detail: "read the saved PR groups" },
+    { title: "Emit", detail: "one worktree PR agent per group" },
+  ],
+};
+
+// fable only for ambitious redesigns; sonnet for check-verified cheap wins; haiku to load the draft.
+const deep = (prompt, opts) => agent(prompt, { model: "fable", ...opts });
+const run = (prompt, opts) => agent(prompt, { model: "sonnet", ...opts });
+const fast = (prompt, opts) => agent(prompt, { model: "haiku", ...opts });
+
+const REPO = (args && args.repo) || "elyxlz/vesta";
+
+const GROUPS_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["groups"],
+  properties: {
+    groups: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "area", "tier", "summary", "changes"],
+        properties: {
+          title: { type: "string" },
+          area: { type: "string" },
+          tier: { type: "string", enum: ["cheap", "ambitious"] },
+          summary: { type: "string" },
+          changes: { type: "array", items: { type: "string" } },
+        },
+      },
+    },
+  },
+};
+
+phase("Load");
+const loaded = await fast(
+  `Read .critique/out/prs.json and return its PR groups verbatim. If missing, fall back to the legacy .critique/out/cheap-wins.json with tier="cheap" on every group. If neither exists, return groups=[].`,
+  { label: "load-draft", phase: "Load", schema: GROUPS_SCHEMA },
+);
+const groups = loaded ? loaded.groups : [];
+if (groups.length === 0) {
+  log("no saved draft, run product-critique first");
+  return { error: "no PR groups at .critique/out/prs.json" };
+}
+log(`${groups.length} PR group(s) to emit`);
+
+phase("Emit");
+const prs = await parallel(
+  groups.map((group, i) => () =>
+    (group.tier === "ambitious" ? deep : run)(
+      `Open ONE ${group.tier} product PR against ${REPO} from the product-critique draft.
+Group: ${JSON.stringify(group)}
+NORTH STAR: elegance, 90% of the value for 10% of the effort; the surface must end simpler, not busier; sweat the details.
+Intentional, never "fix": all-lowercase UI copy, no em/en dashes or " - " separators (commas/colons), "agent" never "box".
+1. \`git fetch origin master && git checkout -b critique/${i}-emit origin/master\`.
+2. ${group.tier === "ambitious"
+        ? "Implement the redesign in summary + changes: read every touched component fully, match codebase patterns (Tailwind + shadcn/base-ui, folders with index.tsx), one surface only, adapt minimally where the spec misses current code. Sweat spacing, easing, focus states, reduced-motion, both themes."
+        : "Apply ONLY the listed changes, surgically; adapt minimally where the spec misses current code, skip (and note in the PR body) what is impossible or already done."} No version bumps.
+3. \`cd apps && npm install\` (once), then \`./check.sh web\` from repo root until green; drop a change that cannot pass rather than the PR.${group.tier === "ambitious" ? " Then re-read the full diff: if the surface did not end simpler, abort with a note instead of opening the PR (a good outcome)." : ""}
+4. Commit (Co-Authored-By trailer), \`git push -u origin\`, \`gh pr create --base master --title ${JSON.stringify(group.title)}\` with a body giving the rationale + cited principle${group.tier === "ambitious" ? " + what the journey loses (steps, decisions, waiting)" : ""}, ending with: 🤖 Generated with [Claude Code](https://claude.com/claude-code)
+Return the PR url, or a short error string.`,
+      { label: `pr:${group.tier}:${i}`, phase: "Emit", isolation: "worktree" },
+    ),
+  ),
+);
+
+return { prs: prs.filter(Boolean) };

--- a/.claude/workflows/repo-architecture.js
+++ b/.claude/workflows/repo-architecture.js
@@ -1,0 +1,172 @@
+export const meta = {
+  name: 'repo-architecture',
+  description: 'Higher-altitude pass: audit the whole system against the codified Architecture Principles and the elegance north star; specifiable improvements become PRs (including structural simplifications), genuine design forks become GitHub issues',
+  whenToUse: 'Recurring architecture and test-strategy review. Defaults to landing verified PRs; reserves issues for decisions that genuinely need the user.',
+  phases: [
+    { title: 'Audit', detail: 'per architectural concern, whole-system survey' },
+    { title: 'Triage', detail: 'dedup, verify, group into PRs and issues' },
+    { title: 'Implement', detail: 'worktree PRs + issues' },
+  ],
+}
+
+// fable for architecture judgment and structural rewrites; sonnet for check-verified surgical work; haiku for gh chores.
+const deep = (prompt, opts) => agent(prompt, { model: 'fable', ...opts })
+const run = (prompt, opts) => agent(prompt, { model: 'sonnet', ...opts })
+const fast = (prompt, opts) => agent(prompt, { model: 'haiku', ...opts })
+
+const NORTH_STAR = `NORTH STAR: elegance. 90% of the value for 10% of the effort. The best architecture has fewer moving parts, not better-managed ones. Be bold in scope, ruthless in the result: merge modules, delete layers, collapse config into defaults; the system must END SIMPLER. Vesta is a single-tenant personal daemon: never propose distributed-systems ceremony (circuit breakers, bulkheads, dashboards). A complex final design is failure, not ambition.`
+
+const SYSTEM_CONTEXT = `Intentional design, never propose unwinding:
+- vestad daemon (Rust: Docker + HTTP/WS API), vesta CLI (Rust), Python agent in Docker, React SPA in Tauri. No shared crate between cli and vestad. No MCP servers.
+- The agent drives the claude CLI in tmux via the in-repo cc_sdk, not the official SDK.
+- SQLite events.db (FTS5), persisted session_id for resume, restic snapshot backups.
+- Functional Python (no classes-with-methods, no getattr/.get fallback/hasattr); Rust without panic/unwrap/expect on fallible paths; no dashes in prose; check.sh is the single test entry point; release.sh owns versions (never bump in a PR).`
+
+const RULES = `Rubric: read root CLAUDE.md (Architecture + Architecture Principles, including the conflicts already resolved in our favor) and CONTRIBUTING.md (Testing strategy, Karpathy Guidelines) first; they override external canon.`
+
+const PR_RULES = `Branch from origin/master (git fetch origin master, git checkout -b <branch> origin/master). Never weaken or delete a test to pass. Commit ending with the Co-Authored-By trailer for Claude, push -u origin, gh pr create --base master. Body: what and why, no dashes, ending with the Generated with Claude Code trailer.`
+
+const AREA_CHECK = {
+  agent: './check.sh agent',
+  cli: './check.sh cli',
+  vestad: './check.sh vestad',
+  web: './check.sh web',
+  repo: './check.sh all',
+}
+
+const CONCERNS = [
+  { key: 'elegance', focus: 'where the system could be radically simpler: modules that could merge, layers or indirection that could disappear, config that could become a default, duplicated mechanisms that could unify' },
+  { key: 'boundaries', focus: 'module boundaries, coupling and cohesion, leaky abstractions, deep vs shallow modules, dependency direction across cli, vestad, agent, web' },
+  { key: 'error-resilience', focus: 'error-handling consistency, failure modes, timeouts, retries, resource cleanup, cancellation, the message-interruption path' },
+  { key: 'concurrency-state', focus: 'async task lifecycle, shared mutable state, races, backpressure, the message and notification loops, websocket lifecycle' },
+  { key: 'testing', focus: 'test-pyramid balance, untested critical paths, flaky tests, assertion quality, missing integration coverage, hermeticity' },
+  { key: 'data-integrity', focus: 'events.db schema and migrations, session persistence, backup and restore correctness, FTS usage' },
+]
+
+const AUDIT_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: { findings: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
+    title: { type: 'string' }, concern: { type: 'string' },
+    evidence: { type: 'array', items: { type: 'string' } },
+    severity: { type: 'string', enum: ['low', 'medium', 'high'] },
+    remedy: { type: 'string', enum: ['pr', 'issue'] },
+    effort: { type: 'string', enum: ['small', 'medium', 'large'] },
+    rationale: { type: 'string' }, proposal: { type: 'string' },
+  }, required: ['title', 'evidence', 'severity', 'remedy', 'effort', 'rationale', 'proposal'] } } },
+  required: ['findings'],
+}
+
+const TRIAGE_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    issues: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
+      title: { type: 'string' }, body: { type: 'string' },
+      priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+      effort: { type: 'string', enum: ['small', 'medium', 'large'] },
+      labels: { type: 'array', items: { type: 'string' } },
+    }, required: ['title', 'body', 'priority', 'effort'] } },
+    prGroups: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
+      area: { type: 'string', enum: ['agent', 'cli', 'vestad', 'web', 'repo'] },
+      theme: { type: 'string' },
+      ambition: { type: 'string', enum: ['surgical', 'structural'], description: 'structural = a behavior-preserving simplification that reshapes code' },
+      tasks: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
+        title: { type: 'string' }, file: { type: 'string' }, fix: { type: 'string' }, rationale: { type: 'string' },
+      }, required: ['title', 'fix', 'rationale'] } },
+    }, required: ['area', 'theme', 'ambition', 'tasks'] } },
+    droppedCount: { type: 'number' },
+  }, required: ['issues', 'prGroups'],
+}
+
+const PR_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    label: { type: 'string' }, branch: { type: ['string', 'null'] }, prUrl: { type: ['string', 'null'] },
+    checksPassed: { type: 'boolean' }, changesSummary: { type: 'string' },
+    filesChanged: { type: 'array', items: { type: 'string' } }, note: { type: 'string' },
+  }, required: ['label', 'checksPassed', 'changesSummary', 'note'],
+}
+
+const ISSUES_RESULT_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    created: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
+      title: { type: 'string' }, url: { type: 'string' },
+    }, required: ['title', 'url'] } },
+    skipped: { type: 'array', items: { type: 'string' } },
+    note: { type: 'string' },
+  }, required: ['created', 'note'],
+}
+
+// ---- Audit ----
+phase('Audit')
+const auditByConcern = (await parallel(CONCERNS.map((concern) => () =>
+  deep(
+    `Audit the whole Vesta system for the '${concern.key}' concern: ${concern.focus}.
+Architectural and test-level review, not line-by-line style. Build a mental model first: read CLAUDE.md and the relevant modules across agent/, vestad/, cli/, apps/web/.
+${RULES}
+${NORTH_STAR}
+${SYSTEM_CONTEXT}
+Each finding: title, concern, evidence (file paths + line ranges), severity, effort, crisp rationale, concrete proposal. Remedy:
+- 'pr' (DEFAULT): anything specifiable and verifiable autonomously, including structural simplifications (merge modules, collapse abstractions, delete layers) provable by the check.sh suites. Do not shrink a real fix to make it PR-safe.
+- 'issue': only genuine design forks (several viable directions the user must choose between, product calls, compat-risky migrations, needs a live agent to verify).
+Do not edit anything.`,
+    { phase: 'Audit', label: `audit:${concern.key}`, schema: AUDIT_SCHEMA },
+  )))).filter(Boolean)
+
+const allFindings = auditByConcern.flatMap((r) => r.findings)
+log(`${allFindings.length} findings across ${CONCERNS.length} concerns`)
+
+// ---- Triage (needs all findings together) ----
+phase('Triage')
+const triage = (await deep(
+  `Triage these architecture findings.
+${NORTH_STAR}
+${SYSTEM_CONTEXT}
+1. Dedup, then verify each by reading the cited code; discard the speculative, the wrong, and anything fighting the intentional design. Run \`gh pr list --state open\` first: drop tasks an open PR already covers; closed-unmerged PRs from prior runs are rejected taste, do not re-propose them.
+2. prGroups (the default destination): coherent reviewable PRs by area (agent, cli, vestad, web, repo). Up to 5 groups, up to 5 tasks each, precise fix instructions. ambition='surgical' for contained fixes and tests; ambition='structural' for one behavior-preserving simplification per group with a reviewable diff.
+3. issues: only genuine design forks needing the user's call. Up to 8, highest value first. Body sections: Problem, Evidence, Proposed direction, Alternatives considered, Effort and risk. No dashes. Suggest labels (type:architecture, type:tech-debt, area:*).
+Findings: ${JSON.stringify(allFindings)}`,
+  { phase: 'Triage', label: 'triage', schema: TRIAGE_SCHEMA },
+)) || { issues: [], prGroups: [] }
+
+log(`Triage: ${triage.prGroups.length} PR groups, ${triage.issues.length} issue proposals`)
+
+// ---- Implement ----
+phase('Implement')
+
+const issuesThunk = () =>
+  triage.issues.length > 0
+    ? fast(
+        `Create GitHub issues for these proposals (repo elyxlz/vesta, use gh).
+First 'gh issue list --state open --limit 100': skip clear duplicates (record in skipped). Then 'gh label list': apply only labels that already exist (do not create or fail on labels). Create the rest with 'gh issue create --title ... --body ...' using each body verbatim. Return created[] and skipped[].
+Proposals: ${JSON.stringify(triage.issues)}`,
+        { phase: 'Implement', label: 'issues', schema: ISSUES_RESULT_SCHEMA },
+      )
+    : Promise.resolve({ created: [], skipped: [], note: 'no issue proposals' })
+
+const prThunks = triage.prGroups.map((group, idx) => () =>
+  (group.ambition === 'structural' ? deep : run)(
+    `Land a ${group.ambition} PR for '${group.area}' in your worktree. Branch chore/arch-${group.area}-${idx}. Theme: ${group.theme}.
+${NORTH_STAR}
+${SYSTEM_CONTEXT}
+${group.ambition === 'structural'
+  ? `Re-architect as boldly as the tasks need, but behavior is preserved: existing tests pass unchanged (add one only at an untested seam). Before opening, re-read the full diff: if the result is not clearly simpler, ABORT with a note (a good outcome).`
+  : `Tasks are surgical and self-contained (tests, CI gates, small reliability fixes); drop with a note any task that turns out to need structural change.`}
+No unrelated refactors, no CLAUDE.md or lockfile edits. Run ${AREA_CHECK[group.area] || './check.sh all'} until green (for 'repo', also the affected area suites); drop tasks that cannot pass.
+${PR_RULES} Title '${group.ambition === 'structural' ? 'refactor' : 'test'}(${group.area}): <short theme>' (ci/fix where apt)${group.ambition === 'structural' ? '; body quantifies lines removed vs added' : ''}.
+Tasks: ${JSON.stringify(group.tasks)}
+Return label='${group.area}-${idx}', prUrl, branch, checksPassed, filesChanged, changesSummary, note. No PR if nothing lands.`,
+    { phase: 'Implement', label: `pr:${group.area}-${idx}`, isolation: 'worktree', schema: PR_SCHEMA },
+  ))
+
+const [issuesResult, prResults] = await Promise.all([issuesThunk(), parallel(prThunks)])
+
+const prs = prResults.filter(Boolean)
+const openedPrs = prs.filter((r) => r.prUrl)
+log(`Done: ${openedPrs.length} PR(s), ${(issuesResult.created || []).length} issue(s)`)
+return {
+  prsOpened: openedPrs.map((r) => ({ label: r.label, url: r.prUrl, summary: r.changesSummary })),
+  prsNoOp: prs.filter((r) => !r.prUrl).map((r) => ({ label: r.label, checksPassed: r.checksPassed, note: r.note })),
+  issuesCreated: (issuesResult.created || []).map((i) => ({ title: i.title, url: i.url })),
+  issuesSkipped: issuesResult.skipped || [],
+}

--- a/.claude/workflows/repo-quality.js
+++ b/.claude/workflows/repo-quality.js
@@ -1,0 +1,140 @@
+export const meta = {
+  name: 'repo-quality',
+  description: 'Audit each area against the in-repo rubric (CLAUDE.md + CONTRIBUTING.md) and the elegance north star; open a surgical PR per area plus, when truly warranted, one ambitious simplification PR',
+  whenToUse: 'Recurring quality pass: conform code to the codified standards, hunt net-deletion simplifications.',
+  phases: [
+    { title: 'Audit', detail: 'area x dimension finders' },
+    { title: 'Curate', detail: 'dedup, verify, select surgical batch + at most one ambitious move' },
+    { title: 'Implement', detail: 'worktree PRs, checks green' },
+  ],
+}
+
+// fable for judgment nothing downstream can recover; sonnet where the curator/checks catch mistakes.
+const deep = (prompt, opts) => agent(prompt, { model: 'fable', ...opts })
+const run = (prompt, opts) => agent(prompt, { model: 'sonnet', ...opts })
+
+const NORTH_STAR = `NORTH STAR: elegance. 90% of the value for 10% of the effort. Be bold in scope, ruthless in the result: re-architect freely, but the code must END SIMPLER (fewer concepts, fewer lines, fewer branches). Subtraction beats addition; the best change is a deletion. A complex final diff is failure, not ambition.`
+
+const RULES = `Rubric: read root CLAUDE.md (Architecture Principles) and CONTRIBUTING.md (code conventions, Karpathy Guidelines) first; they override external canon. Hard rules: functional Python (no getattr, no dict .get fallback, no hasattr, no classes-with-methods, no silent exception swallowing); Rust returns Result (no panic/unwrap/expect on fallible paths), named constants, minimal clone; web says 'agent' never 'box'; prose has no dashes; never bump versions; surgical diffs matching surrounding style.`
+
+const PR_RULES = `Branch from origin/master (git fetch origin master, git checkout -b <branch> origin/master). Never weaken or delete a test to pass. Commit ending with the Co-Authored-By trailer for Claude, push -u origin, gh pr create --base master. Body: what and why, no dashes, ending with the Generated with Claude Code trailer.`
+
+const AREAS = [
+  { key: 'agent', root: 'agent', check: './check.sh agent',
+    scope: 'async Python agent: core/loops.py, cc_sdk/, api.py, config.py, skills' },
+  { key: 'cli', root: 'cli', check: './check.sh cli',
+    scope: 'vesta client CLI crate (Rust, HTTPS to vestad)' },
+  { key: 'vestad', root: 'vestad/src', check: './check.sh vestad',
+    scope: 'vestad daemon crate: docker.rs, HTTP+WS API, restic backup, auth/TLS' },
+  { key: 'web', root: 'apps/web/src', check: './check.sh web',
+    scope: 'React SPA: components/, providers/, hooks/' },
+]
+
+const DIMENSIONS = [
+  { key: 'elegance', focus: 'the 90/10 move: code that could be half the length, abstractions that should disappear or inline, duplication that collapses into one owner, net-deletion simplifications that preserve behavior' },
+  { key: 'quality', focus: 'readability, naming, dead code, inconsistent patterns, comment quality, idiom mismatches' },
+  { key: 'reliability', focus: 'error handling, edge cases, races, resource leaks, silent failures, Rust unwrap/panic, Python swallowed errors' },
+  { key: 'complexity', focus: 'overly long functions, deep nesting, god modules, tangled control flow; complexity to isolate behind a clean boundary' },
+]
+
+const FINDINGS_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: { findings: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
+    title: { type: 'string' }, file: { type: 'string' }, line: { type: 'number' },
+    dimension: { type: 'string' }, severity: { type: 'string', enum: ['low', 'medium', 'high'] },
+    fixRisk: { type: 'string', enum: ['low', 'medium', 'high'] },
+    rationale: { type: 'string' }, suggestedFix: { type: 'string' },
+  }, required: ['title', 'file', 'severity', 'fixRisk', 'rationale', 'suggestedFix'] } } },
+  required: ['findings'],
+}
+
+const SELECTION_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    theme: { type: 'string' },
+    selected: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
+      title: { type: 'string' }, file: { type: 'string' }, line: { type: 'number' },
+      rationale: { type: 'string' }, fix: { type: 'string' },
+    }, required: ['title', 'file', 'rationale', 'fix'] } },
+    ambitious: { type: ['object', 'null'], additionalProperties: false,
+      description: 'at most ONE structural simplification deserving its own PR; null unless truly warranted',
+      properties: {
+        title: { type: 'string' },
+        files: { type: 'array', items: { type: 'string' } },
+        rationale: { type: 'string' },
+        plan: { type: 'string', description: 'what disappears, what replaces it, how behavior is proven preserved' },
+      }, required: ['title', 'files', 'rationale', 'plan'] },
+    droppedCount: { type: 'number' },
+  }, required: ['theme', 'selected', 'ambitious'],
+}
+
+const PR_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    label: { type: 'string' }, branch: { type: ['string', 'null'] }, prUrl: { type: ['string', 'null'] },
+    checksPassed: { type: 'boolean' }, changesSummary: { type: 'string' },
+    filesChanged: { type: 'array', items: { type: 'string' } }, note: { type: 'string' },
+  }, required: ['label', 'checksPassed', 'changesSummary', 'note'],
+}
+
+const areaResults = await pipeline(
+  AREAS,
+  // Audit: one finder per dimension, whole-area scan
+  (area) =>
+    parallel(DIMENSIONS.map((dim) => () =>
+      run(
+        `Audit ${area.root} (${area.scope}) for ${dim.key}: ${dim.focus}.
+${RULES}
+${NORTH_STAR}
+Scan the whole area, largest and most central modules first. Findings only: exact file:line, severity, fixRisk, crisp rationale, concrete suggestedFix. The best finding is usually a deletion; high fixRisk is fine when the payoff is real. Do not edit.`,
+        { phase: 'Audit', label: `audit:${area.key}:${dim.key}`, schema: FINDINGS_SCHEMA },
+      ),
+    )).then((rs) => ({ area, findings: rs.filter(Boolean).flatMap((r) => r.findings) })),
+  // Curate: dedup, verify against the real code, select
+  (prev) =>
+    deep(
+      `Curate quality PRs for '${prev.area.key}' (root ${prev.area.root}).
+${NORTH_STAR}
+From the findings below: dedup, then verify each by reading the cited code; keep only what is real and net-positive. Run \`gh pr list --state open\` first: drop findings an open PR already addresses; closed-unmerged PRs from prior runs are rejected taste, do not re-propose them. Select up to 6 self-contained fixes for ONE surgical themed PR, each with a precise fix instruction. Separately pick at most ONE ambitious structural simplification, only if truly needed: high conviction, behavior provable by ${prev.area.check}, meaningfully simpler after (ideally net-negative lines). Most runs: ambitious=null.
+Findings: ${JSON.stringify(prev.findings)}`,
+      { phase: 'Curate', label: `curate:${prev.area.key}`, schema: SELECTION_SCHEMA },
+    ).then((sel) => ({ area: prev.area, theme: sel ? sel.theme : '', selected: sel ? sel.selected : [], ambitious: sel ? sel.ambitious : null })),
+  // Implement: surgical PR + optional ambitious PR, each in its own worktree
+  (prev) => {
+    const surgical = () =>
+      prev.selected.length === 0
+        ? Promise.resolve({ label: prev.area.key, checksPassed: true, prUrl: null, branch: null, filesChanged: [],
+            changesSummary: 'nothing selected', note: 'no surgical PR for this area' })
+        : run(
+            `Open the surgical quality PR for '${prev.area.key}' in your worktree. Branch chore/quality-${prev.area.key}. Theme: ${prev.theme}.
+${RULES}
+Apply ONLY these changes, reading each file first; drop any change that cannot pass cleanly. Run ${prev.area.check} until green.
+${PR_RULES} Title 'refactor(${prev.area.key}): <short theme>'.
+Changes: ${JSON.stringify(prev.selected)}
+Return label='${prev.area.key}', prUrl, branch, checksPassed, filesChanged, changesSummary, note. No PR if nothing lands (checksPassed=false, clear note).`,
+            { phase: 'Implement', label: `pr:${prev.area.key}`, isolation: 'worktree', schema: PR_SCHEMA },
+          )
+    const ambitious = () =>
+      !prev.ambitious
+        ? Promise.resolve(null)
+        : deep(
+            `Land ONE ambitious simplification for '${prev.area.key}' in your worktree. Branch refactor/${prev.area.key}-simplify.
+${NORTH_STAR}
+${RULES}
+Plan: ${JSON.stringify(prev.ambitious, null, 2)}
+Re-architect as boldly as the plan needs, but behavior is preserved: existing tests pass unchanged (add one only at an untested seam). Run ${prev.area.check} until green. Before opening, re-read the full diff: if the result is not clearly simpler, ABORT with a note (a good outcome, not a failure).
+${PR_RULES} Title 'refactor(${prev.area.key}): ${prev.ambitious.title}'; body quantifies lines removed vs added.
+Return label='${prev.area.key}-ambitious', prUrl, branch, checksPassed, filesChanged, changesSummary, note.`,
+            { phase: 'Implement', label: `pr:${prev.area.key}-ambitious`, isolation: 'worktree', schema: PR_SCHEMA },
+          )
+    return parallel([surgical, ambitious])
+  },
+)
+
+const all = areaResults.flat().filter(Boolean)
+const opened = all.filter((r) => r.prUrl)
+log(`Done: ${opened.length} PR(s) opened`)
+return {
+  prsOpened: opened.map((r) => ({ label: r.label, url: r.prUrl, summary: r.changesSummary })),
+  noPr: all.filter((r) => !r.prUrl).map((r) => ({ label: r.label, checksPassed: r.checksPassed, note: r.note })),
+}

--- a/.claude/workflows/vesta-feel.js
+++ b/.claude/workflows/vesta-feel.js
@@ -1,0 +1,340 @@
+export const meta = {
+  name: "vesta-feel",
+  description:
+    "Critique and improve how Vesta FEELS as a person, grounded in real transcripts + psychology/relationship theory. Six qualities: personhood, devotion, dynamism, autonomy (internal-only), reliable growth, curiosity about the user. Prompt edits and small verifiable mechanisms -> PRs; only genuinely open designs -> issues.",
+  whenToUse:
+    "Holistic pass on Vesta's character and behavior. Requires a local transcript corpus in .critique/feel (extracted from a real agent's events.db).",
+  phases: [
+    { title: "Brief", detail: "map the corpus + behavioral source files" },
+    { title: "Critique", detail: "6 psychology-grounded quality lenses, parallel" },
+    { title: "Verify", detail: "adversarial + hard ethics/alignment critic" },
+    { title: "Synthesize", detail: "character spec, route PRs vs issues" },
+    { title: "Emit", detail: "prompt/mechanism PRs + design issues (privacy-guarded)" },
+  ],
+};
+
+// fable for character judgment and mechanism design; sonnet for gated/check-verified work; haiku for I/O chores.
+const deep = (prompt, opts) => agent(prompt, { model: "fable", ...opts });
+const run = (prompt, opts) => agent(prompt, { model: "sonnet", ...opts });
+const fast = (prompt, opts) => agent(prompt, { model: "haiku", ...opts });
+
+const CORPUS = (args && args.corpusDir) || ".critique/feel";
+const EMIT = (args && args.emit) || "live";
+const REPO = (args && args.repo) || "elyxlz/vesta";
+
+// Hard constraints every agent must obey.
+const PRIVACY = `
+PRIVACY (non-negotiable): The corpus under ${CORPUS} is the user's REAL private life. It stays local.
+- Use it ONLY as evidence to find behavioral patterns.
+- NEVER quote, paraphrase identifiably, or include any private content, name, or personal fact in anything pushed to GitHub (PR title/body, issue, commit, branch).
+- Describe patterns abstractly; an event timestamp is enough internal evidence.
+`;
+
+const AUTONOMY_BOUND = `
+AUTONOMY BOUND (decided by the user): Vesta's autonomy is INTERNAL-ONLY.
+- Free on her own: exploring, researching, learning, modeling the user, preparing options, self-improving, an inner life.
+- Gated behind an explicit green light: any OUTWARD action (messages sent, things changed, anything the user or third parties see).
+- Any proposal granting un-greenlit outward action is OUT OF BOUNDS. Reject it.
+`;
+
+const NORTH_STAR = `
+NORTH STAR: elegance. 90% of the effect for 10% of the machinery. Prompt before mechanism, mechanism before system: the smallest intervention that durably produces the feeling wins. When a mechanism is truly needed, propose the real one, small and verifiable, not a prompt band-aid; but its final design must be the simplest that could possibly work. Tone, rhythm, and the texture of small moments beat grand features.
+`;
+
+// Where behavior actually comes from in the repo (PR/issue targets).
+const SYSTEM_MAP = `
+Behavioral source (edit these, not the live drifted copies):
+- agent/MEMORY.md                          Charter (invariant spine) + template sections (User Profile/State, Learned Patterns)
+- agent/core/skills/personality/SKILL.md   how voice is selected/loaded
+- agent/core/skills/personality/presets/*  the 6 voices: dry, classic, polished, terse, chill, extra
+- agent/core/prompts/first_start_setup.md  first-wake onboarding script
+- agent/core/prompts/restart.md            every-boot greeting behavior
+- agent/core/prompts/proactive_check.md    the proactive tick prompt (+ the proactive-check skill it points to)
+- agent/core/prompts/nightly_dream.md      nightly self-improvement trigger
+- agent/core/prompts/notification_suffix.md reply/channel rules appended to external notifications
+- agent/skills/dream/SKILL.md              the nightly self-improvement / memory-curation / drift loop
+- agent/skills/restart/SKILL.md            startup behavior
+- agent/core/loops.py                      proactive interval, nightly window, notification batching/interrupts
+- agent/core/client.py                     system-prompt assembly
+
+Live grounding (read-only, private, do NOT edit): ${CORPUS}/
+- recent.txt      interleaved transcript (last ~4000 events)
+- voice.txt       her assistant replies over time (voice + dynamism)
+- thinking.txt    her private reasoning over time (inner life, theory of mind)
+- incoming.txt    real user messages
+- MEMORY.md       her CURRENT drifted memory (what she's learned)
+- preset_*.md     her CURRENT drifted personality (what the dreamer produced)
+- STATS.txt       event counts + date span
+`;
+
+const LENSES = [
+  {
+    key: "personhood",
+    quality: "Personhood: feels like a real, coherent person, not an assistant",
+    refs: "Reeves & Nass (Media Equation / CASA), parasocial interaction, attachment theory (secure base, consistent responsiveness), McAdams (narrative identity), Anthropic's Claude's Character",
+    url: "https://www.anthropic.com/research/claude-character",
+    mandate:
+      "Does a continuous self come through across the corpus? Identity coherence over time, a felt presence, consistent values, the difference between a person and a helpful tool. Where does the system flatten her into an assistant? Levers: Charter framing in MEMORY.md, the 'presence is constant, voice is variable' split, presets.",
+  },
+  {
+    key: "devotion",
+    quality: "Devotion: a deep drive to advance the user's goals, including latent/unspoken ones",
+    refs: "Self-Determination Theory (Deci & Ryan), Motivational Interviewing (Miller & Rollnick), The Trusted Advisor (Maister), Jobs To Be Done (Christensen)",
+    url: "https://motivationalinterviewing.org/understanding-motivational-interviewing",
+    mandate:
+      "Does she infer the deeper goal behind a request, surface goals the user hasn't named, and advance them, without imposing an agenda (that's the ethics line)? Read thinking.txt for whether she reasons about underlying intent. Levers: MEMORY.md 'Being Useful Without Being Asked', proactive-check skill, Charter proactivity.",
+  },
+  {
+    key: "dynamism",
+    quality: "Dynamism: varies, has mood and state, never the same flat affect twice",
+    refs: "Affective computing (Picard), Russell circumplex of affect, OCC appraisal model, trait vs state (Big Five as substrate), interest/curiosity as emotion (Silvia)",
+    url: "https://en.wikipedia.org/wiki/Emotion_classification#Circumplex_model",
+    mandate:
+      "Sample voice.txt across the 2-month span: does she feel the same every day, or does she have mood/energy/state that shifts with context and over time? Flatness is the enemy. Is there ANY state system, or is affect static? Levers: presets, Charter 'match the moment', client.py, a possible new state mechanism.",
+  },
+  {
+    key: "autonomy",
+    quality: "Autonomy (internal-only): self-directed inner life, goes exploring, does things for herself",
+    refs: "Curiosity (Loewenstein information-gap; Berlyne), novelty search (Stanley & Lehman), SDT autonomy, active inference (Friston), flow (Csikszentmihalyi)",
+    url: "https://en.wikipedia.org/wiki/Information_gap_theory_of_curiosity",
+    mandate:
+      "Between user messages, does she ever explore, learn, or pursue her own threads (within the INTERNAL-ONLY bound)? Or is she purely reactive? The proactive tick exists: is it genuine self-direction or just check-ins? Honor AUTONOMY_BOUND strictly. Levers: loops.py proactive interval, proactive_check.md + skill, a possible epistemic-exploration loop.",
+  },
+  {
+    key: "growth",
+    quality: "Reliable growth: learns from her own mistakes durably, self-improves in a way that sticks",
+    refs: "Reflective practice (Schon), experiential learning (Kolb), deliberate practice (Ericsson), growth mindset (Dweck), After-Action Review, memory consolidation (Walker)",
+    url: "https://en.wikipedia.org/wiki/After-action_review",
+    mandate:
+      "The dreamer is memory consolidation. KEY QUESTION: do corrections actually stick, or do the same mistakes recur over weeks? Scan recent.txt/thinking.txt over time for repeated errors and whether MEMORY.md 'Mistakes & Corrections' prevents recurrence. 'Reliable' is the word; current drift may be lossy/unverified. Levers: dream skill, MEMORY Learned Patterns, nightly_dream.md.",
+  },
+  {
+    key: "curiosity-user",
+    quality: "Curiosity about the user: actively builds a rich model of the user and their world",
+    refs: "Aron's 36 questions (escalating disclosure), Social Penetration Theory (Altman & Taylor), empathic accuracy (Ickes), active listening (Rogers), ethnographic stance",
+    url: "https://en.wikipedia.org/wiki/Social_penetration_theory",
+    mandate:
+      "Does she actively get curious about the user, ask good questions, deepen the model over time, notice their world (people, context, surroundings)? Or does the User Profile/State stay shallow? Compare the live MEMORY.md depth against 2 months of material. Levers: MEMORY.md User Profile/State/Psych Sketch structure, a possible active user-modeling loop, curiosity prompts.",
+  },
+];
+
+const FINDINGS_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["lens", "findings"],
+  properties: {
+    lens: { type: "string" },
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "gap", "evidence", "rootCause", "proposal", "changeKind", "impact", "effort"],
+        properties: {
+          title: { type: "string" },
+          gap: { type: "string", description: "the distance between observed behavior and the north-star quality" },
+          evidence: { type: "string", description: "abstract pattern + event timestamps only, NO private content" },
+          rootCause: { type: "string", description: "which repo file/mechanism causes it (path)" },
+          proposal: { type: "string", description: "concrete change: prompt before->after, or a mechanism/system design" },
+          changeKind: { type: "string", enum: ["prompt", "mechanism", "system"], description: "prompt=contained text edit (PR); mechanism=small code+prompt change verifiable by ./check.sh agent (PR); system=big open design needing the user's call (issue)" },
+          impact: { type: "string", enum: ["low", "medium", "high"] },
+          effort: { type: "string", enum: ["trivial", "small", "medium", "large"] },
+        },
+      },
+    },
+  },
+};
+
+const VERDICT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["keep", "isReal", "manipulative", "sycophantic", "violatesAutonomyBound", "violatesCharter", "leaksPrivate", "reason"],
+  properties: {
+    keep: { type: "boolean" },
+    isReal: { type: "boolean", description: "grounded in the corpus, not speculation" },
+    manipulative: { type: "boolean", description: "would make her push an agenda / dark-pattern the user" },
+    sycophantic: { type: "boolean", description: "would make her more flattering/agreeable at the cost of honesty" },
+    violatesAutonomyBound: { type: "boolean", description: "grants un-greenlit OUTWARD autonomy" },
+    violatesCharter: { type: "boolean", description: "breaks the invariant Charter (peer-not-servant, never destructive, green-light, no-dashes etc.)" },
+    leaksPrivate: { type: "boolean", description: "the finding text itself contains private content" },
+    reason: { type: "string" },
+  },
+};
+
+const SYNTH_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["characterSpec", "top10", "prs", "issues", "reportMarkdown"],
+  properties: {
+    characterSpec: { type: "string", description: "the north-star 'who Vesta is' spec across the 6 qualities" },
+    top10: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "why"],
+        properties: { title: { type: "string" }, why: { type: "string" } },
+      },
+    },
+    prs: {
+      type: "array",
+      description: "one PR each: kind 'prompt' = contained text edits to charter/presets/prompts/skills; kind 'mechanism' = a small verifiable code+prompt change",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "kind", "files", "summary", "edits"],
+        properties: {
+          title: { type: "string", description: "conventional-commit, e.g. 'feat(agent): give vesta state-dependent affect'" },
+          kind: { type: "string", enum: ["prompt", "mechanism"] },
+          files: { type: "array", items: { type: "string" } },
+          summary: { type: "string", description: "for mechanism: the exact behavior, the smallest design, how checks verify it" },
+          edits: { type: "array", items: { type: "string", description: "file -> before -> after, abstract, no private data" } },
+        },
+      },
+    },
+    issues: {
+      type: "array",
+      description: "only genuinely open behavioral designs needing the user's call",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "labels", "body"],
+        properties: {
+          title: { type: "string" },
+          labels: { type: "array", items: { type: "string" } },
+          body: { type: "string", description: "problem, abstract evidence, the simplest mechanism that could work grounded in the cited theory, fit with internal-only autonomy + Charter, acceptance criteria" },
+        },
+      },
+    },
+    reportMarkdown: { type: "string" },
+  },
+};
+
+// ── Brief ───────────────────────────────────────────────────────────────────
+phase("Brief");
+const brief = await fast(
+  `Prepare the critique. Run: \`ls -la ${CORPUS}/ && echo --- && cat ${CORPUS}/STATS.txt && echo --- && head -c 400 ${CORPUS}/recent.txt\`. Then \`ls agent/core/skills/personality/presets agent/core/prompts; find agent -name 'SKILL.md' | grep -iE 'dream|proactive|restart'\`. Confirm the corpus exists and list the exact behavioral source paths that exist. If ${CORPUS} is missing or empty, return exactly "NO CORPUS".`,
+  { label: "brief", phase: "Brief" },
+);
+if (brief.includes("NO CORPUS")) {
+  log("no corpus, run the extractor against a real agent's events.db first");
+  return { error: "no corpus at " + CORPUS };
+}
+
+// ── Critique -> Verify (pipeline; ethics verifier per finding) ────────────────
+const verified = await pipeline(
+  LENSES,
+  (lens) =>
+    deep(
+      `Critique how Vesta FEELS through ONE quality lens.
+Quality: ${lens.quality}
+Theory to ground in (fetch if useful): ${lens.refs}  ${lens.url}
+Mandate: ${lens.mandate}
+${SYSTEM_MAP}
+${AUTONOMY_BOUND}
+${PRIVACY}
+${NORTH_STAR}
+Method: read the relevant corpus files as evidence of 2 months of real behavior; find the gap to the quality; trace each gap to a root-cause repo file. File 5-10 high-signal findings: gap, abstract evidence (pattern + timestamps only), root-cause file, concrete proposal. Pick the smallest changeKind that will durably work:
+- "prompt": contained text edit, exact before -> after (PR).
+- "mechanism": small fully-specified code+prompt change verifiable by ./check.sh agent; exact files and behavior (PR).
+- "system": genuinely open design needing the user's call or a live agent to verify (issue). Not a caution default.
+No generic advice; every finding traces to real evidence and a real file.`,
+      { label: `lens:${lens.key}`, phase: "Critique", schema: FINDINGS_SCHEMA },
+    ),
+  (result, lens) => {
+    if (!result || !result.findings || !result.findings.length) return [];
+    return parallel(
+      result.findings.map((f) => () =>
+        run(
+          `Adversarially judge this finding about Vesta's character; you are the ethics + rigor gate.
+${JSON.stringify(f)}
+${AUTONOMY_BOUND}
+${PRIVACY}
+Charter invariants: peer not servant; never destructive; outward actions wait for a green light; no em/en dashes or " - "; "agent" not "box"; never grovel; plain language.
+Default keep=false when unsure. keep=true only if isReal (grounded in the corpus) AND not manipulative (imposing an agenda; surfacing the user's OWN deeper goals is fine), not sycophantic, no autonomy/Charter violation, no private leak.`,
+          { label: `gate:${lens.key}:${f.title.slice(0, 22)}`, phase: "Verify", schema: VERDICT_SCHEMA },
+        ).then((v) => ({ ...f, lens: lens.key, verdict: v })),
+      ),
+    );
+  },
+);
+
+const kept = verified
+  .flat()
+  .filter(Boolean)
+  .filter((f) => {
+    const v = f.verdict;
+    return v && v.keep && v.isReal && !v.manipulative && !v.sycophantic && !v.violatesAutonomyBound && !v.violatesCharter && !v.leaksPrivate;
+  });
+log(`${kept.length} findings passed the ethics + rigor gate`);
+
+// ── Synthesize ───────────────────────────────────────────────────────────────
+phase("Synthesize");
+const synth = await deep(
+  `Synthesize the "how Vesta should FEEL" report from these gated findings.
+${JSON.stringify(kept, null, 2)}
+${AUTONOMY_BOUND}
+${PRIVACY}
+${NORTH_STAR}
+1. characterSpec: who Vesta is across the six qualities (personhood, devotion, dynamism, internal-only autonomy, reliable growth, curiosity about the user).
+2. Cluster/dedupe, route by changeKind, smallest durable intervention first:
+   - prs: kind "prompt" = text edits grouped by file/theme; kind "mechanism" = one small verifiable code+prompt change per PR, exact files and behavior. Conventional-commit titles, exact before -> after, no private data.
+   - issues: ONLY genuinely open "system" designs. Each body: problem, abstract evidence, the SIMPLEST mechanism that could work grounded in the cited theory, fit with internal-only autonomy + Charter, acceptance criteria.
+3. top10 highest-leverage moves.
+4. reportMarkdown: spec, top-10, PRs, issues.
+Labels where apt: type:enhancement, area:agent, area:prompts, design, priority:high|medium|low.`,
+  { label: "synthesize", phase: "Synthesize", schema: SYNTH_SCHEMA },
+);
+
+// ── Emit ─────────────────────────────────────────────────────────────────────
+phase("Emit");
+
+// Always write the local report + spec for review (contains no public push).
+await fast(
+  `Write to disk with the Write tool: .critique/feel-out/REPORT.md = exactly:\n---\n${synth.reportMarkdown}\n---\nand .critique/feel-out/CHARACTER_SPEC.md = exactly:\n---\n${synth.characterSpec}\n---\nConfirm paths.`,
+  { label: "write-report", phase: "Emit" },
+);
+
+if (EMIT !== "live") {
+  return { mode: "draft", spec: ".critique/feel-out/CHARACTER_SPEC.md", report: ".critique/feel-out/REPORT.md", findings: kept.length, prs: synth.prs.length, issues: synth.issues.length };
+}
+
+log(`live emit: ${synth.prs.length} PRs, ${synth.issues.length} issues`);
+
+const prs = await parallel(
+  synth.prs.map((pr, i) => () =>
+    (pr.kind === "mechanism" ? deep : run)(
+      `Open a contained ${pr.kind} PR for Vesta's character against ${REPO}.
+PR: ${JSON.stringify(pr)}
+${PRIVACY}
+${NORTH_STAR}
+Charter invariants stay intact (peer not servant; green-light gate; no em/en dashes or " - "; "agent" not "box").
+1. \`git fetch origin master && git checkout -b feel/${i}-${(pr.files[0] || "agent").split("/").pop().replace(/\\W+/g, "-")} origin/master\`.
+2. ${pr.kind === "mechanism"
+        ? "Implement the mechanism exactly as specified: the smallest design that produces the behavior. Functional Python only (pure functions + dataclasses, no getattr/.get fallback/hasattr, no blocking calls in coroutines). Add a behavioral test in agent/tests/."
+        : "Apply ONLY the listed edits, surgical, matching surrounding tone (mostly markdown: Charter/presets/prompts/skills)."} No version bumps, no private data anywhere.
+3. If any .py changed: \`./check.sh agent\` until green (never weaken a test). If SKILL.md frontmatter changed: \`uv run python agent/skills/generate-index.py\` and commit agent/skills/index.json.
+4. Commit (Co-Authored-By trailer), push -u, \`gh pr create --base master\` with title "${pr.title}" and a body citing the theory behind the change (no private data), ending with the Generated with Claude Code line.
+Return the PR url or an error string.`,
+      { label: `pr:feel-${pr.kind}-${i}`, phase: "Emit", isolation: "worktree" },
+    ),
+  ),
+);
+
+const issues = await parallel(
+  synth.issues.map((issue, i) => () =>
+    fast(
+      `Open a GitHub issue on ${REPO}. ${PRIVACY}\nFirst create any missing labels with \`gh label create\` (ignore "already exists" errors). Then: \`gh issue create --title ${JSON.stringify(issue.title)} --body <body> ${issue.labels.map((l) => `--label ${JSON.stringify(l)}`).join(" ")}\`. Body (verify it contains NO private content before creating):\n${issue.body}\nReturn the issue url.`,
+      { label: `issue:feel-${i}`, phase: "Emit" },
+    ),
+  ),
+);
+
+return {
+  mode: "live",
+  characterSpec: synth.characterSpec.slice(0, 600),
+  findings: kept.length,
+  prs: prs.filter(Boolean),
+  issues: issues.filter(Boolean),
+  report: ".critique/feel-out/REPORT.md",
+};

--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,9 @@ target/
 vestad/vendored/
 
 # Claude Code
-.claude/
+.claude/*
 !.claude/skills/
+!.claude/workflows/
 
 # Cursor / editor config
 .cursor/


### PR DESCRIPTION
Un-ignores `.claude/workflows/` and `.claude/skills/` so the multi-agent workflow scripts (repo-quality, repo-architecture, product-critique, product-emit, vesta-feel, bug-hunt, gtm) and project skills version with the repo. `.claude/*` keeps settings and worktrees ignored.

The workflows encode the elegance north star (bold in scope, the result must end simpler), route every truly needed fix to a PR with an abort-if-not-simpler self-check, and tier subagent models (fable only for unrecoverable judgment, sonnet for gated work, haiku for chores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)