### PR TITLE
refactor(skills): disambiguate service vs daemon terminology

### DIFF
--- a/agent/core/skills/app-chat/SKILL.md
+++ b/agent/core/skills/app-chat/SKILL.md
@@ -12,7 +12,7 @@ uv tool install ~/agent/core/skills/app-chat/cli
 ```
 
 **Background**: `screen -dmS app-chat app-chat serve --notifications-dir ~/agent/notifications`
-**Restart**: Add to the `## Services` section of `~/agent/skills/restart/SKILL.md`:
+**Restart**: Add to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
 ```
 screen -dmS app-chat app-chat serve --notifications-dir ~/agent/notifications
 ```

--- a/agent/skills/agentmail/SETUP.md
+++ b/agent/skills/agentmail/SETUP.md
@@ -69,7 +69,7 @@ PORT=$(~/agent/skills/service/scripts/register-service agentmail --public)
 screen -dmS agentmail agentmail serve --port $PORT
 ```
 
-Register it for restart (see [service](../service/SKILL.md)) by adding this startup command to the `## Services` section of `~/agent/skills/restart/SKILL.md`:
+Register it for restart (see [service](../service/SKILL.md)) by adding this startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
 
 ```
 PORT=$(~/agent/skills/service/scripts/register-service agentmail --public) && screen -dmS agentmail agentmail serve --port $PORT

--- a/agent/skills/browser/SETUP.md
+++ b/agent/skills/browser/SETUP.md
@@ -32,7 +32,7 @@ screen -dmS xvfb Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp
 DISPLAY=:99 browser launch --stealth
 ```
 
-Add the Xvfb start line to the `## Services` section of `~/agent/skills/restart/SKILL.md` so it comes back up on container restart.
+Add the Xvfb start line to the `## Daemons` section of `~/agent/skills/restart/SKILL.md` so it comes back up on container restart.
 
 ## Remote assist (user takeover)
 

--- a/agent/skills/dashboard/SETUP.md
+++ b/agent/skills/dashboard/SETUP.md
@@ -24,7 +24,7 @@ screen -dmS dashboard sh -c "cd ~/agent/skills/dashboard/app && npx vite preview
 
 ## 4. Register the service
 
-Add this startup command to the `## Services` section of `~/agent/skills/restart/SKILL.md`:
+Add this startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
 ```
 PORT=$(~/agent/skills/service/scripts/register-service dashboard --public) && screen -dmS dashboard sh -c "cd ~/agent/skills/dashboard/app && npx vite preview --port $PORT --host 0.0.0.0"
 ```

--- a/agent/skills/email-client/SETUP.md
+++ b/agent/skills/email-client/SETUP.md
@@ -140,7 +140,11 @@ email-client notify add --folder Archive --account personal
 
 Without this the daemon watches `INBOX` only. Note that `--all` includes folders like Sent/Drafts/Spam/Trash, which can be noisy; drop any the user doesn't want with `email-client notify remove --folder <name>`.
 
