### PR TITLE
refactor(agent): drop the stdin input_handler and aioconsole dependency

### DIFF
--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -1,14 +1,12 @@
 """Vesta main entry point and orchestration."""
 
 import asyncio
-import errno
 import os
 import signal
 import tomllib
 import types
 import typing as tp
 
-import aioconsole
 from rich import print_json
 
 from . import models as vm
@@ -24,38 +22,6 @@ from .loops import (
 )
 from .default_skills import reconcile_default_skills
 from .migrations import drop_pending_migrations
-
-
-async def input_handler(queue: asyncio.Queue[tuple[str, bool, list[str]]], *, state: vm.State) -> None:
-    while not state.shutdown_event.is_set():
-        try:
-            user_msg = await aioconsole.ainput("")
-            if state.shutdown_event.is_set():
-                break
-            if not user_msg.strip():
-                continue
-
-            logger.user(user_msg.strip())
-            await queue.put((user_msg.strip(), True, []))
-        except KeyboardInterrupt:
-            logger.shutdown("stdin: KeyboardInterrupt, shutting down")
-            state.shutdown_event.set()
-            break
-        except EOFError:
-            logger.shutdown("stdin: EOF (no TTY?), shutting down")
-            state.shutdown_event.set()
-            break
-        except asyncio.CancelledError:
-            break
-        except BlockingIOError:
-            await asyncio.sleep(0.1)
-            continue
-        except OSError as e:
-            if e.errno == errno.EAGAIN or e.errno == errno.EWOULDBLOCK:
-                await asyncio.sleep(0.1)
-                continue
-            else:
-                raise
 
 
 def _make_signal_handler(state: vm.State, *, allow_force_exit: bool = False) -> tp.Callable[[int, types.FrameType | None], None]:
@@ -120,7 +86,6 @@ async def run_vesta(config: vm.VestaConfig, *, state: vm.State, first_start: boo
     processor_task.add_done_callback(lambda t: handle_processor_done(t, state=state, config=config))
 
     tasks = [
-        asyncio.create_task(input_handler(message_queue, state=state)),
         processor_task,
         asyncio.create_task(monitor_loop(message_queue, state=state, config=config)),
     ]

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "aioconsole>=0.8.2",
     "aiohttp>=3.14.1",
     "claude-agent-sdk>=0.2.108",
     "pydantic>=2.13.4",

--- a/agent/tests/test_crash_recovery.py
+++ b/agent/tests/test_crash_recovery.py
@@ -143,7 +143,6 @@ async def test_processor_crash_triggers_graceful_shutdown(tmp_path):
         patch("core.main.start_ws_server", new_callable=AsyncMock) as mock_ws,
         patch("core.main.message_processor", side_effect=crashing_processor),
         patch("core.main.monitor_loop", new_callable=AsyncMock),
-        patch("core.main.input_handler", new_callable=AsyncMock),
         patch("core.main.drop_greeting_notification", return_value=False),
         patch("core.main.drop_pending_migrations", return_value=0),
     ):

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -292,7 +292,6 @@ async def test_run_vesta_force_exits_on_hung_cleanup(config, state):
 
     with (
         patch("core.main.start_ws_server", new_callable=AsyncMock) as mock_ws,
-        patch("core.main.input_handler", hanging_on_cancel),
         patch("core.main.message_processor", hanging_on_cancel),
         patch("core.main.monitor_loop", hanging_on_cancel),
         patch("core.main.drop_greeting_notification", return_value=False),
@@ -303,9 +302,9 @@ async def test_run_vesta_force_exits_on_hung_cleanup(config, state):
         mock_ws.return_value.cleanup = AsyncMock()
 
         async def trigger_shutdown():
-            # All three patched workers (input_handler, message_processor, monitor_loop) running
+            # Both patched workers (message_processor, monitor_loop) running
             # means run_vesta is fully started and waiting on graceful_shutdown.
-            await wait_for_condition(lambda: len(started_tasks) >= 3, message="run_vesta worker tasks never started")
+            await wait_for_condition(lambda: len(started_tasks) >= 2, message="run_vesta worker tasks never started")
             assert state.graceful_shutdown is not None
             state.graceful_shutdown.set()
             await exit_event.wait()

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -9,15 +9,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "aioconsole"
-version = "0.8.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/4a/71f535c85991e18e1626429a283d4fc6720053f38211affa888809089ded/aioconsole-0.8.2.tar.gz", hash = "sha256:25cb5530f58f7ab431e9af84fbb5417178287b6c3300d5b1185e3b129a227cef", size = 37712, upload-time = "2025-10-14T05:44:33.245Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/10/04ef3313a07e9152a84ce197aa11586376478c167322141e9c79eaedc25b/aioconsole-0.8.2-py3-none-any.whl", hash = "sha256:00f3fabd6de5df2fad635e1e6a13ebe5bb2456b83b31e881ae41bc5862fd6a68", size = 31510, upload-time = "2025-10-14T05:44:32.161Z" },
-]
-
-[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1235,7 +1226,6 @@ name = "vesta"
 version = "0.1.160"
 source = { virtual = "." }
 dependencies = [
-    { name = "aioconsole" },
     { name = "aiohttp" },
     { name = "claude-agent-sdk" },
     { name = "pydantic" },
@@ -1255,7 +1245,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aioconsole", specifier = ">=0.8.2" },
     { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "claude-agent-sdk", specifier = ">=0.2.108" },
     { name = "pydantic", specifier = ">=2.13.4" },


### PR DESCRIPTION
Closes #810

## What
Removes the stdin `input_handler` task, the `aioconsole` dependency, and the two test patch-outs that only existed to disable it.

## Why
`main.py` unconditionally spawned an `input_handler` task reading stdin via `aioconsole`, with an EAGAIN/EWOULDBLOCK retry ladder and an EOF path that shut the whole agent down. Nothing drives it in production: containers are created with `tty:true` and no `open_stdin`, and vestad and the apps talk only over the WS API. It survived purely as a local-dev affordance, at the cost of a dependency, a permanent task, and a shutdown-on-EOF hazard if stdin behavior ever changed. Dev interaction goes through the WS API / `vesta chat` like every other client.

## Changes
- `core/main.py`: delete the `input_handler` function, its task spawn, and the now-unused `aioconsole`/`errno` imports.
- `pyproject.toml` + `uv.lock`: drop `aioconsole`.
- `tests/test_crash_recovery.py`: remove the `input_handler` patch.
- `tests/test_interrupts.py`: remove the `input_handler` patch; the force-exit test now waits on two workers (message_processor, monitor_loop) instead of three.

Net deletion (+2 / -51). Verified with `./check.sh agent` (375 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)