### PR TITLE
chore: share superpowers plugin via committed .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ vestad/vendored/
 .claude/*
 !.claude/skills/
 !.claude/workflows/
+!.claude/settings.json
 
 # Cursor / editor config
 .cursor/


### PR DESCRIPTION
## What

Commit `.claude/settings.json` so every developer who opens this repo in Claude Code automatically gets the **superpowers** and **frontend-design** plugins enabled — no manual install/enable per machine.

## Why

These plugins were only enabled in individual developers' local config. Committing the project-scoped `enabledPlugins` makes them part of the repo so the whole team shares the same baseline tooling.

## Changes

- `.claude/settings.json` (new, now tracked) — enables `frontend-design@claude-plugins-official` and `superpowers@claude-plugins-official`. Both live on the built-in `claude-plugins-official` marketplace, so no extra marketplace registration is required.
- `.gitignore` — un-ignore `.claude/settings.json`. `settings.local.json` remains ignored so personal local permissions/config stay out of the repo.

## Notes / scope

- Deliberately **excludes** `superwhisper` (a personal voice-input integration) and the `cloudflare` plugin — only the shared dev-coding tooling is committed.
- Claude Code built-ins (`code-review`, `simplify`, `run`, etc.) and MCP servers (Gmail/Calendar/Drive/M365 — per-user auth) are not committable and unaffected.
- The Vesta repo skills/workflows under `.claude/skills/` and `.claude/workflows/` were already tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)