### PR TITLE
refactor(vestad): persist --expose-lan in settings.json, not the systemd unit

### DIFF
--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -469,6 +469,11 @@ async fn try_establish_tunnel(config: &std::path::Path, port: u16) -> Result<Str
 fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
     let config = config_dir();
 
+    // The systemd unit launches `serve --standalone` with no flag, so the
+    // persisted preference is the source of truth; an explicit --standalone
+    // --expose-lan (CI/dev) still wins.
+    let expose_lan = expose_lan || serve::expose_lan_setting();
+
     let docker = docker::connect().unwrap_or_else(|e| die(&e));
     docker::ensure_docker_sync(&docker).unwrap_or_else(|e| die(&e));
 
@@ -588,15 +593,17 @@ fn run_server_systemd(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
 
     let docker = docker::connect().unwrap_or_else(|e| die(&e));
     docker::ensure_docker_sync(&docker).unwrap_or_else(|e| die(&e));
-    let unit_changed = systemd::ensure_service_installed(expose_lan).unwrap_or_else(|e| die(&e));
+    systemd::ensure_service_installed().unwrap_or_else(|e| die(&e));
+
+    // --expose-lan is a persisted binding preference (like the port file), not part
+    // of the static unit. Write it before the daemon (re)starts so it reads the new
+    // value; a running daemon only re-binds on restart.
+    let lan_changed = serve::set_expose_lan(expose_lan);
 
     if systemd::is_active() {
-        // A changed unit (e.g. --expose-lan toggled) only takes effect on the
-        // live daemon after a restart, so apply it instead of leaving the user
-        // on a stale binding.
-        if unit_changed {
+        if lan_changed {
             systemd::restart().unwrap_or_else(|e| die(&e));
-            eprintln!("vestad restarted to apply updated configuration.");
+            eprintln!("vestad restarted to apply the --expose-lan change.");
             return;
         }
         if let Some(pid) = systemd::main_pid() {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1356,6 +1356,11 @@ pub(crate) struct Settings {
     /// the active channel. On by default; opt out at runtime via PUT /settings/auto-update.
     #[serde(default = "default_true")]
     pub(crate) auto_update: bool,
+    /// Bind the HTTPS API to the LAN (0.0.0.0) instead of loopback only. A binding
+    /// preference like the port file — it lives here, not in the static systemd
+    /// unit, and the daemon reads it at startup. Set via `vestad serve --expose-lan`.
+    #[serde(default)]
+    pub(crate) expose_lan: bool,
 }
 
 // Manual `Default` (not derived) so a fresh install with no settings.json gets
@@ -1369,6 +1374,7 @@ impl Default for Settings {
             agents: HashMap::new(),
             channel: default_channel(),
             auto_update: true,
+            expose_lan: false,
         }
     }
 }
@@ -1518,6 +1524,23 @@ fn save_settings(settings: &Settings) {
     }
 }
 
+/// The persisted LAN-exposure preference (default: loopback only). The daemon
+/// reads this at startup to decide the HTTPS bind address.
+pub(crate) fn expose_lan_setting() -> bool {
+    load_settings().expose_lan
+}
+
+/// Persist the LAN-exposure preference. Returns `true` when the stored value
+/// changed, so the caller can restart the daemon to apply the new bind address.
+pub(crate) fn set_expose_lan(expose: bool) -> bool {
+    let mut settings = load_settings();
+    if settings.expose_lan == expose {
+        return false;
+    }
+    settings.expose_lan = expose;
+    save_settings(&settings);
+    true
+}
 
 const SERVICE_PORT_MIN: u16 = 49152;
 const SERVICE_PORT_MAX: u16 = 65535;
@@ -2616,6 +2639,27 @@ mod tests {
         let s: super::Settings =
             serde_json::from_str(r#"{"auto_update": false}"#).expect("valid Settings");
         assert!(!s.auto_update);
+    }
+
+    // --- expose_lan defaults off: a settings.json predating the field must keep the
+    // HTTPS API on loopback, never silently bind a fleet of agents to the LAN ---
+
+    #[test]
+    fn settings_default_keeps_lan_unexposed() {
+        assert!(!super::Settings::default().expose_lan);
+    }
+
+    #[test]
+    fn settings_missing_expose_lan_field_deserializes_false() {
+        let s: super::Settings = serde_json::from_str("{}").expect("empty object is valid Settings");
+        assert!(!s.expose_lan);
+    }
+
+    #[test]
+    fn settings_expose_lan_true_is_honored() {
+        let s: super::Settings =
+            serde_json::from_str(r#"{"expose_lan": true}"#).expect("valid Settings");
+        assert!(s.expose_lan);
     }
 
     // --- user_desired drives vestad's boot-start; a wrong default would silently keep every

--- a/vestad/src/systemd.rs
+++ b/vestad/src/systemd.rs
@@ -9,38 +9,7 @@ fn unit_file_path() -> Result<String, String> {
     Ok(format!("{}/.config/systemd/user/vestad.service", home))
 }
 
-/// Build the systemd unit file content. `expose_lan` bakes `--expose-lan` into
-/// the `ExecStart` line so the systemd-managed daemon binds the HTTPS API to the
-/// LAN — the unit is the only persistence for this choice, so it survives
-/// restarts and self-updates (which deliberately don't rewrite the unit).
-fn build_unit_content(vestad_path: &str, working_dir: Option<&str>, expose_lan: bool) -> String {
-    let working_dir_line = match working_dir {
-        Some(dir) => format!("WorkingDirectory={dir}\n"),
-        None => String::new(),
-    };
-    let expose_lan_arg = if expose_lan { " --expose-lan" } else { "" };
-
-    format!(
-        r#"[Unit]
-Description=Vesta API Server
-After=docker.service network-online.target
-Wants=network-online.target
-
-[Service]
-ExecStart={vestad_path} serve --standalone{expose_lan_arg}
-{working_dir_line}Restart=always
-RestartSec=5
-
-[Install]
-WantedBy=default.target
-"#
-    )
-}
-
-/// Install or update the systemd user unit. Returns `true` when the unit was
-/// written (newly installed or changed), `false` when it already matched — the
-/// caller restarts a running daemon only on a real change.
-pub fn ensure_service_installed(expose_lan: bool) -> Result<bool, String> {
+pub fn ensure_service_installed() -> Result<(), String> {
     let vestad_path = std::env::current_exe()
         .map_err(|e| format!("cannot determine binary path: {}", e))?
         .to_str()
@@ -58,11 +27,30 @@ pub fn ensure_service_installed(expose_lan: bool) -> Result<bool, String> {
         None
     };
 
-    let unit_content = build_unit_content(&vestad_path, working_dir.as_deref(), expose_lan);
+    let working_dir_line = match &working_dir {
+        Some(dir) => format!("WorkingDirectory={dir}\n"),
+        None => String::new(),
+    };
+
+    let unit_content = format!(
+        r#"[Unit]
+Description=Vesta API Server
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart={vestad_path} serve --standalone
+{working_dir_line}Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"#
+    );
 
     if let Ok(existing) = std::fs::read_to_string(&unit_path) {
         if existing == unit_content {
-            return Ok(false);
+            return Ok(());
         }
         eprintln!("updating systemd service...");
     } else {
@@ -91,7 +79,7 @@ pub fn ensure_service_installed(expose_lan: bool) -> Result<bool, String> {
         eprintln!("warning: loginctl enable-linger failed — vestad may stop on logout");
     }
 
-    Ok(true)
+    Ok(())
 }
 
 pub fn is_active() -> bool {
@@ -220,26 +208,7 @@ fn run_systemctl(args: &[&str]) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_unit_content, journal_args, SERVICE_NAME};
-
-    #[test]
-    fn unit_content_appends_expose_lan_flag_when_exposing_lan() {
-        let unit = build_unit_content("/usr/bin/vestad", None, true);
-        assert!(
-            unit.contains("ExecStart=/usr/bin/vestad serve --standalone --expose-lan\n"),
-            "ExecStart must carry --expose-lan so the systemd daemon binds the LAN: {unit}"
-        );
-    }
-
-    #[test]
-    fn unit_content_omits_expose_lan_flag_by_default() {
-        let unit = build_unit_content("/usr/bin/vestad", None, false);
-        assert!(
-            unit.contains("ExecStart=/usr/bin/vestad serve --standalone\n"),
-            "default ExecStart stays loopback-only: {unit}"
-        );
-        assert!(!unit.contains("--expose-lan"), "no LAN flag when not exposing: {unit}");
-    }
+    use super::{journal_args, SERVICE_NAME};
 
     #[test]
     fn journal_args_scope_the_vestad_unit_and_forward_follow() {


### PR DESCRIPTION
## Context

PR #940 was merged early and shipped a **superseded revision** of the `--expose-lan` fix that baked the flag into the systemd unit's `ExecStart`. This PR replaces that with the approved final design (the one the `/simplify` review settled on).

## What changes

`--expose-lan` is a binding preference, so it now lives in the config-dir `Settings` store (`settings.json`, next to `auto_update`) — the same model the `port` file already uses — instead of in the static systemd unit.

- **`systemd.rs`**: reverted to static (drops `build_unit_content` and the unit-baking).
- **`serve.rs`**: `expose_lan` added to `Settings` (defaults to `false`/loopback), with `expose_lan_setting()` (read) and `set_expose_lan()` (write, returns whether it changed). Serde tests cover the default-off behavior.
- **`main.rs`**: the systemd-launched daemon reads the preference at startup (`expose_lan || serve::expose_lan_setting()`, so `--standalone --expose-lan` still wins for CI/dev); the systemd path writes the preference and restarts only when it changed; plain `vestad serve` clears it back to loopback.

Net behavior is identical to #940 (`--expose-lan` works under systemd), but the preference sits at the right altitude and the unit stays static — leaving a clean path to a future runtime `PUT /settings/expose-lan` toggle.

## Tests

Serde tests assert `expose_lan` defaults to `false` and that an explicit `true` is honored, mirroring the existing `auto_update` tests.

> vestad is Linux-only (`compile_error!` on non-Linux), so clippy + tests run on CI, not the macOS dev host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)