### PR TITLE
feat(config): own timezone and seed_context in the agent config store, not env

### DIFF
--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pathlib as pl
+import time
 import typing as tp
 
 import pydantic as pyd
@@ -142,6 +143,11 @@ def migrate_legacy_config_to_store() -> None:
         "agent_provider": provider if provider in ("claude", "openrouter") else None,
         "openrouter_key": legacy("ANTHROPIC_AUTH_TOKEN") if provider == "openrouter" else None,
         "max_context_tokens": int(ctx) if ctx and ctx.isdigit() else None,
+        # Fleet agents created before timezone moved into the store carry it as the TZ env var
+        # (from /run/vestad-env or ~/.bashrc); drain a real value into the store so it owns it. UTC
+        # is the default floor, so there's nothing to converge (and skipping it keeps a fresh agent's
+        # store clean until the client delivers the real tz).
+        "timezone": tz if (tz := legacy("TZ")) and tz != "UTC" else None,
     }
     updates = {key: value for key, value in candidates.items() if value is not None and key not in store}
     if updates:
@@ -275,6 +281,23 @@ class VestaConfig(pyd_settings.BaseSettings):
     agent_personality: str = pyd.Field(init=False)
     # None for Claude. SecretStr redacts it in GET /config; client.py injects the real value into the SDK env.
     openrouter_key: pyd.SecretStr | None = None
