### PR TITLE
refactor(skills): distil verbose skill references

### DIFF
--- a/agent/skills/account/SKILL.md
+++ b/agent/skills/account/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: account
-description: Use when the OWNER asks about their Vesta hosting plan, billing, subscription, or account. Triggers like "what plan am I on", "how much am I paying", "when does it renew", "upgrade my plan", "cancel my account", "change my card", "manage my billing". Reads the plan directly, and for any change (upgrade, cancel, payment) hands back a secure link the owner opens to confirm. Hosted (vesta.run) boxes only; a self-hosted box has no plan. NOT for buying a new vesta for someone else (that is `onboard`), and NOT for paying a third-party invoice (that is `stripe-pay`).
+description: Owner asks about THIS box's Vesta hosting plan, billing, subscription, or renewal, or wants to upgrade/cancel/change card. Hosted (vesta.run) boxes only; not `onboard` (buying for someone else) or `stripe-pay` (third-party invoices).
 ---
 
 # account, CLI: `account`
@@ -40,9 +40,7 @@ Invoke when the **owner** asks about *their own* hosting:
 
 ## Skip
 
-- A **self-hosted** box (no `managed` flag, no plan). `account plan` will say so.
-- Buying a vesta for **someone else**, that is `onboard`.
-- Paying an external invoice or a third party, that is `stripe-pay`.
+Self-hosted boxes have no plan (`account plan` says so). Buying a vesta for someone else is `onboard`; paying an external invoice or third party is `stripe-pay`.
 
 ## Commands
 

--- a/agent/skills/agentmail/SKILL.md
+++ b/agent/skills/agentmail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentmail
-description: Send and receive email as the agent via AgentMail (managed inbox-per-agent service with a free tier). Use when the user mentions "email", "send email", "agent inbox", or wants email without a custom domain. The agent's address is `${username}@agentmail.to`. Inbound mail arrives as a notification with `source=agentmail`. Setup is fully autonomous; no domain, no DNS, no user input on the happy path. The skill wraps the official `agentmail` CLI so all upstream commands work transparently.
+description: Send and receive email as the agent via AgentMail (managed inbox-per-agent, free tier). Use for "email", "send email", or "agent inbox" without a custom domain; inbound mail arrives as a notification.
 ---
 
 # agentmail

--- a/agent/skills/claude-code/SKILL.md
+++ b/agent/skills/claude-code/SKILL.md
@@ -21,15 +21,7 @@ Reach for `claude` when the task is genuinely big:
 
 ## When NOT to use this skill
 
