### PR TITLE
fix(client): one long-lived SDK stream consumer ends the per-turn desync

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -152,6 +152,13 @@ async def _dispatch_message(msg: Message, *, state: vm.State, config: vm.VestaCo
         state.compacting = False
     if isinstance(msg, SystemMessage) and msg.subtype == "compact_boundary":
         logger.client("Compaction boundary reached")
+    # The CLI streams a thinking_tokens counter while the model reasons (dozens per turn, dropped
+    # from the log by parse_sdk_message). Track it on the open turn so the wait loop's liveness
+    # notes can say "thinking, ~N tokens" instead of guessing what the quiet means.
+    if turn and isinstance(msg, SystemMessage) and msg.subtype == "thinking_tokens":
+        if isinstance(msg.data, dict) and "estimated_tokens" in msg.data and isinstance(msg.data["estimated_tokens"], int):
+            turn.thinking_tokens = msg.data["estimated_tokens"]
+            turn.thinking_tokens_at = time.monotonic()
     texts, thinking_blocks, session_id = sdk_parsing.parse_sdk_message(msg)
     if session_id and session_id != state.persisted.session_id:
         if state.persisted.session_id:
@@ -162,6 +169,8 @@ async def _dispatch_message(msg: Message, *, state: vm.State, config: vm.VestaCo
         for block in thinking_blocks:
             _emit_thinking(block, state=state)
     text = "\n".join(texts) if texts else None
+    if turn and (text or thinking_blocks):
+        turn.last_visible_at = time.monotonic()
     if text:
         if turn:
             turn.texts.append(text)
@@ -261,7 +270,7 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 if time.monotonic() - turn.last_message_at >= config.response_timeout:
                     await attempt_interrupt(state, config=config, reason="Response timeout")
                     raise TimeoutError
-                diagnostics.note_stream_silence(state, noted_at=noted_silence)
+                diagnostics.note_turn_liveness(state, turn=turn, noted_at=noted_silence)
                 continue
 
             if done_task in done:

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -3,6 +3,7 @@
 import asyncio
 import datetime as dt
 import os
+import time
 import typing as tp
 
 import aiohttp
@@ -99,9 +100,10 @@ def persist_session_id(session_id: str, *, state: vm.State, config: vm.VestaConf
     logger.debug(f"Captured session_id: {session_id[:16]}...")
 
 
-_STOP = object()
-
-_INTERRUPT_DRAIN_TIMEOUT_S = 5.0  # cap the post-interrupt drain so a stalled stream can't block forever
+# Post-interrupt wait for the interrupted turn's ResultMessage. Purely a labeling nicety so the
+# next turn usually opens against a clean stream; when the CLI's wind-down outlives it, the
+# consumer still receives everything and the late result is dropped as advisory (issue #958).
+_INTERRUPT_TURN_END_GRACE_S = 5.0
 
 
 async def _cancel_task(task: asyncio.Task[tp.Any]) -> None:
@@ -112,6 +114,111 @@ async def _cancel_task(task: asyncio.Task[tp.Any]) -> None:
         pass
 
 
+def _open_turn(state: vm.State, *, show_output: bool) -> vm.TurnSignals:
+    turn = vm.TurnSignals(show_output=show_output)
+    state.turn = turn
+    return turn
+
+
+def _close_turn(state: vm.State, turn: vm.TurnSignals) -> None:
+    if state.turn is turn:
+        state.turn = None
+
+
+def _emit_text(text: str, *, state: vm.State) -> None:
+    logger.assistant(text)
+    state.event_bus.emit({"type": "assistant", "text": text})
+
+
+def _emit_thinking(block: ThinkingBlock, *, state: vm.State) -> None:
+    if not block.thinking.strip():
+        return
+    logger.thinking(block.thinking)
+    state.event_bus.emit({"type": "thinking", "text": block.thinking, "signature": block.signature})
+
+
+async def _dispatch_message(msg: Message, *, state: vm.State, config: vm.VestaConfig) -> None:
+    """Handle one SDK stream message: emit content, persist session ids, detect auth loss, and
+    close the open turn on its ResultMessage. Messages with no open turn (a self-initiated
+    continuation turn, or an interrupted turn's wind-down) still emit — nothing is ever lost —
+    and their ResultMessage is dropped."""
+    diagnostics.touch_activity(state, "sdk_message")
+    turn = state.turn
+    if turn:
+        turn.last_message_at = time.monotonic()
+    if isinstance(msg, AssistantMessage):
+        state.compacting = False
+    if isinstance(msg, SystemMessage) and msg.subtype == "compact_boundary":
+        logger.client("Compaction boundary reached")
+    texts, thinking_blocks, session_id = sdk_parsing.parse_sdk_message(msg)
+    if session_id and session_id != state.persisted.session_id:
+        if state.persisted.session_id:
+            logger.warning(f"Session ID changed: {state.persisted.session_id[:16]} -> {session_id[:16]} (resume may have failed)")
+        persist_session_id(session_id, state=state, config=config)
+    show = turn.show_output if turn else True
+    if show:
+        for block in thinking_blocks:
+            _emit_thinking(block, state=state)
+    text = "\n".join(texts) if texts else None
+    if text:
+        if turn:
+            turn.texts.append(text)
+        if show:
+            filtered = sdk_parsing.filter_tool_lines(text)
+            if filtered:
+                _emit_text(filtered, state=state)
+    # OpenRouter's upstream 401/402 is caught by its cache proxy. Claude bypasses that proxy,
+    # so a terminal auth/billing failure surfaces through the SDK either as the assistant
+    # turn's classified error (authentication_failed / billing_error) OR as the result's HTTP
+    # status (api_error_status). Check BOTH so a token expiry can't stay invisible to the app.
+    auth_lost = (isinstance(msg, AssistantMessage) and is_terminal_auth_error(msg.error)) or (
+        isinstance(msg, ResultMessage) and msg.api_error_status in TERMINAL_PROVIDER_ERRORS
+    )
+    if auth_lost:
+        # Flip to not_authenticated, stop the CLI's internal retries, and end the turn cleanly
+        # so the app shows "not signed in" in ~3s instead of hanging to the response timeout
+        # and restart-looping.
+        logger.error("Provider auth lost (terminal upstream 401/402); flipping to not_authenticated")
+        state.provider_status = observed_provider_failure(state.provider_status)
+        await attempt_interrupt(state, config=config, reason="Provider auth lost")
+    if isinstance(msg, ResultMessage) or auth_lost:
+        if turn and not turn.done.is_set():
+            turn.done.set()
+        elif isinstance(msg, ResultMessage):
+            logger.debug("ResultMessage with no open turn (continuation or interrupted-turn wind-down); dropped")
+
+
+async def consume_stream(*, state: vm.State, config: vm.VestaConfig) -> None:
+    """Single long-lived consumer of the SDK stream — one per client session, connect to disconnect.
+
+    Reading continuously is the fix for issue #958: with per-turn readers, messages left unconsumed
+    after an abandoned interrupt drain filled the SDK's bounded buffer, blocking its reader task
+    (jamming interrupt acks and control responses) and desyncing every later turn by one
+    ResultMessage. Here nothing is ever left unconsumed, by construction."""
+    assert state.client is not None
+    client = state.client
+
+    def _fail_open_turn(error: Exception) -> None:
+        turn = state.turn
+        if turn and not turn.done.is_set():
+            turn.error = error
+            turn.done.set()
+
+    try:
+        async for msg in client.receive_messages():
+            await _dispatch_message(msg, state=state, config=config)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        # Stream death: surface it through the open turn so run_one's error handling restarts.
+        # While idle, the next query() fails on the dead transport and takes the same path.
+        logger.error(f"SDK stream consumer died: {type(e).__name__}: {e}")
+        _fail_open_turn(e)
+        return
+    # Clean EOF mid-turn still means the CLI is gone; only consumer cancellation is a normal end.
+    _fail_open_turn(RuntimeError("SDK stream ended"))
+
+
 async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show_output: bool) -> list[str]:
     assert state.client is not None
     client = state.client
@@ -119,38 +226,14 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
     query = sdk_parsing.build_query(prompt, timestamp=dt.datetime.now())
     diagnostics.touch_activity(state, "query_start")
     state.active_tools.clear()
+    turn = _open_turn(state, show_output=show_output)
     try:
         await asyncio.wait_for(client.query(query), timeout=config.query_timeout)
     except TimeoutError:
+        _close_turn(state, turn)
         await attempt_interrupt(state, config=config, reason="Query timeout")
         raise
     diagnostics.touch_activity(state, "query_sent")
-
-    responses: list[str] = []
-
-    def _emit(t: str) -> None:
-        logger.assistant(t)
-        state.event_bus.emit({"type": "assistant", "text": t})
-
-    def _emit_thinking(block: ThinkingBlock) -> None:
-        if not block.thinking.strip():
-            return
-        logger.thinking(block.thinking)
-        state.event_bus.emit({"type": "thinking", "text": block.thinking, "signature": block.signature})
-
-    def _render(texts: list[str], thinking_blocks: list[ThinkingBlock]) -> str | None:
-        """Emit thinking + filtered assistant text (when shown); return the joined text so the caller can record it."""
-        if show_output:
-            for block in thinking_blocks:
-                _emit_thinking(block)
-        text = "\n".join(texts) if texts else None
-        if text and show_output:
-            filtered = sdk_parsing.filter_tool_lines(text)
-            if filtered:
-                _emit(filtered)
-        return text
-
-    response_iter = client.receive_response().__aiter__()
 
     interrupt_task: asyncio.Task[tp.Any] | None = None
     if state.interrupt_event and not state.interrupt_event.is_set():
@@ -158,84 +241,49 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
 
     watchdog_stop = asyncio.Event()
     watchdog_task = asyncio.create_task(diagnostics.sdk_watchdog(state, stop=watchdog_stop))
+    done_task = asyncio.create_task(turn.done.wait())
 
     try:
         while True:
-            anext_task = asyncio.create_task(anext(response_iter, _STOP))
-            waitables: set[asyncio.Task[tp.Any]] = {anext_task}
+            waitables: set[asyncio.Task[tp.Any]] = {done_task}
             if interrupt_task and not interrupt_task.done():
                 waitables.add(interrupt_task)
 
-            done, pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED, timeout=config.response_timeout)
+            # Same silence budget as the old per-message wait: measured from the last stream
+            # message (the consumer touches last_message_at), so quiet stretches still time out.
+            silence_budget = config.response_timeout - (time.monotonic() - turn.last_message_at)
+            done, _ = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED, timeout=max(silence_budget, 0))
 
             if not done:
-                await _cancel_task(anext_task)
-                await attempt_interrupt(state, config=config, reason="Response timeout")
-                raise TimeoutError
-
-            if interrupt_task and interrupt_task in done:
-                await attempt_interrupt(state, config=config, reason="New message interrupt")
-                await _cancel_task(anext_task)
-                # Cancelling anext_task finalizes response_iter, so drain leftover
-                # messages with a fresh iterator to keep the stream clean.
-                # Emit any text so it's not lost.
-                try:
-                    drain = client.receive_response().__aiter__()
-                    while (leftover := await asyncio.wait_for(anext(drain, None), timeout=_INTERRUPT_DRAIN_TIMEOUT_S)) is not None:
-                        texts, thinking_blocks, _ = sdk_parsing.parse_sdk_message(leftover)
-                        _render(texts, thinking_blocks)
-                except (TimeoutError, StopAsyncIteration):
-                    pass
-                break
-
-            result = anext_task.result()
-            if result is _STOP:
-                break
-
-            diagnostics.touch_activity(state, "sdk_message")
-            msg = tp.cast(Message, result)
-            if isinstance(msg, AssistantMessage):
-                state.compacting = False
-            texts, thinking_blocks, session_id = sdk_parsing.parse_sdk_message(msg)
-            if session_id and session_id != state.persisted.session_id:
-                if state.persisted.session_id:
-                    logger.warning(f"Session ID changed: {state.persisted.session_id[:16]} -> {session_id[:16]} (resume may have failed)")
-                persist_session_id(session_id, state=state, config=config)
-            if show_output:
-                for block in thinking_blocks:
-                    _emit_thinking(block)
-            text = "\n".join(texts) if texts else None
-            # OpenRouter's upstream 401/402 is caught by its cache proxy. Claude bypasses that proxy,
-            # so a terminal auth/billing failure surfaces through the SDK either as the assistant
-            # turn's classified error (authentication_failed / billing_error) OR as the result's HTTP
-            # status (api_error_status). Check BOTH so a token expiry can't stay invisible to the app.
-            auth_lost = (isinstance(msg, AssistantMessage) and is_terminal_auth_error(msg.error)) or (
-                isinstance(msg, ResultMessage) and msg.api_error_status in TERMINAL_PROVIDER_ERRORS
-            )
-            if auth_lost:
-                # Flip to not_authenticated, stop the CLI's internal retries, and end the turn cleanly
-                # so the app shows "not signed in" in ~3s instead of hanging to the response timeout
-                # and restart-looping.
-                logger.error("Provider auth lost (terminal upstream 401/402); flipping to not_authenticated")
-                state.provider_status = observed_provider_failure(state.provider_status)
-                await attempt_interrupt(state, config=config, reason="Provider auth lost")
-                break
-            if not text:
+                if time.monotonic() - turn.last_message_at >= config.response_timeout:
+                    await attempt_interrupt(state, config=config, reason="Response timeout")
+                    raise TimeoutError
                 continue
-            responses.append(text)
-            if not show_output:
-                continue
-            filtered = sdk_parsing.filter_tool_lines(text)
-            if filtered:
-                _emit(filtered)
+
+            if done_task in done:
+                if turn.error is not None:
+                    raise turn.error
+                break
+
+            await attempt_interrupt(state, config=config, reason="New message interrupt")
+            # Give the wind-down a bounded window to deliver its ResultMessage so the next turn
+            # usually opens clean; on expiry the consumer still receives everything (emitted live,
+            # late result dropped), so nothing jams or leaks — the issue #958 failure mode.
+            try:
+                await asyncio.wait_for(turn.done.wait(), timeout=_INTERRUPT_TURN_END_GRACE_S)
+            except TimeoutError:
+                pass
+            break
     finally:
         state.compacting = False
+        _close_turn(state, turn)
         watchdog_stop.set()
         await _cancel_task(watchdog_task)
+        await _cancel_task(done_task)
         if interrupt_task and not interrupt_task.done():
             await _cancel_task(interrupt_task)
 
-    return responses
+    return turn.texts
 
 
 _EM_DASH = "—"
@@ -274,19 +322,20 @@ async def compact_session(*, state: vm.State) -> None:
     The official Claude Agent SDK has no compact() method; the documented path is to send the
     `/compact` slash command as a query (code.claude.com/docs/en/agent-sdk/slash-commands). Manual
     /compact rewrites the same session, so resume keeps working and the dreamer can restart into
-    the compacted conversation. The turn ends with SystemMessage(subtype="compact_boundary") then
-    a ResultMessage; draining the response blocks until compaction completes. Bounded so a stuck
-    summarization still lets the caller restart."""
+    the compacted conversation. The turn ends with SystemMessage(subtype="compact_boundary") — the
+    stream consumer logs it — then a ResultMessage, which closes the turn; waiting on the turn
+    blocks until compaction completes. Bounded so a stuck summarization still lets the caller
+    restart."""
     assert state.client is not None
     client = state.client
-    await client.query("/compact")
-
-    async def _drain() -> None:
-        async for msg in client.receive_response():
-            if isinstance(msg, SystemMessage) and msg.subtype == "compact_boundary":
-                logger.client("Compaction boundary reached")
-
-    await asyncio.wait_for(_drain(), timeout=_COMPACT_TIMEOUT_S)
+    turn = _open_turn(state, show_output=False)
+    try:
+        await client.query("/compact")
+        await asyncio.wait_for(turn.done.wait(), timeout=_COMPACT_TIMEOUT_S)
+        if turn.error is not None:
+            raise turn.error
+    finally:
+        _close_turn(state, turn)
 
 
 def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgentOptions:

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -100,6 +100,8 @@ def persist_session_id(session_id: str, *, state: vm.State, config: vm.VestaConf
     logger.debug(f"Captured session_id: {session_id[:16]}...")
 
 
+_SILENCE_POLL_S = 15.0  # wake the turn's wait loop during quiet stretches to log liveness notes
+
 # Post-interrupt wait for the interrupted turn's ResultMessage. Purely a labeling nicety so the
 # next turn usually opens against a clean stream; when the CLI's wind-down outlives it, the
 # consumer still receives everything and the late result is dropped as advisory (issue #958).
@@ -239,9 +241,8 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
     if state.interrupt_event and not state.interrupt_event.is_set():
         interrupt_task = asyncio.create_task(state.interrupt_event.wait())
 
-    watchdog_stop = asyncio.Event()
-    watchdog_task = asyncio.create_task(diagnostics.sdk_watchdog(state, stop=watchdog_stop))
     done_task = asyncio.create_task(turn.done.wait())
+    noted_silence: set[int] = set()
 
     try:
         while True:
@@ -251,13 +252,16 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
 
             # Same silence budget as the old per-message wait: measured from the last stream
             # message (the consumer touches last_message_at), so quiet stretches still time out.
+            # Wake at least every _SILENCE_POLL_S so long thinking gets liveness notes.
             silence_budget = config.response_timeout - (time.monotonic() - turn.last_message_at)
-            done, _ = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED, timeout=max(silence_budget, 0))
+            wait_timeout = max(min(silence_budget, _SILENCE_POLL_S), 0)
+            done, _ = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED, timeout=wait_timeout)
 
             if not done:
                 if time.monotonic() - turn.last_message_at >= config.response_timeout:
                     await attempt_interrupt(state, config=config, reason="Response timeout")
                     raise TimeoutError
+                diagnostics.note_stream_silence(state, noted_at=noted_silence)
                 continue
 
             if done_task in done:
@@ -277,8 +281,6 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
     finally:
         state.compacting = False
         _close_turn(state, turn)
