### PR TITLE
feat(skills): add reduce-loc skill

### DIFF
--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -92,6 +92,10 @@
     "description": "Periodic self-directed check-in; fires on interval to reach out or research."
   },
   {
+    "name": "reduce-loc",
+    "description": "Shrink a codebase's line count without changing behavior; dead code, dedup, then architectural simplification. Use when asked to reduce LOC, simplify, or trim a repo."
+  },
+  {
     "name": "restart",
     "description": "What to do after a container restart. Holds the per-skill daemon startup commands."
   },

--- a/agent/skills/reduce-loc/SKILL.md
+++ b/agent/skills/reduce-loc/SKILL.md
@@ -30,18 +30,18 @@ merging; never accept a bold deletion on trust.
 
 ## What to cut, in order
 
-1. **Dead code** — unused functions, imports, fields, files, unreachable branches. Confirm with
+1. **Dead code**: unused functions, imports, fields, files, unreachable branches. Confirm with
    tooling, not eyeballing: `vulture` (Python), `knip` (TS), `clippy -D warnings` (Rust forbids
    dead code structurally). Grep every symbol repo-wide before deleting.
-2. **Surface dedup** — a literal/constant/block repeated 2+ times moves to one owner; idiomatic
+2. **Surface dedup**: a literal/constant/block repeated 2+ times moves to one owner; idiomatic
    collapse (guard clauses, `?`/`map`/comprehensions) *only when it reads cleaner*.
 3. **Architecture** (where the real wins are once 1-2 are exhausted):
-   - **Single source of truth** — one owner per constant, format, type, validation, event shape.
-   - **Smaller stacks** — inline single-caller wrappers; delete barrel/re-export indirection;
+   - **Single source of truth**: one owner per constant, format, type, validation, event shape.
+   - **Smaller stacks**: inline single-caller wrappers; delete barrel/re-export indirection;
      flatten deep call chains and over-layered error mapping.
-   - **Collapse structural boilerplate** — many handlers/commands repeating the same
+   - **Collapse structural boilerplate**: many handlers/commands repeating the same
      parse->guard->call->respond shape share one small typed helper.
-   - **External libraries** — replace hand-rolled retry/backoff, date math, arg parsing,
+   - **External libraries**: replace hand-rolled retry/backoff, date math, arg parsing,
      pagination, table formatting with a maintained lib *when* it nets a real deletion, reads
      cleaner, and adds little risk. Prefer a lib already in the dependency tree; if adding one,
      update the lockfile so the freshness check passes. Justify every new dependency.
@@ -50,7 +50,7 @@ merging; never accept a bold deletion on trust.
 
 - **No behavior change.** No wire/HTTP/CLI/env/event-shape changes, no error-message text that
   tests assert on, no public signature changes.
-- **"Zero importers" is not enough** — check for *implicit* consumers before deleting: sync
+- **"Zero importers" is not enough**: check for *implicit* consumers before deleting: sync
   scripts that `cp`/mirror files, codegen inputs, reflection, dynamic dispatch, a canonical
   registry feeding another tree. (A registry deleted because one app didn't import it can still
   feed a generated mirror.)
@@ -58,7 +58,7 @@ merging; never accept a bold deletion on trust.
   Remove only genuinely dead/duplicate tests.
 - **Don't touch generated code** (shadcn `components/ui/`, vendored, `@ts-nocheck`) beyond
   deleting truly unreferenced whole files, and respect any "do not delete" guard.
-- **Surgical** — every changed line traces to LOC reduction; don't refactor adjacent working code.
+- **Surgical**: every changed line traces to LOC reduction; don't refactor adjacent working code.
 - Honor the repo's own conventions (see its CLAUDE.md / CONTRIBUTING.md).
 
 ## Verify

