### PR TITLE
test(live): give the agent the exact file path for settle/probe markers

### DIFF
--- a/vestad/tests/live/common.rs
+++ b/vestad/tests/live/common.rs
@@ -110,6 +110,13 @@ pub fn write_notification(container: &str, message: &str, interrupt: bool) -> Re
     Ok(())
 }
 
+/// The notification body for a "create this exact file" probe (the settle / post-update / dream-resume
+/// signals). "at this exact path" keeps the agent from paraphrasing the absolute path into a
+/// `~`-relative one (which writes to the wrong place and the probe never settles).
+pub fn create_file_request(path: &str, content: &str) -> String {
+    format!("Create the file at this exact path: \"{path}\" containing only the word: {content}")
+}
+
 pub fn wait_for_file_contains(container: &str, path: &str, needle: &str, timeout: Duration) -> Result<String, String> {
     let deadline = std::time::Instant::now() + timeout;
     while std::time::Instant::now() < deadline {
@@ -162,7 +169,7 @@ const FIRST_START_AUTH_FAILURE_MARKERS: &[&str] = &["Provider auth lost (termina
 fn wait_for_first_start_settled(container: &str) -> Result<(), String> {
     write_notification(
         container,
-        &format!("Create the file \"{READY_MARKER}\" containing only the word: READY"),
+        &create_file_request(READY_MARKER, "READY"),
         false, // passive: the monitor loop delivers this only once the agent is idle
     )?;
     wait_for_file_contains(container, READY_MARKER, "READY", FIRST_START_SETTLE_TIMEOUT).map(|_| ())

--- a/vestad/tests/live/dreamer.rs
+++ b/vestad/tests/live/dreamer.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use vesta_tests::exec_in_container;
 
-use super::common::{lock_live_agent_b, wait_for_file_contains, write_notification, E2E_FILES_DIR};
+use super::common::{create_file_request, lock_live_agent_b, wait_for_file_contains, write_notification, E2E_FILES_DIR};
 
 /// Poll a container shell command until its stdout contains `needle`, or time out.
 fn wait_for_exec_contains(container: &str, script: &str, needle: &str, timeout: Duration) -> Result<String, String> {
@@ -73,7 +73,7 @@ fn dreamer_complete_compacts_in_place_and_restart_resumes_the_session() {
     // again after the restart, so the marker's appearance proves it came back alive on a resumed
     // session. (Passive notifications survive the restart; the monitor loop flushes them when idle.)
     let marker = format!("{E2E_FILES_DIR}/dream-resumed.txt");
-    write_notification(&container, &format!("Create the file \"{marker}\" containing only: DREAM_RESUMED"), false)
+    write_notification(&container, &create_file_request(&marker, "DREAM_RESUMED"), false)
         .expect("write resume marker task");
     wait_for_file_contains(&container, &marker, "DREAM_RESUMED", Duration::from_secs(300))
         .expect("agent did not come back alive after the dreamer restart");

--- a/vestad/tests/live/upgrade.rs
+++ b/vestad/tests/live/upgrade.rs
@@ -28,7 +28,8 @@ use vesta_tests::{
 };
 
 use super::common::{
-    openrouter_key, provision_and_settle, wait_for_file_contains, wait_until_alive_or_die, write_notification, ProviderApi,
+    create_file_request, openrouter_key, provision_and_settle, wait_for_file_contains, wait_until_alive_or_die, write_notification,
+    ProviderApi,
 };
 
 const AGENT_NAME: &str = "upgrade";
@@ -168,7 +169,7 @@ fn upgrade_from_previous_release_converges_migrations_and_keeps_agent_healthy() 
     // The agent must still do real work after the update, not just survive boot.
     write_notification(
         &container,
-        &format!("Create the file \"{UPGRADE_PROBE_MARKER}\" containing only the word: UPGRADED"),
+        &create_file_request(UPGRADE_PROBE_MARKER, "UPGRADED"),
         false,
     )
     .expect("send post-update probe");


### PR DESCRIPTION
## Why

The live tests signal "first-start settled", "did real work after update", and "dream resumed" by dropping a passive notification that asks the agent to create a marker file, then waiting for that file. The instruction was `Create the file "<absolute path>" containing only the word: X`.

A weaker live model (deepseek-v4-flash) **paraphrased the absolute path** — it rewrote `/root/agent/e2e-test/ready.txt` as `~/e2e-test/ready.txt` (dropping `agent/`), wrote to the wrong place, verified its own wrong file, and went idle "done." The harness was waiting on the real path, so the upgrade test timed out (`agent did not settle after first-start`).

## What

Route those markers through a small `create_file_request(path, content)` helper that phrases it as **"Create the file at this exact path: \"<path>\""**. It's still a real task the agent performs (create the file with the right contents) — there's just no room left to mis-render the path. Applied to the settle (`ready.txt`), post-update (`upgrade-ok.txt`), and dream-resume markers.

Keeps the precise action as a genuine capability bar (per the project's intent that tests exercise the agent doing tasks); only removes the path-paraphrasing failure mode.

Live target compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)