### PR TITLE
fix(telegram): escape MarkdownV2 so Stripe pay-link URLs aren't corrupted

### DIFF
--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -219,8 +219,8 @@ The cases you'll actually hit, and the move for each:
 The link arrived changed. A checkout url must be exact (the `cs_live_...` id and
 the whole `#...` tail); one altered character breaks it. Check both ends: you
 re-send it as a Markdown link matching the exact `onboard checkout` output, never
-retyped; they open it straight from your message in a real browser tab. Only if it
-is byte for byte identical and still fails is it not the link.
+retyped; they confirm the link they opened matches it exactly. Only if it is byte
+for byte identical and still fails is it not the link.
 
 ## Referral attribution
 

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -214,25 +214,13 @@ The cases you'll actually hit, and the move for each:
 - `rate limited`: too many attempts from here today. Tell them you'll pick it back
   up later, and continue then.
 
-### If the Stripe page won't load ("something went wrong")
+### Stripe page says "something went wrong"
 
-Usually the link arrived **changed**, not that Stripe or the payment is broken. A
-checkout url is exact: it carries the `cs_live_...` session id plus a long `#...`
-fragment, and if a single character is missing or altered (a dropped underscore, a
-cut `#...` tail, a smart quote, a trailing space or a line break) Stripe loads a
-broken page that says `something went wrong` or `ID not set`. Verify the link is
-identical on both ends before assuming anything else is wrong:
-
-- **You:** compare what you sent against the exact `url` the last `onboard checkout`
-  printed, character for character. Re-send it as a Markdown link (`[Complete your
-  payment](<url>)`) so no chat formatting can eat the underscores, and never retype
-  it by hand.
-- **Them:** ask them to open the link straight from your message (not a retyped or
-  auto-previewed copy), in a normal browser tab, and confirm it starts with
-  `https://checkout.stripe.com/c/pay/cs_live_` with the whole `#...` tail present.
-
-Only once the link is confirmed byte for byte identical and it still fails is it
-not the link: tell the owner so they can check the payment setup.
+The link arrived changed. A checkout url must be exact (the `cs_live_...` id and
+the whole `#...` tail); one altered character breaks it. Check both ends: you
+re-send it as a Markdown link matching the exact `onboard checkout` output, never
+retyped; they open it straight from your message in a real browser tab. Only if it
+is byte for byte identical and still fails is it not the link.
 
 ## Referral attribution
 

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -214,6 +214,26 @@ The cases you'll actually hit, and the move for each:
 - `rate limited`: too many attempts from here today. Tell them you'll pick it back
   up later, and continue then.
 
+### If the Stripe page won't load ("something went wrong")
+
+Usually the link arrived **changed**, not that Stripe or the payment is broken. A
+checkout url is exact: it carries the `cs_live_...` session id plus a long `#...`
+fragment, and if a single character is missing or altered (a dropped underscore, a
+cut `#...` tail, a smart quote, a trailing space or a line break) Stripe loads a
+broken page that says `something went wrong` or `ID not set`. Verify the link is
+identical on both ends before assuming anything else is wrong:
+
+- **You:** compare what you sent against the exact `url` the last `onboard checkout`
+  printed, character for character. Re-send it as a Markdown link (`[Complete your
+  payment](<url>)`) so no chat formatting can eat the underscores, and never retype
+  it by hand.
+- **Them:** ask them to open the link straight from your message (not a retyped or
+  auto-previewed copy), in a normal browser tab, and confirm it starts with
+  `https://checkout.stripe.com/c/pay/cs_live_` with the whole `#...` tail present.
+
+Only once the link is confirmed byte for byte identical and it still fails is it
+not the link: tell the owner so they can check the payment setup.
+
 ## Referral attribution
 
 A completed invite only credits this account (you earn 50% of their first month)

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -83,8 +83,12 @@ and links between them and the CLI.
    (`onboard presets` for personalities + skills)? Agree the monthly price (see
    **Pricing**).
 4. **Send the Stripe link.** `onboard checkout --email <e> [--price <usd>] [--code
-   <code>]` → `{ url, subdomain }`. Send the `url` verbatim and **stop**. If they
-   hesitate at the link, the guarantee is real and worth saying: first 7 days, full
+   <code>]` → `{ url, subdomain }`. Send the `url` as a tappable link, never bare
+   text: where the channel renders Markdown links, format it as `[Complete your
+   payment](<url>)`; otherwise put the raw `url` on its own line. Never wrap, split,
+   or alter the url, its Stripe session id must arrive byte for byte (a bare url
+   dropped into some chats gets its underscores eaten and the link dies). Then
+   **stop**. If they hesitate at the link, the guarantee is real and worth saying: first 7 days, full
    refund, no questions. They risk nothing by trying. Never ask for card numbers;
    Stripe collects payment on their device, and they tick the terms box right there
    (share `onboard links` → `terms`/`privacy` if asked). The subdomain is assigned
@@ -149,7 +153,9 @@ onboard links                                          # marketing + app install
 ```
 
 All commands print **JSON** to stdout. `checkout` returns `{ "url": "https://checkout.stripe.com/..." }`.
