### PR TITLE
fix(web): restore pointer cursor on buttons

### DIFF
--- a/agent/skills/dashboard/app/src/index.css
+++ b/agent/skills/dashboard/app/src/index.css
@@ -186,6 +186,13 @@ html[data-platform="android"] {
   * {
     @apply border-border outline-ring/50;
   }
+  /* Tailwind v4 Preflight dropped the cursor:pointer that v3 applied to buttons.
+     Restore it for native buttons and role=button so every clickable control
+     shows the pointer; utilities still override, and disabled controls keep the default. */
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
   html {
     background: transparent;
     @apply box-border flex h-dvh flex-col font-sans overscroll-none;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -183,6 +183,13 @@ html[data-platform="android"] {
   * {
     @apply border-border outline-ring/50;
   }
+  /* Tailwind v4 Preflight dropped the cursor:pointer that v3 applied to buttons.
+     Restore it for native buttons and role=button so every clickable control
+     shows the pointer; utilities still override, and disabled controls keep the default. */
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
   html {
     @apply box-border flex h-dvh flex-col bg-background font-sans overscroll-none;
   }


### PR DESCRIPTION
## Problem

Some buttons in the web app didn't show the clickable (pointer) cursor on hover, while others did.

## Investigation

The app uses **Tailwind CSS v4** (`tailwindcss@^4.0.0`) with shadcn UI. Tailwind v4's Preflight changed a long-standing default: it **no longer applies `cursor: pointer` to `<button>` elements** the way v3 did. The shadcn `Button` component (`ui/button.tsx`) never sets `cursor-pointer` explicitly, and `index.css` had no global rule.

Result: only the ~10 component files that happened to add an explicit `cursor-pointer` class showed the pointer. The other ~36 files using `<Button>` / `<button>` (theme toggle, menus, dialogs, agent cards, window controls, etc.) fell back to the default arrow cursor — the inconsistency the user noticed.

```
$ grep -rl 'cursor-pointer' src | wc -l   # 10
$ grep -rlE '<button|role="button"|<Button' src | wc -l   # 46
$ grep -n cursor src/index.css   # (none)
```

## Fix

One base-layer rule in `index.css` restoring v3 behavior for every clickable control:

```css
button:not(:disabled),
[role="button"]:not(:disabled) {
  cursor: pointer;
}
```

- Covers native buttons and `role="button"` elements app-wide — fixes all of them in one place rather than patching 36 call sites.
- Disabled controls keep the default cursor.
- Lives in `@layer base`, so explicit `cursor-*` utilities still take precedence where intentionally set.

## Verification

`./check.sh web` passes (eslint 0 errors, prettier clean, tsc clean, 72 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)