### PR TITLE
feat(agent): show the running version in startup logs

### DIFF
--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -4,6 +4,7 @@ import asyncio
 import errno
 import os
 import signal
+import tomllib
 import types
 import typing as tp
 
@@ -187,6 +188,19 @@ def init_state(*, config: vm.VestaConfig) -> vm.State:
     return vm.State(persisted=persisted, event_bus=event_bus, provider_status=provider_status)
 
 
+def _vesta_version(*, config: vm.VestaConfig) -> str:
+    """Version of the code actually running, read from the bind-mounted pyproject.toml (re-extracted
+    on upgrade, so it tracks the running core). Best-effort: never block startup over a version label."""
+    pyproject = config.agent_dir / "pyproject.toml"
+    if not pyproject.exists():
+        return "unknown"
+    try:
+        return tomllib.loads(pyproject.read_text())["project"]["version"]
+    except (tomllib.TOMLDecodeError, KeyError, OSError) as e:
+        logger.init(f"could not read version: {e}")
+        return "unknown"
+
+
 async def async_main() -> None:
     config, config_issues = vm.load_config()
     logger.init("Config:")
@@ -196,7 +210,7 @@ async def async_main() -> None:
         path.mkdir(parents=True, exist_ok=True)
 
     logger.setup(config.logs_dir, log_level=config.log_level)
-    logger.init(f"{config.agent_name} starting")
+    logger.init(f"{config.agent_name} starting on vesta v{_vesta_version(config=config)}")
     _report_config_issues(config_issues, config=config)
 
     # Converge a legacy agent's env-based preferences into the writable config store, so the whole

--- a/agent/tests/test_version.py
+++ b/agent/tests/test_version.py
@@ -1,0 +1,21 @@
+"""Startup version reporting."""
+
+import core.main as main
+import core.models as vm
+
+
+def test_reads_version_from_pyproject(tmp_path):
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "vesta"\nversion = "9.9.9"\n')
+    config = vm.VestaConfig(agent_dir=tmp_path)
+    assert main._vesta_version(config=config) == "9.9.9"
+
+
+def test_missing_pyproject_returns_unknown(tmp_path):
+    config = vm.VestaConfig(agent_dir=tmp_path)
+    assert main._vesta_version(config=config) == "unknown"
+
+
+def test_malformed_pyproject_returns_unknown(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("not = valid = toml ==")
+    config = vm.VestaConfig(agent_dir=tmp_path)
+    assert main._vesta_version(config=config) == "unknown"


### PR DESCRIPTION
## What

The agent's startup logs never showed which version it was running. This logs it on boot:

```
[INIT] <agent> starting on vesta v0.1.160
```

## How

Read the version from the **bind-mounted `pyproject.toml`** (`/root/agent/pyproject.toml`), which is re-extracted on every upgrade, so it always reflects the code actually running (not a stale creation-time value). No new env var or vestad change needed. Best-effort: a missing or malformed manifest logs `unknown` and never blocks startup.

`vestad`'s own startup banner already prints its version (`personal AI daemon · vX.Y.Z`); this brings the agent to parity, which is handy when verifying an upgrade or debugging the fleet.

## Tests

`tests/test_version.py`: reads the version, and falls back to `unknown` for missing / malformed manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)