### PR TITLE
fix(agent): skip catch-up nightly dream until first-start completes

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -386,6 +386,10 @@ def process_nightly_memory(*, state: vm.State, config: vm.VestaConfig) -> None:
     """Drop a dream notification if today's dream hasn't completed yet. Caller (`monitor_loop`) rate-limits this to once an hour and we bound retries to `DREAMER_CATCHUP_HOURS` after the configured hour, so a silent failure to call `mark_dreamer_complete` retries a few times but cannot preempt the agent for the rest of the day."""
     if config.ephemeral or config.nightly_memory_hour is None:
         return
+    # A brand-new agent has no history to curate; a catch-up dream firing inside the morning
+    # window would compact + restart mid-onboarding. Wait until first-start has completed.
+    if not state.persisted.first_start_done:
+        return
     now = _now()
     # Circular window so a late hour (e.g. 22:00) still catches up past midnight.
     hours_since_start = (now.hour - config.nightly_memory_hour) % 24

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -19,11 +19,31 @@ def _setup(tmp_path, *, dreamer_hour=4):
     return config
 
 
+def test_skips_dream_before_first_start_done(tmp_path):
+    """A brand-new agent (first_start_done=False) has nothing to curate, so a catch-up dream
+    landing inside the morning window must not fire mid-onboarding."""
+    from core.loops import process_nightly_memory
+
+    config = _setup(tmp_path)
+    state = vm.State()
+    assert state.persisted.first_start_done is False
+    fake_now = dt.datetime(2025, 6, 15, config.nightly_memory_hour, 0, 0)
+
+    with (
+        patch("core.loops._now", return_value=fake_now),
+        patch("core.loops.load_prompt", return_value="dreamer prompt"),
+    ):
+        process_nightly_memory(state=state, config=config)
+
+    assert list(config.notifications_dir.glob("nightly_dream-*.json")) == []
+
+
 def test_drops_dream_notification(tmp_path):
     from core.loops import process_nightly_memory
 
     config = _setup(tmp_path)
     state = vm.State()
+    state.persisted.first_start_done = True
     fake_now = dt.datetime(2025, 6, 15, config.nightly_memory_hour, 0, 0)
 
     with (
@@ -60,6 +80,7 @@ def test_nightly_memory_scheduling(tmp_path, dreamer_hour, last_dreamer_run, now
 
     config = _setup(tmp_path, dreamer_hour=dreamer_hour)
     state = vm.State()
+    state.persisted.first_start_done = True
     state.persisted.last_dreamer_run = last_dreamer_run
 
     with (

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -29,10 +29,8 @@ def test_skips_dream_before_first_start_done(tmp_path):
     assert state.persisted.first_start_done is False
     fake_now = dt.datetime(2025, 6, 15, config.nightly_memory_hour, 0, 0)
 
-    with (
-        patch("core.loops._now", return_value=fake_now),
-        patch("core.loops.load_prompt", return_value="dreamer prompt"),
-    ):
+    # No load_prompt patch: the first_start_done guard returns before load_prompt is reached.
+    with patch("core.loops._now", return_value=fake_now):
         process_nightly_memory(state=state, config=config)
 
     assert list(config.notifications_dir.glob("nightly_dream-*.json")) == []


### PR DESCRIPTION
Closes #905.

## Problem

A brand-new agent whose **first boot** lands inside the nightly-dream catch-up window (default **03:00–09:00**) fires a catch-up `nightly_dream` on its very first wake, when there is no history to dream about. The dream runs `mark_dreamer_complete`, which compacts the conversation and **restarts the agent mid-first-start**, interrupting onboarding.

- **Production:** a fresh agent created in the morning window gets yanked into a meaningless dream + compact-restart during onboarding.
- **Tests:** any live test that provisions a fresh agent is flaky by time-of-day (the `test-live` upgrade/dreamer gates fail intermittently when CI happens to run in the window).

## Root cause

`process_nightly_memory` only gated on the time window and `last_dreamer_run`. On a fresh agent `last_dreamer_run is None`, so inside the 6h window the dream fired immediately — even before first-start had completed.

## Fix

Gate `process_nightly_memory` on `state.persisted.first_start_done` (the issue's proposed primary fix). A brand-new agent has nothing to curate, so it should not dream until it has actually been onboarded. One early-return; no behavior change once an agent has finished first-start.

## Tests

- Added `test_skips_dream_before_first_start_done` — asserts no dream notification drops when `first_start_done=False` inside the morning window (red → green).
- Updated `test_drops_dream_notification` and `test_nightly_memory_scheduling` to set `first_start_done=True`, since they exercise the scheduling logic rather than the first-start gate.

`./check.sh agent` slice run locally: 12/12 dreamer tests pass, ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)