### PR TITLE
feat: external restart-reason interface

### DIFF
--- a/agent/core/helpers.py
+++ b/agent/core/helpers.py
@@ -32,10 +32,10 @@ def load_prompt(name: str, config: vm.VestaConfig) -> str | None:
 
 def build_restart_context(reason: str, config: vm.VestaConfig, *, extras: list[str] | None = None) -> str:
     # Reasons are stored as "category: detail"; most categories are internal routing tags, so show
-    # only the human detail under a clear restart header. crash/error stay whole: the restart skill
-    # branches on a crash boot ("crash -> mention it"), so their marker must survive the render.
-    category, _, detail = reason.partition(": ")
-    shown = reason if category in ("crash", "error") or not detail else detail
+    # only the human detail under a clear restart header. Crash reasons stay whole: the restart
+    # skill branches on a crash boot ("crash -> mention it"), so their marker must survive.
+    detail = reason.partition(": ")[2]
+    shown = reason if vm.is_crash_reason(reason) or not detail else detail
     parts = [f"[System Restart]\nReason: {shown}"]
     if extras:
         parts.extend(extras)

--- a/agent/core/helpers.py
+++ b/agent/core/helpers.py
@@ -31,10 +31,12 @@ def load_prompt(name: str, config: vm.VestaConfig) -> str | None:
 
 
 def build_restart_context(reason: str, config: vm.VestaConfig, *, extras: list[str] | None = None) -> str:
-    # Reasons are stored as "category: detail"; the category is an internal tag (it drives the
-    # crash exit-code path), so show only the human detail under a clear restart header.
-    detail = reason.split(": ", 1)[1] if ": " in reason else reason
-    parts = [f"[System Restart]\nReason: {detail}"]
+    # Reasons are stored as "category: detail"; most categories are internal routing tags, so show
+    # only the human detail under a clear restart header. crash/error stay whole: the restart skill
+    # branches on a crash boot ("crash -> mention it"), so their marker must survive the render.
+    category, _, detail = reason.partition(": ")
+    shown = reason if category in ("crash", "error") or not detail else detail
+    parts = [f"[System Restart]\nReason: {shown}"]
     if extras:
         parts.extend(extras)
     greeting = load_prompt("restart", config) or ""

--- a/agent/core/helpers.py
+++ b/agent/core/helpers.py
@@ -31,7 +31,10 @@ def load_prompt(name: str, config: vm.VestaConfig) -> str | None:
 
 
 def build_restart_context(reason: str, config: vm.VestaConfig, *, extras: list[str] | None = None) -> str:
