### PR TITLE
test+fix(vestad): live upgrade e2e across releases, and the rebuild reliability fix it surfaced

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -18,12 +18,23 @@ Suites:
                  set VESTAD_AGENT_IMAGE or docker pull ghcr.io/elyxlz/vesta:latest)
   web            eslint + prettier --check + tsc + vitest
   integration    vestad integration tests (needs Docker)
-  live           live agent e2e tests (needs Docker + ~/.claude/.credentials.json; real Claude)
+  live           live agent e2e tests, incl. the upgrade gate (needs Docker + ~/.claude/.credentials.json; real Claude)
+  upgrade        just the upgrade e2e: create an agent on the previous release, update in place
+                 to this build, assert migrations converge (needs Docker + credentials; real Claude)
+                   ./check.sh upgrade                       # previous release -> this build
+                   ./check.sh upgrade --from v0.1.155        # from a specific release
+                   ./check.sh upgrade --from v0.1.155 --to v0.1.159   # both released versions
+                 Note: a debug build syncs the agent from the CURRENT BRANCH ref, so when the
+                 target is this build, push your branch first (else the agent's migration sync
+                 can't fetch it). The release gate builds in release mode and uses the version
+                 tag, so it needs no push.
   all            agent + cli + vestad + web
 
 Environment:
   TARGET=<triple>  cross-compilation target for cargo suites, e.g.
                    TARGET=x86_64-pc-windows-msvc ./check.sh cli
+  VESTA_UPGRADE_FROM / VESTA_UPGRADE_TO  release tags for the upgrade suite
+                   (the `upgrade` subcommand's --from/--to set these)
 EOF
   exit 1
 }
@@ -96,13 +107,38 @@ check_live() {
     cd vestad
     # The live tests use a 2-agent pool (see tests/live/common.rs); run enough threads that
     # every test starts and self-organizes onto its pool's mutex, so the two agents run in
-    # parallel instead of serializing on one.
+    # parallel instead of serializing on one. The upgrade e2e (tests/live/upgrade.rs) is part of
+    # this suite, so the release gate covers it alongside the other live tests.
     cargo test -p vestad --test live -- --test-threads=8
+  )
+}
+
+check_upgrade() {
+  (
+    cd vestad
+    # Just the upgrade e2e from the live suite. --nocapture streams the agent's container log live.
+    # Skip the embedded web app build: this is a backend/daemon test that never serves the app, and
+    # building it would couple the run to apps/ npm deps being installed and current.
+    VESTAD_SKIP_APP_BUILD=1 cargo test -p vestad --test live upgrade -- --test-threads=8 --nocapture
   )
 }
 
 if [ $# -lt 1 ]; then
   usage
+fi
+
+# `upgrade` takes optional --from/--to flags, so handle it before the plain suite loop.
+if [ "${1:-}" = "upgrade" ]; then
+  shift
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --from) export VESTA_UPGRADE_FROM="${2:?--from needs a release tag}"; shift 2 ;;
+      --to) export VESTA_UPGRADE_TO="${2:?--to needs a release tag}"; shift 2 ;;
+      *) echo "error: unknown upgrade flag '$1'" >&2; usage ;;
+    esac
+  done
+  check_upgrade
+  exit $?
 fi
 
 for suite in "$@"; do

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -121,6 +121,11 @@ pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
 
 const CONTAINER_STOP_TIMEOUT_SECS: i32 = 10;
 const CONTAINER_RESTART_TIMEOUT_SECS: i32 = 10;
+/// `docker rm --force` can return before the container name is actually released, and a transient
+/// daemon error can leave it present; poll-and-retry until it's gone so a follow-up create under the
+/// same name (rebuild_agent) can't collide. Bounded so a genuinely stuck removal fails loudly.
+const CONTAINER_REMOVE_MAX_ATTEMPTS: u32 = 5;
+const CONTAINER_REMOVE_POLL_MS: u64 = 200;
 /// Free space the Docker storage filesystem must have before vestad will rebuild or
 /// restart agent containers at startup. Below this, reconcile is skipped entirely so a
 /// full disk can't corrupt a container's writable layer (events.db, session) mid-restart.
@@ -1235,6 +1240,30 @@ pub async fn remove_container_force(docker: &Docker, cname: &str) -> Result<(), 
     Ok(())
 }
 
+/// Force-remove a container and confirm it is actually gone before returning. Needed when the name
+/// is reused immediately after (rebuild_agent recreates under the same name): a bare force-remove
+/// can return before the name frees, and a transient daemon error can leave the container present —
+/// either makes the follow-up create collide on the name and silently leaves the agent down. Retry
+/// the remove and poll until docker no longer reports it; error out loudly if it never disappears
+/// rather than letting the caller hit a confusing name conflict.
+pub async fn ensure_container_removed(docker: &Docker, cname: &str) -> Result<(), DockerError> {
+    for _ in 0..CONTAINER_REMOVE_MAX_ATTEMPTS {
+        if container_status(docker, cname).await == ContainerStatus::NotFound {
+            return Ok(());
+        }
+        // Per-attempt remove is best-effort: the authoritative signal is the status check above, so
+        // a transient error just means we retry; a persistent one falls through to the loud error.
+        let _ = docker.remove_container(cname, Some(RemoveContainerOptions { force: true, v: false, link: false })).await;
+        tokio::time::sleep(std::time::Duration::from_millis(CONTAINER_REMOVE_POLL_MS)).await;
+    }
+    if container_status(docker, cname).await == ContainerStatus::NotFound {
+        return Ok(());
+    }
+    Err(DockerError::Failed(format!(
+        "container {cname} still present after {CONTAINER_REMOVE_MAX_ATTEMPTS} force-remove attempts"
+    )))
+}
+
 // --- Snapshot ---
 
 const SNAPSHOT_TIMEOUT_SECS: u64 = 7200; // 2 hours — 25GB+ containers can take a long time
