### PR TITLE
feat(cli,app): toggle vestad auto-update from the CLI and app settings

### DIFF
--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -62,12 +62,14 @@ export function SettingsDialog({
     gatewayVersion,
     gatewayBranch,
     gatewayChannel,
+    gatewayAutoUpdate,
     updateAvailable,
     checkForUpdate,
   } = useGateway();
   const [checking, setChecking] = useState(false);
   const [showLogs, setShowLogs] = useState(false);
   const [channelSaving, setChannelSaving] = useState(false);
+  const [autoUpdateSaving, setAutoUpdateSaving] = useState(false);
 
   const onToggleBeta = async (enabled: boolean) => {
     setChannelSaving(true);
@@ -85,6 +87,23 @@ export function SettingsDialog({
       console.warn("[settings] failed to set release channel:", err);
     } finally {
       setChannelSaving(false);
+    }
+  };
+
+  const onToggleAutoUpdate = async (enabled: boolean) => {
+    setAutoUpdateSaving(true);
+    try {
+      await apiJson("/settings/auto-update", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ auto_update: enabled }),
+      });
+      // Re-read so the toggle reflects the daemon's persisted value.
+      await checkForUpdate();
+    } catch (err) {
+      console.warn("[settings] failed to set auto-update:", err);
+    } finally {
+      setAutoUpdateSaving(false);
     }
   };
 
@@ -275,6 +294,26 @@ export function SettingsDialog({
                   checked={gatewayChannel === "beta"}
                   disabled={channelSaving}
                   onCheckedChange={onToggleBeta}
+                />
+              </Field>
+            )}
+            {reachable && (
+              <Field
+                orientation="horizontal"
+                className="mt-3 items-center justify-between"
+              >
+                <FieldContent>
+                  <FieldLabel className="text-sm">automatic updates</FieldLabel>
+                  <FieldDescription>
+                    apply new releases automatically in the background;
+                    switching off keeps you on the current version until you
+                    update manually
+                  </FieldDescription>
+                </FieldContent>
+                <Switch
+                  checked={gatewayAutoUpdate}
+                  disabled={autoUpdateSaving}
+                  onCheckedChange={onToggleAutoUpdate}
                 />
               </Field>
             )}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -74,4 +74,5 @@ export interface GatewayVersionInfo {
   update_available: boolean | null;
   branch?: string | null;
   channel?: ReleaseChannel;
+  auto_update?: boolean;
 }

--- a/apps/web/src/lib/vestad-api-fixtures.ts
+++ b/apps/web/src/lib/vestad-api-fixtures.ts
@@ -97,6 +97,7 @@ export const vestadApiFixtures = {
   },
   "version": {
     "api_compat": "0.2",
+    "auto_update": true,
     "channel": "stable",
     "dev_mode": false,
     "latest_version": "0.1.1",

--- a/apps/web/src/providers/GatewayProvider/index.tsx
+++ b/apps/web/src/providers/GatewayProvider/index.tsx
@@ -65,6 +65,7 @@ interface GatewayContextValue {
   gatewayVersion: string;
   gatewayBranch: string | null;
   gatewayChannel: ReleaseChannel;
+  gatewayAutoUpdate: boolean;
   gatewayPort: number;
   versionChecked: boolean;
   updateAvailable: boolean;
@@ -84,6 +85,7 @@ const disconnectedValue: GatewayContextValue = {
   gatewayVersion: "",
   gatewayBranch: null,
   gatewayChannel: "stable",
+  gatewayAutoUpdate: true,
   gatewayPort: 0,
   versionChecked: true,
   updateAvailable: false,
@@ -110,6 +112,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
   const [gatewayBranch, setGatewayBranch] = useState<string | null>(null);
   const [gatewayChannel, setGatewayChannel] =
     useState<ReleaseChannel>("stable");
+  const [gatewayAutoUpdate, setGatewayAutoUpdate] = useState(true);
   const [gatewayPort, setGatewayPort] = useState(0);
 
   const [versionChecked, setVersionChecked] = useState(false);
@@ -147,6 +150,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
       setUpdateAvailable(!!data.update_available);
       setLatestVersion(data.latest_version ?? null);
       setGatewayChannel(data.channel ?? "stable");
+      setGatewayAutoUpdate(data.auto_update ?? true);
     } catch (err) {
       console.warn("[gateway] update check request failed:", err);
     }
@@ -179,6 +183,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
         setGatewayVersion(data.version);
         setGatewayBranch(data.branch ?? null);
         setGatewayChannel(data.channel ?? "stable");
+        setGatewayAutoUpdate(data.auto_update ?? true);
         setUpdateAvailable(!!data.update_available);
         setLatestVersion(data.latest_version ?? null);
         setVersionChecked(true);
@@ -262,6 +267,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
       setUpdateAvailable(!!data.update_available);
       setLatestVersion(data.latest_version ?? null);
       setGatewayChannel(data.channel ?? "stable");
+      setGatewayAutoUpdate(data.auto_update ?? true);
     };
 
     const timer = setInterval(pollVersion, VERSION_POLL_MS);
@@ -305,6 +311,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
         gatewayVersion,
         gatewayBranch,
         gatewayChannel,
+        gatewayAutoUpdate,
         gatewayPort,
         versionChecked,
         updateAvailable,

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -395,6 +395,24 @@ impl Client {
         }
     }
 
