### PR TITLE
refactor(auth): derive per-purpose HKDF subkeys for vestad tokens

### DIFF
--- a/vestad/src/jwt.rs
+++ b/vestad/src/jwt.rs
@@ -1,8 +1,46 @@
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use ring::hkdf;
 use serde::{Deserialize, Serialize};
 
 pub const ACCESS_TOKEN_TTL: u64 = 3600; // 1 hour
 pub const REFRESH_TOKEN_TTL: u64 = 7 * 86400; // 7 days
+
+// --- Per-purpose key derivation (HKDF-SHA256) ---------------------------------
+//
+// Every token is HS256-signed, but NOT with the raw `api_key`: we derive a
+// distinct subkey per purpose so a token minted for one role cannot verify for
+// another, cryptographically (not merely because consumers check `typ`). The
+// `typ` claim is kept as defense-in-depth.
+//
+// CROSS-REPO CONTRACT: the vesta-cloud control plane derives the SAME subkeys
+// (functions/lib/tokens.ts) to mint access / verify server-identity tokens, so
+// these constants and the derivation (salt, label = PREFIX || typ, 32-byte
+// output) MUST stay byte-identical on both sides. The known-answer test below
+// pins the vector; its twin in vesta-cloud pins the same one.
+const HKDF_SALT: &[u8] = b"vesta-auth-hkdf-v1";
+const KEY_LABEL_PREFIX: &[u8] = b"vesta/auth/";
+
+/// `KeyType` for `hkdf::Prk::expand` — fixes the derived-key length at 32 bytes.
+struct OkmLen;
+impl hkdf::KeyType for OkmLen {
+    fn len(&self) -> usize {
+        32
+    }
+}
+
+/// Derive the HS256 signing/verifying key for `typ` from the per-VM `api_key`.
+/// `info = KEY_LABEL_PREFIX || typ`, so each role ("access", "refresh",
+/// "server-identity") gets its own subkey — the label IS the role.
+fn signing_key(api_key: &str, typ: &str) -> [u8; 32] {
+    let prk = hkdf::Salt::new(hkdf::HKDF_SHA256, HKDF_SALT).extract(api_key.as_bytes());
+    let info = [KEY_LABEL_PREFIX, typ.as_bytes()];
+    let okm = prk
+        .expand(&info, OkmLen)
+        .expect("hkdf expand to 32 bytes is infallible");
+    let mut out = [0u8; 32];
+    okm.fill(&mut out).expect("hkdf fill of matching length is infallible");
+    out
+}
 
 /// `typ` of a server-identity token — the VM proving its OWN identity to the
 /// vesta-cloud control plane (issue #20), distinct from the `"access"` token the
@@ -40,7 +78,7 @@ pub fn create_token(api_key: &str, typ: &str, ttl_secs: u64) -> String {
     encode(
         &Header::new(Algorithm::HS256),
         &claims,
-        &EncodingKey::from_secret(api_key.as_bytes()),
+        &EncodingKey::from_secret(&signing_key(api_key, typ)),
     )
     .expect("HS256 encoding of a serializable struct is infallible")
 }
@@ -61,7 +99,7 @@ pub fn create_refresh_token(api_key: &str, jti: &str, fam: &str) -> String {
     encode(
         &Header::new(Algorithm::HS256),
         &claims,
-        &EncodingKey::from_secret(api_key.as_bytes()),
+        &EncodingKey::from_secret(&signing_key(api_key, "refresh")),
     )
     .expect("HS256 encoding of a serializable struct is infallible")
 }
@@ -86,7 +124,7 @@ pub fn create_server_identity_token(api_key: &str, server_id: &str) -> String {
     encode(
         &Header::new(Algorithm::HS256),
         &claims,
-        &EncodingKey::from_secret(api_key.as_bytes()),
+        &EncodingKey::from_secret(&signing_key(api_key, SERVER_IDENTITY_TYP)),
     )
     .expect("HS256 encoding of a serializable struct is infallible")
 }
@@ -95,7 +133,10 @@ pub fn validate_token(api_key: &str, token: &str, expected_typ: &str) -> Result<
     let mut validation = Validation::new(Algorithm::HS256);
     // Tokens carry no audience claim; only `exp` (validated by default) is required.
     validation.validate_aud = false;
