### PR TITLE
feat(agent): move first-start setup into the birth skill

### DIFF
--- a/agent/core/default-skills.txt
+++ b/agent/core/default-skills.txt
@@ -1,4 +1,5 @@
 account
+birth
 browser
 claude-code
 dashboard

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -156,14 +156,14 @@ def greeting_turn(*, config: vm.VestaConfig, state: vm.State, reason: str) -> st
         return None
 
     if reason == "first_start":
-        setup_prompt = load_prompt("first_start_setup", config)
+        setup_prompt = load_prompt("birth", config)
         if not setup_prompt:
             # No prompt to run, flip the flag so we don't loop into first-start every reboot.
             state.persisted.first_start_done = True
             state_store.save_state(state.persisted, config)
             return None
-        logger.startup("Boot turn: first_start_setup")
-        return f"[System: your name is {config.agent_name}]\n\n{setup_prompt.strip()}"
+        logger.startup("Boot turn: birth")
+        return setup_prompt.strip()
 
     extras = []
     if state.persisted.show_dreamer_summary:

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -125,7 +125,7 @@ async def run_vesta(
 
     # Bind the HTTP/WS server on every boot, including first start. vestad reaches
     # GET/PUT /config over this port to read auth state and deliver credentials, so a
-    # fresh unauthenticated agent must be reachable before the first_start_setup
+    # fresh unauthenticated agent must be reachable before the birth
     # conversation (which itself needs a provider) can run.
     state.ws_runner = await start_ws_server(state.event_bus, config, state)
     logger.init(f"WebSocket server started on port {config.ws_port}")

--- a/agent/core/prompts/birth.md
+++ b/agent/core/prompts/birth.md
@@ -1,0 +1,1 @@
+This is your first wake. Use the `birth` skill now and follow it exactly.

--- a/agent/skills/birth/SKILL.md
+++ b/agent/skills/birth/SKILL.md
@@ -1,7 +1,14 @@
+---
+name: birth
+description: Vesta's first-wake setup and onboarding, run once on a brand-new agent's very first boot. Come online, meet the user, move to their preferred channel, connect their email, and set up the highest-leverage skills. Invoked by the first-wake boot turn; not for later boots or restarts.
+---
+
+# Birth
+
 Hello world. First wake.
 
 Come online first, silently, in order:
-1. Read `/run/vestad-env` for ports and token (already exported as env vars).
+1. Read `/run/vestad-env` for ports and token (already exported as env vars). Your name is `$AGENT_NAME`.
 2. Set up app-chat, your only way to reach them, from `~/agent/core/skills/app-chat/` (SKILL.md / SETUP.md). No asking.
 3. Call `mark_setup_done`. Until you do, the WebSocket stays down and no one can reach you.
 4. Say hi.

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -12,6 +12,10 @@
     "description": "Send and receive email as the agent via AgentMail (managed inbox-per-agent, free tier). Use for \"email\", \"send email\", or \"agent inbox\" without a custom domain; inbound mail arrives as a notification."
   },
   {
+    "name": "birth",
+    "description": "Vesta's first-wake setup and onboarding, run once on a brand-new agent's very first boot. Come online, meet the user, move to their preferred channel, connect their email, and set up the highest-leverage skills. Invoked by the first-wake boot turn; not for later boots or restarts."
+  },
+  {
     "name": "browser",
     "description": "Browse, navigate, click, fill forms, screenshot, or scrape web pages via CDP."
   },

--- a/agent/tests/test_boot_turns.py
+++ b/agent/tests/test_boot_turns.py
@@ -42,7 +42,7 @@ def test_boot_turns_ordered_migrations_then_skill_then_config_then_greeting(tmp_
 def test_first_start_pre_marks_migrations_and_greets_with_setup(tmp_path):
     config = _boot_config(tmp_path)
     (config.agent_dir / "core" / "migrations" / "001-x.md").write_text("x")  # pre-marked, not run
-    (config.core_prompts_dir / "first_start_setup.md").write_text("welcome, run setup")
+    (config.core_prompts_dir / "birth.md").write_text("welcome, run setup")
     state = _authed_state()
 
     turns = collect_boot_turns(state=state, config=config, config_issues=[], greeting_reason="first_start", first_start=True)


### PR DESCRIPTION
## What

The first-wake onboarding workflow was written inline in the `first_start` boot-turn prompt. This moves that content into a new skill named **`birth`** and reduces the boot-turn prompt to a one-line pointer:

> This is your first wake. Use the `birth` skill now and follow it exactly.

## Design

- **`birth` is a regular skill in `agent/skills/`, registered as a default skill** (`agent/core/default-skills.txt`). Default is required: the Dockerfile prunes `agent/skills/*` down to the default list, so a non-default skill wouldn't survive into fresh images, and the first-wake pointer needs the skill present on boot #1. Default skills are baked into fresh images and symlinked into `~/.claude/skills` on every boot.
- **Prompt renamed** `first_start_setup.md` → `birth.md` so the trigger prompt and the skill share one name.
- **Dropped the hardcoded `[System: your name is {name}]` prefix** from `greeting_turn`. The name lives in `AGENT_NAME` (`/run/vestad-env`), which `birth` already reads in step 1; the skill now states it directly. `greeting_turn` returns the static prompt with no interpolation.
- `agent/skills/index.json` regenerated.

## Fleet impact

- **Fresh agents:** `birth` is baked in; first boot delivers the pointer and the agent runs the skill.
- **Existing agents:** on their next boot after upgrade, the standard default-skill-sync reconciler notices `birth` is missing and delivers one "install `birth`, then restart" boot turn (the normal one-time cost of adding any default skill). `birth` is then inert for them: they have `first_start_done` set and never re-run first-start. No migration needed.

## Verification

- `uv run pytest tests/test_boot_turns.py tests/test_default_skills.py` → 10 passed.
- `ruff` + `ty` clean on changed Python.
- Skills index regenerated and committed (CI `skills-index-check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)