### PR TITLE
fix(agent): cc_sdk interrupt()'s non-atomic guard/credit over-credits _stops_received: a racing Stop hook (or concurrent/cancelled interrupt) silently swallows the next turn's response

### DIFF
--- a/agent/core/cc_sdk/client.py
+++ b/agent/core/cc_sdk/client.py
@@ -141,6 +141,7 @@ class ClaudeSDKClient:
         self._turn_index = 0
         self._stops_received = 0
         self._turn_started = 0.0
+        self._interrupt_lock = asyncio.Lock()
         self._last_usage: dict[str, tp.Any] | None = None
         self._exit_code: int | None = None
         self._stderr_read = 0
@@ -223,6 +224,13 @@ class ClaudeSDKClient:
         else:
             self._offset = 0
         self._turn_index += 1
+        # Clamp stops_received so it cannot pre-satisfy the new turn's threshold.
+        # interrupt() credits stops_received = turn_index, but a late Stop hook can
+        # still arrive in the 50-200ms window and push it one higher. Clamping here
+        # restores the invariant (stops_received < turn_index) before receive_response()
+        # runs, so the new turn always waits for its own Stop rather than being satisfied
+        # instantly by an over-credited count from the previous turn.
+        self._stops_received = min(self._stops_received, self._turn_index - 1)
         self._turn_started = time.monotonic()
         await tmux.submit_text(self._tmux_socket, self._tmux_session, prompt)
 
@@ -243,19 +251,27 @@ class ClaudeSDKClient:
             await asyncio.sleep(_POLL_S)
 
     async def interrupt(self) -> None:
-        # Skip if the current turn already completed: at idle, Escapes don't interrupt
-        # anything and a double-Escape opens the TUI's rewind dialog instead.
-        if self._stops_received >= self._turn_index:
-            return
-        # A single ESC byte never registers: the TUI's escape-sequence parser buffers it
-        # waiting for a follow-up byte that never comes (verified against claude v2.1.159,
-        # where a lone Escape let generation run to completion). Sending Escape twice
-        # flushes the first as a real Escape keypress and reliably interrupts.
-        await tmux.send_double_escape(self._tmux_socket, self._tmux_session)
-        # An interrupted turn never fires its Stop hook (verified: no late Stop arrives
-        # either), so account for the abandoned turn here. Without this, every turn after
-        # an interrupt waits for a Stop count that can never be reached and hangs.
-        self._stops_received = max(self._stops_received, self._turn_index)
+        # The lock serialises concurrent callers (monitor-loop vs processor) so the guard
+        # and credit are atomic: a second caller sees the updated stops_received after the
+        # first credits, rather than both passing the guard and sending four Escapes.
+        async with self._interrupt_lock:
+            # Skip if the current turn already completed: at idle, Escapes don't interrupt
+            # anything and a double-Escape opens the TUI's rewind dialog instead.
+            if self._stops_received >= self._turn_index:
+                return
+            # A single ESC byte never registers: the TUI's escape-sequence parser buffers it
+            # waiting for a follow-up byte that never comes (verified against claude v2.1.159,
+            # where a lone Escape let generation run to completion). Sending Escape twice
+            # flushes the first as a real Escape keypress and reliably interrupts.
+            try:
+                await tmux.send_double_escape(self._tmux_socket, self._tmux_session)
+            finally:
+                # Credit in finally so a cancelled send_double_escape still accounts for the
+                # abandoned turn and doesn't wedge receive_response until response_timeout.
+                # An interrupted turn never fires its Stop hook, so account for the abandoned
+                # turn here. Without this, every turn after an interrupt waits for a Stop
+                # count that can never be reached and hangs.
+                self._stops_received = max(self._stops_received, self._turn_index)
 
     async def get_context_usage(self) -> dict[str, tp.Any]:
         usage = self._last_usage or {}
@@ -332,7 +348,10 @@ class ClaudeSDKClient:
             self._ready.set()
 
         async def on_stop(payload: dict[str, tp.Any]) -> None:
