### PR TITLE
feat(notifications): control + reason about interrupt-rule precedence

### DIFF
--- a/agent/skills/notifications/SKILL.md
+++ b/agent/skills/notifications/SKILL.md
@@ -43,7 +43,14 @@ notification's other fields. Every field/condition you set must hold (AND); what
   `is_group`, `media_type`, and so on). Two aliases search across a source's synonym fields so you needn't
   know the exact name: `sender` (the identity fields) and `text` (body/message). `--sender X` and
   `--keyword RE` are shortcuts for `--match 'sender=X'` and `--match 'text~=RE'`.
-- Rules are an ordered list, **first match wins**, so put specific rules before broad ones.
+- Rules are an ordered list, **first match wins**: evaluation runs top to bottom and stops at the first
+  rule that matches, so the top rule has the highest priority. Order is the only precedence; a later,
+  more-specific rule never overrides an earlier, broader one. To OR across different fields, write
+  separate rules (a single rule's conditions are all ANDed).
+- **Placement is handled for you, but you can override it.** `add` auto-places a new rule above any
+  broader rule (one with fewer conditions), so a narrow exception is not shadowed by a broad rule that
+  would match first. Use `--before <id>` / `--after <id>` to place it explicitly, or `move <id>` to
+  reorder later (`--before`/`--after`/`--top`/`--bottom`). `list` shows rules in priority order.
 - A rule with no `source`/`type`/`match` is a catch-all; only useful as the last rule.
 - Precedence when deciding interrupt vs pool: (1) the first matching rule, then (2) your per-`(source, type)`
   **default override** if you set one, then (3) the default the source chose. Your internal notifications
@@ -76,6 +83,12 @@ uv run ~/agent/skills/notifications/scripts/notif-interrupt-rules.py add --sourc
 
 # Negate: interrupt for any chat that is NOT that one group
 uv run ~/agent/skills/notifications/scripts/notif-interrupt-rules.py add --source whatsapp --match 'chat_name!=Bride squad' --action interrupt
+
+# Reorder when precedence matters (first match wins). New rules auto-place above broader ones, but you
+# can force position on add, or move an existing rule by id.
+uv run ~/agent/skills/notifications/scripts/notif-interrupt-rules.py add --source whatsapp --action pool --after <id>
+uv run ~/agent/skills/notifications/scripts/notif-interrupt-rules.py move <id> --top
+uv run ~/agent/skills/notifications/scripts/notif-interrupt-rules.py move <id> --before <other-id>
 
 # Remove a rule by id, or clear them all
 uv run ~/agent/skills/notifications/scripts/notif-interrupt-rules.py remove <id>

--- a/agent/skills/notifications/scripts/notif-interrupt-rules.py
+++ b/agent/skills/notifications/scripts/notif-interrupt-rules.py
@@ -145,7 +145,12 @@ def _render(rules: list[dict[str, object]]) -> str:
 
 
 def cmd_list(_: argparse.Namespace) -> int:
-    print(_render(load_section("rules")))
+    rules = load_section("rules")
+    if rules:
+        # Guidance on stderr so stdout stays pure JSON: the list is the priority order. Top = highest
+        # priority (first match wins); reorder with `move` or `add --before|--after`.
+        print("rules in priority order (first match wins; top = highest priority):", file=sys.stderr)
+    print(_render(rules))
     return 0
 
 
@@ -167,6 +172,36 @@ def _parse_match(spec: str) -> dict[str, object]:
     if op == "regex":
         re.compile(value)  # surfaces re.error -> reported by main()
     return {"field": field, "op": op, "value": value, "negate": opsym.startswith("!")}
+
+
+def _specificity(rule: dict[str, object]) -> int:
+    """How narrowly a rule matches = its condition count (source, type, and each match predicate). Used
+    only to place a new rule; the engine itself is purely first-match-wins, never specificity-ranked."""
+    count = sum(1 for field in ("source", "type") if rule.get(field) is not None)
+    match = rule.get("match")
+    return count + (len(match) if isinstance(match, list) else 0)
+
+
+def _index_of(rules: list[dict[str, object]], rule_id: str) -> int:
+    for index, rule in enumerate(rules):
+        if rule.get("id") == rule_id:
+            return index
+    raise ValueError(f"no rule with id {rule_id}")
+
+
+def _placement_index(rules: list[dict[str, object]], new_rule: dict[str, object], before: str | None, after: str | None) -> int:
+    """Where to insert a new rule. Explicit --before/--after win; otherwise auto-place by specificity:
+    above the first existing rule that is strictly broader (fewer conditions), so a narrow exception
+    lands ahead of the broad rule it refines instead of being shadowed by it. Touches no other rule."""
+    if before is not None:
+        return _index_of(rules, before)
+    if after is not None:
+        return _index_of(rules, after) + 1
+    spec = _specificity(new_rule)
+    for index, rule in enumerate(rules):
+        if _specificity(rule) < spec:
+            return index
+    return len(rules)
 
 
 def cmd_add(args: argparse.Namespace) -> int:
@@ -194,9 +229,45 @@ def cmd_add(args: argparse.Namespace) -> int:
             return 1
     rule: dict[str, object] = {"id": uuid.uuid4().hex, "source": args.source, "type": args.type, "match": predicates, "action": args.action}
     rules = load_section("rules")
-    rules.append(rule)
+    try:
+        index = _placement_index(rules, rule, args.before, args.after)
+    except ValueError as e:
+        print(f"error: {e} (run `list` to see rule ids)", file=sys.stderr)
+        return 1
+    rules.insert(index, rule)
     save_section("rules", rules)
-    print(f"Added rule {rule['id']}: {_describe_scope(rule)} -> {args.action}. Now {len(rules)} rule(s); applies next tick.")
+    where = "" if index == len(rules) - 1 else f" at position {index + 1} of {len(rules)}"
+    print(f"Added rule {rule['id']}: {_describe_scope(rule)} -> {args.action}{where}. Now {len(rules)} rule(s); applies next tick.")
+    return 0
+
+
+def cmd_move(args: argparse.Namespace) -> int:
+    rules = load_section("rules")
+    try:
+        current = _index_of(rules, args.id)
+    except ValueError as e:
+        print(f"error: {e} (run `list` to see rule ids)", file=sys.stderr)
+        return 1
+    rule = rules.pop(current)
+    rest = rules  # the list without the moved rule; target ids resolve against this
+    try:
+        if args.to_top:
+            target = 0
+        elif args.to_bottom:
+            target = len(rest)
+        elif args.before is not None:
+            target = _index_of(rest, args.before)
+        elif args.after is not None:
+            target = _index_of(rest, args.after) + 1
+        else:
+            print("error: move needs one of --before, --after, --top, --bottom", file=sys.stderr)
+            return 1
+    except ValueError as e:
+        print(f"error: {e} (run `list` to see rule ids)", file=sys.stderr)
+        return 1
+    rest.insert(target, rule)
+    save_section("rules", rest)
+    print(f"Moved rule {args.id} to position {target + 1} of {len(rest)}; applies next tick.")
     return 0
 
 
@@ -338,7 +409,11 @@ def main() -> int:
 
     sub.add_parser("list", help="Print the current ordered ruleset as JSON.")
 
-    add = sub.add_parser("add", help="Append a rule (first matching rule wins, so order matters).")
+    add = sub.add_parser(
+        "add",
+        help="Add a rule. First matching rule wins (top = highest priority). By default a new rule is "
+        "placed above broader rules so a narrow exception is not shadowed; use --before/--after to override.",
+    )
     add.add_argument("--action", choices=ACTIONS, required=True, help="interrupt = preempt the current turn; pool = wait until idle.")
     add.add_argument("--source", help="Exact match on notification source (case-insensitive), e.g. twitter, whatsapp.")
     add.add_argument("--type", help="Exact match on notification type (case-insensitive), e.g. message, tweet.")
@@ -355,6 +430,17 @@ def main() -> int:
         "'!=' not, '!~=' not-regex. Repeatable (all must match). e.g. --match 'chat_name=Bride squad', "
         "--match 'chat_type!=group', --match 'chat_name~=^proj-'. Case-insensitive.",
     )
