### PR TITLE
fix(prompts): reword triage prompt "focused" to "busy"

### DIFF
--- a/agent/core/prompts/notification_triage.md
+++ b/agent/core/prompts/notification_triage.md
@@ -1,1 +1,1 @@
-These notifications came in while you were focused. Read the `notifications` skill and triage them: act on what genuinely needs you now, note anything worth surfacing to the user, and drop the rest. Spend effort proportional to value; you do not need to respond to each one.
+These notifications came in while you were busy. Read the `notifications` skill and triage them: act on what genuinely needs you now, note anything worth surfacing to the user, and drop the rest. Spend effort proportional to value; you do not need to respond to each one.


### PR DESCRIPTION
Rewords the notification triage prompt to say the agent was "busy" rather than "focused" while notifications came in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)