### PR TITLE
onboard: read personalities/models/defaults from vestad instead of hardcoding

### DIFF
--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from . import state
 from .client import Client, OnboardError
-from .config import DEFAULT_MODEL, LINKS, PERSONALITY_PRESETS, PLAN, PLAN_FLOOR_USD, Config
+from .config import LINKS, PLAN, PLAN_FLOOR_USD, Config
 
 
 def _print(payload: dict[str, Any]) -> None:
@@ -221,7 +221,7 @@ def _cmd_claude_finish(args: argparse.Namespace, client: Client, cfg: Config) ->
         server_token=server_token,
         name=name,
         credentials=credentials,
-        model=(args.model or DEFAULT_MODEL),
+        model=(args.model or client.fetch_agent_defaults()["model"]),
     )
     if "error" in result:
         _print(
@@ -254,12 +254,17 @@ def _installable_skills() -> list[str]:
 
 
 def _cmd_presets(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    # Read the live reference data from this box's vestad (the one source of truth) rather
+    # than keeping hardcoded copies; skills still come from the on-box index.
+    defaults = client.fetch_agent_defaults()
     _print(
         {
-            "personalities": list(PERSONALITY_PRESETS),
+            "personalities": [p["name"] for p in client.fetch_personalities()],
             "skills": _installable_skills(),
             "plan_floor_usd": PLAN_FLOOR_USD,
-            "claude_models": ["opus", "sonnet", "haiku"],
+            "claude_models": [m["id"] for m in client.fetch_claude_models()],
+            "default_personality": defaults["personality"],
+            "default_model": defaults["model"],
         }
     )
     return 0
@@ -308,7 +313,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p_cfinish.add_argument("--email", required=True)
     p_cfinish.add_argument("--code", required=True, help="The code the buyer pasted from the auth page.")
     p_cfinish.add_argument("--name", help="Agent name (defaults to the one from create-agent).")
-    p_cfinish.add_argument("--model", help=f"Claude model (default {DEFAULT_MODEL}).")
+    p_cfinish.add_argument("--model", help="Claude model (defaults to the box's configured default).")
 
     sub.add_parser("presets", help="Personality presets + installable skills + models.")
     sub.add_parser("links", help="Marketing + desktop/mobile install URLs.")

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -68,6 +68,32 @@ class Client:
             raise OnboardError(data.get("error") or "vestad did not return a server-identity token")
         return token
 
+    # --- vestad: read-only reference data over the loopback ------------------
+
+    def _vestad_get(self, path: str) -> Any:
+        """GET a public reference endpoint on THIS box's vestad. The onboard skill is just
+        another frontend, so it reads personalities / models / defaults from vestad rather
+        than keeping its own copies."""
+        cfg = self._cfg
+        if not cfg.vestad_base:
+            raise OnboardError("not running inside an agent container (no VESTAD_PORT) — only a hosted vesta can onboard")
+        resp = self._send("GET", f"{cfg.vestad_base}{path}", verify=False)
+        if resp.status_code >= 400:
+            raise OnboardError(f"vestad {path} -> {resp.status_code}: {resp.text[:200]}")
+        try:
+            return resp.json()
+        except ValueError:
+            raise OnboardError(f"vestad {path} returned non-JSON ({resp.status_code})") from None
+
+    def fetch_agent_defaults(self) -> dict[str, Any]:
+        return self._vestad_get("/agent-defaults")
+
+    def fetch_personalities(self) -> list[dict[str, Any]]:
+        return self._vestad_get("/personalities")
+
+    def fetch_claude_models(self) -> list[dict[str, Any]]:
+        return self._vestad_get("/providers/claude/models")
+
     # --- control plane: account pre-create (authed as THIS vesta) ------------
 
     def create_account(self, email: str, identity_token: str) -> dict[str, Any]:

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -23,10 +23,6 @@ from urllib.parse import urlparse
 # Production control plane. Override with VESTA_CONTROL_URL for staging/testing.
 DEFAULT_CONTROL_URL = "https://vesta.run/api"
 
-# Default Claude model for a freshly onboarded agent (the buyer can switch later
-# in the app). Anthropic's curated picker is opus / sonnet / haiku.
-DEFAULT_MODEL = "sonnet"
-
 # Hosted Vesta is ONE plan, one box — the control plane's `pro` tier (4 vCPU /
 # 8 GB). The control plane also defines starter/power for admin provisioning and
 # upgrades, but onboarding only ever sells this one.
@@ -37,10 +33,6 @@ PLAN = "pro"
 # this is for the agent's UX + a friendly local error. Keep in sync with the
 # control plane's listMonthlyCents("pro").
 PLAN_FLOOR_USD = 24
-
-# Personality presets shipped by the `personality` skill (presets/<name>.md).
-# Listed here so `onboard presets` works even if that skill isn't installed yet.
-PERSONALITY_PRESETS = ("chill", "classic", "dry", "extra", "polished", "terse")
 
 # Public marketing + install links surfaced by `onboard links`.
 LINKS = {

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -51,13 +51,20 @@ def test_links(capsys):
     assert rc == 0 and data["marketing"] == "https://vesta.run"
 
 
-def test_presets_has_models_and_floor(capsys):
+def test_presets_lists_live_reference_data(capsys, monkeypatch):
+    # `onboard presets` now reads personalities / models / defaults from the box's vestad
+    # instead of hardcoding them, so the command is a pure consumer of that one source.
+    monkeypatch.setattr(cli_mod.Client, "fetch_personalities", lambda self: [{"name": "dry"}, {"name": "chill"}])
+    monkeypatch.setattr(cli_mod.Client, "fetch_claude_models", lambda self: [{"id": "opus"}, {"id": "sonnet"}, {"id": "haiku"}])
+    monkeypatch.setattr(cli_mod.Client, "fetch_agent_defaults", lambda self: {"personality": "dry", "model": "opus"})
     rc, data = _run(["presets"], capsys)
     assert rc == 0
     assert "dry" in data["personalities"]
     assert data["plan_floor_usd"] == 24
     assert "plans" not in data  # single plan — no tier list
     assert data["claude_models"] == ["opus", "sonnet", "haiku"]
+    assert data["default_personality"] == "dry"
+    assert data["default_model"] == "opus"
 
 
 # --- verify -----------------------------------------------------------------
@@ -252,9 +259,11 @@ def test_claude_finish_connects_and_clears(capsys, monkeypatch):
         return {"ok": True}
 
     monkeypatch.setattr(cli_mod.Client, "set_provider", fake_set)
+    # No --model: the default is read from the box's vestad, not a hardcoded onboard constant.
+    monkeypatch.setattr(cli_mod.Client, "fetch_agent_defaults", lambda self: {"model": "opus"})
     rc, data = _run(["claude-finish", "--email", E, "--code", "PASTE"], capsys)
     assert rc == 0 and data["connected"] is True and data["name"] == "Ada"
-    assert captured == {"name": "Ada", "credentials": "CREDS", "model": "sonnet"}
+    assert captured == {"name": "Ada", "credentials": "CREDS", "model": "opus"}
     # onboarding complete -> session forgotten
     assert state_mod.token_for(E) is None
 
@@ -275,6 +284,7 @@ def test_claude_finish_clears_session_when_attach_fails(capsys, monkeypatch):
         "claude_oauth_complete",
         lambda self, *, subdomain, server_token, session_id, code: "CREDS",
     )
+    monkeypatch.setattr(cli_mod.Client, "fetch_agent_defaults", lambda self: {"model": "opus"})
     # The attach (set_provider) fails after OAuth was consumed on the VM.
     monkeypatch.setattr(
         cli_mod.Client,

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2058,7 +2058,14 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/health", get(health))
         .route("/info", get(info))
         .route("/auth/session", post(auth::create_session_handler))
-        .route("/auth/refresh", post(auth::refresh_session_handler));
+        .route("/auth/refresh", post(auth::refresh_session_handler))
+        // Reference data: read-only and non-sensitive (static per version, already shown in the
+        // public onboarding UI). Unauthenticated so every frontend reads it the same way — the
+        // app, the CLI, and the onboard skill (just another frontend hitting its own box's vestad
+        // over the loopback), none of which then need to keep a hardcoded copy.
+        .route("/personalities", get(list_personalities_handler))
+        .route("/providers/claude/models", get(crate::providers::claude::list_models_handler))
+        .route("/agent-defaults", get(crate::defaults::agent_defaults_handler));
 
     // Control/JSON routes: bounded request/response handlers. A finite TimeoutLayer caps each
     // request so a stalled docker/restic call cannot hold a connection open indefinitely.
@@ -2073,11 +2080,8 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/gateway/update", post(gateway_update_handler))
         .route("/gateway/restart", post(restart_gateway_handler))
         .route("/tunnel", get(tunnel_handler))
-        .route("/personalities", get(list_personalities_handler))
-        .route("/agent-defaults", get(crate::defaults::agent_defaults_handler))
         .route("/providers/claude/oauth/start", post(crate::providers::claude::oauth_start_handler))
         .route("/providers/claude/oauth/complete", post(crate::providers::claude::oauth_complete_handler))
-        .route("/providers/claude/models", get(crate::providers::claude::list_models_handler))
         .route("/providers/openrouter/models/top", get(crate::providers::openrouter::list_top_models_handler))
         .route("/providers/openrouter/validate-key", post(crate::providers::openrouter::validate_key_handler))
         .route("/agents", get(list_agents_handler))


### PR DESCRIPTION
## What

The `onboard` skill is just another frontend, so it reads reference data from its own box's vestad (over the loopback it already uses to mint tokens) instead of keeping hardcoded copies. Removes three duplications and resolves the divergent default model.

- **vestad**: move `/personalities`, `/providers/claude/models`, and `/agent-defaults` to the unauthenticated **public** tier (read-only, non-sensitive, identical per version, already shown in the onboarding UI). The `api-or-agent-token` tier can't serve them: it derives the agent from an `/agents/{name}` path these routes don't have.
- **onboard CLI**: `onboard presets` and `claude-finish` now fetch personalities, the Claude model list, and the creation defaults from vestad. Removed `PERSONALITY_PRESETS`, the `["opus","sonnet","haiku"]` list, and `DEFAULT_MODEL = "sonnet"`.

## Behavior change
`claude-finish` without `--model` now defaults to vestad's default (**opus**) instead of the onboard CLI's **sonnet**. Only affects the no-`--model` path. If hosted agents should start on a cheaper model, that belongs in vestad's defaults (one source).

## Tests
onboard CLI 19 pass; vestad clippy clean + 135 bins; no test asserted auth on the moved endpoints.

(Supersedes #830, which auto-closed when its stacked base branch was deleted during the merge. Now branched directly off master.)