-    parts = [f"[System: {reason}]"]
+    # Reasons are stored as "category: detail"; the category is an internal tag (it drives the
+    # crash exit-code path), so show only the human detail under a clear restart header.
+    detail = reason.split(": ", 1)[1] if ": " in reason else reason
+    parts = [f"[System Restart]\nReason: {detail}"]
     if extras:
         parts.extend(extras)
     greeting = load_prompt("restart", config) or ""

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -221,7 +221,7 @@ async def _run_messages_with_interrupts(
                 raise
             logger.error("Message processing cancelled unexpectedly, triggering restart")
             state.event_bus.emit({"type": "error", "text": "processing cancelled"})
-            state.persisted.last_restart_reason = "error: processing cancelled"
+            state.persisted.last_restart_reason = "error: a turn was cancelled unexpectedly"
             state_store.save_state(state.persisted, config)
             state.graceful_shutdown.set()
             raise

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -149,7 +149,7 @@ async def run_vesta(
     # policy recovers us. Intentional restarts/stops are driven by vestad (docker restart/stop) and
     # a SIGTERM-driven shutdown carries no crash reason, so those exit 0 — vestad starts us back, or
     # leaves us down. Capture intent before the clean-restart default below overwrites a blank reason.
-    crashed = _is_crash_reason(state.persisted.last_restart_reason)
+    crashed = vm.is_crash_reason(state.persisted.last_restart_reason)
     reason = state.persisted.last_restart_reason or vm.CLEAN_RESTART
     logger.shutdown(f"Shutting down ({reason})")
     if not state.persisted.last_restart_reason:
@@ -208,13 +208,6 @@ def collect_boot_turns(
     return turns
 
 
-def _is_crash_reason(reason: str | None) -> bool:
-    """Whether a persisted restart reason marks an unexpected exit (set by the processor/loop error
-    handlers as `crash:`/`error:`), as opposed to a clean or vestad-driven shutdown. Drives the
-    non-zero exit that lets Docker's on-failure policy recover the agent."""
-    return reason is not None and (reason.startswith("crash:") or reason.startswith("error:"))
-
-
 def _consume_restart_reason(state: vm.State, config: vm.VestaConfig, *, first_start: bool) -> str:
     """Return the reason to log for this boot and clear it from persisted state. On a never-run agent the absence of a stored reason is innocent; report FIRST_START_REASON instead of a misleading crash label."""
     # Drain the inbox on every boot, including first start: a file left behind would fire stale
@@ -223,7 +216,7 @@ def _consume_restart_reason(state: vm.State, config: vm.VestaConfig, *, first_st
     if first_start:
         return vm.FIRST_START_REASON
     stored = state.persisted.last_restart_reason
-    if pending is not None and not _is_crash_reason(stored):
+    if pending is not None and not vm.is_crash_reason(stored):
         # An external actor (vestad backup/mounts/manual restart) handed in a reason for this boot.
         # It overrides the clean-restart placeholder the prior run persisted on its way down, but
         # never a recorded crash: the crash detail is the more important story to surface.

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -81,7 +81,7 @@ def handle_processor_done(task: asyncio.Task[None], *, state: vm.State, config: 
         return
     if task.cancelled():
         logger.error("message_processor cancelled unexpectedly, restarting")
-        state.persisted.last_restart_reason = "crash: processor cancelled unexpectedly"
+        state.persisted.last_restart_reason = "crash: the processor was cancelled unexpectedly"
     else:
         exc = task.exception()
         if exc is not None:
@@ -90,7 +90,7 @@ def handle_processor_done(task: asyncio.Task[None], *, state: vm.State, config: 
             state.persisted.last_restart_reason = f"crash: {type(exc).__name__}: {exc}"
         else:
             logger.error("message_processor exited without error, restarting")
-            state.persisted.last_restart_reason = "crash: processor exited silently"
+            state.persisted.last_restart_reason = "crash: the processor exited silently"
     state_store.save_state(state.persisted, config)
     state.graceful_shutdown.set()
 

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -219,6 +219,11 @@ def _consume_restart_reason(state: vm.State, config: vm.VestaConfig, *, first_st
     """Return the reason to log for this boot and clear it from persisted state. On a never-run agent the absence of a stored reason is innocent; report FIRST_START_REASON instead of a misleading crash label."""
     if first_start:
         return vm.FIRST_START_REASON
+    pending = state_store.take_pending_reason(config)
+    if pending is not None:
+        # An external actor (vestad backup/mounts/manual restart) handed in a reason for this boot;
+        # it overrides the clean-restart placeholder the prior run persisted on its way down.
+        state.persisted.last_restart_reason = pending
     stored = state.persisted.last_restart_reason
     state.persisted.last_restart_reason = None
     state_store.save_state(state.persisted, config)

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -217,14 +217,17 @@ def _is_crash_reason(reason: str | None) -> bool:
 
 def _consume_restart_reason(state: vm.State, config: vm.VestaConfig, *, first_start: bool) -> str:
     """Return the reason to log for this boot and clear it from persisted state. On a never-run agent the absence of a stored reason is innocent; report FIRST_START_REASON instead of a misleading crash label."""
+    # Drain the inbox on every boot, including first start: a file left behind would fire stale
+    # on some later, unrelated boot.
+    pending = state_store.take_pending_reason(config)
     if first_start:
         return vm.FIRST_START_REASON
-    pending = state_store.take_pending_reason(config)
-    if pending is not None:
-        # An external actor (vestad backup/mounts/manual restart) handed in a reason for this boot;
-        # it overrides the clean-restart placeholder the prior run persisted on its way down.
-        state.persisted.last_restart_reason = pending
     stored = state.persisted.last_restart_reason
+    if pending is not None and not _is_crash_reason(stored):
+        # An external actor (vestad backup/mounts/manual restart) handed in a reason for this boot.
+        # It overrides the clean-restart placeholder the prior run persisted on its way down, but
+        # never a recorded crash: the crash detail is the more important story to surface.
+        stored = pending
     state.persisted.last_restart_reason = None
     state_store.save_state(state.persisted, config)
     return stored or vm.CRASH_RESTART

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -57,6 +57,14 @@ CRASH_RESTART = "crash: restarted after an unexpected exit"
 FIRST_START_REASON = "first start"
 
 
+def is_crash_reason(reason: str | None) -> bool:
+    """Whether a restart reason marks an unexpected exit (the `crash:`/`error:` categories the
+    processor/loop error handlers write). The single owner of the crash-category vocabulary: it
+    drives the non-zero exit that lets Docker's on-failure policy recover the agent, the
+    inbox-override precedence on boot, and the render (crash reasons keep their marker)."""
+    return reason is not None and (reason.startswith("crash:") or reason.startswith("error:"))
+
+
 @dc.dataclass
 class ActiveTool:
     name: str

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -51,9 +51,9 @@ class QueuedTurn(tp.NamedTuple):
     interruptible: bool = True
 
 
-CLEAN_RESTART = "restart: clean restart"
-NIGHTLY_RESTART = "nightly: dreamer ran, session compacted for continuous context"
-CRASH_RESTART = "crash: restarted after unexpected exit"
+CLEAN_RESTART = "clean: routine restart, no specific reason"
+NIGHTLY_RESTART = "nightly: the dreamer ran and compacted your session for continuous context"
+CRASH_RESTART = "crash: restarted after an unexpected exit"
 FIRST_START_REASON = "first start"
 
 

--- a/agent/core/prompts/restart.md
+++ b/agent/core/prompts/restart.md
@@ -1,1 +1,1 @@
-You've restarted. Read the `restart` skill and follow it.
+Read the `restart` skill and follow it.

--- a/agent/core/state_store.py
+++ b/agent/core/state_store.py
@@ -42,6 +42,26 @@ def state_path(config: cfg.VestaConfig) -> pl.Path:
     return config.data_dir / STATE_FILENAME
 
 
+PENDING_REASON_FILENAME = "pending_restart_reason"
+
+
+def pending_reason_path(config: cfg.VestaConfig) -> pl.Path:
+    return config.data_dir / PENDING_REASON_FILENAME
+
+
+def take_pending_reason(config: cfg.VestaConfig) -> str | None:
+    """Read + delete the one-shot restart-reason inbox vestad may have written before this boot.
+
+    The file is transport, not storage: it is drained into last_restart_reason and removed so it
+    never re-fires on a later boot. Returns the stripped reason, or None if absent/empty."""
+    path = pending_reason_path(config)
+    if not path.exists():
+        return None
+    reason = path.read_text(encoding="utf-8").strip()
+    path.unlink(missing_ok=True)
+    return reason or None
+
+
 def load_state(config: cfg.VestaConfig) -> PersistedState:
     path = state_path(config)
     if path.exists():

--- a/agent/tests/test_boot_turns.py
+++ b/agent/tests/test_boot_turns.py
@@ -30,7 +30,7 @@ def test_boot_turns_ordered_migrations_then_skill_then_config_then_greeting(tmp_
         state=_authed_state(),
         config=config,
         config_issues=["BAD=1 is invalid; reverted to default"],
-        greeting_reason="restart: clean restart",
+        greeting_reason="clean: routine restart, no specific reason",
         first_start=False,
     )
 
@@ -39,7 +39,7 @@ def test_boot_turns_ordered_migrations_then_skill_then_config_then_greeting(tmp_
     assert "[Workspace sync]" in turns[1]
     assert "skills-install alpha" in turns[2]
     assert "BAD=1" in turns[3]
-    assert "[System: restart: clean restart]" in turns[4]
+    assert "[System Restart]\nReason: routine restart, no specific reason" in turns[4]
 
 
 def test_first_start_pre_marks_migrations_and_greets_with_setup(tmp_path):

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -202,6 +202,13 @@ def test_build_restart_context_renders_system_restart_header(tmp_path):
     assert summary.startswith("[Dreamer Summary: x]")
     assert prompt == "Read the `restart` skill and follow it."
 
+    # Crash/error reasons keep their marker: the restart skill branches on a crash boot
+    # ("crash -> mention it"), so the category must stay visible for dynamic crash strings.
+    out4 = helpers.build_restart_context("crash: JSONDecodeError: Expecting value", config)
+    assert "Reason: crash: JSONDecodeError: Expecting value" in out4
+    out5 = helpers.build_restart_context("error: Response timed out", config)
+    assert "Reason: error: Response timed out" in out5
+
 
 def test_shipped_restart_prompt_has_no_redundant_restarted_line():
     import pathlib
@@ -231,6 +238,35 @@ def test_consume_restart_reason_drains_pending_inbox(tmp_path):
 
     # Drained: the next boot falls back to CRASH_RESTART like any consumed reason.
     assert _consume_restart_reason(state, config, first_start=False) == vm.CRASH_RESTART
+
+
+def test_pending_inbox_never_masks_a_crash_reason(tmp_path):
+    from core.main import _consume_restart_reason
+
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent")
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+
+    state = vm.State()
+    state.persisted.last_restart_reason = "crash: TypeError: boom"
+    (config.data_dir / "pending_restart_reason").write_text("backup: you were paused for a scheduled backup\n")
+
+    # The crash the prior run recorded wins over the external reason, and the inbox is still
+    # consumed so it can't fire stale on a later boot.
+    assert _consume_restart_reason(state, config, first_start=False) == "crash: TypeError: boom"
+    assert not (config.data_dir / "pending_restart_reason").exists()
+
+
+def test_first_start_drains_the_inbox_so_it_cannot_fire_later(tmp_path):
+    from core.main import _consume_restart_reason
+
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent")
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+
+    state = vm.State()
+    (config.data_dir / "pending_restart_reason").write_text("mounts: you now have access to /media/Plex (read-only)\n")
+
+    assert _consume_restart_reason(state, config, first_start=True) == vm.FIRST_START_REASON
+    assert not (config.data_dir / "pending_restart_reason").exists(), "a stale inbox must not fire on a later boot"
 
 
 @pytest.mark.anyio

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -179,6 +179,37 @@ def test_reason_constants_follow_category_detail_shape():
     assert vm.NIGHTLY_RESTART == "nightly: the dreamer ran and compacted your session for continuous context"
 
 
+def test_build_restart_context_renders_system_restart_header(tmp_path):
+    from core import helpers
+
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent")
+    # core_prompts_dir == agent_dir/core/prompts; write a stand-in restart.md so load_prompt resolves.
+    config.core_prompts_dir.mkdir(parents=True, exist_ok=True)
+    (config.core_prompts_dir / "restart.md").write_text("Read the `restart` skill and follow it.\n")
+
+    out = helpers.build_restart_context(vm.NIGHTLY_RESTART, config)
+    assert out.startswith("[System Restart]\nReason: the dreamer ran and compacted your session for continuous context")
+    assert out.endswith("Read the `restart` skill and follow it.")
+
+    # A reason without a category prefix renders whole.
+    out2 = helpers.build_restart_context("first start", config)
+    assert "Reason: first start" in out2
+
+    # Extras (dreamer summary) slot between the header and the restart prompt.
+    out3 = helpers.build_restart_context(vm.NIGHTLY_RESTART, config, extras=["[Dreamer Summary: x]\nhello"])
+    header, summary, prompt = out3.split("\n\n")
+    assert header.startswith("[System Restart]")
+    assert summary.startswith("[Dreamer Summary: x]")
+    assert prompt == "Read the `restart` skill and follow it."
+
+
+def test_shipped_restart_prompt_has_no_redundant_restarted_line():
+    import pathlib
+
+    text = (pathlib.Path(__file__).parents[1] / "core" / "prompts" / "restart.md").read_text()
+    assert "You've restarted" not in text
+
+
 @pytest.mark.anyio
 async def test_client_cleared_on_cancellation(tmp_path):
     from core.loops import message_processor

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -210,6 +210,29 @@ def test_shipped_restart_prompt_has_no_redundant_restarted_line():
     assert "You've restarted" not in text
 
 
+def test_consume_restart_reason_drains_pending_inbox(tmp_path):
+    from core.main import _consume_restart_reason
+
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent")
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+
+    state = vm.State()
+    state.persisted.last_restart_reason = vm.CLEAN_RESTART
+
+    # No inbox -> existing behavior (returns the persisted reason).
+    assert _consume_restart_reason(state, config, first_start=False) == vm.CLEAN_RESTART
+
+    # Inbox present -> it wins over the persisted clean reason and the file is removed one-shot.
+    state.persisted.last_restart_reason = vm.CLEAN_RESTART
+    (config.data_dir / "pending_restart_reason").write_text("mounts: you now have read-only access to /media/Plex\n")
+    got = _consume_restart_reason(state, config, first_start=False)
+    assert got == "mounts: you now have read-only access to /media/Plex"
+    assert not (config.data_dir / "pending_restart_reason").exists()
+
+    # Drained: the next boot falls back to CRASH_RESTART like any consumed reason.
+    assert _consume_restart_reason(state, config, first_start=False) == vm.CRASH_RESTART
+
+
 @pytest.mark.anyio
 async def test_client_cleared_on_cancellation(tmp_path):
     from core.loops import message_processor

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -169,6 +169,16 @@ def test_restart_reason_round_trip(tmp_path):
     assert _consume_restart_reason(again, config, first_start=False) == vm.CRASH_RESTART
 
 
+def test_reason_constants_follow_category_detail_shape():
+    for const in (vm.CLEAN_RESTART, vm.NIGHTLY_RESTART, vm.CRASH_RESTART):
+        assert ": " in const, f"{const!r} must be 'category: detail'"
+        category = const.split(": ", 1)[0]
+        assert category in {"clean", "nightly", "crash", "error"}, category
+        assert "—" not in const and "–" not in const
+    assert vm.CLEAN_RESTART == "clean: routine restart, no specific reason"
+    assert vm.NIGHTLY_RESTART == "nightly: the dreamer ran and compacted your session for continuous context"
+
+
 @pytest.mark.anyio
 async def test_client_cleared_on_cancellation(tmp_path):
     from core.loops import message_processor
@@ -431,7 +441,7 @@ async def test_cancellation_triggers_restart(tmp_path):
             await _run_messages_with_interrupts(vm.QueuedTurn("msg", True, []), queue=queue, state=state, config=config)
 
     assert state.graceful_shutdown.is_set()
-    assert state.persisted.last_restart_reason == "error: processing cancelled"
+    assert state.persisted.last_restart_reason == "error: a turn was cancelled unexpectedly"
 
 
 @pytest.mark.anyio
@@ -490,7 +500,7 @@ async def test_handle_processor_done_silent_cancel_triggers_restart(tmp_path):
     handle_processor_done(task, state=state, config=config)
 
     assert state.graceful_shutdown.is_set()
-    assert state.persisted.last_restart_reason == "crash: processor cancelled unexpectedly"
+    assert state.persisted.last_restart_reason == "crash: the processor was cancelled unexpectedly"
 
 
 @pytest.mark.anyio
@@ -534,7 +544,7 @@ async def test_handle_processor_done_silent_exit_triggers_restart(tmp_path):
     handle_processor_done(task, state=state, config=config)
 
     assert state.graceful_shutdown.is_set()
-    assert state.persisted.last_restart_reason == "crash: processor exited silently"
+    assert state.persisted.last_restart_reason == "crash: the processor exited silently"
 
 
 @pytest.mark.anyio

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -136,6 +136,7 @@ async def test_restarts_on_timeout(tmp_path):
     reason, and that reason must classify as a CRASH so main() exits non-zero and Docker's
     on-failure policy restarts the container — under on-failure a clean exit 0 would leave the agent
     hung-then-permanently-down."""
+
     async def side_effect(msg, *, state, config, is_user):
         raise TimeoutError()
 

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -136,8 +136,6 @@ async def test_restarts_on_timeout(tmp_path):
     reason, and that reason must classify as a CRASH so main() exits non-zero and Docker's
     on-failure policy restarts the container — under on-failure a clean exit 0 would leave the agent
     hung-then-permanently-down."""
-    from core.main import _is_crash_reason
-
     async def side_effect(msg, *, state, config, is_user):
         raise TimeoutError()
 
@@ -146,7 +144,7 @@ async def test_restarts_on_timeout(tmp_path):
     )
     assert state.graceful_shutdown.is_set()
     assert state.persisted.last_restart_reason == "error: Response timed out"
-    assert _is_crash_reason(state.persisted.last_restart_reason), "an SDK-hang timeout must classify as a crash so on-failure restarts it"
+    assert vm.is_crash_reason(state.persisted.last_restart_reason), "an SDK-hang timeout must classify as a crash so on-failure restarts it"
 
 
 def test_restart_reason_round_trip(tmp_path):
@@ -208,13 +206,6 @@ def test_build_restart_context_renders_system_restart_header(tmp_path):
     assert "Reason: crash: JSONDecodeError: Expecting value" in out4
     out5 = helpers.build_restart_context("error: Response timed out", config)
     assert "Reason: error: Response timed out" in out5
-
-
-def test_shipped_restart_prompt_has_no_redundant_restarted_line():
-    import pathlib
-
-    text = (pathlib.Path(__file__).parents[1] / "core" / "prompts" / "restart.md").read_text()
-    assert "You've restarted" not in text
 
 
 def test_consume_restart_reason_drains_pending_inbox(tmp_path):

--- a/docs/superpowers/plans/2026-07-05-restart-reason-interface.md
+++ b/docs/superpowers/plans/2026-07-05-restart-reason-interface.md
@@ -1,0 +1,626 @@
+# Restart-reason interface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let external actors (vestad backup, mount grants, the app) attach a human restart reason the agent surfaces on boot, and standardize all restart-reason copy + the boot message.
+
+**Architecture:** One store (`state.persisted.last_restart_reason`) plus a transient host→container inbox file (`pending_restart_reason`) that vestad writes and the agent drains into that store on boot. Every reason is a `category: detail` string; the boot turn renders as `[System Restart] / Reason: {detail}`.
+
+**Tech Stack:** Python 3 async agent (`uv`), Rust (`vestad`, bollard/axum), docker `cp` via existing `docker_cp_content`.
+
+## Global Constraints
+
+- Python: always `uv run`; no `getattr`/dict `.get()`/`hasattr`; functional (no classes-with-methods); line length 144; `%`-style logging.
+- Rust: no `unwrap`/`expect`/`panic!` on fallible paths; named consts for literals; descriptive names.
+- Copy: no em-dash (`—`) or en-dash (`–`) in `agent/core/prompts/**` or `agent/skills/**/SKILL.md` (CI `test_deployment.py`). Keep reason strings ASCII-hyphen only.
+- Brand voice: never gender Vesta; the agent is addressed as "you" in these strings, which is fine.
+- Reason contract: every reason is `"<category>: <detail>"`; `category` ∈ {`clean`,`nightly`,`crash`,`error`,`backup`,`mounts`,`manual`}; `detail` is lowercase, no trailing period, no dash.
+- Inbox file path (both sides must agree): container path `/root/agent/data/pending_restart_reason`.
+
+---
+
+### Task 1: Standardize the reason copy (agent constants + call sites)
+
+**Files:**
+- Modify: `agent/core/models.py:54-57`
+- Modify: `agent/core/main.py:84,90,93` (crash strings)
+- Modify: `agent/core/loops.py:224,246` (error strings)
+- Test: `agent/tests/test_processor.py` (new assertion near `test_restart_reason_round_trip`)
+
+**Interfaces:**
+- Produces: standardized reason constants `CLEAN_RESTART`, `NIGHTLY_RESTART`, `CRASH_RESTART` and the `crash:`/`error:` prefixes consumed by `_is_crash_reason` and by Task 2's renderer.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `agent/tests/test_processor.py`:
+
+```python
+def test_reason_constants_follow_category_detail_shape():
+    from core import models as vm
+
+    for const in (vm.CLEAN_RESTART, vm.NIGHTLY_RESTART, vm.CRASH_RESTART):
+        assert ": " in const, f"{const!r} must be 'category: detail'"
+        category = const.split(": ", 1)[0]
+        assert category in {"clean", "nightly", "crash", "error"}, category
+        assert "—" not in const and "–" not in const
+    assert vm.CLEAN_RESTART == "clean: routine restart, no specific reason"
+    assert vm.NIGHTLY_RESTART == "nightly: the dreamer ran and compacted your session for continuous context"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd agent && uv run pytest tests/test_processor.py::test_reason_constants_follow_category_detail_shape -v`
+Expected: FAIL (`CLEAN_RESTART` is still `"restart: clean restart"`).
+
+- [ ] **Step 3: Standardize the constants and inline strings**
+
+`agent/core/models.py` (lines 54-56; leave `FIRST_START_REASON` as is):
+
+```python
+CLEAN_RESTART = "clean: routine restart, no specific reason"
+NIGHTLY_RESTART = "nightly: the dreamer ran and compacted your session for continuous context"
+CRASH_RESTART = "crash: restarted after an unexpected exit"
+```
+
+`agent/core/main.py` — update the three crash strings to conversational detail (keep the `crash:` prefix):
+- line 84: `state.persisted.last_restart_reason = "crash: the processor was cancelled unexpectedly"`
+- line 90: `state.persisted.last_restart_reason = f"crash: {type(exc).__name__}: {exc}"`  *(unchanged — already conformant)*
+- line 93: `state.persisted.last_restart_reason = "crash: the processor exited silently"`
+
+`agent/core/loops.py` — error strings (keep `error:` prefix):
+- line 224: `state.persisted.last_restart_reason = "error: a turn was cancelled"`
+- line 246: `state.persisted.last_restart_reason = f"error: {error_msg}"`  *(unchanged)*
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd agent && uv run pytest tests/test_processor.py::test_reason_constants_follow_category_detail_shape -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/core/models.py agent/core/main.py agent/core/loops.py agent/tests/test_processor.py
+git commit -m "refactor(agent): standardize restart reasons to category: detail"
+```
+
+---
+
+### Task 2: New boot-message render (`[System Restart]` / `Reason:`)
+
+**Files:**
+- Modify: `agent/core/helpers.py:21-28` (`build_restart_context`)
+- Modify: `agent/core/prompts/restart.md`
+- Test: `agent/tests/test_processor.py`
+
+**Interfaces:**
+- Consumes: the `category: detail` reason strings from Task 1.
+- Produces: `build_restart_context(reason, config, *, extras)` rendering `[System Restart]\nReason: {detail}\n\n{extras}\n\n{restart.md}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_build_restart_context_renders_system_restart_header(tmp_path):
+    from core import helpers, models as vm
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent")
+    # core_prompts_dir == agent_dir/core/prompts; write a stand-in restart.md so load_prompt resolves.
+    config.core_prompts_dir.mkdir(parents=True, exist_ok=True)
+    (config.core_prompts_dir / "restart.md").write_text("Read the `restart` skill and follow it.\n")
+
+    out = helpers.build_restart_context(
+        "nightly: the dreamer ran and compacted your session for continuous context", config
+    )
+    assert out.startswith(
+        "[System Restart]\nReason: the dreamer ran and compacted your session for continuous context"
+    )
+    assert out.endswith("Read the `restart` skill and follow it.")
+    # a reason without a category prefix renders whole
+    out2 = helpers.build_restart_context("first start", config)
+    assert "Reason: first start" in out2
+```
+
+Also verify the shipped prompt was trimmed:
+
+```python
+def test_shipped_restart_prompt_has_no_redundant_restarted_line():
+    import pathlib
+    text = (pathlib.Path(__file__).parents[1] / "core" / "prompts" / "restart.md").read_text()
+    assert "You've restarted" not in text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd agent && uv run pytest tests/test_processor.py::test_build_restart_context_renders_system_restart_header -v`
+Expected: FAIL (current output is `[System: nightly: ...]`).
+
+- [ ] **Step 3: Implement the render + trim restart.md**
+
+`agent/core/helpers.py` replace `build_restart_context`:
+
+```python
+def build_restart_context(reason: str, config: vm.VestaConfig, *, extras: list[str] | None = None) -> str:
+    # Reasons are stored as "category: detail"; the category is an internal tag (drives the
+    # crash exit-code path), so show only the human detail under a clear restart header.
+    detail = reason.split(": ", 1)[1] if ": " in reason else reason
+    parts = [f"[System Restart]\nReason: {detail}"]
+    if extras:
+        parts.extend(extras)
+    greeting = load_prompt("restart", config) or ""
+    if greeting.strip():
+        parts.append(greeting.strip())
+    return "\n\n".join(parts)
+```
+
+`agent/core/prompts/restart.md` — drop the redundant lead sentence (first line becomes):
+
+```
+Read the `restart` skill and follow it.
+```
+
+(Leave the rest of `restart.md` unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd agent && uv run pytest tests/test_processor.py::test_build_restart_context_renders_system_restart_header -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/core/helpers.py agent/core/prompts/restart.md agent/tests/test_processor.py
+git commit -m "feat(agent): render boot reason as [System Restart] / Reason:"
+```
+
+---
+
+### Task 3: Drain the `pending_restart_reason` inbox on boot
+
+**Files:**
+- Modify: `agent/core/state_store.py` (add path + take helper)
+- Modify: `agent/core/main.py:218-225` (`_consume_restart_reason`)
+- Test: `agent/tests/test_processor.py`
+
+**Interfaces:**
+- Consumes: `config.data_dir`.
+- Produces: `state_store.take_pending_reason(config) -> str | None` (reads + unlinks the inbox), and `_consume_restart_reason` draining it into `last_restart_reason`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_consume_restart_reason_drains_pending_inbox(tmp_path):
+    from core import state_store, models as vm
+    from core.main import _consume_restart_reason
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent")
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+
+    state = vm.State()
+    state.persisted.last_restart_reason = vm.CLEAN_RESTART
+
+    # No inbox -> existing behavior (returns the persisted reason).
+    assert _consume_restart_reason(state, config, first_start=False) == vm.CLEAN_RESTART
+
+    # Inbox present -> it wins and the file is removed one-shot.
+    state.persisted.last_restart_reason = vm.CLEAN_RESTART
+    (config.data_dir / "pending_restart_reason").write_text("mounts: you now have read-only access to /media/Plex\n")
+    got = _consume_restart_reason(state, config, first_start=False)
+    assert got == "mounts: you now have read-only access to /media/Plex"
+    assert not (config.data_dir / "pending_restart_reason").exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd agent && uv run pytest tests/test_processor.py::test_consume_restart_reason_drains_pending_inbox -v`
+Expected: FAIL (`take_pending_reason` undefined / inbox ignored).
+
+- [ ] **Step 3: Implement the path + drain**
+
+`agent/core/state_store.py` add near `state_path`:
+
+```python
+PENDING_REASON_FILENAME = "pending_restart_reason"
+
+
+def pending_reason_path(config: cfg.VestaConfig) -> pl.Path:
+    return config.data_dir / PENDING_REASON_FILENAME
+
+
+def take_pending_reason(config: cfg.VestaConfig) -> str | None:
+    """Read + delete the one-shot restart-reason inbox vestad may have written before this boot.
+
+    Returns the stripped reason, or None if absent. The file is transport, not storage: it is
+    drained into last_restart_reason and removed so it never re-fires on a later boot."""
+    path = pending_reason_path(config)
+    if not path.exists():
+        return None
+    reason = path.read_text(encoding="utf-8").strip()
+    path.unlink(missing_ok=True)
+    return reason or None
+```
+
+`agent/core/main.py` — update `_consume_restart_reason`:
+
+```python
+def _consume_restart_reason(state: vm.State, config: vm.VestaConfig, *, first_start: bool) -> str:
+    """Return the reason to log for this boot and clear it from persisted state. On a never-run agent the absence of a stored reason is innocent; report FIRST_START_REASON instead of a misleading crash label."""
+    if first_start:
+        return vm.FIRST_START_REASON
+    pending = state_store.take_pending_reason(config)
+    if pending is not None:
+        # An external actor (vestad backup/mounts/manual) handed in a reason for this boot.
+        state.persisted.last_restart_reason = pending
+    stored = state.persisted.last_restart_reason
+    state.persisted.last_restart_reason = None
+    state_store.save_state(state.persisted, config)
+    return stored or vm.CRASH_RESTART
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd agent && uv run pytest tests/test_processor.py::test_consume_restart_reason_drains_pending_inbox -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole agent suite gate**
+
+Run: `cd agent && uv run pytest tests/test_processor.py -q`
+Expected: PASS (no regressions in the existing restart-reason round-trip).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/core/state_store.py agent/core/main.py agent/tests/test_processor.py
+git commit -m "feat(agent): drain pending_restart_reason inbox into the boot reason"
+```
+
+---
+
+### Task 4: vestad `write_pending_restart_reason` helper + route backup through it
+
+**Files:**
+- Modify: `vestad/src/docker.rs` (near `docker_cp_content` @ 1530)
+- Modify: `vestad/src/backup.rs:106-119`
+- Test: `vestad/src/docker.rs` (unit: const value)
+
+**Interfaces:**
+- Produces: `pub(crate) const PENDING_RESTART_REASON_PATH: &str` and `pub(crate) async fn write_pending_restart_reason(docker: &Docker, cname: &str, reason: &str) -> Result<(), DockerError>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)]` module in `vestad/src/docker.rs`:
+
+```rust
+#[test]
+fn pending_restart_reason_path_matches_agent_contract() {
+    assert_eq!(super::PENDING_RESTART_REASON_PATH, "/root/agent/data/pending_restart_reason");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd vestad && VESTAD_SKIP_APP_BUILD=1 cargo test -p vestad --bin vestad pending_restart_reason_path -- --nocapture`
+Expected: FAIL to compile (const undefined).
+
+- [ ] **Step 3: Add the helper and const**
+
+`vestad/src/docker.rs` just above `docker_cp_content`:
+
+```rust
+/// One-shot inbox the agent drains on its next boot (see agent `state_store.take_pending_reason`).
+/// Written before a stop/recreate so the reason survives into the next boot; plain text, no schema.
+pub(crate) const PENDING_RESTART_REASON_PATH: &str = "/root/agent/data/pending_restart_reason";
+
+/// Write `reason` into the agent's boot inbox. Best-effort at the call site: a failed write only
+/// costs a missing greeting line, never the restart itself.
+pub(crate) async fn write_pending_restart_reason(docker: &Docker, cname: &str, reason: &str) -> Result<(), DockerError> {
+    docker_cp_content(docker, cname, reason, PENDING_RESTART_REASON_PATH).await
+}
+```
+
+- [ ] **Step 4: Route backup through the helper (standardized copy, new path)**
+
+`vestad/src/backup.rs` replace the inline `docker_cp_content(...)` block (106-119) with:
+
+```rust
+        tracing::info!(agent = %name, "stopping agent for backup");
+        if let Err(err) = write_pending_restart_reason(docker, &cname, "backup: you were paused for a scheduled backup").await {
+            tracing::warn!(agent = %name, error = %err, "failed to write restart reason");
+        }
+        stop_container_with_timeout(docker, &cname, BACKUP_STOP_TIMEOUT_SECS).await.ok();
+```
+
+Update the import at `vestad/src/backup.rs:7` — replace `docker_cp_content` with `write_pending_restart_reason`.
+
+- [ ] **Step 5: Run test + compile**
+
+Run: `cd vestad && VESTAD_SKIP_APP_BUILD=1 cargo test -p vestad --bin vestad pending_restart_reason_path`
+Expected: PASS. Then `VESTAD_SKIP_APP_BUILD=1 cargo check -p vestad` → clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vestad/src/docker.rs vestad/src/backup.rs
+git commit -m "feat(vestad): write_pending_restart_reason helper; route backup through it"
+```
+
+---
+
+### Task 5: Mount-change reason generator (pure)
+
+**Files:**
+- Modify: `vestad/src/mounts.rs`
+- Test: `vestad/src/mounts.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `actual: &[(String, String, bool)]` (container mounts as `(host, container, writable)`, from `docker::actual_user_mounts`) and `desired: &[HostMount]`.
+- Produces: `pub fn mount_change_reason(actual: &[(String, String, bool)], desired: &[HostMount]) -> Option<String>` returning a `mounts: …` string or None if nothing changed.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `vestad/src/mounts.rs` tests:
+
+```rust
+    fn m(c: &str, w: bool) -> HostMount {
+        HostMount { host_path: c.into(), container_path: c.into(), writable: w }
+    }
+
+    #[test]
+    fn mount_change_reason_grants_removals_and_mixed() {
+        // single grant
+        assert_eq!(
+            mount_change_reason(&[], &[m("/media/Plex", false)]).as_deref(),
+            Some("mounts: you now have access to /media/Plex (read-only)")
+        );
+        // multiple grants
+        assert_eq!(
+            mount_change_reason(&[], &[m("/media/Plex", false), m("/downloads", true)]).as_deref(),
+            Some("mounts: you now have access to /media/Plex (read-only) and /downloads (read-write)")
+        );
+        // removal only
+        assert_eq!(
+            mount_change_reason(&[("/media/Plex".into(), "/media/Plex".into(), false)], &[]).as_deref(),
+            Some("mounts: your access to /media/Plex was removed")
+        );
+        // mixed
+        assert_eq!(
+            mount_change_reason(
+                &[("/old".into(), "/old".into(), false)],
+                &[m("/media/Plex", false)]
+            ).as_deref(),
+            Some("mounts: filesystem access changed. granted: /media/Plex (read-only); removed: /old")
+        );
+        // no change
+        assert_eq!(mount_change_reason(&[("/x".into(), "/x".into(), true)], &[m("/x", true)]), None);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd vestad && VESTAD_SKIP_APP_BUILD=1 cargo test -p vestad --bin vestad mount_change_reason`
+Expected: FAIL to compile (function undefined).
+
+- [ ] **Step 3: Implement the generator**
+
+`vestad/src/mounts.rs`:
+
+```rust
+/// Join items as "a", "a and b", or "a, b and c" for human-readable reason copy.
+fn join_and(items: &[String]) -> String {
+    match items {
+        [] => String::new(),
+        [one] => one.clone(),
+        [head @ .., last] => format!("{} and {}", head.join(", "), last),
+    }
+}
+
+/// A `mounts:` restart reason describing a grant change, or None if nothing changed.
+/// `actual` is the container's current user binds as (host, container, writable); `desired` is the
+/// new grant list. Classification is by container_path; a writable flip reads as a fresh grant.
+pub fn mount_change_reason(actual: &[(String, String, bool)], desired: &[HostMount]) -> Option<String> {
+    let actual_set: std::collections::HashSet<(&str, bool)> =
+        actual.iter().map(|(_, c, w)| (c.as_str(), *w)).collect();
+    let actual_paths: std::collections::HashSet<&str> = actual.iter().map(|(_, c, _)| c.as_str()).collect();
+    let desired_paths: std::collections::HashSet<&str> = desired.iter().map(|m| m.container_path.as_str()).collect();
+
+    let mode = |w: bool| if w { "read-write" } else { "read-only" };
+
+    let granted: Vec<String> = desired
+        .iter()
+        .filter(|mnt| !actual_set.contains(&(mnt.container_path.as_str(), mnt.writable)))
+        .map(|mnt| format!("{} ({})", mnt.container_path, mode(mnt.writable)))
+        .collect();
+    let removed: Vec<String> = actual
+        .iter()
+        .filter(|(_, c, _)| !desired_paths.contains(c.as_str()))
+        .map(|(_, c, _)| c.clone())
+        .collect();
+    let _ = actual_paths; // reserved for future writable-change wording
+
+    match (granted.is_empty(), removed.is_empty()) {
+        (true, true) => None,
+        (false, true) => Some(format!("mounts: you now have access to {}", join_and(&granted))),
+        (true, false) => Some(format!("mounts: your access to {} was removed", join_and(&removed))),
+        (false, false) => Some(format!(
+            "mounts: filesystem access changed. granted: {}; removed: {}",
+            granted.join(", "),
+            removed.join(", ")
+        )),
+    }
+}
+```
+
+> Remove the unused `actual_paths`/`let _ =` lines if clippy flags them; they are only a hint for a future writable-change branch.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd vestad && VESTAD_SKIP_APP_BUILD=1 cargo test -p vestad --bin vestad mount_change_reason`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vestad/src/mounts.rs
+git commit -m "feat(vestad): mount-change restart-reason generator"
+```
+
+---
+
+### Task 6: Thread the reason through `restart_agent` + optional `{reason}` API
+
+**Files:**
+- Modify: `vestad/src/docker.rs:1835-1862` (`restart_agent`)
+- Modify: `vestad/src/serve.rs:634-655` (`restart_agent_handler`) + a `RestartBody` struct
+- Test: `vestad/src/docker.rs` behavioral note (compile + existing docker-gated coverage)
+
+**Interfaces:**
+- Consumes: `write_pending_restart_reason` (Task 4), `mount_change_reason` (Task 5), `actual_user_mounts`/`user_mounts_drifted` (existing).
+- Produces: `restart_agent(docker, name, env_config, user_mounts, reason: Option<String>)` and a handler accepting an optional `{ "reason": "manual: ..." }` body.
+
+- [ ] **Step 1: Add `reason` param to `restart_agent` and write the inbox once**
+
+Rewrite `vestad/src/docker.rs` `restart_agent` so it inspects once, picks the effective reason (caller-supplied wins; else mount-drift synthesized), writes it before any stop, then branches:
+
+```rust
+pub async fn restart_agent(
+    docker: &Docker,
+    name: &str,
+    env_config: &AgentEnvConfig,
+    user_mounts: &[crate::mounts::HostMount],
+    reason: Option<String>,
+) -> Result<(), DockerError> {
+    validate_name(name)?;
+    let cname = container_name(name);
+    ensure_exists(docker, &cname).await?;
+
+    let inspected = docker.inspect_container(&cname, None).await.ok();
+    let drifted = inspected
+        .as_ref()
+        .map(|raw| user_mounts_drifted(&actual_user_mounts(raw), user_mounts))
+        .unwrap_or(false);
+
+    // Effective reason for this boot: an explicit caller reason wins; otherwise, if grants drifted,
+    // synthesize one from the delta. Written before the container stops so it lands in the snapshot.
+    let effective_reason = reason.or_else(|| {
+        inspected
+            .as_ref()
+            .and_then(|raw| crate::mounts::mount_change_reason(&actual_user_mounts(raw), user_mounts))
+    });
+    if let Some(text) = &effective_reason {
+        if let Err(err) = write_pending_restart_reason(docker, &cname, text).await {
+            tracing::warn!(agent = %name, error = %err, "failed to write restart reason");
+        }
+    }
+
+    if drifted {
+        let available = docker_storage_available_bytes(docker).await;
+        if reconcile_blocked_by_disk(available) {
+            tracing::warn!(agent = %name, "mount grants changed but disk is critically low; skipping recreate, applying on next reconcile");
+        } else {
+            tracing::info!(agent = %name, "restart: mount grants drifted, recreating");
+            rebuild_agent(docker, name, env_config, user_mounts).await?;
+            return start_agent(docker, name).await;
+        }
+    }
+    docker.restart_container(&cname, Some(RestartContainerOptions { t: Some(CONTAINER_RESTART_TIMEOUT_SECS), signal: None })).await?;
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Update the handler to accept an optional reason**
+
+`vestad/src/serve.rs` — add near the other body structs:
+
+```rust
+#[derive(Deserialize, Default)]
+struct RestartBody {
+    #[serde(default)]
+    reason: Option<String>,
+}
+```
+
+Change `restart_agent_handler` to take an optional body (last extractor) and thread it through the detached op. Signature + call:
+
+```rust
+async fn restart_agent_handler(
+    State(state): State<SharedState>,
+    Path(name): Path<String>,
+    body: Option<Json<RestartBody>>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    tracing::info!(name = %name, "restarting agent");
+    let reason = body.and_then(|Json(b)| b.reason);
+    // Detached from this request's connection (see spawn_detached): a self-restart's client is the
+    // agent inside the very container this stops.
+    spawn_detached(async move {
+        let _guard = agent_write_guard(&state, &name).await;
+        {
+            let mut settings = state.settings.write().await;
+            settings.agents.entry(name.clone()).or_default().user_desired = UserDesired::Running;
+            save_settings(&settings);
+        }
+        let user_mounts = {
+            let settings = state.settings.read().await;
+            settings.agents.get(&name).map(|s| s.mounts.clone()).unwrap_or_default()
+        };
+        docker::restart_agent(&state.docker, &name, &state.env_config, &user_mounts, reason)
+            .await
+            .map_err(map_docker_err)?;
+        Ok(ok_json())
+    })
+    .await
+}
+```
+
+- [ ] **Step 3: Fix other `restart_agent` call sites**
+
+Run: `cd vestad && rg -n 'restart_agent\(' src | rg -v 'fn restart_agent|restart_agent_handler'`
+For each caller not passing a reason, add a trailing `None`. Expected callers: none outside the handler — but verify; if any internal caller exists (e.g. provider flow), pass `None`.
+
+- [ ] **Step 4: Compile + full vestad unit suite**
+
+Run: `cd vestad && VESTAD_SKIP_APP_BUILD=1 cargo test -p vestad --bin vestad`
+Expected: PASS (168+ tests, including the earlier `restart_detach` test).
+
+Run: `cd vestad && VESTAD_SKIP_APP_BUILD=1 cargo clippy -p vestad --all-targets -- -D warnings 2>&1 | rg -v '2994|assertions_on_constants' | tail`
+Expected: no new warnings from these files (the pre-existing `assertions_on_constants` at serve.rs:2994 is unrelated).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vestad/src/docker.rs vestad/src/serve.rs
+git commit -m "feat(vestad): attach restart reason (manual + mount delta) to the boot inbox"
+```
+
+---
+
+### Task 7: End-to-end verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Agent checks**
+
+Run: `./check.sh agent`
+Expected: ruff + ty + pytest all green.
+
+- [ ] **Step 2: vestad checks (skip web build)**
+
+Run: `VESTAD_SKIP_APP_BUILD=1 ./check.sh vestad`
+Expected: clippy clean (modulo the pre-existing serve.rs:2994 lint) + `cargo test -p vestad` green.
+
+- [ ] **Step 3: Manual render sanity**
+
+Run (from `agent/`, so `agent_dir=.` resolves `./core/prompts/restart.md`):
+`cd agent && uv run python -c "from pathlib import Path; from core import helpers, models as vm; c=vm.VestaConfig(agent_dir=Path('.')); print(helpers.build_restart_context('mounts: you now have read-only access to /media/Plex', c))"`
+Expected output begins:
+```
+[System Restart]
+Reason: you now have read-only access to /media/Plex
+```
+
+- [ ] **Step 4: Commit any doc touch-ups, then open the stacked PR**
+
+```bash
+gh pr create --base feat/host-filesystem-grants --title "feat: external restart-reason interface" --body "<summary + 'stacked on #974; retarget to master after it merges'>"
+```
+
+## Self-Review notes
+
+- Spec coverage: reader (Task 3), writer helper + backup (Task 4), mounts generator (Task 5), API `{reason}` + mount-drift wiring (Task 6), standardized copy (Task 1) + render (Task 2). All spec sections mapped.
+- Out of scope (per spec): web app sending a `{reason}` on manual restart; richer structured reasons.
+- Crash/exit path untouched: `_is_crash_reason` still reads the stored `crash:`/`error:` prefixed string; the render only strips the prefix for display.

--- a/docs/superpowers/specs/2026-07-05-restart-reason-interface-design.md
+++ b/docs/superpowers/specs/2026-07-05-restart-reason-interface-design.md
@@ -65,9 +65,8 @@ it reads the field:
    `state.persisted.last_restart_reason`, and `unlink` the file (one-shot).
 2. Then the function proceeds exactly as today: return the field, clear it, save state.
 
-The result flows unchanged into `greeting_reason` → the greeting boot turn, so the agent
-naturally says e.g. "you're awake — you now have read-only access to `/media/Plex`." Absent
-inbox file → today's behavior, unchanged.
+The result flows unchanged into `greeting_reason` → the greeting boot turn, rendered per the
+standardized format below. Absent inbox file → today's behavior, unchanged.
 
 **Why draining is safe and unambiguous:** a `vestad`-driven restart exits the agent cleanly,
 so the field would otherwise be `CLEAN_RESTART`; draining overwrites that placeholder with the
@@ -84,21 +83,59 @@ untouched.
   the path from `restart_reason` to `pending_restart_reason`) and stops being a dead write —
   the agent will now surface "I was paused for a backup."
 - **Mounts (motivating caller):** `restart_agent` already computes the actual-vs-desired mount
-  diff to decide whether to rebuild. In that branch it writes a reason describing the delta
-  (e.g. "granted read-only access to /media/Plex") before recreating. **No app or API change
-  needed** — vestad synthesizes it from the diff it already has.
+  diff to decide whether to rebuild. In that branch it synthesizes a `mounts:` reason from the
+  full delta (adds and removes together — one `PUT /mounts` can change several at once) before
+  recreating. **No app or API change needed** — vestad has the diff. Copy generator:
+  - only grants: `mounts: you now have access to /media/Plex (read-only) and /downloads (read-write)`
+  - only removals: `mounts: your access to /media/Plex and /old was removed`
+  - both: `mounts: filesystem access changed. granted: /media/Plex (read-only); removed: /old`
 - **The general interface:** `POST /agents/{name}/restart` gains an optional `{reason}` field.
-  When present, vestad writes it before the restart. This is the interface external callers
-  (app "restart" button, CLI) use to attach a human reason.
+  When present, vestad writes it before the restart. This is the interface external callers use
+  to attach a human reason — e.g. the app, after a provider change, restarts with
+  `manual: switching to Claude Opus 4.8` (it knows the model it just set).
+
+## Standardized reason copy and boot message
+
+Every reason is a single `category: detail` string; `category` is a fixed small set, `detail`
+is a lowercase plain-language phrase with no trailing period and no em/en dash. The `category`
+is a machine tag (`_is_crash_reason` keys on `crash`/`error`); it is **not shown** to the agent.
+
+| Category | Copy |
+|---|---|
+| `clean` | `clean: routine restart, no specific reason` |
+| `nightly` | `nightly: the dreamer ran and compacted your session for continuous context` |
+| `crash` | `crash: {detail}` (e.g. `crash: the processor exited unexpectedly`) |
+| `error` | `error: {detail}` (e.g. `error: a turn failed to complete`) |
+| `backup` | `backup: you were paused for a scheduled backup` |
+| `mounts` | `mounts: {delta}` (see the generator above) |
+| `manual` | `manual: {caller-supplied}` (e.g. `manual: switching to Claude Opus 4.8`) |
+
+**Render (`build_restart_context`).** The stored `category: detail` is split on the first
+`": "`; only the detail is shown, under a clear restart header:
+
+```
+[System Restart]
+Reason: {detail}
+
+Read the `restart` skill and follow it.
+```
+
+A pending dreamer summary still slots between the `Reason:` line and the `restart.md` line.
+`restart.md` drops its leading "You've restarted." — the `[System Restart]` header now carries
+that, avoiding the doubled statement (per the "no redundant instructions" guidance). If a
+stored reason somehow lacks a `category: ` prefix, the whole string renders as the detail.
 
 ## Scope
 
 **In:**
 - Agent-side drain in `_consume_restart_reason` + an inbox-path constant + unit tests.
+- Standardized reason copy (the constants in `models.py` + the crash/error/dreamer strings)
+  and the new `[System Restart]` / `Reason:` render in `build_restart_context`; `restart.md`
+  drops "You've restarted."
 - `write_pending_restart_reason` helper; `backup.rs` routed through it; path renamed to
-  `pending_restart_reason`.
+  `pending_restart_reason`; its copy standardized to `backup: …`.
 - Optional `{reason}` on `POST /agents/{name}/restart`.
-- Mount-drift branch of `restart_agent` writes a synthesized reason.
+- Mount-drift branch of `restart_agent` writes a synthesized `mounts:` reason (multi-mount).
 
 **Out (follow-ups, not this change):**
 - Wiring the web app to *send* a reason on manual restart. The API accepting `{reason}` is the
@@ -110,8 +147,11 @@ untouched.
 - **Agent** (`tests/test_processor.py`, near the existing `test_restart_reason_round_trip`):
   inbox present → `_consume_restart_reason` returns its content and the file is removed; inbox
   present over a persisted `CLEAN_RESTART` → inbox wins; inbox absent → existing behavior.
-- **vestad:** `write_pending_restart_reason` writes the agreed path (docker-gated); the
-  mount-drift restart writes a reason (docker-gated, alongside the existing recreate coverage).
+- **Agent render:** `build_restart_context` strips the `category:` prefix and emits the
+  `[System Restart]` / `Reason:` block; a prefix-less reason renders whole; `_is_crash_reason`
+  still true for `crash:`/`error:` categories.
+- **vestad:** `write_pending_restart_reason` writes the agreed path (docker-gated); the mount
+  reason generator (only-grants / only-removals / both, single and multi) as a pure unit test.
 
 ## Blast radius
 

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -91,11 +91,14 @@ fn parse_rfc3339_epoch(ts: &str) -> Option<u64> {
     Some(dt.unix_timestamp() as u64)
 }
 
-/// Stop (if running), run `op`, restart. Writes a restart reason for the agent.
+/// Stop (if running), run `op`, restart. Writes `resume_reason` into the agent's boot inbox for
+/// the restart. The write happens AFTER `op` — writing before the stop would bake the reason into
+/// the snapshot `op` takes, and a restore of that backup would replay it as a stale greeting.
 async fn with_container_paused<F, Fut, T>(
     docker: &Docker,
     name: &str,
     cs: ContainerStatus,
+    resume_reason: &str,
     op: F,
 ) -> T
 where
@@ -106,9 +109,6 @@ where
     let was_running = cs == ContainerStatus::Running;
     if was_running {
         tracing::info!(agent = %name, "stopping agent for backup");
-        if let Err(err) = write_pending_restart_reason(docker, &cname, "backup: you were paused for a scheduled backup").await {
-            tracing::warn!(agent = %name, error = %err, "failed to write restart reason");
-        }
         stop_container_with_timeout(docker, &cname, BACKUP_STOP_TIMEOUT_SECS).await.ok();
     }
 
@@ -116,9 +116,21 @@ where
 
     if was_running {
         tracing::info!(agent = %name, "restarting agent");
+        if let Err(err) = write_pending_restart_reason(docker, &cname, resume_reason).await {
+            tracing::warn!(agent = %name, error = %err, "failed to write restart reason");
+        }
         start_container(docker, &cname).await;
     }
     result
+}
+
+/// The boot reason for the restart after a backup pause, by what triggered the backup.
+fn backup_resume_reason(backup_type: &BackupType) -> &'static str {
+    match backup_type {
+        BackupType::Manual => "backup: you were paused for a manual backup",
+        BackupType::PreRestore => "backup: you were paused for a safety backup before a restore",
+        BackupType::Daily | BackupType::Weekly | BackupType::Monthly => "backup: you were paused for a scheduled backup",
+    }
 }
 
 /// Validate the agent, confirm its container is backup-able (not NotFound/Dead),
@@ -151,7 +163,7 @@ pub async fn create_backup(
 ) -> Result<BackupInfo, DockerError> {
     let cs = backup_preflight(docker, name).await?;
 
-    let result = with_container_paused(docker, name, cs, || async {
+    let result = with_container_paused(docker, name, cs, backup_resume_reason(&backup_type), || async {
         tracing::info!(agent = %name, backup_type = %backup_type, "snapshotting backup");
         crate::restic::snapshot(name, &backup_type).await
     })
@@ -190,7 +202,8 @@ pub async fn create_backups_batch(
         Err(e) => return fail_all(types, e),
     };
 
-    with_container_paused(docker, name, cs, || async {
+    // Batch backups are only ever the auto-backup's scheduled set, so one scheduled reason fits.
+    with_container_paused(docker, name, cs, "backup: you were paused for a scheduled backup", || async {
         let mut results = Vec::new();
         for bt in types {
             let result = crate::restic::snapshot(name, &bt).await;

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -4,8 +4,8 @@ use bollard::Docker;
 
 use crate::docker::{
     container_created, container_name, container_size_root_fs, container_size_rw, container_status, create_container,
-    docker_cp_content, inspect_container, remove_container_force, start_container,
-    stop_container_with_timeout, validate_name, AgentEnvConfig, ContainerStatus, DockerError,
+    inspect_container, remove_container_force, start_container, stop_container_with_timeout, validate_name,
+    write_pending_restart_reason, AgentEnvConfig, ContainerStatus, DockerError,
 };
 use crate::types::{BackupInfo, BackupType, RetentionPolicy};
 
@@ -106,14 +106,7 @@ where
     let was_running = cs == ContainerStatus::Running;
     if was_running {
         tracing::info!(agent = %name, "stopping agent for backup");
-        if let Err(err) = docker_cp_content(
-            docker,
-            &cname,
-            "backup — paused for backup",
-            "/root/agent/data/restart_reason",
-        )
-        .await
-        {
+        if let Err(err) = write_pending_restart_reason(docker, &cname, "backup: you were paused for a scheduled backup").await {
             tracing::warn!(agent = %name, error = %err, "failed to write restart reason");
         }
         stop_container_with_timeout(docker, &cname, BACKUP_STOP_TIMEOUT_SECS).await.ok();

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -124,12 +124,14 @@ where
     result
 }
 
+const SCHEDULED_BACKUP_RESUME_REASON: &str = "backup: you were paused for a scheduled backup";
+
 /// The boot reason for the restart after a backup pause, by what triggered the backup.
 fn backup_resume_reason(backup_type: &BackupType) -> &'static str {
     match backup_type {
         BackupType::Manual => "backup: you were paused for a manual backup",
         BackupType::PreRestore => "backup: you were paused for a safety backup before a restore",
-        BackupType::Daily | BackupType::Weekly | BackupType::Monthly => "backup: you were paused for a scheduled backup",
+        BackupType::Daily | BackupType::Weekly | BackupType::Monthly => SCHEDULED_BACKUP_RESUME_REASON,
     }
 }
 
@@ -203,7 +205,7 @@ pub async fn create_backups_batch(
     };
 
     // Batch backups are only ever the auto-backup's scheduled set, so one scheduled reason fits.
-    with_container_paused(docker, name, cs, "backup: you were paused for a scheduled backup", || async {
+    with_container_paused(docker, name, cs, SCHEDULED_BACKUP_RESUME_REASON, || async {
         let mut results = Vec::new();
         for bt in types {
             let result = crate::restic::snapshot(name, &bt).await;

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1876,10 +1876,12 @@ pub async fn restart_agent(
             }
             tracing::info!(agent = %name, "restart: mount grants drifted, recreating");
             // A caller-supplied reason wins; else describe the grant delta the rebuild applies.
-            // Written before the stop so it lands in the snapshot the new container boots from.
             let effective = reason.or_else(|| crate::mounts::mount_change_reason(&actual_user_mounts(&raw), user_mounts));
-            write_boot_reason(docker, name, &cname, effective).await;
             rebuild_agent(docker, name, env_config, user_mounts).await?;
+            // Written into the freshly created container AFTER the rebuild: a write before it
+            // would survive a failed rebuild in the old container, claiming access that was
+            // never applied (and would bake the reason into the rebuild snapshot).
+            write_boot_reason(docker, name, &cname, effective).await;
             return start_agent(docker, name).await;
         }
     } else {

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1862,7 +1862,8 @@ pub async fn restart_agent(
         // Scope the recreate to GRANT changes only: a plain restart can't add/remove a bind, but we
         // must not turn every restart into a full rebuild for unrelated drift (that's reconcile's job,
         // and it would mint a new agent token mid-session). Only user-mount drift triggers a recreate.
-        if user_mounts_drifted(&actual_user_mounts(&raw), user_mounts) {
+        let actual_mounts = actual_user_mounts(&raw);
+        if user_mounts_drifted(&actual_mounts, user_mounts) {
             // A recreate snapshots the container; skip it when disk is critically low (a mid-snapshot
             // failure corrupts the writable layer). Applying the grant IS the point of this restart, and
             // reconcile also skips rebuilds on low disk — so a plain restart wouldn't apply it either.
@@ -1876,7 +1877,7 @@ pub async fn restart_agent(
             }
             tracing::info!(agent = %name, "restart: mount grants drifted, recreating");
             // A caller-supplied reason wins; else describe the grant delta the rebuild applies.
-            let effective = crate::mounts::effective_restart_reason(reason, &actual_user_mounts(&raw), user_mounts);
+            let effective = crate::mounts::effective_restart_reason(reason, &actual_mounts, user_mounts);
             rebuild_agent(docker, name, env_config, user_mounts).await?;
             // Written into the freshly created container AFTER the rebuild: a write before it
             // would survive a failed rebuild in the old container, claiming access that was

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1876,7 +1876,7 @@ pub async fn restart_agent(
             }
             tracing::info!(agent = %name, "restart: mount grants drifted, recreating");
             // A caller-supplied reason wins; else describe the grant delta the rebuild applies.
-            let effective = reason.or_else(|| crate::mounts::mount_change_reason(&actual_user_mounts(&raw), user_mounts));
+            let effective = crate::mounts::effective_restart_reason(reason, &actual_user_mounts(&raw), user_mounts);
             rebuild_agent(docker, name, env_config, user_mounts).await?;
             // Written into the freshly created container AFTER the rebuild: a write before it
             // would survive a failed rebuild in the old container, claiming access that was
@@ -2028,7 +2028,13 @@ pub async fn reconcile_containers(
             }
         }
         match rebuild_agent(docker, name, env_config, &desired_mounts).await {
-            Ok(()) => tracing::info!(agent = %name, "rebuild complete"),
+            Ok(()) => {
+                tracing::info!(agent = %name, "rebuild complete");
+                // Grants can also land here (restart_agent defers to reconcile when disk is low or
+                // inspect fails); tell the agent about the delta, same as the restart path would.
+                let mount_reason = crate::mounts::mount_change_reason(&actual_user_mounts(&raw), &desired_mounts);
+                write_boot_reason(docker, name, cname, mount_reason).await;
+            }
             Err(e) => tracing::error!(agent = %name, error = %e, "rebuild failed"),
         }
     }

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1525,6 +1525,19 @@ pub async fn create_container(
     }
 }
 
+// --- Restart-reason inbox ---
+
+/// One-shot inbox the agent drains on its next boot (agent `state_store.take_pending_reason`).
+/// Written before a stop/recreate so the reason lands in the filesystem the next boot reads;
+/// plain text, no schema shared across the crate boundary.
+pub(crate) const PENDING_RESTART_REASON_PATH: &str = "/root/agent/data/pending_restart_reason";
+
+/// Write `reason` into the agent's boot inbox. Best-effort at every call site: a failed write
+/// only costs a missing greeting line, never the restart itself.
+pub(crate) async fn write_pending_restart_reason(docker: &Docker, cname: &str, reason: &str) -> Result<(), DockerError> {
+    docker_cp_content(docker, cname, reason, PENDING_RESTART_REASON_PATH).await
+}
+
 // --- Credential injection ---
 
 pub(crate) async fn docker_cp_content(docker: &Docker, container: &str, content: &str, dest: &str) -> Result<(), DockerError> {
@@ -2295,6 +2308,12 @@ mod tests {
     // sets it via the bollard enum (create_container / ensure_on_failure_policy); the tests only
     // need a "normal container" policy to build fixtures with.
     const RESTART_POLICY: &str = "on-failure";
+
+    #[test]
+    fn pending_restart_reason_path_matches_agent_contract() {
+        // The agent drains this exact path on boot (agent state_store.take_pending_reason).
+        assert_eq!(PENDING_RESTART_REASON_PATH, "/root/agent/data/pending_restart_reason");
+    }
 
     #[test]
     fn assemble_binds_appends_user_mounts() {

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1845,7 +1845,13 @@ pub async fn stop_all_agents(docker: &Docker) {
     }
 }
 
-pub async fn restart_agent(docker: &Docker, name: &str, env_config: &AgentEnvConfig, user_mounts: &[crate::mounts::HostMount]) -> Result<(), DockerError> {
+pub async fn restart_agent(
+    docker: &Docker,
+    name: &str,
+    env_config: &AgentEnvConfig,
+    user_mounts: &[crate::mounts::HostMount],
+    reason: Option<String>,
+) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
     ensure_exists(docker, &cname).await?;
@@ -1869,14 +1875,31 @@ pub async fn restart_agent(docker: &Docker, name: &str, env_config: &AgentEnvCon
                 )));
             }
             tracing::info!(agent = %name, "restart: mount grants drifted, recreating");
+            // A caller-supplied reason wins; else describe the grant delta the rebuild applies.
+            // Written before the stop so it lands in the snapshot the new container boots from.
+            let effective = reason.or_else(|| crate::mounts::mount_change_reason(&actual_user_mounts(&raw), user_mounts));
+            write_boot_reason(docker, name, &cname, effective).await;
             rebuild_agent(docker, name, env_config, user_mounts).await?;
             return start_agent(docker, name).await;
         }
     } else {
         tracing::warn!(agent = %name, "restart: container inspect failed; doing a plain restart (mount changes apply on next reconcile)");
     }
+    // The container's filesystem survives a plain restart, so the inbox written here is read on the
+    // very next boot.
+    write_boot_reason(docker, name, &cname, reason).await;
     docker.restart_container(&cname, Some(RestartContainerOptions { t: Some(CONTAINER_RESTART_TIMEOUT_SECS), signal: None })).await?;
     Ok(())
+}
+
+/// Best-effort write of an optional boot reason to the agent's inbox: a failed write only costs a
+/// missing greeting line, never the restart itself.
+async fn write_boot_reason(docker: &Docker, name: &str, cname: &str, reason: Option<String>) {
+    if let Some(text) = reason {
+        if let Err(err) = write_pending_restart_reason(docker, cname, &text).await {
+            tracing::warn!(agent = %name, error = %err, "failed to write restart reason");
+        }
+    }
 }
 
 /// Free space (in bytes) on the filesystem backing `path`, or `None` if it can't be read.

--- a/vestad/src/mounts.rs
+++ b/vestad/src/mounts.rs
@@ -133,6 +133,48 @@ pub fn bind_string(m: &HostMount) -> String {
     format!("{}:{}:{mode}", m.host_path, m.container_path)
 }
 
+/// Join items as "a", "a and b", or "a, b and c" for human-readable reason copy.
+fn join_and(items: &[String]) -> String {
+    match items {
+        [] => String::new(),
+        [one] => one.clone(),
+        [head @ .., last] => format!("{} and {}", head.join(", "), last),
+    }
+}
+
+/// A `mounts:` restart reason describing a grant change, or None if nothing changed.
+/// `actual` is the container's current user binds as (host, container, writable) tuples
+/// (`docker::actual_user_mounts`); `desired` is the new grant list. Classification is by
+/// container_path + mode, so a writable flip reads as a fresh grant of the new mode.
+pub fn mount_change_reason(actual: &[(String, String, bool)], desired: &[HostMount]) -> Option<String> {
+    let actual_set: std::collections::HashSet<(&str, bool)> = actual.iter().map(|(_, container, writable)| (container.as_str(), *writable)).collect();
+    let desired_paths: std::collections::HashSet<&str> = desired.iter().map(|mount| mount.container_path.as_str()).collect();
+
+    let mode = |writable: bool| if writable { "read-write" } else { "read-only" };
+
+    let granted: Vec<String> = desired
+        .iter()
+        .filter(|mount| !actual_set.contains(&(mount.container_path.as_str(), mount.writable)))
+        .map(|mount| format!("{} ({})", mount.container_path, mode(mount.writable)))
+        .collect();
+    let removed: Vec<String> = actual
+        .iter()
+        .filter(|(_, container, _)| !desired_paths.contains(container.as_str()))
+        .map(|(_, container, _)| container.clone())
+        .collect();
+
+    match (granted.is_empty(), removed.is_empty()) {
+        (true, true) => None,
+        (false, true) => Some(format!("mounts: you now have access to {}", join_and(&granted))),
+        (true, false) => Some(format!("mounts: your access to {} was removed", join_and(&removed))),
+        (false, false) => Some(format!(
+            "mounts: filesystem access changed. granted: {}; removed: {}",
+            granted.join(", "),
+            removed.join(", ")
+        )),
+    }
+}
+
 /// Host roots whose immediate subdirectories are common places to share (media libraries,
 /// downloads, data disks). Their children — e.g. `/mnt/media` — are the suggestions.
 pub const SUGGESTION_ROOTS: &[&str] = &["/mnt", "/media", "/srv", "/data", "/pool", "/tank"];
@@ -184,6 +226,41 @@ mod tests {
 
     fn no_known() -> HashSet<String> {
         HashSet::new()
+    }
+
+    fn m(container: &str, writable: bool) -> HostMount {
+        HostMount { host_path: container.into(), container_path: container.into(), writable }
+    }
+
+    #[test]
+    fn mount_change_reason_grants_removals_and_mixed() {
+        // single grant
+        assert_eq!(
+            mount_change_reason(&[], &[m("/media/Plex", false)]).as_deref(),
+            Some("mounts: you now have access to /media/Plex (read-only)")
+        );
+        // multiple grants
+        assert_eq!(
+            mount_change_reason(&[], &[m("/media/Plex", false), m("/downloads", true)]).as_deref(),
+            Some("mounts: you now have access to /media/Plex (read-only) and /downloads (read-write)")
+        );
+        // removal only
+        assert_eq!(
+            mount_change_reason(&[("/media/Plex".into(), "/media/Plex".into(), false)], &[]).as_deref(),
+            Some("mounts: your access to /media/Plex was removed")
+        );
+        // mixed
+        assert_eq!(
+            mount_change_reason(&[("/old".into(), "/old".into(), false)], &[m("/media/Plex", false)]).as_deref(),
+            Some("mounts: filesystem access changed. granted: /media/Plex (read-only); removed: /old")
+        );
+        // writable flip reads as a fresh grant
+        assert_eq!(
+            mount_change_reason(&[("/x".into(), "/x".into(), false)], &[m("/x", true)]).as_deref(),
+            Some("mounts: you now have access to /x (read-write)")
+        );
+        // no change
+        assert_eq!(mount_change_reason(&[("/x".into(), "/x".into(), true)], &[m("/x", true)]), None);
     }
 
     #[test]

--- a/vestad/src/mounts.rs
+++ b/vestad/src/mounts.rs
@@ -144,35 +144,63 @@ fn join_and(items: &[String]) -> String {
 
 /// A `mounts:` restart reason describing a grant change, or None if nothing changed.
 /// `actual` is the container's current user binds as (host, container, writable) tuples
-/// (`docker::actual_user_mounts`); `desired` is the new grant list. Classification is by
-/// container_path + mode, so a writable flip reads as a fresh grant of the new mode.
+/// (`docker::actual_user_mounts`); `desired` is the new grant list. Classified per
+/// container_path: new path = granted, dropped path = removed, same path with a different
+/// mode = changed — a downgrade must read as a revocation of write access, never a gain.
 pub fn mount_change_reason(actual: &[(String, String, bool)], desired: &[HostMount]) -> Option<String> {
-    let actual_set: std::collections::HashSet<(&str, bool)> = actual.iter().map(|(_, container, writable)| (container.as_str(), *writable)).collect();
+    let actual_modes: std::collections::HashMap<&str, bool> =
+        actual.iter().map(|(_, container, writable)| (container.as_str(), *writable)).collect();
     let desired_paths: std::collections::HashSet<&str> = desired.iter().map(|mount| mount.container_path.as_str()).collect();
 
     let mode = |writable: bool| if writable { "read-write" } else { "read-only" };
 
-    let granted: Vec<String> = desired
-        .iter()
-        .filter(|mount| !actual_set.contains(&(mount.container_path.as_str(), mount.writable)))
-        .map(|mount| format!("{} ({})", mount.container_path, mode(mount.writable)))
-        .collect();
+    let mut granted: Vec<String> = Vec::new();
+    let mut changed: Vec<String> = Vec::new();
+    for mount in desired {
+        match actual_modes.get(mount.container_path.as_str()) {
+            None => granted.push(format!("{} ({})", mount.container_path, mode(mount.writable))),
+            Some(current) if *current != mount.writable => {
+                changed.push(format!("{} (now {})", mount.container_path, mode(mount.writable)));
+            }
+            Some(_) => {}
+        }
+    }
     let removed: Vec<String> = actual
         .iter()
         .filter(|(_, container, _)| !desired_paths.contains(container.as_str()))
         .map(|(_, container, _)| container.clone())
         .collect();
 
-    match (granted.is_empty(), removed.is_empty()) {
-        (true, true) => None,
-        (false, true) => Some(format!("mounts: you now have access to {}", join_and(&granted))),
-        (true, false) => Some(format!("mounts: your access to {} was removed", join_and(&removed))),
-        (false, false) => Some(format!(
-            "mounts: filesystem access changed. granted: {}; removed: {}",
-            granted.join(", "),
-            removed.join(", ")
-        )),
+    match (granted.is_empty(), removed.is_empty(), changed.is_empty()) {
+        (true, true, true) => None,
+        (false, true, true) => Some(format!("mounts: you now have access to {}", join_and(&granted))),
+        (true, false, true) => Some(format!("mounts: your access to {} was removed", join_and(&removed))),
+        (true, true, false) => Some(format!("mounts: your access changed: {}", join_and(&changed))),
+        _ => {
+            let mut segments: Vec<String> = Vec::new();
+            if !granted.is_empty() {
+                segments.push(format!("granted: {}", granted.join(", ")));
+            }
+            if !removed.is_empty() {
+                segments.push(format!("removed: {}", removed.join(", ")));
+            }
+            if !changed.is_empty() {
+                segments.push(format!("changed: {}", changed.join(", ")));
+            }
+            Some(format!("mounts: filesystem access changed. {}", segments.join("; ")))
+        }
     }
+}
+
+/// The reason a restart should hand the agent: an explicit caller reason wins; otherwise the
+/// mount delta the restart applies speaks for itself; no delta, no reason. Factored pure so the
+/// precedence is pinned by a fast test (`restart_agent` itself needs Docker).
+pub fn effective_restart_reason(
+    caller: Option<String>,
+    actual: &[(String, String, bool)],
+    desired: &[HostMount],
+) -> Option<String> {
+    caller.or_else(|| mount_change_reason(actual, desired))
 }
 
 /// Host roots whose immediate subdirectories are common places to share (media libraries,
@@ -254,13 +282,37 @@ mod tests {
             mount_change_reason(&[("/old".into(), "/old".into(), false)], &[m("/media/Plex", false)]).as_deref(),
             Some("mounts: filesystem access changed. granted: /media/Plex (read-only); removed: /old")
         );
-        // writable flip reads as a fresh grant
+        // writable flips are mode changes, not fresh grants: a downgrade must not read as a gain
+        assert_eq!(
+            mount_change_reason(&[("/x".into(), "/x".into(), true)], &[m("/x", false)]).as_deref(),
+            Some("mounts: your access changed: /x (now read-only)")
+        );
         assert_eq!(
             mount_change_reason(&[("/x".into(), "/x".into(), false)], &[m("/x", true)]).as_deref(),
-            Some("mounts: you now have access to /x (read-write)")
+            Some("mounts: your access changed: /x (now read-write)")
+        );
+        // grant + mode change fold into the general branch
+        assert_eq!(
+            mount_change_reason(&[("/x".into(), "/x".into(), false)], &[m("/x", true), m("/new", false)]).as_deref(),
+            Some("mounts: filesystem access changed. granted: /new (read-only); changed: /x (now read-write)")
         );
         // no change
         assert_eq!(mount_change_reason(&[("/x".into(), "/x".into(), true)], &[m("/x", true)]), None);
+    }
+
+    #[test]
+    fn effective_restart_reason_prefers_the_caller_reason() {
+        // Caller intent wins over the synthesized delta...
+        assert_eq!(
+            effective_restart_reason(Some("manual: switching model".into()), &[], &[m("/new", false)]).as_deref(),
+            Some("manual: switching model")
+        );
+        // ...else the delta speaks, and no delta means no reason.
+        assert_eq!(
+            effective_restart_reason(None, &[], &[m("/new", false)]).as_deref(),
+            Some("mounts: you now have access to /new (read-only)")
+        );
+        assert_eq!(effective_restart_reason(None, &[], &[]), None);
     }
 
     #[test]

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -650,11 +650,20 @@ async fn stop_agent_handler(
     Ok(ok_json())
 }
 
+#[derive(Deserialize, Default)]
+struct RestartBody {
+    /// Optional human reason the agent surfaces on its next boot ("manual: switching to ...").
+    #[serde(default)]
+    reason: Option<String>,
+}
+
 async fn restart_agent_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
+    body: Option<Json<RestartBody>>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     tracing::info!(name = %name, "restarting agent");
+    let reason = body.and_then(|Json(restart_body)| restart_body.reason);
     // Detached from this request's connection: a self-restart's client is the agent inside the very
     // container this stops, so the loopback drops the instant rebuild_agent stops it. An inline await
     // would be cancelled before the recreate finishes, leaving the agent down (see spawn_detached).
@@ -671,7 +680,7 @@ async fn restart_agent_handler(
             let settings = state.settings.read().await;
             settings.agent_mounts(&name)
         };
-        docker::restart_agent(&state.docker, &name, &state.env_config, &user_mounts)
+        docker::restart_agent(&state.docker, &name, &state.env_config, &user_mounts, reason)
             .await
             .map_err(map_docker_err)?;
         Ok(ok_json())

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -657,13 +657,26 @@ struct RestartBody {
     reason: Option<String>,
 }
 
+/// Lenient body parse for POST /restart: the endpoint predates the body, so bodyless requests
+/// (the CLI, the agent's self-restart, curl with a stray JSON Content-Type) must keep working.
+/// An Option<Json<...>> extractor would 400 an empty body sent with a JSON header and 415 any
+/// other Content-Type; raw bytes sidestep the header entirely.
+fn parse_restart_reason(body: &[u8]) -> Result<Option<String>, String> {
+    if body.is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_slice::<RestartBody>(body)
+        .map(|restart_body| restart_body.reason)
+        .map_err(|e| format!("invalid restart body: {e}"))
+}
+
 async fn restart_agent_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
-    body: Option<Json<RestartBody>>,
+    body: axum::body::Bytes,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     tracing::info!(name = %name, "restarting agent");
-    let reason = body.and_then(|Json(restart_body)| restart_body.reason);
+    let reason = parse_restart_reason(&body).map_err(|msg| err_response(StatusCode::BAD_REQUEST, &msg))?;
     // Detached from this request's connection: a self-restart's client is the agent inside the very
     // container this stops, so the loopback drops the instant rebuild_agent stops it. An inline await
     // would be cancelled before the recreate finishes, leaving the agent down (see spawn_detached).
@@ -3245,6 +3258,25 @@ mod gateway_settings_tests {
         assert_eq!(off["lan"]["exposed"], serde_json::json!(false));
         assert_eq!(off["lan"]["url"], serde_json::Value::Null);
         assert_eq!(off["tunnel_url"], serde_json::Value::Null);
+    }
+}
+
+#[cfg(test)]
+mod restart_body_tests {
+    use super::parse_restart_reason;
+
+    #[test]
+    fn tolerates_empty_bodies_and_parses_reason() {
+        // Bodyless POSTs (the CLI, the agent's self-restart, curl with a stray JSON header)
+        // must keep working — the pre-reason handler accepted them all.
+        assert_eq!(parse_restart_reason(b"").unwrap(), None);
+        assert_eq!(parse_restart_reason(b"{}").unwrap(), None);
+        assert_eq!(parse_restart_reason(br#"{"reason": null}"#).unwrap(), None);
+        assert_eq!(
+            parse_restart_reason(br#"{"reason": "manual: switching to Claude Opus 4.8"}"#).unwrap(),
+            Some("manual: switching to Claude Opus 4.8".to_string())
+        );
+        assert!(parse_restart_reason(b"not json").is_err());
     }
 }
 


### PR DESCRIPTION
Replaces #984, which GitHub auto-closed (and refuses to reopen) when its stacked base `feat/host-filesystem-grants` merged as #974 and was deleted. Branch rebased onto master; identical content, all review fixes included.

## Summary

Agents restarted from outside their container (backup, mount grants, the app) now boot knowing **why**: vestad writes a one-shot inbox file (`/root/agent/data/pending_restart_reason`) before starting the container, and the agent drains it into its single `last_restart_reason` store on boot.

- **Reader (agent):** `state_store.take_pending_reason` + drain in `_consume_restart_reason` — drained every boot (incl. first start), never overriding a persisted crash reason.
- **Standardized copy:** every reason is `category: detail` (`clean`/`nightly`/`crash`/`error`/`backup`/`mounts`/`manual`); `models.is_crash_reason` is the single owner of the crash-category vocabulary (exit code, precedence, render).
- **New boot render:** `[System Restart]` / `Reason: {detail}` / restart prompt; crash/error reasons render whole so the restart skill's crash branch still triggers.
- **Writers (vestad):** `write_pending_restart_reason` helper; backup writes on the resume side of the pause (copy per backup type, never baked into the snapshot); grant-drift rebuilds write the mount delta into the fresh container after the rebuild succeeds (granted/removed/mode-changed aware); `POST /agents/{name}/restart` accepts an optional `{reason}` parsed leniently so bodyless callers keep working.

Includes all 10 verified findings from the high-effort code review of #984 and a simplification pass.

Spec: `docs/superpowers/specs/2026-07-05-restart-reason-interface-design.md`
Plan: `docs/superpowers/plans/2026-07-05-restart-reason-interface.md`

## Test plan
- [x] `./check.sh agent` (499 passed)
- [x] `./check.sh vestad` (174 passed)
- [x] Full CI was green on #984 pre-retarget (run 28744963717)

🤖 Generated with [Claude Code](https://claude.com/claude-code)