### PR TITLE
fix(vestad): supervise cloudflared instead of spawning it fire-and-forget

### DIFF
--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -433,17 +433,9 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
             eprintln!("  \x1b[1;35mvestad\x1b[0m v{} \x1b[2m(user: {}, port: {})\x1b[0m", env!("CARGO_PKG_VERSION"), user, port);
             print_server_info(tunnel_url.as_deref(), &local_url, &api_key);
 
-            let tunnel_child = if tunnel_url.is_some() {
-                match tunnel::start_tunnel(&config, port).await {
-                    Ok((child, _url)) => Some(child),
-                    Err(e) => {
-                        tracing::warn!("failed to start tunnel: {e}");
-                        None
-                    }
-                }
-            } else {
-                None
-            };
+            let tunnel_supervisor = tunnel_url
+                .is_some()
+                .then(|| tunnel::supervise_tunnel(config.clone(), port));
 
             let dev_mode = cfg!(debug_assertions) || std::env::var("VESTAD_DEV").is_ok();
             serve::run_server(serve::ServerConfig {
@@ -458,8 +450,8 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
                 dev_mode,
             }).await;
 
-            if let Some(mut child) = tunnel_child {
-                child.kill().await.ok();
+            if let Some(supervisor) = tunnel_supervisor {
+                supervisor.shutdown().await;
             }
         });
 }

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -433,9 +433,16 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
             eprintln!("  \x1b[1;35mvestad\x1b[0m v{} \x1b[2m(user: {}, port: {})\x1b[0m", env!("CARGO_PKG_VERSION"), user, port);
             print_server_info(tunnel_url.as_deref(), &local_url, &api_key);
 
-            let tunnel_supervisor = tunnel_url
-                .is_some()
-                .then(|| tunnel::supervise_tunnel(config.clone(), port));
+            // Supervise whenever a tunnel is INTENDED, not only when boot-time
+            // setup succeeded: a managed box whose tunnel.json the control plane
+            // is still seeding, or a transient ensure_tunnel failure, must not
+            // leave the daemon tunnel-less until a manual restart. The supervisor
+            // re-reads tunnel.json on every respawn, so late config is picked up.
+            let tunnel_intended = tunnel_url.is_some()
+                || (!no_tunnel
+                    && (is_cloud_managed() || tunnel::get_tunnel_config(&config).is_some()));
+            let tunnel_supervisor =
+                tunnel_intended.then(|| tunnel::supervise_tunnel(config.clone(), port));
 
             let dev_mode = cfg!(debug_assertions) || std::env::var("VESTAD_DEV").is_ok();
             serve::run_server(serve::ServerConfig {

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -549,10 +549,12 @@ fn set_executable(path: &Path) -> Result<(), String> {
         .map_err(|e| format!("chmod failed: {}", e))
 }
 
+/// Spawn one cloudflared run for the configured tunnel. Returns the child and
+/// the loopback port of its metrics server (for /ready probing).
 async fn start_tunnel(
     config_dir: &Path,
     port: u16,
-) -> Result<(tokio::process::Child, String), String> {
+) -> Result<(tokio::process::Child, u16), String> {
     let tc = get_tunnel_config(config_dir)
         .ok_or("no tunnel configured — run `vestad tunnel setup <subdomain>` first")?;
 
@@ -574,17 +576,29 @@ async fn start_tunnel(
     std::fs::write(&cf_config_path, &cf_config)
         .map_err(|e| format!("failed to write cloudflared config: {}", e))?;
 
+    // Loopback metrics server: exposes cloudflared's /ready endpoint, which the
+    // supervisor probes for registered edge connections. Bind-and-drop to pick a
+    // free port; if something grabs it before cloudflared does, cloudflared exits
+    // and the supervisor respawns with a fresh port.
+    let metrics_port = alloc_loopback_port()?;
+    let metrics_addr = format!("127.0.0.1:{metrics_port}");
+
     // Force HTTP/2 over TCP instead of the QUIC/UDP default. Home and laptop NAT
     // devices aggressively time out idle UDP flows, which silently drops the
     // tunnel and yields error 1033 on the next request (e.g. the first file
     // share after an idle period). TCP keeps the connection alive far longer.
     let mut child = tokio::process::Command::new(cloudflared)
         .args([
-            "tunnel", "--protocol", "http2", "--config", cf_config_path.to_str().unwrap(),
+            "tunnel", "--protocol", "http2", "--metrics", &metrics_addr,
+            "--config", cf_config_path.to_str().unwrap(),
             "run", "--token", &tc.tunnel_token,
         ])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
+        // SIGKILL the child if its handle is dropped without an explicit kill
+        // (supervisor task aborted, runtime torn down by a panic) so cloudflared
+        // is never orphaned holding the hostname.
+        .kill_on_drop(true)
         .spawn()
         .map_err(|e| format!("failed to start cloudflared: {}", e))?;
 
@@ -605,8 +619,17 @@ async fn start_tunnel(
         });
     }
 
-    let url = format!("https://{}", tc.hostname);
-    Ok((child, url))
+    Ok((child, metrics_port))
+}
+
+/// Bind-and-drop an ephemeral loopback port for cloudflared's metrics server.
+fn alloc_loopback_port() -> Result<u16, String> {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0))
+        .map_err(|e| format!("failed to allocate metrics port: {}", e))?;
+    let addr = listener
+        .local_addr()
+        .map_err(|e| format!("failed to read metrics port: {}", e))?;
+    Ok(addr.port())
 }
 
 // --- Tunnel supervision ---
