### PR TITLE
feat: unify gateway settings endpoint + read-only setup display

### DIFF
--- a/apps/web/src/api/gateway.ts
+++ b/apps/web/src/api/gateway.ts
@@ -1,5 +1,6 @@
 import { getConnection } from "@/lib/connection";
-import type { LogEvent } from "@/lib/types";
+import type { LogEvent, ReleaseChannel } from "@/lib/types";
+import { apiJson } from "./client";
 import { openLogStream } from "./log-stream";
 
 let gatewayLogSource: EventSource | null = null;
@@ -32,4 +33,41 @@ export function stopGatewayLogs(): void {
     gatewayLogSource.close();
     gatewayLogSource = null;
   }
+}
+
+export interface GatewayLan {
+  exposed: boolean;
+  url: string | null;
+}
+
+export interface GatewayInfo {
+  lan: GatewayLan;
+  tunnel_url: string | null;
+  port: number;
+}
+
+export interface GatewayRetention {
+  daily: number;
+  weekly: number;
+  monthly: number;
+}
+
+export interface GatewayAutoBackup {
+  enabled: boolean;
+  hour: number;
+  retention: GatewayRetention;
+}
+
+export interface GatewaySettings {
+  auto_update: boolean;
+  channel: ReleaseChannel;
+  auto_backup: GatewayAutoBackup;
+}
+
+export async function fetchGatewayInfo(): Promise<GatewayInfo> {
+  return apiJson<GatewayInfo>("/gateway/info");
+}
+
+export async function fetchGatewaySettings(): Promise<GatewaySettings> {
+  return apiJson<GatewaySettings>("/gateway/settings");
 }

