### PR TITLE
feat(stream): live thinking + reply previews via partial-message deltas

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -26,6 +26,7 @@ from .provider import OPENROUTER_SMALL_FAST_MODEL, TERMINAL_PROVIDER_ERRORS, is_
 from .config import CONTEXT_1M_BETA, DEFAULT_CONTEXT_WINDOW
 from . import diagnostics
 from . import sdk_parsing
+from . import stream_preview
 from .helpers import get_constitution_path, get_memory_path
 from .tools import build_vesta_tools_server
 
@@ -139,25 +140,48 @@ def _emit_thinking(block: ThinkingBlock, *, state: vm.State) -> None:
 
 
 def _dispatch_stream_delta(msg: StreamEvent, *, state: vm.State, turn: vm.TurnSignals | None) -> None:
-    """Broadcast an extended-thinking chunk as a live thinking_delta event.
+    """Broadcast streaming previews: extended-thinking chunks as thinking_delta, and the reply
+    the agent is typing into `app-chat send` as chat_delta (extracted live from the Bash tool
+    input, see stream_preview.py).
 
-    Partial stream events are a display-only preview: the complete AssistantMessage that follows
-    carries the authoritative block (emitted + persisted as usual), so deltas are never logged or
-    stored. Sub-agent streams (parent_tool_use_id set) are skipped — their interleaved chunks
-    belong to no visible thinking block."""
+    Partial stream events are a display-only preview: the complete AssistantMessage / ChatEvent
+    that follows is the record, so deltas are never logged or stored. Sub-agent streams
+    (parent_tool_use_id set) are skipped — their interleaved chunks belong to no visible block."""
     if msg.parent_tool_use_id is not None:
         return
     if turn and not turn.show_output:
         return
     event = msg.event
+    if event["type"] == "content_block_start" and turn:
+        block = event["content_block"]
+        if block["type"] == "tool_use" and block["name"] == "Bash":
+            turn.preview_block = event["index"]
+            turn.preview_raw = ""
+            turn.preview_sent = ""
+        return
+    if event["type"] == "content_block_stop" and turn and event["index"] == turn.preview_block:
+        turn.preview_block = None
+        return
     if event["type"] != "content_block_delta":
         return
     delta = event["delta"]
-    if delta["type"] != "thinking_delta":
+    if delta["type"] == "thinking_delta":
+        chunk = delta["thinking"]
+        if chunk:
+            state.event_bus.emit({"type": "thinking_delta", "text": chunk})
         return
-    chunk = delta["thinking"]
-    if chunk:
-        state.event_bus.emit({"type": "thinking_delta", "text": chunk})
+    if delta["type"] != "input_json_delta" or not turn or event["index"] != turn.preview_block:
+        return
+    turn.preview_raw += delta["partial_json"]
+    message = stream_preview.extract_chat_preview(turn.preview_raw)
+    if message is None or message == turn.preview_sent:
+        return
+    if message.startswith(turn.preview_sent):
+        state.event_bus.emit({"type": "chat_delta", "text": message[len(turn.preview_sent) :], "reset": False})
+    else:
+        # A chained second `app-chat send` restarted the preview; replace the draft.
+        state.event_bus.emit({"type": "chat_delta", "text": message, "reset": True})
+    turn.preview_sent = message
 
 
 async def _dispatch_message(msg: Message, *, state: vm.State, config: vm.VestaConfig) -> None:

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -13,6 +13,7 @@ from claude_agent_sdk import (
     ClaudeAgentOptions,
     Message,
     ResultMessage,
+    StreamEvent,
     SystemMessage,
     ThinkingBlock,
 )
@@ -137,6 +138,28 @@ def _emit_thinking(block: ThinkingBlock, *, state: vm.State) -> None:
     state.event_bus.emit({"type": "thinking", "text": block.thinking, "signature": block.signature})
 
 
