### PR TITLE
fix(vestad): bind vestad HTTPS and agent WS to localhost only

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -340,7 +340,10 @@ async def start_ws_server(
     config: VestaConfig,
     state: State | None = None,
     *,
-    host: str = "0.0.0.0",
+    # Loopback only: the container runs with host networking and vestad's proxy
+    # reaches this server via localhost, so binding 127.0.0.1 keeps the agent API
+    # off the LAN (and, behind the cloud firewall, off every external interface).
+    host: str = "127.0.0.1",
 ) -> web.AppRunner:
     app = web.Application(middlewares=[_auth_middleware])
     app["event_bus"] = event_bus

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -170,10 +170,10 @@ fn paint(code: &str, s: &str) -> String {
 }
 
 fn find_available_port() -> Option<u16> {
-    // serve.rs binds HTTPS on 0.0.0.0:N and HTTP on 127.0.0.1:N+1, so both must be free.
+    // serve.rs binds HTTPS on 127.0.0.1:N and HTTP on 127.0.0.1:N+1, so both must be free.
     const MAX_ATTEMPTS: u8 = 16;
     for _ in 0..MAX_ATTEMPTS {
-        let port = std::net::TcpListener::bind(("0.0.0.0", 0))
+        let port = std::net::TcpListener::bind(("127.0.0.1", 0))
             .ok()
             .and_then(|l| l.local_addr().ok())
             .map(|addr| addr.port())?;
@@ -194,7 +194,7 @@ fn resolve_port(explicit: Option<u16>, config: &std::path::Path) -> u16 {
         .ok()
         .and_then(|s| s.trim().parse::<u16>().ok())
     {
-        if std::net::TcpListener::bind(("0.0.0.0", stored)).is_ok()
+        if std::net::TcpListener::bind(("127.0.0.1", stored)).is_ok()
             && std::net::TcpListener::bind(("127.0.0.1", stored + 1)).is_ok()
         {
             return stored;

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2457,9 +2457,15 @@ pub async fn run_server(cfg: ServerConfig) {
     // the async block, closing the TOCTOU race on the HTTP port. HTTPS binds
     // inside axum_server::bind_rustls below; its window is short and a loss is
     // loud (the task panics) rather than silent.
-    let https_addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+    // Bind the HTTPS control API to loopback only. Every path that reaches vestad
+    // arrives via localhost: the Cloudflare tunnel's cloudflared dials
+    // https://localhost:{port} (see tunnel.rs) and the plain HTTP server is
+    // already loopback-only, so this keeps the API off the LAN and the public
+    // internet. On cloud-managed VMs a deny-all host firewall is the boundary
+    // regardless, so loopback binding there is defence in depth, not a regression.
+    let https_addr = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
 
-    tracing::info!(port, "https listening on 0.0.0.0");
+    tracing::info!(port, "https listening on 127.0.0.1");
     tracing::info!(http_port = port + 1, "http listening on 127.0.0.1");
 
     let http_app = app.clone();


### PR DESCRIPTION
## What

Two listeners were bound to `0.0.0.0` (all interfaces):
- `vestad`'s HTTPS control API (`serve.rs`)
- the in-container agent WS server, which defaulted to `0.0.0.0` under Docker host networking (`api.py`)

So both were reachable from the LAN, and from the public internet on any directly-reachable host. The only intended ways to reach vestad are localhost and the Cloudflare tunnel. This binds both to `127.0.0.1`.

## Why it's safe (every caller already uses localhost)

- **Cloudflare tunnel**: cloudflared dials `https://localhost:{port}` (`tunnel.rs:568`), self-hosted and cloud-managed use the same `start_tunnel`.
- **Agent proxy**: vestad reaches the agent WS via `localhost:{ws_port}` (`agent_proxy.rs`); clients never connect to the agent directly, they go through vestad.
- **localhost** and the integration suite (`https://127.0.0.1:{port}`) are unaffected.

## Why unconditional (not gated on cloud)

vesta-cloud VMs sit behind a deny-all-inbound firewall (Hetzner + host nftables) and reach vestad only through the tunnel, which dials localhost. So `0.0.0.0` there exposed nothing the firewall didn't already block, and `127.0.0.1` works identically. Binding loopback everywhere is simpler (no `is_cloud_managed` branch) and strictly safer (defence in depth if a firewall rule ever regresses). A companion docs/test update in vesta-cloud follows, since its cloud-init comment ("firewall is the boundary, we do not bind localhost") is now stale.

## What changes for users

Connecting to a self-hosted vestad by its raw LAN IP (undocumented, not shown in the startup UI) stops working. Reach a self-hosted vestad via localhost or the Cloudflare tunnel.

## Tests

`./check.sh vestad` (135 pass, clippy clean) and `./check.sh agent` (324 pass) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)