### PR TITLE
fix(app): stop rendering agent error events in app chat

### DIFF
--- a/apps/web/src/components/Chat/ChatBubble/index.tsx
+++ b/apps/web/src/components/Chat/ChatBubble/index.tsx
@@ -25,14 +25,6 @@ export const ChatBubble = memo(function ChatBubble({
       })
     : "";
 
-  if (event.type === "error") {
-    return (
-      <div className={cn("flex justify-center px-4 py-1", className)}>
-        <span className="text-xs text-destructive">{event.text}</span>
-      </div>
-    );
-  }
-
   if (event.type === "tool_start") {
     return (
       <ToolCallLabel

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -79,7 +79,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
         (m) =>
           m.type === "user" ||
           m.type === "chat" ||
-          m.type === "error" ||
           (showToolCalls &&
             m.type === "tool_start" &&
             !(m.tool === "Bash" && m.input.includes("app-chat"))),


### PR DESCRIPTION
## What

Agent error events (`{type: "error"}` — watchdog timeouts, SDK errors, context-usage warnings, interrupt timeouts) were rendered inline in the app chat as centered red text. The chat is the conversation; errors belong in the logs.

## Change

- `Chat/index.tsx` — drop `m.type === "error"` from the `chatMessages` filter so error events no longer reach the message list.
- `ChatBubble/index.tsx` — remove the now-dead error-rendering branch.

Error events still stream over the WebSocket and persist to `events.db`, so they remain available in the logs — just not shown in chat. The bottom banner's `error` prop is fed by `voiceError` (voice input), unrelated to these events, so it's untouched.

## Verification

`./check.sh web` passes (tsc, eslint, prettier, 72 vitest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)