@@ -2007,7 +2036,10 @@ pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvCon
     snapshot_container(docker, &cname, &backup_tag, &[]).await?;
 
     tracing::info!(agent = %name, "[3/4] removing old container...");
-    remove_container_force(docker, &cname).await.ok();
+    // Confirm it's actually gone (don't swallow): the snapshot is safely captured, so failing here
+    // and re-running reconcile next boot is far better than letting [4/4] collide on the name and
+    // leave the agent stopped.
+    ensure_container_removed(docker, &cname).await?;
 
     tracing::info!(agent = %name, "[4/4] creating container with new config...");
     create_container(docker, &cname, &backup_tag, port, name, env_config, manage_core_code, None).await?;
@@ -2453,6 +2485,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn rebuild_agent_confirms_removal_before_create() {
+        // rebuild_agent recreates under the SAME name, so the old container must be confirmed gone
+        // before [4/4] create. A best-effort `remove_container_force(...).await.ok()` silently left
+        // the agent stopped on the old image whenever the remove didn't take (docker rm can return
+        // before the name frees, or fail transiently) — the create then collided on the name.
+        let src = include_str!("docker.rs");
+        let rebuild_start = src.find("pub async fn rebuild_agent").expect("rebuild_agent present");
+        let rename_start = src.find("pub async fn rename_agent").expect("rename_agent present");
+        let rebuild_body = &src[rebuild_start..rename_start];
+
+        let remove_pos = rebuild_body
+            .find("ensure_container_removed")
+            .expect("rebuild_agent must confirm the old container is gone via ensure_container_removed before recreating");
+        let create_pos = rebuild_body.find("create_container").expect("create_container must be called in rebuild_agent");
+        assert!(remove_pos < create_pos, "rebuild_agent must remove the old container before creating the new one");
+        assert!(
+            !rebuild_body.contains("remove_container_force"),
+            "rebuild_agent must use ensure_container_removed (confirms gone), not the best-effort remove_container_force"
+        );
+    }
+
     // --- Docker integration tests (require Docker daemon) ---
     // Run with: cargo test -p vestad -- --ignored
 
