### PR TITLE
fix(vestad): keep idle websockets alive with server-side pings

### DIFF
--- a/vestad/src/agent_proxy.rs
+++ b/vestad/src/agent_proxy.rs
@@ -13,7 +13,7 @@ use tokio::time::Instant;
 
 use crate::auth;
 use crate::docker;
-use crate::serve::{ServiceEntry, SharedState, err_response, map_docker_err, PROXY_MAX_BODY_BYTES};
+use crate::serve::{ServiceEntry, SharedState, err_response, map_docker_err, PROXY_MAX_BODY_BYTES, WS_KEEPALIVE_INTERVAL_SECS};
 
 // When a freshly-registered service is still binding its port (e.g. `vite preview`
 // takes a couple of seconds), wait briefly for the upstream to start accepting
@@ -174,8 +174,8 @@ async fn ws_proxy(client_ws: axum::extract::ws::WebSocket, agent_port: u16, path
 
     tracing::info!(port = agent_port, "client websocket connected");
 
-    let (mut client_tx, mut client_rx) = client_ws.split();
-    let (mut agent_tx, mut agent_rx) = agent_ws.split();
+    let (client_tx, mut client_rx) = client_ws.split();
+    let (mut agent_tx, agent_rx) = agent_ws.split();
 
     let client_to_agent = async {
         while let Some(Ok(msg)) = client_rx.next().await {
@@ -192,28 +192,59 @@ async fn ws_proxy(client_ws: axum::extract::ws::WebSocket, agent_port: u16, path
         }
     };
 
-    let agent_to_client = async {
-        while let Some(Ok(msg)) = agent_rx.next().await {
-            let axum_msg = match msg {
-                TungMsg::Text(t) => AxumMsg::Text(t.as_str().into()),
-                TungMsg::Binary(b) => AxumMsg::Binary(b),
-                TungMsg::Ping(p) => AxumMsg::Ping(p),
-                TungMsg::Pong(p) => AxumMsg::Pong(p),
-                TungMsg::Close(_) => break,
-                _ => continue,
-            };
-            if client_tx.send(axum_msg).await.is_err() {
-                break;
-            }
-        }
-    };
-
+    let keepalive = Duration::from_secs(WS_KEEPALIVE_INTERVAL_SECS);
     tokio::select! {
         _ = client_to_agent => {},
-        _ = agent_to_client => {},
+        _ = pump_agent_to_client(client_tx, agent_rx, keepalive) => {},
     }
 
     tracing::info!(port = agent_port, "client websocket disconnected");
+}
+
+/// Forward agent frames to the client, and ping the client every `keepalive` when otherwise
+/// idle so the Cloudflare tunnel never sees the socket as idle and reaps it (~100s window).
+/// Only the client hop is tunneled, so only it needs keepalive; the agent hop is local.
+/// Returns when the agent stream ends/closes or the client send fails. Generic over the
+/// sink/stream so it can be exercised in-process with in-memory streams (see tests).
+async fn pump_agent_to_client<ClientSink, AgentStream, AgentErr>(
+    mut client_tx: ClientSink,
+    mut agent_rx: AgentStream,
+    keepalive: Duration,
+) where
+    ClientSink: futures_util::Sink<axum::extract::ws::Message> + Unpin,
+    AgentStream:
+        futures_util::Stream<Item = Result<tokio_tungstenite::tungstenite::Message, AgentErr>> + Unpin,
+{
+    use axum::extract::ws::Message as AxumMsg;
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::Message as TungMsg;
+
+    let mut ticker = tokio::time::interval(keepalive);
+    ticker.tick().await; // the first tick is immediate; drop it so the first ping waits a full interval
+
+    loop {
+        tokio::select! {
+            agent_msg = agent_rx.next() => {
+                let Some(Ok(msg)) = agent_msg else { break };
+                let axum_msg = match msg {
+                    TungMsg::Text(t) => AxumMsg::Text(t.as_str().into()),
+                    TungMsg::Binary(b) => AxumMsg::Binary(b),
+                    TungMsg::Ping(p) => AxumMsg::Ping(p),
+                    TungMsg::Pong(p) => AxumMsg::Pong(p),
+                    TungMsg::Close(_) => break,
+                    _ => continue,
+                };
+                if client_tx.send(axum_msg).await.is_err() {
+                    break;
+                }
+            }
+            _ = ticker.tick() => {
+                if client_tx.send(AxumMsg::Ping(Default::default())).await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
 }
 
 async fn forward_http_to_container(
@@ -275,11 +306,74 @@ async fn forward_http_to_container(
 
 #[cfg(test)]
 mod tests {
-    use super::{split_service_subpath, wait_for_upstream};
+    use super::{pump_agent_to_client, split_service_subpath, wait_for_upstream};
+    use axum::extract::ws::Message as AxumMsg;
+    use futures_util::stream;
+    use std::convert::Infallible;
     use std::net::Ipv4Addr;
     use std::time::Duration;
     use tokio::net::TcpListener;
     use tokio::time::Instant;
+    use tokio_tungstenite::tungstenite::Message as TungMsg;
+
+    /// A `Sink<AxumMsg>` that records every frame to an unbounded channel, so a test can
+    /// observe exactly what the pump sent to the client.
+    fn recording_client_sink() -> (
+        impl futures_util::Sink<AxumMsg, Error = ()> + Unpin,
+        tokio::sync::mpsc::UnboundedReceiver<AxumMsg>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let sink = futures_util::sink::unfold(tx, |tx, msg: AxumMsg| async move {
+            tx.send(msg).map_err(|_| ())?;
+            Ok(tx)
+        });
+        (Box::pin(sink), rx)
+    }
+
+    #[tokio::test]
+    async fn idle_connection_pings_the_client_every_interval() {
+        let (sink, mut rx) = recording_client_sink();
+        // Agent never speaks: the only frames the client can receive are keepalive pings.
+        let agent_rx = stream::pending::<Result<TungMsg, Infallible>>();
+
+        let keepalive = Duration::from_millis(100);
+        let pump = tokio::spawn(pump_agent_to_client(sink, agent_rx, keepalive));
+
+        let start = Instant::now();
+        let first = rx.recv().await.expect("first keepalive ping");
+        let second = rx.recv().await.expect("second keepalive ping");
+        assert!(matches!(first, AxumMsg::Ping(_)), "expected a ping, got {first:?}");
+        assert!(matches!(second, AxumMsg::Ping(_)), "expected a ping, got {second:?}");
+        // First ping waits a full interval (the immediate tick is dropped), two pings ~= 2 intervals.
+        let elapsed = start.elapsed();
+        assert!(elapsed >= keepalive, "first ping fired too early: {elapsed:?}");
+        assert!(elapsed < keepalive * 6, "pings too slow: {elapsed:?}");
+
+        pump.abort();
+    }
+
+    #[tokio::test]
+    async fn agent_close_ends_the_pump() {
+        let (sink, mut rx) = recording_client_sink();
+        let agent_rx = stream::iter([Ok::<_, Infallible>(TungMsg::Close(None))]);
+
+        // A long keepalive guarantees the pump returns because of the Close, not a tick.
+        pump_agent_to_client(sink, agent_rx, Duration::from_secs(3600)).await;
+
+        // The Close is consumed (not forwarded) and the pump has returned, so the channel is empty/closed.
+        assert!(rx.try_recv().is_err(), "Close frame should not be forwarded to the client");
+    }
+
+    #[tokio::test]
+    async fn agent_text_is_forwarded_to_the_client() {
+        let (sink, mut rx) = recording_client_sink();
+        let agent_rx = stream::iter([Ok::<_, Infallible>(TungMsg::Text("hello".into()))]);
+
+        pump_agent_to_client(sink, agent_rx, Duration::from_secs(3600)).await;
+
+        let forwarded = rx.try_recv().expect("text frame forwarded");
+        assert!(matches!(forwarded, AxumMsg::Text(ref t) if t.as_str() == "hello"), "got {forwarded:?}");
+    }
 
     #[test]
     fn splits_service_name_from_forwarded_subpath() {

--- a/vestad/src/control_ws.rs
+++ b/vestad/src/control_ws.rs
@@ -7,8 +7,10 @@ use axum::{
     Json,
 };
 
+use std::time::Duration;
+
 use crate::docker;
-use crate::serve::{ServiceEntry, SharedState, err_response, ok_json};
+use crate::serve::{ServiceEntry, SharedState, err_response, ok_json, WS_KEEPALIVE_INTERVAL_SECS};
 
 pub async fn invalidate_service_handler(
     State(state): State<SharedState>,
@@ -112,7 +114,11 @@ async fn control_ws_session(state: SharedState, socket: axum::extract::ws::WebSo
         return;
     }
 
-    // 3. Event loop
+    // 3. Event loop. The ping keeps an idle socket alive through the Cloudflare tunnel, which
+    // reaps connections silent for ~100s; without it an idle client is dropped and forced to
+    // reconnect, which tears the whole app tree down and back up.
+    let mut keepalive = tokio::time::interval(Duration::from_secs(WS_KEEPALIVE_INTERVAL_SECS));
+    keepalive.tick().await; // the first tick is immediate; drop it so the first ping waits a full interval
     loop {
         tokio::select! {
             result = agents_rx.changed() => { if result.is_err() { break; } }
@@ -124,6 +130,10 @@ async fn control_ws_session(state: SharedState, socket: axum::extract::ws::WebSo
                     Some(Ok(Message::Close(_))) | None => break,
                     _ => { continue; }
                 }
+            }
+            _ = keepalive.tick() => {
+                if tx.send(Message::Ping(Default::default())).await.is_err() { break; }
+                continue;
             }
         }
 

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -31,6 +31,12 @@ const LONGRUN_REQUEST_TIMEOUT_SECS: u64 = 1800;
 const API_KEY_BYTES: usize = 32;
 pub(crate) const PROXY_MAX_BODY_BYTES: usize = 10 * 1024 * 1024; // 10 MB
 
+// Server-originated WebSocket ping cadence for the control (`/ws`) and agent-proxy
+// (`/agents/{name}/ws`) sockets. Idle connections through the Cloudflare tunnel are reaped
+// by the edge after ~100s of silence; a periodic ping keeps frames flowing so the socket
+// survives an idle client. Must stay comfortably under that window.
+pub(crate) const WS_KEEPALIVE_INTERVAL_SECS: u64 = 30;
+
 const RESERVED_SERVICE_NAMES: &[&str] = &[
     "start", "stop", "restart", "destroy", "rebuild",
     "auth", "logs", "tree", "file", "backups", "settings", "services",


### PR DESCRIPTION
## Problem

On an idle client, the app's connection to vestad cycles connect → disconnect → reconnect roughly every ~2 minutes (sometimes faster). The gateway logs show repeated `client websocket connected` / `client websocket disconnected` for the agent port, each followed by a full `/version` → `/info` → `/ws` → `/agents/{name}/ws` reconnect burst.

## Root cause

There is **no application-level WebSocket keepalive anywhere** — not in `control_ws_session` (`/ws`), not in `ws_proxy` (`/agents/{name}/ws`), and not in the web client (`reconnecting-ws.ts` reconnects but never pings). The remote `vesta connect` path runs through the **Cloudflare tunnel** (`tunnel.rs` + `cloudflared`), and Cloudflare's edge reaps a WebSocket that goes idle for ~100s. With zero frames flowing on an idle connection, the socket is dropped at ~100s — matching the ~110–127s outer interval in the logs.

The `/version` HTTP poll every 60s does not help: it's a separate HTTP request and puts no traffic on the WS.

Each control-`/ws` drop flips `GatewayProvider` to `reachable = false`, which tears the whole provider tree down and re-establishes every socket — that cascade is the full reconnect burst (and the shorter 9–20s child-socket churn) seen in the logs.

## Fix

Send a **server-originated `Ping` every 30s** on both sockets so an idle connection keeps frames flowing and survives the edge idle window; the browser auto-responds with a pong. Server-side is the right layer: browsers' `WebSocket` API can't originate ping frames from JS, and this fixes every client (web, CLI, mobile) from one place.

- `serve.rs` — single shared `WS_KEEPALIVE_INTERVAL_SECS = 30` const.
- `agent_proxy.rs` — extract the client-bound half of the bridge into `pump_agent_to_client()`, which pings the client when idle. Only the tunneled client hop is pinged (the agent hop is local). The concurrent two-halves bridge design is preserved.
- `control_ws.rs` — add the same ticker arm to the `/ws` `select!` loop.

This is the standard, root-cause fix (RFC 6455 ping/pong is exactly for keeping long-lived connections alive through intermediaries), not a workaround.

## Tests

`pump_agent_to_client` is generic over its sink/stream so it's unit-testable in-process (`cargo test -p vestad --bins`):
- idle agent stream → client receives a `Ping` every interval
- agent `Close` → pump returns, Close not forwarded
- agent text frame → forwarded to client

The keepalive logic was additionally verified against the exact `axum 0.8` / `tokio-tungstenite 0.29` deps in a standalone repro (all three tests green) since `vestad` is Linux-only and can't compile on macOS. Full `./check.sh vestad` + `./check.sh integration` run in CI.

## Not included (separate follow-up)

The reconnect **cascade** — a single control-`/ws` drop unmounting the whole tree — is a latent fragility independent of keepalive. The ping makes drops rare so it fires rarely; left as a deliberate follow-up to revisit only if disruptive reconnects persist (e.g. around sleep / network changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)