### PR TITLE
fix(agent): Message arriving during the dreamer's compact-then-restart window is silently lost: file deleted at enqueue, in-memory queue dies with the process

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -102,10 +102,18 @@ async def load_new_notifications(*, state: vm.State, config: vm.VestaConfig) -> 
     return notifications
 
 
+def _delete_paths(file_paths: list[str]) -> None:
+    for path_str in file_paths:
+        pl.Path(path_str).unlink(missing_ok=True)
+
+
 async def process_batch(
-    notifications: list[vm.Notification], *, queue: asyncio.Queue[tuple[str, bool]], state: vm.State, config: vm.VestaConfig
+    notifications: list[vm.Notification], *, queue: asyncio.Queue[tuple[str, bool, list[str]]], state: vm.State, config: vm.VestaConfig
 ) -> None:
-    """Render a batch as one prompt and queue it. Internal (`source=core`) notifications skip the external-message suffix; mixed batches render in two sections, system first."""
+    """Render a batch as one prompt and queue it. Internal (`source=core`) notifications skip the external-message suffix; mixed batches render in two sections, system first.
+
+    File paths are carried in the queue item and deleted only after the message is processed,
+    so that a mid-compaction restart can recover unprocessed notifications from disk."""
     if not notifications:
         return
 
@@ -116,12 +124,12 @@ async def process_batch(
     external = [n for n in notifications if n.source != CORE_SOURCE]
 
     if system:
-        await queue.put((format_notification_batch(system, suffix=""), False))
+        system_paths = [n.file_path for n in system if n.file_path]
+        await queue.put((format_notification_batch(system, suffix=""), False, system_paths))
     if external:
         suffix = load_prompt("notification_suffix", config) or ""
-        await queue.put((format_notification_batch(external, suffix=suffix), False))
-
-    await delete_notification_files(notifications)
+        external_paths = [n.file_path for n in external if n.file_path]
+        await queue.put((format_notification_batch(external, suffix=suffix), False, external_paths))
 
 
 def drop_greeting_notification(*, config: vm.VestaConfig, state: vm.State, reason: str) -> bool:
@@ -161,7 +169,13 @@ def drop_greeting_notification(*, config: vm.VestaConfig, state: vm.State, reaso
 
 
 async def _run_messages_with_interrupts(
-    msg: str, *, is_user: bool, queue: asyncio.Queue[tuple[str, bool]], state: vm.State, config: vm.VestaConfig
+    msg: str,
+    *,
+    is_user: bool,
+    file_paths: list[str],
+    queue: asyncio.Queue[tuple[str, bool, list[str]]],
+    state: vm.State,
+    config: vm.VestaConfig,
 ) -> None:
     """Run a message and any follow-ups; new queue items interrupt the current turn (deferred during compaction)."""
 
@@ -202,7 +216,7 @@ async def _run_messages_with_interrupts(
         finally:
             state.event_bus.set_state("idle")
 
-    pending: collections.deque[tuple[str, bool]] = collections.deque([(msg, is_user)])
+    pending: collections.deque[tuple[str, bool, list[str]]] = collections.deque([(msg, is_user, file_paths)])
     process_task: asyncio.Task[None] | None = None
 
     try:
@@ -212,12 +226,12 @@ async def _run_messages_with_interrupts(
                     await queue.put(remaining)
                 break
 
-            current_msg, current_is_user = pending.popleft()
+            current_msg, current_is_user, current_file_paths = pending.popleft()
             state.interrupt_event = asyncio.Event()
             process_task = asyncio.create_task(run_one(current_msg, user=current_is_user))
 
             while not process_task.done():
-                queue_task: asyncio.Task[tuple[str, bool]] = asyncio.create_task(queue.get())
+                queue_task: asyncio.Task[tuple[str, bool, list[str]]] = asyncio.create_task(queue.get())
                 done, _ = await asyncio.wait({process_task, queue_task}, return_when=asyncio.FIRST_COMPLETED)
 
                 if queue_task in done:
@@ -233,6 +247,7 @@ async def _run_messages_with_interrupts(
                     await _cancel_task(queue_task)
 
             await process_task
+            _delete_paths(current_file_paths)
             process_task = None
             state.interrupt_event = None
     except asyncio.CancelledError:
@@ -265,7 +280,7 @@ async def compact_then_restart_if_requested(*, state: vm.State) -> None:
     state.graceful_shutdown.set()
 
 
-async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.State, config: vm.VestaConfig) -> None:
+async def message_processor(queue: asyncio.Queue[tuple[str, bool, list[str]]], *, state: vm.State, config: vm.VestaConfig) -> None:
     logger.client("Creating new client session...")
     if config.agent_provider == "openrouter":
         if state.openrouter_max_tokens is None:
@@ -291,13 +306,15 @@ async def message_processor(queue: asyncio.Queue[tuple[str, bool]], *, state: vm
                 try:
                     while not state.shutdown_event.is_set():
                         try:
-                            msg, is_user = await asyncio.wait_for(queue.get(), timeout=1.0)
+                            msg, is_user, file_paths = await asyncio.wait_for(queue.get(), timeout=1.0)
                         except TimeoutError:
                             continue
 
                         state.processor_busy = True
                         try:
-                            await _run_messages_with_interrupts(msg, is_user=is_user, queue=queue, state=state, config=config)
+                            await _run_messages_with_interrupts(
+                                msg, is_user=is_user, file_paths=file_paths, queue=queue, state=state, config=config
+                            )
                             await compact_then_restart_if_requested(state=state)
                         finally:
                             state.processor_busy = False
@@ -383,11 +400,14 @@ async def _notification_watcher(notify: asyncio.Event, *, notifications_dir: pl.
         bridge_task.cancel()
 
 
-async def monitor_loop(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.State, config: vm.VestaConfig) -> None:
+async def monitor_loop(queue: asyncio.Queue[tuple[str, bool, list[str]]], *, state: vm.State, config: vm.VestaConfig) -> None:
     last_proactive = _now()
     # Init one hour back so the first dreamer check runs on the first tick after boot.
     last_dreamer_check = _now() - dt.timedelta(hours=1)
     pending_passive: list[vm.Notification] = []
+    # Files sent to the queue but not yet processed (and thus not yet deleted from disk).
+    # Trimmed each tick to the paths that still exist; prevents re-queueing mid-compaction.
+    queued_paths: set[str] = set()
     notify = asyncio.Event()
 
     watcher_task = asyncio.create_task(_notification_watcher(notify, notifications_dir=config.notifications_dir, shutdown=state.shutdown_event))
@@ -417,11 +437,17 @@ async def monitor_loop(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.Stat
                 process_nightly_memory(state=state, config=config)
                 last_dreamer_check = now
 
+            # Prune paths that were processed and deleted; this is how we know a queued item
+            # completed and its file is gone, preventing unbounded set growth.
+            queued_paths = {p for p in queued_paths if pl.Path(p).exists()}
+
             notifications = await load_new_notifications(state=state, config=config)
-            interrupt_notifs = [n for n in notifications if n.interrupt]
-            # Passive files stay on disk until the batch flushes, so reloads would duplicate.
-            queued_paths = {n.file_path for n in pending_passive if n.file_path}
-            pending_passive.extend(n for n in notifications if not n.interrupt and (not n.file_path or n.file_path not in queued_paths))
+            interrupt_notifs = [n for n in notifications if n.interrupt and (not n.file_path or n.file_path not in queued_paths)]
+            queued_paths.update(n.file_path for n in interrupt_notifs if n.file_path)
+
+            new_passive = [n for n in notifications if not n.interrupt and (not n.file_path or n.file_path not in queued_paths)]
+            queued_paths.update(n.file_path for n in new_passive if n.file_path)
+            pending_passive.extend(new_passive)
 
             if interrupt_notifs:
                 await process_batch(interrupt_notifs, queue=queue, state=state, config=config)

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -26,7 +26,7 @@ from .migrations import drop_pending_migrations
 SignalHandler = tp.Callable[[int, types.FrameType | None], None]
 
 
-async def input_handler(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.State) -> None:
+async def input_handler(queue: asyncio.Queue[tuple[str, bool, list[str]]], *, state: vm.State) -> None:
     while not state.shutdown_event.is_set():
         try:
             user_msg = await aioconsole.ainput("")
@@ -36,7 +36,7 @@ async def input_handler(queue: asyncio.Queue[tuple[str, bool]], *, state: vm.Sta
                 continue
 
             logger.user(user_msg.strip())
-            await queue.put((user_msg.strip(), True))
+            await queue.put((user_msg.strip(), True, []))
         except KeyboardInterrupt:
             logger.shutdown("stdin: KeyboardInterrupt, shutting down")
             state.shutdown_event.set()
@@ -102,7 +102,7 @@ async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: boo
 
     logger.init(f"{config.agent_name.upper()} started")
 
-    message_queue: asyncio.Queue[tuple[str, bool]] = asyncio.Queue()
+    message_queue: asyncio.Queue[tuple[str, bool, list[str]]] = asyncio.Queue()
 
     drop_pending_migrations(state=state, config=config, first_start=first_start)
     greeting_reason = "first_start" if first_start else restart_reason

--- a/agent/tests/test_crash_recovery.py
+++ b/agent/tests/test_crash_recovery.py
@@ -68,7 +68,7 @@ async def test_resume_fallback_clears_session_and_retries(tmp_path):
     state.persisted.session_id = "stale-session-id-1234567890"
     state_store.save_state(state.persisted, config)
     state.shutdown_event = asyncio.Event()
-    queue: asyncio.Queue[tuple[str, bool]] = asyncio.Queue()
+    queue: asyncio.Queue[tuple[str, bool, list[str]]] = asyncio.Queue()
 
     enter_count = 0
     mock_client = MagicMock()
@@ -111,7 +111,7 @@ async def test_resume_fallback_raises_without_session(tmp_path):
     config.data_dir.mkdir(parents=True, exist_ok=True)
     state = vm.State()
     state.shutdown_event = asyncio.Event()
-    queue: asyncio.Queue[tuple[str, bool]] = asyncio.Queue()
+    queue: asyncio.Queue[tuple[str, bool, list[str]]] = asyncio.Queue()
 
     mock_client = MagicMock()
 
@@ -141,7 +141,7 @@ async def test_resume_fallback_raises_on_second_failure(tmp_path):
     state = vm.State()
     state.persisted.session_id = "stale-session-1234567890"
     state.shutdown_event = asyncio.Event()
-    queue: asyncio.Queue[tuple[str, bool]] = asyncio.Queue()
+    queue: asyncio.Queue[tuple[str, bool, list[str]]] = asyncio.Queue()
 
     mock_client = MagicMock()
 

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -1,5 +1,6 @@
 """Tests for nightly dreamer/memory scheduling."""
 
+import asyncio
 import datetime as dt
 import json
 import typing as tp
@@ -233,3 +234,60 @@ async def test_drain_restarts_even_when_compaction_fails():
 
     assert state.compacting is False
     assert state.graceful_shutdown.is_set()
+
+
+@pytest.mark.anyio
+async def test_notification_file_deleted_before_processing_is_lost_on_restart(tmp_path):
+    """BUG: A notification arriving while compaction runs is silently lost on restart.
+
+    process_batch deletes the file immediately after queue.put (loops.py line 124).
+    compact_then_restart_if_requested then calls client.compact() and sets graceful_shutdown.
+    run_vesta cancels all tasks and the in-memory asyncio.Queue is dropped with the process.
+    A restarted process finds an empty notifications dir and the message is gone with no trace.
+    """
+    from core.loops import process_batch, compact_then_restart_if_requested, load_notifications
+
+    config = _setup(tmp_path)
+    state = vm.State()
+
+    # Simulate a user notification arriving while the dreamer's compaction is running.
+    notif_file = config.notifications_dir / "user-msg.json"
+    notif = vm.Notification(
+        timestamp=dt.datetime(2025, 1, 1),
+        source="telegram",
+        type="message",
+        interrupt=True,
+        body="urgent user message",
+    )
+    notif_file.write_text(notif.model_dump_json())
+    notif.file_path = str(notif_file)
+
+    dying_queue: asyncio.Queue[tuple[str, bool, list[str]]] = asyncio.Queue()
+
+    # monitor_loop calls process_batch on the interrupt notification.
+    # process_batch queues the message and keeps the file on disk until processing completes.
+    with patch("core.loops.load_prompt", return_value=""), patch("core.loops.attempt_interrupt", new_callable=AsyncMock):
+        await process_batch([notif], queue=dying_queue, state=state, config=config)
+
+    # File is preserved on disk until after the message is fully processed (the fix).
+    assert notif_file.exists(), "process_batch must not delete the file before processing completes"
+    # Message sits in the queue waiting to be processed.
+    assert dying_queue.qsize() == 1, "message is in the queue"
+
+    # Compaction finishes: compact_then_restart_if_requested sets graceful_shutdown.
+    state.compact_then_restart = True
+    client = AsyncMock()
+    state.client = tp.cast(ClaudeSDKClient, client)
+    await compact_then_restart_if_requested(state=state)
+    assert state.graceful_shutdown.is_set(), "graceful_shutdown fires after compaction"
+
+    # The process restarts: run_vesta creates a fresh queue and init_state loads from disk.
+    # A restarted process can only recover messages that are still on disk.
+    recovered = await load_notifications(config=config)
+
+    # The file was kept on disk by process_batch, so the restarted process recovers it.
+    # The dying_queue (qsize=1) is dropped on restart, but the file provides durability.
+    assert len(recovered) == 1, (
+        f"Message queued mid-compact must survive restart (recovered {len(recovered)})."
+        f" dying_queue qsize={dying_queue.qsize()} is dropped on restart."
+    )

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -123,7 +123,7 @@ async def test_message_processor_interrupts_on_new_message(tmp_path):
     state.shutdown_event = asyncio.Event()
     queue: asyncio.Queue = asyncio.Queue()
 
-    await queue.put(("slow processing message", True))
+    await queue.put(("slow processing message", True, []))
 
     processed: list[str] = []
     original = slow_side_effect
@@ -138,7 +138,7 @@ async def test_message_processor_interrupts_on_new_message(tmp_path):
 
     async def inject_message_and_shutdown():
         await processing_started.wait()
-        await queue.put(("urgent message", True))
+        await queue.put(("urgent message", True, []))
         await interrupt_seen.wait()
         await wait_for_condition(lambda: "urgent message" in processed, message="urgent message never processed after interrupt")
         assert state.shutdown_event is not None
@@ -178,7 +178,7 @@ async def test_message_processor_sets_busy_flag_during_turn(tmp_path):
     state.shutdown_event = asyncio.Event()
     queue: asyncio.Queue = asyncio.Queue()
 
-    await queue.put(("message", True))
+    await queue.put(("message", True, []))
 
     mock_client = MagicMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -230,7 +230,7 @@ async def test_run_messages_with_interrupts_cancels_process_task(tmp_path):
 
     with patch("core.loops.process_message", hanging_process):
         interruptible_task = asyncio.create_task(
-            _run_messages_with_interrupts("test msg", is_user=True, queue=queue, state=state, config=config)
+            _run_messages_with_interrupts("test msg", is_user=True, file_paths=[], queue=queue, state=state, config=config)
         )
         await task_started.wait()
         interruptible_task.cancel()
@@ -263,9 +263,9 @@ async def test_run_messages_with_interrupts_defers_interrupt_during_compaction(t
         return (["OK"], state)
 
     with patch("core.loops.process_message", fake_process):
-        task = asyncio.create_task(_run_messages_with_interrupts("first", is_user=True, queue=queue, state=state, config=config))
+        task = asyncio.create_task(_run_messages_with_interrupts("first", is_user=True, file_paths=[], queue=queue, state=state, config=config))
         await first_started.wait()
-        await queue.put(("second", True))
+        await queue.put(("second", True, []))
         # Negative assertion: prove "second" does NOT run while compaction holds the interrupt.
         # Waiting for absence requires a real time window; this sleep is intentional.
         await asyncio.sleep(0.1)

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -327,7 +327,7 @@ async def test_process_batch_queues_prompt(tmp_path):
         await process_batch([notif], queue=queue, state=state, config=config)
 
     assert not queue.empty()
-    prompt, is_user = await queue.get()
+    prompt, is_user, file_paths = await queue.get()
     assert '<notification source="test" type="message">' in prompt
     assert is_user is False
 
@@ -343,20 +343,24 @@ async def test_process_batch_empty_is_noop():
 
 
 @pytest.mark.anyio
-async def test_process_batch_deletes_files(tmp_path):
+async def test_process_batch_keeps_files_until_processing(tmp_path):
+    """process_batch must NOT delete files at enqueue time; files stay on disk until the message
+    is fully processed so that a mid-compaction restart can recover unprocessed notifications."""
     config = vm.VestaConfig(agent_dir=tmp_path / "agent")
     config.notifications_dir.mkdir(parents=True, exist_ok=True)
     state = vm.State()
     queue: asyncio.Queue = asyncio.Queue()
 
-    f = tmp_path / "to-delete.json"
+    f = tmp_path / "to-keep.json"
     f.write_text("x")
     notif = vm.Notification(timestamp=dt.datetime(2025, 1, 1), source="t", type="m", file_path=str(f))
 
     with patch("core.loops.load_prompt", return_value=""):
         await process_batch([notif], queue=queue, state=state, config=config)
 
-    assert not f.exists(), "notification file should be deleted after processing"
+    assert f.exists(), "notification file must stay on disk until the queued message is processed"
+    _, _, file_paths = await queue.get()
+    assert str(f) in file_paths, "file path is carried in the queue item for deferred deletion"
 
 
 # --- _is_new_json ---
@@ -425,7 +429,7 @@ async def test_monitor_loop_interrupt_queued_while_not_idle(tmp_path):
         _write_notif(config.notifications_dir, "urgent", interrupt=True)
         await wait_for_condition(lambda: not queue.empty(), message="interrupt notification was never queued")
 
-        prompt, is_user = await queue.get()
+        prompt, is_user, file_paths = await queue.get()
         assert '<notification source="test" type="message">' in prompt
         assert is_user is False
         assert state.event_bus.state == "thinking", "interrupt routing must not depend on idle state"
@@ -456,14 +460,14 @@ async def test_monitor_loop_passive_held_until_idle_then_flushed_once(tmp_path):
         state.event_bus.set_state("idle")
         await wait_for_condition(lambda: not queue.empty(), message="passive batch never flushed after idle")
 
-        prompt, is_user = await queue.get()
+        prompt, is_user, file_paths = await queue.get()
         assert '<notification source="test" type="message">' in prompt
         assert is_user is False
 
-        # Exactly once: the file is deleted and nothing else lands in the queue.
-        await wait_for_condition(lambda: not path.exists(), message="flushed passive file should be deleted")
+        # Exactly once: file stays on disk (deleted only after processing), but nothing re-queues.
         await asyncio.sleep(0.05)
         assert queue.empty(), "passive batch must flush exactly once"
+        assert path.exists(), "file stays on disk until _run_messages_with_interrupts deletes it after processing"
     finally:
         await runner.aclose()
 
@@ -495,11 +499,12 @@ async def test_monitor_loop_passive_not_double_queued_across_ticks(tmp_path):
 
             state.event_bus.set_state("idle")
             await wait_for_condition(lambda: not queue.empty(), message="passive batch never flushed")
-            await wait_for_condition(lambda: not path.exists(), message="flushed file should be deleted")
             await asyncio.sleep(0.05)
 
             # Despite being observed on multiple ticks, the file produces a single queued batch.
+            # File stays on disk (deleted only after processing), but queued_paths dedup prevents re-queueing.
             assert queue.qsize() == 1, f"passive file must be queued once, got {queue.qsize()}"
+            assert path.exists(), "file stays on disk until _run_messages_with_interrupts deletes it after processing"
     finally:
         await runner.aclose()
 

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -15,7 +15,7 @@ async def _run_processor_test(
     *,
     message_side_effect,
     pre_state: vm.State | None = None,
-    initial_queue: list[tuple[str, bool]] | None = None,
+    initial_queue: list[tuple[str, bool, list[str]]] | None = None,
     extra_patches: dict | None = None,
 ):
     """Shared helper for message_processor tests."""
@@ -86,7 +86,7 @@ async def test_restarts_on_error(tmp_path):
         raise RuntimeError("Simulated SDK buffer overflow")
 
     state, session_count, messages = await _run_processor_test(
-        tmp_path, message_side_effect=side_effect, initial_queue=[("first message - will fail", True)]
+        tmp_path, message_side_effect=side_effect, initial_queue=[("first message - will fail", True, [])]
     )
     assert state.graceful_shutdown.is_set()
     assert state.persisted.last_restart_reason == "error: Simulated SDK buffer overflow"
@@ -108,7 +108,7 @@ async def test_error_path_emits_error_event_and_resets_state_idle(tmp_path):
         tmp_path,
         message_side_effect=side_effect,
         pre_state=state,
-        initial_queue=[("will crash", True)],
+        initial_queue=[("will crash", True, [])],
     )
 
     assert state.persisted.last_restart_reason == "error: kaboom in the SDK"
@@ -128,7 +128,7 @@ async def test_restarts_on_timeout(tmp_path):
         raise TimeoutError()
 
     state, session_count, messages = await _run_processor_test(
-        tmp_path, message_side_effect=side_effect, initial_queue=[("slow request", True)]
+        tmp_path, message_side_effect=side_effect, initial_queue=[("slow request", True, [])]
     )
     assert state.graceful_shutdown.is_set()
     assert state.persisted.last_restart_reason == "error: Response timed out"
@@ -258,7 +258,7 @@ async def test_cancellation_triggers_restart(tmp_path):
 
     with patch("core.loops.process_message", side_effect=cancel_side_effect):
         with pytest.raises(asyncio.CancelledError):
-            await _run_messages_with_interrupts("msg", is_user=True, queue=queue, state=state, config=config)
+            await _run_messages_with_interrupts("msg", is_user=True, file_paths=[], queue=queue, state=state, config=config)
 
     assert state.graceful_shutdown.is_set()
     assert state.persisted.last_restart_reason == "error: processing cancelled"
@@ -290,7 +290,7 @@ async def test_cancellation_during_shutdown_is_silent(tmp_path):
         task.cancel()
 
     with patch("core.loops.process_message", hang):
-        task = asyncio.create_task(_run_messages_with_interrupts("msg", is_user=True, queue=queue, state=state, config=config))
+        task = asyncio.create_task(_run_messages_with_interrupts("msg", is_user=True, file_paths=[], queue=queue, state=state, config=config))
         canceller = asyncio.create_task(shutdown_and_cancel(task))
         with pytest.raises(asyncio.CancelledError):
             await task

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -193,7 +193,7 @@ async def test_watchdog_warning_includes_pane_tail():
     client = MagicMock()
     client.is_alive = MagicMock(return_value=True)
     client.snapshot_pane = AsyncMock(return_value="\x1b[34m●\x1b[0m wedged\n❯ yeah run it\n  ⏵⏵ bypass permissions on\n")
-    state.client = client  # ty: ignore[invalid-assignment]
+    state.client = client
     stop = asyncio.Event()
     warnings: list[str] = []
 


### PR DESCRIPTION
## Bug

A notification (telegram, whatsapp, app-chat) arriving while the nightly dreamer's
compaction is running was silently lost with no trace.

## Root cause

`process_batch` deleted notification files immediately after `queue.put` (loops.py line 124).
From that point the message existed only in the in-process `asyncio.Queue`. The dreamer calls
`mark_dreamer_complete`, which sets `compact_then_restart`; after compaction finishes
`graceful_shutdown` is set, `run_vesta` cancels all tasks, and the queue is dropped with the
process. The restarted process found an empty notifications dir and the message was gone.

The same loss window applied to any graceful shutdown (restart_vesta, signal) that fired while
a notification was queued but not yet processed.

## Trigger

Nightly dream completes (mark_dreamer_complete sets compact_then_restart). During the subsequent
/compact a user message arrives via any channel. monitor_loop queues it and the old code deleted
the file. Compaction finishes, graceful restart fires, and the message is gone.

## Fix

The on-disk file is now the durable record. File paths are carried in the queue item as a
third element `(prompt, is_user, file_paths)` and deleted only after
`_run_messages_with_interrupts` finishes the message. A compact-then-restart or any graceful
shutdown now finds unprocessed messages still on disk and recovers them on next boot.

`monitor_loop` gains a persistent `queued_paths` set covering both interrupt and passive
notifications, trimmed each tick to paths that still exist on disk. This prevents
re-queueing of files that linger while their message is queued but not yet processed.

## Test

`tests/test_dreamer.py::test_notification_file_deleted_before_processing_is_lost_on_restart`
proves the fix: process_batch must not delete the file, and a fresh load_notifications call
after graceful_shutdown recovers the message from disk.

Fixes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)