@@ -2742,6 +2796,24 @@ mod tests {
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
         assert!(!inspect_then_needs_rebuild(&docker, &tc.name).await, "rebuilt container should NOT need rebuild");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn ensure_container_removed_removes_and_is_idempotent() {
+        let docker = test_docker();
+        let tc = TestContainer::new("ensure-removed");
+        let env_file = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(env_file.path(), "export WS_PORT=12345\n").unwrap();
+        let env_mount = (env_file.path().to_str().unwrap(), MOUNT_DESTS[0]);
+        create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
+        assert_ne!(container_status(&docker, &tc.name).await, ContainerStatus::NotFound, "precondition: container exists");
+
+        ensure_container_removed(&docker, &tc.name).await.expect("removes a present container");
+        assert_eq!(container_status(&docker, &tc.name).await, ContainerStatus::NotFound, "container must be gone after ensure_container_removed");
+
+        // Idempotent: the name is free, which is exactly what rebuild_agent's create depends on.
+        ensure_container_removed(&docker, &tc.name).await.expect("no-op when already absent");
     }
 
     // Bound on retries while the container's `mkdir` races its start (200ms apart).

--- a/vestad/tests-integration/src/lib.rs
+++ b/vestad/tests-integration/src/lib.rs
@@ -62,6 +62,7 @@ pub struct TestServerBuilder {
     user: Option<String>,
     home: Option<PathBuf>,
     vestad_bin: Option<PathBuf>,
+    env_remove: Vec<String>,
 }
 
 impl TestServerBuilder {
@@ -86,9 +87,18 @@ impl TestServerBuilder {
         self
     }
 
+    /// Clear an env var the test process inherited before spawning vestad. The upgrade test
+    /// clears `VESTAD_AGENT_IMAGE` for the OLD vestad so it falls back to its own released
+    /// image (`ghcr.io/elyxlz/vesta:<tag>`), making the agent a faithful fleet member of that
+    /// version rather than running on the checkout's image.
+    pub fn env_remove(mut self, key: &str) -> Self {
+        self.env_remove.push(key.to_string());
+        self
+    }
+
     pub fn start(self) -> Result<TestServer, String> {
         let user = self.user.unwrap_or_else(|| unique_user("test"));
-        TestServer::start_with_options(Some(user), self.home, self.vestad_bin)
+        TestServer::start_with_options(Some(user), self.home, self.vestad_bin, &self.env_remove)
     }
 }
 
@@ -158,10 +168,10 @@ pub struct TestServer {
 
 impl TestServer {
     pub fn start() -> Result<Self, String> {
-        Self::start_with_options(None, None, None)
+        Self::start_with_options(None, None, None, &[])
     }
 
-    fn start_with_options(user: Option<String>, home: Option<PathBuf>, vestad_bin: Option<PathBuf>) -> Result<Self, String> {
+    fn start_with_options(user: Option<String>, home: Option<PathBuf>, vestad_bin: Option<PathBuf>, env_remove: &[String]) -> Result<Self, String> {
         rustls::crypto::ring::default_provider()
             .install_default()
             .ok();
@@ -185,16 +195,24 @@ impl TestServer {
         let stderr_path = home.join("vestad-stderr.log");
         let stderr_file = std::fs::File::create(&stderr_path)
             .map_err(|e| format!("create stderr log: {e}"))?;
+        // Capture stdout too: vestad's tracing (reconcile/rebuild decisions) goes here, and the
+        // upgrade e2e dumps it on failure to explain why an agent didn't come back after update.
+        let stdout_path = home.join("vestad-stdout.log");
+        let stdout_file = std::fs::File::create(&stdout_path)
+            .map_err(|e| format!("create stdout log: {e}"))?;
 
         let mut cmd = Command::new(&vestad);
         cmd.args(["serve", "--standalone", "--no-tunnel"])
             .env("HOME", &home)
             .env("DOCKER_CONFIG", &docker_config)
-            .stdout(Stdio::null())
+            .stdout(Stdio::from(stdout_file))
             .stderr(Stdio::from(stderr_file));
 
         if let Some(ref user_name) = user {
             cmd.env("USER", user_name);
+        }
+        for key in env_remove {
+            cmd.env_remove(key);
         }
 
         let process = cmd.spawn().map_err(|e| format!("spawn vestad: {e}"))?;
@@ -453,22 +471,7 @@ pub struct ReleasedVestad {
 }
 
 pub fn download_latest_released_vestad() -> Result<ReleasedVestad, String> {
-    let output = Command::new("curl")
-        .arg("-fsSL")
-        .args(CURL_RETRY_ARGS)
-        .args([
-            "-H",
-            "Accept: application/vnd.github+json",
-            "-H",
-            "User-Agent: vesta-tests",
-            "https://api.github.com/repos/elyxlz/vesta/releases/latest",
-        ])
-        .output()
-        .map_err(|e| format!("fetch latest release metadata: {e}"))?;
-    if !output.status.success() {
-        return Err("failed to fetch latest release metadata".into());
-    }
-    let body = String::from_utf8_lossy(&output.stdout);
+    let body = github_get("https://api.github.com/repos/elyxlz/vesta/releases/latest")?;
     let data: serde_json::Value =
         serde_json::from_str(&body).map_err(|e| format!("parse latest release metadata: {e}"))?;
     let tag = data
@@ -476,7 +479,64 @@ pub fn download_latest_released_vestad() -> Result<ReleasedVestad, String> {
         .and_then(|v| v.as_str())
         .ok_or_else(|| "latest release tag missing".to_string())?
         .to_string();
+    download_released_vestad(&tag)
+}
 
+/// Parse a `vX.Y.Z` (or `X.Y.Z`) release tag into numeric components for ordering.
+/// Returns `None` for tags that don't parse, so the upgrade test ignores any
+/// non-standard tag rather than mis-ordering it.
+fn parse_release_tag(tag: &str) -> Option<Vec<u64>> {
+    let parts: Option<Vec<u64>> = tag.trim_start_matches('v').split('.').map(|s| s.parse().ok()).collect();
+    parts.filter(|components| components.len() == 3)
+}
+
+/// The highest released tag strictly older than `current` (e.g. `0.1.159` -> `v0.1.158`).
+///
+/// Queries the published releases rather than decrementing the patch number, because the
+/// beta channel lets users skip versions — the version directly below `current` may never
+/// have been released. Returns `Ok(None)` when no older release exists (nothing to upgrade
+/// from). This is the version a fleet member actually runs before taking `current`.
+pub fn previous_released_tag(current: &str) -> Result<Option<String>, String> {
+    let current_parts = parse_release_tag(current).ok_or_else(|| format!("unparseable current version: {current}"))?;
+    let body = github_get("https://api.github.com/repos/elyxlz/vesta/releases?per_page=100")?;
+    let releases: serde_json::Value =
+        serde_json::from_str(&body).map_err(|e| format!("parse releases list: {e}"))?;
+    let entries = releases.as_array().ok_or_else(|| "releases response was not a list".to_string())?;
+    let mut best: Option<(Vec<u64>, String)> = None;
+    for entry in entries {
+        let Some(tag) = entry.get("tag_name").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        let Some(parts) = parse_release_tag(tag) else {
+            continue;
+        };
+        if parts >= current_parts {
+            continue;
+        }
+        if best.as_ref().is_none_or(|(best_parts, _)| parts > *best_parts) {
+            best = Some((parts, tag.to_string()));
+        }
+    }
+    Ok(best.map(|(_, tag)| tag))
+}
+
+fn github_get(url: &str) -> Result<String, String> {
+    let output = Command::new("curl")
+        .arg("-fsSL")
+        .args(CURL_RETRY_ARGS)
+        .args(["-H", "Accept: application/vnd.github+json", "-H", "User-Agent: vesta-tests", url])
+        .output()
+        .map_err(|e| format!("github GET {url}: {e}"))?;
+    if !output.status.success() {
+        return Err(format!("github GET {url} failed"));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Download and extract the released `vestad` binary for a specific tag (e.g. `v0.1.158`).
+/// The extracted binary carries that release's embedded agent core, so running it produces
+/// an agent exactly as that version's fleet members have it.
+pub fn download_released_vestad(tag: &str) -> Result<ReleasedVestad, String> {
     let rust_target = match std::env::consts::ARCH {
         "x86_64" => "x86_64-unknown-linux-gnu",
         "aarch64" => "aarch64-unknown-linux-gnu",
@@ -520,7 +580,7 @@ pub fn download_latest_released_vestad() -> Result<ReleasedVestad, String> {
 
     Ok(ReleasedVestad {
         _tmpdir: tmpdir,
-        tag,
+        tag: tag.to_string(),
         bin_path,
     })
 }

--- a/vestad/tests/live/common.rs
+++ b/vestad/tests/live/common.rs
@@ -72,7 +72,7 @@ fn exec_ok(container: &str, script: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn host_credentials_path() -> Option<PathBuf> {
+pub fn host_credentials_path() -> Option<PathBuf> {
     let home = std::env::var_os("HOME")?;
     let path = PathBuf::from(home).join(".claude/.credentials.json");
     path.exists().then_some(path)
@@ -114,7 +114,7 @@ pub fn wait_for_file_contains(container: &str, path: &str, needle: &str, timeout
     Err(format!("timed out waiting for {path} to contain {needle}"))
 }
 
-fn wait_for_container_running(container: &str, timeout: Duration) -> Result<(), String> {
+pub fn wait_for_container_running(container: &str, timeout: Duration) -> Result<(), String> {
     let deadline = std::time::Instant::now() + timeout;
     while std::time::Instant::now() < deadline {
         if let Ok(state) = docker_cmd(&["inspect", container, "--format", "{{.State.Running}}"]) {
@@ -157,14 +157,72 @@ fn wait_for_first_start_settled(container: &str) -> Result<(), String> {
     wait_for_file_contains(container, READY_MARKER, "READY", FIRST_START_SETTLE_TIMEOUT).map(|_| ())
 }
 
-fn setup_live_agent(name: &str) -> Option<(TestAgent<'static>, String)> {
-    let Some(credentials_path) = host_credentials_path() else {
-        eprintln!("skipping live e2e: ~/.claude/.credentials.json not found");
-        return None;
-    };
+/// Block until the agent reports `alive`, failing fast with diagnostics on an auth error.
+///
+/// `wait_until_alive` would block for the full timeout if the injected credentials are
+/// rejected. Poll the agent's own log alongside its status and bail the moment an auth
+/// error appears (a dead/expired CLAUDE_CREDENTIALS is the usual cause).
+pub fn wait_until_alive_or_die(client: &vesta_tests::client::Client, name: &str, container: &str) {
+    let alive_deadline = std::time::Instant::now() + FIRST_START_SETTLE_TIMEOUT;
+    loop {
+        if std::time::Instant::now() >= alive_deadline {
+            dump_agent_diagnostics(name);
+            panic!("timeout waiting for agent to go alive");
+        }
+        if client.agent_status(name).map(|s| s.status).unwrap_or_default() == "alive" {
+            return;
+        }
+        let agent_log = exec_in_container(container, "cat /root/agent/logs/vesta.log 2>/dev/null || true").unwrap_or_default();
+        if FIRST_START_AUTH_FAILURE_MARKERS.iter().any(|marker| agent_log.contains(marker)) {
+            dump_agent_diagnostics(name);
+            panic!("agent hit an auth error — CLAUDE_CREDENTIALS is invalid/expired; re-seed the secret (agent diagnostics above)");
+        }
+        thread::sleep(FIRST_START_ALIVE_POLL);
+    }
+}
 
+/// Provision a freshly-created agent for live e2e (sonnet model, test memory, real
+/// credentials) and block until it has fully settled after first-start. Shared by the live
+/// agent pool and the upgrade e2e test, both of which need a real, idle agent. Panics with
+/// diagnostics on failure, matching the pool's fail-fast behavior. Callers must have already
+/// confirmed credentials exist (via `host_credentials_path`).
+pub fn provision_and_settle(client: &vesta_tests::client::Client, name: &str, container: &str) {
+    let credentials_path = host_credentials_path().expect("credentials present (caller checked)");
     let credentials = fs::read_to_string(&credentials_path)
         .unwrap_or_else(|e| panic!("read {}: {e}", credentials_path.display()));
+
+    wait_for_container_running(container, Duration::from_secs(60)).expect("container running");
+
+    // Use sonnet for e2e tests — cheaper and faster than the default opus
+    exec_in_container(container, "echo 'export AGENT_MODEL=sonnet' >> ~/.bashrc")
+        .expect("set AGENT_MODEL=sonnet");
+
+    exec_in_container(container, &format!("mkdir -p {E2E_FILES_DIR}")).expect("create e2e dir");
+    exec_in_container(container, &format!("cat > {MEMORY_PATH} <<'EOF'\n{TEST_MEMORY}\nEOF"))
+        .expect("write test memory");
+
+    client.inject_token(name, &credentials).expect("inject real credentials");
+    // Always restart after injection so the agent boots with BOTH the credentials and
+    // the AGENT_MODEL=sonnet override from ~/.bashrc. Without the restart, the
+    // already-running agent picks up the credentials but keeps the default (opus)
+    // model for the whole first-start conversation.
+    client.restart_agent(name).expect("restart agent to apply model + credentials");
+
+    wait_until_alive_or_die(client, name, container);
+
+    // First-start keeps going after the agent reports alive; wait (via the agent's own idle
+    // signal) until it has fully settled before any test sends notifications.
+    if let Err(e) = wait_for_first_start_settled(container) {
+        dump_agent_diagnostics(name);
+        panic!("agent did not settle after first-start: {e}");
+    }
+}
+
+fn setup_live_agent(name: &str) -> Option<(TestAgent<'static>, String)> {
+    if host_credentials_path().is_none() {
+        eprintln!("skipping live e2e: ~/.claude/.credentials.json not found");
+        return None;
+    }
 
     // Follow the real user creation path: build the image, then discover
     // the container via the API (not by hardcoding the naming convention).
@@ -189,51 +247,6 @@ fn setup_live_agent(name: &str) -> Option<(TestAgent<'static>, String)> {
     let status = client.agent_status(&agent.name).unwrap();
     let container = status.id.unwrap_or_else(|| panic!("agent {} has no container id", agent.name));
 
-    wait_for_container_running(&container, Duration::from_secs(60)).expect("container running");
-
-    // Use sonnet for e2e tests — cheaper and faster than the default opus
-    exec_in_container(&container, "echo 'export AGENT_MODEL=sonnet' >> ~/.bashrc")
-        .expect("set AGENT_MODEL=sonnet");
-
-    exec_in_container(&container, &format!("mkdir -p {E2E_FILES_DIR}")).expect("create e2e dir");
-    exec_in_container(
-        &container,
-        &format!("cat > {MEMORY_PATH} <<'EOF'\n{TEST_MEMORY}\nEOF"),
-    )
-    .expect("write test memory");
-
-    client.inject_token(&agent.name, &credentials).expect("inject real credentials");
-    // Always restart after injection so the agent boots with BOTH the credentials and
-    // the AGENT_MODEL=sonnet override from ~/.bashrc. Without the restart, the
-    // already-running agent picks up the credentials but keeps the default (opus)
-    // model for the whole first-start conversation.
-    client.restart_agent(&agent.name).expect("restart agent to apply model + credentials");
-
-    // wait_until_alive would block for the full timeout if the injected credentials are rejected.
-    // Poll the agent's own log alongside its status and fail fast with diagnostics the moment an
-    // auth error appears (a dead/expired CLAUDE_CREDENTIALS is the usual cause).
-    let alive_deadline = std::time::Instant::now() + FIRST_START_SETTLE_TIMEOUT;
-    loop {
-        if std::time::Instant::now() >= alive_deadline {
-            dump_agent_diagnostics(&agent.name);
-            panic!("timeout waiting for first-start to go alive");
-        }
-        if client.agent_status(&agent.name).map(|s| s.status).unwrap_or_default() == "alive" {
-            break;
-        }
-        let agent_log = exec_in_container(&container, "cat /root/agent/logs/vesta.log 2>/dev/null || true").unwrap_or_default();
-        if FIRST_START_AUTH_FAILURE_MARKERS.iter().any(|marker| agent_log.contains(marker)) {
-            dump_agent_diagnostics(&agent.name);
-            panic!("first-start hit an auth error — CLAUDE_CREDENTIALS is invalid/expired; re-seed the secret (agent diagnostics above)");
-        }
-        thread::sleep(FIRST_START_ALIVE_POLL);
-    }
-
-    // First-start keeps going after the agent reports alive; wait (via the agent's own idle
-    // signal) until it has fully settled before any test sends notifications.
-    if let Err(e) = wait_for_first_start_settled(&container) {
-        dump_agent_diagnostics(&agent.name);
-        panic!("agent did not settle after first-start: {e}");
-    }
+    provision_and_settle(client, &agent.name, &container);
     Some((agent, container))
 }

--- a/vestad/tests/live/mod.rs
+++ b/vestad/tests/live/mod.rs
@@ -11,3 +11,4 @@ mod dreamer;
 mod file_ops;
 mod interrupt;
 mod mcp_tools;
+mod upgrade;

--- a/vestad/tests/live/upgrade.rs
+++ b/vestad/tests/live/upgrade.rs
@@ -1,0 +1,386 @@
+//! Release-gated e2e: upgrade a real agent from the PREVIOUS released vestad to the current
+//! checkout via an in-place self-update, and assert the agent survives and its migrations
+//! converge.
+//!
+//! Why this exists: agent-state migrations (`agent/core/migrations/*.md`) run as prompts
+//! against a real legacy filesystem when a fleet member updates. The in-process pytest suite
+//! covers the migration *runner*, but only a live upgrade proves the new release actually
+//! converges an old agent without breaking it.
+//!
+//! The upgrade is functionally identical to `vestad update` (`self_update::perform_update`)
+//! minus systemd: the installed vestad binary is replaced in place via an atomic rename (exactly
+//! what `self_replace` does) and the daemon is restarted. On the next startup the new binary
+//! re-extracts its embedded core (`ensure_agent_code`, fingerprinted in `agent_code.rs`) and
+//! `reconcile_containers` restarts the agent, which boots on the new core and runs the migration
+//! runner. We drive that restart directly instead of through systemd, which the standalone test
+//! daemon does not use. The update runs only AFTER first-start setup has fully settled.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use vesta_tests::{
+    docker_cmd, download_released_vestad, dump_agent_diagnostics, exec_in_container, find_vestad, previous_released_tag,
+    TestServerBuilder,
+};
+
+use super::common::{
+    host_credentials_path, provision_and_settle, wait_for_file_contains, wait_until_alive_or_die, write_notification,
+};
+
+const AGENT_NAME: &str = "upgrade";
+/// Generous bound on the whole post-update convergence: a cross-version rebuild snapshots the
+/// container filesystem (minutes), then the agent boots on the new core and runs migration prompts
+/// against real Claude (more minutes). Reconcile runs in the background, so the test polls through
+/// all of it; this only has to not be hit in practice.
+const MIGRATION_CONVERGE_TIMEOUT: Duration = Duration::from_secs(1200);
+const MIGRATION_POLL_INTERVAL: Duration = Duration::from_secs(5);
+const LOG_STREAM_POLL: Duration = Duration::from_secs(2);
+const UPGRADE_PROBE_MARKER: &str = "/root/agent/e2e-test/upgrade-ok.txt";
+
+#[test]
+fn upgrade_from_previous_release_converges_migrations_and_keeps_agent_healthy() {
+    if host_credentials_path().is_none() {
+        eprintln!("skipping upgrade e2e: ~/.claude/.credentials.json not found");
+        return;
+    }
+
+    // Source release (upgrade FROM): VESTA_UPGRADE_FROM overrides; otherwise the highest release
+    // below the crate version — the version a fleet member runs before taking this build. No prior
+    // release (or no network to discover one) -> nothing to test.
+    let current = env!("CARGO_PKG_VERSION");
+    let previous_tag = match env_tag("VESTA_UPGRADE_FROM") {
+        Some(tag) => tag,
+        None => match previous_released_tag(current) {
+            Ok(Some(tag)) => tag,
+            Ok(None) => {
+                eprintln!("skipping upgrade e2e: no released version older than {current}");
+                return;
+            }
+            Err(e) => {
+                eprintln!("skipping upgrade e2e: could not resolve previous release ({e})");
+                return;
+            }
+        },
+    };
+    let old_vestad = match download_released_vestad(&previous_tag) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("skipping upgrade e2e: could not download vestad {previous_tag} ({e})");
+            return;
+        }
+    };
+
+    // Target (upgrade TO): VESTA_UPGRADE_TO downloads that released vestad; otherwise the current
+    // checkout's build (the default, and what the release gate uses). Kept alive for the run so
+    // its extracted binary survives.
+    let target_tag = env_tag("VESTA_UPGRADE_TO");
+    let target_vestad = match &target_tag {
+        Some(tag) => match download_released_vestad(tag) {
+            Ok(v) => Some(v),
+            Err(e) => {
+                eprintln!("skipping upgrade e2e: could not download target vestad {tag} ({e})");
+                return;
+            }
+        },
+        None => None,
+    };
+    let new_vestad_bin: PathBuf = match &target_vestad {
+        Some(v) => v.bin_path.clone(),
+        None => find_vestad().expect("locate current vestad build"),
+    };
+    let target_label = target_tag.clone().unwrap_or_else(|| current.to_string());
+    eprintln!("upgrade e2e: {previous_tag} -> {target_label}");
+
+    // This test runs alongside the shared live pool (full `cargo test --test live`). The pool's
+    // SERVER runs one-time orphan cleanups at init (kill_orphan_vestads targets /tmp-home
+    // vestads; cleanup_orphan_test_containers targets `-t{pid}-` users / `test-e2e-` names). Keep
+    // our resources OUT of both patterns so a concurrent SERVER init can't wipe them mid-run: a
+    // home under the cargo target tmpdir (not /tmp) and a user containing neither `-t<digit>` nor
+    // `test-e2e-`. We do our own cleanup instead.
+    remove_stale_upgrade_containers();
+    let home = tempfile::TempDir::new_in(env!("CARGO_TARGET_TMPDIR")).expect("create persistent home");
+    let user = format!("upgrade-e2e-{}", std::process::id());
+
+    // The downloaded old binary's path is the "installed" vestad: the update replaces this exact
+    // file and every daemon (old then new) runs from it, so the install location never moves —
+    // exactly like a real self-update on a host.
+    let installed_vestad = old_vestad.bin_path.clone();
+
+    // ── Old version: a faithful v{N-1} fleet member ──────────────────────────────────────────
+    // Clear VESTAD_AGENT_IMAGE so the old vestad uses its OWN released image (matching its
+    // embedded core + lockfile), not the checkout's image.
+    let old_server = TestServerBuilder::new()
+        .user(&user)
+        .home(home.path().to_path_buf())
+        .vestad_bin(installed_vestad.clone())
+        .env_remove("VESTAD_AGENT_IMAGE")
+        .start()
+        .expect("start old vestad");
+
+    let old_client = old_server.client();
+    let agent_name = old_client.create_agent(AGENT_NAME).expect("create agent on old vestad");
+    // Address the agent by its stable container NAME, never the id from agent_status: reconcile
+    // may REBUILD the container on the update (snapshot + recreate -> new id), and migration
+    // prompts restart it, so any cached id goes stale. The name survives restarts and rebuilds.
+    let container = format!("vesta-{user}-{agent_name}");
+
+    // Stream the agent's own log to the test output for the whole run; survives every restart.
+    let _log_stream = AgentLogStream::start(&container);
+
+    provision_and_settle(&old_client, &agent_name, &container);
+    let pre_applied = applied_migrations(&container);
+    eprintln!("upgrade e2e: setup complete on {previous_tag}; {} migration(s) pre-applied", pre_applied.len());
+
+    // ── The update: replace the installed binary in place, then restart the daemon ────────────
+    // Functionally identical to `vestad update` (perform_update) without systemd: self_replace the
+    // binary, then restart. The old daemon is still running from the file; an atomic rename over
+    // it is safe (the running process keeps the old inode), just as self_replace relies on.
+    eprintln!("upgrade e2e: replacing installed vestad with {target_label} and restarting");
+    install_vestad_binary(&new_vestad_bin, &installed_vestad);
+    drop(old_client);
+    drop(old_server);
+
+    // Restart the daemon from the SAME installed path — now the new binary. On startup it
+    // re-extracts the new core and reconcile_containers restarts the agent onto it.
+    let new_server = TestServerBuilder::new()
+        .user(&user)
+        .home(home.path().to_path_buf())
+        .vestad_bin(installed_vestad.clone())
+        .start()
+        .expect("restart vestad after update");
+    let new_client = new_server.client();
+
+    // The new vestad runs reconcile (and any rebuild) in the BACKGROUND (serve.rs), and a
+    // cross-version rebuild snapshots the container's filesystem — minutes. So don't gate on an
+    // early "alive": that would pass against the OLD agent before reconcile even stops it. The real
+    // end state is the agent back on the NEW core with its migrations applied. Take the expected set
+    // from the host agent-code the new vestad extracted at startup (stable; the container is
+    // mid-rebuild and answers nothing). wait_for_migrations_applied polls through the whole rebuild.
+    let expected = host_core_migrations(home.path());
+    assert!(!expected.is_empty(), "new core ships no migrations — host agent-code path is wrong");
+    wait_for_migrations_applied(home.path(), &container, &expected);
+    wait_until_alive_or_die(&new_client, &agent_name, &container);
+
+    // The agent must still do real work after the update, not just survive boot.
+    write_notification(
+        &container,
+        &format!("Create the file \"{UPGRADE_PROBE_MARKER}\" containing only the word: UPGRADED"),
+        false,
+    )
+    .expect("send post-update probe");
+    if let Err(e) = wait_for_file_contains(&container, UPGRADE_PROBE_MARKER, "UPGRADED", MIGRATION_CONVERGE_TIMEOUT) {
+        dump_agent_diagnostics(&agent_name);
+        panic!("agent did not process work after update: {e}");
+    }
+
+    let converged = applied_migrations(&container);
+    drop(new_client);
+    drop(new_server);
+
+    // ── Idempotency: a second boot must not re-run or thrash migrations ──────────────────────
+    let rebooted_server = TestServerBuilder::new()
+        .user(&user)
+        .home(home.path().to_path_buf())
+        .vestad_bin(installed_vestad.clone())
+        .start()
+        .expect("reboot vestad");
+    let rebooted_client = rebooted_server.client();
+    // Second boot needs no rebuild (the container already matches the current spec), just a
+    // backgrounded restart; wait for the agent to come back rather than gating immediately.
+    wait_until_alive_or_die(&rebooted_client, &agent_name, &container);
+
+    let mut after_reboot = applied_migrations(&container);
+    let mut converged_sorted = converged.clone();
+    after_reboot.sort();
+    converged_sorted.sort();
+    assert_eq!(
+        after_reboot, converged_sorted,
+        "applied migrations changed on a clean reboot — migrations are not idempotent"
+    );
+    assert_eq!(
+        pending_migration_notifications(&container),
+        0,
+        "a migration re-fired on a clean reboot — the agent would thrash on every restart"
+    );
+
+    let _ = rebooted_client.stop_agent(&agent_name);
+    let _ = rebooted_client.destroy_agent(&agent_name);
+}
+
+/// Install `src` at `dst`, atomically. Mirrors `self_replace`: stage a copy next to the target,
+/// then rename over it. The rename is safe even while a vestad is still running from `dst` (the
+/// running process keeps the old inode; the path flips to the new one).
+fn install_vestad_binary(src: &Path, dst: &Path) {
+    let staged = dst.with_extension("incoming");
+    fs::copy(src, &staged).expect("stage new vestad binary");
+    fs::set_permissions(&staged, fs::Permissions::from_mode(0o755)).expect("make staged vestad executable");
+    fs::rename(&staged, dst).expect("replace installed vestad binary");
+}
+
+/// Streams an agent container's `vesta.log` to the test's stderr in the background. Polls by
+/// container NAME (stable across restarts/rebuilds) and prints only newly appended lines, so the
+/// agent's first-start, migration runs, and reboots are all visible live under `--nocapture`.
+struct AgentLogStream {
+    stop: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl AgentLogStream {
+    fn start(container_name: &str) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_flag = stop.clone();
+        let name = container_name.to_string();
+        let handle = std::thread::spawn(move || {
+            let mut printed = 0usize;
+            while !stop_flag.load(Ordering::Relaxed) {
+                // `cat` fails (Err) when the container is mid-restart or the log doesn't exist yet;
+                // just retry on the next tick.
+                if let Ok(log) = docker_cmd(&["exec", &name, "cat", "/root/agent/logs/vesta.log"]) {
+                    let lines: Vec<&str> = log.lines().collect();
+                    if lines.len() < printed {
+                        printed = 0; // log was rotated/truncated; re-stream from the top
+                    }
+                    for line in &lines[printed..] {
+                        eprintln!("[agent] {line}");
+                    }
+                    printed = lines.len();
+                }
+                std::thread::sleep(LOG_STREAM_POLL);
+            }
+        });
+        Self { stop, handle: Some(handle) }
+    }
+}
+
+impl Drop for AgentLogStream {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Remove any agent container left by a previous upgrade-test run. These use a `upgrade-e2e-*`
+/// name that the shared harness orphan cleanup deliberately ignores, so the upgrade test owns
+/// its own hygiene.
+fn remove_stale_upgrade_containers() {
+    let Ok(list) = docker_cmd(&["ps", "-aq", "--filter", "name=vesta-upgrade-e2e-", "--format", "{{.Names}}"]) else {
+        return;
+    };
+    for name in list.lines().map(str::trim).filter(|name| !name.is_empty()) {
+        let _ = docker_cmd(&["rm", "-f", name]);
+    }
+}
+
+/// The new core's migration set, read from the host agent-code the new vestad extracted at startup
+/// (ensure_agent_code, before the background reconcile). This is the stable convergence target: the
+/// container itself is unreadable through the rebuild (stopped, then snapshotted for minutes), so we
+/// can't ask it. Path mirrors vestad's `<config_dir>/agent-code/core`.
+fn host_core_migrations(home: &Path) -> Vec<String> {
+    let dir = home.join(".config/vesta/vestad/agent-code/core/migrations");
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .filter_map(|name| name.strip_suffix(".md").map(str::to_string))
+        .collect();
+    names.sort();
+    names
+}
+
+/// Read a non-empty env override as a release tag (e.g. `VESTA_UPGRADE_FROM=v0.1.158`).
+fn env_tag(key: &str) -> Option<String> {
+    std::env::var(key).ok().map(|v| v.trim().to_string()).filter(|v| !v.is_empty())
+}
+
+/// Poll `state.json` until every expected migration is recorded as applied. Real Claude drives
+/// this asynchronously after the update reboot, so it can take minutes.
+fn wait_for_migrations_applied(home: &Path, container: &str, expected: &[String]) {
+    let deadline = std::time::Instant::now() + MIGRATION_CONVERGE_TIMEOUT;
+    loop {
+        let applied = applied_migrations(container);
+        let missing: Vec<&String> = expected.iter().filter(|m| !applied.contains(m)).collect();
+        if missing.is_empty() {
+            eprintln!("upgrade e2e: all {} migration(s) applied", expected.len());
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            dump_upgrade_diagnostics(home, container);
+            panic!("migrations did not converge after update; still pending: {missing:?}");
+        }
+        std::thread::sleep(MIGRATION_POLL_INTERVAL);
+    }
+}
+
+/// On a failed update, print why: the updated vestad's own log (its reconcile decisions live
+/// here), the container's state, and what the new core mount actually contains.
+fn dump_upgrade_diagnostics(home: &Path, container_name: &str) {
+    eprintln!("\n===== UPGRADE DIAGNOSTICS =====");
+    match docker_cmd(&["inspect", container_name, "--format", "status={{.State.Status}} exit={{.State.ExitCode}} restarts={{.RestartCount}}"]) {
+        Ok(state) => eprintln!("container {container_name}: {state}"),
+        Err(e) => eprintln!("container {container_name}: inspect failed ({e})"),
+    }
+    // `docker logs` works even when the container has exited, so it shows WHY it stopped
+    // (entrypoint `uv sync` failures, a crash on the new core, etc.).
+    match docker_cmd(&["logs", "--tail", "60", container_name]) {
+        Ok(out) => eprintln!("--- container logs (tail 60) ---\n{out}"),
+        Err(e) => eprintln!("container logs unavailable ({e})"),
+    }
+    match docker_cmd(&["exec", container_name, "sh", "-c", "ls /root/agent/core/migrations/ 2>&1; echo '--- core dir:'; ls /root/agent/core/ 2>&1 | head"]) {
+        Ok(out) => eprintln!("core mount:\n{out}"),
+        Err(e) => eprintln!("core mount: exec failed ({e}) — container not running"),
+    }
+    // Reconcile/rebuild decisions go to vestad's tracing on stdout; the banner is on stderr. Surface
+    // the relevant lines from both so a failed rebuild (e.g. "[3/4] removing", a rebuild error) shows.
+    for (label, file) in [("stdout", "vestad-stdout.log"), ("stderr", "vestad-stderr.log")] {
+        match fs::read_to_string(home.join(file)) {
+            Ok(content) => {
+                let relevant: Vec<&str> = content
+                    .lines()
+                    .filter(|l| {
+                        ["reconcile", "rebuild", "[1/4]", "[2/4]", "[3/4]", "[4/4]", "restart", "agent code", "stopped", "starting", "still present", "error", "ERROR", "WARN"]
+                            .iter()
+                            .any(|k| l.contains(k))
+                    })
+                    .collect();
+                if !relevant.is_empty() {
+                    eprintln!("--- updated vestad {label} (reconcile) ---");
+                    for line in relevant.iter().rev().take(40).rev() {
+                        eprintln!("{line}");
+                    }
+                }
+            }
+            Err(e) => eprintln!("vestad {label} unreadable ({e})"),
+        }
+    }
+    eprintln!("===== END DIAGNOSTICS =====\n");
+}
+
+/// The `applied_migrations` list from the agent's persisted state (empty when state.json or the
+/// field is absent — both mean "nothing applied yet").
+fn applied_migrations(container: &str) -> Vec<String> {
+    let raw = exec_in_container(container, "cat /root/agent/data/state.json 2>/dev/null || echo '{}'")
+        .unwrap_or_else(|_| "{}".to_string());
+    let value: serde_json::Value = serde_json::from_str(raw.trim()).unwrap_or(serde_json::Value::Null);
+    value
+        .get("applied_migrations")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|x| x.as_str().map(str::to_string)).collect())
+        .unwrap_or_default()
+}
+
+/// Count of undelivered migration notification files. Nonzero after a settled boot means a
+/// migration re-fired even though it was already applied.
+fn pending_migration_notifications(container: &str) -> usize {
+    docker_cmd(&["exec", container, "bash", "-lc", "ls /root/agent/notifications/migration-*.json 2>/dev/null | wc -l"])
+        .ok()
+        .and_then(|out| out.trim().parse().ok())
+        .unwrap_or(0)
+}


### PR DESCRIPTION
Two tightly-coupled changes shipped together: the live upgrade e2e, and the `rebuild_agent` reliability fix the test surfaced (the test exercises exactly the rebuild path the fix repairs, so they belong in one PR).

## 1. Live upgrade e2e (release-gated)

Reproduces a real fleet upgrade end to end: an agent born on a previous released vestad (its own ghcr image + embedded core) is upgraded **in place** to the build under test; it must come back healthy with every shipped migration applied and stay quiet on the next boot (idempotent).

- Upgrade = functionally identical to `vestad update` minus systemd: replace the installed binary via atomic rename, restart the daemon; on startup it re-extracts the new core and `reconcile_containers` restarts the agent onto it.
- Runner: `./check.sh upgrade [--from TAG] [--to TAG]` (streams the agent's container log live; defaults source=previous release, target=this build). Also `VESTA_UPGRADE_FROM/TO`. Lives in the `live` suite, so the release-gated `test-live` job covers it.
- Reads address the stable container **name** (survives reconcile rebuilds); diagnostics dump container logs + the vestad reconcile log on failure.

## 2. The fix it surfaced — `rebuild_agent` removal (`fix(vestad)`)

A cross-version upgrade rebuilds the container (`stop → snapshot → remove → recreate` under the same name). `[3/4]` removal was best-effort (`remove_container_force(...).await.ok()`); when `docker rm --force` returned before the name freed (or failed transiently), `[4/4] create` collided on the name and `rebuild_agent` errored. `reconcile_containers` treats that as non-fatal, so vestad came up while the agent stayed **stopped on the old image** — an intermittently broken upgrade.

Fix at the root: `ensure_container_removed` retries the force-remove and **polls until docker confirms it's gone**, erroring loudly otherwise; `rebuild_agent` uses it and propagates the error so create only runs once the name is free. `rename_agent` creates under a different name (can't self-collide) — left as-is.

## Tests / verification

- vestad unit: structural guard (rebuild confirms removal before create, no swallow) + docker-gated `ensure_container_removed` behavioral test. All 118 vestad unit tests pass, clippy clean.
- Upgrade e2e verified green locally across 158→159, 159→160, 158→current, 160→current, plus repeated runs after the fix to confirm the rebuild flake is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)