### PR TITLE
fix(web): drop duplicate update button on settings navbar

### DIFF
--- a/apps/web/src/components/CheckForUpdates/index.tsx
+++ b/apps/web/src/components/CheckForUpdates/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { UpdatePill } from "@/components/UpdatePill";
 import { useGateway } from "@/providers/GatewayProvider";
 
 // How long the "already on latest" confirmation lingers after a manual check.
@@ -21,7 +20,9 @@ export function CheckForUpdates() {
   );
 
   if (!reachable) return null;
-  if (updateAvailable) return <UpdatePill className="shrink-0" />;
+  // The adjacent StatusPill owns the update pill, so when an update is
+  // available we render nothing here and let it surface there instead.
+  if (updateAvailable) return null;
 
   const onCheckForUpdate = async () => {
     if (latestNoticeTimer.current) clearTimeout(latestNoticeTimer.current);
@@ -30,8 +31,8 @@ export function CheckForUpdates() {
     try {
       await checkForUpdate();
       // If a newer version exists the gateway flips updateAvailable and this
-      // component renders the UpdatePill instead, so the notice only surfaces
-      // when we're already up to date.
+      // component renders nothing (the StatusPill shows the pill), so the
+      // notice only surfaces when we're already up to date.
       setOnLatest(true);
       latestNoticeTimer.current = setTimeout(
         () => setOnLatest(false),


### PR DESCRIPTION
## Problem

On the app settings page, when a gateway update is available, **two identical "update" buttons** appeared in the top-right of the navbar.

The cause: `UpdatePill` is embedded inside `StatusPill` (`StatusPill/index.tsx:30`), and the settings navbar renders `<StatusPill />` and `<CheckForUpdates />` side by side (`AppSettings/index.tsx:32-33`). `CheckForUpdates` also early-returned its own `<UpdatePill />` when `updateAvailable`, so both lit up at once.

## Fix

Keep the update pill where it already lives — embedded in `StatusPill` — and stop `CheckForUpdates` from rendering a second one. `CheckForUpdates` is only ever placed next to a `StatusPill`, so the adjacent `StatusPill` owns the pill; `CheckForUpdates` now renders nothing when an update is available and keeps only its manual "Check for updates" / "On latest version already" affordance.

## Behavior after

- **Settings navbar** → one update button (from `StatusPill`); the "Check for updates" button shows only when up to date.
- **Home / Agent / Version-mismatch** screens → unchanged, one pill each from their `StatusPill`.
- **Gateway card** (mid-page settings) → unchanged; still surfaces its `StatusPill` pill.

## Verification

`./check.sh web` passes — tsc clean, prettier clean, 0 lint errors, all 94 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSDRjnrZLypPmrpwJFnM4v)_