### PR TITLE
fix(web): reduce collapsed agent island name nudge to 1px

### DIFF
--- a/apps/web/src/components/AgentIsland/Collapsed.tsx
+++ b/apps/web/src/components/AgentIsland/Collapsed.tsx
@@ -28,7 +28,7 @@ export function AgentIslandCollapsed({
           label={`${name}: ${statusLabel || orbState}`}
         />
       </div>
-      <div className="relative -top-0.5 flex min-w-0 flex-1 items-baseline gap-1.5">
+      <div className="relative -top-px flex min-w-0 flex-1 items-baseline gap-1.5">
         <span className="min-w-0 truncate font-serif text-base font-medium leading-tight tracking-tight sm:text-lg">
           {name}
         </span>


### PR DESCRIPTION
## Summary
- The collapsed Agent Island pill nudged the agent name + status row up by 2px (`relative -top-0.5`) to optically align the text with the orb.
- Brings that upward nudge down to 1px (`relative -top-px`).

## Test plan
- Visual: collapsed Agent Island pill — name/status text sits 1px higher rather than 2px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)