### PR TITLE
feat: represent unprovisioned agents honestly (fixes live upgrade e2e)

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -253,14 +253,16 @@ async def _provider_get_handler(request: web.Request) -> web.Response:
 
 
 async def _status_handler(request: web.Request) -> web.Response:
-    """The agent's operational readiness: whether the active provider is authenticated and whether
-    first-start has finished. vestad polls this to gate Alive vs SettingUp vs NotAuthenticated (an
+    """The agent's operational readiness: whether the active provider is authenticated, whether one is
+    configured at all (so vestad can tell unprovisioned from unauthenticated), and whether first-start
+    has finished. vestad polls this to gate Alive / SettingUp / NotAuthenticated / Unprovisioned (an
     authenticated agent that hasn't finished first-start is not yet ready)."""
     state: State = request.app["state"]
     status = state.provider_status
     return web.json_response(
         {
             "authed": status is not None and status.state == ProviderAuthState.AUTHENTICATED,
+            "provider_configured": status is not None and status.kind != "none",
             "setup_complete": state.persisted.first_start_done,
         }
     )

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -319,11 +319,18 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
     # Scope ANTHROPIC_BASE_URL to the Claude Code subprocess only; mutating
     # os.environ here would leak the OpenRouter URL into every other subprocess
     # the agent spawns (skill CLIs, gh, git, ...) and silently misroute them.
+    # The single guard at the real provider dereference: the work loop never queues while
+    # unprovisioned (the auth gate defers everything), so reaching here with no provider means the
+    # gate regressed — fail loudly instead of mis-building options.
+    provider = config.provider
+    if provider is None:
+        raise RuntimeError("build_client_options reached with no provider configured (auth gate failed)")
+
     sdk_env: dict[str, str] = {}
     betas: list[str] = []
     # 1M-context beta and thinking are Anthropic-only; openrouter forces thinking disabled.
     thinking_config = ThinkingConfigDisabled(type="disabled")
-    if isinstance(config.provider, vm.OpenRouterConfig):
+    if isinstance(provider, vm.OpenRouterConfig):
         # The SDK always routes through the local caching proxy, never OpenRouter
         # directly. start_cache_proxy runs first in message_processor, so the URL is set.
         if not state.openrouter_proxy_url:
@@ -331,7 +338,7 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
         sdk_env["ANTHROPIC_BASE_URL"] = state.openrouter_proxy_url
         # The OpenRouter key + background model the subprocess talks to OpenRouter with, injected
         # from the config store (no shell env inheritance). The union guarantees the key.
-        sdk_env["ANTHROPIC_AUTH_TOKEN"] = config.provider.key.get_secret_value()
+        sdk_env["ANTHROPIC_AUTH_TOKEN"] = provider.key.get_secret_value()
         sdk_env["ANTHROPIC_SMALL_FAST_MODEL"] = OPENROUTER_SMALL_FAST_MODEL
         # Tell claude-code the model's real window so autocompact uses the right
         # threshold instead of its 200k default for non-Anthropic models.
@@ -341,19 +348,19 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
         # Claude. The 1M-context beta unlocks windows above claude-code's 200k default.
         # Honor a user-chosen window: cap the autocompact threshold to it, and request the 1M
         # beta only when the choice needs the larger window. Unset keeps 1M beta on, no cap.
-        chosen = config.provider.max_context_tokens
+        chosen = provider.max_context_tokens
         if chosen is None or chosen > DEFAULT_CONTEXT_WINDOW:
             betas = [CONTEXT_1M_BETA]
         if chosen is not None:
             sdk_env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] = str(chosen)
