### PR TITLE
fix(web): reduce Linux desktop vibrancy transparency by half

### DIFF
--- a/agent/skills/dashboard/app/src/index.css
+++ b/agent/skills/dashboard/app/src/index.css
@@ -82,21 +82,21 @@ html[data-platform="android"] {
 }
 
 [data-platform="linux"].vibrancy {
-  --background: oklch(0.995 0.005 80 / 85%);
-  --card: oklch(0.995 0.005 80 / 85%);
-  --muted: oklch(0.97 0.006 80 / 90%);
-  --accent: oklch(0.97 0.006 80 / 85%);
-  --sidebar: oklch(0.985 0.006 80 / 85%);
-  --sidebar-accent: oklch(0.97 0.006 80 / 85%);
+  --background: oklch(0.995 0.005 80 / 92.5%);
+  --card: oklch(0.995 0.005 80 / 92.5%);
+  --muted: oklch(0.97 0.006 80 / 95%);
+  --accent: oklch(0.97 0.006 80 / 92.5%);
+  --sidebar: oklch(0.985 0.006 80 / 92.5%);
+  --sidebar-accent: oklch(0.97 0.006 80 / 92.5%);
 }
 
 [data-platform="linux"].vibrancy.dark {
-  --background: oklch(0.147 0.005 80 / 85%);
-  --card: oklch(0.216 0.007 80 / 85%);
-  --muted: oklch(0.19 0.007 80 / 90%);
-  --accent: oklch(0.268 0.008 80 / 85%);
-  --sidebar: oklch(0.216 0.007 80 / 85%);
-  --sidebar-accent: oklch(0.268 0.008 80 / 85%);
+  --background: oklch(0.147 0.005 80 / 92.5%);
+  --card: oklch(0.216 0.007 80 / 92.5%);
+  --muted: oklch(0.19 0.007 80 / 95%);
+  --accent: oklch(0.268 0.008 80 / 92.5%);
+  --sidebar: oklch(0.216 0.007 80 / 92.5%);
+  --sidebar-accent: oklch(0.268 0.008 80 / 92.5%);
 }
 
 .dark {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -79,21 +79,21 @@ html[data-platform="android"] {
 }
 
 [data-platform="linux"].vibrancy {
-  --background: oklch(0.995 0.005 80 / 85%);
-  --card: oklch(0.995 0.005 80 / 85%);
-  --muted: oklch(0.97 0.006 80 / 90%);
-  --accent: oklch(0.97 0.006 80 / 85%);
-  --sidebar: oklch(0.985 0.006 80 / 85%);
-  --sidebar-accent: oklch(0.97 0.006 80 / 85%);
+  --background: oklch(0.995 0.005 80 / 92.5%);
+  --card: oklch(0.995 0.005 80 / 92.5%);
+  --muted: oklch(0.97 0.006 80 / 95%);
+  --accent: oklch(0.97 0.006 80 / 92.5%);
+  --sidebar: oklch(0.985 0.006 80 / 92.5%);
+  --sidebar-accent: oklch(0.97 0.006 80 / 92.5%);
 }
 
 [data-platform="linux"].vibrancy.dark {
-  --background: oklch(0.147 0.005 80 / 85%);
-  --card: oklch(0.216 0.007 80 / 85%);
-  --muted: oklch(0.19 0.007 80 / 90%);
-  --accent: oklch(0.268 0.008 80 / 85%);
-  --sidebar: oklch(0.216 0.007 80 / 85%);
-  --sidebar-accent: oklch(0.268 0.008 80 / 85%);
+  --background: oklch(0.147 0.005 80 / 92.5%);
+  --card: oklch(0.216 0.007 80 / 92.5%);
+  --muted: oklch(0.19 0.007 80 / 95%);
+  --accent: oklch(0.268 0.008 80 / 92.5%);
+  --sidebar: oklch(0.216 0.007 80 / 92.5%);
+  --sidebar-accent: oklch(0.268 0.008 80 / 92.5%);
 }
 
 .dark {


### PR DESCRIPTION
## What

Halve the transparency of the Linux desktop vibrancy surfaces so the app window reads as more solid (less see-through) on Linux.

In `apps/web/src/index.css`, the `[data-platform="linux"].vibrancy` (light + dark) blocks went from:
- background/card/accent/sidebar/sidebar-accent: **85% → 92.5%** opaque (15% → 7.5% transparent)
- muted: **90% → 95%** opaque (10% → 5% transparent)

Each surface's transparent portion is exactly halved.

## Scope

- Linux only. The base `.vibrancy` / `.vibrancy.dark` blocks (macOS/Windows, 50%/60%) are untouched.

## Test

- `./check.sh web` passes (eslint, prettier, tsc, vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)