### PR TITLE
fix(logs): drop thinking_tokens spam and crop log messages less aggressively

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -198,7 +198,7 @@ async def _run_messages_with_interrupts(
                 logger.user(text)
                 state.event_bus.emit({"type": "user", "text": text})
             else:
-                preview = text[:200] + "..." if len(text) > 200 else text
+                preview = text[:1000] + "..." if len(text) > 1000 else text
                 logger.system(preview.replace("\n", " "))
             state.event_bus.set_state("thinking")
             await process_message(text, state=state, config=config, is_user=user)

--- a/agent/core/sdk_parsing.py
+++ b/agent/core/sdk_parsing.py
@@ -117,8 +117,11 @@ def parse_sdk_message(msg: Message) -> tuple[list[str], list[ThinkingBlock], str
             if init_sid:
                 logger.debug(f"[init] session_id={init_sid[:16]}")
             return [], [], init_sid
+        # thinking_tokens is a per-delta streaming counter the SDK emits dozens of times per turn; it floods the log with no signal.
+        if msg.subtype == "thinking_tokens":
+            return [], [], None
         raw = json.dumps(msg.data, default=str)
-        logger.system(f"[{msg.subtype}] {raw[:500]}")
+        logger.system(f"[{msg.subtype}] {raw[:2000]}")
         return [], [], None
 
     if not isinstance(msg, AssistantMessage):

--- a/agent/tests/test_formatting.py
+++ b/agent/tests/test_formatting.py
@@ -158,6 +158,24 @@ def test_parse_sdk_message_returns_session_id_from_init():
     assert texts == []
 
 
+def test_parse_sdk_message_skips_thinking_tokens_system_message():
+    """thinking_tokens is a per-delta streaming counter the SDK emits dozens of times per turn;
+    parse must drop it without logging so it does not flood the agent log."""
+    from unittest.mock import patch
+
+    from claude_agent_sdk import SystemMessage
+
+    msg = SystemMessage(subtype="thinking_tokens", data={"estimated_tokens": 312, "estimated_tokens_delta": 5})
+
+    with patch("core.sdk_parsing.logger.system") as mock_system:
+        texts, thinking_blocks, session_id = parse_sdk_message(msg)
+
+    mock_system.assert_not_called()
+    assert texts == []
+    assert thinking_blocks == []
+    assert session_id is None
+
+
 def test_process_message_always_streams():
     """process_message must always pass show_output=True -- regression guard."""
     import ast


### PR DESCRIPTION
## What

Two changes to the agent log noise/legibility, per request:

1. **Drop `thinking_tokens` system messages.** The Claude Agent SDK emits a `thinking_tokens` system message on *every* streaming delta (dozens per turn), each landing as a full `[SYSTEM] - [MESSAGE]` line carrying just an `estimated_tokens` counter. They drown out real log signal. `parse_sdk_message` now drops that subtype without logging.

2. **Crop less aggressively.** Logged messages were truncated very early. Raised the limits so more context survives while still capping runaway lines:
   - system messages: `500` → `2000` chars (`sdk_parsing.py`)
   - boot/system turn previews: `200` → `1000` chars (`loops.py`)

## Test

Added `test_parse_sdk_message_skips_thinking_tokens_system_message` asserting a `thinking_tokens` system message produces no `logger.system` call and yields empty parse output. `tests/test_formatting.py` passes (24 tests), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)