### PR TITLE
docs(readme): bridge to hosted, sharpen the bullets, name the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 A personal AI agent that lives in a Docker container, powered by Claude.
 
+Don't want to run a server? [vesta.run](https://vesta.run) hosts one for you. Invite-only.
+
 ## Why Vesta
 
 - **Opinionated and easy to set up.** One command to install, one command to start. No gateway, no infrastructure to manage.
-- **Bitter lesson pilled.** Nothing is hardcoded. Every way Vesta reaches the world (messaging, email, calendars) is just a skill it can read and rewrite. It can even edit its own code: by default it stays in sync with official updates, but you can let it fully rewrite itself.
-- **Self-improving.** Vesta has a powerful self-improvement core. It can edit its own source code, write new skills, and fix its own bugs.
+- **Self-improving.** Every way Vesta reaches the world (messaging, email, calendars) is a skill it can read and rewrite. It can edit its own source code, write new skills, and fix its own bugs: by default it stays in sync with official updates, but you can let it fully rewrite itself.
 - **1 agent = 1 container.** The Docker container is the state. No external databases, no config drift. Back up the container, restore the container.
 - **Agentic bidirectional sync.** Vesta instances can evolve and diverge from the source. Syncing is semantic; the agent understands what changed and why, and merges upstream updates or contributes patches back intelligently.
-- **Self-proliferating.** A Vesta can encourage and help other users onboard and create their own Vestas.
+- **Spreads by invitation.** Your Vesta can walk your friends through getting their own.
 - **Secure by default.** You write a constitution that Vesta must follow and can never edit, so your rules always hold. A security layer that screens for prompt-injection attacks and can only be overridden by you is on the roadmap.
 - **Built on Claude's own harness.** Benefits from Anthropic RL-maxing their models on it.
 


### PR DESCRIPTION
## Funnel leak

GitHub is the only crawlable surface for new users. Three gaps were costing conversions:

1. No hosted option visible above the fold. Anyone without a Linux server was silently excluded. A single sentence now bridges them to vesta.run before they hit the prerequisites section.

2. Two overlapping bullets ("Bitter lesson pilled" + "Self-improving") described the same capability with in-group jargon. Merged into one plain-English bullet that leads with the concrete benefit: skills are readable and rewritable, the agent can edit its own source, and it stays in sync by default but can fully diverge.

3. The viral-growth bullet used growth-hacker vocabulary ("self-proliferating", "encourage and help other users onboard"). Renamed to plain English: "Spreads by invitation. Your Vesta can walk your friends through getting their own."

4. Repo description and homepage were empty, invisible to search engines and the GitHub explore page. Updated via `gh repo edit` alongside this PR.

All changes are README.md only (markdown/prose). No code, no tests, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)