### PR TITLE
ci: retry rustup install to fix flaky "Install Rust" step

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -1,0 +1,39 @@
+name: "Install Rust"
+description: "Install the stable Rust toolchain, retrying on transient rustup network failures"
+
+inputs:
+  targets:
+    description: "Comma- or space-separated target triples to add"
+    required: false
+    default: ""
+  components:
+    description: "Comma- or space-separated components to add (e.g. clippy)"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    # dtolnay/rust-toolchain has no retry, so a single transient rustup download
+    # blip fails the whole job. rustup is preinstalled on every GitHub runner, so
+    # we drive it directly and retry with backoff.
+    - shell: bash
+      env:
+        RUST_TARGETS: ${{ inputs.targets }}
+        RUST_COMPONENTS: ${{ inputs.components }}
+      run: |
+        set -euo pipefail
+        args=(stable --profile minimal --no-self-update)
+        for target in ${RUST_TARGETS//,/ }; do args+=(--target "$target"); done
+        for component in ${RUST_COMPONENTS//,/ }; do args+=(--component "$component"); done
+        for attempt in 1 2 3; do
+          if rustup toolchain install "${args[@]}"; then
+            rustup default stable
+            exit 0
+          fi
+          delay=$((attempt * 10))
+          echo "::warning::rustup install failed (attempt ${attempt}/3); retrying in ${delay}s"
+          sleep "${delay}"
+        done
+        echo "::error::rustup install failed after 3 attempts"
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
 
       - uses: Swatinem/rust-cache@v2
         # Caching is best-effort: a transient cache-service outage must not fail the
@@ -408,7 +408,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
 
       - uses: Swatinem/rust-cache@v2
         # Caching is best-effort: a transient cache-service outage must not fail the
@@ -495,7 +495,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
         with:
           targets: ${{ matrix.target }}
           components: clippy
@@ -569,7 +569,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
         with:
           targets: ${{ matrix.target }}
 
@@ -628,7 +628,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
         with:
           targets: ${{ matrix.target }}
 
@@ -697,7 +697,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
         with:
           targets: x86_64-pc-windows-msvc
           components: clippy
@@ -729,7 +729,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
         with:
           targets: x86_64-pc-windows-msvc
 
@@ -795,7 +795,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
         with:
           targets: ${{ matrix.target }}
 
@@ -874,7 +874,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
         with:
           targets: ${{ matrix.target }}
 
@@ -956,7 +956,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
 
       - uses: Swatinem/rust-cache@v2
         # Caching is best-effort: a transient cache-service outage must not fail the
@@ -1039,7 +1039,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
 
@@ -1191,7 +1191,7 @@ jobs:
 
       - name: Install Rust
         if: env.SKIP_IOS != 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
         with:
           targets: aarch64-apple-ios
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           token: ${{ secrets.RELEASE_PAT }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/install-rust
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
## Why

PR #898's `build-tauri-linux (x86_64)` job failed in ~7s at the **Install Rust** step — a transient rustup download blip. `dtolnay/rust-toolchain@stable` has no retry, so any single network hiccup fails the whole job. This pattern is repeated across 13 jobs in `ci.yml` + `release.yml`, so the flake can hit anywhere.

## What

One local composite action, `.github/actions/install-rust`, that drives the **preinstalled** rustup directly and retries the install with backoff (3 attempts, 10s/20s). Every `Install Rust` step now routes through it.

The action's inputs are named `targets` / `components` to exactly match the old action, so the existing `with:` blocks need **no changes** — only the `uses:` line is swapped. This also gives the toolchain install a single owner.

## Verification
- All 13 `dtolnay/rust-toolchain@stable` references replaced (12 in `ci.yml`, 1 in `release.yml`); zero remain.
- Every `Install Rust` step is preceded by `actions/checkout` in its job (required for a local action) — checked programmatically.
- All three workflow/action YAMLs parse.
- The embedded shell was tested locally with a stubbed `rustup`: correct invocations for no-input, single-target, target+clippy, and comma-separated multi-target cases, and the retry loop recovers after a simulated transient failure.

This will be fully exercised by this PR's own CI run, which goes through the new action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)