### PR TITLE
revert(app): remove chat composer interrupt/stop control

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -37,7 +37,6 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
     Recv: clients can emit events (e.g. user messages, chat replies).
     On connect: sends recent history unless ?skip_history=1 is passed."""
     event_bus: EventBus = request.app["event_bus"]
-    state: State | None = request.app["state"]
     skip_history = request.query.get("skip_history", "") in ("1", "true")
 
     ws = web.WebSocketResponse()
@@ -52,7 +51,7 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
             events, cursor = event_bus.recent()
             if events:
                 await ws.send_json(HistoryEvent(type="history", events=events, state=event_bus.state, cursor=cursor))
-        recv_task = asyncio.create_task(_recv_loop(ws, event_bus, state))
+        recv_task = asyncio.create_task(_recv_loop(ws, event_bus))
         send_task = asyncio.create_task(_send_loop(ws, sub))
         await asyncio.wait([recv_task, send_task], return_when=asyncio.FIRST_COMPLETED)
     finally:
@@ -67,7 +66,7 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
     return ws
 
 
-async def _recv_loop(ws: web.WebSocketResponse, event_bus: EventBus, state: State | None) -> None:
+async def _recv_loop(ws: web.WebSocketResponse, event_bus: EventBus) -> None:
     """Receive events from clients and emit to event bus."""
     async for msg in ws:
         if msg.type == web.WSMsgType.TEXT:
@@ -90,14 +89,6 @@ async def _recv_loop(ws: web.WebSocketResponse, event_bus: EventBus, state: Stat
                         event_bus.emit(event)
                     else:
                         event_bus.emit(ChatEvent(type="chat", text=text))
-            elif msg_type == "interrupt":
-                # Pure stop: halt the in-flight turn without queueing a new message.
-                # The message processor owns the interrupt sequence (drain + return to
-                # idle) by waiting on state.interrupt_event; setting it here is a no-op
-                # when the agent is idle (interrupt_event is None between turns).
-                if state is not None and state.interrupt_event is not None and not state.interrupt_event.is_set():
-                    state.interrupt_event.set()
-                    logger.info("client interrupt received")
         elif msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):
             break
 

--- a/agent/tests/test_api.py
+++ b/agent/tests/test_api.py
@@ -21,10 +21,9 @@ def _pick_port() -> int:
         return s.getsockname()[1]
 
 
-async def _start_server(event_bus, state=None):
+async def _start_server(event_bus):
     app = web.Application()
     app["event_bus"] = event_bus
-    app["state"] = state
     app["websockets"] = weakref.WeakSet()
     app.router.add_get("/ws", _ws_handler)
     runner = web.AppRunner(app)
@@ -81,40 +80,6 @@ async def test_ws_skip_history_omits_history_event(event_bus):
                 )
                 assert not any(e.get("type") == "history" for e in received)
                 assert any(e.get("type") == "chat" and e.get("text") == "live" for e in received)
-    finally:
-        await runner.cleanup()
-
-
-@pytest.mark.anyio
-async def test_ws_interrupt_sets_interrupt_event(event_bus):
-    """A {type: interrupt} message halts the in-flight turn by setting state.interrupt_event."""
-    state = vm.State()
-    interrupt_event = asyncio.Event()
-    state.interrupt_event = interrupt_event
-    runner, base = await _start_server(event_bus, state)
-    try:
-        async with ClientSession() as session:
-            async with session.ws_connect(f"{base}/ws?skip_history=1") as ws:
-                await ws.send_json({"type": "interrupt"})
-                await wait_for_condition(interrupt_event.is_set, message="interrupt_event never set")
-    finally:
-        await runner.cleanup()
-
-
-@pytest.mark.anyio
-async def test_ws_interrupt_is_noop_when_idle(event_bus):
-    """With no turn in flight (interrupt_event is None) the interrupt is ignored and the socket stays healthy."""
-    state = vm.State()
-    assert state.interrupt_event is None
-    runner, base = await _start_server(event_bus, state)
-    try:
-        async with ClientSession() as session:
-            async with session.ws_connect(f"{base}/ws?skip_history=1") as ws:
-                await ws.send_json({"type": "interrupt"})
-                event_bus.emit(ChatEvent(type="chat", text="alive"))
-                received = await _drain_until(ws, lambda r: any(e.get("text") == "alive" for e in r))
-                assert any(e.get("type") == "chat" and e.get("text") == "alive" for e in received)
-        assert state.interrupt_event is None
     finally:
         await runner.cleanup()
 

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -32,8 +32,6 @@ interface ChatComposerProps {
   onInputChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
   onKeyDown: (e: KeyboardEvent) => void;
   onSend: () => void;
-  isBusy: boolean;
-  onStop: () => void;
   textareaRef: RefObject<HTMLTextAreaElement | null>;
 }
 
@@ -51,8 +49,6 @@ export function ChatComposer({
   onInputChange,
   onKeyDown,
   onSend,
-  isBusy,
-  onStop,
   textareaRef,
 }: ChatComposerProps) {
   const activation = useVoiceActivation((s) => s.mode);
@@ -115,11 +111,11 @@ export function ChatComposer({
             <InputGroupButton
               size="icon-sm"
               variant="ghost"
-              aria-label={isBusy ? "stop agent" : "send message"}
+              aria-label="send message"
               disabled={!connected}
-              onClick={isBusy ? onStop : onSend}
+              onClick={onSend}
             >
-              {isBusy ? <Square fill="currentColor" /> : <SendHorizontal />}
+              <SendHorizontal />
             </InputGroupButton>
           </InputGroupAddon>
         )}

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -50,8 +50,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     loadingMore,
     loadMore,
     send,
-    sendEvent,
-    agentState,
     showToolCalls,
   } = useChatContext();
 
@@ -122,10 +120,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
       if (ta) ta.style.height = "auto";
       requestAnimationFrame(scrollToBottom);
     }
-  };
-
-  const handleStop = () => {
-    sendEvent({ type: "interrupt" });
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -206,8 +200,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
             onInputChange={handleInput}
             onKeyDown={handleKeyDown}
             onSend={handleSend}
-            isBusy={agentState === "thinking"}
-            onStop={handleStop}
             textareaRef={textareaRef}
           />
         </div>


### PR DESCRIPTION
Fully reverts #766 ("feat(app): add stop control to chat composer while agent thinks").

## What

Reverts the squash commit `30dc1529` in its entirety:

- **Frontend** (`Chat`, `ChatComposer`): removes the stop button, the `isBusy`/`onStop` props, and the `{type: "interrupt"}` send path. The send arrow is the only composer action again.
- **Agent** (`api.py`): removes the `type: "interrupt"` WS handler and the `state` threading through `_ws_handler`/`_recv_loop`.
- **Tests**: removes `test_ws_interrupt_sets_interrupt_event` and `test_ws_interrupt_is_noop_when_idle`.

The `Square` icon remains imported in `ChatComposer` (still used for the voice recording state), so no dangling references.

## Why

Per request: revert the app-chat interrupt feature entirely.

## Tests

- `./check.sh web` — eslint/prettier/tsc/vitest green (72 tests).
- `./check.sh agent` — ruff/ty/pytest green (313 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)