### PR TITLE
feat(vestad): show agents in the status banner

### DIFF
--- a/docs/superpowers/specs/2026-07-03-agents-in-status-banner-design.md
+++ b/docs/superpowers/specs/2026-07-03-agents-in-status-banner-design.md
@@ -1,0 +1,86 @@
+# Agents in the vestad status banner — design
+
+**Date:** 2026-07-03
+**Status:** approved
+
+## Goal
+
+`vestad status` shows each agent's live status. Every banner path (daemon startup and
+`vestad status`) shows the number of agents and their names.
+
+```
+── agents (2) ─────────────────────
+vesta      alive
+backup     stopped
+```
+
+At daemon startup the status column is empty (agents are just being started by
+`reconcile_containers`; any status printed then would be stale seconds later).
+
+## How the status crosses the process boundary
+
+`vestad status` is a separate process from the daemon, so it cannot read the daemon's
+in-memory `AgentStatusCache`. Rather than adding an HTTP client + tokio runtime to the
+status command, the daemon persists its cached agent list into `status.json` — the file
+`vestad status` already loads, pid-gated so a dead daemon's snapshot is never shown.
+
+Rejected alternative: `GET /agents` from the status command. It gives fresher data
+(the file is at most ~3s stale, one cache poll) but requires a runtime (reqwest's
+`blocking` feature is not enabled), a timeout, and a fallback branch. Staleness of a
+few seconds is acceptable for a status command.
+
+## Changes
+
+### `docker.rs`
+
+- `AgentStatus` derives `Deserialize` (it already serializes `snake_case` into the
+  `GET /agents` responses; `Status::load` now needs to read it back).
+- A human-text helper next to the enum (one owner): `alive`, `setting up`,
+  `not authenticated`, ... — snake_case with spaces.
+- `env_file_names` becomes `pub(crate)` so `main.rs` can seed agent names at boot
+  without re-implementing the read_dir.
+
+### `status.rs`
+
+- `Status` gains `agents: Vec<AgentEntry>`; `AgentEntry { name: String, status:
+  Option<AgentStatus> }` lives here — this module owns the `status.json` format.
+- `BoxRow::Kv` label widens from `&'static str` to `String` (mechanical `.into()` at
+  the existing call sites). Agent names are runtime values, and `print_banner`
+  pre-pads them to `max(BANNER_LABEL_W, longest_name + 2)` so the status column stays
+  aligned for names longer than the fixed 9-char label column.
+- `print_banner` renders a `── agents (N) ──` rule followed by one row per agent;
+  the status column renders the human text, or empty when `None`. Zero agents renders
+  the rule with `(0)` and no rows.
+
+### `main.rs` (daemon boot)
+
+- `Status::new` gains the agents vector; boot seeds it with names from the env files
+  (`docker::env_file_names`), statuses `None`. Banner prints count + names.
+
+### Live updates (mirrors `on_tunnel_up`)
+
+- `main.rs` builds `on_agents_changed: Arc<dyn Fn(Vec<ListEntry>) + Send + Sync>`
+  capturing the existing `Arc<Mutex<Status>>` + config dir: it maps `ListEntry` →
+  `AgentEntry`, swaps `Status.agents`, persists.
+- Threaded through `ServerConfig` → `serve::run_server` → `spawn_agent_status_task`.
+- The polling task invokes it exactly when `agents_tx.send_if_modified` reports a real
+  change, so `status.json` is rewritten only on agent transitions (boot churn, then
+  quiet).
+
+### `vestad status`
+
+Mechanically unchanged: load `status.json`, pid-gate, render. Statuses appear because
+the daemon persisted them (at most ~3s stale).
+
+## Testing
+
+- `status.rs` unit tests: agent rows render with and without statuses; count appears
+  in the rule; zero-agent case; long-name column alignment.
+- Round-trip test extended to cover `agents` (exercises `AgentStatus` Deserialize),
+  mirroring `status_json_round_trips_all_tunnel_states`.
+
+## Out of scope
+
+- The `Status` command's existing header line (`vestad vX (path, N agents)`) keeps its
+  count — partially redundant with the new section, left alone (surgical).
+- No changes to `GET /agents`, `AgentStatusCache` semantics, or the web app.

