### PR TITLE
config: single source of truth for agent creation defaults

### DIFF
--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -22,9 +22,10 @@ class VestaConfig(pyd_settings.BaseSettings):
     Set in ~/.bashrc and run restart_vesta to apply.
 
     Key overrides:
-        AGENT_MODEL   - model name, e.g. "sonnet", "opus", "haiku" (default: "opus")
+        AGENT_MODEL   - model name, e.g. "sonnet", "opus", "haiku" (required from env; vestad
+                        seeds the default and the provider file overrides it)
         AGENT_NAME    - agent name (default: "vesta")
-        AGENT_PROVIDER - "claude" (OAuth) or "openrouter" (API key) (default: "claude")
+        AGENT_PROVIDER - "claude" (OAuth) or "openrouter" (API key) (required from env, as AGENT_MODEL)
         LOG_LEVEL     - DEBUG | INFO | WARNING | ERROR (default: "INFO")
         THINKING      - adaptive | enabled | disabled (default: "adaptive")
         PROACTIVE_CHECK_INTERVAL - seconds between proactive checks (default: 60)
@@ -131,8 +132,12 @@ class VestaConfig(pyd_settings.BaseSettings):
         return self.agent_dir / "dreamer"
 
     agent_name: str = "vesta"
-    agent_model: str = "opus"
-    agent_provider: tp.Literal["claude", "openrouter"] = "claude"
+    # Model and provider are required from the env, not defaulted here: vestad is the single
+    # source of truth (vestad/src/defaults.rs) and seeds AGENT_MODEL / AGENT_PROVIDER into the
+    # agent env at creation, while the provider file (vesta-provider.env, sourced after) overrides
+    # them once a provider is configured. Keeping a Python default would duplicate that default.
+    agent_model: str = pyd.Field(init=False)
+    agent_provider: tp.Literal["claude", "openrouter"] = pyd.Field(init=False)
     # Active personality preset, read on every boot (a live selector, not consumed once at creation).
     # build_client_options loads the shared personality SKILL.md plus presets/<value>.md into
     # the system prompt. Required from the env: vestad always writes AGENT_PERSONALITY, and the

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -7,9 +7,13 @@ from core.events import EventBus
 
 os.environ.pop("CLAUDECODE", None)
 os.environ.setdefault("WS_PORT", "17865")
-# vestad always writes AGENT_PERSONALITY into the agent's env; mirror that for the suite
-# so VestaConfig (which now requires it) constructs without each test having to set it.
+# vestad always writes AGENT_PERSONALITY / AGENT_PROVIDER / AGENT_MODEL into the agent's env;
+# mirror that for the suite so VestaConfig (which now requires them) constructs without each
+# test having to set them. These are test scaffolding, not the product defaults (those live in
+# vestad/src/defaults.rs); a test that cares sets its own value via monkeypatch.setenv.
 os.environ.setdefault("AGENT_PERSONALITY", "dry")
+os.environ.setdefault("AGENT_PROVIDER", "claude")
+os.environ.setdefault("AGENT_MODEL", "opus")
 
 
 @pytest.fixture

--- a/apps/web/src/api/agent-defaults.ts
+++ b/apps/web/src/api/agent-defaults.ts
@@ -1,0 +1,21 @@
+import { apiJson } from "./client";
+
+export interface ContextPreset {
+  tokens: number;
+  label: string;
+  note: string;
+}
+
+// Creation-time defaults a new agent gets. vestad owns these (vestad/src/defaults.rs);
+// the wizard reads them here instead of hardcoding its own copies.
+export interface AgentDefaults {
+  personality: string;
+  provider: string;
+  model: string;
+  context_tokens: number;
+  context_presets: ContextPreset[];
+}
+
+export async function fetchAgentDefaults(): Promise<AgentDefaults> {
+  return apiJson<AgentDefaults>("/agent-defaults");
+}

