### PR TITLE
feat(onboard): say the guarantee at the link, send links that resolve

### DIFF
--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -84,10 +84,12 @@ and links between them and the CLI.
    (`onboard presets` for personalities + skills)? Agree the monthly price (see
    **Pricing**).
 4. **Send the Stripe link.** `onboard checkout --email <e> [--price <usd>] [--code
-   <code>]` → `{ url, subdomain }`. Send the `url` verbatim and **stop**. Never ask
-   for card numbers; Stripe collects payment on their device, and they tick the
-   terms box right there (share `onboard links` → `terms`/`privacy` if asked). The
-   subdomain is assigned for them.
+   <code>]` → `{ url, subdomain }`. Send the `url` verbatim and **stop**. If they
+   hesitate at the link, the guarantee is real and worth saying: first 7 days, full
+   refund, no questions. They risk nothing by trying. Never ask for card numbers;
+   Stripe collects payment on their device, and they tick the terms box right there
+   (share `onboard links` → `terms`/`privacy` if asked). The subdomain is assigned
+   for them.
 5. **Wait for the box.** Poll `onboard status --email <e>` until `status` is
    `active` (a minute or two after they pay).
 6. **Create their agent.** `onboard create-agent --email <e> --name <name>

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -46,10 +46,7 @@ PERSONALITY_PRESETS = ("chill", "classic", "dry", "extra", "polished", "terse")
 LINKS = {
     "marketing": "https://vesta.run",
     "account": "https://vesta.run/account",
-    "download": "https://vesta.run/download",
-    "ios": "https://vesta.run/download#ios",
-    "android": "https://vesta.run/download#android",
-    "desktop": "https://vesta.run/download#desktop",
+    "download": "https://github.com/elyxlz/vesta/releases/latest",
     "terms": "https://vesta.run/legal/terms",
     "privacy": "https://vesta.run/legal/privacy",
 }


### PR DESCRIPTION
## Funnel leaks fixed

Two closing-step gaps in the onboard skill:

**1. The guarantee was real but unsaid.** When a prospect hesitates at the Stripe link, the agent had no instruction to surface the 7-day full-refund guarantee (terms clause 6). Hesitation at the payment page is a predictable moment of friction; the right move is to say the thing that removes risk. Step 4 now tells the agent: if they hesitate, the guarantee is real and worth saying. One sentence, zero pushiness.

**2. The download link 404'd.** `onboard links` returned `https://vesta.run/download` for `download`, plus ios/android/desktop anchor variants on the same base. That route does not exist in the vesta-cloud SPA router (`src/router.tsx` has no `/download` path), so every fresh member who followed the link landed on the RouteErrorBoundary. Fixed to `https://github.com/elyxlz/vesta/releases/latest`, which resolves today. The platform-specific anchor keys are dropped until store listings exist; the agent can only send links that work.

## Changes

- `agent/skills/onboard/SKILL.md`: one line added to step 4 with the guarantee hint
- `agent/skills/onboard/cli/src/onboard_cli/config.py`: `download` URL corrected; `ios`/`android`/`desktop` keys removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)