-Send that URL verbatim and stop. (There is no `--subdomain` or `--plan`: the
+Send that URL as a Markdown link where the channel renders one (`[Complete your
+payment](<url>)`), otherwise on its own line, and stop. Never alter the url; its
+session id must arrive byte for byte. (There is no `--subdomain` or `--plan`: the
 subdomain is auto-assigned and there is one plan, defaulted for you.)
 
 ### Examples

--- a/agent/skills/telegram/cli/markdownv2_test.go
+++ b/agent/skills/telegram/cli/markdownv2_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestToMarkdownV2PreservesBareStripeURL pins the original bug: a bare
+// `cs_live_...` checkout URL had its underscores eaten by legacy Markdown
+// (parsed as italics), corrupting the Stripe session id -> a dead pay page.
+// Under MarkdownV2 every underscore is backslash-escaped, so Telegram renders
+// the literal character and the id survives; Telegram then auto-links the URL.
+func TestToMarkdownV2PreservesBareStripeURL(t *testing.T) {
+	in := "Pay here: https://checkout.stripe.com/c/pay/cs_live_a1IUB9_c3"
+	out := toMarkdownV2(in)
+	if !strings.Contains(out, `cs\_live\_a1IUB9\_c3`) {
+		t.Fatalf("underscores not escaped, id would be corrupted: %q", out)
+	}
+	// A bare URL is not a Markdown link, so brackets/parens are absent.
+	if strings.Contains(out, "](") {
+		t.Fatalf("bare URL should not become a link construct: %q", out)
+	}
+}
+
+// TestToMarkdownV2PreservesMarkdownLink verifies an explicit [label](url) link
+// is kept intact -- label escaped as text, URL byte-for-byte inside the
+// destination -- so the onboard skill can hand out a real clickable pay link
+// whose session id is not mangled.
+func TestToMarkdownV2PreservesMarkdownLink(t *testing.T) {
+	url := "https://checkout.stripe.com/c/pay/cs_live_a1IUB9"
+	in := "[Complete your payment](" + url + ")"
+	out := toMarkdownV2(in)
+	want := "[Complete your payment](" + url + ")"
+	if out != want {
+		t.Fatalf("link not preserved:\n got %q\nwant %q", out, want)
+	}
+}
+
+// TestToMarkdownV2EscapesReservedSpecials checks a run of literal specials is
+// fully escaped so Telegram never rejects the message or drops characters.
+func TestToMarkdownV2EscapesReservedSpecials(t *testing.T) {
+	if out := toMarkdownV2("2+2=4."); out != `2\+2\=4\.` {
+		t.Fatalf("reserved specials not escaped: %q", out)
+	}
+}
+
+// TestToMarkdownV2LabelSpecialsEscaped ensures special characters inside a
+// link label are escaped (only the URL destination is exempt), so a label
+// can't break MarkdownV2 parsing.
+func TestToMarkdownV2LabelSpecialsEscaped(t *testing.T) {
+	out := toMarkdownV2("[pay now!](https://example.com/x)")
+	if !strings.Contains(out, `[pay now\!]`) {
+		t.Fatalf("label specials not escaped: %q", out)
+	}
+	if !strings.Contains(out, "](https://example.com/x)") {
+		t.Fatalf("url destination not preserved: %q", out)
+	}
+}

--- a/agent/skills/telegram/cli/telegram.go
+++ b/agent/skills/telegram/cli/telegram.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -254,6 +255,58 @@ func (tc *TelegramClient) handleMessage(msg *tgbotapi.Message) {
 	}
 }
 