--- a/vestad/src/agent_status.rs
+++ b/vestad/src/agent_status.rs
@@ -11,6 +11,10 @@ use crate::serve::ServiceEntry;
 
 const POLL_INTERVAL_SECS: u64 = 3;
 
+/// Invoked with the fresh agent list whenever the polled list actually changes
+/// (the daemon persists it into `status.json` for the `vestad status` banner).
+pub type OnAgentsChanged = Arc<dyn Fn(&[ListEntry]) + Send + Sync>;
+
 /// Cached agent list + activity states, updated by a background task.
 /// WS handlers subscribe via the watch receivers.
 pub struct AgentStatusCache {
@@ -101,6 +105,7 @@ pub fn spawn_agent_status_task(
     docker: Docker,
     http_client: reqwest::Client,
     agents_dir: PathBuf,
+    on_agents_changed: OnAgentsChanged,
 ) {
     tokio::spawn(async move {
         let mut agent_ws_handles: HashMap<String, AgentWsHandle> = HashMap::new();
@@ -112,13 +117,16 @@ pub fn spawn_agent_status_task(
             let agents = docker::list_agents(&docker, &http_client, &agents_dir).await;
 
             // Update the agents watch channel (only notifies if changed)
-            cache.agents_tx.send_if_modified(|current| {
+            let changed = cache.agents_tx.send_if_modified(|current| {
                 if *current == agents {
                     return false;
                 }
                 *current = agents.clone();
                 true
             });
+            if changed {
+                on_agents_changed(&agents);
+            }
 
             // Reconcile internal WS connections for activity state
             let alive_agents: HashMap<String, u16> = agents

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -8,7 +8,7 @@ use bollard::query_parameters::{
 use bollard::Docker;
 use bytes::Bytes;
 use futures_util::StreamExt;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -162,7 +162,7 @@ pub enum ContainerStatus {
     Dead,
 }
 
-#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentStatus {
     Alive,
@@ -178,6 +178,23 @@ pub enum AgentStatus {
     Stopped,
     Dead,
     NotFound,
+}
+
+impl AgentStatus {
+    /// Human-readable form for terminal surfaces (the status banner): the
+    /// snake_case wire name with spaces.
+    pub fn human_text(self) -> &'static str {
+        match self {
+            AgentStatus::Alive => "alive",
+            AgentStatus::SettingUp => "setting up",
+            AgentStatus::Starting => "starting",
+            AgentStatus::NotAuthenticated => "not authenticated",
+            AgentStatus::Unprovisioned => "unprovisioned",
+            AgentStatus::Stopped => "stopped",
+            AgentStatus::Dead => "dead",
+            AgentStatus::NotFound => "not found",
+        }
+    }
 }
 
 #[derive(Serialize, Clone)]
@@ -806,7 +823,7 @@ fn all_agent_ports(agents_dir: &std::path::Path) -> HashSet<u16> {
 }
 
 /// List agent names that have env files in the agents directory.
-fn env_file_names(agents_dir: &std::path::Path) -> Vec<String> {
+pub(crate) fn env_file_names(agents_dir: &std::path::Path) -> Vec<String> {
     let Ok(entries) = std::fs::read_dir(agents_dir) else { return Vec::new() };
     entries
         .flatten()
@@ -2221,6 +2238,14 @@ mod tests {
         assert_eq!(status_from_readiness(true, false, true), SettingUp);
         assert_eq!(status_from_readiness(false, false, true), NotAuthenticated);
         assert_eq!(status_from_readiness(false, false, false), Unprovisioned);
+    }
+
+    #[test]
+    fn agent_status_human_text_reads_as_words() {
+        assert_eq!(AgentStatus::Alive.human_text(), "alive");
+        assert_eq!(AgentStatus::SettingUp.human_text(), "setting up");
+        assert_eq!(AgentStatus::NotAuthenticated.human_text(), "not authenticated");
+        assert_eq!(AgentStatus::NotFound.human_text(), "not found");
     }
 
     #[test]

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -31,7 +31,7 @@ mod tunnel;
 mod types;
 mod update_check;
 
-use status::{Status, TunnelStatus};
+use status::{AgentEntry, Status, TunnelStatus};
 
 
 #[derive(Parser)]
@@ -512,6 +512,12 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
             // Build the status snapshot, persist it before the API opens (so any
             // reader that sees the daemon reachable also sees status.json), and
             // print the banner from it — the same banner `vestad status` renders.
+            // Agents are seeded by name only (statuses unknown until the status
+            // cache polls the just-started containers).
+            let agents = docker::env_file_names(&config.join("agents"))
+                .into_iter()
+                .map(|name| AgentEntry { name, status: None })
+                .collect();
             let status = Status::new(
                 env!("CARGO_PKG_VERSION").to_string(),
                 user,
@@ -520,6 +526,7 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
                 expose_lan,
                 lan_url.clone(),
                 tunnel_status,
+                agents,
             );
             status.persist(&config);
             status.print_banner(&api_key);
@@ -561,6 +568,23 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
             let tunnel_supervisor = tunnel_intended
                 .then(|| tunnel::supervise_tunnel(config.clone(), port, on_tunnel_up));
 
+            // Keep the agents section of status.json fresh: the agent-status cache
+            // task invokes this whenever the polled agent list actually changes.
+            let on_agents_changed: agent_status::OnAgentsChanged = {
+                let status = status.clone();
+                let config = config.clone();
+                std::sync::Arc::new(move |entries: &[docker::ListEntry]| {
+                    let agents = entries
+                        .iter()
+                        .map(|entry| AgentEntry { name: entry.name.clone(), status: Some(entry.status) })
+                        .collect();
+                    if let Ok(mut s) = status.lock() {
+                        s.set_agents(agents);
+                        s.persist(&config);
+                    }
+                })
+            };
+
             serve::run_server(serve::ServerConfig {
                 port,
                 http_listener,
@@ -573,6 +597,7 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
                 dev_mode,
                 expose_lan,
                 lan_url,
+                on_agents_changed,
             }).await;
 
             if let Some(supervisor) = tunnel_supervisor {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2463,6 +2463,7 @@ pub struct ServerConfig {
     pub dev_mode: bool,
     pub expose_lan: bool,
     pub lan_url: Option<String>,
+    pub on_agents_changed: agent_status::OnAgentsChanged,
 }
 
 pub async fn run_server(cfg: ServerConfig) {
@@ -2478,6 +2479,7 @@ pub async fn run_server(cfg: ServerConfig) {
         dev_mode,
         expose_lan,
         lan_url,
+        on_agents_changed,
     } = cfg;
     let agents_dir = config_dir.join("agents");
     let env_config = docker::AgentEnvConfig {
@@ -2528,6 +2530,7 @@ pub async fn run_server(cfg: ServerConfig) {
         docker,
         state.http_client.clone(),
         state.env_config.agents_dir.clone(),
+        on_agents_changed,
     );
     let app = build_router(state.clone());
     spawn_auto_backup_task(state.clone());

--- a/vestad/src/status.rs
+++ b/vestad/src/status.rs
@@ -4,6 +4,7 @@
 //! they never show a dead daemon's state. This module owns the file path, its
 //! format, and the banner rendering ("one owner per decision").
 
+use crate::docker::AgentStatus;
 use crate::paint;
 use qrcode::{render::unicode, EcLevel, QrCode};
 use serde::{Deserialize, Serialize};
@@ -32,12 +33,12 @@ const VESTA_ART: [&str; 6] = [
 /// so the renderer can size the box and pad every line to a uniform interior.
 enum BoxRow {
     Gap,
-    Art(usize),               // index into VESTA_ART, centered, accent colour
-    Center(String),           // centered dim text (e.g. the version subtitle)
-    Raw(String),              // left-aligned uncoloured text (QR rows must stay scannable)
-    Kv(&'static str, String), // "label   value", left-aligned
-    Value(String),            // a full-width left-aligned value (e.g. the api key)
-    Rule(&'static str),       // "── label ─────" section divider
+    Art(usize),     // index into VESTA_ART, centered, accent colour
+    Center(String), // centered dim text (e.g. the version subtitle)
+    Raw(String),    // left-aligned uncoloured text (QR rows must stay scannable)
+    Kv(String, String), // "label   value", left-aligned; labels longer than the fixed column widen it
+    Value(String),  // a full-width left-aligned value (e.g. the api key)
+    Rule(String),   // "── label ─────" section divider
 }
 
 impl BoxRow {
@@ -47,7 +48,7 @@ impl BoxRow {
             BoxRow::Gap => 0,
             BoxRow::Art(_) => BANNER_ART_W,
             BoxRow::Center(s) | BoxRow::Raw(s) | BoxRow::Value(s) => s.chars().count(),
-            BoxRow::Kv(_, value) => BANNER_LABEL_W + value.chars().count(),
+            BoxRow::Kv(label, value) => label.chars().count().max(BANNER_LABEL_W) + value.chars().count(),
             BoxRow::Rule(label) => label.chars().count() + 5, // "── " + " ─"
         }
     }
@@ -82,8 +83,9 @@ impl BoxRow {
                 .collect(),
             BoxRow::Raw(text) => vec![(text.clone(), text.clone())],
             BoxRow::Kv(label, value) => {
-                let label_col = format!("{:<width$}", label, width = BANNER_LABEL_W);
-                let value_width = inner.saturating_sub(BANNER_LABEL_W).max(1);
+                let label_w = label.chars().count().max(BANNER_LABEL_W);
+                let label_col = format!("{:<width$}", label, width = label_w);
+                let value_width = inner.saturating_sub(label_w).max(1);
                 wrap_chars(value, value_width)
                     .into_iter()
                     .enumerate()
@@ -92,7 +94,7 @@ impl BoxRow {
                             (format!("{label_col}{chunk}"), format!("{}{chunk}", paint(BANNER_DIM, &label_col)))
                         } else {
                             // continuation lines align under the value column
-                            let pad = " ".repeat(BANNER_LABEL_W);
+                            let pad = " ".repeat(label_w);
                             (format!("{pad}{chunk}"), format!("{pad}{chunk}"))
                         }
                     })
@@ -210,6 +212,21 @@ fn qr_lines(data: &str) -> Vec<String> {
         .collect()
 }
 
+/// The `── agents (N) ──` section: one row per agent, name column padded so the
+/// status column stays aligned even for names longer than the config label column.
+fn agent_rows(agents: &[AgentEntry]) -> Vec<BoxRow> {
+    let name_w = agents.iter().map(|agent| agent.name.chars().count() + 2).max().unwrap_or(0).max(BANNER_LABEL_W);
+    let mut rows = vec![BoxRow::Rule(format!("agents ({})", agents.len()))];
+    for agent in agents {
+        let status_text = match agent.status {
+            Some(status) => status.human_text(),
+            None => "",
+        };
+        rows.push(BoxRow::Kv(format!("{:<name_w$}", agent.name), status_text.to_string()));
+    }
+    rows
+}
+
 // --- Status ---
 
 /// How the Cloudflare tunnel stands, as surfaced in the banner. Held in memory by
@@ -230,9 +247,18 @@ impl TunnelStatus {
     }
 }
 
-/// The daemon's startup state. Every field except `tunnel` is fixed for the life
-/// of the process; `tunnel` is kept current by the supervisor. `pid` lets readers
-/// of `status.json` confirm the snapshot belongs to the live daemon.
+/// One agent as shown in the banner: its name plus the daemon's last known status
+/// (`None` at boot, before the status cache has polled the containers).
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
+pub struct AgentEntry {
+    pub name: String,
+    pub status: Option<AgentStatus>,
+}
+
+/// The daemon's startup state. Every field except `tunnel` and `agents` is fixed
+/// for the life of the process; `tunnel` is kept current by the supervisor and
+/// `agents` by the agent-status cache task. `pid` lets readers of `status.json`
+/// confirm the snapshot belongs to the live daemon.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Status {
     pub version: String,
@@ -242,10 +268,13 @@ pub struct Status {
     pub expose_lan: bool,
     pub lan_url: Option<String>,
     pub tunnel: TunnelStatus,
+    #[serde(default)]
+    pub agents: Vec<AgentEntry>,
     pub pid: u32,
 }
 
 impl Status {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         version: String,
         user: String,
@@ -254,8 +283,9 @@ impl Status {
         expose_lan: bool,
         lan_url: Option<String>,
         tunnel: TunnelStatus,
+        agents: Vec<AgentEntry>,
     ) -> Self {
-        Status { version, user, port, dev_mode, expose_lan, lan_url, tunnel, pid: std::process::id() }
+        Status { version, user, port, dev_mode, expose_lan, lan_url, tunnel, agents, pid: std::process::id() }
     }
 
     /// Sole owner of the `status.json` path.
@@ -286,6 +316,10 @@ impl Status {
 
     pub fn set_tunnel(&mut self, tunnel: TunnelStatus) {
         self.tunnel = tunnel;
+    }
+
+    pub fn set_agents(&mut self, agents: Vec<AgentEntry>) {
+        self.agents = agents;
     }
 
     /// Print the boxed banner: VESTA art, config grid, connection summary, and the
@@ -324,21 +358,25 @@ impl Status {
             BoxRow::Gap,
             BoxRow::Center(format!("personal AI daemon · v{}", self.version)),
             BoxRow::Gap,
-            BoxRow::Kv("user", self.user.clone()),
-            BoxRow::Kv("port", self.port.to_string()),
-            BoxRow::Kv("mode", if self.dev_mode { "development".to_string() } else { "production".to_string() }),
-            BoxRow::Kv("tunnel", tunnel_desc),
-            BoxRow::Kv("lan", lan_desc),
+            BoxRow::Kv("user".into(), self.user.clone()),
+            BoxRow::Kv("port".into(), self.port.to_string()),
+            BoxRow::Kv("mode".into(), if self.dev_mode { "development".to_string() } else { "production".to_string() }),
+            BoxRow::Kv("tunnel".into(), tunnel_desc),
+            BoxRow::Kv("lan".into(), lan_desc),
             BoxRow::Gap,
-            BoxRow::Rule("connection"),
-            BoxRow::Kv("address", address),
-            BoxRow::Kv("api key", api_key.to_string()),
-            BoxRow::Gap,
-            BoxRow::Rule("connect the app"),
         ];
+        rows.extend(agent_rows(&self.agents));
+        rows.extend([
+            BoxRow::Gap,
+            BoxRow::Rule("connection".into()),
+            BoxRow::Kv("address".into(), address),
+            BoxRow::Kv("api key".into(), api_key.to_string()),
+            BoxRow::Gap,
+            BoxRow::Rule("connect the app".into()),
+        ]);
         // remote tier: the public link when a tunnel is up (with the QR for it
         // right beneath, left-aligned), otherwise how to get one.
-        rows.push(BoxRow::Kv("remote", String::new()));
+        rows.push(BoxRow::Kv("remote".into(), String::new()));
         match tunnel_url {
             Some(url) => {
                 let link = connect_link(url, api_key);
@@ -350,11 +388,11 @@ impl Status {
         }
         if let Some(url) = lan_app {
             rows.push(BoxRow::Gap);
-            rows.push(BoxRow::Kv("lan", String::new()));
+            rows.push(BoxRow::Kv("lan".into(), String::new()));
             rows.push(BoxRow::Value(connect_link(url, api_key)));
         }
         rows.push(BoxRow::Gap);
-        rows.push(BoxRow::Kv("local", String::new()));
+        rows.push(BoxRow::Kv("local".into(), String::new()));
         rows.push(BoxRow::Value(connect_link(&local_url, api_key)));
         rows.push(BoxRow::Gap);
 
@@ -414,8 +452,8 @@ mod tests {
             BoxRow::Gap,
             BoxRow::Art(0),
             BoxRow::Center("personal AI daemon".into()),
-            BoxRow::Kv("user", "emi".into()),
-            BoxRow::Rule("connection"),
+            BoxRow::Kv("user".into(), "emi".into()),
+            BoxRow::Rule("connection".into()),
             BoxRow::Value("0123456789abcdef0123456789abcdef".into()),
         ];
         let lines = render_box(&rows);
@@ -449,13 +487,76 @@ mod tests {
             TunnelStatus::Active("https://host.example/".into()),
             TunnelStatus::Failed("invalid token".into()),
         ] {
-            let status = Status::new("0.1.0".into(), "emi".into(), 8080, true, false, None, tunnel.clone());
+            let status = Status::new("0.1.0".into(), "emi".into(), 8080, true, false, None, tunnel.clone(), Vec::new());
             let json = serde_json::to_string(&status).expect("serialize");
             let back: Status = serde_json::from_str(&json).expect("deserialize");
             assert!(back.tunnel == tunnel);
             assert_eq!(back.port, 8080);
             assert_eq!(back.pid, status.pid);
         }
+    }
+
+    #[test]
+    fn status_json_round_trips_agents() {
+        let agents = vec![
+            AgentEntry { name: "vesta".into(), status: Some(AgentStatus::Alive) },
+            AgentEntry { name: "fresh".into(), status: None },
+        ];
+        let status =
+            Status::new("0.1.0".into(), "emi".into(), 8080, false, false, None, TunnelStatus::Disabled, agents.clone());
+        let json = serde_json::to_string(&status).expect("serialize");
+        let back: Status = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.agents == agents);
+    }
+
+    #[test]
+    fn agent_section_renders_count_names_and_statuses() {
+        let agents = vec![
+            AgentEntry { name: "vesta".into(), status: Some(AgentStatus::Alive) },
+            AgentEntry { name: "backup".into(), status: Some(AgentStatus::NotAuthenticated) },
+        ];
+        let text = render_box_capped(&agent_rows(&agents), 60).join("\n");
+        assert!(text.contains("agents (2)"));
+        assert!(text.contains("vesta"));
+        assert!(text.contains("alive"));
+        assert!(text.contains("backup"));
+        assert!(text.contains("not authenticated"));
+    }
+
+    #[test]
+    fn agent_section_without_statuses_shows_names_only() {
+        let agents = vec![AgentEntry { name: "vesta".into(), status: None }];
+        let text = render_box_capped(&agent_rows(&agents), 60).join("\n");
+        assert!(text.contains("agents (1)"));
+        assert!(text.contains("vesta"));
+    }
+
+    #[test]
+    fn agent_section_with_no_agents_renders_only_the_rule() {
+        let lines = render_box_capped(&agent_rows(&[]), 60);
+        assert!(lines.iter().any(|line| line.contains("agents (0)")));
+        // top border + rule + bottom border: no agent rows
+        assert_eq!(lines.len(), 3);
+    }
+
+    #[test]
+    fn agent_names_longer_than_the_label_column_stay_separated_and_aligned() {
+        let agents = vec![
+            AgentEntry { name: "vesta".into(), status: Some(AgentStatus::Alive) },
+            AgentEntry { name: "longagentname".into(), status: Some(AgentStatus::Stopped) },
+        ];
+        let lines = render_box_capped(&agent_rows(&agents), 60);
+        let column_of = |needle: &str| {
+            lines
+                .iter()
+                .find_map(|line| line.find(needle))
+                .unwrap_or_else(|| panic!("no line contains {needle}"))
+        };
+        assert_eq!(column_of("alive"), column_of("stopped"), "status column is aligned across rows");
+        assert!(
+            lines.iter().any(|line| line.contains("longagentname ")),
+            "long name stays separated from its status"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an `── agents (N) ──` section to the vestad banner. Every render shows the agent count and names; `vestad status` also shows each agent's live status:

```
│   ── agents (2) ─────────────────   │
│   vesta      alive                  │
│   backup     stopped                │
```

- **How the status crosses the process boundary**: the daemon's agent-status polling task persists its cached list into `status.json` via an `on_agents_changed` callback (mirrors `on_tunnel_up`), invoked only when `send_if_modified` reports a real change. `vestad status` keeps reading the pid-gated file — no HTTP client/runtime in the CLI path, statuses at most one poll (~3s) stale.
- **Startup banner**: seeded with names from the env files, statuses empty (agents are just being started by reconcile; anything else would be stale seconds later).
- **Rendering**: `BoxRow::Kv`/`Rule` labels widen from `&'static str` to `String`; the label column auto-widens for agent names longer than the fixed 9-char column so the status column stays aligned.
- **Compat**: old-format `status.json` loads via `#[serde(default)]`, so the update→restart window degrades to an empty section rather than a parse failure.
- `AgentStatus` gains `Deserialize` and a `human_text()` helper (`not authenticated`, `setting up`, ...) next to the enum.

Design doc included: `docs/superpowers/specs/2026-07-03-agents-in-status-banner-design.md`.

## Test plan

- 6 new unit tests (TDD red→green): agent section rendering with/without statuses, count in the rule, zero agents, long-name column alignment, `status.json` round-trip incl. `AgentStatus` Deserialize, `human_text` mapping.
- `check.sh vestad` equivalents run on a Linux host: 150 tests passed, `cargo clippy -p vestad -- -D warnings` clean.
- End-to-end: fresh debug binary's `vestad status` run against a live daemon with an old-format `status.json` — banner renders, section shows `agents (0)` until the new daemon rewrites the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)