### PR TITLE
refactor(config): merge provider-prefs into config; rename provisioning endpoint to /provision

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -7,10 +7,9 @@ Routes:
   - GET  /provider/usage       normalized, provider-agnostic plan usage
   - GET  /provider/status      LLM-provider auth state
   - POST /provider             set Claude credentials or OpenRouter key (auth only)
-  - PUT  /provider/config      update provider-owned prefs (model, context, thinking)
   - DELETE /provider           sign out: clear credentials, leaving not_authenticated
   - GET  /config               full live config (read), secrets redacted
-  - PUT  /config               update general preferences (personality, operational); provider-owned keys rejected
+  - PUT  /config               update any preference (model, context, thinking, personality, timezone, ...); auth fields rejected
   - GET  /memory               read MEMORY.md
   - PUT  /memory               overwrite MEMORY.md (applies on next restart)
 """
@@ -28,10 +27,10 @@ import pydantic as pyd
 from aiohttp import web
 
 from .events import ChatEvent, EventBus, HistoryEvent, UserEvent, VestaEvent
-from .config import VestaConfig, update_config_store, validate_config_updates, validate_provider_prefs
+from .config import VestaConfig, update_config_store, validate_config_updates
 from .helpers import get_memory_path
 from .models import State
-from .provider import UsageError, clear_provider, get_usage, set_claude, set_openrouter, set_provider_prefs
+from .provider import UsageError, clear_provider, get_usage, set_claude, set_openrouter
 
 
 logger = logging.getLogger("vesta.api")
@@ -267,8 +266,8 @@ async def _apply_sparse_update(
     validate: tp.Callable[[VestaConfig, object], dict[str, tp.Any]],
     apply: tp.Callable[[dict[str, tp.Any]], None],
 ) -> web.Response:
-    """Shared body of the sparse PUT-and-restart endpoints (/config, /provider/config): parse, validate,
-    apply the non-empty update, ask vestad to restart. `noun` names the surface in error messages."""
+    """Shared body of the sparse PUT-and-restart config endpoint: parse, validate, apply the non-empty
+    update, ask vestad to restart. `noun` names the surface in error messages."""
     config: VestaConfig = request.app["config"]
     try:
         data = await request.json()
@@ -287,15 +286,6 @@ async def _apply_sparse_update(
     except OSError as e:
         return web.json_response({"error": f"failed to write {noun}: {e}"}, status=500)
     return web.json_response({"ok": True, "restart_required": True})
-
-
-async def _provider_config_put_handler(request: web.Request) -> web.Response:
-    """Update provider-owned preferences (model, context window, thinking). Sparse: an omitted field
-    is left unchanged, a null clears it. Vestad restarts the agent to apply."""
-    config: VestaConfig = request.app["config"]
-    return await _apply_sparse_update(
-        request, noun="provider config", validate=validate_provider_prefs, apply=lambda updates: set_provider_prefs(updates, config=config)
-    )
 
 
 async def _provider_clear_handler(request: web.Request) -> web.Response:
@@ -387,7 +377,6 @@ async def start_ws_server(
     app.router.add_get("/provider/usage", _provider_usage_handler)
     app.router.add_get("/provider/status", _provider_status_handler)
     app.router.add_post("/provider", _provider_set_handler)
-    app.router.add_put("/provider/config", _provider_config_put_handler)
     app.router.add_delete("/provider", _provider_clear_handler)
     app.router.add_get("/config", _config_get_handler)
     app.router.add_get("/config/schema", _config_schema_handler)

--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -62,9 +62,12 @@ def update_config_store(updates: dict[str, tp.Any]) -> None:
     tmp.replace(path)
 
 
-# Provider-owned settings flow through provider.py and the /provider* endpoints, never the generic
-# config API. Preferences (model/context/thinking) are settable via PUT /provider/config; the auth
-# fields are written only by provider.py's set_claude/set_openrouter/clear_provider.
+# PROVIDER_PREF_FIELDS names the preferences that are tied to the provider/account lifecycle: they
+# are wiped on sign-out (clear_provider) because a new account may not offer the same model, while
+# general config (personality, timezone, ...) survives. They are still set through the generic PUT
+# /config like any other preference — this set exists only for the sign-out wipe, not for routing.
+# The auth fields are written only by provider.py's set_claude/set_openrouter/clear_provider and are
+# rejected by PUT /config (they carry credential-file + provider-status side effects).
 PROVIDER_PREF_FIELDS = frozenset({"agent_model", "max_context_tokens", "thinking"})
 _PROVIDER_AUTH_FIELDS = frozenset({"agent_provider", "openrouter_key"})
 
@@ -82,26 +85,17 @@ def _merge_validate(config: "VestaConfig", data: dict[str, tp.Any]) -> dict[str,
 
 
 def validate_config_updates(config: "VestaConfig", data: object) -> dict[str, tp.Any]:
-    """Validate a sparse PUT /config body. Provider-owned settings (model, context, thinking, and the
-    auth fields) are rejected here — they flow through the /provider endpoints."""
+    """Validate a sparse PUT /config body. Every agent preference is settable here — model, context,
+    thinking, personality, timezone, seed_context — since they all live in one config store. Only the
+    auth fields (provider choice + OpenRouter key) are rejected: those flow through POST /provider,
+    which owns the credential files and the derived provider status. PROVIDER_PREF_FIELDS still names
+    the model/context/thinking subset, but only for clear_provider's sign-out wipe, not for routing."""
     if not isinstance(data, dict):
         raise ValueError("config body must be a JSON object")
     data = tp.cast("dict[str, tp.Any]", data)
