### PR TITLE
ci: run on-demand live e2e from the vestad crate dir

### DIFF
--- a/.github/workflows/test-live-on-demand.yml
+++ b/.github/workflows/test-live-on-demand.yml
@@ -98,6 +98,8 @@ jobs:
           max_attempts: 2
           retry_wait_seconds: 30
           shell: bash
-          # An empty TEST_FILTER is a substring that matches every test name, so it runs the
-          # whole suite; a non-empty one narrows to matching tests (e.g. the upgrade e2e).
-          command: VESTAD_AGENT_IMAGE=vesta:local cargo test -p vestad --test live "$TEST_FILTER" -- --test-threads=8 --nocapture
+          # The crates are standalone (no workspace Cargo.toml at the repo root), so the test
+          # runs from vestad/ — same as check.sh's check_live. An empty TEST_FILTER is a substring
+          # that matches every test name, so it runs the whole suite; a non-empty one narrows to
+          # matching tests (e.g. the upgrade e2e).
+          command: cd vestad && VESTAD_AGENT_IMAGE=vesta:local cargo test -p vestad --test live "$TEST_FILTER" -- --test-threads=8 --nocapture


### PR DESCRIPTION
Follow-up to #902. The crates are standalone (no workspace `Cargo.toml` at the repo root), so `cargo test` must run from `vestad/` — same as `check.sh`'s `check_live`. The retry step ran from the repo root and failed immediately with `could not find Cargo.toml`. `cd vestad` before invoking cargo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)