### PR TITLE
fix(notifications): drop the in-flight notification before an intentional restart

### DIFF
--- a/agent/core/helpers.py
+++ b/agent/core/helpers.py
@@ -3,6 +3,18 @@ import pathlib as pl
 from . import models as vm
 
 
+def clear_notifications(state: vm.State, file_paths: list[str]) -> None:
+    """Drop processed notification files and tell live clients they cleared.
+
+    One owner for the unlink + notification_cleared emit, shared by the message loop (after a turn
+    completes) and the restart/stop tools (before an intentional restart, when the turn's
+    notification is already handled). notif_id is the file stem, matching the arrival's
+    NotificationEvent.notif_id so clients pair the clear with the pending entry."""
+    for path_str in file_paths:
+        pl.Path(path_str).unlink(missing_ok=True)
+        state.event_bus.emit({"type": "notification_cleared", "notif_id": pl.Path(path_str).stem})
+
+
 def get_memory_path(config: vm.VestaConfig) -> pl.Path:
     return config.agent_dir / "MEMORY.md"
 

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -29,7 +29,7 @@ from .client import (
     _cancel_task,
 )
 from .diagnostics import format_crash_detail
-from .helpers import load_prompt, build_restart_context
+from .helpers import load_prompt, build_restart_context, clear_notifications
 from .openrouter_cache import start_cache_proxy
 from .provider import ProviderAuthState
 