-        watchdog_stop.set()
-        await _cancel_task(watchdog_task)
         await _cancel_task(done_task)
         if interrupt_task and not interrupt_task.done():
             await _cancel_task(interrupt_task)

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -100,7 +100,7 @@ def persist_session_id(session_id: str, *, state: vm.State, config: vm.VestaConf
     logger.debug(f"Captured session_id: {session_id[:16]}...")
 
 
-_SILENCE_POLL_S = 15.0  # wake the turn's wait loop during quiet stretches to log liveness notes
+_SILENCE_POLL_S = 10.0  # wake the turn's wait loop during quiet stretches to log liveness notes
 
 # Post-interrupt wait for the interrupted turn's ResultMessage. Purely a labeling nicety so the
 # next turn usually opens against a clean stream; when the CLI's wind-down outlives it, the
@@ -157,6 +157,8 @@ async def _dispatch_message(msg: Message, *, state: vm.State, config: vm.VestaCo
     # notes can say "thinking, ~N tokens" instead of guessing what the quiet means.
     if turn and isinstance(msg, SystemMessage) and msg.subtype == "thinking_tokens":
         if isinstance(msg.data, dict) and "estimated_tokens" in msg.data and isinstance(msg.data["estimated_tokens"], int):
+            if turn.thinking_tokens_at is None:
+                logger.client("Thinking...")
             turn.thinking_tokens = msg.data["estimated_tokens"]
             turn.thinking_tokens_at = time.monotonic()
     texts, thinking_blocks, session_id = sdk_parsing.parse_sdk_message(msg)

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -13,7 +13,6 @@ from claude_agent_sdk import (
     ClaudeAgentOptions,
     Message,
     ResultMessage,
-    SystemMessage,
     ThinkingBlock,
 )
 from claude_agent_sdk.types import PermissionResultAllow, ThinkingConfigDisabled, ToolPermissionContext
@@ -72,11 +71,10 @@ async def attempt_interrupt(state: vm.State, *, config: vm.VestaConfig, reason: 
         logger.debug(f"Interrupt sent: {reason}")
         return True
     except TimeoutError:
-        # The SDK didn't ack the interrupt within the window. Log + emit but
-        # don't SIGTERM the whole process: in practice this fires more often
-        # during heavy thinking or a long-running tool than during a real hang,
-        # and the watchdog in core/diagnostics.py SIGTERMs if the SDK is
-        # genuinely stuck idle past its higher threshold.
+        # The SDK didn't ack the interrupt within the window. Log + emit but don't kill the
+        # process: in practice this fires more often during heavy thinking or a long-running
+        # tool than during a real hang, and converse's response-timeout path already ends a
+        # genuinely dead turn (TimeoutError -> restart).
         diag = diagnostics.format_hang_diagnostics(state)
         msg = f"SDK interrupt timed out | reason={reason} | {diag}"
         logger.warning(msg)
@@ -150,17 +148,11 @@ async def _dispatch_message(msg: Message, *, state: vm.State, config: vm.VestaCo
         turn.last_message_at = time.monotonic()
     if isinstance(msg, AssistantMessage):
         state.compacting = False
-    if isinstance(msg, SystemMessage) and msg.subtype == "compact_boundary":
-        logger.client("Compaction boundary reached")
-    # The CLI streams a thinking_tokens counter while the model reasons (dozens per turn, dropped
-    # from the log by parse_sdk_message). Track it on the open turn so the wait loop's liveness
-    # notes can say "thinking, ~N tokens" instead of guessing what the quiet means.
-    if turn and isinstance(msg, SystemMessage) and msg.subtype == "thinking_tokens":
-        if isinstance(msg.data, dict) and "estimated_tokens" in msg.data and isinstance(msg.data["estimated_tokens"], int):
-            if turn.thinking_tokens_at is None:
-                logger.client("Thinking...")
-            turn.thinking_tokens = msg.data["estimated_tokens"]
-            turn.thinking_tokens_at = time.monotonic()
+    # The CLI ticks a thinking counter while the model reasons; diagnostics turns it into the
+    # turn's liveness narrative ("Thinking..." on the first tick, interval notes from the wait loop).
+    thinking_estimate = sdk_parsing.thinking_tokens_estimate(msg)
+    if turn and thinking_estimate is not None:
+        diagnostics.note_thinking_tick(turn, tokens=thinking_estimate)
     texts, thinking_blocks, session_id = sdk_parsing.parse_sdk_message(msg)
     if session_id and session_id != state.persisted.session_id:
         if state.persisted.session_id:
@@ -253,14 +245,12 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
         interrupt_task = asyncio.create_task(state.interrupt_event.wait())
 
     done_task = asyncio.create_task(turn.done.wait())
-    noted_silence: set[int] = set()
+    waitables: set[asyncio.Task[tp.Any]] = {done_task}
+    if interrupt_task:
+        waitables.add(interrupt_task)
 
     try:
         while True:
-            waitables: set[asyncio.Task[tp.Any]] = {done_task}
-            if interrupt_task and not interrupt_task.done():
-                waitables.add(interrupt_task)
-
             # Same silence budget as the old per-message wait: measured from the last stream
             # message (the consumer touches last_message_at), so quiet stretches still time out.
             # Wake at least every _SILENCE_POLL_S so long thinking gets liveness notes.
@@ -272,7 +262,7 @@ async def converse(prompt: str, *, state: vm.State, config: vm.VestaConfig, show
                 if time.monotonic() - turn.last_message_at >= config.response_timeout:
                     await attempt_interrupt(state, config=config, reason="Response timeout")
                     raise TimeoutError
-                diagnostics.note_turn_liveness(state, turn=turn, noted_at=noted_silence)
+                diagnostics.note_turn_liveness(state, turn=turn)
                 continue
 
             if done_task in done:

--- a/agent/core/diagnostics.py
+++ b/agent/core/diagnostics.py
@@ -11,7 +11,6 @@ from . import models as vm
 _QUIET_NOTE_INTERVAL_S = 20.0  # one liveness note per interval of nothing-visible
 _QUIET_ESCALATION_S = 300  # past this, dead air with no tool running is suspicious: warn + emit
 _THINKING_TICK_FRESH_S = 30.0  # a thinking_tokens tick this recent proves the model is reasoning
-_ESCALATED_SENTINEL = -1  # noted_at member marking that this quiet stretch already warned
 _CONTEXT_USAGE_TIMEOUT_S = 10.0
 _CONTEXT_USAGE_WARN_PCT = 80.0
 
@@ -65,42 +64,53 @@ def make_stderr_handler(state: vm.State) -> tp.Callable[[str], None]:
     return handler
 
 
-def note_turn_liveness(state: vm.State, *, turn: "vm.TurnSignals", noted_at: set[int]) -> None:
+def note_thinking_tick(turn: "vm.TurnSignals", *, tokens: int) -> None:
+    """Record one thinking_tokens tick on the turn. The first tick of a turn logs "Thinking..."
+    immediately (the wait loop only wakes once per poll interval); later ticks just refresh the
+    counter and freshness timestamp that note_turn_liveness reads."""
+    if turn.thinking_tokens_at is None:
+        logger.client("Thinking...")
+    turn.thinking_tokens = tokens
+    turn.thinking_tokens_at = time.monotonic()
+
+
+def note_turn_liveness(state: vm.State, *, turn: "vm.TurnSignals") -> None:
     """Log one liveness note per _QUIET_NOTE_INTERVAL_S while a turn produces nothing visible.
 
     Called from converse's wait loop — the one place that waits on the model, so this cannot
     silently stop running while turns still complete. The quiet clock is time since the last
     *visible* output (query sent, text or thinking emitted), because the stream itself is rarely
     silent: the CLI ticks a thinking_tokens counter throughout extended thinking (which is
-    exactly why the old idle-based watchdog task never fired in production). `noted_at` holds
-    the interval buckets already noted, cleared when output lands, so each stretch of quiet
-    logs each interval once.
+    exactly why the old idle-based watchdog task never fired in production). Buckets are
+    monotonic within a quiet stretch, so turn.quiet_noted_bucket rate-limits to one note per
+    interval; both it and the once-per-stretch escalation flag reset when output lands.
 
     Specificity, best signal first: a tool in flight explains the quiet (its tool-call lines
     already show liveness) — debug. A recently ticking thinking counter means the model is
     demonstrably reasoning — calm INFO with the token count, never escalated. Otherwise the
     stream is genuinely dead air; the first note past _QUIET_ESCALATION_S is a warning + error
-    event, once per stretch (_ESCALATED_SENTINEL)."""
+    event."""
     quiet = time.monotonic() - turn.last_visible_at
     bucket = int(quiet // _QUIET_NOTE_INTERVAL_S)
     if bucket < 1:
-        noted_at.clear()
+        turn.quiet_noted_bucket = 0
+        turn.quiet_escalated = False
         return
-    if bucket in noted_at:
+    if bucket <= turn.quiet_noted_bucket:
         return
-    noted_at.add(bucket)
+    turn.quiet_noted_bucket = bucket
     elapsed = int(bucket * _QUIET_NOTE_INTERVAL_S)
     thinking_live = turn.thinking_tokens_at is not None and (time.monotonic() - turn.thinking_tokens_at) < _THINKING_TICK_FRESH_S
     if state.active_tools:
         logger.debug(f"No output for {elapsed}s (tool in flight) | {format_hang_diagnostics(state)}")
     elif thinking_live:
         logger.client(f"Thinking for {elapsed}s (~{turn.thinking_tokens:,} tokens so far)")
-    elif quiet >= _QUIET_ESCALATION_S and _ESCALATED_SENTINEL not in noted_at:
-        noted_at.add(_ESCALATED_SENTINEL)
+    elif quiet >= _QUIET_ESCALATION_S and not turn.quiet_escalated:
+        turn.quiet_escalated = True
         msg = f"No output and no stream activity for {elapsed}s | {format_hang_diagnostics(state)}"
         logger.warning(msg)
-        # One event per quiet stretch (the sentinel gates re-emit), so a genuine stall
-        # reaches the observability surface without spamming the stream.
+        # One event per quiet stretch, so a genuine stall reaches the observability surface
+        # without spamming the stream.
         state.event_bus.emit({"type": "error", "text": msg})
     else:
         logger.client(f"Model quiet for {elapsed}s | {format_hang_diagnostics(state)}")

--- a/agent/core/diagnostics.py
+++ b/agent/core/diagnostics.py
@@ -8,8 +8,9 @@ import typing as tp
 from . import logger
 from . import models as vm
 
-_SILENCE_THRESHOLDS_S = (60, 120, 300)
-_SILENCE_ESCALATION_S = 300  # past this, quiet with no tool running is suspicious: warn + emit
+_QUIET_THRESHOLDS_S = (60, 120, 300)
+_QUIET_ESCALATION_S = 300  # past this, dead air with no tool running is suspicious: warn + emit
+_THINKING_TICK_FRESH_S = 30.0  # a thinking_tokens tick this recent proves the model is reasoning
 _CONTEXT_USAGE_TIMEOUT_S = 10.0
 _CONTEXT_USAGE_WARN_PCT = 80.0
 
@@ -63,37 +64,43 @@ def make_stderr_handler(state: vm.State) -> tp.Callable[[str], None]:
     return handler
 
 
-def note_stream_silence(state: vm.State, *, noted_at: set[int]) -> None:
-    """Log bounded liveness lines while a turn waits out a quiet stream.
+def note_turn_liveness(state: vm.State, *, turn: "vm.TurnSignals", noted_at: set[int]) -> None:
+    """Log bounded liveness notes while a turn produces nothing visible.
 
     Called from converse's wait loop — the one place that waits on the model, so this cannot
-    silently stop running while turns still complete (unlike the background watchdog task it
-    replaced, which never fired in production). One line per threshold crossing, cleared when
-    the stream talks again, so a multi-minute extended-thinking stretch reads as "still
-    thinking" instead of dead air, without flooding the log.
+    silently stop running while turns still complete. The quiet clock is time since the last
+    *visible* output (query sent, text or thinking emitted), because the stream itself is rarely
+    silent: the CLI ticks a thinking_tokens counter throughout extended thinking (which is
+    exactly why the old idle-based watchdog task never fired in production). One note per
+    threshold crossing, cleared when output lands, so a turn logs at most three lines however
+    long it thinks.
 
-    A tool in flight explains the silence (a long build, a `sleep`, a subagent), so it logs at
-    debug — the tool-call lines already show liveness. With no tool running, the early
-    thresholds are calm INFO notes (long thinking is normal); past _SILENCE_ESCALATION_S the
-    quiet is suspicious and escalates to a warning + error event, once."""
-    idle = sdk_idle_seconds(state)
-    if idle < _SILENCE_THRESHOLDS_S[0]:
+    Specificity, best signal first: a tool in flight explains the quiet (its tool-call lines
+    already show liveness) — debug. A recently ticking thinking counter means the model is
+    demonstrably reasoning — calm INFO with the token count, never escalated. Otherwise the
+    stream is genuinely dead air; past _QUIET_ESCALATION_S that is suspicious: warning + error
+    event, once."""
+    quiet = time.monotonic() - turn.last_visible_at
+    if quiet < _QUIET_THRESHOLDS_S[0]:
         noted_at.clear()
         return
-    for threshold in _SILENCE_THRESHOLDS_S:
-        if idle < threshold or threshold in noted_at:
+    thinking_live = turn.thinking_tokens_at is not None and (time.monotonic() - turn.thinking_tokens_at) < _THINKING_TICK_FRESH_S
+    for threshold in _QUIET_THRESHOLDS_S:
+        if quiet < threshold or threshold in noted_at:
             continue
         noted_at.add(threshold)
-        msg = f"Model quiet for {threshold}s (thinking or long generation) | {format_hang_diagnostics(state)}"
         if state.active_tools:
-            logger.debug(msg)
-        elif threshold >= _SILENCE_ESCALATION_S:
+            logger.debug(f"No output for {threshold}s (tool in flight) | {format_hang_diagnostics(state)}")
+        elif thinking_live:
+            logger.client(f"Thinking for {threshold}s (~{turn.thinking_tokens:,} tokens so far)")
+        elif threshold >= _QUIET_ESCALATION_S:
+            msg = f"No output and no stream activity for {threshold}s | {format_hang_diagnostics(state)}"
             logger.warning(msg)
             # One event per threshold crossing (noted_at gates re-emit), so a genuine stall
             # reaches the observability surface without spamming the stream.
             state.event_bus.emit({"type": "error", "text": msg})
         else:
-            logger.client(msg)
+            logger.client(f"Model quiet for {threshold}s | {format_hang_diagnostics(state)}")
 
 
 async def log_context_usage(state: vm.State) -> None:

--- a/agent/core/diagnostics.py
+++ b/agent/core/diagnostics.py
@@ -8,7 +8,8 @@ import typing as tp
 from . import logger
 from . import models as vm
 
-_WATCHDOG_THRESHOLDS_S = (60, 120, 300)
+_SILENCE_THRESHOLDS_S = (60, 120, 300)
+_SILENCE_ESCALATION_S = 300  # past this, quiet with no tool running is suspicious: warn + emit
 _CONTEXT_USAGE_TIMEOUT_S = 10.0
 _CONTEXT_USAGE_WARN_PCT = 80.0
 
@@ -62,55 +63,37 @@ def make_stderr_handler(state: vm.State) -> tp.Callable[[str], None]:
     return handler
 
 
-def _check_sdk_subprocess_alive(state: vm.State) -> bool | None:
-    """Returns None if we can't determine (no client, or session not yet launched).
+def note_stream_silence(state: vm.State, *, noted_at: set[int]) -> None:
+    """Log bounded liveness lines while a turn waits out a quiet stream.
 
-    The official claude_agent_sdk client exposes no liveness probe (cc_sdk does); fall
-    back to None so the watchdog reports process_alive=unknown instead of crashing.
-    """
-    if state.client is None:
-        return None
-    try:
-        return state.client.is_alive()  # ty: ignore[unresolved-attribute]
-    except AttributeError:
-        return None
+    Called from converse's wait loop — the one place that waits on the model, so this cannot
+    silently stop running while turns still complete (unlike the background watchdog task it
+    replaced, which never fired in production). One line per threshold crossing, cleared when
+    the stream talks again, so a multi-minute extended-thinking stretch reads as "still
+    thinking" instead of dead air, without flooding the log.
 
-
-async def sdk_watchdog(state: vm.State, *, stop: asyncio.Event) -> None:
-    warned_at: set[int] = set()
-    while not stop.is_set():
-        try:
-            await asyncio.wait_for(stop.wait(), timeout=15)
-            break
-        except TimeoutError:
-            pass
-        idle = sdk_idle_seconds(state)
-        for threshold in _WATCHDOG_THRESHOLDS_S:
-            if idle >= threshold and threshold not in warned_at:
-                warned_at.add(threshold)
-                alive = _check_sdk_subprocess_alive(state)
-                alive_str = f"process_alive={alive}" if alive is not None else "process_alive=unknown"
-                diag = format_hang_diagnostics(state)
-                msg = f"SDK silent for {threshold}s | {alive_str} | {diag}"
-                # Only escalate when something is actually wrong: the alive check returned
-                # False (verified subprocess death), OR a turn is in flight with no tool
-                # running. A tool actively executing (a long build, a `sleep`, a subagent)
-                # fully explains the silence: the SDK is busy doing real work, not hung,
-                # so a foreground `sleep 180` should not look like a stall. This mirrors
-                # attempt_interrupt (client.py), which likewise refuses to act while a tool
-                # is in flight. Otherwise the SDK is just idle; log at debug so quiet
-                # stretches (between turns, or mid-tool) don't spam the warning stream.
-                turn_in_flight = state.interrupt_event is not None
-                tool_running = bool(state.active_tools)
-                if alive is False or (turn_in_flight and not tool_running):
-                    logger.warning(msg)
-                    # One event per threshold crossing (warned_at gates re-emit), so a multi-minute
-                    # hang reaches the observability surface without spamming the stream every poll.
-                    state.event_bus.emit({"type": "error", "text": msg})
-                else:
-                    logger.debug(msg)
-        if idle < _WATCHDOG_THRESHOLDS_S[0]:
-            warned_at.clear()
+    A tool in flight explains the silence (a long build, a `sleep`, a subagent), so it logs at
+    debug — the tool-call lines already show liveness. With no tool running, the early
+    thresholds are calm INFO notes (long thinking is normal); past _SILENCE_ESCALATION_S the
+    quiet is suspicious and escalates to a warning + error event, once."""
+    idle = sdk_idle_seconds(state)
+    if idle < _SILENCE_THRESHOLDS_S[0]:
+        noted_at.clear()
+        return
+    for threshold in _SILENCE_THRESHOLDS_S:
+        if idle < threshold or threshold in noted_at:
+            continue
+        noted_at.add(threshold)
+        msg = f"Model quiet for {threshold}s (thinking or long generation) | {format_hang_diagnostics(state)}"
+        if state.active_tools:
+            logger.debug(msg)
+        elif threshold >= _SILENCE_ESCALATION_S:
+            logger.warning(msg)
+            # One event per threshold crossing (noted_at gates re-emit), so a genuine stall
+            # reaches the observability surface without spamming the stream.
+            state.event_bus.emit({"type": "error", "text": msg})
+        else:
+            logger.client(msg)
 
 
 async def log_context_usage(state: vm.State) -> None:

--- a/agent/core/diagnostics.py
+++ b/agent/core/diagnostics.py
@@ -8,9 +8,10 @@ import typing as tp
 from . import logger
 from . import models as vm
 
-_QUIET_THRESHOLDS_S = (60, 120, 300)
+_QUIET_NOTE_INTERVAL_S = 20.0  # one liveness note per interval of nothing-visible
 _QUIET_ESCALATION_S = 300  # past this, dead air with no tool running is suspicious: warn + emit
 _THINKING_TICK_FRESH_S = 30.0  # a thinking_tokens tick this recent proves the model is reasoning
+_ESCALATED_SENTINEL = -1  # noted_at member marking that this quiet stretch already warned
 _CONTEXT_USAGE_TIMEOUT_S = 10.0
 _CONTEXT_USAGE_WARN_PCT = 80.0
 
@@ -65,42 +66,44 @@ def make_stderr_handler(state: vm.State) -> tp.Callable[[str], None]:
 
 
 def note_turn_liveness(state: vm.State, *, turn: "vm.TurnSignals", noted_at: set[int]) -> None:
-    """Log bounded liveness notes while a turn produces nothing visible.
+    """Log one liveness note per _QUIET_NOTE_INTERVAL_S while a turn produces nothing visible.
 
     Called from converse's wait loop — the one place that waits on the model, so this cannot
     silently stop running while turns still complete. The quiet clock is time since the last
     *visible* output (query sent, text or thinking emitted), because the stream itself is rarely
     silent: the CLI ticks a thinking_tokens counter throughout extended thinking (which is
-    exactly why the old idle-based watchdog task never fired in production). One note per
-    threshold crossing, cleared when output lands, so a turn logs at most three lines however
-    long it thinks.
+    exactly why the old idle-based watchdog task never fired in production). `noted_at` holds
+    the interval buckets already noted, cleared when output lands, so each stretch of quiet
+    logs each interval once.
 
     Specificity, best signal first: a tool in flight explains the quiet (its tool-call lines
     already show liveness) — debug. A recently ticking thinking counter means the model is
     demonstrably reasoning — calm INFO with the token count, never escalated. Otherwise the
-    stream is genuinely dead air; past _QUIET_ESCALATION_S that is suspicious: warning + error
-    event, once."""
+    stream is genuinely dead air; the first note past _QUIET_ESCALATION_S is a warning + error
+    event, once per stretch (_ESCALATED_SENTINEL)."""
     quiet = time.monotonic() - turn.last_visible_at
-    if quiet < _QUIET_THRESHOLDS_S[0]:
+    bucket = int(quiet // _QUIET_NOTE_INTERVAL_S)
+    if bucket < 1:
         noted_at.clear()
         return
+    if bucket in noted_at:
+        return
+    noted_at.add(bucket)
+    elapsed = int(bucket * _QUIET_NOTE_INTERVAL_S)
     thinking_live = turn.thinking_tokens_at is not None and (time.monotonic() - turn.thinking_tokens_at) < _THINKING_TICK_FRESH_S
-    for threshold in _QUIET_THRESHOLDS_S:
-        if quiet < threshold or threshold in noted_at:
-            continue
-        noted_at.add(threshold)
-        if state.active_tools:
-            logger.debug(f"No output for {threshold}s (tool in flight) | {format_hang_diagnostics(state)}")
-        elif thinking_live:
-            logger.client(f"Thinking for {threshold}s (~{turn.thinking_tokens:,} tokens so far)")
-        elif threshold >= _QUIET_ESCALATION_S:
-            msg = f"No output and no stream activity for {threshold}s | {format_hang_diagnostics(state)}"
-            logger.warning(msg)
-            # One event per threshold crossing (noted_at gates re-emit), so a genuine stall
-            # reaches the observability surface without spamming the stream.
-            state.event_bus.emit({"type": "error", "text": msg})
-        else:
-            logger.client(f"Model quiet for {threshold}s | {format_hang_diagnostics(state)}")
+    if state.active_tools:
+        logger.debug(f"No output for {elapsed}s (tool in flight) | {format_hang_diagnostics(state)}")
+    elif thinking_live:
+        logger.client(f"Thinking for {elapsed}s (~{turn.thinking_tokens:,} tokens so far)")
+    elif quiet >= _QUIET_ESCALATION_S and _ESCALATED_SENTINEL not in noted_at:
+        noted_at.add(_ESCALATED_SENTINEL)
+        msg = f"No output and no stream activity for {elapsed}s | {format_hang_diagnostics(state)}"
+        logger.warning(msg)
+        # One event per quiet stretch (the sentinel gates re-emit), so a genuine stall
+        # reaches the observability surface without spamming the stream.
+        state.event_bus.emit({"type": "error", "text": msg})
+    else:
+        logger.client(f"Model quiet for {elapsed}s | {format_hang_diagnostics(state)}")
 
 
 async def log_context_usage(state: vm.State) -> None:

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -25,6 +25,7 @@ from .client import (
     persist_session_id,
     resolve_openrouter_max_tokens,
     compact_session,
+    consume_stream,
     _cancel_task,
 )
 from .diagnostics import format_crash_detail
@@ -366,6 +367,9 @@ async def message_processor(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.St
         try:
             async with ClaudeSDKClient(options=options) as client:
                 state.client = client
+                # The one consumer of the SDK stream for this whole session (see consume_stream);
+                # turn drivers only wait on state.turn signals, they never read the stream.
+                consumer_task = asyncio.create_task(consume_stream(state=state, config=config))
                 logger.client("Client session started")
 
                 try:
@@ -382,9 +386,11 @@ async def message_processor(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.St
                         finally:
                             state.processor_busy = False
                 finally:
+                    await _cancel_task(consumer_task)
                     state.client = None
                     state.interrupt_event = None
                     state.compacting = False
+                    state.turn = None
                     logger.client("Client session closed")
             break
         except (ClaudeSDKError, OSError, RuntimeError) as exc:

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -79,12 +79,16 @@ class TurnSignals:
     done: asyncio.Event = dc.field(default_factory=asyncio.Event)
     error: Exception | None = None
     last_message_at: float = dc.field(default_factory=time.monotonic)
-    # Liveness for the turn's wait loop: the CLI streams a thinking_tokens counter while the
-    # model reasons (tracked here, never logged per-delta), and last_visible_at marks the last
-    # output the user could see (query sent, text, or thinking emitted).
+    # Liveness for the turn's wait loop (owned by diagnostics.note_turn_liveness /
+    # note_thinking_tick): the CLI streams a thinking_tokens counter while the model reasons
+    # (tracked here, never logged per-delta), last_visible_at marks the last output the user
+    # could see (query sent, text, or thinking emitted), and the quiet_* pair rate-limits the
+    # notes to one per interval with a single escalation per quiet stretch.
     thinking_tokens: int = 0
     thinking_tokens_at: float | None = None
     last_visible_at: float = dc.field(default_factory=time.monotonic)
+    quiet_noted_bucket: int = 0
+    quiet_escalated: bool = False
 
 
 @dc.dataclass

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -66,6 +66,22 @@ class ActiveTool:
 
 
 @dc.dataclass
+class TurnSignals:
+    """Bridge between the long-lived stream consumer (writer) and the turn driver (waiter).
+
+    The consumer accumulates the open turn's text and closes `done` when the turn's
+    ResultMessage arrives (or the stream dies, carried in `error`). Attribution is advisory:
+    the stream-json protocol has no query<->result correlation, so a ResultMessage closes
+    whichever turn is open and one arriving with no open turn is dropped."""
+
+    show_output: bool = True
+    texts: list[str] = dc.field(default_factory=list)
+    done: asyncio.Event = dc.field(default_factory=asyncio.Event)
+    error: Exception | None = None
+    last_message_at: float = dc.field(default_factory=time.monotonic)
+
+
+@dc.dataclass
 class State:
     client: ClaudeSDKClient | None = None
     shutdown_event: asyncio.Event = dc.field(default_factory=asyncio.Event)
@@ -85,6 +101,9 @@ class State:
     openrouter_proxy_url: str | None = None
     cache_proxy_runner: AppRunner | None = None
     interrupt_event: asyncio.Event | None = None
+    # The currently open turn's signals; written by the stream consumer, waited on by converse /
+    # compact_session. None while no turn is open (results arriving then are dropped as advisory).
+    turn: TurnSignals | None = None
     compacting: bool = False
     # True while a non-interruptible turn (a boot turn) is being processed. process_batch consults
     # this before firing client.interrupt(), so a concurrent interrupt notification queues and waits

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -79,6 +79,12 @@ class TurnSignals:
     done: asyncio.Event = dc.field(default_factory=asyncio.Event)
     error: Exception | None = None
     last_message_at: float = dc.field(default_factory=time.monotonic)
+    # Liveness for the turn's wait loop: the CLI streams a thinking_tokens counter while the
+    # model reasons (tracked here, never logged per-delta), and last_visible_at marks the last
+    # output the user could see (query sent, text, or thinking emitted).
+    thinking_tokens: int = 0
+    thinking_tokens_at: float | None = None
+    last_visible_at: float = dc.field(default_factory=time.monotonic)
 
 
 @dc.dataclass

--- a/agent/core/sdk_parsing.py
+++ b/agent/core/sdk_parsing.py
@@ -56,6 +56,17 @@ def build_query(prompt: str, *, timestamp: dt.datetime) -> str:
     return f"[Current time: {timestamp_str}]\n{prompt}"
 
 
+def thinking_tokens_estimate(msg: Message) -> int | None:
+    """The CLI streams SystemMessage(subtype="thinking_tokens") counters throughout extended
+    thinking. Return the running token estimate, or None for any other message (or a payload
+    without the expected int field)."""
+    if not isinstance(msg, SystemMessage) or msg.subtype != "thinking_tokens":
+        return None
+    if isinstance(msg.data, dict) and "estimated_tokens" in msg.data and isinstance(msg.data["estimated_tokens"], int):
+        return msg.data["estimated_tokens"]
+    return None
+
+
 def filter_tool_lines(text: str) -> str:
     return "\n".join(s for line in text.split("\n") if (s := line.strip()) and not s.startswith("[TOOL]") and not s.startswith("[TASK]"))
 
@@ -117,8 +128,12 @@ def parse_sdk_message(msg: Message) -> tuple[list[str], list[ThinkingBlock], str
             if init_sid:
                 logger.debug(f"[init] session_id={init_sid[:16]}")
             return [], [], init_sid
-        # thinking_tokens is a per-delta streaming counter the SDK emits dozens of times per turn; it floods the log with no signal.
+        # thinking_tokens is a per-delta streaming counter the SDK emits dozens of times per turn; it
+        # floods the log with no signal here (thinking_tokens_estimate exposes it for liveness notes).
         if msg.subtype == "thinking_tokens":
+            return [], [], None
+        if msg.subtype == "compact_boundary":
+            logger.client("Compaction boundary reached")
             return [], [], None
         raw = json.dumps(msg.data, default=str)
         logger.system(f"[{msg.subtype}] {raw[:2000]}")

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -1,5 +1,9 @@
 import asyncio
+import contextlib
 import os
+import time
+import typing as tp
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import core.models as vm
@@ -43,3 +47,83 @@ def idle_message_stream():
         yield  # never reached; makes this an async generator
 
     return _stream()
+
+
+def assistant_msg(content):
+    from claude_agent_sdk import AssistantMessage
+
+    msg = MagicMock(spec=AssistantMessage)
+    msg.content = content
+    return msg
+
+
+def result_msg():
+    from claude_agent_sdk import ResultMessage
+
+    msg = MagicMock(spec=ResultMessage)
+    msg.content = []
+    return msg
+
+
+def make_stream_harness(response_timeout: int | None = None):
+    """Build a stream-consumer test harness: state/config and a mock SDK client whose
+    receive_messages() yields from `message_queue`.
+
+    Returns (state, config, mock_client, emitted, message_queue, consumed). Run the real
+    consume_stream task (via `consuming`) for converse/compact_session to make progress;
+    `consumed` records each message right after the consumer finished dispatching it,
+    giving tests a handshake signal instead of guessing with sleeps.
+    """
+    from core.provider import ProviderAuthState, ProviderStatus
+
+    emitted: list[tuple[str, float]] = []
+    if response_timeout is None:
+        config = vm.VestaConfig(interrupt_timeout=0.5)
+    else:
+        config = vm.VestaConfig(interrupt_timeout=0.5, response_timeout=response_timeout)
+    state = vm.State()
+    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
+    state.event_bus = EventBus()
+
+    original_emit = state.event_bus.emit
+
+    def tracking_emit(event):
+        if isinstance(event, dict) and event.get("type") == "assistant":
+            emitted.append((event["text"], time.monotonic()))
+        original_emit(event)
+
+    state.event_bus.emit = tracking_emit  # ty: ignore[invalid-assignment]
+
+    mock_client = MagicMock()
+    mock_client.query = AsyncMock()
+    mock_client.interrupt = AsyncMock()
+    state.client = mock_client
+
+    message_queue: asyncio.Queue[tp.Any] = asyncio.Queue()
+    consumed: list[tp.Any] = []
+
+    async def _receive_messages():
+        while True:
+            msg = await message_queue.get()
+            yield msg
+            # The generator only resumes here once the consumer's async-for advanced past
+            # `msg` — i.e. its dispatch (emit/turn bookkeeping) has fully completed.
+            consumed.append(msg)
+
+    mock_client.receive_messages = MagicMock(side_effect=lambda: _receive_messages())
+
+    return state, config, mock_client, emitted, message_queue, consumed
+
+
+@contextlib.asynccontextmanager
+async def consuming(state, config):
+    """Run the real consume_stream task for the duration of the block (cancelled on exit)."""
+    from core.client import consume_stream
+
+    task = asyncio.create_task(consume_stream(state=state, config=config))
+    try:
+        yield task
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -30,3 +30,16 @@ def state():
     s = vm.State()
     s.shutdown_event = asyncio.Event()
     return s
+
+
+def idle_message_stream():
+    """receive_messages() stand-in that never yields: parks the stream consumer.
+
+    message_processor spawns consume_stream against its client; mock clients hand it this
+    so the consumer idles instead of erroring on a non-iterable MagicMock."""
+
+    async def _stream():
+        await asyncio.Event().wait()
+        yield  # never reached; makes this an async generator
+
+    return _stream()

--- a/agent/tests/test_crash_recovery.py
+++ b/agent/tests/test_crash_recovery.py
@@ -8,6 +8,7 @@ import pytest
 from claude_agent_sdk import ClaudeSDKError
 
 import core.models as vm
+from conftest import idle_message_stream
 from core.diagnostics import format_crash_detail
 from wait_util import wait_for_condition
 
@@ -44,6 +45,7 @@ def _mock_client(enter):
     """Build a ClaudeSDKClient stand-in whose async __aenter__ runs `enter`."""
     client = MagicMock()
     client.return_value = client
+    client.receive_messages = idle_message_stream
     client.__aenter__ = enter
     client.__aexit__ = AsyncMock(return_value=None)
     return client

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -1,7 +1,6 @@
 """Tests for nightly dreamer/memory scheduling."""
 
 import asyncio
-import contextlib
 import datetime as dt
 import json
 import typing as tp
@@ -10,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import core.models as vm
+from conftest import consuming
 from claude_agent_sdk import ClaudeSDKClient, ClaudeSDKError, ResultMessage, SystemMessage
 from wait_util import wait_for_condition
 
@@ -129,8 +129,6 @@ async def _run_with_compaction_stream(state, config, action, *, pre_tokens):
 
     The stream waits for compact_session to open its turn (the real CLI only responds after the
     /compact query), then yields the boundary and the turn-closing ResultMessage."""
-    from core.client import consume_stream
-
     state.persisted.session_id = state.persisted.session_id or "sess-compact"
     client = AsyncMock()
 
@@ -144,13 +142,8 @@ async def _run_with_compaction_stream(state, config, action, *, pre_tokens):
 
     client.receive_messages = MagicMock(side_effect=lambda: stream())
     state.client = tp.cast(ClaudeSDKClient, client)
-    consumer = asyncio.create_task(consume_stream(state=state, config=config))
-    try:
+    async with consuming(state, config):
         await asyncio.wait_for(action(), timeout=5.0)
-    finally:
-        consumer.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await consumer
     return client
 
 

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -1,6 +1,7 @@
 """Tests for nightly dreamer/memory scheduling."""
 
 import asyncio
+import contextlib
 import datetime as dt
 import json
 import typing as tp
@@ -9,7 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import core.models as vm
-from claude_agent_sdk import ClaudeSDKClient, ClaudeSDKError, SystemMessage
+from claude_agent_sdk import ClaudeSDKClient, ClaudeSDKError, ResultMessage, SystemMessage
+from wait_util import wait_for_condition
 
 
 def _setup(tmp_path, *, dreamer_hour=4):
@@ -122,21 +124,46 @@ async def test_mark_dreamer_complete_keeps_session_and_defers_compact_restart(tm
 # --- compact_then_restart_if_requested drain ---
 
 
+async def _run_with_compaction_stream(state, config, action, *, pre_tokens):
+    """Run `action` with the real stream consumer fed a compaction turn (boundary then result).
+
+    The stream waits for compact_session to open its turn (the real CLI only responds after the
+    /compact query), then yields the boundary and the turn-closing ResultMessage."""
+    from core.client import consume_stream
+
+    state.persisted.session_id = state.persisted.session_id or "sess-compact"
+    client = AsyncMock()
+
+    async def stream():
+        await wait_for_condition(lambda: state.turn is not None, message="compact_session never opened a turn")
+        yield SystemMessage(subtype="compact_boundary", data={"compact_metadata": {"pre_tokens": pre_tokens, "trigger": "manual"}})
+        yield ResultMessage(
+            subtype="success", duration_ms=1, duration_api_ms=1, is_error=False, num_turns=1, session_id=state.persisted.session_id
+        )
+        await asyncio.Event().wait()
+
+    client.receive_messages = MagicMock(side_effect=lambda: stream())
+    state.client = tp.cast(ClaudeSDKClient, client)
+    consumer = asyncio.create_task(consume_stream(state=state, config=config))
+    try:
+        await asyncio.wait_for(action(), timeout=5.0)
+    finally:
+        consumer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await consumer
+    return client
+
+
 @pytest.mark.anyio
-async def test_drain_compacts_then_triggers_restart():
+async def test_drain_compacts_then_triggers_restart(tmp_path):
     from core.loops import compact_then_restart_if_requested
 
-    async def compact_response():
-        yield SystemMessage(subtype="compact_boundary", data={"compact_metadata": {"pre_tokens": 1000, "trigger": "manual"}})
-
+    config = _setup(tmp_path)
     state = vm.State()
-    client = AsyncMock()
-    client.receive_response = MagicMock(return_value=compact_response())
-    state.client = tp.cast(ClaudeSDKClient, client)
     state.compact_then_restart = True
 
     with patch("core.loops.vestad_client.request_restart", new_callable=AsyncMock, return_value=True) as restart:
-        await compact_then_restart_if_requested(state=state)
+        client = await _run_with_compaction_stream(state, config, lambda: compact_then_restart_if_requested(state=state), pre_tokens=1000)
 
     client.query.assert_awaited_once_with("/compact")
     assert state.compact_then_restart is False
@@ -216,15 +243,9 @@ async def test_notification_file_deleted_before_processing_is_lost_on_restart(tm
     assert dying_queue.qsize() == 1, "message is in the queue"
 
     # Compaction finishes: compact_then_restart_if_requested sets graceful_shutdown.
-    async def compact_response():
-        yield SystemMessage(subtype="compact_boundary", data={"compact_metadata": {"pre_tokens": 1, "trigger": "manual"}})
-
     state.compact_then_restart = True
-    client = AsyncMock()
-    client.receive_response = MagicMock(return_value=compact_response())
-    state.client = tp.cast(ClaudeSDKClient, client)
     with patch("core.loops.vestad_client.request_restart", new_callable=AsyncMock, return_value=True) as restart:
-        await compact_then_restart_if_requested(state=state)
+        await _run_with_compaction_stream(state, config, lambda: compact_then_restart_if_requested(state=state), pre_tokens=1)
     restart.assert_awaited_once()  # restart fires after compaction (via vestad)
 
     # The process restarts: run_vesta creates a fresh queue and init_state loads from disk.

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -1,7 +1,6 @@
 """Tests for interrupt system, converse streaming, and drain behavior."""
 
 import asyncio
-import contextlib
 import datetime as dt
 import typing as tp
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -9,9 +8,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import core.models as vm
 from claude_agent_sdk.types import SubagentStartHookInput
-from conftest import idle_message_stream
+from conftest import assistant_msg, consuming, idle_message_stream, make_stream_harness, result_msg
 from core.sdk_parsing import _subagent_hook
-from core.events import EventBus, SubagentStartEvent, SubagentStopEvent
+from core.events import SubagentStartEvent, SubagentStopEvent
 from wait_util import wait_for_condition
 
 
@@ -39,86 +38,23 @@ async def test_subagent_hook_emits_event(verb, event_type, agent_id, agent_type)
 # --- Converse harness ---
 
 
-def _assistant_msg(content):
-    from claude_agent_sdk import AssistantMessage
-
-    msg = MagicMock(spec=AssistantMessage)
-    msg.content = content
-    return msg
-
-
-def _result_msg():
-    from claude_agent_sdk import ResultMessage
-
-    msg = MagicMock(spec=ResultMessage)
-    msg.content = []
-    return msg
+async def _set_interrupt_after_consumed(state, consumed, *, count: int = 1) -> None:
+    """Fire the turn's interrupt only after the consumer has dispatched `count` messages."""
+    await wait_for_condition(lambda: len(consumed) >= count, message="consumer never dispatched the first message")
+    assert state.interrupt_event is not None
+    state.interrupt_event.set()
 
 
-def _make_stream_harness(response_timeout: int | None = None):
-    """Build a stream-consumer test harness: state/config and a mock SDK client whose
-    receive_messages() yields from `message_queue`.
+async def _interrupt_then_winddown(state, mock_client, message_queue, consumed, *, winddown_text: str) -> None:
+    """The #958 seed choreography: a tool message, an interrupt once it's consumed, then the
+    interrupted turn's wind-down (text + result) once converse has fired client.interrupt()."""
+    from claude_agent_sdk import TextBlock, ToolUseBlock
 
-    Returns (state, config, mock_client, emitted, message_queue, consumed). Run the real
-    consume_stream task (via _consuming) for converse/compact_session to make progress;
-    `consumed` records each message right after the consumer finished dispatching it,
-    giving tests a handshake signal instead of guessing with sleeps.
-    """
-    import time
-
-    emitted: list[tuple[str, float]] = []
-    if response_timeout is None:
-        config = vm.VestaConfig(interrupt_timeout=0.5)
-    else:
-        config = vm.VestaConfig(interrupt_timeout=0.5, response_timeout=response_timeout)
-    state = vm.State()
-    from core.provider import ProviderAuthState, ProviderStatus
-
-    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
-    state.event_bus = EventBus()
-
-    original_emit = state.event_bus.emit
-
-    def tracking_emit(event):
-        if isinstance(event, dict) and event.get("type") == "assistant":
-            emitted.append((event["text"], time.monotonic()))
-        original_emit(event)
-
-    state.event_bus.emit = tracking_emit  # ty: ignore[invalid-assignment]
-
-    mock_client = MagicMock()
-    mock_client.query = AsyncMock()
-    mock_client.interrupt = AsyncMock()
-    state.client = mock_client
-
-    message_queue: asyncio.Queue[tp.Any] = asyncio.Queue()
-    consumed: list[tp.Any] = []
-
-    async def _receive_messages():
-        while True:
-            msg = await message_queue.get()
-            yield msg
-            # The generator only resumes here once the consumer's async-for advanced past
-            # `msg` — i.e. its dispatch (emit/turn bookkeeping) has fully completed.
-            consumed.append(msg)
-
-    mock_client.receive_messages = MagicMock(side_effect=lambda: _receive_messages())
-
-    return state, config, mock_client, emitted, message_queue, consumed
-
-
-@contextlib.asynccontextmanager
-async def _consuming(state, config):
-    """Run the real consume_stream task for the duration of the block (cancelled on exit)."""
-    from core.client import consume_stream
-
-    task = asyncio.create_task(consume_stream(state=state, config=config))
-    try:
-        yield task
-    finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
+    await message_queue.put(assistant_msg([ToolUseBlock("1", "Bash", {})]))
+    await _set_interrupt_after_consumed(state, consumed)
+    await wait_for_condition(lambda: mock_client.interrupt.called, message="converse never called interrupt()")
+    await message_queue.put(assistant_msg([TextBlock(winddown_text)]))
+    await message_queue.put(result_msg())
 
 
 # --- Message processor interrupt ---
@@ -422,8 +358,8 @@ async def test_attempt_interrupt_timeout_warns_without_sigterm(tmp_path, state, 
     instead of SIGTERMing the process.
 
     The 5s timeout fires more often during heavy thinking than during a real hang, so a
-    false-positive must not kill the whole container; the diagnostics watchdog owns the
-    genuinely-stuck-idle SIGTERM path (see issue #737)."""
+    false-positive must not kill the whole container; converse's response-timeout path owns
+    ending a genuinely dead turn (see issue #737)."""
     from core.client import attempt_interrupt
 
     config = vm.VestaConfig(agent_dir=tmp_path / "agent", interrupt_timeout=0.01)
@@ -503,12 +439,12 @@ async def test_converse_collects_texts_and_ends_on_result():
     from claude_agent_sdk import TextBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, config, mock_client, emitted, message_queue, consumed = make_stream_harness()
 
-    async with _consuming(state, config):
-        await message_queue.put(_assistant_msg([TextBlock("one")]))
-        await message_queue.put(_assistant_msg([TextBlock("two")]))
-        await message_queue.put(_result_msg())
+    async with consuming(state, config):
+        await message_queue.put(assistant_msg([TextBlock("one")]))
+        await message_queue.put(assistant_msg([TextBlock("two")]))
+        await message_queue.put(result_msg())
         responses = await converse("test prompt", state=state, config=config, show_output=True)
 
     assert responses == ["one", "two"]
@@ -522,13 +458,13 @@ async def test_converse_emits_text_immediately_with_tool_use():
     from claude_agent_sdk import TextBlock, ToolUseBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, config, mock_client, emitted, message_queue, consumed = make_stream_harness()
 
-    async with _consuming(state, config):
-        await message_queue.put(_assistant_msg([TextBlock("restarting daemon"), ToolUseBlock("1", "Bash", {})]))
-        await message_queue.put(_assistant_msg([TextBlock("checking status"), ToolUseBlock("2", "Bash", {})]))
-        await message_queue.put(_assistant_msg([TextBlock("all done")]))
-        await message_queue.put(_result_msg())
+    async with consuming(state, config):
+        await message_queue.put(assistant_msg([TextBlock("restarting daemon"), ToolUseBlock("1", "Bash", {})]))
+        await message_queue.put(assistant_msg([TextBlock("checking status"), ToolUseBlock("2", "Bash", {})]))
+        await message_queue.put(assistant_msg([TextBlock("all done")]))
+        await message_queue.put(result_msg())
         await converse("test", state=state, config=config, show_output=True)
 
     texts = [t for t, _ in emitted]
@@ -540,7 +476,7 @@ async def test_converse_emits_thinking_events():
     from claude_agent_sdk import TextBlock, ThinkingBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, config, mock_client, emitted, message_queue, consumed = make_stream_harness()
     thinking_events: list[tuple[str, str]] = []
     original_emit = state.event_bus.emit
 
@@ -551,9 +487,9 @@ async def test_converse_emits_thinking_events():
 
     state.event_bus.emit = tracking_emit
 
-    async with _consuming(state, config):
-        await message_queue.put(_assistant_msg([ThinkingBlock("step one\nstep two", "sig-123"), TextBlock("done")]))
-        await message_queue.put(_result_msg())
+    async with consuming(state, config):
+        await message_queue.put(assistant_msg([ThinkingBlock("step one\nstep two", "sig-123"), TextBlock("done")]))
+        await message_queue.put(result_msg())
         await converse("test", state=state, config=config, show_output=True)
 
     assert thinking_events == [("step one\nstep two", "sig-123")]
@@ -569,17 +505,12 @@ async def test_converse_exits_promptly_on_interrupt_event():
     from claude_agent_sdk import TextBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, config, mock_client, emitted, message_queue, consumed = make_stream_harness()
     state.interrupt_event = asyncio.Event()
 
-    async def trigger_interrupt():
-        await wait_for_condition(lambda: len(consumed) >= 1, message="consumer never dispatched the first message")
-        assert state.interrupt_event is not None
-        state.interrupt_event.set()
-
-    async with _consuming(state, config):
-        await message_queue.put(_assistant_msg([TextBlock("working on it")]))
-        trigger = asyncio.create_task(trigger_interrupt())
+    async with consuming(state, config):
+        await message_queue.put(assistant_msg([TextBlock("working on it")]))
+        trigger = asyncio.create_task(_set_interrupt_after_consumed(state, consumed))
         with patch("core.client._INTERRUPT_TURN_END_GRACE_S", 0.1):
             start = time.monotonic()
             responses = await converse("test prompt", state=state, config=config, show_output=True)
@@ -595,23 +526,14 @@ async def test_converse_exits_promptly_on_interrupt_event():
 async def test_interrupt_winddown_within_grace_stays_attributed():
     """A wind-down that finishes inside the grace is emitted AND attributed to the interrupted
     turn, and the next turn starts against a clean stream."""
-    from claude_agent_sdk import TextBlock, ToolUseBlock
+    from claude_agent_sdk import TextBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, config, mock_client, emitted, message_queue, consumed = make_stream_harness()
     state.interrupt_event = asyncio.Event()
 
-    async def sim_conv1():
-        await message_queue.put(_assistant_msg([ToolUseBlock("1", "Bash", {})]))
-        await wait_for_condition(lambda: len(consumed) >= 1, message="consumer never dispatched the tool message")
-        assert state.interrupt_event is not None
-        state.interrupt_event.set()
-        await wait_for_condition(lambda: mock_client.interrupt.called, message="converse never called interrupt()")
-        await message_queue.put(_assistant_msg([TextBlock("here are the files")]))
-        await message_queue.put(_result_msg())
-
-    async with _consuming(state, config):
-        sim = asyncio.create_task(sim_conv1())
+    async with consuming(state, config):
+        sim = asyncio.create_task(_interrupt_then_winddown(state, mock_client, message_queue, consumed, winddown_text="here are the files"))
         responses = await converse("list /tmp", state=state, config=config, show_output=True)
         await sim
 
@@ -624,8 +546,8 @@ async def test_interrupt_winddown_within_grace_stays_attributed():
 
         async def sim_conv2():
             await wait_for_condition(lambda: mock_client.query.await_count >= 2, message="conv 2 query never sent")
-            await message_queue.put(_assistant_msg([TextBlock("fresh response")]))
-            await message_queue.put(_result_msg())
+            await message_queue.put(assistant_msg([TextBlock("fresh response")]))
+            await message_queue.put(result_msg())
 
         sim2 = asyncio.create_task(sim_conv2())
         responses2 = await converse("well?", state=state, config=config, show_output=True)
@@ -644,20 +566,11 @@ async def test_interrupt_then_response_arrives_without_user_input():
     from claude_agent_sdk import TextBlock, ToolUseBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, config, mock_client, emitted, message_queue, consumed = make_stream_harness()
     state.interrupt_event = asyncio.Event()
 
-    async def sim_conv1():
-        await message_queue.put(_assistant_msg([ToolUseBlock("1", "Bash", {})]))
-        await wait_for_condition(lambda: len(consumed) >= 1, message="consumer never dispatched the tool message")
-        assert state.interrupt_event is not None
-        state.interrupt_event.set()
-        await wait_for_condition(lambda: mock_client.interrupt.called, message="converse never called interrupt()")
-        await message_queue.put(_assistant_msg([TextBlock("checking logs")]))
-        await message_queue.put(_result_msg())
-
-    async with _consuming(state, config):
-        sim = asyncio.create_task(sim_conv1())
+    async with consuming(state, config):
+        sim = asyncio.create_task(_interrupt_then_winddown(state, mock_client, message_queue, consumed, winddown_text="checking logs"))
         await converse("i did it instantly", state=state, config=config, show_output=True)
         await sim
 
@@ -669,10 +582,10 @@ async def test_interrupt_then_response_arrives_without_user_input():
 
         async def sim_conv2():
             consumed_before = len(consumed)
-            await message_queue.put(_assistant_msg([ToolUseBlock("2", "Bash", {})]))
+            await message_queue.put(assistant_msg([ToolUseBlock("2", "Bash", {})]))
             await wait_for_condition(lambda: len(consumed) > consumed_before, message="conv 2 tool message never consumed")
-            await message_queue.put(_assistant_msg([TextBlock("daemon's back up")]))
-            await message_queue.put(_result_msg())
+            await message_queue.put(assistant_msg([TextBlock("daemon's back up")]))
+            await message_queue.put(result_msg())
 
         sim2 = asyncio.create_task(sim_conv2())
         await converse("daemon_died notification", state=state, config=config, show_output=True)
@@ -694,19 +607,14 @@ async def test_late_result_after_interrupt_does_not_wedge_later_turns():
     from claude_agent_sdk import TextBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, config, mock_client, emitted, message_queue, consumed = make_stream_harness()
 
-    async def trigger_interrupt():
-        await wait_for_condition(lambda: len(consumed) >= 1, message="consumer never dispatched the first message")
-        assert state.interrupt_event is not None
-        state.interrupt_event.set()
-
-    async with _consuming(state, config):
+    async with consuming(state, config):
         with patch("core.client._INTERRUPT_TURN_END_GRACE_S", 0.1):
             # Turn 1: interrupted; its wind-down outlives the grace (no result arrives).
             state.interrupt_event = asyncio.Event()
-            await message_queue.put(_assistant_msg([TextBlock("turn one partial")]))
-            trigger = asyncio.create_task(trigger_interrupt())
+            await message_queue.put(assistant_msg([TextBlock("turn one partial")]))
+            trigger = asyncio.create_task(_set_interrupt_after_consumed(state, consumed))
             await converse("turn one", state=state, config=config, show_output=True)
             await trigger
             assert mock_client.interrupt.called
@@ -715,27 +623,27 @@ async def test_late_result_after_interrupt_does_not_wedge_later_turns():
         state.interrupt_event = None
         conv2 = asyncio.create_task(converse("turn two", state=state, config=config, show_output=True))
         await wait_for_condition(lambda: mock_client.query.await_count >= 2, message="turn 2 query never sent")
-        stale_result = _result_msg()
+        stale_result = result_msg()
         await message_queue.put(stale_result)
         await conv2  # closed by the stale result — must not hang
 
         # Turn 2's real output arrives after its label closed: still emitted in real time...
         n_before = len(emitted)
-        await message_queue.put(_assistant_msg([TextBlock("turn two answer")]))
+        await message_queue.put(assistant_msg([TextBlock("turn two answer")]))
         await wait_for_condition(
             lambda: any(t == "turn two answer" for t, _ in emitted[n_before:]),
             message="post-close output was not emitted — this is the wedge #958 describes",
         )
         # ...and its own result, arriving with no open turn, is dropped without harm.
-        own_result = _result_msg()
+        own_result = result_msg()
         await message_queue.put(own_result)
         await wait_for_condition(lambda: own_result in consumed, message="stray result never consumed")
 
         # Turn 3: fully self-healed — a normal turn completes end-to-end.
         async def feed_turn3():
             await wait_for_condition(lambda: mock_client.query.await_count >= 3, message="turn 3 query never sent")
-            await message_queue.put(_assistant_msg([TextBlock("turn three answer")]))
-            await message_queue.put(_result_msg())
+            await message_queue.put(assistant_msg([TextBlock("turn three answer")]))
+            await message_queue.put(result_msg())
 
         feeder = asyncio.create_task(feed_turn3())
         responses3 = await converse("turn three", state=state, config=config, show_output=True)
@@ -751,12 +659,12 @@ async def test_result_with_no_open_turn_is_dropped():
     from claude_agent_sdk import TextBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, config, mock_client, emitted, message_queue, consumed = make_stream_harness()
 
-    async with _consuming(state, config):
+    async with consuming(state, config):
         # Idle: a continuation turn's output + result arrive with no query outstanding.
-        continuation_text = _assistant_msg([TextBlock("background task finished")])
-        continuation_result = _result_msg()
+        continuation_text = assistant_msg([TextBlock("background task finished")])
+        continuation_result = result_msg()
         await message_queue.put(continuation_text)
         await message_queue.put(continuation_result)
         await wait_for_condition(lambda: continuation_result in consumed, message="continuation messages never consumed")
@@ -765,8 +673,8 @@ async def test_result_with_no_open_turn_is_dropped():
         # The next real turn sees only its own messages.
         async def feed():
             await wait_for_condition(lambda: mock_client.query.await_count >= 1, message="query never sent")
-            await message_queue.put(_assistant_msg([TextBlock("real answer")]))
-            await message_queue.put(_result_msg())
+            await message_queue.put(assistant_msg([TextBlock("real answer")]))
+            await message_queue.put(result_msg())
 
         feeder = asyncio.create_task(feed())
         responses = await converse("real question", state=state, config=config, show_output=True)
@@ -781,15 +689,15 @@ async def test_converse_raises_when_stream_dies_mid_turn():
     from claude_agent_sdk import ClaudeSDKError, TextBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, config, mock_client, emitted, message_queue, consumed = make_stream_harness()
 
     async def dying_stream():
-        yield _assistant_msg([TextBlock("partial")])
+        yield assistant_msg([TextBlock("partial")])
         raise ClaudeSDKError("subprocess died")
 
     mock_client.receive_messages = MagicMock(side_effect=lambda: dying_stream())
 
-    async with _consuming(state, config):
+    async with consuming(state, config):
         with pytest.raises(ClaudeSDKError, match="subprocess died"):
             await converse("test", state=state, config=config, show_output=True)
 
@@ -800,9 +708,9 @@ async def test_converse_times_out_on_stream_silence():
     same silence budget the per-message wait enforced before the consumer restructure."""
     from core.client import converse
 
-    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness(response_timeout=1)
+    state, config, mock_client, emitted, message_queue, consumed = make_stream_harness(response_timeout=1)
 
-    async with _consuming(state, config):
+    async with consuming(state, config):
         with pytest.raises(TimeoutError):
             await converse("test", state=state, config=config, show_output=True)
 
@@ -815,12 +723,12 @@ async def test_compact_session_waits_for_result(config):
     from claude_agent_sdk import SystemMessage
     from core.client import compact_session
 
-    state, _, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, _, mock_client, emitted, message_queue, consumed = make_stream_harness()
 
-    async with _consuming(state, config):
+    async with consuming(state, config):
         boundary = SystemMessage(subtype="compact_boundary", data={"compact_metadata": {"pre_tokens": 1000, "trigger": "manual"}})
         await message_queue.put(boundary)
-        await message_queue.put(_result_msg())
+        await message_queue.put(result_msg())
         await asyncio.wait_for(compact_session(state=state), timeout=5.0)
 
     mock_client.query.assert_awaited_once_with("/compact")
@@ -839,10 +747,10 @@ async def test_converse_flips_to_unauthenticated_on_claude_401(config):
     from core.provider import ProviderAuthState, ProviderStatus
 
     config.data_dir.mkdir(parents=True, exist_ok=True)
-    state, _, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, _, mock_client, emitted, message_queue, consumed = make_stream_harness()
     state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
 
-    async with _consuming(state, config):
+    async with consuming(state, config):
         await message_queue.put(
             AssistantMessage(
                 content=[TextBlock(text="Please run /login · API Error: 401 Invalid authentication credentials")],
@@ -866,10 +774,10 @@ async def test_converse_ignores_transient_api_error(config):
     from core.provider import ProviderAuthState, ProviderStatus
 
     config.data_dir.mkdir(parents=True, exist_ok=True)
-    state, _, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, _, mock_client, emitted, message_queue, consumed = make_stream_harness()
     state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
 
-    async with _consuming(state, config):
+    async with consuming(state, config):
         await message_queue.put(
             AssistantMessage(
                 content=[TextBlock(text="API Error: 502 Bad Gateway. This is a server-side issue, usually temporary")],
@@ -877,7 +785,7 @@ async def test_converse_ignores_transient_api_error(config):
                 error="server_error",
             )
         )
-        await message_queue.put(_result_msg())
+        await message_queue.put(result_msg())
         await asyncio.wait_for(converse("test prompt", state=state, config=config, show_output=False), timeout=5.0)
 
     assert state.provider_status.state == ProviderAuthState.AUTHENTICATED
@@ -893,10 +801,10 @@ async def test_converse_flips_auth_on_result_api_error_status(config):
     from core.provider import ProviderAuthState, ProviderStatus
 
     config.data_dir.mkdir(parents=True, exist_ok=True)
-    state, _, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state, _, mock_client, emitted, message_queue, consumed = make_stream_harness()
     state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
 
-    async with _consuming(state, config):
+    async with consuming(state, config):
         await message_queue.put(
             ResultMessage(
                 subtype="error_during_execution",

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -1,6 +1,7 @@
 """Tests for interrupt system, converse streaming, and drain behavior."""
 
 import asyncio
+import contextlib
 import datetime as dt
 import typing as tp
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import core.models as vm
 from claude_agent_sdk.types import SubagentStartHookInput
+from conftest import idle_message_stream
 from core.sdk_parsing import _subagent_hook
 from core.events import EventBus, SubagentStartEvent, SubagentStopEvent
 from wait_util import wait_for_condition
@@ -53,20 +55,23 @@ def _result_msg():
     return msg
 
 
-def _make_converse_harness(*, use_shared_queue: bool = False):
-    """Build a converse() test harness with tracking and a mock SDK client.
+def _make_stream_harness(response_timeout: int | None = None):
+    """Build a stream-consumer test harness: state/config and a mock SDK client whose
+    receive_messages() yields from `message_queue`.
 
-    Returns (state, config, mock_client, emitted, message_queue, consumed). `consumed`
-    records each queued message right after converse's stream loop receives it, giving
-    tests a handshake signal ("converse has seen message N") instead of guessing with sleeps.
+    Returns (state, config, mock_client, emitted, message_queue, consumed). Run the real
+    consume_stream task (via _consuming) for converse/compact_session to make progress;
+    `consumed` records each message right after the consumer finished dispatching it,
+    giving tests a handshake signal instead of guessing with sleeps.
     """
     import time
 
     emitted: list[tuple[str, float]] = []
-    config = vm.VestaConfig(interrupt_timeout=0.5)
+    if response_timeout is None:
+        config = vm.VestaConfig(interrupt_timeout=0.5)
+    else:
+        config = vm.VestaConfig(interrupt_timeout=0.5, response_timeout=response_timeout)
     state = vm.State()
-    # message_processor runs the client loop only for an authenticated provider; these interrupt tests
-    # drive that loop, so mark the agent authenticated.
     from core.provider import ProviderAuthState, ProviderStatus
 
     state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
@@ -86,26 +91,34 @@ def _make_converse_harness(*, use_shared_queue: bool = False):
     mock_client.interrupt = AsyncMock()
     state.client = mock_client
 
-    message_queue: asyncio.Queue[tp.Any] | None = None
+    message_queue: asyncio.Queue[tp.Any] = asyncio.Queue()
     consumed: list[tp.Any] = []
-    if use_shared_queue:
-        message_queue = asyncio.Queue()
 
-        async def _receive_response():
-            from claude_agent_sdk import ResultMessage
+    async def _receive_messages():
+        while True:
+            msg = await message_queue.get()
+            yield msg
+            # The generator only resumes here once the consumer's async-for advanced past
+            # `msg` — i.e. its dispatch (emit/turn bookkeeping) has fully completed.
+            consumed.append(msg)
 
-            while True:
-                msg = await message_queue.get()
-                yield msg
-                # The generator only resumes here once the consumer's async-for advanced
-                # past `msg` — i.e. converse has genuinely received it.
-                consumed.append(msg)
-                if isinstance(msg, ResultMessage):
-                    return
-
-        mock_client.receive_response = MagicMock(side_effect=lambda: _receive_response())
+    mock_client.receive_messages = MagicMock(side_effect=lambda: _receive_messages())
 
     return state, config, mock_client, emitted, message_queue, consumed
+
+
+@contextlib.asynccontextmanager
+async def _consuming(state, config):
+    """Run the real consume_stream task for the duration of the block (cancelled on exit)."""
+    from core.client import consume_stream
+
+    task = asyncio.create_task(consume_stream(state=state, config=config))
+    try:
+        yield task
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
 
 # --- Message processor interrupt ---
@@ -139,6 +152,7 @@ async def test_message_processor_interrupts_on_new_message(config, state):
         return await original(msg, state=state, config=config, is_user=is_user)
 
     mock_client = MagicMock()
+    mock_client.receive_messages = idle_message_stream
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
 
@@ -187,6 +201,7 @@ async def test_message_processor_sets_busy_flag_during_turn(config, state):
     await queue.put(vm.QueuedTurn("message", True, []))
 
     mock_client = MagicMock()
+    mock_client.receive_messages = idle_message_stream
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
 
@@ -479,176 +494,26 @@ async def test_attempt_interrupt_fires_while_tool_in_flight(tmp_path, state, eve
     assert interrupted is True, "client.interrupt() must be called even while a tool is in flight"
 
 
-# --- Converse interrupt behavior ---
+# --- Converse under the long-lived stream consumer ---
 
 
 @pytest.mark.anyio
-async def test_converse_breaks_on_interrupt_event():
-    """converse exits promptly when interrupt_event is set."""
+async def test_converse_collects_texts_and_ends_on_result():
+    """A normal turn: converse returns every text the consumer attributed to it, in order."""
+    from claude_agent_sdk import TextBlock
     from core.client import converse
 
-    yielded_count = 0
+    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
 
-    async def slow_response():
-        nonlocal yielded_count
-        msg = MagicMock()
-        msg.content = []
-        yielded_count += 1
-        yield msg
-        await asyncio.sleep(10)
-        yielded_count += 1
-        yield msg
+    async with _consuming(state, config):
+        await message_queue.put(_assistant_msg([TextBlock("one")]))
+        await message_queue.put(_assistant_msg([TextBlock("two")]))
+        await message_queue.put(_result_msg())
+        responses = await converse("test prompt", state=state, config=config, show_output=True)
 
-    state, config, mock_client, *_ = _make_converse_harness()
-    state.interrupt_event = asyncio.Event()
-    mock_client.receive_response = MagicMock(return_value=slow_response())
-
-    async def trigger_interrupt():
-        await wait_for_condition(lambda: yielded_count == 1, message="converse never consumed the first message")
-        assert state.interrupt_event is not None
-        state.interrupt_event.set()
-
-    asyncio.create_task(trigger_interrupt())
-
-    import time
-
-    start = time.monotonic()
-    await converse("test prompt", state=state, config=config, show_output=False)
-    elapsed = time.monotonic() - start
-
-    assert elapsed < 2.0, f"converse should have exited promptly but took {elapsed:.1f}s"
-    assert mock_client.interrupt.called, "interrupt should have been called"
-    assert yielded_count == 1, "should have only yielded once before interrupt"
-
-
-@pytest.mark.anyio
-async def test_converse_works_normally_without_interrupt():
-    """converse processes all messages when no interrupt is set."""
-    from core.client import converse
-
-    messages_yielded = 0
-
-    async def normal_response():
-        nonlocal messages_yielded
-        for _ in range(3):
-            msg = MagicMock()
-            msg.content = []
-            messages_yielded += 1
-            yield msg
-
-    state, config, mock_client, *_ = _make_converse_harness()
-    mock_client.receive_response = MagicMock(return_value=normal_response())
-
-    await converse("test prompt", state=state, config=config, show_output=False)
-
-    assert messages_yielded == 3, "all messages should have been processed"
-    assert not mock_client.interrupt.called, "interrupt should not have been called"
-
-
-@pytest.mark.anyio
-async def test_converse_flips_to_unauthenticated_on_claude_401(config):
-    """A terminal Claude api-error turn (401) flips the provider to not_authenticated, interrupts the
-    CLI's retries, and ends the turn cleanly (no exception -> no restart loop)."""
-    from core.client import converse
-    from claude_agent_sdk import AssistantMessage, TextBlock
-    from core.provider import ProviderAuthState, ProviderStatus
-
-    config.data_dir.mkdir(parents=True, exist_ok=True)
-
-    async def auth_error_response():
-        yield AssistantMessage(
-            content=[TextBlock(text="Please run /login · API Error: 401 Invalid authentication credentials")],
-            model="opus",
-            error="authentication_failed",
-        )
-        # A second message would only arrive if converse failed to break.
-        await asyncio.sleep(10)
-        yield AssistantMessage(content=[TextBlock(text="should never be reached")], model="opus")
-
-    state = vm.State()
-    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
-
-    mock_client = MagicMock()
-    mock_client.query = AsyncMock()
-    mock_client.receive_response = MagicMock(return_value=auth_error_response())
-    mock_client.interrupt = AsyncMock()
-    state.client = mock_client
-
-    await converse("test prompt", state=state, config=config, show_output=False)
-
-    # The flip is in-memory only (no persisted auth flag); the live status reflects it this session.
-    assert state.provider_status.state == ProviderAuthState.NOT_AUTHENTICATED
-    assert state.provider_status.model is None
-    assert mock_client.interrupt.called, "should interrupt the CLI's retries on auth loss"
-
-
-@pytest.mark.anyio
-async def test_converse_ignores_transient_api_error(config):
-    """A transient api-error turn (502) must NOT flip auth — it resolves on retry."""
-    from core.client import converse
-    from claude_agent_sdk import AssistantMessage, TextBlock
-    from core.provider import ProviderAuthState, ProviderStatus
-
-    config.data_dir.mkdir(parents=True, exist_ok=True)
-
-    async def transient_error_response():
-        yield AssistantMessage(
-            content=[TextBlock(text="API Error: 502 Bad Gateway. This is a server-side issue, usually temporary")],
-            model="opus",
-            error="server_error",
-        )
-
-    state = vm.State()
-    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
-
-    mock_client = MagicMock()
-    mock_client.query = AsyncMock()
-    mock_client.receive_response = MagicMock(return_value=transient_error_response())
-    mock_client.interrupt = AsyncMock()
-    state.client = mock_client
-
-    await converse("test prompt", state=state, config=config, show_output=False)
-
-    assert state.provider_status.state == ProviderAuthState.AUTHENTICATED
+    assert responses == ["one", "two"]
+    assert [t for t, _ in emitted] == ["one", "two"]
     assert not mock_client.interrupt.called
-
-
-@pytest.mark.anyio
-async def test_converse_flips_auth_on_result_api_error_status(config):
-    """A terminal 401/402 may surface on the ResultMessage's HTTP status rather than the assistant
-    turn's error field; that must still flip the agent to not_authenticated."""
-    from core.client import converse
-    from claude_agent_sdk import ResultMessage
-    from core.provider import ProviderAuthState, ProviderStatus
-
-    config.data_dir.mkdir(parents=True, exist_ok=True)
-
-    async def auth_error_result():
-        yield ResultMessage(
-            subtype="error_during_execution",
-            duration_ms=100,
-            duration_api_ms=80,
-            is_error=True,
-            num_turns=1,
-            session_id="sess-xyz",
-            api_error_status=401,
-        )
-
-    state = vm.State()
-    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
-
-    mock_client = MagicMock()
-    mock_client.query = AsyncMock()
-    mock_client.receive_response = MagicMock(return_value=auth_error_result())
-    mock_client.interrupt = AsyncMock()
-    state.client = mock_client
-
-    await converse("test prompt", state=state, config=config, show_output=False)
-
-    assert state.provider_status.state == ProviderAuthState.NOT_AUTHENTICATED
-
-
-# --- Converse streaming regression tests ---
 
 
 @pytest.mark.anyio
@@ -657,16 +522,14 @@ async def test_converse_emits_text_immediately_with_tool_use():
     from claude_agent_sdk import TextBlock, ToolUseBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, _, _ = _make_converse_harness()
+    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
 
-    async def response_with_tool_use():
-        yield _assistant_msg([TextBlock("restarting daemon"), ToolUseBlock("1", "Bash", {})])
-        yield _assistant_msg([TextBlock("checking status"), ToolUseBlock("2", "Bash", {})])
-        yield _assistant_msg([TextBlock("all done")])
-
-    mock_client.receive_response = MagicMock(return_value=response_with_tool_use())
-
-    await converse("test", state=state, config=config, show_output=True)
+    async with _consuming(state, config):
+        await message_queue.put(_assistant_msg([TextBlock("restarting daemon"), ToolUseBlock("1", "Bash", {})]))
+        await message_queue.put(_assistant_msg([TextBlock("checking status"), ToolUseBlock("2", "Bash", {})]))
+        await message_queue.put(_assistant_msg([TextBlock("all done")]))
+        await message_queue.put(_result_msg())
+        await converse("test", state=state, config=config, show_output=True)
 
     texts = [t for t, _ in emitted]
     assert texts == ["restarting daemon", "checking status", "all done"], f"All text must be emitted immediately, got: {texts}"
@@ -677,7 +540,7 @@ async def test_converse_emits_thinking_events():
     from claude_agent_sdk import TextBlock, ThinkingBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, _, _ = _make_converse_harness()
+    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
     thinking_events: list[tuple[str, str]] = []
     original_emit = state.event_bus.emit
 
@@ -688,113 +551,132 @@ async def test_converse_emits_thinking_events():
 
     state.event_bus.emit = tracking_emit
 
-    async def response_with_thinking():
-        yield _assistant_msg([ThinkingBlock("step one\nstep two", "sig-123"), TextBlock("done")])
-        yield _result_msg()
-
-    mock_client.receive_response = MagicMock(return_value=response_with_thinking())
-
-    await converse("test", state=state, config=config, show_output=True)
+    async with _consuming(state, config):
+        await message_queue.put(_assistant_msg([ThinkingBlock("step one\nstep two", "sig-123"), TextBlock("done")]))
+        await message_queue.put(_result_msg())
+        await converse("test", state=state, config=config, show_output=True)
 
     assert thinking_events == [("step one\nstep two", "sig-123")]
     assert [t for t, _ in emitted] == ["done"]
 
 
 @pytest.mark.anyio
-async def test_interrupt_drains_stream_and_emits_leftovers():
-    """After an interrupt, leftover messages must be emitted (not lost)
-    and must NOT leak into the next converse() call."""
+async def test_converse_exits_promptly_on_interrupt_event():
+    """converse interrupts and returns within the bounded grace even when the interrupted turn's
+    ResultMessage never arrives (the CLI wind-down outliving the grace is the #958 seed)."""
     import time
 
+    from claude_agent_sdk import TextBlock
+    from core.client import converse
+
+    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state.interrupt_event = asyncio.Event()
+
+    async def trigger_interrupt():
+        await wait_for_condition(lambda: len(consumed) >= 1, message="consumer never dispatched the first message")
+        assert state.interrupt_event is not None
+        state.interrupt_event.set()
+
+    async with _consuming(state, config):
+        await message_queue.put(_assistant_msg([TextBlock("working on it")]))
+        trigger = asyncio.create_task(trigger_interrupt())
+        with patch("core.client._INTERRUPT_TURN_END_GRACE_S", 0.1):
+            start = time.monotonic()
+            responses = await converse("test prompt", state=state, config=config, show_output=True)
+            elapsed = time.monotonic() - start
+        await trigger
+
+    assert elapsed < 2.0, f"converse should have exited promptly but took {elapsed:.1f}s"
+    assert mock_client.interrupt.called, "interrupt should have been called"
+    assert responses == ["working on it"]
+
+
+@pytest.mark.anyio
+async def test_interrupt_winddown_within_grace_stays_attributed():
+    """A wind-down that finishes inside the grace is emitted AND attributed to the interrupted
+    turn, and the next turn starts against a clean stream."""
     from claude_agent_sdk import TextBlock, ToolUseBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, message_queue, consumed = _make_converse_harness(use_shared_queue=True)
-    assert message_queue is not None
-
+    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
     state.interrupt_event = asyncio.Event()
 
     async def sim_conv1():
         await message_queue.put(_assistant_msg([ToolUseBlock("1", "Bash", {})]))
-        # Handshake: converse received the tool message, now interrupt it.
-        await wait_for_condition(lambda: len(consumed) >= 1, message="converse never consumed the tool message")
+        await wait_for_condition(lambda: len(consumed) >= 1, message="consumer never dispatched the tool message")
         assert state.interrupt_event is not None
         state.interrupt_event.set()
-        # Handshake: converse reacted to the interrupt; the drain window is open for leftovers.
         await wait_for_condition(lambda: mock_client.interrupt.called, message="converse never called interrupt()")
         await message_queue.put(_assistant_msg([TextBlock("here are the files")]))
         await message_queue.put(_result_msg())
 
-    asyncio.create_task(sim_conv1())
-    await converse("list /tmp", state=state, config=config, show_output=True)
+    async with _consuming(state, config):
+        sim = asyncio.create_task(sim_conv1())
+        responses = await converse("list /tmp", state=state, config=config, show_output=True)
+        await sim
 
-    assert any(t == "here are the files" for t, _ in emitted), f"Leftover must be emitted during drain: {[t for t, _ in emitted]}"
+        assert responses == ["here are the files"], f"wind-down text must be attributed to the interrupted turn: {responses}"
+        assert any(t == "here are the files" for t, _ in emitted), f"wind-down text must be emitted: {[t for t, _ in emitted]}"
 
-    # Conv 2: must NOT see conv 1's leftovers
-    state.interrupt_event = None
-    n_before = len(emitted)
-    fresh_put_at: list[float] = []
+        # Conv 2: starts clean, gets exactly its own messages.
+        state.interrupt_event = None
+        n_before = len(emitted)
 
-    async def sim_conv2():
-        # Adversarial window: if conv 1's leftovers leaked into conv 2, they would surface
-        # here, before "fresh response" is even queued.
-        await asyncio.sleep(0.3)
-        fresh_put_at.append(time.monotonic())
-        await message_queue.put(_assistant_msg([TextBlock("fresh response")]))
-        await message_queue.put(_result_msg())
+        async def sim_conv2():
+            await wait_for_condition(lambda: mock_client.query.await_count >= 2, message="conv 2 query never sent")
+            await message_queue.put(_assistant_msg([TextBlock("fresh response")]))
+            await message_queue.put(_result_msg())
 
-    asyncio.create_task(sim_conv2())
-    await converse("well?", state=state, config=config, show_output=True)
+        sim2 = asyncio.create_task(sim_conv2())
+        responses2 = await converse("well?", state=state, config=config, show_output=True)
+        await sim2
 
-    conv2 = emitted[n_before:]
-    assert len(conv2) == 1 and conv2[0][0] == "fresh response", f"Conv 2 got wrong messages: {[t for t, _ in conv2]}"
-    assert conv2[0][1] >= fresh_put_at[0], "Response was emitted before sim_conv2 queued it — leaked from conv 1"
+    assert responses2 == ["fresh response"], f"Conv 2 got wrong messages: {responses2}"
+    assert [t for t, _ in emitted[n_before:]] == ["fresh response"]
 
 
 @pytest.mark.anyio
 async def test_interrupt_then_response_arrives_without_user_input():
-    """Reproduces the exact bug from docker logs: user conversation is interrupted
-    by a notification, notification does tool calls then responds -- that response
-    must arrive on its own without the user sending another message."""
+    """Reproduces the #958 user-visible bug: a notification turn interrupts the conversation, does
+    tool calls, then responds — that response must arrive on its own, without another user poke."""
     import time
 
     from claude_agent_sdk import TextBlock, ToolUseBlock
     from core.client import converse
 
-    state, config, mock_client, emitted, message_queue, consumed = _make_converse_harness(use_shared_queue=True)
-    assert message_queue is not None
-
+    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
     state.interrupt_event = asyncio.Event()
 
     async def sim_conv1():
         await message_queue.put(_assistant_msg([ToolUseBlock("1", "Bash", {})]))
-        await wait_for_condition(lambda: len(consumed) >= 1, message="converse never consumed the tool message")
+        await wait_for_condition(lambda: len(consumed) >= 1, message="consumer never dispatched the tool message")
         assert state.interrupt_event is not None
         state.interrupt_event.set()
         await wait_for_condition(lambda: mock_client.interrupt.called, message="converse never called interrupt()")
         await message_queue.put(_assistant_msg([TextBlock("checking logs")]))
         await message_queue.put(_result_msg())
 
-    asyncio.create_task(sim_conv1())
-    await converse("i did it instantly", state=state, config=config, show_output=True)
+    async with _consuming(state, config):
+        sim = asyncio.create_task(sim_conv1())
+        await converse("i did it instantly", state=state, config=config, show_output=True)
+        await sim
 
-    assert any(t == "checking logs" for t, _ in emitted), f"Conv 1 leftover not emitted: {[t for t, _ in emitted]}"
+        assert any(t == "checking logs" for t, _ in emitted), f"Conv 1 wind-down not emitted: {[t for t, _ in emitted]}"
 
-    state.interrupt_event = None
-    n_before = len(emitted)
-    t0 = time.monotonic()
+        state.interrupt_event = None
+        n_before = len(emitted)
+        t0 = time.monotonic()
 
-    async def sim_conv2():
-        # Simulates the notification turn: a tool call, then the response, paced by
-        # what converse has actually consumed rather than by wall-clock guesses.
-        consumed_before = len(consumed)
-        await message_queue.put(_assistant_msg([ToolUseBlock("2", "Bash", {})]))
-        await wait_for_condition(lambda: len(consumed) > consumed_before, message="conv 2 tool message never consumed")
-        await message_queue.put(_assistant_msg([TextBlock("daemon's back up")]))
-        await message_queue.put(_result_msg())
+        async def sim_conv2():
+            consumed_before = len(consumed)
+            await message_queue.put(_assistant_msg([ToolUseBlock("2", "Bash", {})]))
+            await wait_for_condition(lambda: len(consumed) > consumed_before, message="conv 2 tool message never consumed")
+            await message_queue.put(_assistant_msg([TextBlock("daemon's back up")]))
+            await message_queue.put(_result_msg())
 
-    asyncio.create_task(sim_conv2())
-    await converse("daemon_died notification", state=state, config=config, show_output=True)
+        sim2 = asyncio.create_task(sim_conv2())
+        await converse("daemon_died notification", state=state, config=config, show_output=True)
+        await sim2
 
     conv2_texts = [t for t, _ in emitted[n_before:]]
     assert "daemon's back up" in conv2_texts, f"Conv 2 response must arrive without user interaction: {conv2_texts}"
@@ -805,42 +687,227 @@ async def test_interrupt_then_response_arrives_without_user_input():
 
 
 @pytest.mark.anyio
-async def test_drain_timeout_does_not_block_forever():
-    """If the SDK is slow to send ResultMessage after interrupt, the drain must
-    time out and not block the next conversation forever."""
-    from claude_agent_sdk import ToolUseBlock
+async def test_late_result_after_interrupt_does_not_wedge_later_turns():
+    """The #958 regression: an interrupted turn's ResultMessage lands after the grace, during the
+    next turn. That next turn's label closes early (advisory), but every message still reaches the
+    user in real time, the stray result is dropped, and the stream self-heals by the turn after."""
+    from claude_agent_sdk import TextBlock
     from core.client import converse
 
-    state, config, mock_client, _, _, _ = _make_converse_harness()
+    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
 
-    call_count = 0
-    first_message_consumed = asyncio.Event()
-
-    async def slow_drain_response():
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            yield _assistant_msg([ToolUseBlock("1", "Bash", {})])
-            # Resumed = converse advanced past the first message.
-            first_message_consumed.set()
-            await asyncio.sleep(60)
-        else:
-            await asyncio.sleep(60)
-
-    mock_client.receive_response = MagicMock(side_effect=lambda: slow_drain_response())
-    state.client = mock_client
-    state.interrupt_event = asyncio.Event()
-
-    async def trigger():
-        await first_message_consumed.wait()
+    async def trigger_interrupt():
+        await wait_for_condition(lambda: len(consumed) >= 1, message="consumer never dispatched the first message")
         assert state.interrupt_event is not None
         state.interrupt_event.set()
 
-    import time
+    async with _consuming(state, config):
+        with patch("core.client._INTERRUPT_TURN_END_GRACE_S", 0.1):
+            # Turn 1: interrupted; its wind-down outlives the grace (no result arrives).
+            state.interrupt_event = asyncio.Event()
+            await message_queue.put(_assistant_msg([TextBlock("turn one partial")]))
+            trigger = asyncio.create_task(trigger_interrupt())
+            await converse("turn one", state=state, config=config, show_output=True)
+            await trigger
+            assert mock_client.interrupt.called
 
-    asyncio.create_task(trigger())
-    t0 = time.monotonic()
-    await converse("test", state=state, config=config, show_output=True)
-    elapsed = time.monotonic() - t0
+        # Turn 2: turn 1's stale result lands mid-turn and closes its label early.
+        state.interrupt_event = None
+        conv2 = asyncio.create_task(converse("turn two", state=state, config=config, show_output=True))
+        await wait_for_condition(lambda: mock_client.query.await_count >= 2, message="turn 2 query never sent")
+        stale_result = _result_msg()
+        await message_queue.put(stale_result)
+        await conv2  # closed by the stale result — must not hang
 
-    assert elapsed < 8.0, f"converse took {elapsed:.1f}s — drain blocked too long"
+        # Turn 2's real output arrives after its label closed: still emitted in real time...
+        n_before = len(emitted)
+        await message_queue.put(_assistant_msg([TextBlock("turn two answer")]))
+        await wait_for_condition(
+            lambda: any(t == "turn two answer" for t, _ in emitted[n_before:]),
+            message="post-close output was not emitted — this is the wedge #958 describes",
+        )
+        # ...and its own result, arriving with no open turn, is dropped without harm.
+        own_result = _result_msg()
+        await message_queue.put(own_result)
+        await wait_for_condition(lambda: own_result in consumed, message="stray result never consumed")
+
+        # Turn 3: fully self-healed — a normal turn completes end-to-end.
+        async def feed_turn3():
+            await wait_for_condition(lambda: mock_client.query.await_count >= 3, message="turn 3 query never sent")
+            await message_queue.put(_assistant_msg([TextBlock("turn three answer")]))
+            await message_queue.put(_result_msg())
+
+        feeder = asyncio.create_task(feed_turn3())
+        responses3 = await converse("turn three", state=state, config=config, show_output=True)
+        await feeder
+
+    assert responses3 == ["turn three answer"], f"stream did not self-heal: {responses3}"
+
+
+@pytest.mark.anyio
+async def test_result_with_no_open_turn_is_dropped():
+    """An unprompted ResultMessage (a self-initiated CLI continuation turn) arriving while idle is
+    dropped, its text still emitted, and the next real turn is unaffected."""
+    from claude_agent_sdk import TextBlock
+    from core.client import converse
+
+    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+
+    async with _consuming(state, config):
+        # Idle: a continuation turn's output + result arrive with no query outstanding.
+        continuation_text = _assistant_msg([TextBlock("background task finished")])
+        continuation_result = _result_msg()
+        await message_queue.put(continuation_text)
+        await message_queue.put(continuation_result)
+        await wait_for_condition(lambda: continuation_result in consumed, message="continuation messages never consumed")
+        assert any(t == "background task finished" for t, _ in emitted), "idle output must still reach the user"
+
+        # The next real turn sees only its own messages.
+        async def feed():
+            await wait_for_condition(lambda: mock_client.query.await_count >= 1, message="query never sent")
+            await message_queue.put(_assistant_msg([TextBlock("real answer")]))
+            await message_queue.put(_result_msg())
+
+        feeder = asyncio.create_task(feed())
+        responses = await converse("real question", state=state, config=config, show_output=True)
+        await feeder
+
+    assert responses == ["real answer"], f"continuation result leaked into the next turn: {responses}"
+
+
+@pytest.mark.anyio
+async def test_converse_raises_when_stream_dies_mid_turn():
+    """A stream death mid-turn surfaces through the open turn so run_one's restart path fires."""
+    from claude_agent_sdk import ClaudeSDKError, TextBlock
+    from core.client import converse
+
+    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+
+    async def dying_stream():
+        yield _assistant_msg([TextBlock("partial")])
+        raise ClaudeSDKError("subprocess died")
+
+    mock_client.receive_messages = MagicMock(side_effect=lambda: dying_stream())
+
+    async with _consuming(state, config):
+        with pytest.raises(ClaudeSDKError, match="subprocess died"):
+            await converse("test", state=state, config=config, show_output=True)
+
+
+@pytest.mark.anyio
+async def test_converse_times_out_on_stream_silence():
+    """No stream message for response_timeout ends the turn with TimeoutError (restart path),
+    same silence budget the per-message wait enforced before the consumer restructure."""
+    from core.client import converse
+
+    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness(response_timeout=1)
+
+    async with _consuming(state, config):
+        with pytest.raises(TimeoutError):
+            await converse("test", state=state, config=config, show_output=True)
+
+    assert mock_client.interrupt.called, "a response timeout must attempt to interrupt the hung turn"
+
+
+@pytest.mark.anyio
+async def test_compact_session_waits_for_result(config):
+    """compact_session blocks until the compaction turn's ResultMessage closes the turn."""
+    from claude_agent_sdk import SystemMessage
+    from core.client import compact_session
+
+    state, _, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+
+    async with _consuming(state, config):
+        boundary = SystemMessage(subtype="compact_boundary", data={"compact_metadata": {"pre_tokens": 1000, "trigger": "manual"}})
+        await message_queue.put(boundary)
+        await message_queue.put(_result_msg())
+        await asyncio.wait_for(compact_session(state=state), timeout=5.0)
+
+    mock_client.query.assert_awaited_once_with("/compact")
+    assert state.turn is None
+
+
+# --- Converse auth handling ---
+
+
+@pytest.mark.anyio
+async def test_converse_flips_to_unauthenticated_on_claude_401(config):
+    """A terminal Claude api-error turn (401) flips the provider to not_authenticated, interrupts the
+    CLI's retries, and ends the turn cleanly (no exception -> no restart loop)."""
+    from claude_agent_sdk import AssistantMessage, TextBlock
+    from core.client import converse
+    from core.provider import ProviderAuthState, ProviderStatus
+
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+    state, _, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
+
+    async with _consuming(state, config):
+        await message_queue.put(
+            AssistantMessage(
+                content=[TextBlock(text="Please run /login · API Error: 401 Invalid authentication credentials")],
+                model="opus",
+                error="authentication_failed",
+            )
+        )
+        await asyncio.wait_for(converse("test prompt", state=state, config=config, show_output=False), timeout=5.0)
+
+    # The flip is in-memory only (no persisted auth flag); the live status reflects it this session.
+    assert state.provider_status.state == ProviderAuthState.NOT_AUTHENTICATED
+    assert state.provider_status.model is None
+    assert mock_client.interrupt.called, "should interrupt the CLI's retries on auth loss"
+
+
+@pytest.mark.anyio
+async def test_converse_ignores_transient_api_error(config):
+    """A transient api-error turn (502) must NOT flip auth — it resolves on retry."""
+    from claude_agent_sdk import AssistantMessage, TextBlock
+    from core.client import converse
+    from core.provider import ProviderAuthState, ProviderStatus
+
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+    state, _, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
+
+    async with _consuming(state, config):
+        await message_queue.put(
+            AssistantMessage(
+                content=[TextBlock(text="API Error: 502 Bad Gateway. This is a server-side issue, usually temporary")],
+                model="opus",
+                error="server_error",
+            )
+        )
+        await message_queue.put(_result_msg())
+        await asyncio.wait_for(converse("test prompt", state=state, config=config, show_output=False), timeout=5.0)
+
+    assert state.provider_status.state == ProviderAuthState.AUTHENTICATED
+    assert not mock_client.interrupt.called
+
+
+@pytest.mark.anyio
+async def test_converse_flips_auth_on_result_api_error_status(config):
+    """A terminal 401/402 may surface on the ResultMessage's HTTP status rather than the assistant
+    turn's error field; that must still flip the agent to not_authenticated."""
+    from claude_agent_sdk import ResultMessage
+    from core.client import converse
+    from core.provider import ProviderAuthState, ProviderStatus
+
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+    state, _, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
+
+    async with _consuming(state, config):
+        await message_queue.put(
+            ResultMessage(
+                subtype="error_during_execution",
+                duration_ms=100,
+                duration_api_ms=80,
+                is_error=True,
+                num_turns=1,
+                session_id="sess-xyz",
+                api_error_status=401,
+            )
+        )
+        await asyncio.wait_for(converse("test prompt", state=state, config=config, show_output=False), timeout=5.0)
+
+    assert state.provider_status.state == ProviderAuthState.NOT_AUTHENTICATED

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import core.models as vm
+from conftest import idle_message_stream
 from core.client import process_message
 from wait_util import wait_for_condition
 
@@ -47,6 +48,7 @@ async def _run_processor_test(
 
     mock_client = MagicMock()
     mock_client.return_value = mock_client
+    mock_client.receive_messages = idle_message_stream
 
     async def mock_enter(self):
         nonlocal session_count
@@ -179,6 +181,7 @@ async def test_client_cleared_on_cancellation(tmp_path):
     queue: asyncio.Queue = asyncio.Queue()
 
     mock_client = MagicMock()
+    mock_client.receive_messages = idle_message_stream
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
 

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -13,7 +13,7 @@ from wait_util import wait_for_condition
 from core.diagnostics import (
     format_hang_diagnostics,
     longest_running_tool,
-    note_stream_silence,
+    note_turn_liveness,
     sdk_idle_seconds,
     touch_activity,
 )
@@ -109,104 +109,123 @@ def test_format_hang_diagnostics_includes_stderr_tail():
     assert "line 9" in diag
 
 
-# --- note_stream_silence ---
+# --- note_turn_liveness ---
 
 
-def _quiet_state(idle_s: float) -> vm.State:
-    state = vm.State()
-    state.last_sdk_activity = time.monotonic() - idle_s
-    return state
+def _quiet_turn(quiet_s: float) -> vm.TurnSignals:
+    turn = vm.TurnSignals()
+    turn.last_visible_at = time.monotonic() - quiet_s
+    return turn
 
 
-def test_silence_notes_once_per_threshold(captured_notes):
-    state = _quiet_state(65)
+def test_liveness_notes_once_per_threshold(captured_notes, state):
+    turn = _quiet_turn(65)
     noted: set[int] = set()
 
-    note_stream_silence(state, noted_at=noted)
-    note_stream_silence(state, noted_at=noted)
+    note_turn_liveness(state, turn=turn, noted_at=noted)
+    note_turn_liveness(state, turn=turn, noted_at=noted)
 
-    assert len([n for n in captured_notes if "Model quiet for 60s" in n]) == 1, f"one note per crossing, got: {captured_notes}"
+    assert len([n for n in captured_notes if "quiet for 60s" in n]) == 1, f"one note per crossing, got: {captured_notes}"
     assert noted == {60}
 
 
-def test_silence_notes_each_threshold_as_idle_grows(captured_notes):
-    state = _quiet_state(65)
+def test_liveness_notes_each_threshold_as_quiet_grows(captured_notes, state):
+    turn = _quiet_turn(65)
     noted: set[int] = set()
 
-    note_stream_silence(state, noted_at=noted)
-    state.last_sdk_activity = time.monotonic() - 125
-    note_stream_silence(state, noted_at=noted)
+    note_turn_liveness(state, turn=turn, noted_at=noted)
+    turn.last_visible_at = time.monotonic() - 125
+    note_turn_liveness(state, turn=turn, noted_at=noted)
 
-    assert [n for n in captured_notes if "Model quiet" in n] == [
-        next(n for n in captured_notes if "60s" in n),
-        next(n for n in captured_notes if "120s" in n),
-    ], f"expected a 60s then a 120s note, got: {captured_notes}"
+    quiet_notes = [n for n in captured_notes if "quiet" in n]
+    assert len(quiet_notes) == 2 and "60s" in quiet_notes[0] and "120s" in quiet_notes[1], f"expected 60s then 120s, got: {captured_notes}"
 
 
-def test_silence_resets_when_stream_talks_again(captured_notes):
-    state = _quiet_state(65)
+def test_liveness_resets_when_output_lands(captured_notes, state):
+    turn = _quiet_turn(65)
     noted: set[int] = set()
 
-    note_stream_silence(state, noted_at=noted)
-    touch_activity(state, "sdk_message")
-    note_stream_silence(state, noted_at=noted)  # fresh activity clears the noted set
+    note_turn_liveness(state, turn=turn, noted_at=noted)
+    turn.last_visible_at = time.monotonic()  # output emitted
+    note_turn_liveness(state, turn=turn, noted_at=noted)
     assert noted == set()
 
-    state.last_sdk_activity = time.monotonic() - 65
-    note_stream_silence(state, noted_at=noted)
+    turn.last_visible_at = time.monotonic() - 65
+    note_turn_liveness(state, turn=turn, noted_at=noted)
 
-    assert len([n for n in captured_notes if "Model quiet for 60s" in n]) == 2, f"expected a re-note after reset, got: {captured_notes}"
+    assert len([n for n in captured_notes if "quiet for 60s" in n]) == 2, f"expected a re-note after output, got: {captured_notes}"
 
 
-def test_silence_escalates_to_warning_and_event_past_escalation(captured_warnings, captured_notes, tmp_path):
-    state = _quiet_state(305)
+def test_liveness_reports_thinking_with_token_count(captured_notes, captured_warnings, state, tmp_path):
+    """A recently ticking thinking counter makes the note specific — and is never escalated,
+    however long the think runs: the model is demonstrably reasoning, not stalled."""
     state.event_bus = vm.EventBus(data_dir=tmp_path)
     queue = state.event_bus.subscribe()
+    turn = _quiet_turn(305)
+    turn.thinking_tokens = 2340
+    turn.thinking_tokens_at = time.monotonic() - 5
     noted: set[int] = set()
 
-    note_stream_silence(state, noted_at=noted)
-    note_stream_silence(state, noted_at=noted)
+    note_turn_liveness(state, turn=turn, noted_at=noted)
 
-    warnings_300 = [w for w in captured_warnings if "Model quiet for 300s" in w]
+    thinking_notes = [n for n in captured_notes if "Thinking for" in n and "2,340 tokens" in n]
+    assert len(thinking_notes) == 3, f"expected token-count notes at 60/120/300, got: {captured_notes}"
+    assert captured_warnings == [], f"healthy thinking must never warn, got: {captured_warnings}"
+    assert queue.empty(), "healthy thinking must not emit error events"
+    state.event_bus.close()
+
+
+def test_liveness_escalates_dead_air_past_escalation(captured_warnings, captured_notes, state, tmp_path):
+    """No output AND no thinking ticks past the escalation threshold is a suspected stall:
+    one warning + one error event."""
+    state.event_bus = vm.EventBus(data_dir=tmp_path)
+    queue = state.event_bus.subscribe()
+    turn = _quiet_turn(305)  # no thinking_tokens ever seen
+    noted: set[int] = set()
+
+    note_turn_liveness(state, turn=turn, noted_at=noted)
+    note_turn_liveness(state, turn=turn, noted_at=noted)
+
+    warnings_300 = [w for w in captured_warnings if "no stream activity for 300s" in w]
     assert len(warnings_300) == 1, f"expected exactly one 300s warning, got: {captured_warnings}"
     events = []
     while not queue.empty():
         event = queue.get_nowait()
-        if event["type"] == "error" and "Model quiet" in event["text"]:
+        if event["type"] == "error" and "no stream activity" in event["text"]:
             events.append(event)
     assert len(events) == 1, f"expected exactly one error event, got: {events}"
     # The earlier thresholds stay calm INFO notes, not warnings.
-    assert len([n for n in captured_notes if "Model quiet" in n]) == 2, f"60s+120s notes expected, got: {captured_notes}"
+    assert len([n for n in captured_notes if "quiet" in n]) == 2, f"60s+120s notes expected, got: {captured_notes}"
     state.event_bus.close()
 
 
-def test_silence_stays_debug_while_tool_runs(captured_warnings, captured_notes, tmp_path):
+def test_liveness_stays_debug_while_tool_runs(captured_warnings, captured_notes, state, tmp_path):
     """A running tool explains the quiet (a long build, a sleep): no notes, no warnings, no events."""
-    state = _quiet_state(305)
     state.event_bus = vm.EventBus(data_dir=tmp_path)
     queue = state.event_bus.subscribe()
     state.active_tools["tool-1"] = vm.ActiveTool(name="Bash", summary="sleep 180", started_at=time.monotonic() - 305)
+    turn = _quiet_turn(305)
     noted: set[int] = set()
 
-    note_stream_silence(state, noted_at=noted)
+    note_turn_liveness(state, turn=turn, noted_at=noted)
 
-    assert [n for n in captured_notes if "Model quiet" in n] == [], f"expected no notes mid-tool, got: {captured_notes}"
-    assert [w for w in captured_warnings if "Model quiet" in w] == [], f"expected no warnings mid-tool, got: {captured_warnings}"
+    assert [n for n in captured_notes if "quiet" in n or "Thinking" in n] == [], f"expected no notes mid-tool, got: {captured_notes}"
+    assert captured_warnings == [], f"expected no warnings mid-tool, got: {captured_warnings}"
     assert queue.empty(), "expected no error events mid-tool"
     state.event_bus.close()
 
 
 @pytest.mark.anyio
-async def test_converse_notes_silence_while_waiting(captured_notes, monkeypatch):
-    """The wait loop itself emits the liveness note during a long quiet stretch: a silent model
-    reads as 'still thinking' in the log before the turn completes."""
+async def test_converse_notes_thinking_while_waiting(captured_notes, monkeypatch):
+    """End to end through the wait loop: thinking_tokens system messages keep the turn's counter
+    fresh while producing no visible output, and the liveness note reports the token count."""
     import core.client as client_mod
     import core.diagnostics as diagnostics_mod
-    from claude_agent_sdk import ResultMessage
+    from claude_agent_sdk import ResultMessage, SystemMessage
     from core.client import consume_stream
 
     monkeypatch.setattr(client_mod, "_SILENCE_POLL_S", 0.02)
-    monkeypatch.setattr(diagnostics_mod, "_SILENCE_THRESHOLDS_S", (0,))
+    monkeypatch.setattr(diagnostics_mod, "_QUIET_THRESHOLDS_S", (0,))
 
     state = vm.State()
     config = vm.VestaConfig(interrupt_timeout=0.5)
@@ -224,22 +243,26 @@ async def test_converse_notes_silence_while_waiting(captured_notes, monkeypatch)
     mock_client.receive_messages = MagicMock(side_effect=lambda: stream())
     consumer = asyncio.create_task(consume_stream(state=state, config=config))
 
-    async def end_turn_after_quiet():
-        await wait_for_condition(lambda: any("Model quiet" in n for n in captured_notes), message="no liveness note during silence")
+    async def think_then_finish():
+        await q.put(SystemMessage(subtype="thinking_tokens", data={"estimated_tokens": 312, "estimated_tokens_delta": 5}))
+        await wait_for_condition(
+            lambda: any("Thinking for" in n and "312 tokens" in n for n in captured_notes),
+            message="no thinking note during quiet stretch",
+        )
         result = MagicMock(spec=ResultMessage)
         result.content = []
         await q.put(result)
 
-    ender = asyncio.create_task(end_turn_after_quiet())
+    thinker = asyncio.create_task(think_then_finish())
     try:
         await asyncio.wait_for(converse("test", state=state, config=config, show_output=False), timeout=5.0)
-        await ender
+        await thinker
     finally:
         consumer.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await consumer
 
-    assert any("Model quiet" in n for n in captured_notes), f"expected a liveness note, got: {captured_notes}"
+    assert any("Thinking for" in n for n in captured_notes), f"expected a thinking note, got: {captured_notes}"
 
 
 # --- Tool duration tracking via hooks ---

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -2,22 +2,19 @@
 
 import asyncio
 import contextlib
-import tempfile
 import time
 import typing as tp
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import core.models as vm
-from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
 from core.client import converse
 from wait_util import wait_for_condition
 from core.diagnostics import (
-    _check_sdk_subprocess_alive,
     format_hang_diagnostics,
     longest_running_tool,
+    note_stream_silence,
     sdk_idle_seconds,
-    sdk_watchdog,
     touch_activity,
 )
 
@@ -33,16 +30,13 @@ def captured_warnings(monkeypatch):
 
 
 @pytest.fixture
-def fast_watchdog_poll(monkeypatch):
-    """Collapse the watchdog's poll interval so sdk_watchdog ticks immediately."""
+def captured_notes(monkeypatch):
+    """Capture the INFO-band liveness notes note_stream_silence logs via logger.client."""
     import core.diagnostics as diagnostics_mod
 
-    original_wait_for = asyncio.wait_for
-
-    async def fast_wait_for(coro, *, timeout):  # type: ignore[no-untyped-def]
-        return await original_wait_for(coro, timeout=0.01)
-
-    monkeypatch.setattr(diagnostics_mod.asyncio, "wait_for", fast_wait_for)
+    notes: list[str] = []
+    monkeypatch.setattr(diagnostics_mod.logger, "client", lambda msg: notes.append(str(msg)))
+    return notes
 
 
 # --- ActiveTool and State activity tracking ---
@@ -115,160 +109,137 @@ def test_format_hang_diagnostics_includes_stderr_tail():
     assert "line 9" in diag
 
 
-# --- _check_sdk_subprocess_alive ---
-# Liveness is read through the client's public is_alive() accessor. The alive/dead
-# distinction needs a launched claude process and lives in test_e2e_transport.py; the
-# reachable-without-tmux cases (no client, and a constructed-but-unlaunched real client)
-# are covered here.
+# --- note_stream_silence ---
 
 
-def test_subprocess_alive_returns_none_when_no_client():
+def _quiet_state(idle_s: float) -> vm.State:
     state = vm.State()
-    state.client = None
-    assert _check_sdk_subprocess_alive(state) is None
+    state.last_sdk_activity = time.monotonic() - idle_s
+    return state
 
 
-def test_subprocess_alive_returns_none_before_launch():
-    state = vm.State()
-    state.client = ClaudeSDKClient(options=ClaudeAgentOptions(cwd=tempfile.mkdtemp()))
-    assert _check_sdk_subprocess_alive(state) is None
+def test_silence_notes_once_per_threshold(captured_notes):
+    state = _quiet_state(65)
+    noted: set[int] = set()
+
+    note_stream_silence(state, noted_at=noted)
+    note_stream_silence(state, noted_at=noted)
+
+    assert len([n for n in captured_notes if "Model quiet for 60s" in n]) == 1, f"one note per crossing, got: {captured_notes}"
+    assert noted == {60}
 
 
-# --- sdk_watchdog ---
+def test_silence_notes_each_threshold_as_idle_grows(captured_notes):
+    state = _quiet_state(65)
+    noted: set[int] = set()
+
+    note_stream_silence(state, noted_at=noted)
+    state.last_sdk_activity = time.monotonic() - 125
+    note_stream_silence(state, noted_at=noted)
+
+    assert [n for n in captured_notes if "Model quiet" in n] == [
+        next(n for n in captured_notes if "60s" in n),
+        next(n for n in captured_notes if "120s" in n),
+    ], f"expected a 60s then a 120s note, got: {captured_notes}"
+
+
+def test_silence_resets_when_stream_talks_again(captured_notes):
+    state = _quiet_state(65)
+    noted: set[int] = set()
+
+    note_stream_silence(state, noted_at=noted)
+    touch_activity(state, "sdk_message")
+    note_stream_silence(state, noted_at=noted)  # fresh activity clears the noted set
+    assert noted == set()
+
+    state.last_sdk_activity = time.monotonic() - 65
+    note_stream_silence(state, noted_at=noted)
+
+    assert len([n for n in captured_notes if "Model quiet for 60s" in n]) == 2, f"expected a re-note after reset, got: {captured_notes}"
+
+
+def test_silence_escalates_to_warning_and_event_past_escalation(captured_warnings, captured_notes, tmp_path):
+    state = _quiet_state(305)
+    state.event_bus = vm.EventBus(data_dir=tmp_path)
+    queue = state.event_bus.subscribe()
+    noted: set[int] = set()
+
+    note_stream_silence(state, noted_at=noted)
+    note_stream_silence(state, noted_at=noted)
+
+    warnings_300 = [w for w in captured_warnings if "Model quiet for 300s" in w]
+    assert len(warnings_300) == 1, f"expected exactly one 300s warning, got: {captured_warnings}"
+    events = []
+    while not queue.empty():
+        event = queue.get_nowait()
+        if event["type"] == "error" and "Model quiet" in event["text"]:
+            events.append(event)
+    assert len(events) == 1, f"expected exactly one error event, got: {events}"
+    # The earlier thresholds stay calm INFO notes, not warnings.
+    assert len([n for n in captured_notes if "Model quiet" in n]) == 2, f"60s+120s notes expected, got: {captured_notes}"
+    state.event_bus.close()
+
+
+def test_silence_stays_debug_while_tool_runs(captured_warnings, captured_notes, tmp_path):
+    """A running tool explains the quiet (a long build, a sleep): no notes, no warnings, no events."""
+    state = _quiet_state(305)
+    state.event_bus = vm.EventBus(data_dir=tmp_path)
+    queue = state.event_bus.subscribe()
+    state.active_tools["tool-1"] = vm.ActiveTool(name="Bash", summary="sleep 180", started_at=time.monotonic() - 305)
+    noted: set[int] = set()
+
+    note_stream_silence(state, noted_at=noted)
+
+    assert [n for n in captured_notes if "Model quiet" in n] == [], f"expected no notes mid-tool, got: {captured_notes}"
+    assert [w for w in captured_warnings if "Model quiet" in w] == [], f"expected no warnings mid-tool, got: {captured_warnings}"
+    assert queue.empty(), "expected no error events mid-tool"
+    state.event_bus.close()
 
 
 @pytest.mark.anyio
-async def test_watchdog_warns_at_thresholds(captured_warnings, fast_watchdog_poll):
-    state = vm.State()
-    state.last_sdk_activity = time.monotonic() - 65  # Idle for 65s
-    state.interrupt_event = asyncio.Event()  # Turn in flight, so silence is suspicious
-    stop = asyncio.Event()
-
-    async def stop_after_warning():
-        await wait_for_condition(lambda: any("SDK silent for 60s" in w for w in captured_warnings), message="watchdog never warned")
-        stop.set()
-
-    await asyncio.gather(sdk_watchdog(state, stop=stop), stop_after_warning())
-
-    assert any("SDK silent for 60s" in w for w in captured_warnings), f"Expected 60s warning, got: {captured_warnings}"
-
-
-@pytest.mark.anyio
-async def test_watchdog_resets_after_activity_resumes(captured_warnings, monkeypatch):
+async def test_converse_notes_silence_while_waiting(captured_notes, monkeypatch):
+    """The wait loop itself emits the liveness note during a long quiet stretch: a silent model
+    reads as 'still thinking' in the log before the turn completes."""
+    import core.client as client_mod
     import core.diagnostics as diagnostics_mod
+    from claude_agent_sdk import ResultMessage
+    from core.client import consume_stream
+
+    monkeypatch.setattr(client_mod, "_SILENCE_POLL_S", 0.02)
+    monkeypatch.setattr(diagnostics_mod, "_SILENCE_THRESHOLDS_S", (0,))
 
     state = vm.State()
-    state.last_sdk_activity = time.monotonic() - 65  # Idle
-    state.interrupt_event = asyncio.Event()  # Turn in flight, so silence is suspicious
-    stop = asyncio.Event()
+    config = vm.VestaConfig(interrupt_timeout=0.5)
+    mock_client = MagicMock()
+    mock_client.query = AsyncMock()
+    mock_client.interrupt = AsyncMock()
+    state.client = mock_client
 
-    original_wait_for = asyncio.wait_for
-    ticks = 0
+    q: asyncio.Queue = asyncio.Queue()
 
-    async def fast_wait_for(coro, *, timeout):  # type: ignore[no-untyped-def]
-        # One call per watchdog loop iteration; the idle check runs right after each call returns.
-        nonlocal ticks
-        ticks += 1
-        return await original_wait_for(coro, timeout=0.01)
+    async def stream():
+        while True:
+            yield await q.get()
 
-    monkeypatch.setattr(diagnostics_mod.asyncio, "wait_for", fast_wait_for)
+    mock_client.receive_messages = MagicMock(side_effect=lambda: stream())
+    consumer = asyncio.create_task(consume_stream(state=state, config=config))
 
-    def sixty_warning_count() -> int:
-        return len([w for w in captured_warnings if "SDK silent for 60s" in w])
+    async def end_turn_after_quiet():
+        await wait_for_condition(lambda: any("Model quiet" in n for n in captured_notes), message="no liveness note during silence")
+        result = MagicMock(spec=ResultMessage)
+        result.content = []
+        await q.put(result)
 
-    async def resume_then_idle_again():
-        await wait_for_condition(lambda: sixty_warning_count() >= 1, message="watchdog never warned the first time")
-        touch_activity(state, "sdk_message")
-        # Wait two full ticks so at least one idle check definitely ran with the fresh
-        # activity timestamp (clearing the watchdog's warned state), then go idle again.
-        ticks_at_resume = ticks
-        await wait_for_condition(lambda: ticks >= ticks_at_resume + 2, message="watchdog stopped ticking")
-        state.last_sdk_activity = time.monotonic() - 65
-        await wait_for_condition(lambda: sixty_warning_count() >= 2, message="watchdog never re-warned after reset")
-        stop.set()
+    ender = asyncio.create_task(end_turn_after_quiet())
+    try:
+        await asyncio.wait_for(converse("test", state=state, config=config, show_output=False), timeout=5.0)
+        await ender
+    finally:
+        consumer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await consumer
 
-    await asyncio.gather(sdk_watchdog(state, stop=stop), resume_then_idle_again())
-
-    sixty_warnings = [w for w in captured_warnings if "SDK silent for 60s" in w]
-    assert len(sixty_warnings) >= 2, f"Expected 60s warning to fire again after reset, got {len(sixty_warnings)}: {captured_warnings}"
-
-
-@pytest.mark.anyio
-async def test_watchdog_stops_cleanly():
-    state = vm.State()
-    stop = asyncio.Event()
-    stop.set()  # Stop immediately
-    await sdk_watchdog(state, stop=stop)  # Should not hang
-
-
-@pytest.mark.anyio
-async def test_watchdog_emits_error_event_once_per_threshold(fast_watchdog_poll, tmp_path):
-    """Crossing a watchdog threshold emits exactly one error event to the bus, not one per poll."""
-    state = vm.State()
-    state.event_bus = vm.EventBus(data_dir=tmp_path)
-    queue = state.event_bus.subscribe()
-    state.last_sdk_activity = time.monotonic() - 65  # Idle past the 60s threshold
-    state.interrupt_event = asyncio.Event()  # Turn in flight, so silence is suspicious
-    stop = asyncio.Event()
-    seen: list[tp.Any] = []
-
-    def sixty_events() -> list[str]:
-        while not queue.empty():
-            seen.append(queue.get_nowait())
-        return [e["text"] for e in seen if e["type"] == "error" and "SDK silent for 60s" in e["text"]]
-
-    async def stop_after_some_polls():
-        # Wait until the threshold has fired, then let several more polls run to prove
-        # the event is emitted once per crossing rather than once per poll.
-        await wait_for_condition(lambda: len(sixty_events()) >= 1, message="watchdog never emitted")
-        for _ in range(5):
-            await asyncio.sleep(0.02)
-        stop.set()
-
-    await asyncio.gather(sdk_watchdog(state, stop=stop), stop_after_some_polls())
-
-    assert len(sixty_events()) == 1, f"expected exactly one 60s error event, got {sixty_events()}"
-    state.event_bus.close()
-
-
-@pytest.mark.parametrize(
-    "interrupt_in_flight,with_running_tool",
-    [(False, False), (True, True)],
-    ids=["idle-between-turns", "turn-in-flight-tool-running"],
-)
-@pytest.mark.anyio
-async def test_watchdog_stays_quiet_when_silence_is_benign(
-    captured_warnings, fast_watchdog_poll, tmp_path, interrupt_in_flight, with_running_tool
-):
-    """Benign silence emits nothing: either no turn is in flight, or a turn is in flight while a
-    tool actively runs (a long `sleep` or build leaves the SDK silent without being hung)."""
-    state = vm.State()
-    state.event_bus = vm.EventBus(data_dir=tmp_path)
-    queue = state.event_bus.subscribe()
-    state.last_sdk_activity = time.monotonic() - 65  # Idle past the 60s threshold
-    state.interrupt_event = asyncio.Event() if interrupt_in_flight else None
-    if with_running_tool:
-        state.active_tools["tool-1"] = vm.ActiveTool(name="Bash", summary="sleep 180", started_at=time.monotonic() - 65)
-    stop = asyncio.Event()
-
-    def error_events() -> list[tp.Any]:
-        events: list[tp.Any] = []
-        while not queue.empty():
-            event = queue.get_nowait()
-            if event["type"] == "error" and "SDK silent" in event["text"]:
-                events.append(event)
-        return events
-
-    async def let_several_polls_run():
-        for _ in range(5):
-            await asyncio.sleep(0.02)
-        stop.set()
-
-    await asyncio.gather(sdk_watchdog(state, stop=stop), let_several_polls_run())
-
-    assert not [w for w in captured_warnings if "SDK silent" in w], f"expected no warnings for benign silence, got {captured_warnings}"
-    assert error_events() == [], f"expected no error events for benign silence, got {error_events()}"
-    state.event_bus.close()
+    assert any("Model quiet" in n for n in captured_notes), f"expected a liveness note, got: {captured_notes}"
 
 
 # --- Tool duration tracking via hooks ---

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -1,13 +1,13 @@
-"""Tests for SDK activity watchdog, tool duration tracking, and hang diagnostics."""
+"""Tests for turn liveness notes, tool duration tracking, and hang diagnostics."""
 
 import asyncio
-import contextlib
 import time
 import typing as tp
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import core.models as vm
+from conftest import consuming, make_stream_harness, result_msg
 from core.client import converse
 from wait_util import wait_for_condition
 from core.diagnostics import (
@@ -120,21 +120,19 @@ def _quiet_turn(quiet_s: float) -> vm.TurnSignals:
 
 def test_liveness_notes_once_per_interval(captured_notes, state):
     turn = _quiet_turn(25)
-    noted: set[int] = set()
 
-    note_turn_liveness(state, turn=turn, noted_at=noted)
-    note_turn_liveness(state, turn=turn, noted_at=noted)
+    note_turn_liveness(state, turn=turn)
+    note_turn_liveness(state, turn=turn)
 
     assert len([n for n in captured_notes if "quiet for 20s" in n]) == 1, f"one note per interval, got: {captured_notes}"
 
 
 def test_liveness_notes_again_each_interval(captured_notes, state):
     turn = _quiet_turn(25)
-    noted: set[int] = set()
 
-    note_turn_liveness(state, turn=turn, noted_at=noted)
+    note_turn_liveness(state, turn=turn)
     turn.last_visible_at = time.monotonic() - 45
-    note_turn_liveness(state, turn=turn, noted_at=noted)
+    note_turn_liveness(state, turn=turn)
 
     quiet_notes = [n for n in captured_notes if "quiet" in n]
     assert len(quiet_notes) == 2 and "20s" in quiet_notes[0] and "40s" in quiet_notes[1], f"expected 20s then 40s, got: {captured_notes}"
@@ -142,15 +140,14 @@ def test_liveness_notes_again_each_interval(captured_notes, state):
 
 def test_liveness_resets_when_output_lands(captured_notes, state):
     turn = _quiet_turn(25)
-    noted: set[int] = set()
 
-    note_turn_liveness(state, turn=turn, noted_at=noted)
+    note_turn_liveness(state, turn=turn)
     turn.last_visible_at = time.monotonic()  # output emitted
-    note_turn_liveness(state, turn=turn, noted_at=noted)
-    assert noted == set()
+    note_turn_liveness(state, turn=turn)
+    assert turn.quiet_noted_bucket == 0 and not turn.quiet_escalated
 
     turn.last_visible_at = time.monotonic() - 25
-    note_turn_liveness(state, turn=turn, noted_at=noted)
+    note_turn_liveness(state, turn=turn)
 
     assert len([n for n in captured_notes if "quiet for 20s" in n]) == 2, f"expected a re-note after output, got: {captured_notes}"
 
@@ -163,9 +160,8 @@ def test_liveness_reports_thinking_with_token_count(captured_notes, captured_war
     turn = _quiet_turn(325)
     turn.thinking_tokens = 2340
     turn.thinking_tokens_at = time.monotonic() - 5
-    noted: set[int] = set()
 
-    note_turn_liveness(state, turn=turn, noted_at=noted)
+    note_turn_liveness(state, turn=turn)
 
     thinking_notes = [n for n in captured_notes if "Thinking for 320s" in n and "2,340 tokens" in n]
     assert len(thinking_notes) == 1, f"expected a token-count note, got: {captured_notes}"
@@ -180,11 +176,10 @@ def test_liveness_escalates_dead_air_once_past_escalation(captured_warnings, cap
     state.event_bus = vm.EventBus(data_dir=tmp_path)
     queue = state.event_bus.subscribe()
     turn = _quiet_turn(305)  # no thinking_tokens ever seen
-    noted: set[int] = set()
 
-    note_turn_liveness(state, turn=turn, noted_at=noted)
+    note_turn_liveness(state, turn=turn)
     turn.last_visible_at = time.monotonic() - 325  # next interval, still dead air
-    note_turn_liveness(state, turn=turn, noted_at=noted)
+    note_turn_liveness(state, turn=turn)
 
     warnings_seen = [w for w in captured_warnings if "no stream activity for 300s" in w]
     assert len(warnings_seen) == 1, f"expected exactly one warning, got: {captured_warnings}"
@@ -205,9 +200,8 @@ def test_liveness_stays_debug_while_tool_runs(captured_warnings, captured_notes,
     queue = state.event_bus.subscribe()
     state.active_tools["tool-1"] = vm.ActiveTool(name="Bash", summary="sleep 180", started_at=time.monotonic() - 305)
     turn = _quiet_turn(305)
-    noted: set[int] = set()
 
-    note_turn_liveness(state, turn=turn, noted_at=noted)
+    note_turn_liveness(state, turn=turn)
 
     assert [n for n in captured_notes if "quiet" in n or "Thinking" in n] == [], f"expected no notes mid-tool, got: {captured_notes}"
     assert captured_warnings == [], f"expected no warnings mid-tool, got: {captured_warnings}"
@@ -216,59 +210,34 @@ def test_liveness_stays_debug_while_tool_runs(captured_warnings, captured_notes,
 
 
 @pytest.mark.anyio
-async def test_converse_notes_thinking_while_waiting(monkeypatch):
+async def test_converse_notes_thinking_while_waiting(captured_notes, monkeypatch):
     """End to end through the wait loop: the first thinking_tokens tick logs "Thinking..." once,
     the counter stays fresh while producing no visible output, and the interval note reports it."""
     import core.client as client_mod
     import core.diagnostics as diagnostics_mod
-    from claude_agent_sdk import ResultMessage, SystemMessage
-    from core.client import consume_stream
+    from claude_agent_sdk import SystemMessage
 
-    # client.py and diagnostics.py share the core.logger module, so one capture sees both
-    # the first-tick "Thinking..." and the interval notes.
-    client_notes: list[str] = []
-    monkeypatch.setattr(client_mod.logger, "client", lambda msg: client_notes.append(str(msg)))
     monkeypatch.setattr(client_mod, "_SILENCE_POLL_S", 0.02)
     monkeypatch.setattr(diagnostics_mod, "_QUIET_NOTE_INTERVAL_S", 0.01)
 
-    state = vm.State()
-    config = vm.VestaConfig(interrupt_timeout=0.5)
-    mock_client = MagicMock()
-    mock_client.query = AsyncMock()
-    mock_client.interrupt = AsyncMock()
-    state.client = mock_client
-
-    q: asyncio.Queue = asyncio.Queue()
-
-    async def stream():
-        while True:
-            yield await q.get()
-
-    mock_client.receive_messages = MagicMock(side_effect=lambda: stream())
-    consumer = asyncio.create_task(consume_stream(state=state, config=config))
+    state, config, mock_client, emitted, message_queue, consumed = make_stream_harness()
 
     async def think_then_finish():
-        await q.put(SystemMessage(subtype="thinking_tokens", data={"estimated_tokens": 312, "estimated_tokens_delta": 5}))
-        await q.put(SystemMessage(subtype="thinking_tokens", data={"estimated_tokens": 624, "estimated_tokens_delta": 5}))
+        await message_queue.put(SystemMessage(subtype="thinking_tokens", data={"estimated_tokens": 312, "estimated_tokens_delta": 5}))
+        await message_queue.put(SystemMessage(subtype="thinking_tokens", data={"estimated_tokens": 624, "estimated_tokens_delta": 5}))
         await wait_for_condition(
-            lambda: any("Thinking for" in n and "624 tokens" in n for n in client_notes),
+            lambda: any("Thinking for" in n and "624 tokens" in n for n in captured_notes),
             message="no thinking note during quiet stretch",
         )
-        result = MagicMock(spec=ResultMessage)
-        result.content = []
-        await q.put(result)
+        await message_queue.put(result_msg())
 
-    thinker = asyncio.create_task(think_then_finish())
-    try:
+    async with consuming(state, config):
+        thinker = asyncio.create_task(think_then_finish())
         await asyncio.wait_for(converse("test", state=state, config=config, show_output=False), timeout=5.0)
         await thinker
-    finally:
-        consumer.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await consumer
 
-    assert client_notes.count("Thinking...") == 1, f"first tick must log Thinking... exactly once, got: {client_notes}"
-    assert any("Thinking for" in n for n in client_notes), f"expected an interval note, got: {client_notes}"
+    assert captured_notes.count("Thinking...") == 1, f"first tick must log Thinking... exactly once, got: {captured_notes}"
+    assert any("Thinking for" in n for n in captured_notes), f"expected an interval note, got: {captured_notes}"
 
 
 # --- Tool duration tracking via hooks ---
@@ -326,12 +295,11 @@ async def test_tool_failure_hook_cleans_up():
     assert state.last_sdk_activity_label == "tool_fail:Bash"
 
 
-# --- converse() watchdog integration ---
+# --- converse() liveness integration ---
 
 
 async def _run_converse_with_consumer(state, config, messages):
     """Drive one converse() turn with the real stream consumer fed from `messages`."""
-    from core.client import consume_stream
 
     async def stream():
         for msg in messages:
@@ -340,19 +308,13 @@ async def _run_converse_with_consumer(state, config, messages):
 
     assert state.client is not None
     state.client.receive_messages = MagicMock(side_effect=lambda: stream())
-    consumer = asyncio.create_task(consume_stream(state=state, config=config))
-    try:
+    async with consuming(state, config):
         await converse("test", state=state, config=config, show_output=False)
-    finally:
-        consumer.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await consumer
 
 
 @pytest.mark.anyio
 async def test_converse_touches_activity_on_messages():
     """The stream consumer updates last_sdk_activity when SDK messages arrive."""
-    from claude_agent_sdk import ResultMessage
 
     state = vm.State()
     config = vm.VestaConfig(interrupt_timeout=0.5)
@@ -367,9 +329,7 @@ async def test_converse_touches_activity_on_messages():
         msg = MagicMock()
         msg.content = []
         messages.append(msg)
-    result = MagicMock(spec=ResultMessage)
-    result.content = []
-    messages.append(result)
+    messages.append(result_msg())
 
     await _run_converse_with_consumer(state, config, messages)
 
@@ -379,7 +339,6 @@ async def test_converse_touches_activity_on_messages():
 @pytest.mark.anyio
 async def test_converse_clears_active_tools_on_start():
     """converse clears stale active_tools from prior calls."""
-    from claude_agent_sdk import ResultMessage
 
     state = vm.State()
     config = vm.VestaConfig(interrupt_timeout=0.5)
@@ -390,9 +349,6 @@ async def test_converse_clears_active_tools_on_start():
     mock_client.interrupt = AsyncMock()
     state.client = mock_client
 
-    result = MagicMock(spec=ResultMessage)
-    result.content = []
-
-    await _run_converse_with_consumer(state, config, [result])
+    await _run_converse_with_consumer(state, config, [result_msg()])
 
     assert "stale" not in state.active_tools

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -118,31 +118,30 @@ def _quiet_turn(quiet_s: float) -> vm.TurnSignals:
     return turn
 
 
-def test_liveness_notes_once_per_threshold(captured_notes, state):
-    turn = _quiet_turn(65)
+def test_liveness_notes_once_per_interval(captured_notes, state):
+    turn = _quiet_turn(25)
     noted: set[int] = set()
 
     note_turn_liveness(state, turn=turn, noted_at=noted)
     note_turn_liveness(state, turn=turn, noted_at=noted)
 
-    assert len([n for n in captured_notes if "quiet for 60s" in n]) == 1, f"one note per crossing, got: {captured_notes}"
-    assert noted == {60}
+    assert len([n for n in captured_notes if "quiet for 20s" in n]) == 1, f"one note per interval, got: {captured_notes}"
 
 
-def test_liveness_notes_each_threshold_as_quiet_grows(captured_notes, state):
-    turn = _quiet_turn(65)
+def test_liveness_notes_again_each_interval(captured_notes, state):
+    turn = _quiet_turn(25)
     noted: set[int] = set()
 
     note_turn_liveness(state, turn=turn, noted_at=noted)
-    turn.last_visible_at = time.monotonic() - 125
+    turn.last_visible_at = time.monotonic() - 45
     note_turn_liveness(state, turn=turn, noted_at=noted)
 
     quiet_notes = [n for n in captured_notes if "quiet" in n]
-    assert len(quiet_notes) == 2 and "60s" in quiet_notes[0] and "120s" in quiet_notes[1], f"expected 60s then 120s, got: {captured_notes}"
+    assert len(quiet_notes) == 2 and "20s" in quiet_notes[0] and "40s" in quiet_notes[1], f"expected 20s then 40s, got: {captured_notes}"
 
 
 def test_liveness_resets_when_output_lands(captured_notes, state):
-    turn = _quiet_turn(65)
+    turn = _quiet_turn(25)
     noted: set[int] = set()
 
     note_turn_liveness(state, turn=turn, noted_at=noted)
@@ -150,10 +149,10 @@ def test_liveness_resets_when_output_lands(captured_notes, state):
     note_turn_liveness(state, turn=turn, noted_at=noted)
     assert noted == set()
 
-    turn.last_visible_at = time.monotonic() - 65
+    turn.last_visible_at = time.monotonic() - 25
     note_turn_liveness(state, turn=turn, noted_at=noted)
 
-    assert len([n for n in captured_notes if "quiet for 60s" in n]) == 2, f"expected a re-note after output, got: {captured_notes}"
+    assert len([n for n in captured_notes if "quiet for 20s" in n]) == 2, f"expected a re-note after output, got: {captured_notes}"
 
 
 def test_liveness_reports_thinking_with_token_count(captured_notes, captured_warnings, state, tmp_path):
@@ -161,41 +160,42 @@ def test_liveness_reports_thinking_with_token_count(captured_notes, captured_war
     however long the think runs: the model is demonstrably reasoning, not stalled."""
     state.event_bus = vm.EventBus(data_dir=tmp_path)
     queue = state.event_bus.subscribe()
-    turn = _quiet_turn(305)
+    turn = _quiet_turn(325)
     turn.thinking_tokens = 2340
     turn.thinking_tokens_at = time.monotonic() - 5
     noted: set[int] = set()
 
     note_turn_liveness(state, turn=turn, noted_at=noted)
 
-    thinking_notes = [n for n in captured_notes if "Thinking for" in n and "2,340 tokens" in n]
-    assert len(thinking_notes) == 3, f"expected token-count notes at 60/120/300, got: {captured_notes}"
+    thinking_notes = [n for n in captured_notes if "Thinking for 320s" in n and "2,340 tokens" in n]
+    assert len(thinking_notes) == 1, f"expected a token-count note, got: {captured_notes}"
     assert captured_warnings == [], f"healthy thinking must never warn, got: {captured_warnings}"
     assert queue.empty(), "healthy thinking must not emit error events"
     state.event_bus.close()
 
 
-def test_liveness_escalates_dead_air_past_escalation(captured_warnings, captured_notes, state, tmp_path):
+def test_liveness_escalates_dead_air_once_past_escalation(captured_warnings, captured_notes, state, tmp_path):
     """No output AND no thinking ticks past the escalation threshold is a suspected stall:
-    one warning + one error event."""
+    one warning + one error event per quiet stretch, later intervals go back to calm notes."""
     state.event_bus = vm.EventBus(data_dir=tmp_path)
     queue = state.event_bus.subscribe()
     turn = _quiet_turn(305)  # no thinking_tokens ever seen
     noted: set[int] = set()
 
     note_turn_liveness(state, turn=turn, noted_at=noted)
+    turn.last_visible_at = time.monotonic() - 325  # next interval, still dead air
     note_turn_liveness(state, turn=turn, noted_at=noted)
 
-    warnings_300 = [w for w in captured_warnings if "no stream activity for 300s" in w]
-    assert len(warnings_300) == 1, f"expected exactly one 300s warning, got: {captured_warnings}"
+    warnings_seen = [w for w in captured_warnings if "no stream activity for 300s" in w]
+    assert len(warnings_seen) == 1, f"expected exactly one warning, got: {captured_warnings}"
     events = []
     while not queue.empty():
         event = queue.get_nowait()
         if event["type"] == "error" and "no stream activity" in event["text"]:
             events.append(event)
     assert len(events) == 1, f"expected exactly one error event, got: {events}"
-    # The earlier thresholds stay calm INFO notes, not warnings.
-    assert len([n for n in captured_notes if "quiet" in n]) == 2, f"60s+120s notes expected, got: {captured_notes}"
+    # The post-escalation interval logs a calm note, not another warning.
+    assert len([n for n in captured_notes if "quiet for 320s" in n]) == 1, f"expected a calm 320s note, got: {captured_notes}"
     state.event_bus.close()
 
 
@@ -216,16 +216,20 @@ def test_liveness_stays_debug_while_tool_runs(captured_warnings, captured_notes,
 
 
 @pytest.mark.anyio
-async def test_converse_notes_thinking_while_waiting(captured_notes, monkeypatch):
-    """End to end through the wait loop: thinking_tokens system messages keep the turn's counter
-    fresh while producing no visible output, and the liveness note reports the token count."""
+async def test_converse_notes_thinking_while_waiting(monkeypatch):
+    """End to end through the wait loop: the first thinking_tokens tick logs "Thinking..." once,
+    the counter stays fresh while producing no visible output, and the interval note reports it."""
     import core.client as client_mod
     import core.diagnostics as diagnostics_mod
     from claude_agent_sdk import ResultMessage, SystemMessage
     from core.client import consume_stream
 
+    # client.py and diagnostics.py share the core.logger module, so one capture sees both
+    # the first-tick "Thinking..." and the interval notes.
+    client_notes: list[str] = []
+    monkeypatch.setattr(client_mod.logger, "client", lambda msg: client_notes.append(str(msg)))
     monkeypatch.setattr(client_mod, "_SILENCE_POLL_S", 0.02)
-    monkeypatch.setattr(diagnostics_mod, "_QUIET_THRESHOLDS_S", (0,))
+    monkeypatch.setattr(diagnostics_mod, "_QUIET_NOTE_INTERVAL_S", 0.01)
 
     state = vm.State()
     config = vm.VestaConfig(interrupt_timeout=0.5)
@@ -245,8 +249,9 @@ async def test_converse_notes_thinking_while_waiting(captured_notes, monkeypatch
 
     async def think_then_finish():
         await q.put(SystemMessage(subtype="thinking_tokens", data={"estimated_tokens": 312, "estimated_tokens_delta": 5}))
+        await q.put(SystemMessage(subtype="thinking_tokens", data={"estimated_tokens": 624, "estimated_tokens_delta": 5}))
         await wait_for_condition(
-            lambda: any("Thinking for" in n and "312 tokens" in n for n in captured_notes),
+            lambda: any("Thinking for" in n and "624 tokens" in n for n in client_notes),
             message="no thinking note during quiet stretch",
         )
         result = MagicMock(spec=ResultMessage)
@@ -262,7 +267,8 @@ async def test_converse_notes_thinking_while_waiting(captured_notes, monkeypatch
         with contextlib.suppress(asyncio.CancelledError):
             await consumer
 
-    assert any("Thinking for" in n for n in captured_notes), f"expected a thinking note, got: {captured_notes}"
+    assert client_notes.count("Thinking...") == 1, f"first tick must log Thinking... exactly once, got: {client_notes}"
+    assert any("Thinking for" in n for n in client_notes), f"expected an interval note, got: {client_notes}"
 
 
 # --- Tool duration tracking via hooks ---

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -1,6 +1,7 @@
 """Tests for SDK activity watchdog, tool duration tracking, and hang diagnostics."""
 
 import asyncio
+import contextlib
 import tempfile
 import time
 import typing as tp
@@ -328,9 +329,31 @@ async def test_tool_failure_hook_cleans_up():
 # --- converse() watchdog integration ---
 
 
+async def _run_converse_with_consumer(state, config, messages):
+    """Drive one converse() turn with the real stream consumer fed from `messages`."""
+    from core.client import consume_stream
+
+    async def stream():
+        for msg in messages:
+            yield msg
+        await asyncio.Event().wait()
+
+    assert state.client is not None
+    state.client.receive_messages = MagicMock(side_effect=lambda: stream())
+    consumer = asyncio.create_task(consume_stream(state=state, config=config))
+    try:
+        await converse("test", state=state, config=config, show_output=False)
+    finally:
+        consumer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await consumer
+
+
 @pytest.mark.anyio
 async def test_converse_touches_activity_on_messages():
-    """converse updates last_sdk_activity when SDK messages arrive."""
+    """The stream consumer updates last_sdk_activity when SDK messages arrive."""
+    from claude_agent_sdk import ResultMessage
+
     state = vm.State()
     config = vm.VestaConfig(interrupt_timeout=0.5)
 
@@ -339,15 +362,16 @@ async def test_converse_touches_activity_on_messages():
     mock_client.interrupt = AsyncMock()
     state.client = mock_client
 
-    async def three_messages():
-        for _ in range(3):
-            msg = MagicMock()
-            msg.content = []
-            yield msg
+    messages = []
+    for _ in range(3):
+        msg = MagicMock()
+        msg.content = []
+        messages.append(msg)
+    result = MagicMock(spec=ResultMessage)
+    result.content = []
+    messages.append(result)
 
-    mock_client.receive_response = MagicMock(return_value=three_messages())
-
-    await converse("test", state=state, config=config, show_output=False)
+    await _run_converse_with_consumer(state, config, messages)
 
     assert state.last_sdk_activity_label == "sdk_message"
 
@@ -355,6 +379,8 @@ async def test_converse_touches_activity_on_messages():
 @pytest.mark.anyio
 async def test_converse_clears_active_tools_on_start():
     """converse clears stale active_tools from prior calls."""
+    from claude_agent_sdk import ResultMessage
+
     state = vm.State()
     config = vm.VestaConfig(interrupt_timeout=0.5)
     state.active_tools["stale"] = vm.ActiveTool(name="Old", summary="leftover", started_at=0)
@@ -364,12 +390,9 @@ async def test_converse_clears_active_tools_on_start():
     mock_client.interrupt = AsyncMock()
     state.client = mock_client
 
-    async def empty_response():
-        return
-        yield  # Make it an async generator
+    result = MagicMock(spec=ResultMessage)
+    result.content = []
 
-    mock_client.receive_response = MagicMock(return_value=empty_response())
-
-    await converse("test", state=state, config=config, show_output=False)
+    await _run_converse_with_consumer(state, config, [result])
 
     assert "stale" not in state.active_tools


### PR DESCRIPTION
## Problem (#958)

`converse` consumed the SDK stream in per-turn `receive_response()` bites and abandoned it between bites — the post-interrupt drain gave up after 5s. When an interrupted turn's wind-down outlived that drain (routine under heavy thinking / long tools / 1M contexts), its remaining output and `ResultMessage` sat unconsumed:

1. the next turn's `receive_response()` terminated on the **stale** result in ~0s → every turn's output arrived one user message late, indefinitely;
2. with nobody consuming, the SDK's bounded buffer (100 msgs) filled and blocked its single reader task → interrupt acks and `get_context_usage` responses could never be processed (the `SDK interrupt timed out` / `get_context_usage hung` storm in the production logs).

Counting outstanding results was tried and abandoned (#957): stream-json has no query↔result correlation ID and self-initiated CLI continuation turns emit unprompted results, so any bookkeeping degenerates into stacked timing heuristics.

## Fix: never stop consuming

One **`consume_stream` task per client session** reads `receive_messages()` from connect to disconnect and dispatches everything on arrival (emit text/thinking, persist session ids, detect auth loss, log usage). Turn boundaries become advisory **`TurnSignals`**: `converse`/`compact_session` send their query and wait on the open turn's `done` event; a `ResultMessage` closes whichever turn is open, and one arriving with **no** open turn is dropped.

- Nothing can sit unconsumed, jam the SDK's reader, or flush late — by construction, independent of interrupt rate, context size, or load.
- Worst case under weird CLI behavior (a result landing after the bounded post-interrupt grace) is a briefly mislabeled turn boundary: every message still reaches the user in real time, and the labels self-heal at the first idle gap (the final stray result finds no open turn and is dropped).
- The interrupt path no longer abandons anything; the entire drain apparatus (`_STOP`, fresh-iterator drain, `_INTERRUPT_DRAIN_TIMEOUT_S`) is deleted. Silence timeout keeps the exact same budget (`response_timeout` measured from the last stream message).
- `converse` still returns the turn's collected text, so the dash-correction contract and `loops.py` orchestration (boot turns, compaction deferral, notification file lifecycle, idle triage) are untouched.

## Tests

New regression coverage (fast tier, fake stream + real consumer):
- the #958 seed: late result after an interrupt does **not** wedge later turns (real-time delivery + self-heal asserted)
- unprompted continuation result while idle is dropped; next turn unaffected
- wind-down inside the grace stays attributed to the interrupted turn
- stream death mid-turn surfaces through the turn (restart path); silence raises `TimeoutError`
- compaction boundary + result via the consumer

Existing converse/dreamer/watchdog/processor suites ported to the stream harness. `./check.sh agent` green (485 passed, incl. cc_sdk tmux transport suite).

## Field evidence

Both agents on the shared box hit this: `elio-vesta` had interrupt timeouts since 06/29 (the day after the new SDK path went live), `apollo` first wedged 07/02 23:01 after a WhatsApp-daemon-death notification storm (interrupts every 1–2 min) during long 1M-context turns — matching the issue's timeline exactly.

Closes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)