### PR TITLE
feat: host filesystem access for agents (+ files/settings UI redesign)

### DIFF
--- a/agent/skills/dashboard/app/src/components/ui/item.tsx
+++ b/agent/skills/dashboard/app/src/components/ui/item.tsx
@@ -138,7 +138,7 @@ function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="item-description"
       className={cn(
-        "line-clamp-2 text-left text-sm font-normal text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        "line-clamp-2 text-left text-[11px] font-normal text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
         className,
       )}
       {...props}

--- a/agent/skills/dashboard/app/src/components/ui/item.tsx
+++ b/agent/skills/dashboard/app/src/components/ui/item.tsx
@@ -40,7 +40,7 @@ const itemVariants = cva(
       variant: {
         default: "border-transparent",
         outline: "border-border",
-        muted: "border-transparent bg-muted/50",
+        muted: "border-transparent bg-muted",
       },
       size: {
         default: "gap-3.5 px-4 py-3.5",

--- a/agent/skills/dashboard/app/src/components/ui/item.tsx
+++ b/agent/skills/dashboard/app/src/components/ui/item.tsx
@@ -40,7 +40,7 @@ const itemVariants = cva(
       variant: {
         default: "border-transparent",
         outline: "border-border",
-        muted: "border-border bg-muted/50",
+        muted: "border-transparent bg-muted/50",
       },
       size: {
         default: "gap-3.5 px-4 py-3.5",

--- a/agent/skills/dashboard/app/src/components/ui/item.tsx
+++ b/agent/skills/dashboard/app/src/components/ui/item.tsx
@@ -40,7 +40,7 @@ const itemVariants = cva(
       variant: {
         default: "border-transparent",
         outline: "border-border",
-        muted: "border-transparent bg-muted/50",
+        muted: "border-border bg-muted/50",
       },
       size: {
         default: "gap-3.5 px-4 py-3.5",

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -1,4 +1,4 @@
-import { apiJson, apiFetch } from "./client";
+import { apiJson, apiFetch, jsonInit } from "./client";
 import type { VestaEvent } from "@/lib/types";
 
 export type NotificationEvent = Extract<VestaEvent, { type: "notification" }>;
@@ -159,7 +159,11 @@ export async function createAgent(name: string): Promise<void> {
 /// the create POST is in flight. The image step (`pulling` on a release build,
 /// `building` from a local checkout) is the dominant wait.
 export type BuildPhase =
-  "pulling" | "building" | "preparing" | "creating" | "starting";
+  | "pulling"
+  | "building"
+  | "preparing"
+  | "creating"
+  | "starting";
 
 const BUILD_PHASE_MESSAGES: Record<BuildPhase, string> = {
   pulling: "downloading the agent image...",
@@ -395,4 +399,34 @@ export async function getNotificationHistory(
   // Newest-first for the view; the history endpoint returns ascending within a page.
   items.reverse();
   return { notifications: items, cursor: resp.cursor };
+}
+
+/// A user-granted host filesystem access: a host path bind-mounted into the agent's container at
+/// `container_path` (defaults to `host_path` when unset by the caller), read-only unless `writable`.
+export interface HostMount {
+  host_path: string;
+  container_path: string;
+  writable: boolean;
+}
+
+/// Read the agent's host filesystem grants (GET /mounts).
+export async function getAgentMounts(name: string): Promise<HostMount[]> {
+  const resp = await apiJson<{ mounts: HostMount[] }>(
+    `/agents/${encodeURIComponent(name)}/mounts`,
+  );
+  return resp.mounts;
+}
+
+/// Replace the agent's host filesystem grants (PUT /mounts). The server validates each grant
+/// (host path exists, container path isn't protected, no duplicate container paths) and returns the
+/// validated list plus whether a restart is needed to apply it (always true today).
+export async function setAgentMounts(
+  name: string,
+  mounts: HostMount[],
+): Promise<{ mounts: HostMount[]; restartRequired: boolean }> {
+  const resp = await apiJson<{
+    mounts: HostMount[];
+    restart_required: boolean;
+  }>(`/agents/${encodeURIComponent(name)}/mounts`, jsonInit("PUT", { mounts }));
+  return { mounts: resp.mounts, restartRequired: resp.restart_required };
 }

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -159,11 +159,7 @@ export async function createAgent(name: string): Promise<void> {
 /// the create POST is in flight. The image step (`pulling` on a release build,
 /// `building` from a local checkout) is the dominant wait.
 export type BuildPhase =
-  | "pulling"
-  | "building"
-  | "preparing"
-  | "creating"
-  | "starting";
+  "pulling" | "building" | "preparing" | "creating" | "starting";
 
 const BUILD_PHASE_MESSAGES: Record<BuildPhase, string> = {
   pulling: "downloading the agent image...",

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -430,3 +430,10 @@ export async function setAgentMounts(
   }>(`/agents/${encodeURIComponent(name)}/mounts`, jsonInit("PUT", { mounts }));
   return { mounts: resp.mounts, restartRequired: resp.restart_required };
 }
+
+/// Existing host folders vestad suggests sharing (GET /host/folders), so the user doesn't
+/// hand-type a path. Host-level (not agent-scoped) and API-key only.
+export async function getHostFolderSuggestions(): Promise<string[]> {
+  const resp = await apiJson<{ folders: string[] }>("/host/folders");
+  return resp.folders;
+}

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -74,7 +74,8 @@ export function SimpleView({
   );
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-4 p-1">
+    <div className="flex h-full min-h-0 flex-col gap-3 p-1">
+      <GroupLabel>vesta's mind</GroupLabel>
       <MindCard
         memorySelected={selected === MEMORY_PATH && !dreamsActive}
         constitutionSelected={selected === CONSTITUTION_PATH && !dreamsActive}
@@ -85,10 +86,30 @@ export function SimpleView({
         onShowDreams={onShowDreams}
       />
       <SkillsCard skills={skills} selected={selected} onSelect={onSelect} />
+      <GroupLabel className="pt-1">on this computer</GroupLabel>
       <div className="shrink-0">
         <HostAccessCard />
       </div>
     </div>
+  );
+}
+
+function GroupLabel({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <p
+      className={cn(
+        "shrink-0 px-1 text-[11px] font-medium text-muted-foreground/70",
+        className,
+      )}
+    >
+      {children}
+    </p>
   );
 }
 

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -91,7 +91,7 @@ export function SimpleView({
     // right. The wrappers use `display: contents` on mobile so all three sections flatten into one
     // column and interleave; at lg they become the two real columns.
     <div className="flex flex-col gap-3 p-1 lg:grid lg:grid-cols-2 lg:items-start">
-      <div className="contents lg:flex lg:flex-col lg:gap-3">
+      <div className="contents lg:flex lg:flex-col lg:gap-6">
         <div className="flex flex-col gap-3">
           <GroupLabel>{name}'s mind</GroupLabel>
           <MindCard
@@ -112,7 +112,7 @@ export function SimpleView({
           <HostAccessCard />
         </div>
       </div>
-      <div className="contents lg:flex lg:flex-col lg:gap-3">
+      <div className="contents lg:flex lg:flex-col lg:gap-6">
         <div className="order-2 flex flex-col gap-3 lg:order-none">
           <GroupLabel>skills</GroupLabel>
           <SkillsCard skills={skills} selected={selected} onSelect={onSelect} />

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -93,7 +93,7 @@ export function SimpleView({
     <div className="flex flex-col gap-3 p-1 lg:grid lg:grid-cols-2 lg:items-start lg:gap-x-6">
       <div className="contents lg:flex lg:flex-col lg:gap-6">
         <div className="flex flex-col gap-3">
-          <GroupLabel>{name}'s mind</GroupLabel>
+          <GroupLabel>who {name} is</GroupLabel>
           <MindCard
             name={name}
             memorySelected={selected === MEMORY_PATH && !dreamsActive}
@@ -108,13 +108,13 @@ export function SimpleView({
           />
         </div>
         <div className="order-3 flex flex-col gap-3 lg:order-none">
-          <GroupLabel>on this computer</GroupLabel>
+          <GroupLabel>shared folders</GroupLabel>
           <HostAccessCard />
         </div>
       </div>
       <div className="contents lg:flex lg:flex-col lg:gap-6">
         <div className="order-2 flex flex-col gap-3 lg:order-none">
-          <GroupLabel>skills</GroupLabel>
+          <GroupLabel>abilities</GroupLabel>
           <SkillsCard skills={skills} selected={selected} onSelect={onSelect} />
         </div>
       </div>

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -229,9 +229,7 @@ function HubRow({
         <ItemContent className="gap-0.5">
           <ItemTitle>{title}</ItemTitle>
           {description ? (
-            <ItemDescription className="text-[11px]">
-              {description}
-            </ItemDescription>
+            <ItemDescription>{description}</ItemDescription>
           ) : null}
         </ItemContent>
         {trailing ? <ItemActions>{trailing}</ItemActions> : null}

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -90,7 +90,7 @@ export function SimpleView({
     // bento — the left column (mind + shared folders) is a continuous flex column, skills on the
     // right. The wrappers use `display: contents` on mobile so all three sections flatten into one
     // column and interleave; at lg they become the two real columns.
-    <div className="flex flex-col gap-3 p-1 lg:grid lg:grid-cols-2 lg:items-start">
+    <div className="flex flex-col gap-3 p-1 lg:grid lg:grid-cols-2 lg:items-start lg:gap-x-6">
       <div className="contents lg:flex lg:flex-col lg:gap-6">
         <div className="flex flex-col gap-3">
           <GroupLabel>{name}'s mind</GroupLabel>

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -33,6 +33,7 @@ interface SimpleViewProps {
   entries: FileTreeEntry[];
   selected: string | null;
   dreamsActive: boolean;
+  agentName?: string;
   onSelect: (path: string) => void;
   onShowDreams: () => void;
 }
@@ -73,6 +74,7 @@ export function SimpleView({
   entries,
   selected,
   dreamsActive,
+  agentName,
   onSelect,
   onShowDreams,
 }: SimpleViewProps) {
@@ -81,11 +83,13 @@ export function SimpleView({
     () => collectDreamPaths(entries).length,
     [entries],
   );
+  const name = agentName ?? "the agent";
 
   return (
     <div className="flex flex-col gap-3 p-1">
-      <GroupLabel>vesta's mind</GroupLabel>
+      <GroupLabel>{name}'s mind</GroupLabel>
       <MindCard
+        name={name}
         memorySelected={selected === MEMORY_PATH && !dreamsActive}
         constitutionSelected={selected === CONSTITUTION_PATH && !dreamsActive}
         dreamsActive={dreamsActive}
@@ -124,6 +128,7 @@ function GroupLabel({
 }
 
 function MindCard({
+  name,
   memorySelected,
   constitutionSelected,
   dreamsActive,
@@ -132,6 +137,7 @@ function MindCard({
   onSelectConstitution,
   onShowDreams,
 }: {
+  name: string;
   memorySelected: boolean;
   constitutionSelected: boolean;
   dreamsActive: boolean;
@@ -150,7 +156,7 @@ function MindCard({
             iconClass="bg-amber-500/12 text-amber-600 dark:text-amber-400"
             icon={<BookOpen />}
             title="memory"
-            description="what vesta remembers about you"
+            description={`what ${name} remembers about you`}
           />
           <HubRow
             onClick={onSelectConstitution}
@@ -158,7 +164,7 @@ function MindCard({
             iconClass="bg-emerald-500/12 text-emerald-600 dark:text-emerald-400"
             icon={<ScrollText />}
             title="constitution"
-            description="the directives you set that vesta follows"
+            description={`the directives you set that ${name} follows`}
           />
           <HubRow
             onClick={onShowDreams}

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -266,7 +266,7 @@ function SkillsCard({
 
   return (
     <Card size="sm" className="!py-0">
-      <ScrollArea className="max-h-80 [&_[data-slot=scroll-area-viewport]]:px-3 [&_[data-slot=scroll-area-viewport]]:py-0">
+      <ScrollArea className="[&_[data-slot=scroll-area-viewport]]:max-h-80 [&_[data-slot=scroll-area-viewport]]:px-3 [&_[data-slot=scroll-area-viewport]]:py-0">
         <div className="flex flex-col gap-2">
           {inSkillView && activeSkill ? (
             <>

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -266,7 +266,7 @@ function SkillsCard({
 
   return (
     <Card size="sm" className="!py-0">
-      <ScrollArea className="[&_[data-slot=scroll-area-viewport]]:max-h-80 [&_[data-slot=scroll-area-viewport]]:px-3 [&_[data-slot=scroll-area-viewport]]:py-0">
+      <ScrollArea className="**:data-[slot=scroll-area-viewport]:max-h-80 **:data-[slot=scroll-area-viewport]:px-3 **:data-[slot=scroll-area-viewport]:py-0">
         <div className="flex flex-col gap-2">
           {inSkillView && activeSkill ? (
             <>

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -131,65 +131,93 @@ function MindCard({
   onShowDreams: () => void;
 }) {
   return (
-    <Card size="sm" className="!py-0 !gap-0 flex shrink-0 flex-col">
-      <button
-        type="button"
-        onClick={onSelectMemory}
-        className={cn(
-          "flex w-full items-center gap-2.5 border-b border-border/60 px-4 py-3 text-left text-sm transition-colors",
-          memorySelected
-            ? "bg-muted text-foreground"
-            : "hover:bg-muted/60 active:bg-muted",
-        )}
-      >
-        <BookOpen className="size-4 shrink-0 text-muted-foreground" />
-        <span className="flex min-w-0 flex-col">
-          <span className="font-medium">memory</span>
-          <span className="text-[11px] text-muted-foreground">
-            what vesta remembers about you
-          </span>
-        </span>
-      </button>
-
-      <button
-        type="button"
-        onClick={onSelectConstitution}
-        className={cn(
-          "flex w-full items-center gap-2.5 border-b border-border/60 px-4 py-3 text-left text-sm transition-colors",
-          constitutionSelected
-            ? "bg-muted text-foreground"
-            : "hover:bg-muted/60 active:bg-muted",
-        )}
-      >
-        <ScrollText className="size-4 shrink-0 text-muted-foreground" />
-        <span className="flex min-w-0 flex-col">
-          <span className="font-medium">constitution</span>
-          <span className="text-[11px] text-muted-foreground">
-            the directives you set that vesta follows
-          </span>
-        </span>
-      </button>
-
-      <button
-        type="button"
-        onClick={onShowDreams}
-        className={cn(
-          "flex w-full items-center gap-2.5 px-4 py-3 text-left text-sm transition-colors",
-          dreamsActive
-            ? "bg-muted text-foreground"
-            : "hover:bg-muted/60 active:bg-muted",
-        )}
-      >
-        <Moon className="size-4 text-muted-foreground" />
-        <span className="font-medium">dreams</span>
-        {dreamCount > 0 && (
-          <span className="text-[10px] text-muted-foreground/60">
-            {dreamCount}
-          </span>
-        )}
-        <ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground/60" />
-      </button>
+    <Card size="sm" className="shrink-0">
+      <CardContent className="flex flex-col gap-1.5">
+        <HubRow
+          onClick={onSelectMemory}
+          selected={memorySelected}
+          iconClass="bg-amber-500/12 text-amber-600 dark:text-amber-400"
+          icon={<BookOpen className="size-[18px]" />}
+          title="memory"
+          description="what vesta remembers about you"
+        />
+        <HubRow
+          onClick={onSelectConstitution}
+          selected={constitutionSelected}
+          iconClass="bg-emerald-500/12 text-emerald-600 dark:text-emerald-400"
+          icon={<ScrollText className="size-[18px]" />}
+          title="constitution"
+          description="the directives you set that vesta follows"
+        />
+        <HubRow
+          onClick={onShowDreams}
+          selected={dreamsActive}
+          iconClass="bg-indigo-500/12 text-indigo-500 dark:text-indigo-400"
+          icon={<Moon className="size-[18px]" />}
+          title="dreams"
+          description="nightly reflections on the day"
+          trailing={
+            <div className="flex items-center gap-1.5">
+              {dreamCount > 0 && (
+                <span className="text-[11px] text-muted-foreground">
+                  {dreamCount}
+                </span>
+              )}
+              <ChevronRight className="size-4 shrink-0 text-muted-foreground/60" />
+            </div>
+          }
+        />
+      </CardContent>
     </Card>
+  );
+}
+
+// A soft, tappable "cell" inside a hub card: a tinted icon square, a title,
+// an optional secondary line, and optional trailing content.
+function HubRow({
+  icon,
+  iconClass,
+  title,
+  description,
+  trailing,
+  selected = false,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  iconClass: string;
+  title: string;
+  description?: string;
+  trailing?: React.ReactNode;
+  selected?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-xl px-2.5 py-2.5 text-left transition-colors",
+        selected ? "bg-muted" : "bg-muted/40 hover:bg-muted/70 active:bg-muted",
+      )}
+    >
+      <span
+        className={cn(
+          "flex size-9 shrink-0 items-center justify-center rounded-[10px]",
+          iconClass,
+        )}
+      >
+        {icon}
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="text-sm font-medium leading-tight">{title}</span>
+        {description ? (
+          <span className="truncate text-[11px] text-muted-foreground">
+            {description}
+          </span>
+        ) : null}
+      </span>
+      {trailing}
+    </button>
   );
 }
 
@@ -249,7 +277,7 @@ function SkillsCard({
         )}
       </CardHeader>
 
-      <CardContent className="flex-1 min-h-0 overflow-auto !px-0">
+      <CardContent className="flex flex-1 min-h-0 flex-col gap-1.5 overflow-auto">
         {inSkillView && activeSkill ? (
           activeSkill.mdFiles.length === 0 ? (
             <EmptyRow>no markdown files</EmptyRow>
@@ -258,6 +286,7 @@ function SkillsCard({
               <Row
                 key={file.path}
                 icon={<FileText className="size-4" />}
+                iconClass="bg-muted text-muted-foreground"
                 label={file.name}
                 selected={selected === file.path}
                 onClick={() => onSelect(file.path)}
@@ -271,6 +300,7 @@ function SkillsCard({
             <Row
               key={skill.path}
               icon={<Wand2 className="size-4" />}
+              iconClass="bg-violet-500/12 text-violet-600 dark:text-violet-400"
               label={skill.name}
               hasChevron
               selected={
@@ -287,12 +317,14 @@ function SkillsCard({
 
 function Row({
   icon,
+  iconClass,
   label,
   hasChevron = false,
   selected,
   onClick,
 }: {
   icon: React.ReactNode;
+  iconClass: string;
   label: string;
   hasChevron?: boolean;
   selected: boolean;
@@ -303,13 +335,18 @@ function Row({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex w-full items-center gap-2.5 border-b border-border/60 px-4 py-2.5 text-left text-sm transition-colors last:border-b-0",
-        selected
-          ? "bg-muted text-foreground"
-          : "hover:bg-muted/60 active:bg-muted",
+        "flex w-full items-center gap-3 rounded-xl px-2.5 py-2 text-left text-sm transition-colors",
+        selected ? "bg-muted" : "bg-muted/40 hover:bg-muted/70 active:bg-muted",
       )}
     >
-      <span className="text-muted-foreground">{icon}</span>
+      <span
+        className={cn(
+          "flex size-8 shrink-0 items-center justify-center rounded-[9px]",
+          iconClass,
+        )}
+      >
+        {icon}
+      </span>
       <span className="flex-1 truncate">{label}</span>
       {hasChevron && (
         <ChevronRight className="size-4 shrink-0 text-muted-foreground/60" />

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -86,29 +86,37 @@ export function SimpleView({
   const name = agentName ?? "the agent";
 
   return (
-    // Mobile: one stacked column (mind → skills → shared folders). Desktop: a bento — mind and
-    // shared folders on the left, skills on the right (grid auto-flow places them from this order).
-    <div className="grid grid-cols-1 gap-3 p-1 lg:grid-cols-2 lg:items-start">
-      <div className="flex flex-col gap-3">
-        <GroupLabel>{name}'s mind</GroupLabel>
-        <MindCard
-          name={name}
-          memorySelected={selected === MEMORY_PATH && !dreamsActive}
-          constitutionSelected={selected === CONSTITUTION_PATH && !dreamsActive}
-          dreamsActive={dreamsActive}
-          dreamCount={dreamCount}
-          onSelectMemory={() => onSelect(MEMORY_PATH)}
-          onSelectConstitution={() => onSelect(CONSTITUTION_PATH)}
-          onShowDreams={onShowDreams}
-        />
+    // Mobile: one stacked column (mind → skills → shared folders), ordered via `order`. Desktop: a
+    // bento — the left column (mind + shared folders) is a continuous flex column, skills on the
+    // right. The wrappers use `display: contents` on mobile so all three sections flatten into one
+    // column and interleave; at lg they become the two real columns.
+    <div className="flex flex-col gap-3 p-1 lg:grid lg:grid-cols-2 lg:items-start">
+      <div className="contents lg:flex lg:flex-col lg:gap-3">
+        <div className="flex flex-col gap-3">
+          <GroupLabel>{name}'s mind</GroupLabel>
+          <MindCard
+            name={name}
+            memorySelected={selected === MEMORY_PATH && !dreamsActive}
+            constitutionSelected={
+              selected === CONSTITUTION_PATH && !dreamsActive
+            }
+            dreamsActive={dreamsActive}
+            dreamCount={dreamCount}
+            onSelectMemory={() => onSelect(MEMORY_PATH)}
+            onSelectConstitution={() => onSelect(CONSTITUTION_PATH)}
+            onShowDreams={onShowDreams}
+          />
+        </div>
+        <div className="order-3 flex flex-col gap-3 lg:order-none">
+          <GroupLabel>on this computer</GroupLabel>
+          <HostAccessCard />
+        </div>
       </div>
-      <div className="flex flex-col gap-3">
-        <GroupLabel>skills</GroupLabel>
-        <SkillsCard skills={skills} selected={selected} onSelect={onSelect} />
-      </div>
-      <div className="flex flex-col gap-3">
-        <GroupLabel>on this computer</GroupLabel>
-        <HostAccessCard />
+      <div className="contents lg:flex lg:flex-col lg:gap-3">
+        <div className="order-2 flex flex-col gap-3 lg:order-none">
+          <GroupLabel>skills</GroupLabel>
+          <SkillsCard skills={skills} selected={selected} onSelect={onSelect} />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Card, CardContent } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Item,
   ItemActions,
@@ -264,57 +265,61 @@ function SkillsCard({
   const inSkillView = activeSkill !== null;
 
   return (
-    <Card size="sm">
-      <CardContent className="flex max-h-80 flex-col gap-2 overflow-auto">
-        {inSkillView && activeSkill ? (
-          <>
-            <button
-              type="button"
-              onClick={() => setNav({ view: "root" })}
-              className="flex items-center gap-1 self-start px-1 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <ChevronLeft className="size-3.5" />
-              <span className="font-medium text-foreground">
-                {activeSkill.name}
-              </span>
-            </button>
-            {activeSkill.mdFiles.length === 0 ? (
-              <EmptyRow>no markdown files</EmptyRow>
-            ) : (
-              <ItemGroup>
-                {activeSkill.mdFiles.map((file) => (
-                  <Row
-                    key={file.path}
-                    icon={<FileText />}
-                    iconClass="bg-muted text-muted-foreground"
-                    label={file.name}
-                    selected={selected === file.path}
-                    onClick={() => onSelect(file.path)}
-                  />
-                ))}
-              </ItemGroup>
-            )}
-          </>
-        ) : skills.length === 0 ? (
-          <EmptyRow>no skills installed</EmptyRow>
-        ) : (
-          <ItemGroup>
-            {skills.map((skill) => (
-              <Row
-                key={skill.path}
-                icon={<Wand2 />}
-                iconClass="bg-violet-500/12 text-violet-600 dark:text-violet-400"
-                label={skill.name}
-                hasChevron
-                selected={
-                  selected !== null && selected.startsWith(`${skill.path}/`)
-                }
-                onClick={() => setNav({ view: "skill", skillPath: skill.path })}
-              />
-            ))}
-          </ItemGroup>
-        )}
-      </CardContent>
+    <Card size="sm" className="!py-0">
+      <ScrollArea className="h-80">
+        <div className="flex flex-col gap-2 p-3">
+          {inSkillView && activeSkill ? (
+            <>
+              <button
+                type="button"
+                onClick={() => setNav({ view: "root" })}
+                className="flex items-center gap-1 self-start px-1 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <ChevronLeft className="size-3.5" />
+                <span className="font-medium text-foreground">
+                  {activeSkill.name}
+                </span>
+              </button>
+              {activeSkill.mdFiles.length === 0 ? (
+                <EmptyRow>no markdown files</EmptyRow>
+              ) : (
+                <ItemGroup>
+                  {activeSkill.mdFiles.map((file) => (
+                    <Row
+                      key={file.path}
+                      icon={<FileText />}
+                      iconClass="bg-muted text-muted-foreground"
+                      label={file.name}
+                      selected={selected === file.path}
+                      onClick={() => onSelect(file.path)}
+                    />
+                  ))}
+                </ItemGroup>
+              )}
+            </>
+          ) : skills.length === 0 ? (
+            <EmptyRow>no skills installed</EmptyRow>
+          ) : (
+            <ItemGroup>
+              {skills.map((skill) => (
+                <Row
+                  key={skill.path}
+                  icon={<Wand2 />}
+                  iconClass="bg-violet-500/12 text-violet-600 dark:text-violet-400"
+                  label={skill.name}
+                  hasChevron
+                  selected={
+                    selected !== null && selected.startsWith(`${skill.path}/`)
+                  }
+                  onClick={() =>
+                    setNav({ view: "skill", skillPath: skill.path })
+                  }
+                />
+              ))}
+            </ItemGroup>
+          )}
+        </div>
+      </ScrollArea>
     </Card>
   );
 }

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { FileTreeEntry } from "@/api/files";
+import { HostAccessCard } from "../HostAccessCard";
 import {
   collectDreamPaths,
   CONSTITUTION_PATH,
@@ -84,6 +85,9 @@ export function SimpleView({
         onShowDreams={onShowDreams}
       />
       <SkillsCard skills={skills} selected={selected} onSelect={onSelect} />
+      <div className="shrink-0">
+        <HostAccessCard />
+      </div>
     </div>
   );
 }
@@ -117,8 +121,13 @@ function MindCard({
             : "hover:bg-muted/60 active:bg-muted",
         )}
       >
-        <BookOpen className="size-4 text-muted-foreground" />
-        <span className="font-medium">memory</span>
+        <BookOpen className="size-4 shrink-0 text-muted-foreground" />
+        <span className="flex min-w-0 flex-col">
+          <span className="font-medium">memory</span>
+          <span className="text-[11px] text-muted-foreground">
+            what vesta remembers about you
+          </span>
+        </span>
       </button>
 
       <button
@@ -131,8 +140,13 @@ function MindCard({
             : "hover:bg-muted/60 active:bg-muted",
         )}
       >
-        <ScrollText className="size-4 text-muted-foreground" />
-        <span className="font-medium">constitution</span>
+        <ScrollText className="size-4 shrink-0 text-muted-foreground" />
+        <span className="flex min-w-0 flex-col">
+          <span className="font-medium">constitution</span>
+          <span className="text-[11px] text-muted-foreground">
+            the directives you set that vesta follows
+          </span>
+        </span>
       </button>
 
       <button

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -10,7 +10,6 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Card, CardContent } from "@/components/ui/card";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Item,
   ItemActions,
@@ -265,61 +264,57 @@ function SkillsCard({
   const inSkillView = activeSkill !== null;
 
   return (
-    <Card size="sm" className="!py-0">
-      <ScrollArea className="**:data-[slot=scroll-area-viewport]:max-h-80 **:data-[slot=scroll-area-viewport]:px-3 **:data-[slot=scroll-area-viewport]:py-0">
-        <div className="flex flex-col gap-2">
-          {inSkillView && activeSkill ? (
-            <>
-              <button
-                type="button"
-                onClick={() => setNav({ view: "root" })}
-                className="flex items-center gap-1 self-start px-1 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <ChevronLeft className="size-3.5" />
-                <span className="font-medium text-foreground">
-                  {activeSkill.name}
-                </span>
-              </button>
-              {activeSkill.mdFiles.length === 0 ? (
-                <EmptyRow>no markdown files</EmptyRow>
-              ) : (
-                <ItemGroup>
-                  {activeSkill.mdFiles.map((file) => (
-                    <Row
-                      key={file.path}
-                      icon={<FileText />}
-                      iconClass="bg-muted text-muted-foreground"
-                      label={file.name}
-                      selected={selected === file.path}
-                      onClick={() => onSelect(file.path)}
-                    />
-                  ))}
-                </ItemGroup>
-              )}
-            </>
-          ) : skills.length === 0 ? (
-            <EmptyRow>no skills installed</EmptyRow>
-          ) : (
-            <ItemGroup>
-              {skills.map((skill) => (
-                <Row
-                  key={skill.path}
-                  icon={<Wand2 />}
-                  iconClass="bg-violet-500/12 text-violet-600 dark:text-violet-400"
-                  label={skill.name}
-                  hasChevron
-                  selected={
-                    selected !== null && selected.startsWith(`${skill.path}/`)
-                  }
-                  onClick={() =>
-                    setNav({ view: "skill", skillPath: skill.path })
-                  }
-                />
-              ))}
-            </ItemGroup>
-          )}
-        </div>
-      </ScrollArea>
+    <Card size="sm">
+      <CardContent className="flex max-h-80 flex-col gap-2 overflow-auto">
+        {inSkillView && activeSkill ? (
+          <>
+            <button
+              type="button"
+              onClick={() => setNav({ view: "root" })}
+              className="flex items-center gap-1 self-start px-1 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <ChevronLeft className="size-3.5" />
+              <span className="font-medium text-foreground">
+                {activeSkill.name}
+              </span>
+            </button>
+            {activeSkill.mdFiles.length === 0 ? (
+              <EmptyRow>no markdown files</EmptyRow>
+            ) : (
+              <ItemGroup>
+                {activeSkill.mdFiles.map((file) => (
+                  <Row
+                    key={file.path}
+                    icon={<FileText />}
+                    iconClass="bg-muted text-muted-foreground"
+                    label={file.name}
+                    selected={selected === file.path}
+                    onClick={() => onSelect(file.path)}
+                  />
+                ))}
+              </ItemGroup>
+            )}
+          </>
+        ) : skills.length === 0 ? (
+          <EmptyRow>no skills installed</EmptyRow>
+        ) : (
+          <ItemGroup>
+            {skills.map((skill) => (
+              <Row
+                key={skill.path}
+                icon={<Wand2 />}
+                iconClass="bg-violet-500/12 text-violet-600 dark:text-violet-400"
+                label={skill.name}
+                hasChevron
+                selected={
+                  selected !== null && selected.startsWith(`${skill.path}/`)
+                }
+                onClick={() => setNav({ view: "skill", skillPath: skill.path })}
+              />
+            ))}
+          </ItemGroup>
+        )}
+      </CardContent>
     </Card>
   );
 }

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Card, CardContent } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Item,
   ItemActions,
@@ -264,57 +265,61 @@ function SkillsCard({
   const inSkillView = activeSkill !== null;
 
   return (
-    <Card size="sm">
-      <CardContent className="flex max-h-80 flex-col gap-2 overflow-auto">
-        {inSkillView && activeSkill ? (
-          <>
-            <button
-              type="button"
-              onClick={() => setNav({ view: "root" })}
-              className="flex items-center gap-1 self-start px-1 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <ChevronLeft className="size-3.5" />
-              <span className="font-medium text-foreground">
-                {activeSkill.name}
-              </span>
-            </button>
-            {activeSkill.mdFiles.length === 0 ? (
-              <EmptyRow>no markdown files</EmptyRow>
-            ) : (
-              <ItemGroup>
-                {activeSkill.mdFiles.map((file) => (
-                  <Row
-                    key={file.path}
-                    icon={<FileText />}
-                    iconClass="bg-muted text-muted-foreground"
-                    label={file.name}
-                    selected={selected === file.path}
-                    onClick={() => onSelect(file.path)}
-                  />
-                ))}
-              </ItemGroup>
-            )}
-          </>
-        ) : skills.length === 0 ? (
-          <EmptyRow>no skills installed</EmptyRow>
-        ) : (
-          <ItemGroup>
-            {skills.map((skill) => (
-              <Row
-                key={skill.path}
-                icon={<Wand2 />}
-                iconClass="bg-violet-500/12 text-violet-600 dark:text-violet-400"
-                label={skill.name}
-                hasChevron
-                selected={
-                  selected !== null && selected.startsWith(`${skill.path}/`)
-                }
-                onClick={() => setNav({ view: "skill", skillPath: skill.path })}
-              />
-            ))}
-          </ItemGroup>
-        )}
-      </CardContent>
+    <Card size="sm" className="!py-0">
+      <ScrollArea className="max-h-80 [&_[data-slot=scroll-area-viewport]]:px-3 [&_[data-slot=scroll-area-viewport]]:py-0">
+        <div className="flex flex-col gap-2">
+          {inSkillView && activeSkill ? (
+            <>
+              <button
+                type="button"
+                onClick={() => setNav({ view: "root" })}
+                className="flex items-center gap-1 self-start px-1 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <ChevronLeft className="size-3.5" />
+                <span className="font-medium text-foreground">
+                  {activeSkill.name}
+                </span>
+              </button>
+              {activeSkill.mdFiles.length === 0 ? (
+                <EmptyRow>no markdown files</EmptyRow>
+              ) : (
+                <ItemGroup>
+                  {activeSkill.mdFiles.map((file) => (
+                    <Row
+                      key={file.path}
+                      icon={<FileText />}
+                      iconClass="bg-muted text-muted-foreground"
+                      label={file.name}
+                      selected={selected === file.path}
+                      onClick={() => onSelect(file.path)}
+                    />
+                  ))}
+                </ItemGroup>
+              )}
+            </>
+          ) : skills.length === 0 ? (
+            <EmptyRow>no skills installed</EmptyRow>
+          ) : (
+            <ItemGroup>
+              {skills.map((skill) => (
+                <Row
+                  key={skill.path}
+                  icon={<Wand2 />}
+                  iconClass="bg-violet-500/12 text-violet-600 dark:text-violet-400"
+                  label={skill.name}
+                  hasChevron
+                  selected={
+                    selected !== null && selected.startsWith(`${skill.path}/`)
+                  }
+                  onClick={() =>
+                    setNav({ view: "skill", skillPath: skill.path })
+                  }
+                />
+              ))}
+            </ItemGroup>
+          )}
+        </div>
+      </ScrollArea>
     </Card>
   );
 }

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -11,6 +11,14 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+} from "@/components/ui/item";
 import type { FileTreeEntry } from "@/api/files";
 import { HostAccessCard } from "../HostAccessCard";
 import {
@@ -132,48 +140,50 @@ function MindCard({
 }) {
   return (
     <Card size="sm" className="shrink-0">
-      <CardContent className="flex flex-col gap-1.5">
-        <HubRow
-          onClick={onSelectMemory}
-          selected={memorySelected}
-          iconClass="bg-amber-500/12 text-amber-600 dark:text-amber-400"
-          icon={<BookOpen className="size-[18px]" />}
-          title="memory"
-          description="what vesta remembers about you"
-        />
-        <HubRow
-          onClick={onSelectConstitution}
-          selected={constitutionSelected}
-          iconClass="bg-emerald-500/12 text-emerald-600 dark:text-emerald-400"
-          icon={<ScrollText className="size-[18px]" />}
-          title="constitution"
-          description="the directives you set that vesta follows"
-        />
-        <HubRow
-          onClick={onShowDreams}
-          selected={dreamsActive}
-          iconClass="bg-indigo-500/12 text-indigo-500 dark:text-indigo-400"
-          icon={<Moon className="size-[18px]" />}
-          title="dreams"
-          description="nightly reflections on the day"
-          trailing={
-            <div className="flex items-center gap-1.5">
-              {dreamCount > 0 && (
-                <span className="text-[11px] text-muted-foreground">
-                  {dreamCount}
-                </span>
-              )}
-              <ChevronRight className="size-4 shrink-0 text-muted-foreground/60" />
-            </div>
-          }
-        />
+      <CardContent>
+        <ItemGroup>
+          <HubRow
+            onClick={onSelectMemory}
+            selected={memorySelected}
+            iconClass="bg-amber-500/12 text-amber-600 dark:text-amber-400"
+            icon={<BookOpen />}
+            title="memory"
+            description="what vesta remembers about you"
+          />
+          <HubRow
+            onClick={onSelectConstitution}
+            selected={constitutionSelected}
+            iconClass="bg-emerald-500/12 text-emerald-600 dark:text-emerald-400"
+            icon={<ScrollText />}
+            title="constitution"
+            description="the directives you set that vesta follows"
+          />
+          <HubRow
+            onClick={onShowDreams}
+            selected={dreamsActive}
+            iconClass="bg-indigo-500/12 text-indigo-500 dark:text-indigo-400"
+            icon={<Moon />}
+            title="dreams"
+            description="nightly reflections on the day"
+            trailing={
+              <>
+                {dreamCount > 0 && (
+                  <span className="text-[11px] text-muted-foreground">
+                    {dreamCount}
+                  </span>
+                )}
+                <ChevronRight className="size-4 text-muted-foreground/60" />
+              </>
+            }
+          />
+        </ItemGroup>
       </CardContent>
     </Card>
   );
 }
 
-// A soft, tappable "cell" inside a hub card: a tinted icon square, a title,
-// an optional secondary line, and optional trailing content.
+// A soft, tappable "cell" inside a hub card, built on the shadcn Item primitive:
+// a tinted icon square, a title, an optional secondary line, optional trailing.
 function HubRow({
   icon,
   iconClass,
@@ -192,32 +202,30 @@ function HubRow({
   onClick: () => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "flex w-full items-center gap-3 rounded-xl px-2.5 py-2.5 text-left transition-colors",
-        selected ? "bg-muted" : "bg-muted/40 hover:bg-muted/70 active:bg-muted",
-      )}
+    <Item
+      asChild
+      variant="muted"
+      size="sm"
+      className={cn("cursor-pointer hover:bg-muted/70", selected && "bg-muted")}
     >
-      <span
-        className={cn(
-          "flex size-9 shrink-0 items-center justify-center rounded-[10px]",
-          iconClass,
-        )}
-      >
-        {icon}
-      </span>
-      <span className="flex min-w-0 flex-1 flex-col">
-        <span className="text-sm font-medium leading-tight">{title}</span>
-        {description ? (
-          <span className="truncate text-[11px] text-muted-foreground">
-            {description}
-          </span>
-        ) : null}
-      </span>
-      {trailing}
-    </button>
+      <button type="button" onClick={onClick}>
+        <ItemMedia
+          variant="icon"
+          className={cn("size-9 rounded-[10px]", iconClass)}
+        >
+          {icon}
+        </ItemMedia>
+        <ItemContent className="gap-0">
+          <ItemTitle>{title}</ItemTitle>
+          {description ? (
+            <span className="truncate text-[11px] text-muted-foreground">
+              {description}
+            </span>
+          ) : null}
+        </ItemContent>
+        {trailing ? <ItemActions>{trailing}</ItemActions> : null}
+      </button>
+    </Item>
   );
 }
 
@@ -277,38 +285,42 @@ function SkillsCard({
         )}
       </CardHeader>
 
-      <CardContent className="flex flex-1 min-h-0 flex-col gap-1.5 overflow-auto">
+      <CardContent className="flex-1 min-h-0 overflow-auto">
         {inSkillView && activeSkill ? (
           activeSkill.mdFiles.length === 0 ? (
             <EmptyRow>no markdown files</EmptyRow>
           ) : (
-            activeSkill.mdFiles.map((file) => (
-              <Row
-                key={file.path}
-                icon={<FileText className="size-4" />}
-                iconClass="bg-muted text-muted-foreground"
-                label={file.name}
-                selected={selected === file.path}
-                onClick={() => onSelect(file.path)}
-              />
-            ))
+            <ItemGroup>
+              {activeSkill.mdFiles.map((file) => (
+                <Row
+                  key={file.path}
+                  icon={<FileText />}
+                  iconClass="bg-muted text-muted-foreground"
+                  label={file.name}
+                  selected={selected === file.path}
+                  onClick={() => onSelect(file.path)}
+                />
+              ))}
+            </ItemGroup>
           )
         ) : skills.length === 0 ? (
           <EmptyRow>no skills installed</EmptyRow>
         ) : (
-          skills.map((skill) => (
-            <Row
-              key={skill.path}
-              icon={<Wand2 className="size-4" />}
-              iconClass="bg-violet-500/12 text-violet-600 dark:text-violet-400"
-              label={skill.name}
-              hasChevron
-              selected={
-                selected !== null && selected.startsWith(`${skill.path}/`)
-              }
-              onClick={() => setNav({ view: "skill", skillPath: skill.path })}
-            />
-          ))
+          <ItemGroup>
+            {skills.map((skill) => (
+              <Row
+                key={skill.path}
+                icon={<Wand2 />}
+                iconClass="bg-violet-500/12 text-violet-600 dark:text-violet-400"
+                label={skill.name}
+                hasChevron
+                selected={
+                  selected !== null && selected.startsWith(`${skill.path}/`)
+                }
+                onClick={() => setNav({ view: "skill", skillPath: skill.path })}
+              />
+            ))}
+          </ItemGroup>
         )}
       </CardContent>
     </Card>
@@ -331,27 +343,29 @@ function Row({
   onClick: () => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "flex w-full items-center gap-3 rounded-xl px-2.5 py-2 text-left text-sm transition-colors",
-        selected ? "bg-muted" : "bg-muted/40 hover:bg-muted/70 active:bg-muted",
-      )}
+    <Item
+      asChild
+      variant="muted"
+      size="sm"
+      className={cn("cursor-pointer hover:bg-muted/70", selected && "bg-muted")}
     >
-      <span
-        className={cn(
-          "flex size-8 shrink-0 items-center justify-center rounded-[9px]",
-          iconClass,
-        )}
-      >
-        {icon}
-      </span>
-      <span className="flex-1 truncate">{label}</span>
-      {hasChevron && (
-        <ChevronRight className="size-4 shrink-0 text-muted-foreground/60" />
-      )}
-    </button>
+      <button type="button" onClick={onClick}>
+        <ItemMedia
+          variant="icon"
+          className={cn("size-8 rounded-[9px]", iconClass)}
+        >
+          {icon}
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>{label}</ItemTitle>
+        </ItemContent>
+        {hasChevron ? (
+          <ItemActions>
+            <ChevronRight className="size-4 text-muted-foreground/60" />
+          </ItemActions>
+        ) : null}
+      </button>
+    </Item>
   );
 }
 

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -86,22 +86,28 @@ export function SimpleView({
   const name = agentName ?? "the agent";
 
   return (
-    <div className="flex flex-col gap-3 p-1">
-      <GroupLabel>{name}'s mind</GroupLabel>
-      <MindCard
-        name={name}
-        memorySelected={selected === MEMORY_PATH && !dreamsActive}
-        constitutionSelected={selected === CONSTITUTION_PATH && !dreamsActive}
-        dreamsActive={dreamsActive}
-        dreamCount={dreamCount}
-        onSelectMemory={() => onSelect(MEMORY_PATH)}
-        onSelectConstitution={() => onSelect(CONSTITUTION_PATH)}
-        onShowDreams={onShowDreams}
-      />
-      <GroupLabel className="pt-1">skills</GroupLabel>
-      <SkillsCard skills={skills} selected={selected} onSelect={onSelect} />
-      <GroupLabel className="pt-1">on this computer</GroupLabel>
-      <div className="shrink-0">
+    // Mobile: one stacked column (mind → skills → shared folders). Desktop: a bento — mind and
+    // shared folders on the left, skills on the right (grid auto-flow places them from this order).
+    <div className="grid grid-cols-1 gap-3 p-1 lg:grid-cols-2 lg:items-start">
+      <div className="flex flex-col gap-3">
+        <GroupLabel>{name}'s mind</GroupLabel>
+        <MindCard
+          name={name}
+          memorySelected={selected === MEMORY_PATH && !dreamsActive}
+          constitutionSelected={selected === CONSTITUTION_PATH && !dreamsActive}
+          dreamsActive={dreamsActive}
+          dreamCount={dreamCount}
+          onSelectMemory={() => onSelect(MEMORY_PATH)}
+          onSelectConstitution={() => onSelect(CONSTITUTION_PATH)}
+          onShowDreams={onShowDreams}
+        />
+      </div>
+      <div className="flex flex-col gap-3">
+        <GroupLabel>skills</GroupLabel>
+        <SkillsCard skills={skills} selected={selected} onSelect={onSelect} />
+      </div>
+      <div className="flex flex-col gap-3">
+        <GroupLabel>on this computer</GroupLabel>
         <HostAccessCard />
       </div>
     </div>

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -15,6 +15,7 @@ import {
   Item,
   ItemActions,
   ItemContent,
+  ItemDescription,
   ItemGroup,
   ItemMedia,
   ItemTitle,
@@ -82,7 +83,7 @@ export function SimpleView({
   );
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-3 p-1">
+    <div className="flex flex-col gap-3 p-1">
       <GroupLabel>vesta's mind</GroupLabel>
       <MindCard
         memorySelected={selected === MEMORY_PATH && !dreamsActive}
@@ -206,7 +207,10 @@ function HubRow({
       asChild
       variant="muted"
       size="sm"
-      className={cn("cursor-pointer hover:bg-muted/70", selected && "bg-muted")}
+      className={cn(
+        "cursor-pointer text-left hover:bg-muted/70",
+        selected && "bg-muted",
+      )}
     >
       <button type="button" onClick={onClick}>
         <ItemMedia
@@ -215,12 +219,12 @@ function HubRow({
         >
           {icon}
         </ItemMedia>
-        <ItemContent className="gap-0">
+        <ItemContent className="gap-0.5">
           <ItemTitle>{title}</ItemTitle>
           {description ? (
-            <span className="truncate text-[11px] text-muted-foreground">
+            <ItemDescription className="text-[11px]">
               {description}
-            </span>
+            </ItemDescription>
           ) : null}
         </ItemContent>
         {trailing ? <ItemActions>{trailing}</ItemActions> : null}
@@ -260,7 +264,7 @@ function SkillsCard({
   const inSkillView = activeSkill !== null;
 
   return (
-    <Card size="sm" className="!py-0 !gap-0 flex flex-1 min-h-0 flex-col">
+    <Card size="sm" className="!py-0 !gap-0 flex flex-col">
       <CardHeader className="shrink-0 !flex !flex-row !items-center !gap-2.5 !px-5 !py-2.5 border-b border-border/60 [.border-b]:!pb-2.5">
         {inSkillView && activeSkill ? (
           <>
@@ -285,7 +289,7 @@ function SkillsCard({
         )}
       </CardHeader>
 
-      <CardContent className="flex-1 min-h-0 overflow-auto">
+      <CardContent className="max-h-80 overflow-auto py-2">
         {inSkillView && activeSkill ? (
           activeSkill.mdFiles.length === 0 ? (
             <EmptyRow>no markdown files</EmptyRow>
@@ -347,7 +351,10 @@ function Row({
       asChild
       variant="muted"
       size="sm"
-      className={cn("cursor-pointer hover:bg-muted/70", selected && "bg-muted")}
+      className={cn(
+        "cursor-pointer text-left hover:bg-muted/70",
+        selected && "bg-muted",
+      )}
     >
       <button type="button" onClick={onClick}>
         <ItemMedia

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -6,11 +6,10 @@ import {
   FileText,
   Moon,
   ScrollText,
-  Sparkles,
   Wand2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import {
   Item,
   ItemActions,
@@ -94,6 +93,7 @@ export function SimpleView({
         onSelectConstitution={() => onSelect(CONSTITUTION_PATH)}
         onShowDreams={onShowDreams}
       />
+      <GroupLabel className="pt-1">skills</GroupLabel>
       <SkillsCard skills={skills} selected={selected} onSelect={onSelect} />
       <GroupLabel className="pt-1">on this computer</GroupLabel>
       <div className="shrink-0">
@@ -264,49 +264,37 @@ function SkillsCard({
   const inSkillView = activeSkill !== null;
 
   return (
-    <Card size="sm" className="!py-0 !gap-0 flex flex-col">
-      <CardHeader className="shrink-0 !flex !flex-row !items-center !gap-2.5 !px-5 !py-2.5 border-b border-border/60 [.border-b]:!pb-2.5">
+    <Card size="sm">
+      <CardContent className="flex max-h-80 flex-col gap-2 overflow-auto">
         {inSkillView && activeSkill ? (
           <>
             <button
               type="button"
               onClick={() => setNav({ view: "root" })}
-              className="flex items-center gap-0.5 text-sm hover:opacity-80"
+              className="flex items-center gap-1 self-start px-1 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
             >
-              <ChevronLeft className="size-4" />
-              skills
+              <ChevronLeft className="size-3.5" />
+              <span className="font-medium text-foreground">
+                {activeSkill.name}
+              </span>
             </button>
-            <span className="text-muted-foreground/60">/</span>
-            <CardTitle className="!text-sm !font-medium truncate">
-              {activeSkill.name}
-            </CardTitle>
+            {activeSkill.mdFiles.length === 0 ? (
+              <EmptyRow>no markdown files</EmptyRow>
+            ) : (
+              <ItemGroup>
+                {activeSkill.mdFiles.map((file) => (
+                  <Row
+                    key={file.path}
+                    icon={<FileText />}
+                    iconClass="bg-muted text-muted-foreground"
+                    label={file.name}
+                    selected={selected === file.path}
+                    onClick={() => onSelect(file.path)}
+                  />
+                ))}
+              </ItemGroup>
+            )}
           </>
-        ) : (
-          <>
-            <Sparkles className="size-4 text-muted-foreground" />
-            <CardTitle className="!text-sm !font-medium">skills</CardTitle>
-          </>
-        )}
-      </CardHeader>
-
-      <CardContent className="max-h-80 overflow-auto py-2">
-        {inSkillView && activeSkill ? (
-          activeSkill.mdFiles.length === 0 ? (
-            <EmptyRow>no markdown files</EmptyRow>
-          ) : (
-            <ItemGroup>
-              {activeSkill.mdFiles.map((file) => (
-                <Row
-                  key={file.path}
-                  icon={<FileText />}
-                  iconClass="bg-muted text-muted-foreground"
-                  label={file.name}
-                  selected={selected === file.path}
-                  onClick={() => onSelect(file.path)}
-                />
-              ))}
-            </ItemGroup>
-          )
         ) : skills.length === 0 ? (
           <EmptyRow>no skills installed</EmptyRow>
         ) : (

--- a/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/SimpleView.tsx
@@ -229,8 +229,8 @@ function HubRow({
       variant="muted"
       size="sm"
       className={cn(
-        "cursor-pointer text-left hover:bg-muted/70",
-        selected && "bg-muted",
+        "cursor-pointer text-left transition hover:brightness-95 dark:hover:brightness-110",
+        selected && "brightness-95 dark:brightness-110",
       )}
     >
       <button type="button" onClick={onClick}>
@@ -363,8 +363,8 @@ function Row({
       variant="muted"
       size="sm"
       className={cn(
-        "cursor-pointer text-left hover:bg-muted/70",
-        selected && "bg-muted",
+        "cursor-pointer text-left transition hover:brightness-95 dark:hover:brightness-110",
+        selected && "brightness-95 dark:brightness-110",
       )}
     >
       <button type="button" onClick={onClick}>

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Item, ItemContent, ItemGroup, ItemMedia } from "@/components/ui/item";
 import { cn, errorMessage } from "@/lib/utils";
 import {
   fetchFileTree,
@@ -80,34 +81,44 @@ function AdvancedSkeleton() {
   );
 }
 
-function SkeletonRow() {
+// A hub cell placeholder, shaped like the Item cells the simple view renders.
+function HubRowSkeleton() {
   return (
-    <div className="flex w-full items-center gap-2.5 px-4 py-3">
-      <Skeleton className="size-4 shrink-0 rounded-full" />
-      <Skeleton className="h-3 flex-1 rounded" />
-    </div>
+    <Item variant="muted" size="sm">
+      <ItemMedia variant="icon" className="size-9 rounded-[10px] bg-muted">
+        <Skeleton className="size-4 rounded" />
+      </ItemMedia>
+      <ItemContent className="gap-1.5">
+        <Skeleton className="h-3.5 w-24 rounded" />
+        <Skeleton className="h-3 w-40 max-w-full rounded" />
+      </ItemContent>
+    </Item>
+  );
+}
+
+function SkeletonSection({ rows }: { rows: number }) {
+  return (
+    <>
+      <Skeleton className="ml-1 h-3 w-20 rounded" />
+      <Card size="sm">
+        <CardContent>
+          <ItemGroup>
+            {Array.from({ length: rows }).map((_, i) => (
+              <HubRowSkeleton key={i} />
+            ))}
+          </ItemGroup>
+        </CardContent>
+      </Card>
+    </>
   );
 }
 
 function SimpleSkeleton() {
   return (
-    <div className="flex h-full min-h-0 flex-col gap-4 p-1">
-      <Card size="sm" className="!py-0 !gap-0 flex shrink-0 flex-col">
-        <SkeletonRow />
-        <SkeletonRow />
-        <SkeletonRow />
-      </Card>
-      <Card size="sm" className="!py-0 !gap-0 flex flex-1 min-h-0 flex-col">
-        <CardHeader className="shrink-0 !flex !flex-row !items-center !gap-2.5 !px-4 !py-2.5">
-          <Skeleton className="size-4 rounded-full" />
-          <Skeleton className="h-3 w-12" />
-        </CardHeader>
-        <CardContent className="flex-1 min-h-0 !px-0 !py-0">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <SkeletonRow key={i} />
-          ))}
-        </CardContent>
-      </Card>
+    <div className="flex flex-col gap-3 p-1">
+      <SkeletonSection rows={3} />
+      <SkeletonSection rows={3} />
+      <SkeletonSection rows={2} />
     </div>
   );
 }

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -129,16 +129,16 @@ function SimpleSkeleton({ agentName }: { agentName?: string }) {
   return (
     <div className="flex flex-col gap-3 p-1 lg:grid lg:grid-cols-2 lg:items-start lg:gap-x-6">
       <div className="contents lg:flex lg:flex-col lg:gap-6">
-        <SkeletonSection label={`${name}'s mind`} rows={3} />
+        <SkeletonSection label={`who ${name} is`} rows={3} />
         <SkeletonSection
-          label="on this computer"
+          label="shared folders"
           rows={2}
           className="order-3 lg:order-none"
         />
       </div>
       <div className="contents lg:flex lg:flex-col lg:gap-6">
         <SkeletonSection
-          label="skills"
+          label="abilities"
           rows={3}
           className="order-2 lg:order-none"
         />

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -298,6 +298,7 @@ export function FilesTab() {
           entries={entries}
           selected={selectedPath}
           dreamsActive={dreamsActive}
+          agentName={agentName}
           onSelect={selectFile}
           onShowDreams={showDreams}
         />

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -22,6 +22,7 @@ import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useFillHeight } from "@/hooks/use-fill-height";
 import { useAppMode } from "@/stores/use-app-mode";
+import { useRestartPending } from "@/stores/use-restart-pending";
 import { DreamsViewer } from "./DreamsViewer";
 import { FileTree } from "./FileTree";
 import { FileEditor } from "./FileEditor";
@@ -45,7 +46,7 @@ function statusText(status: SaveStatus, dirty: boolean): string {
     case "saving":
       return "saving...";
     case "saved":
-      return "saved — restart the agent for changes to take effect";
+      return "saved";
     case "error":
       return status.message;
     default:
@@ -150,6 +151,7 @@ export function FilesTab() {
   const [editorContent, setEditorContent] = useState("");
   const [status, setStatus] = useState<SaveStatus>({ kind: "idle" });
   const mode = useAppMode((s) => s.mode);
+  const markRestartPending = useRestartPending((s) => s.markPending);
   const [dreamsActive, setDreamsActive] = useState(false);
 
   useEffect(() => {
@@ -244,6 +246,7 @@ export function FilesTab() {
       await writeFile(agentName, loadedFile.path, editorContent);
       setLoadedFile({ ...loadedFile, content: editorContent });
       setStatus({ kind: "saved" });
+      markRestartPending(agentName);
     } catch (e) {
       setStatus({ kind: "error", message: errorMessage(e, "save failed") });
     }

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -386,19 +386,28 @@ export function FilesTab() {
       treeInner
     );
 
-    // Mobile fills the screen; desktop centers a calm, bounded column.
-    return isMobile ? (
-      <div
-        ref={fillRef}
-        style={{ height: fillHeight }}
-        className="flex min-h-0 flex-col"
-      >
-        {panel}
-      </div>
-    ) : (
+    // The detail view (editor/dreams) is bounded so it scrolls internally; the
+    // hub flows naturally and scrolls with the page. Mobile fills the screen.
+    if (isMobile) {
+      return (
+        <div
+          ref={fillRef}
+          style={{ height: fillHeight }}
+          className={cn(
+            "flex min-h-0 flex-col",
+            !inDetail && "overflow-y-auto",
+          )}
+        >
+          {panel}
+        </div>
+      );
+    }
+    return inDetail ? (
       <div className="mx-auto flex h-[70vh] w-full max-w-2xl min-h-0 flex-col">
         {panel}
       </div>
+    ) : (
+      <div className="mx-auto w-full max-w-2xl">{panel}</div>
     );
   }
 

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -358,37 +358,46 @@ export function FilesTab() {
     </CardContent>
   );
 
-  // Mobile drill-in: the tree, then the editor/dreams detail view with a back
-  // button. Only one panel shows at a time, each filling the screen.
-  if (isMobile) {
+  // Drill-in layout: a hub, then the editor/dreams detail with a back button,
+  // one panel at a time. Used on mobile (any mode) and for the calm simple-mode
+  // hub on desktop. Advanced desktop keeps the two-pane tree + editor below.
+  const drillIn = isMobile || mode === "simple";
+  if (drillIn) {
     const inDetail = dreamsActive || selectedPath !== null;
-    return (
+    const panel = inDetail ? (
+      <Card size="sm" className="!py-0 !gap-0 flex flex-1 min-w-0 flex-col">
+        <div className="shrink-0 flex items-center gap-2 border-b border-border/60 px-3 py-2.5">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="back to files"
+            onClick={goBack}
+          >
+            <ChevronLeft className="size-5" />
+          </Button>
+          <span className="flex-1 truncate text-xs text-muted-foreground">
+            {headerLabel}
+          </span>
+          {!dreamsActive && saveControls}
+        </div>
+        {editorBody}
+      </Card>
+    ) : (
+      treeInner
+    );
+
+    // Mobile fills the screen; desktop centers a calm, bounded column.
+    return isMobile ? (
       <div
         ref={fillRef}
         style={{ height: fillHeight }}
         className="flex min-h-0 flex-col"
       >
-        {inDetail ? (
-          <Card size="sm" className="!py-0 !gap-0 flex flex-1 min-w-0 flex-col">
-            <div className="shrink-0 flex items-center gap-2 border-b border-border/60 px-3 py-2.5">
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label="back to files"
-                onClick={goBack}
-              >
-                <ChevronLeft className="size-5" />
-              </Button>
-              <span className="flex-1 truncate text-xs text-muted-foreground">
-                {headerLabel}
-              </span>
-              {!dreamsActive && saveControls}
-            </div>
-            {editorBody}
-          </Card>
-        ) : (
-          treeInner
-        )}
+        {panel}
+      </div>
+    ) : (
+      <div className="mx-auto flex h-[70vh] w-full max-w-2xl min-h-0 flex-col">
+        {panel}
       </div>
     );
   }

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -96,9 +96,17 @@ function HubRowSkeleton() {
   );
 }
 
-function SkeletonSection({ label, rows }: { label: string; rows: number }) {
+function SkeletonSection({
+  label,
+  rows,
+  className,
+}: {
+  label: string;
+  rows: number;
+  className?: string;
+}) {
   return (
-    <div className="flex flex-col gap-3">
+    <div className={cn("flex flex-col gap-3", className)}>
       <p className="px-1 text-[11px] font-medium text-muted-foreground/70">
         {label}
       </p>
@@ -115,13 +123,26 @@ function SkeletonSection({ label, rows }: { label: string; rows: number }) {
   );
 }
 
+// Matches SimpleView's bento: mind + shared folders left, skills right; one stacked column on mobile.
 function SimpleSkeleton({ agentName }: { agentName?: string }) {
   const name = agentName ?? "the agent";
   return (
-    <div className="grid grid-cols-1 gap-3 p-1 lg:grid-cols-2 lg:items-start">
-      <SkeletonSection label={`${name}'s mind`} rows={3} />
-      <SkeletonSection label="skills" rows={3} />
-      <SkeletonSection label="on this computer" rows={2} />
+    <div className="flex flex-col gap-3 p-1 lg:grid lg:grid-cols-2 lg:items-start">
+      <div className="contents lg:flex lg:flex-col lg:gap-3">
+        <SkeletonSection label={`${name}'s mind`} rows={3} />
+        <SkeletonSection
+          label="on this computer"
+          rows={2}
+          className="order-3 lg:order-none"
+        />
+      </div>
+      <div className="contents lg:flex lg:flex-col lg:gap-3">
+        <SkeletonSection
+          label="skills"
+          rows={3}
+          className="order-2 lg:order-none"
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -128,7 +128,7 @@ function SimpleSkeleton({ agentName }: { agentName?: string }) {
   const name = agentName ?? "the agent";
   return (
     <div className="flex flex-col gap-3 p-1 lg:grid lg:grid-cols-2 lg:items-start">
-      <div className="contents lg:flex lg:flex-col lg:gap-3">
+      <div className="contents lg:flex lg:flex-col lg:gap-6">
         <SkeletonSection label={`${name}'s mind`} rows={3} />
         <SkeletonSection
           label="on this computer"
@@ -136,7 +136,7 @@ function SimpleSkeleton({ agentName }: { agentName?: string }) {
           className="order-3 lg:order-none"
         />
       </div>
-      <div className="contents lg:flex lg:flex-col lg:gap-3">
+      <div className="contents lg:flex lg:flex-col lg:gap-6">
         <SkeletonSection
           label="skills"
           rows={3}

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -98,7 +98,7 @@ function HubRowSkeleton() {
 
 function SkeletonSection({ label, rows }: { label: string; rows: number }) {
   return (
-    <>
+    <div className="flex flex-col gap-3">
       <p className="px-1 text-[11px] font-medium text-muted-foreground/70">
         {label}
       </p>
@@ -111,14 +111,14 @@ function SkeletonSection({ label, rows }: { label: string; rows: number }) {
           </ItemGroup>
         </CardContent>
       </Card>
-    </>
+    </div>
   );
 }
 
 function SimpleSkeleton({ agentName }: { agentName?: string }) {
   const name = agentName ?? "the agent";
   return (
-    <div className="flex flex-col gap-3 p-1">
+    <div className="grid grid-cols-1 gap-3 p-1 lg:grid-cols-2 lg:items-start">
       <SkeletonSection label={`${name}'s mind`} rows={3} />
       <SkeletonSection label="skills" rows={3} />
       <SkeletonSection label="on this computer" rows={2} />
@@ -419,7 +419,7 @@ export function FilesTab() {
         {panel}
       </div>
     ) : (
-      <div className="mx-auto w-full max-w-2xl">{panel}</div>
+      <div className="mx-auto w-full max-w-4xl">{panel}</div>
     );
   }
 

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -127,7 +127,7 @@ function SkeletonSection({
 function SimpleSkeleton({ agentName }: { agentName?: string }) {
   const name = agentName ?? "the agent";
   return (
-    <div className="flex flex-col gap-3 p-1 lg:grid lg:grid-cols-2 lg:items-start">
+    <div className="flex flex-col gap-3 p-1 lg:grid lg:grid-cols-2 lg:items-start lg:gap-x-6">
       <div className="contents lg:flex lg:flex-col lg:gap-6">
         <SkeletonSection label={`${name}'s mind`} rows={3} />
         <SkeletonSection

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -61,7 +61,7 @@ function statusClass(status: SaveStatus): string {
 function AdvancedSkeleton() {
   return (
     <Card size="sm" className="!py-0 !gap-0 flex flex-1 min-h-0 flex-col">
-      <CardHeader className="shrink-0 !flex !flex-row !items-center !gap-2.5 !px-5 !py-2.5 border-b border-border/60 [.border-b]:!pb-2.5">
+      <CardHeader className="shrink-0 !flex !flex-row !items-center !gap-2.5 !px-5 !py-2.5">
         <Skeleton className="size-4 rounded-full" />
         <Skeleton className="h-3 w-16" />
       </CardHeader>
@@ -93,23 +93,17 @@ function SimpleSkeleton() {
     <div className="flex h-full min-h-0 flex-col gap-4 p-1">
       <Card size="sm" className="!py-0 !gap-0 flex shrink-0 flex-col">
         <SkeletonRow />
-        <div className="border-t border-border/60">
-          <SkeletonRow />
-        </div>
-        <div className="border-t border-border/60">
-          <SkeletonRow />
-        </div>
+        <SkeletonRow />
+        <SkeletonRow />
       </Card>
       <Card size="sm" className="!py-0 !gap-0 flex flex-1 min-h-0 flex-col">
-        <CardHeader className="shrink-0 !flex !flex-row !items-center !gap-2.5 !px-4 !py-2.5 border-b border-border/60 [.border-b]:!pb-2.5">
+        <CardHeader className="shrink-0 !flex !flex-row !items-center !gap-2.5 !px-4 !py-2.5">
           <Skeleton className="size-4 rounded-full" />
           <Skeleton className="h-3 w-12" />
         </CardHeader>
         <CardContent className="flex-1 min-h-0 !px-0 !py-0">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="border-b border-border/60 last:border-b-0">
-              <SkeletonRow />
-            </div>
+            <SkeletonRow key={i} />
           ))}
         </CardContent>
       </Card>
@@ -309,7 +303,7 @@ export function FilesTab() {
         />
       ) : root ? (
         <Card size="sm" className="!py-0 !gap-0 flex flex-1 min-h-0 flex-col">
-          <CardHeader className="shrink-0 !flex !flex-row !items-center !gap-2.5 !px-5 !py-2.5 border-b border-border/60 [.border-b]:!pb-2.5">
+          <CardHeader className="shrink-0 !flex !flex-row !items-center !gap-2.5 !px-5 !py-2.5">
             <FolderTree className="size-4 text-muted-foreground" />
             <CardTitle className="!text-sm !font-medium">/root</CardTitle>
           </CardHeader>
@@ -366,7 +360,7 @@ export function FilesTab() {
     const inDetail = dreamsActive || selectedPath !== null;
     const panel = inDetail ? (
       <Card size="sm" className="!py-0 !gap-0 flex flex-1 min-w-0 flex-col">
-        <div className="shrink-0 flex items-center gap-2 border-b border-border/60 px-3 py-2.5">
+        <div className="shrink-0 flex items-center gap-2 px-3 py-2.5">
           <Button
             variant="ghost"
             size="icon-sm"
@@ -417,7 +411,7 @@ export function FilesTab() {
 
       <Card size="sm" className="!py-0 !gap-0 flex min-w-0 flex-col">
         {!dreamsActive && (
-          <CardHeader className="shrink-0 items-center !px-5 !py-2.5 border-b border-border/60 [.border-b]:!pb-2.5">
+          <CardHeader className="shrink-0 items-center !px-5 !py-2.5">
             <CardTitle className="truncate !text-xs !font-normal text-muted-foreground">
               {!entries && !treeError ? (
                 <Skeleton className="h-3 w-28" />

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -96,10 +96,12 @@ function HubRowSkeleton() {
   );
 }
 
-function SkeletonSection({ rows }: { rows: number }) {
+function SkeletonSection({ label, rows }: { label: string; rows: number }) {
   return (
     <>
-      <Skeleton className="ml-1 h-3 w-20 rounded" />
+      <p className="px-1 text-[11px] font-medium text-muted-foreground/70">
+        {label}
+      </p>
       <Card size="sm">
         <CardContent>
           <ItemGroup>
@@ -113,12 +115,13 @@ function SkeletonSection({ rows }: { rows: number }) {
   );
 }
 
-function SimpleSkeleton() {
+function SimpleSkeleton({ agentName }: { agentName?: string }) {
+  const name = agentName ?? "the agent";
   return (
     <div className="flex flex-col gap-3 p-1">
-      <SkeletonSection rows={3} />
-      <SkeletonSection rows={3} />
-      <SkeletonSection rows={2} />
+      <SkeletonSection label={`${name}'s mind`} rows={3} />
+      <SkeletonSection label="skills" rows={3} />
+      <SkeletonSection label="on this computer" rows={2} />
     </div>
   );
 }
@@ -303,7 +306,7 @@ export function FilesTab() {
         </p>
       ) : !entries ? (
         mode === "simple" ? (
-          <SimpleSkeleton />
+          <SimpleSkeleton agentName={agentName} />
         ) : (
           <AdvancedSkeleton />
         )

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useState } from "react";
+import { FolderOpen, HardDrive, Lock, Plus } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { getAgentMounts, setAgentMounts, type HostMount } from "@/api/agents";
+import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
+import { errorMessage } from "@/lib/utils";
+
+// Host filesystem grants: host paths the agent may read (and, if writable, write) inside its
+// container. A list with add/remove that PUTs the whole list, mirroring the notification rules
+// card's data-flow (plain state + effect, no react-query).
+export function HostAccessCard() {
+  const { name: agentName } = useSelectedAgent();
+  const [mounts, setMounts] = useState<HostMount[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [restartHint, setRestartHint] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const [hostPath, setHostPath] = useState("");
+  const [containerPath, setContainerPath] = useState("");
+  const [writable, setWritable] = useState(false);
+
+  useEffect(() => {
+    if (!agentName) return;
+    let ignore = false;
+    setMounts(null);
+    setLoadError(null);
+    getAgentMounts(agentName)
+      .then((m) => {
+        if (ignore) return;
+        setMounts(m);
+      })
+      .catch((e: unknown) => {
+        if (!ignore)
+          setLoadError(errorMessage(e, "failed to load host access"));
+      });
+    return () => {
+      ignore = true;
+    };
+  }, [agentName]);
+
+  const save = async (next: HostMount[]) => {
+    if (!agentName) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const result = await setAgentMounts(agentName, next);
+      setMounts(result.mounts);
+      setRestartHint(result.restartRequired);
+    } catch (e) {
+      setSaveError(errorMessage(e, "failed to update host access"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const addPath = () => {
+    const path = hostPath.trim();
+    if (!path || !mounts) return;
+    const next: HostMount = {
+      host_path: path,
+      container_path: containerPath.trim() || path,
+      writable,
+    };
+    void save([...mounts, next]).then(() => {
+      setHostPath("");
+      setContainerPath("");
+      setWritable(false);
+    });
+  };
+
+  const removePath = (index: number) => {
+    if (!mounts) return;
+    void save(mounts.filter((_, i) => i !== index));
+  };
+
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <HardDrive className="size-4 text-muted-foreground" />
+          host access
+        </CardTitle>
+        <CardDescription className="text-xs">
+          host paths {agentName || "the agent"} can reach inside its container.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-3">
+          {loadError ? (
+            <p className="text-xs text-destructive">
+              failed to load: {loadError}
+            </p>
+          ) : mounts === null ? (
+            <div className="flex flex-col gap-2">
+              {Array.from({ length: 2 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <Skeleton className="h-5 w-40 rounded-3xl" />
+                  <Skeleton className="h-5 w-14 rounded-3xl" />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <>
+              {mounts.length > 0 ? (
+                <div className="flex flex-col gap-2">
+                  {mounts.map((mount, index) => (
+                    <div
+                      key={`${mount.container_path}-${index}`}
+                      className="flex items-center gap-2 rounded-md"
+                    >
+                      <FolderOpen className="size-3.5 shrink-0 text-muted-foreground/60" />
+                      <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
+                        <span
+                          className="truncate text-xs font-medium"
+                          title={mount.host_path}
+                        >
+                          {mount.host_path}
+                        </span>
+                        {mount.container_path !== mount.host_path ? (
+                          <span
+                            className="truncate text-[11px] text-muted-foreground"
+                            title={mount.container_path}
+                          >
+                            -&gt; {mount.container_path}
+                          </span>
+                        ) : null}
+                      </div>
+                      <Badge variant={mount.writable ? "default" : "secondary"}>
+                        {mount.writable ? "read-write" : "read-only"}
+                      </Badge>
+                      <Button
+                        size="icon-xs"
+                        variant="ghost"
+                        aria-label={`remove ${mount.host_path}`}
+                        disabled={saving}
+                        onClick={() => removePath(index)}
+                      >
+                        ✕
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground/60">
+                  no host paths granted yet.
+                </p>
+              )}
+
+              <div className="flex flex-col gap-2 rounded-xl border border-border/60 bg-muted/40 p-3">
+                <div className="flex items-center gap-2">
+                  <Input
+                    value={hostPath}
+                    onChange={(e) => setHostPath(e.target.value)}
+                    placeholder="/mnt/media"
+                    aria-label="host path"
+                    className="h-8 flex-1 text-xs"
+                  />
+                  <Input
+                    value={containerPath}
+                    onChange={(e) => setContainerPath(e.target.value)}
+                    placeholder="container path (optional)"
+                    aria-label="container path"
+                    className="h-8 flex-1 text-xs"
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <Label className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Switch
+                      size="sm"
+                      checked={writable}
+                      onCheckedChange={setWritable}
+                    />
+                    writable
+                    {!writable ? (
+                      <Lock className="size-3 text-muted-foreground/60" />
+                    ) : null}
+                  </Label>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={!hostPath.trim() || saving}
+                    onClick={addPath}
+                  >
+                    <Plus className="size-4" />
+                    add path
+                  </Button>
+                </div>
+              </div>
+
+              {saveError ? (
+                <p className="text-xs text-destructive">{saveError}</p>
+              ) : restartHint ? (
+                <p className="text-xs text-muted-foreground/60">
+                  restart {agentName || "the agent"} to apply.
+                </p>
+              ) : null}
+            </>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -118,7 +118,7 @@ export function HostAccessCard() {
                 <div className="flex flex-col gap-2">
                   {mounts.map((mount, index) => (
                     <div
-                      key={`${mount.container_path}-${index}`}
+                      key={mount.container_path}
                       className="flex items-center gap-2 rounded-md"
                     >
                       <FolderOpen className="size-3.5 shrink-0 text-muted-foreground/60" />

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -1,25 +1,30 @@
 import { useEffect, useState } from "react";
-import { FolderOpen, HardDrive, Lock, Plus } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import { FolderOpen, Lock, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+} from "@/components/ui/item";
 import { getAgentMounts, setAgentMounts, type HostMount } from "@/api/agents";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { errorMessage } from "@/lib/utils";
 
-// Host filesystem grants: host paths the agent may read (and, if writable, write) inside its
-// container. A list with add/remove that PUTs the whole list, mirroring the notification rules
-// card's data-flow (plain state + effect, no react-query).
+function folderName(path: string): string {
+  const segments = path.split("/").filter(Boolean);
+  return segments.length > 0 ? segments[segments.length - 1] : path;
+}
+
+// Host filesystem grants: folders on the host the agent may open (and, if writable, write) inside
+// its container. A list with add/remove/toggle that PUTs the whole list (plain state + effect).
 export function HostAccessCard() {
   const { name: agentName } = useSelectedAgent();
   const [mounts, setMounts] = useState<HostMount[] | null>(null);
@@ -90,61 +95,71 @@ export function HostAccessCard() {
     void save(mounts.filter((_, i) => i !== index));
   };
 
+  const toggleWritable = (index: number, value: boolean) => {
+    if (!mounts) return;
+    void save(
+      mounts.map((m, i) => (i === index ? { ...m, writable: value } : m)),
+    );
+  };
+
   return (
     <Card size="sm">
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-sm font-medium">
-          <HardDrive className="size-4 text-muted-foreground" />
-          shared folders
-        </CardTitle>
-        <CardDescription className="text-xs">
-          folders on this computer {agentName || "vesta"} can open.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-col gap-3">
-          {loadError ? (
-            <p className="text-xs text-destructive">
-              failed to load: {loadError}
-            </p>
-          ) : mounts === null ? (
-            <div className="flex flex-col gap-2">
-              {Array.from({ length: 2 }).map((_, i) => (
-                <div key={i} className="flex items-center gap-2">
-                  <Skeleton className="h-5 w-40 rounded-3xl" />
-                  <Skeleton className="h-5 w-14 rounded-3xl" />
-                </div>
-              ))}
-            </div>
-          ) : (
-            <>
-              {mounts.length > 0 ? (
-                <div className="flex flex-col gap-2">
-                  {mounts.map((mount, index) => (
-                    <div
-                      key={mount.container_path}
-                      className="flex items-center gap-2 rounded-md"
+      <CardContent className="flex flex-col gap-2">
+        {loadError ? (
+          <p className="px-1 text-xs text-destructive">
+            failed to load: {loadError}
+          </p>
+        ) : mounts === null ? (
+          <ItemGroup>
+            {Array.from({ length: 2 }).map((_, i) => (
+              <Item key={i} variant="muted" size="sm">
+                <ItemMedia
+                  variant="icon"
+                  className="size-9 rounded-[10px] bg-muted"
+                >
+                  <Skeleton className="size-4 rounded" />
+                </ItemMedia>
+                <ItemContent>
+                  <Skeleton className="h-3 w-36 rounded" />
+                </ItemContent>
+              </Item>
+            ))}
+          </ItemGroup>
+        ) : (
+          <>
+            {mounts.length > 0 ? (
+              <ItemGroup>
+                {mounts.map((mount, index) => (
+                  <Item key={mount.container_path} variant="muted" size="sm">
+                    <ItemMedia
+                      variant="icon"
+                      className="size-9 rounded-[10px] bg-sky-500/12 text-sky-600 dark:text-sky-400"
                     >
-                      <FolderOpen className="size-3.5 shrink-0 text-muted-foreground/60" />
-                      <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
-                        <span
-                          className="truncate text-xs font-medium"
-                          title={mount.host_path}
-                        >
-                          {mount.host_path}
-                        </span>
-                        {mount.container_path !== mount.host_path ? (
-                          <span
-                            className="truncate text-[11px] text-muted-foreground"
-                            title={mount.container_path}
-                          >
-                            -&gt; {mount.container_path}
-                          </span>
-                        ) : null}
-                      </div>
-                      <Badge variant={mount.writable ? "default" : "secondary"}>
-                        {mount.writable ? "can edit" : "view only"}
-                      </Badge>
+                      <FolderOpen />
+                    </ItemMedia>
+                    <ItemContent className="gap-0.5">
+                      <ItemTitle>{folderName(mount.host_path)}</ItemTitle>
+                      <ItemDescription
+                        className="text-[11px]"
+                        title={mount.host_path}
+                      >
+                        {mount.host_path}
+                        {mount.container_path !== mount.host_path
+                          ? ` · seen at ${mount.container_path}`
+                          : ""}
+                      </ItemDescription>
+                    </ItemContent>
+                    <ItemActions>
+                      <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                        <Switch
+                          size="sm"
+                          checked={mount.writable}
+                          disabled={saving}
+                          aria-label={`allow ${agentName || "vesta"} to edit ${folderName(mount.host_path)}`}
+                          onCheckedChange={(v) => toggleWritable(index, v)}
+                        />
+                        can edit
+                      </span>
                       <Button
                         size="icon-xs"
                         variant="ghost"
@@ -152,66 +167,67 @@ export function HostAccessCard() {
                         disabled={saving}
                         onClick={() => removePath(index)}
                       >
-                        ✕
+                        <Trash2 className="size-3.5" />
                       </Button>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-xs text-muted-foreground/60">
-                  no shared folders yet.
-                </p>
-              )}
+                    </ItemActions>
+                  </Item>
+                ))}
+              </ItemGroup>
+            ) : (
+              <p className="px-1 text-xs text-muted-foreground/60">
+                no shared folders yet.
+              </p>
+            )}
 
-              <div className="flex flex-col gap-2 rounded-xl border border-border/60 bg-muted/40 p-3">
-                <Input
-                  value={hostPath}
-                  onChange={(e) => setHostPath(e.target.value)}
-                  placeholder="/mnt/media"
-                  aria-label="folder path on this computer"
-                  className="h-8 text-xs"
-                />
-                <Input
-                  value={containerPath}
-                  onChange={(e) => setContainerPath(e.target.value)}
-                  placeholder="where vesta sees it (optional)"
-                  aria-label="path inside the container"
-                  className="h-8 text-xs"
-                />
-                <div className="flex items-center justify-between">
-                  <Label className="flex items-center gap-2 text-xs text-muted-foreground">
-                    <Switch
-                      size="sm"
-                      checked={writable}
-                      onCheckedChange={setWritable}
-                    />
-                    can edit
-                    {!writable ? (
-                      <Lock className="size-3 text-muted-foreground/60" />
-                    ) : null}
-                  </Label>
-                  <Button
+            <div className="flex flex-col gap-2 rounded-xl bg-muted/40 p-3">
+              <Input
+                value={hostPath}
+                onChange={(e) => setHostPath(e.target.value)}
+                placeholder="/mnt/media"
+                aria-label="folder path on this computer"
+                className="h-8 text-xs"
+              />
+              <Input
+                value={containerPath}
+                onChange={(e) => setContainerPath(e.target.value)}
+                placeholder="where vesta sees it (optional)"
+                aria-label="path inside the container"
+                className="h-8 text-xs"
+              />
+              <div className="flex items-center justify-between">
+                <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Switch
                     size="sm"
-                    variant="outline"
-                    disabled={!hostPath.trim() || saving}
-                    onClick={addPath}
-                  >
-                    <Plus className="size-4" />
-                    add folder
-                  </Button>
-                </div>
+                    checked={writable}
+                    onCheckedChange={setWritable}
+                    aria-label="allow editing"
+                  />
+                  can edit
+                  {!writable ? (
+                    <Lock className="size-3 text-muted-foreground/60" />
+                  ) : null}
+                </span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={!hostPath.trim() || saving}
+                  onClick={addPath}
+                >
+                  <Plus className="size-4" />
+                  add folder
+                </Button>
               </div>
+            </div>
 
-              {saveError ? (
-                <p className="text-xs text-destructive">{saveError}</p>
-              ) : restartHint ? (
-                <p className="text-xs text-muted-foreground/60">
-                  restart {agentName || "the agent"} to apply.
-                </p>
-              ) : null}
-            </>
-          )}
-        </div>
+            {saveError ? (
+              <p className="px-1 text-xs text-destructive">{saveError}</p>
+            ) : restartHint ? (
+              <p className="px-1 text-xs text-muted-foreground/60">
+                restart {agentName || "the agent"} to apply.
+              </p>
+            ) : null}
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -49,6 +49,7 @@ export function HostAccessCard() {
   const [hostPath, setHostPath] = useState("");
   const [containerPath, setContainerPath] = useState("");
   const [writable, setWritable] = useState(false);
+  const [showContainerPath, setShowContainerPath] = useState(false);
   const [suggestions, setSuggestions] = useState<string[] | null>(null);
 
   // Fetch folder suggestions lazily, the first time the dialog opens.
@@ -116,6 +117,7 @@ export function HostAccessCard() {
         setHostPath("");
         setContainerPath("");
         setWritable(false);
+        setShowContainerPath(false);
       }
     });
   };
@@ -285,13 +287,24 @@ export function HostAccessCard() {
                     aria-label="folder path on this computer"
                     className="h-8 text-xs"
                   />
-                  <Input
-                    value={containerPath}
-                    onChange={(e) => setContainerPath(e.target.value)}
-                    placeholder="where vesta sees it (optional)"
-                    aria-label="path inside the container"
-                    className="h-8 text-xs"
-                  />
+                  {showContainerPath ? (
+                    <Input
+                      value={containerPath}
+                      onChange={(e) => setContainerPath(e.target.value)}
+                      placeholder="where vesta sees it (optional)"
+                      aria-label="path inside the container"
+                      className="h-8 text-xs"
+                      autoFocus
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setShowContainerPath(true)}
+                      className="self-start text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                      change where vesta sees it
+                    </button>
+                  )}
                   <div className="flex items-center justify-between">
                     <span className="flex items-center gap-2 text-xs text-muted-foreground">
                       <Switch

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -189,22 +189,20 @@ export function HostAccessCard() {
                       </ItemDescription>
                     </ItemContent>
                     <ItemActions>
-                      <div className="flex flex-col items-end gap-1">
-                        <span className="text-[11px] text-muted-foreground">
-                          {mount.writable ? "can edit" : "view only"}
-                        </span>
-                        <Switch
-                          size="sm"
-                          checked={mount.writable}
-                          disabled={saving}
-                          aria-label={`allow editing ${folderName(mount.host_path)}`}
-                          onCheckedChange={(v) => toggleWritable(index, v)}
-                        />
-                      </div>
+                      <span className="text-[11px] text-muted-foreground">
+                        {mount.writable ? "can edit" : "view only"}
+                      </span>
+                      <Switch
+                        size="sm"
+                        checked={mount.writable}
+                        disabled={saving}
+                        aria-label={`allow editing ${folderName(mount.host_path)}`}
+                        onCheckedChange={(v) => toggleWritable(index, v)}
+                      />
                       <Button
                         size="icon-xs"
                         variant="ghost"
-                        className="opacity-0 transition-opacity group-hover/item:opacity-100 focus-visible:opacity-100"
+                        className="text-muted-foreground/60 hover:text-foreground"
                         aria-label={`remove ${mount.host_path}`}
                         disabled={saving}
                         onClick={() => removePath(index)}
@@ -231,7 +229,7 @@ export function HostAccessCard() {
                     <ItemContent className="gap-0.5">
                       <ItemTitle>add a folder</ItemTitle>
                       <ItemDescription>
-                        choose a folder to share with vesta
+                        choose a folder to share with {agentName || "the agent"}
                       </ItemDescription>
                     </ItemContent>
                   </button>
@@ -255,7 +253,7 @@ export function HostAccessCard() {
           <DialogHeader>
             <DialogTitle>add a folder</DialogTitle>
             <DialogDescription>
-              choose a folder on this computer for {agentName || "vesta"} to
+              choose a folder on this computer for {agentName || "the agent"} to
               open.
             </DialogDescription>
           </DialogHeader>
@@ -296,7 +294,7 @@ export function HostAccessCard() {
               <Input
                 value={containerPath}
                 onChange={(e) => setContainerPath(e.target.value)}
-                placeholder="where vesta sees it (optional)"
+                placeholder={`where ${agentName || "the agent"} sees it (optional)`}
                 aria-label="path inside the container"
                 className="h-8 text-xs"
                 autoFocus
@@ -307,7 +305,7 @@ export function HostAccessCard() {
                 onClick={() => setShowContainerPath(true)}
                 className="self-start text-[11px] text-muted-foreground transition-colors hover:text-foreground"
               >
-                change where vesta sees it
+                change where {agentName || "the agent"} sees it
               </button>
             )}
 

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -21,7 +21,12 @@ import {
   ItemMedia,
   ItemTitle,
 } from "@/components/ui/item";
-import { getAgentMounts, setAgentMounts, type HostMount } from "@/api/agents";
+import {
+  getAgentMounts,
+  getHostFolderSuggestions,
+  setAgentMounts,
+  type HostMount,
+} from "@/api/agents";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { errorMessage } from "@/lib/utils";
 
@@ -44,6 +49,23 @@ export function HostAccessCard() {
   const [hostPath, setHostPath] = useState("");
   const [containerPath, setContainerPath] = useState("");
   const [writable, setWritable] = useState(false);
+  const [suggestions, setSuggestions] = useState<string[] | null>(null);
+
+  // Fetch folder suggestions lazily, the first time the dialog opens.
+  useEffect(() => {
+    if (!open || suggestions !== null) return;
+    let ignore = false;
+    getHostFolderSuggestions()
+      .then((f) => {
+        if (!ignore) setSuggestions(f);
+      })
+      .catch(() => {
+        if (!ignore) setSuggestions([]);
+      });
+    return () => {
+      ignore = true;
+    };
+  }, [open, suggestions]);
 
   useEffect(() => {
     if (!agentName) return;
@@ -116,6 +138,11 @@ export function HostAccessCard() {
       : mounts.length === 0
         ? "none shared yet"
         : `${mounts.length} folder${mounts.length === 1 ? "" : "s"} shared`;
+
+  // Suggestions not already shared, and not the one being typed.
+  const availableSuggestions = (suggestions ?? []).filter(
+    (s) => !(mounts ?? []).some((m) => m.host_path === s) && s !== hostPath,
+  );
 
   return (
     <>
@@ -228,6 +255,29 @@ export function HostAccessCard() {
                 )}
 
                 <div className="flex flex-col gap-2 rounded-xl bg-muted/40 p-3">
+                  {availableSuggestions.length > 0 ? (
+                    <div className="flex flex-col gap-1.5">
+                      <span className="text-[11px] text-muted-foreground">
+                        suggested folders
+                      </span>
+                      <div className="flex flex-wrap gap-1.5">
+                        {availableSuggestions.map((s) => (
+                          <button
+                            key={s}
+                            type="button"
+                            onClick={() => {
+                              setHostPath(s);
+                              setContainerPath("");
+                            }}
+                            className="max-w-full truncate rounded-full bg-background px-2.5 py-1 text-[11px] text-muted-foreground ring-1 ring-border transition-colors hover:text-foreground"
+                            title={s}
+                          >
+                            {s}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
                   <Input
                     value={hostPath}
                     onChange={(e) => setHostPath(e.target.value)}

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -227,7 +227,7 @@ export function HostAccessCard() {
                     </ItemMedia>
                     <ItemContent className="gap-0.5">
                       <ItemTitle>add a folder</ItemTitle>
-                      <ItemDescription>
+                      <ItemDescription className="text-[11px]">
                         choose a folder to share with {agentName || "the agent"}
                       </ItemDescription>
                     </ItemContent>

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -95,10 +95,10 @@ export function HostAccessCard() {
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-sm font-medium">
           <HardDrive className="size-4 text-muted-foreground" />
-          host access
+          shared folders
         </CardTitle>
         <CardDescription className="text-xs">
-          host paths {agentName || "the agent"} can reach inside its container.
+          folders on this computer {agentName || "vesta"} can open.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -143,7 +143,7 @@ export function HostAccessCard() {
                         ) : null}
                       </div>
                       <Badge variant={mount.writable ? "default" : "secondary"}>
-                        {mount.writable ? "read-write" : "read-only"}
+                        {mount.writable ? "can edit" : "view only"}
                       </Badge>
                       <Button
                         size="icon-xs"
@@ -159,27 +159,25 @@ export function HostAccessCard() {
                 </div>
               ) : (
                 <p className="text-xs text-muted-foreground/60">
-                  no host paths granted yet.
+                  no shared folders yet.
                 </p>
               )}
 
               <div className="flex flex-col gap-2 rounded-xl border border-border/60 bg-muted/40 p-3">
-                <div className="flex items-center gap-2">
-                  <Input
-                    value={hostPath}
-                    onChange={(e) => setHostPath(e.target.value)}
-                    placeholder="/mnt/media"
-                    aria-label="host path"
-                    className="h-8 flex-1 text-xs"
-                  />
-                  <Input
-                    value={containerPath}
-                    onChange={(e) => setContainerPath(e.target.value)}
-                    placeholder="container path (optional)"
-                    aria-label="container path"
-                    className="h-8 flex-1 text-xs"
-                  />
-                </div>
+                <Input
+                  value={hostPath}
+                  onChange={(e) => setHostPath(e.target.value)}
+                  placeholder="/mnt/media"
+                  aria-label="folder path on this computer"
+                  className="h-8 text-xs"
+                />
+                <Input
+                  value={containerPath}
+                  onChange={(e) => setContainerPath(e.target.value)}
+                  placeholder="where vesta sees it (optional)"
+                  aria-label="path inside the container"
+                  className="h-8 text-xs"
+                />
                 <div className="flex items-center justify-between">
                   <Label className="flex items-center gap-2 text-xs text-muted-foreground">
                     <Switch
@@ -187,7 +185,7 @@ export function HostAccessCard() {
                       checked={writable}
                       onCheckedChange={setWritable}
                     />
-                    writable
+                    can edit
                     {!writable ? (
                       <Lock className="size-3 text-muted-foreground/60" />
                     ) : null}
@@ -199,7 +197,7 @@ export function HostAccessCard() {
                     onClick={addPath}
                   >
                     <Plus className="size-4" />
-                    add path
+                    add folder
                   </Button>
                 </div>
               </div>

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from "react";
-import { FolderOpen, Lock, Plus, Trash2 } from "lucide-react";
+import { ChevronRight, FolderOpen, Lock, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -23,8 +30,8 @@ function folderName(path: string): string {
   return segments.length > 0 ? segments[segments.length - 1] : path;
 }
 
-// Host filesystem grants: folders on the host the agent may open (and, if writable, write) inside
-// its container. A list with add/remove/toggle that PUTs the whole list (plain state + effect).
+// Host filesystem grants, behind progressive disclosure: the hub shows a single "shared folders"
+// cell; opening it reveals the full list + add/remove/toggle in a dialog. PUTs the whole list.
 export function HostAccessCard() {
   const { name: agentName } = useSelectedAgent();
   const [mounts, setMounts] = useState<HostMount[] | null>(null);
@@ -32,6 +39,7 @@ export function HostAccessCard() {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [restartHint, setRestartHint] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [open, setOpen] = useState(false);
 
   const [hostPath, setHostPath] = useState("");
   const [containerPath, setContainerPath] = useState("");
@@ -102,133 +110,175 @@ export function HostAccessCard() {
     );
   };
 
+  const summary =
+    mounts === null
+      ? "…"
+      : mounts.length === 0
+        ? "none shared yet"
+        : `${mounts.length} folder${mounts.length === 1 ? "" : "s"} shared`;
+
   return (
-    <Card size="sm">
-      <CardContent className="flex flex-col gap-2">
-        {loadError ? (
-          <p className="px-1 text-xs text-destructive">
-            failed to load: {loadError}
-          </p>
-        ) : mounts === null ? (
+    <>
+      <Card size="sm">
+        <CardContent>
           <ItemGroup>
-            {Array.from({ length: 2 }).map((_, i) => (
-              <Item key={i} variant="muted" size="sm">
+            <Item
+              asChild
+              variant="muted"
+              size="sm"
+              className="cursor-pointer text-left hover:bg-muted/70"
+            >
+              <button type="button" onClick={() => setOpen(true)}>
                 <ItemMedia
                   variant="icon"
-                  className="size-9 rounded-[10px] bg-muted"
+                  className="size-9 rounded-[10px] bg-sky-500/12 text-sky-600 dark:text-sky-400"
                 >
-                  <Skeleton className="size-4 rounded" />
+                  <FolderOpen />
                 </ItemMedia>
-                <ItemContent>
-                  <Skeleton className="h-3 w-36 rounded" />
+                <ItemContent className="gap-0.5">
+                  <ItemTitle>shared folders</ItemTitle>
+                  <ItemDescription className="text-[11px]">
+                    {summary}
+                  </ItemDescription>
                 </ItemContent>
-              </Item>
-            ))}
+                <ItemActions>
+                  <ChevronRight className="size-4 text-muted-foreground/60" />
+                </ItemActions>
+              </button>
+            </Item>
           </ItemGroup>
-        ) : (
-          <>
-            {mounts.length > 0 ? (
-              <ItemGroup>
-                {mounts.map((mount, index) => (
-                  <Item key={mount.container_path} variant="muted" size="sm">
-                    <ItemMedia
-                      variant="icon"
-                      className="size-9 rounded-[10px] bg-sky-500/12 text-sky-600 dark:text-sky-400"
-                    >
-                      <FolderOpen />
-                    </ItemMedia>
-                    <ItemContent className="gap-0.5">
-                      <ItemTitle>{folderName(mount.host_path)}</ItemTitle>
-                      <ItemDescription
-                        className="text-[11px]"
-                        title={mount.host_path}
-                      >
-                        {mount.host_path}
-                        {mount.container_path !== mount.host_path
-                          ? ` · seen at ${mount.container_path}`
-                          : ""}
-                      </ItemDescription>
-                    </ItemContent>
-                    <ItemActions>
-                      <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                        <Switch
-                          size="sm"
-                          checked={mount.writable}
-                          disabled={saving}
-                          aria-label={`allow ${agentName || "vesta"} to edit ${folderName(mount.host_path)}`}
-                          onCheckedChange={(v) => toggleWritable(index, v)}
-                        />
-                        can edit
-                      </span>
-                      <Button
-                        size="icon-xs"
-                        variant="ghost"
-                        aria-label={`remove ${mount.host_path}`}
-                        disabled={saving}
-                        onClick={() => removePath(index)}
-                      >
-                        <Trash2 className="size-3.5" />
-                      </Button>
-                    </ItemActions>
-                  </Item>
-                ))}
-              </ItemGroup>
-            ) : (
-              <p className="px-1 text-xs text-muted-foreground/60">
-                no shared folders yet.
-              </p>
-            )}
+        </CardContent>
+      </Card>
 
-            <div className="flex flex-col gap-2 rounded-xl bg-muted/40 p-3">
-              <Input
-                value={hostPath}
-                onChange={(e) => setHostPath(e.target.value)}
-                placeholder="/mnt/media"
-                aria-label="folder path on this computer"
-                className="h-8 text-xs"
-              />
-              <Input
-                value={containerPath}
-                onChange={(e) => setContainerPath(e.target.value)}
-                placeholder="where vesta sees it (optional)"
-                aria-label="path inside the container"
-                className="h-8 text-xs"
-              />
-              <div className="flex items-center justify-between">
-                <span className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <Switch
-                    size="sm"
-                    checked={writable}
-                    onCheckedChange={setWritable}
-                    aria-label="allow editing"
-                  />
-                  can edit
-                  {!writable ? (
-                    <Lock className="size-3 text-muted-foreground/60" />
-                  ) : null}
-                </span>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={!hostPath.trim() || saving}
-                  onClick={addPath}
-                >
-                  <Plus className="size-4" />
-                  add folder
-                </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>shared folders</DialogTitle>
+            <DialogDescription>
+              folders on this computer {agentName || "vesta"} can open.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex min-w-0 flex-col gap-3">
+            {loadError ? (
+              <p className="text-xs text-destructive">
+                failed to load: {loadError}
+              </p>
+            ) : mounts === null ? (
+              <div className="flex flex-col gap-2">
+                <Skeleton className="h-12 w-full rounded-2xl" />
+                <Skeleton className="h-12 w-full rounded-2xl" />
               </div>
-            </div>
+            ) : (
+              <>
+                {mounts.length > 0 ? (
+                  <ItemGroup className="min-w-0">
+                    {mounts.map((mount, index) => (
+                      <Item
+                        key={mount.container_path}
+                        variant="muted"
+                        size="sm"
+                      >
+                        <ItemMedia
+                          variant="icon"
+                          className="size-9 rounded-[10px] bg-sky-500/12 text-sky-600 dark:text-sky-400"
+                        >
+                          <FolderOpen />
+                        </ItemMedia>
+                        <ItemContent className="min-w-0 gap-0.5">
+                          <ItemTitle>{folderName(mount.host_path)}</ItemTitle>
+                          <ItemDescription
+                            className="text-[11px]"
+                            title={mount.host_path}
+                          >
+                            {mount.host_path}
+                            {mount.container_path !== mount.host_path
+                              ? ` · seen at ${mount.container_path}`
+                              : ""}
+                          </ItemDescription>
+                        </ItemContent>
+                        <ItemActions>
+                          <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                            <Switch
+                              size="sm"
+                              checked={mount.writable}
+                              disabled={saving}
+                              aria-label={`allow editing ${folderName(mount.host_path)}`}
+                              onCheckedChange={(v) => toggleWritable(index, v)}
+                            />
+                            can edit
+                          </span>
+                          <Button
+                            size="icon-xs"
+                            variant="ghost"
+                            aria-label={`remove ${mount.host_path}`}
+                            disabled={saving}
+                            onClick={() => removePath(index)}
+                          >
+                            <Trash2 className="size-3.5" />
+                          </Button>
+                        </ItemActions>
+                      </Item>
+                    ))}
+                  </ItemGroup>
+                ) : (
+                  <p className="text-xs text-muted-foreground/60">
+                    no shared folders yet.
+                  </p>
+                )}
 
-            {saveError ? (
-              <p className="px-1 text-xs text-destructive">{saveError}</p>
-            ) : restartHint ? (
-              <p className="px-1 text-xs text-muted-foreground/60">
-                restart {agentName || "the agent"} to apply.
-              </p>
-            ) : null}
-          </>
-        )}
-      </CardContent>
-    </Card>
+                <div className="flex flex-col gap-2 rounded-xl bg-muted/40 p-3">
+                  <Input
+                    value={hostPath}
+                    onChange={(e) => setHostPath(e.target.value)}
+                    placeholder="/mnt/media"
+                    aria-label="folder path on this computer"
+                    className="h-8 text-xs"
+                  />
+                  <Input
+                    value={containerPath}
+                    onChange={(e) => setContainerPath(e.target.value)}
+                    placeholder="where vesta sees it (optional)"
+                    aria-label="path inside the container"
+                    className="h-8 text-xs"
+                  />
+                  <div className="flex items-center justify-between">
+                    <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <Switch
+                        size="sm"
+                        checked={writable}
+                        onCheckedChange={setWritable}
+                        aria-label="allow editing"
+                      />
+                      can edit
+                      {!writable ? (
+                        <Lock className="size-3 text-muted-foreground/60" />
+                      ) : null}
+                    </span>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={!hostPath.trim() || saving}
+                      onClick={addPath}
+                    >
+                      <Plus className="size-4" />
+                      add folder
+                    </Button>
+                  </div>
+                </div>
+
+                {saveError ? (
+                  <p className="text-xs text-destructive">{saveError}</p>
+                ) : restartHint ? (
+                  <p className="text-xs text-muted-foreground/60">
+                    restart {agentName || "the agent"} to apply.
+                  </p>
+                ) : null}
+              </>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -204,7 +204,6 @@ export function HostAccessCard() {
                         variant="ghost"
                         className="text-muted-foreground/60 hover:text-foreground"
                         aria-label={`remove ${mount.host_path}`}
-                        disabled={saving}
                         onClick={() => removePath(index)}
                       >
                         <Trash2 className="size-3.5" />

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -28,6 +28,7 @@ import {
   type HostMount,
 } from "@/api/agents";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
+import { useRestartPending } from "@/stores/use-restart-pending";
 import { errorMessage } from "@/lib/utils";
 
 function folderName(path: string): string {
@@ -40,10 +41,10 @@ function folderName(path: string): string {
 // path). PUTs the whole list on every change.
 export function HostAccessCard() {
   const { name: agentName } = useSelectedAgent();
+  const markRestartPending = useRestartPending((s) => s.markPending);
   const [mounts, setMounts] = useState<HostMount[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [restartHint, setRestartHint] = useState(false);
   const [saving, setSaving] = useState(false);
   const [open, setOpen] = useState(false);
 
@@ -95,7 +96,7 @@ export function HostAccessCard() {
     try {
       const result = await setAgentMounts(agentName, next);
       setMounts(result.mounts);
-      setRestartHint(result.restartRequired);
+      if (result.restartRequired) markRestartPending(agentName);
       return true;
     } catch (e) {
       setSaveError(errorMessage(e, "failed to update host access"));
@@ -234,10 +235,6 @@ export function HostAccessCard() {
 
               {saveError ? (
                 <p className="px-1 text-xs text-destructive">{saveError}</p>
-              ) : restartHint ? (
-                <p className="px-1 text-xs text-muted-foreground/60">
-                  restart {agentName || "the agent"} to apply.
-                </p>
               ) : null}
             </>
           )}

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -51,16 +51,18 @@ export function HostAccessCard() {
     };
   }, [agentName]);
 
-  const save = async (next: HostMount[]) => {
-    if (!agentName) return;
+  const save = async (next: HostMount[]): Promise<boolean> => {
+    if (!agentName) return false;
     setSaving(true);
     setSaveError(null);
     try {
       const result = await setAgentMounts(agentName, next);
       setMounts(result.mounts);
       setRestartHint(result.restartRequired);
+      return true;
     } catch (e) {
       setSaveError(errorMessage(e, "failed to update host access"));
+      return false;
     } finally {
       setSaving(false);
     }
@@ -74,10 +76,12 @@ export function HostAccessCard() {
       container_path: containerPath.trim() || path,
       writable,
     };
-    void save([...mounts, next]).then(() => {
-      setHostPath("");
-      setContainerPath("");
-      setWritable(false);
+    void save([...mounts, next]).then((ok) => {
+      if (ok) {
+        setHostPath("");
+        setContainerPath("");
+        setWritable(false);
+      }
     });
   };
 

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ChevronRight, FolderOpen, Lock, Plus, Trash2 } from "lucide-react";
+import { FolderOpen, Lock, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -35,8 +35,9 @@ function folderName(path: string): string {
   return segments.length > 0 ? segments[segments.length - 1] : path;
 }
 
-// Host filesystem grants, behind progressive disclosure: the hub shows a single "shared folders"
-// cell; opening it reveals the full list + add/remove/toggle in a dialog. PUTs the whole list.
+// Host filesystem grants: the shared folders are listed inline as cells (with a per-folder
+// can-edit toggle); an "add a folder" cell opens a dialog for the add flow (suggestions +
+// path). PUTs the whole list on every change.
 export function HostAccessCard() {
   const { name: agentName } = useSelectedAgent();
   const [mounts, setMounts] = useState<HostMount[] | null>(null);
@@ -51,22 +52,6 @@ export function HostAccessCard() {
   const [writable, setWritable] = useState(false);
   const [showContainerPath, setShowContainerPath] = useState(false);
   const [suggestions, setSuggestions] = useState<string[] | null>(null);
-
-  // Fetch folder suggestions lazily, the first time the dialog opens.
-  useEffect(() => {
-    if (!open || suggestions !== null) return;
-    let ignore = false;
-    getHostFolderSuggestions()
-      .then((f) => {
-        if (!ignore) setSuggestions(f);
-      })
-      .catch(() => {
-        if (!ignore) setSuggestions([]);
-      });
-    return () => {
-      ignore = true;
-    };
-  }, [open, suggestions]);
 
   useEffect(() => {
     if (!agentName) return;
@@ -86,6 +71,22 @@ export function HostAccessCard() {
       ignore = true;
     };
   }, [agentName]);
+
+  // Fetch folder suggestions lazily, the first time the add dialog opens.
+  useEffect(() => {
+    if (!open || suggestions !== null) return;
+    let ignore = false;
+    getHostFolderSuggestions()
+      .then((f) => {
+        if (!ignore) setSuggestions(f);
+      })
+      .catch(() => {
+        if (!ignore) setSuggestions([]);
+      });
+    return () => {
+      ignore = true;
+    };
+  }, [open, suggestions]);
 
   const save = async (next: HostMount[]): Promise<boolean> => {
     if (!agentName) return false;
@@ -118,6 +119,7 @@ export function HostAccessCard() {
         setContainerPath("");
         setWritable(false);
         setShowContainerPath(false);
+        setOpen(false);
       }
     });
   };
@@ -134,13 +136,6 @@ export function HostAccessCard() {
     );
   };
 
-  const summary =
-    mounts === null
-      ? "…"
-      : mounts.length === 0
-        ? "none shared yet"
-        : `${mounts.length} folder${mounts.length === 1 ? "" : "s"} shared`;
-
   // Suggestions not already shared, and not the one being typed.
   const availableSuggestions = (suggestions ?? []).filter(
     (s) => !(mounts ?? []).some((m) => m.host_path === s) && s !== hostPath,
@@ -149,196 +144,199 @@ export function HostAccessCard() {
   return (
     <>
       <Card size="sm">
-        <CardContent>
-          <ItemGroup>
-            <Item
-              asChild
-              variant="muted"
-              size="sm"
-              className="cursor-pointer text-left hover:bg-muted/70"
-            >
-              <button type="button" onClick={() => setOpen(true)}>
-                <ItemMedia
-                  variant="icon"
-                  className="size-9 rounded-[10px] bg-sky-500/12 text-sky-600 dark:text-sky-400"
+        <CardContent className="flex flex-col gap-2">
+          {loadError ? (
+            <p className="px-1 text-xs text-destructive">
+              failed to load: {loadError}
+            </p>
+          ) : mounts === null ? (
+            <ItemGroup>
+              {Array.from({ length: 2 }).map((_, i) => (
+                <Item key={i} variant="muted" size="sm">
+                  <ItemMedia
+                    variant="icon"
+                    className="size-9 rounded-[10px] bg-muted"
+                  >
+                    <Skeleton className="size-4 rounded" />
+                  </ItemMedia>
+                  <ItemContent>
+                    <Skeleton className="h-3 w-36 rounded" />
+                  </ItemContent>
+                </Item>
+              ))}
+            </ItemGroup>
+          ) : (
+            <>
+              <ItemGroup>
+                {mounts.map((mount, index) => (
+                  <Item key={mount.container_path} variant="muted" size="sm">
+                    <ItemMedia
+                      variant="icon"
+                      className="size-9 rounded-[10px] bg-sky-500/12 text-sky-600 dark:text-sky-400"
+                    >
+                      <FolderOpen />
+                    </ItemMedia>
+                    <ItemContent className="min-w-0 gap-0.5">
+                      <ItemTitle>{folderName(mount.host_path)}</ItemTitle>
+                      <ItemDescription
+                        className="text-[11px]"
+                        title={mount.host_path}
+                      >
+                        {mount.host_path}
+                        {mount.container_path !== mount.host_path
+                          ? ` · seen at ${mount.container_path}`
+                          : ""}
+                      </ItemDescription>
+                    </ItemContent>
+                    <ItemActions>
+                      <div className="flex flex-col items-end gap-1">
+                        <span className="text-[11px] text-muted-foreground">
+                          {mount.writable ? "can edit" : "view only"}
+                        </span>
+                        <Switch
+                          size="sm"
+                          checked={mount.writable}
+                          disabled={saving}
+                          aria-label={`allow editing ${folderName(mount.host_path)}`}
+                          onCheckedChange={(v) => toggleWritable(index, v)}
+                        />
+                      </div>
+                      <Button
+                        size="icon-xs"
+                        variant="ghost"
+                        className="opacity-0 transition-opacity group-hover/item:opacity-100 focus-visible:opacity-100"
+                        aria-label={`remove ${mount.host_path}`}
+                        disabled={saving}
+                        onClick={() => removePath(index)}
+                      >
+                        <Trash2 className="size-3.5" />
+                      </Button>
+                    </ItemActions>
+                  </Item>
+                ))}
+
+                <Item
+                  asChild
+                  variant="outline"
+                  size="sm"
+                  className="cursor-pointer border-dashed text-left hover:bg-muted/40"
                 >
-                  <FolderOpen />
-                </ItemMedia>
-                <ItemContent className="gap-0.5">
-                  <ItemTitle>shared folders</ItemTitle>
-                  <ItemDescription className="text-[11px]">
-                    {summary}
-                  </ItemDescription>
-                </ItemContent>
-                <ItemActions>
-                  <ChevronRight className="size-4 text-muted-foreground/60" />
-                </ItemActions>
-              </button>
-            </Item>
-          </ItemGroup>
+                  <button type="button" onClick={() => setOpen(true)}>
+                    <ItemMedia
+                      variant="icon"
+                      className="size-9 rounded-[10px] bg-amber-500/12 text-amber-600 dark:text-amber-400"
+                    >
+                      <Plus />
+                    </ItemMedia>
+                    <ItemContent className="gap-0.5">
+                      <ItemTitle>add a folder</ItemTitle>
+                      <ItemDescription>
+                        choose a folder to share with vesta
+                      </ItemDescription>
+                    </ItemContent>
+                  </button>
+                </Item>
+              </ItemGroup>
+
+              {saveError ? (
+                <p className="px-1 text-xs text-destructive">{saveError}</p>
+              ) : restartHint ? (
+                <p className="px-1 text-xs text-muted-foreground/60">
+                  restart {agentName || "the agent"} to apply.
+                </p>
+              ) : null}
+            </>
+          )}
         </CardContent>
       </Card>
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
-            <DialogTitle>shared folders</DialogTitle>
+            <DialogTitle>add a folder</DialogTitle>
             <DialogDescription>
-              folders on this computer {agentName || "vesta"} can open.
+              choose a folder on this computer for {agentName || "vesta"} to
+              open.
             </DialogDescription>
           </DialogHeader>
 
           <div className="flex min-w-0 flex-col gap-3">
-            {loadError ? (
-              <p className="text-xs text-destructive">
-                failed to load: {loadError}
-              </p>
-            ) : mounts === null ? (
-              <div className="flex flex-col gap-2">
-                <Skeleton className="h-12 w-full rounded-2xl" />
-                <Skeleton className="h-12 w-full rounded-2xl" />
-              </div>
-            ) : (
-              <>
-                {mounts.length > 0 ? (
-                  <ItemGroup className="min-w-0">
-                    {mounts.map((mount, index) => (
-                      <Item
-                        key={mount.container_path}
-                        variant="muted"
-                        size="sm"
-                      >
-                        <ItemMedia
-                          variant="icon"
-                          className="size-9 rounded-[10px] bg-sky-500/12 text-sky-600 dark:text-sky-400"
-                        >
-                          <FolderOpen />
-                        </ItemMedia>
-                        <ItemContent className="min-w-0 gap-0.5">
-                          <ItemTitle>{folderName(mount.host_path)}</ItemTitle>
-                          <ItemDescription
-                            className="text-[11px]"
-                            title={mount.host_path}
-                          >
-                            {mount.host_path}
-                            {mount.container_path !== mount.host_path
-                              ? ` · seen at ${mount.container_path}`
-                              : ""}
-                          </ItemDescription>
-                        </ItemContent>
-                        <ItemActions>
-                          <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                            <Switch
-                              size="sm"
-                              checked={mount.writable}
-                              disabled={saving}
-                              aria-label={`allow editing ${folderName(mount.host_path)}`}
-                              onCheckedChange={(v) => toggleWritable(index, v)}
-                            />
-                            can edit
-                          </span>
-                          <Button
-                            size="icon-xs"
-                            variant="ghost"
-                            aria-label={`remove ${mount.host_path}`}
-                            disabled={saving}
-                            onClick={() => removePath(index)}
-                          >
-                            <Trash2 className="size-3.5" />
-                          </Button>
-                        </ItemActions>
-                      </Item>
-                    ))}
-                  </ItemGroup>
-                ) : (
-                  <p className="text-xs text-muted-foreground/60">
-                    no shared folders yet.
-                  </p>
-                )}
-
-                <div className="flex flex-col gap-2 rounded-xl bg-muted/40 p-3">
-                  {availableSuggestions.length > 0 ? (
-                    <div className="flex flex-col gap-1.5">
-                      <span className="text-[11px] text-muted-foreground">
-                        suggested folders
-                      </span>
-                      <div className="flex flex-wrap gap-1.5">
-                        {availableSuggestions.map((s) => (
-                          <button
-                            key={s}
-                            type="button"
-                            onClick={() => {
-                              setHostPath(s);
-                              setContainerPath("");
-                            }}
-                            className="max-w-full truncate rounded-full bg-background px-2.5 py-1 text-[11px] text-muted-foreground ring-1 ring-border transition-colors hover:text-foreground"
-                            title={s}
-                          >
-                            {s}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  ) : null}
-                  <Input
-                    value={hostPath}
-                    onChange={(e) => setHostPath(e.target.value)}
-                    placeholder="/mnt/media"
-                    aria-label="folder path on this computer"
-                    className="h-8 text-xs"
-                  />
-                  {showContainerPath ? (
-                    <Input
-                      value={containerPath}
-                      onChange={(e) => setContainerPath(e.target.value)}
-                      placeholder="where vesta sees it (optional)"
-                      aria-label="path inside the container"
-                      className="h-8 text-xs"
-                      autoFocus
-                    />
-                  ) : (
+            {availableSuggestions.length > 0 ? (
+              <div className="flex flex-col gap-1.5">
+                <span className="text-[11px] text-muted-foreground">
+                  suggested folders
+                </span>
+                <div className="flex flex-wrap gap-1.5">
+                  {availableSuggestions.map((s) => (
                     <button
+                      key={s}
                       type="button"
-                      onClick={() => setShowContainerPath(true)}
-                      className="self-start text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+                      onClick={() => {
+                        setHostPath(s);
+                        setContainerPath("");
+                      }}
+                      className="max-w-full truncate rounded-full bg-muted px-2.5 py-1 text-[11px] text-muted-foreground ring-1 ring-border transition-colors hover:text-foreground"
+                      title={s}
                     >
-                      change where vesta sees it
+                      {s}
                     </button>
-                  )}
-                  <div className="flex items-center justify-between">
-                    <span className="flex items-center gap-2 text-xs text-muted-foreground">
-                      <Switch
-                        size="sm"
-                        checked={writable}
-                        onCheckedChange={setWritable}
-                        aria-label="allow editing"
-                      />
-                      can edit
-                      {!writable ? (
-                        <Lock className="size-3 text-muted-foreground/60" />
-                      ) : null}
-                    </span>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={!hostPath.trim() || saving}
-                      onClick={addPath}
-                    >
-                      <Plus className="size-4" />
-                      add folder
-                    </Button>
-                  </div>
+                  ))}
                 </div>
+              </div>
+            ) : null}
 
-                {saveError ? (
-                  <p className="text-xs text-destructive">{saveError}</p>
-                ) : restartHint ? (
-                  <p className="text-xs text-muted-foreground/60">
-                    restart {agentName || "the agent"} to apply.
-                  </p>
-                ) : null}
-              </>
+            <Input
+              value={hostPath}
+              onChange={(e) => setHostPath(e.target.value)}
+              placeholder="/mnt/media"
+              aria-label="folder path on this computer"
+              className="h-8 text-xs"
+            />
+            {showContainerPath ? (
+              <Input
+                value={containerPath}
+                onChange={(e) => setContainerPath(e.target.value)}
+                placeholder="where vesta sees it (optional)"
+                aria-label="path inside the container"
+                className="h-8 text-xs"
+                autoFocus
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => setShowContainerPath(true)}
+                className="self-start text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+              >
+                change where vesta sees it
+              </button>
             )}
+
+            <div className="flex items-center justify-between">
+              <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Switch
+                  size="sm"
+                  checked={writable}
+                  onCheckedChange={setWritable}
+                  aria-label="allow editing"
+                />
+                can edit
+                {!writable ? (
+                  <Lock className="size-3 text-muted-foreground/60" />
+                ) : null}
+              </span>
+              <Button
+                size="sm"
+                disabled={!hostPath.trim() || saving}
+                onClick={addPath}
+              >
+                <Plus className="size-4" />
+                add folder
+              </Button>
+            </div>
+
+            {saveError ? (
+              <p className="text-xs text-destructive">{saveError}</p>
+            ) : null}
           </div>
         </DialogContent>
       </Dialog>

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -178,10 +178,7 @@ export function HostAccessCard() {
                     </ItemMedia>
                     <ItemContent className="min-w-0 gap-0.5">
                       <ItemTitle>{folderName(mount.host_path)}</ItemTitle>
-                      <ItemDescription
-                        className="text-[11px]"
-                        title={mount.host_path}
-                      >
+                      <ItemDescription title={mount.host_path}>
                         {mount.host_path}
                         {mount.container_path !== mount.host_path
                           ? ` · seen at ${mount.container_path}`
@@ -227,7 +224,7 @@ export function HostAccessCard() {
                     </ItemMedia>
                     <ItemContent className="gap-0.5">
                       <ItemTitle>add a folder</ItemTitle>
-                      <ItemDescription className="text-[11px]">
+                      <ItemDescription>
                         choose a folder to share with {agentName || "the agent"}
                       </ItemDescription>
                     </ItemContent>

--- a/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.tsx
@@ -12,8 +12,10 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Item,
+  ItemActions,
   ItemContent,
   ItemDescription,
+  ItemGroup,
   ItemTitle,
 } from "@/components/ui/item";
 import {
@@ -188,15 +190,16 @@ export function NotificationInterruptRulesCard() {
               {/* Active rules in priority order (first match wins). Drag to reorder; read-only
                   summaries with a clickable action badge + delete. */}
               {rules.length > 0 ? (
-                <div className="flex flex-col gap-2">
+                <ItemGroup>
                   {rules.map((rule, index) => {
                     const conditions = ruleConditions(rule);
                     const draggable = rules.length > 1;
                     return (
-                      <div
+                      <Item
                         key={rule.id}
+                        variant="muted"
+                        size="sm"
                         className={cn(
-                          "flex items-center gap-2 rounded-md",
                           dragIndex !== null &&
                             dragIndex !== index &&
                             "outline-dashed outline-1 outline-border/60",
@@ -240,40 +243,42 @@ export function NotificationInterruptRulesCard() {
                             ))
                           )}
                         </div>
-                        <Badge
-                          asChild
-                          variant={
-                            rule.action === "interrupt"
-                              ? "default"
-                              : "secondary"
-                          }
-                        >
-                          <button
-                            type="button"
-                            onClick={() => toggleAction(index)}
-                            aria-label={`action: ${
+                        <ItemActions>
+                          <Badge
+                            asChild
+                            variant={
                               rule.action === "interrupt"
-                                ? "interrupt"
-                                : "snooze"
-                            }, click to toggle`}
+                                ? "default"
+                                : "outline"
+                            }
                           >
-                            {rule.action === "interrupt"
-                              ? "interrupt"
-                              : "snooze"}
-                          </button>
-                        </Badge>
-                        <Button
-                          size="icon-xs"
-                          variant="ghost"
-                          aria-label="delete rule"
-                          onClick={() => deleteRule(index)}
-                        >
-                          ✕
-                        </Button>
-                      </div>
+                            <button
+                              type="button"
+                              onClick={() => toggleAction(index)}
+                              aria-label={`action: ${
+                                rule.action === "interrupt"
+                                  ? "interrupt"
+                                  : "snooze"
+                              }, click to toggle`}
+                            >
+                              {rule.action === "interrupt"
+                                ? "interrupt"
+                                : "snooze"}
+                            </button>
+                          </Badge>
+                          <Button
+                            size="icon-xs"
+                            variant="ghost"
+                            aria-label="delete rule"
+                            onClick={() => deleteRule(index)}
+                          >
+                            ✕
+                          </Button>
+                        </ItemActions>
+                      </Item>
                     );
                   })}
-                </div>
+                </ItemGroup>
               ) : null}
 
               {/* Rules are authored by the agent: ask it in chat instead of a form. */}

--- a/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.tsx
@@ -11,6 +11,13 @@ import {
 } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from "@/components/ui/item";
+import {
   getNotificationInterruptRules,
   setNotificationInterruptRules,
   type FieldPredicate,
@@ -271,21 +278,30 @@ export function NotificationInterruptRulesCard() {
               ) : null}
 
               {/* Rules are authored by the agent: ask it in chat instead of a form. */}
-              <div className="flex items-start gap-2 rounded-xl border border-border/60 bg-muted/40 p-3">
-                <Sparkles className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-                <p className="text-xs leading-relaxed text-muted-foreground">
-                  {rules.length === 0 ? "No rules yet. " : ""}
-                  To add a rule, just ask {agentName || "the agent"} — e.g.{" "}
-                  <span className="text-foreground">
-                    "don't let Twitter interrupt you"
-                  </span>{" "}
-                  or{" "}
-                  <span className="text-foreground">
-                    "snooze the Bride Squad group chat"
-                  </span>
-                  .
-                </p>
-              </div>
+              <Item variant="muted" size="sm" className="items-start">
+                <ItemMedia
+                  variant="icon"
+                  className="size-9 rounded-[10px] bg-amber-500/12 text-amber-600 dark:text-amber-400"
+                >
+                  <Sparkles />
+                </ItemMedia>
+                <ItemContent className="gap-0.5">
+                  <ItemTitle>
+                    {rules.length === 0 ? "no rules yet" : "add a rule"}
+                  </ItemTitle>
+                  <ItemDescription className="line-clamp-none">
+                    just ask {agentName || "the agent"} — e.g.{" "}
+                    <span className="text-foreground">
+                      "don't let Twitter interrupt you"
+                    </span>{" "}
+                    or{" "}
+                    <span className="text-foreground">
+                      "snooze the Bride Squad group chat"
+                    </span>
+                    .
+                  </ItemDescription>
+                </ItemContent>
+              </Item>
 
               {saveError ? (
                 <p className="text-xs text-destructive">{saveError}</p>

--- a/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { GripVertical, ListFilter, Sparkles } from "lucide-react";
+import { GripVertical, ListFilter } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,7 +14,6 @@ import {
   Item,
   ItemContent,
   ItemDescription,
-  ItemMedia,
   ItemTitle,
 } from "@/components/ui/item";
 import {
@@ -279,12 +278,6 @@ export function NotificationInterruptRulesCard() {
 
               {/* Rules are authored by the agent: ask it in chat instead of a form. */}
               <Item variant="muted" size="sm" className="items-start">
-                <ItemMedia
-                  variant="icon"
-                  className="size-9 rounded-[10px] bg-amber-500/12 text-amber-600 dark:text-amber-400"
-                >
-                  <Sparkles />
-                </ItemMedia>
                 <ItemContent className="gap-0.5">
                   <ItemTitle>
                     {rules.length === 0 ? "no rules yet" : "add a rule"}

--- a/apps/web/src/components/AgentSettings/NotificationsCard/NotificationRow.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationsCard/NotificationRow.tsx
@@ -1,28 +1,72 @@
 import { useEffect, useRef, useState } from "react";
+import { Bell, Cog, Mail, MessageCircle, Wallet } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemMedia,
+  ItemTitle,
+} from "@/components/ui/item";
 import { type NotificationEvent } from "@/api/agents";
 import { cn } from "@/lib/utils";
 
-// Loading placeholder shaped like a NotificationRow card.
+// Loading placeholder shaped like a NotificationRow cell.
 export function NotificationRowSkeleton() {
   return (
-    <Card
-      size="sm"
-      className="!gap-2.5 border border-border bg-muted/40 px-4 !py-3.5 shadow-none ring-0"
-    >
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2">
-          <Skeleton className="h-4 w-20 rounded-3xl" />
-          <Skeleton className="h-4 w-14 rounded-full" />
-        </div>
-        <Skeleton className="h-3 w-10 rounded" />
-      </div>
-      <Skeleton className="h-3 w-full rounded" />
-      <Skeleton className="h-3 w-3/4 rounded" />
-    </Card>
+    <Item variant="muted" size="sm" className="items-start">
+      <ItemMedia variant="icon" className="size-9 rounded-[10px] bg-muted">
+        <Skeleton className="size-4 rounded" />
+      </ItemMedia>
+      <ItemContent className="gap-1.5">
+        <Skeleton className="h-3.5 w-24 rounded" />
+        <Skeleton className="h-3 w-full rounded" />
+        <Skeleton className="h-3 w-3/4 rounded" />
+      </ItemContent>
+    </Item>
   );
+}
+
+// A source-appropriate icon for the cell's media square.
+function SourceIcon({ source }: { source: string }) {
+  const s = source.toLowerCase();
+  if (s.includes("mail")) return <Mail />;
+  if (
+    s.includes("whatsapp") ||
+    s.includes("telegram") ||
+    s.includes("chat") ||
+    s.includes("message")
+  )
+    return <MessageCircle />;
+  if (s.includes("finance") || s.includes("bank") || s.includes("pay"))
+    return <Wallet />;
+  if (s === "core") return <Cog />;
+  return <Bell />;
+}
+
+// Icon-box tints. A source is hashed to one of these so the same source always gets the same color
+// (and different sources spread across the palette). Kept as full literal class strings so Tailwind
+// picks them up.
+const SOURCE_COLORS = [
+  "bg-sky-500/12 text-sky-600 dark:text-sky-400",
+  "bg-emerald-500/12 text-emerald-600 dark:text-emerald-400",
+  "bg-amber-500/12 text-amber-600 dark:text-amber-400",
+  "bg-violet-500/12 text-violet-600 dark:text-violet-400",
+  "bg-rose-500/12 text-rose-600 dark:text-rose-400",
+  "bg-cyan-500/12 text-cyan-600 dark:text-cyan-400",
+  "bg-indigo-500/12 text-indigo-600 dark:text-indigo-400",
+  "bg-orange-500/12 text-orange-600 dark:text-orange-400",
+  "bg-teal-500/12 text-teal-600 dark:text-teal-400",
+  "bg-fuchsia-500/12 text-fuchsia-600 dark:text-fuchsia-400",
+];
+
+function sourceColor(source: string): string {
+  let hash = 0;
+  for (let i = 0; i < source.length; i++) {
+    hash = (hash * 31 + source.charCodeAt(i)) | 0;
+  }
+  return SOURCE_COLORS[Math.abs(hash) % SOURCE_COLORS.length];
 }
 
 // The stored summary is `<notification source=… type=…>INNER</notification>` (see
@@ -76,9 +120,9 @@ function Disposition({ event }: { event: NotificationEvent }) {
   );
 }
 
-// One notification row: source · type lead with the disposition + time on the right (a pending dot
-// marks unprocessed ones), the sender sits on a quiet line, and the body text clamps to two lines and
-// expands on demand.
+// One notification as an Item cell (matching the files hub): a source icon, the source · type on the
+// title line, the sender + field tags, and the body text (clamped to two lines, expandable). Time and
+// disposition sit in the trailing actions; a pending ring + dot marks unprocessed ones.
 export function NotificationRow({
   event,
   isPending,
@@ -112,16 +156,22 @@ export function NotificationRow({
   }, [body, expanded]);
 
   return (
-    <Card
+    <Item
+      variant="muted"
       size="sm"
       className={cn(
-        // Muted, flat surface (no shadow) with a hairline border to separate rows, so they don't
-        // read as cards-inside-a-card but are still distinct.
-        "!gap-2.5 border border-border bg-muted/40 px-4 !py-3.5 shadow-none ring-0",
+        "items-start",
         isPending && "bg-primary/5 ring-2 ring-primary",
       )}
     >
-      <div className="flex items-start justify-between gap-3">
+      <ItemMedia
+        variant="icon"
+        className={cn("size-9 rounded-[10px]", sourceColor(event.source))}
+      >
+        <SourceIcon source={event.source} />
+      </ItemMedia>
+
+      <ItemContent className="min-w-0 gap-1.5">
         <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
           {isPending ? (
             <>
@@ -132,65 +182,64 @@ export function NotificationRow({
               <span className="sr-only">pending</span>
             </>
           ) : null}
-          <span className="text-sm font-semibold text-foreground">
-            {event.source}
-          </span>
+          <ItemTitle>{event.source}</ItemTitle>
           {event.notif_type ? (
             <Badge variant="secondary">{event.notif_type}</Badge>
           ) : null}
         </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <time className="text-xs text-muted-foreground/70">
-            {relativeTime(event.ts)}
-          </time>
-          <Disposition event={event} />
-        </div>
-      </div>
 
-      {event.sender ? (
-        <span className="truncate text-xs text-muted-foreground/80">
-          {event.sender}
-        </span>
-      ) : null}
+        {event.sender ? (
+          <span className="truncate text-xs text-muted-foreground/80">
+            {event.sender}
+          </span>
+        ) : null}
 
-      {tagFields.length > 0 ? (
-        <div className="flex flex-wrap gap-1">
-          {tagFields.map((field) => (
-            <span
-              key={field.key}
-              className="inline-flex max-w-full items-center gap-1 rounded-md bg-muted/60 px-1.5 py-0.5 text-[10px] text-muted-foreground"
-            >
-              <span className="font-medium text-foreground/70">
-                {field.key}
+        {tagFields.length > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {tagFields.map((field) => (
+              <span
+                key={field.key}
+                className="inline-flex max-w-full items-center gap-1 rounded-md bg-muted/60 px-1.5 py-0.5 text-[10px] text-muted-foreground"
+              >
+                <span className="font-medium text-foreground/70">
+                  {field.key}
+                </span>
+                <span className="truncate">{field.value}</span>
               </span>
-              <span className="truncate">{field.value}</span>
-            </span>
-          ))}
-        </div>
-      ) : null}
+            ))}
+          </div>
+        ) : null}
 
-      {body ? (
-        <div className="flex flex-col gap-1">
-          <p
-            ref={textRef}
-            className={cn(
-              "text-sm leading-relaxed whitespace-pre-wrap text-muted-foreground",
-              expanded ? "" : "line-clamp-2",
-            )}
-          >
-            {body}
-          </p>
-          {overflows ? (
-            <button
-              type="button"
-              className="self-start text-xs font-medium text-primary"
-              onClick={() => setExpanded((value) => !value)}
+        {body ? (
+          <div className="flex flex-col gap-1">
+            <p
+              ref={textRef}
+              className={cn(
+                "text-sm leading-relaxed whitespace-pre-wrap text-muted-foreground",
+                expanded ? "" : "line-clamp-2",
+              )}
             >
-              {expanded ? "show less" : "show more"}
-            </button>
-          ) : null}
-        </div>
-      ) : null}
-    </Card>
+              {body}
+            </p>
+            {overflows ? (
+              <button
+                type="button"
+                className="self-start text-xs font-medium text-primary"
+                onClick={() => setExpanded((value) => !value)}
+              >
+                {expanded ? "show less" : "show more"}
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+      </ItemContent>
+
+      <ItemActions className="self-start">
+        <time className="text-xs text-muted-foreground/70">
+          {relativeTime(event.ts)}
+        </time>
+        <Disposition event={event} />
+      </ItemActions>
+    </Item>
   );
 }

--- a/apps/web/src/components/AgentSettings/NotificationsCard/NotificationRow.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationsCard/NotificationRow.tsx
@@ -59,6 +59,13 @@ const SOURCE_COLORS = [
   "bg-orange-500/12 text-orange-600 dark:text-orange-400",
   "bg-teal-500/12 text-teal-600 dark:text-teal-400",
   "bg-fuchsia-500/12 text-fuchsia-600 dark:text-fuchsia-400",
+  "bg-blue-500/12 text-blue-600 dark:text-blue-400",
+  "bg-lime-500/12 text-lime-600 dark:text-lime-400",
+  "bg-pink-500/12 text-pink-600 dark:text-pink-400",
+  "bg-purple-500/12 text-purple-600 dark:text-purple-400",
+  "bg-red-500/12 text-red-600 dark:text-red-400",
+  "bg-green-500/12 text-green-600 dark:text-green-400",
+  "bg-yellow-500/12 text-yellow-600 dark:text-yellow-400",
 ];
 
 function sourceColor(source: string): string {

--- a/apps/web/src/components/AgentSettings/NotificationsCard/NotificationRow.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationsCard/NotificationRow.tsx
@@ -119,7 +119,7 @@ function Disposition({ event }: { event: NotificationEvent }) {
   if (!decided) return null;
   return (
     <Badge
-      variant={decided === "interrupt" ? "default" : "secondary"}
+      variant={decided === "interrupt" ? "default" : "outline"}
       className="w-[4.5rem]"
     >
       {decided === "interrupt" ? "interrupt" : "snooze"}
@@ -191,7 +191,7 @@ export function NotificationRow({
           ) : null}
           <ItemTitle>{event.source}</ItemTitle>
           {event.notif_type ? (
-            <Badge variant="secondary">{event.notif_type}</Badge>
+            <Badge variant="outline">{event.notif_type}</Badge>
           ) : null}
         </div>
 

--- a/apps/web/src/components/AgentSettings/NotificationsCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationsCard/index.tsx
@@ -15,6 +15,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty";
+import { ItemGroup } from "@/components/ui/item";
 import { getNotificationHistory, type NotificationEvent } from "@/api/agents";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { NotificationRow, NotificationRowSkeleton } from "./NotificationRow";
@@ -122,11 +123,11 @@ export function NotificationsCard() {
         {error ? (
           <p className="text-xs text-destructive">failed to load: {error}</p>
         ) : items === null ? (
-          <div className="flex flex-col gap-2.5">
+          <ItemGroup>
             {Array.from({ length: 4 }).map((_, i) => (
               <NotificationRowSkeleton key={i} />
             ))}
-          </div>
+          </ItemGroup>
         ) : items.length === 0 ? (
           <Empty>
             <EmptyHeader>
@@ -141,14 +142,16 @@ export function NotificationsCard() {
           </Empty>
         ) : (
           <div className="flex flex-col gap-2.5">
-            {items.map((event, i) => (
-              <NotificationRow
-                key={event.notif_id ?? event.ts ?? `row-${i}`}
-                event={event}
-                // Pending = received but not yet processed (still on disk per the live pending set).
-                isPending={!!event.notif_id && pendingIds.has(event.notif_id)}
-              />
-            ))}
+            <ItemGroup>
+              {items.map((event, i) => (
+                <NotificationRow
+                  key={event.notif_id ?? event.ts ?? `row-${i}`}
+                  event={event}
+                  // Pending = received but not yet processed (still on disk per the live pending set).
+                  isPending={!!event.notif_id && pendingIds.has(event.notif_id)}
+                />
+              ))}
+            </ItemGroup>
             {cursor !== null ? (
               <Button
                 size="xs"

--- a/apps/web/src/components/AgentSettings/index.tsx
+++ b/apps/web/src/components/AgentSettings/index.tsx
@@ -1,6 +1,7 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SettingsScrollArea } from "@/components/SettingsScrollArea";
 import { ActionsCard } from "./ActionsCard";
+import { HostAccessCard } from "./HostAccessCard";
 import { NotificationInterruptRulesCard } from "./NotificationInterruptRulesCard";
 import { NotificationsCard } from "./NotificationsCard";
 import { FilesTab } from "./FilesTab";
@@ -29,6 +30,7 @@ export function AgentSettings() {
             </div>
             <div className="flex min-w-0 flex-col gap-4">
               <ProviderCard />
+              <HostAccessCard />
               <SttCard />
               <TtsCard />
             </div>

--- a/apps/web/src/components/AgentSettings/index.tsx
+++ b/apps/web/src/components/AgentSettings/index.tsx
@@ -47,8 +47,10 @@ export function AgentSettings() {
         </TabsContent>
 
         <TabsContent value="files">
-          <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
-            <HostAccessCard />
+          <div className="mx-auto grid w-full max-w-6xl gap-4 lg:grid-cols-[280px_minmax(0,1fr)] lg:items-start">
+            <div className="flex flex-col gap-4 lg:sticky lg:top-0">
+              <HostAccessCard />
+            </div>
             <FilesTab />
           </div>
         </TabsContent>

--- a/apps/web/src/components/AgentSettings/index.tsx
+++ b/apps/web/src/components/AgentSettings/index.tsx
@@ -30,7 +30,6 @@ export function AgentSettings() {
             </div>
             <div className="flex min-w-0 flex-col gap-4">
               <ProviderCard />
-              <HostAccessCard />
               <SttCard />
               <TtsCard />
             </div>
@@ -48,7 +47,8 @@ export function AgentSettings() {
         </TabsContent>
 
         <TabsContent value="files">
-          <div className="mx-auto w-full max-w-5xl">
+          <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
+            <HostAccessCard />
             <FilesTab />
           </div>
         </TabsContent>

--- a/apps/web/src/components/AgentSettings/index.tsx
+++ b/apps/web/src/components/AgentSettings/index.tsx
@@ -1,7 +1,6 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SettingsScrollArea } from "@/components/SettingsScrollArea";
 import { ActionsCard } from "./ActionsCard";
-import { HostAccessCard } from "./HostAccessCard";
 import { NotificationInterruptRulesCard } from "./NotificationInterruptRulesCard";
 import { NotificationsCard } from "./NotificationsCard";
 import { FilesTab } from "./FilesTab";
@@ -47,10 +46,7 @@ export function AgentSettings() {
         </TabsContent>
 
         <TabsContent value="files">
-          <div className="mx-auto grid w-full max-w-6xl gap-4 lg:grid-cols-[280px_minmax(0,1fr)] lg:items-start">
-            <div className="flex flex-col gap-4 lg:sticky lg:top-0">
-              <HostAccessCard />
-            </div>
+          <div className="mx-auto w-full max-w-6xl">
             <FilesTab />
           </div>
         </TabsContent>

--- a/apps/web/src/components/Navbar/AgentNavbar/index.tsx
+++ b/apps/web/src/components/Navbar/AgentNavbar/index.tsx
@@ -25,7 +25,6 @@ import { useModals } from "@/providers/ModalsProvider";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { useLayout } from "@/stores/use-layout";
 import { useRestartPending } from "@/stores/use-restart-pending";
-import { restartAgent } from "@/api/agents";
 import { Navbar } from "..";
 
 export function AgentNavbar({
@@ -39,7 +38,7 @@ export function AgentNavbar({
 }) {
   const { connected } = useAuth();
   const { reachable } = useGateway();
-  const { name, agent } = useSelectedAgent();
+  const { name, agent, restart } = useSelectedAgent();
   const { handleOpenAuth } = useModals();
   const navigate = useNavigate();
   const isMobile = useIsMobile();
@@ -47,16 +46,15 @@ export function AgentNavbar({
   const restartPending = useRestartPending((s) =>
     name ? (s.pending[name] ?? false) : false,
   );
-  const clearRestartPending = useRestartPending((s) => s.clearPending);
   const [restarting, setRestarting] = useState(false);
+  // Route through the provider's restart so clearing the pending flag has a single owner (the
+  // provider), whichever surface triggers a restart. withOp resolves after completion (it handles
+  // failure internally and keeps the flag set), so the spinner ends correctly either way.
   const applyRestart = async () => {
     if (!name) return;
     setRestarting(true);
     try {
-      await restartAgent(name);
-      clearRestartPending(name);
-    } catch {
-      // Leave the flag set so the user can retry.
+      await restart();
     } finally {
       setRestarting(false);
     }

--- a/apps/web/src/components/Navbar/AgentNavbar/index.tsx
+++ b/apps/web/src/components/Navbar/AgentNavbar/index.tsx
@@ -1,7 +1,13 @@
-import { type Dispatch, type SetStateAction } from "react";
+import { type Dispatch, type SetStateAction, useState } from "react";
 import { type MotionValue } from "motion/react";
 import { useMatch, useNavigate } from "react-router-dom";
-import { Home, KeyRound, LayoutDashboard, MessageSquare } from "lucide-react";
+import {
+  Home,
+  KeyRound,
+  LayoutDashboard,
+  MessageSquare,
+  RotateCw,
+} from "lucide-react";
 import { AgentIsland } from "@/components/AgentIsland";
 import { AgentMenu } from "@/components/AgentMenu";
 import { MobileNavbar } from "@/components/MobileNavbar";
@@ -18,6 +24,8 @@ import { useGateway } from "@/providers/GatewayProvider";
 import { useModals } from "@/providers/ModalsProvider";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { useLayout } from "@/stores/use-layout";
+import { useRestartPending } from "@/stores/use-restart-pending";
+import { restartAgent } from "@/api/agents";
 import { Navbar } from "..";
 
 export function AgentNavbar({
@@ -36,6 +44,23 @@ export function AgentNavbar({
   const navigate = useNavigate();
   const isMobile = useIsMobile();
   const chatKeyboardFocused = useLayout((s) => s.chatKeyboardFocused);
+  const restartPending = useRestartPending((s) =>
+    name ? (s.pending[name] ?? false) : false,
+  );
+  const clearRestartPending = useRestartPending((s) => s.clearPending);
+  const [restarting, setRestarting] = useState(false);
+  const applyRestart = async () => {
+    if (!name) return;
+    setRestarting(true);
+    try {
+      await restartAgent(name);
+      clearRestartPending(name);
+    } catch {
+      // Leave the flag set so the user can retry.
+    } finally {
+      setRestarting(false);
+    }
+  };
   const needsAuth =
     (agent?.status === "not_authenticated" ||
       agent?.status === "unprovisioned") &&
@@ -97,6 +122,22 @@ export function AgentNavbar({
           connected ? (
             <div className="flex items-center gap-2">
               <StatusPill showHostname={false} />
+              {restartPending && (
+                <Button
+                  variant="default"
+                  size={isMobile ? "icon-lg" : "lg"}
+                  disabled={restarting}
+                  aria-label="restart to apply changes"
+                  onClick={() => void applyRestart()}
+                >
+                  <RotateCw
+                    data-icon={isMobile ? undefined : "inline-start"}
+                    className={restarting ? "animate-spin" : undefined}
+                  />
+                  {!isMobile &&
+                    (restarting ? "restarting…" : "restart to apply")}
+                </Button>
+              )}
               {!isMobile && needsAuth && (
                 <Button
                   variant="default"

--- a/apps/web/src/components/ui/item.tsx
+++ b/apps/web/src/components/ui/item.tsx
@@ -138,7 +138,7 @@ function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="item-description"
       className={cn(
-        "line-clamp-2 text-left text-sm font-normal text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        "line-clamp-2 text-left text-[11px] font-normal text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/item.tsx
+++ b/apps/web/src/components/ui/item.tsx
@@ -40,7 +40,7 @@ const itemVariants = cva(
       variant: {
         default: "border-transparent",
         outline: "border-border",
-        muted: "border-transparent bg-muted/50",
+        muted: "border-transparent bg-muted",
       },
       size: {
         default: "gap-3.5 px-4 py-3.5",

--- a/apps/web/src/components/ui/item.tsx
+++ b/apps/web/src/components/ui/item.tsx
@@ -40,7 +40,7 @@ const itemVariants = cva(
       variant: {
         default: "border-transparent",
         outline: "border-border",
-        muted: "border-border bg-muted/50",
+        muted: "border-transparent bg-muted/50",
       },
       size: {
         default: "gap-3.5 px-4 py-3.5",

--- a/apps/web/src/components/ui/item.tsx
+++ b/apps/web/src/components/ui/item.tsx
@@ -40,7 +40,7 @@ const itemVariants = cva(
       variant: {
         default: "border-transparent",
         outline: "border-border",
-        muted: "border-transparent bg-muted/50",
+        muted: "border-border bg-muted/50",
       },
       size: {
         default: "gap-3.5 px-4 py-3.5",

--- a/apps/web/src/providers/SelectedAgentProvider/context.ts
+++ b/apps/web/src/providers/SelectedAgentProvider/context.ts
@@ -23,7 +23,7 @@ export interface SelectedAgentContextValue {
 
   start: () => void;
   stop: () => void;
-  restart: () => void;
+  restart: () => Promise<void>;
   rebuild: () => void;
   backup: () => void;
   backups: BackupInfo[];

--- a/apps/web/src/providers/SelectedAgentProvider/index.tsx
+++ b/apps/web/src/providers/SelectedAgentProvider/index.tsx
@@ -11,7 +11,8 @@ import {
   deleteAgent,
   type BackupInfo,
 } from "@/api";
-import { useAgentOps } from "@/stores/use-agent-ops";
+import { useAgentOps, type AgentOperation } from "@/stores/use-agent-ops";
+import { useRestartPending } from "@/stores/use-restart-pending";
 import type { AgentInfo, AgentActivityState } from "@/lib/types";
 import { getAgentVisualStatus } from "@/components/Orb/styles";
 import { SelectedAgentContext } from "./context";
@@ -33,6 +34,7 @@ export function SelectedAgentProvider({
 
   const withOp = useAgentOps((s) => s.withOp);
   const removeAgentOp = useAgentOps((s) => s.removeAgent);
+  const clearRestartPending = useRestartPending((s) => s.clearPending);
   const opState = useAgentOps((s) => s.getOp(name));
   const isBusy = opState.operation !== "idle";
 
@@ -57,8 +59,25 @@ export function SelectedAgentProvider({
 
   const start = op("starting", () => startAgent(name), "start failed");
   const stop = op("stopping", () => stopAgent(name), "stop failed");
-  const restart = op("starting", () => restartAgent(name), "restart failed");
-  const rebuild = op("rebuilding", () => rebuildAgent(name), "rebuild failed");
+  // A restart/rebuild applies any pending saved changes, so clear the "restart to apply" reminder on
+  // success (the run callback throws on failure, so a failed restart keeps the reminder). This is the
+  // single owner of clearing it, whichever surface (navbar button, agent menu) triggers the restart.
+  const restart = op(
+    "starting",
+    async () => {
+      await restartAgent(name);
+      clearRestartPending(name);
+    },
+    "restart failed",
+  );
+  const rebuild = op(
+    "rebuilding",
+    async () => {
+      await rebuildAgent(name);
+      clearRestartPending(name);
+    },
+    "rebuild failed",
+  );
 
   const [backups, setBackups] = useState<BackupInfo[]>([]);
 

--- a/apps/web/src/providers/SelectedAgentProvider/index.tsx
+++ b/apps/web/src/providers/SelectedAgentProvider/index.tsx
@@ -60,22 +60,29 @@ export function SelectedAgentProvider({
   const start = op("starting", () => startAgent(name), "start failed");
   const stop = op("stopping", () => stopAgent(name), "stop failed");
   // A restart/rebuild applies any pending saved changes, so clear the "restart to apply" reminder on
-  // success (the run callback throws on failure, so a failed restart keeps the reminder). This is the
-  // single owner of clearing it, whichever surface (navbar button, agent menu) triggers the restart.
-  const restart = op(
+  // success (the run callback throws on failure, so a failed op keeps the reminder). This is the single
+  // owner of clearing it, whichever surface (navbar button, agent menu) triggers the op.
+  const applyPending = (
+    operation: AgentOperation,
+    run: () => Promise<unknown>,
+    failure: string,
+  ) =>
+    op(
+      operation,
+      async () => {
+        await run();
+        clearRestartPending(name);
+      },
+      failure,
+    );
+  const restart = applyPending(
     "starting",
-    async () => {
-      await restartAgent(name);
-      clearRestartPending(name);
-    },
+    () => restartAgent(name),
     "restart failed",
   );
-  const rebuild = op(
+  const rebuild = applyPending(
     "rebuilding",
-    async () => {
-      await rebuildAgent(name);
-      clearRestartPending(name);
-    },
+    () => rebuildAgent(name),
     "rebuild failed",
   );
 

--- a/apps/web/src/stores/use-onboarding.ts
+++ b/apps/web/src/stores/use-onboarding.ts
@@ -1,7 +1,11 @@
 import { create } from "zustand";
 
 export type OnboardingStep =
-  "name" | "provider" | "creating" | "personality" | "done";
+  | "name"
+  | "provider"
+  | "creating"
+  | "personality"
+  | "done";
 
 interface OnboardingState {
   step: OnboardingStep | null;

--- a/apps/web/src/stores/use-onboarding.ts
+++ b/apps/web/src/stores/use-onboarding.ts
@@ -1,11 +1,7 @@
 import { create } from "zustand";
 
 export type OnboardingStep =
-  | "name"
-  | "provider"
-  | "creating"
-  | "personality"
-  | "done";
+  "name" | "provider" | "creating" | "personality" | "done";
 
 interface OnboardingState {
   step: OnboardingStep | null;

--- a/apps/web/src/stores/use-restart-pending.ts
+++ b/apps/web/src/stores/use-restart-pending.ts
@@ -1,24 +1,31 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 // Tracks agents that have a saved change which only applies after a restart. Features flag their
 // agent here instead of rendering their own "restart to apply" hint, so the navbar can offer a
-// single restart action. In-memory: a page reload clears it (the change is already saved
-// server-side; only the reminder is transient).
+// single restart action. Persisted to localStorage so a page reload keeps the reminder — the change
+// is already saved server-side, and a lost reminder means the user never restarts and the edit stays
+// silently inert. Cleared when the agent is restarted (see SelectedAgentProvider).
 interface RestartPendingState {
   pending: Record<string, boolean>;
   markPending: (agent: string) => void;
   clearPending: (agent: string) => void;
 }
 
-export const useRestartPending = create<RestartPendingState>((set) => ({
-  pending: {},
-  markPending: (agent) =>
-    set((state) => ({ pending: { ...state.pending, [agent]: true } })),
-  clearPending: (agent) =>
-    set((state) => {
-      if (!state.pending[agent]) return state;
-      const next = { ...state.pending };
-      delete next[agent];
-      return { pending: next };
+export const useRestartPending = create<RestartPendingState>()(
+  persist(
+    (set) => ({
+      pending: {},
+      markPending: (agent) =>
+        set((state) => ({ pending: { ...state.pending, [agent]: true } })),
+      clearPending: (agent) =>
+        set((state) => {
+          if (!state.pending[agent]) return state;
+          const next = { ...state.pending };
+          delete next[agent];
+          return { pending: next };
+        }),
     }),
-}));
+    { name: "vesta-restart-pending" },
+  ),
+);

--- a/apps/web/src/stores/use-restart-pending.ts
+++ b/apps/web/src/stores/use-restart-pending.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+
+// Tracks agents that have a saved change which only applies after a restart. Features flag their
+// agent here instead of rendering their own "restart to apply" hint, so the navbar can offer a
+// single restart action. In-memory: a page reload clears it (the change is already saved
+// server-side; only the reminder is transient).
+interface RestartPendingState {
+  pending: Record<string, boolean>;
+  markPending: (agent: string) => void;
+  clearPending: (agent: string) => void;
+}
+
+export const useRestartPending = create<RestartPendingState>((set) => ({
+  pending: {},
+  markPending: (agent) =>
+    set((state) => ({ pending: { ...state.pending, [agent]: true } })),
+  clearPending: (agent) =>
+    set((state) => {
+      if (!state.pending[agent]) return state;
+      const next = { ...state.pending };
+      delete next[agent];
+      return { pending: next };
+    }),
+}));

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -678,6 +678,14 @@ impl Client {
         read_json(self.get("/backups")?)
     }
 
+    pub fn get_agent_mounts(&self, name: &str) -> Result<serde_json::Value, String> {
+        read_json(self.get(&format!("/agents/{name}/mounts"))?)
+    }
+
+    pub fn set_agent_mounts(&self, name: &str, body: &serde_json::Value) -> Result<serde_json::Value, String> {
+        read_json(self.put_json(&format!("/agents/{name}/mounts"), body)?)
+    }
+
     pub fn get_agent_backup_settings(&self, name: &str) -> Result<serde_json::Value, String> {
         read_json(self.get(&format!("/agents/{name}/settings/backup"))?)
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1592,20 +1592,33 @@ fn run(cli: Cli) {
                         mounts.push(MountEntry { host_path: host_path.clone(), container_path, writable });
                         let body = serde_json::json!({ "mounts": mounts });
                         c.set_agent_mounts(&agent, &body).unwrap_or_else(|e| platform::die(&e));
-                        eprintln!("granted {host_path} (restart to apply: vesta restart {agent})");
+                        eprintln!("granted {host_path}; applies on restart: vesta restart {agent}");
                     }
                 }
                 MountCommand::Rm { agent, host_path } => {
                     let mounts = get_mount_entries(&c, &agent);
-                    let original_count = mounts.len();
-                    let filtered: Vec<MountEntry> =
-                        mounts.into_iter().filter(|m| m.host_path != host_path && m.container_path != host_path).collect();
-                    if filtered.len() == original_count {
-                        eprintln!("no grant for {host_path}");
-                    } else {
-                        let body = serde_json::json!({ "mounts": filtered });
-                        c.set_agent_mounts(&agent, &body).unwrap_or_else(|e| platform::die(&e));
-                        eprintln!("revoked {host_path} (restart to apply)");
+                    let matched = mounts.iter().find(|m| m.host_path == host_path || m.container_path == host_path).cloned();
+                    match matched {
+                        Some(entry) => {
+                            let filtered: Vec<MountEntry> = mounts
+                                .into_iter()
+                                .filter(|m| m.host_path != entry.host_path || m.container_path != entry.container_path)
+                                .collect();
+                            let body = serde_json::json!({ "mounts": filtered });
+                            c.set_agent_mounts(&agent, &body).unwrap_or_else(|e| platform::die(&e));
+                            let target = if entry.container_path == entry.host_path {
+                                String::new()
+                            } else {
+                                format!(" (container path {})", entry.container_path)
+                            };
+                            eprintln!(
+                                "revoked {}{}; access remains until you restart: vesta restart {agent}",
+                                entry.host_path, target
+                            );
+                        }
+                        None => {
+                            eprintln!("no grant for {host_path} — run 'vesta mount ls {agent}' to see stored paths");
+                        }
                     }
                 }
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1586,17 +1586,20 @@ fn run(cli: Cli) {
                 MountCommand::Add { agent, host_path, container_path, writable } => {
                     let mut mounts = get_mount_entries(&c, &agent);
                     let container_path = container_path.unwrap_or_else(|| host_path.clone());
-                    if !mounts.iter().any(|m| m.container_path == container_path) {
+                    if mounts.iter().any(|m| m.container_path == container_path) {
+                        eprintln!("a grant already targets {container_path}");
+                    } else {
                         mounts.push(MountEntry { host_path: host_path.clone(), container_path, writable });
+                        let body = serde_json::json!({ "mounts": mounts });
+                        c.set_agent_mounts(&agent, &body).unwrap_or_else(|e| platform::die(&e));
+                        eprintln!("granted {host_path} (restart to apply: vesta restart {agent})");
                     }
-                    let body = serde_json::json!({ "mounts": mounts });
-                    c.set_agent_mounts(&agent, &body).unwrap_or_else(|e| platform::die(&e));
-                    eprintln!("granted {host_path} (restart to apply: vesta restart {agent})");
                 }
                 MountCommand::Rm { agent, host_path } => {
                     let mounts = get_mount_entries(&c, &agent);
                     let original_count = mounts.len();
-                    let filtered: Vec<MountEntry> = mounts.into_iter().filter(|m| m.host_path != host_path).collect();
+                    let filtered: Vec<MountEntry> =
+                        mounts.into_iter().filter(|m| m.host_path != host_path && m.container_path != host_path).collect();
                     if filtered.len() == original_count {
                         eprintln!("no grant for {host_path}");
                     } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -156,6 +156,11 @@ enum Command {
         #[command(subcommand)]
         action: BackupAction,
     },
+    /// Manage host filesystem access for an agent
+    Mount {
+        #[command(subcommand)]
+        cmd: MountCommand,
+    },
     /// View or change agent settings. With no flags, prints model + context window
     /// (manage_agent_code is fixed at create time and read-only here).
     Settings {
@@ -328,6 +333,35 @@ enum BackupAction {
     },
 }
 
+#[derive(Subcommand)]
+enum MountCommand {
+    /// List host paths this agent can access
+    Ls { agent: String },
+    /// Grant the agent access to a host path (read-only by default)
+    Add {
+        agent: String,
+        host_path: String,
+        /// Container path (defaults to mirroring the host path)
+        #[arg(long = "as")]
+        container_path: Option<String>,
+        /// Allow the agent to write (default read-only)
+        #[arg(long)]
+        writable: bool,
+    },
+    /// Revoke a grant by host path
+    Rm { agent: String, host_path: String },
+}
+
+/// A single host filesystem grant, as returned by / sent to GET|PUT /agents/{name}/mounts.
+/// The server validates and canonicalizes host_path/container_path on PUT.
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
+struct MountEntry {
+    host_path: String,
+    container_path: String,
+    #[serde(default)]
+    writable: bool,
+}
+
 #[derive(Clone, clap::ValueEnum)]
 enum Toggle {
     On,
@@ -462,6 +496,18 @@ fn print_agent_backup_settings(result: &serde_json::Value) {
         if has_override { "(override)" } else { "(global)" });
     let (daily, weekly, monthly) = retention_fields(&result["retention"]);
     eprintln!("  retention: daily={daily}, weekly={weekly}, monthly={monthly}");
+}
+
+fn get_mount_entries(c: &client::Client, agent: &str) -> Vec<MountEntry> {
+    let value = c.get_agent_mounts(agent).unwrap_or_else(|e| platform::die(&e));
+    match value["mounts"].as_array() {
+        Some(entries) => entries
+            .iter()
+            .cloned()
+            .map(|entry| serde_json::from_value(entry).unwrap_or_else(|e| platform::die(&format!("failed to parse mount entry: {e}"))))
+            .collect(),
+        None => Vec::new(),
+    }
 }
 
 fn read_file_or_stdin(path: &std::path::Path) -> String {
@@ -1519,6 +1565,49 @@ fn run(cli: Cli) {
             }
         }
 
+        Command::Mount { cmd } => {
+            let c = get_client(host_ref, token_ref);
+            match cmd {
+                MountCommand::Ls { agent } => {
+                    let mounts = get_mount_entries(&c, &agent);
+                    if mounts.is_empty() {
+                        eprintln!("no host grants for '{agent}'");
+                    } else {
+                        for m in &mounts {
+                            let target = if m.container_path == m.host_path {
+                                String::new()
+                            } else {
+                                format!(" -> {}", m.container_path)
+                            };
+                            println!("  {}{}  [{}]", m.host_path, target, if m.writable { "rw" } else { "ro" });
+                        }
+                    }
+                }
+                MountCommand::Add { agent, host_path, container_path, writable } => {
+                    let mut mounts = get_mount_entries(&c, &agent);
+                    let container_path = container_path.unwrap_or_else(|| host_path.clone());
+                    if !mounts.iter().any(|m| m.container_path == container_path) {
+                        mounts.push(MountEntry { host_path: host_path.clone(), container_path, writable });
+                    }
+                    let body = serde_json::json!({ "mounts": mounts });
+                    c.set_agent_mounts(&agent, &body).unwrap_or_else(|e| platform::die(&e));
+                    eprintln!("granted {host_path} (restart to apply: vesta restart {agent})");
+                }
+                MountCommand::Rm { agent, host_path } => {
+                    let mounts = get_mount_entries(&c, &agent);
+                    let original_count = mounts.len();
+                    let filtered: Vec<MountEntry> = mounts.into_iter().filter(|m| m.host_path != host_path).collect();
+                    if filtered.len() == original_count {
+                        eprintln!("no grant for {host_path}");
+                    } else {
+                        let body = serde_json::json!({ "mounts": filtered });
+                        c.set_agent_mounts(&agent, &body).unwrap_or_else(|e| platform::die(&e));
+                        eprintln!("revoked {host_path} (restart to apply)");
+                    }
+                }
+            }
+        }
+
         Command::Destroy { name } => {
             let c = get_client(host_ref, token_ref);
             c.destroy_agent(&name).unwrap_or_else(|e| platform::die(&e));
@@ -1712,5 +1801,32 @@ mod tests {
         let rules = vec![serde_json::json!({ "id": "a" }), serde_json::json!({ "id": "b" })];
         assert_eq!(remove_rule(&rules, "a").unwrap(), vec![serde_json::json!({ "id": "b" })]);
         assert!(remove_rule(&rules, "missing").is_none());
+    }
+
+    #[test]
+    fn parses_mount_add_with_flags() {
+        let cli = Cli::try_parse_from(["vesta", "mount", "add", "media", "/mnt/media", "--as", "/mnt/media", "--writable"]).unwrap();
+        match cli.command {
+            Some(Command::Mount {
+                cmd: MountCommand::Add { agent, host_path, container_path, writable },
+            }) => {
+                assert_eq!(agent, "media");
+                assert_eq!(host_path, "/mnt/media");
+                assert_eq!(container_path, Some("/mnt/media".to_string()));
+                assert!(writable);
+            }
+            _ => panic!("expected Command::Mount {{ cmd: MountCommand::Add {{ .. }} }}"),
+        }
+    }
+
+    #[test]
+    fn parses_mount_ls() {
+        let cli = Cli::try_parse_from(["vesta", "mount", "ls", "media"]).unwrap();
+        match cli.command {
+            Some(Command::Mount { cmd: MountCommand::Ls { agent } }) => {
+                assert_eq!(agent, "media");
+            }
+            _ => panic!("expected Command::Mount {{ cmd: MountCommand::Ls {{ .. }} }}"),
+        }
     }
 }

--- a/docs/superpowers/specs/2026-07-05-restart-reason-interface-design.md
+++ b/docs/superpowers/specs/2026-07-05-restart-reason-interface-design.md
@@ -1,0 +1,117 @@
+# External restart-reason interface
+
+**Date:** 2026-07-05
+**Status:** Design approved, pending spec review
+
+## Problem
+
+When something restarts an agent from *outside* the container — the app's restart button,
+a `vestad` backup, or (the motivating case) applying a newly-granted host mount — the agent
+boots with no idea *why*. It just took a `SIGTERM` and came back. For mounts specifically,
+the user grants a folder in the UI, the agent is recreated, and it silently has new
+filesystem access it was never told about.
+
+The agent already surfaces a "why you're awake" line on boot: `_consume_restart_reason`
+reads `state.persisted.last_restart_reason` and feeds it as `greeting_reason` into the
+greeting boot turn. But that field is only ever written *by the agent, from inside the
+container* — on a crash (`main.py` error handlers), on the dreamer's self-restart
+(`tools.py`), else it defaults to `CLEAN_RESTART`. An external actor has no way to set it.
+
+## Key finding: the channel is half-built and currently dead
+
+`vestad` already writes an external restart reason into the container — and the agent never
+reads it. `backup.rs` calls:
+
+```rust
+docker_cp_content(docker, &cname, "backup — paused for backup", "/root/agent/data/restart_reason")
+```
+
+before stopping an agent for a backup. `docker_cp_content` (docker.rs) is the only caller,
+and **nothing in the agent or the container entrypoint reads that file.** So the write is
+inert: vestad supplies a reason that is silently dropped.
+
+This design completes that channel and exposes it as a general interface. The writer half
+already exists; the load-bearing missing piece is the agent-side reader.
+
+## The contract
+
+A one-shot plain-text file at `/root/agent/data/last_restart_reason`.
+
+- **Writer:** `vestad` (host), via `docker_cp_content`, before it stops/recreates the container.
+- **Reader:** the agent, once, on boot.
+- **Payload:** a short human-readable string. Plain text — no JSON, no schema shared across
+  the crate boundary.
+- **Lifecycle:** written before a restart, read exactly once on the next boot, then unlinked.
+  Absent file → today's behavior, unchanged.
+
+The file is named `last_restart_reason` to match the concept the agent already uses
+(`state.persisted.last_restart_reason`). It is the same value — the reason for this boot —
+just supplied from outside instead of from the agent's own prior run. The rename from the
+current `restart_reason` path is safe: nothing reads the old name, and the file is transient,
+so no compatibility shim is needed.
+
+## Reader (agent) — the missing piece
+
+`_consume_restart_reason` resolves the effective reason on boot with a single clear precedence:
+
+1. **External file** `~/agent/data/last_restart_reason`, if present — read it, strip it, and
+   `unlink` it (one-shot).
+2. Otherwise the agent-persisted `state.persisted.last_restart_reason` (crash / dreamer).
+3. Otherwise `CLEAN_RESTART`.
+
+The resolved reason flows unchanged into `greeting_reason` → the greeting boot turn, so the
+agent naturally says e.g. "you're awake — you now have read-only access to `/media/Plex`."
+
+**Why the two sources don't collide:** a crash reason is agent-set in `state.json` on the
+*prior* run and only occurs when vestad was *not* involved (the agent crashed and Docker's
+`on-failure` recovered it); a file reason is only written when vestad drives the restart, in
+which case the agent exits cleanly and persists `CLEAN_RESTART`. They are mutually exclusive
+in practice. The file reason is plain text and never starts with `crash:`/`error:`, so it is
+correctly treated as a clean reason.
+
+**Interaction with crash/exit logic is none:** `_is_crash_reason` runs at *shutdown* against
+the field the current run sets for its *own* exit code — a separate concern from the boot
+reason the file feeds. The file is consumed only at boot.
+
+## Writer (vestad)
+
+- **Extract one helper**, `write_restart_reason(docker, name, reason)`, as the single owner of
+  the path + `docker_cp_content` recipe. `backup.rs` switches to it (and stops being a dead
+  write — the agent will now surface "I was paused for a backup").
+- **Mounts (motivating caller):** `restart_agent` already computes the actual-vs-desired mount
+  diff to decide whether to rebuild. In that branch it writes a reason describing the delta
+  (e.g. "granted read-only access to /media/Plex") before recreating. **No app or API change
+  needed** — vestad synthesizes it from the diff it already has.
+- **The general interface:** `POST /agents/{name}/restart` gains an optional `{reason}` field.
+  When present, vestad writes it before the restart. This is the interface external callers
+  (app "restart" button, CLI) use to attach a human reason.
+
+## Scope
+
+**In:**
+- Agent-side reader in `_consume_restart_reason` + a path constant + unit tests.
+- `write_restart_reason` helper; `backup.rs` routed through it; path renamed to
+  `last_restart_reason`.
+- Optional `{reason}` on `POST /agents/{name}/restart`.
+- Mount-drift branch of `restart_agent` writes a synthesized reason.
+
+**Out (follow-ups, not this change):**
+- Wiring the web app to *send* a reason on manual restart. The API accepting `{reason}` is the
+  interface; the app populating it is a separate enhancement.
+- Any richer structured reason (multiple deltas, i18n). Plain string is sufficient.
+
+## Testing
+
+- **Agent** (`tests/test_processor.py`, near the existing `test_restart_reason_round_trip`):
+  file present → `_consume_restart_reason` returns its content and the file is removed; file
+  absent → existing behavior; file present alongside a persisted clean reason → file wins.
+- **vestad:** `write_restart_reason` writes the agreed path (docker-gated); the mount-drift
+  restart writes a reason (docker-gated, alongside the existing recreate coverage).
+
+## Blast radius
+
+- **Agent:** one file read + `unlink` in `_consume_restart_reason`, one path constant, tests.
+- **vestad:** extract one helper, rename one path, one optional API field, one call in the
+  mount-drift branch. No new IO pattern (`docker_cp_content` exists), no cross-crate schema
+  coupling (plain string).
+- **web:** none.

--- a/docs/superpowers/specs/2026-07-05-restart-reason-interface-design.md
+++ b/docs/superpowers/specs/2026-07-05-restart-reason-interface-design.md
@@ -33,51 +33,56 @@ inert: vestad supplies a reason that is silently dropped.
 This design completes that channel and exposes it as a general interface. The writer half
 already exists; the load-bearing missing piece is the agent-side reader.
 
-## The contract
+## One store, one delivery channel
 
-A one-shot plain-text file at `/root/agent/data/last_restart_reason`.
+There is exactly **one store** for "why this boot happened":
+`state.persisted.last_restart_reason` in `state.json`. It stays the single source of truth
+and keeps its second job of gating the exit code (a `crash:`/`error:` reason makes the agent
+exit non-zero so Docker's `on-failure` policy recovers it).
 
-- **Writer:** `vestad` (host), via `docker_cp_content`, before it stops/recreates the container.
-- **Reader:** the agent, once, on boot.
-- **Payload:** a short human-readable string. Plain text — no JSON, no schema shared across
-  the crate boundary.
-- **Lifecycle:** written before a restart, read exactly once on the next boot, then unlinked.
-  Absent file → today's behavior, unchanged.
+The problem is only that an *external* actor can't reach that store: `vestad` must not write
+`state.json` (the running agent re-saves it from memory on shutdown and would clobber the
+edit). So we give it a **delivery channel**, not a second store:
 
-The file is named `last_restart_reason` to match the concept the agent already uses
-(`state.persisted.last_restart_reason`). It is the same value — the reason for this boot —
-just supplied from outside instead of from the agent's own prior run. The rename from the
-current `restart_reason` path is safe: nothing reads the old name, and the file is transient,
-so no compatibility shim is needed.
+- A transient inbox file `/root/agent/data/pending_restart_reason`.
+- `vestad` (host) writes it before it stops/recreates the container.
+- On the next boot the agent **drains** it into `last_restart_reason` and deletes it.
+
+At rest there is only ever the one field; the file exists only in the window between a
+`vestad` write and the next boot, then it's gone — a message in a queue, not a parallel copy.
+Naming it `pending_restart_reason` (distinct from the `last_restart_reason` store) keeps that
+role obvious: it is an incoming reason awaiting consumption, not a second copy of the record.
+
+**Payload:** a short human-readable string. Plain text — no JSON, no schema shared across the
+crate boundary.
 
 ## Reader (agent) — the missing piece
 
-`_consume_restart_reason` resolves the effective reason on boot with a single clear precedence:
+The drain happens at the single existing consumption point, `_consume_restart_reason`, before
+it reads the field:
 
-1. **External file** `~/agent/data/last_restart_reason`, if present — read it, strip it, and
-   `unlink` it (one-shot).
-2. Otherwise the agent-persisted `state.persisted.last_restart_reason` (crash / dreamer).
-3. Otherwise `CLEAN_RESTART`.
+1. If `~/agent/data/pending_restart_reason` exists, read + strip it, assign it to
+   `state.persisted.last_restart_reason`, and `unlink` the file (one-shot).
+2. Then the function proceeds exactly as today: return the field, clear it, save state.
 
-The resolved reason flows unchanged into `greeting_reason` → the greeting boot turn, so the
-agent naturally says e.g. "you're awake — you now have read-only access to `/media/Plex`."
+The result flows unchanged into `greeting_reason` → the greeting boot turn, so the agent
+naturally says e.g. "you're awake — you now have read-only access to `/media/Plex`." Absent
+inbox file → today's behavior, unchanged.
 
-**Why the two sources don't collide:** a crash reason is agent-set in `state.json` on the
-*prior* run and only occurs when vestad was *not* involved (the agent crashed and Docker's
-`on-failure` recovered it); a file reason is only written when vestad drives the restart, in
-which case the agent exits cleanly and persists `CLEAN_RESTART`. They are mutually exclusive
-in practice. The file reason is plain text and never starts with `crash:`/`error:`, so it is
-correctly treated as a clean reason.
-
-**Interaction with crash/exit logic is none:** `_is_crash_reason` runs at *shutdown* against
-the field the current run sets for its *own* exit code — a separate concern from the boot
-reason the file feeds. The file is consumed only at boot.
+**Why draining is safe and unambiguous:** a `vestad`-driven restart exits the agent cleanly,
+so the field would otherwise be `CLEAN_RESTART`; draining overwrites that placeholder with the
+specific reason. A crash reason is agent-set and only occurs when `vestad` was *not* involved
+(so no inbox file exists), meaning the two never realistically co-occur. If they somehow did,
+the external file wins for that boot; the inbox payload is plain text and never carries a
+`crash:`/`error:` prefix, so `_is_crash_reason` is unaffected and the exit-code path is
+untouched.
 
 ## Writer (vestad)
 
-- **Extract one helper**, `write_restart_reason(docker, name, reason)`, as the single owner of
-  the path + `docker_cp_content` recipe. `backup.rs` switches to it (and stops being a dead
-  write — the agent will now surface "I was paused for a backup").
+- **Extract one helper**, `write_pending_restart_reason(docker, name, reason)`, as the single
+  owner of the inbox path + `docker_cp_content` recipe. `backup.rs` switches to it (renaming
+  the path from `restart_reason` to `pending_restart_reason`) and stops being a dead write —
+  the agent will now surface "I was paused for a backup."
 - **Mounts (motivating caller):** `restart_agent` already computes the actual-vs-desired mount
   diff to decide whether to rebuild. In that branch it writes a reason describing the delta
   (e.g. "granted read-only access to /media/Plex") before recreating. **No app or API change
@@ -89,9 +94,9 @@ reason the file feeds. The file is consumed only at boot.
 ## Scope
 
 **In:**
-- Agent-side reader in `_consume_restart_reason` + a path constant + unit tests.
-- `write_restart_reason` helper; `backup.rs` routed through it; path renamed to
-  `last_restart_reason`.
+- Agent-side drain in `_consume_restart_reason` + an inbox-path constant + unit tests.
+- `write_pending_restart_reason` helper; `backup.rs` routed through it; path renamed to
+  `pending_restart_reason`.
 - Optional `{reason}` on `POST /agents/{name}/restart`.
 - Mount-drift branch of `restart_agent` writes a synthesized reason.
 
@@ -103,14 +108,15 @@ reason the file feeds. The file is consumed only at boot.
 ## Testing
 
 - **Agent** (`tests/test_processor.py`, near the existing `test_restart_reason_round_trip`):
-  file present → `_consume_restart_reason` returns its content and the file is removed; file
-  absent → existing behavior; file present alongside a persisted clean reason → file wins.
-- **vestad:** `write_restart_reason` writes the agreed path (docker-gated); the mount-drift
-  restart writes a reason (docker-gated, alongside the existing recreate coverage).
+  inbox present → `_consume_restart_reason` returns its content and the file is removed; inbox
+  present over a persisted `CLEAN_RESTART` → inbox wins; inbox absent → existing behavior.
+- **vestad:** `write_pending_restart_reason` writes the agreed path (docker-gated); the
+  mount-drift restart writes a reason (docker-gated, alongside the existing recreate coverage).
 
 ## Blast radius
 
-- **Agent:** one file read + `unlink` in `_consume_restart_reason`, one path constant, tests.
+- **Agent:** a file read + `unlink` folded into `_consume_restart_reason`, one path constant,
+  tests. No change to the crash/exit path or `state.json` schema.
 - **vestad:** extract one helper, rename one path, one optional API field, one call in the
   mount-drift branch. No new IO pattern (`docker_cp_content` exists), no cross-crate schema
   coupling (plain string).

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -281,7 +281,7 @@ pub async fn restore_backup(
         .ok_or_else(|| DockerError::Failed("agent has no port in env file".into()))?;
     tracing::debug!(agent = %name, backup_id = %backup_id, "restoring snapshot into image");
     let image = crate::restic::restore_to_image(name, backup_id).await?;
-    create_container(docker, &cname, &image, port, name, env_config, manage_core_code).await?;
+    create_container(docker, &cname, &image, port, name, env_config, manage_core_code, &[]).await?;
 
     if !start_container(docker, &cname).await {
         return Err(DockerError::Failed("failed to start restored agent".into()));

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -248,6 +248,7 @@ pub async fn restore_backup(
     backup_id: &str,
     env_config: &AgentEnvConfig,
     manage_core_code: bool,
+    user_mounts: &[crate::mounts::HostMount],
 ) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
@@ -281,9 +282,7 @@ pub async fn restore_backup(
         .ok_or_else(|| DockerError::Failed("agent has no port in env file".into()))?;
     tracing::debug!(agent = %name, backup_id = %backup_id, "restoring snapshot into image");
     let image = crate::restic::restore_to_image(name, backup_id).await?;
-    // No host mounts here: the restored container regains its grants on the next reconcile
-    // (vestad startup or `vesta restart`), not immediately.
-    create_container(docker, &cname, &image, port, name, env_config, manage_core_code, &[]).await?;
+    create_container(docker, &cname, &image, port, name, env_config, manage_core_code, user_mounts).await?;
 
     if !start_container(docker, &cname).await {
         return Err(DockerError::Failed("failed to start restored agent".into()));

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -281,6 +281,8 @@ pub async fn restore_backup(
         .ok_or_else(|| DockerError::Failed("agent has no port in env file".into()))?;
     tracing::debug!(agent = %name, backup_id = %backup_id, "restoring snapshot into image");
     let image = crate::restic::restore_to_image(name, backup_id).await?;
+    // No host mounts here: the restored container regains its grants on the next reconcile
+    // (vestad startup or `vesta restart`), not immediately.
     create_container(docker, &cname, &image, port, name, env_config, manage_core_code, &[]).await?;
 
     if !start_container(docker, &cname).await {

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1842,7 +1842,8 @@ pub async fn restart_agent(docker: &Docker, name: &str, env_config: &AgentEnvCon
     if let Ok(raw) = docker.inspect_container(&cname, None).await {
         if needs_rebuild(&cname, &raw, user_mounts) {
             tracing::info!(agent = %name, "restart: mount config drifted, recreating");
-            return rebuild_agent(docker, name, env_config, user_mounts).await;
+            rebuild_agent(docker, name, env_config, user_mounts).await?;
+            return start_agent(docker, name).await;
         }
     }
     docker.restart_container(&cname, Some(RestartContainerOptions { t: Some(CONTAINER_RESTART_TIMEOUT_SECS), signal: None })).await?;
@@ -2832,6 +2833,17 @@ mod tests {
         }
     }
 
+    /// Remove a test host tmpdir on drop, so an assertion panic mid-test doesn't leak it.
+    struct TestHostDir {
+        path: std::path::PathBuf,
+    }
+
+    impl Drop for TestHostDir {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.path).ok();
+        }
+    }
+
     /// Clean up a test image on drop.
     struct TestImage {
         tag: String,
@@ -3175,6 +3187,7 @@ mod tests {
         // validate_mount's default of using the canonicalized host path as the container path).
         let host_dir = std::env::temp_dir().join(format!("vesta-grant-{}", std::process::id()));
         std::fs::create_dir_all(&host_dir).expect("create host grant dir");
+        let _host_dir_guard = TestHostDir { path: host_dir.clone() };
         std::fs::write(host_dir.join("hello.txt"), "hi").expect("write hello.txt");
         let host_path = host_dir.to_str().expect("host grant path is utf8").to_string();
         let container_path = host_path.clone();
@@ -3213,7 +3226,5 @@ mod tests {
 
         let missing = docker_exec(&tc_none.name, &["test", "-f", &hello_path]);
         assert!(!missing.success, "without a grant, the host path must not appear inside the container");
-
-        std::fs::remove_dir_all(&host_dir).ok();
     }
 }

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1845,15 +1845,19 @@ pub async fn restart_agent(docker: &Docker, name: &str, env_config: &AgentEnvCon
         // and it would mint a new agent token mid-session). Only user-mount drift triggers a recreate.
         if user_mounts_drifted(&actual_user_mounts(&raw), user_mounts) {
             // A recreate snapshots the container; skip it when disk is critically low (a mid-snapshot
-            // failure corrupts the writable layer) — the grant then applies on the next reconcile.
+            // failure corrupts the writable layer). Applying the grant IS the point of this restart, and
+            // reconcile also skips rebuilds on low disk — so a plain restart wouldn't apply it either.
+            // Surface a truthful error instead of reporting success on a grant we didn't apply.
             let available = docker_storage_available_bytes(docker).await;
             if reconcile_blocked_by_disk(available) {
-                tracing::warn!(agent = %name, "mount grants changed but disk is critically low; skipping recreate, applying on next reconcile");
-            } else {
-                tracing::info!(agent = %name, "restart: mount grants drifted, recreating");
-                rebuild_agent(docker, name, env_config, user_mounts).await?;
-                return start_agent(docker, name).await;
+                tracing::error!(agent = %name, "mount grants changed but disk is critically low; cannot recreate to apply them");
+                return Err(DockerError::Failed(format!(
+                    "cannot apply host-folder grants for '{name}': disk is critically low (a recreate needs free space); free space and retry"
+                )));
             }
+            tracing::info!(agent = %name, "restart: mount grants drifted, recreating");
+            rebuild_agent(docker, name, env_config, user_mounts).await?;
+            return start_agent(docker, name).await;
         }
     } else {
         tracing::warn!(agent = %name, "restart: container inspect failed; doing a plain restart (mount changes apply on next reconcile)");
@@ -2096,11 +2100,8 @@ fn user_mounts_drifted(actual: &[(String, String, bool)], desired: &[crate::moun
 
 fn needs_rebuild(cname: &str, info: &bollard::models::ContainerInspectResponse, desired_mounts: &[crate::mounts::HostMount]) -> bool {
     let mounts = info.mounts.as_deref().unwrap_or(&[]);
-    let mount_dests: Vec<&str> = mounts.iter()
-        .filter_map(|m| m.destination.as_deref())
-        .collect();
-
-    if !mount_dests.contains(&ENV_MOUNT_DEST) {
+    let has_env_mount = mounts.iter().any(|m| m.destination.as_deref() == Some(ENV_MOUNT_DEST));
+    if !has_env_mount {
         tracing::info!(container = %cname, "rebuild needed: missing env-file mount");
         return true;
     }
@@ -2300,7 +2301,7 @@ mod tests {
         let m = crate::mounts::HostMount { host_path: "/mnt/media".into(), container_path: "/mnt/media".into(), writable: false };
         let binds = assemble_binds("/e:/run/vestad-env:ro,z".into(), "/c:/root/agent/constitution.md:ro,z".into(), None, std::slice::from_ref(&m));
         assert_eq!(binds.len(), 3);
-        assert_eq!(binds[2], "/mnt/media:/mnt/media:ro,z");
+        assert_eq!(binds[2], "/mnt/media:/mnt/media:ro");
     }
 
     #[test]

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1424,8 +1424,30 @@ pub async fn snapshot_container(_docker: &Docker, cname: &str, tag: &str, change
 
 // --- Container creation ---
 
+/// Assemble the full bind list for a container: base mounts (env, constitution, optional core)
+/// plus user-granted host mounts.
+fn assemble_binds(env_mount: String, constitution_mount: String, core_mount: Option<String>, user_mounts: &[crate::mounts::HostMount]) -> Vec<String> {
+    let mut binds = vec![env_mount, constitution_mount];
+    if let Some(core) = core_mount {
+        binds.push(core);
+    }
+    for m in user_mounts {
+        binds.push(crate::mounts::bind_string(m));
+    }
+    binds
+}
+
 #[allow(clippy::too_many_arguments)]
-pub async fn create_container(docker: &Docker, cname: &str, image: &str, port: u16, agent_name: &str, env_config: &AgentEnvConfig, manage_core_code: bool) -> Result<(), DockerError> {
+pub async fn create_container(
+    docker: &Docker,
+    cname: &str,
+    image: &str,
+    port: u16,
+    agent_name: &str,
+    env_config: &AgentEnvConfig,
+    manage_core_code: bool,
+    user_mounts: &[crate::mounts::HostMount],
+) -> Result<(), DockerError> {
     let agent_token = generate_agent_token();
     let env_path = write_agent_env_file(env_config, agent_name, port, &agent_token)?;
     let env_mount = format!("{}:{}:ro,z", env_path.display(), ENV_MOUNT_DEST);
@@ -1441,10 +1463,8 @@ pub async fn create_container(docker: &Docker, cname: &str, image: &str, port: u
     labels.insert(LABEL_USER.to_string(), current_user());
     labels.insert(LABEL_AGENT_NAME.to_string(), agent_name.to_string());
 
-    let mut binds = vec![env_mount, constitution_mount];
-    if manage_core_code {
-        binds.push(core_mount);
-    }
+    let core_mount_opt = if manage_core_code { Some(core_mount) } else { None };
+    let binds = assemble_binds(env_mount, constitution_mount, core_mount_opt, user_mounts);
 
     let mut device_requests = None;
     match gpu_available(docker).await {
@@ -1752,7 +1772,7 @@ pub async fn create_agent(docker: &Docker, name: &str, env_config: &AgentEnvConf
 
     progress.set(BuildPhase::Creating);
     let port = allocate_port(&env_config.agents_dir)?;
-    create_container(docker, &cname, &image, port, name, env_config, manage_core_code).await?;
+    create_container(docker, &cname, &image, port, name, env_config, manage_core_code, &[]).await?;
 
     Ok(name.to_string())
 }
@@ -2132,7 +2152,7 @@ pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvCon
     ensure_container_removed(docker, &cname).await?;
 
     tracing::info!(agent = %name, "[4/4] creating container with new config...");
-    create_container(docker, &cname, &backup_tag, port, name, env_config, manage_core_code).await?;
+    create_container(docker, &cname, &backup_tag, port, name, env_config, manage_core_code, &[]).await?;
 
     Ok(())
 }
@@ -2202,7 +2222,7 @@ pub async fn rename_agent(
     delete_constitution_file(&env_config.agents_dir, old_name);
 
     tracing::info!(new = %new_name, "[4/4] creating renamed container from snapshot...");
-    create_container(docker, &new_cname, &snapshot_tag, port, new_name, env_config, manage_core_code).await?;
+    create_container(docker, &new_cname, &snapshot_tag, port, new_name, env_config, manage_core_code, &[]).await?;
 
     // Repos are keyed by agent name, so carry the backup history across the rename.
     crate::restic::rename_repo(old_name, new_name)?;
@@ -2218,6 +2238,14 @@ mod tests {
     // sets it via the bollard enum (create_container / ensure_on_failure_policy); the tests only
     // need a "normal container" policy to build fixtures with.
     const RESTART_POLICY: &str = "on-failure";
+
+    #[test]
+    fn assemble_binds_appends_user_mounts() {
+        let m = crate::mounts::HostMount { host_path: "/mnt/media".into(), container_path: "/mnt/media".into(), writable: false };
+        let binds = assemble_binds("/e:/run/vestad-env:ro,z".into(), "/c:/root/agent/constitution.md:ro,z".into(), None, std::slice::from_ref(&m));
+        assert_eq!(binds.len(), 3);
+        assert_eq!(binds[2], "/mnt/media:/mnt/media:ro,z");
+    }
 
     #[test]
     fn status_from_readiness_distinguishes_unprovisioned_from_unauthenticated() {

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -2854,7 +2854,12 @@ mod tests {
         let binds: Vec<String> = mounts.iter()
             .map(|(src, dst)| format!("{}:{}:ro,z", src, dst))
             .collect();
+        create_test_container_with_binds_async(docker, tc, binds, cmd, network, restart).await;
+    }
 
+    /// Like `create_test_container_async`, but takes fully-assembled bind strings instead of
+    /// hardcoding `:ro,z` — needed to exercise a writable grant via `crate::mounts::bind_string`.
+    async fn create_test_container_with_binds_async(docker: &Docker, tc: &TestContainer, binds: Vec<String>, cmd: Vec<String>, network: &str, restart: &str) {
         let restart_policy = match restart {
             "on-failure" => bollard::models::RestartPolicyNameEnum::ON_FAILURE,
             "unless-stopped" => bollard::models::RestartPolicyNameEnum::UNLESS_STOPPED,
@@ -3141,5 +3146,74 @@ mod tests {
         assert_eq!(payload["interrupt"], true);
         assert_eq!(payload["old_name"], "old-name");
         assert_eq!(payload["new_name"], agent_name);
+    }
+
+    /// Result of a `docker exec` invocation against a running test container.
+    struct ExecResult {
+        success: bool,
+        stdout: String,
+    }
+
+    /// Run `docker exec <cname> <args>` via the CLI (same idiom as `docker_cleanup`) and
+    /// capture the outcome for assertions.
+    fn docker_exec(cname: &str, args: &[&str]) -> ExecResult {
+        let output = std::process::Command::new("docker")
+            .arg("exec")
+            .arg(cname)
+            .args(args)
+            .output()
+            .expect("failed to run docker exec");
+        ExecResult { success: output.status.success(), stdout: String::from_utf8_lossy(&output.stdout).trim().to_string() }
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn granted_host_path_readable_writable_removable_in_container() {
+        let docker = test_docker();
+
+        // A host tempdir with one file, mirrored 1:1 into the container (matches
+        // validate_mount's default of using the canonicalized host path as the container path).
+        let host_dir = std::env::temp_dir().join(format!("vesta-grant-{}", std::process::id()));
+        std::fs::create_dir_all(&host_dir).expect("create host grant dir");
+        std::fs::write(host_dir.join("hello.txt"), "hi").expect("write hello.txt");
+        let host_path = host_dir.to_str().expect("host grant path is utf8").to_string();
+        let container_path = host_path.clone();
+        let hello_path = format!("{container_path}/hello.txt");
+        let new_file_path = format!("{container_path}/new.txt");
+        let cmd = vec!["sleep".to_string(), "300".to_string()];
+
+        // Step 1: read-only grant. Built via the real production `bind_string`, not a
+        // hand-written bind spec, so the test exercises our actual mount assembly.
+        let ro_mount = crate::mounts::HostMount { host_path: host_path.clone(), container_path: container_path.clone(), writable: false };
+        let tc_ro = TestContainer::new("grant-ro");
+        create_test_container_with_binds_async(&docker, &tc_ro, vec![crate::mounts::bind_string(&ro_mount)], cmd.clone(), NETWORK_MODE, RESTART_POLICY).await;
+        assert!(start_container(&docker, &tc_ro.name).await, "read-only grant container should start");
+
+        let read = docker_exec(&tc_ro.name, &["cat", &hello_path]);
+        assert!(read.success, "cat of granted file should succeed");
+        assert_eq!(read.stdout, "hi", "granted host file must be readable inside the container");
+
+        let blocked_write = docker_exec(&tc_ro.name, &["sh", "-c", &format!("echo x > {new_file_path}")]);
+        assert!(!blocked_write.success, "a read-only grant must block writes inside the container");
+
+        // Step 2: the same mount, but writable: true -> the write now succeeds.
+        let rw_mount = crate::mounts::HostMount { host_path: host_path.clone(), container_path: container_path.clone(), writable: true };
+        let tc_rw = TestContainer::new("grant-rw");
+        create_test_container_with_binds_async(&docker, &tc_rw, vec![crate::mounts::bind_string(&rw_mount)], cmd.clone(), NETWORK_MODE, RESTART_POLICY).await;
+        assert!(start_container(&docker, &tc_rw.name).await, "writable grant container should start");
+
+        let allowed_write = docker_exec(&tc_rw.name, &["sh", "-c", &format!("echo x > {new_file_path}")]);
+        assert!(allowed_write.success, "a writable grant must allow writes inside the container");
+
+        // Step 3: no user mount at all -> the path is absent inside the container (the grant,
+        // not the host directory, controls visibility).
+        let tc_none = TestContainer::new("grant-none");
+        create_test_container_async(&docker, &tc_none, &[], cmd, NETWORK_MODE, RESTART_POLICY).await;
+        assert!(start_container(&docker, &tc_none.name).await, "no-grant container should start");
+
+        let missing = docker_exec(&tc_none.name, &["test", "-f", &hello_path]);
+        assert!(!missing.success, "without a grant, the host path must not appear inside the container");
+
+        std::fs::remove_dir_all(&host_dir).ok();
     }
 }

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1840,11 +1840,23 @@ pub async fn restart_agent(docker: &Docker, name: &str, env_config: &AgentEnvCon
     // A grant change can't be applied by a plain restart (binds are fixed at creation), so if the
     // desired mounts drifted from the container, recreate; otherwise a cheap restart.
     if let Ok(raw) = docker.inspect_container(&cname, None).await {
-        if needs_rebuild(&cname, &raw, user_mounts) {
-            tracing::info!(agent = %name, "restart: mount config drifted, recreating");
-            rebuild_agent(docker, name, env_config, user_mounts).await?;
-            return start_agent(docker, name).await;
+        // Scope the recreate to GRANT changes only: a plain restart can't add/remove a bind, but we
+        // must not turn every restart into a full rebuild for unrelated drift (that's reconcile's job,
+        // and it would mint a new agent token mid-session). Only user-mount drift triggers a recreate.
+        if user_mounts_drifted(&actual_user_mounts(&raw), user_mounts) {
+            // A recreate snapshots the container; skip it when disk is critically low (a mid-snapshot
+            // failure corrupts the writable layer) — the grant then applies on the next reconcile.
+            let available = docker_storage_available_bytes(docker).await;
+            if reconcile_blocked_by_disk(available) {
+                tracing::warn!(agent = %name, "mount grants changed but disk is critically low; skipping recreate, applying on next reconcile");
+            } else {
+                tracing::info!(agent = %name, "restart: mount grants drifted, recreating");
+                rebuild_agent(docker, name, env_config, user_mounts).await?;
+                return start_agent(docker, name).await;
+            }
         }
+    } else {
+        tracing::warn!(agent = %name, "restart: container inspect failed; doing a plain restart (mount changes apply on next reconcile)");
     }
     docker.restart_container(&cname, Some(RestartContainerOptions { t: Some(CONTAINER_RESTART_TIMEOUT_SECS), signal: None })).await?;
     Ok(())

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1943,7 +1943,8 @@ pub async fn reconcile_containers(
                 "settings.manage_agent_code disagrees with container, using container as source of truth. fix by destroying and recreating the agent."
             );
         }
-        if !needs_rebuild(cname, &raw) {
+        // TODO(task 5): pass the agent's actual desired host-mount grants instead of `&[]`.
+        if !needs_rebuild(cname, &raw, &[]) {
             tracing::info!(agent = %name, "config ok, no rebuild needed");
             continue;
         }
@@ -2044,7 +2045,33 @@ fn mounts_have_core_code(mounts: &[bollard::models::MountPoint]) -> bool {
 /// divergence is intentionally NOT a trigger here: it's reported by reconcile as a
 /// warning. See `rebuild_agent` for why mount topology must come from the container,
 /// not from settings.
-fn needs_rebuild(cname: &str, info: &bollard::models::ContainerInspectResponse) -> bool {
+/// Extract the user-granted bind mounts from a container's inspect data: every bind whose
+/// destination is not one of the reserved dests (env/core/constitution).
+fn actual_user_mounts(info: &bollard::models::ContainerInspectResponse) -> Vec<(String, String, bool)> {
+    info.mounts.as_deref().unwrap_or(&[]).iter()
+        .filter_map(|m| {
+            let dest = m.destination.as_deref()?;
+            if MOUNT_DESTS.contains(&dest) {
+                return None;
+            }
+            let source = m.source.as_deref()?;
+            Some((source.to_string(), dest.to_string(), m.rw.unwrap_or(false)))
+        })
+        .collect()
+}
+
+/// True when the container's actual user mounts differ (by source, dest, or rw) from desired.
+fn user_mounts_drifted(actual: &[(String, String, bool)], desired: &[crate::mounts::HostMount]) -> bool {
+    let mut a: Vec<(String, String, bool)> = actual.to_vec();
+    let mut d: Vec<(String, String, bool)> = desired.iter()
+        .map(|m| (m.host_path.clone(), m.container_path.clone(), m.writable))
+        .collect();
+    a.sort();
+    d.sort();
+    a != d
+}
+
+fn needs_rebuild(cname: &str, info: &bollard::models::ContainerInspectResponse, desired_mounts: &[crate::mounts::HostMount]) -> bool {
     let mounts = info.mounts.as_deref().unwrap_or(&[]);
     let mount_dests: Vec<&str> = mounts.iter()
         .filter_map(|m| m.destination.as_deref())
@@ -2097,6 +2124,11 @@ fn needs_rebuild(cname: &str, info: &bollard::models::ContainerInspectResponse) 
         .unwrap_or(&[]);
     if !caps.iter().any(|c| c == "SYS_ADMIN") {
         tracing::info!(container = %cname, "rebuild needed: missing SYS_ADMIN capability");
+        return true;
+    }
+
+    if user_mounts_drifted(&actual_user_mounts(info), desired_mounts) {
+        tracing::info!(container = %cname, "rebuild needed: host-mount grants changed");
         return true;
     }
 
@@ -2483,6 +2515,21 @@ mod tests {
     }
 
     #[test]
+    fn user_mounts_drift_detects_add_remove_and_mode_change() {
+        let media = crate::mounts::HostMount { host_path: "/mnt/media".into(), container_path: "/mnt/media".into(), writable: false };
+        // No actual, one desired -> drift (add).
+        assert!(user_mounts_drifted(&[], std::slice::from_ref(&media)));
+        // Matching -> no drift.
+        let actual = vec![("/mnt/media".to_string(), "/mnt/media".to_string(), false)];
+        assert!(!user_mounts_drifted(&actual, std::slice::from_ref(&media)));
+        // Same paths, rw differs -> drift.
+        let actual_rw = vec![("/mnt/media".to_string(), "/mnt/media".to_string(), true)];
+        assert!(user_mounts_drifted(&actual_rw, std::slice::from_ref(&media)));
+        // Actual present, none desired -> drift (remove).
+        assert!(user_mounts_drifted(&actual, &[]));
+    }
+
+    #[test]
     fn retry_import_pipeline_recovers_after_transient_failure() {
         let tries = std::cell::Cell::new(0u32);
         let result = retry_import_pipeline("test", || {
@@ -2739,9 +2786,9 @@ mod tests {
         std::env::var(AGENT_IMAGE_ENV).unwrap_or_else(|_| vesta_image())
     }
 
-    async fn inspect_then_needs_rebuild(docker: &Docker, cname: &str) -> bool {
+    async fn inspect_then_needs_rebuild(docker: &Docker, cname: &str, desired: &[crate::mounts::HostMount]) -> bool {
         let info = docker.inspect_container(cname, None).await.expect("inspect");
-        needs_rebuild(cname, &info)
+        needs_rebuild(cname, &info, desired)
     }
 
     /// Best-effort cleanup via docker CLI (safe to call from Drop inside tokio).
@@ -2893,7 +2940,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(!inspect_then_needs_rebuild(&docker, &tc.name).await, "fresh container should NOT need rebuild");
+        assert!(!inspect_then_needs_rebuild(&docker, &tc.name, &[]).await, "fresh container should NOT need rebuild");
     }
 
     #[tokio::test]
@@ -2918,7 +2965,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &mounts, agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(!inspect_then_needs_rebuild(&docker, &tc.name).await, "container with all mounts should NOT need rebuild");
+        assert!(!inspect_then_needs_rebuild(&docker, &tc.name, &[]).await, "container with all mounts should NOT need rebuild");
     }
 
     #[tokio::test]
@@ -2932,7 +2979,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], vec!["sh".into(), "-c".into(), "echo wrong".into()], NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(inspect_then_needs_rebuild(&docker, &tc.name).await, "container with wrong cmd SHOULD need rebuild");
+        assert!(inspect_then_needs_rebuild(&docker, &tc.name, &[]).await, "container with wrong cmd SHOULD need rebuild");
     }
 
     #[tokio::test]
@@ -2943,7 +2990,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(inspect_then_needs_rebuild(&docker, &tc.name).await, "container without env mount SHOULD need rebuild");
+        assert!(inspect_then_needs_rebuild(&docker, &tc.name, &[]).await, "container without env mount SHOULD need rebuild");
     }
 
     #[tokio::test]
@@ -2957,7 +3004,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(!inspect_then_needs_rebuild(&docker, &tc.name).await, "missing core code mounts should NOT trigger rebuild");
+        assert!(!inspect_then_needs_rebuild(&docker, &tc.name, &[]).await, "missing core code mounts should NOT trigger rebuild");
     }
 
     #[tokio::test]
@@ -2971,7 +3018,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), "bridge", RESTART_POLICY).await;
 
-        assert!(inspect_then_needs_rebuild(&docker, &tc.name).await, "container with wrong network SHOULD need rebuild");
+        assert!(inspect_then_needs_rebuild(&docker, &tc.name, &[]).await, "container with wrong network SHOULD need rebuild");
     }
 
     #[tokio::test]
@@ -2988,7 +3035,7 @@ mod tests {
 
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, "unless-stopped").await;
 
-        assert!(!inspect_then_needs_rebuild(&docker, &tc.name).await, "a policy mismatch must NOT trigger a rebuild — it's reconciled in place");
+        assert!(!inspect_then_needs_rebuild(&docker, &tc.name, &[]).await, "a policy mismatch must NOT trigger a rebuild — it's reconciled in place");
         assert_eq!(container_restart_policy(&docker, &tc.name).await, "unless-stopped");
         ensure_on_failure_policy(&docker, &tc.name).await.expect("update policy in place");
         assert_eq!(container_restart_policy(&docker, &tc.name).await, "on-failure", "policy reconciled to on-failure without a rebuild");
@@ -3006,7 +3053,7 @@ mod tests {
 
         // Create with wrong network to force rebuild
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), "bridge", RESTART_POLICY).await;
-        assert!(inspect_then_needs_rebuild(&docker, &tc.name).await, "precondition: should need rebuild");
+        assert!(inspect_then_needs_rebuild(&docker, &tc.name, &[]).await, "precondition: should need rebuild");
 
         // Snapshot
         snapshot_container(&docker, &tc.name, &img.tag, &[]).await.expect("snapshot should succeed");
@@ -3015,7 +3062,7 @@ mod tests {
         remove_container_force(&docker, &tc.name).await.ok();
         create_test_container_async(&docker, &tc, &[env_mount], agent_container_entrypoint_cmd(), NETWORK_MODE, RESTART_POLICY).await;
 
-        assert!(!inspect_then_needs_rebuild(&docker, &tc.name).await, "rebuilt container should NOT need rebuild");
+        assert!(!inspect_then_needs_rebuild(&docker, &tc.name, &[]).await, "rebuilt container should NOT need rebuild");
     }
 
     #[tokio::test]

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1832,10 +1832,19 @@ pub async fn stop_all_agents(docker: &Docker) {
     }
 }
 
-pub async fn restart_agent(docker: &Docker, name: &str) -> Result<(), DockerError> {
+pub async fn restart_agent(docker: &Docker, name: &str, env_config: &AgentEnvConfig, user_mounts: &[crate::mounts::HostMount]) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
     ensure_exists(docker, &cname).await?;
+
+    // A grant change can't be applied by a plain restart (binds are fixed at creation), so if the
+    // desired mounts drifted from the container, recreate; otherwise a cheap restart.
+    if let Ok(raw) = docker.inspect_container(&cname, None).await {
+        if needs_rebuild(&cname, &raw, user_mounts) {
+            tracing::info!(agent = %name, "restart: mount config drifted, recreating");
+            return rebuild_agent(docker, name, env_config, user_mounts).await;
+        }
+    }
     docker.restart_container(&cname, Some(RestartContainerOptions { t: Some(CONTAINER_RESTART_TIMEOUT_SECS), signal: None })).await?;
     Ok(())
 }
@@ -1872,6 +1881,7 @@ pub async fn reconcile_containers(
     agent_code_changed: bool,
     manages_core_code: &(dyn Fn(&str) -> bool + Send + Sync),
     wants_running: &(dyn Fn(&str) -> bool + Send + Sync),
+    mounts_for: &(dyn Fn(&str) -> Vec<crate::mounts::HostMount> + Send + Sync),
 ) {
     let agents = list_managed_agents(docker).await;
     if agents.is_empty() {
@@ -1943,8 +1953,8 @@ pub async fn reconcile_containers(
                 "settings.manage_agent_code disagrees with container, using container as source of truth. fix by destroying and recreating the agent."
             );
         }
-        // TODO(task 5): pass the agent's actual desired host-mount grants instead of `&[]`.
-        if !needs_rebuild(cname, &raw, &[]) {
+        let desired_mounts = mounts_for(name);
+        if !needs_rebuild(cname, &raw, &desired_mounts) {
             tracing::info!(agent = %name, "config ok, no rebuild needed");
             continue;
         }
@@ -1962,7 +1972,7 @@ pub async fn reconcile_containers(
                 }
             }
         }
-        match rebuild_agent(docker, name, env_config).await {
+        match rebuild_agent(docker, name, env_config, &desired_mounts).await {
             Ok(()) => tracing::info!(agent = %name, "rebuild complete"),
             Err(e) => tracing::error!(agent = %name, error = %e, "rebuild failed"),
         }
@@ -2153,7 +2163,7 @@ async fn resolve_existing_port(docker: &Docker, cname: &str, info: &ContainerInf
 /// a new one from the snapshot. Mount topology is preserved from the existing container,
 /// not re-derived from settings: `manage_agent_code` is fixed at create time, so the
 /// running container is the source of truth for which bind mounts to attach.
-pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvConfig) -> Result<(), DockerError> {
+pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvConfig, user_mounts: &[crate::mounts::HostMount]) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
     let raw = docker.inspect_container(&cname, None).await.map_err(DockerError::from)?;
@@ -2184,7 +2194,7 @@ pub async fn rebuild_agent(docker: &Docker, name: &str, env_config: &AgentEnvCon
     ensure_container_removed(docker, &cname).await?;
 
     tracing::info!(agent = %name, "[4/4] creating container with new config...");
-    create_container(docker, &cname, &backup_tag, port, name, env_config, manage_core_code, &[]).await?;
+    create_container(docker, &cname, &backup_tag, port, name, env_config, manage_core_code, user_mounts).await?;
 
     Ok(())
 }
@@ -2199,6 +2209,7 @@ pub async fn rename_agent(
     old_name: &str,
     new_name: &str,
     env_config: &AgentEnvConfig,
+    user_mounts: &[crate::mounts::HostMount],
 ) -> Result<(), DockerError> {
     validate_name(old_name)?;
     validate_name(new_name)?;
@@ -2254,7 +2265,7 @@ pub async fn rename_agent(
     delete_constitution_file(&env_config.agents_dir, old_name);
 
     tracing::info!(new = %new_name, "[4/4] creating renamed container from snapshot...");
-    create_container(docker, &new_cname, &snapshot_tag, port, new_name, env_config, manage_core_code, &[]).await?;
+    create_container(docker, &new_cname, &snapshot_tag, port, new_name, env_config, manage_core_code, user_mounts).await?;
 
     // Repos are keyed by agent name, so carry the backup history across the rename.
     crate::restic::rename_repo(old_name, new_name)?;

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -16,7 +16,9 @@ mod cloudflared_embed;
 mod control_ws;
 mod docker;
 mod manifest;
-// Foundation for host filesystem grants; consumed starting with AgentSettings.mounts (next task).
+// HostMount is now consumed by AgentSettings.mounts; validate_mount/validate_mounts/bind_string/
+// is_protected/MountError are still unused until Tasks 3/6 wire up grant validation and the
+// container mount pipeline. Remove this allow once those tasks land.
 #[allow(dead_code)]
 mod mounts;
 mod jwt;

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -16,10 +16,6 @@ mod cloudflared_embed;
 mod control_ws;
 mod docker;
 mod manifest;
-// HostMount is consumed by AgentSettings.mounts and bind_string by the container mount pipeline;
-// validate_mount/validate_mounts/is_protected/MountError are still unused until Task 6 wires up
-// grant validation. Remove this allow once that task lands.
-#[allow(dead_code)]
 mod mounts;
 mod jwt;
 mod paths;

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -16,6 +16,9 @@ mod cloudflared_embed;
 mod control_ws;
 mod docker;
 mod manifest;
+// Foundation for host filesystem grants; consumed starting with AgentSettings.mounts (next task).
+#[allow(dead_code)]
+mod mounts;
 mod jwt;
 mod paths;
 mod providers;

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -16,9 +16,9 @@ mod cloudflared_embed;
 mod control_ws;
 mod docker;
 mod manifest;
-// HostMount is now consumed by AgentSettings.mounts; validate_mount/validate_mounts/bind_string/
-// is_protected/MountError are still unused until Tasks 3/6 wire up grant validation and the
-// container mount pipeline. Remove this allow once those tasks land.
+// HostMount is consumed by AgentSettings.mounts and bind_string by the container mount pipeline;
+// validate_mount/validate_mounts/is_protected/MountError are still unused until Task 6 wires up
+// grant validation. Remove this allow once that task lands.
 #[allow(dead_code)]
 mod mounts;
 mod jwt;
@@ -855,7 +855,7 @@ fn main() {
                         agent_code::ensure_agent_code(&config)
                             .unwrap_or_else(|e| die(format!("failed to populate agent code: {e}")));
                         let port = docker::allocate_port(&env_config.agents_dir).unwrap_or_else(|e| die(&e));
-                        docker::create_container(&docker, &cname, loaded_image, port, &name, &env_config, true).await
+                        docker::create_container(&docker, &cname, loaded_image, port, &name, &env_config, true, &[]).await
                             .unwrap_or_else(|e| die(&e));
 
                         if !docker::start_container(&docker, &cname).await {

--- a/vestad/src/mounts.rs
+++ b/vestad/src/mounts.rs
@@ -108,6 +108,51 @@ pub fn bind_string(m: &HostMount) -> String {
     format!("{}:{}:{mode},z", m.host_path, m.container_path)
 }
 
+/// Host roots whose immediate subdirectories are common places to share (media libraries,
+/// downloads, data disks). Their children — e.g. `/mnt/media` — are the suggestions.
+pub const SUGGESTION_ROOTS: &[&str] = &["/mnt", "/media", "/srv", "/data", "/pool", "/tank"];
+
+/// Well-known folders inside the host user's home worth suggesting when they exist.
+pub const HOME_SUGGESTIONS: &[&str] =
+    &["Downloads", "Movies", "Videos", "Music", "Pictures", "Documents"];
+
+/// Existing host folders to suggest as shares, so the user doesn't hand-type a path. Scans the
+/// immediate children of the common mount roots plus a few well-known home folders. Only
+/// directories that actually exist are returned.
+pub fn suggest_host_folders() -> Vec<String> {
+    scan_candidate_folders(
+        SUGGESTION_ROOTS,
+        std::env::var("HOME").ok().as_deref(),
+        HOME_SUGGESTIONS,
+    )
+}
+
+fn scan_candidate_folders(roots: &[&str], home: Option<&str>, home_dirs: &[&str]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for root in roots {
+        let Ok(entries) = std::fs::read_dir(root) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.push(path.to_string_lossy().into_owned());
+            }
+        }
+    }
+    if let Some(home) = home {
+        for name in home_dirs {
+            let path = std::path::Path::new(home).join(name);
+            if path.is_dir() {
+                out.push(path.to_string_lossy().into_owned());
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -125,6 +170,27 @@ mod tests {
     #[test]
     fn rejects_relative_host_path() {
         assert!(matches!(validate_mount("relative/path", None, false), Err(MountError::NotAbsolute)));
+    }
+
+    #[test]
+    fn scan_lists_existing_subdirs_and_home_media_only() {
+        let tmp = std::env::temp_dir().join(format!("vesta-suggest-{}", std::process::id()));
+        let root = tmp.join("mnt");
+        std::fs::create_dir_all(root.join("media")).unwrap();
+        std::fs::create_dir_all(root.join("downloads")).unwrap();
+        std::fs::write(root.join("a-file"), b"x").unwrap(); // a file, not a dir — excluded
+        let home = tmp.join("home");
+        std::fs::create_dir_all(home.join("Downloads")).unwrap(); // exists
+        // "Movies" intentionally not created — must be excluded.
+
+        let got = scan_candidate_folders(&[root.to_str().unwrap()], home.to_str(), &["Downloads", "Movies"]);
+
+        assert!(got.iter().any(|p| p.ends_with("/media")), "should list /mnt/media child: {got:?}");
+        assert!(got.iter().any(|p| p.ends_with("/downloads")));
+        assert!(got.iter().any(|p| p.ends_with("/Downloads")), "should include existing home folder");
+        assert!(!got.iter().any(|p| p.ends_with("/a-file")), "files must be excluded");
+        assert!(!got.iter().any(|p| p.ends_with("/Movies")), "nonexistent home folder must be excluded");
+        std::fs::remove_dir_all(&tmp).ok();
     }
 
     #[test]

--- a/vestad/src/mounts.rs
+++ b/vestad/src/mounts.rs
@@ -1,0 +1,176 @@
+//! Host filesystem grants: user-authored bind mounts that give an agent access to
+//! specific host paths. The single owner of the mount format, validation, and the
+//! protected-prefix rule. A grant is a decision only the user makes (see serve.rs auth).
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Container-path roots a grant may never mount onto. `/root` covers the agent's entire
+/// world (home, `/root/agent/data` = events.db + state.json, `/root/.claude` = auth,
+/// `/root/agent/core` = code); the rest are OS dirs whose replacement would break the
+/// container. Everything outside these — `/mnt`, `/media`, `/data`, `/srv`, … — is allowed.
+pub const PROTECTED_PREFIXES: &[&str] = &[
+    "/root", "/etc", "/usr", "/bin", "/sbin", "/lib", "/lib64", "/run", "/proc", "/sys", "/dev", "/boot",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostMount {
+    pub host_path: String,
+    pub container_path: String,
+    #[serde(default)]
+    pub writable: bool,
+}
+
+#[derive(Debug)]
+pub enum MountError {
+    NotAbsolute,
+    HostPathMissing,
+    ContainerPathProtected(String),
+    DuplicateContainerPath(String),
+}
+
+impl fmt::Display for MountError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MountError::NotAbsolute => write!(f, "path must be absolute"),
+            MountError::HostPathMissing => write!(f, "host path does not exist"),
+            MountError::ContainerPathProtected(path) => {
+                write!(f, "container path '{path}' is protected; choose a path outside /root and system dirs, e.g. under /mnt")
+            }
+            MountError::DuplicateContainerPath(path) => write!(f, "duplicate container path '{path}'"),
+        }
+    }
+}
+
+impl std::error::Error for MountError {}
+
+/// Normalize by stripping a single trailing slash (but keep root "/").
+fn normalize(path: &str) -> &str {
+    if path.len() > 1 {
+        path.strip_suffix('/').unwrap_or(path)
+    } else {
+        path
+    }
+}
+
+/// True if `container_path` is at or under any protected root, or is `/` itself.
+pub fn is_protected(container_path: &str) -> bool {
+    let path = normalize(container_path);
+    if path == "/" {
+        return true;
+    }
+    PROTECTED_PREFIXES.iter().any(|root| path == *root || path.starts_with(&format!("{root}/")))
+}
+
+/// Validate one grant. `host_path` must be absolute and exist (canonicalized). The container
+/// path defaults to the (canonicalized) host path and must not be protected.
+pub fn validate_mount(host_path: &str, container_path: Option<&str>, writable: bool) -> Result<HostMount, MountError> {
+    if !host_path.starts_with('/') {
+        return Err(MountError::NotAbsolute);
+    }
+    let canonical = std::fs::canonicalize(host_path).map_err(|_| MountError::HostPathMissing)?;
+    let canonical = canonical.to_string_lossy().to_string();
+
+    let container = match container_path {
+        Some(cp) => {
+            if !cp.starts_with('/') {
+                return Err(MountError::NotAbsolute);
+            }
+            normalize(cp).to_string()
+        }
+        None => canonical.clone(),
+    };
+    if is_protected(&container) {
+        return Err(MountError::ContainerPathProtected(container));
+    }
+    Ok(HostMount { host_path: canonical, container_path: container, writable })
+}
+
+/// Validate a full list and reject duplicate container paths (two grants can't target one dest).
+pub fn validate_mounts(inputs: &[(String, Option<String>, bool)]) -> Result<Vec<HostMount>, MountError> {
+    let mut out: Vec<HostMount> = Vec::with_capacity(inputs.len());
+    for (host, container, writable) in inputs {
+        let mount = validate_mount(host, container.as_deref(), *writable)?;
+        if out.iter().any(|m| m.container_path == mount.container_path) {
+            return Err(MountError::DuplicateContainerPath(mount.container_path));
+        }
+        out.push(mount);
+    }
+    Ok(out)
+}
+
+/// The Docker `-v` bind spec: `host:container:{ro|rw},z`.
+pub fn bind_string(m: &HostMount) -> String {
+    let mode = if m.writable { "rw" } else { "ro" };
+    format!("{}:{}:{mode},z", m.host_path, m.container_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mirror_uses_canonical_host_path_as_container_path() {
+        let dir = std::env::temp_dir();
+        let sub = dir.join("vesta-mount-test");
+        std::fs::create_dir_all(&sub).unwrap();
+        let m = validate_mount(sub.to_str().unwrap(), None, false).unwrap();
+        assert_eq!(m.container_path, m.host_path);
+        assert!(!m.writable);
+    }
+
+    #[test]
+    fn rejects_relative_host_path() {
+        assert!(matches!(validate_mount("relative/path", None, false), Err(MountError::NotAbsolute)));
+    }
+
+    #[test]
+    fn rejects_missing_host_path() {
+        assert!(matches!(validate_mount("/definitely/does/not/exist/xyzzy", None, false), Err(MountError::HostPathMissing)));
+    }
+
+    #[test]
+    fn rejects_protected_container_paths() {
+        assert!(is_protected("/root"));
+        assert!(is_protected("/root/agent/data"));
+        assert!(is_protected("/root/.claude"));
+        assert!(is_protected("/etc/passwd"));
+        assert!(is_protected("/"));
+        assert!(is_protected("/usr/bin"));
+    }
+
+    #[test]
+    fn allows_neutral_roots() {
+        assert!(!is_protected("/mnt/media"));
+        assert!(!is_protected("/data/movies"));
+        assert!(!is_protected("/srv/plex"));
+        assert!(!is_protected("/media"));
+        // A prefix that merely starts with "/roo" but is not "/root" must be allowed.
+        assert!(!is_protected("/rootfs/data"));
+    }
+
+    #[test]
+    fn bind_string_ro_and_rw() {
+        let ro = HostMount { host_path: "/mnt/media".into(), container_path: "/mnt/media".into(), writable: false };
+        assert_eq!(bind_string(&ro), "/mnt/media:/mnt/media:ro,z");
+        let rw = HostMount { host_path: "/mnt/dl".into(), container_path: "/mnt/dl".into(), writable: true };
+        assert_eq!(bind_string(&rw), "/mnt/dl:/mnt/dl:rw,z");
+    }
+
+    #[test]
+    fn validate_mounts_rejects_duplicate_container_path() {
+        // Host paths must exist (validate_mount canonicalizes them), so use real tmpdirs
+        // rather than the brief's illustrative "/mnt/a"/"/mnt/b" which don't exist on
+        // arbitrary hosts.
+        let dir = std::env::temp_dir();
+        let sub_a = dir.join("vesta-mount-test-dup-a");
+        let sub_b = dir.join("vesta-mount-test-dup-b");
+        std::fs::create_dir_all(&sub_a).unwrap();
+        std::fs::create_dir_all(&sub_b).unwrap();
+        let inputs = vec![
+            (sub_a.to_str().unwrap().to_string(), Some("/mnt/x".to_string()), false),
+            (sub_b.to_str().unwrap().to_string(), Some("/mnt/x".to_string()), false),
+        ];
+        assert!(matches!(validate_mounts(&inputs), Err(MountError::DuplicateContainerPath(_))));
+    }
+}

--- a/vestad/src/mounts.rs
+++ b/vestad/src/mounts.rs
@@ -3,15 +3,20 @@
 //! protected-prefix rule. A grant is a decision only the user makes (see serve.rs auth).
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::fmt;
 
-/// Container-path roots a grant may never mount onto. `/root` covers the agent's entire
-/// world (home, `/root/agent/data` = events.db + state.json, `/root/.claude` = auth,
-/// `/root/agent/core` = code); the rest are OS dirs whose replacement would break the
-/// container. Everything outside these — `/mnt`, `/media`, `/data`, `/srv`, … — is allowed.
+/// Container-path roots a grant may never mount onto at all (prefix match). `/root` covers the
+/// agent's entire world (home, `/root/agent/data` = events.db + state.json, `/root/.claude` = auth,
+/// `/root/agent/core` = code); the rest are OS dirs whose replacement would break the container.
 pub const PROTECTED_PREFIXES: &[&str] = &[
     "/root", "/etc", "/usr", "/bin", "/sbin", "/lib", "/lib64", "/run", "/proc", "/sys", "/dev", "/boot",
 ];
+
+/// Writable container runtime roots that must not be *shadowed at their top level* (mounting onto
+/// `/tmp`/`/var`/`/opt` breaks the agent's temp files, logs, etc.), but whose subpaths ARE fine —
+/// a grant onto e.g. `/var/lib/plexmediaserver` is legitimate. Exact match only, unlike the prefixes.
+pub const PROTECTED_EXACT: &[&str] = &["/tmp", "/var", "/opt"];
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HostMount {
@@ -24,7 +29,7 @@ pub struct HostMount {
 #[derive(Debug)]
 pub enum MountError {
     NotAbsolute,
-    HostPathMissing,
+    HostPathMissing(String),
     ContainerPathProtected(String),
     DuplicateContainerPath(String),
 }
@@ -33,7 +38,7 @@ impl fmt::Display for MountError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             MountError::NotAbsolute => write!(f, "path must be absolute"),
-            MountError::HostPathMissing => write!(f, "host path does not exist"),
+            MountError::HostPathMissing(path) => write!(f, "host path '{path}' does not exist"),
             MountError::ContainerPathProtected(path) => {
                 write!(f, "container path '{path}' is protected; choose a path outside /root and system dirs, e.g. under /mnt")
             }
@@ -53,23 +58,37 @@ fn normalize(path: &str) -> &str {
     }
 }
 
-/// True if `container_path` is at or under any protected root, or is `/` itself.
+/// True if `container_path` is `/`, exactly a protected runtime root (`/tmp`, `/var`, `/opt`), or at
+/// or under any protected prefix (`/root` and the OS dirs).
 pub fn is_protected(container_path: &str) -> bool {
     let path = normalize(container_path);
-    if path == "/" {
+    if path == "/" || PROTECTED_EXACT.contains(&path) {
         return true;
     }
     PROTECTED_PREFIXES.iter().any(|root| path == *root || path.starts_with(&format!("{root}/")))
 }
 
-/// Validate one grant. `host_path` must be absolute and exist (canonicalized). The container
-/// path defaults to the (canonicalized) host path and must not be protected.
-pub fn validate_mount(host_path: &str, container_path: Option<&str>, writable: bool) -> Result<HostMount, MountError> {
+/// Validate one grant. `host_path` must be absolute and (normally) exist — it is canonicalized so the
+/// stored form resolves symlinks. The container path defaults to the (canonicalized) host path and
+/// must not be protected. `known_host_paths` are the host paths of grants already accepted for this
+/// agent: a path in that set that is *temporarily* missing (unplugged drive, unmounted NFS) is kept
+/// as-is instead of rejected, so one offline grant can't block edits to unrelated grants. A brand-new
+/// missing path is still rejected.
+pub fn validate_mount(
+    host_path: &str,
+    container_path: Option<&str>,
+    writable: bool,
+    known_host_paths: &HashSet<String>,
+) -> Result<HostMount, MountError> {
     if !host_path.starts_with('/') {
         return Err(MountError::NotAbsolute);
     }
-    let canonical = std::fs::canonicalize(host_path).map_err(|_| MountError::HostPathMissing)?;
-    let canonical = canonical.to_string_lossy().to_string();
+    let canonical = match std::fs::canonicalize(host_path) {
+        Ok(p) => p.to_string_lossy().to_string(),
+        // A grant that was accepted before is already canonical; if it's merely offline now, keep it.
+        Err(_) if known_host_paths.contains(host_path) => host_path.to_string(),
+        Err(_) => return Err(MountError::HostPathMissing(host_path.to_string())),
+    };
 
     let container = match container_path {
         Some(cp) => {
@@ -90,10 +109,12 @@ pub fn validate_mount(host_path: &str, container_path: Option<&str>, writable: b
 }
 
 /// Validate a full list and reject duplicate container paths (two grants can't target one dest).
-pub fn validate_mounts(inputs: &[(String, Option<String>, bool)]) -> Result<Vec<HostMount>, MountError> {
+/// `known_host_paths` (the agent's already-accepted grant paths) grandfathers temporarily-offline
+/// existing grants so a single missing path can't reject the whole edit — see `validate_mount`.
+pub fn validate_mounts(inputs: &[(String, Option<String>, bool)], known_host_paths: &HashSet<String>) -> Result<Vec<HostMount>, MountError> {
     let mut out: Vec<HostMount> = Vec::with_capacity(inputs.len());
     for (host, container, writable) in inputs {
-        let mount = validate_mount(host, container.as_deref(), *writable)?;
+        let mount = validate_mount(host, container.as_deref(), *writable, known_host_paths)?;
         if out.iter().any(|m| m.container_path == mount.container_path) {
             return Err(MountError::DuplicateContainerPath(mount.container_path));
         }
@@ -102,10 +123,14 @@ pub fn validate_mounts(inputs: &[(String, Option<String>, bool)]) -> Result<Vec<
     Ok(out)
 }
 
-/// The Docker `-v` bind spec: `host:container:{ro|rw},z`.
+/// The Docker `-v` bind spec: `host:container:{ro|rw}`. Deliberately no SELinux `z`/`Z` relabel: a
+/// grant shares an *existing* host directory that host services (Plex, Samba, the user) may also use,
+/// and `z` would recursively `chcon` the whole tree to a container-shared label — slow on large trees
+/// and a host-wide change that can break those services. On an SELinux-enforcing host the user relabels
+/// intentionally if needed; we never mutate host labels behind their back.
 pub fn bind_string(m: &HostMount) -> String {
     let mode = if m.writable { "rw" } else { "ro" };
-    format!("{}:{}:{mode},z", m.host_path, m.container_path)
+    format!("{}:{}:{mode}", m.host_path, m.container_path)
 }
 
 /// Host roots whose immediate subdirectories are common places to share (media libraries,
@@ -157,19 +182,46 @@ fn scan_candidate_folders(roots: &[&str], home: Option<&str>, home_dirs: &[&str]
 mod tests {
     use super::*;
 
+    fn no_known() -> HashSet<String> {
+        HashSet::new()
+    }
+
     #[test]
     fn mirror_uses_canonical_host_path_as_container_path() {
         let dir = std::env::temp_dir();
         let sub = dir.join("vesta-mount-test");
         std::fs::create_dir_all(&sub).unwrap();
-        let m = validate_mount(sub.to_str().unwrap(), None, false).unwrap();
+        let m = validate_mount(sub.to_str().unwrap(), None, false, &no_known()).unwrap();
         assert_eq!(m.container_path, m.host_path);
         assert!(!m.writable);
     }
 
     #[test]
     fn rejects_relative_host_path() {
-        assert!(matches!(validate_mount("relative/path", None, false), Err(MountError::NotAbsolute)));
+        assert!(matches!(validate_mount("relative/path", None, false, &no_known()), Err(MountError::NotAbsolute)));
+    }
+
+    #[test]
+    fn known_but_offline_host_path_is_kept_not_rejected() {
+        // A grant that was accepted before but whose host path is now missing (unplugged drive)
+        // must validate so edits to OTHER grants aren't blocked. It's already canonical, so it's
+        // kept as-is; a NEW missing path is still rejected.
+        let missing = "/definitely/does/not/exist/offline-drive";
+        let known: HashSet<String> = [missing.to_string()].into_iter().collect();
+        let m = validate_mount(missing, Some("/mnt/offline"), false, &known).unwrap();
+        assert_eq!(m.host_path, missing);
+        assert!(matches!(validate_mount(missing, Some("/mnt/offline"), false, &no_known()), Err(MountError::HostPathMissing(_))));
+    }
+
+    #[test]
+    fn known_offline_path_still_enforces_container_protection() {
+        // Grandfathering an offline host path must not bypass the protected-container-path rule.
+        let missing = "/definitely/does/not/exist/offline-drive";
+        let known: HashSet<String> = [missing.to_string()].into_iter().collect();
+        assert!(matches!(
+            validate_mount(missing, Some("/root/.claude"), false, &known),
+            Err(MountError::ContainerPathProtected(_))
+        ));
     }
 
     #[test]
@@ -195,7 +247,7 @@ mod tests {
 
     #[test]
     fn rejects_missing_host_path() {
-        assert!(matches!(validate_mount("/definitely/does/not/exist/xyzzy", None, false), Err(MountError::HostPathMissing)));
+        assert!(matches!(validate_mount("/definitely/does/not/exist/xyzzy", None, false, &no_known()), Err(MountError::HostPathMissing(_))));
     }
 
     #[test]
@@ -204,7 +256,7 @@ mod tests {
         let sub = dir.join("vesta-mount-test-dotdot");
         std::fs::create_dir_all(&sub).unwrap();
         assert!(matches!(
-            validate_mount(sub.to_str().unwrap(), Some("/mnt/../root/.claude"), false),
+            validate_mount(sub.to_str().unwrap(), Some("/mnt/../root/.claude"), false, &no_known()),
             Err(MountError::ContainerPathProtected(_))
         ));
     }
@@ -217,6 +269,13 @@ mod tests {
         assert!(is_protected("/etc/passwd"));
         assert!(is_protected("/"));
         assert!(is_protected("/usr/bin"));
+        // Writable container runtime roots: shadowing the root itself is blocked...
+        assert!(is_protected("/tmp"));
+        assert!(is_protected("/var"));
+        assert!(is_protected("/opt"));
+        // ...but a subpath is fine (e.g. Plex config lives under /var/lib/plexmediaserver).
+        assert!(!is_protected("/var/lib/plexmediaserver"));
+        assert!(!is_protected("/tmp/shared"));
     }
 
     #[test]
@@ -232,9 +291,9 @@ mod tests {
     #[test]
     fn bind_string_ro_and_rw() {
         let ro = HostMount { host_path: "/mnt/media".into(), container_path: "/mnt/media".into(), writable: false };
-        assert_eq!(bind_string(&ro), "/mnt/media:/mnt/media:ro,z");
+        assert_eq!(bind_string(&ro), "/mnt/media:/mnt/media:ro");
         let rw = HostMount { host_path: "/mnt/dl".into(), container_path: "/mnt/dl".into(), writable: true };
-        assert_eq!(bind_string(&rw), "/mnt/dl:/mnt/dl:rw,z");
+        assert_eq!(bind_string(&rw), "/mnt/dl:/mnt/dl:rw");
     }
 
     #[test]
@@ -251,6 +310,6 @@ mod tests {
             (sub_a.to_str().unwrap().to_string(), Some("/mnt/x".to_string()), false),
             (sub_b.to_str().unwrap().to_string(), Some("/mnt/x".to_string()), false),
         ];
-        assert!(matches!(validate_mounts(&inputs), Err(MountError::DuplicateContainerPath(_))));
+        assert!(matches!(validate_mounts(&inputs, &no_known()), Err(MountError::DuplicateContainerPath(_))));
     }
 }

--- a/vestad/src/mounts.rs
+++ b/vestad/src/mounts.rs
@@ -83,6 +83,9 @@ pub fn validate_mount(host_path: &str, container_path: Option<&str>, writable: b
     if is_protected(&container) {
         return Err(MountError::ContainerPathProtected(container));
     }
+    if std::path::Path::new(&container).components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+        return Err(MountError::ContainerPathProtected(container));
+    }
     Ok(HostMount { host_path: canonical, container_path: container, writable })
 }
 
@@ -127,6 +130,17 @@ mod tests {
     #[test]
     fn rejects_missing_host_path() {
         assert!(matches!(validate_mount("/definitely/does/not/exist/xyzzy", None, false), Err(MountError::HostPathMissing)));
+    }
+
+    #[test]
+    fn rejects_dotdot_in_container_path() {
+        let dir = std::env::temp_dir();
+        let sub = dir.join("vesta-mount-test-dotdot");
+        std::fs::create_dir_all(&sub).unwrap();
+        assert!(matches!(
+            validate_mount(sub.to_str().unwrap(), Some("/mnt/../root/.claude"), false),
+            Err(MountError::ContainerPathProtected(_))
+        ));
     }
 
     #[test]

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -669,7 +669,7 @@ async fn restart_agent_handler(
         }
         let user_mounts = {
             let settings = state.settings.read().await;
-            settings.agents.get(&name).map(|s| s.mounts.clone()).unwrap_or_default()
+            settings.agent_mounts(&name)
         };
         docker::restart_agent(&state.docker, &name, &state.env_config, &user_mounts)
             .await
@@ -708,7 +708,7 @@ async fn rebuild_agent_handler(
 
     let user_mounts = {
         let settings = state.settings.read().await;
-        settings.agents.get(&name).map(|s| s.mounts.clone()).unwrap_or_default()
+        settings.agent_mounts(&name)
     };
     docker::rebuild_agent(&state.docker, &name, &state.env_config, &user_mounts)
         .await
@@ -753,7 +753,7 @@ async fn rename_agent_handler(
 
     let user_mounts = {
         let settings = state.settings.read().await;
-        settings.agents.get(&name).map(|a| a.mounts.clone()).unwrap_or_default()
+        settings.agent_mounts(&name)
     };
     docker::rename_agent(&state.docker, &name, &new_name, &state.env_config, &user_mounts)
         .await
@@ -1470,6 +1470,13 @@ impl Settings {
     fn manages_core_code(&self, name: &str) -> bool {
         self.agents.get(name).is_none_or(|s| s.manage_agent_code)
     }
+
+    /// The agent's host-folder grants, or an empty list if the agent has none recorded.
+    /// One reader so every mount-consuming path (restart, rebuild, rename, restore, list,
+    /// reconcile) sees grants the same way.
+    fn agent_mounts(&self, name: &str) -> Vec<crate::mounts::HostMount> {
+        self.agents.get(name).map(|s| s.mounts.clone()).unwrap_or_default()
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -1825,7 +1832,7 @@ async fn restore_backup_handler(
         let manage_core_code = state.settings.read().await.manages_core_code(&path.name);
         let user_mounts = {
             let settings = state.settings.read().await;
-            settings.agents.get(&path.name).map(|a| a.mounts.clone()).unwrap_or_default()
+            settings.agent_mounts(&path.name)
         };
         backup::restore_backup(&state.docker, &path.name, &path.backup_id, &state.env_config, manage_core_code, &user_mounts).await?;
         tracing::info!(agent = %path.name, backup_id = %path.backup_id, "backup restored");
@@ -2101,7 +2108,7 @@ async fn list_mounts_handler(
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     let settings = state.settings.read().await;
-    let mounts = settings.agents.get(&name).map(|a| a.mounts.clone()).unwrap_or_default();
+    let mounts = settings.agent_mounts(&name);
     Ok(Json(serde_json::json!({ "mounts": mounts })))
 }
 
@@ -2112,7 +2119,17 @@ async fn set_mounts_handler(
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     let inputs: Vec<(String, Option<String>, bool)> =
         body.mounts.into_iter().map(|m| (m.host_path, m.container_path, m.writable)).collect();
-    let validated = crate::mounts::validate_mounts(&inputs)
+    // The agent's already-accepted grant paths grandfather a temporarily-offline existing grant so
+    // one missing drive can't reject the whole edit (see mounts::validate_mount).
+    let known_host_paths: std::collections::HashSet<String> = {
+        let settings = state.settings.read().await;
+        settings.agent_mounts(&name).into_iter().map(|m| m.host_path).collect()
+    };
+    // validate_mounts canonicalizes each host path (blocking std::fs, and a hung network mount can
+    // stall for a long time), so run it off the async worker.
+    let validated = tokio::task::spawn_blocking(move || crate::mounts::validate_mounts(&inputs, &known_host_paths))
+        .await
+        .map_err(|_| err_response(StatusCode::INTERNAL_SERVER_ERROR, "mount validation task failed"))?
         .map_err(|e| (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": e.to_string() }))))?;
     {
         let mut settings = state.settings.write().await;
@@ -2125,9 +2142,13 @@ async fn set_mounts_handler(
 
 /// Suggest existing host folders the user might share, so they don't hand-type a path. Reads the
 /// host filesystem (common mount roots + home media folders), so it is API-key only — never the
-/// agent token; an agent must not enumerate the host.
-async fn host_folder_suggestions_handler() -> Json<serde_json::Value> {
-    Json(serde_json::json!({ "folders": crate::mounts::suggest_host_folders() }))
+/// agent token; an agent must not enumerate the host. The scan is blocking std::fs (and a hung
+/// network mount under one of the roots can stall it), so it runs off the async worker.
+async fn host_folder_suggestions_handler() -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let folders = tokio::task::spawn_blocking(crate::mounts::suggest_host_folders)
+        .await
+        .map_err(|_| err_response(StatusCode::INTERNAL_SERVER_ERROR, "folder scan task failed"))?;
+    Ok(Json(serde_json::json!({ "folders": folders })))
 }
 
 // --- Constitution ---
@@ -2337,10 +2358,20 @@ pub fn build_router(state: SharedState) -> Router {
     // X-Agent-Token. The agent-token branch is inherently self-scoped — the middleware checks the
     // token against the agent name in the path — so an agent can stop/restart only itself. This is
     // how the agent's restart_vesta/stop_vesta tools reach vestad (it then does the docker action).
-    let agents_self_lifecycle = Router::new()
+    // Stop is quick (control tier); restart can trigger a full snapshot+recreate when host-folder
+    // grants drifted (docker export|import), which for a multi-GB agent exceeds the control deadline —
+    // so it rides the longrun timeout like the rebuild route, not the control tier.
+    let agents_self_stop = Router::new()
         .route("/agents/{name}/stop", post(stop_agent_handler))
-        .route("/agents/{name}/restart", post(restart_agent_handler))
         .layer(control_timeout_layer())
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::auth_middleware_api_or_agent_token,
+        ))
+        .with_state(state.clone());
+    let agents_self_restart = Router::new()
+        .route("/agents/{name}/restart", post(restart_agent_handler))
+        .layer(longrun_timeout_layer())
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth::auth_middleware_api_or_agent_token,
@@ -2371,7 +2402,8 @@ pub fn build_router(state: SharedState) -> Router {
         .merge(vestad_protected_timed)
         .merge(vestad_protected_longrun)
         .merge(vestad_protected_streaming)
-        .merge(agents_self_lifecycle)
+        .merge(agents_self_stop)
+        .merge(agents_self_restart)
         .merge(agents_services)
         .merge(agents_services_read)
         .merge(gateway_logs)
@@ -2652,7 +2684,7 @@ pub async fn run_server(cfg: ServerConfig) {
             &|name| load_settings().agents.get(name).is_none_or(|s| s.user_desired == UserDesired::Running),
             // Mount grants are also read LIVE so a grant added/removed during the reconcile window
             // (or via a later `vesta restart`) is reflected without needing a fresh vestad boot.
-            &|name| load_settings().agents.get(name).map(|s| s.mounts.clone()).unwrap_or_default(),
+            &|name| load_settings().agent_mounts(name),
         )
         .await;
     });

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2047,6 +2047,53 @@ async fn delete_agent_backup_settings_handler(
     agent_backup_json(settings.backup.enabled, settings.backup.retention, false)
 }
 
+// --- Host filesystem grants ---
+//
+// A grant is a decision only the user makes: PUT sits behind the API-key-only middleware
+// (never the agent token), so an agent can never mount itself extra host access. GET is
+// dual-auth (API key or the agent's own token) so a skill can list its own grants.
+
+#[derive(Deserialize)]
+struct MountInput {
+    host_path: String,
+    #[serde(default)]
+    container_path: Option<String>,
+    #[serde(default)]
+    writable: bool,
+}
+
+#[derive(Deserialize)]
+struct SetMountsBody {
+    mounts: Vec<MountInput>,
+}
+
+async fn list_mounts_handler(
+    State(state): State<SharedState>,
+    Path(name): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let settings = state.settings.read().await;
+    let mounts = settings.agents.get(&name).map(|a| a.mounts.clone()).unwrap_or_default();
+    Ok(Json(serde_json::json!({ "mounts": mounts })))
+}
+
+async fn set_mounts_handler(
+    State(state): State<SharedState>,
+    Path(name): Path<String>,
+    Json(body): Json<SetMountsBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let inputs: Vec<(String, Option<String>, bool)> =
+        body.mounts.into_iter().map(|m| (m.host_path, m.container_path, m.writable)).collect();
+    let validated = crate::mounts::validate_mounts(&inputs)
+        .map_err(|e| (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": e.to_string() }))))?;
+    {
+        let mut settings = state.settings.write().await;
+        settings.agents.entry(name.clone()).or_default().mounts = validated.clone();
+        save_settings(&settings);
+    }
+    tracing::info!(agent = %name, "agent mounts updated");
+    Ok(Json(serde_json::json!({ "mounts": validated, "restart_required": true })))
+}
+
 // --- Constitution ---
 //
 // A user-authored charter prepended to the agent's system prompt ahead of MEMORY.md.
@@ -2200,6 +2247,7 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/agents/{name}/settings/backup", get(get_agent_backup_settings_handler))
         .route("/agents/{name}/settings/backup", axum::routing::put(set_agent_backup_settings_handler))
         .route("/agents/{name}/settings/backup", axum::routing::delete(delete_agent_backup_settings_handler))
+        .route("/agents/{name}/mounts", put(set_mounts_handler))
         .route("/gateway/settings", get(get_gateway_settings_handler).put(put_gateway_settings_handler))
         .layer(control_timeout_layer())
         .layer(middleware::from_fn_with_state(
@@ -2265,6 +2313,7 @@ pub fn build_router(state: SharedState) -> Router {
     // Service listing: read-only, accepts either API key or the agent's token
     let agents_services_read = Router::new()
         .route("/agents/{name}/services", get(list_services_handler))
+        .route("/agents/{name}/mounts", get(list_mounts_handler))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth::auth_middleware_api_or_agent_token,

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1798,7 +1798,11 @@ async fn restore_backup_handler(
         let _guard = agent_write_guard(&state, &path.name).await;
         let _file_lock = backup::agent_file_lock(&path.name)?;
         let manage_core_code = state.settings.read().await.manages_core_code(&path.name);
-        backup::restore_backup(&state.docker, &path.name, &path.backup_id, &state.env_config, manage_core_code).await?;
+        let user_mounts = {
+            let settings = state.settings.read().await;
+            settings.agents.get(&path.name).map(|a| a.mounts.clone()).unwrap_or_default()
+        };
+        backup::restore_backup(&state.docker, &path.name, &path.backup_id, &state.env_config, manage_core_code, &user_mounts).await?;
         tracing::info!(agent = %path.name, backup_id = %path.backup_id, "backup restored");
         Ok(r#"{"ok":true}"#.to_string())
     })

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -289,6 +289,25 @@ pub(crate) fn map_docker_err(e: docker::DockerError) -> (StatusCode, Json<serde_
     err_response(status, &e.to_string())
 }
 
+/// Run a container-mutating operation on a detached task and await its single result over a oneshot
+/// channel. Load-bearing invariant for a self-restart: the request's client is the agent inside the
+/// very container the operation stops, so the loopback connection drops the instant the container
+/// goes down — and an inline `.await` would be cancelled mid-recreate, stranding the agent stopped.
+/// Spawning runs the op to completion regardless of the client; the request only observes its result
+/// (so a still-connected app caller still gets a truthful response). JSON analogue of the SSE
+/// `spawn_pipeline_sse` used by backup/restore, which fixed this same drop-cancellation class.
+async fn spawn_detached<Fut>(op: Fut) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)>
+where
+    Fut: std::future::Future<Output = Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)>> + Send + 'static,
+{
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let _ = tx.send(op.await);
+    });
+    rx.await
+        .unwrap_or_else(|_| Err(err_response(StatusCode::INTERNAL_SERVER_ERROR, "restart task panicked")))
+}
+
 // --- Handlers ---
 
 async fn health() -> Json<serde_json::Value> {
@@ -636,22 +655,28 @@ async fn restart_agent_handler(
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     tracing::info!(name = %name, "restarting agent");
-    let _guard = agent_write_guard(&state, &name).await;
+    // Detached from this request's connection: a self-restart's client is the agent inside the very
+    // container this stops, so the loopback drops the instant rebuild_agent stops it. An inline await
+    // would be cancelled before the recreate finishes, leaving the agent down (see spawn_detached).
+    spawn_detached(async move {
+        let _guard = agent_write_guard(&state, &name).await;
 
-    // A restart implies the agent should be running — record it so boot-start agrees with intent.
-    {
-        let mut settings = state.settings.write().await;
-        settings.agents.entry(name.clone()).or_default().user_desired = UserDesired::Running;
-        save_settings(&settings);
-    }
-    let user_mounts = {
-        let settings = state.settings.read().await;
-        settings.agents.get(&name).map(|s| s.mounts.clone()).unwrap_or_default()
-    };
-    docker::restart_agent(&state.docker, &name, &state.env_config, &user_mounts)
-        .await
-        .map_err(map_docker_err)?;
-    Ok(ok_json())
+        // A restart implies the agent should be running — record it so boot-start agrees with intent.
+        {
+            let mut settings = state.settings.write().await;
+            settings.agents.entry(name.clone()).or_default().user_desired = UserDesired::Running;
+            save_settings(&settings);
+        }
+        let user_mounts = {
+            let settings = state.settings.read().await;
+            settings.agents.get(&name).map(|s| s.mounts.clone()).unwrap_or_default()
+        };
+        docker::restart_agent(&state.docker, &name, &state.env_config, &user_mounts)
+            .await
+            .map_err(map_docker_err)?;
+        Ok(ok_json())
+    })
+    .await
 }
 
 async fn destroy_agent_handler(
@@ -3179,5 +3204,54 @@ mod gateway_settings_tests {
         assert_eq!(off["lan"]["exposed"], serde_json::json!(false));
         assert_eq!(off["lan"]["url"], serde_json::Value::Null);
         assert_eq!(off["tunnel_url"], serde_json::Value::Null);
+    }
+}
+
+#[cfg(test)]
+mod restart_detach_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::Notify;
+
+    /// Regression for the nightly-dream restart that stranded the agent: a self-restart's client is
+    /// the agent inside the container being stopped, so the request future is dropped mid-operation.
+    /// spawn_detached must run the operation to completion regardless — mirroring the drop-cancellation
+    /// fix already covered for backup/restore in backup.rs::sse_stream_drop_cancels_container_restart.
+    #[tokio::test]
+    async fn detached_op_completes_after_request_future_dropped() {
+        let completed = Arc::new(AtomicBool::new(false));
+        let op_started = Arc::new(Notify::new());
+        let op_gate = Arc::new(Notify::new());
+
+        let completed_c = completed.clone();
+        let op_started_c = op_started.clone();
+        let op_gate_c = op_gate.clone();
+
+        // The request side: spawn_detached spawns the op, then awaits its oneshot result. Drive it on
+        // its own task so we can drop it (client disconnect) once the op is in flight.
+        let request = tokio::spawn(spawn_detached(async move {
+            op_started_c.notify_one();
+            // Mirrors the multi-step rebuild in progress (stop -> snapshot -> recreate -> start).
+            op_gate_c.notified().await;
+            completed_c.store(true, Ordering::SeqCst);
+            Ok(ok_json())
+        }));
+
+        // Once the op is running, drop the request future — as hyper does when the loopback client dies.
+        op_started.notified().await;
+        assert!(!completed.load(Ordering::SeqCst), "op should still be in flight");
+        request.abort();
+
+        // The detached op must still finish despite the dropped request.
+        op_gate.notify_one();
+        for _ in 0..200 {
+            if completed.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(completed.load(Ordering::SeqCst), "detached op must run to completion after request dropped");
     }
 }

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1419,11 +1419,13 @@ struct AgentSettings {
     manage_agent_code: bool,
     #[serde(default)]
     user_desired: UserDesired,
+    #[serde(default)]
+    mounts: Vec<crate::mounts::HostMount>,
 }
 
 impl Default for AgentSettings {
     fn default() -> Self {
-        Self { manage_agent_code: true, user_desired: UserDesired::Running }
+        Self { manage_agent_code: true, user_desired: UserDesired::Running, mounts: Vec::new() }
     }
 }
 
@@ -2714,11 +2716,41 @@ mod tests {
 
     #[test]
     fn agent_settings_user_desired_stopped_round_trips() {
-        let s = super::AgentSettings { manage_agent_code: true, user_desired: super::UserDesired::Stopped };
+        let s = super::AgentSettings {
+            manage_agent_code: true,
+            user_desired: super::UserDesired::Stopped,
+            mounts: Vec::new(),
+        };
         let json = serde_json::to_string(&s).expect("serialize");
         assert!(json.contains(r#""user_desired":"stopped""#), "serialized as: {json}");
         let back: super::AgentSettings = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.user_desired, super::UserDesired::Stopped);
+    }
+
+    // --- mounts persists user-granted host filesystem access; a settings.json predating the
+    // field must still deserialize (to no grants), and a granted mount must round-trip ---
+
+    #[test]
+    fn agent_settings_defaults_mounts_to_empty() {
+        let json = r#"{"manage_agent_code": true, "user_desired": "running"}"#;
+        let s: super::AgentSettings = serde_json::from_str(json).expect("valid AgentSettings");
+        assert!(s.mounts.is_empty());
+    }
+
+    #[test]
+    fn agent_settings_roundtrips_mounts() {
+        let s = super::AgentSettings {
+            manage_agent_code: true,
+            user_desired: super::UserDesired::Running,
+            mounts: vec![crate::mounts::HostMount {
+                host_path: "/mnt/media".into(),
+                container_path: "/mnt/media".into(),
+                writable: false,
+            }],
+        };
+        let json = serde_json::to_string(&s).expect("serialize");
+        let back: super::AgentSettings = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.mounts, s.mounts);
     }
 
     // --- Rename notification payload (the content contract the agent self-heals on) ---

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -644,7 +644,11 @@ async fn restart_agent_handler(
         settings.agents.entry(name.clone()).or_default().user_desired = UserDesired::Running;
         save_settings(&settings);
     }
-    docker::restart_agent(&state.docker, &name)
+    let user_mounts = {
+        let settings = state.settings.read().await;
+        settings.agents.get(&name).map(|s| s.mounts.clone()).unwrap_or_default()
+    };
+    docker::restart_agent(&state.docker, &name, &state.env_config, &user_mounts)
         .await
         .map_err(map_docker_err)?;
     Ok(ok_json())
@@ -677,7 +681,11 @@ async fn rebuild_agent_handler(
     tracing::info!(name = %name, "rebuilding agent");
     let _guard = agent_write_guard(&state, &name).await;
 
-    docker::rebuild_agent(&state.docker, &name, &state.env_config)
+    let user_mounts = {
+        let settings = state.settings.read().await;
+        settings.agents.get(&name).map(|s| s.mounts.clone()).unwrap_or_default()
+    };
+    docker::rebuild_agent(&state.docker, &name, &state.env_config, &user_mounts)
         .await
         .map_err(map_docker_err)?;
     // A rebuild ends by starting the agent, so record it as desired-running for boot-start.
@@ -718,7 +726,11 @@ async fn rename_agent_handler(
     let _g1 = lock_first.write().await;
     let _g2 = lock_second.write().await;
 
-    docker::rename_agent(&state.docker, &name, &new_name, &state.env_config)
+    let user_mounts = {
+        let settings = state.settings.read().await;
+        settings.agents.get(&name).map(|a| a.mounts.clone()).unwrap_or_default()
+    };
+    docker::rename_agent(&state.docker, &name, &new_name, &state.env_config, &user_mounts)
         .await
         .map_err(map_docker_err)?;
 
@@ -2552,6 +2564,9 @@ pub async fn run_server(cfg: ServerConfig) {
             // Desired-run state is read LIVE (not a boot snapshot): a stop/start the user issues
             // during the slow reconcile window would otherwise be reverted by the start/stop step.
             &|name| load_settings().agents.get(name).is_none_or(|s| s.user_desired == UserDesired::Running),
+            // Mount grants are also read LIVE so a grant added/removed during the reconcile window
+            // (or via a later `vesta restart`) is reflected without needing a fresh vestad boot.
+            &|name| load_settings().agents.get(name).map(|s| s.mounts.clone()).unwrap_or_default(),
         )
         .await;
     });

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2098,6 +2098,13 @@ async fn set_mounts_handler(
     Ok(Json(serde_json::json!({ "mounts": validated, "restart_required": true })))
 }
 
+/// Suggest existing host folders the user might share, so they don't hand-type a path. Reads the
+/// host filesystem (common mount roots + home media folders), so it is API-key only — never the
+/// agent token; an agent must not enumerate the host.
+async fn host_folder_suggestions_handler() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "folders": crate::mounts::suggest_host_folders() }))
+}
+
 // --- Constitution ---
 //
 // A user-authored charter prepended to the agent's system prompt ahead of MEMORY.md.
@@ -2252,6 +2259,7 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/agents/{name}/settings/backup", axum::routing::put(set_agent_backup_settings_handler))
         .route("/agents/{name}/settings/backup", axum::routing::delete(delete_agent_backup_settings_handler))
         .route("/agents/{name}/mounts", put(set_mounts_handler))
+        .route("/host/folders", get(host_folder_suggestions_handler))
         .route("/gateway/settings", get(get_gateway_settings_handler).put(put_gateway_settings_handler))
         .layer(control_timeout_layer())
         .layer(middleware::from_fn_with_state(


### PR DESCRIPTION
This branch delivers two things that grew together: the **host filesystem access** feature, and — because its UI landed in the agent-settings **files** tab — a broader **files/settings UI redesign** onto a consistent `Item`-cell language. See the scope note at the bottom.

---

## 1. Host filesystem access (the feature)

Let a user grant an agent access to specific host paths, so skills (e.g. Plex, #955) can reach media disks.

- **Model** (`vestad/src/mounts.rs`): `HostMount { host_path, container_path, writable }`, validation, `bind_string`. Grants persist per-agent in `settings.json`.
- **Protected paths**: a grant can't mount onto `/root` (the agent's world — events.db, `.claude`, core) or OS roots, and `..` traversal is rejected; everything else (where media lives) is allowed. Container path defaults to mirroring the host path.
- **Security**: `PUT /agents/{name}/mounts` is **API-key only** — the agent's token is rejected, so an agent can never grant itself host access. `GET` is dual-auth. Validation runs on every write.
- **Apply**: injected into the container binds at (re)create; `needs_rebuild` detects mount drift; applied on next reconcile or a `vesta restart` (mount-drift-aware, with a disk-full guard so it never snapshots on a full disk). Restore threads grants too.
- **Suggestions**: `GET /host/folders` (API-key only) scans common host locations (`/mnt`, `/media`, `/srv`, `/data`, home media folders) so the UI can offer folders to share instead of hand-typed paths.
- **Surfaces**: `vesta mount ls|add|rm` CLI; a "shared folders" section in the agent's **files** tab (folders listed as cells with a can-edit toggle, an "add a folder" dialog with suggestion chips + advanced remap behind progressive disclosure).
- **Restart plumbing**: agent restart is detached from the request connection, and a shared restart-reason interface (spec under `docs/`) so a "restart to apply" nudge surfaces once in the navbar.
- **Testing**: unit coverage for validation / bind assembly / drift detection / settings serde; an `#[ignore]` Docker e2e (`granted_host_path_readable_writable_removable_in_container`) run locally against `vesta:local` and **passing**.

## 2. Files / settings UI redesign

The files tab became a calm hub built on the shadcn `Item` primitive, and the pattern spread to the notification surfaces for consistency.

- **Files hub** (simple mode): a centered hub of soft `Item` cells — **who {name} is** (memory / constitution / dreams), **abilities** (skills), **shared folders** — drilling into a detail view; a **desktop bento** (mind + folders left, skills right) that collapses to one stacked column on mobile.
- **Notifications**: each notification and each interrupt-rule is now an `Item` cell (per-source deterministic icon colors; outline badges for legibility).
- **Restart-to-apply**: a shared `use-restart-pending` store drives a single restart button in the navbar instead of scattered inline hints.
- **Primitive tweaks**: `ItemDescription` defaults to 11px; muted `Item` cells use a fuller fill for card contrast (synced to the dashboard registry mirror).
- Left as-is where `Item` would be the wrong primitive: forms (`Field`/`ToggleGroup`), gauges (`Progress`), action buttons, the file tree, logs.

## Testing / CI

- `check.sh vestad` (clippy + unit tests), `check.sh cli`, `check.sh web` (lint/format/tsc/vitest) green locally.
- Docker e2e (`check.sh vestad-docker`) not run in CI on PRs; the mount e2e was run locally and passes.

## Notes

- **Scope**: this is larger than one concern — the UI redesign grew out of the host-access files UI. Given the commits are interleaved across `apps/web/AgentSettings`, splitting cleanly would be significant surgery. Happy to split into a feature PR + a UI-redesign PR if preferred.
- **Visual verification**: the UI was iterated against a local dev server; a final visual pass on a reviewer's machine is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)