+// --- Telegram MarkdownV2 rendering -----------------------------------------
+//
+// Outbound messages are sent as MarkdownV2. Telegram's legacy "Markdown" mode
+// silently drops the underscores in a matched pair like `cs_live_...` (it reads
+// them as italics), which corrupted the Stripe Checkout links handed to users
+// -> a dead pay page. MarkdownV2 has the same hazard, so we ESCAPE every
+// reserved character in literal text. Explicit `[label](url)` links are kept
+// intact (label escaped; url only needs `)`/`\` escaped) so the onboard skill
+// can hand out a real, clickable pay link whose Stripe session id survives
+// byte-for-byte. Text that isn't a recognised link is still escaped, so a bare
+// URL survives verbatim (Telegram auto-links it) -- worst case a link renders
+// unlabelled, never corrupted.
+
+// mdV2Escaper backslash-escapes every MarkdownV2 reserved character in a run of
+// literal text. Backslash is listed first so we never double-escape our own
+// escapes.
+var mdV2Escaper = strings.NewReplacer(
+	"\\", "\\\\",
+	"_", "\\_", "*", "\\*", "[", "\\[", "]", "\\]",
+	"(", "\\(", ")", "\\)", "~", "\\~", "`", "\\`",
+	">", "\\>", "#", "\\#", "+", "\\+", "-", "\\-",
+	"=", "\\=", "|", "\\|", "{", "\\{", "}", "\\}",
+	".", "\\.", "!", "\\!",
+)
+
+// mdV2LinkURLEscaper escapes the only two characters reserved inside a
+// MarkdownV2 `(...)` link destination.
+var mdV2LinkURLEscaper = strings.NewReplacer("\\", "\\\\", ")", "\\)")
+
+// mdLinkRe matches a Markdown inline link `[label](http(s)://url)` with a plain
+// label and a whitespace/paren-free URL -- the shape the skills emit.
+var mdLinkRe = regexp.MustCompile(`\[([^\[\]]*)\]\((https?://[^\s)]+)\)`)
+
+// toMarkdownV2 renders an agent message as safe Telegram MarkdownV2: literal
+// text is fully escaped (so a URL's underscores can never parse as italics)
+// while explicit [label](url) links are preserved with their URL byte-for-byte.
+func toMarkdownV2(text string) string {
+	var b strings.Builder
+	last := 0
+	for _, m := range mdLinkRe.FindAllStringSubmatchIndex(text, -1) {
+		b.WriteString(mdV2Escaper.Replace(text[last:m[0]]))
+		b.WriteString("[")
+		b.WriteString(mdV2Escaper.Replace(text[m[2]:m[3]]))
+		b.WriteString("](")
+		b.WriteString(mdV2LinkURLEscaper.Replace(text[m[4]:m[5]]))
+		b.WriteString(")")
+		last = m[1]
+	}
+	b.WriteString(mdV2Escaper.Replace(text[last:]))
+	return b.String()
+}
+
 func (tc *TelegramClient) SendMessage(recipientID int64, text string) (int64, error) {
 	// Split long messages
 	if len(text) > MaxMessageLength {
@@ -264,11 +317,12 @@ func (tc *TelegramClient) SendMessage(recipientID int64, text string) (int64, er
 			if len(chunks) > 1 {
 				prefix = fmt.Sprintf("(%d/%d) ", i+1, len(chunks))
 			}
-			msg := tgbotapi.NewMessage(recipientID, prefix+chunk)
-			msg.ParseMode = "Markdown"
+			msg := tgbotapi.NewMessage(recipientID, toMarkdownV2(prefix+chunk))
+			msg.ParseMode = "MarkdownV2"
 			sent, err := tc.bot.Send(msg)
 			if err != nil {
-				// Retry without parse mode
+				// Retry as plain text (the unescaped original) if MarkdownV2 is rejected.
+				msg.Text = prefix + chunk
 				msg.ParseMode = ""
 				sent, err = tc.bot.Send(msg)
 				if err != nil {
@@ -285,11 +339,12 @@ func (tc *TelegramClient) SendMessage(recipientID int64, text string) (int64, er
 		return lastID, nil
 	}
 
-	msg := tgbotapi.NewMessage(recipientID, text)
-	msg.ParseMode = "Markdown"
+	msg := tgbotapi.NewMessage(recipientID, toMarkdownV2(text))
+	msg.ParseMode = "MarkdownV2"
 	sent, err := tc.bot.Send(msg)
 	if err != nil {
-		// Retry without parse mode
+		// Retry as plain text (the unescaped original) if MarkdownV2 is rejected.
+		msg.Text = text
 		msg.ParseMode = ""
 		sent, err = tc.bot.Send(msg)
 		if err != nil {
@@ -453,8 +508,8 @@ func (tc *TelegramClient) SendMessageWithOptions(recipientID int64, text, button
 	if len(text) > MaxMessageLength {
 		return 0, fmt.Errorf("message too long: %d chars (max %d for a message with buttons/reply)", len(text), MaxMessageLength)
 	}
-	msg := tgbotapi.NewMessage(recipientID, text)
-	msg.ParseMode = "Markdown"
+	msg := tgbotapi.NewMessage(recipientID, toMarkdownV2(text))
+	msg.ParseMode = "MarkdownV2"
 	if replyTo != 0 {
 		msg.ReplyToMessageID = int(replyTo)
 	}
@@ -463,6 +518,7 @@ func (tc *TelegramClient) SendMessageWithOptions(recipientID int64, text, button
 	}
 	sent, err := tc.bot.Send(msg)
 	if err != nil {
+		msg.Text = text
 		msg.ParseMode = ""
 		sent, err = tc.bot.Send(msg)
 		if err != nil {
@@ -480,18 +536,20 @@ func (tc *TelegramClient) SendMessageWithOptions(recipientID int64, text, button
 // This is the core of the "dynamic UI": update a status line, swap a menu, mark a choice taken.
 func (tc *TelegramClient) EditMessage(chatID, messageID int64, text, buttons string) error {
 	if kb, ok := parseInlineKeyboard(buttons); ok {
-		edit := tgbotapi.NewEditMessageTextAndMarkup(chatID, int(messageID), text, kb)
-		edit.ParseMode = "Markdown"
+		edit := tgbotapi.NewEditMessageTextAndMarkup(chatID, int(messageID), toMarkdownV2(text), kb)
+		edit.ParseMode = "MarkdownV2"
 		if _, err := tc.bot.Send(edit); err != nil {
+			edit.Text = text
 			edit.ParseMode = ""
 			if _, err = tc.bot.Send(edit); err != nil {
 				return fmt.Errorf("failed to edit message: %v", err)
 			}
 		}
 	} else {
-		edit := tgbotapi.NewEditMessageText(chatID, int(messageID), text)
-		edit.ParseMode = "Markdown"
+		edit := tgbotapi.NewEditMessageText(chatID, int(messageID), toMarkdownV2(text))
+		edit.ParseMode = "MarkdownV2"
 		if _, err := tc.bot.Send(edit); err != nil {
+			edit.Text = text
 			edit.ParseMode = ""
 			if _, err = tc.bot.Send(edit); err != nil {
 				return fmt.Errorf("failed to edit message: %v", err)


### PR DESCRIPTION
## The bug

The Telegram CLI sent every message with legacy `ParseMode = "Markdown"`. The `cs_live_…` in a Stripe Checkout URL contains the matched underscore pair `_live_`, which legacy Markdown treats as **italic** syntax. Telegram rendered it as italics and **silently dropped both underscores** from the delivered text, so `…/pay/cs_live_a1IUB9…` arrived as `…/pay/cslivea1IUB9…` — an unresolvable session id. On the hosted page: `CheckoutInitError: ID not set` / "Something went wrong."

The existing `ParseMode = ""` retry only fires on an **API error**; valid-markdown-but-wrong-render produces no error, so the corruption was **silent**. Net effect: **every hosted onboarding shipped a dead pay link.** (Confirmed live: the Stripe request log shows a `200` create with the correct `cs_live_` URL; the delivered Telegram link had the underscores stripped.)

## The fix

- Switch all Telegram sends to **MarkdownV2** and add `toMarkdownV2()`, which **escapes every reserved character** in literal text — so a URL's underscores can never parse as formatting.
- **Preserve explicit `[label](url)` links**: the label is escaped as text, the URL kept **byte-for-byte** inside the `()` destination. This lets the onboard skill hand out a real, clickable pay link.
- Safe degradation: any text that isn't a recognized link is still fully escaped, so a **bare URL survives verbatim** (Telegram auto-links it). Worst case a link renders unlabeled — never corrupted.
- The plain-text fallback now re-sends the **original unescaped** text (previously it would have re-sent the escaped form).
- **onboard SKILL.md**: hand out the checkout URL as a Markdown link where the channel renders one (`[Complete your payment](<url>)`), else on its own line; never alter the url.

Applied at all five send sites: `SendMessage` (chunked + single), `SendMessageWithOptions`, and both `EditMessage` branches.

## Behavior change

Agent Telegram messages now render **literally** (MarkdownV2-escaped); intentional `*bold*` / `_italic_` will show as literal characters. That is the deliberate cost of never corrupting a URL again — explicit `[label](url)` links still render as links. If we later want to preserve intended formatting, that's a follow-up (a real Markdown → MarkdownV2 converter).

## Verification

⚠️ **Inspection only.** Go isn't installed on my box, and this repo's CI has **no `go test` step** for the telegram CLI (the Go job only gofmt-checks `whatsapp/cli`; `go vet` is skipped). Compilation is gated by the **container image build** in CI. I added `markdownv2_test.go` (bare `cs_live_` URL, `[label](url)` link, reserved specials, label escaping) for anyone running `go test ./…` locally — please run it before merge if you have a Go toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)