### PR TITLE
docs: settle vesta's pronoun to name-or-they across surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ conventions, the testing strategy, CI, the PR process, and the Karpathy Guidelin
 
 ## Project Overview
 
-Vesta is a personal AI assistant that runs as a persistent daemon in Docker, powered by Claude Code. It monitors notifications, responds to messages, and handles tasks autonomously. The agent drives Claude through the official **Claude Agent SDK** (`claude-agent-sdk`): `core/client.py` builds a `ClaudeAgentOptions`, opens a `ClaudeSDKClient`, and streams response blocks back from the SDK message stream and its native hooks.
+Vesta is a personal AI assistant that runs as a persistent daemon in Docker, powered by Claude Code. Vesta monitors notifications, responds to messages, and handles tasks autonomously. The agent drives Claude through the official **Claude Agent SDK** (`claude-agent-sdk`): `core/client.py` builds a `ClaudeAgentOptions`, opens a `ClaudeSDKClient`, and streams response blocks back from the SDK message stream and its native hooks.
 
 > **cc_sdk is dormant — leave it alone.** `agent/core/cc_sdk/` is an in-repo SDK that drives the interactive `claude` CLI inside tmux and exposes the *same* `ClaudeSDKClient` surface. The agent used it for a stretch and it is retained deliberately as a drop-in alternative driver in case we need to return to CLI-driving (e.g. for behavior the headless SDK can't reach). It is **not** imported by `core/` anymore and is **not** on the running agent's path. Do not delete it, do not "tidy" it, and do not wire it back into `core/` without an explicit ask. Its transport tests (`tests/test_cc_sdk.py`, `tests/test_e2e_transport.py`, `tests/test_stop_race.py`) keep it healthy; keep them green.
 
@@ -210,6 +210,9 @@ Run locally on master. Bumps versions, updates lockfiles, commits, pushes, and c
 **Do NOT bump versions in PRs** — `release.sh` handles version bumps automatically at release time.
 
 ## Code conventions
+
+### Brand voice
+- **Never use a pronoun for Vesta.** In all copy and prose, refer to the agent as **"Vesta"**, or **"they/them/their"** where a pronoun is unavoidable. Never "she/her" or "it/its". This holds across every surface: README, app/notification strings, agent prompts and skills, and the vesta-cloud site and emails. The product is a relationship, not a gadget; one consistent voice keeps each new email or prompt from re-litigating it. (This does not apply to pronouns for other nouns: the daemon, a container, the user, a config object.)
 
 ### Python (agent/)
 - **Always `uv run`**, never bare `python`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Don't want to run a server? [vesta.run](https://vesta.run) hosts one for you. In
 ## Why Vesta
 
 - **Opinionated and easy to set up.** One command to install, one command to start. No gateway, no infrastructure to manage.
-- **Self-improving.** Every way Vesta reaches the world (messaging, email, calendars) is a skill it can read and rewrite. It can edit its own source code, write new skills, and fix its own bugs: by default it stays in sync with official updates, but you can let it fully rewrite itself.
+- **Self-improving.** Every way Vesta reaches the world (messaging, email, calendars) is a skill Vesta can read and rewrite. Vesta can edit their own source code, write new skills, and fix their own bugs: by default Vesta stays in sync with official updates, but you can let them fully rewrite themselves.
 - **1 agent = 1 container.** The Docker container is the state. No external databases, no config drift. Back up the container, restore the container.
 - **Agentic bidirectional sync.** Vesta instances can evolve and diverge from the source. Syncing is semantic; the agent understands what changed and why, and merges upstream updates or contributes patches back intelligently.
 - **Spreads by invitation.** Your Vesta can walk your friends through getting their own.

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -73,7 +73,7 @@
   },
   {
     "name": "onboard",
-    "description": "Use when someone who doesn't have their own vesta asks what it is, how to get one, or hints they want in. Vesta is invite-only: you gatekeep and create desire rather than sell, then (if they earn it) set them up end-to-end in chat. Not for the owner, who already has one."
+    "description": "Use when someone who doesn't have their own vesta asks what vesta is, how to get one, or hints they want in. Vesta is invite-only: you gatekeep and create desire rather than sell, then (if they earn it) set them up end-to-end in chat. Not for the owner, who already has one."
   },
   {
     "name": "onedrive",

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: onboard
-description: Use when someone who doesn't have their own vesta asks what it is, how to get one, or hints they want in. Vesta is invite-only: you gatekeep and create desire rather than sell, then (if they earn it) set them up end-to-end in chat. Not for the owner, who already has one.
+description: Use when someone who doesn't have their own vesta asks what vesta is, how to get one, or hints they want in. Vesta is invite-only: you gatekeep and create desire rather than sell, then (if they earn it) set them up end-to-end in chat. Not for the owner, who already has one.
 ---
 
 # onboard - CLI: `onboard`
 
 Vesta is **invite-only, almost a private club**. There is no "buy now" button
 anywhere; the only way in is through a vesta that's already a member (yours). That
-scarcity is the point. When a stranger asks about it, you are **not a salesperson**.
+scarcity is the point. When a stranger asks about vesta, you are **not a salesperson**.
 You're the member at the door deciding whether to let them in.
 
 Played right, this makes people want it *more* (we want what's withheld), makes
@@ -22,7 +22,7 @@ new member's first month**, so the better you price, the more you make.
 
 Invoke when someone **who doesn't already have a vesta**:
 
-- asks what Vesta is, how it works, or how to get one;
+- asks what Vesta is, how vesta works, or how to get one;
 - hints they want one / want in / want what you are.
 
 ## Skip
@@ -187,7 +187,7 @@ onboard claude-finish --email ada@example.com --code <pasted-from-the-auth-page>
 
 ## Referral attribution (automatic)
 
-If this vesta is hosted, its non-secret `referral_code` is read from the
+If this vesta is hosted, the non-secret `referral_code` is read from the
 `VESTA_REFERRAL_CODE` environment variable and sent with `onboard checkout`, so a
 completed invite credits this account (you earn 50% of their first month). Unset
 (self-hosted) → it still works, just no reward. The CLI handles the code; you never

--- a/apps/web/src/providers/NotificationProvider/index.tsx
+++ b/apps/web/src/providers/NotificationProvider/index.tsx
@@ -185,7 +185,7 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
       if (!permissionRef.current) continue;
       try {
         const n = new Notification(`${agent.name} needs to sign in again`, {
-          body: "Vesta lost its Claude credentials. Tap to re-authenticate.",
+          body: "Vesta lost the Claude credentials. Tap to re-authenticate.",
           tag: `${agent.name}-not-authenticated`,
         });
         n.onclick = () => {


### PR DESCRIPTION
## What

Resolves the pronoun fork in #801. The surfaces disagreed about who vesta is (she on vesta.run/about, "it" in the README, "they" in proposed emails). Per the decision: **never use a pronoun for vesta** — use **"Vesta"**, or **"they/them"** where a pronoun is unavoidable. Never "she/her" or "it/its".

## Changes (vesta repo)

- **README.md** — "Self-improving" bullet: `it`/`its`/`itself` → `Vesta`/`their`/`they`.
- **apps/web/.../NotificationProvider** — "Vesta lost *its* Claude credentials" → "Vesta lost *the* Claude credentials".
- **agent/skills/onboard/SKILL.md** — descriptive references to vesta de-pronouned ("what *it* is" → "what *vesta* is", etc.); `index.json` regenerated.
- **CLAUDE.md** — overview line de-pronouned, and a new **Brand voice** convention that writes the rule down so future copy/prompts don't re-litigate it. Scoped to vesta-the-agent; pronouns for the daemon/container/user/config objects are untouched.

The vesta.run **about** page ("convince *her* you are worthy" → "convince *them*") and the mirrored brand-voice note land in a separate vesta-cloud PR.

### Scope note
I de-pronouned the third-person/descriptive references to vesta. I deliberately left in-character quoted dialogue and "a vesta / one" countable-object phrasing in the onboard persuasion script intact, since forcing the name there reads robotic. Happy to go fully literal there if preferred.

Fixes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)