@@ -269,6 +269,7 @@ async def _run_messages_with_interrupts(
                 continue
             state.interrupt_event = asyncio.Event()
             state.noninterruptible_turn_active = not current.interruptible
+            state.in_flight_notification_paths = current.file_paths
             process_task = asyncio.create_task(run_one(current.text, user=current.is_user))
 
             while not process_task.done():
@@ -294,13 +295,11 @@ async def _run_messages_with_interrupts(
             state.noninterruptible_turn_active = False
             # Keep the file if the turn flipped auth to not_authenticated (converse detects a
             # terminal 401/402 mid-turn): like a deferred message above, it must re-run after re-auth.
+            # Operate on in_flight_notification_paths, not current.file_paths: an intentional restart
+            # mid-turn already cleared and emptied it, so this stays a no-op instead of re-emitting.
             if state.provider_status is None or state.provider_status.state == ProviderAuthState.AUTHENTICATED:
-                _delete_paths(current.file_paths)
-                # Tell live clients the notification cleared (file gone). Only notification turns carry
-                # file_paths, so user-message turns emit nothing. notif_id is the file stem, matching
-                # the arrival's NotificationEvent.notif_id.
-                for path_str in current.file_paths:
-                    state.event_bus.emit({"type": "notification_cleared", "notif_id": pl.Path(path_str).stem})
+                clear_notifications(state, state.in_flight_notification_paths)
+            state.in_flight_notification_paths = []
             process_task = None
             state.interrupt_event = None
     except asyncio.CancelledError:

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -120,6 +120,11 @@ class State:
     # rather than SDK-aborting the boot turn mid-stream (the queue-watcher's interruptible guard only
     # covers the queue-driven path, not this direct SDK path).
     noninterruptible_turn_active: bool = False
+    # File paths of the notification the current turn is handling (empty for user-message turns).
+    # The message loop clears these after the turn; the restart/stop tools clear them first when an
+    # intentional restart fires mid-turn, since the notification is already handled and its file
+    # would otherwise survive the SIGTERM and be re-delivered on reboot.
+    in_flight_notification_paths: list[str] = dc.field(default_factory=list)
     # Set by mark_dreamer_complete; the message processor compacts the live session at the next
     # idle point, then triggers the restart (which resumes the compacted session). Deferred rather
     # than done inline because /compact only works while the session is idle, never mid-turn.

--- a/agent/core/tools.py
+++ b/agent/core/tools.py
@@ -10,6 +10,7 @@ from . import models as vm
 from . import state_store
 from . import vestad_client
 from .api import start_ws_server
+from .helpers import clear_notifications
 from .workspace_sync import vesta_version
 
 
@@ -21,6 +22,10 @@ def _vesta_tools(state: vm.State, config: vm.VestaConfig) -> list[tp.Any]:
         if state.graceful_shutdown.is_set():
             return {"content": [{"type": "text", "text": "Already shutting down."}]}
         logger.shutdown(f"Container {verb} requested via vestad")
+        # The turn asking for this restart has handled its notification; drop the file now so the
+        # SIGTERM doesn't beat the loop's post-turn cleanup and leave it to be re-delivered on reboot.
+        clear_notifications(state, state.in_flight_notification_paths)
+        state.in_flight_notification_paths = []
         if not await request():
             return {"content": [{"type": "text", "text": f"Could not reach vestad to {verb} — is the daemon running?"}]}
         return {"content": [{"type": "text", "text": f"Container {verb} initiated."}]}

--- a/agent/core/uv.lock
+++ b/agent/core/uv.lock
@@ -1232,7 +1232,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.167"
+version = "0.1.168"
 source = { virtual = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -199,6 +199,53 @@ async def test_client_cleared_on_cancellation(tmp_path):
     assert state.client is None
 
 
+# --- Intentional restart mid-notification-turn: drop the file so it isn't re-delivered ---
+
+
+@pytest.mark.anyio
+async def test_notification_dropped_before_intentional_restart(tmp_path):
+    """A notification turn that ends with the agent calling restart_vesta must delete the
+    notification file before the restart, so it isn't re-delivered on the next boot.
+
+    At-least-once keeps the file until the turn completes (crash recovery), but an intentional
+    restart mid-turn means the notification was handled — dropping it here avoids the duplicate the
+    SIGTERM-beats-cleanup race would otherwise produce."""
+    from core.tools import _vesta_tools
+
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent")
+    config.notifications_dir.mkdir(parents=True, exist_ok=True)
+    notif_file = config.notifications_dir / "whatsapp-123.json"
+    notif_file.write_text("{}")
+
+    state = vm.State()
+    subscriber = state.event_bus.subscribe()
+
+    async def side_effect(msg, *, state, config, is_user):
+        # Mid-turn: the loop has exposed the in-flight notification; the agent handles it and
+        # asks to restart. The restart tool must drop the file here, not leave it for the loop's
+        # post-turn cleanup that the SIGTERM would beat.
+        assert state.in_flight_notification_paths == [str(notif_file)]
+        restart = next(t.handler for t in _vesta_tools(state, config) if t.name == "restart_vesta")
+        await restart({})
+
+    with patch("core.vestad_client.request_restart", new_callable=AsyncMock, return_value=True):
+        state, _, _ = await _run_processor_test(
+            tmp_path,
+            message_side_effect=side_effect,
+            pre_state=state,
+            initial_queue=[vm.QueuedTurn("<notification/>", False, [str(notif_file)])],
+        )
+
+    assert not notif_file.exists(), "handled notification must be gone before the restart, not re-delivered"
+    assert state.in_flight_notification_paths == []
+
+    drained = []
+    while not subscriber.empty():
+        drained.append(subscriber.get_nowait())
+    cleared = [e for e in drained if e["type"] == "notification_cleared"]
+    assert [e["notif_id"] for e in cleared] == ["whatsapp-123"], "clients must be told the notification cleared"
+
+
 # --- Em/en dash correction in process_message ---
 
 


### PR DESCRIPTION
## Problem

The same notification was delivered twice: a "run sync" message arrived, was handled, the agent restarted (post-rebase, via `restart_vesta`), and then the **identical** notification reappeared after the reboot.

Notifications are **at-least-once by design** — the notification file is unlinked only *after* the handling turn completes, so a mid-turn crash can recover the unprocessed notification from disk on reboot (`loops.py`). The flip side: when the agent calls `restart_vesta`/`stop_vesta` *inside* the turn handling a notification, vestad SIGTERMs the process **before** the post-turn unlink runs. The file survives → the notification is re-delivered on the next boot.

It's pre-existing (any `restart_vesta` mid-notification-turn does it) and benign (re-processing is idempotent, the agent recognizes the duplicate), but the new workspace-sync restart path made it common enough to surface in the logs.

## Fix

An intentional restart mid-turn means the notification **was handled** — so drop its file at restart-request time, while keeping at-least-once for genuine crashes and queued-but-unstarted notifications.

- The message loop stashes the current turn's paths on `state.in_flight_notification_paths` (empty for user-message turns).
- `restart_vesta`/`stop_vesta` (both via `_lifecycle_via_vestad`) clear those files — and emit `notification_cleared` to live clients — before asking vestad to act, then empty the list so the loop's post-turn cleanup is a no-op.
- The unlink + `notification_cleared` emit moves into one owner, `helpers.clear_notifications`, shared by the loop and the tools.

Genuine crashes (task cancelled, no intentional restart) and notifications still queued-but-unstarted keep their files and recover from disk unchanged.

## Test

`test_notification_dropped_before_intentional_restart` drives the real message processor through a notification turn whose (mocked) handler calls `restart_vesta`, and asserts the file is gone before the restart and a `notification_cleared` event fired — it fails on `master` (file re-delivered) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)