+    # IANA timezone, owned here (not env): clients deliver it via PUT /config at provision time, the
+    # timezone skill changes it the same way. _apply_timezone below pushes it into the process env.
+    # The TZ alias lets a legacy agent (TZ still in /run/vestad-env or ~/.bashrc) seed the field, so
+    # _apply_timezone re-exports its real value instead of clobbering it with the UTC default.
+    timezone: str = pyd.Field(default="UTC", validation_alias=pyd.AliasChoices("timezone", "TZ"))
+    # One-shot freeform setup notes from whoever created the agent. Delivered via PUT /config; the
+    # agent materializes it to data/seed-context.md on boot and reads it once at first wake.
+    seed_context: str = pyd.Field(default="")
+
+    @pyd.model_validator(mode="after")
+    def _apply_timezone(self) -> "VestaConfig":
+        # The config object owns timezone, so applying it to the process env on construction means
+        # every consumer (shell `date`, the calendar/reminders skills, tasks' tzlocal) inherits it,
+        # and a PUT /config change just takes effect on the next boot with no separate mechanism.
+        os.environ["TZ"] = self.timezone
+        time.tzset()
+        return self
 
     @classmethod
     def settings_customise_sources(

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -195,6 +195,13 @@ async def async_main() -> None:
     for path in [config.agent_dir, config.notifications_dir, config.logs_dir, config.data_dir, config.dreamer_dir]:
         path.mkdir(parents=True, exist_ok=True)
 
+    # seed_context (one-shot setup notes) is delivered through the config store; materialize it to the
+    # file the first-wake prompt reads. Only when absent, so a re-delivery never clobbers notes the
+    # agent already consumed.
+    seed_path = config.data_dir / "seed-context.md"
+    if config.seed_context and not seed_path.exists():
+        seed_path.write_text(config.seed_context)
+
     logger.setup(config.logs_dir, log_level=config.log_level)
     logger.init(f"{config.agent_name} starting")
     _report_config_issues(config_issues, config=config)

--- a/agent/core/prompts/first_start_setup.md
+++ b/agent/core/prompts/first_start_setup.md
@@ -1,12 +1,12 @@
 Hello world. First wake. Do these in order, then stop:
 
-1. Read `/run/vestad-env` for ports, token, timezone (already exported as env vars).
+1. Read `/run/vestad-env` for ports and token (already exported as env vars).
 2. Set up app-chat from its SKILL.md / SETUP.md. Silently, no asking. `app-chat` is a core skill under `~/agent/core/skills/app-chat/` (not `~/agent/skills/`).
 3. **Call `mark_setup_done`.** This records completion and brings the WebSocket server online. Until you call it, no users can reach you.
 4. Use the app-chat skill to say hi.
 5. Get their name.
 6. Finish the rest silently between replies, never make them wait on it: run `~/agent/skills/upstream-sync/SETUP.md` end to end (git init, branch, checkpoint); if `~/agent/data/seed-context.md` exists and is non-empty, read it (freeform setup notes from whoever created you: background about you and your user, plus any skills or services they want set up), install each skill it names with `~/agent/skills/skills-registry/scripts/skills-install <name>` (skip silently if a name isn't in the registry), and weave the useful background into MEMORY.md (§4 user state, important people, preferences, the nudge mandate), confirming naturally in conversation later; in MEMORY.md replace every `[agent_name]` with your name; set up tasks and dashboard from their SKILL.md / SETUP.md (`tasks` and `dashboard` live under `~/agent/skills/`).
-7. If `$TZ` looks set already, confirm it. Otherwise ask where they're based and use the `timezone` skill to set it. The new value only takes effect after the restart in the final step. Update MEMORY.md §4 with name, location, timezone.
+7. Check `$TZ` (the client usually sets it from the user's device at setup). If it already matches where they are, confirm it. Otherwise ask where they're based and use the `timezone` skill to set it. The new value only takes effect after the restart in the final step. Update MEMORY.md §4 with name, location, timezone.
 8. Ask where they would like to keep chatting, whatsapp, telegram, email, etc.. and set that up. Move the conversation over there (or stay on app-chat).
 9. Have a real first conversation. Be genuinely curious about them, not a setup target: what they're into, what they're building toward, what a good day looks like. Ask, listen, ask one more. Also ask how hard they want to be pushed when something important slips (gentle nudge or relentless until done), and record that as a standing nudge mandate. Understanding them first is what makes you useful. Then search the skill registry for adapt skills.
 10. Ask what to set up: email, calendar, daily briefing.

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -133,7 +133,7 @@
   },
   {
     "name": "timezone",
-    "description": "Set or change the agent's IANA timezone. Use whenever the user relocates, moves, travels, or goes on holiday somewhere on a different timezone, or on first setup when `$TZ` is not set yet."
+    "description": "Set or change the agent's IANA timezone. Use whenever the user relocates, moves, travels, or goes on holiday somewhere on a different timezone, or on first setup when the timezone is still the default `UTC`."
   },
   {
     "name": "torrents",

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -151,20 +151,17 @@ def _cmd_create_agent(args: argparse.Namespace, client: Client, cfg: Config) -> 
 
     name = args.name.strip()
     context = args.context.strip() if args.context else None
+    personality = args.personality.strip().lower() if args.personality else None
     server_token = client.server_token(token, server["id"])
-    result = client.create_agent(
-        subdomain=server["subdomain"],
-        server_token=server_token,
-        name=name,
-        personality=(args.personality.strip().lower() if args.personality else None),
-        context=context,
-    )
+    result = client.create_agent(subdomain=server["subdomain"], server_token=server_token, name=name)
     if "error" in result:
         raise _Invalid(result)
     # vestad normalizes the name (lowercases/strips); store what it ACTUALLY created
     # so claude-finish addresses /agents/<name>/provider with a name that validates.
+    # Personality + seed context are stashed here and delivered through claude-finish's
+    # set_provider, since the agent owns its config store (no env/create-time delivery).
     created_name = result.get("name", name)
-    state.update(email, agent_name=created_name)
+    state.update(email, agent_name=created_name, personality=personality, seed_context=context)
     _print({"created": True, "name": created_name})
     return 0
 
@@ -212,6 +209,8 @@ def _cmd_claude_finish(args: argparse.Namespace, client: Client, cfg: Config) ->
         name=name,
         credentials=credentials,
         model=(args.model or client.fetch_agent_defaults()["model"]),
+        personality=st.get("personality"),
+        seed_context=st.get("seed_context"),
     )
     if "error" in result:
         raise _Invalid(

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -176,23 +176,12 @@ class Client:
 
     # --- the buyer's vestad (Bearer = minted server-token) -------------------
 
-    def create_agent(
-        self,
-        *,
-        subdomain: str,
-        server_token: str,
-        name: str,
-        personality: str | None,
-        context: str | None,
-    ) -> dict[str, Any]:
-        """POST <tenant>/agents — create the buyer's first (empty) agent."""
-        body: dict[str, Any] = {"name": name}
-        if personality:
-            body["personality"] = personality
-        if context:
-            body["seed_context"] = context  # freeform setup notes, incl. any skills to install
+    def create_agent(self, *, subdomain: str, server_token: str, name: str) -> dict[str, Any]:
+        """POST <tenant>/agents — create the buyer's first (empty) agent. Personality and the
+        freeform seed context are delivered later, once the agent is up, through set_provider's
+        config field (the agent owns its config store; vestad no longer accepts them at create)."""
         url = f"{self._cfg.tenant_base(subdomain)}/agents"
-        return self._json(self._raw_post(url, json=body, token=server_token, timeout=_CREATE_TIMEOUT))
+        return self._json(self._raw_post(url, json={"name": name}, token=server_token, timeout=_CREATE_TIMEOUT))
 
     def claude_oauth_start(self, *, subdomain: str, server_token: str) -> dict[str, Any]:
         """POST <tenant>/providers/claude/oauth/start -> {auth_url, session_id}."""
@@ -216,12 +205,22 @@ class Client:
         name: str,
         credentials: str,
         model: str | None,
+        personality: str | None = None,
+        seed_context: str | None = None,
     ) -> dict[str, Any]:
-        """POST <tenant>/agents/{name}/provider — attach Claude creds, agent wakes."""
-        body: dict[str, Any] = {"credentials": credentials}
+        """POST <tenant>/agents/{name}/provider/config — attach Claude creds and, in the same restart,
+        the model (provider pref) plus personality and the freeform seed context (general config). The
+        agent wakes with everything in place."""
+        provider_config: dict[str, Any] = {}
         if model:
-            body["model"] = model
-        url = f"{self._cfg.tenant_base(subdomain)}/agents/{name}/provider"
+            provider_config["agent_model"] = model
+        config: dict[str, Any] = {}
+        if personality:
+            config["agent_personality"] = personality
+        if seed_context:
+            config["seed_context"] = seed_context
+        body = {"provider": {"credentials": credentials}, "provider_config": provider_config, "config": config}
+        url = f"{self._cfg.tenant_base(subdomain)}/agents/{name}/provider/config"
         return self._json(self._raw_post(url, json=body, token=server_token, timeout=120))
 
     # --- low-level helpers ---------------------------------------------------

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -202,13 +202,13 @@ def test_create_agent_needs_active_server(capsys, monkeypatch):
     assert rc == 2 and "not ready" in data["error"]
 
 
-def test_create_agent_passes_seed(capsys, monkeypatch):
+def test_create_agent_stashes_personality_and_seed(capsys, monkeypatch):
     _verified()
     _active_server(monkeypatch)
     captured = {}
 
-    def fake_create(self, *, subdomain, server_token, name, personality, context):
-        captured.update(subdomain=subdomain, server_token=server_token, name=name, personality=personality, context=context)
+    def fake_create(self, *, subdomain, server_token, name):
+        captured.update(subdomain=subdomain, server_token=server_token, name=name)
         # vestad normalizes the name and returns the actual created name.
         return {"name": "ada"}
 
@@ -218,11 +218,14 @@ def test_create_agent_passes_seed(capsys, monkeypatch):
         capsys,
     )
     assert rc == 0 and data["created"] is True and data["name"] == "ada"
-    assert captured["subdomain"] == "ada" and captured["server_token"] == "VTOK"
-    assert captured["personality"] == "dry" and captured["context"] == "designer in NYC; set up email and calendar"
-    # the NORMALIZED name vestad returned is stored, so claude-finish addresses a
-    # path vestad's validate_name accepts (not the raw "Ada").
-    assert state_mod.load(E)["agent_name"] == "ada"
+    # Create carries only the name now; vestad no longer accepts personality/seed at create time.
+    assert captured == {"subdomain": "ada", "server_token": "VTOK", "name": "Ada"}
+    # Personality + seed context are stashed for claude-finish to deliver via the config channel. The
+    # NORMALIZED name vestad returned is stored so claude-finish addresses a path vestad accepts.
+    stashed = state_mod.load(E)
+    assert stashed["agent_name"] == "ada"
+    assert stashed["personality"] == "dry"
+    assert stashed["seed_context"] == "designer in NYC; set up email and calendar"
 
 
 # --- claude connect ---------------------------------------------------------
@@ -243,7 +246,8 @@ def test_claude_start_stores_session(capsys, monkeypatch):
 
 def test_claude_finish_connects_and_clears(capsys, monkeypatch):
     _verified()
-    state_mod.update(E, claude_session_id="CS", agent_name="Ada")
+    # create-agent stashed the personality + seed context; claude-finish delivers them.
+    state_mod.update(E, claude_session_id="CS", agent_name="Ada", personality="dry", seed_context="designer in NYC")
     _active_server(monkeypatch)
     monkeypatch.setattr(
         cli_mod.Client,
@@ -254,8 +258,8 @@ def test_claude_finish_connects_and_clears(capsys, monkeypatch):
     )
     captured = {}
 
-    def fake_set(self, *, subdomain, server_token, name, credentials, model):
-        captured.update(name=name, credentials=credentials, model=model)
+    def fake_set(self, *, subdomain, server_token, name, credentials, model, personality, seed_context):
+        captured.update(name=name, credentials=credentials, model=model, personality=personality, seed_context=seed_context)
         return {"ok": True}
 
     monkeypatch.setattr(cli_mod.Client, "set_provider", fake_set)
@@ -263,7 +267,13 @@ def test_claude_finish_connects_and_clears(capsys, monkeypatch):
     monkeypatch.setattr(cli_mod.Client, "fetch_agent_defaults", lambda self: {"model": "opus"})
     rc, data = _run(["claude-finish", "--email", E, "--code", "PASTE"], capsys)
     assert rc == 0 and data["connected"] is True and data["name"] == "Ada"
-    assert captured == {"name": "Ada", "credentials": "CREDS", "model": "opus"}
+    assert captured == {
+        "name": "Ada",
+        "credentials": "CREDS",
+        "model": "opus",
+        "personality": "dry",
+        "seed_context": "designer in NYC",
+    }
     # onboarding complete -> session forgotten
     assert state_mod.token_for(E) is None
 
@@ -289,7 +299,7 @@ def test_claude_finish_clears_session_when_attach_fails(capsys, monkeypatch):
     monkeypatch.setattr(
         cli_mod.Client,
         "set_provider",
-        lambda self, *, subdomain, server_token, name, credentials, model: {"error": "bad gateway"},
+        lambda self, *, subdomain, server_token, name, credentials, model, personality, seed_context: {"error": "bad gateway"},
     )
     rc, data = _run(["claude-finish", "--email", E, "--code", "PASTE"], capsys)
     assert rc == 2 and "claude-start" in data["error"]

--- a/agent/skills/timezone/SKILL.md
+++ b/agent/skills/timezone/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: timezone
-description: Set or change the agent's IANA timezone. Use whenever the user relocates, moves, travels, or goes on holiday somewhere on a different timezone, or on first setup when `$TZ` is not set yet.
+description: Set or change the agent's IANA timezone. Use whenever the user relocates, moves, travels, or goes on holiday somewhere on a different timezone, or on first setup when the timezone is still the default `UTC`.
 ---
 
 # Timezone
 
-`TZ` lives in `~/.bashrc` as `export TZ=<IANA tz>`. Sourced at container start and on every interactive shell, so dates, calendar events, reminders, and `what-day` all read from it.
+The timezone lives in the agent's config store (`~/agent/data/config.json`, key `timezone`). On boot the config object applies it to the process `TZ`, so dates, calendar events, reminders, and `what-day` all read from it. The live value is the `$TZ` env var.
 
 ## How to change it
 
 1. Work out the IANA tz (e.g. `Europe/London`, `America/New_York`, `Asia/Tokyo`). Ask if unsure.
-2. `Edit` `~/.bashrc`. Drop any existing line starting with `export TZ=`, then append `export TZ=<tz>` at the bottom.
+2. Write it to the config store (the canonical writer, atomic):
+   ```
+   cd ~/agent && uv run python -c "from core.config import update_config_store; update_config_store({'timezone': 'Europe/London'})"
+   ```
 3. Takes effect on the next container restart. Call the `restart_vesta` MCP tool when you want it applied immediately.
 
 ## When to use
 
-- First start, if `$TZ` is not already set.
+- First start, if the timezone is still the default `UTC`.
 - The user relocates, moves, travels, or goes on holiday somewhere on a different timezone.

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -164,8 +164,24 @@ def test_migrate_drains_genuine_env_values_into_store(agentdir, monkeypatch):
     monkeypatch.setenv("AGENT_MODEL", "sonnet")
     monkeypatch.setenv("AGENT_PERSONALITY", "warm")
     monkeypatch.setenv("MAX_CONTEXT_TOKENS", "500000")
+    monkeypatch.delenv("TZ", raising=False)
     migrate_legacy_config_to_store()
     assert read_config_store() == {"agent_model": "sonnet", "agent_personality": "warm", "max_context_tokens": 500000}
+
+
+def test_migrate_drains_legacy_tz_into_store(agentdir, monkeypatch):
+    # A legacy agent carries its real timezone in the TZ env var (old /run/vestad-env or ~/.bashrc);
+    # converge it into the store so the store owns it.
+    monkeypatch.setenv("TZ", "America/New_York")
+    migrate_legacy_config_to_store()
+    assert read_config_store()["timezone"] == "America/New_York"
+
+
+def test_migrate_skips_utc_default_tz(agentdir, monkeypatch):
+    # UTC is the default floor, so there's nothing to converge — keep a fresh agent's store clean.
+    monkeypatch.setenv("TZ", "UTC")
+    migrate_legacy_config_to_store()
+    assert "timezone" not in read_config_store()
 
 
 def test_migrate_skips_keys_absent_from_env_no_default_lock_in(agentdir, monkeypatch):
@@ -260,6 +276,23 @@ def test_validate_config_accepts_general_keys(config):
     from core.config import validate_config_updates
 
     assert validate_config_updates(config, {"agent_personality": "playful"}) == {"agent_personality": "playful"}
+
+
+def test_validate_config_accepts_timezone_and_seed_context(config):
+    # Both are general (agent-owned) config delivered via PUT /config, not provider-owned.
+    from core.config import validate_config_updates
+
+    update = {"timezone": "Europe/London", "seed_context": "they like terse replies"}
+    assert validate_config_updates(config, update) == update
+
+
+def test_config_applies_timezone_to_process_env(monkeypatch):
+    # The config object owns timezone: constructing it pushes the value into TZ so every child
+    # process (shell, calendar/reminders skills, tasks' tzlocal) inherits it.
+    monkeypatch.setenv("TZ", "Asia/Tokyo")
+    config = vm.VestaConfig()
+    assert config.timezone == "Asia/Tokyo"
+    assert os.environ["TZ"] == "Asia/Tokyo"
 
 
 def test_validate_provider_prefs_accepts_only_prefs(config):

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -26,6 +26,7 @@ export async function setProvider(
   name: string,
   result: ProviderResult,
   personality?: string,
+  timezone?: string,
 ): Promise<void> {
   const provider: Record<string, unknown> =
     result.kind === "claude"
@@ -41,9 +42,11 @@ export async function setProvider(
     providerConfig.agent_model = result.model;
   if (result.maxContextTokens != null)
     providerConfig.max_context_tokens = result.maxContextTokens;
-  // General prefs.
+  // General prefs. Timezone is delivered here at provision time (not via env at create), so the
+  // agent's config store owns it; callers re-provisioning an existing agent omit it to keep its tz.
   const config: Record<string, unknown> = {};
   if (personality) config.agent_personality = personality;
+  if (timezone) config.timezone = timezone;
   await apiFetch(`/agents/${encodeURIComponent(name)}/provider/config`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -98,13 +101,12 @@ export async function setContextWindow(
 }
 
 /// Create an empty agent container. Credentials and preferences (provider, model, personality,
-/// context) are sent once it's up, via `setProvider`.
+/// context, timezone) are sent once it's up, via `setProvider`.
 export async function createAgent(name: string): Promise<void> {
-  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   await apiJson("/agents", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name, timezone }),
+    body: JSON.stringify({ name }),
   });
 }
 

--- a/apps/web/src/components/NewAgent/index.tsx
+++ b/apps/web/src/components/NewAgent/index.tsx
@@ -50,8 +50,13 @@ export function NewAgent() {
         await waitUntilRunning(agentName, START_TIMEOUT_MS);
         if (cancelled) return;
 
-        // Phase 3: set credentials + preferences (provider, personality, model, context).
-        await setProvider(agentName, providerResult, personality ?? undefined);
+        // Phase 3: set credentials + preferences (provider, personality, model, context, timezone).
+        await setProvider(
+          agentName,
+          providerResult,
+          personality ?? undefined,
+          Intl.DateTimeFormat().resolvedOptions().timeZone,
+        );
         if (cancelled) return;
 
         // Phase 4: wait for the provision-triggered restart to settle.

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -157,6 +157,16 @@ fn provider_prefs(model: Option<&str>, max_context_tokens: Option<u64>) -> serde
     prefs
 }
 
+/// General (non-provider) preferences carried in the combined `/provider/config` call's `config`
+/// field. Empty when nothing to set, which vestad treats as "skip the PUT /config".
+fn general_config(timezone: Option<&str>) -> serde_json::Value {
+    let mut config = serde_json::Map::new();
+    if let Some(tz) = timezone {
+        config.insert("timezone".to_string(), serde_json::json!(tz));
+    }
+    serde_json::Value::Object(config)
+}
+
 fn require_bool(value: &serde_json::Value, field: &str) -> Result<bool, String> {
     value[field].as_bool().ok_or_else(|| format!("response missing {field}"))
 }
@@ -414,14 +424,11 @@ impl Client {
         read_json(self.get(&format!("/agents/{name}"))?)
     }
 
-    /// Create an empty agent container. Provider config is sent separately via
-    /// `set_provider` once the agent is up (vestad no longer accepts credentials
-    /// at create time — see refactor for agent-owned auth state).
-    pub fn create_agent(&self, name: &str, manage_agent_code: bool, timezone: Option<&str>) -> Result<String, String> {
-        let mut body = serde_json::json!({"name": name, "manage_agent_code": manage_agent_code});
-        if let Some(tz) = timezone {
-            body["timezone"] = serde_json::json!(tz);
-        }
+    /// Create an empty agent container. Provider config, timezone, and other preferences are sent
+    /// separately via `set_provider_*` once the agent is up (vestad no longer accepts credentials or
+    /// timezone at create time — the agent owns its config store).
+    pub fn create_agent(&self, name: &str, manage_agent_code: bool) -> Result<String, String> {
+        let body = serde_json::json!({"name": name, "manage_agent_code": manage_agent_code});
         let v: serde_json::Value = read_json(self.post_json("/agents", &body)?)?;
         Ok(v["name"].as_str().unwrap_or(name).to_string())
     }
@@ -430,7 +437,14 @@ impl Client {
     /// model/context preferences in one request, so vestad writes both and restarts once.
     /// Splitting this into separate restart-on-write calls raced: a later call hit the agent
     /// mid-restart and was dropped. Model/context are provider-owned, sent under `provider_config`.
-    pub fn set_provider_credentials(&self, name: &str, credentials: &str, model: Option<&str>, max_context_tokens: Option<u64>) -> Result<(), String> {
+    pub fn set_provider_credentials(
+        &self,
+        name: &str,
+        credentials: &str,
+        model: Option<&str>,
+        max_context_tokens: Option<u64>,
+        timezone: Option<&str>,
+    ) -> Result<(), String> {
         serde_json::from_str::<serde_json::Value>(credentials)
             .map_err(|e| format!("invalid credentials JSON: {e}"))?;
         self.post_json(
@@ -438,6 +452,7 @@ impl Client {
             &serde_json::json!({
                 "provider": {"credentials": credentials},
                 "provider_config": serde_json::Value::Object(provider_prefs(model, max_context_tokens)),
+                "config": general_config(timezone),
             }),
         )?;
         Ok(())
@@ -462,12 +477,13 @@ impl Client {
         read_json(self.get(&format!("/agents/{name}/provider"))?)
     }
 
-    pub fn set_provider_openrouter(&self, name: &str, args: &OpenRouterArgs) -> Result<(), String> {
+    pub fn set_provider_openrouter(&self, name: &str, args: &OpenRouterArgs, timezone: Option<&str>) -> Result<(), String> {
+        // Combined endpoint so the openrouter auth and the timezone preference land in one restart.
         let body = serde_json::json!({
-            "openrouter_key": args.key,
-            "openrouter_model": args.model,
+            "provider": {"openrouter_key": args.key, "openrouter_model": args.model},
+            "config": general_config(timezone),
         });
-        self.post_json(&format!("/agents/{name}/provider"), &body)?;
+        self.post_json(&format!("/agents/{name}/provider/config"), &body)?;
         Ok(())
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -637,9 +637,9 @@ fn oauth_dance(client: &client::Client) -> String {
 
 fn authenticate_agent(client: &client::Client, name: &str) {
     let credentials = oauth_dance(client);
-    // Reauth only: model + context window are preserved server-side (None = keep).
+    // Reauth only: model, context window, and timezone are preserved server-side (None = keep).
     client
-        .set_provider_credentials(name, &credentials, None, None)
+        .set_provider_credentials(name, &credentials, None, None, None)
         .unwrap_or_else(|e| platform::die(&e));
     eprintln!("authenticated!");
 }
@@ -962,9 +962,10 @@ fn run(cli: Cli) {
             let plan = resolve_setup_provider(&c, openrouter, claude_token, claude_model, context_window, yes);
             let timezone = detect_timezone();
 
-            // 1. Create an empty agent. Vestad no longer accepts credentials at
-            //    create time — the agent owns its own auth state.
-            let created_name = match c.create_agent(&name, !no_manage_core_code, timezone.as_deref()) {
+            // 1. Create an empty agent. Vestad no longer accepts credentials or timezone at
+            //    create time — the agent owns its own auth state and config store. Timezone rides
+            //    the provider provisioning call below.
+            let created_name = match c.create_agent(&name, !no_manage_core_code) {
                 Ok(n) => { eprintln!("created agent '{n}'"); n }
                 Err(e) if e.contains("already exists") && yes => {
                     eprintln!("agent '{name}' already exists, continuing...");
@@ -986,19 +987,19 @@ fn run(cli: Cli) {
             //    dance first.
             match plan {
                 ProvisionPlan::OpenRouter(or) => {
-                    c.set_provider_openrouter(&created_name, &or)
+                    c.set_provider_openrouter(&created_name, &or, timezone.as_deref())
                         .unwrap_or_else(|e| platform::die(&e));
                     eprintln!("running on OpenRouter (no Claude login needed)");
                 }
                 ProvisionPlan::ClaudeCredentials { credentials, opts } => {
-                    c.set_provider_credentials(&created_name, &credentials, opts.model.as_deref(), opts.max_context_tokens)
+                    c.set_provider_credentials(&created_name, &credentials, opts.model.as_deref(), opts.max_context_tokens, timezone.as_deref())
                         .unwrap_or_else(|e| platform::die(&e));
                     eprintln!("authenticated (claude)");
                 }
                 ProvisionPlan::ClaudeOAuth { opts } => {
                     eprintln!("authenticating claude...");
                     let credentials = oauth_dance(&c);
-                    c.set_provider_credentials(&created_name, &credentials, opts.model.as_deref(), opts.max_context_tokens)
+                    c.set_provider_credentials(&created_name, &credentials, opts.model.as_deref(), opts.max_context_tokens, timezone.as_deref())
                         .unwrap_or_else(|e| platform::die(&e));
                     eprintln!("authenticated!");
                 }
@@ -1035,17 +1036,17 @@ fn run(cli: Cli) {
                     .unwrap_or_else(|e| platform::die(&e));
             }
 
-            let name = c.create_agent(&name, !no_manage_core_code, timezone.as_deref())
+            let name = c.create_agent(&name, !no_manage_core_code)
                 .unwrap_or_else(|e| platform::die(&e));
 
-            // If --openrouter-key was provided, finish provisioning the agent
-            // immediately. Otherwise leave it unprovisioned for the user to run
-            // `vesta auth` later.
+            // If --openrouter-key was provided, finish provisioning the agent immediately, carrying
+            // the timezone in the same call. Otherwise leave it unprovisioned for `vesta auth` later;
+            // the agent boots on UTC and asks for the timezone at first wake.
             if let Some(or) = &openrouter {
                 eprintln!("waiting for agent to start...");
                 c.wait_until_running(&name, START_READY_TIMEOUT)
                     .unwrap_or_else(|e| platform::die(&e));
-                c.set_provider_openrouter(&name, or)
+                c.set_provider_openrouter(&name, or, timezone.as_deref())
                     .unwrap_or_else(|e| platform::die(&e));
                 eprintln!("created (running on OpenRouter)");
             } else {
@@ -1173,7 +1174,7 @@ fn run(cli: Cli) {
         Command::Auth { name, token } => {
             let c = get_client(host_ref, token_ref);
             if let Some(token_str) = token {
-                c.set_provider_credentials(&name, &token_str, None, None)
+                c.set_provider_credentials(&name, &token_str, None, None, None)
                     .unwrap_or_else(|e| platform::die(&e));
                 eprintln!("{name}: authenticated");
             } else {

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -281,7 +281,7 @@ pub async fn restore_backup(
         .ok_or_else(|| DockerError::Failed("agent has no port in env file".into()))?;
     tracing::debug!(agent = %name, backup_id = %backup_id, "restoring snapshot into image");
     let image = crate::restic::restore_to_image(name, backup_id).await?;
-    create_container(docker, &cname, &image, port, name, env_config, manage_core_code, None).await?;
+    create_container(docker, &cname, &image, port, name, env_config, manage_core_code).await?;
 
     if !start_container(docker, &cname).await {
         return Err(DockerError::Failed("failed to start restored agent".into()));

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -912,7 +912,6 @@ pub fn write_agent_env_file(
     agent_name: &str,
     ws_port: u16,
     agent_token: &str,
-    timezone: Option<&str>,
 ) -> Result<std::path::PathBuf, DockerError> {
     std::fs::create_dir_all(&env_config.agents_dir)
         .map_err(|e| DockerError::Failed(format!("failed to create agents dir: {e}")))?;
@@ -932,9 +931,8 @@ pub fn write_agent_env_file(
     };
     append_optional("VESTAD_TUNNEL", env_config.vestad_tunnel.as_deref());
     append_optional("VESTA_UPSTREAM_REF", detect_upstream_ref().as_deref());
-    append_optional("TZ", timezone);
-    // The env carries only identity; the agent owns model/provider/personality and provider auth
-    // in its config store (preferences) and .credentials.json (Claude OAuth blob).
+    // The env carries only identity; the agent owns model/provider/personality, timezone, and provider
+    // auth in its config store (preferences) and .credentials.json (Claude OAuth blob).
     if std::fs::read_to_string(&env_path).map(|prev| prev == content).unwrap_or(false) {
         return Ok(env_path);
     }
@@ -1324,9 +1322,9 @@ pub async fn snapshot_container(_docker: &Docker, cname: &str, tag: &str, change
 // --- Container creation ---
 
 #[allow(clippy::too_many_arguments)]
-pub async fn create_container(docker: &Docker, cname: &str, image: &str, port: u16, agent_name: &str, env_config: &AgentEnvConfig, manage_core_code: bool, timezone: Option<&str>) -> Result<(), DockerError> {
+pub async fn create_container(docker: &Docker, cname: &str, image: &str, port: u16, agent_name: &str, env_config: &AgentEnvConfig, manage_core_code: bool) -> Result<(), DockerError> {
     let agent_token = generate_agent_token();
-    let env_path = write_agent_env_file(env_config, agent_name, port, &agent_token, timezone)?;
+    let env_path = write_agent_env_file(env_config, agent_name, port, &agent_token)?;
     let env_mount = format!("{}:{}:ro,z", env_path.display(), ENV_MOUNT_DEST);
 
     let constitution_path = ensure_constitution_file(&env_config.agents_dir, agent_name)?;
@@ -1630,7 +1628,7 @@ impl std::fmt::Debug for BuildProgress {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn create_agent(docker: &Docker, name: &str, env_config: &AgentEnvConfig, manage_core_code: bool, timezone: Option<&str>, seed_context: Option<&str>, progress: &BuildProgress) -> Result<String, DockerError> {
+pub async fn create_agent(docker: &Docker, name: &str, env_config: &AgentEnvConfig, manage_core_code: bool, progress: &BuildProgress) -> Result<String, DockerError> {
     let name = if name == "ignisinextinctus" { "vesta" } else { name };
     validate_name(name)?;
     if name != "vesta" && name.contains("vesta") {
@@ -1653,18 +1651,7 @@ pub async fn create_agent(docker: &Docker, name: &str, env_config: &AgentEnvConf
 
     progress.set(BuildPhase::Creating);
     let port = allocate_port(&env_config.agents_dir)?;
-    create_container(docker, &cname, &image, port, name, env_config, manage_core_code, timezone).await?;
-
-    // Freeform creator-supplied context (e.g. what an onboarding vesta learned about the
-    // user). Delivered into the not-yet-started container's data dir so first-wake setup can
-    // fold it into MEMORY.md. Only at creation — it's consumed once, so no rebuild/rename
-    // persistence is needed. A failure here must not abort an otherwise-good agent: log and
-    // move on, the agent just starts without the head-start context.
-    if let Some(context) = seed_context.filter(|c| !c.trim().is_empty()) {
-        if let Err(e) = docker_cp_content(docker, &cname, context, "/root/agent/data/seed-context.md").await {
-            tracing::warn!(agent = %name, error = %e, "failed to write seed-context file; agent will start without it");
-        }
-    }
+    create_container(docker, &cname, &image, port, name, env_config, manage_core_code).await?;
 
     Ok(name.to_string())
 }
@@ -1786,7 +1773,7 @@ pub async fn reconcile_containers(docker: &Docker, env_config: &AgentEnvConfig, 
                 .or_else(|| allocate_port(&env_config.agents_dir).ok());
             if let Some(port) = port {
                 let token = generate_agent_token();
-                if let Err(e) = write_agent_env_file(env_config, name, port, &token, None) {
+                if let Err(e) = write_agent_env_file(env_config, name, port, &token) {
                     tracing::error!(agent = %name, error = %e, "failed to create env file");
                 }
             } else {
@@ -2010,7 +1997,7 @@ pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvCon
     remove_container_force(docker, &cname).await.ok();
 
     tracing::info!(agent = %name, "[4/4] creating container with new config...");
-    create_container(docker, &cname, &backup_tag, port, name, env_config, manage_core_code, None).await?;
+    create_container(docker, &cname, &backup_tag, port, name, env_config, manage_core_code).await?;
 
     Ok(())
 }
@@ -2080,7 +2067,7 @@ pub async fn rename_agent(
     delete_constitution_file(&env_config.agents_dir, old_name);
 
     tracing::info!(new = %new_name, "[4/4] creating renamed container from snapshot...");
-    create_container(docker, &new_cname, &snapshot_tag, port, new_name, env_config, manage_core_code, None).await?;
+    create_container(docker, &new_cname, &snapshot_tag, port, new_name, env_config, manage_core_code).await?;
 
     // Repos are keyed by agent name, so carry the backup history across the rename.
     crate::restic::rename_repo(old_name, new_name)?;

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -788,7 +788,7 @@ fn main() {
                         agent_code::ensure_agent_code(&config)
                             .unwrap_or_else(|e| die(format!("failed to populate agent code: {e}")));
                         let port = docker::allocate_port(&env_config.agents_dir).unwrap_or_else(|e| die(&e));
-                        docker::create_container(&docker, &cname, loaded_image, port, &name, &env_config, true, None).await
+                        docker::create_container(&docker, &cname, loaded_image, port, &name, &env_config, true).await
                             .unwrap_or_else(|e| die(&e));
 
                         if !docker::start_container(&docker, &cname).await {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -514,12 +514,6 @@ async fn list_agents_handler(
 struct CreateBody {
     name: Option<String>,
     manage_agent_code: Option<bool>,
-    timezone: Option<String>,
-    /// Freeform setup notes the creator wants the new agent to start with: what it
-    /// learned about the user during onboarding, plus any skills or services to set
-    /// up. Written to ~/agent/data/seed-context.md in the container; the agent folds
-    /// the background into its memory and acts on the setup it asks for at first wake.
-    seed_context: Option<String>,
 }
 
 async fn create_agent_handler(
@@ -553,7 +547,7 @@ async fn create_agent_handler(
         phases.set_build_phase(&progress_name, phase);
     }));
 
-    let result = create_and_start(&state, &name, manage_core_code, &body, &progress).await;
+    let result = create_and_start(&state, &name, manage_core_code, &progress).await;
     state.clear_build_phase(&name);
     let name = result?;
 
@@ -566,10 +560,9 @@ async fn create_and_start(
     state: &SharedState,
     name: &str,
     manage_core_code: bool,
-    body: &CreateBody,
     progress: &docker::BuildProgress,
 ) -> Result<String, (StatusCode, Json<serde_json::Value>)> {
-    let name = docker::create_agent(&state.docker, name, &state.env_config, manage_core_code, body.timezone.as_deref(), body.seed_context.as_deref(), progress)
+    let name = docker::create_agent(&state.docker, name, &state.env_config, manage_core_code, progress)
         .await
         .map_err(map_docker_err)?;
 


### PR DESCRIPTION
## What

Timezone was the odd preference out: classified as env **identity** (seeded into `agents/{name}.env`, changed by hand-editing `~/.bashrc`), while every other agent preference lives in the agent-owned config store and changes through `PUT /config`. This moves `timezone` (and the one-shot `seed_context`) into the config store, delivered through the existing post-create config channel. No timezone through env.

Per the design discussion: clients route timezone into the config setting at provision time, and the **`VestaConfig` object itself** applies it.

## How

**Agent**
- `config.py`: new `timezone` + `seed_context` fields. A `@model_validator(mode="after")` does `os.environ["TZ"] = self.timezone; time.tzset()` on construction, so every child (shell `date`, calendar/reminders, tasks' `tzlocal`) inherits it and a `PUT /config` change just applies on the next boot. A `TZ` validation alias lets a legacy agent (TZ still in env) seed the field, so it re-exports the real value instead of clobbering it with the UTC default.
- `main.py`: materialize `seed_context` to `data/seed-context.md` (the file first-wake reads) when absent.
- `migrate_legacy_config_to_store`: drain a legacy agent's real `TZ` env into the store (skips UTC).
- `timezone` skill: write the store via `update_config_store`, not `~/.bashrc`.
- first-wake prompt: stop attributing timezone to `/run/vestad-env`.

**vestad**
- Drop `timezone` + `seed_context` from the create body, the env-file seed, and the seed-context `docker cp`. The agent owns them.

**Clients** (web, cli, onboard skill)
- Deliver `timezone` / `seed_context` / `personality` through the combined `/provider/config` call's `config` field at provision time (one restart, no env). Re-auth paths omit timezone so an existing agent keeps its own. The onboard skill stashes personality + seed context at create and delivers them at claude-finish.
- An agent created without immediate provisioning boots on UTC and asks for the timezone at first wake (prompt step 7), so there's no gap.

## Tests
- `agent`: new coverage for TZ application, `PUT /config` accepting timezone/seed_context, and legacy TZ drain (skip-UTC). Full suite green (364).
- `onboard`: updated for the new create/set_provider split.
- `cli`, `vestad --bins`, `web`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)