### PR TITLE
refactor(migrations): append mark_migration_applied step in runner

### DIFF
--- a/agent/core/migrations.py
+++ b/agent/core/migrations.py
@@ -3,8 +3,9 @@
 Each migration is a markdown file under `agent/core/migrations/`. The file's
 stem is the migration name. On boot we drop every unapplied migration as a
 passive notification under `~/agent/notifications/` (source `core`, type
-`migration`). The migration prompt's last step instructs the agent to call
-`mark_migration_applied(name)`, which records it in `state.json`. If the
+`migration`). The runner appends a final step instructing the agent to call
+`mark_migration_applied(name)` — authors do not write it per file — which
+records it in `state.json`. If the
 agent never calls the tool — rate limit, crash, hallucinated success — the
 migration runs again on the next boot. Migration prompts must therefore be
 idempotent.
@@ -52,7 +53,11 @@ def drop_pending_migrations(*, state: vm.State, config: vm.VestaConfig, first_st
             logger.startup(f"Pre-marked {len(pending)} migration(s) as applied (fresh agent)")
         return 0
     for name, content in pending:
-        body = f"[Migration: {name}]\n\n{content.strip()}"
+        # Append the completion step here so migration authors never hand-write the name
+        # (a typo would mark the wrong name and loop the migration forever). The canonical
+        # name is known here, so it is always correct by construction.
+        mark_step = f'## Final step\n\nCall `mark_migration_applied` with `name="{name}"`.'
+        body = f"[Migration: {name}]\n\n{content.strip()}\n\n{mark_step}"
         drop_core_notification(type_=vm.TYPE_MIGRATION, body=body, interrupt=False, config=config, name=f"{vm.TYPE_MIGRATION}-{name}")
         logger.startup(f"Dropped migration notification: {name}")
     return len(pending)

--- a/agent/tests/test_migrations.py
+++ b/agent/tests/test_migrations.py
@@ -69,6 +69,19 @@ def test_drop_writes_one_notification_per_migration(tmp_path):
     assert "[Migration: 001-first]" in payload["body"]
 
 
+def test_drop_appends_mark_applied_step_with_correct_name(tmp_path):
+    """The runner appends the mark_migration_applied step so authors never hand-write the name."""
+    config = _make_config(tmp_path)
+    migrations_dir = config.agent_dir / "core" / "migrations"
+    (migrations_dir / "001-first.md").write_text("do the thing")
+    state = _make_state()
+
+    drop_pending_migrations(state=state, config=config)
+
+    payload = json.loads((config.notifications_dir / "migration-001-first.json").read_text())
+    assert 'Call `mark_migration_applied` with `name="001-first"`.' in payload["body"]
+
+
 def test_drop_no_pending_returns_zero(tmp_path):
     config = _make_config(tmp_path)
     state = _make_state()


### PR DESCRIPTION
## What

The migration runner (`drop_pending_migrations`) now appends the `mark_migration_applied` completion step to each migration notification itself, using the canonical `name` it already has. Migration authors no longer hand-write that step.

## Why

Every migration markdown hand-wrote the same trailing step:

```
### N. Mark this migration applied
Call `mark_migration_applied` with `name="<stem>"`.
```

Beyond being duplicated boilerplate, it's **error-prone**: the name is typed by hand, so a typo or a name that doesn't match the file stem makes the agent mark the *wrong* migration. Since a migration re-runs until its real name is marked, that loops it forever on every boot.

Moving the step into the runner means the name is correct **by construction** — `drop_pending_migrations` already builds the body and knows the canonical `name`.

## Notes

- **Append-only**: the 3 existing `.md` files are left untouched, so they'll briefly carry the step twice in their prompt body (harmless — they're already applied on most agents, and the tool call is idempotent). New migrations should simply omit the "Mark this migration applied" section.
- Updated the module docstring to reflect that the runner appends the step.
- Added `test_drop_appends_mark_applied_step_with_correct_name`.

## Testing

`./check.sh agent` → 316 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)