### PR TITLE
design(web): collapse orb visual states to 5, surface status on hover

### DIFF
--- a/apps/web/src/components/AgentCard/index.tsx
+++ b/apps/web/src/components/AgentCard/index.tsx
@@ -6,11 +6,16 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Orb } from "@/components/Orb";
 import type { AgentInfo } from "@/lib/types";
 import { useNavigate } from "react-router-dom";
 import { useAgentOps, getOpLabel } from "@/stores/use-agent-ops";
-import { useOrbState } from "@/hooks/use-orb-state";
+import { useOrbStatus } from "@/hooks/use-orb-state";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
@@ -24,7 +29,7 @@ export function AgentCard({ agent, enableTracking = false }: AgentCardProps) {
   const isMobile = useIsMobile();
 
   const opState = useAgentOps((s) => s.getOp(agent.name));
-  const orbState = useOrbState(agent, agent.activityState);
+  const { orbState, label } = useOrbStatus(agent, agent.activityState);
 
   return (
     <Card
@@ -32,12 +37,19 @@ export function AgentCard({ agent, enableTracking = false }: AgentCardProps) {
       onClick={() => navigate(`/agent/${agent.name}${isMobile ? "/chat" : ""}`)}
     >
       <CardContent className="flex flex-col items-center gap-3 px-5 pt-0 pb-0">
-        <Orb
-          state={orbState}
-          size={112}
-          enableTracking={enableTracking}
-          label={`${agent.name}: ${orbState}`}
-        />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex">
+              <Orb
+                state={orbState}
+                size={112}
+                enableTracking={enableTracking}
+                label={`${agent.name}: ${label}`}
+              />
+            </span>
+          </TooltipTrigger>
+          {label && <TooltipContent>{label}</TooltipContent>}
+        </Tooltip>
         <CardTitle className="font-serif text-center text-2xl -mt-3 font-medium tracking-tight text-foreground">
           {agent.name}
         </CardTitle>

--- a/apps/web/src/components/AgentIsland/Collapsed.tsx
+++ b/apps/web/src/components/AgentIsland/Collapsed.tsx
@@ -30,7 +30,7 @@ export function AgentIslandCollapsed({
           state={orbState}
           size={28}
           suppressMotion
-          label={`${name}: ${orbState}`}
+          label={`${name}: ${statusLabel || orbState}`}
         />
       </motion.div>
       <div className="relative -top-0.5 min-w-0 flex-1 flex items-baseline gap-1.5">

--- a/apps/web/src/components/AgentIsland/Expanded.tsx
+++ b/apps/web/src/components/AgentIsland/Expanded.tsx
@@ -33,7 +33,7 @@ export function AgentIslandExpanded({
           state={orbState}
           size={100}
           enableTracking
-          label={`${name}: ${orbState}`}
+          label={`${name}: ${statusLabel || orbState}`}
         />
       </motion.div>
       <div className="-mt-4 flex flex-col items-center justify-center gap-1 text-center will-change-transform">

--- a/apps/web/src/components/AgentIsland/index.tsx
+++ b/apps/web/src/components/AgentIsland/index.tsx
@@ -54,7 +54,9 @@ export function AgentIsland() {
         role={expanded ? undefined : "button"}
         tabIndex={expanded ? -1 : 0}
         aria-expanded={expanded}
-        aria-label={expanded ? undefined : `${name}, ${orbState}`}
+        aria-label={
+          expanded ? undefined : `${name}, ${statusLabel || orbState}`
+        }
         onClick={expanded ? undefined : () => setExpanded(true)}
         onFocus={expanded ? undefined : () => setExpanded(true)}
         onKeyDown={

--- a/apps/web/src/components/LoadingScreen/index.tsx
+++ b/apps/web/src/components/LoadingScreen/index.tsx
@@ -34,7 +34,7 @@ export function LoadingScreen({ ready, onFinished }: LoadingScreenProps) {
         initial={{ opacity: 0, scale: 0.8 }}
         animate={{ opacity: 1, scale: 1 }}
       >
-        <Orb state="loading" size={96} />
+        <Orb state="thinking" size={96} />
       </motion.div>
     </motion.div>
   );

--- a/apps/web/src/components/Orb/index.tsx
+++ b/apps/web/src/components/Orb/index.tsx
@@ -12,14 +12,7 @@ interface OrbProps {
   label?: string;
 }
 
-const LIVE_STATES = new Set<OrbVisualState>([
-  "alive",
-  "thinking",
-  "booting",
-  "authenticating",
-  "starting",
-  "loading",
-]);
+const LIVE_STATES = new Set<OrbVisualState>(["alive", "thinking", "busy"]);
 
 const COLOR_LERP_SPEED = 3;
 const VALUE_LERP_SPEED = 4;

--- a/apps/web/src/components/Orb/styles.ts
+++ b/apps/web/src/components/Orb/styles.ts
@@ -1,16 +1,7 @@
 import type { AgentActivityState } from "@/lib/types";
 import type { AgentOperation } from "@/stores/use-agent-ops";
 
-export type OrbVisualState =
-  | "loading"
-  | "alive"
-  | "thinking"
-  | "booting"
-  | "authenticating"
-  | "stopping"
-  | "starting"
-  | "deleting"
-  | "dead";
+export type OrbVisualState = "alive" | "thinking" | "busy" | "off" | "deleting";
 
 interface AgentLike {
   status: string;
@@ -33,22 +24,22 @@ function resolveStatus(
 ): { label: string; orbState: OrbVisualState } {
   switch (operation) {
     case "stopping":
-      return { label: "stopping...", orbState: "stopping" };
+      return { label: "stopping...", orbState: "busy" };
     case "starting":
-      return { label: "starting...", orbState: "starting" };
+      return { label: "starting...", orbState: "busy" };
     case "authenticating":
-      return { label: "signing in...", orbState: "authenticating" };
+      return { label: "signing in...", orbState: "busy" };
     case "deleting":
       return { label: "deleting...", orbState: "deleting" };
     case "rebuilding":
-      return { label: "rebuilding...", orbState: "starting" };
+      return { label: "rebuilding...", orbState: "busy" };
     case "backing-up":
       return { label: "backing up...", orbState: "alive" };
     case "restoring":
-      return { label: "restoring...", orbState: "starting" };
+      return { label: "restoring...", orbState: "busy" };
   }
 
-  if (!agent) return { label: "", orbState: "dead" };
+  if (!agent) return { label: "", orbState: "off" };
 
   switch (agent.status) {
     case "alive":
@@ -56,30 +47,26 @@ function resolveStatus(
         return { label: "thinking", orbState: "thinking" };
       return { label: "alive", orbState: "alive" };
     case "starting":
-      return { label: "waking up...", orbState: "booting" };
+      return { label: "waking up...", orbState: "busy" };
     case "setting_up":
-      return { label: "setting up...", orbState: "booting" };
+      return { label: "setting up...", orbState: "busy" };
     case "not_authenticated":
-      return { label: "not signed in", orbState: "authenticating" };
+      return { label: "not signed in", orbState: "busy" };
     case "restarting":
-      return { label: "restarting...", orbState: "starting" };
+      return { label: "restarting...", orbState: "busy" };
     case "stopped":
-      return { label: "stopped", orbState: "dead" };
+      return { label: "stopped", orbState: "off" };
     case "dead":
-      return { label: "broken — delete and recreate", orbState: "dead" };
+      return { label: "broken — delete and recreate", orbState: "off" };
     default:
-      return { label: agent.status, orbState: "dead" };
+      return { label: agent.status, orbState: "off" };
   }
 }
 
 export const orbColors: Record<OrbVisualState, [string, string, string]> = {
-  loading: ["#e8cc8a", "#d4a84a", "#9e7e34"],
   alive: ["#b8ceb0", "#7a9e70", "#5a7e50"],
   thinking: ["#e8d0a0", "#c4a060", "#a08040"],
-  booting: ["#c0d0e0", "#8a9eb0", "#6a8094"],
-  authenticating: ["#90a8c8", "#5870a0", "#3a5080"],
-  stopping: ["#c0d0e0", "#8a9eb0", "#6a8094"],
-  starting: ["#c0d0e0", "#8a9eb0", "#6a8094"],
+  busy: ["#c0d0e0", "#8a9eb0", "#6a8094"],
+  off: ["#c2c0ba", "#8e8c84", "#66645e"],
   deleting: ["#e0a0a0", "#c45050", "#a03030"],
-  dead: ["#c2c0ba", "#8e8c84", "#66645e"],
 };

--- a/apps/web/src/hooks/use-orb-state.ts
+++ b/apps/web/src/hooks/use-orb-state.ts
@@ -10,12 +10,25 @@ interface AgentLike {
   status: string;
 }
 
+export function useOrbStatus(
+  agent: AgentLike | null,
+  activityState: AgentActivityState,
+): { orbState: OrbVisualState; label: string } {
+  const operation = useAgentOps((s) =>
+    agent ? s.getOp(agent.name).operation : "idle",
+  );
+  const { orbState, label } = getAgentVisualStatus(
+    agent,
+    operation,
+    "",
+    activityState,
+  );
+  return { orbState, label };
+}
+
 export function useOrbState(
   agent: AgentLike | null,
   activityState: AgentActivityState,
 ): OrbVisualState {
-  const operation = useAgentOps((s) =>
-    agent ? s.getOp(agent.name).operation : "idle",
-  );
-  return getAgentVisualStatus(agent, operation, "", activityState).orbState;
+  return useOrbStatus(agent, activityState).orbState;
 }

--- a/apps/web/src/pages/Debug/index.tsx
+++ b/apps/web/src/pages/Debug/index.tsx
@@ -7,13 +7,9 @@ import type { VestaEvent } from "@/lib/types";
 const states: OrbVisualState[] = [
   "alive",
   "thinking",
-  "booting",
-  "authenticating",
-  "starting",
-  "stopping",
+  "busy",
+  "off",
   "deleting",
-  "dead",
-  "loading",
 ];
 
 const ts = "2026-04-19T12:34:00Z";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "orb-5-states",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Closes #805.

## What

Collapses `OrbVisualState` from **9 → 5**: `alive`, `thinking`, `busy`, `off`, `deleting`.

| Before (9) | Color | → After (5) | Notes |
|---|---|---|---|
| `alive` | green | `alive` | unchanged |
| `thinking` | gold | `thinking` | unchanged |
| `loading` | gold twin | `thinking` | folded in |
| `booting` | blue | `busy` | |
| `starting` | blue | `busy` | |
| `stopping` | blue | `busy` | |
| `authenticating` | darker blue | `busy` | loses its distinct blue |
| `dead` | gray | `off` | renamed (also covers `stopped`) |
| `deleting` | red | `deleting` | unchanged |

`resolveStatus`'s label strings are **untouched** — 'waking up...', 'signing in...', 'stopping...', 'stopped', etc. all still reach the user. Only the color vocabulary shrinks, along with `orbColors`, the favicon map (generic, no code change), `Orb`'s `LIVE_STATES`, and the Debug grid.

## Keeping the "what's happening" metadata on hover

Since the collapsed color no longer distinguishes (four states are now one `busy` blue), the orb's `label` previously interpolated the *visual-state name* (`name: busy`) which says nothing. Fixed two ways:

- The orb `label` now carries the **rich status label** (`name: signing in...`) everywhere — better `aria-label` for screen readers.
- **AgentCard** (home grid, where status isn't otherwise shown) wraps the orb in a hover **tooltip** showing the rich label. The AgentIsland already renders the status as visible text, so no tooltip needed there.

New `useOrbStatus` hook returns `{ orbState, label }`; `useOrbState` delegates to it (unchanged for the favicon caller).

## Minor behavior note

`busy` is in `LIVE_STATES`, so `stopping` (previously dim) now gets the same subtle live pulse as the other transitional states — intentional, reads as "working".

## Checks

`./check.sh web` green: tsc clean, eslint 0 errors, prettier clean, 94/94 vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)