### PR TITLE
fix(release): revert the bump commit on failed release, not just the tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1470,18 +1470,42 @@ jobs:
   # release.sh creates the GitHub release BEFORE CI runs, so a failure (e.g.
   # test-live) leaves a published-but-asset-less release. Updaters that follow
   # prereleases then pick it up and 404 on the missing binary. Delete the
-  # release and its tag so the version vanishes cleanly; re-run ./release.sh
-  # after fixing to retry the same version.
+  # release and its tag, AND revert the "Bump version to X" commit release.yml
+  # pushed to master — otherwise the version is stranded (master sits at the
+  # bumped version with no release, and the next ./release.sh skips to the next
+  # patch). Reverting it lets a re-run retry the same version.
   revert-failed-release:
     needs: [build-vesta, build-vestad, test-frontend, test-integration, test-live, test-linux, build-windows, build-tauri-macos, build-tauri-linux, build-tauri-windows, build-tauri-android, build-tauri-ios, push-image, release]
     if: ${{ failure() && github.event_name == 'release' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Delete the failed release and its tag
+      - uses: actions/checkout@v7
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Delete the failed release and revert the bump
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           TAG="${{ github.event.release.tag_name }}"
           echo "::warning::release CI failed for ${TAG} — deleting the release and its tag so updaters cannot pick up an asset-less release. Re-run ./release.sh after fixing to retry ${TAG}."
           gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag
+          # Undo the bump with a revert commit, not a force-push: branch protection
+          # forbids force-pushes to master (allow_force_pushes: false). Only revert
+          # when the bump is still the tip, so a commit that landed after it is safe.
+          git fetch origin master
+          if git log origin/master -1 --pretty=%s | grep -q "^Bump version to "; then
+            git reset --hard origin/master
+            git revert --no-edit HEAD
+            git push origin master
+          else
+            echo "::warning::master tip is not a 'Bump version to' commit — leaving it for manual cleanup."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,8 +113,12 @@ jobs:
           TAG: ${{ steps.bump.outputs.tag }}
         run: |
           gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
+          # Undo the bump with a revert commit, not a force-push: branch protection
+          # forbids force-pushes to master (allow_force_pushes: false). Only revert
+          # when the bump is still the tip, so a commit that landed after it is safe.
           git fetch origin master
           if git log origin/master -1 --pretty=%s | grep -q "^Bump version to "; then
-            git reset --hard HEAD~1
-            git push --force-with-lease origin master
+            git reset --hard origin/master
+            git revert --no-edit HEAD
+            git push origin master
           fi


### PR DESCRIPTION
## Problem

Running `./release.sh` left master bumped to `0.1.161` with **no `v0.1.161` release or tag**, and the next release would skip to `0.1.162`.

What actually happened (run `28156224837` → release event run `28156538726`):

1. `release.yml` bumped to `0.1.161`, pushed the `Bump version to 0.1.161` commit to master, and created the `v0.1.161` prerelease — all succeeded.
2. Creating the release fired `ci.yml` on the `release` event; **`test-live` failed**.
3. `ci.yml`'s `revert-failed-release` deleted the release and tag — but **never reverted the bump commit** on master.

So the version was stranded: master at `0.1.161`, no release, and `release.sh` would have skipped `161`. This directly contradicted that job's own comment ("re-run `./release.sh` after fixing to retry the same version").

`release.yml`'s own on-failure cleanup *does* revert the bump — but it only runs when `release.yml` itself fails, not when the downstream release-event CI fails. That asymmetry was the bug.

## Fix

- `revert-failed-release` now checks out master (with `RELEASE_PAT`) and reverts the `Bump version to X` commit after deleting the release+tag, guarded to only fire when the bump is still the tip.
- Both cleanup paths switch from `reset --hard` + `--force-with-lease` to a **revert commit**. Branch protection has `allow_force_pushes: false` for everyone (including the `RELEASE_PAT`), so the old force-push cleanup could never have worked; a revert is a fast-forward push, which is allowed.

## Recovery already done

Master's stranded `Bump version to 0.1.161` commit was reverted out-of-band (commit `bcecc2da`), so master is back at `0.1.160`. The next `./release.sh` will produce a real `0.1.161`. (Note: `test-live` failed for `161`; worth a glance before re-releasing in case it's a real regression vs. a flaky live-Claude run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)