-        thinking_config = config.provider.thinking
+        thinking_config = provider.thinking
 
     # Context-usage % is reported by the official client's get_context_usage(), which measures
     # against the CLI's own window (set via CLAUDE_CODE_MAX_CONTEXT_TOKENS above); the headless
     # ClaudeAgentOptions has no context_window field, so nothing is passed here.
     return ClaudeAgentOptions(
         system_prompt=system_prompt,
-        model=config.provider.model,
+        model=provider.model,
         betas=betas,  # ty: ignore[invalid-argument-type]
         hooks=sdk_parsing.make_hooks(state),
         permission_mode="bypassPermissions",

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -319,12 +319,12 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
     # Scope ANTHROPIC_BASE_URL to the Claude Code subprocess only; mutating
     # os.environ here would leak the OpenRouter URL into every other subprocess
     # the agent spawns (skill CLIs, gh, git, ...) and silently misroute them.
-    # The single guard at the real provider dereference: the work loop never queues while
-    # unprovisioned (the auth gate defers everything), so reaching here with no provider means the
-    # gate regressed — fail loudly instead of mis-building options.
+    # message_processor only reaches here once the provider is authenticated (it idles otherwise), so a
+    # provider is always present. Narrow the Optional for the type checker and fail loudly rather than
+    # mis-build options if that invariant ever regresses.
     provider = config.provider
     if provider is None:
-        raise RuntimeError("build_client_options reached with no provider configured (auth gate failed)")
+        raise RuntimeError("build_client_options reached with no authenticated provider")
 
     sdk_env: dict[str, str] = {}
     betas: list[str] = []

--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -367,7 +367,12 @@ def load_config() -> tuple[VestaConfig, list[str]]:
     Config is on the container's boot path: an exception here exits the process, and with
     `--restart=unless-stopped` that becomes a tight crash loop. So drop each offending env override and
     rebuild, reverting only that field; if nothing is droppable, fall back to a default claude provider.
+
+    Legacy convergence runs first (before the config is built), so the loaded config reflects the
+    migrated nested provider rather than a stale default. This makes load_config the single owner of
+    "what config does the agent run on" — there is no separate boot step to sequence wrongly.
     """
+    migrate_legacy_config_to_store()
     issues: list[str] = []
     dropped: set[str] = set()
     while True:

--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -220,7 +220,9 @@ class VestaConfig(pyd_settings.BaseSettings):
 
     model_config = pyd_settings.SettingsConfigDict(extra="ignore", populate_by_name=True)
 
-    provider: Provider = pyd.Field(default_factory=ClaudeConfig)
+    # None means no provider chosen yet (fresh agent, or signed out) — distinct from a chosen provider
+    # whose credential is missing/expired. A concrete provider always reflects an explicit choice.
+    provider: Provider | None = None
     agent_personality: str = _DEFAULT_PERSONALITY
 
     ephemeral: bool = False
@@ -318,7 +320,12 @@ def merge_provider(config: "VestaConfig", patch: dict[str, pyd.JsonValue]) -> di
     same-kind patch keeps the rest (a model-only change keeps the key; a re-auth keeps model/context/
     thinking) while a kind switch replaces wholesale. The single merge for both PATCH and sign-in."""
     store = read_config_store()
-    current = store["provider"] if "provider" in store and isinstance(store["provider"], dict) else {"kind": config.provider.kind}
+    if "provider" in store and isinstance(store["provider"], dict):
+        current = store["provider"]
+    elif config.provider is not None:
+        current = {"kind": config.provider.kind}
+    else:
+        current = {}  # no provider chosen yet; a sign-in patch carries its own kind
     current = tp.cast("dict[str, pyd.JsonValue]", current)
     if "kind" in patch and ("kind" not in current or current["kind"] != patch["kind"]):
         return dict(patch)

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -138,8 +138,8 @@ async def process_batch(
 
 def drop_greeting_notification(*, config: vm.VestaConfig, state: vm.State, reason: str) -> bool:
     """Drop a greeting notification (first_start_setup interrupting, restart greeting passive). Returns True if a notification was dropped."""
-    if isinstance(config.provider, vm.ClaudeConfig) and config.provider.oauth is None:
-        logger.startup("No credentials yet, waiting for auth before starting")
+    if state.provider_status is None or state.provider_status.state != ProviderAuthState.AUTHENTICATED:
+        logger.startup("No authenticated provider yet, waiting for sign-in before starting")
         return False
 
     if reason == "first_start":

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -300,6 +300,14 @@ async def compact_then_restart_if_requested(*, state: vm.State) -> None:
 
 
 async def message_processor(queue: asyncio.Queue[tuple[str, bool, list[str]]], *, state: vm.State, config: vm.VestaConfig) -> None:
+    # An agent with no authenticated provider can't drive the model. It still boots and stays reachable
+    # so vestad can deliver credentials over the API, but there is nothing to process here until sign-in
+    # restarts the process with a provider applied — so idle instead of building an SDK client (which
+    # requires a provider). Messages are deferred upstream while unauthenticated, so the queue stays empty.
+    if state.provider_status is None or state.provider_status.state != ProviderAuthState.AUTHENTICATED:
+        logger.client("No authenticated provider; idling until sign-in")
+        await state.shutdown_event.wait()
+        return
     logger.client("Creating new client session...")
     if isinstance(config.provider, vm.OpenRouterConfig):
         if state.openrouter_max_tokens is None:

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -187,10 +187,6 @@ async def async_main() -> None:
     logger.init(f"{config.agent_name} starting on vesta v{_vesta_version(config=config)}")
     _report_config_issues(config_issues, config=config)
 
-    # Converge a legacy agent's env-based preferences into the writable config store, so the whole
-    # fleet ends up on the new config system. Idempotent and safe (see migrate_legacy_config_to_store).
-    vm.migrate_legacy_config_to_store()
-
     initial_state = init_state(config=config)
     first_start = not initial_state.persisted.first_start_done
     restart_reason = _consume_restart_reason(initial_state, config, first_start=first_start)

--- a/agent/core/provider.py
+++ b/agent/core/provider.py
@@ -77,7 +77,8 @@ def derive_status(config: VestaConfig) -> ProviderStatus:
     actually provisioned. Model comes from the config store via VestaConfig."""
     kind, authed = _derive_kind_and_auth(config)
     state = ProviderAuthState.AUTHENTICATED if authed else ProviderAuthState.NOT_AUTHENTICATED
-    return ProviderStatus(state=state, kind=kind, model=config.provider.model)
+    model = config.provider.model if config.provider is not None else None
+    return ProviderStatus(state=state, kind=kind, model=model)
 
 
 def _sign_in(kind: str, *, model: str | None, max_context_tokens: int | None, key: str | None, config: VestaConfig) -> str | None:
@@ -118,11 +119,11 @@ def set_openrouter(key: str, model: str, max_context_tokens: int | None, *, conf
 
 
 def clear_provider(*, config: VestaConfig) -> ProviderStatus:
-    """Sign out: remove the Claude OAuth blob and reset the stored provider to a valid signed-out
-    default (claude, no credentials), leaving the agent not_authenticated. General config (personality,
-    timezone, ...) survives. Vestad restarts the agent."""
+    """Sign out: remove the Claude OAuth blob and clear the stored provider to None (no provider
+    chosen), leaving the agent unprovisioned. General config (personality, timezone, ...) survives.
+    Vestad restarts the agent."""
     CREDENTIALS_PATH.unlink(missing_ok=True)
-    update_config_store({"provider": {"kind": "claude", "model": "opus"}})
+    update_config_store({"provider": None})
     logger.startup("Provider cleared (signed out)")
     return ProviderStatus(state=ProviderAuthState.NOT_AUTHENTICATED, kind="none", model=None)
 
@@ -142,14 +143,15 @@ def observed_provider_failure(status: ProviderStatus | None) -> ProviderStatus |
 
 
 def _derive_kind_and_auth(config: VestaConfig) -> tuple[ProviderKind, bool]:
-    """The usable provider and whether its credential is valid: openrouter when chosen (key is
-    type-guaranteed), claude when the OAuth blob loaded from disk is valid, else none (unprovisioned)."""
+    """The usable provider and whether its credential is valid: none when no provider is chosen (fresh
+    / signed out); openrouter when chosen (key is type-guaranteed); claude when chosen, authed only if
+    the OAuth blob loaded from disk is valid (an expired/absent blob is claude-but-unauthenticated)."""
     provider = config.provider
+    if provider is None:
+        return "none", False
     if isinstance(provider, OpenRouterConfig):
         return "openrouter", bool(provider.key.get_secret_value())
-    if provider.oauth is not None:
-        return "claude", _check_claude_oauth(provider.oauth)
-    return "none", False
+    return "claude", provider.oauth is not None and _check_claude_oauth(provider.oauth)
 
 
 def _check_claude_oauth(oauth: ClaudeOAuth) -> bool:

--- a/agent/tests/test_api.py
+++ b/agent/tests/test_api.py
@@ -296,8 +296,12 @@ async def test_status_reports_readiness_separate_from_provider(config):
     # /status carries the readiness gate (authed + setup_complete); /provider carries the config + authed
     # but NOT setup_complete (that's agent lifecycle, not the provider resource).
     import core.api as api_mod
+    from core.config import update_config_store
     from core.provider import ProviderAuthState, ProviderStatus
 
+    # A signed-in Claude agent: the chosen provider lives in the store, so /provider reports its kind.
+    update_config_store({"provider": {"kind": "claude", "model": "opus"}})
+    config = vm.VestaConfig()
     state = vm.State()
     state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
     state.persisted.first_start_done = True

--- a/agent/tests/test_api.py
+++ b/agent/tests/test_api.py
@@ -310,13 +310,30 @@ async def test_status_reports_readiness_separate_from_provider(config):
         app = {"state": state, "config": config}
 
     status_resp = await api_mod._status_handler(typing.cast("web.Request", _Req()))
-    assert json.loads(typing.cast("str", status_resp.text)) == {"authed": True, "setup_complete": True}
+    assert json.loads(typing.cast("str", status_resp.text)) == {"authed": True, "provider_configured": True, "setup_complete": True}
 
     provider_resp = await api_mod._provider_get_handler(typing.cast("web.Request", _Req()))
     provider_body = json.loads(typing.cast("str", provider_resp.text))
     assert provider_body["authed"] is True
     assert "setup_complete" not in provider_body  # readiness moved to /status
     assert provider_body["kind"] == "claude"
+
+
+@pytest.mark.anyio
+async def test_status_reports_unprovisioned_distinct_from_unauthenticated(config):
+    # A fresh agent (no provider chosen) reports provider_configured=False, so vestad can show
+    # "needs first sign-in" rather than "re-authenticate".
+    import core.api as api_mod
+    from core.provider import ProviderAuthState, ProviderStatus
+
+    state = vm.State()
+    state.provider_status = ProviderStatus(state=ProviderAuthState.NOT_AUTHENTICATED, kind="none", model=None)
+
+    class _Req:
+        app = {"state": state, "config": config}
+
+    status_resp = await api_mod._status_handler(typing.cast("web.Request", _Req()))
+    assert json.loads(typing.cast("str", status_resp.text)) == {"authed": False, "provider_configured": False, "setup_complete": False}
 
 
 @pytest.mark.anyio

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -36,11 +36,14 @@ def test_memory_paths(config):
     assert config.skills_dir == config.agent_dir / "skills"
 
 
-def test_default_provider_is_claude_opus():
-    provider = vm.VestaConfig().provider
-    assert isinstance(provider, ClaudeConfig)
-    assert provider.kind == "claude"
-    assert provider.model == "opus"
+def test_default_provider_is_none_when_unprovisioned(agentdir, monkeypatch, tmp_path):
+    """A fresh agent (no store, no legacy file, no creds) has no provider chosen at all."""
+    from core import config as config_mod
+
+    monkeypatch.setattr(config_mod, "CREDENTIALS_PATH", tmp_path / ".credentials.json")
+    monkeypatch.setattr(config_mod, "_LEGACY_PROVIDER_ENV", tmp_path / "absent.env")
+    config, _ = config_mod.load_config()
+    assert config.provider is None
 
 
 # Both the plain-string form (thinking="adaptive") and the legacy JSON-dict form written before
@@ -122,10 +125,15 @@ def agentdir(tmp_path, monkeypatch):
     return tmp_path / "agent"
 
 
-def test_loads_shipped_defaults_with_no_env_or_store(agentdir, monkeypatch):
-    # The crash class: nothing in env, no store -> field defaults, no raise.
+def test_loads_shipped_defaults_with_no_env_or_store(agentdir, monkeypatch, tmp_path):
+    # The crash class: nothing in env, no store -> field defaults (provider unchosen), no raise.
+    from core import config as config_mod
+
+    monkeypatch.setattr(config_mod, "CREDENTIALS_PATH", tmp_path / ".credentials.json")
+    monkeypatch.setattr(config_mod, "_LEGACY_PROVIDER_ENV", tmp_path / "absent.env")
     config, issues = load_config()
-    assert (config.provider.model, config.provider.kind, config.agent_personality) == ("opus", "claude", "dry")
+    assert config.provider is None
+    assert config.agent_personality == "dry"
     assert issues == []
     assert isinstance(config, vm.VestaConfig)
 
@@ -149,11 +157,25 @@ def test_update_rejects_keys_that_are_not_config_fields(agentdir):
         update_config_store({"not_a_field": "x"})
 
 
-def test_corrupt_store_does_not_crash_load(agentdir):
+def test_corrupt_store_does_not_crash_load(agentdir, monkeypatch, tmp_path):
+    from core import config as config_mod
+
+    monkeypatch.setattr(config_mod, "CREDENTIALS_PATH", tmp_path / ".credentials.json")
+    monkeypatch.setattr(config_mod, "_LEGACY_PROVIDER_ENV", tmp_path / "absent.env")
     config_store_path().write_text("{ not json")
     assert read_config_store() == {}
     config, _ = load_config()
-    assert config.provider.model == "opus"
+    assert config.provider is None
+
+
+def test_stored_config_serializes_null_provider(agentdir, monkeypatch, tmp_path):
+    from core import config as config_mod
+    from core.config import stored_config
+
+    monkeypatch.setattr(config_mod, "CREDENTIALS_PATH", tmp_path / ".credentials.json")
+    monkeypatch.setattr(config_mod, "_LEGACY_PROVIDER_ENV", tmp_path / "absent.env")
+    config, _ = config_mod.load_config()
+    assert stored_config(config)["provider"] is None
 
 
 # --- Legacy fleet convergence: flat -> nested provider ---
@@ -286,7 +308,9 @@ def test_validate_config_accepts_every_preference(config, key, value):
 
 
 def test_validate_provider_partial_deep_merges(config):
-    # A provider partial (PATCH /provider) merges onto the current provider and revalidates.
+    # A provider partial (PATCH /provider) merges onto the current provider and revalidates. PATCH only
+    # applies to an already-chosen provider, so seed one in the store first.
+    update_config_store({"provider": {"kind": "claude", "model": "opus"}})
     updates = validate_config_updates(config, {"provider": {"model": "sonnet"}})
     assert updates["provider"] == {"kind": "claude", "model": "sonnet"}
 

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -239,6 +239,30 @@ def test_migrate_legacy_claude_file_carries_no_key(agentdir, monkeypatch, tmp_pa
     assert not legacy.exists()
 
 
+def test_load_config_converges_legacy_provider_file_first(agentdir, monkeypatch, tmp_path):
+    """A legacy OpenRouter agent stores its provider only in vesta-provider.env. load_config must
+    drain it into the store BEFORE building the config, so the returned config is the OpenRouter
+    provider — not the default (which would derive not_authenticated and defer all work)."""
+    from core import config as config_mod
+    from core.config import OpenRouterConfig
+
+    for key in ("AGENT_MODEL", "AGENT_PROVIDER", "MAX_CONTEXT_TOKENS", "AGENT_PERSONALITY", "ANTHROPIC_AUTH_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(config_mod, "CREDENTIALS_PATH", tmp_path / ".credentials.json")
+    legacy = tmp_path / "vesta-provider.env"
+    legacy.write_text(
+        "export AGENT_PROVIDER=openrouter\nexport AGENT_MODEL='deepseek/deepseek-v4-flash'\nexport ANTHROPIC_AUTH_TOKEN='sk-or-v1-secret'\n"
+    )
+    monkeypatch.setattr(config_mod, "_LEGACY_PROVIDER_ENV", legacy)
+
+    config, _ = config_mod.load_config()
+
+    assert isinstance(config.provider, OpenRouterConfig)
+    assert config.provider.model == "deepseek/deepseek-v4-flash"
+    assert config.provider.key.get_secret_value() == "sk-or-v1-secret"
+    assert not legacy.exists()  # convergence ran and retired the legacy file
+
+
 # --- PUT /config (prefs) + PATCH /provider validation ---
 
 

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -140,7 +140,9 @@ def test_loads_shipped_defaults_with_no_env_or_store(agentdir, monkeypatch, tmp_
 
 def test_store_sets_nested_provider(agentdir):
     update_config_store({"provider": {"kind": "claude", "model": "sonnet"}})
-    assert vm.VestaConfig().provider.model == "sonnet"
+    provider = vm.VestaConfig().provider
+    assert isinstance(provider, ClaudeConfig)
+    assert provider.model == "sonnet"
 
 
 def test_update_merges_and_clear_reverts(agentdir):

--- a/agent/tests/test_constitution.py
+++ b/agent/tests/test_constitution.py
@@ -4,9 +4,12 @@ but cannot edit it; these tests cover the prompt-assembly side."""
 
 import core.models as vm
 from core.client import build_client_options
+from core.config import ClaudeConfig
 
 
 def _config(tmp_path, **overrides):
+    # build_client_options requires a chosen provider; default to Claude for these prompt-assembly tests.
+    overrides.setdefault("provider", ClaudeConfig())
     config = vm.VestaConfig(agent_dir=tmp_path / "agent", **overrides)
     config.agent_dir.mkdir(parents=True, exist_ok=True)
     (config.agent_dir / "MEMORY.md").write_text("my memory body")

--- a/agent/tests/test_crash_recovery.py
+++ b/agent/tests/test_crash_recovery.py
@@ -50,9 +50,14 @@ def _mock_client(enter):
 
 
 def _processor_config_state(tmp_path, session_id=None):
+    from core.provider import ProviderAuthState, ProviderStatus
+
     config = vm.VestaConfig(agent_dir=tmp_path / "agent")
     config.data_dir.mkdir(parents=True, exist_ok=True)
     state = vm.State()
+    # These tests exercise the client-session/resume path, which message_processor runs only for an
+    # authenticated provider (it idles otherwise).
+    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
     state.persisted.session_id = session_id
     state.shutdown_event = asyncio.Event()
     return config, state

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -64,6 +64,11 @@ def _make_converse_harness(*, use_shared_queue: bool = False):
     emitted: list[tuple[str, float]] = []
     config = vm.VestaConfig(interrupt_timeout=0.5)
     state = vm.State()
+    # message_processor runs the client loop only for an authenticated provider; these interrupt tests
+    # drive that loop, so mark the agent authenticated.
+    from core.provider import ProviderAuthState, ProviderStatus
+
+    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
     state.event_bus = EventBus()
 
     original_emit = state.event_bus.emit
@@ -108,6 +113,9 @@ def _make_converse_harness(*, use_shared_queue: bool = False):
 @pytest.mark.anyio
 async def test_message_processor_interrupts_on_new_message(config, state):
     """New messages arriving during processing set the interrupt event and are processed after."""
+    from core.provider import ProviderAuthState, ProviderStatus
+
+    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
     processing_started = asyncio.Event()
     interrupt_seen = asyncio.Event()
 
@@ -161,6 +169,9 @@ async def test_message_processor_interrupts_on_new_message(config, state):
 @pytest.mark.anyio
 async def test_message_processor_sets_busy_flag_during_turn(config, state):
     """processor_busy is True while a turn runs and False once it finishes (gates the proactive check)."""
+    from core.provider import ProviderAuthState, ProviderStatus
+
+    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
     processing_started = asyncio.Event()
     busy_during_turn = False
 

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -12,12 +12,25 @@ from core.loops import (
     _load_notification_files,
     _notification_watcher,
     delete_notification_files,
+    drop_greeting_notification,
     format_notification_batch,
     load_notifications,
     monitor_loop,
     process_batch,
 )
+from core.provider import ProviderAuthState, ProviderStatus
 from wait_util import wait_for_condition
+
+
+@pytest.mark.parametrize("kind", ["openrouter", "claude", "none"])
+def test_greeting_deferred_until_authenticated(config, kind):
+    """The greeting (and so first-start) is gated on the derived auth STATUS, not the provider shape:
+    any not-authenticated agent defers — a fresh agent with no provider (none), a chosen provider whose
+    key/token is rejected (openrouter/claude), or one whose Claude token expired. Regression for an
+    upgraded agent that loaded a stale unauthenticated provider and never ran its migrations."""
+    state = vm.State()
+    state.provider_status = ProviderStatus(state=ProviderAuthState.NOT_AUTHENTICATED, kind=kind, model=None)
+    assert drop_greeting_notification(config=config, state=state, reason="first_start") is False
 
 
 # --- _load_notification_files ---

--- a/agent/tests/test_openrouter.py
+++ b/agent/tests/test_openrouter.py
@@ -11,15 +11,16 @@ def test_config_accepts_openrouter_provider(tmp_path):
     assert config.provider.kind == "openrouter"
 
 
-def test_config_defaults_to_claude(tmp_path):
+def test_config_defaults_to_no_provider(tmp_path):
+    # A fresh agent has no provider chosen yet (distinct from a chosen-but-unauthenticated provider).
     config = vm.VestaConfig(agent_dir=tmp_path / "agent")
-    assert config.provider.kind == "claude"
+    assert config.provider is None
 
 
 def test_config_max_context_tokens_defaults_to_unset(tmp_path):
-    """Unset (None) by default: Claude runs at its model default (1M via beta) and OpenRouter falls
-    back to a 200k working cap. A chosen value overrides both."""
-    config = vm.VestaConfig(agent_dir=tmp_path / "agent")
+    """Unset (None) by default on a chosen provider: Claude runs at its model default (1M via beta) and
+    OpenRouter falls back to a 200k working cap. A chosen value overrides both."""
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent", provider=ClaudeConfig(model="opus"))
     assert config.provider.max_context_tokens is None
 
 
@@ -29,9 +30,8 @@ def test_config_provider_carries_max_context_tokens(tmp_path):
 
 
 def _config_with_memory(tmp_path, *, provider=None):
-    kwargs = {"agent_dir": tmp_path / "agent"}
-    if provider is not None:
-        kwargs["provider"] = provider
+    # build_client_options requires a chosen provider; default to Claude when a test doesn't pin one.
+    kwargs = {"agent_dir": tmp_path / "agent", "provider": provider if provider is not None else ClaudeConfig()}
     config = vm.VestaConfig(**kwargs)
     config.agent_dir.mkdir(parents=True, exist_ok=True)
     (config.agent_dir / "MEMORY.md").write_text("test memory")

--- a/agent/tests/test_openrouter.py
+++ b/agent/tests/test_openrouter.py
@@ -21,18 +21,22 @@ def test_config_max_context_tokens_defaults_to_unset(tmp_path):
     """Unset (None) by default on a chosen provider: Claude runs at its model default (1M via beta) and
     OpenRouter falls back to a 200k working cap. A chosen value overrides both."""
     config = vm.VestaConfig(agent_dir=tmp_path / "agent", provider=ClaudeConfig(model="opus"))
+    assert isinstance(config.provider, ClaudeConfig)
     assert config.provider.max_context_tokens is None
 
 
 def test_config_provider_carries_max_context_tokens(tmp_path):
     config = vm.VestaConfig(agent_dir=tmp_path / "agent", provider=ClaudeConfig(model="opus", max_context_tokens=400_000))
+    assert isinstance(config.provider, ClaudeConfig)
     assert config.provider.max_context_tokens == 400_000
 
 
 def _config_with_memory(tmp_path, *, provider=None):
     # build_client_options requires a chosen provider; default to Claude when a test doesn't pin one.
-    kwargs = {"agent_dir": tmp_path / "agent", "provider": provider if provider is not None else ClaudeConfig()}
-    config = vm.VestaConfig(**kwargs)
+    config = vm.VestaConfig(
+        agent_dir=tmp_path / "agent",
+        provider=provider if provider is not None else ClaudeConfig(),
+    )
     config.agent_dir.mkdir(parents=True, exist_ok=True)
     (config.agent_dir / "MEMORY.md").write_text("test memory")
     return config

--- a/agent/tests/test_personality.py
+++ b/agent/tests/test_personality.py
@@ -11,6 +11,11 @@ from core.client import build_client_options
 def _config(tmp_path, monkeypatch):
     # Drive agent_dir through AGENT_DIR so the config field and config_store_path() agree.
     monkeypatch.setenv("AGENT_DIR", str(tmp_path / "agent"))
+    # A signed-in agent: build_client_options needs a chosen provider. Seed it in the store so a
+    # rebuilt VestaConfig() (the config-store test re-reads after a write) keeps it.
+    from core.config import update_config_store
+
+    update_config_store({"provider": {"kind": "claude", "model": "opus"}})
     config = vm.VestaConfig()
     config.agent_dir.mkdir(parents=True, exist_ok=True)
     (config.agent_dir / "MEMORY.md").write_text("my memory body")

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -21,9 +21,15 @@ async def _run_processor_test(
     """Shared helper for message_processor tests."""
     from core.loops import message_processor
 
+    from core.provider import ProviderAuthState, ProviderStatus
+
     config = vm.VestaConfig(agent_dir=tmp_path / "agent")
     config.data_dir.mkdir(parents=True, exist_ok=True)
     state = pre_state or vm.State()
+    # These tests exercise the active processing path; an authenticated provider lets message_processor
+    # build the (mocked) client rather than idling. Tests of the unauthenticated path set their own.
+    if state.provider_status is None:
+        state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
     state.shutdown_event = asyncio.Event()
     queue: asyncio.Queue = asyncio.Queue()
 
@@ -157,9 +163,11 @@ def test_restart_reason_round_trip(tmp_path):
 @pytest.mark.anyio
 async def test_client_cleared_on_cancellation(tmp_path):
     from core.loops import message_processor
+    from core.provider import ProviderAuthState, ProviderStatus
 
     config = vm.VestaConfig(agent_dir=tmp_path / "agent")
     state = vm.State()
+    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
     state.shutdown_event = asyncio.Event()
     queue: asyncio.Queue = asyncio.Queue()
 
@@ -225,6 +233,37 @@ async def test_process_message_no_correction(tmp_path, response):
         await process_message("hello", state=state, config=config, is_user=True)
 
     assert len(converse_calls) == 1
+
+
+@pytest.mark.anyio
+async def test_unauthenticated_agent_idles_without_building_client(tmp_path):
+    """A boot with no authenticated provider must NOT build an SDK client (which requires a provider) —
+    it idles until sign-in restarts the process. Regression: build_client_options was called eagerly at
+    session start and crashed an unprovisioned agent."""
+    from core.loops import message_processor
+    from core.provider import ProviderAuthState, ProviderStatus
+
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent")
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+    state = vm.State()
+    state.shutdown_event = asyncio.Event()
+    state.provider_status = ProviderStatus(state=ProviderAuthState.NOT_AUTHENTICATED, kind="none", model=None)
+    queue: asyncio.Queue = asyncio.Queue()
+
+    built = MagicMock()
+    with (
+        patch("core.loops.build_client_options", built),
+        patch("core.loops.ClaudeSDKClient") as mock_client,
+    ):
+        task = asyncio.create_task(message_processor(queue, state=state, config=config))
+        await asyncio.sleep(0.05)
+        assert not task.done()  # idling, not crashed or returned early
+        state.shutdown_event.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+    built.assert_not_called()
+    mock_client.assert_not_called()
+    assert state.client is None
 
 
 @pytest.mark.anyio

--- a/agent/tests/test_provider.py
+++ b/agent/tests/test_provider.py
@@ -47,7 +47,8 @@ def test_derive_claude_authenticated_when_oauth_refreshable():
 
 
 def test_derive_openrouter_authenticated_with_key():
-    assert _derive_kind_and_auth(_cfg(OpenRouterConfig(model="m", key="sk-or-v1-x"))) == ("openrouter", True)
+    cfg = _cfg(OpenRouterConfig.model_validate({"model": "m", "key": "sk-or-v1-x"}))
+    assert _derive_kind_and_auth(cfg) == ("openrouter", True)
 
 
 _CREDS = json.dumps({"claudeAiOauth": {"accessToken": "a", "expiresAt": 2**62}})
@@ -117,7 +118,7 @@ def test_set_claude_writes_creds_and_store(prov):
     assert status.kind == "claude"
     assert provider_mod.CREDENTIALS_PATH.read_text() == _CREDS
     assert read_config_store()["provider"] == {"kind": "claude", "model": "opus"}
-    assert vm.VestaConfig().provider.kind == "claude"
+    assert isinstance(vm.VestaConfig().provider, ClaudeConfig)
 
 
 def test_set_openrouter_writes_nested_provider_to_store(prov):
@@ -139,9 +140,10 @@ def test_set_openrouter_writes_nested_provider_to_store(prov):
 
 def test_model_context_prefs_persist_to_store_and_reload(prov):
     update_config_store({"provider": {"kind": "claude", "model": "opus", "max_context_tokens": 500_000}})
-    fresh = vm.VestaConfig()
-    assert fresh.provider.model == "opus"
-    assert fresh.provider.max_context_tokens == 500_000
+    provider = vm.VestaConfig().provider
+    assert isinstance(provider, ClaudeConfig)
+    assert provider.model == "opus"
+    assert provider.max_context_tokens == 500_000
 
 
 def test_clear_provider_removes_creds_and_resets_state(prov):

--- a/agent/tests/test_provider.py
+++ b/agent/tests/test_provider.py
@@ -7,12 +7,13 @@ import json
 import pytest
 
 import core.models as vm
-from core.config import OpenRouterConfig, read_config_store, update_config_store
+from core.config import ClaudeConfig, ClaudeOAuth, OpenRouterConfig, read_config_store, update_config_store
 from core.provider import (
     ProviderAuthState,
     UsageCredits,
     UsageError,
     _check_claude_auth,
+    _derive_kind_and_auth,
     clear_provider,
     derive_status,
     get_usage,
@@ -21,6 +22,33 @@ from core.provider import (
     set_claude,
     set_openrouter,
 )
+
+
+def _cfg(provider):
+    return vm.VestaConfig.model_construct(provider=provider)
+
+
+# --- Honest derivation: unprovisioned vs set-but-unauthenticated vs authenticated ---
+
+
+def test_derive_none_when_no_provider_chosen():
+    assert _derive_kind_and_auth(_cfg(None)) == ("none", False)
+
+
+def test_derive_claude_unauthenticated_when_oauth_invalid():
+    # Provider SET to claude (a real choice) but the OAuth blob is expired with no refresh token.
+    expired = ClaudeOAuth(accessToken="x", refreshToken=None, expiresAt=1)
+    assert _derive_kind_and_auth(_cfg(ClaudeConfig(oauth=expired))) == ("claude", False)
+
+
+def test_derive_claude_authenticated_when_oauth_refreshable():
+    refreshable = ClaudeOAuth(accessToken="x", refreshToken="r", expiresAt=0)
+    assert _derive_kind_and_auth(_cfg(ClaudeConfig(oauth=refreshable))) == ("claude", True)
+
+
+def test_derive_openrouter_authenticated_with_key():
+    assert _derive_kind_and_auth(_cfg(OpenRouterConfig(model="m", key="sk-or-v1-x"))) == ("openrouter", True)
+
 
 _CREDS = json.dumps({"claudeAiOauth": {"accessToken": "a", "expiresAt": 2**62}})
 
@@ -125,12 +153,15 @@ def test_clear_provider_removes_creds_and_resets_state(prov):
 
     status = clear_provider(config=prov)
     assert status.state == ProviderAuthState.NOT_AUTHENTICATED
+    assert status.kind == "none"
     assert status.model is None
     assert not provider_mod.CREDENTIALS_PATH.exists()
-    # The store resets to a valid signed-out default (claude, no key/oauth).
-    assert read_config_store()["provider"] == {"kind": "claude", "model": "opus"}
-    # A fresh boot re-derives not_authenticated from disk (creds removed).
-    assert derive_status(vm.VestaConfig()).state == ProviderAuthState.NOT_AUTHENTICATED
+    # Sign-out clears the provider entirely (no provider chosen), not a fake default.
+    assert "provider" not in read_config_store()
+    # A fresh boot re-derives unprovisioned from disk (no provider, creds removed).
+    fresh = derive_status(vm.VestaConfig())
+    assert fresh.state == ProviderAuthState.NOT_AUTHENTICATED
+    assert fresh.kind == "none"
 
 
 def test_set_claude_replaces_openrouter_provider(prov):
@@ -180,6 +211,8 @@ def test_observed_provider_failure_flips_in_memory_only(prov):
 def test_boot_derives_authenticated_from_disk_when_no_persisted_state(prov):
     from core import provider as provider_mod
 
+    # A signed-in Claude agent: the chosen provider in the store + valid creds on disk.
+    update_config_store({"provider": {"kind": "claude", "model": "opus"}})
     provider_mod.CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
     provider_mod.CREDENTIALS_PATH.write_text(_CREDS)
     status = derive_status(vm.VestaConfig())
@@ -205,7 +238,9 @@ def test_authenticated_provider_reports_model(prov):
 def test_boot_derives_no_model_when_credentials_are_invalid(prov):
     from core import provider as provider_mod
 
-    # Credentials on disk (so kind=claude) but unusable (expired, no refresh token) -> not authenticated.
+    # Claude chosen in the store, but the creds on disk are unusable (expired, no refresh token) ->
+    # set-but-unauthenticated: kind stays claude, state not_authenticated.
+    update_config_store({"provider": {"kind": "claude", "model": "opus"}})
     provider_mod.CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
     provider_mod.CREDENTIALS_PATH.write_text(json.dumps({"claudeAiOauth": {"accessToken": "a", "expiresAt": 0}}))
     status = derive_status(vm.VestaConfig())
@@ -237,6 +272,7 @@ async def test_get_usage_empty_when_no_provider(prov):
 async def test_get_usage_claude_normalizes_buckets_and_credits(prov, monkeypatch):
     from core import provider as provider_mod
 
+    update_config_store({"provider": {"kind": "claude", "model": "opus"}})
     provider_mod.CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
     provider_mod.CREDENTIALS_PATH.write_text(json.dumps({"claudeAiOauth": {"accessToken": "tok", "refreshToken": "r"}}))
     sample = {
@@ -278,6 +314,7 @@ async def test_get_usage_openrouter_normalizes_credits(prov, monkeypatch):
 async def test_get_usage_propagates_fetch_error(prov, monkeypatch):
     from core import provider as provider_mod
 
+    update_config_store({"provider": {"kind": "claude", "model": "opus"}})
     provider_mod.CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
     provider_mod.CREDENTIALS_PATH.write_text(json.dumps({"claudeAiOauth": {"accessToken": "tok", "refreshToken": "r"}}))
 

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -90,13 +90,17 @@ export async function signOutProvider(name: string): Promise<void> {
 }
 
 export interface ProviderInfo {
+  /// "none" means no provider chosen (fresh agent, or signed out). A concrete kind with
+  /// `authed: false` means a provider IS chosen but its credential is invalid/expired (re-auth).
   kind: "claude" | "openrouter" | "none";
   model: string | null;
   max_context_tokens: number | null;
+  authed: boolean;
 }
 
-/// Read an agent's active provider from its `GET /provider`. An unauthenticated agent (no creds, or
-/// signed out) reports `authed: false`, which we surface as `kind: "none"` for the UI.
+/// Read an agent's active provider from its `GET /provider`. The agent reports `kind` only when a
+/// provider is chosen (omitted when unprovisioned) plus an `authed` flag — so the UI can tell
+/// "no provider yet" (kind "none") apart from "chosen but credential expired" (kind set, authed false).
 export async function getProvider(name: string): Promise<ProviderInfo> {
   const provider = await apiJson<{
     kind?: "claude" | "openrouter";
@@ -105,9 +109,10 @@ export async function getProvider(name: string): Promise<ProviderInfo> {
     authed?: boolean;
   }>(`/agents/${encodeURIComponent(name)}/provider`);
   return {
-    kind: provider.authed ? (provider.kind ?? "none") : "none",
+    kind: provider.kind ?? "none",
     model: provider.model,
     max_context_tokens: provider.max_context_tokens,
+    authed: provider.authed ?? false,
   };
 }
 
@@ -181,8 +186,8 @@ export async function getBuildPhase(name: string): Promise<BuildPhase | null> {
   return resp.phase;
 }
 
-/// Poll /agents/{name} until it reports "alive" or "not_authenticated".
-/// A brand-new empty agent boots into not_authenticated until provisioned.
+/// Poll /agents/{name} until it reports a settled HTTP-up status. A brand-new empty agent boots into
+/// "unprovisioned" (no provider chosen) until provisioned; a re-auth case reports "not_authenticated".
 export async function waitUntilRunning(
   name: string,
   timeoutMs: number,
@@ -193,7 +198,12 @@ export async function waitUntilRunning(
     const resp = await apiJson<{ status: string }>(
       `/agents/${encodeURIComponent(name)}`,
     );
-    if (resp.status === "alive" || resp.status === "not_authenticated") return;
+    if (
+      resp.status === "alive" ||
+      resp.status === "not_authenticated" ||
+      resp.status === "unprovisioned"
+    )
+      return;
     if (
       resp.status === "dead" ||
       resp.status === "stopped" ||
@@ -221,7 +231,8 @@ export async function waitUntilAlive(
       resp.status === "dead" ||
       resp.status === "stopped" ||
       resp.status === "not_found" ||
-      resp.status === "not_authenticated"
+      resp.status === "not_authenticated" ||
+      resp.status === "unprovisioned"
     ) {
       throw new Error(`${name}: ${resp.status}`);
     }

--- a/apps/web/src/components/AgentIsland/Expanded.tsx
+++ b/apps/web/src/components/AgentIsland/Expanded.tsx
@@ -20,7 +20,10 @@ export function AgentIslandExpanded({
   error,
 }: AgentIslandExpandedProps) {
   const { provider } = useProvider(name);
-  const model = provider && provider.kind !== "none" ? provider.model : null;
+  const model =
+    provider && provider.kind !== "none" && provider.authed
+      ? provider.model
+      : null;
   return (
     <div className="relative -top-2 flex h-[168px] w-[168px] flex-col items-center justify-center gap-2 will-change-transform">
       <motion.div

--- a/apps/web/src/components/AgentMenu/index.tsx
+++ b/apps/web/src/components/AgentMenu/index.tsx
@@ -52,7 +52,11 @@ export function AgentMenu() {
     onRebuild: () => void rebuild(),
     onBackup: () => void backup(),
     onAuthenticate: gateway.reachable ? () => handleOpenAuth() : undefined,
-    isAuthenticated: Boolean(agent && agent.status !== "not_authenticated"),
+    isAuthenticated: Boolean(
+      agent &&
+      agent.status !== "not_authenticated" &&
+      agent.status !== "unprovisioned",
+    ),
     onDelete: () => setDeleteDialogOpen(true),
     onDebugInfo: appMode === "advanced" ? () => setDebugOpen(true) : undefined,
   };

--- a/apps/web/src/components/AgentSettings/ActionsCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ActionsCard/index.tsx
@@ -30,7 +30,9 @@ export function ActionsCard() {
     agent?.status !== "not_found";
   const showAliveActions = agent?.status === "alive";
   const isAuthenticated = Boolean(
-    agent && agent.status !== "not_authenticated",
+    agent &&
+    agent.status !== "not_authenticated" &&
+    agent.status !== "unprovisioned",
   );
 
   // On mobile (no navbar sign-in button) an agent that needs auth is an urgent

--- a/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
@@ -4,6 +4,7 @@ import {
   MoreHorizontal,
   RefreshCw,
   LogOut,
+  Plug,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -112,8 +113,54 @@ export function ProviderCard() {
     refresh: refreshUsage,
   } = useUsage(name);
 
-  if (!provider || provider.kind === "none") return null;
+  // The card always renders; its content reflects the provider state. While the first fetch is in
+  // flight, show a skeleton rather than collapsing the layout.
+  if (!provider) {
+    return (
+      <Card size="sm">
+        <CardContent className="flex items-center gap-3">
+          <Skeleton className="size-11 shrink-0 rounded-2xl" />
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
 
+  // Unprovisioned: no provider chosen yet (fresh agent, or signed out). Offer to connect one.
+  if (provider.kind === "none") {
+    return (
+      <Card size="sm">
+        <CardContent className="flex flex-col gap-3">
+          <div className="flex items-center gap-3">
+            <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-muted [corner-shape:squircle]">
+              <Plug className="size-6 text-muted-foreground" />
+            </div>
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <span className="text-xs text-muted-foreground">provider</span>
+              <span className="truncate text-sm font-medium">
+                not connected
+              </span>
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {name} needs a provider before it can respond. Connect Claude or
+            OpenRouter to get started.
+          </p>
+          <Button size="sm" onClick={() => void handleOpenAuth()}>
+            <Plug className="size-4" />
+            set up provider
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // From here a provider IS chosen. `ready` means its credential is valid; otherwise the card shows a
+  // re-authenticate state (credential expired/rejected) instead of model/usage controls.
+  const ready = provider.authed;
   const isOpenRouter = provider.kind === "openrouter";
   const { Logo } = providerMeta(provider.kind);
   const contextLabel =
@@ -182,79 +229,99 @@ export function ProviderCard() {
                 {provider.model ?? "unknown"}
               </span>
               <Badge variant="secondary" className="shrink-0">
-                {contextLabel}
+                {ready ? contextLabel : "signed out"}
               </Badge>
             </div>
           </div>
         </div>
 
-        <div className="flex flex-col gap-2.5">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium text-muted-foreground">
-              plan usage
-            </span>
-            <button
-              onClick={refreshUsage}
-              aria-label="refresh usage"
-              className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-            >
-              <RefreshCw
-                className={`size-3.5 ${usageLoading ? "animate-spin" : ""}`}
-              />
-            </button>
-          </div>
-          {usageLoading ? (
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center justify-between">
-                <Skeleton className="h-3 w-24" />
-                <Skeleton className="h-3 w-8" />
-              </div>
-              <Skeleton className="h-1.5 w-full" />
+        {ready ? (
+          <div className="flex flex-col gap-2.5">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-muted-foreground">
+                plan usage
+              </span>
+              <button
+                onClick={refreshUsage}
+                aria-label="refresh usage"
+                className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+              >
+                <RefreshCw
+                  className={`size-3.5 ${usageLoading ? "animate-spin" : ""}`}
+                />
+              </button>
             </div>
-          ) : usageError ? (
-            <p className="text-xs text-muted-foreground">
-              failed to load usage data
-            </p>
-          ) : meters.length === 0 && !credits ? (
-            <p className="text-xs text-muted-foreground">
-              no usage data available
-            </p>
-          ) : (
-            <div className="flex flex-col gap-2.5">
-              {meters.map((m) => (
-                <UsageBar key={m.label} meter={m} />
-              ))}
-              {credits && (
-                <div className="flex items-center justify-between text-xs">
-                  <span className="text-muted-foreground">credits</span>
-                  <span className="text-foreground tabular-nums">
-                    {credits.used != null
-                      ? `$${credits.used.toFixed(2)}${credits.limit != null ? ` / $${credits.limit.toFixed(2)}` : ""}`
-                      : "—"}
-                  </span>
+            {usageLoading ? (
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <Skeleton className="h-3 w-24" />
+                  <Skeleton className="h-3 w-8" />
                 </div>
-              )}
-            </div>
-          )}
-        </div>
+                <Skeleton className="h-1.5 w-full" />
+              </div>
+            ) : usageError ? (
+              <p className="text-xs text-muted-foreground">
+                failed to load usage data
+              </p>
+            ) : meters.length === 0 && !credits ? (
+              <p className="text-xs text-muted-foreground">
+                no usage data available
+              </p>
+            ) : (
+              <div className="flex flex-col gap-2.5">
+                {meters.map((m) => (
+                  <UsageBar key={m.label} meter={m} />
+                ))}
+                {credits && (
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-muted-foreground">credits</span>
+                    <span className="text-foreground tabular-nums">
+                      {credits.used != null
+                        ? `$${credits.used.toFixed(2)}${credits.limit != null ? ` / $${credits.limit.toFixed(2)}` : ""}`
+                        : "—"}
+                    </span>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            {name}&apos;s credentials expired or were rejected. Sign in again to
+            reconnect.
+          </p>
+        )}
 
         <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className="flex-1"
-            onClick={() => setModelOpen(true)}
-          >
-            change model
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="flex-1"
-            onClick={() => setContextOpen(true)}
-          >
-            change context
-          </Button>
+          {ready ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex-1"
+                onClick={() => setModelOpen(true)}
+              >
+                change model
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex-1"
+                onClick={() => setContextOpen(true)}
+              >
+                change context
+              </Button>
+            </>
+          ) : (
+            <Button
+              size="sm"
+              className="flex-1"
+              onClick={() => void handleOpenAuth()}
+            >
+              <RefreshCw className="size-4" />
+              sign in again
+            </Button>
+          )}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -27,7 +27,8 @@ interface ChatProps {
 
 export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   const { name, agent } = useSelectedAgent();
-  const notAuthenticated = agent?.status === "not_authenticated";
+  const notAuthenticated =
+    agent?.status === "not_authenticated" || agent?.status === "unprovisioned";
   const isMobile = useIsMobile();
   const navbarHeight = useLayout((s) => s.navbarHeight);
   const {

--- a/apps/web/src/components/Navbar/AgentNavbar/index.tsx
+++ b/apps/web/src/components/Navbar/AgentNavbar/index.tsx
@@ -36,7 +36,10 @@ export function AgentNavbar({
   const navigate = useNavigate();
   const isMobile = useIsMobile();
   const chatKeyboardFocused = useLayout((s) => s.chatKeyboardFocused);
-  const needsAuth = agent?.status === "not_authenticated" && reachable;
+  const needsAuth =
+    (agent?.status === "not_authenticated" ||
+      agent?.status === "unprovisioned") &&
+    reachable;
 
   const agentDashboardMatch = useMatch({ path: "/agent/:name", end: true });
   const chatMatch = useMatch({ path: "/agent/:name/chat", end: true });

--- a/apps/web/src/components/Orb/styles.ts
+++ b/apps/web/src/components/Orb/styles.ts
@@ -51,7 +51,9 @@ function resolveStatus(
     case "setting_up":
       return { label: "setting up...", orbState: "busy" };
     case "not_authenticated":
-      return { label: "not signed in", orbState: "busy" };
+      return { label: "needs to sign in again", orbState: "busy" };
+    case "unprovisioned":
+      return { label: "not set up", orbState: "busy" };
     case "restarting":
       return { label: "restarting...", orbState: "busy" };
     case "stopped":

--- a/apps/web/src/lib/api-contract.test.ts
+++ b/apps/web/src/lib/api-contract.test.ts
@@ -28,6 +28,7 @@ describe("vestad API contract", () => {
       vestadApiFixtures.agent_statuses satisfies readonly AgentStatus[];
     expect(statuses).toContain("alive");
     expect(statuses).toContain("not_authenticated");
+    expect(statuses).toContain("unprovisioned");
   });
 
   it("control WS agents message rows satisfy AgentInfo", () => {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,7 +1,9 @@
 export type AgentStatus =
   | "alive"
   | "starting"
+  | "setting_up"
   | "not_authenticated"
+  | "unprovisioned"
   | "restarting"
   | "stopped"
   | "dead"

--- a/apps/web/src/lib/vestad-api-fixtures.ts
+++ b/apps/web/src/lib/vestad-api-fixtures.ts
@@ -10,8 +10,10 @@ export const vestadApiFixtures = {
   },
   "agent_statuses": [
     "alive",
+    "setting_up",
     "starting",
     "not_authenticated",
+    "unprovisioned",
     "stopped",
     "dead",
     "not_found"

--- a/apps/web/src/providers/ChatProvider/index.tsx
+++ b/apps/web/src/providers/ChatProvider/index.tsx
@@ -21,7 +21,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   // Connect once the agent's WS is up so chat history loads — including when the
   // agent isn't authenticated yet (the composer stays disabled until sign-in).
   const connectable =
-    agent?.status === "alive" || agent?.status === "not_authenticated";
+    agent?.status === "alive" ||
+    agent?.status === "not_authenticated" ||
+    agent?.status === "unprovisioned";
   const chat = useChat({
     name,
     active: connectable,

--- a/apps/web/src/providers/NotificationProvider/index.tsx
+++ b/apps/web/src/providers/NotificationProvider/index.tsx
@@ -181,12 +181,23 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
       const previous = prevStatusRef.current.get(agent.name);
       prevStatusRef.current.set(agent.name, agent.status);
       if (!previous || previous === agent.status) continue;
-      if (agent.status !== "not_authenticated") continue;
+      if (
+        agent.status !== "not_authenticated" &&
+        agent.status !== "unprovisioned"
+      )
+        continue;
       if (!permissionRef.current) continue;
+      const unprovisioned = agent.status === "unprovisioned";
+      const title = unprovisioned
+        ? `${agent.name} needs to be set up`
+        : `${agent.name} needs to sign in again`;
+      const body = unprovisioned
+        ? "Tap to choose a provider and sign in."
+        : "Vesta lost the provider credentials. Tap to re-authenticate.";
       try {
-        const n = new Notification(`${agent.name} needs to sign in again`, {
-          body: "Vesta lost the Claude credentials. Tap to re-authenticate.",
-          tag: `${agent.name}-not-authenticated`,
+        const n = new Notification(title, {
+          body,
+          tag: `${agent.name}-${agent.status}`,
         });
         n.onclick = () => {
           void focusAndNavigate(agent.name);

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -548,12 +548,12 @@ impl Client {
         Ok(())
     }
 
-    /// Poll until status is `alive` OR `not_authenticated`. Used right after
+    /// Poll until status is `alive`, `not_authenticated`, or `unprovisioned`. Used right after
     /// `create_agent` to know the agent's HTTP server is up and ready to accept
-    /// `PUT /agents/{name}/config` — a brand-new empty agent will report
-    /// `not_authenticated` until the provider is provisioned.
+    /// `PUT /agents/{name}/config` — a brand-new empty agent reports `unprovisioned`
+    /// (no provider chosen) until the provider is provisioned.
     pub fn wait_until_running(&self, name: &str, timeout: Duration) -> Result<(), String> {
-        self.wait_for_status(name, timeout, &["alive", "not_authenticated"], "HTTP server", |_| {})
+        self.wait_for_status(name, timeout, &["alive", "not_authenticated", "unprovisioned"], "HTTP server", |_| {})
     }
 
     /// Poll `/agents/{name}` until `status == "alive"` or the deadline passes.
@@ -587,7 +587,7 @@ impl Client {
         wait_label: &str,
         mut on_change: impl FnMut(&str),
     ) -> Result<(), String> {
-        const TERMINAL_STATES: [&str; 4] = ["not_found", "dead", "stopped", "not_authenticated"];
+        const TERMINAL_STATES: [&str; 5] = ["not_found", "dead", "stopped", "not_authenticated", "unprovisioned"];
         let deadline = Instant::now() + timeout;
         let mut backoff = Duration::from_millis(200);
         let mut last = String::new();

--- a/vestad/src/agent_provider.rs
+++ b/vestad/src/agent_provider.rs
@@ -28,6 +28,11 @@ pub struct AgentStatusView {
     /// Same back-compat default so a response without the field isn't stuck in `SettingUp`.
     #[serde(default = "default_true")]
     pub setup_complete: bool,
+    /// Whether the agent has a provider chosen at all. Defaults to `true` for back-compat so an older
+    /// agent that omits the field isn't mislabeled Unprovisioned; a fresh/signed-out agent reports
+    /// `provider_configured: false` explicitly.
+    #[serde(default = "default_true")]
+    pub provider_configured: bool,
 }
 
 fn default_true() -> bool {

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -157,6 +157,9 @@ pub enum AgentStatus {
     SettingUp,
     Starting,
     NotAuthenticated,
+    /// Reachable, but no provider is chosen yet (fresh agent, or signed out) — needs first sign-in,
+    /// distinct from `NotAuthenticated` (a chosen provider whose credential is invalid/expired).
+    Unprovisioned,
     Stopped,
     Dead,
     NotFound,
@@ -398,15 +401,25 @@ pub async fn combined_status(
             let agent_name = name_from_cname(cname);
             let provider = crate::agent_provider::AgentProvider::new(http_client, agents_dir, agent_name);
             match provider.status().await {
-                Ok(s) if s.authed && s.setup_complete => AgentStatus::Alive,
-                Ok(s) if s.authed => AgentStatus::SettingUp,
-                Ok(_) => AgentStatus::NotAuthenticated,
+                Ok(s) => status_from_readiness(s.authed, s.setup_complete, s.provider_configured),
                 Err(_) => AgentStatus::Starting,
             }
         }
         ContainerStatus::Dead => AgentStatus::Dead,
         ContainerStatus::Stopped => AgentStatus::Stopped,
         ContainerStatus::NotFound => AgentStatus::NotFound,
+    }
+}
+
+/// Map the agent's `GET /status` readiness slice to its `AgentStatus`. An authenticated agent is
+/// `SettingUp` until first-start finishes, then `Alive`; a not-authenticated agent is `Unprovisioned`
+/// when it has no provider chosen at all, else `NotAuthenticated` (a chosen credential is invalid).
+fn status_from_readiness(authed: bool, setup_complete: bool, provider_configured: bool) -> AgentStatus {
+    match (authed, setup_complete, provider_configured) {
+        (true, true, _) => AgentStatus::Alive,
+        (true, false, _) => AgentStatus::SettingUp,
+        (false, _, true) => AgentStatus::NotAuthenticated,
+        (false, _, false) => AgentStatus::Unprovisioned,
     }
 }
 
@@ -2110,6 +2123,23 @@ pub async fn rename_agent(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn status_from_readiness_distinguishes_unprovisioned_from_unauthenticated() {
+        use AgentStatus::*;
+        // (authed, setup_complete, provider_configured) -> AgentStatus
+        assert_eq!(status_from_readiness(true, true, true), Alive);
+        assert_eq!(status_from_readiness(true, false, true), SettingUp);
+        assert_eq!(status_from_readiness(false, false, true), NotAuthenticated);
+        assert_eq!(status_from_readiness(false, false, false), Unprovisioned);
+    }
+
+    #[test]
+    fn agent_status_serializes_unprovisioned_to_snake_case() {
+        let to_str = |s: AgentStatus| serde_json::to_value(s).expect("serialize").as_str().expect("string").to_string();
+        assert_eq!(to_str(AgentStatus::Unprovisioned), "unprovisioned");
+        assert_eq!(to_str(AgentStatus::NotAuthenticated), "not_authenticated");
+    }
 
     #[test]
     fn build_phase_serializes_to_snake_case() {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2679,8 +2679,10 @@ mod tests {
     fn contract_fixtures() -> serde_json::Value {
         let agent_statuses: Vec<serde_json::Value> = [
             AgentStatus::Alive,
+            AgentStatus::SettingUp,
             AgentStatus::Starting,
             AgentStatus::NotAuthenticated,
+            AgentStatus::Unprovisioned,
             AgentStatus::Stopped,
             AgentStatus::Dead,
             AgentStatus::NotFound,

--- a/vestad/tests-integration/src/client.rs
+++ b/vestad/tests-integration/src/client.rs
@@ -235,7 +235,7 @@ impl Client {
             let status = self.agent_status(name)?;
             match status.status.as_str() {
                 "alive" => return Ok(()),
-                "not_found" | "dead" | "stopped" | "not_authenticated" =>
+                "not_found" | "dead" | "stopped" | "not_authenticated" | "unprovisioned" =>
                     return Err(format!("{}: {}", name, status.status)),
                 _ => {}
             }
@@ -277,7 +277,7 @@ impl Client {
         loop {
             let status = self.agent_status(name)?.status;
             match status.as_str() {
-                "alive" | "setting_up" | "not_authenticated" => return Ok(status),
+                "alive" | "setting_up" | "not_authenticated" | "unprovisioned" => return Ok(status),
                 "not_found" | "dead" => return Err(format!("{}: {}", name, status)),
                 _ => {}
             }

--- a/vestad/tests-integration/src/lib.rs
+++ b/vestad/tests-integration/src/lib.rs
@@ -461,7 +461,7 @@ fn cp_container_file(cname: &str, container_path: &str) -> Option<String> {
 
 /// Container is up (regardless of auth/readiness state).
 pub fn is_up(status: &str) -> bool {
-    matches!(status, "not_authenticated" | "starting" | "setting_up" | "alive" | "restarting")
+    matches!(status, "not_authenticated" | "unprovisioned" | "starting" | "setting_up" | "alive" | "restarting")
 }
 
 pub struct ReleasedVestad {

--- a/vestad/tests/multi_user/lifecycle.rs
+++ b/vestad/tests/multi_user/lifecycle.rs
@@ -35,8 +35,8 @@ fn stop_start_independent() {
 
     let alice_running = alice_client.wait_until_running(&name, 180).unwrap();
     let bob_running = bob_client.wait_until_running(&name, 180).unwrap();
-    assert_eq!(alice_running, "not_authenticated");
-    assert_eq!(bob_running, "not_authenticated");
+    assert_eq!(alice_running, "unprovisioned");
+    assert_eq!(bob_running, "unprovisioned");
 
     alice_client.stop_agent(&name).unwrap();
 
@@ -44,5 +44,5 @@ fn stop_start_independent() {
     assert_eq!(alice_stopped.status, "stopped", "alice's agent should be stopped");
 
     let bob_still_running = bob_client.agent_status(&name).unwrap();
-    assert_eq!(bob_still_running.status, "not_authenticated", "bob's agent should still be running");
+    assert_eq!(bob_still_running.status, "unprovisioned", "bob's agent should still be running");
 }

--- a/vestad/tests/server/auth.rs
+++ b/vestad/tests/server/auth.rs
@@ -20,12 +20,12 @@ fn agent_without_credentials_is_not_authenticated() {
     let c = SERVER.client();
     let agent = TestAgent::create(&c, &unique_agent("no-creds")).unwrap();
 
-    // No credentials are injected, so the agent re-derives provider state on restart
-    // and settles at not_authenticated. A fake token can't reach `authenticated` (the
+    // No provider is configured, so the agent re-derives provider state on restart
+    // and settles at unprovisioned. A fake token can't reach `authenticated` (the
     // agent's first turn 401s upstream and flips it back), so the authenticated path
     // is covered by the live tests with real credentials, not here.
     mark_first_start_done(&agent.name).unwrap();
     c.restart_agent(&agent.name).unwrap();
     let status = c.wait_until_running(&agent.name, 180).unwrap();
-    assert_eq!(status, "not_authenticated");
+    assert_eq!(status, "unprovisioned");
 }

--- a/vestad/tests/server/lifecycle.rs
+++ b/vestad/tests/server/lifecycle.rs
@@ -96,12 +96,12 @@ fn creation_flow() {
     let c = SERVER.client();
     let agent = TestAgent::create(&c, &unique_agent("flow")).unwrap();
 
-    // A fresh agent has no credentials, so it settles at not_authenticated. The
+    // A fresh agent has no provider chosen, so it settles at unprovisioned. The
     // authenticated -> alive path needs a real token that survives an upstream call
     // (a fake one is correctly rejected and flipped back), so it's covered by the
     // live tests, not here.
     let status = c.wait_until_running(&agent.name, 180).unwrap();
-    assert_eq!(status, "not_authenticated");
+    assert_eq!(status, "unprovisioned");
 }
 
 #[test]


### PR DESCRIPTION
## Why

The release-gated live upgrade e2e (`upgrade::upgrade_from_previous_release_converges_migrations_and_keeps_agent_healthy`) failed: after an in-place update, the agent booted **unauthenticated** and deferred every message, so its migration prompts never converged.

**Root cause:** `async_main` called `load_config()` *before* `migrate_legacy_config_to_store()`. A v0.1.160 agent keeps its provider in `vesta-provider.env`, not the nested store, so the boot loaded a default-Claude provider with no OAuth, derived `not_authenticated`, and the running process kept that stale config — the migration's write to the store only took effect on a *second* boot. The live e2e recently switched to OpenRouter, which (unlike Claude, whose creds live in a separate file) rides inside the provider config that got defaulted away — exposing a latent ordering bug.

A deeper smell sat underneath: `config.provider` could not represent "no provider chosen", so a fresh/signed-out agent was indistinguishable from a chosen-but-unauthenticated one. The default Claude provider was a stand-in for "nothing", and that masquerade is what let an ordering bug masquerade as a legitimate "waiting for sign-in" state.

## What

**The fix (single owner):** `load_config()` now converges legacy config *before* building it, so the loaded config is always authoritative — the wrong order is unrepresentable.

**The model (two orthogonal axes — provisioned? and authenticated?):**
- `config.provider: ClaudeConfig | OpenRouterConfig | None`, default `None` (fresh, or signed out). Sign-out clears the provider entirely instead of writing a fake default.
- Derivation yields three honest states: `none` (unprovisioned), `claude`/`openrouter` + `not_authenticated` (set but credential invalid/expired), and authenticated.
- The greeting/work gate keys off the derived auth **status**, not a Claude-only `isinstance` check — fixing the upgrade hang and a latent expired-Claude-token slip.
- Surfaced end-to-end: agent `GET /status` exposes `provider_configured`; vestad gains `AgentStatus::Unprovisioned` (distinct from `NotAuthenticated`); CLI + integration harness treat it as a resting status; the web app gives each state its own copy/orb/notification.
- **Provider card always renders**, with content per state: "set up provider" (unprovisioned), "sign in again" (credential expired), or full model/context/usage controls (authenticated).

## Tests

- Agent: `load_config` converges a legacy OpenRouter file first; gate defers for any not-authenticated provider; honest 3-state derivation; `provider_configured` on `/status`. Full agent suite green (357 passed; cc_sdk transport tests are tmux-gated on CI).
- vestad: `status_from_readiness` maps the four readiness states; `Unprovisioned` serde round-trip.
- web: api-contract test asserts `unprovisioned` is a known status; 94 vitest pass.
- All `check.sh` subcommands green locally (agent, cli, vestad, web).

## Notes

- The provider-card visual states are **not yet visually verified** (logic/types/tests pass; the app wasn't run).
- One pre-existing clippy lint (`serve.rs` `assertions-on-constants`) is flagged by a newer local toolchain than CI's; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)