-            self._stops_received += 1
+            # Clamp to turn_index: interrupt() already credits stops_received up to turn_index
+            # when it fires, so a late Stop that arrives in the 50-200ms window after interrupt()
+            # must not increment past the current turn's threshold and pre-satisfy the next turn.
+            self._stops_received = min(self._stops_received + 1, self._turn_index)
 
         async def on_precompact(payload: dict[str, tp.Any]) -> None:
             self._compaction_started.set()

--- a/agent/tests/test_stop_race.py
+++ b/agent/tests/test_stop_race.py
@@ -1,0 +1,125 @@
+"""Prove the interrupt()/Stop-hook race that over-credits _stops_received.
+
+Bug: interrupt() fires while the Stop hook subprocess is still in flight (50-200ms
+window). It sees _stops_received < _turn_index, sends double-Escape, and sets
+_stops_received = _turn_index. When the real Stop arrives moments later, on_stop
+increments again: _stops_received = _turn_index + 1. The next query() bumps
+_turn_index by one, so receive_response() immediately sees _stops_received >= threshold
+and returns a bare ResultMessage — the entire response for that turn is silently
+swallowed.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from core.cc_sdk.client import ClaudeSDKClient
+from core.cc_sdk.messages import AssistantMessage, ClaudeAgentOptions
+
+
+def _make_client(transcript_path=None):
+    options = ClaudeAgentOptions()
+    client = ClaudeSDKClient(options=options)
+    if transcript_path is not None:
+        client._transcript_path = transcript_path
+        client._offset = 0
+    return client
+
+
+def _write_assistant_line(path, text: str) -> None:
+    obj = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": text}],
+        },
+        "session_id": "test-session",
+    }
+    with path.open("a") as f:
+        f.write(json.dumps(obj) + "\n")
+
+
+@pytest.mark.anyio
+async def test_interrupt_racing_stop_hook_next_turn_is_not_pre_satisfied(tmp_path):
+    """After interrupt() races a Stop-hook delivery, the next turn must start with
+    _stops_received < _turn_index so that receive_response() actually waits for the
+    real response. This test asserts the correct invariant and FAILS because the
+    race leaves _stops_received == _turn_index (pre-satisfied), causing the response
+    to be silently swallowed.
+    """
+    transcript = tmp_path / "turn.jsonl"
+    transcript.write_text("")
+    client = _make_client(transcript)
+
+    # Turn 1 in progress: turn_index=1, stops_received=0 (Stop subprocess in-flight).
+    client._turn_index = 1
+    client._stops_received = 0
+
+    # interrupt() fires before Stop hook delivers.
+    with patch("core.cc_sdk.client.tmux.send_double_escape", new=AsyncMock()):
+        await client.interrupt()
+
+    # The real Stop hook now arrives (the subprocess was already in-flight).
+    # This is the on_stop handler: _stops_received += 1.
+    client._stops_received += 1  # late Stop delivery
+
+    # Turn 2 starts.
+    with patch("core.cc_sdk.client.tmux.submit_text", new=AsyncMock()):
+        await client.query("hello, turn 2")
+
+    # CORRECT invariant: a freshly-started turn that has not yet completed must have
+    # _stops_received < _turn_index, so receive_response() waits for real content.
+    # BUG: the race leaves stops_received == turn_index == 2 (pre-satisfied), so
+    # receive_response() returns immediately without any response.
+    assert client._stops_received < client._turn_index, (
+        f"BUG: _stops_received ({client._stops_received}) >= _turn_index ({client._turn_index}) "
+        "immediately after starting turn 2 — receive_response() will exit without waiting "
+        "for the real response (turn-2 response is silently swallowed)"
+    )
+
+
+@pytest.mark.anyio
+async def test_interrupt_racing_stop_swallows_next_turn_response(tmp_path):
+    """After the race, receive_response() for turn 2 must yield the actual response
+    content. This test asserts that and FAILS because the over-credited stop causes
+    receive_response() to exit in ~0.2 s (post-stop drain with 2 empty polls), before
+    the 0.5 s delayed response arrives.
+    """
+    transcript = tmp_path / "turn.jsonl"
+    transcript.write_text("")
+    client = _make_client(transcript)
+
+    # Reproduce the race.
+    client._turn_index = 1
+    client._stops_received = 0
+
+    with patch("core.cc_sdk.client.tmux.send_double_escape", new=AsyncMock()):
+        await client.interrupt()
+    client._stops_received += 1  # late Stop delivery
+
+    with patch("core.cc_sdk.client.tmux.submit_text", new=AsyncMock()):
+        await client.query("hello, turn 2")
+
+    # Simulate the TUI generating the turn-2 response with a 0.5 s delay.
+    # Without the bug, receive_response() would wait for this content; with the bug
+    # it exits after ~0.2 s (2 empty polls * 0.1 s each) and misses the content.
+    async def write_response_after_delay():
+        await asyncio.sleep(0.5)
+        _write_assistant_line(transcript, "turn-2 response content")
+        # The Stop hook for turn 2 arrives after the response is written.
+        client._stops_received += 1
+
+    asyncio.create_task(write_response_after_delay())
+
+    collected: list[object] = []
+    async for msg in client.receive_response():
+        collected.append(msg)
+
+    content_messages = [m for m in collected if isinstance(m, AssistantMessage)]
+
+    # A correctly-behaving receive_response() would have waited and yielded this.
+    # With the bug it returns early and the content is never consumed.
+    assert len(content_messages) == 1, (
+        f"BUG: turn-2 response was swallowed — expected 1 AssistantMessage, got: {content_messages}. Collected: {collected}"
+    )


### PR DESCRIPTION
## Bug

`interrupt()` checks `_stops_received >= _turn_index` as an idle guard and credits `_stops_received = max(stops, turn_index)` after sending the double Escape, but the Stop hook is a subprocess that takes 50-200ms to reach the bridge. In the in-flight window, interrupt() fires, credits stops to turn_index, and then the real Stop arrives and on_stop increments again: `stops_received = turn_index + 1`. The next `query()` bumps `turn_index` by one, so `receive_response()` immediately sees `stops_received >= threshold` and returns a bare `ResultMessage` without waiting. The next user turn's entire response is silently swallowed.

Two related failure modes share the same check-then-act root cause: (1) two concurrent `interrupt()` callers both pass the guard before either credits, sending four Escapes; (2) cancellation of `attempt_interrupt`'s `asyncio.wait_for` between the escape and the credit loses the Stop credit, wedging `receive_response` until the 600s response timeout.

## Root cause

Three non-atomic gaps in the interrupt/Stop accounting:
- `on_stop` increments `_stops_received` unconditionally, so a late Stop after `interrupt()` already credited the count pushes it past `_turn_index`.
- `interrupt()`'s guard and credit are separated by an `await`, allowing concurrent callers to both pass the guard.
- The credit is not in a `finally`, so a cancelled `send_double_escape` loses it.

## Trigger

A turn finishes generating. Before the Stop hook subprocess delivers its payload (~50-200ms window) an interrupt arrives: an interrupt-flagged notification, the WS stop button, or a queued message while `converse` polls for the Stop. On a daemon processing notifications around the clock this window is hit eventually and the failure is silent.

## Fix

Three minimal changes to `agent/core/cc_sdk/client.py`:

1. `query()` clamps `_stops_received = min(_stops_received, _turn_index - 1)` immediately after incrementing `_turn_index`. This restores the invariant `stops_received < turn_index` at each turn start regardless of how many stray Stops or double-credits accumulated during the prior turn.

2. `on_stop` uses `min(stops + 1, turn_index)` so a late Stop that arrives after `interrupt()` already credited cannot push the count past the current turn's threshold.

3. `interrupt()` wraps its guard, escape, and credit in an `asyncio.Lock` with the credit in `finally`: concurrent callers no-op on the guard after the first credits, and a cancelled escape still accounts for the abandoned turn.

## Tests

`agent/tests/test_stop_race.py` ships two behavioral tests that were failing before this fix:
- `test_interrupt_racing_stop_hook_next_turn_is_not_pre_satisfied`: asserts `_stops_received < _turn_index` immediately after `query()` when a late Stop arrived between `interrupt()` and `query()`.
- `test_interrupt_racing_stop_swallows_next_turn_response`: asserts `receive_response()` actually yields the turn-2 `AssistantMessage` rather than returning an instant empty `ResultMessage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)