--- a/apps/web/src/components/NewAgent/Steps/PersonalityStep/index.tsx
+++ b/apps/web/src/components/NewAgent/Steps/PersonalityStep/index.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { FieldDescription } from "@/components/ui/field";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchPersonalities, type Personality } from "@/api/personalities";
+import { useAgentDefaults } from "@/hooks/use-agent-defaults";
 
 export function PersonalityStep({
   onPicked,
@@ -13,7 +14,11 @@ export function PersonalityStep({
     null,
   );
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string>("dry");
+  // The default preset comes from vestad (GET /agent-defaults), not a hardcoded copy.
+  // Until the user picks, fall through to vestad's default once it loads.
+  const defaults = useAgentDefaults();
+  const [picked, setPicked] = useState<string | null>(null);
+  const selected = picked ?? defaults?.personality ?? "";
 
   useEffect(() => {
     fetchPersonalities()
@@ -46,7 +51,7 @@ export function PersonalityStep({
             return (
               <button
                 key={p.name}
-                onClick={() => setSelected(p.name)}
+                onClick={() => setPicked(p.name)}
                 aria-pressed={isSelected}
                 className={`group flex h-full flex-col items-center gap-2 rounded-2xl border p-4 text-center transition-all cursor-pointer ${
                   isSelected
@@ -75,7 +80,7 @@ export function PersonalityStep({
       <Button
         className="w-full"
         onClick={() => onPicked(selected)}
-        disabled={personalities === null && !loadError}
+        disabled={(personalities === null && !loadError) || !selected}
       >
         continue
       </Button>

--- a/apps/web/src/components/ProviderPicker/ContextStep/index.tsx
+++ b/apps/web/src/components/ProviderPicker/ContextStep/index.tsx
@@ -1,33 +1,22 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { FieldDescription } from "@/components/ui/field";
+import type { ContextPreset } from "@/api/agent-defaults";
 
-interface ContextPreset {
-  tokens: number;
-  label: string;
-  note: string;
-}
-
-/// Context-window presets. 1M is the default (largest); smaller windows compact
-/// sooner and make prompt-cache reads cheaper.
-const CONTEXT_PRESETS: ContextPreset[] = [
-  { tokens: 1_000_000, label: "1M", note: "most context (default)" },
-  { tokens: 500_000, label: "500K", note: "balanced" },
-  { tokens: 200_000, label: "200K", note: "cheapest, compacts soonest" },
-];
-
+// Presets + the default come from vestad (GET /agent-defaults), passed in by the parent,
+// so this step holds no copy of either.
 export function ContextStep({
+  presets,
   initial,
   onSubmit,
   submitLabel = "continue",
 }: {
-  initial?: number;
+  presets: ContextPreset[];
+  initial: number;
   onSubmit: (tokens: number) => void;
   submitLabel?: string;
 }) {
-  const [selected, setSelected] = useState<number>(
-    initial ?? CONTEXT_PRESETS[0].tokens,
-  );
+  const [selected, setSelected] = useState<number>(initial);
 
   return (
     <form
@@ -46,7 +35,7 @@ export function ContextStep({
       </div>
 
       <div className="flex w-full flex-col gap-1.5">
-        {CONTEXT_PRESETS.map((preset) => (
+        {presets.map((preset) => (
           <button
             key={preset.tokens}
             type="button"

--- a/apps/web/src/components/ProviderPicker/index.tsx
+++ b/apps/web/src/components/ProviderPicker/index.tsx
@@ -12,8 +12,8 @@ import { ModelStep } from "./ModelStep";
 import { ContextStep } from "./ContextStep";
 import { AuthStep } from "./AuthStep";
 import type { ProviderMode } from "./types";
-
-const CLAUDE_DEFAULT_MAX_CONTEXT_TOKENS = 1_000_000;
+import { useAgentDefaults } from "@/hooks/use-agent-defaults";
+import { Skeleton } from "@/components/ui/skeleton";
 
 type InternalStep = "choice" | "auth" | "key" | "model" | "context";
 
@@ -29,6 +29,8 @@ export function ProviderPicker({
   const [model, setModel] = useState("");
   const [authStart, setAuthStart] = useState<AuthStartResult | null>(null);
   const [authStartError, setAuthStartError] = useState<string | null>(null);
+  // Creation defaults (context window + presets) come from vestad, not a local copy.
+  const defaults = useAgentDefaults();
 
   // Kick off the standalone OAuth session once when entering the auth substep.
   // Owned here (not by AuthStep) so AuthStep remounts don't restart a fresh
@@ -53,6 +55,16 @@ export function ProviderPicker({
     };
   }, [step, authStart, authStartError]);
 
+  // Wait for vestad's defaults before rendering any step that needs the context window.
+  // The user reaches this picker after the personality step, so it is loaded in practice.
+  if (!defaults) {
+    return (
+      <div className="flex w-[380px] max-w-full flex-col items-center gap-4 px-4">
+        <Skeleton className="h-40 w-full rounded-2xl" />
+      </div>
+    );
+  }
+
   const handleChoice = (next: ProviderMode) => {
     setStep(next === "claude" ? "auth" : "key");
   };
@@ -62,7 +74,7 @@ export function ProviderPicker({
       kind: "claude",
       credentials: creds,
       model: undefined,
-      maxContextTokens: CLAUDE_DEFAULT_MAX_CONTEXT_TOKENS,
+      maxContextTokens: defaults.context_tokens,
     });
   };
 
@@ -135,7 +147,13 @@ export function ProviderPicker({
               }}
             />
           )}
-          {step === "context" && <ContextStep onSubmit={handleContextSubmit} />}
+          {step === "context" && (
+            <ContextStep
+              presets={defaults.context_presets}
+              initial={defaults.context_tokens}
+              onSubmit={handleContextSubmit}
+            />
+          )}
         </motion.div>
       </AnimatePresence>
     </div>

--- a/apps/web/src/hooks/use-agent-defaults.ts
+++ b/apps/web/src/hooks/use-agent-defaults.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { fetchAgentDefaults, type AgentDefaults } from "@/api/agent-defaults";
+
+// Fetches the creation-time defaults vestad owns (vestad/src/defaults.rs) so the wizard
+// never keeps its own copy. `undefined` until the one-shot fetch resolves; consumers render
+// a loading state until then rather than falling back to a duplicated local default.
+export function useAgentDefaults(): AgentDefaults | undefined {
+  const [defaults, setDefaults] = useState<AgentDefaults | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAgentDefaults()
+      .then((d) => {
+        if (!cancelled) setDefaults(d);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return defaults;
+}

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -249,6 +249,21 @@ pub struct ClaudeModel {
     pub note: String,
 }
 
+#[derive(serde::Deserialize)]
+pub struct ContextPreset {
+    pub tokens: u64,
+    pub label: String,
+    pub note: String,
+}
+
+/// Creation-time defaults vestad owns (vestad/src/defaults.rs), fetched so the CLI keeps
+/// no copy of the context-window presets or default.
+#[derive(serde::Deserialize)]
+pub struct AgentDefaults {
+    pub context_tokens: u64,
+    pub context_presets: Vec<ContextPreset>,
+}
+
 impl Client {
     pub fn new(config: &ServerConfig) -> Result<Self, String> {
         let tls_config = if let Some(ref pem) = config.cert_pem {
@@ -619,6 +634,11 @@ impl Client {
 
     pub fn fetch_claude_models(&self) -> Result<Vec<ClaudeModel>, String> {
         let resp = self.get("/providers/claude/models")?;
+        read_json(resp)
+    }
+
+    pub fn fetch_agent_defaults(&self) -> Result<AgentDefaults, String> {
+        let resp = self.get("/agent-defaults")?;
         read_json(resp)
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -460,7 +460,7 @@ fn resolve_setup_provider(c: &client::Client, flags: OpenRouterFlags, claude_tok
 /// defaults (Opus, 1M window).
 fn resolve_claude_options(c: &client::Client, model_flag: Option<String>, ctx_flag: Option<u64>, yes: bool) -> ClaudeOptions {
     let model = model_flag.or_else(|| (!yes).then(|| prompt_claude_model(c)));
-    let max_context_tokens = ctx_flag.or_else(|| (!yes).then(prompt_context_window));
+    let max_context_tokens = ctx_flag.or_else(|| if yes { None } else { prompt_context_window(c) });
     ClaudeOptions { model, max_context_tokens }
 }
 
@@ -496,18 +496,22 @@ fn prompt_claude_model(c: &client::Client) -> String {
     models[prompt_indexed_choice(&labels, 0)].id.clone()
 }
 
-/// Context-window presets (tokens, label). 1M is the default (largest).
-const CONTEXT_PRESETS: [(u64, &str); 3] = [
-    (200_000, "200K — cheapest prompt-cache reads, compacts soonest"),
-    (500_000, "500K — balanced"),
-    (1_000_000, "1M — most context"),
-];
-
-/// Prompt for a context-window preset. Default = 1M (the largest, last entry).
-fn prompt_context_window() -> u64 {
+/// Prompt for a context-window preset. The presets and the default come from vestad
+/// (GET /agent-defaults), so the CLI keeps no copy. Returns None if they can't be
+/// fetched, letting the server apply its own default.
+fn prompt_context_window(c: &client::Client) -> Option<u64> {
+    let defaults = c.fetch_agent_defaults().ok()?;
+    if defaults.context_presets.is_empty() {
+        return None;
+    }
     eprintln!("context window?");
-    let labels: Vec<String> = CONTEXT_PRESETS.iter().map(|(_, label)| label.to_string()).collect();
-    CONTEXT_PRESETS[prompt_indexed_choice(&labels, CONTEXT_PRESETS.len() - 1)].0
+    let labels: Vec<String> = defaults.context_presets.iter().map(|p| format!("{} — {}", p.label, p.note)).collect();
+    let default_idx = defaults
+        .context_presets
+        .iter()
+        .position(|p| p.tokens == defaults.context_tokens)
+        .unwrap_or(0);
+    Some(defaults.context_presets[prompt_indexed_choice(&labels, default_idx)].tokens)
 }
 
 /// Ask the user which provider to run the agent on. Defaults to a Claude

--- a/vestad/src/defaults.rs
+++ b/vestad/src/defaults.rs
@@ -1,0 +1,50 @@
+//! Single source of truth for the defaults a brand-new agent gets.
+//!
+//! These are the values the create wizard (web + CLI) pre-selects and that
+//! `write_agent_env_file` seeds into the agent's env. The Python agent requires
+//! `AGENT_MODEL` / `AGENT_PROVIDER` / `AGENT_PERSONALITY` from the env rather than
+//! re-defining their defaults, so each default lives here only. Clients read them
+//! from `GET /agent-defaults` instead of hardcoding their own copies.
+
+use serde::Serialize;
+
+pub const DEFAULT_PERSONALITY: &str = "dry";
+pub const DEFAULT_PROVIDER: &str = "claude";
+pub const DEFAULT_MODEL: &str = "opus";
+pub const DEFAULT_CONTEXT_TOKENS: u32 = 1_000_000;
+
+/// Selectable context-window presets, largest first. The first entry is the default
+/// (`DEFAULT_CONTEXT_TOKENS` points at it). Smaller windows give cheaper prompt-cache
+/// reads and compact sooner.
+pub const CONTEXT_PRESETS: &[ContextPreset] = &[
+    ContextPreset { tokens: 1_000_000, label: "1M", note: "most context" },
+    ContextPreset { tokens: 500_000, label: "500K", note: "balanced" },
+    ContextPreset { tokens: 200_000, label: "200K", note: "cheapest prompt-cache reads, compacts soonest" },
+];
+
+#[derive(Serialize, Clone, Copy)]
+pub struct ContextPreset {
+    pub tokens: u32,
+    pub label: &'static str,
+    pub note: &'static str,
+}
+
+#[derive(Serialize)]
+pub struct AgentDefaults {
+    pub personality: &'static str,
+    pub provider: &'static str,
+    pub model: &'static str,
+    pub context_tokens: u32,
+    pub context_presets: &'static [ContextPreset],
+}
+
+/// `GET /agent-defaults`: everything the create wizard needs to pre-select.
+pub async fn agent_defaults_handler() -> axum::Json<AgentDefaults> {
+    axum::Json(AgentDefaults {
+        personality: DEFAULT_PERSONALITY,
+        provider: DEFAULT_PROVIDER,
+        model: DEFAULT_MODEL,
+        context_tokens: DEFAULT_CONTEXT_TOKENS,
+        context_presets: CONTEXT_PRESETS,
+    })
+}

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -943,7 +943,12 @@ pub fn write_agent_env_file(
     append_optional("VESTAD_TUNNEL", env_config.vestad_tunnel.as_deref());
     append_optional("VESTA_UPSTREAM_REF", detect_upstream_ref().as_deref());
     append_optional("TZ", timezone);
-    append_optional("AGENT_PERSONALITY", Some(personality.unwrap_or("dry")));
+    // Seed the creation-time defaults the Python agent now requires from the env (it no
+    // longer re-defines them). vesta-provider.env is sourced after this file, so once a
+    // provider is configured its AGENT_PROVIDER/AGENT_MODEL override these defaults.
+    append_optional("AGENT_PERSONALITY", Some(personality.unwrap_or(crate::defaults::DEFAULT_PERSONALITY)));
+    append_optional("AGENT_PROVIDER", Some(crate::defaults::DEFAULT_PROVIDER));
+    append_optional("AGENT_MODEL", Some(crate::defaults::DEFAULT_MODEL));
     if std::fs::read_to_string(&env_path).map(|prev| prev == content).unwrap_or(false) {
         return Ok(env_path);
     }

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -14,6 +14,7 @@ mod backup;
 mod channel;
 mod cloudflared_embed;
 mod control_ws;
+mod defaults;
 mod docker;
 mod jwt;
 mod paths;

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2074,6 +2074,7 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/gateway/restart", post(restart_gateway_handler))
         .route("/tunnel", get(tunnel_handler))
         .route("/personalities", get(list_personalities_handler))
+        .route("/agent-defaults", get(crate::defaults::agent_defaults_handler))
         .route("/providers/claude/oauth/start", post(crate::providers::claude::oauth_start_handler))
         .route("/providers/claude/oauth/complete", post(crate::providers::claude::oauth_complete_handler))
         .route("/providers/claude/models", get(crate::providers::claude::list_models_handler))


### PR DESCRIPTION
## What

The defaults a new agent gets (personality, provider, model, context window + presets) were duplicated across the web wizard, the CLI, vestad, and the Python config. This makes **vestad the one source** and has everyone read it.

- **`vestad/src/defaults.rs`**: the canonical creation defaults (`DEFAULT_MODEL`, `DEFAULT_PROVIDER`, `DEFAULT_PERSONALITY`, `DEFAULT_CONTEXT_TOKENS`, `CONTEXT_PRESETS`), exposed at **`GET /agent-defaults`**.
- **`write_agent_env_file`** seeds `AGENT_PERSONALITY`/`AGENT_PROVIDER`/`AGENT_MODEL` from those consts. `vesta-provider.env` is sourced *after* the agent env (docker.rs:103,109), so a configured provider still overrides the model/provider defaults.
- **agent `config.py`**: `agent_model` and `agent_provider` become `pyd.Field(init=False)`, required from the env, so Python no longer re-defines those defaults (same pattern as `agent_personality` from #821). `conftest` mirrors vestad by setting them for the suite.
- **web**: `ContextStep` takes presets/default as props; `ProviderPicker` and `PersonalityStep` read `GET /agent-defaults` via a `use-agent-defaults` hook instead of hardcoding `1M` / `"dry"` / the preset list.
- **cli**: `prompt_context_window` fetches `/agent-defaults` instead of a local `CONTEXT_PRESETS` copy.

Net: "what default does a new agent get?" is answered in exactly one place (`vestad/src/defaults.rs`); web/CLI/agent are pure consumers.

## Not touched (by design)
The `opus`/`sonnet`/`haiku` model **list** stays in vestad (`providers/claude.rs`); the default model is its first entry. The web `use-claude-models` and CLI `"opus"` fallbacks remain as offline-degraded resilience, not sources of truth. `DEFAULT_CONTEXT_WINDOW = 200_000` in the agent stays as the autocompact/OpenRouter assumption (a different role from the wizard default).

## Tests
- agent 323, vestad 135 + clippy, cli 20 + clippy, web 83 (eslint 0 errors + prettier + tsc) all green locally.

## Note
Stacked on #821 (base = `feature/personality-voice-hook`), which introduced the `init=false` pattern and `AGENT_PERSONALITY`. GitHub will retarget this to `master` when #821 merges.