--- a/agent/skills/reduce-loc/SKILL.md
+++ b/agent/skills/reduce-loc/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: reduce-loc
+description: Shrink a codebase's line count without changing behavior; dead code, dedup, then architectural simplification. Use when asked to reduce LOC, simplify, or trim a repo.
+---
+
+# Reduce LOC
+
+Make a repo smaller while keeping it simple, clean, and behavior-identical. Not code golf:
+every change must read as clean or cleaner to a senior engineer. The result must end
+*simpler*, not denser. Bias to net deletion; a change that adds indirection to save lines is
+a regression.
+
+## Method
+
+Work area by area in **parallel, isolated git worktrees** so passes never collide, then merge
+each into one branch.
+
+```bash
+base=refactor/reduce-loc
+git worktree add -b "$base" ../wt-reduce origin/master
+for area in <areas>; do git worktree add -b "reduce-loc/$area" "../wt-rl-$area" "$base"; done
+# one subagent per worktree -> commit on its branch -> merge all into $base -> push
+bash scripts/worktrees.sh setup <repo-root> <area>...   # helper for the above
+```
+
+Dispatch one subagent per area. Each: reduces LOC in its scope only, **verifies against that
+area's `./check.sh` subcommand before committing**, commits to its branch, does not push.
+Then merge every area branch into the base branch and open one PR. Review each diff before
+merging; never accept a bold deletion on trust.
+
+## What to cut, in order
+
+1. **Dead code** — unused functions, imports, fields, files, unreachable branches. Confirm with
+   tooling, not eyeballing: `vulture` (Python), `knip` (TS), `clippy -D warnings` (Rust forbids
+   dead code structurally). Grep every symbol repo-wide before deleting.
+2. **Surface dedup** — a literal/constant/block repeated 2+ times moves to one owner; idiomatic
+   collapse (guard clauses, `?`/`map`/comprehensions) *only when it reads cleaner*.
+3. **Architecture** (where the real wins are once 1-2 are exhausted):
+   - **Single source of truth** — one owner per constant, format, type, validation, event shape.
+   - **Smaller stacks** — inline single-caller wrappers; delete barrel/re-export indirection;
+     flatten deep call chains and over-layered error mapping.
+   - **Collapse structural boilerplate** — many handlers/commands repeating the same
+     parse->guard->call->respond shape share one small typed helper.
+   - **External libraries** — replace hand-rolled retry/backoff, date math, arg parsing,
+     pagination, table formatting with a maintained lib *when* it nets a real deletion, reads
+     cleaner, and adds little risk. Prefer a lib already in the dependency tree; if adding one,
+     update the lockfile so the freshness check passes. Justify every new dependency.
+
+## Hard rules
+
+- **No behavior change.** No wire/HTTP/CLI/env/event-shape changes, no error-message text that
+  tests assert on, no public signature changes.
+- **"Zero importers" is not enough** — check for *implicit* consumers before deleting: sync
+  scripts that `cp`/mirror files, codegen inputs, reflection, dynamic dispatch, a canonical
+  registry feeding another tree. (A registry deleted because one app didn't import it can still
+  feed a generated mirror.)
+- **Leave DAMP tests alone.** Test setup is intentionally explicit; do not DRY it for a few lines.
+  Remove only genuinely dead/duplicate tests.
+- **Don't touch generated code** (shadcn `components/ui/`, vendored, `@ts-nocheck`) beyond
+  deleting truly unreferenced whole files, and respect any "do not delete" guard.
+- **Surgical** — every changed line traces to LOC reduction; don't refactor adjacent working code.
+- Honor the repo's own conventions (see its CLAUDE.md / CONTRIBUTING.md).
+
+## Verify
+
+Run the affected `./check.sh` subcommands; they must pass. Prove exhaustion with the dead-code
+tools above rather than asserting it. Never report done until CI is green.

--- a/agent/skills/reduce-loc/scripts/worktrees.sh
+++ b/agent/skills/reduce-loc/scripts/worktrees.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Scaffold or tear down per-area worktrees for a parallel LOC-reduction pass.
+#
+#   worktrees.sh setup    <repo-root> <area>...   # base branch + one worktree per area
+#   worktrees.sh teardown <repo-root> <area>...   # remove them again
+#
+# Worktrees are created as siblings of <repo-root> (../wt-rl-<area>) on branches
+# reduce-loc/<area>, all forked from a base branch refactor/reduce-loc tracking origin/master.
+set -euo pipefail
+
+BASE_BRANCH="refactor/reduce-loc"
+
+cmd="${1:?usage: worktrees.sh setup|teardown <repo-root> <area>...}"
+root="${2:?missing <repo-root>}"
+shift 2
+[ "$#" -gt 0 ] || { echo "give at least one <area>" >&2; exit 1; }
+
+parent="$(cd "$root/.." && pwd)"
+git -C "$root" fetch origin master -q
+
+case "$cmd" in
+  setup)
+    git -C "$root" worktree add -b "$BASE_BRANCH" "$parent/wt-reduce" origin/master
+    for area in "$@"; do
+      git -C "$root" worktree add -b "reduce-loc/$area" "$parent/wt-rl-$area" "$BASE_BRANCH"
+      echo "ready: $parent/wt-rl-$area  (branch reduce-loc/$area)"
+    done
+    ;;
+  teardown)
+    for area in "$@"; do
+      git -C "$root" worktree remove --force "$parent/wt-rl-$area" 2>/dev/null || true
+      git -C "$root" branch -D "reduce-loc/$area" 2>/dev/null || true
+    done
+    git -C "$root" worktree remove --force "$parent/wt-reduce" 2>/dev/null || true
+    git -C "$root" worktree prune
+    ;;
+  *) echo "unknown command: $cmd" >&2; exit 1 ;;
+esac


### PR DESCRIPTION
Adds a `reduce-loc` skill: a playbook for shrinking a codebase without changing behavior.

## What it captures
- **Method**: parallel per-area git worktrees, one subagent each, verify against `./check.sh`, merge into one branch.
- **Order of cuts**: dead code (proven via vulture/knip/clippy) -> surface dedup -> architecture (single source of truth, smaller stacks, collapse boilerplate, justified external-lib swaps).
- **Hard rules learned the hard way**: no behavior change; not code golf (must read cleaner, not denser); **"zero importers" is not enough** — check implicit consumers like sync-mirrored registries/codegen; leave DAMP tests alone; don't touch generated code or a guarded canonical registry; never report done until CI is green.
- Ships `scripts/worktrees.sh` to scaffold/tear down the per-area worktrees.

`agent/skills/index.json` regenerated (45 skills).

## Verification
- `agent/skills/generate-index.py` runs clean and includes the new skill (index committed, so `skills-index-check` passes).
- `bash -n` clean on the helper script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)