--- a/apps/web/src/components/ConnectionControls/index.tsx
+++ b/apps/web/src/components/ConnectionControls/index.tsx
@@ -55,7 +55,7 @@ export function ConnectionControls() {
   const onToggleBeta = async (enabled: boolean) => {
     setChannelSaving(true);
     try {
-      await apiJson("/settings/channel", {
+      await apiJson("/gateway/settings", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ channel: enabled ? "beta" : "stable" }),
@@ -71,7 +71,7 @@ export function ConnectionControls() {
   const onToggleAutoUpdate = async (enabled: boolean) => {
     setAutoUpdateSaving(true);
     try {
-      await apiJson("/settings/auto-update", {
+      await apiJson("/gateway/settings", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ auto_update: enabled }),

--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -187,8 +187,8 @@ export function AppSettings() {
                   </FieldContent>
                   <span className="shrink-0 text-sm text-muted-foreground">
                     {gatewaySetup.info.lan.exposed
-                      ? (gatewaySetup.info.lan.url ?? "exposed")
-                      : "off"}
+                      ? (gatewaySetup.info.lan.url ?? "enabled")
+                      : "disabled"}
                   </span>
                 </Field>
                 <Field
@@ -219,7 +219,7 @@ export function AppSettings() {
                   <span className="shrink-0 text-sm text-muted-foreground">
                     {gatewaySetup.settings.auto_backup.enabled
                       ? `daily at ${String(gatewaySetup.settings.auto_backup.hour).padStart(2, "0")}:00`
-                      : "off"}
+                      : "disabled"}
                   </span>
                 </Field>
               </div>

--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -31,6 +31,7 @@ import { useAppMode, type AppMode } from "@/stores/use-app-mode";
 import { openExternalUrl } from "@/lib/open-external-url";
 import { KeybindsCard } from "@/components/Settings/KeybindsSection";
 import { ConnectionControls } from "@/components/ConnectionControls";
+import { useGatewaySetup } from "@/components/Settings/use-gateway-setup";
 
 // Hosted (managed) boxes are always under vesta.run; the account + billing page
 // lives on the control plane. Self-hosted boxes never reach this.
@@ -48,6 +49,7 @@ export function AppSettings() {
   const appMode = useAppMode((s) => s.mode);
   const setAppMode = useAppMode((s) => s.setMode);
   const hostname = connectionHostname();
+  const gatewaySetup = useGatewaySetup();
 
   return (
     <div className="mx-auto mt-4 grid w-full max-w-5xl grid-cols-1 gap-4 pb-6 md:auto-rows-min md:grid-cols-2">
@@ -170,6 +172,58 @@ export function AppSettings() {
               </Button>
             </div>
             <ConnectionControls />
+            {gatewaySetup && (
+              <div className="mt-4 flex flex-col gap-3">
+                <Field
+                  orientation="horizontal"
+                  className="items-center justify-between"
+                >
+                  <FieldContent>
+                    <FieldLabel className="text-sm">LAN access</FieldLabel>
+                    <FieldDescription>
+                      whether other devices on your network can reach this
+                      gateway
+                    </FieldDescription>
+                  </FieldContent>
+                  <span className="shrink-0 text-sm text-muted-foreground">
+                    {gatewaySetup.info.lan.exposed
+                      ? (gatewaySetup.info.lan.url ?? "exposed")
+                      : "off"}
+                  </span>
+                </Field>
+                <Field
+                  orientation="horizontal"
+                  className="items-center justify-between"
+                >
+                  <FieldContent>
+                    <FieldLabel className="text-sm">remote access</FieldLabel>
+                    <FieldDescription>
+                      secure tunnel address for reaching this gateway from
+                      anywhere
+                    </FieldDescription>
+                  </FieldContent>
+                  <span className="min-w-0 shrink-0 truncate text-sm text-muted-foreground">
+                    {gatewaySetup.info.tunnel_url ?? "—"}
+                  </span>
+                </Field>
+                <Field
+                  orientation="horizontal"
+                  className="items-center justify-between"
+                >
+                  <FieldContent>
+                    <FieldLabel className="text-sm">backups</FieldLabel>
+                    <FieldDescription>
+                      automatic nightly snapshots of your agents
+                    </FieldDescription>
+                  </FieldContent>
+                  <span className="shrink-0 text-sm text-muted-foreground">
+                    {gatewaySetup.settings.auto_backup.enabled
+                      ? `daily at ${String(gatewaySetup.settings.auto_backup.hour).padStart(2, "0")}:00`
+                      : "off"}
+                  </span>
+                </Field>
+              </div>
+            )}
           </MenuSection>
         </CardContent>
       </Card>

--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -179,7 +179,7 @@ export function AppSettings() {
                   className="items-center justify-between"
                 >
                   <FieldContent>
-                    <FieldLabel className="text-sm">LAN access</FieldLabel>
+                    <FieldLabel className="text-sm">lan access</FieldLabel>
                     <FieldDescription>
                       whether other devices on your network can reach this
                       gateway

--- a/apps/web/src/components/Settings/use-gateway-setup.ts
+++ b/apps/web/src/components/Settings/use-gateway-setup.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import {
+  fetchGatewayInfo,
+  fetchGatewaySettings,
+  type GatewayInfo,
+  type GatewaySettings,
+} from "@/api/gateway";
+
+export interface GatewaySetup {
+  info: GatewayInfo;
+  settings: GatewaySettings;
+}
+
+// One-shot read of the daemon's setup for the read-only Gateway "Setup" section.
+// Mirrors useAgentDefaults: `undefined` until both fetches resolve; the section
+// renders nothing until then rather than flashing partial state.
+export function useGatewaySetup(): GatewaySetup | undefined {
+  const [setup, setSetup] = useState<GatewaySetup | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([fetchGatewayInfo(), fetchGatewaySettings()])
+      .then(([info, settings]) => {
+        if (!cancelled) setSetup({ info, settings });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return setup;
+}

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -400,22 +400,22 @@ impl Client {
     }
 
     pub fn get_channel(&self) -> Result<String, String> {
-        let value: serde_json::Value = read_json(self.get("/settings/channel")?)?;
+        let value: serde_json::Value = read_json(self.get("/gateway/settings")?)?;
         require_str(&value, "channel")
     }
 
     pub fn set_channel(&self, channel: &str) -> Result<String, String> {
-        let value: serde_json::Value = read_json(self.put_json("/settings/channel", &serde_json::json!({ "channel": channel }))?)?;
+        let value: serde_json::Value = read_json(self.put_json("/gateway/settings", &serde_json::json!({ "channel": channel }))?)?;
         require_str(&value, "channel")
     }
 
     pub fn get_auto_update(&self) -> Result<bool, String> {
-        let value: serde_json::Value = read_json(self.get("/settings/auto-update")?)?;
+        let value: serde_json::Value = read_json(self.get("/gateway/settings")?)?;
         require_bool(&value, "auto_update")
     }
 
     pub fn set_auto_update(&self, enabled: bool) -> Result<bool, String> {
-        let value: serde_json::Value = read_json(self.put_json("/settings/auto-update", &serde_json::json!({ "auto_update": enabled }))?)?;
+        let value: serde_json::Value = read_json(self.put_json("/gateway/settings", &serde_json::json!({ "auto_update": enabled }))?)?;
         require_bool(&value, "auto_update")
     }
 
@@ -657,11 +657,13 @@ impl Client {
     }
 
     pub fn get_auto_backup_settings(&self) -> Result<serde_json::Value, String> {
-        read_json(self.get("/settings/auto-backup")?)
+        let value: serde_json::Value = read_json(self.get("/gateway/settings")?)?;
+        Ok(value["auto_backup"].clone())
     }
 
     pub fn set_auto_backup_settings(&self, body: &serde_json::Value) -> Result<serde_json::Value, String> {
-        read_json(self.put_json("/settings/auto-backup", body)?)
+        let value: serde_json::Value = read_json(self.put_json("/gateway/settings", &serde_json::json!({ "auto_backup": body }))?)?;
+        Ok(value["auto_backup"].clone())
     }
 
     pub fn list_all_backups(&self) -> Result<Vec<BackupInfo>, String> {

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -419,6 +419,14 @@ impl Client {
         require_bool(&value, "auto_update")
     }
 
+    pub fn get_gateway_settings(&self) -> Result<serde_json::Value, String> {
+        read_json(self.get("/gateway/settings")?)
+    }
+
+    pub fn get_gateway_info(&self) -> Result<serde_json::Value, String> {
+        read_json(self.get("/gateway/info")?)
+    }
+
     pub fn list_agents(&self) -> Result<Vec<ListEntry>, String> {
         read_json(self.get("/agents")?)
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1186,14 +1186,14 @@ fn run(cli: Cli) {
 
                 let lan = &info["lan"];
                 let lan_line = if lan["exposed"].as_bool().unwrap_or(false) {
-                    format!("exposed at {}", lan["url"].as_str().unwrap_or("unknown"))
+                    format!("enabled at {}", lan["url"].as_str().unwrap_or("unknown"))
                 } else {
-                    "off".to_string()
+                    "disabled".to_string()
                 };
                 eprintln!("lan:          {lan_line}");
                 eprintln!("tunnel:       {}", info["tunnel_url"].as_str().unwrap_or("—"));
                 eprintln!("port:         {}", info["port"].as_u64().unwrap_or(0));
-                eprintln!("auto-update:  {}", if settings["auto_update"].as_bool().unwrap_or(false) { "on" } else { "off" });
+                eprintln!("auto-update:  {}", if settings["auto_update"].as_bool().unwrap_or(false) { "enabled" } else { "disabled" });
                 eprintln!("channel:      {}", settings["channel"].as_str().unwrap_or("stable"));
 
                 let backup = &settings["auto_backup"];
@@ -1202,7 +1202,7 @@ fn run(cli: Cli) {
                     eprintln!("backups:      daily at {hour:02}:00");
                     print_retention(&backup["retention"]);
                 } else {
-                    eprintln!("backups:      off");
+                    eprintln!("backups:      disabled");
                 }
             }
         },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -240,6 +240,8 @@ enum Command {
 enum GatewayAction {
     /// Restart the remote vestad daemon
     Restart,
+    /// Show the gateway setup: LAN, tunnel, port, auto-update, channel, backups
+    Info,
     /// Stream vestad logs from the remote gateway
     Logs {
         /// Number of lines to show initially
@@ -1176,6 +1178,32 @@ fn run(cli: Cli) {
             GatewayAction::Logs { tail, follow } => {
                 let c = get_client(host_ref, token_ref);
                 c.stream_gateway_logs(tail, follow).unwrap_or_else(|e| platform::die(&e));
+            }
+            GatewayAction::Info => {
+                let c = get_client(host_ref, token_ref);
+                let settings = c.get_gateway_settings().unwrap_or_else(|e| platform::die(&e));
+                let info = c.get_gateway_info().unwrap_or_else(|e| platform::die(&e));
+
+                let lan = &info["lan"];
+                let lan_line = if lan["exposed"].as_bool().unwrap_or(false) {
+                    format!("exposed at {}", lan["url"].as_str().unwrap_or("unknown"))
+                } else {
+                    "off".to_string()
+                };
+                eprintln!("lan:          {lan_line}");
+                eprintln!("tunnel:       {}", info["tunnel_url"].as_str().unwrap_or("—"));
+                eprintln!("port:         {}", info["port"].as_u64().unwrap_or(0));
+                eprintln!("auto-update:  {}", if settings["auto_update"].as_bool().unwrap_or(false) { "on" } else { "off" });
+                eprintln!("channel:      {}", settings["channel"].as_str().unwrap_or("stable"));
+
+                let backup = &settings["auto_backup"];
+                if backup["enabled"].as_bool().unwrap_or(false) {
+                    let hour = backup["hour"].as_u64().unwrap_or(0);
+                    eprintln!("backups:      daily at {hour:02}:00");
+                    print_retention(&backup["retention"]);
+                } else {
+                    eprintln!("backups:      off");
+                }
             }
         },
 

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -518,7 +518,7 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
                 port,
                 dev_mode,
                 expose_lan,
-                lan_url,
+                lan_url.clone(),
                 tunnel_status,
             );
             status.persist(&config);
@@ -572,6 +572,7 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
                 docker: docker.clone(),
                 dev_mode,
                 expose_lan,
+                lan_url,
             }).await;
 
             if let Some(supervisor) = tunnel_supervisor {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -161,6 +161,11 @@ pub struct AppState {
     dev_mode: bool,
     pub(crate) agent_status_cache: Arc<agent_status::AgentStatusCache>,
     pub(crate) https_port: u16,
+    /// LAN exposure facts captured at startup (read-only; surfaced by /gateway/info).
+    /// `expose_lan` mirrors the `--expose-lan` flag; `lan_url` is the advertised
+    /// `https://<lan-ip>:<port>` (only set when exposed and an IP was resolvable).
+    expose_lan: bool,
+    lan_url: Option<String>,
     /// Coarse, in-flight build phase per agent, keyed by normalized name. Written
     /// by the create handler as `create_agent` progresses and read by the
     /// build-phase endpoint so onboarding shows honest status. Entries exist only
@@ -169,7 +174,16 @@ pub struct AppState {
 }
 
 impl AppState {
-    fn new(api_key: String, env_config: docker::AgentEnvConfig, docker: bollard::Docker, tunnel_url: Option<String>, dev_mode: bool, https_port: u16) -> Self {
+    fn new(
+        api_key: String,
+        env_config: docker::AgentEnvConfig,
+        docker: bollard::Docker,
+        tunnel_url: Option<String>,
+        dev_mode: bool,
+        https_port: u16,
+        expose_lan: bool,
+        lan_url: Option<String>,
+    ) -> Self {
         let settings = load_settings();
         // Restore the refresh-token registry from disk (dropping expired families)
         // so a restart/self-update doesn't log everyone out. Read before `env_config`
@@ -190,6 +204,8 @@ impl AppState {
             dev_mode,
             agent_status_cache: Arc::new(agent_status::AgentStatusCache::new()),
             https_port,
+            expose_lan,
+            lan_url,
             build_phases: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
@@ -439,17 +455,6 @@ async fn gateway_update_handler(
         Err(e) => Err(err_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string())),
     }
 }
-
-async fn tunnel_handler(
-    State(state): State<SharedState>,
-) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    let url = state.tunnel_url.lock().await;
-    match url.as_ref() {
-        Some(tunnel_url) => Ok(Json(serde_json::json!({"tunnel_url": tunnel_url}))),
-        None => Err(err_response(StatusCode::NOT_FOUND, "no tunnel configured")),
-    }
-}
-
 
 async fn list_agents_handler(
     State(state): State<SharedState>,
@@ -1848,6 +1853,23 @@ async fn put_gateway_settings_handler(
     Ok(Json(gateway_settings_json(&settings, channel.as_str())))
 }
 
+// --- Read-only gateway info ---
+
+/// Read-only daemon reachability facts surfaced by GET /gateway/info. Pure so the
+/// wire shape is unit-testable without constructing AppState.
+fn gateway_info_json(expose_lan: bool, lan_url: &Option<String>, tunnel_url: &Option<String>, port: u16) -> serde_json::Value {
+    serde_json::json!({
+        "lan": { "exposed": expose_lan, "url": lan_url },
+        "tunnel_url": tunnel_url,
+        "port": port,
+    })
+}
+
+async fn gateway_info_handler(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    let tunnel_url = state.tunnel_url.lock().await.clone();
+    Json(gateway_info_json(state.expose_lan, &state.lan_url, &tunnel_url, state.https_port))
+}
+
 // --- Per-agent settings ---
 
 async fn get_agent_settings_handler(
@@ -2040,7 +2062,7 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/version/check", post(version_check))
         .route("/gateway/update", post(gateway_update_handler))
         .route("/gateway/restart", post(restart_gateway_handler))
-        .route("/tunnel", get(tunnel_handler))
+        .route("/gateway/info", get(gateway_info_handler))
         .route("/providers/claude/oauth/start", post(crate::providers::claude::oauth_start_handler))
         .route("/providers/claude/oauth/complete", post(crate::providers::claude::oauth_complete_handler))
         .route("/providers/openrouter/models/top", get(crate::providers::openrouter::list_top_models_handler))
@@ -2354,6 +2376,7 @@ pub struct ServerConfig {
     pub docker: bollard::Docker,
     pub dev_mode: bool,
     pub expose_lan: bool,
+    pub lan_url: Option<String>,
 }
 
 pub async fn run_server(cfg: ServerConfig) {
@@ -2368,6 +2391,7 @@ pub async fn run_server(cfg: ServerConfig) {
         docker,
         dev_mode,
         expose_lan,
+        lan_url,
     } = cfg;
     let agents_dir = config_dir.join("agents");
     let env_config = docker::AgentEnvConfig {
@@ -2389,7 +2413,7 @@ pub async fn run_server(cfg: ServerConfig) {
         tracing::error!(error = %e, "failed to ensure agent code");
     }
     let agent_settings = load_settings().agents.clone();
-    let state = Arc::new(AppState::new(api_key, env_config, docker.clone(), tunnel_url, dev_mode, port));
+    let state = Arc::new(AppState::new(api_key, env_config, docker.clone(), tunnel_url, dev_mode, port, expose_lan, lan_url));
     // Reconcile in the background so the API serves immediately: a rebuild (entrypoint/mount change)
     // snapshots each container's filesystem (minutes), and awaiting it would leave vestad unreachable.
     let reconcile_docker = docker.clone();
@@ -2799,5 +2823,24 @@ mod gateway_settings_tests {
         assert_eq!(backup.hour, original_hour, "hour absent in body must be unchanged");
         assert_eq!(backup.retention.daily, 9, "daily should be updated");
         assert_eq!(backup.retention.weekly, default_retention().weekly, "weekly absent must be unchanged");
+    }
+
+    #[test]
+    fn info_json_reports_lan_tunnel_and_port() {
+        let exposed = gateway_info_json(
+            true,
+            &Some("https://192.168.1.4:7777".to_string()),
+            &Some("https://x.trycloudflare.com".to_string()),
+            7777,
+        );
+        assert_eq!(exposed["lan"]["exposed"], serde_json::json!(true));
+        assert_eq!(exposed["lan"]["url"], serde_json::json!("https://192.168.1.4:7777"));
+        assert_eq!(exposed["tunnel_url"], serde_json::json!("https://x.trycloudflare.com"));
+        assert_eq!(exposed["port"], serde_json::json!(7777));
+
+        let off = gateway_info_json(false, &None, &None, 7777);
+        assert_eq!(off["lan"]["exposed"], serde_json::json!(false));
+        assert_eq!(off["lan"]["url"], serde_json::Value::Null);
+        assert_eq!(off["tunnel_url"], serde_json::Value::Null);
     }
 }

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1717,18 +1717,39 @@ async fn delete_backup_handler(
 
 // --- Auto-backup settings ---
 
-/// The `{enabled, hour, retention}` body the global auto-backup GET/PUT both return.
-fn auto_backup_json(backup: &BackupGlobalSettings) -> Json<serde_json::Value> {
-    Json(serde_json::json!({ "enabled": backup.enabled, "hour": backup.hour, "retention": backup.retention }))
+/// The unified settings view returned by GET/PUT /gateway/settings. Single owner of
+/// the daemon-settings wire shape, shared by both handlers.
+fn gateway_settings_json(settings: &Settings, channel: &str) -> serde_json::Value {
+    serde_json::json!({
+        "auto_update": settings.auto_update,
+        "channel": channel,
+        "auto_backup": {
+            "enabled": settings.backup.enabled,
+            "hour": settings.backup.hour,
+            "retention": settings.backup.retention,
+        },
+    })
+}
+
+/// Apply a sparse backup update in place. Validation (retention floor, hour range)
+/// runs in the handler before this is called.
+fn apply_backup_update(backup: &mut BackupGlobalSettings, body: &SetBackupSettingsBody) {
+    if let Some(enabled) = body.enabled {
+        backup.enabled = enabled;
+    }
+    if let Some(hour) = body.hour {
+        backup.hour = hour;
+    }
+    if let Some(ref ret) = body.retention {
+        if let Some(d) = ret.daily { backup.retention.daily = d; }
+        if let Some(w) = ret.weekly { backup.retention.weekly = w; }
+        if let Some(m) = ret.monthly { backup.retention.monthly = m; }
+    }
 }
 
 /// The `{enabled, retention, has_override}` body the per-agent backup GET/PUT/DELETE all return.
 fn agent_backup_json(enabled: bool, retention: crate::types::RetentionPolicy, has_override: bool) -> Json<serde_json::Value> {
     Json(serde_json::json!({ "enabled": enabled, "retention": retention, "has_override": has_override }))
-}
-
-async fn get_auto_backup_handler(State(state): State<SharedState>) -> Json<serde_json::Value> {
-    auto_backup_json(&state.settings.read().await.backup)
 }
 
 #[derive(Deserialize)]
@@ -1758,104 +1779,73 @@ fn validate_retention(update: &RetentionUpdate) -> Result<(), (StatusCode, Json<
     Ok(())
 }
 
-async fn set_auto_backup_handler(
+// --- Unified gateway settings ---
+
+#[derive(Deserialize)]
+struct UpdateSettingsBody {
+    auto_update: Option<bool>,
+    channel: Option<String>,
+    auto_backup: Option<SetBackupSettingsBody>,
+}
+
+async fn get_gateway_settings_handler(State(state): State<SharedState>) -> Json<serde_json::Value> {
+    let settings = state.settings.read().await;
+    let channel = crate::channel::Channel::resolve(&settings.channel);
+    Json(gateway_settings_json(&settings, channel.as_str()))
+}
+
+async fn put_gateway_settings_handler(
     State(state): State<SharedState>,
-    Json(body): Json<SetBackupSettingsBody>,
+    Json(body): Json<UpdateSettingsBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    if let Some(ref ret) = body.retention {
-        validate_retention(ret)?;
+    if let Some(ref backup) = body.auto_backup {
+        if let Some(ref ret) = backup.retention {
+            validate_retention(ret)?;
+        }
+        if let Some(hour) = backup.hour {
+            if hour > 23 {
+                return Err(err_response(StatusCode::BAD_REQUEST, "hour must be 0-23"));
+            }
+        }
+    }
+    let parsed_channel = match body.channel {
+        Some(ref c) => Some(
+            crate::channel::Channel::parse(c)
+                .ok_or_else(|| err_response(StatusCode::BAD_REQUEST, "channel must be 'stable' or 'beta'"))?,
+        ),
+        None => None,
+    };
+
+    {
+        let mut settings = state.settings.write().await;
+        if let Some(auto_update) = body.auto_update {
+            settings.auto_update = auto_update;
+            tracing::info!(auto_update, "auto-update setting updated");
+        }
+        if let Some(channel) = parsed_channel {
+            settings.channel = channel.as_str().to_string();
+            tracing::info!(channel = channel.as_str(), "release channel updated");
+        }
+        if let Some(ref backup) = body.auto_backup {
+            apply_backup_update(&mut settings.backup, backup);
+            tracing::info!("auto-backup settings updated");
+        }
+        save_settings(&settings);
     }
 
-    if let Some(hour) = body.hour {
-        if hour > 23 {
-            return Err(err_response(StatusCode::BAD_REQUEST, "hour must be 0-23"));
+    // A channel switch must refresh the cached update info so /version reflects the new
+    // channel without waiting for the next periodic poll (mirrors the old channel handler).
+    if let Some(channel) = parsed_channel {
+        match tokio::task::spawn_blocking(move || update_check::check_once(channel)).await {
+            Ok(Ok(info)) => *state.update_info.lock().await = Some(info),
+            Ok(Err(e)) => tracing::warn!("update check after channel switch failed: {}", e),
+            Err(e) => tracing::error!("update check task after channel switch failed: {}", e),
         }
     }
 
-    let mut settings = state.settings.write().await;
-
-    if let Some(enabled) = body.enabled {
-        settings.backup.enabled = enabled;
-        tracing::info!(enabled, "auto-backup toggled");
-    }
-
-    if let Some(hour) = body.hour {
-        settings.backup.hour = hour;
-        tracing::info!(hour, "auto-backup hour updated");
-    }
-
-    if let Some(ret) = body.retention {
-        if let Some(d) = ret.daily { settings.backup.retention.daily = d; }
-        if let Some(w) = ret.weekly { settings.backup.retention.weekly = w; }
-        if let Some(m) = ret.monthly { settings.backup.retention.monthly = m; }
-        tracing::info!(
-            daily = settings.backup.retention.daily,
-            weekly = settings.backup.retention.weekly,
-            monthly = settings.backup.retention.monthly,
-            "backup retention updated"
-        );
-    }
-
-    save_settings(&settings);
-
-    Ok(auto_backup_json(&settings.backup))
-}
-
-// --- Release channel ---
-
-async fn get_channel_handler(State(state): State<SharedState>) -> Json<serde_json::Value> {
-    Json(serde_json::json!({ "channel": effective_channel(&state).await.as_str() }))
-}
-
-#[derive(Deserialize)]
-struct SetChannelBody {
-    channel: String,
-}
-
-async fn set_channel_handler(
-    State(state): State<SharedState>,
-    Json(body): Json<SetChannelBody>,
-) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    let channel = crate::channel::Channel::parse(&body.channel)
-        .ok_or_else(|| err_response(StatusCode::BAD_REQUEST, "channel must be 'stable' or 'beta'"))?;
-    {
-        let mut settings = state.settings.write().await;
-        settings.channel = channel.as_str().to_string();
-        save_settings(&settings);
-    }
-    tracing::info!(channel = channel.as_str(), "release channel updated");
-    // Refresh the cached update info against the new channel so /version reflects it
-    // without waiting for the next periodic poll.
-    match tokio::task::spawn_blocking(move || update_check::check_once(channel)).await {
-        Ok(Ok(info)) => *state.update_info.lock().await = Some(info),
-        Ok(Err(e)) => tracing::warn!("update check after channel switch failed: {}", e),
-        Err(e) => tracing::error!("update check task after channel switch failed: {}", e),
-    }
-    Ok(Json(serde_json::json!({ "channel": effective_channel(&state).await.as_str() })))
-}
-
-// --- Auto-update ---
-
-async fn get_auto_update_handler(State(state): State<SharedState>) -> Json<serde_json::Value> {
-    Json(serde_json::json!({ "auto_update": state.settings.read().await.auto_update }))
-}
-
-#[derive(Deserialize)]
-struct SetAutoUpdateBody {
-    auto_update: bool,
-}
-
-async fn set_auto_update_handler(
-    State(state): State<SharedState>,
-    Json(body): Json<SetAutoUpdateBody>,
-) -> Json<serde_json::Value> {
-    {
-        let mut settings = state.settings.write().await;
-        settings.auto_update = body.auto_update;
-        save_settings(&settings);
-    }
-    tracing::info!(auto_update = body.auto_update, "auto-update setting updated");
-    Json(serde_json::json!({ "auto_update": body.auto_update }))
+    let settings = state.settings.read().await;
+    let channel = crate::channel::Channel::resolve(&settings.channel);
+    Ok(Json(gateway_settings_json(&settings, channel.as_str())))
 }
 
 // --- Per-agent settings ---
@@ -2085,12 +2075,7 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/agents/{name}/settings/backup", get(get_agent_backup_settings_handler))
         .route("/agents/{name}/settings/backup", axum::routing::put(set_agent_backup_settings_handler))
         .route("/agents/{name}/settings/backup", axum::routing::delete(delete_agent_backup_settings_handler))
-        .route("/settings/auto-backup", get(get_auto_backup_handler))
-        .route("/settings/auto-backup", axum::routing::put(set_auto_backup_handler))
-        .route("/settings/channel", get(get_channel_handler))
-        .route("/settings/channel", axum::routing::put(set_channel_handler))
-        .route("/settings/auto-update", get(get_auto_update_handler))
-        .route("/settings/auto-update", axum::routing::put(set_auto_update_handler))
+        .route("/gateway/settings", get(get_gateway_settings_handler).put(put_gateway_settings_handler))
         .layer(control_timeout_layer())
         .layer(middleware::from_fn_with_state(
             state.clone(),
@@ -2782,5 +2767,37 @@ mod tests {
             "\n\nAPI contract fixtures are stale.\nRegenerate with:\n  cd vestad && REGEN_API_FIXTURES=1 cargo test -p vestad api_contract\nthen commit {}\n",
             path.display()
         );
+    }
+}
+
+#[cfg(test)]
+mod gateway_settings_tests {
+    use super::*;
+
+    #[test]
+    fn settings_json_has_unified_shape() {
+        let settings = Settings::default();
+        let value = gateway_settings_json(&settings, "beta");
+        assert_eq!(value["auto_update"], serde_json::json!(true));
+        assert_eq!(value["channel"], serde_json::json!("beta"));
+        assert_eq!(value["auto_backup"]["enabled"], serde_json::json!(true));
+        assert_eq!(value["auto_backup"]["hour"], serde_json::json!(DEFAULT_AUTO_BACKUP_HOUR));
+        assert_eq!(value["auto_backup"]["retention"]["daily"], serde_json::json!(backup::DEFAULT_RETENTION_DAILY));
+    }
+
+    #[test]
+    fn backup_update_applies_only_present_fields() {
+        let mut backup = BackupGlobalSettings::default();
+        let original_hour = backup.hour;
+        let body = SetBackupSettingsBody {
+            enabled: Some(false),
+            hour: None,
+            retention: Some(RetentionUpdate { daily: Some(9), weekly: None, monthly: None }),
+        };
+        apply_backup_update(&mut backup, &body);
+        assert!(!backup.enabled, "enabled should be updated");
+        assert_eq!(backup.hour, original_hour, "hour absent in body must be unchanged");
+        assert_eq!(backup.retention.daily, 9, "daily should be updated");
+        assert_eq!(backup.retention.weekly, default_retention().weekly, "weekly absent must be unchanged");
     }
 }

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -174,6 +174,10 @@ pub struct AppState {
 }
 
 impl AppState {
+    // Private, single-call startup constructor: its params mirror the fields of
+    // ServerConfig (the caller), so grouping them into a param struct would just
+    // duplicate that type. Allow the arg count rather than add a redundant struct.
+    #[allow(clippy::too_many_arguments)]
     fn new(
         api_key: String,
         env_config: docker::AgentEnvConfig,


### PR DESCRIPTION
## What

Two related changes to how the `vestad` daemon's own configuration is exposed and viewed.

**1. Unify the settings API.** Collapses the three sibling endpoints into one:

- `GET /gateway/settings` → `{ auto_update, channel, auto_backup: { enabled, hour, retention } }`
- `PUT /gateway/settings` → sparse partial update, returns the full object

Replaces (hard break) `GET/PUT /settings/auto-update`, `/settings/channel`, `/settings/auto-backup`. All callers moved: web `ConnectionControls` toggles and the CLI `channel`/`auto-update`/`backup` commands.

**2. Read-only setup view.** New `GET /gateway/info` → `{ lan: { exposed, url }, tunnel_url, port }` (absorbs and replaces the standalone `GET /tunnel`). Surfaced read-only in two places:

- **App** — a "Setup" section in the Gateway card showing LAN access, remote-access tunnel, and backup schedule (auto-update/channel already have toggles there, so not duplicated).
- **CLI** — `vesta gateway info` prints the full setup (LAN, tunnel, port, auto-update, channel, backups).

Editing LAN/etc. from the app/CLI is intentionally out of scope (deferred — LAN is a startup-only flag today).

## API changes

| Endpoint | Change |
|---|---|
| `GET/PUT /gateway/settings` | **new** (unified) |
| `GET /gateway/info` | **new** (read-only lan/tunnel/port) |
| `/settings/auto-update`, `/settings/channel`, `/settings/auto-backup` | **removed** |
| `/tunnel` | **removed** (data now in `/gateway/info`) |
| `/info` (public `managed` probe) | unchanged — still pre-auth for the connect flow |

## Notes

- `/info` stays a public, pre-auth probe (the connect screen reads `managed` before the user has a key), so `managed` is **not** folded into the authed `/gateway/info`.
- `expose_lan`/`lan_url` are threaded from startup into `AppState` so `/gateway/info` can serve them.

## Testing

- ✅ **cli** — `./check.sh cli` (clippy + 21 tests)
- ✅ **web** — `./check.sh web` (eslint, prettier, tsc, 92 vitest tests)
- ⏳ **vestad** — Linux-only; not runnable on the author's macOS host, gated by CI. New pure-function unit tests added (`gateway_settings_json`, `apply_backup_update`, `gateway_info_json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)