### PR TITLE
fix(client): resync the SDK stream when an interrupted turn outlives the drain

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -122,8 +122,11 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
     try:
         await asyncio.wait_for(client.query(query), timeout=config.query_timeout)
     except TimeoutError:
+        # No results_outstanding increment: delivery is unknown, and this raise ends in a
+        # restart (run_one -> graceful_shutdown), which rebuilds the session and resets the count.
         await attempt_interrupt(state, config=config, reason="Query timeout")
         raise
+    state.results_outstanding += 1
     diagnostics.touch_activity(state, "query_sent")
 
     responses: list[str] = []
@@ -176,14 +179,25 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
             if interrupt_task and interrupt_task in done:
                 await attempt_interrupt(state, config=config, reason="New message interrupt")
                 await _cancel_task(anext_task)
-                # Cancelling anext_task finalizes response_iter, so drain leftover
-                # messages with a fresh iterator to keep the stream clean.
-                # Emit any text so it's not lost.
+                # Cancelling anext_task finalizes response_iter, so drain leftover messages with
+                # fresh iterators (each ends at a ResultMessage) until every outstanding query has
+                # delivered its result. Emit any text so it's not lost. If the CLI winds down slower
+                # than the window, stop waiting — results_outstanding stays above zero and the next
+                # turn resyncs by skipping the stale result instead of terminating on it.
                 try:
-                    drain = client.receive_response().__aiter__()
-                    while (leftover := await asyncio.wait_for(anext(drain, None), timeout=_INTERRUPT_DRAIN_TIMEOUT_S)) is not None:
-                        texts, thinking_blocks, _ = sdk_parsing.parse_sdk_message(leftover)
-                        _render(texts, thinking_blocks)
+                    while state.results_outstanding > 0:
+                        drain = client.receive_response().__aiter__()
+                        drained_any = False
+                        while (leftover := await asyncio.wait_for(anext(drain, None), timeout=_INTERRUPT_DRAIN_TIMEOUT_S)) is not None:
+                            drained_any = True
+                            texts, thinking_blocks, _ = sdk_parsing.parse_sdk_message(leftover)
+                            _render(texts, thinking_blocks)
+                            if isinstance(leftover, ResultMessage):
+                                state.results_outstanding -= 1
+                        if not drained_any:
+                            # The iterator ended without delivering anything: the stream is closed
+                            # or has gone quiet — retrying would spin, not drain.
+                            break
                 except (TimeoutError, StopAsyncIteration):
                     pass
                 break
@@ -205,6 +219,10 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 for block in thinking_blocks:
                     _emit_thinking(block)
             text = "\n".join(texts) if texts else None
+            if isinstance(msg, ResultMessage):
+                # Unconditional bookkeeping: every consumed result settles one outstanding query,
+                # whichever branch below ends up handling the message.
+                state.results_outstanding -= 1
             # OpenRouter's upstream 401/402 is caught by its cache proxy. Claude bypasses that proxy,
             # so a terminal auth/billing failure surfaces through the SDK either as the assistant
             # turn's classified error (authentication_failed / billing_error) OR as the result's HTTP
@@ -220,6 +238,14 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 state.provider_status = observed_provider_failure(state.provider_status)
                 await attempt_interrupt(state, config=config, reason="Provider auth lost")
                 break
+            if isinstance(msg, ResultMessage) and state.results_outstanding > 0:
+                # A stale result from an abandoned turn whose wind-down outlived the interrupt
+                # drain. This query's own result is still coming: resync with a fresh iterator
+                # (this one terminates after any result) instead of letting the stale one end
+                # the turn — which would desync every later turn by one.
+                logger.client(f"Consumed stale result from an abandoned turn ({state.results_outstanding} still outstanding)")
+                response_iter = client.receive_response().__aiter__()
+                continue
             if not text:
                 continue
             responses.append(text)

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -112,6 +112,13 @@ _INTERRUPT_DRAIN_TOTAL_S = 15.0
 # even when results_outstanding disagrees — a phantom count (a query whose result never comes) must
 # not make converse skip the real result and hang to response_timeout.
 _STALE_RESULT_WINDOW_S = 30.0
