### PR TITLE
fix(agent): One unreadable entry in ~/agent/notifications silently and permanently kills monitor_loop (notifications, proactive checks, nightly dreamer)

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -34,7 +34,16 @@ def _now() -> dt.datetime:
 def _load_notification_files(directory: pl.Path) -> list[tuple[pl.Path, str]]:
     if not directory.exists():
         return []
-    return [(f, f.read_text(encoding="utf-8")) for f in sorted(directory.glob("*.json"))]
+    results = []
+    for f in sorted(directory.glob("*.json")):
+        if not f.is_file():
+            logger.warning(f"skipping non-file notification entry {f.name}")
+            continue
+        try:
+            results.append((f, f.read_text(encoding="utf-8")))
+        except (OSError, UnicodeDecodeError) as e:
+            logger.error(f"skipping unreadable notification {f.name}: {e}")
+    return results
 
 
 def drop_core_notification(*, type_: str, body: str, interrupt: bool, config: vm.VestaConfig, name: str | None = None) -> pl.Path:

--- a/agent/tests/test_notification_unreadable_entry.py
+++ b/agent/tests/test_notification_unreadable_entry.py
@@ -1,0 +1,29 @@
+"""Prove that a directory named *.json inside notifications_dir kills load_notifications.
+
+The bug: _load_notification_files calls f.read_text() inside a list comprehension with no
+error handling.  load_notifications only catches json/pydantic parse errors, not OSError.
+A directory entry named foo.json raises IsADirectoryError, which propagates uncaught.
+The correct behavior is that the bad entry is skipped and an empty list is returned.
+"""
+
+import pytest
+import core.models as vm
+from core.loops import load_notifications
+
+
+@pytest.mark.anyio
+async def test_directory_named_dot_json_is_skipped_not_fatal(tmp_path):
+    """A *.json directory entry should be skipped; load_notifications must not raise."""
+    agent_dir = tmp_path / "agent"
+    notifs_dir = agent_dir / "notifications"
+    notifs_dir.mkdir(parents=True)
+
+    # Create a directory (not a file) named foo.json — reproduced exactly as described.
+    bad_entry = notifs_dir / "foo.json"
+    bad_entry.mkdir()
+
+    config = vm.VestaConfig(agent_dir=agent_dir)
+
+    # Bug: raises IsADirectoryError instead of returning [] and skipping the bad entry.
+    result = await load_notifications(config=config)
+    assert result == []


### PR DESCRIPTION
## Bug

`_load_notification_files` (loops.py) called `f.read_text(encoding="utf-8")` inside a list comprehension over `directory.glob("*.json")` with no error handling. The surrounding `load_notifications` only caught `json.JSONDecodeError`, `ValidationError`, `KeyError`, and `TypeError` at the parse step, so any read error propagated uncaught into `monitor_loop`.

## Root cause

Three failure modes all hit the same missing guard:

- `IsADirectoryError`: a directory whose name ends in `.json` inside `~/agent/notifications/` (the agent itself has full shell access, external channel writers can do this accidentally).
- `FileNotFoundError`: a writer deletes the file between the `glob` and the `read_text` call (TOCTOU).
- `UnicodeDecodeError`: a non-atomic writer truncated mid-multibyte character leaves a corrupt file on disk.

`monitor_loop` is created via `create_task` in `main.py` with no done callback, so the task dies silently. Because the corrupt entry stays on disk it crashes again on every subsequent boot. The agent becomes permanently deaf to notifications, proactive checks, and the nightly dreamer until a human removes the entry.

## Trigger

Create a directory (or any unreadable or invalid-UTF-8 file) named `foo.json` inside `~/agent/notifications`, then wait one monitor tick. `load_notifications` raises, `monitor_loop` dies silently, and all subsequent notifications and dreamer runs are ignored across restarts.

## Fix

`_load_notification_files` now iterates with an explicit loop instead of a list comprehension. Each entry is skipped with a warning log if `f.is_file()` is false (handles directories and other non-regular-file entries), and any `OSError` or `UnicodeDecodeError` raised by `f.read_text` is caught and logged per-entry so one bad file can never take down the whole loop.

## Tests

`agent/tests/test_notification_unreadable_entry.py` reproduces the exact `IsADirectoryError` trigger (a directory named `foo.json`) and asserts `load_notifications` returns an empty list without raising.

Fixes #

🤖 Generated with [Claude Code](https://claude.ai/claude-code)