-    let claims = decode::<Claims>(token, &DecodingKey::from_secret(api_key.as_bytes()), &validation)?.claims;
+    // Verify under the subkey derived for the EXPECTED role: a token minted for
+    // another role won't even verify here (defense beyond the `typ` check below).
+    let key = signing_key(api_key, expected_typ);
+    let claims = decode::<Claims>(token, &DecodingKey::from_secret(&key), &validation)?.claims;
     if claims.typ != expected_typ {
         return Err(jsonwebtoken::errors::ErrorKind::InvalidToken.into());
     }
@@ -105,6 +146,51 @@ pub fn validate_token(api_key: &str, token: &str, expected_typ: &str) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    // CROSS-REPO CONTRACT: these vectors pin HKDF(api_key, "vesta/auth/"||typ).
+    // The twin test in vesta-cloud (functions/lib/__tests__/tokens.test.ts) pins
+    // the SAME values; if either repo's derivation drifts, its test fails.
+    const VECTOR_API_KEY: &str = "vesta-auth-hkdf-test-vector";
+
+    #[test]
+    fn derived_keys_match_cross_repo_vector() {
+        assert_eq!(
+            hex(&signing_key(VECTOR_API_KEY, "access")),
+            "053b2ecb9c39a57934146727d3572f4485505b52c9c632b6fa124612eebee828"
+        );
+        assert_eq!(
+            hex(&signing_key(VECTOR_API_KEY, "refresh")),
+            "2cc6a960bc8986cc6e2bca9d2964ecc453820fe7aaefcc10bb83cf5daf74efd7"
+        );
+        assert_eq!(
+            hex(&signing_key(VECTOR_API_KEY, "server-identity")),
+            "852ca4fc9d91a8537c802bcc4687a27b3dada004cf6fde2816b8460c2caf547b"
+        );
+    }
+
+    #[test]
+    fn each_role_derives_a_distinct_key() {
+        let a = signing_key("k", "access");
+        let r = signing_key("k", "refresh");
+        let i = signing_key("k", "server-identity");
+        assert_ne!(a, r);
+        assert_ne!(a, i);
+        assert_ne!(r, i);
+    }
+
+    #[test]
+    fn access_token_cannot_be_replayed_as_another_role() {
+        // An access token must not verify as refresh or server-identity: the
+        // derived subkey differs, so the SIGNATURE fails (not just the typ check).
+        let token = create_token("secret", "access", ACCESS_TOKEN_TTL);
+        assert!(validate_token("secret", &token, "refresh").is_err());
+        assert!(validate_token("secret", &token, SERVER_IDENTITY_TYP).is_err());
+        assert!(validate_token("secret", &token, "access").is_ok());
+    }
 
     #[test]
     fn roundtrip_valid() {


### PR DESCRIPTION
Box side of **elyxlz/vesta-cloud#31** seam #1 (per-purpose derived keys). Pairs with the control-plane PR **elyxlz/vesta-cloud#54** — they change the token signing key on both sides with no backcompat, so they must deploy together. Safe: no users on vesta cloud yet.

## What
Every token (`access`, `refresh`, `server-identity`) was HS256-signed with the raw `api_key`; the only thing stopping cross-role replay was each consumer passing the right `expected_typ`. Now each role is signed/verified under its **own HKDF-SHA256 subkey** derived from the api_key (`info = "vesta/auth/" + typ`), so a token minted for one role **cannot verify** for another — cryptographic domain separation. `typ` is kept as defense-in-depth.

- `signing_key(api_key, typ)` via `ring::hkdf` (ring already a dep), one owner for salt + label.
- `create_token` / `create_refresh_token` / `create_server_identity_token` sign with their role's subkey; `validate_token` derives the subkey for `expected_typ` before `decode`.
- Raw `api_key` stays the root credential (self-hosted paste path in `auth.rs`, `/auth/session` body check) — unchanged.

## Cross-repo contract
A known-answer test (`derived_keys_match_cross_repo_vector`) pins the derived-key hex for a fixed api_key. Its twin in vesta-cloud (`functions/lib/__tests__/tokens.test.ts`) pins the **same** vector — if either repo's derivation drifts, its test fails.

## Tests
`./check.sh vestad` green (clippy -D warnings + 127 tests), incl. the new vector test, per-role distinctness, and "an access token can't be replayed as another role".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