+# The mirror case: the CLI runs self-initiated turns (background-task continuations) that end with
+# ResultMessages no query ever counted (verified against CLI 2.1.187 — the continuation turn's
+# init/result are indistinguishable from a queried turn's). A result consumed this early into a
+# turn cannot be the turn's own (a real result needs an API round trip), so converse treats it as
+# an uncounted turn's buffered result and confirms with a bounded peek before ending the turn.
+_EARLY_RESULT_SUSPECT_S = 1.0
+_EARLY_RESULT_CONFIRM_S = 3.0  # how long to wait for the real turn to follow a suspect result
 
 
 async def _cancel_task(task: asyncio.Task[tp.Any]) -> None:
@@ -173,6 +180,9 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
     watchdog_stop = asyncio.Event()
     watchdog_task = asyncio.create_task(diagnostics.sdk_watchdog(state, stop=watchdog_stop))
 
+    # True while confirming a suspiciously early result (see _EARLY_RESULT_SUSPECT_S): the next
+    # wait is bounded by the confirmation window, and silence ends the turn instead of raising.
+    confirming_early_result = False
     try:
         while True:
             anext_task = asyncio.create_task(anext(response_iter, _STOP))
@@ -180,10 +190,15 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
             if interrupt_task and not interrupt_task.done():
                 waitables.add(interrupt_task)
 
-            done, pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED, timeout=config.response_timeout)
+            wait_timeout = _EARLY_RESULT_CONFIRM_S if confirming_early_result else config.response_timeout
+            done, pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED, timeout=wait_timeout)
 
             if not done:
                 await _cancel_task(anext_task)
+                if confirming_early_result:
+                    # Nothing followed the suspect result within the confirmation window: it really
+                    # was this turn's own (a very fast turn), so end normally.
+                    break
                 await attempt_interrupt(state, config=config, reason="Response timeout")
                 raise TimeoutError
 
@@ -226,6 +241,12 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
 
             diagnostics.touch_activity(state, "sdk_message")
             msg = tp.cast(Message, result)
+            if confirming_early_result:
+                # A message followed the suspect result, confirming it was NOT this turn's own: the
+                # content consumed before it belonged to an uncounted CLI-initiated turn. This turn
+                # starts here — drop the misattributed responses (they were already emitted/shown).
+                confirming_early_result = False
+                responses.clear()
             if isinstance(msg, AssistantMessage):
                 state.compacting = False
             texts, thinking_blocks, session_id = sdk_parsing.parse_sdk_message(msg)
@@ -281,6 +302,16 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                     "treating it as this turn's end and resetting the count"
                 )
                 state.results_outstanding = 0
+                continue
+            if isinstance(msg, ResultMessage) and time.monotonic() - turn_started < _EARLY_RESULT_SUSPECT_S:
+                # The count says this turn is settled, but a real result needs an API round trip —
+                # one landing this fast was buffered before the query, i.e. it belongs to a turn the
+                # counter never saw (a CLI-initiated background continuation; verified these end in
+                # results indistinguishable from a queried turn's). Peek for the real turn instead
+                # of ending on it: if nothing follows within the confirmation window, it was ours.
+                logger.client("Result arrived suspiciously early; confirming it is this turn's own before ending")
+                confirming_early_result = True
+                response_iter = client.receive_response().__aiter__()
                 continue
             if not text:
                 continue

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -3,6 +3,7 @@
 import asyncio
 import datetime as dt
 import os
+import time
 import typing as tp
 
 import aiohttp
