### PR TITLE
fix(core): keep the SDK watchdog quiet while a tool is running

### DIFF
--- a/agent/core/diagnostics.py
+++ b/agent/core/diagnostics.py
@@ -118,12 +118,17 @@ async def sdk_watchdog(state: vm.State, *, stop: asyncio.Event) -> None:
                 alive_str = f"process_alive={alive}" if alive is not None else "process_alive=unknown"
                 diag = format_hang_diagnostics(state)
                 msg = f"SDK silent for {threshold}s | {alive_str} | {diag}"
-                # Only escalate when something is actually wrong: a turn is in flight
-                # (so silence = stalled processing) OR the alive check returned False
-                # (verified subprocess death). Otherwise the SDK is just idle between
-                # turns; log at debug so quiet stretches don't spam the warning stream.
+                # Only escalate when something is actually wrong: the alive check returned
+                # False (verified subprocess death), OR a turn is in flight with no tool
+                # running. A tool actively executing (a long build, a `sleep`, a subagent)
+                # fully explains the silence: the SDK is busy doing real work, not hung,
+                # so a foreground `sleep 180` should not look like a stall. This mirrors
+                # attempt_interrupt (client.py), which likewise refuses to act while a tool
+                # is in flight. Otherwise the SDK is just idle; log at debug so quiet
+                # stretches (between turns, or mid-tool) don't spam the warning stream.
                 turn_in_flight = state.interrupt_event is not None
-                if turn_in_flight or alive is False:
+                tool_running = bool(state.active_tools)
+                if alive is False or (turn_in_flight and not tool_running):
                     pane_tail = await _capture_pane_tail(state)
                     if pane_tail:
                         msg = f"{msg} | pane_tail={pane_tail!r}"

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -372,6 +372,60 @@ async def test_watchdog_stays_quiet_when_idle_between_turns(tmp_path):
     state.event_bus.close()
 
 
+@pytest.mark.anyio
+async def test_watchdog_stays_quiet_while_tool_runs(tmp_path):
+    """A turn in flight is benign while a tool is actively running: a long `sleep` or build
+    leaves the SDK silent without being hung, so log at debug and emit no error event."""
+    from unittest.mock import patch as _patch
+
+    import core.diagnostics as diagnostics_mod
+
+    state = vm.State()
+    state.event_bus = vm.EventBus(data_dir=tmp_path)
+    queue = state.event_bus.subscribe()
+    state.last_sdk_activity = time.monotonic() - 65  # Idle past the 60s threshold
+    state.interrupt_event = asyncio.Event()  # Turn in flight...
+    state.active_tools["tool-1"] = vm.ActiveTool(name="Bash", summary="sleep 180", started_at=time.monotonic() - 65)
+    stop = asyncio.Event()
+    warnings: list[str] = []
+
+    original_warning = diagnostics_mod.logger.warning
+
+    def capture_warning(msg):
+        warnings.append(str(msg))
+
+    diagnostics_mod.logger.warning = capture_warning  # ty: ignore[invalid-assignment]
+
+    original_wait_for = asyncio.wait_for
+
+    async def fast_wait_for(coro, *, timeout):  # type: ignore[no-untyped-def]
+        return await original_wait_for(coro, timeout=0.01)
+
+    def error_events() -> list[tp.Any]:
+        events: list[tp.Any] = []
+        while not queue.empty():
+            event = queue.get_nowait()
+            if event["type"] == "error" and "SDK silent" in event["text"]:
+                events.append(event)
+        return events
+
+    try:
+
+        async def let_several_polls_run():
+            for _ in range(5):
+                await asyncio.sleep(0.02)
+            stop.set()
+
+        with _patch("core.diagnostics.asyncio.wait_for", fast_wait_for):
+            await asyncio.gather(sdk_watchdog(state, stop=stop), let_several_polls_run())
+    finally:
+        diagnostics_mod.logger.warning = original_warning
+
+    assert not [w for w in warnings if "SDK silent" in w], f"expected no warnings while a tool is running, got {warnings}"
+    assert error_events() == [], f"expected no error events while a tool is running, got {error_events()}"
+    state.event_bus.close()
+
+
 # --- Tool duration tracking via hooks ---
 
 


### PR DESCRIPTION
## What

The `SDK silent for 60s/120s` WARNING fires whenever a turn is in flight, even when a tool is **legitimately** executing. A foreground `Bash: sleep 180` (used to wait before polling CI), a long build, or a subagent all leave the claude SDK silent for minutes without being hung, yet they tripped the warning. `process_alive=True` in those logs already showed nothing was actually wrong.

## Fix

Gate the watchdog escalation on tool activity. An actively-running tool fully explains SDK silence: the process is busy doing real work, not stalled. This mirrors `attempt_interrupt` (`client.py:66-72`, #758), which already refuses to SIGTERM while a tool is in flight for the same reason.

```
before: warn when  turn_in_flight or alive is False
after:  warn when  alive is False or (turn_in_flight and not tool_running)
```

The watchdog now warns only on:
- verified subprocess death (`alive is False`), or
- a turn in flight with **no** tool running (a genuine mid-turn stall).

A long-running tool drops to `debug`, same as the between-turns idle case (#753).

## Test

`test_watchdog_stays_quiet_while_tool_runs` mirrors the existing idle-between-turns test: turn in flight + a `Bash sleep 180` in `active_tools`, idle past 60s, asserts no warning and no error event. The existing threshold/pane-tail/reset/emit tests (turn in flight, no active tool) still warn as before. 22/22 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)