-## 5. Add to restart.md
+## 5. Register for restart
+
+Add this to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`. The poller only
+connects out to IMAP and writes notification files, so it needs no inbound port: it is a
+daemon, not a vestad service.
 
 ```
 screen -dmS email-client bash -c "cd ~/.email-client/runtime && PYTHONUNBUFFERED=1 uv run python3 ~/.email-client/poll_daemon.py --interval 15 > ~/.email-client/poll_daemon.log 2>&1"

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -97,7 +97,7 @@
   },
   {
     "name": "restart",
-    "description": "What to do after a container restart. Holds the per-skill service startup commands."
+    "description": "What to do after a container restart. Holds the per-skill daemon startup commands."
   },
   {
     "name": "service",

--- a/agent/skills/restart/SKILL.md
+++ b/agent/skills/restart/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: restart
-description: What to do after a container restart. Holds the per-skill service startup commands.
+description: What to do after a container restart. Holds the per-skill daemon startup commands.
 ---
 
 # Restart
 
 Read `/run/vestad-env` so the values are in your context (Read tool, not bash).
 
-`screen -ls` to see what's already up. Start anything in the Services section below that isn't. Then check User State in MEMORY.md and reach out on their preferred channel. Match the moment: new day → warm; mid-convo restart → brief; crash → mention it; middle of the night → wait.
+`screen -ls` to see what's already up. Start anything in the Daemons section below that isn't. Then check User State in MEMORY.md and reach out on their preferred channel. Match the moment: new day → warm; mid-convo restart → brief; crash → mention it; middle of the night → wait.
 
 On a fresh start only (after the nightly dream or a first start, not a mid-conversation resume or crash/timeout recovery), reason through your personality for the day before anything else. Don't restate the rules: given what's on today and what you know about them, how will the voice genuinely show through, as the same message and not garnish on the work? Name two or three concrete openings (a callback, a contradiction worth teasing, a pattern you've clocked). This is what makes character stick instead of decaying into flat task-mode the moment work shows up.
 
-## Services
+## Daemons
 
-Skill setup steps add their service startup commands here, one fenced block per skill. Run each on every restart unless the corresponding screen session is already up.
+Skill setup steps add their daemon startup commands here, one fenced block per skill (a daemon that vestad proxies on a port is a service, registered via the `service` skill; a portless background process still goes here). Run each on every restart unless the corresponding screen session is already up.
 
 ```bash
-# (empty until a skill registers a service)
+# (empty until a skill adds a daemon)
 ```

--- a/agent/skills/service/SKILL.md
+++ b/agent/skills/service/SKILL.md
@@ -5,7 +5,13 @@ description: Register a background daemon with vestad to get a port, and keep it
 
 # Service Registration
 
-Skills that run a daemon register it with vestad to get a port, then start it. The
+A service is a port inside the container that vestad reverse-proxies, optionally public
+(reachable through the tunnel without a token) or token-gated. Register one when something
+outside the process needs to reach it: a web UI, an inbound webhook, an API the app calls.
+A background process that needs no inbound port is just a daemon: it does not register here,
+it only goes in the restart skill's `## Daemons` section.
+
+Skills that run a service register it with vestad to get a port, then start it. The
 `register-service` helper does the curl and prints the port (idempotent: same port per name):
 
 ```bash
@@ -16,7 +22,7 @@ PORT=$(~/agent/skills/service/scripts/register-service dashboard --public)
 ```
 
 So the service comes back after a container restart, add its startup command to the
-`## Services` section of `~/agent/skills/restart/SKILL.md`, one fenced block per skill. Use a
+`## Daemons` section of `~/agent/skills/restart/SKILL.md`, one fenced block per skill. Use a
 single line that re-registers and starts, e.g.:
 
 ```bash

--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -127,7 +127,7 @@ screen -dmS tasks tasks serve --notifications-dir ~/agent/notifications --port $
 
 One daemon handles everything, both task due-date monitoring and reminder scheduling. No separate reminder daemon needed.
 
-**Restart**: Add this startup command to the `## Services` section of `~/agent/skills/restart/SKILL.md`:
+**Restart**: Add this startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
 ```
 PORT=$(~/agent/skills/service/scripts/register-service tasks) && screen -dmS tasks tasks serve --notifications-dir ~/agent/notifications --port $PORT
 ```

--- a/agent/skills/voice/SETUP.md
+++ b/agent/skills/voice/SETUP.md
@@ -7,7 +7,7 @@
    PORT=$(~/agent/skills/service/scripts/register-service voice)
    SKILL_PORT=$PORT PYTHONPATH=~/agent/skills screen -dmS voice uv run python -m voice.server
    ```
-2. Add this startup command to the `## Services` section of `~/agent/skills/restart/SKILL.md`:
+2. Add this startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
    ```
    PORT=$(~/agent/skills/service/scripts/register-service voice) && SKILL_PORT=$PORT PYTHONPATH=~/agent/skills screen -dmS voice uv run python -m voice.server
    ```


### PR DESCRIPTION
## What

Follow-up to #834. The `service` skill landed, but the `## Services` → `## Daemons` terminology cleanup was committed to the branch after #834 squash-merged, so it never reached master. This PR carries just that cleanup.

## Why

`service` was overloaded. `vestad` and the web app use it precisely (a container port vestad reverse-proxies, the Docker/k8s meaning), but the restart skill's `## Services` section listed *every* background process, including portless ones like the email-client IMAP poller. That double scope is the only place the word was stretched.

## Changes (agent-prose only, no wire-contract change)

- Rename the restart skill's `## Services` section to `## Daemons` (it holds all background-process startup commands; a daemon vestad proxies on a port is a service, a portless one still goes here).
- Repoint the 7 "add to the `## Services` section" references to `## Daemons`.
- State the distinction outright in the `service` skill (a service is a vestad-proxied port; a portless background process is a daemon).
- Make `email-client` the worked example: its restart step now says it is a daemon, not a vestad service, because the poller only connects out.

`vestad` and the web app keep `service` unchanged. Net model: skill (capability), daemon (any background process), service (a daemon vestad gives a port and proxies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)