### PR TITLE
fix(web): stop agent log viewer looping against a stopped agent

### DIFF
--- a/apps/web/src/api/logs.ts
+++ b/apps/web/src/api/logs.ts
@@ -7,6 +7,7 @@ const logSources = new Map<string, EventSource>();
 export function streamLogs(
   name: string,
   onEvent: (event: LogEvent) => void,
+  opts?: { replay?: boolean },
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const conn = getConnection();
@@ -15,7 +16,12 @@ export function streamLogs(
       return;
     }
 
-    const url = `${conn.url}/agents/${encodeURIComponent(name)}/logs?token=${encodeURIComponent(conn.accessToken)}`;
+    // A fresh stream replays the recent tail; a reconnect after a transport drop
+    // passes tail=0 so the server follows new lines only and we don't re-append
+    // the same block as duplicates.
+    const replay = opts?.replay ?? true;
+    const tailParam = replay ? "" : "&tail=0";
+    const url = `${conn.url}/agents/${encodeURIComponent(name)}/logs?token=${encodeURIComponent(conn.accessToken)}${tailParam}`;
     logSources.get(name)?.close();
     logSources.set(
       name,

--- a/apps/web/src/components/Console/index.tsx
+++ b/apps/web/src/components/Console/index.tsx
@@ -17,7 +17,7 @@ import { useLayout } from "@/stores/use-layout";
 import { streamLogs, stopLogs } from "@/api";
 import { stripAnsi } from "@/lib/ansi";
 import { linkify } from "@/lib/linkify";
-import { logStreamAction } from "@/lib/log-stream-policy";
+import { logStreamAction, isAgentContainerUp } from "@/lib/log-stream-policy";
 import type { AgentStatus } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -143,11 +143,18 @@ interface ConsoleProps {
 export function Console({ name, status, onClose, fullscreen }: ConsoleProps) {
   const navbarHeight = useLayout((s) => s.navbarHeight);
   const [lines, setLines] = useState<LogLine[]>([]);
-  const [streamState, setStreamState] = useState<StreamState>("live");
+  const [streamState, setStreamStateRaw] = useState<StreamState>("live");
   const idRef = useRef(0);
   const reconnectDelayRef = useRef(RECONNECT_BASE);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const activeRef = useRef(true);
+  // Mirror of streamState so the status-resume effect can read it synchronously
+  // without taking streamState as a dependency (which would re-key the stream).
+  const streamStateRef = useRef<StreamState>("live");
+  const setStreamState = (next: StreamState) => {
+    streamStateRef.current = next;
+    setStreamStateRaw(next);
+  };
 
   const connect = useRef<(replay: boolean) => void>(undefined);
 
@@ -206,8 +213,8 @@ export function Console({ name, status, onClose, fullscreen }: ConsoleProps) {
     };
   });
 
-  // Re-keyed on status so an agent start/stop/restart re-streams a fresh tail;
-  // within a session, transport drops reconnect (tail=0) without re-keying.
+  // Open a fresh stream on mount / agent switch. Status changes are handled by the
+  // resume effect below, so a stop doesn't clear and re-dump the final tail.
   useEffect(() => {
     activeRef.current = true;
     idRef.current = 0;
@@ -219,7 +226,24 @@ export function Console({ name, status, onClose, fullscreen }: ConsoleProps) {
       if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
       if (name) stopLogs(name);
     };
-  }, [name, status]);
+  }, [name]);
+
+  // Resume a fresh stream only when the agent comes back up after a stop. We never
+  // re-stream on the down transition (that re-dumped the same final tail), and never
+  // poll a stopped agent — the authoritative status tells us when it's back.
+  const prevStatusRef = useRef(status);
+  useEffect(() => {
+    const prev = prevStatusRef.current;
+    prevStatusRef.current = status;
+    if (prev === status || streamStateRef.current === "live") return;
+    if (isAgentContainerUp(status)) {
+      idRef.current = 0;
+      setLines([]);
+      reconnectDelayRef.current = RECONNECT_BASE;
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+      connect.current?.(true);
+    }
+  }, [status]);
 
   useEffect(() => {
     if (!onClose) return;

--- a/apps/web/src/components/Console/index.tsx
+++ b/apps/web/src/components/Console/index.tsx
@@ -143,18 +143,11 @@ interface ConsoleProps {
 export function Console({ name, status, onClose, fullscreen }: ConsoleProps) {
   const navbarHeight = useLayout((s) => s.navbarHeight);
   const [lines, setLines] = useState<LogLine[]>([]);
-  const [streamState, setStreamStateRaw] = useState<StreamState>("live");
+  const [streamState, setStreamState] = useState<StreamState>("live");
   const idRef = useRef(0);
   const reconnectDelayRef = useRef(RECONNECT_BASE);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const activeRef = useRef(true);
-  // Mirror of streamState so the status-resume effect can read it synchronously
-  // without taking streamState as a dependency (which would re-key the stream).
-  const streamStateRef = useRef<StreamState>("live");
-  const setStreamState = (next: StreamState) => {
-    streamStateRef.current = next;
-    setStreamStateRaw(next);
-  };
 
   const connect = useRef<(replay: boolean) => void>(undefined);
 
@@ -235,7 +228,10 @@ export function Console({ name, status, onClose, fullscreen }: ConsoleProps) {
   useEffect(() => {
     const prev = prevStatusRef.current;
     prevStatusRef.current = status;
-    if (prev === status || streamStateRef.current === "live") return;
+    // Only a genuine status change matters; streamState is a dep purely so the
+    // guard reads the current liveness, and the prev === status check makes
+    // streamState-only re-runs no-ops.
+    if (prev === status || streamState === "live") return;
     if (isAgentContainerUp(status)) {
       idRef.current = 0;
       setLines([]);
@@ -243,7 +239,7 @@ export function Console({ name, status, onClose, fullscreen }: ConsoleProps) {
       if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
       connect.current?.(true);
     }
-  }, [status]);
+  }, [status, streamState]);
 
   useEffect(() => {
     if (!onClose) return;

--- a/apps/web/src/components/Console/index.tsx
+++ b/apps/web/src/components/Console/index.tsx
@@ -17,6 +17,8 @@ import { useLayout } from "@/stores/use-layout";
 import { streamLogs, stopLogs } from "@/api";
 import { stripAnsi } from "@/lib/ansi";
 import { linkify } from "@/lib/linkify";
+import { logStreamAction } from "@/lib/log-stream-policy";
+import type { AgentStatus } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 const MAX_LINES = 5000;
@@ -101,12 +103,24 @@ interface LogLine {
   html: string;
 }
 
-function ReconnectingNotice() {
-  return <div className="text-center text-white/70 py-2">— reconnecting —</div>;
+// "live" while the stream is healthy, "stopped" once the agent cleanly signals
+// agent_stopped (terminal — no reconnect), "reconnecting" during transport-drop backoff.
+type StreamState = "live" | "stopped" | "reconnecting";
+
+const STREAM_NOTICE: Record<Exclude<StreamState, "live">, string> = {
+  stopped: "— agent stopped —",
+  reconnecting: "— reconnecting —",
+};
+
+function StreamNotice({ state }: { state: StreamState }) {
+  if (state === "live") return null;
+  return (
+    <div className="text-center text-white/70 py-2">{STREAM_NOTICE[state]}</div>
+  );
 }
 
-function StreamingPlaceholder({ ended }: { ended: boolean }) {
-  if (ended) return <ReconnectingNotice />;
+function StreamingPlaceholder({ state }: { state: StreamState }) {
+  if (state !== "live") return <StreamNotice state={state} />;
   return (
     <div className="min-h-full flex flex-col items-center justify-end gap-2 py-1">
       <div className="flex items-center gap-1">
@@ -121,75 +135,91 @@ function StreamingPlaceholder({ ended }: { ended: boolean }) {
 
 interface ConsoleProps {
   name: string;
+  status: AgentStatus;
   onClose?: () => void;
   fullscreen?: boolean;
 }
 
-export function Console({ name, onClose, fullscreen }: ConsoleProps) {
+export function Console({ name, status, onClose, fullscreen }: ConsoleProps) {
   const navbarHeight = useLayout((s) => s.navbarHeight);
   const [lines, setLines] = useState<LogLine[]>([]);
-  const [ended, setEnded] = useState(false);
+  const [streamState, setStreamState] = useState<StreamState>("live");
   const idRef = useRef(0);
   const reconnectDelayRef = useRef(RECONNECT_BASE);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const activeRef = useRef(true);
 
-  const startStream = useRef<() => void>(undefined);
+  const connect = useRef<(replay: boolean) => void>(undefined);
 
   useEffect(() => {
-    startStream.current = () => {
+    connect.current = (replay: boolean) => {
       if (!name || !activeRef.current) return;
       stopLogs(name);
-      setEnded(false);
+      setStreamState("live");
 
-      streamLogs(name, (event) => {
-        switch (event.kind) {
-          case "Line": {
-            // A line means the connection is healthy, so reset the backoff.
-            reconnectDelayRef.current = RECONNECT_BASE;
-            const stripped = stripAnsi(event.text);
-            setLines((prev) => {
-              const next = [
-                ...prev,
-                {
-                  id: idRef.current++,
-                  colorClass: lineColorClass(stripped),
-                  html: linkify(stripped),
-                },
-              ];
-              return next.length > MAX_LINES ? next.slice(-MAX_LINES) : next;
-            });
-            break;
-          }
-          case "End":
-          case "Error":
-            setEnded(true);
-            if (activeRef.current) {
-              reconnectTimerRef.current = setTimeout(() => {
-                reconnectDelayRef.current = Math.min(
-                  reconnectDelayRef.current * 2,
-                  RECONNECT_MAX,
-                );
-                startStream.current?.();
-              }, reconnectDelayRef.current);
+      streamLogs(
+        name,
+        (event) => {
+          const action = logStreamAction(event);
+          switch (action.kind) {
+            case "append": {
+              // A line means the connection is healthy, so reset the backoff.
+              reconnectDelayRef.current = RECONNECT_BASE;
+              const stripped = stripAnsi(action.text);
+              setLines((prev) => {
+                const next = [
+                  ...prev,
+                  {
+                    id: idRef.current++,
+                    colorClass: lineColorClass(stripped),
+                    html: linkify(stripped),
+                  },
+                ];
+                return next.length > MAX_LINES ? next.slice(-MAX_LINES) : next;
+              });
+              break;
             }
-            break;
-        }
-      });
+            case "stopped":
+              // agent_stopped is a clean terminal signal, not a failure: show the
+              // final tail and wait. A restart re-streams via the status effect
+              // below, so we never blind-reconnect against a stopped container.
+              setStreamState("stopped");
+              break;
+            case "reconnect":
+              // A transport drop while the agent is up: reconnect with backoff,
+              // requesting no replay (tail=0) so the tail isn't re-appended.
+              setStreamState("reconnecting");
+              if (activeRef.current) {
+                reconnectTimerRef.current = setTimeout(() => {
+                  reconnectDelayRef.current = Math.min(
+                    reconnectDelayRef.current * 2,
+                    RECONNECT_MAX,
+                  );
+                  connect.current?.(false);
+                }, reconnectDelayRef.current);
+              }
+              break;
+          }
+        },
+        { replay },
+      );
     };
   });
 
+  // Re-keyed on status so an agent start/stop/restart re-streams a fresh tail;
+  // within a session, transport drops reconnect (tail=0) without re-keying.
   useEffect(() => {
     activeRef.current = true;
     idRef.current = 0;
     setLines([]);
-    startStream.current?.();
+    reconnectDelayRef.current = RECONNECT_BASE;
+    connect.current?.(true);
     return () => {
       activeRef.current = false;
       if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
       if (name) stopLogs(name);
     };
-  }, [name]);
+  }, [name, status]);
 
   useEffect(() => {
     if (!onClose) return;
@@ -271,7 +301,7 @@ export function Console({ name, onClose, fullscreen }: ConsoleProps) {
           }
         >
           {count === 0 ? (
-            <StreamingPlaceholder ended={ended} />
+            <StreamingPlaceholder state={streamState} />
           ) : (
             <div
               ref={virtualizer.containerRef}
@@ -313,7 +343,7 @@ export function Console({ name, onClose, fullscreen }: ConsoleProps) {
                     />
                     {isLast && (
                       <div className={fullscreen ? "pb-page" : "pb-2"}>
-                        {ended && <ReconnectingNotice />}
+                        <StreamNotice state={streamState} />
                       </div>
                     )}
                   </div>

--- a/apps/web/src/lib/log-stream-policy.test.ts
+++ b/apps/web/src/lib/log-stream-policy.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { logStreamAction } from "./log-stream-policy";
+
+describe("logStreamAction", () => {
+  it("appends a line with its text", () => {
+    expect(logStreamAction({ kind: "Line", text: "hello" })).toEqual({
+      kind: "append",
+      text: "hello",
+    });
+  });
+
+  it("treats agent_stopped (End) as terminal, not a reconnect", () => {
+    expect(logStreamAction({ kind: "End" })).toEqual({ kind: "stopped" });
+  });
+
+  it("reconnects on a transport Error", () => {
+    expect(logStreamAction({ kind: "Error", message: "disconnected" })).toEqual(
+      { kind: "reconnect" },
+    );
+  });
+});

--- a/apps/web/src/lib/log-stream-policy.test.ts
+++ b/apps/web/src/lib/log-stream-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { logStreamAction } from "./log-stream-policy";
+import { logStreamAction, isAgentContainerUp } from "./log-stream-policy";
+import type { AgentStatus } from "./types";
 
 describe("logStreamAction", () => {
   it("appends a line with its text", () => {
@@ -17,5 +18,25 @@ describe("logStreamAction", () => {
     expect(logStreamAction({ kind: "Error", message: "disconnected" })).toEqual(
       { kind: "reconnect" },
     );
+  });
+});
+
+describe("isAgentContainerUp", () => {
+  const up: AgentStatus[] = [
+    "alive",
+    "starting",
+    "setting_up",
+    "not_authenticated",
+    "unprovisioned",
+    "restarting",
+  ];
+  const down: AgentStatus[] = ["stopped", "dead", "not_found"];
+
+  it.each(up)("treats %s as up (streams live logs)", (status) => {
+    expect(isAgentContainerUp(status)).toBe(true);
+  });
+
+  it.each(down)("treats %s as down (no live logs)", (status) => {
+    expect(isAgentContainerUp(status)).toBe(false);
   });
 });

--- a/apps/web/src/lib/log-stream-policy.ts
+++ b/apps/web/src/lib/log-stream-policy.ts
@@ -1,10 +1,10 @@
-import type { LogEvent } from "./types";
+import type { AgentStatus, LogEvent } from "./types";
 
-// The single owner of how a log-stream event maps to a viewer action. Kept pure
-// and separate from the Console component so the reconnect policy is unit-testable:
-// crucially, a clean "agent_stopped" (End) is terminal and must NOT trigger a
-// reconnect (otherwise a stopped agent re-replays its log tail on a tight loop),
-// while a genuine transport Error must reconnect.
+// The single owner of how the log viewer reacts to the stream and to agent
+// liveness. Kept pure and separate from the Console component so the policy is
+// unit-testable: crucially, a clean "agent_stopped" (End) is terminal and must
+// NOT trigger a reconnect (otherwise a stopped agent re-replays its log tail on a
+// tight loop), while a genuine transport Error must reconnect.
 export type LogStreamAction =
   | { kind: "append"; text: string }
   | { kind: "stopped" }
@@ -19,4 +19,18 @@ export function logStreamAction(event: LogEvent): LogStreamAction {
     case "Error":
       return { kind: "reconnect" };
   }
+}
+
+// The statuses where the agent's container is not running, so the log endpoint
+// returns the final tail + agent_stopped rather than a live `tail -f`.
+const CONTAINER_DOWN_STATUSES: ReadonlySet<AgentStatus> = new Set<AgentStatus>([
+  "stopped",
+  "dead",
+  "not_found",
+]);
+
+// Whether the container is up and will stream live logs. Drives resume-on-restart
+// off the authoritative status instead of polling a stopped agent.
+export function isAgentContainerUp(status: AgentStatus): boolean {
+  return !CONTAINER_DOWN_STATUSES.has(status);
 }

--- a/apps/web/src/lib/log-stream-policy.ts
+++ b/apps/web/src/lib/log-stream-policy.ts
@@ -1,0 +1,22 @@
+import type { LogEvent } from "./types";
+
+// The single owner of how a log-stream event maps to a viewer action. Kept pure
+// and separate from the Console component so the reconnect policy is unit-testable:
+// crucially, a clean "agent_stopped" (End) is terminal and must NOT trigger a
+// reconnect (otherwise a stopped agent re-replays its log tail on a tight loop),
+// while a genuine transport Error must reconnect.
+export type LogStreamAction =
+  | { kind: "append"; text: string }
+  | { kind: "stopped" }
+  | { kind: "reconnect" };
+
+export function logStreamAction(event: LogEvent): LogStreamAction {
+  switch (event.kind) {
+    case "Line":
+      return { kind: "append", text: event.text };
+    case "End":
+      return { kind: "stopped" };
+    case "Error":
+      return { kind: "reconnect" };
+  }
+}

--- a/apps/web/src/pages/AgentLogs/index.tsx
+++ b/apps/web/src/pages/AgentLogs/index.tsx
@@ -2,7 +2,7 @@ import { Console } from "@/components/Console";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 
 export function AgentLogs() {
-  const { name } = useSelectedAgent();
+  const { name, agent } = useSelectedAgent();
 
-  return <Console name={name} fullscreen />;
+  return <Console name={name} status={agent.status} fullscreen />;
 }


### PR DESCRIPTION
## Problem

When an agent is stopped, the logs page reconnected to the SSE log endpoint roughly every second and re-appended the same block of ~500 lines endlessly (looks like fast polling in the Network tab).

Root cause was a layered smell, not just a symptom:
- The `Console` treated the clean `agent_stopped` SSE event the same as a transport error and reconnected on a timer.
- vestad replays the last 500 log lines on every connection, so each reconnect re-dumped the tail.
- Liveness had **two owners**: vestad already computes authoritative `AgentInfo.status` and pushes it live over the gateway WS, but the Console re-derived "is the agent back?" by blind-reconnecting.

## Fix

Give liveness a single owner. The Console now consumes the agent's `status` (via `useSelectedAgent`) instead of probing it:

- A clean `agent_stopped` (`End`) is **terminal** — show the final tail + a "— agent stopped —" notice, no reconnect.
- **Resume** is driven by a dedicated status effect that fires only when the container transitions back **up** after a stop — never on the down transition (so stopping no longer clears and re-dumps the tail), and never by polling a stopped agent.
- Only a genuine transport `Error` reconnects, with backoff, and it now requests `tail=0` so the replayed tail isn't re-appended as duplicates.

The server already supported the no-replay request (`tail=0` makes the stopped path slice empty and the running path run `tail -n 0 -f`), so this needed **no Rust/wire-protocol change** — just the client requesting it on reconnect.

The reconnect policy and the container up/down classification live in a pure `log-stream-policy` module so they're unit-tested: `End` is terminal, `Error` reconnects, and the up/down set matches vestad's container→status mapping (`docker.rs`).

## Behavior after

| Screen / event | Before | After |
| --- | --- | --- |
| Stopped agent logs | reconnects ~1/s, block repeats | final tail + "— agent stopped —", no loop |
| Stop a running agent | (n/a) | no flicker, no tail re-dump |
| Restart / start | (n/a) | one clean fresh stream on the up transition |
| Transport blip (alive) | re-dumped tail | reconnects with `tail=0`, no duplicates |

## Known limitation (by design)

On a transport reconnect, `tail=0` follows new lines only, so a handful of lines written during the brief disconnect window could be skipped. Acceptable for a live tail viewer — events.db is the durable record. A lossless `Last-Event-ID`/cursor resume is a possible follow-up but is a real wire-protocol change for marginal benefit.

## Tests / checks

`./check.sh web` passes — tsc, prettier, eslint (0 errors), 106 tests (incl. new `log-stream-policy` unit tests parametrized over every `AgentStatus`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSDRjnrZLypPmrpwJFnM4v)_