### PR TITLE
fix(core): re-enable interrupts while a tool is in flight

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -63,26 +63,18 @@ async def attempt_interrupt(state: vm.State, *, config: vm.VestaConfig, reason: 
     if not client:
         return False
 
-    # Skip the interrupt entirely while a tool is running; the SDK is busy doing
-    # real work, and a 5s timeout against an actively-executing tool is a
-    # false-positive SIGTERM. The next notification is processed once the tool
-    # returns. See issue #737.
-    if state.active_tools:
-        logger.debug(f"Interrupt skipped (tool in flight): {reason}")
-        return False
-
     try:
         await asyncio.wait_for(client.interrupt(), timeout=config.interrupt_timeout)
         logger.debug(f"Interrupt sent: {reason}")
         return True
     except TimeoutError:
-        # No tool in flight but the SDK didn't ack the interrupt within the
-        # window. Log + emit but don't SIGTERM the whole process: in practice
-        # this fires more often during heavy thinking than during a real hang,
+        # The SDK didn't ack the interrupt within the window. Log + emit but
+        # don't SIGTERM the whole process: in practice this fires more often
+        # during heavy thinking or a long-running tool than during a real hang,
         # and the watchdog in core/diagnostics.py SIGTERMs if the SDK is
         # genuinely stuck idle past its higher threshold.
         diag = diagnostics.format_hang_diagnostics(state)
-        msg = f"SDK interrupt timed out (no tool in flight) | reason={reason} | {diag}"
+        msg = f"SDK interrupt timed out | reason={reason} | {diag}"
         logger.warning(msg)
         # The event bus has no "warning" severity; like log_context_usage's warning-band
         # crossing (diagnostics.py), surface warn-level conditions as an "error" event.

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -334,8 +334,8 @@ async def test_run_vesta_force_exits_on_hung_cleanup(tmp_path):
 
 @pytest.mark.anyio
 async def test_attempt_interrupt_timeout_warns_without_sigterm(tmp_path):
-    """When client.interrupt() times out with no tool in flight, attempt_interrupt warns and
-    returns False instead of SIGTERMing the process.
+    """When client.interrupt() times out, attempt_interrupt warns and returns False
+    instead of SIGTERMing the process.
 
     The 5s timeout fires more often during heavy thinking than during a real hang, so a
     false-positive must not kill the whole container; the diagnostics watchdog owns the
@@ -371,7 +371,7 @@ async def test_attempt_interrupt_timeout_warns_without_sigterm(tmp_path):
     ):
         result = await attempt_interrupt(state, config=config, reason="hung SDK")
 
-    assert result is False, "a timed-out interrupt with no tool in flight must report failure, not success"
+    assert result is False, "a timed-out interrupt must report failure, not success"
     assert kills == [], f"timed-out interrupt must not SIGTERM the process, got {kills}"
     assert exits == [], f"timed-out interrupt must not force-exit, got {exits}"
 
@@ -386,9 +386,10 @@ async def test_attempt_interrupt_timeout_warns_without_sigterm(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_attempt_interrupt_skips_while_tool_in_flight(tmp_path):
-    """While a tool is executing, attempt_interrupt is a no-op: the SDK is doing real work and a
-    5s timeout against it would be a false-positive interrupt (see issue #737)."""
+async def test_attempt_interrupt_fires_while_tool_in_flight(tmp_path):
+    """attempt_interrupt still asks the SDK to interrupt while a tool is executing. The SDK
+    services the request at its next yield point; a timeout no longer SIGTERMs (see issue #737),
+    so there is no reason to suppress the interrupt during tool work."""
     from core.client import attempt_interrupt
 
     config = vm.VestaConfig(agent_dir=tmp_path / "agent", interrupt_timeout=0.01)
@@ -408,8 +409,8 @@ async def test_attempt_interrupt_skips_while_tool_in_flight(tmp_path):
 
     result = await attempt_interrupt(state, config=config, reason="notification")
 
-    assert result is False, "skipping the interrupt must report failure"
-    assert interrupted is False, "client.interrupt() must not be called while a tool is in flight"
+    assert result is True, "a serviced interrupt must report success"
+    assert interrupted is True, "client.interrupt() must be called even while a tool is in flight"
     state.event_bus.close()
 
 


### PR DESCRIPTION
## Summary
Reverts the **tool-in-flight gate** added in #758, keeping that PR's other change (the SIGTERM downgrade) intact.

#758 made two changes to `attempt_interrupt()`:
1. **Tool-in-flight gate** — if `state.active_tools` is non-empty, skip the interrupt entirely and return `False`.
2. **SIGTERM downgrade** — on a timeout, log a warning + emit an event instead of `os.kill(SIGTERM)`.

Change (2) is what actually fixed the false-positive self-kill from #737. Once a timed-out interrupt no longer kills the process, the gate (1) has no upside left: it just makes the agent **uninterruptible for the entire lifetime of a tool call** — which can be a multi-minute `Bash` command or sub-agent. A notification arriving in that window was silently dropped until the tool returned.

This PR removes the gate so `attempt_interrupt()` always asks the SDK to interrupt. The SDK services the request at its next yield point, and a timeout (during a tool or otherwise) just logs a warning — no SIGTERM. The diagnostics watchdog (#753) remains the sole owner of the genuinely-stuck-idle SIGTERM path.

## Changes
- `agent/core/client.py`: drop the `if state.active_tools: return False` early-out; reword the timeout comment/message which no longer need the "no tool in flight" qualifier.
- `agent/tests/test_interrupts.py`: replace `test_attempt_interrupt_skips_while_tool_in_flight` (asserted the interrupt was *not* called during a tool) with `test_attempt_interrupt_fires_while_tool_in_flight` (asserts it *is* called); trim the stale "no tool in flight" wording from the timeout test.

## Test plan
- [x] `uv run pytest tests/test_interrupts.py` — 16 passed
- [x] `ruff check` / `ruff format --check` / `ty check` clean
- [ ] CI green

## Refs
- Reverts the tool-in-flight gate from #758
- Related: #737 (interrupt-timeout SIGTERM), #753 (diagnostics watchdog owns the idle-hang SIGTERM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)