+def _dispatch_stream_delta(msg: StreamEvent, *, state: vm.State, turn: vm.TurnSignals | None) -> None:
+    """Broadcast an extended-thinking chunk as a live thinking_delta event.
+
+    Partial stream events are a display-only preview: the complete AssistantMessage that follows
+    carries the authoritative block (emitted + persisted as usual), so deltas are never logged or
+    stored. Sub-agent streams (parent_tool_use_id set) are skipped — their interleaved chunks
+    belong to no visible thinking block."""
+    if msg.parent_tool_use_id is not None:
+        return
+    if turn and not turn.show_output:
+        return
+    event = msg.event
+    if event["type"] != "content_block_delta":
+        return
+    delta = event["delta"]
+    if delta["type"] != "thinking_delta":
+        return
+    chunk = delta["thinking"]
+    if chunk:
+        state.event_bus.emit({"type": "thinking_delta", "text": chunk})
+
+
 async def _dispatch_message(msg: Message, *, state: vm.State, config: vm.VestaConfig) -> None:
     """Handle one SDK stream message: emit content, persist session ids, detect auth loss, and
     close the open turn on its ResultMessage. Messages with no open turn (a self-initiated
@@ -146,6 +169,9 @@ async def _dispatch_message(msg: Message, *, state: vm.State, config: vm.VestaCo
     turn = state.turn
     if turn:
         turn.last_message_at = time.monotonic()
+    if isinstance(msg, StreamEvent):
+        _dispatch_stream_delta(msg, state=state, turn=turn)
+        return
     if isinstance(msg, AssistantMessage):
         state.compacting = False
     if isinstance(msg, SystemMessage) and msg.subtype == "compact_boundary":
@@ -423,6 +449,9 @@ def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgent
         skills="all",
         add_dirs=[str(config.agent_dir), os.path.expanduser("~")],
         thinking=thinking_config,
+        # Stream extended-thinking chunks as they are produced (consume_stream broadcasts them as
+        # live thinking_delta events) instead of one silent multi-minute wait per thinking block.
+        include_partial_messages=True,
         max_buffer_size=10 * 1024 * 1024,
         stderr=diagnostics.make_stderr_handler(state),
         mcp_servers={"vesta": build_vesta_tools_server(state, config)},

--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -118,6 +118,16 @@ class ChatEvent(_BaseEvent):
     text: str
 
 
+class ChatDeltaEvent(_BaseEvent):
+    type: tp.Literal["chat_delta"]
+    # One live chunk of the reply the agent is currently typing into `app-chat send` (extracted
+    # from the streaming tool input, see stream_preview.py). Broadcast-only, like thinking_delta:
+    # the real ChatEvent that follows is the record. reset=True replaces the accumulated draft
+    # (a chained second send restarted the preview) instead of appending.
+    text: str
+    reset: bool
+
+
 type StreamEvent = (
     StatusEvent
     | ToolStartEvent
@@ -132,6 +142,7 @@ type StreamEvent = (
     | SubagentStartEvent
     | SubagentStopEvent
     | ChatEvent
+    | ChatDeltaEvent
 )
 
 
@@ -261,10 +272,10 @@ class EventBus:
 
     def emit(self, event: StreamEvent) -> None:
         event["ts"] = dt.datetime.now(dt.UTC).isoformat()
-        # status (activity flips), notification_cleared (pending deltas), and thinking_delta
-        # (streaming preview chunks) are live-only signals with no place in history — broadcast
-        # them but don't persist.
-        if event["type"] not in ("status", "notification_cleared", "thinking_delta") and self._conn:
+        # status (activity flips), notification_cleared (pending deltas), and the streaming
+        # preview chunks (thinking_delta, chat_delta) are live-only signals with no place in
+        # history — broadcast them but don't persist.
+        if event["type"] not in ("status", "notification_cleared", "thinking_delta", "chat_delta") and self._conn:
             # Event-logging is best-effort: a failed history write must NEVER crash the
             # agent loop. Without this guard, a transient "database is locked" (the db
             # held by a long maintenance op past the busy timeout) propagated out of emit

--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -53,6 +53,14 @@ class ThinkingEvent(_BaseEvent):
     signature: str
 
 
+class ThinkingDeltaEvent(_BaseEvent):
+    type: tp.Literal["thinking_delta"]
+    # One raw extended-thinking chunk, streamed as the model produces it. A live broadcast-only
+    # preview (never persisted, see emit()): the complete ThinkingEvent that follows is the record;
+    # clients accumulate deltas for display and drop the buffer when the full block arrives.
+    text: str
+
+
 class UserEvent(_BaseEvent):
     type: tp.Literal["user"]
     text: str
@@ -116,6 +124,7 @@ type StreamEvent = (
     | ToolEndEvent
     | AssistantEvent
     | ThinkingEvent
+    | ThinkingDeltaEvent
     | UserEvent
     | ErrorEvent
     | NotificationEvent
@@ -252,9 +261,10 @@ class EventBus:
 
     def emit(self, event: StreamEvent) -> None:
         event["ts"] = dt.datetime.now(dt.UTC).isoformat()
-        # status (activity flips) and notification_cleared (pending deltas) are live-only signals with
-        # no place in history — broadcast them but don't persist.
-        if event["type"] not in ("status", "notification_cleared") and self._conn:
+        # status (activity flips), notification_cleared (pending deltas), and thinking_delta
+        # (streaming preview chunks) are live-only signals with no place in history — broadcast
+        # them but don't persist.
+        if event["type"] not in ("status", "notification_cleared", "thinking_delta") and self._conn:
             # Event-logging is best-effort: a failed history write must NEVER crash the
             # agent loop. Without this guard, a transient "database is locked" (the db
             # held by a long maintenance op past the busy timeout) propagated out of emit

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -79,6 +79,11 @@ class TurnSignals:
     done: asyncio.Event = dc.field(default_factory=asyncio.Event)
     error: Exception | None = None
     last_message_at: float = dc.field(default_factory=time.monotonic)
+    # Live chat-reply preview (stream_preview.py): the Bash tool_use block being watched, its
+    # accumulated partial input JSON, and the preview text already broadcast as chat_delta.
+    preview_block: int | None = None
+    preview_raw: str = ""
+    preview_sent: str = ""
 
 
 @dc.dataclass

--- a/agent/core/stream_preview.py
+++ b/agent/core/stream_preview.py
@@ -1,0 +1,85 @@
+"""Best-effort live extraction of an outgoing chat message from a streaming Bash tool call.
+
+The agent's chat replies are typed as the `-m`/`--message` argument of an `app-chat send`
+command inside a Bash tool call. With partial messages enabled the tool input streams as
+`input_json_delta` chunks, so the reply text is visible while the model writes it. This module
+owns that one decision: given the raw partial JSON accumulated so far, what reply text (if any)
+is readable? It is a display-only preview — wrong or absent extraction costs nothing, because
+the real ChatEvent that follows is the record.
+"""
+
+import re
+
+# `"command"` value opener inside the streamed Bash tool-input JSON.
+_COMMAND_KEY_RE = re.compile(r'"command"\s*:\s*"')
+# `app-chat send … -m/--message <quote>` inside the decoded command string.
+_SEND_MESSAGE_RE = re.compile(r"app-chat\s+send\s+(?:[^;|&]*?\s)??(?:-m|--message)\s+(['\"])")
+
+_JSON_ESCAPES = {"n": "\n", "t": "\t", "r": "\r", '"': '"', "\\": "\\", "/": "/", "b": "\b", "f": "\f"}
+
+
+def _decode_json_string_prefix(body: str) -> str:
+    """Decode a (possibly incomplete) JSON string value prefix, stopping at its closing quote
+    or at a partial escape sequence cut by a chunk boundary."""
+    out: list[str] = []
+    i = 0
+    while i < len(body):
+        ch = body[i]
+        if ch == '"':
+            break
+        if ch == "\\":
+            if i + 1 >= len(body):
+                break
+            esc = body[i + 1]
+            if esc == "u":
+                if i + 6 > len(body):
+                    break
+                out.append(chr(int(body[i + 2 : i + 6], 16)))
+                i += 6
+                continue
+            out.append(_JSON_ESCAPES[esc] if esc in _JSON_ESCAPES else esc)
+            i += 2
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _shell_quoted_prefix(body: str, quote: str) -> str:
+    """The content of a shell-quoted string prefix, up to its closing quote if present.
+
+    Double quotes honor backslash escapes for `"` and `\\`; single quotes take everything
+    verbatim until the next single quote."""
+    if quote == "'":
+        end = body.find("'")
+        return body if end == -1 else body[:end]
+    out: list[str] = []
+    i = 0
+    while i < len(body):
+        ch = body[i]
+        if ch == '"':
+            break
+        if ch == "\\" and i + 1 < len(body) and body[i + 1] in ('"', "\\"):
+            out.append(body[i + 1])
+            i += 2
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def extract_chat_preview(raw_partial_json: str) -> str | None:
+    """The app-chat reply text visible so far in a partially streamed Bash tool input.
+
+    None until an `app-chat send … -m/--message <quote>` opener has streamed. Chained commands
+    preview the last send; the caller detects a restart by prefix mismatch."""
+    key = _COMMAND_KEY_RE.search(raw_partial_json)
+    if not key:
+        return None
+    command = _decode_json_string_prefix(raw_partial_json[key.end() :])
+    opener = None
+    for match in _SEND_MESSAGE_RE.finditer(command):
+        opener = match
+    if not opener:
+        return None
+    return _shell_quoted_prefix(command[opener.end() :], opener.group(1))

--- a/agent/tests/test_contract.py
+++ b/agent/tests/test_contract.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from core.events import (
     AssistantEvent,
+    ChatDeltaEvent,
     ChatEvent,
     ErrorEvent,
     EventBus,
@@ -39,6 +40,7 @@ _STREAM_FIXTURES: list[tp.Any] = [
     ThinkingEvent(type="thinking", ts="2026-01-01T00:00:00Z", text="hmm", signature="sig"),
     ThinkingDeltaEvent(type="thinking_delta", ts="2026-01-01T00:00:00Z", text="hm"),
     ChatEvent(type="chat", ts="2026-01-01T00:00:00Z", text="yo"),
+    ChatDeltaEvent(type="chat_delta", ts="2026-01-01T00:00:00Z", text="y", reset=False),
     ToolStartEvent(type="tool_start", ts="2026-01-01T00:00:00Z", tool="Bash", input="ls", subagent=False),
     ToolEndEvent(type="tool_end", ts="2026-01-01T00:00:00Z", tool="Bash", subagent=False),
     ErrorEvent(type="error", ts="2026-01-01T00:00:00Z", text="oops"),
@@ -112,9 +114,11 @@ def test_eventbus_roundtrip_all_types(tmp_path):
     """Emit each persistable event type, read back, verify the type tag survives."""
     bus = EventBus(data_dir=tmp_path)
 
-    # `status`, `notification_cleared`, and `thinking_delta` are transient live signals,
-    # intentionally not persisted (see EventBus.emit).
-    persistable = [event for event in _STREAM_FIXTURES if event["type"] not in ("status", "notification_cleared", "thinking_delta")]
+    # `status`, `notification_cleared`, and the streaming previews (`thinking_delta`,
+    # `chat_delta`) are transient live signals, intentionally not persisted (see EventBus.emit).
+    persistable = [
+        event for event in _STREAM_FIXTURES if event["type"] not in ("status", "notification_cleared", "thinking_delta", "chat_delta")
+    ]
     for event in persistable:
         bus.emit(event)
 

--- a/agent/tests/test_contract.py
+++ b/agent/tests/test_contract.py
@@ -22,6 +22,7 @@ from core.events import (
     StatusEvent,
     SubagentStartEvent,
     SubagentStopEvent,
+    ThinkingDeltaEvent,
     ThinkingEvent,
     ToolEndEvent,
     ToolStartEvent,
@@ -36,6 +37,7 @@ _STREAM_FIXTURES: list[tp.Any] = [
     UserEvent(type="user", ts="2026-01-01T00:00:00Z", text="hello", input_method="typed"),
     AssistantEvent(type="assistant", ts="2026-01-01T00:00:00Z", text="hi"),
     ThinkingEvent(type="thinking", ts="2026-01-01T00:00:00Z", text="hmm", signature="sig"),
+    ThinkingDeltaEvent(type="thinking_delta", ts="2026-01-01T00:00:00Z", text="hm"),
     ChatEvent(type="chat", ts="2026-01-01T00:00:00Z", text="yo"),
     ToolStartEvent(type="tool_start", ts="2026-01-01T00:00:00Z", tool="Bash", input="ls", subagent=False),
     ToolEndEvent(type="tool_end", ts="2026-01-01T00:00:00Z", tool="Bash", subagent=False),
@@ -110,9 +112,9 @@ def test_eventbus_roundtrip_all_types(tmp_path):
     """Emit each persistable event type, read back, verify the type tag survives."""
     bus = EventBus(data_dir=tmp_path)
 
-    # `status` and `notification_cleared` are transient live signals, intentionally not persisted
-    # (see EventBus.emit).
-    persistable = [event for event in _STREAM_FIXTURES if event["type"] not in ("status", "notification_cleared")]
+    # `status`, `notification_cleared`, and `thinking_delta` are transient live signals,
+    # intentionally not persisted (see EventBus.emit).
+    persistable = [event for event in _STREAM_FIXTURES if event["type"] not in ("status", "notification_cleared", "thinking_delta")]
     for event in persistable:
         bus.emit(event)
 

--- a/agent/tests/test_eventbus.py
+++ b/agent/tests/test_eventbus.py
@@ -54,6 +54,19 @@ def test_status_not_persisted(event_bus):
     assert len(events) == 0
 
 
+def test_thinking_delta_broadcast_but_not_persisted(event_bus):
+    """thinking_delta is a live streaming preview: subscribers get it, history never does
+    (the complete ThinkingEvent that follows is the persisted record)."""
+    q = event_bus.subscribe()
+    event_bus.emit({"type": "thinking_delta", "text": "chunk one"})
+    received = q.get_nowait()
+    assert received["type"] == "thinking_delta"
+    assert received["text"] == "chunk one"
+
+    events, _ = event_bus.recent()
+    assert len(events) == 0
+
+
 def test_no_data_dir():
     """EventBus works without persistence (no data_dir)."""
     bus = EventBus()

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -561,6 +561,55 @@ async def test_converse_emits_thinking_events():
 
 
 @pytest.mark.anyio
+async def test_thinking_deltas_stream_live_and_stay_out_of_the_turn():
+    """Partial thinking chunks are broadcast as thinking_delta the moment they arrive (no waiting
+    for the block to finish); sub-agent and non-thinking deltas are skipped, and none of it
+    disturbs the turn's collected texts."""
+    from claude_agent_sdk import StreamEvent, TextBlock
+    from core.client import converse
+
+    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    deltas: list[str] = []
+    original_emit = state.event_bus.emit
+
+    def tracking_emit(event):
+        if isinstance(event, dict) and event.get("type") == "thinking_delta":
+            deltas.append(event["text"])
+        original_emit(event)
+
+    state.event_bus.emit = tracking_emit
+
+    def thinking_delta(chunk, parent_tool_use_id=None):
+        return StreamEvent(
+            uuid="u1",
+            session_id="sess-1",
+            event={"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": chunk}},
+            parent_tool_use_id=parent_tool_use_id,
+        )
+
+    async with _consuming(state, config):
+        await message_queue.put(thinking_delta("let me "))
+        await message_queue.put(thinking_delta("think"))
+        await message_queue.put(thinking_delta("subagent noise", parent_tool_use_id="tool-x"))
+        await message_queue.put(
+            StreamEvent(
+                uuid="u2",
+                session_id="sess-1",
+                event={"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "ignored"}},
+            )
+        )
+        # Deltas arrive live, before the turn is anywhere near done.
+        await wait_for_condition(lambda: len(consumed) >= 4, message="deltas never consumed")
+        assert deltas == ["let me ", "think"]
+        await message_queue.put(_assistant_msg([TextBlock("the answer")]))
+        await message_queue.put(_result_msg())
+        responses = await converse("test", state=state, config=config, show_output=True)
+
+    assert responses == ["the answer"], f"deltas must not leak into the turn texts: {responses}"
+    assert deltas == ["let me ", "think"]
+
+
+@pytest.mark.anyio
 async def test_converse_exits_promptly_on_interrupt_event():
     """converse interrupts and returns within the bounded grace even when the interrupted turn's
     ResultMessage never arrives (the CLI wind-down outliving the grace is the #958 seed)."""

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -610,6 +610,71 @@ async def test_thinking_deltas_stream_live_and_stay_out_of_the_turn():
 
 
 @pytest.mark.anyio
+async def test_chat_reply_preview_streams_from_bash_tool_input():
+    """The reply being typed into `app-chat send -m "..."` streams as chat_delta chunks while
+    the tool input forms; a chained second send resets the draft."""
+    import json as _json
+
+    from claude_agent_sdk import StreamEvent, TextBlock
+    from core.client import converse
+
+    state, config, mock_client, emitted, message_queue, consumed = _make_stream_harness()
+    deltas: list[tuple[str, bool]] = []
+    original_emit = state.event_bus.emit
+
+    def tracking_emit(event):
+        if isinstance(event, dict) and event.get("type") == "chat_delta":
+            deltas.append((event["text"], event["reset"]))
+        original_emit(event)
+
+    state.event_bus.emit = tracking_emit
+
+    def stream_event(event):
+        return StreamEvent(uuid="u", session_id="s", event=event)
+
+    full_input = _json.dumps({"command": 'app-chat send -m "hey, on it"; app-chat send -m "brb"'})
+    async with _consuming(state, config):
+        # The tool input streams mid-turn (a turn must be open for the preview to attach).
+        conv = asyncio.create_task(converse("test", state=state, config=config, show_output=True))
+        await wait_for_condition(lambda: mock_client.query.await_count >= 1, message="query never sent")
+        await message_queue.put(
+            stream_event(
+                {"type": "content_block_start", "index": 1, "content_block": {"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}}
+            )
+        )
+        for start in range(0, len(full_input), 7):
+            await message_queue.put(
+                stream_event(
+                    {
+                        "type": "content_block_delta",
+                        "index": 1,
+                        "delta": {"type": "input_json_delta", "partial_json": full_input[start : start + 7]},
+                    }
+                )
+            )
+        await message_queue.put(stream_event({"type": "content_block_stop", "index": 1}))
+        await message_queue.put(_assistant_msg([TextBlock("sent")]))
+        await message_queue.put(_result_msg())
+        await conv
+
+    assert deltas, "no chat_delta emitted"
+    # Replay the draft the way a client would: append, or replace on reset.
+    draft = ""
+    saw_reset = False
+    for text, reset in deltas:
+        saw_reset = saw_reset or reset
+        draft = text if reset else draft + text
+    assert draft == "brb", f"final draft wrong: {draft!r}"
+    assert saw_reset, "chained send must reset the draft"
+    first_draft = ""
+    for text, reset in deltas:
+        if reset:
+            break
+        first_draft += text
+    assert first_draft == "hey, on it", f"first send preview wrong: {first_draft!r}"
+
+
+@pytest.mark.anyio
 async def test_converse_exits_promptly_on_interrupt_event():
     """converse interrupts and returns within the bounded grace even when the interrupted turn's
     ResultMessage never arrives (the CLI wind-down outliving the grace is the #958 seed)."""

--- a/agent/tests/test_stream_preview.py
+++ b/agent/tests/test_stream_preview.py
@@ -1,0 +1,71 @@
+"""Tests for the live chat-reply preview extractor (stream_preview.py)."""
+
+import json
+
+import pytest
+
+from core.stream_preview import extract_chat_preview
+
+
+def _bash_input_json(command: str) -> str:
+    return json.dumps({"command": command})
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # The common shapes googe actually produces.
+        (_bash_input_json('app-chat send -m "hey, on it"'), "hey, on it"),
+        (_bash_input_json("app-chat send --message 'single quoted'"), "single quoted"),
+        (_bash_input_json('sleep 4; app-chat send -m "second message"'), "second message"),
+        # Chained sends preview the last one.
+        (_bash_input_json('app-chat send -m "first"; app-chat send -m "second"'), "second"),
+        # Shell escapes inside double quotes.
+        (_bash_input_json('app-chat send -m "she said \\"hi\\""'), 'she said "hi"'),
+        # JSON escapes in the command string (newlines in the message).
+        (_bash_input_json('app-chat send -m "line one\nline two"'), "line one\nline two"),
+        # Not a chat send: no preview.
+        (_bash_input_json("ls -la /tmp"), None),
+        (_bash_input_json("app-chat history --limit 5"), None),
+        # Other keys before command: still found once command streams.
+        (json.dumps({"description": "reply", "command": 'app-chat send -m "yo"'}), "yo"),
+    ],
+)
+def test_complete_inputs(raw, expected):
+    assert extract_chat_preview(raw) == expected
+
+
+def test_streams_incrementally():
+    """The preview grows chunk by chunk as the tool input streams."""
+    full = _bash_input_json('app-chat send -m "hello there, world"')
+    seen: list[str | None] = []
+    for cut in range(0, len(full) + 1, 3):
+        seen.append(extract_chat_preview(full[:cut]))
+    # None until the opening quote has streamed, then a growing prefix, ending complete.
+    non_null = [s for s in seen if s is not None]
+    assert non_null, "preview never appeared"
+    assert non_null[-1] == "hello there, world"
+    for earlier, later in zip(non_null, non_null[1:]):
+        assert later.startswith(earlier), f"preview must only grow: {earlier!r} -> {later!r}"
+
+
+def test_partial_json_escape_at_chunk_boundary():
+    """A chunk ending mid-escape must not corrupt the preview (decode stops at the boundary)."""
+    full = _bash_input_json('app-chat send -m "before\\after"')  # \\ in json = one backslash
+    # Cut right after the lone backslash inside the JSON string.
+    cut = full.index("\\\\") + 1
+    partial = extract_chat_preview(full[:cut])
+    assert partial == "before" or partial is None
+
+
+def test_incomplete_unicode_escape_is_deferred():
+    raw = '{"command": "app-chat send -m \\"caf\\u00'
+    assert extract_chat_preview(raw) in ("caf", None)
+    raw_done = '{"command": "app-chat send -m \\"caf\\u00e9'
+    assert extract_chat_preview(raw_done) == "café"
+
+
+def test_message_capped_at_closing_quote():
+    """Trailing command text after the closing quote never leaks into the preview."""
+    raw = _bash_input_json('app-chat send -m "done" && echo ok')
+    assert extract_chat_preview(raw) == "done"

--- a/apps/web/src/components/Chat/ChatMessageArea/index.tsx
+++ b/apps/web/src/components/Chat/ChatMessageArea/index.tsx
@@ -13,6 +13,7 @@ import { ArrowDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CardContent } from "@/components/ui/card";
 import type { VestaEvent } from "@/lib/types";
+import { Markdown } from "@/lib/markdown";
 import { cn } from "@/lib/utils";
 import { ChatBubble } from "../ChatBubble";
 import { buildDecorated } from "./virtual";
@@ -51,6 +52,7 @@ interface ChatMessageAreaProps {
   notAuthenticated: boolean;
   isTyping: boolean;
   liveThinking: string;
+  liveReply: string;
   isMobile: boolean;
 }
 
@@ -121,6 +123,7 @@ export function ChatMessageArea({
   notAuthenticated,
   isTyping,
   liveThinking,
+  liveReply,
   isMobile,
 }: ChatMessageAreaProps) {
   const decorated = useMemo(() => buildDecorated(chatMessages), [chatMessages]);
@@ -321,7 +324,16 @@ export function ChatMessageArea({
                         </div>
                       </div>
                     )}
-                    {isTyping && (
+                    {liveReply && (
+                      <div className="mt-2 flex justify-start">
+                        <div className="max-w-[85%] rounded-2xl rounded-bl-sm bg-secondary/70 px-3.5 py-2.5 text-secondary-foreground/90">
+                          <div className="min-w-0 break-words">
+                            <Markdown>{liveReply}</Markdown>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                    {isTyping && !liveReply && (
                       <div className="flex justify-start mt-2">
                         <div className="flex items-center gap-1 bg-secondary text-secondary-foreground rounded-2xl rounded-bl-sm px-3.5 py-2.5">
                           <span className="size-1.5 rounded-full bg-secondary-foreground/45 animate-bounce [animation-delay:0ms]" />

--- a/apps/web/src/components/Chat/ChatMessageArea/index.tsx
+++ b/apps/web/src/components/Chat/ChatMessageArea/index.tsx
@@ -13,7 +13,6 @@ import { ArrowDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CardContent } from "@/components/ui/card";
 import type { VestaEvent } from "@/lib/types";
-import { Markdown } from "@/lib/markdown";
 import { cn } from "@/lib/utils";
 import { ChatBubble } from "../ChatBubble";
 import { buildDecorated } from "./virtual";
@@ -325,13 +324,17 @@ export function ChatMessageArea({
                       </div>
                     )}
                     {liveReply && (
-                      <div className="mt-2 flex justify-start">
-                        <div className="max-w-[85%] rounded-2xl rounded-bl-sm bg-secondary/70 px-3.5 py-2.5 text-secondary-foreground/90">
-                          <div className="min-w-0 break-words">
-                            <Markdown>{liveReply}</Markdown>
-                          </div>
-                        </div>
-                      </div>
+                      /* Rendered through ChatBubble as a timestamp-less chat event so the draft is
+                         pixel-identical to the committed bubble that replaces it — same primitives,
+                         same padding, and the same gap buildDecorated will assign that row. */
+                      <ChatBubble
+                        event={{ type: "chat", text: liveReply }}
+                        className={
+                          row.event.type === "chat" ? "mt-1.5" : "mt-5"
+                        }
+                        fullscreen={fullscreen}
+                        isMobile={isMobile}
+                      />
                     )}
                     {isTyping && !liveReply && (
                       <div className="flex justify-start mt-2">

--- a/apps/web/src/components/Chat/ChatMessageArea/index.tsx
+++ b/apps/web/src/components/Chat/ChatMessageArea/index.tsx
@@ -50,6 +50,7 @@ interface ChatMessageAreaProps {
   agentName: string;
   notAuthenticated: boolean;
   isTyping: boolean;
+  liveThinking: string;
   isMobile: boolean;
 }
 
@@ -119,6 +120,7 @@ export function ChatMessageArea({
   agentName,
   notAuthenticated,
   isTyping,
+  liveThinking,
   isMobile,
 }: ChatMessageAreaProps) {
   const decorated = useMemo(() => buildDecorated(chatMessages), [chatMessages]);
@@ -306,6 +308,19 @@ export function ChatMessageArea({
                 </div>
                 {isLast && (
                   <div className="px-4 pb-4">
+                    {liveThinking && (
+                      <div className="mt-2 flex justify-start">
+                        {/* Bottom-anchored peephole: overflow clips from the top, so the newest
+                            thinking lines stay visible as the block grows. */}
+                        <div className="flex max-h-24 max-w-[85%] flex-col justify-end overflow-hidden">
+                          <p className="whitespace-pre-wrap text-xs italic leading-relaxed text-muted-foreground/70">
+                            {liveThinking.length > 600
+                              ? `…${liveThinking.slice(-600)}`
+                              : liveThinking}
+                          </p>
+                        </div>
+                      </div>
+                    )}
                     {isTyping && (
                       <div className="flex justify-start mt-2">
                         <div className="flex items-center gap-1 bg-secondary text-secondary-foreground rounded-2xl rounded-bl-sm px-3.5 py-2.5">

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -46,6 +46,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   const {
     messages,
     liveThinking,
+    liveReply,
     isTyping,
     connected,
     historyLoaded,
@@ -139,6 +140,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
           hasMore={hasMore}
           chatMessages={chatMessages}
           liveThinking={liveThinking}
+          liveReply={liveReply}
           connected={connected}
           historyLoaded={historyLoaded}
           agentName={name}

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -45,6 +45,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
 
   const {
     messages,
+    liveThinking,
     isTyping,
     connected,
     historyLoaded,
@@ -137,6 +138,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
           loadingMore={loadingMore}
           hasMore={hasMore}
           chatMessages={chatMessages}
+          liveThinking={liveThinking}
           connected={connected}
           historyLoaded={historyLoaded}
           agentName={name}

--- a/apps/web/src/lib/api-contract.test.ts
+++ b/apps/web/src/lib/api-contract.test.ts
@@ -85,6 +85,7 @@ describe("agent stream contract", () => {
       "thinking",
       "thinking_delta",
       "chat",
+      "chat_delta",
       "tool_start",
       "tool_end",
       "error",

--- a/apps/web/src/lib/api-contract.test.ts
+++ b/apps/web/src/lib/api-contract.test.ts
@@ -83,6 +83,7 @@ describe("agent stream contract", () => {
       "user",
       "assistant",
       "thinking",
+      "thinking_delta",
       "chat",
       "tool_start",
       "tool_end",

--- a/apps/web/src/lib/stream-event-fixtures.ts
+++ b/apps/web/src/lib/stream-event-fixtures.ts
@@ -26,6 +26,11 @@ export const streamEventFixtures = {
       "signature": "sig"
     },
     {
+      "type": "thinking_delta",
+      "ts": "2026-01-01T00:00:00Z",
+      "text": "hm"
+    },
+    {
       "type": "chat",
       "ts": "2026-01-01T00:00:00Z",
       "text": "yo"

--- a/apps/web/src/lib/stream-event-fixtures.ts
+++ b/apps/web/src/lib/stream-event-fixtures.ts
@@ -36,6 +36,12 @@ export const streamEventFixtures = {
       "text": "yo"
     },
     {
+      "type": "chat_delta",
+      "ts": "2026-01-01T00:00:00Z",
+      "text": "y",
+      "reset": false
+    },
+    {
       "type": "tool_start",
       "ts": "2026-01-01T00:00:00Z",
       "tool": "Bash",

--- a/apps/web/src/lib/types.test.ts
+++ b/apps/web/src/lib/types.test.ts
@@ -9,6 +9,7 @@ describe("VestaEvent contract", () => {
     "thinking",
     "thinking_delta",
     "chat",
+    "chat_delta",
     "tool_start",
     "tool_end",
     "error",

--- a/apps/web/src/lib/types.test.ts
+++ b/apps/web/src/lib/types.test.ts
@@ -7,6 +7,7 @@ describe("VestaEvent contract", () => {
     "user",
     "assistant",
     "thinking",
+    "thinking_delta",
     "chat",
     "tool_start",
     "tool_end",

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -32,6 +32,9 @@ export type VestaEvent =
   | (BaseEvent & { type: "user"; text: string; input_method?: InputMethod })
   | (BaseEvent & { type: "assistant"; text: string })
   | (BaseEvent & { type: "thinking"; text: string; signature: string })
+  // Live streaming preview of an in-progress extended-thinking block. Broadcast-only (never in
+  // history): accumulate for display, drop the buffer when the complete `thinking` event arrives.
+  | (BaseEvent & { type: "thinking_delta"; text: string })
   | (BaseEvent & { type: "chat"; text: string })
   | (BaseEvent & {
       type: "tool_start";

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -36,6 +36,9 @@ export type VestaEvent =
   // history): accumulate for display, drop the buffer when the complete `thinking` event arrives.
   | (BaseEvent & { type: "thinking_delta"; text: string })
   | (BaseEvent & { type: "chat"; text: string })
+  // Live chunk of the reply the agent is typing into `app-chat send`. Broadcast-only preview:
+  // append to the draft (or replace it when reset), drop it when the real chat event arrives.
+  | (BaseEvent & { type: "chat_delta"; text: string; reset: boolean })
   | (BaseEvent & {
       type: "tool_start";
       tool: string;

--- a/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
+++ b/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
@@ -47,6 +47,9 @@ export function useAgentSocketState({
   // Live preview of the in-progress extended-thinking block, accumulated from thinking_delta
   // events. Cleared when the turn's visible output lands (the complete block is the record).
   const [liveThinking, setLiveThinking] = useState("");
+  // Live draft of the reply the agent is typing into `app-chat send`, accumulated from
+  // chat_delta events. Replaced by the real chat bubble the moment it arrives.
+  const [liveReply, setLiveReply] = useState("");
   const [isTyping, setIsTyping] = useState(false);
   const [connected, setConnected] = useState(false);
   const [historyLoaded, setHistoryLoaded] = useState(false);
@@ -63,6 +66,8 @@ export function useAgentSocketState({
   const liveThinkingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const liveReplyRef = useRef("");
+  const liveReplyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingEchoesRef = useRef<string[]>([]);
   const cursorRef = useRef<number | null>(null);
   const onAssistantMessageRef = useRef(onAssistantMessage);
@@ -91,6 +96,24 @@ export function useAgentSocketState({
     }
     liveThinkingRef.current = "";
     setLiveThinking("");
+  }, []);
+
+  const appendLiveReply = useCallback((text: string, reset: boolean) => {
+    liveReplyRef.current = reset ? text : liveReplyRef.current + text;
+    if (liveReplyTimerRef.current) return;
+    liveReplyTimerRef.current = setTimeout(() => {
+      liveReplyTimerRef.current = null;
+      setLiveReply(liveReplyRef.current);
+    }, 150);
+  }, []);
+
+  const clearLiveReply = useCallback(() => {
+    if (liveReplyTimerRef.current) {
+      clearTimeout(liveReplyTimerRef.current);
+      liveReplyTimerRef.current = null;
+    }
+    liveReplyRef.current = "";
+    setLiveReply("");
   }, []);
 
   const flushQueue = useCallback(() => {
@@ -134,11 +157,16 @@ export function useAgentSocketState({
   }, [flushQueue]);
 
   const enqueueChatMessage = useCallback(
-    (event: VestaEvent) => {
+    (event: VestaEvent, opts?: { immediate: boolean }) => {
       chatQueueRef.current.push(event);
+      if (opts?.immediate) {
+        if (typingTimerRef.current) clearTimeout(typingTimerRef.current);
+        flushQueue();
+        return;
+      }
       drainQueue();
     },
-    [drainQueue],
+    [drainQueue, flushQueue],
   );
 
   useEffect(() => {
@@ -158,6 +186,7 @@ export function useAgentSocketState({
       pendingEchoesRef.current = [];
       resetTyping();
       clearLiveThinking();
+      clearLiveReply();
     };
 
     resetConnection();
@@ -190,6 +219,10 @@ export function useAgentSocketState({
             appendLiveThinking(event.text);
             return;
           }
+          if (event.type === "chat_delta") {
+            appendLiveReply(event.text, event.reset);
+            return;
+          }
           // The turn's visible output (or the finished block itself) supersedes the preview.
           if (
             event.type === "thinking" ||
@@ -200,7 +233,11 @@ export function useAgentSocketState({
             clearLiveThinking();
           }
           if (event.type === "chat") {
-            enqueueChatMessage(event);
+            // A streamed draft already showed this reply forming; the typing-pacing
+            // simulation would only delay the committed bubble behind its own preview.
+            const hadDraft = liveReplyRef.current !== "";
+            clearLiveReply();
+            enqueueChatMessage(event, { immediate: hadDraft });
           } else {
             setMessages((prev) => capTail([...prev, event]));
           }
@@ -224,8 +261,16 @@ export function useAgentSocketState({
       setConnected(false);
       resetTyping();
       clearLiveThinking();
+      clearLiveReply();
     };
-  }, [active, name, appendLiveThinking, clearLiveThinking]);
+  }, [
+    active,
+    name,
+    appendLiveThinking,
+    clearLiveThinking,
+    appendLiveReply,
+    clearLiveReply,
+  ]);
 
   const sendEvent = useCallback((event: object): boolean => {
     const ws = wsRef.current?.current();
@@ -278,6 +323,7 @@ export function useAgentSocketState({
     messages,
     agentState,
     liveThinking,
+    liveReply,
     isTyping,
     connected,
     historyLoaded,

--- a/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
+++ b/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
@@ -44,6 +44,9 @@ export function useAgentSocketState({
 }: UseAgentSocketOptions) {
   const [messages, setMessages] = useState<VestaEvent[]>([]);
   const [agentState, setAgentState] = useState<AgentActivityState>("idle");
+  // Live preview of the in-progress extended-thinking block, accumulated from thinking_delta
+  // events. Cleared when the turn's visible output lands (the complete block is the record).
+  const [liveThinking, setLiveThinking] = useState("");
   const [isTyping, setIsTyping] = useState(false);
   const [connected, setConnected] = useState(false);
   const [historyLoaded, setHistoryLoaded] = useState(false);
@@ -56,6 +59,10 @@ export function useAgentSocketState({
   const loadingMoreRef = useRef(false);
 
   const wsRef = useRef<ReconnectingWsHandle | null>(null);
+  const liveThinkingRef = useRef("");
+  const liveThinkingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const pendingEchoesRef = useRef<string[]>([]);
   const cursorRef = useRef<number | null>(null);
   const onAssistantMessageRef = useRef(onAssistantMessage);
@@ -65,6 +72,26 @@ export function useAgentSocketState({
   const chatQueueRef = useRef<VestaEvent[]>([]);
   const drainingRef = useRef(false);
   const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Deltas arrive many times a second; batch them into one state update per frame-ish tick so
+  // a long thinking stretch doesn't re-render the chat per chunk.
+  const appendLiveThinking = useCallback((text: string) => {
+    liveThinkingRef.current += text;
+    if (liveThinkingTimerRef.current) return;
+    liveThinkingTimerRef.current = setTimeout(() => {
+      liveThinkingTimerRef.current = null;
+      setLiveThinking(liveThinkingRef.current);
+    }, 150);
+  }, []);
+
+  const clearLiveThinking = useCallback(() => {
+    if (liveThinkingTimerRef.current) {
+      clearTimeout(liveThinkingTimerRef.current);
+      liveThinkingTimerRef.current = null;
+    }
+    liveThinkingRef.current = "";
+    setLiveThinking("");
+  }, []);
 
   const flushQueue = useCallback(() => {
     for (const event of chatQueueRef.current) {
@@ -130,6 +157,7 @@ export function useAgentSocketState({
       cursorRef.current = null;
       pendingEchoesRef.current = [];
       resetTyping();
+      clearLiveThinking();
     };
 
     resetConnection();
@@ -158,6 +186,19 @@ export function useAgentSocketState({
               return;
             }
           }
+          if (event.type === "thinking_delta") {
+            appendLiveThinking(event.text);
+            return;
+          }
+          // The turn's visible output (or the finished block itself) supersedes the preview.
+          if (
+            event.type === "thinking" ||
+            event.type === "assistant" ||
+            event.type === "chat" ||
+            (event.type === "status" && event.state === "idle")
+          ) {
+            clearLiveThinking();
+          }
           if (event.type === "chat") {
             enqueueChatMessage(event);
           } else {
@@ -182,8 +223,9 @@ export function useAgentSocketState({
       wsRef.current = null;
       setConnected(false);
       resetTyping();
+      clearLiveThinking();
     };
-  }, [active, name]);
+  }, [active, name, appendLiveThinking, clearLiveThinking]);
 
   const sendEvent = useCallback((event: object): boolean => {
     const ws = wsRef.current?.current();
@@ -235,6 +277,7 @@ export function useAgentSocketState({
   return {
     messages,
     agentState,
+    liveThinking,
     isTyping,
     connected,
     historyLoaded,

--- a/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
+++ b/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { VestaEvent, AgentActivityState, InputMethod } from "@/lib/types";
 import { wsUrl, fetchHistory } from "@/lib/connection";
 import {
@@ -29,6 +29,90 @@ function typingDelay(charCount: number): number {
   return raw + Math.floor(Math.random() * variance * 2) - variance;
 }
 
+// Reveal speed for streamed previews: fraction of the backlog revealed per animation frame,
+// with a floor so short backlogs still type steadily (~60cps at 60fps). Proportional catch-up
+// keeps the draft close to the wire without the chunk-at-a-time jumps of raw delta cadence.
+const REVEAL_BACKLOG_FRACTION = 0.08;
+const REVEAL_MIN_CHARS_PER_FRAME = 1;
+
+/** Streamed-text smoother: chunks append to a buffer, an rAF loop reveals the buffer
+ * incrementally so the preview reads as continuous typing regardless of chunk cadence.
+ * Returns the revealed text plus a stable controls object (safe in effect deps — the
+ * text updates per frame, the controls never change identity). */
+function useStreamedText(): [
+  string,
+  {
+    append: (chunk: string, reset?: boolean) => void;
+    clear: () => void;
+    hasBuffered: () => boolean;
+  },
+] {
+  const [text, setText] = useState("");
+  const bufferRef = useRef("");
+  const revealedRef = useRef(0);
+  const frameRef = useRef<number | null>(null);
+
+  const schedule = useCallback(() => {
+    if (frameRef.current !== null) return;
+    const tick = () => {
+      frameRef.current = null;
+      const backlog = bufferRef.current.length - revealedRef.current;
+      if (backlog <= 0) return;
+      const step = Math.max(
+        REVEAL_MIN_CHARS_PER_FRAME,
+        Math.ceil(backlog * REVEAL_BACKLOG_FRACTION),
+      );
+      revealedRef.current = Math.min(
+        bufferRef.current.length,
+        revealedRef.current + step,
+      );
+      setText(bufferRef.current.slice(0, revealedRef.current));
+      if (revealedRef.current < bufferRef.current.length) {
+        frameRef.current = requestAnimationFrame(tick);
+      }
+    };
+    frameRef.current = requestAnimationFrame(tick);
+  }, []);
+
+  const append = useCallback(
+    (chunk: string, reset = false) => {
+      if (reset) {
+        bufferRef.current = chunk;
+        revealedRef.current = 0;
+      } else {
+        bufferRef.current += chunk;
+      }
+      schedule();
+    },
+    [schedule],
+  );
+
+  const clear = useCallback(() => {
+    if (frameRef.current !== null) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+    bufferRef.current = "";
+    revealedRef.current = 0;
+    setText("");
+  }, []);
+
+  // Whether anything has streamed in (buffered, not necessarily revealed yet).
+  const hasBuffered = useCallback(() => bufferRef.current !== "", []);
+
+  useEffect(() => {
+    return () => {
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    };
+  }, []);
+
+  const controls = useMemo(
+    () => ({ append, clear, hasBuffered }),
+    [append, clear, hasBuffered],
+  );
+  return [text, controls];
+}
+
 interface UseAgentSocketOptions {
   name: string | null;
   active: boolean;
@@ -44,12 +128,11 @@ export function useAgentSocketState({
 }: UseAgentSocketOptions) {
   const [messages, setMessages] = useState<VestaEvent[]>([]);
   const [agentState, setAgentState] = useState<AgentActivityState>("idle");
-  // Live preview of the in-progress extended-thinking block, accumulated from thinking_delta
-  // events. Cleared when the turn's visible output lands (the complete block is the record).
-  const [liveThinking, setLiveThinking] = useState("");
-  // Live draft of the reply the agent is typing into `app-chat send`, accumulated from
-  // chat_delta events. Replaced by the real chat bubble the moment it arrives.
-  const [liveReply, setLiveReply] = useState("");
+  // Live preview of the in-progress extended-thinking block (thinking_delta events), and the
+  // draft of the reply the agent is typing into `app-chat send` (chat_delta events). Both are
+  // smoothed by useStreamedText and cleared when the turn's visible output lands.
+  const [liveThinking, thinkingStream] = useStreamedText();
+  const [liveReply, replyStream] = useStreamedText();
   const [isTyping, setIsTyping] = useState(false);
   const [connected, setConnected] = useState(false);
   const [historyLoaded, setHistoryLoaded] = useState(false);
@@ -62,12 +145,6 @@ export function useAgentSocketState({
   const loadingMoreRef = useRef(false);
 
   const wsRef = useRef<ReconnectingWsHandle | null>(null);
-  const liveThinkingRef = useRef("");
-  const liveThinkingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-  const liveReplyRef = useRef("");
-  const liveReplyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingEchoesRef = useRef<string[]>([]);
   const cursorRef = useRef<number | null>(null);
   const onAssistantMessageRef = useRef(onAssistantMessage);
@@ -77,44 +154,6 @@ export function useAgentSocketState({
   const chatQueueRef = useRef<VestaEvent[]>([]);
   const drainingRef = useRef(false);
   const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Deltas arrive many times a second; batch them into one state update per frame-ish tick so
-  // a long thinking stretch doesn't re-render the chat per chunk.
-  const appendLiveThinking = useCallback((text: string) => {
-    liveThinkingRef.current += text;
-    if (liveThinkingTimerRef.current) return;
-    liveThinkingTimerRef.current = setTimeout(() => {
-      liveThinkingTimerRef.current = null;
-      setLiveThinking(liveThinkingRef.current);
-    }, 150);
-  }, []);
-
-  const clearLiveThinking = useCallback(() => {
-    if (liveThinkingTimerRef.current) {
-      clearTimeout(liveThinkingTimerRef.current);
-      liveThinkingTimerRef.current = null;
-    }
-    liveThinkingRef.current = "";
-    setLiveThinking("");
-  }, []);
-
-  const appendLiveReply = useCallback((text: string, reset: boolean) => {
-    liveReplyRef.current = reset ? text : liveReplyRef.current + text;
-    if (liveReplyTimerRef.current) return;
-    liveReplyTimerRef.current = setTimeout(() => {
-      liveReplyTimerRef.current = null;
-      setLiveReply(liveReplyRef.current);
-    }, 150);
-  }, []);
-
-  const clearLiveReply = useCallback(() => {
-    if (liveReplyTimerRef.current) {
-      clearTimeout(liveReplyTimerRef.current);
-      liveReplyTimerRef.current = null;
-    }
-    liveReplyRef.current = "";
-    setLiveReply("");
-  }, []);
 
   const flushQueue = useCallback(() => {
     for (const event of chatQueueRef.current) {
@@ -185,8 +224,8 @@ export function useAgentSocketState({
       cursorRef.current = null;
       pendingEchoesRef.current = [];
       resetTyping();
-      clearLiveThinking();
-      clearLiveReply();
+      thinkingStream.clear();
+      replyStream.clear();
     };
 
     resetConnection();
@@ -216,11 +255,11 @@ export function useAgentSocketState({
             }
           }
           if (event.type === "thinking_delta") {
-            appendLiveThinking(event.text);
+            thinkingStream.append(event.text);
             return;
           }
           if (event.type === "chat_delta") {
-            appendLiveReply(event.text, event.reset);
+            replyStream.append(event.text, event.reset);
             return;
           }
           // The turn's visible output (or the finished block itself) supersedes the preview.
@@ -230,13 +269,13 @@ export function useAgentSocketState({
             event.type === "chat" ||
             (event.type === "status" && event.state === "idle")
           ) {
-            clearLiveThinking();
+            thinkingStream.clear();
           }
           if (event.type === "chat") {
             // A streamed draft already showed this reply forming; the typing-pacing
             // simulation would only delay the committed bubble behind its own preview.
-            const hadDraft = liveReplyRef.current !== "";
-            clearLiveReply();
+            const hadDraft = replyStream.hasBuffered();
+            replyStream.clear();
             enqueueChatMessage(event, { immediate: hadDraft });
           } else {
             setMessages((prev) => capTail([...prev, event]));
@@ -260,17 +299,10 @@ export function useAgentSocketState({
       wsRef.current = null;
       setConnected(false);
       resetTyping();
-      clearLiveThinking();
-      clearLiveReply();
+      thinkingStream.clear();
+      replyStream.clear();
     };
-  }, [
-    active,
-    name,
-    appendLiveThinking,
-    clearLiveThinking,
-    appendLiveReply,
-    clearLiveReply,
-  ]);
+  }, [active, name, thinkingStream, replyStream]);
 
   const sendEvent = useCallback((event: object): boolean => {
     const ws = wsRef.current?.current();

--- a/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
+++ b/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
@@ -29,11 +29,21 @@ function typingDelay(charCount: number): number {
   return raw + Math.floor(Math.random() * variance * 2) - variance;
 }
 
-// Reveal speed for streamed previews: fraction of the backlog revealed per animation frame,
-// with a floor so short backlogs still type steadily (~60cps at 60fps). Proportional catch-up
-// keeps the draft close to the wire without the chunk-at-a-time jumps of raw delta cadence.
-const REVEAL_BACKLOG_FRACTION = 0.08;
-const REVEAL_MIN_CHARS_PER_FRAME = 1;
+// Streamed previews reveal exactly ONE word per tick — a steady rhythm reads as typing, while
+// variable multi-char steps read as pops. Backlog pressure shortens the interval between words
+// (never enlarges the step), so catch-up is faster typing, not bigger jumps.
+const REVEAL_INTERVAL_RELAXED_MS = 64;
+const REVEAL_INTERVAL_BUSY_MS = 32;
+const REVEAL_INTERVAL_BACKLOGGED_MS = 16;
+const REVEAL_BUSY_BACKLOG_CHARS = 150;
+const REVEAL_BACKLOGGED_CHARS = 400;
+
+function nextWordBoundary(text: string, from: number): number {
+  let i = from;
+  while (i < text.length && /\s/.test(text[i])) i++;
+  while (i < text.length && !/\s/.test(text[i])) i++;
+  return i;
+}
 
 /** Streamed-text smoother: chunks append to a buffer, an rAF loop reveals the buffer
  * incrementally so the preview reads as continuous typing regardless of chunk cadence.
@@ -52,22 +62,27 @@ function useStreamedText(): [
   const revealedRef = useRef(0);
   const frameRef = useRef<number | null>(null);
 
+  const lastRevealRef = useRef(0);
+
   const schedule = useCallback(() => {
     if (frameRef.current !== null) return;
-    const tick = () => {
+    const tick = (now: number) => {
       frameRef.current = null;
-      const backlog = bufferRef.current.length - revealedRef.current;
+      const buffer = bufferRef.current;
+      const backlog = buffer.length - revealedRef.current;
       if (backlog <= 0) return;
-      const step = Math.max(
-        REVEAL_MIN_CHARS_PER_FRAME,
-        Math.ceil(backlog * REVEAL_BACKLOG_FRACTION),
-      );
-      revealedRef.current = Math.min(
-        bufferRef.current.length,
-        revealedRef.current + step,
-      );
-      setText(bufferRef.current.slice(0, revealedRef.current));
-      if (revealedRef.current < bufferRef.current.length) {
+      const interval =
+        backlog > REVEAL_BACKLOGGED_CHARS
+          ? REVEAL_INTERVAL_BACKLOGGED_MS
+          : backlog > REVEAL_BUSY_BACKLOG_CHARS
+            ? REVEAL_INTERVAL_BUSY_MS
+            : REVEAL_INTERVAL_RELAXED_MS;
+      if (now - lastRevealRef.current >= interval) {
+        lastRevealRef.current = now;
+        revealedRef.current = nextWordBoundary(buffer, revealedRef.current);
+        setText(buffer.slice(0, revealedRef.current));
+      }
+      if (revealedRef.current < buffer.length) {
         frameRef.current = requestAnimationFrame(tick);
       }
     };
@@ -94,6 +109,7 @@ function useStreamedText(): [
     }
     bufferRef.current = "";
     revealedRef.current = 0;
+    lastRevealRef.current = 0;
     setText("");
   }, []);
 


### PR DESCRIPTION
Stacked on #959 (base branch: `fix/stream-consumer`).

## Problem

Long turns are silent until they finish: extended thinking arrives as one complete block after minutes of nothing, and the reply bubble lands whole after a further gap while the model types the `app-chat send` command. On big-context agents this reads as "hung".

## Change

Two live previews, both built on `include_partial_messages=True` and dispatched by the #959 stream consumer. Both are **broadcast-only** (never persisted, never logged) — the complete `ThinkingEvent` / `ChatEvent` that follows remains the record, so a wrong or missing preview costs nothing.

**`thinking_delta`** — top-level extended-thinking chunks, streamed as they're produced. The web chat shows a muted, bottom-anchored ticker under the last message while the agent thinks. Bonus: deltas refresh the turn's silence budget, so long thinking can no longer trip `response_timeout`.

**`chat_delta`** — the reply the agent is *typing into* `app-chat send`, extracted live from the streaming Bash tool input. `stream_preview.py` owns the extraction: incrementally decode the `"command"` JSON string prefix, find the last `app-chat send -m/--message <quote>`, return the shell-quoted text visible so far (both quote styles, JSON + shell escapes, chunk-boundary-safe, capped at the closing quote; `reset=true` when a chained second send restarts the draft). The web chat renders it as a forming agent bubble in place of the typing dots, and commits the real bubble immediately on arrival (skipping the typing-pacing simulation, which would only delay the bubble behind its own preview).

Sub-agent streams and hidden turns are skipped. CLI/vestad ignore unknown event types — unaffected.

## Verified live

`thinking_delta` verified end-to-end on a real agent (googe): WS capture shows chunks streaming during the turn and rendering in the dev app. `chat_delta` verified by tests; live check pending (same deploy).

## Tests

Extractor table tests (quote styles, escapes, incremental growth, chunk-boundary escapes, chained sends, non-chat commands), consumer emission tests for both delta types (sub-agent filtering, turn texts undisturbed, reset replay), bus non-persistence, regenerated cross-language contract fixtures. `./check.sh agent` green (501 passed), web vitest green (123 passed), eslint 0 errors.

Note: `prettier --check` and `tsc -b` fail on `origin/master` in files untouched here — pre-existing breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)