### PR TITLE
refactor(cc_sdk): single-source the 200k window and 1M beta in core

### DIFF
--- a/agent/core/cc_sdk/client.py
+++ b/agent/core/cc_sdk/client.py
@@ -51,8 +51,6 @@ _POST_STOP_DRAIN_S = 2.5
 _COMPACT_START_TIMEOUT_S = 60.0
 _COMPACT_TIMEOUT_S = 900.0
 _ALWAYS_EVENTS = ("SessionStart", "Stop", "PreCompact")
-_DEFAULT_MAX_TOKENS = 200_000
-_BETA_1M = "context-1m-2025-08-07"
 
 
 def _preseed_config(cwd: str) -> None:
@@ -115,8 +113,8 @@ def _claude_args(
         args += ["--mcp-config", str(mcp_file)]
     for d in options.add_dirs:
         args += ["--add-dir", d]
-    if _BETA_1M in options.betas:
-        args += ["--betas", _BETA_1M]
+    for beta in options.betas:
+        args += ["--betas", beta]
     return args
 
 
@@ -282,13 +280,15 @@ class ClaudeSDKClient:
             # The user pinned a window; report usage against exactly that.
             max_tokens = configured
         else:
-            # Don't assume the 1M beta took effect (it is silently ignored on some auth modes).
-            # Stay on the conservative 200k ceiling until usage actually exceeds it — which can
-            # only happen if the larger window is really active — so the overflow warning in
-            # diagnostics.log_context_usage still fires near the real limit instead of never.
-            max_tokens = _DEFAULT_MAX_TOKENS
-            if _BETA_1M in self._options.betas and total > _DEFAULT_MAX_TOKENS:
-                max_tokens = 1_000_000
+            # The caller supplies both windows (no model constants here). Stay on the conservative
+            # `context_window` until usage actually exceeds it — which can only happen if the larger
+            # `expanded_context_window` is really active (the 1M beta is silently ignored on some
+            # auth modes) — so the overflow warning in diagnostics.log_context_usage still fires
+            # near the real limit instead of never.
+            max_tokens = self._options.context_window or 0
+            expanded = self._options.expanded_context_window
+            if expanded and max_tokens and total > max_tokens:
+                max_tokens = expanded
         percentage = (total / max_tokens * 100) if max_tokens else 0.0
         return {"percentage": percentage, "totalTokens": total, "maxTokens": max_tokens}
 

--- a/agent/core/cc_sdk/messages.py
+++ b/agent/core/cc_sdk/messages.py
@@ -104,9 +104,16 @@ class ClaudeAgentOptions:
     model: str | None = None
     betas: list[str] = dc.field(default_factory=list)
     # Effective context window, when the user has chosen one. Drives the context-usage
-    # percentage; None falls back to the 200k/1M heuristic. claude-code itself is told
-    # via CLAUDE_CODE_MAX_CONTEXT_TOKENS in the launch env (see client.build_client_options).
+    # percentage. claude-code itself is told via CLAUDE_CODE_MAX_CONTEXT_TOKENS in the launch
+    # env (see client.build_client_options).
     max_context_tokens: int | None = None
+    # Windows for the context-usage percentage when `max_context_tokens` is unset, supplied by
+    # the caller so cc_sdk holds no model-specific constants. `context_window` is the
+    # conservative fallback; `expanded_context_window`, when set, is the larger window usage may
+    # unlock once it exceeds `context_window` (proving the larger window is really active). Both
+    # None -> usage reports a 0 window (nothing to report against).
+    context_window: int | None = None
+    expanded_context_window: int | None = None
     hooks: dict[HookEvent, list[HookMatcher]] = dc.field(default_factory=dict)
     permission_mode: str = "default"
     can_use_tool: tp.Callable[..., tp.Any] | None = None

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -18,7 +18,7 @@ from core.cc_sdk.types import PermissionResultAllow, ThinkingConfigDisabled, Too
 from . import logger
 from . import models as vm
 from . import state_store
-from .config import DEFAULT_CONTEXT_WINDOW
+from .config import CONTEXT_1M_BETA, DEFAULT_CONTEXT_WINDOW, EXPANDED_CONTEXT_WINDOW
 from . import diagnostics
 from . import sdk_parsing
 from .helpers import get_constitution_path, get_memory_path
@@ -300,7 +300,7 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
         # Unset (existing agents) keeps the historical default: 1M beta on, no explicit cap.
         chosen = config.max_context_tokens
         if chosen is None or chosen > DEFAULT_CONTEXT_WINDOW:
-            betas = ["context-1m-2025-08-07"]
+            betas = [CONTEXT_1M_BETA]
         if chosen is not None:
             sdk_env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] = str(chosen)
 