-    provider_owned = sorted(set(data) & (PROVIDER_PREF_FIELDS | _PROVIDER_AUTH_FIELDS))
-    if provider_owned:
-        raise ValueError(f"provider-owned, set via /provider/config: {', '.join(provider_owned)}")
-    return _merge_validate(config, data)
-
-
-def validate_provider_prefs(config: "VestaConfig", data: object) -> dict[str, tp.Any]:
-    """Validate a sparse PUT /provider/config body — only the provider preferences (model, context,
-    thinking) are accepted."""
-    if not isinstance(data, dict):
-        raise ValueError("provider config body must be a JSON object")
-    data = tp.cast("dict[str, tp.Any]", data)
-    disallowed = sorted(set(data) - PROVIDER_PREF_FIELDS)
-    if disallowed:
-        raise ValueError(f"not provider preferences: {', '.join(disallowed)}")
+    auth_owned = sorted(set(data) & _PROVIDER_AUTH_FIELDS)
+    if auth_owned:
+        raise ValueError(f"auth-owned, set via POST /provider: {', '.join(auth_owned)}")
     return _merge_validate(config, data)
 
 

--- a/agent/core/provider.py
+++ b/agent/core/provider.py
@@ -109,14 +109,6 @@ def set_openrouter(key: str, model: str, *, config: VestaConfig, persisted: Pers
     return status
 
 
-def set_provider_prefs(updates: dict[str, tp.Any], *, config: VestaConfig) -> None:
-    """Persist provider-owned preferences (agent_model, max_context_tokens, thinking) to the config
-    store. Owned here so every provider setting flows through provider.py; the keys are pre-validated
-    by validate_provider_prefs. Vestad restarts the agent to apply them."""
-    update_config_store(updates)
-    logger.startup(f"Provider prefs updated: {sorted(updates)}")
-
-
 def clear_provider(*, config: VestaConfig, persisted: PersistedState) -> ProviderStatus:
     """Sign out: clear everything provider-owned — the Claude OAuth blob, the OpenRouter key, and the
     provider preferences (model, context, thinking) — leaving the agent not_authenticated. Only

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -208,19 +208,18 @@ class Client:
         personality: str | None = None,
         seed_context: str | None = None,
     ) -> dict[str, Any]:
-        """POST <tenant>/agents/{name}/provider/config — attach Claude creds and, in the same restart,
-        the model (provider pref) plus personality and the freeform seed context (general config). The
-        agent wakes with everything in place."""
-        provider_config: dict[str, Any] = {}
-        if model:
-            provider_config["agent_model"] = model
+        """POST <tenant>/agents/{name}/provision — attach Claude creds and, in the same restart, the
+        agent's preferences (model, personality, freeform seed context). The agent wakes with
+        everything in place."""
         config: dict[str, Any] = {}
+        if model:
+            config["agent_model"] = model
         if personality:
             config["agent_personality"] = personality
         if seed_context:
             config["seed_context"] = seed_context
-        body = {"provider": {"credentials": credentials}, "provider_config": provider_config, "config": config}
-        url = f"{self._cfg.tenant_base(subdomain)}/agents/{name}/provider/config"
+        body = {"provider": {"credentials": credentials}, "config": config}
+        url = f"{self._cfg.tenant_base(subdomain)}/agents/{name}/provision"
         return self._json(self._raw_post(url, json=body, token=server_token, timeout=120))
 
     # --- low-level helpers ---------------------------------------------------

--- a/agent/tests/test_api.py
+++ b/agent/tests/test_api.py
@@ -216,13 +216,13 @@ def test_config_update_rejects_bad_values(config):
             validate_config_updates(config, bad)
 
 
-def test_provider_prefs_reject_bad_values(config):
-    from core.config import validate_provider_prefs
+def test_config_update_rejects_bad_pref_values(config):
+    from core.config import validate_config_updates
 
-    # Provider prefs go through the same field constraints, on the /provider/config path.
+    # Model/context/thinking are now plain config keys; they keep their field constraints on PUT /config.
     for bad in [{"max_context_tokens": 0}, {"thinking": "x"}]:
         with pytest.raises(pyd.ValidationError):
-            validate_provider_prefs(config, bad)
+            validate_config_updates(config, bad)
 
 
 def test_provider_update_accepts_each_provider():

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -252,7 +252,17 @@ def test_migrate_legacy_claude_file_carries_no_key(agentdir, monkeypatch, tmp_pa
     assert not legacy.exists()
 
 
-# --- Provider/general config ownership split (PUT /config vs PUT /provider/config) ---
+# --- PUT /config accepts every preference; only auth fields are rejected ---
+
+
+@pytest.mark.parametrize("key,value", [("openrouter_key", "sk-or-v1-x"), ("agent_provider", "openrouter")])
+def test_validate_config_rejects_auth_fields(config, key, value):
+    # Auth fields carry credential-file + provider-status side effects, so they go through POST
+    # /provider, never the generic config write.
+    from core.config import validate_config_updates
+
+    with pytest.raises(ValueError, match="auth-owned"):
+        validate_config_updates(config, {key: value})
 
 
 @pytest.mark.parametrize(
@@ -261,29 +271,17 @@ def test_migrate_legacy_claude_file_carries_no_key(agentdir, monkeypatch, tmp_pa
         ("agent_model", "opus"),
         ("max_context_tokens", 500_000),
         ("thinking", "enabled"),
-        ("openrouter_key", "sk-or-v1-x"),
-        ("agent_provider", "openrouter"),
+        ("agent_personality", "playful"),
+        ("timezone", "Europe/London"),
+        ("seed_context", "they like terse replies"),
     ],
 )
-def test_validate_config_rejects_provider_owned_keys(config, key, value):
+def test_validate_config_accepts_every_preference(config, key, value):
+    # Model/context/thinking used to route through a separate /provider/config; now every preference
+    # is settable on the one config surface.
     from core.config import validate_config_updates
 
-    with pytest.raises(ValueError, match="provider-owned"):
-        validate_config_updates(config, {key: value})
-
-
-def test_validate_config_accepts_general_keys(config):
-    from core.config import validate_config_updates
-
-    assert validate_config_updates(config, {"agent_personality": "playful"}) == {"agent_personality": "playful"}
-
-
-def test_validate_config_accepts_timezone_and_seed_context(config):
-    # Both are general (agent-owned) config delivered via PUT /config, not provider-owned.
-    from core.config import validate_config_updates
-
-    update = {"timezone": "Europe/London", "seed_context": "they like terse replies"}
-    assert validate_config_updates(config, update) == update
+    assert validate_config_updates(config, {key: value}) == {key: value}
 
 
 def test_config_applies_timezone_to_process_env(monkeypatch):
@@ -293,14 +291,3 @@ def test_config_applies_timezone_to_process_env(monkeypatch):
     config = vm.VestaConfig()
     assert config.timezone == "Asia/Tokyo"
     assert os.environ["TZ"] == "Asia/Tokyo"
-
-
-def test_validate_provider_prefs_accepts_only_prefs(config):
-    from core.config import validate_provider_prefs
-
-    assert validate_provider_prefs(config, {"agent_model": "opus", "max_context_tokens": 500_000}) == {
-        "agent_model": "opus",
-        "max_context_tokens": 500_000,
-    }
-    with pytest.raises(ValueError, match="not provider preferences"):
-        validate_provider_prefs(config, {"agent_personality": "playful"})

--- a/agent/tests/test_provider.py
+++ b/agent/tests/test_provider.py
@@ -7,7 +7,7 @@ import json
 import pytest
 
 import core.models as vm
-from core.config import read_config_store
+from core.config import read_config_store, update_config_store
 from core.provider import (
     ProviderAuthState,
     UsageCredits,
@@ -20,7 +20,6 @@ from core.provider import (
     observed_provider_failure,
     set_claude,
     set_openrouter,
-    set_provider_prefs,
 )
 from core.state_store import PersistedState, load_state
 
@@ -109,9 +108,10 @@ def test_set_openrouter_writes_provider_key_and_model_to_store(prov):
     assert derive_status(fresh, persisted).kind == "openrouter"
 
 
-def test_set_provider_prefs_writes_model_context_thinking(prov):
-    config, _persisted = prov
-    set_provider_prefs({"agent_model": "opus", "max_context_tokens": 500_000}, config=config)
+def test_model_context_prefs_persist_to_store_and_reload(prov):
+    # Model/context are plain config keys now (PUT /config -> update_config_store); a fresh config
+    # reads them back. This is the persistence the merged config surface relies on.
+    update_config_store({"agent_model": "opus", "max_context_tokens": 500_000})
     store = read_config_store()
     assert store["agent_model"] == "opus"
     assert store["max_context_tokens"] == 500_000

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -18,10 +18,10 @@ export type ProviderResult =
       maxContextTokens?: number;
     };
 
-/// Provision an agent: set provider auth, provider-owned prefs (model, context window), and the
-/// general personality pref in one request. Vestad writes each to its owner and restarts the agent
-/// once — doing them as separate restart-on-write calls raced (a later write hit the agent
-/// mid-restart and was dropped). The caller splits the parts; vestad just forwards each.
+/// Provision an agent: set provider auth and the agent's preferences (model, context, personality,
+/// timezone) in one request. Vestad forwards auth to POST /provider and the config to PUT /config,
+/// then restarts once — doing them as separate restart-on-write calls raced (a later write hit the
+/// agent mid-restart and was dropped).
 export async function setProvider(
   name: string,
   result: ProviderResult,
@@ -35,35 +35,34 @@ export async function setProvider(
           openrouter_key: result.config.key,
           openrouter_model: result.config.model,
         };
-  // Provider-owned prefs. OpenRouter's model rides in the auth body above (openrouter_model), so
-  // only Claude carries an explicit agent_model here; context applies to both.
-  const providerConfig: Record<string, unknown> = {};
-  if (result.kind === "claude" && result.model)
-    providerConfig.agent_model = result.model;
-  if (result.maxContextTokens != null)
-    providerConfig.max_context_tokens = result.maxContextTokens;
-  // General prefs. Timezone is delivered here at provision time (not via env at create), so the
-  // agent's config store owns it; callers re-provisioning an existing agent omit it to keep its tz.
+  // Every preference rides one config surface. OpenRouter's model is part of its auth body above
+  // (openrouter_model), so only Claude carries an explicit agent_model here; context applies to both.
+  // Timezone is delivered at provision time (not via env at create) so the agent's store owns it;
+  // callers re-provisioning an existing agent omit timezone/personality to keep the agent's own.
   const config: Record<string, unknown> = {};
+  if (result.kind === "claude" && result.model)
+    config.agent_model = result.model;
+  if (result.maxContextTokens != null)
+    config.max_context_tokens = result.maxContextTokens;
   if (personality) config.agent_personality = personality;
   if (timezone) config.timezone = timezone;
-  await apiFetch(`/agents/${encodeURIComponent(name)}/provider/config`, {
+  await apiFetch(`/agents/${encodeURIComponent(name)}/provision`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ provider, provider_config: providerConfig, config }),
+    body: JSON.stringify({ provider, config }),
   });
 }
 
-/// Update provider-owned preferences (model and/or context window) without touching auth. Vestad
+/// Update preferences (model and/or context window) without touching auth, via PUT /config. Vestad
 /// restarts the agent to apply.
-export async function setProviderConfig(
+export async function setConfig(
   name: string,
   prefs: { agent_model?: string; max_context_tokens?: number },
 ): Promise<void> {
-  await apiFetch(`/agents/${encodeURIComponent(name)}/provider/config`, {
-    method: "POST",
+  await apiFetch(`/agents/${encodeURIComponent(name)}/config`, {
+    method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ provider_config: prefs }),
+    body: JSON.stringify(prefs),
   });
 }
 
@@ -87,17 +86,17 @@ export async function getProvider(name: string): Promise<ProviderInfo> {
   return apiJson<ProviderInfo>(`/agents/${encodeURIComponent(name)}/provider`);
 }
 
-/// Change only the model preference (provider-owned). Vestad restarts the agent so it takes effect.
+/// Change only the model preference. Vestad restarts the agent so it takes effect.
 export async function setModel(name: string, model: string): Promise<void> {
-  await setProviderConfig(name, { agent_model: model });
+  await setConfig(name, { agent_model: model });
 }
 
-/// Change only the context window (provider-owned). Vestad restarts the agent so it takes effect.
+/// Change only the context window. Vestad restarts the agent so it takes effect.
 export async function setContextWindow(
   name: string,
   maxContextTokens: number,
 ): Promise<void> {
-  await setProviderConfig(name, { max_context_tokens: maxContextTokens });
+  await setConfig(name, { max_context_tokens: maxContextTokens });
 }
 
 /// Create an empty agent container. Credentials and preferences (provider, model, personality,

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -145,22 +145,17 @@ fn require_str(value: &serde_json::Value, field: &str) -> Result<String, String>
     value[field].as_str().map(str::to_string).ok_or_else(|| format!("response missing {field}"))
 }
 
-/// Build the sparse provider-owned preferences body (model + context window) for /provider/config.
-fn provider_prefs(model: Option<&str>, max_context_tokens: Option<u64>) -> serde_json::Map<String, serde_json::Value> {
-    let mut prefs = serde_json::Map::new();
+/// Build the sparse agent-preferences body for `PUT /config` (or the `config` part of `/provision`).
+/// Every preference lives on one config surface now, so model/context sit alongside timezone. Empty
+/// when nothing is set, which vestad treats as "skip the PUT /config".
+fn config_body(model: Option<&str>, max_context_tokens: Option<u64>, timezone: Option<&str>) -> serde_json::Value {
+    let mut config = serde_json::Map::new();
     if let Some(model) = model {
-        prefs.insert("agent_model".to_string(), serde_json::json!(model));
+        config.insert("agent_model".to_string(), serde_json::json!(model));
     }
     if let Some(ctx) = max_context_tokens {
-        prefs.insert("max_context_tokens".to_string(), serde_json::json!(ctx));
+        config.insert("max_context_tokens".to_string(), serde_json::json!(ctx));
     }
-    prefs
-}
-
-/// General (non-provider) preferences carried in the combined `/provider/config` call's `config`
-/// field. Empty when nothing to set, which vestad treats as "skip the PUT /config".
-fn general_config(timezone: Option<&str>) -> serde_json::Value {
-    let mut config = serde_json::Map::new();
     if let Some(tz) = timezone {
         config.insert("timezone".to_string(), serde_json::json!(tz));
     }
@@ -433,10 +428,10 @@ impl Client {
         Ok(v["name"].as_str().unwrap_or(name).to_string())
     }
 
-    /// Provision an existing agent with Claude credentials (the OAuth JSON blob) and the
-    /// model/context preferences in one request, so vestad writes both and restarts once.
-    /// Splitting this into separate restart-on-write calls raced: a later call hit the agent
-    /// mid-restart and was dropped. Model/context are provider-owned, sent under `provider_config`.
+    /// Provision an existing agent with Claude credentials (the OAuth JSON blob) and its preferences
+    /// (model/context/timezone) in one request, so vestad writes both and restarts once. Splitting
+    /// this into separate restart-on-write calls raced: a later call hit the agent mid-restart and
+    /// was dropped. Preferences ride the `config` field; only the credentials are provider auth.
     pub fn set_provider_credentials(
         &self,
         name: &str,
@@ -448,27 +443,23 @@ impl Client {
         serde_json::from_str::<serde_json::Value>(credentials)
             .map_err(|e| format!("invalid credentials JSON: {e}"))?;
         self.post_json(
-            &format!("/agents/{name}/provider/config"),
+            &format!("/agents/{name}/provision"),
             &serde_json::json!({
                 "provider": {"credentials": credentials},
-                "provider_config": serde_json::Value::Object(provider_prefs(model, max_context_tokens)),
-                "config": general_config(timezone),
+                "config": config_body(model, max_context_tokens, timezone),
             }),
         )?;
         Ok(())
     }
 
-    /// Update provider-owned preferences (model and/or context window) via POST /provider/config.
-    /// A no-op when both are None. Vestad restarts the agent so they take effect.
-    pub fn set_provider_prefs(&self, name: &str, model: Option<&str>, max_context_tokens: Option<u64>) -> Result<(), String> {
-        let prefs = provider_prefs(model, max_context_tokens);
-        if prefs.is_empty() {
+    /// Update preferences (model and/or context window) via PUT /config. A no-op when both are None.
+    /// Vestad restarts the agent so they take effect.
+    pub fn set_prefs(&self, name: &str, model: Option<&str>, max_context_tokens: Option<u64>) -> Result<(), String> {
+        let config = config_body(model, max_context_tokens, None);
+        if config.as_object().is_none_or(serde_json::Map::is_empty) {
             return Ok(());
         }
-        self.post_json(
-            &format!("/agents/{name}/provider/config"),
-            &serde_json::json!({"provider_config": serde_json::Value::Object(prefs)}),
-        )?;
+        self.put_json(&format!("/agents/{name}/config"), &config)?;
         Ok(())
     }
 
@@ -478,12 +469,12 @@ impl Client {
     }
 
     pub fn set_provider_openrouter(&self, name: &str, args: &OpenRouterArgs, timezone: Option<&str>) -> Result<(), String> {
-        // Combined endpoint so the openrouter auth and the timezone preference land in one restart.
+        // Provision endpoint so the openrouter auth and the timezone preference land in one restart.
         let body = serde_json::json!({
             "provider": {"openrouter_key": args.key, "openrouter_model": args.model},
-            "config": general_config(timezone),
+            "config": config_body(None, None, timezone),
         });
-        self.post_json(&format!("/agents/{name}/provider/config"), &body)?;
+        self.post_json(&format!("/agents/{name}/provision"), &body)?;
         Ok(())
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1057,7 +1057,7 @@ fn run(cli: Cli) {
         Command::Settings { name, model, context_window } => {
             let c = get_client(host_ref, token_ref);
             if model.is_some() || context_window.is_some() {
-                c.set_provider_prefs(&name, model.as_deref(), context_window)
+                c.set_prefs(&name, model.as_deref(), context_window)
                     .unwrap_or_else(|e| platform::die(&e));
                 eprintln!("updated. the agent is restarting to apply the change.");
             } else {

--- a/vestad/src/agent_provider.rs
+++ b/vestad/src/agent_provider.rs
@@ -125,26 +125,6 @@ impl<'a> AgentProvider<'a> {
         Err(format!("agent /config returned HTTP {status}: {body_text}"))
     }
 
-    /// PUT a sparse provider-preferences body (model/context/thinking) to the agent's
-    /// /provider/config. Applies on next restart.
-    pub async fn put_provider_config(&self, body: &serde_json::Value) -> Result<(), String> {
-        let (port, token) = self.port_and_token()?;
-        let resp = self.http_client
-            .put(format!("http://127.0.0.1:{port}/provider/config"))
-            .header("X-Agent-Token", token)
-            .json(body)
-            .timeout(SET_TIMEOUT)
-            .send()
-            .await
-            .map_err(|e| format!("agent /provider/config request failed: {e}"))?;
-        let status = resp.status();
-        if status.is_success() {
-            return Ok(());
-        }
-        let body_text = resp.text().await.unwrap_or_default();
-        Err(format!("agent /provider/config returned HTTP {status}: {body_text}"))
-    }
-
     /// DELETE the agent's /provider — sign out, clearing its credentials. Applies on next restart.
     pub async fn clear(&self) -> Result<(), String> {
         let (port, token) = self.port_and_token()?;

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -805,10 +805,10 @@ async fn get_provider_handler(
 enum AgentWrite {
     /// The agent's `POST /provider` (auth), forwarded verbatim.
     Provider(serde_json::Value),
-    /// The agent's `PUT /config` (general prefs), forwarded verbatim.
+    /// The agent's `PUT /config` (any preference), forwarded verbatim.
     Config(serde_json::Value),
-    /// Any of provider auth / provider prefs / general prefs, each to its own agent endpoint.
-    ProviderConfig(ProviderConfigRequest),
+    /// Provisioning: auth and/or preferences, each to its own agent endpoint, one restart.
+    Provision(ProvisionRequest),
     /// The agent's `DELETE /provider` — sign out.
     Clear,
 }
@@ -816,7 +816,7 @@ enum AgentWrite {
 /// Run a write against a (possibly stopped) agent's own HTTP API, then restart the container so the
 /// change applies on next boot. Ensures the agent exists, takes the per-agent write lock, and
 /// auto-starts a stopped agent so it can receive the proxied call — the shared skeleton behind every
-/// provider/config setter. The agent owns the file writes, format, and validation; any forward
+/// auth/config/provision setter. The agent owns the file writes, format, and validation; any forward
 /// failure surfaces as BAD_GATEWAY.
 async fn write_to_agent_and_restart(
     state: &SharedState,
@@ -839,15 +839,12 @@ async fn write_to_agent_and_restart(
         AgentWrite::Provider(body) => provider.set(&body).await,
         AgentWrite::Config(body) => provider.put_config(&body).await,
         AgentWrite::Clear => provider.clear().await,
-        AgentWrite::ProviderConfig(req) => {
+        AgentWrite::Provision(req) => {
             // Each present part is written before the single restart below, so a later write can't
             // hit the agent mid-restart and 502, dropping the change.
             async {
                 if has_entries(&req.provider) {
                     provider.set(&req.provider).await?;
-                }
-                if has_entries(&req.provider_config) {
-                    provider.put_provider_config(&req.provider_config).await?;
                 }
                 if has_entries(&req.config) {
                     provider.put_config(&req.config).await?;
@@ -900,31 +897,28 @@ fn has_entries(value: &serde_json::Value) -> bool {
 }
 
 #[derive(Deserialize)]
-struct ProviderConfigRequest {
+struct ProvisionRequest {
     /// Provider auth body for the agent's `POST /provider` (`{credentials}` for Claude or
     /// `{openrouter_key, openrouter_model}`). Omitted when only preferences change.
     #[serde(default)]
     provider: serde_json::Value,
-    /// Sparse provider-owned preferences for the agent's `PUT /provider/config`
-    /// (model, context, thinking).
-    #[serde(default)]
-    provider_config: serde_json::Value,
-    /// Sparse general preferences for the agent's `PUT /config` (personality).
+    /// Sparse preferences for the agent's `PUT /config` (model, context, thinking, personality,
+    /// timezone, seed_context). Omitted when only auth changes.
     #[serde(default)]
     config: serde_json::Value,
 }
 
-/// Apply any of provider auth / provider preferences / general preferences, then restart the
-/// container ONCE. Each named part is forwarded to its own agent endpoint, so vestad carries no
-/// field taxonomy. Doing these as separate restart-on-write calls raced — a later write hit the
-/// agent mid-restart and 502'd, dropping the change. Writing everything before a single restart
-/// designs that race out of existence.
-async fn set_provider_config_handler(
+/// Provision an agent: apply provider auth and/or preferences, then restart the container ONCE. Each
+/// named part is forwarded to its own agent endpoint, so vestad carries no field taxonomy. Doing
+/// these as separate restart-on-write calls raced — a later write hit the agent mid-restart and
+/// 502'd, dropping the change. Writing everything before a single restart designs that race out of
+/// existence.
+async fn provision_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
-    Json(req): Json<ProviderConfigRequest>,
+    Json(req): Json<ProvisionRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    write_to_agent_and_restart(&state, &name, AgentWrite::ProviderConfig(req)).await
+    write_to_agent_and_restart(&state, &name, AgentWrite::Provision(req)).await
 }
 
 /// Sign out: clear the agent's provider credentials (`DELETE /provider`), then restart once so it
@@ -2135,7 +2129,7 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/agents/{name}/destroy", post(destroy_agent_handler))
         .route("/agents/{name}/rename", post(rename_agent_handler))
         .route("/agents/{name}/provider", post(set_provider_handler).get(get_provider_handler).delete(clear_provider_handler))
-        .route("/agents/{name}/provider/config", post(set_provider_config_handler))
+        .route("/agents/{name}/provision", post(provision_handler))
         .route("/agents/{name}/config", put(set_config_handler).get(get_config_handler))
         .route("/agents/{name}/tree", get(tree_handler))
         .route("/agents/{name}/file", get(read_file_handler))


### PR DESCRIPTION
**Stacked on #880** (base = `feat/tz-seedcontext-via-config`). Review/merge #880 first; this retargets to `master` once #880 lands.

## Why

The combined provisioning endpoint was `POST /agents/{name}/provider/config` with three buckets — `provider` (auth), `provider_config` (model/context/thinking), `config` (general). Investigation showed the `provider_config` bucket wasn't functionally distinct:

- `set_provider_prefs` was literally `update_config_store(...)` — it wrote the **same** `config.json` as the general `config` bucket, with the **same** `_merge_validate`.
- No provider-conditional logic (model is never checked against provider availability).
- The *only* real distinction: `clear_provider` wipes `PROVIDER_PREF_FIELDS` (model/context/thinking) on sign-out while keeping personality/timezone — an auth-lifecycle coupling, not a write-path one.

And the name was misleading: most of what flowed through `/provider/config` wasn't provider-related.

## What

Two buckets instead of three, with an honest name:

- **agent**: `PUT /config` accepts every preference (model, context, thinking, personality, timezone, seed_context); only the auth fields (`agent_provider`, `openrouter_key`) are rejected. Removed `PUT /provider/config`, `set_provider_prefs`, `validate_provider_prefs`. `PROVIDER_PREF_FIELDS` stays — but only as `clear_provider`'s sign-out wipe list, where it actually does work.
- **vestad**: `POST /agents/{name}/provider/config` → **`POST /agents/{name}/provision`**, body `{provider, config}`. Dropped the `provider_config` leg and `AgentProvider::put_provider_config`.
- **clients**: model/context now ride the `config` field (provision) or `PUT /config` (standalone changes). web `setProviderConfig`→`setConfig` (PUT /config); cli `set_provider_prefs`→`set_prefs` (PUT /config); onboard sends `{provider, config}` to `/provision`.

## No behavior change
Sign-out still wipes model/context/thinking and keeps general config; timezone/seed_context correctly **survive** a re-auth (they're general, not provider-lifecycle). Net `-74` lines.

## Tests
- agent (364) + onboard (19): boundary tests rewritten (PUT /config now accepts every pref; only auth rejected); clear-on-signout unchanged.
- `vestad --bins` (117), cli (21), web (tsc/prettier/eslint + 92 vitest): green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)