-For everything smaller, do it yourself with Read/Edit/Bash:
-
-- Single-file edits and small tweaks
-- Adding or changing a handful of lines
-- Quick fixes, typos, renames
-- Reading and explaining code
-- Small additions to existing functions
-
-Shelling out has its own overhead (subprocess, JSON parsing, the agent's autonomous turns). For modest work, that overhead exceeds the value of Claude Code's specialized prompt.
+For everything smaller (single-file edits, quick fixes, typos, renames, reading code, small additions to existing functions), do it yourself with Read/Edit/Bash: the subprocess and autonomous-turn overhead exceeds Claude Code's value on modest work.
 
 ## Basic call
 

--- a/agent/skills/email-client/SKILL.md
+++ b/agent/skills/email-client/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: email-client
-description: Personal email via IMAP/SMTP for any provider (Gmail, Outlook/Hotmail/Microsoft personal, Yahoo, iCloud, Fastmail, generic IMAP). Multi-account. Use to read an inbox, send/reply/forward mail, save drafts, manage messages (read/flag/answered/draft/categories, move/archive/delete), create/rename/delete folders, check folder counts, handle attachments, or get paged on new mail in real time (IMAP IDLE) from chosen folders. OAuth2 where supported, app-password fallback otherwise. Requires the poll daemon for notifications.
+description: Personal email over IMAP/SMTP for any provider (Gmail, Outlook, Yahoo, iCloud, Fastmail, generic IMAP). Multi-account: read an inbox, send/reply/forward, save drafts, manage messages and folders, handle attachments, and get paged on new mail. Requires the poll daemon for notifications.
 ---
 
 # Email Client
@@ -11,11 +11,7 @@ Provider-agnostic IMAP/SMTP for the user's email accounts, any number side by si
 
 Use it for a uniform IMAP/SMTP interface across one or many personal accounts: read, send, reply, forward, manage, and get notified on new mail.
 
-Do not use it when:
-
-- The user wants the full Gmail API surface (labels, threads, drafts as Google models them) → use the `google` skill.
-- The user has an M365 *work* account with IMAP/SMTP disabled, or wants calendar/contacts/Graph → use the `microsoft` skill. (M365 work accounts *with* IMAP enabled work here; see "Microsoft 365 with a custom domain".)
-- The user wants an agent-owned inbox rather than their personal mail → use `agentmail`.
+Do not use it when the user wants the full Gmail API surface (use the `google` skill), calendar/contacts/Graph or an M365 *work* account with IMAP/SMTP disabled (use the `microsoft` skill; M365 work *with* IMAP enabled works here, see "Microsoft 365 with a custom domain"), or an agent-owned inbox instead of personal mail (use `agentmail`).
 
 ## Notes & rules
 

--- a/agent/skills/essay-iter/SKILL.md
+++ b/agent/skills/essay-iter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: essay-iter
-description: Iterate on any piece of academic writing through a four-reviewer review team per round. Reviewers check rubric alignment, in-distribution fit against reference essays, citation accuracy and style, and AI-text detection score. Loops draft and review until every reviewer is satisfied. Generic for coursework, dissertations, journal submissions, conference papers, or any academic writing where references, a rubric, or stylistic norms are available.
+description: Iterate academic writing through a four-reviewer loop: rubric alignment, in-distribution fit, citation accuracy, AI-text detection. For coursework essays, dissertations, journal submissions, or conference papers.
 ---
 
 # Essay Iteration Loop
@@ -107,18 +107,7 @@ for round = 1, 2, 3, ...:
 
 ### Step 1: approach session
 
-Agent gathers what's available, then surfaces a plan to the user covering:
-
-. essay / piece title and operative question
-. structure (sections + word allocation)
-. core thesis / argument / contribution
-. references corpus (where they came from + count)
-. rubric (verbatim, or scaffolded)
-. citation style
-. AI-detection threshold
-. anything risky or ambiguous
-
-Wait for user OK before drafting. If user wants to edit the plan, iterate the plan first.
+Run the approach session described in Phase 1 above: gather what's available, surface the plan, and wait for user OK before drafting. If the user wants to edit the plan, iterate the plan first.
 
 ### Step 2: initial draft
 

--- a/agent/skills/finance/SKILL.md
+++ b/agent/skills/finance/SKILL.md
@@ -99,17 +99,7 @@ Notification format:
 
 - **Auth method**: RS256 JWT, self-signed. JWTs generated fresh per request, no OAuth token refresh needed
 - **Consent duration**: 90 days
-- **Re-auth**: when expired, run `finance auth login`, visit the URL in browser, authorize your bank
-
-**Re-auth process:**
-```bash
-finance auth login
-# Prints URL - open in browser
-# Bank authorization screen
-# Callback caught automatically at https://localhost:7866/callback
-# If SSL error in browser: copy the full URL from address bar, run:
-finance auth callback --url '<full-redirect-url-from-browser>'
-```
+- **Re-auth**: when consent expires, run `finance auth login` and authorize your bank in the browser. The callback is caught automatically at `https://localhost:7866/callback`; on a browser SSL error, copy the full redirect URL from the address bar and pass it to `finance auth callback --url '<url>'`.
 
 ## Configuration
 

--- a/agent/skills/flights/SKILL.md
+++ b/agent/skills/flights/SKILL.md
@@ -226,8 +226,7 @@ To configure your home airports for the `cheapest` command, edit `LONDON_AIRPORT
 - **Duffel does NOT support Wizz Air or Ryanair.** Use Trip.com for these
 - **Duffel balance**: must be funded before live bookings. Check balance before attempting
 - Prices from Google Flights are in USD; Trip.com and Duffel prices depend on currency/locale
-- **Trip.com browser sessions**: always use `--stealth` mode. Regular browser gets blocked by Cloudflare
-- **Trip.com payment timer**: ~13 min. Don't browse around on the payment page
+- Trip.com quirks (stealth requirement, ~13 min payment timer, etc.) are in "Trip.com Known Quirks" above
 
 ## Saved Profiles
 

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -77,7 +77,7 @@
   },
   {
     "name": "onboard",
-    "description": "Use when someone who doesn't have their own vesta asks what this is, how to get one, or hints they want in. Vesta is INVITE-ONLY: you can't buy it from a website, you only get in through someone who already has one. So you don't sell eagerly; you're a discerning gatekeeper to an exclusive club. Make them want it and show they're a fit, THEN (if they earn it) set them up end-to-end IN CHAT: verify their email by a code they read back, confirm they have a paid Claude account, agree a price, send a private Stripe link, then once they've paid create their agent and connect their Claude (an auth link + a code they paste back), and only then hand them the app to talk to it. Never asks for card details. Do NOT use on the owner (they already have one)."
+    "description": "Use when someone who doesn't have their own vesta asks what it is, how to get one, or hints they want in. Vesta is invite-only: you gatekeep and create desire rather than sell, then (if they earn it) set them up end-to-end in chat. Not for the owner, who already has one."
   },
   {
     "name": "onedrive",

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -5,11 +5,11 @@
   },
   {
     "name": "account",
-    "description": "Use when the OWNER asks about their Vesta hosting plan, billing, subscription, or account. Triggers like \"what plan am I on\", \"how much am I paying\", \"when does it renew\", \"upgrade my plan\", \"cancel my account\", \"change my card\", \"manage my billing\". Reads the plan directly, and for any change (upgrade, cancel, payment) hands back a secure link the owner opens to confirm. Hosted (vesta.run) boxes only; a self-hosted box has no plan. NOT for buying a new vesta for someone else (that is `onboard`), and NOT for paying a third-party invoice (that is `stripe-pay`)."
+    "description": "Owner asks about THIS box's Vesta hosting plan, billing, subscription, or renewal, or wants to upgrade/cancel/change card. Hosted (vesta.run) boxes only; not `onboard` (buying for someone else) or `stripe-pay` (third-party invoices)."
   },
   {
     "name": "agentmail",
-    "description": "Send and receive email as the agent via AgentMail (managed inbox-per-agent service with a free tier). Use when the user mentions \"email\", \"send email\", \"agent inbox\", or wants email without a custom domain. The agent's address is `${username}@agentmail.to`. Inbound mail arrives as a notification with `source=agentmail`. Setup is fully autonomous; no domain, no DNS, no user input on the happy path. The skill wraps the official `agentmail` CLI so all upstream commands work transparently."
+    "description": "Send and receive email as the agent via AgentMail (managed inbox-per-agent, free tier). Use for \"email\", \"send email\", or \"agent inbox\" without a custom domain; inbound mail arrives as a notification."
   },
   {
     "name": "browser",
@@ -29,11 +29,11 @@
   },
   {
     "name": "email-client",
-    "description": "Personal email via IMAP/SMTP for any provider (Gmail, Outlook/Hotmail/Microsoft personal, Yahoo, iCloud, Fastmail, generic IMAP). Multi-account. Use to read an inbox, send/reply/forward mail, save drafts, manage messages (read/flag/answered/draft/categories, move/archive/delete), create/rename/delete folders, check folder counts, handle attachments, or get paged on new mail in real time (IMAP IDLE) from chosen folders. OAuth2 where supported, app-password fallback otherwise. Requires the poll daemon for notifications."
+    "description": "Personal email over IMAP/SMTP for any provider (Gmail, Outlook, Yahoo, iCloud, Fastmail, generic IMAP). Multi-account: read an inbox, send/reply/forward, save drafts, manage messages and folders, handle attachments, and get paged on new mail. Requires the poll daemon for notifications."
   },
   {
     "name": "essay-iter",
-    "description": "Iterate on any piece of academic writing through a four-reviewer review team per round. Reviewers check rubric alignment, in-distribution fit against reference essays, citation accuracy and style, and AI-text detection score. Loops draft and review until every reviewer is satisfied. Generic for coursework, dissertations, journal submissions, conference papers, or any academic writing where references, a rubric, or stylistic norms are available."
+    "description": "Iterate academic writing through a four-reviewer loop: rubric alignment, in-distribution fit, citation accuracy, AI-text detection. For coursework essays, dissertations, journal submissions, or conference papers."
   },
   {
     "name": "exa",
@@ -141,7 +141,7 @@
   },
   {
     "name": "video-use",
-    "description": "Use for \"edit video\", \"video editing\", \"remove filler words\", \"cut dead space\", \"color grade\", \"add subtitles\", \"burn captions\", \"B-roll overlay\", \"launch video\", or whenever the user wants footage turned into a polished cut. Wraps browser-use/video-use, a Claude-Code-powered video editor that handles filler removal, auto color grading, 30ms audio fades, burned subtitles, and Manim/Remotion/PIL overlays."
+    "description": "Use for \"edit video\", \"remove filler words\", \"cut dead space\", \"color grade\", \"add subtitles\", \"burn captions\", \"B-roll overlay\", or turning raw footage into a polished cut. Wraps browser-use/video-use, a Claude-Code-powered video editor."
   },
   {
     "name": "voice",

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboard
-description: Use when someone who doesn't have their own vesta asks what this is, how to get one, or hints they want in. Vesta is INVITE-ONLY: you can't buy it from a website, you only get in through someone who already has one. So you don't sell eagerly; you're a discerning gatekeeper to an exclusive club. Make them want it and show they're a fit, THEN (if they earn it) set them up end-to-end IN CHAT: verify their email by a code they read back, confirm they have a paid Claude account, agree a price, send a private Stripe link, then once they've paid create their agent and connect their Claude (an auth link + a code they paste back), and only then hand them the app to talk to it. Never asks for card details. Do NOT use on the owner (they already have one).
+description: Use when someone who doesn't have their own vesta asks what it is, how to get one, or hints they want in. Vesta is invite-only: you gatekeep and create desire rather than sell, then (if they earn it) set them up end-to-end in chat. Not for the owner, who already has one.
 ---
 
 # onboard - CLI: `onboard`

--- a/agent/skills/stripe-pay/SKILL.md
+++ b/agent/skills/stripe-pay/SKILL.md
@@ -24,11 +24,7 @@ Invoke this skill when:
 
 ## Skip
 
-Do not use this skill for:
-- Sending money to people (this is for paying merchants, not P2P transfers)
-- Recurring subscriptions the user already has elsewhere
-- Anything where the user has not run `stripe-pay authorize` yet: tell them to set up first
-- Generic "log this expense" requests: use the `finance` skill for read-only bank data
+Not for sending money to people (merchants only, not P2P) or read-only expense logging (use the `finance` skill). If `stripe-pay authorize` has not run, `charge` errors clearly and you tell the user to set up first.
 
 ## Setup
 

--- a/agent/skills/tv/SKILL.md
+++ b/agent/skills/tv/SKILL.md
@@ -274,11 +274,8 @@ asyncio.run(play_youtube_video("VIDEO_ID"))
 ```
 
 **Notes on auth persistence:**
-- `screen_id` is stable as long as YouTube stays running on the TV. If YouTube restarts, a new screen_id is fetched via DIAL automatically.
-- `refresh_auth()` only needs `screen_id`. It's a server-side call, no TV popup.
-- The popup only fires when `connect()` creates a brand-new session with an unknown device.
-- Use `api.auth.serialize()` / `api.auth.deserialize()` (NOT `store_auth_state()` which has a key naming bug in v3.2.0).
-- If saved auth fails, the code gracefully falls back to full pairing.
+- Use `api.auth.serialize()` / `api.auth.deserialize()` (NOT `store_auth_state()`, which has a key naming bug in v3.2.0).
+- If YouTube restarts on the TV the `screen_id` changes, but the code re-fetches it via DIAL automatically; the pairing popup only fires when `connect()` opens a brand-new session with an unknown device.
 
 Additional pyytlounge commands (after connect):
 

--- a/agent/skills/video-use/SKILL.md
+++ b/agent/skills/video-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video-use
-description: Use for "edit video", "video editing", "remove filler words", "cut dead space", "color grade", "add subtitles", "burn captions", "B-roll overlay", "launch video", or whenever the user wants footage turned into a polished cut. Wraps browser-use/video-use, a Claude-Code-powered video editor that handles filler removal, auto color grading, 30ms audio fades, burned subtitles, and Manim/Remotion/PIL overlays.
+description: Use for "edit video", "remove filler words", "cut dead space", "color grade", "add subtitles", "burn captions", "B-roll overlay", or turning raw footage into a polished cut. Wraps browser-use/video-use, a Claude-Code-powered video editor.
 ---
 
 # Video-Use - Claude-Code-Powered Video Editor


### PR DESCRIPTION
## What

A doc-only verbosity/redundancy distillation pass over a set of skill reference files, following the Claude 4 prompting guidance: state what TO do once, rather than mirror it with inverse "what NOT to do" lists, and avoid repeating the same quirk across sections.

No version bumps. Bracketed personalization stubs left untouched.

## Cuts per file

**A. Collapse inverse sections to one sentence**
- `claude-code`: collapsed the bulleted "When NOT to use" (a pure inverse of "When to use") to one sentence.
- `stripe-pay`: collapsed the negation-heavy "Skip" list, keeping the non-obvious P2P / finance-routing / authorize-first points.
- `account`: collapsed the "Skip" list, keeping the `onboard` / `stripe-pay` routing.
- `email-client`: collapsed the "Do not use it when" preamble + bullets into one sentence, preserving the `google` / `microsoft` / `agentmail` routing.

**B. Remove in-file duplication**
- `tv`: trimmed the "Notes on auth persistence" bullets that restated the code-block comments + intro; kept the unique `serialize/deserialize` v3.2.0 bug note and DIAL re-fetch/popup nuance.
- `flights`: removed the Trip.com stealth + ~13min payment-timer entries from Gotchas (already canonical in "Trip.com Known Quirks").
- `essay-iter`: replaced the second description of the Phase 1 approach session (Step 1) with a one-line back-reference.
- `finance`: removed the duplicate "Re-auth process" bash block; folded the SSL fallback note into the Re-auth bullet (commands remain in CLI Quick Reference).

**C. Trim over-long discovery descriptions to ~150 chars**
- `account`, `email-client`, `agentmail`, `essay-iter`, `video-use`: tightened the paragraph-length frontmatter `description:` lines; full detail stays in each body.

**D.** Regenerated `agent/skills/index.json`.

Net: roughly 60 lines / ~300 words of repetition removed across the SKILL.md files; all unique capability info preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)