+    add_pos = add.add_mutually_exclusive_group()
+    add_pos.add_argument("--before", metavar="ID", help="Place the new rule directly above this rule id (higher priority).")
+    add_pos.add_argument("--after", metavar="ID", help="Place the new rule directly below this rule id (lower priority).")
+
+    move = sub.add_parser("move", help="Reorder a rule (first match wins, so position is priority).")
+    move.add_argument("id", help="The rule id to move (see `list`).")
+    move_to = move.add_mutually_exclusive_group(required=True)
+    move_to.add_argument("--before", metavar="ID", help="Move directly above this rule id.")
+    move_to.add_argument("--after", metavar="ID", help="Move directly below this rule id.")
+    move_to.add_argument("--top", dest="to_top", action="store_true", help="Move to the top (highest priority).")
+    move_to.add_argument("--bottom", dest="to_bottom", action="store_true", help="Move to the bottom (lowest priority).")
 
     remove = sub.add_parser("remove", help="Remove a rule by id (see `list`).")
     remove.add_argument("id", help="The rule id to remove.")
@@ -383,6 +469,7 @@ def main() -> int:
     handlers = {
         "list": cmd_list,
         "add": cmd_add,
+        "move": cmd_move,
         "remove": cmd_remove,
         "clear": cmd_clear,
         "facets": cmd_facets,

--- a/agent/tests/test_notif_rules_skill.py
+++ b/agent/tests/test_notif_rules_skill.py
@@ -29,7 +29,9 @@ def _load_skill(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
 
 def test_skill_writes_a_rule_core_reads_and_applies(tmp_path, monkeypatch):
     skill = _load_skill(tmp_path, monkeypatch)
-    skill.cmd_add(argparse.Namespace(source="app-chat", type=None, sender=None, keyword=None, match=None, action="pool"))
+    skill.cmd_add(
+        argparse.Namespace(source="app-chat", type=None, sender=None, keyword=None, match=None, action="pool", before=None, after=None)
+    )
 
     # The exact file + shape core reads, validated by core's own model.
     config = vm.VestaConfig(agent_dir=tmp_path)

--- a/agent/tests/test_notification_interrupt_rules_skill.py
+++ b/agent/tests/test_notification_interrupt_rules_skill.py
@@ -72,10 +72,72 @@ def test_add_catch_all_has_no_conditions(tmp_path):
 
 
 def test_add_preserves_order(tmp_path):
-    _run(tmp_path, "add", "--source", "whatsapp", "--sender", "wife", "--action", "interrupt")
+    # Two equally-specific rules (1 condition each) keep insertion order: the second appends after.
+    _run(tmp_path, "add", "--source", "whatsapp", "--action", "interrupt")
     _run(tmp_path, "add", "--source", "twitter", "--action", "pool")
     rules = npn.load_rules(_config(tmp_path))
     assert [r.action for r in rules] == ["interrupt", "pool"]
+
+
+def _ids(tmp_path):
+    return [r.id for r in npn.load_rules(_config(tmp_path))]
+
+
+def test_add_auto_places_specific_above_broad(tmp_path):
+    # Broad pool rule first, then a narrower interrupt exception: the exception must land ABOVE the
+    # broad rule so first-match-wins reaches it instead of being shadowed.
+    _run(tmp_path, "add", "--source", "whatsapp", "--action", "pool")
+    _run(tmp_path, "add", "--source", "whatsapp", "--sender", "wife", "--action", "interrupt")
+    rules = npn.load_rules(_config(tmp_path))
+    assert [r.action for r in rules] == ["interrupt", "pool"]
+
+
+def test_add_auto_places_broad_below_specific(tmp_path):
+    # Reverse insertion order: a later broad rule still sinks below the existing specific one.
+    _run(tmp_path, "add", "--source", "whatsapp", "--match", "chat_name=Bride squad", "--action", "interrupt")
+    _run(tmp_path, "add", "--source", "whatsapp", "--action", "pool")
+    rules = npn.load_rules(_config(tmp_path))
+    assert [r.action for r in rules] == ["interrupt", "pool"]
+
+
+def test_add_before_and_after_place_explicitly(tmp_path):
+    _run(tmp_path, "add", "--source", "a", "--action", "pool")
+    _run(tmp_path, "add", "--source", "b", "--action", "pool")
+    first, second = _ids(tmp_path)
+    _run(tmp_path, "add", "--source", "c", "--action", "pool", "--before", second)
+    assert [r.source for r in npn.load_rules(_config(tmp_path))] == ["a", "c", "b"]
+    _run(tmp_path, "add", "--source", "d", "--action", "pool", "--after", first)
+    assert [r.source for r in npn.load_rules(_config(tmp_path))] == ["a", "d", "c", "b"]
+
+
+def test_add_before_unknown_id_errors(tmp_path):
+    _run(tmp_path, "add", "--source", "a", "--action", "pool")
+    result = _run(tmp_path, "add", "--source", "b", "--action", "pool", "--before", "nope")
+    assert result.returncode == 1
+    # The rejected add did not write anything.
+    assert [r.source for r in npn.load_rules(_config(tmp_path))] == ["a"]
+
+
+def test_move_top_bottom_before_after(tmp_path):
+    # Three equally-specific rules keep insertion order a, b, c.
+    _run(tmp_path, "add", "--source", "a", "--action", "pool")
+    _run(tmp_path, "add", "--source", "b", "--action", "pool")
+    _run(tmp_path, "add", "--source", "c", "--action", "pool")
+    id_a, id_b, id_c = _ids(tmp_path)
+    _run(tmp_path, "move", id_c, "--top")
+    assert [r.source for r in npn.load_rules(_config(tmp_path))] == ["c", "a", "b"]
+    _run(tmp_path, "move", id_c, "--bottom")
+    assert [r.source for r in npn.load_rules(_config(tmp_path))] == ["a", "b", "c"]
+    _run(tmp_path, "move", id_a, "--after", id_b)
+    assert [r.source for r in npn.load_rules(_config(tmp_path))] == ["b", "a", "c"]
+    _run(tmp_path, "move", id_c, "--before", id_b)
+    assert [r.source for r in npn.load_rules(_config(tmp_path))] == ["c", "b", "a"]
+
+
+def test_move_unknown_id_errors(tmp_path):
+    _run(tmp_path, "add", "--source", "a", "--action", "pool")
+    result = _run(tmp_path, "move", "nope", "--top")
+    assert result.returncode == 1
 
 
 def test_remove_by_id(tmp_path):

--- a/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.test.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.test.tsx
@@ -6,6 +6,7 @@ import {
   cleanup,
   act,
   within,
+  fireEvent,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef } from "react";
@@ -415,6 +416,68 @@ describe("NotificationInterruptRulesCard cascade", () => {
     expect(rulesArg[0].match).toEqual([
       { field: "chat_name", op: "contains", value: "Bride squad" },
     ]);
+  });
+
+  it("auto-places a specific rule above a broader one", async () => {
+    // An existing catch-all rule (0 conditions); the new keyword rule (1 condition) must land above it.
+    vi.spyOn(api, "getNotificationInterruptRules").mockResolvedValue([
+      { id: "broad", action: "pool" },
+    ]);
+    vi.spyOn(api, "getNotificationHistory").mockResolvedValue({
+      notifications: [],
+      cursor: null,
+    });
+    const setSpy = vi
+      .spyOn(api, "setNotificationInterruptRules")
+      .mockResolvedValue([]);
+    render(<NotificationInterruptRulesCard />);
+    await waitFor(() =>
+      expect(api.getNotificationInterruptRules).toHaveBeenCalled(),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /add rule/i }));
+    await userEvent.type(screen.getByLabelText("keyword"), "urgent");
+    await userEvent.click(screen.getByRole("button", { name: /next/i }));
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: /add rule/i,
+      }),
+    );
+
+    await waitFor(() => expect(setSpy).toHaveBeenCalledTimes(1));
+    const [, rulesArg] = setSpy.mock.calls[0];
+    // The new, more-specific rule is placed first; the catch-all sinks below it.
+    expect(rulesArg).toHaveLength(2);
+    expect(rulesArg[1].id).toBe("broad");
+    expect(rulesArg[0].match).toEqual([
+      { field: "text", op: "regex", value: "urgent" },
+    ]);
+  });
+
+  it("reorders rules by drag and persists the new order", async () => {
+    vi.spyOn(api, "getNotificationInterruptRules").mockResolvedValue([
+      { id: "a", source: "twitter", action: "pool" },
+      { id: "b", source: "whatsapp", action: "pool" },
+    ]);
+    const setSpy = vi
+      .spyOn(api, "setNotificationInterruptRules")
+      .mockResolvedValue([]);
+    render(<NotificationInterruptRulesCard />);
+    await screen.findByText(/twitter/);
+
+    const handles = screen.getAllByRole("button", {
+      name: /drag to reorder rule/i,
+    });
+    expect(handles).toHaveLength(2);
+    // Drag rule b (index 1) and drop it on rule a's row (index 0): b moves above a.
+    const row0 = handles[0].closest("div")!;
+    fireEvent.dragStart(handles[1]);
+    fireEvent.dragOver(row0);
+    fireEvent.drop(row0);
+
+    await waitFor(() => expect(setSpy).toHaveBeenCalled());
+    const lastCall = setSpy.mock.calls.at(-1)!;
+    expect(lastCall[1].map((r: { id: string }) => r.id)).toEqual(["b", "a"]);
   });
 
   it("reveals type only after a source is picked", async () => {

--- a/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { ListFilter, Plus, X } from "lucide-react";
+import { GripVertical, ListFilter, Plus, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -187,6 +187,38 @@ function predicateMatchesNotif(
   return p.negate ? !hit : hit;
 }
 
+// Whether a whole rule matches a notification (source/type exact + all predicates), approximating the
+// engine for the live preview / shadow check.
+function ruleMatchesNotif(
+  rule: Pick<NotificationInterruptRule, "source" | "type" | "match">,
+  n: NotificationEvent,
+): boolean {
+  if (rule.source && n.source !== rule.source) return false;
+  if (rule.type && n.notif_type !== rule.type) return false;
+  return (rule.match ?? []).every((p) => predicateMatchesNotif(p, n));
+}
+
+// How narrowly a rule matches = its condition count. Used only to place a new rule (the engine is
+// first-match-wins, never specificity-ranked) so a narrow exception lands above the broad rule it refines.
+function specificity(
+  rule: Pick<NotificationInterruptRule, "source" | "type" | "match">,
+): number {
+  return (
+    (rule.source ? 1 : 0) + (rule.type ? 1 : 0) + (rule.match?.length ?? 0)
+  );
+}
+
+// Insert position for a new rule: above the first existing rule that is strictly broader (fewer
+// conditions), else at the end. Matches the skill CLI's _placement_index.
+function placementIndex(
+  rules: NotificationInterruptRule[],
+  newRule: Pick<NotificationInterruptRule, "source" | "type" | "match">,
+): number {
+  const spec = specificity(newRule);
+  const i = rules.findIndex((r) => specificity(r) < spec);
+  return i === -1 ? rules.length : i;
+}
+
 export interface NotificationInterruptRulesHandle {
   addFromNotification: (seed: { source?: string; type?: string }) => void;
 }
@@ -243,6 +275,8 @@ export const NotificationInterruptRulesCard = forwardRef<
   // The dialog's content element, so the combobox popups portal inside it — otherwise they land in
   // body, which the dialog marks inert (pointer-events: none) and the options become unclickable.
   const [dialogEl, setDialogEl] = useState<HTMLElement | null>(null);
+  // The rule row currently being dragged, for reordering (null when not dragging).
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
 
   useEffect(() => {
     if (!agentName) return;
@@ -377,20 +411,49 @@ export const NotificationInterruptRulesCard = forwardRef<
         })()
       : null;
 
+  // Would the draft be shadowed? At its specificity-placement, if every recent notification it catches
+  // is already caught by a higher-priority rule above it, first-match-wins means it would never fire.
+  const draftShadowed = (() => {
+    if (!draftHasCondition || hasRegexError) return false;
+    const draftRule = {
+      source: draft.source.trim() || undefined,
+      type: draft.type.trim() || undefined,
+      match: draftToMatch(draft),
+    };
+    const hits = notifications.filter((n) => ruleMatchesNotif(draftRule, n));
+    if (hits.length === 0) return false;
+    const above = (rules ?? []).slice(
+      0,
+      placementIndex(rules ?? [], draftRule),
+    );
+    return hits.every((n) => above.some((r) => ruleMatchesNotif(r, n)));
+  })();
+
   const addDraft = () => {
     if (!draftHasCondition || hasRegexError) return;
     setSaveError(null);
-    commit([
-      ...(rules ?? []),
-      {
-        id: newRuleId(),
-        action: draft.action,
-        source: draft.source.trim() || undefined,
-        type: draft.type.trim() || undefined,
-        match: draftToMatch(draft),
-      },
-    ]);
+    const newRule: NotificationInterruptRule = {
+      id: newRuleId(),
+      action: draft.action,
+      source: draft.source.trim() || undefined,
+      type: draft.type.trim() || undefined,
+      match: draftToMatch(draft),
+    };
+    // Auto-place by specificity so a narrow exception isn't shadowed by a broader rule above it.
+    const next = [...(rules ?? [])];
+    next.splice(placementIndex(next, newRule), 0, newRule);
+    commit(next);
     setDraft(EMPTY_DRAFT);
+  };
+
+  // Drag-to-reorder: move the rule at `from` to `to`, then persist. Order is priority (first match wins).
+  const reorderRule = (from: number, to: number) => {
+    const current = rules ?? [];
+    if (from === to || from < 0 || to < 0 || from >= current.length) return;
+    const next = [...current];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    commit(next);
   };
 
   // Close the dialog and discard any half-entered draft.
@@ -636,13 +699,48 @@ export const NotificationInterruptRulesCard = forwardRef<
             </div>
           ) : (
             <>
-              {/* Active rules: read-only summaries with a clickable action badge + delete. */}
+              {/* Active rules in priority order (first match wins). Drag to reorder; read-only
+                  summaries with a clickable action badge + delete. */}
               {rules.length > 0 ? (
                 <div className="flex flex-col gap-2">
                   {rules.map((rule, index) => {
                     const conditions = ruleConditions(rule);
+                    const draggable = rules.length > 1;
                     return (
-                      <div key={rule.id} className="flex items-center gap-2">
+                      <div
+                        key={rule.id}
+                        className={cn(
+                          "flex items-center gap-2 rounded-md",
+                          dragIndex !== null &&
+                            dragIndex !== index &&
+                            "outline-dashed outline-1 outline-border/60",
+                        )}
+                        onDragOver={
+                          draggable ? (e) => e.preventDefault() : undefined
+                        }
+                        onDrop={
+                          draggable
+                            ? (e) => {
+                                e.preventDefault();
+                                if (dragIndex !== null)
+                                  reorderRule(dragIndex, index);
+                                setDragIndex(null);
+                              }
+                            : undefined
+                        }
+                      >
+                        {draggable ? (
+                          <button
+                            type="button"
+                            draggable
+                            aria-label="drag to reorder rule"
+                            className="cursor-grab text-muted-foreground/50 hover:text-muted-foreground active:cursor-grabbing"
+                            onDragStart={() => setDragIndex(index)}
+                            onDragEnd={() => setDragIndex(null)}
+                          >
+                            <GripVertical className="size-3.5" />
+                          </button>
+                        ) : null}
                         <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
                           {conditions.length === 0 ? (
                             <span className="text-[11px] text-muted-foreground/60">
@@ -835,6 +933,10 @@ export const NotificationInterruptRulesCard = forwardRef<
                         ) : predicateRegexError ? (
                           <p className="mr-auto min-w-0 self-center truncate text-xs text-destructive">
                             invalid field regex
+                          </p>
+                        ) : draftShadowed ? (
+                          <p className="mr-auto min-w-0 self-center truncate text-xs text-amber-600 dark:text-amber-500">
+                            a higher-priority rule already catches these
                           </p>
                         ) : draftMatchCount !== null ? (
                           <p className="mr-auto min-w-0 self-center truncate text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

Interrupt rules are evaluated **first-match-wins** (ordered list, top = highest priority) — the right, predictable model (firewalls, ACLs, `.gitignore`). But both surfaces were **append-only**: a newly-added specific rule landed at the *bottom*, exactly the wrong place to override a broad rule above it. Now that #935 makes negation and many complex rules expressible, controlling and reasoning about order is the bottleneck. This keeps the engine unchanged and adds **control + visibility** (Option 1 from discussion).

Stacked on #935 (`feat/notification-match-predicates`) — review/merge that first.

## What it adds

**1. Smart auto-placement (predictable, position-only).** A new rule is inserted above any *strictly broader* rule (fewer conditions), so a narrow exception isn't shadowed by a broad rule that would match first. Specificity = condition count (`source` + `type` + #predicates). It only chooses the *new* rule's position; nothing else moves. The CLI (`_placement_index`) and web (`placementIndex`) use identical logic.

```bash
# broad pool first, then a narrow interrupt exception -> exception auto-lands ABOVE the pool
add --source whatsapp --action pool
add --source whatsapp --sender wife --action interrupt   # placed first, not shadowed
```

**2. Explicit placement + reorder.**
- CLI: `add --before <id>` / `--after <id>`, and a new `move <id> {--before <id> | --after <id> | --top | --bottom}`.
- Web: drag-to-reorder the rule list (a grip handle per row when there's more than one).

**3. Visibility.**
- CLI `list` prints "rules in priority order (first match wins; top = highest priority)" (on stderr, so stdout stays pure JSON).
- Web: the draft preview warns *"a higher-priority rule already catches these"* when the rule being added would be fully shadowed by rules above its placement, using the recent-notification history.

## Engine unchanged

`should_interrupt` / `_matches` are untouched — still pure first-match-wins. Specificity is used **only** to position a new rule at write time; it never ranks rules at evaluation. So precedence stays debuggable and order remains the single source of truth, now with the controls to set it.

## Tests

CLI: auto-placement (specific-above-broad both insertion orders), `--before`/`--after`, unknown-id errors, `move` (`--top`/`--bottom`/`--before`/`--after`), unknown-id move error. Web: specificity-insert places the new rule above a catch-all; drag-drop reorders and persists. Agent + web suites green (pre-existing unrelated failures only).

## SKILL.md

Documents the precedence model (first-match-wins, OR-across-rules, AND-within-a-rule), auto-placement, and the reorder commands, with examples.