@@ -101,7 +102,16 @@ def persist_session_id(session_id: str, *, state: vm.State, config: vm.VestaConf
 
 _STOP = object()
 
-_INTERRUPT_DRAIN_TIMEOUT_S = 5.0  # cap the post-interrupt drain so a stalled stream can't block forever
+_INTERRUPT_DRAIN_TIMEOUT_S = 5.0  # cap each post-interrupt drain read so a stalled stream can't block forever
+# Total budget for the post-interrupt drain across all outstanding results. Without it, a chatty
+# wind-down (messages arriving steadily under the per-read cap) could hold the interrupting user's
+# new turn hostage for the full wind-down of every outstanding query.
+_INTERRUPT_DRAIN_TOTAL_S = 15.0
+# A stale result from an abandoned turn sits in the buffer and surfaces within moments of the next
+# query. A result arriving later than this into a live turn is therefore trusted as the turn's own
+# even when results_outstanding disagrees — a phantom count (a query whose result never comes) must
+# not make converse skip the real result and hang to response_timeout.
+_STALE_RESULT_WINDOW_S = 30.0
 
 
 async def _cancel_task(task: asyncio.Task[tp.Any]) -> None:
@@ -128,6 +138,7 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
         raise
     state.results_outstanding += 1
     diagnostics.touch_activity(state, "query_sent")
+    turn_started = time.monotonic()
 
     responses: list[str] = []
 
@@ -182,20 +193,27 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 # Cancelling anext_task finalizes response_iter, so drain leftover messages with
                 # fresh iterators (each ends at a ResultMessage) until every outstanding query has
                 # delivered its result. Emit any text so it's not lost. If the CLI winds down slower
-                # than the window, stop waiting — results_outstanding stays above zero and the next
+                # than the budget, stop waiting — results_outstanding stays above zero and the next
                 # turn resyncs by skipping the stale result instead of terminating on it.
+                drain_deadline = time.monotonic() + _INTERRUPT_DRAIN_TOTAL_S
                 try:
                     while state.results_outstanding > 0:
                         drain = client.receive_response().__aiter__()
                         drained_any = False
-                        while (leftover := await asyncio.wait_for(anext(drain, None), timeout=_INTERRUPT_DRAIN_TIMEOUT_S)) is not None:
-                            drained_any = True
+                        while True:
+                            remaining = drain_deadline - time.monotonic()
+                            if remaining <= 0:
+                                raise TimeoutError  # total drain budget spent; the interrupting turn must start
+                            leftover = await asyncio.wait_for(anext(drain, None), timeout=min(_INTERRUPT_DRAIN_TIMEOUT_S, remaining))
+                            if leftover is None:
+                                break
                             texts, thinking_blocks, _ = sdk_parsing.parse_sdk_message(leftover)
                             _render(texts, thinking_blocks)
                             if isinstance(leftover, ResultMessage):
-                                state.results_outstanding -= 1
+                                state.results_outstanding = max(0, state.results_outstanding - 1)
+                                drained_any = True
                         if not drained_any:
-                            # The iterator ended without delivering anything: the stream is closed
+                            # The iterator ended without delivering a result: the stream is closed
                             # or has gone quiet — retrying would spin, not drain.
                             break
                 except (TimeoutError, StopAsyncIteration):
@@ -219,10 +237,15 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 for block in thinking_blocks:
                     _emit_thinking(block)
             text = "\n".join(texts) if texts else None
+            # An earlier query's result still owed means content arriving now is an abandoned turn's
+            # late tail, not this turn's reply. Checked before the result decrement below so the
+            # boundary is consistent: everything up to and including the stale result is tail.
+            stale_tail = state.results_outstanding > 1
             if isinstance(msg, ResultMessage):
-                # Unconditional bookkeeping: every consumed result settles one outstanding query,
-                # whichever branch below ends up handling the message.
-                state.results_outstanding -= 1
+                # Bookkeeping for every consumed result, whichever branch below handles the message.
+                # Clamped: an unprompted result (e.g. a CLI-initiated background continuation) must
+                # not push the count negative and corrupt later turns' accounting.
+                state.results_outstanding = max(0, state.results_outstanding - 1)
             # OpenRouter's upstream 401/402 is caught by its cache proxy. Claude bypasses that proxy,
             # so a terminal auth/billing failure surfaces through the SDK either as the assistant
             # turn's classified error (authentication_failed / billing_error) OR as the result's HTTP
@@ -239,14 +262,36 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 await attempt_interrupt(state, config=config, reason="Provider auth lost")
                 break
             if isinstance(msg, ResultMessage) and state.results_outstanding > 0:
-                # A stale result from an abandoned turn whose wind-down outlived the interrupt
-                # drain. This query's own result is still coming: resync with a fresh iterator
-                # (this one terminates after any result) instead of letting the stale one end
-                # the turn — which would desync every later turn by one.
-                logger.client(f"Consumed stale result from an abandoned turn ({state.results_outstanding} still outstanding)")
-                response_iter = client.receive_response().__aiter__()
+                turn_age = time.monotonic() - turn_started
+                if turn_age < _STALE_RESULT_WINDOW_S:
+                    # A stale result from an abandoned turn whose wind-down outlived the interrupt
+                    # drain. This query's own result is still coming: resync with a fresh iterator
+                    # (this one terminates after any result) instead of letting the stale one end
+                    # the turn — which would desync every later turn by one.
+                    logger.client(f"Consumed stale result from an abandoned turn ({state.results_outstanding} still outstanding)")
+                    response_iter = client.receive_response().__aiter__()
+                    continue
+                # The count says more results are owed, but stale results surface within moments of
+                # the query — one landing this deep into a live turn is almost certainly the turn's
+                # own, and the count is phantom (an abandoned query whose result never came).
+                # Trust the stream over the count: end the turn here and hard-reset the bookkeeping,
+                # instead of skipping the real result and hanging to response_timeout.
+                logger.warning(
+                    f"Result arrived {turn_age:.0f}s into the turn with {state.results_outstanding} still outstanding; "
+                    "treating it as this turn's end and resetting the count"
+                )
+                state.results_outstanding = 0
                 continue
             if not text:
+                continue
+            if stale_tail:
+                # An abandoned turn's late output: show it (it's real work, and losing it hides what
+                # the agent did) but don't attribute it to this turn — appending it to responses
+                # would present it as the reply to the new message and feed the dash correction.
+                if show_output:
+                    filtered = sdk_parsing.filter_tool_lines(text)
+                    if filtered:
+                        _emit(filtered)
                 continue
             responses.append(text)
             if not show_output:
@@ -306,9 +351,16 @@ async def compact_session(*, state: vm.State) -> None:
     assert state.client is not None
     client = state.client
     await client.query("/compact")
+    # /compact is a query like any other: count it, so a compaction that outlives the timeout
+    # leaves results_outstanding above zero and the next turn resyncs past the late compact
+    # result instead of terminating on it (the restart that normally follows can fail — see
+    # compact_then_restart_if_requested's fallback — so the counter must not assume it).
+    state.results_outstanding += 1
 
     async def _drain() -> None:
         async for msg in client.receive_response():
+            if isinstance(msg, ResultMessage):
+                state.results_outstanding = max(0, state.results_outstanding - 1)
             if isinstance(msg, SystemMessage) and msg.subtype == "compact_boundary":
                 logger.client("Compaction boundary reached")
 

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -366,6 +366,8 @@ async def message_processor(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.St
         try:
             async with ClaudeSDKClient(options=options) as client:
                 state.client = client
+                # Fresh subprocess, fresh stream: no query of the old session can deliver here.
+                state.results_outstanding = 0
                 logger.client("Client session started")
 
                 try:

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -85,6 +85,12 @@ class State:
     openrouter_proxy_url: str | None = None
     cache_proxy_runner: AppRunner | None = None
     interrupt_event: asyncio.Event | None = None
+    # Queries sent to the SDK whose ResultMessage hasn't been consumed yet. converse ends a turn only
+    # when a ResultMessage brings this to 0: an interrupted turn whose wind-down outlives the drain
+    # window leaves its result in the shared stream, and without this bookkeeping the next turn would
+    # terminate on that stale result — desyncing every later turn by one (the agent looks hung, and
+    # each new user message flushes the previous turn's output). Reset when the SDK session is rebuilt.
+    results_outstanding: int = 0
     compacting: bool = False
     # True while a non-interruptible turn (a boot turn) is being processed. process_batch consults
     # this before firing client.interrupt(), so a concurrent interrupt notification queues and waits

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -30,3 +30,13 @@ def state():
     s = vm.State()
     s.shutdown_event = asyncio.Event()
     return s
+
+
+@pytest.fixture(autouse=True)
+def _no_early_result_suspicion(monkeypatch):
+    # Mocked turns complete in milliseconds, which converse would treat as a suspiciously early
+    # result (production turns need an API round trip) and pay the confirmation wait on every
+    # test. Disable the suspicion window by default; tests exercising it patch it back on.
+    import core.client
+
+    monkeypatch.setattr(core.client, "_EARLY_RESULT_SUSPECT_S", 0.0)

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -961,3 +961,63 @@ async def test_interrupt_drain_total_budget_bounds_a_chatty_wind_down():
     await sim_task
 
     assert elapsed < 2.0, f"the drain must respect its total budget; took {elapsed:.1f}s"
+
+
+@pytest.mark.anyio
+async def test_unprompted_continuation_result_does_not_end_the_next_turn():
+    """The CLI runs self-initiated turns (background-task continuations) ending in ResultMessages no
+    query ever counted (verified against CLI 2.1.187). One buffered ahead of the next turn must not
+    terminate that turn: a result this early cannot be the turn's own (a real result needs an API
+    round trip), so converse confirms with a bounded peek and keeps reading its actual response."""
+    from claude_agent_sdk import TextBlock
+    from core.client import converse
+
+    state, config, mock_client, emitted, message_queue, consumed = _make_converse_harness(use_shared_queue=True)
+    assert message_queue is not None
+
+    # The continuation's block is already buffered when the user's next message arrives.
+    await message_queue.put(_assistant_msg([TextBlock("background task completed")]))
+    await message_queue.put(_result_msg())
+
+    async def sim_real_turn():
+        # The real turn streams shortly after (well inside the confirmation window).
+        await asyncio.sleep(0.2)
+        await message_queue.put(_assistant_msg([TextBlock("actual reply")]))
+        await message_queue.put(_result_msg())
+
+    sim_task = asyncio.create_task(sim_real_turn())
+    with patch("core.client._EARLY_RESULT_SUSPECT_S", 1.0), patch("core.client._EARLY_RESULT_CONFIRM_S", 2.0):
+        responses = await converse("hello", state=state, config=config, show_output=True)
+    await sim_task
+
+    assert any("actual reply" in r for r in responses), (
+        f"the turn must survive the unprompted continuation result and return its own reply; got responses={responses}"
+    )
+    assert not any("background task completed" in r for r in responses), (
+        f"the continuation's content must not be attributed to this turn; got responses={responses}"
+    )
+    assert any(t == "background task completed" for t, _ in emitted), "the continuation's text must still be shown"
+
+
+@pytest.mark.anyio
+async def test_early_result_with_nothing_following_ends_the_turn():
+    """The confirmation peek is bounded: when a suspiciously early result is followed by silence,
+    it really was the turn's own (a very fast turn) and converse ends instead of hanging."""
+    import time
+
+    from claude_agent_sdk import TextBlock
+    from core.client import converse
+
+    state, config, mock_client, emitted, message_queue, consumed = _make_converse_harness(use_shared_queue=True)
+    assert message_queue is not None
+
+    await message_queue.put(_assistant_msg([TextBlock("quick reply")]))
+    await message_queue.put(_result_msg())
+
+    t0 = time.monotonic()
+    with patch("core.client._EARLY_RESULT_SUSPECT_S", 1.0), patch("core.client._EARLY_RESULT_CONFIRM_S", 0.2):
+        responses = await converse("hi", state=state, config=config, show_output=True)
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < 3.0, f"the confirmation peek must be bounded; converse took {elapsed:.1f}s"
+    assert any("quick reply" in r for r in responses), f"a genuinely fast turn must keep its reply; got responses={responses}"

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -844,3 +844,46 @@ async def test_drain_timeout_does_not_block_forever():
     elapsed = time.monotonic() - t0
 
     assert elapsed < 8.0, f"converse took {elapsed:.1f}s — drain blocked too long"
+
+
+@pytest.mark.anyio
+async def test_late_result_after_drain_timeout_does_not_desync_next_turn():
+    """Reproduces the stream desync from the 2026-07-02 logs: a turn is interrupted but the
+    CLI winds down slower than the drain window, so the turn's tail (including its
+    ResultMessage) lands in the stream after converse abandoned it. The next converse must
+    still deliver ITS OWN response — a stale ResultMessage from the abandoned turn must not
+    terminate the new turn instantly (which leaves every subsequent turn off by one: the
+    agent looks hung, and each new user message flushes the previous turn's output)."""
+    from claude_agent_sdk import TextBlock, ToolUseBlock
+    from core.client import converse
+
+    state, config, mock_client, emitted, message_queue, consumed = _make_converse_harness(use_shared_queue=True)
+    assert message_queue is not None
+
+    state.interrupt_event = asyncio.Event()
+
+    async def sim_conv1():
+        await message_queue.put(_assistant_msg([ToolUseBlock("1", "Bash", {})]))
+        # Handshake: converse received the tool message, now interrupt it. The queue stays
+        # empty through the drain window — the CLI is "still thinking" and winds down late.
+        await wait_for_condition(lambda: len(consumed) >= 1, message="converse never consumed the tool message")
+        assert state.interrupt_event is not None
+        state.interrupt_event.set()
+
+    asyncio.create_task(sim_conv1())
+    with patch("core.client._INTERRUPT_DRAIN_TIMEOUT_S", 0.05):
+        await converse("update whatsmeow", state=state, config=config, show_output=True)
+
+    # The CLI finishes the abandoned turn late: its tail + ResultMessage arrive after the
+    # drain gave up. Then the next turn's real response follows on the same stream.
+    await message_queue.put(_assistant_msg([TextBlock("late tail of the abandoned turn")]))
+    await message_queue.put(_result_msg())
+    await message_queue.put(_assistant_msg([TextBlock("fresh response")]))
+    await message_queue.put(_result_msg())
+
+    state.interrupt_event = None
+    responses = await converse("eta?", state=state, config=config, show_output=True)
+
+    assert any("fresh response" in r for r in responses), (
+        f"conv 2 must sync to its own result, not terminate on the abandoned turn's stale ResultMessage; got responses={responses}"
+    )

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -870,9 +870,10 @@ async def test_late_result_after_drain_timeout_does_not_desync_next_turn():
         assert state.interrupt_event is not None
         state.interrupt_event.set()
 
-    asyncio.create_task(sim_conv1())
+    sim_task = asyncio.create_task(sim_conv1())
     with patch("core.client._INTERRUPT_DRAIN_TIMEOUT_S", 0.05):
         await converse("update whatsmeow", state=state, config=config, show_output=True)
+    await sim_task
 
     # The CLI finishes the abandoned turn late: its tail + ResultMessage arrive after the
     # drain gave up. Then the next turn's real response follows on the same stream.
@@ -887,3 +888,76 @@ async def test_late_result_after_drain_timeout_does_not_desync_next_turn():
     assert any("fresh response" in r for r in responses), (
         f"conv 2 must sync to its own result, not terminate on the abandoned turn's stale ResultMessage; got responses={responses}"
     )
+    assert not any("late tail" in r for r in responses), (
+        f"the abandoned turn's late tail must not be attributed to conv 2's responses; got responses={responses}"
+    )
+    assert any(t == "late tail of the abandoned turn" for t, _ in emitted), "the late tail must still be emitted (shown), just not attributed"
+
+
+@pytest.mark.anyio
+async def test_phantom_outstanding_result_ends_the_turn_instead_of_hanging():
+    """A results_outstanding count whose result never comes (an abandoned query the CLI dropped)
+    must not make converse skip the live turn's own result and hang to response_timeout: past the
+    stale-result window, the stream is trusted over the count and the bookkeeping is reset."""
+    import time
+
+    from claude_agent_sdk import TextBlock
+    from core.client import converse
+
+    state, config, mock_client, emitted, message_queue, consumed = _make_converse_harness(use_shared_queue=True)
+    assert message_queue is not None
+    state.results_outstanding = 1  # phantom: no result for this will ever arrive
+
+    async def sim():
+        # Past the (patched) stale window, so the result must be trusted as the live turn's own.
+        await asyncio.sleep(0.2)
+        await message_queue.put(_assistant_msg([TextBlock("real answer")]))
+        await message_queue.put(_result_msg())
+
+    sim_task = asyncio.create_task(sim())
+    t0 = time.monotonic()
+    with patch("core.client._STALE_RESULT_WINDOW_S", 0.05):
+        await converse("hello", state=state, config=config, show_output=True)
+    elapsed = time.monotonic() - t0
+    await sim_task
+
+    assert elapsed < 5.0, f"converse hung {elapsed:.1f}s on a phantom outstanding count"
+    assert state.results_outstanding == 0, "a phantom count must be hard-reset when the stream is trusted over it"
+    assert any(t == "real answer" for t, _ in emitted), "the live turn's text must still be shown"
+
+
+@pytest.mark.anyio
+async def test_interrupt_drain_total_budget_bounds_a_chatty_wind_down():
+    """The post-interrupt drain is bounded overall, not just per read: a wind-down streaming
+    messages steadily (each inside the per-read cap) while more than one result is outstanding
+    must not hold the interrupting user's new turn hostage."""
+    import time
+
+    from claude_agent_sdk import TextBlock, ToolUseBlock
+    from core.client import converse
+
+    state, config, mock_client, emitted, message_queue, consumed = _make_converse_harness(use_shared_queue=True)
+    assert message_queue is not None
+    state.results_outstanding = 1  # a prior abandoned turn is still owed a result
+    state.interrupt_event = asyncio.Event()
+    feeding = True
+
+    async def sim():
+        await message_queue.put(_assistant_msg([ToolUseBlock("1", "Bash", {})]))
+        await wait_for_condition(lambda: len(consumed) >= 1, message="converse never consumed the tool message")
+        assert state.interrupt_event is not None
+        state.interrupt_event.set()
+        # Chatty wind-down: messages keep arriving inside the per-read cap, never a result.
+        while feeding:
+            await message_queue.put(_assistant_msg([TextBlock("still winding down")]))
+            await asyncio.sleep(0.05)
+
+    sim_task = asyncio.create_task(sim())
+    t0 = time.monotonic()
+    with patch("core.client._INTERRUPT_DRAIN_TIMEOUT_S", 0.5), patch("core.client._INTERRUPT_DRAIN_TOTAL_S", 0.3):
+        await converse("guarded", state=state, config=config, show_output=True)
+    elapsed = time.monotonic() - t0
+    feeding = False
+    await sim_task
+
+    assert elapsed < 2.0, f"the drain must respect its total budget; took {elapsed:.1f}s"


### PR DESCRIPTION
## The bug (from production logs, 2026-07-02)

Agent appears to hang mid-conversation; every `attempt_interrupt` times out; when the user sends any new message, the *previous* turn's entire output (thinking, task events, usage) floods the log in a single second, and the cycle repeats — every turn's output arrives one user-message late, forever.

## Root cause

`converse` ends a turn when `receive_response()` yields a ResultMessage — but the SDK message stream is shared across turns:

1. **Seed:** an interrupt's wind-down outlives the 5s drain window (`_INTERRUPT_DRAIN_TIMEOUT_S`). This is common: under heavy thinking/long tools the CLI acks interrupts late (18s+ observed — confirmed by a Stop hook firing 18s after the interrupt, matching the buffered result's `duration` to the second). The drain gives up and converse abandons the stream with that turn's ResultMessage still to come.
2. **Desync:** the next turn's `receive_response()` immediately yields the stale buffered output, terminates on the *stale* ResultMessage, and Vesta marks the turn complete in ~0s while the CLI is still working on the actual query. Off-by-one from then on, self-perpetuating.
3. **Why interrupts also time out:** the SDK's internal message buffer is bounded (`max_buffer_size=100`), and its single reader task processes both messages *and* interrupt acks — with nobody consuming, the buffer fills, the reader blocks, and `interrupt()` can never be acknowledged.

The current driving path (official SDK + this converse/drain code) shipped in 0.1.161; before that the tmux/cc_sdk transport had different interrupt mechanics, so this failure mode is new to recent releases — matching when it was first observed in the field.

## The fix

Enforce the real invariant — *a turn ends at its own result* — by counting: `State.results_outstanding` increments per `query()`, decrements per consumed ResultMessage.

- converse ends a turn only when a result brings the count to 0; a stale result is consumed (its late output still emitted, nothing lost), logged, and skipped via a fresh iterator
- the interrupt drain keeps draining until the count settles, the stream goes quiet, or the window expires
- the count resets when the SDK session is rebuilt

Any abandonment (slow interrupt, auth-loss break) now self-heals on the next turn instead of desyncing the agent until restart.

## Verification

- New test `test_late_result_after_drain_timeout_does_not_desync_next_turn` reproduces the production failure deterministically: **red on master** (`got responses=['late tail of the abandoned turn']` — the new turn returning the abandoned turn's output), green with the fix
- Full `tests/test_interrupts.py`: 23 passed (all 22 pre-existing behaviors intact)
- `./check.sh agent`: ruff + format + ty clean; 462 passed (3 pre-existing local-env failures in test_cc_sdk/test_upstream_sync, unrelated, fail on clean master too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)