+    pub fn get_auto_update(&self) -> Result<bool, String> {
+        let resp = self.get("/settings/auto-update")?;
+        let value: serde_json::Value = read_json(resp)?;
+        match value.get("auto_update").and_then(|v| v.as_bool()) {
+            Some(enabled) => Ok(enabled),
+            None => Err("response missing auto_update".into()),
+        }
+    }
+
+    pub fn set_auto_update(&self, enabled: bool) -> Result<bool, String> {
+        let resp = self.put_json("/settings/auto-update", &serde_json::json!({ "auto_update": enabled }))?;
+        let value: serde_json::Value = read_json(resp)?;
+        match value.get("auto_update").and_then(|v| v.as_bool()) {
+            Some(enabled) => Ok(enabled),
+            None => Err("response missing auto_update".into()),
+        }
+    }
+
     pub fn list_agents(&self) -> Result<Vec<ListEntry>, String> {
         let resp = self.get("/agents")?;
         read_json(resp)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -226,6 +226,11 @@ enum Command {
         /// Channel to switch to: stable or beta. Omit to show the current channel.
         channel: Option<String>,
     },
+    /// Show or set whether vestad applies updates automatically
+    AutoUpdate {
+        /// Set to "on" or "off" (omit to show current status)
+        toggle: Option<Toggle>,
+    },
     /// Uninstall vesta CLI and remove config
     Uninstall,
     /// Print version information
@@ -1420,6 +1425,21 @@ fn run(cli: Cli) {
                 None => {
                     let current = c.get_channel().unwrap_or_else(|e| platform::die(&e));
                     println!("{current}");
+                }
+            }
+        }
+
+        Command::AutoUpdate { toggle } => {
+            let c = get_client(host_ref, token_ref);
+            match toggle {
+                Some(toggle) => {
+                    let enabled = matches!(toggle, Toggle::On);
+                    let set = c.set_auto_update(enabled).unwrap_or_else(|e| platform::die(&e));
+                    eprintln!("auto-update: {}", if set { "enabled" } else { "disabled" });
+                }
+                None => {
+                    let enabled = c.get_auto_update().unwrap_or_else(|e| platform::die(&e));
+                    eprintln!("auto-update: {}", if enabled { "enabled" } else { "disabled" });
                 }
             }
         }

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2688,6 +2688,7 @@ mod tests {
             "update_available": true,
             "dev_mode": false,
             "channel": "stable",
+            "auto_update": true,
         });
 
         serde_json::json!({


### PR DESCRIPTION
## What

Adds a first-class way to enable/disable vestad's automatic updates, from both the CLI and the app — no more hand-editing `settings.json` or curling the API.

- **CLI**: `vesta auto-update [on|off]` (omit the arg to print current status). Mirrors `vesta channel` and reuses the existing `AutoBackup` `Toggle` (On/Off) enum.
- **App**: an "automatic updates" switch in **Settings → Connection**, right beside the existing beta-releases toggle.

## Why

The `auto_update` flag is already a persisted vestad setting with `GET`/`PUT /settings/auto-update` endpoints (default on, checked every 6h), and `/version` already reports it — but neither client exposed a control for it. This wires the existing backend through to the surfaces users actually touch.

## How it works

- No daemon behavior changes. The endpoints and the `/version` `auto_update` field already existed.
- CLI: new `get_auto_update`/`set_auto_update` client methods + an `AutoUpdate` command.
- App: `auto_update` is threaded through `GatewayProvider` (from `/version`, `/version/check`, and the 60s poll) and exposed as `gatewayAutoUpdate`; the Settings toggle PUTs the setting and re-reads to reflect the persisted value. Field defaults to `true` when absent, matching vestad's default-on semantics.
- The Rust API-contract fixture generator (`serve.rs`) now includes `auto_update`, keeping the generated `vestad-api-fixtures.ts` in sync with `version_json()` so the web type check stays honest.

## Testing

`./check.sh cli`, `./check.sh web`, and `./check.sh vestad` all pass locally (clippy `-D warnings`, tsc, vitest, prettier, and the API contract test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)