### PR TITLE
fix(test): make upgrade e2e provider sign-in version-aware

### DIFF
--- a/vestad/tests-integration/src/client.rs
+++ b/vestad/tests-integration/src/client.rs
@@ -314,6 +314,19 @@ impl Client {
         Ok(())
     }
 
+    /// LEGACY(remove-when: the upgrade e2e's from-version (`previous_released_tag`) >= 0.1.161 —
+    /// the first release speaking the current PUT `/provider` + `{kind,model,key}` contract; true
+    /// once 0.1.160 is no longer an upgrade-from target): sign in against a pre-0.1.161 daemon,
+    /// which serves `POST /agents/{name}/provider` and whose agent core expects
+    /// `{openrouter_key, openrouter_model}`. The upgrade test provisions on the previous released
+    /// daemon before upgrading, so it must speak whatever contract that daemon shipped.
+    pub fn sign_in_openrouter_legacy_pre_put(&self, name: &str, key: &str, model: &str) -> Result<(), String> {
+        self.wait_until_running(name, 60)?;
+        let body = serde_json::json!({"openrouter_key": key, "openrouter_model": model});
+        self.post_json(&format!("/agents/{}/provider", name), &body)?;
+        Ok(())
+    }
+
     pub fn create_backup(&self, name: &str) -> Result<BackupInfo, String> {
         let resp = self.post(&format!("/agents/{}/backups", name))?;
         let data = read_sse_result(resp)?;

--- a/vestad/tests-integration/src/lib.rs
+++ b/vestad/tests-integration/src/lib.rs
@@ -485,7 +485,7 @@ pub fn download_latest_released_vestad() -> Result<ReleasedVestad, String> {
 /// Parse a `vX.Y.Z` (or `X.Y.Z`) release tag into numeric components for ordering.
 /// Returns `None` for tags that don't parse, so the upgrade test ignores any
 /// non-standard tag rather than mis-ordering it.
-fn parse_release_tag(tag: &str) -> Option<Vec<u64>> {
+pub fn parse_release_tag(tag: &str) -> Option<Vec<u64>> {
     let parts: Option<Vec<u64>> = tag.trim_start_matches('v').split('.').map(|s| s.parse().ok()).collect();
     parts.filter(|components| components.len() == 3)
 }

--- a/vestad/tests/live/common.rs
+++ b/vestad/tests/live/common.rs
@@ -4,7 +4,7 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
-use vesta_tests::{SERVER, TestAgent, docker_cmd, dump_agent_diagnostics, exec_in_container};
+use vesta_tests::{SERVER, TestAgent, docker_cmd, dump_agent_diagnostics, exec_in_container, parse_release_tag};
 
 type SharedAgent = Option<(TestAgent<'static>, String)>;
 
@@ -192,12 +192,41 @@ pub fn wait_until_alive_or_die(client: &vesta_tests::client::Client, name: &str,
     }
 }
 
+/// First release whose provider sign-in is the current `PUT /provider` + `{kind,model,key}`
+/// contract; every earlier release serves `POST /provider` + `{openrouter_key, openrouter_model}`.
+/// LEGACY(remove-when: `previous_released_tag` >= 0.1.161 — i.e. once 0.1.160 is no longer an
+/// upgrade-from target, which holds after the 0.1.161 release): delete this, `LegacyPrePut`, and
+/// `for_daemon_tag`, leaving the upgrade test on `ProviderApi::Current`.
+const PROVIDER_PUT_CONTRACT_SINCE: [u64; 3] = [0, 1, 161];
+
+/// Which provider sign-in contract `provision_and_settle` uses. The live pool always talks to the
+/// current daemon; the upgrade e2e provisions against the previous released daemon, whose sign-in
+/// may predate the current contract — so it derives the variant from that daemon's version rather
+/// than hardcoding one, keeping the test correct for any upgrade-from version.
+#[derive(Clone, Copy)]
+pub enum ProviderApi {
+    Current,
+    /// LEGACY(remove-when: see `PROVIDER_PUT_CONTRACT_SINCE`): pre-0.1.161 sign-in shape.
+    LegacyPrePut,
+}
+
+impl ProviderApi {
+    /// The sign-in contract a daemon released as `tag` speaks. Unparseable/newer tags default to
+    /// the current contract.
+    pub fn for_daemon_tag(tag: &str) -> ProviderApi {
+        match parse_release_tag(tag) {
+            Some(parts) if parts.as_slice() < &PROVIDER_PUT_CONTRACT_SINCE[..] => ProviderApi::LegacyPrePut,
+            _ => ProviderApi::Current,
+        }
+    }
+}
+
 /// Provision a freshly-created agent for live e2e (OpenRouter provider on `live_model()`, test
 /// memory, real key) and block until it has fully settled after first-start. Shared by the live
 /// agent pool and the upgrade e2e test, both of which need a real, idle agent. Panics with
 /// diagnostics on failure, matching the pool's fail-fast behavior. Callers must have already
 /// confirmed the key exists (via `openrouter_key`).
-pub fn provision_and_settle(client: &vesta_tests::client::Client, name: &str, container: &str) {
+pub fn provision_and_settle(client: &vesta_tests::client::Client, name: &str, container: &str, api: ProviderApi) {
     let key = openrouter_key().expect("OPENROUTER_KEY present (caller checked)");
     let model = live_model();
 
@@ -207,7 +236,11 @@ pub fn provision_and_settle(client: &vesta_tests::client::Client, name: &str, co
     exec_in_container(container, &format!("cat > {MEMORY_PATH} <<'EOF'\n{TEST_MEMORY}\nEOF"))
         .expect("write test memory");
 
-    client.sign_in_openrouter(name, &key, &model).expect("sign in with OpenRouter");
+    match api {
+        ProviderApi::Current => client.sign_in_openrouter(name, &key, &model),
+        ProviderApi::LegacyPrePut => client.sign_in_openrouter_legacy_pre_put(name, &key, &model),
+    }
+    .expect("sign in with OpenRouter");
     // Restart after sign-in so the agent boots with the OpenRouter provider applied: vestad applies
     // a provider write only on the next boot, so first-start then runs entirely on the chosen model.
     client.restart_agent(name).expect("restart agent to apply provider");
@@ -251,6 +284,6 @@ fn setup_live_agent(name: &str) -> Option<(TestAgent<'static>, String)> {
     let status = client.agent_status(&agent.name).unwrap();
     let container = status.id.unwrap_or_else(|| panic!("agent {} has no container id", agent.name));
 
-    provision_and_settle(client, &agent.name, &container);
+    provision_and_settle(client, &agent.name, &container, ProviderApi::Current);
     Some((agent, container))
 }

--- a/vestad/tests/live/upgrade.rs
+++ b/vestad/tests/live/upgrade.rs
@@ -28,7 +28,7 @@ use vesta_tests::{
 };
 
 use super::common::{
-    openrouter_key, provision_and_settle, wait_for_file_contains, wait_until_alive_or_die, write_notification,
+    openrouter_key, provision_and_settle, wait_for_file_contains, wait_until_alive_or_die, write_notification, ProviderApi,
 };
 
 const AGENT_NAME: &str = "upgrade";
@@ -131,7 +131,7 @@ fn upgrade_from_previous_release_converges_migrations_and_keeps_agent_healthy() 
     // Stream the agent's own log to the test output for the whole run; survives every restart.
     let _log_stream = AgentLogStream::start(&container);
 
-    provision_and_settle(&old_client, &agent_name, &container);
+    provision_and_settle(&old_client, &agent_name, &container, ProviderApi::for_daemon_tag(&previous_tag));
     let pre_applied = applied_migrations(&container);
     eprintln!("upgrade e2e: setup complete on {previous_tag}; {} migration(s) pre-applied", pre_applied.len());
 


### PR DESCRIPTION
## Problem

The `test-live` release gate failed (and rolled back the v0.1.161 release) on:

```
upgrade::upgrade_from_previous_release_converges_migrations_and_keeps_agent_healthy
sign in with OpenRouter: "server error (405)"
```

The upgrade e2e provisions an agent on the **previous released** vestad before upgrading in place, but drives it with the **current** test client. PR #882 moved provider sign-in from `POST /provider` + `{openrouter_key, openrouter_model}` to `PUT` + `{kind,model,key}`. v0.1.160's router only serves `POST` on `/agents/{name}/provider`, so the current client's `PUT` returns **405**. This was never caught earlier because `test-live` runs only on the release event, not on PRs.

## Fix

The upgrade-from version is always `previous_released_tag` and advances every release, so hardcoding a single contract is the wrong shape — it would need a manual flip each cycle (and would break in reverse next release). Instead, **derive the sign-in contract from the daemon's own version**:

- `parse_release_tag` is now `pub` (reuse its `Vec<u64>` ordering; no new dep).
- `sign_in_openrouter_legacy_pre_put` speaks the pre-0.1.161 contract.
- `ProviderApi::for_daemon_tag(tag)` selects the contract by comparing the from-tag against `PROVIDER_PUT_CONTRACT_SINCE = [0,1,161]`. Unparseable/newer tags default to the current contract.

Provisioning stays on **vestad's HTTP gateway** (no CLI), so the test still exercises the app rather than the client.

Correct for any upgrade-from version, no per-release edit:
- this release (from 0.1.160) → legacy `POST` + old body
- next release (from 0.1.161) → current `PUT` + new body, automatically

Marked `LEGACY(remove-when: previous_released_tag >= 0.1.161)` — the legacy branch goes dead once 0.1.160 is no longer an upgrade-from target.

## Verification

`vesta-tests` compiles locally. The live-test binary builds only on Linux (`vestad`'s `statvfs` doesn't compile on macOS), and `test-live` runs only with Docker + `OPENROUTER_KEY` on the release event — so the real run happens in CI / the release gate this fix is meant to unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)