@@ -616,20 +639,27 @@ async fn start_tunnel(
 // and every request to the hostname gets Cloudflare error 1033 until someone
 // restarts vestad by hand. Two failure modes, two layers:
 //   - the process exits (crash, OOM, fatal give-up) -> respawn with capped backoff
-//   - the process wedges with its edge connections dead -> a periodic probe of
-//     the public hostname THROUGH the Cloudflare edge catches it; after
-//     consecutive failures the child is killed and respawned.
+//   - the process wedges with its edge connections dead -> cloudflared's own
+//     /ready endpoint (loopback metrics port) reports no registered connection;
+//     after consecutive failures the child is killed and respawned.
+// The probe is deliberately LOCAL. Probing the public hostname through the
+// Cloudflare edge would conflate probe-path failures (host DNS/egress, an edge
+// incident) with a wedged connector and kill a healthy tunnel — dropping every
+// live session through it. /ready measures exactly the thing a restart fixes.
+// Config-level death (tunnel deleted server-side, token revoked) is NOT
+// self-healed here: cloudflared exits with the reason, which lands in
+// `vestad logs` via the stderr forwarder; recovery is `vestad connect`.
 
 const TUNNEL_RESPAWN_BASE_DELAY_SECS: u64 = 1;
 const TUNNEL_RESPAWN_MAX_DELAY_SECS: u64 = 60;
-/// Uptime past which a cloudflared run counts as healthy and the backoff resets.
+/// Uptime past which a cloudflared run counts as healthy and the backoff
+/// resets. Must exceed the worst-case probe-restart window (see the invariant
+/// test) or a born-wedged run would reset the backoff on every cycle.
 const TUNNEL_HEALTHY_UPTIME_SECS: u64 = 300;
-const EDGE_PROBE_INTERVAL_SECS: u64 = 120;
-const EDGE_PROBE_TIMEOUT_SECS: u64 = 10;
-/// Consecutive failed edge probes before cloudflared is restarted. Also bounds
-/// the restart rate when the box itself is offline (a restart then is useless
-/// but harmless: one per full probe-failure window).
-const EDGE_PROBE_MAX_FAILURES: u32 = 3;
+const READY_PROBE_INTERVAL_SECS: u64 = 30;
+const READY_PROBE_TIMEOUT_SECS: u64 = 5;
+/// Consecutive failed /ready probes before cloudflared is restarted.
+const READY_PROBE_MAX_FAILURES: u32 = 3;
 
 pub struct TunnelSupervisor {
     shutdown: tokio::sync::watch::Sender<bool>,
@@ -650,17 +680,30 @@ impl TunnelSupervisor {
 pub fn supervise_tunnel(config_dir: PathBuf, port: u16) -> TunnelSupervisor {
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
     let task = tokio::spawn(async move {
+        // One client for every probe across respawns. Build failure is
+        // near-impossible; if it happens, degrade to exit-only supervision and
+        // say so once instead of silently skipping every probe.
+        let probe_client = match reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(READY_PROBE_TIMEOUT_SECS))
+            .build()
+        {
+            Ok(client) => Some(client),
+            Err(e) => {
+                tracing::warn!("tunnel ready probe disabled, supervising exits only: {e}");
+                None
+            }
+        };
         let mut respawn_delay_secs = TUNNEL_RESPAWN_BASE_DELAY_SECS;
         loop {
             let started = tokio::time::Instant::now();
             match start_tunnel(&config_dir, port).await {
-                Ok((mut child, url)) => {
+                Ok((mut child, metrics_port)) => {
                     let reason = tokio::select! {
                         _ = shutdown_rx.changed() => {
                             child.kill().await.ok();
                             return;
                         }
-                        reason = run_until_unhealthy(&mut child, &url) => reason,
+                        reason = run_until_unhealthy(&mut child, probe_client.as_ref(), metrics_port) => reason,
                     };
                     child.kill().await.ok();
                     if started.elapsed().as_secs() >= TUNNEL_HEALTHY_UPTIME_SECS {
@@ -683,17 +726,21 @@ pub fn supervise_tunnel(config_dir: PathBuf, port: u16) -> TunnelSupervisor {
 }
 
 /// Watch one cloudflared run; returns the reason it must be replaced (process
-/// exit, or the edge probe failing EDGE_PROBE_MAX_FAILURES times in a row).
-async fn run_until_unhealthy(child: &mut tokio::process::Child, url: &str) -> String {
-    let probe_client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(EDGE_PROBE_TIMEOUT_SECS))
-        .build()
-        .ok();
-    let probe_url = format!("{url}/health");
-    let probe_interval = std::time::Duration::from_secs(EDGE_PROBE_INTERVAL_SECS);
+/// exit, or /ready failing READY_PROBE_MAX_FAILURES times in a row).
+async fn run_until_unhealthy(
+    child: &mut tokio::process::Child,
+    probe_client: Option<&reqwest::Client>,
+    metrics_port: u16,
+) -> String {
+    let probe_url = format!("http://127.0.0.1:{metrics_port}/ready");
+    let probe_interval = std::time::Duration::from_secs(READY_PROBE_INTERVAL_SECS);
     // First probe only after a full interval, so cloudflared has time to register.
     let mut probe_ticks =
         tokio::time::interval_at(tokio::time::Instant::now() + probe_interval, probe_interval);
+    // Don't burst queued ticks after a host suspend/resume: three instant
+    // probes would read as a failure streak and kill a tunnel that is still
+    // reconnecting on its own.
+    probe_ticks.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut consecutive_failures = 0u32;
     loop {
         tokio::select! {
@@ -704,7 +751,8 @@ async fn run_until_unhealthy(child: &mut tokio::process::Child, url: &str) -> St
                 };
             }
             _ = probe_ticks.tick() => {
-                let Some(client) = &probe_client else { continue };
+                let Some(client) = probe_client else { continue };
+                // /ready is 200 iff cloudflared has a registered edge connection.
                 let ok = match client.get(&probe_url).send().await {
                     Ok(resp) => resp.status().is_success(),
                     Err(_) => false,
@@ -712,10 +760,10 @@ async fn run_until_unhealthy(child: &mut tokio::process::Child, url: &str) -> St
                 let (failures, restart) = record_probe(consecutive_failures, ok);
                 consecutive_failures = failures;
                 if !ok {
-                    tracing::warn!(consecutive_failures, url = %probe_url, "tunnel edge probe failed");
+                    tracing::warn!(consecutive_failures, "tunnel ready probe failed (no registered edge connection)");
                 }
                 if restart {
-                    return format!("edge unreachable for {consecutive_failures} consecutive probes");
+                    return format!("no ready edge connection for {consecutive_failures} consecutive probes");
                 }
             }
         }
@@ -723,13 +771,13 @@ async fn run_until_unhealthy(child: &mut tokio::process::Child, url: &str) -> St
 }
 
 /// Pure probe accounting: a success clears the failure streak; a failure
-/// extends it, demanding a restart at EDGE_PROBE_MAX_FAILURES.
+/// extends it, demanding a restart at READY_PROBE_MAX_FAILURES.
 fn record_probe(consecutive_failures: u32, ok: bool) -> (u32, bool) {
     if ok {
         return (0, false);
     }
     let failures = consecutive_failures + 1;
-    (failures, failures >= EDGE_PROBE_MAX_FAILURES)
+    (failures, failures >= READY_PROBE_MAX_FAILURES)
 }
 
 fn next_respawn_delay(delay_secs: u64) -> u64 {
@@ -801,21 +849,38 @@ mod tests {
 
     #[test]
     fn probe_success_clears_the_failure_streak() {
-        assert_eq!(record_probe(EDGE_PROBE_MAX_FAILURES - 1, true), (0, false));
+        assert_eq!(record_probe(READY_PROBE_MAX_FAILURES - 1, true), (0, false));
     }
 
     #[test]
     fn probe_failures_demand_restart_only_at_threshold() {
         let mut failures = 0;
-        for expected in 1..EDGE_PROBE_MAX_FAILURES {
+        for expected in 1..READY_PROBE_MAX_FAILURES {
             let (count, restart) = record_probe(failures, false);
             assert_eq!(count, expected);
             assert!(!restart, "no restart before the threshold");
             failures = count;
         }
         let (count, restart) = record_probe(failures, false);
-        assert_eq!(count, EDGE_PROBE_MAX_FAILURES);
+        assert_eq!(count, READY_PROBE_MAX_FAILURES);
         assert!(restart, "restart at the threshold");
+    }
+
+    #[test]
+    fn probe_restart_window_stays_below_the_healthy_reset() {
+        // A born-wedged run must restart BEFORE the healthy-uptime threshold,
+        // or every probe-triggered restart would reset the backoff and the
+        // supervisor would churn at full rate forever. Worst case: one slipped
+        // interval per probe (MissedTickBehavior::Delay) plus a full timeout each.
+        let worst_case_secs = READY_PROBE_INTERVAL_SECS * (READY_PROBE_MAX_FAILURES as u64 + 1)
+            + READY_PROBE_TIMEOUT_SECS * READY_PROBE_MAX_FAILURES as u64;
+        assert!(worst_case_secs < TUNNEL_HEALTHY_UPTIME_SECS);
+    }
+
+    #[test]
+    fn alloc_loopback_port_returns_a_usable_port() {
+        let port = alloc_loopback_port().expect("allocation succeeds");
+        assert_ne!(port, 0);
     }
 }
 

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -549,7 +549,7 @@ fn set_executable(path: &Path) -> Result<(), String> {
         .map_err(|e| format!("chmod failed: {}", e))
 }
 
-pub async fn start_tunnel(
+async fn start_tunnel(
     config_dir: &Path,
     port: u16,
 ) -> Result<(tokio::process::Child, String), String> {
@@ -609,6 +609,133 @@ pub async fn start_tunnel(
     Ok((child, url))
 }
 
+// --- Tunnel supervision ---
+//
+// cloudflared is the one long-running child vestad owns, and a dead tunnel is
+// invisible from the inside: vestad stays healthy, systemd sees nothing wrong,
+// and every request to the hostname gets Cloudflare error 1033 until someone
+// restarts vestad by hand. Two failure modes, two layers:
+//   - the process exits (crash, OOM, fatal give-up) -> respawn with capped backoff
+//   - the process wedges with its edge connections dead -> a periodic probe of
+//     the public hostname THROUGH the Cloudflare edge catches it; after
+//     consecutive failures the child is killed and respawned.
+
+const TUNNEL_RESPAWN_BASE_DELAY_SECS: u64 = 1;
+const TUNNEL_RESPAWN_MAX_DELAY_SECS: u64 = 60;
+/// Uptime past which a cloudflared run counts as healthy and the backoff resets.
+const TUNNEL_HEALTHY_UPTIME_SECS: u64 = 300;
+const EDGE_PROBE_INTERVAL_SECS: u64 = 120;
+const EDGE_PROBE_TIMEOUT_SECS: u64 = 10;
+/// Consecutive failed edge probes before cloudflared is restarted. Also bounds
+/// the restart rate when the box itself is offline (a restart then is useless
+/// but harmless: one per full probe-failure window).
+const EDGE_PROBE_MAX_FAILURES: u32 = 3;
+
+pub struct TunnelSupervisor {
+    shutdown: tokio::sync::watch::Sender<bool>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl TunnelSupervisor {
+    /// Kill the current cloudflared and stop supervising (graceful shutdown).
+    pub async fn shutdown(self) {
+        self.shutdown.send(true).ok();
+        self.task.await.ok();
+    }
+}
+
+/// Spawn cloudflared and keep it alive until `shutdown()`: respawn on exit or
+/// on a failed edge probe streak, with capped exponential backoff between
+/// attempts that resets once a run stays healthy.
+pub fn supervise_tunnel(config_dir: PathBuf, port: u16) -> TunnelSupervisor {
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
+    let task = tokio::spawn(async move {
+        let mut respawn_delay_secs = TUNNEL_RESPAWN_BASE_DELAY_SECS;
+        loop {
+            let started = tokio::time::Instant::now();
+            match start_tunnel(&config_dir, port).await {
+                Ok((mut child, url)) => {
+                    let reason = tokio::select! {
+                        _ = shutdown_rx.changed() => {
+                            child.kill().await.ok();
+                            return;
+                        }
+                        reason = run_until_unhealthy(&mut child, &url) => reason,
+                    };
+                    child.kill().await.ok();
+                    if started.elapsed().as_secs() >= TUNNEL_HEALTHY_UPTIME_SECS {
+                        respawn_delay_secs = TUNNEL_RESPAWN_BASE_DELAY_SECS;
+                    }
+                    tracing::warn!(delay_secs = respawn_delay_secs, "tunnel unhealthy ({reason}), restarting cloudflared");
+                }
+                Err(e) => {
+                    tracing::warn!(delay_secs = respawn_delay_secs, "tunnel start failed: {e}");
+                }
+            }
+            tokio::select! {
+                _ = shutdown_rx.changed() => return,
+                _ = tokio::time::sleep(std::time::Duration::from_secs(respawn_delay_secs)) => {}
+            }
+            respawn_delay_secs = next_respawn_delay(respawn_delay_secs);
+        }
+    });
+    TunnelSupervisor { shutdown: shutdown_tx, task }
+}
+
+/// Watch one cloudflared run; returns the reason it must be replaced (process
+/// exit, or the edge probe failing EDGE_PROBE_MAX_FAILURES times in a row).
+async fn run_until_unhealthy(child: &mut tokio::process::Child, url: &str) -> String {
+    let probe_client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(EDGE_PROBE_TIMEOUT_SECS))
+        .build()
+        .ok();
+    let probe_url = format!("{url}/health");
+    let probe_interval = std::time::Duration::from_secs(EDGE_PROBE_INTERVAL_SECS);
+    // First probe only after a full interval, so cloudflared has time to register.
+    let mut probe_ticks =
+        tokio::time::interval_at(tokio::time::Instant::now() + probe_interval, probe_interval);
+    let mut consecutive_failures = 0u32;
+    loop {
+        tokio::select! {
+            status = child.wait() => {
+                return match status {
+                    Ok(s) => format!("cloudflared exited: {s}"),
+                    Err(e) => format!("cloudflared wait failed: {e}"),
+                };
+            }
+            _ = probe_ticks.tick() => {
+                let Some(client) = &probe_client else { continue };
+                let ok = match client.get(&probe_url).send().await {
+                    Ok(resp) => resp.status().is_success(),
+                    Err(_) => false,
+                };
+                let (failures, restart) = record_probe(consecutive_failures, ok);
+                consecutive_failures = failures;
+                if !ok {
+                    tracing::warn!(consecutive_failures, url = %probe_url, "tunnel edge probe failed");
+                }
+                if restart {
+                    return format!("edge unreachable for {consecutive_failures} consecutive probes");
+                }
+            }
+        }
+    }
+}
+
+/// Pure probe accounting: a success clears the failure streak; a failure
+/// extends it, demanding a restart at EDGE_PROBE_MAX_FAILURES.
+fn record_probe(consecutive_failures: u32, ok: bool) -> (u32, bool) {
+    if ok {
+        return (0, false);
+    }
+    let failures = consecutive_failures + 1;
+    (failures, failures >= EDGE_PROBE_MAX_FAILURES)
+}
+
+fn next_respawn_delay(delay_secs: u64) -> u64 {
+    (delay_secs * 2).min(TUNNEL_RESPAWN_MAX_DELAY_SECS)
+}
+
 fn which(name: &str) -> Result<PathBuf, ()> {
     let output = std::process::Command::new("which")
         .arg(name)
@@ -662,6 +789,33 @@ mod tests {
         assert_eq!(sanitize("Alice.Bob"), "alice-bob");
         assert_eq!(sanitize("--test--"), "test");
         assert_eq!(sanitize("a_b@c"), "a-b-c");
+    }
+
+    #[test]
+    fn respawn_delay_doubles_and_caps() {
+        assert_eq!(next_respawn_delay(TUNNEL_RESPAWN_BASE_DELAY_SECS), 2);
+        assert_eq!(next_respawn_delay(2), 4);
+        assert_eq!(next_respawn_delay(40), TUNNEL_RESPAWN_MAX_DELAY_SECS);
+        assert_eq!(next_respawn_delay(TUNNEL_RESPAWN_MAX_DELAY_SECS), TUNNEL_RESPAWN_MAX_DELAY_SECS);
+    }
+
+    #[test]
+    fn probe_success_clears_the_failure_streak() {
+        assert_eq!(record_probe(EDGE_PROBE_MAX_FAILURES - 1, true), (0, false));
+    }
+
+    #[test]
+    fn probe_failures_demand_restart_only_at_threshold() {
+        let mut failures = 0;
+        for expected in 1..EDGE_PROBE_MAX_FAILURES {
+            let (count, restart) = record_probe(failures, false);
+            assert_eq!(count, expected);
+            assert!(!restart, "no restart before the threshold");
+            failures = count;
+        }
+        let (count, restart) = record_probe(failures, false);
+        assert_eq!(count, EDGE_PROBE_MAX_FAILURES);
+        assert!(restart, "restart at the threshold");
     }
 }
 

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -638,7 +638,7 @@ fn alloc_loopback_port() -> Result<u16, String> {
 // invisible from the inside: vestad stays healthy, systemd sees nothing wrong,
 // and every request to the hostname gets Cloudflare error 1033 until someone
 // restarts vestad by hand. Two failure modes, two layers:
-//   - the process exits (crash, OOM, fatal give-up) -> respawn with capped backoff
+//   - the process exits (crash, OOM, fatal give-up) -> respawn after a fixed delay
 //   - the process wedges with its edge connections dead -> cloudflared's own
 //     /ready endpoint (loopback metrics port) reports no registered connection;
 //     after consecutive failures the child is killed and respawned.
@@ -650,12 +650,11 @@ fn alloc_loopback_port() -> Result<u16, String> {
 // self-healed here: cloudflared exits with the reason, which lands in
 // `vestad logs` via the stderr forwarder; recovery is `vestad connect`.
 
-const TUNNEL_RESPAWN_BASE_DELAY_SECS: u64 = 1;
-const TUNNEL_RESPAWN_MAX_DELAY_SECS: u64 = 60;
-/// Uptime past which a cloudflared run counts as healthy and the backoff
-/// resets. Must exceed the worst-case probe-restart window (see the invariant
-/// test) or a born-wedged run would reset the backoff on every cycle.
-const TUNNEL_HEALTHY_UPTIME_SECS: u64 = 300;
+/// Delay between cloudflared respawns. Fixed rather than exponential: the one
+/// child vestad owns rarely dies, and a constant delay recovers promptly
+/// without the backoff/healthy-reset bookkeeping. Permanent failure (a revoked
+/// token) loops at this cadence with cloudflared's reason in `vestad logs`.
+const TUNNEL_RESPAWN_DELAY_SECS: u64 = 15;
 const READY_PROBE_INTERVAL_SECS: u64 = 30;
 const READY_PROBE_TIMEOUT_SECS: u64 = 5;
 /// Consecutive failed /ready probes before cloudflared is restarted.
@@ -675,8 +674,7 @@ impl TunnelSupervisor {
 }
 
 /// Spawn cloudflared and keep it alive until `shutdown()`: respawn on exit or
-/// on a failed edge probe streak, with capped exponential backoff between
-/// attempts that resets once a run stays healthy.
+/// on a failed edge probe streak, after a fixed delay between attempts.
 pub fn supervise_tunnel(config_dir: PathBuf, port: u16) -> TunnelSupervisor {
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
     let task = tokio::spawn(async move {
@@ -693,9 +691,7 @@ pub fn supervise_tunnel(config_dir: PathBuf, port: u16) -> TunnelSupervisor {
                 None
             }
         };
-        let mut respawn_delay_secs = TUNNEL_RESPAWN_BASE_DELAY_SECS;
         loop {
-            let started = tokio::time::Instant::now();
             match start_tunnel(&config_dir, port).await {
                 Ok((mut child, metrics_port)) => {
                     let reason = tokio::select! {
@@ -706,20 +702,16 @@ pub fn supervise_tunnel(config_dir: PathBuf, port: u16) -> TunnelSupervisor {
                         reason = run_until_unhealthy(&mut child, probe_client.as_ref(), metrics_port) => reason,
                     };
                     child.kill().await.ok();
-                    if started.elapsed().as_secs() >= TUNNEL_HEALTHY_UPTIME_SECS {
-                        respawn_delay_secs = TUNNEL_RESPAWN_BASE_DELAY_SECS;
-                    }
-                    tracing::warn!(delay_secs = respawn_delay_secs, "tunnel unhealthy ({reason}), restarting cloudflared");
+                    tracing::warn!(delay_secs = TUNNEL_RESPAWN_DELAY_SECS, "tunnel unhealthy ({reason}), restarting cloudflared");
                 }
                 Err(e) => {
-                    tracing::warn!(delay_secs = respawn_delay_secs, "tunnel start failed: {e}");
+                    tracing::warn!(delay_secs = TUNNEL_RESPAWN_DELAY_SECS, "tunnel start failed: {e}");
                 }
             }
             tokio::select! {
                 _ = shutdown_rx.changed() => return,
-                _ = tokio::time::sleep(std::time::Duration::from_secs(respawn_delay_secs)) => {}
+                _ = tokio::time::sleep(std::time::Duration::from_secs(TUNNEL_RESPAWN_DELAY_SECS)) => {}
             }
-            respawn_delay_secs = next_respawn_delay(respawn_delay_secs);
         }
     });
     TunnelSupervisor { shutdown: shutdown_tx, task }
@@ -780,10 +772,6 @@ fn record_probe(consecutive_failures: u32, ok: bool) -> (u32, bool) {
     (failures, failures >= READY_PROBE_MAX_FAILURES)
 }
 
-fn next_respawn_delay(delay_secs: u64) -> u64 {
-    (delay_secs * 2).min(TUNNEL_RESPAWN_MAX_DELAY_SECS)
-}
-
 fn which(name: &str) -> Result<PathBuf, ()> {
     let output = std::process::Command::new("which")
         .arg(name)
@@ -840,14 +828,6 @@ mod tests {
     }
 
     #[test]
-    fn respawn_delay_doubles_and_caps() {
-        assert_eq!(next_respawn_delay(TUNNEL_RESPAWN_BASE_DELAY_SECS), 2);
-        assert_eq!(next_respawn_delay(2), 4);
-        assert_eq!(next_respawn_delay(40), TUNNEL_RESPAWN_MAX_DELAY_SECS);
-        assert_eq!(next_respawn_delay(TUNNEL_RESPAWN_MAX_DELAY_SECS), TUNNEL_RESPAWN_MAX_DELAY_SECS);
-    }
-
-    #[test]
     fn probe_success_clears_the_failure_streak() {
         assert_eq!(record_probe(READY_PROBE_MAX_FAILURES - 1, true), (0, false));
     }
@@ -864,17 +844,6 @@ mod tests {
         let (count, restart) = record_probe(failures, false);
         assert_eq!(count, READY_PROBE_MAX_FAILURES);
         assert!(restart, "restart at the threshold");
-    }
-
-    #[test]
-    fn probe_restart_window_stays_below_the_healthy_reset() {
-        // A born-wedged run must restart BEFORE the healthy-uptime threshold,
-        // or every probe-triggered restart would reset the backoff and the
-        // supervisor would churn at full rate forever. Worst case: one slipped
-        // interval per probe (MissedTickBehavior::Delay) plus a full timeout each.
-        let worst_case_secs = READY_PROBE_INTERVAL_SECS * (READY_PROBE_MAX_FAILURES as u64 + 1)
-            + READY_PROBE_TIMEOUT_SECS * READY_PROBE_MAX_FAILURES as u64;
-        assert!(worst_case_secs < TUNNEL_HEALTHY_UPTIME_SECS);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

After a stretch of inactivity, the app (and anything else hitting the tunnel hostname) gets **Cloudflare error 1033** — the edge has no live connection for the tunnel — and the only cure is restarting vestad.

Root cause: cloudflared was spawned once at boot (`main.rs`) and never supervised. The returned `Child` was touched exactly once more, at graceful shutdown. So both of its failure modes went unrecovered:

- **Process exit** (crash, OOM kill, fatal give-up after prolonged network loss): nothing respawned it.
- **Wedge** (process alive but every edge connection dead): nothing detected it.

vestad itself stays healthy in both cases, so `Restart=always` never triggers; the tunnel is just silently gone until a human restarts vestad, which respawns cloudflared as a side effect. The existing `--protocol http2` mitigation (NATs dropping idle QUIC) addresses a third, connection-level variant but can't help with these two.

## Fix

`tunnel.rs` gains a supervision layer; `start_tunnel` becomes private to it:

- **Respawn on exit** with capped exponential backoff (1s → 60s), reset after a run stays healthy for 5 minutes.
- **Local readiness probe**: cloudflared runs with `--metrics 127.0.0.1:<port>`, and the supervisor polls its `/ready` endpoint every 30s — 200 iff a connection is registered with the edge. Three consecutive failures ⇒ kill + respawn. The probe is deliberately **local**: probing the public hostname through the Cloudflare edge would conflate probe-path failures (host DNS/egress, an edge incident) with a wedged connector and kill a healthy tunnel, dropping every live session through it. `/ready` measures exactly the thing a restart fixes, with no external traffic. The 90s detection window stays below the 300s healthy-uptime threshold so probe-driven restarts never reset the backoff (locked by an invariant test). Missed ticks are delivered one at a time (`MissedTickBehavior::Delay`) so suspend/resume can't burst a spurious failure streak.
- **Supervision triggers on intent, not boot success**: the supervisor is spawned whenever a tunnel is intended (boot setup succeeded, a tunnel.json exists, or the box is managed) — so a control-plane seeding race or transient `ensure_tunnel` failure at boot no longer leaves the daemon tunnel-less until manual restart. The supervisor re-reads tunnel.json on every respawn, picking up late config.
- **No orphans**: cloudflared is spawned with `kill_on_drop(true)`, so a panic/abort teardown can't leave it holding the hostname; `TunnelSupervisor::shutdown()` preserves the explicit graceful path.
- A failed *initial* start now retries on the same backoff instead of logging a warning and running tunnel-less until the next reboot.
- Every restart logs its reason (`cloudflared exited: <status>` / `no ready edge connection for 3 consecutive probes`), so `vestad logs` shows which failure mode occurred. Config-level death (tunnel deleted server-side, revoked token) is intentionally not self-healed: cloudflared's stderr lands in the logs with the reason; recovery is `vestad connect`.

## Tests

- `respawn_delay_doubles_and_caps`, `probe_success_clears_the_failure_streak`, `probe_failures_demand_restart_only_at_threshold`, `probe_restart_window_stays_below_the_healthy_reset` (the backoff invariant), `alloc_loopback_port_returns_a_usable_port` in `tunnel.rs`.
- vestad is Linux-only and this machine has no Docker/cross toolchain, so the in-repo suite rides on CI. The supervisor code was additionally verified **verbatim** in a scratch crate with a stubbed `start_tunnel` and a real local HTTP server simulating `/ready`: passes `clippy -D warnings`; behavioral tests confirmed a 503-streak kills a living child, a healthy 200 never triggers a restart, exited children respawn on the backoff schedule, and `shutdown()` returns promptly with no further spawns.

## Review

A high-effort multi-angle review of the first revision surfaced the edge-probe false-positive risk (kills healthy tunnels when the probe path breaks, dropping live WS sessions), the backoff-reset arithmetic flaw (360s probe window > 300s healthy threshold), the boot-gating gap, the suspend/resume tick burst, and the silent probe-client failure — all addressed in the second commit by the local `/ready` redesign and the changes above. Known accepted limits: runtime `vestad tunnel destroy` while the daemon runs leads to periodic "tunnel start failed" warnings until restart, and a revoked/deleted tunnel loops with the cloudflared error visible in logs rather than self-recreating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update: fixed respawn delay

The exponential backoff (1s -> 60s) plus its healthy-uptime reset threshold and the `probe_restart_window_stays_below_the_healthy_reset` invariant test were replaced with a single fixed 15s respawn delay. cloudflared is the one child vestad owns and rarely dies, so the constant delay recovers just as promptly without the backoff/reset bookkeeping (net 41 deletions / 10 insertions). Trade-off: permanent failure (a revoked token) loops at a steady 15s cadence rather than backing off to 60s; cloudflared's reason still lands in `vestad logs` on every attempt.