@@ -315,6 +315,12 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
         model=config.agent_model,
         betas=betas,
         max_context_tokens=effective_max_context,
+        # Windows for the context-usage %: the conservative fallback and the larger window it
+        # may unlock. cc_sdk reports against context_window until usage proves the expanded one
+        # is really active (the 1M beta is silently ignored on some auth modes), so the values
+        # live here, not in the transport.
+        context_window=DEFAULT_CONTEXT_WINDOW,
+        expanded_context_window=EXPANDED_CONTEXT_WINDOW if CONTEXT_1M_BETA in betas else None,
         hooks=sdk_parsing.make_hooks(state),
         permission_mode="bypassPermissions",
         can_use_tool=_approve_all_tools,

--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -14,6 +14,12 @@ _THINKING_ENABLED_BUDGET_TOKENS = 10000
 # when the user hasn't explicitly chosen a context window.
 DEFAULT_CONTEXT_WINDOW = 200_000
 
+# The 1M-context beta and the window it unlocks. These are Anthropic-API facts the agent
+# owns: build_client_options decides whether to enable the beta and passes both windows to
+# cc_sdk for usage reporting, so the transport keeps no model-specific constants of its own.
+CONTEXT_1M_BETA = "context-1m-2025-08-07"
+EXPANDED_CONTEXT_WINDOW = 1_000_000
+
 
 class VestaConfig(pyd_settings.BaseSettings):
     """Vesta agent configuration.

--- a/agent/tests/test_cc_sdk.py
+++ b/agent/tests/test_cc_sdk.py
@@ -284,7 +284,7 @@ async def test_interrupt_at_idle_is_noop(tmp_path, monkeypatch):
 
 @pytest.mark.anyio
 async def test_context_usage_conservative_without_proof(tmp_path):
-    client = _new_client(tmp_path, betas=["context-1m-2025-08-07"])
+    client = _new_client(tmp_path, context_window=200_000, expanded_context_window=1_000_000)
     client._last_usage = {"input_tokens": 160_000, "output_tokens": 10_000}
     usage = await client.get_context_usage()
     # 170k of a presumed 200k window -> already >80%, so the overflow warning can fire.
@@ -294,7 +294,7 @@ async def test_context_usage_conservative_without_proof(tmp_path):
 
 @pytest.mark.anyio
 async def test_context_usage_unlocks_1m_when_exceeded(tmp_path):
-    client = _new_client(tmp_path, betas=["context-1m-2025-08-07"])
+    client = _new_client(tmp_path, context_window=200_000, expanded_context_window=1_000_000)
     client._last_usage = {"input_tokens": 300_000, "output_tokens": 10_000}
     usage = await client.get_context_usage()
     # Past 200k proves the 1M window is really active.

--- a/agent/tests/test_e2e_transport.py
+++ b/agent/tests/test_e2e_transport.py
@@ -186,7 +186,8 @@ async def test_sidechain_lines_are_skipped(sandbox: Sandbox) -> None:
 
 @pytest.mark.anyio
 async def test_usage_flows_to_result_and_context_usage(sandbox: Sandbox) -> None:
-    options = ClaudeAgentOptions(cwd=str(sandbox.cwd))
+    # The caller supplies the reporting window; cc_sdk no longer assumes one.
+    options = ClaudeAgentOptions(cwd=str(sandbox.cwd), context_window=200_000)
     async with ClaudeSDKClient(options=options) as client:
         await client.query("hello")
         messages = await collect_with_timeout(client)


### PR DESCRIPTION
## What

The 200k default window and the `context-1m-2025-08-07` beta string were defined in **both** the agent (`config.py` / `client.py`) and `cc_sdk/client.py`. cc_sdk is a generic claude-CLI driver and shouldn't carry model-specific constants, so this moves them to the one place that owns them.

- **`config.py`**: `CONTEXT_1M_BETA` + `EXPANDED_CONTEXT_WINDOW` added next to the existing `DEFAULT_CONTEXT_WINDOW`. `build_client_options` uses the named beta and passes both reporting windows to cc_sdk via two new `ClaudeAgentOptions` fields (`context_window`, `expanded_context_window`).
- **`cc_sdk/client.py`**: drops `_DEFAULT_MAX_TOKENS` and `_BETA_1M`. Now forwards **all** betas generically (not just the 1M one — a latent bug: any other beta core set was silently dropped), and computes context-usage against the caller-supplied windows. The "conservative until the larger window is proven active" heuristic is unchanged, just parameterized.

Net: `200_000` and the beta id live in exactly one place (`config.py`); cc_sdk holds no model facts.

## Tests
Full agent suite green (324), including the cc_sdk transport + e2e tests (updated to pass the reporting window the SDK no longer assumes). ruff + ty clean.