### PR TITLE
feat(vestad): resilient tunnel startup, --expose-lan, and status.json-backed banner

### DIFF
--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -333,21 +333,292 @@ fn connect_link(base_url: &str, api_key: &str) -> String {
     format!("{base_url}/app#k={api_key}")
 }
 
-/// Render `data` as a QR code of half-block characters, inverted (light
-/// modules on a dark glyph) so it scans correctly against a dark terminal.
-/// Silently skips on the rare encode failure rather than failing the command.
+/// Render `data` as QR rows of half-block characters, inverted (light modules on
+/// a dark glyph) so it scans correctly against a dark terminal. Empty on the rare
+/// encode failure.
+fn qr_lines(data: &str) -> Vec<String> {
+    let Ok(code) = QrCode::new(data.as_bytes()) else {
+        return Vec::new();
+    };
+    code.render::<unicode::Dense1x2>()
+        .dark_color(unicode::Dense1x2::Light)
+        .light_color(unicode::Dense1x2::Dark)
+        .quiet_zone(true)
+        .build()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+/// Print a QR code with a small left margin (used by the status / systemd path).
 fn print_qr(data: &str) {
-    if let Ok(code) = QrCode::new(data.as_bytes()) {
-        let rendered = code
-            .render::<unicode::Dense1x2>()
-            .dark_color(unicode::Dense1x2::Light)
-            .light_color(unicode::Dense1x2::Dark)
-            .quiet_zone(true)
-            .build();
-        for line in rendered.lines() {
-            eprintln!("  {line}");
+    for line in qr_lines(data) {
+        eprintln!("  {line}");
+    }
+}
+
+// --- Startup banner ---
+
+const BANNER_ACCENT: &str = "38;2;231;186;140"; // light orange #e7ba8c (24-bit truecolor)
+const BANNER_DIM: &str = "2";
+const BANNER_MARGIN: usize = 3; // spaces between the border and content
+const BANNER_LABEL_W: usize = 9; // config label column width
+const BANNER_ART_W: usize = 46; // fixed width of every VESTA_ART line
+
+/// "VESTA" in an ANSI-shadow block font. Every line is exactly BANNER_ART_W wide
+/// (a unit test enforces this, since the box geometry centers on that width).
+const VESTA_ART: [&str; 6] = [
+    "██╗   ██╗ ███████╗ ███████╗ ████████╗  █████╗ ",
+    "██║   ██║ ██╔════╝ ██╔════╝ ╚══██╔══╝ ██╔══██╗",
+    "██║   ██║ █████╗   ███████╗    ██║    ███████║",
+    "╚██╗ ██╔╝ ██╔══╝   ╚════██║    ██║    ██╔══██║",
+    " ╚████╔╝  ███████╗ ███████║    ██║    ██║  ██║",
+    "  ╚═══╝   ╚══════╝ ╚══════╝    ╚═╝    ╚═╝  ╚═╝",
+];
+
+/// One row of the startup box. Each variant knows its natural (uncolored) width
+/// so the renderer can size the box and pad every line to a uniform interior.
+enum BoxRow {
+    Gap,
+    Art(usize),              // index into VESTA_ART, centered, accent colour
+    Center(String),          // centered dim text (e.g. the version subtitle)
+    CenterRaw(String),       // centered uncoloured text (QR rows must stay scannable)
+    Kv(&'static str, String), // "label   value", left-aligned
+    Value(String),           // a full-width left-aligned value (e.g. the api key)
+    Rule(&'static str),      // "── label ─────" section divider
+}
+
+impl BoxRow {
+    /// Visible width of the row's content, ignoring borders and side margins.
+    fn width(&self) -> usize {
+        match self {
+            BoxRow::Gap => 0,
+            BoxRow::Art(_) => BANNER_ART_W,
+            BoxRow::Center(s) | BoxRow::CenterRaw(s) | BoxRow::Value(s) => s.chars().count(),
+            BoxRow::Kv(_, value) => BANNER_LABEL_W + value.chars().count(),
+            BoxRow::Rule(label) => label.chars().count() + 5, // "── " + " ─"
         }
     }
+
+    /// Render the content fitted to `inner` columns as one or more `(plain,
+    /// shown)` lines — long values (links, api key, a long error) are hard-wrapped
+    /// so the box never overflows a narrow terminal. `plain` drives padding math
+    /// (no ANSI); `shown` is what prints (equal to `plain` when colour is off).
+    fn render(&self, inner: usize) -> Vec<(String, String)> {
+        let centered = |line: &str, code: Option<&str>| {
+            let lead = " ".repeat(inner.saturating_sub(line.chars().count()) / 2);
+            let shown = match code {
+                Some(code) => paint(code, line),
+                None => line.to_string(),
+            };
+            (format!("{lead}{line}"), format!("{lead}{shown}"))
+        };
+        match self {
+            BoxRow::Gap => vec![(String::new(), String::new())],
+            BoxRow::Art(idx) => {
+                let art = VESTA_ART[*idx];
+                // Can't shrink the art; drop it rather than overflow a tiny box.
+                if art.chars().count() > inner {
+                    Vec::new()
+                } else {
+                    vec![centered(art, Some(BANNER_ACCENT))]
+                }
+            }
+            BoxRow::Center(text) => wrap_chars(text, inner)
+                .iter()
+                .map(|line| centered(line, Some(BANNER_DIM)))
+                .collect(),
+            BoxRow::CenterRaw(text) => vec![centered(text, None)],
+            BoxRow::Kv(label, value) => {
+                let label_col = format!("{:<width$}", label, width = BANNER_LABEL_W);
+                let value_width = inner.saturating_sub(BANNER_LABEL_W).max(1);
+                wrap_chars(value, value_width)
+                    .into_iter()
+                    .enumerate()
+                    .map(|(line_no, chunk)| {
+                        if line_no == 0 {
+                            (format!("{label_col}{chunk}"), format!("{}{chunk}", paint(BANNER_DIM, &label_col)))
+                        } else {
+                            // continuation lines align under the value column
+                            let pad = " ".repeat(BANNER_LABEL_W);
+                            (format!("{pad}{chunk}"), format!("{pad}{chunk}"))
+                        }
+                    })
+                    .collect()
+            }
+            BoxRow::Value(value) => wrap_chars(value, inner)
+                .into_iter()
+                .map(|chunk| (chunk.clone(), paint(BANNER_ACCENT, &chunk)))
+                .collect(),
+            BoxRow::Rule(label) => {
+                let prefix = format!("── {} ", label);
+                let fill = inner.saturating_sub(prefix.chars().count());
+                let plain = format!("{}{}", prefix, "─".repeat(fill));
+                vec![(plain.clone(), paint(BANNER_DIM, &plain))]
+            }
+        }
+    }
+}
+
+/// Hard-wrap `text` into chunks of at most `width` characters (character-wise, so
+/// unbreakable strings like URLs and keys still fit). Always returns ≥1 element.
+fn wrap_chars(text: &str, width: usize) -> Vec<String> {
+    if width == 0 || text.is_empty() {
+        return vec![text.to_string()];
+    }
+    text.chars()
+        .collect::<Vec<char>>()
+        .chunks(width)
+        .map(|chunk| chunk.iter().collect())
+        .collect()
+}
+
+/// Terminal width (columns) of stderr, or `None` when it isn't a TTY / can't be
+/// queried — callers fall back to a conservative default.
+fn terminal_width() -> Option<usize> {
+    use std::os::unix::io::AsRawFd;
+    let mut size: libc::winsize = unsafe { std::mem::zeroed() };
+    // SAFETY: TIOCGWINSZ fills the winsize through the pointer for a valid fd; we
+    // pass stderr's fd and a correctly sized, zeroed struct.
+    let rc = unsafe { libc::ioctl(std::io::stderr().as_raw_fd(), libc::TIOCGWINSZ, &mut size) };
+    (rc == 0 && size.ws_col > 0).then_some(size.ws_col as usize)
+}
+
+/// Draw the rows inside a rounded, accent-coloured box. The interior is as wide
+/// as the content but capped to the terminal so the box never wraps; over-long
+/// rows are wrapped to fit. Returns the finished lines (plain when colour is off,
+/// which is how the geometry test inspects them).
+fn render_box(rows: &[BoxRow]) -> Vec<String> {
+    // Reserve the 2-space outer indent, both borders, and both side margins.
+    let overhead = 2 + 2 + BANNER_MARGIN * 2;
+    let cap = terminal_width().unwrap_or(80).saturating_sub(overhead);
+    render_box_capped(rows, cap)
+}
+
+/// [`render_box`] with the interior width cap passed explicitly (so the wrapping
+/// behaviour is testable without a real terminal).
+fn render_box_capped(rows: &[BoxRow], cap: usize) -> Vec<String> {
+    let natural = rows.iter().map(BoxRow::width).max().unwrap_or(0);
+    let inner = natural.min(cap).max(1);
+    let span = BANNER_MARGIN * 2 + inner;
+    let edge = |left: &str, right: &str| {
+        format!("{}{}{}", paint(BANNER_ACCENT, left), paint(BANNER_ACCENT, &"─".repeat(span)), paint(BANNER_ACCENT, right))
+    };
+    let mut out = vec![edge("╭", "╮")];
+    let side = paint(BANNER_ACCENT, "│");
+    for row in rows {
+        for (plain, shown) in row.render(inner) {
+            let trailing = inner.saturating_sub(plain.chars().count());
+            out.push(format!(
+                "{side}{margin}{shown}{trailing}{margin}{side}",
+                margin = " ".repeat(BANNER_MARGIN),
+                trailing = " ".repeat(trailing),
+            ));
+        }
+    }
+    out.push(edge("╰", "╯"));
+    out
+}
+
+/// The full startup banner: the boxed identity/config/connection summary, then
+/// the app connect link + QR below it.
+fn print_startup_banner(fields: BannerFields) {
+    let BannerFields { version, user, port, dev_mode, tunnel, lan_url, expose_lan, local_url, api_key } = fields;
+    let tunnel_url = tunnel.url();
+
+    // enabled = tunnel is up; disabled = --no-tunnel; error — <reason> = a tunnel
+    // was wanted but couldn't be established (no creds, dead tunnel, API failure).
+    let tunnel_desc = match tunnel {
+        TunnelStatus::Active(_) => "enabled".to_string(),
+        TunnelStatus::Disabled => "disabled".to_string(),
+        TunnelStatus::Failed(reason) => format!("error — {}", first_line_truncated(reason, 100)),
+    };
+    let lan_desc = if expose_lan { "enabled".to_string() } else { "disabled".to_string() };
+    // The address most useful to a human: public tunnel, else the LAN URL when
+    // exposed, else the same-machine local URL.
+    let address = tunnel_url
+        .map(str::to_string)
+        .or_else(|| lan_url.map(str::to_string))
+        .unwrap_or_else(|| local_url.to_string());
+
+    // The LAN connect link is only real when the API is actually bound to the LAN.
+    let lan_app = expose_lan.then_some(lan_url).flatten();
+
+    let mut rows = vec![
+        BoxRow::Gap,
+        BoxRow::Art(0),
+        BoxRow::Art(1),
+        BoxRow::Art(2),
+        BoxRow::Art(3),
+        BoxRow::Art(4),
+        BoxRow::Art(5),
+        BoxRow::Gap,
+        BoxRow::Center(format!("personal AI daemon · v{version}")),
+        BoxRow::Gap,
+        BoxRow::Kv("user", user.to_string()),
+        BoxRow::Kv("port", port.to_string()),
+        BoxRow::Kv("mode", if dev_mode { "development".to_string() } else { "production".to_string() }),
+        BoxRow::Kv("tunnel", tunnel_desc),
+        BoxRow::Kv("lan", lan_desc),
+        BoxRow::Gap,
+        BoxRow::Rule("connection"),
+        BoxRow::Kv("address", address),
+        BoxRow::Kv("api key", String::new()),
+        BoxRow::Value(api_key.to_string()),
+        BoxRow::Gap,
+        BoxRow::Rule("connect the app"),
+    ];
+    // One labeled link per reachability tier: remote (public tunnel), lan (same
+    // network), local (this machine only). Local always exists. Each tier shows
+    // its label on its own line, then the link beneath it in the api-key colour.
+    let mut app_links: Vec<(&'static str, String)> = Vec::new();
+    // remote tier is always shown: the public link when a tunnel is up, otherwise
+    // how to get one.
+    match tunnel_url {
+        Some(url) => app_links.push(("remote", connect_link(url, api_key))),
+        None => app_links.push(("remote", "run `vestad connect` for a public URL".to_string())),
+    }
+    if let Some(url) = lan_app {
+        app_links.push(("lan", connect_link(url, api_key)));
+    }
+    app_links.push(("local", connect_link(local_url, api_key)));
+    for (index, (label, link)) in app_links.into_iter().enumerate() {
+        if index > 0 {
+            rows.push(BoxRow::Gap);
+        }
+        rows.push(BoxRow::Kv(label, String::new()));
+        rows.push(BoxRow::Value(link));
+    }
+
+    // QR only for the public (remote) link — that's the one meant for scanning
+    // from a phone.
+    if let Some(url) = tunnel_url {
+        let link = connect_link(url, api_key);
+        rows.push(BoxRow::Gap);
+        rows.extend(qr_lines(&link).into_iter().map(BoxRow::CenterRaw));
+        rows.push(BoxRow::Center("scan the remote link to connect your phone".to_string()));
+    }
+    rows.push(BoxRow::Gap);
+
+    eprintln!();
+    for line in render_box(&rows) {
+        eprintln!("  {line}");
+    }
+    eprintln!();
+}
+
+/// Grouped inputs for [`print_startup_banner`] — past ~5 args a struct reads
+/// better than a positional list.
+struct BannerFields<'a> {
+    version: &'a str,
+    user: &'a str,
+    port: u16,
+    dev_mode: bool,
+    tunnel: &'a TunnelStatus,
+    lan_url: Option<&'a str>,
+    expose_lan: bool,
+    local_url: &'a str,
+    api_key: &'a str,
 }
 
 fn print_server_info(tunnel_url: Option<&str>, local_url: &str, api_key: &str) {

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -751,7 +751,123 @@ async fn bind_http_atomically(
     unreachable!()
 }
 
-fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
+/// Outcome of bringing the tunnel up at startup, surfaced in the banner.
+enum TunnelStatus {
+    Disabled,       // --no-tunnel
+    Active(String), // reachable https URL
+    Failed(String), // wanted, but couldn't be established — concise reason
+}
+
+impl TunnelStatus {
+    fn url(&self) -> Option<&str> {
+        match self {
+            TunnelStatus::Active(url) => Some(url),
+            _ => None,
+        }
+    }
+}
+
+/// First line of `msg`, trimmed and capped to `max` chars with an ellipsis, so a
+/// long or multi-line error can't blow up the banner width.
+fn first_line_truncated(msg: &str, max: usize) -> String {
+    let line = msg.lines().next().unwrap_or(msg).trim();
+    if line.chars().count() <= max {
+        line.to_string()
+    } else {
+        format!("{}…", line.chars().take(max.saturating_sub(1)).collect::<String>())
+    }
+}
+
+/// How many times startup tries to bring the tunnel up before giving up and
+/// starting anyway (with the failure shown in the banner). Absorbs a tunnel that
+/// is slow to register right after boot — e.g. the network isn't up yet.
+const TUNNEL_STARTUP_ATTEMPTS: u32 = 3;
+const TUNNEL_STARTUP_RETRY_DELAY_SECS: u64 = 5;
+
+/// Bring the tunnel up at startup, retrying before giving up. On success the
+/// banner advertises the live URL and the supervisor keeps it alive; if every
+/// attempt fails, vestad starts ANYWAY (local access + agents) with the error
+/// surfaced in the banner — a broken tunnel must not block the rest of the box.
+///
+/// The /ready pre-flight is credential-free, so this works even on a box that
+/// can't reach the Cloudflare API. Managed (vesta.run) boxes are exempt: the
+/// control plane owns the tunnel, so we trust the seeded config and let the
+/// supervisor (re)connect rather than pre-flighting.
+async fn setup_and_verify_tunnel(config: &std::path::Path, port: u16) -> TunnelStatus {
+    let status = retry_tunnel(
+        TUNNEL_STARTUP_ATTEMPTS,
+        std::time::Duration::from_secs(TUNNEL_STARTUP_RETRY_DELAY_SECS),
+        |attempt| async move {
+            let result = try_establish_tunnel(config, port).await;
+            if let Err(reason) = &result {
+                tracing::warn!(attempt, attempts = TUNNEL_STARTUP_ATTEMPTS, "tunnel not up: {reason}");
+            }
+            result
+        },
+    )
+    .await;
+
+    // Gave up. Drop the dead config (unless managed — the control plane owns it)
+    // so the supervisor isn't started into a "Tunnel not found" loop. vestad then
+    // starts anyway with the reason shown on the banner.
+    if matches!(status, TunnelStatus::Failed(_)) && !is_cloud_managed() {
+        tunnel::forget_tunnel(config);
+    }
+    status
+}
+
+/// Retry an async tunnel attempt up to `attempts` times, sleeping `delay` between
+/// tries. Returns `Active` with the first URL that comes up, or `Failed` carrying
+/// the last error once every attempt has failed.
+async fn retry_tunnel<F, Fut>(attempts: u32, delay: std::time::Duration, mut attempt: F) -> TunnelStatus
+where
+    F: FnMut(u32) -> Fut,
+    Fut: std::future::Future<Output = Result<String, String>>,
+{
+    let mut reason = "tunnel could not be established".to_string();
+    for n in 1..=attempts {
+        match attempt(n).await {
+            Ok(url) => return TunnelStatus::Active(url),
+            Err(e) => {
+                reason = e;
+                if n < attempts {
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+    TunnelStatus::Failed(reason)
+}
+
+/// One attempt to bring up and verify the tunnel. `Ok(url)` once it registers an
+/// edge connection; `Err(reason)` describes why this attempt failed.
+async fn try_establish_tunnel(config: &std::path::Path, port: u16) -> Result<String, String> {
+    let tc = tunnel::ensure_cloudflared(config).and_then(|_| tunnel::ensure_tunnel(config))?;
+
+    if is_cloud_managed() {
+        return Ok(format!("https://{}", tc.hostname));
+    }
+
+    if tunnel::preflight_tunnel(config, port).await {
+        return Ok(format!("https://{}", tc.hostname));
+    }
+    tracing::warn!(hostname = %tc.hostname, "saved tunnel failed to register");
+
+    // With our own creds the tunnel may be fixable — recreate it from scratch
+    // (new tunnel + token + DNS) and re-verify.
+    if tunnel::has_cf_creds(config) {
+        let subdomain = tc.hostname.split('.').next().unwrap_or("");
+        let fresh = tunnel::setup_tunnel(config, subdomain)?;
+        if tunnel::preflight_tunnel(config, port).await {
+            tracing::info!(hostname = %fresh.hostname, "tunnel recreated and registered");
+            return Ok(format!("https://{}", fresh.hostname));
+        }
+        return Err("recreated tunnel still could not register".to_string());
+    }
+    Err("saved tunnel could not register".to_string())
+}
+
+fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
     let config = config_dir();
 
     let docker = docker::connect().unwrap_or_else(|e| die(&e));
@@ -777,24 +893,34 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
             let (port, http_listener) = bind_http_atomically(port, &config).await;
             serve::write_port_file(&config, port);
 
-            let tunnel_url = if no_tunnel {
-                None
+            let tunnel_status = if no_tunnel {
+                TunnelStatus::Disabled
             } else {
-                match tunnel::ensure_cloudflared(&config).and_then(|_| tunnel::ensure_tunnel(&config)) {
-                    Ok(tc) => Some(format!("https://{}", tc.hostname)),
-                    Err(e) => {
-                        tracing::warn!("tunnel setup failed: {e}, running without tunnel");
-                        None
-                    }
-                }
+                setup_and_verify_tunnel(&config, port).await
             };
+            let tunnel_url = tunnel_status.url().map(str::to_string);
 
             docker::update_all_agent_env_files(&config.join("agents"), port, tunnel_url.as_deref());
             let local_url = format!("http://localhost:{}", port + 1);
+            // Only advertise a LAN address when the API is actually bound to the
+            // LAN (--expose-lan); otherwise the URL would be unreachable.
+            let lan_url = expose_lan
+                .then(local_lan_ip)
+                .flatten()
+                .map(|ip| format!("https://{}:{}", ip, port));
             let user = std::env::var("USER").or_else(|_| std::env::var("LOGNAME")).unwrap_or_else(|_| "unknown".into());
-            eprintln!();
-            eprintln!("  \x1b[1;35mvestad\x1b[0m v{} \x1b[2m(user: {}, port: {})\x1b[0m", env!("CARGO_PKG_VERSION"), user, port);
-            print_server_info(tunnel_url.as_deref(), &local_url, &api_key);
+            let dev_mode = cfg!(debug_assertions) || std::env::var("VESTAD_DEV").is_ok();
+            print_startup_banner(BannerFields {
+                version: env!("CARGO_PKG_VERSION"),
+                user: &user,
+                port,
+                dev_mode,
+                tunnel: &tunnel_status,
+                lan_url: lan_url.as_deref(),
+                expose_lan,
+                local_url: &local_url,
+                api_key: &api_key,
+            });
 
             // Supervise whenever a tunnel is INTENDED, not only when boot-time
             // setup succeeded: a managed box whose tunnel.json the control plane
@@ -807,7 +933,6 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
             let tunnel_supervisor =
                 tunnel_intended.then(|| tunnel::supervise_tunnel(config.clone(), port));
 
-            let dev_mode = cfg!(debug_assertions) || std::env::var("VESTAD_DEV").is_ok();
             serve::run_server(serve::ServerConfig {
                 port,
                 http_listener,
@@ -1180,6 +1305,91 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn vesta_art_lines_are_uniform_width() {
+        for line in VESTA_ART {
+            assert_eq!(line.chars().count(), BANNER_ART_W, "art line: {line}");
+        }
+    }
+
+    #[test]
+    fn render_box_lines_share_width_and_are_bordered() {
+        // Colour is disabled under `cargo test` (stderr is not a TTY), so the
+        // rendered lines are plain and char count equals display width.
+        let rows = vec![
+            BoxRow::Gap,
+            BoxRow::Art(0),
+            BoxRow::Center("personal AI daemon".into()),
+            BoxRow::Kv("user", "emi".into()),
+            BoxRow::Rule("connection"),
+            BoxRow::Value("0123456789abcdef0123456789abcdef".into()),
+        ];
+        let lines = render_box(&rows);
+        let width = lines[0].chars().count();
+        assert!(lines.iter().all(|l| l.chars().count() == width), "every box line is the same width");
+        assert!(lines.first().unwrap().starts_with('╭') && lines.first().unwrap().ends_with('╮'));
+        assert!(lines.last().unwrap().starts_with('╰') && lines.last().unwrap().ends_with('╯'));
+        for interior in &lines[1..lines.len() - 1] {
+            assert!(interior.starts_with('│') && interior.ends_with('│'), "interior row is bordered: {interior}");
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_tunnel_succeeds_without_retrying_when_first_attempt_works() {
+        let calls = std::cell::Cell::new(0u32);
+        let status = retry_tunnel(3, std::time::Duration::ZERO, |_| {
+            calls.set(calls.get() + 1);
+            async { Ok::<String, String>("https://host".to_string()) }
+        })
+        .await;
+        assert!(matches!(status, TunnelStatus::Active(url) if url == "https://host"));
+        assert_eq!(calls.get(), 1, "should not retry once an attempt succeeds");
+    }
+
+    #[tokio::test]
+    async fn retry_tunnel_retries_until_an_attempt_succeeds() {
+        let calls = std::cell::Cell::new(0u32);
+        let status = retry_tunnel(3, std::time::Duration::ZERO, |attempt| {
+            calls.set(calls.get() + 1);
+            async move {
+                if attempt < 3 {
+                    Err(format!("not up yet (attempt {attempt})"))
+                } else {
+                    Ok("https://up".to_string())
+                }
+            }
+        })
+        .await;
+        assert!(matches!(status, TunnelStatus::Active(url) if url == "https://up"));
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[tokio::test]
+    async fn retry_tunnel_gives_up_with_the_last_error_after_all_attempts() {
+        let calls = std::cell::Cell::new(0u32);
+        let status = retry_tunnel(3, std::time::Duration::ZERO, |attempt| {
+            calls.set(calls.get() + 1);
+            async move { Err::<String, String>(format!("boom {attempt}")) }
+        })
+        .await;
+        assert!(matches!(status, TunnelStatus::Failed(reason) if reason == "boom 3"));
+        assert_eq!(calls.get(), 3, "should try exactly `attempts` times before giving up");
+    }
+
+    #[test]
+    fn render_box_wraps_long_rows_within_a_narrow_cap() {
+        let long = "x".repeat(120);
+        let cap = 30;
+        let lines = render_box_capped(&[BoxRow::Value(long), BoxRow::Art(0)], cap);
+        let width = lines[0].chars().count();
+        // Uniform width, and the whole box stays within the cap (+ borders/margins).
+        assert!(lines.iter().all(|l| l.chars().count() == width), "every box line is the same width");
+        assert!(width <= cap + 2 + BANNER_MARGIN * 2, "box width {width} exceeds cap {cap}");
+        // The 120-char value wrapped across multiple interior lines instead of overflowing.
+        let value_lines = lines.iter().filter(|l| l.contains('x')).count();
+        assert!(value_lines >= 4, "expected the long value to wrap into >=4 lines, got {value_lines}");
+    }
 
     #[test]
     fn local_health_url_targets_http_port_plus_one() {

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -2,7 +2,6 @@
 compile_error!("vestad only supports Linux");
 
 use clap::Parser;
-use qrcode::{render::unicode, QrCode};
 
 mod agent_provider;
 mod agent_code;
@@ -25,10 +24,13 @@ mod restic_embed;
 mod time_utils;
 mod self_update;
 mod serve;
+mod status;
 mod systemd;
 mod tunnel;
 mod types;
 mod update_check;
+
+use status::{Status, TunnelStatus};
 
 
 #[derive(Parser)]
@@ -175,13 +177,13 @@ fn docker_exec_inherit(args: &[&str]) {
 /// Whether to emit ANSI color: only when stderr is a real terminal and NO_COLOR
 /// is unset. Without this, `vestad status > file` / piping captures raw escape
 /// codes.
-fn color_on() -> bool {
+pub(crate) fn color_on() -> bool {
     use std::io::IsTerminal;
     std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none()
 }
 
 /// Wrap `s` in ANSI `code` (e.g. "1;35"), but only when color is enabled.
-fn paint(code: &str, s: &str) -> String {
+pub(crate) fn paint(code: &str, s: &str) -> String {
     if color_on() {
         format!("\x1b[{code}m{s}\x1b[0m")
     } else {
@@ -231,6 +233,14 @@ fn resolve_port(explicit: Option<u16>, config: &std::path::Path) -> u16 {
 fn config_dir() -> std::path::PathBuf {
     paths::config_dir()
         .unwrap_or_else(|| die("couldn't find your home directory ($HOME) — vestad stores its config there"))
+}
+
+/// Read the stored API key from `<config>/api-key`, if present and non-empty.
+fn read_api_key(config: &std::path::Path) -> Option<String> {
+    std::fs::read_to_string(config.join("api-key"))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 /// True iff this VM is managed by the vesta-cloud control plane.
@@ -333,336 +343,6 @@ async fn wait_for_health(client: &reqwest::Client, url: &str, timeout: std::time
 /// fragment (`#k=...`), which browsers never send to the server, so the key
 /// stays out of vestad's and Cloudflare's request logs. Opening the link
 /// connects automatically, no copy-pasting the key.
-fn connect_link(base_url: &str, api_key: &str) -> String {
-    format!("{base_url}/app#k={api_key}")
-}
-
-/// Render `data` as QR rows of half-block characters, inverted (light modules on
-/// a dark glyph) so it scans correctly against a dark terminal. Empty on the rare
-/// encode failure.
-fn qr_lines(data: &str) -> Vec<String> {
-    let Ok(code) = QrCode::new(data.as_bytes()) else {
-        return Vec::new();
-    };
-    code.render::<unicode::Dense1x2>()
-        .dark_color(unicode::Dense1x2::Light)
-        .light_color(unicode::Dense1x2::Dark)
-        .quiet_zone(true)
-        .build()
-        .lines()
-        .map(str::to_string)
-        .collect()
-}
-
-/// Print a QR code with a small left margin (used by the status / systemd path).
-fn print_qr(data: &str) {
-    for line in qr_lines(data) {
-        eprintln!("  {line}");
-    }
-}
-
-// --- Startup banner ---
-
-const BANNER_ACCENT: &str = "38;2;231;186;140"; // light orange #e7ba8c (24-bit truecolor)
-const BANNER_DIM: &str = "2";
-const BANNER_MARGIN: usize = 3; // spaces between the border and content
-const BANNER_LABEL_W: usize = 9; // config label column width
-const BANNER_ART_W: usize = 46; // fixed width of every VESTA_ART line
-
-/// "VESTA" in an ANSI-shadow block font. Every line is exactly BANNER_ART_W wide
-/// (a unit test enforces this, since the box geometry centers on that width).
-const VESTA_ART: [&str; 6] = [
-    "██╗   ██╗ ███████╗ ███████╗ ████████╗  █████╗ ",
-    "██║   ██║ ██╔════╝ ██╔════╝ ╚══██╔══╝ ██╔══██╗",
-    "██║   ██║ █████╗   ███████╗    ██║    ███████║",
-    "╚██╗ ██╔╝ ██╔══╝   ╚════██║    ██║    ██╔══██║",
-    " ╚████╔╝  ███████╗ ███████║    ██║    ██║  ██║",
-    "  ╚═══╝   ╚══════╝ ╚══════╝    ╚═╝    ╚═╝  ╚═╝",
-];
-
-/// One row of the startup box. Each variant knows its natural (uncolored) width
-/// so the renderer can size the box and pad every line to a uniform interior.
-enum BoxRow {
-    Gap,
-    Art(usize),              // index into VESTA_ART, centered, accent colour
-    Center(String),          // centered dim text (e.g. the version subtitle)
-    CenterRaw(String),       // centered uncoloured text (QR rows must stay scannable)
-    Kv(&'static str, String), // "label   value", left-aligned
-    Value(String),           // a full-width left-aligned value (e.g. the api key)
-    Rule(&'static str),      // "── label ─────" section divider
-}
-
-impl BoxRow {
-    /// Visible width of the row's content, ignoring borders and side margins.
-    fn width(&self) -> usize {
-        match self {
-            BoxRow::Gap => 0,
-            BoxRow::Art(_) => BANNER_ART_W,
-            BoxRow::Center(s) | BoxRow::CenterRaw(s) | BoxRow::Value(s) => s.chars().count(),
-            BoxRow::Kv(_, value) => BANNER_LABEL_W + value.chars().count(),
-            BoxRow::Rule(label) => label.chars().count() + 5, // "── " + " ─"
-        }
-    }
-
-    /// Render the content fitted to `inner` columns as one or more `(plain,
-    /// shown)` lines — long values (links, api key, a long error) are hard-wrapped
-    /// so the box never overflows a narrow terminal. `plain` drives padding math
-    /// (no ANSI); `shown` is what prints (equal to `plain` when colour is off).
-    fn render(&self, inner: usize) -> Vec<(String, String)> {
-        let centered = |line: &str, code: Option<&str>| {
-            let lead = " ".repeat(inner.saturating_sub(line.chars().count()) / 2);
-            let shown = match code {
-                Some(code) => paint(code, line),
-                None => line.to_string(),
-            };
-            (format!("{lead}{line}"), format!("{lead}{shown}"))
-        };
-        match self {
-            BoxRow::Gap => vec![(String::new(), String::new())],
-            BoxRow::Art(idx) => {
-                let art = VESTA_ART[*idx];
-                // Can't shrink the art; drop it rather than overflow a tiny box.
-                if art.chars().count() > inner {
-                    Vec::new()
-                } else {
-                    vec![centered(art, Some(BANNER_ACCENT))]
-                }
-            }
-            BoxRow::Center(text) => wrap_chars(text, inner)
-                .iter()
-                .map(|line| centered(line, Some(BANNER_DIM)))
-                .collect(),
-            BoxRow::CenterRaw(text) => vec![centered(text, None)],
-            BoxRow::Kv(label, value) => {
-                let label_col = format!("{:<width$}", label, width = BANNER_LABEL_W);
-                let value_width = inner.saturating_sub(BANNER_LABEL_W).max(1);
-                wrap_chars(value, value_width)
-                    .into_iter()
-                    .enumerate()
-                    .map(|(line_no, chunk)| {
-                        if line_no == 0 {
-                            (format!("{label_col}{chunk}"), format!("{}{chunk}", paint(BANNER_DIM, &label_col)))
-                        } else {
-                            // continuation lines align under the value column
-                            let pad = " ".repeat(BANNER_LABEL_W);
-                            (format!("{pad}{chunk}"), format!("{pad}{chunk}"))
-                        }
-                    })
-                    .collect()
-            }
-            BoxRow::Value(value) => wrap_chars(value, inner)
-                .into_iter()
-                .map(|chunk| (chunk.clone(), paint(BANNER_ACCENT, &chunk)))
-                .collect(),
-            BoxRow::Rule(label) => {
-                let prefix = format!("── {} ", label);
-                let fill = inner.saturating_sub(prefix.chars().count());
-                let plain = format!("{}{}", prefix, "─".repeat(fill));
-                vec![(plain.clone(), paint(BANNER_DIM, &plain))]
-            }
-        }
-    }
-}
-
-/// Hard-wrap `text` into chunks of at most `width` characters (character-wise, so
-/// unbreakable strings like URLs and keys still fit). Always returns ≥1 element.
-fn wrap_chars(text: &str, width: usize) -> Vec<String> {
-    if width == 0 || text.is_empty() {
-        return vec![text.to_string()];
-    }
-    text.chars()
-        .collect::<Vec<char>>()
-        .chunks(width)
-        .map(|chunk| chunk.iter().collect())
-        .collect()
-}
-
-/// Terminal width (columns) of stderr, or `None` when it isn't a TTY / can't be
-/// queried — callers fall back to a conservative default.
-fn terminal_width() -> Option<usize> {
-    use std::os::unix::io::AsRawFd;
-    let mut size: libc::winsize = unsafe { std::mem::zeroed() };
-    // SAFETY: TIOCGWINSZ fills the winsize through the pointer for a valid fd; we
-    // pass stderr's fd and a correctly sized, zeroed struct.
-    let rc = unsafe { libc::ioctl(std::io::stderr().as_raw_fd(), libc::TIOCGWINSZ, &mut size) };
-    (rc == 0 && size.ws_col > 0).then_some(size.ws_col as usize)
-}
-
-/// Draw the rows inside a rounded, accent-coloured box. The interior is as wide
-/// as the content but capped to the terminal so the box never wraps; over-long
-/// rows are wrapped to fit. Returns the finished lines (plain when colour is off,
-/// which is how the geometry test inspects them).
-fn render_box(rows: &[BoxRow]) -> Vec<String> {
-    // Reserve the 2-space outer indent, both borders, and both side margins.
-    let overhead = 2 + 2 + BANNER_MARGIN * 2;
-    let cap = terminal_width().unwrap_or(80).saturating_sub(overhead);
-    render_box_capped(rows, cap)
-}
-
-/// [`render_box`] with the interior width cap passed explicitly (so the wrapping
-/// behaviour is testable without a real terminal).
-fn render_box_capped(rows: &[BoxRow], cap: usize) -> Vec<String> {
-    let natural = rows.iter().map(BoxRow::width).max().unwrap_or(0);
-    let inner = natural.min(cap).max(1);
-    let span = BANNER_MARGIN * 2 + inner;
-    let edge = |left: &str, right: &str| {
-        format!("{}{}{}", paint(BANNER_ACCENT, left), paint(BANNER_ACCENT, &"─".repeat(span)), paint(BANNER_ACCENT, right))
-    };
-    let mut out = vec![edge("╭", "╮")];
-    let side = paint(BANNER_ACCENT, "│");
-    for row in rows {
-        for (plain, shown) in row.render(inner) {
-            let trailing = inner.saturating_sub(plain.chars().count());
-            out.push(format!(
-                "{side}{margin}{shown}{trailing}{margin}{side}",
-                margin = " ".repeat(BANNER_MARGIN),
-                trailing = " ".repeat(trailing),
-            ));
-        }
-    }
-    out.push(edge("╰", "╯"));
-    out
-}
-
-/// The full startup banner: the boxed identity/config/connection summary, then
-/// the app connect link + QR below it.
-fn print_startup_banner(fields: BannerFields) {
-    let BannerFields { version, user, port, dev_mode, tunnel, lan_url, expose_lan, local_url, api_key } = fields;
-    let tunnel_url = tunnel.url();
-
-    // enabled = tunnel is up; disabled = --no-tunnel; error — <reason> = a tunnel
-    // was wanted but couldn't be established (no creds, dead tunnel, API failure).
-    let tunnel_desc = match tunnel {
-        TunnelStatus::Active(_) => "enabled".to_string(),
-        TunnelStatus::Disabled => "disabled".to_string(),
-        TunnelStatus::Failed(reason) => format!("error — {}", first_line_truncated(reason, 100)),
-    };
-    let lan_desc = if expose_lan { "enabled".to_string() } else { "disabled".to_string() };
-    // The address most useful to a human: public tunnel, else the LAN URL when
-    // exposed, else the same-machine local URL.
-    let address = tunnel_url
-        .map(str::to_string)
-        .or_else(|| lan_url.map(str::to_string))
-        .unwrap_or_else(|| local_url.to_string());
-
-    // The LAN connect link is only real when the API is actually bound to the LAN.
-    let lan_app = expose_lan.then_some(lan_url).flatten();
-
-    let mut rows = vec![
-        BoxRow::Gap,
-        BoxRow::Art(0),
-        BoxRow::Art(1),
-        BoxRow::Art(2),
-        BoxRow::Art(3),
-        BoxRow::Art(4),
-        BoxRow::Art(5),
-        BoxRow::Gap,
-        BoxRow::Center(format!("personal AI daemon · v{version}")),
-        BoxRow::Gap,
-        BoxRow::Kv("user", user.to_string()),
-        BoxRow::Kv("port", port.to_string()),
-        BoxRow::Kv("mode", if dev_mode { "development".to_string() } else { "production".to_string() }),
-        BoxRow::Kv("tunnel", tunnel_desc),
-        BoxRow::Kv("lan", lan_desc),
-        BoxRow::Gap,
-        BoxRow::Rule("connection"),
-        BoxRow::Kv("address", address),
-        BoxRow::Kv("api key", String::new()),
-        BoxRow::Value(api_key.to_string()),
-        BoxRow::Gap,
-        BoxRow::Rule("connect the app"),
-    ];
-    // One labeled link per reachability tier: remote (public tunnel), lan (same
-    // network), local (this machine only). Local always exists. Each tier shows
-    // its label on its own line, then the link beneath it in the api-key colour.
-    let mut app_links: Vec<(&'static str, String)> = Vec::new();
-    // remote tier is always shown: the public link when a tunnel is up, otherwise
-    // how to get one.
-    match tunnel_url {
-        Some(url) => app_links.push(("remote", connect_link(url, api_key))),
-        None => app_links.push(("remote", "run `vestad connect` for a public URL".to_string())),
-    }
-    if let Some(url) = lan_app {
-        app_links.push(("lan", connect_link(url, api_key)));
-    }
-    app_links.push(("local", connect_link(local_url, api_key)));
-    for (index, (label, link)) in app_links.into_iter().enumerate() {
-        if index > 0 {
-            rows.push(BoxRow::Gap);
-        }
-        rows.push(BoxRow::Kv(label, String::new()));
-        rows.push(BoxRow::Value(link));
-    }
-
-    // QR only for the public (remote) link — that's the one meant for scanning
-    // from a phone.
-    if let Some(url) = tunnel_url {
-        let link = connect_link(url, api_key);
-        rows.push(BoxRow::Gap);
-        rows.extend(qr_lines(&link).into_iter().map(BoxRow::CenterRaw));
-        rows.push(BoxRow::Center("scan the remote link to connect your phone".to_string()));
-    }
-    rows.push(BoxRow::Gap);
-
-    eprintln!();
-    for line in render_box(&rows) {
-        eprintln!("  {line}");
-    }
-    eprintln!();
-}
-
-/// Grouped inputs for [`print_startup_banner`] — past ~5 args a struct reads
-/// better than a positional list.
-struct BannerFields<'a> {
-    version: &'a str,
-    user: &'a str,
-    port: u16,
-    dev_mode: bool,
-    tunnel: &'a TunnelStatus,
-    lan_url: Option<&'a str>,
-    expose_lan: bool,
-    local_url: &'a str,
-    api_key: &'a str,
-}
-
-fn print_server_info(tunnel_url: Option<&str>, local_url: &str, api_key: &str) {
-    eprintln!();
-    match tunnel_url {
-        Some(url) => {
-            let link = connect_link(url, api_key);
-            eprintln!("  {} {}", paint("36", "connect"), paint("1", &link));
-            eprintln!("          {}", paint("2", "open this link to connect the app; the key is built in"));
-            eprintln!();
-            print_qr(&link);
-            eprintln!("  {}", paint("2", "or scan to connect your phone"));
-        }
-        // A missing tunnel is a first-class, visible state — never a silent
-        // "local only". Tell the user the exact command to fix it.
-        None => {
-            eprintln!(
-                "  {} {}  {}",
-                paint("36", "connect"),
-                paint("1", &connect_link(local_url, api_key)),
-                paint("2", "(same machine only)"),
-            );
-            eprintln!(
-                "          run {} for a public URL + a phone QR code",
-                paint("1", "vestad connect"),
-            );
-            eprintln!();
-            return;
-        }
-    }
-    eprintln!();
-    eprintln!(
-        "  {} {}  {}",
-        paint("36", "local  "),
-        paint("1", &connect_link(local_url, api_key)),
-        paint("2", "(same machine only)"),
-    );
-    eprintln!();
-}
-
 /// Best-effort primary LAN IPv4 — the source address the kernel uses to reach
 /// off-box via the default route, i.e. the address other LAN devices can reach.
 /// `ip route get` is used first so Docker/VPN bridge addresses (172.17.x and the
@@ -694,33 +374,6 @@ fn local_lan_ip() -> Option<String> {
         .map(|ip| ip.to_string())
 }
 
-/// Print connection info when an API key is present (the shape shared by `status`
-/// and the systemd start path), taking the `read_server_info` tuple directly.
-fn print_server_info_opt(info: (Option<String>, Option<String>, Option<String>)) {
-    let (tunnel_url, local_url, api_key) = info;
-    if let Some(api_key) = &api_key {
-        print_server_info(
-            tunnel_url.as_deref(),
-            local_url.as_deref().unwrap_or("http://localhost:?"),
-            api_key,
-        );
-    }
-}
-
-fn read_server_info(config: &std::path::Path) -> (Option<String>, Option<String>, Option<String>) {
-    let api_key = std::fs::read_to_string(config.join("api-key"))
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
-
-    let local_url = read_port_file(config).map(|port| format!("http://localhost:{}", port + 1));
-
-    let tunnel_url = tunnel::get_tunnel_config(config)
-        .map(|tc| format!("https://{}", tc.hostname));
-
-    (tunnel_url, local_url, api_key)
-}
-
 /// Bind the HTTP listener atomically inside the tokio runtime. If the HTTP port
 /// (N+1) is in use, re-select a new N via find_available_port and retry. This
 /// closes the TOCTOU race where find_available_port's probe was dropped before
@@ -749,33 +402,6 @@ async fn bind_http_atomically(
         }
     }
     unreachable!()
-}
-
-/// Outcome of bringing the tunnel up at startup, surfaced in the banner.
-enum TunnelStatus {
-    Disabled,       // --no-tunnel
-    Active(String), // reachable https URL
-    Failed(String), // wanted, but couldn't be established — concise reason
-}
-
-impl TunnelStatus {
-    fn url(&self) -> Option<&str> {
-        match self {
-            TunnelStatus::Active(url) => Some(url),
-            _ => None,
-        }
-    }
-}
-
-/// First line of `msg`, trimmed and capped to `max` chars with an ellipsis, so a
-/// long or multi-line error can't blow up the banner width.
-fn first_line_truncated(msg: &str, max: usize) -> String {
-    let line = msg.lines().next().unwrap_or(msg).trim();
-    if line.chars().count() <= max {
-        line.to_string()
-    } else {
-        format!("{}…", line.chars().take(max.saturating_sub(1)).collect::<String>())
-    }
 }
 
 /// How many times startup tries to bring the tunnel up before giving up and
@@ -901,7 +527,6 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
             let tunnel_url = tunnel_status.url().map(str::to_string);
 
             docker::update_all_agent_env_files(&config.join("agents"), port, tunnel_url.as_deref());
-            let local_url = format!("http://localhost:{}", port + 1);
             // Only advertise a LAN address when the API is actually bound to the
             // LAN (--expose-lan); otherwise the URL would be unreachable.
             let lan_url = expose_lan
@@ -910,17 +535,21 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
                 .map(|ip| format!("https://{}:{}", ip, port));
             let user = std::env::var("USER").or_else(|_| std::env::var("LOGNAME")).unwrap_or_else(|_| "unknown".into());
             let dev_mode = cfg!(debug_assertions) || std::env::var("VESTAD_DEV").is_ok();
-            print_startup_banner(BannerFields {
-                version: env!("CARGO_PKG_VERSION"),
-                user: &user,
+
+            // Build the status snapshot, persist it before the API opens (so any
+            // reader that sees the daemon reachable also sees status.json), and
+            // print the banner from it — the same banner `vestad status` renders.
+            let status = Status::new(
+                env!("CARGO_PKG_VERSION").to_string(),
+                user,
                 port,
                 dev_mode,
-                tunnel: &tunnel_status,
-                lan_url: lan_url.as_deref(),
                 expose_lan,
-                local_url: &local_url,
-                api_key: &api_key,
-            });
+                lan_url,
+                tunnel_status,
+            );
+            status.persist(&config);
+            status.print_banner(&api_key);
 
             // Supervise whenever a tunnel is INTENDED, not only when boot-time
             // setup succeeded: a managed box whose tunnel.json the control plane
@@ -930,8 +559,34 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
             let tunnel_intended = tunnel_url.is_some()
                 || (!no_tunnel
                     && (is_cloud_managed() || tunnel::get_tunnel_config(&config).is_some()));
-            let tunnel_supervisor =
-                tunnel_intended.then(|| tunnel::supervise_tunnel(config.clone(), port));
+
+            // Keep status.json honest: on a SUSTAINED tunnel outage the supervisor
+            // flips the tunnel field to an error and back to enabled on recovery.
+            // Transient blips it recovers from on its own don't change it.
+            let status = std::sync::Arc::new(std::sync::Mutex::new(status));
+            let on_tunnel_up: std::sync::Arc<dyn Fn(bool) + Send + Sync> = {
+                let status = status.clone();
+                let config = config.clone();
+                let tunnel_url = tunnel_url.clone();
+                std::sync::Arc::new(move |up: bool| {
+                    let next = if up {
+                        match tunnel_url.clone().or_else(|| {
+                            tunnel::get_tunnel_config(&config).map(|tc| format!("https://{}", tc.hostname))
+                        }) {
+                            Some(url) => TunnelStatus::Active(url),
+                            None => return, // can't name the URL; leave the field as-is
+                        }
+                    } else {
+                        TunnelStatus::Failed("tunnel connection lost".to_string())
+                    };
+                    if let Ok(mut s) = status.lock() {
+                        s.set_tunnel(next);
+                        s.persist(&config);
+                    }
+                })
+            };
+            let tunnel_supervisor = tunnel_intended
+                .then(|| tunnel::supervise_tunnel(config.clone(), port, on_tunnel_up));
 
             serve::run_server(serve::ServerConfig {
                 port,
@@ -989,8 +644,8 @@ fn run_server_systemd(port: Option<u16>, no_tunnel: bool) {
 
     eprintln!();
     eprintln!("  \x1b[1;35mvestad\x1b[0m v{} is now running as a systemd service.", env!("CARGO_PKG_VERSION"));
-
-    print_server_info_opt(read_server_info(&config));
+    eprintln!("  run {} to see your connection info.", paint("1", "vestad status"));
+    eprintln!();
 
     eprintln!("manage with:");
     eprintln!("  vestad status     show status + your URL");
@@ -1050,7 +705,7 @@ fn main() {
                 if agent_count == 1 { "" } else { "s" },
             );
 
-            print_server_info_opt(read_server_info(&config));
+            status::print_status_banner(&config, read_api_key(&config).as_deref());
 
             systemd::print_status();
         }
@@ -1306,35 +961,6 @@ fn main() {
 mod tests {
     use super::*;
 
-    #[test]
-    fn vesta_art_lines_are_uniform_width() {
-        for line in VESTA_ART {
-            assert_eq!(line.chars().count(), BANNER_ART_W, "art line: {line}");
-        }
-    }
-
-    #[test]
-    fn render_box_lines_share_width_and_are_bordered() {
-        // Colour is disabled under `cargo test` (stderr is not a TTY), so the
-        // rendered lines are plain and char count equals display width.
-        let rows = vec![
-            BoxRow::Gap,
-            BoxRow::Art(0),
-            BoxRow::Center("personal AI daemon".into()),
-            BoxRow::Kv("user", "emi".into()),
-            BoxRow::Rule("connection"),
-            BoxRow::Value("0123456789abcdef0123456789abcdef".into()),
-        ];
-        let lines = render_box(&rows);
-        let width = lines[0].chars().count();
-        assert!(lines.iter().all(|l| l.chars().count() == width), "every box line is the same width");
-        assert!(lines.first().unwrap().starts_with('╭') && lines.first().unwrap().ends_with('╮'));
-        assert!(lines.last().unwrap().starts_with('╰') && lines.last().unwrap().ends_with('╯'));
-        for interior in &lines[1..lines.len() - 1] {
-            assert!(interior.starts_with('│') && interior.ends_with('│'), "interior row is bordered: {interior}");
-        }
-    }
-
     #[tokio::test]
     async fn retry_tunnel_succeeds_without_retrying_when_first_attempt_works() {
         let calls = std::cell::Cell::new(0u32);
@@ -1375,20 +1001,6 @@ mod tests {
         .await;
         assert!(matches!(status, TunnelStatus::Failed(reason) if reason == "boom 3"));
         assert_eq!(calls.get(), 3, "should try exactly `attempts` times before giving up");
-    }
-
-    #[test]
-    fn render_box_wraps_long_rows_within_a_narrow_cap() {
-        let long = "x".repeat(120);
-        let cap = 30;
-        let lines = render_box_capped(&[BoxRow::Value(long), BoxRow::Art(0)], cap);
-        let width = lines[0].chars().count();
-        // Uniform width, and the whole box stays within the cap (+ borders/margins).
-        assert!(lines.iter().all(|l| l.chars().count() == width), "every box line is the same width");
-        assert!(width <= cap + 2 + BANNER_MARGIN * 2, "box width {width} exceeds cap {cap}");
-        // The 120-char value wrapped across multiple interior lines instead of overflowing.
-        let value_lines = lines.iter().filter(|l| l.contains('x')).count();
-        assert!(value_lines >= 4, "expected the long value to wrap into >=4 lines, got {value_lines}");
     }
 
     #[test]

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -51,6 +51,10 @@ enum Command {
         /// Run in foreground without systemd (for CI/dev)
         #[arg(long)]
         standalone: bool,
+        /// Bind the HTTPS API to all interfaces so other devices on the LAN can
+        /// connect (default: loopback only). Standalone mode only.
+        #[arg(long)]
+        expose_lan: bool,
     },
     /// Show vestad service status
     Status,
@@ -659,12 +663,47 @@ fn print_server_info(tunnel_url: Option<&str>, local_url: &str, api_key: &str) {
     eprintln!();
 }
 
+/// Best-effort primary LAN IPv4 — the source address the kernel uses to reach
+/// off-box via the default route, i.e. the address other LAN devices can reach.
+/// `ip route get` is used first so Docker/VPN bridge addresses (172.17.x and the
+/// like, always present since vestad needs Docker) are skipped; it falls back to
+/// the first non-loopback, non-Docker-bridge address from `hostname -I`. Either
+/// way the result is covered by the TLS cert SANs. `None` if undeterminable.
+fn local_lan_ip() -> Option<String> {
+    // `ip -4 route get <external ip>` prints "<dst> via <gw> dev <if> src <LAN_IP> …".
+    if let Ok(output) = std::process::Command::new("ip").args(["-4", "route", "get", "1.1.1.1"]).output() {
+        let text = String::from_utf8_lossy(&output.stdout);
+        if let Some(src) = text.split_whitespace().skip_while(|token| *token != "src").nth(1) {
+            if let Ok(ip) = src.parse::<std::net::Ipv4Addr>() {
+                if !ip.is_loopback() {
+                    return Some(ip.to_string());
+                }
+            }
+        }
+    }
+    // Fallback: first non-loopback IPv4 from `hostname -I`, skipping Docker's
+    // default bridge range (172.17.0.0/16).
+    let output = std::process::Command::new("hostname").arg("-I").output().ok()?;
+    let ips = String::from_utf8_lossy(&output.stdout);
+    ips.split_whitespace()
+        .filter_map(|token| token.parse::<std::net::Ipv4Addr>().ok())
+        .find(|ip| {
+            let octets = ip.octets();
+            !ip.is_loopback() && (octets[0] != 172 || octets[1] != 17)
+        })
+        .map(|ip| ip.to_string())
+}
+
 /// Print connection info when an API key is present (the shape shared by `status`
 /// and the systemd start path), taking the `read_server_info` tuple directly.
 fn print_server_info_opt(info: (Option<String>, Option<String>, Option<String>)) {
     let (tunnel_url, local_url, api_key) = info;
     if let Some(api_key) = &api_key {
-        print_server_info(tunnel_url.as_deref(), local_url.as_deref().unwrap_or("http://localhost:?"), api_key);
+        print_server_info(
+            tunnel_url.as_deref(),
+            local_url.as_deref().unwrap_or("http://localhost:?"),
+            api_key,
+        );
     }
 }
 
@@ -779,6 +818,7 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool) {
                 config_dir: config.clone(),
                 docker: docker.clone(),
                 dev_mode,
+                expose_lan,
             }).await;
 
             if let Some(supervisor) = tunnel_supervisor {
@@ -853,11 +893,14 @@ fn main() {
 
     let cli = Cli::parse();
 
-    match cli.command.unwrap_or(Command::Serve { port: None, no_tunnel: false, standalone: false }) {
-        Command::Serve { port, no_tunnel, standalone } => {
+    match cli.command.unwrap_or(Command::Serve { port: None, no_tunnel: false, standalone: false, expose_lan: false }) {
+        Command::Serve { port, no_tunnel, standalone, expose_lan } => {
             if standalone {
-                run_server_foreground(port, no_tunnel);
+                run_server_foreground(port, no_tunnel, expose_lan);
             } else {
+                if expose_lan {
+                    eprintln!("note: --expose-lan only applies with --standalone");
+                }
                 run_server_systemd(port, no_tunnel);
             }
         }

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2438,6 +2438,7 @@ pub struct ServerConfig {
     pub config_dir: std::path::PathBuf,
     pub docker: bollard::Docker,
     pub dev_mode: bool,
+    pub expose_lan: bool,
 }
 
 pub async fn run_server(cfg: ServerConfig) {
@@ -2451,6 +2452,7 @@ pub async fn run_server(cfg: ServerConfig) {
         config_dir,
         docker,
         dev_mode,
+        expose_lan,
     } = cfg;
     let agents_dir = config_dir.join("agents");
     let env_config = docker::AgentEnvConfig {
@@ -2508,15 +2510,21 @@ pub async fn run_server(cfg: ServerConfig) {
     // the async block, closing the TOCTOU race on the HTTP port. HTTPS binds
     // inside axum_server::bind_rustls below; its window is short and a loss is
     // loud (the task panics) rather than silent.
-    // Bind the HTTPS control API to loopback only. Every path that reaches vestad
-    // arrives via localhost: the Cloudflare tunnel's cloudflared dials
-    // https://localhost:{port} (see tunnel.rs) and the plain HTTP server is
-    // already loopback-only, so this keeps the API off the LAN and the public
-    // internet. On cloud-managed VMs a deny-all host firewall is the boundary
-    // regardless, so loopback binding there is defence in depth, not a regression.
-    let https_addr = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
+    // Bind the HTTPS control API to loopback by default — every normal path
+    // reaches vestad via localhost (cloudflared dials https://localhost:{port}),
+    // so this keeps the API off the LAN and the public internet. `--expose-lan`
+    // opts into binding all interfaces so other devices on the LAN can connect
+    // (0.0.0.0 still includes loopback, so the tunnel keeps working); the API is
+    // then guarded only by the API key + fingerprint-pinned self-signed TLS. The
+    // plain HTTP server stays loopback-only regardless (see main.rs).
+    let https_bind_addr = if expose_lan {
+        std::net::Ipv4Addr::UNSPECIFIED
+    } else {
+        std::net::Ipv4Addr::LOCALHOST
+    };
+    let https_addr = std::net::SocketAddr::from((https_bind_addr, port));
 
-    tracing::info!(port, "https listening on 127.0.0.1");
+    tracing::info!(port, %https_bind_addr, "https listening");
     tracing::info!(http_port = port + 1, "http listening on 127.0.0.1");
 
     let http_app = app.clone();

--- a/vestad/src/status.rs
+++ b/vestad/src/status.rs
@@ -1,0 +1,467 @@
+//! The daemon's status: held in memory and mirrored to `status.json`, rendered as
+//! the startup banner. `status.json` is the single source the `vestad status` and
+//! systemd-install CLI processes read to reproduce the exact banner — pid-gated so
+//! they never show a dead daemon's state. This module owns the file path, its
+//! format, and the banner rendering ("one owner per decision").
+
+use crate::paint;
+use qrcode::{render::unicode, EcLevel, QrCode};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+// --- Banner rendering ---
+
+const BANNER_ACCENT: &str = "38;2;231;186;140"; // light orange #e7ba8c (24-bit truecolor)
+const BANNER_DIM: &str = "2";
+const BANNER_MARGIN: usize = 3; // spaces between the border and content
+const BANNER_LABEL_W: usize = 9; // config label column width
+const BANNER_ART_W: usize = 46; // fixed width of every VESTA_ART line
+
+/// "VESTA" in an ANSI-shadow block font. Every line is exactly BANNER_ART_W wide
+/// (a unit test enforces this, since the box geometry centers on that width).
+const VESTA_ART: [&str; 6] = [
+    "██╗   ██╗ ███████╗ ███████╗ ████████╗  █████╗ ",
+    "██║   ██║ ██╔════╝ ██╔════╝ ╚══██╔══╝ ██╔══██╗",
+    "██║   ██║ █████╗   ███████╗    ██║    ███████║",
+    "╚██╗ ██╔╝ ██╔══╝   ╚════██║    ██║    ██╔══██║",
+    " ╚████╔╝  ███████╗ ███████║    ██║    ██║  ██║",
+    "  ╚═══╝   ╚══════╝ ╚══════╝    ╚═╝    ╚═╝  ╚═╝",
+];
+
+/// One row of the startup box. Each variant knows its natural (uncolored) width
+/// so the renderer can size the box and pad every line to a uniform interior.
+enum BoxRow {
+    Gap,
+    Art(usize),               // index into VESTA_ART, centered, accent colour
+    Center(String),           // centered dim text (e.g. the version subtitle)
+    Raw(String),              // left-aligned uncoloured text (QR rows must stay scannable)
+    Kv(&'static str, String), // "label   value", left-aligned
+    Value(String),            // a full-width left-aligned value (e.g. the api key)
+    Rule(&'static str),       // "── label ─────" section divider
+}
+
+impl BoxRow {
+    /// Visible width of the row's content, ignoring borders and side margins.
+    fn width(&self) -> usize {
+        match self {
+            BoxRow::Gap => 0,
+            BoxRow::Art(_) => BANNER_ART_W,
+            BoxRow::Center(s) | BoxRow::Raw(s) | BoxRow::Value(s) => s.chars().count(),
+            BoxRow::Kv(_, value) => BANNER_LABEL_W + value.chars().count(),
+            BoxRow::Rule(label) => label.chars().count() + 5, // "── " + " ─"
+        }
+    }
+
+    /// Render the content fitted to `inner` columns as one or more `(plain,
+    /// shown)` lines — long values (links, api key, a long error) are hard-wrapped
+    /// so the box never overflows a narrow terminal. `plain` drives padding math
+    /// (no ANSI); `shown` is what prints (equal to `plain` when colour is off).
+    fn render(&self, inner: usize) -> Vec<(String, String)> {
+        let centered = |line: &str, code: Option<&str>| {
+            let lead = " ".repeat(inner.saturating_sub(line.chars().count()) / 2);
+            let shown = match code {
+                Some(code) => paint(code, line),
+                None => line.to_string(),
+            };
+            (format!("{lead}{line}"), format!("{lead}{shown}"))
+        };
+        match self {
+            BoxRow::Gap => vec![(String::new(), String::new())],
+            BoxRow::Art(idx) => {
+                let art = VESTA_ART[*idx];
+                // Can't shrink the art; drop it rather than overflow a tiny box.
+                if art.chars().count() > inner {
+                    Vec::new()
+                } else {
+                    vec![centered(art, Some(BANNER_ACCENT))]
+                }
+            }
+            BoxRow::Center(text) => wrap_chars(text, inner)
+                .iter()
+                .map(|line| centered(line, Some(BANNER_DIM)))
+                .collect(),
+            BoxRow::Raw(text) => vec![(text.clone(), text.clone())],
+            BoxRow::Kv(label, value) => {
+                let label_col = format!("{:<width$}", label, width = BANNER_LABEL_W);
+                let value_width = inner.saturating_sub(BANNER_LABEL_W).max(1);
+                wrap_chars(value, value_width)
+                    .into_iter()
+                    .enumerate()
+                    .map(|(line_no, chunk)| {
+                        if line_no == 0 {
+                            (format!("{label_col}{chunk}"), format!("{}{chunk}", paint(BANNER_DIM, &label_col)))
+                        } else {
+                            // continuation lines align under the value column
+                            let pad = " ".repeat(BANNER_LABEL_W);
+                            (format!("{pad}{chunk}"), format!("{pad}{chunk}"))
+                        }
+                    })
+                    .collect()
+            }
+            BoxRow::Value(value) => wrap_chars(value, inner)
+                .into_iter()
+                .map(|chunk| (chunk.clone(), paint(BANNER_ACCENT, &chunk)))
+                .collect(),
+            BoxRow::Rule(label) => {
+                let prefix = format!("── {} ", label);
+                let fill = inner.saturating_sub(prefix.chars().count());
+                let plain = format!("{}{}", prefix, "─".repeat(fill));
+                vec![(plain.clone(), paint(BANNER_DIM, &plain))]
+            }
+        }
+    }
+}
+
+/// Hard-wrap `text` into chunks of at most `width` characters (character-wise, so
+/// unbreakable strings like URLs and keys still fit). Always returns ≥1 element.
+fn wrap_chars(text: &str, width: usize) -> Vec<String> {
+    if width == 0 || text.is_empty() {
+        return vec![text.to_string()];
+    }
+    text.chars()
+        .collect::<Vec<char>>()
+        .chunks(width)
+        .map(|chunk| chunk.iter().collect())
+        .collect()
+}
+
+/// Terminal width (columns) of stderr, or `None` when it isn't a TTY / can't be
+/// queried — callers fall back to a conservative default.
+fn terminal_width() -> Option<usize> {
+    use std::os::unix::io::AsRawFd;
+    let mut size: libc::winsize = unsafe { std::mem::zeroed() };
+    // SAFETY: TIOCGWINSZ fills the winsize through the pointer for a valid fd; we
+    // pass stderr's fd and a correctly sized, zeroed struct.
+    let rc = unsafe { libc::ioctl(std::io::stderr().as_raw_fd(), libc::TIOCGWINSZ, &mut size) };
+    (rc == 0 && size.ws_col > 0).then_some(size.ws_col as usize)
+}
+
+/// Draw the rows inside a rounded, accent-coloured box. The interior is as wide
+/// as the content but capped to the terminal so the box never wraps; over-long
+/// rows are wrapped to fit. Returns the finished lines (plain when colour is off,
+/// which is how the geometry test inspects them).
+fn render_box(rows: &[BoxRow]) -> Vec<String> {
+    // Reserve the 2-space outer indent, both borders, and both side margins.
+    let overhead = 2 + 2 + BANNER_MARGIN * 2;
+    let cap = terminal_width().unwrap_or(80).saturating_sub(overhead);
+    render_box_capped(rows, cap)
+}
+
+/// [`render_box`] with the interior width cap passed explicitly (so the wrapping
+/// behaviour is testable without a real terminal).
+fn render_box_capped(rows: &[BoxRow], cap: usize) -> Vec<String> {
+    let natural = rows.iter().map(BoxRow::width).max().unwrap_or(0);
+    let inner = natural.min(cap).max(1);
+    let span = BANNER_MARGIN * 2 + inner;
+    let edge = |left: &str, right: &str| {
+        format!("{}{}{}", paint(BANNER_ACCENT, left), paint(BANNER_ACCENT, &"─".repeat(span)), paint(BANNER_ACCENT, right))
+    };
+    let mut out = vec![edge("╭", "╮")];
+    let side = paint(BANNER_ACCENT, "│");
+    for row in rows {
+        for (plain, shown) in row.render(inner) {
+            let trailing = inner.saturating_sub(plain.chars().count());
+            out.push(format!(
+                "{side}{margin}{shown}{trailing}{margin}{side}",
+                margin = " ".repeat(BANNER_MARGIN),
+                trailing = " ".repeat(trailing),
+            ));
+        }
+    }
+    out.push(edge("╰", "╯"));
+    out
+}
+
+/// First line of `msg`, trimmed and capped to `max` chars with an ellipsis, so a
+/// long or multi-line error can't blow up the banner width.
+fn first_line_truncated(msg: &str, max: usize) -> String {
+    let line = msg.lines().next().unwrap_or(msg).trim();
+    if line.chars().count() <= max {
+        line.to_string()
+    } else {
+        format!("{}…", line.chars().take(max.saturating_sub(1)).collect::<String>())
+    }
+}
+
+/// Build the app connect link: the app reads the key from the URL fragment
+/// (`#k=...`), which browsers never send to the server, so the key stays out of
+/// request logs.
+fn connect_link(base_url: &str, api_key: &str) -> String {
+    format!("{base_url}/app#k={api_key}")
+}
+
+/// Render `data` as a square QR using half-block glyphs (the densest *square*
+/// terminal rendering: 1 module wide, 2 modules tall per cell). A light module is
+/// drawn as a filled glyph and a dark module as empty, which on a dark terminal
+/// (light foreground) yields a correct-polarity, scannable code; the quiet zone
+/// is the bright border. Lowest error-correction (`L`) keeps it as small as a
+/// square code gets. Empty on the rare encode failure.
+fn qr_lines(data: &str) -> Vec<String> {
+    let Ok(code) = QrCode::with_error_correction_level(data.as_bytes(), EcLevel::L) else {
+        return Vec::new();
+    };
+    code.render::<unicode::Dense1x2>()
+        .dark_color(unicode::Dense1x2::Light)
+        .light_color(unicode::Dense1x2::Dark)
+        .quiet_zone(true)
+        .build()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+// --- Status ---
+
+/// How the Cloudflare tunnel stands, as surfaced in the banner. Held in memory by
+/// the daemon and serialized into `status.json`.
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
+pub enum TunnelStatus {
+    Disabled,       // --no-tunnel
+    Active(String), // reachable https URL
+    Failed(String), // wanted, but couldn't be established — concise reason
+}
+
+impl TunnelStatus {
+    pub fn url(&self) -> Option<&str> {
+        match self {
+            TunnelStatus::Active(url) => Some(url),
+            _ => None,
+        }
+    }
+}
+
+/// The daemon's startup state. Every field except `tunnel` is fixed for the life
+/// of the process; `tunnel` is kept current by the supervisor. `pid` lets readers
+/// of `status.json` confirm the snapshot belongs to the live daemon.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Status {
+    pub version: String,
+    pub user: String,
+    pub port: u16,
+    pub dev_mode: bool,
+    pub expose_lan: bool,
+    pub lan_url: Option<String>,
+    pub tunnel: TunnelStatus,
+    pub pid: u32,
+}
+
+impl Status {
+    pub fn new(
+        version: String,
+        user: String,
+        port: u16,
+        dev_mode: bool,
+        expose_lan: bool,
+        lan_url: Option<String>,
+        tunnel: TunnelStatus,
+    ) -> Self {
+        Status { version, user, port, dev_mode, expose_lan, lan_url, tunnel, pid: std::process::id() }
+    }
+
+    /// Sole owner of the `status.json` path.
+    fn path(config: &Path) -> PathBuf {
+        config.join("status.json")
+    }
+
+    /// Atomically write `status.json` (tmp + rename). Best-effort: the file is
+    /// re-derivable on the next boot, so a failure is logged, never fatal. Carries
+    /// no secret (the api key stays in the `api-key` file).
+    pub fn persist(&self, config: &Path) {
+        let Ok(json) = serde_json::to_vec_pretty(self) else {
+            return;
+        };
+        let path = Self::path(config);
+        let tmp = path.with_extension("json.tmp");
+        if std::fs::write(&tmp, json).is_ok() {
+            if let Err(e) = std::fs::rename(&tmp, &path) {
+                tracing::warn!("failed to persist status.json: {e}");
+            }
+        }
+    }
+
+    pub fn load(config: &Path) -> Option<Status> {
+        let data = std::fs::read_to_string(Self::path(config)).ok()?;
+        serde_json::from_str(&data).ok()
+    }
+
+    pub fn set_tunnel(&mut self, tunnel: TunnelStatus) {
+        self.tunnel = tunnel;
+    }
+
+    /// Print the boxed banner: VESTA art, config grid, connection summary, and the
+    /// per-tier connect links (with a QR for the remote link). `api_key` is passed
+    /// in rather than persisted, so the secret never lands in `status.json`.
+    pub fn print_banner(&self, api_key: &str) {
+        let local_url = format!("http://localhost:{}", self.port + 1);
+        let tunnel_url = self.tunnel.url();
+
+        // enabled = tunnel up; disabled = --no-tunnel; error — <reason> = a tunnel
+        // was wanted but couldn't be established (no creds, dead tunnel, API error).
+        let tunnel_desc = match &self.tunnel {
+            TunnelStatus::Active(_) => "enabled".to_string(),
+            TunnelStatus::Disabled => "disabled".to_string(),
+            TunnelStatus::Failed(reason) => format!("error — {}", first_line_truncated(reason, 100)),
+        };
+        let lan_desc = if self.expose_lan { "enabled" } else { "disabled" }.to_string();
+        let lan_url = self.lan_url.as_deref();
+        // The address most useful to a human: public tunnel, else the LAN URL when
+        // exposed, else the same-machine local URL.
+        let address = tunnel_url
+            .map(str::to_string)
+            .or_else(|| lan_url.map(str::to_string))
+            .unwrap_or_else(|| local_url.clone());
+        // The LAN connect link is only real when the API is actually bound to the LAN.
+        let lan_app = self.expose_lan.then_some(lan_url).flatten();
+
+        let mut rows = vec![
+            BoxRow::Gap,
+            BoxRow::Art(0),
+            BoxRow::Art(1),
+            BoxRow::Art(2),
+            BoxRow::Art(3),
+            BoxRow::Art(4),
+            BoxRow::Art(5),
+            BoxRow::Gap,
+            BoxRow::Center(format!("personal AI daemon · v{}", self.version)),
+            BoxRow::Gap,
+            BoxRow::Kv("user", self.user.clone()),
+            BoxRow::Kv("port", self.port.to_string()),
+            BoxRow::Kv("mode", if self.dev_mode { "development".to_string() } else { "production".to_string() }),
+            BoxRow::Kv("tunnel", tunnel_desc),
+            BoxRow::Kv("lan", lan_desc),
+            BoxRow::Gap,
+            BoxRow::Rule("connection"),
+            BoxRow::Kv("address", address),
+            BoxRow::Kv("api key", api_key.to_string()),
+            BoxRow::Gap,
+            BoxRow::Rule("connect the app"),
+        ];
+        // remote tier: the public link when a tunnel is up (with the QR for it
+        // right beneath, left-aligned), otherwise how to get one.
+        rows.push(BoxRow::Kv("remote", String::new()));
+        match tunnel_url {
+            Some(url) => {
+                let link = connect_link(url, api_key);
+                rows.push(BoxRow::Value(link.clone()));
+                rows.push(BoxRow::Gap);
+                rows.extend(qr_lines(&link).into_iter().map(BoxRow::Raw));
+            }
+            None => rows.push(BoxRow::Value("run `vestad connect` for a public URL".to_string())),
+        }
+        if let Some(url) = lan_app {
+            rows.push(BoxRow::Gap);
+            rows.push(BoxRow::Kv("lan", String::new()));
+            rows.push(BoxRow::Value(connect_link(url, api_key)));
+        }
+        rows.push(BoxRow::Gap);
+        rows.push(BoxRow::Kv("local", String::new()));
+        rows.push(BoxRow::Value(connect_link(&local_url, api_key)));
+        rows.push(BoxRow::Gap);
+
+        eprintln!();
+        for line in render_box(&rows) {
+            eprintln!("  {line}");
+        }
+        eprintln!();
+    }
+}
+
+/// Whether `pid` names a live process. Same-user `kill(pid, 0)` checks existence
+/// without delivering a signal — enough to confirm a persisted `status.json`
+/// belongs to the currently-running daemon (both run as the same user).
+pub fn pid_is_live(pid: u32) -> bool {
+    // SAFETY: signal 0 performs only existence/permission checks; nothing is sent.
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+/// Render the banner from `status.json` for the `vestad status` / systemd-install
+/// CLIs. Only renders when the persisted daemon pid is live, so a stale file from
+/// a stopped or previous daemon never shows a misleading box.
+pub fn print_status_banner(config: &Path, api_key: Option<&str>) {
+    match Status::load(config) {
+        Some(status) if pid_is_live(status.pid) => match api_key {
+            Some(key) => status.print_banner(key),
+            None => {
+                eprintln!();
+                eprintln!("  {}", paint(BANNER_DIM, "vestad is running (api key unavailable)"));
+                eprintln!();
+            }
+        },
+        _ => {
+            eprintln!();
+            eprintln!("  {}", paint(BANNER_DIM, "vestad is not running"));
+            eprintln!();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vesta_art_lines_are_uniform_width() {
+        for line in VESTA_ART {
+            assert_eq!(line.chars().count(), BANNER_ART_W, "art line: {line}");
+        }
+    }
+
+    #[test]
+    fn render_box_lines_share_width_and_are_bordered() {
+        // Colour is disabled under `cargo test` (stderr is not a TTY), so the
+        // rendered lines are plain and char count equals display width.
+        let rows = vec![
+            BoxRow::Gap,
+            BoxRow::Art(0),
+            BoxRow::Center("personal AI daemon".into()),
+            BoxRow::Kv("user", "emi".into()),
+            BoxRow::Rule("connection"),
+            BoxRow::Value("0123456789abcdef0123456789abcdef".into()),
+        ];
+        let lines = render_box(&rows);
+        let width = lines[0].chars().count();
+        assert!(lines.iter().all(|l| l.chars().count() == width), "every box line is the same width");
+        assert!(lines.first().unwrap().starts_with('╭') && lines.first().unwrap().ends_with('╮'));
+        assert!(lines.last().unwrap().starts_with('╰') && lines.last().unwrap().ends_with('╯'));
+        for interior in &lines[1..lines.len() - 1] {
+            assert!(interior.starts_with('│') && interior.ends_with('│'), "interior row is bordered: {interior}");
+        }
+    }
+
+    #[test]
+    fn render_box_wraps_long_rows_within_a_narrow_cap() {
+        let long = "x".repeat(120);
+        let cap = 30;
+        let lines = render_box_capped(&[BoxRow::Value(long), BoxRow::Art(0)], cap);
+        let width = lines[0].chars().count();
+        // Uniform width, and the whole box stays within the cap (+ borders/margins).
+        assert!(lines.iter().all(|l| l.chars().count() == width), "every box line is the same width");
+        assert!(width <= cap + 2 + BANNER_MARGIN * 2, "box width {width} exceeds cap {cap}");
+        // The 120-char value wrapped across multiple interior lines instead of overflowing.
+        let value_lines = lines.iter().filter(|l| l.contains('x')).count();
+        assert!(value_lines >= 4, "expected the long value to wrap into >=4 lines, got {value_lines}");
+    }
+
+    #[test]
+    fn status_json_round_trips_all_tunnel_states() {
+        for tunnel in [
+            TunnelStatus::Disabled,
+            TunnelStatus::Active("https://host.example/".into()),
+            TunnelStatus::Failed("invalid token".into()),
+        ] {
+            let status = Status::new("0.1.0".into(), "emi".into(), 8080, true, false, None, tunnel.clone());
+            let json = serde_json::to_string(&status).expect("serialize");
+            let back: Status = serde_json::from_str(&json).expect("deserialize");
+            assert!(back.tunnel == tunnel);
+            assert_eq!(back.port, 8080);
+            assert_eq!(back.pid, status.pid);
+        }
+    }
+
+    #[test]
+    fn pid_liveness_detects_self_and_a_dead_pid() {
+        assert!(pid_is_live(std::process::id()), "our own pid must be live");
+        // i32::MAX is above the kernel pid_max, so it can never name a process.
+        assert!(!pid_is_live(i32::MAX as u32), "a never-allocated pid must be dead");
+    }
+}

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -258,6 +258,14 @@ pub fn get_tunnel_config(config_dir: &Path) -> Option<TunnelConfig> {
     serde_json::from_str(&data).ok()
 }
 
+/// Drop the saved tunnel config WITHOUT touching Cloudflare. Used when the box
+/// can't manage the remote tunnel (no creds — e.g. an orphaned `*.vesta.run`
+/// tunnel left behind on a now-self-hosted box) so future boots stop retrying a
+/// tunnel that can never register.
+pub fn forget_tunnel(config_dir: &Path) {
+    std::fs::remove_file(tunnel_config_path(config_dir)).ok();
+}
+
 const ANIMALS: &[&str] = &[
     "alpaca", "badger", "beaver", "bison", "bobcat", "camel", "capybara", "cardinal",
     "caribou", "chameleon", "cheetah", "chinchilla", "chipmunk", "cobra", "condor",
@@ -620,6 +628,64 @@ fn alloc_loopback_port() -> Result<u16, String> {
         .local_addr()
         .map_err(|e| format!("failed to read metrics port: {}", e))?;
     Ok(addr.port())
+}
+
+/// How long boot-time pre-flight waits for cloudflared to register an edge
+/// connection before declaring the saved tunnel dead. Generous enough to absorb
+/// a slow first connect, short enough not to stall startup.
+const PREFLIGHT_READY_TIMEOUT_SECS: u64 = 20;
+const PREFLIGHT_POLL_INTERVAL_MS: u64 = 500;
+
+/// Credential-free boot check that the saved tunnel can actually register.
+///
+/// Spawns one short-lived cloudflared and polls its /ready endpoint until it
+/// reports a registered edge connection, then kills it (the supervisor owns the
+/// long-lived child). Returns `false` if cloudflared exits early — e.g.
+/// "Unauthorized: Tunnel not found" when the tunnel was deleted server-side or
+/// its token revoked — or never registers within PREFLIGHT_READY_TIMEOUT_SECS.
+/// This relies only on cloudflared's local /ready, so it works on a box that
+/// holds no Cloudflare credentials and can't query the API.
+pub async fn preflight_tunnel(config_dir: &Path, port: u16) -> bool {
+    let (mut child, metrics_port) = match start_tunnel(config_dir, port).await {
+        Ok(pair) => pair,
+        Err(e) => {
+            tracing::warn!("tunnel pre-flight could not start cloudflared: {e}");
+            return false;
+        }
+    };
+    let probe_client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(READY_PROBE_TIMEOUT_SECS))
+        .build()
+    {
+        Ok(client) => client,
+        Err(e) => {
+            tracing::warn!("tunnel pre-flight probe client unavailable: {e}");
+            child.kill().await.ok();
+            return false;
+        }
+    };
+    let probe_url = format!("http://127.0.0.1:{metrics_port}/ready");
+    let deadline =
+        tokio::time::Instant::now() + std::time::Duration::from_secs(PREFLIGHT_READY_TIMEOUT_SECS);
+    let ready = loop {
+        // cloudflared gave up on its own (dead tunnel / revoked token).
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            break false;
+        }
+        let registered = match probe_client.get(&probe_url).send().await {
+            Ok(resp) => resp.status().is_success(),
+            Err(_) => false,
+        };
+        if registered {
+            break true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            break false;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(PREFLIGHT_POLL_INTERVAL_MS)).await;
+    };
+    child.kill().await.ok();
+    ready
 }
 
 // --- Tunnel supervision ---

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -715,6 +715,10 @@ const READY_PROBE_INTERVAL_SECS: u64 = 30;
 const READY_PROBE_TIMEOUT_SECS: u64 = 5;
 /// Consecutive failed /ready probes before cloudflared is restarted.
 const READY_PROBE_MAX_FAILURES: u32 = 3;
+/// How long the tunnel must stay unregistered before the supervisor reports it
+/// down to status.json. Longer than a normal restart-recovery cycle, so transient
+/// blips the supervisor heals on its own keep the status showing "enabled".
+const TUNNEL_DOWN_SUSTAINED_SECS: u64 = 120;
 
 pub struct TunnelSupervisor {
     shutdown: tokio::sync::watch::Sender<bool>,
@@ -731,7 +735,18 @@ impl TunnelSupervisor {
 
 /// Spawn cloudflared and keep it alive until `shutdown()`: respawn on exit or
 /// on a failed edge probe streak, after a fixed delay between attempts.
-pub fn supervise_tunnel(config_dir: PathBuf, port: u16) -> TunnelSupervisor {
+///
+/// `on_tunnel_up(bool)` is invoked on SUSTAINED edge changes (debounced) so the
+/// caller can mirror tunnel health into status.json: `true` as soon as the tunnel
+/// re-registers, `false` only after it has been unregistered for
+/// `TUNNEL_DOWN_SUSTAINED_SECS` (so transient blips the supervisor heals don't
+/// flip status). Kept as a plain `Fn(bool)` to keep this module free of caller
+/// types.
+pub fn supervise_tunnel(
+    config_dir: PathBuf,
+    port: u16,
+    on_tunnel_up: std::sync::Arc<dyn Fn(bool) + Send + Sync>,
+) -> TunnelSupervisor {
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
     let task = tokio::spawn(async move {
         // One client for every probe across respawns. Build failure is
@@ -747,6 +762,11 @@ pub fn supervise_tunnel(config_dir: PathBuf, port: u16) -> TunnelSupervisor {
                 None
             }
         };
+        // Edge state for status.json, carried across cloudflared restarts. The
+        // supervisor only runs once the tunnel was verified up, so we start
+        // "reported up" with `now` as the last registered time.
+        let mut reported_up = true;
+        let mut last_registered = tokio::time::Instant::now();
         loop {
             match start_tunnel(&config_dir, port).await {
                 Ok((mut child, metrics_port)) => {
@@ -755,7 +775,14 @@ pub fn supervise_tunnel(config_dir: PathBuf, port: u16) -> TunnelSupervisor {
                             child.kill().await.ok();
                             return;
                         }
-                        reason = run_until_unhealthy(&mut child, probe_client.as_ref(), metrics_port) => reason,
+                        reason = run_until_unhealthy(
+                            &mut child,
+                            probe_client.as_ref(),
+                            metrics_port,
+                            on_tunnel_up.as_ref(),
+                            &mut reported_up,
+                            &mut last_registered,
+                        ) => reason,
                     };
                     child.kill().await.ok();
                     tracing::warn!(delay_secs = TUNNEL_RESPAWN_DELAY_SECS, "tunnel unhealthy ({reason}), restarting cloudflared");
@@ -774,11 +801,16 @@ pub fn supervise_tunnel(config_dir: PathBuf, port: u16) -> TunnelSupervisor {
 }
 
 /// Watch one cloudflared run; returns the reason it must be replaced (process
-/// exit, or /ready failing READY_PROBE_MAX_FAILURES times in a row).
+/// exit, or /ready failing READY_PROBE_MAX_FAILURES times in a row). Drives the
+/// debounced `on_tunnel_up` edge callback via `reported_up`/`last_registered`,
+/// which persist across restarts.
 async fn run_until_unhealthy(
     child: &mut tokio::process::Child,
     probe_client: Option<&reqwest::Client>,
     metrics_port: u16,
+    on_tunnel_up: &(dyn Fn(bool) + Send + Sync),
+    reported_up: &mut bool,
+    last_registered: &mut tokio::time::Instant,
 ) -> String {
     let probe_url = format!("http://127.0.0.1:{metrics_port}/ready");
     let probe_interval = std::time::Duration::from_secs(READY_PROBE_INTERVAL_SECS);
@@ -805,6 +837,20 @@ async fn run_until_unhealthy(
                     Ok(resp) => resp.status().is_success(),
                     Err(_) => false,
                 };
+                // Mirror health into status.json on sustained edges only: "up" the
+                // moment it re-registers, "down" only after a sustained outage.
+                if ok {
+                    *last_registered = tokio::time::Instant::now();
+                    if !*reported_up {
+                        on_tunnel_up(true);
+                        *reported_up = true;
+                    }
+                } else if *reported_up
+                    && last_registered.elapsed() >= std::time::Duration::from_secs(TUNNEL_DOWN_SUSTAINED_SECS)
+                {
+                    on_tunnel_up(false);
+                    *reported_up = false;
+                }
                 let (failures, restart) = record_probe(consecutive_failures, ok);
                 consecutive_failures = failures;
                 if !ok {


### PR DESCRIPTION
## What

Makes the Cloudflare tunnel resilient at startup, adds an opt-in LAN bind, and
redesigns the daemon's startup output as a boxed banner that `vestad status` now
renders from a persisted `status.json` — a single source of truth.

## Why

- A dead/orphaned tunnel (deleted server-side or revoked token) used to print a
  broken URL and leave `cloudflared` looping on "Tunnel not found" forever.
- `vestad serve --standalone` and `vestad status` showed different, diverging
  connection info.

## Changes (by commit)

1. **boxed startup banner** — VESTA art + config grid (user/port/mode/tunnel/lan)
   + connection section + per-tier connect links (`remote`/`lan`/`local`) with a
   QR for the remote link. Box caps to terminal width and wraps long rows so it
   never overflows a narrow terminal.
2. **`--expose-lan`** — bind the HTTPS API to all interfaces (standalone only;
   loopback by default). `local_lan_ip` derives the real LAN address from the
   default-route source IP, skipping Docker/VPN bridges.
3. **resilient tunnel startup** — credential-free `/ready` pre-flight verifies the
   tunnel registers before its URL is advertised; startup retries, recreating the
   tunnel when creds are held; if it still can't come up, vestad starts anyway
   with the failure shown on the banner instead of blocking the box.
4. **`status.json` + `Status` module** — the daemon holds `Status` in memory and
   mirrors it to `status.json` (atomic write, no secret). `vestad status` renders
   the exact same banner, pid-gated so it never shows a stopped daemon's state.
   The supervisor keeps the tunnel field honest via a debounced `Fn(bool)`
   callback (down only after a sustained outage). Old `print_server_info` display
   removed.

## Testing

- `./check.sh vestad` passes: `clippy -D warnings` clean, 147 tests.
- New unit tests: banner geometry + wrapping, `Status` serde round-trip across all
  `TunnelStatus` variants, pid-liveness gate, and tunnel-retry behavior.
- Not yet exercised against a live daemon (tunnel up/down + `vestad status` on a
  real box) — reviewer/author to verify end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
