### PR TITLE
fix(vestad): restart running agents when an upgrade re-extracts new core

### DIFF
--- a/vestad/src/agent_code.rs
+++ b/vestad/src/agent_code.rs
@@ -46,6 +46,17 @@ fn embed_fingerprint() -> &'static str {
 
 /// Re-extracts embedded agent code into `agent-code/` whenever the on-disk
 /// fingerprint marker doesn't match the binary's (i.e. after a rebuild).
+/// Whether the next `ensure_agent_code` call would re-extract (the on-disk fingerprint is missing
+/// or differs from this binary's embedded code). Callers check this BEFORE extracting to learn the
+/// boot is delivering new agent code, so reconcile can restart running agents to pick it up — a
+/// re-extract `remove_dir_all`s the code dir, detaching the inode running agents' core mounts hold.
+pub fn agent_code_is_stale(config: &Path) -> bool {
+    let dir = agent_code_dir(config);
+    let marker = dir.join(FINGERPRINT_MARKER);
+    let main_py = dir.join(MAIN_PY);
+    !(main_py.exists() && fs::read_to_string(&marker).ok().as_deref() == Some(embed_fingerprint()))
+}
+
 pub fn ensure_agent_code(config: &Path) -> Result<PathBuf, AgentCodeError> {
     let dir = agent_code_dir(config);
     let fingerprint = embed_fingerprint();
@@ -121,5 +132,22 @@ mod tests {
         fs::write(dir.join(FINGERPRINT_MARKER), "stale").expect("write stale marker");
         let _ = ensure_agent_code(config).expect("third call");
         assert_ne!(fs::read(&sentinel).expect("read sentinel"), b"SENTINEL");
+    }
+
+    #[test]
+    fn is_stale_tracks_whether_ensure_would_reextract() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = tmp.path();
+
+        // Nothing extracted yet -> stale (the next ensure would extract).
+        assert!(agent_code_is_stale(config), "missing code must read as stale");
+
+        ensure_agent_code(config).expect("extract");
+        assert!(!agent_code_is_stale(config), "freshly extracted code is not stale");
+
+        // A fingerprint mismatch (what a new vestad version produces) reads as stale -> reconcile
+        // restarts running agents to pick up the re-extracted core.
+        fs::write(agent_code_dir(config).join(FINGERPRINT_MARKER), "different-version").expect("write marker");
+        assert!(agent_code_is_stale(config), "a fingerprint mismatch must read as stale");
     }
 }

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1829,10 +1829,13 @@ fn reconcile_blocked_by_disk(available: Option<u64>) -> bool {
 
 /// Ensure all containers match expected config and running agents are restarted.
 /// Called once at startup after agent code and env files are ready.
+/// `agent_code_changed` is true when this boot re-extracted the embedded core (see
+/// `agent_code_is_stale`); running core-mounted agents are restarted to reload it.
 /// `manages_core_code` returns whether a given agent name has vestad-managed core code mounts (default true).
 pub async fn reconcile_containers(
     docker: &Docker,
     env_config: &AgentEnvConfig,
+    agent_code_changed: bool,
     manages_core_code: &(dyn Fn(&str) -> bool + Send + Sync),
     wants_running: &(dyn Fn(&str) -> bool + Send + Sync),
 ) {
@@ -1942,11 +1945,20 @@ pub async fn reconcile_containers(
         if let Err(e) = ensure_on_failure_policy(docker, cname).await {
             tracing::warn!(agent = %name, error = %e, "failed to set on-failure restart policy");
         }
-        let running = container_status(docker, cname).await == ContainerStatus::Running;
+        let raw = docker.inspect_container(cname, None).await.ok();
+        let running = raw.as_ref().and_then(|r| r.state.as_ref()).and_then(|s| s.running).unwrap_or(false);
+        let has_core_mount = raw.as_ref().map(|r| mounts_have_core_code(r.mounts.as_deref().unwrap_or(&[]))).unwrap_or(false);
         if wants_running(name) {
             if !running {
                 tracing::info!(agent = %name, "starting (desired running)");
                 start_container(docker, cname).await;
+            } else if agent_code_changed && has_core_mount {
+                // vestad re-extracted the embedded core this boot. A running agent still holds the
+                // old code in memory and its core mount points at the now-replaced dir, so restart
+                // it to reload the new core and re-bind the mount. (Boot-started agents above came
+                // up fresh already; this catches agents that stayed running across the upgrade.)
+                tracing::info!(agent = %name, "restarting to pick up new agent code");
+                docker.restart_container(cname, Some(RestartContainerOptions { t: Some(CONTAINER_RESTART_TIMEOUT_SECS), signal: None })).await.ok();
             }
         } else if running {
             tracing::info!(agent = %name, "stopping (user-stopped)");

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2472,6 +2472,10 @@ pub async fn run_server(cfg: ServerConfig) {
         mode = if cfg!(debug_assertions) { "dev" } else { "prod" },
         "agent code embedded in binary",
     );
+    // Capture whether this boot will deliver new agent code BEFORE extracting it: a re-extract
+    // replaces the code dir, so reconcile must restart running agents to reload the new core (and
+    // re-bind their now-detached core mount).
+    let agent_code_changed = crate::agent_code::agent_code_is_stale(&env_config.config_dir);
     if let Err(e) = crate::agent_code::ensure_agent_code(&env_config.config_dir) {
         tracing::error!(error = %e, "failed to ensure agent code");
     }
@@ -2485,6 +2489,7 @@ pub async fn run_server(cfg: ServerConfig) {
         docker::reconcile_containers(
             &reconcile_docker,
             &reconcile_env,
+            agent_code_changed,
             &move |name| agent_settings.get(name).is_none_or(|s| s.manage_agent_code),
             // Desired-run state is read LIVE (not a boot snapshot): a stop/start the user issues
             // during the slow reconcile window would otherwise be reverted by the start/stop step.

--- a/vestad/tests/server/lifecycle.rs
+++ b/vestad/tests/server/lifecycle.rs
@@ -1,3 +1,6 @@
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
 use vesta_tests::{
     TestAgent, TestServerBuilder, SERVER, SHARED_RO_AGENT, agent_container_name, docker_cmd,
     find_vestad, inject_fake_token, is_up, unique_agent,
@@ -213,6 +216,72 @@ fn user_desired_persists_and_boot_start_respects_it() {
 
     let _ = client.destroy_agent(&running_name);
     let _ = client.destroy_agent(&stopped_name);
+}
+
+/// Entrypoint-UNCHANGED upgrade path: when vestad re-extracts new agent code without a container
+/// config change (so the container is NOT rebuilt), a RUNNING agent must be restarted to pick up
+/// the new core — its old code stays in memory and its core mount points at the now-replaced dir.
+/// The upgrade e2e only covers entrypoint-CHANGED upgrades (which force a rebuild), so this pins the
+/// gap that left agents serving stale code after a same-entrypoint upgrade.
+#[test]
+fn running_agent_restarts_when_agent_code_changes() {
+    let user = format!("codechange-e2e-{}", std::process::id());
+    let home = tempfile::TempDir::new_in(env!("CARGO_TARGET_TMPDIR")).expect("create persistent home");
+    let vestad = find_vestad().expect("locate vestad binary");
+    let marker = home.path().join(".config/vesta/vestad/agent-code/.vestad-fingerprint");
+
+    let name;
+    let started_before;
+    let container;
+    {
+        let server = TestServerBuilder::new()
+            .user(&user)
+            .home(home.path().to_path_buf())
+            .vestad_bin(vestad.clone())
+            .start()
+            .expect("start vestad");
+        let client = server.client();
+        name = client.create_agent(&unique_agent("code-change")).expect("create agent");
+        client.wait_until_running(&name, 90).expect("agent should come up");
+        container = format!("vesta-{user}-{name}");
+        started_before = started_at(&container);
+        assert!(!started_before.is_empty(), "agent should be running before the simulated upgrade");
+
+        // Simulate a vestad version bump WITHOUT an entrypoint change: corrupt the fingerprint so
+        // the next boot re-extracts the core (agent_code_changed=true) while needs_rebuild stays
+        // false. The agent stays running across the restart (TestServer SIGKILLs vestad, so its
+        // stop-all-on-shutdown never runs) — exactly the case that left agents stale.
+        std::fs::write(&marker, "different-version").expect("corrupt fingerprint marker");
+    }
+
+    let server = TestServerBuilder::new()
+        .user(&user)
+        .home(home.path().to_path_buf())
+        .vestad_bin(vestad)
+        .start()
+        .expect("restart vestad on same home");
+    let client = server.client();
+
+    // Reconcile must restart the still-running agent (no rebuild needed) so it reloads the new core.
+    let deadline = Instant::now() + Duration::from_secs(120);
+    loop {
+        let now = started_at(&container);
+        if !now.is_empty() && now != started_before {
+            break;
+        }
+        if Instant::now() >= deadline {
+            panic!("running agent was NOT restarted after an agent-code change (StartedAt {started_before:?} unchanged)");
+        }
+        sleep(Duration::from_millis(500));
+    }
+    client.wait_until_running(&name, 90).expect("agent should be back up after the code-change restart");
+
+    let _ = client.destroy_agent(&name);
+}
+
+/// A container's `State.StartedAt` (RFC3339), or empty. A restart advances it.
+fn started_at(container: &str) -> String {
+    docker_cmd(&["inspect", "--format", "{{.State.StartedAt}}", container]).unwrap_or_default()
 }
 
 /// Read an agent home's settings.json as JSON (panics if missing/invalid — the test created it).


### PR DESCRIPTION
## The bug (regression from #912, shipped in 0.1.163 beta)
After upgrading vestad to 0.1.163, a **running** agent serves **stale code** — the new agent API endpoints (`/config/notification-policy`, `/notifications/pending`) 404, and its `/root/agent/core` mount is broken.

Diagnosed live on a real agent (apollo): every agent that's **running** when its host upgrades to 0.1.163 hits this; agents that happened to be **stopped** boot-start fresh and are fine (confirmed on a second agent, athena).

### Root cause
Three things compound:
1. The entrypoint didn't change 0.1.162→0.1.163, so `needs_rebuild` is false → **no rebuild**.
2. #912's reconcile **doesn't restart already-running agents** (it removed the old "restart running agents on reconcile").
3. The old 0.1.162 vestad lacks stop-all-on-shutdown, so it didn't stop agents on exit either.

So a running agent is never stopped *or* restarted across the upgrade. Worse, `ensure_agent_code` does `remove_dir_all(dir)` + re-extract on a version change, **detaching the inode** the agent's read-only core bind mount is pinned to — the mounted `api.py` is literally gone. The agent keeps running old in-memory code.

**Why the upgrade e2e missed it:** it upgrades from 0.1.161, where the entrypoint *did* change → forces a rebuild → fresh code → passes. It never exercised an entrypoint-*unchanged* upgrade.

## The fix
Reconcile restarts **running, desired-running, core-mounted** agents when this boot re-extracted the embedded core.
- `agent_code_is_stale(config)` — cheap fingerprint check, reports (before extraction) whether `ensure_agent_code` will re-extract.
- `serve.rs` captures it and threads `agent_code_changed` into `reconcile_containers`.
- Phase 3: a running core-mounted agent gets a `docker restart` when the code changed → reloads the new core + re-binds the replaced mount. (Proven by the live apollo restart that recovered it.)
- Stopped agents already boot-start fresh; user-stopped stay down; a **no-change** vestad restart leaves running agents alone (no gratuitous restarts).

Robust on **any** upgrade path — graceful, or a crash-restart where stop-all-on-shutdown never ran — and targeted (only fires when the core actually changed).

## Tests
- `agent_code::is_stale_tracks_whether_ensure_would_reextract` (unit)
- `lifecycle::running_agent_restarts_when_agent_code_changes` (integration) — the entrypoint-unchanged path the upgrade e2e missed: corrupt the fingerprint between two vestad starts with a running agent, assert reconcile restarts it.

140 bin tests + clippy clean.

## Rollout
Cut as 0.1.164. Agents currently on 0.1.163 recover automatically on that upgrade (0.1.163 *has* stop-all-on-shutdown → they're stopped→boot-started fresh). **Do not promote 0.1.163.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)