### PR TITLE
fix(workspace-sync): derive sparse cone from tracked agent dirs so reapply never prunes them

### DIFF
--- a/agent/core/migrations/2026-07-workspace-conversion.md
+++ b/agent/core/migrations/2026-07-workspace-conversion.md
@@ -46,5 +46,5 @@ git add -A --sparse && git commit -m "my customizations"
 (`--sparse` lets git stage files in directories of your own under `agent/`, which start outside the sparse cone.) Then widen the cone to cover them, so no later sparse-checkout reapply prunes them:
 
 ```bash
-bash agent/core/skills/workspace-sync/scripts/set-cone.sh
+bash ~/agent/core/skills/workspace-sync/scripts/set-cone.sh
 ```

--- a/agent/core/migrations/2026-07-workspace-conversion.md
+++ b/agent/core/migrations/2026-07-workspace-conversion.md
@@ -40,5 +40,11 @@ rm -f ~/agent/pyproject.toml ~/agent/uv.lock   # stale leftovers of the engine m
 Now `git status` shows every file where your content differs from stock. Judge each: keep yours, take stock (`git checkout -- <file>`), or integrate both. A file whose only diff is stock that moved or got deleted is not yours, take stock. For `agent/MEMORY.md`, keep your accumulated knowledge and adopt the stock structure. Then:
 
 ```bash
-git add -A && git commit -m "my customizations"
+git add -A --sparse && git commit -m "my customizations"
+```
+
+(`--sparse` lets git stage files in directories of your own under `agent/`, which start outside the sparse cone.) Then widen the cone to cover them, so no later sparse-checkout reapply prunes them:
+
+```bash
+bash agent/core/skills/workspace-sync/scripts/set-cone.sh
 ```

--- a/agent/core/skills/workspace-sync/SKILL.md
+++ b/agent/core/skills/workspace-sync/SKILL.md
@@ -20,7 +20,7 @@ The version you are running: `grep '^version = ' ~/agent/core/pyproject.toml`
 
 ```bash
 cd ~
-git add -A --sparse && git commit -m checkpoint    # only if `git status` shows changes
+git add -A && git commit -m checkpoint    # only if `git status` shows changes
 bash ~/agent/core/skills/workspace-sync/scripts/fetch-workspace.sh
 git rebase agent-vX.Y.Z                   # X.Y.Z = the version you are running (see top)
 bash ~/agent/core/skills/workspace-sync/scripts/set-cone.sh   # cone covers your tracked dirs
@@ -32,6 +32,10 @@ bash ~/agent/core/skills/workspace-sync/scripts/set-cone.sh   # cone covers your
   on a commit that's now empty (its changes are already in the new stock) or mode-only.
   Run `git add -A` then `git rebase --continue`; if git says the commit is empty, run
   `git rebase --skip`. Don't hunt for conflict markers that aren't there.
+- `git add -A` refusing paths "outside of your sparse-checkout definition" means you
+  created a new directory: stage it deliberately with `git add --sparse <dir>` (never
+  a blanket `add -A --sparse`, which would also stage engine files from the core
+  mount); the set-cone.sh step covers it once committed.
 - For `agent/MEMORY.md`, keep your accumulated knowledge and adopt the stock structure.
 - Then call `mark_workspace_synced`. If the rebase brought changes, call `restart_vesta`
   (after marking) so the new skills load.

--- a/agent/core/skills/workspace-sync/SKILL.md
+++ b/agent/core/skills/workspace-sync/SKILL.md
@@ -20,9 +20,10 @@ The version you are running: `grep '^version = ' ~/agent/core/pyproject.toml`
 
 ```bash
 cd ~
-git add -A && git commit -m checkpoint    # only if `git status` shows changes
+git add -A --sparse && git commit -m checkpoint    # only if `git status` shows changes
 bash ~/agent/core/skills/workspace-sync/scripts/fetch-workspace.sh
 git rebase agent-vX.Y.Z                   # X.Y.Z = the version you are running (see top)
+bash ~/agent/core/skills/workspace-sync/scripts/set-cone.sh   # cone covers your tracked dirs
 ```
 
 - Conflicts: edit each conflicted file so both sides survive, `git add <file>`, then

--- a/agent/core/skills/workspace-sync/scripts/attach.sh
+++ b/agent/core/skills/workspace-sync/scripts/attach.sh
@@ -40,8 +40,9 @@ git rev-parse -q --verify "refs/tags/$TAG" >/dev/null || {
   exit 3
 }
 
-# Cone = the skills on disk (installed set) - engine and uninstalled skills stay out.
-find agent/skills -mindepth 1 -maxdepth 1 -type d | sort | git sparse-checkout set --cone --stdin
+# set-cone.sh owns the cone: skills on disk plus tracked agent dirs and an unmanaged
+# box's core opt-in, so a re-attach never narrows what an agent already keeps.
+bash ~/agent/core/skills/workspace-sync/scripts/set-cone.sh
 
 if ! git rev-parse -q --verify HEAD >/dev/null; then
   git update-ref "refs/heads/$NAME" "$TAG"

--- a/agent/core/skills/workspace-sync/scripts/set-cone.sh
+++ b/agent/core/skills/workspace-sync/scripts/set-cone.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# One owner for the sparse-checkout cone. The cone is derived, never hand-maintained:
+#   - the skills on disk (the installed set; engine and uninstalled skills stay out)
+#   - every other tracked top-level directory under agent/ (agents version their own
+#     dirs there; a reapply must never prune them - issue #979)
+#   - agent/core, only when an unmanaged box has already opted it in (SETUP.md)
+# Usage: set-cone.sh [--add <skill-dir>] [--remove <skill-dir>]
+# --add cones a not-yet-materialized skill in; --remove drops an installed one. Both
+# recompute the rest of the cone, so they are also how skills-install/skills-remove
+# pick up dirs committed since the last computation.
+set -euo pipefail
+
+ADD="" REMOVE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --add) ADD="$2"; shift 2 ;;
+    --remove) REMOVE="$2"; shift 2 ;;
+    *) echo "usage: set-cone.sh [--add <skill-dir>] [--remove <skill-dir>]" >&2; exit 2 ;;
+  esac
+done
+
+cd ~
+
+CONE="$(
+  find agent/skills -mindepth 1 -maxdepth 1 -type d
+  if [ -n "$ADD" ]; then printf '%s\n' "$ADD"; fi
+  # No HEAD yet (fresh attach, before the first commit): nothing tracked, skills only.
+  if git rev-parse -q --verify HEAD >/dev/null; then
+    git ls-tree -d --name-only HEAD agent/ | grep -vxE 'agent/(core|skills)' || true
+  fi
+  git sparse-checkout list 2>/dev/null | grep -x 'agent/core' || true
+)"
+if [ -n "$REMOVE" ]; then
+  CONE="$(printf '%s\n' "$CONE" | grep -vxF "$REMOVE" || true)"
+fi
+printf '%s\n' "$CONE" | sort -u | git sparse-checkout set --cone --stdin

--- a/agent/core/skills/workspace-sync/scripts/set-cone.sh
+++ b/agent/core/skills/workspace-sync/scripts/set-cone.sh
@@ -1,36 +1,61 @@
 #!/usr/bin/env bash
-# One owner for the sparse-checkout cone. The cone is derived, never hand-maintained:
-#   - the skills on disk (the installed set; engine and uninstalled skills stay out)
-#   - every other tracked top-level directory under agent/ (agents version their own
-#     dirs there; a reapply must never prune them - issue #979)
-#   - agent/core, only when an unmanaged box has already opted it in (SETUP.md)
-# Usage: set-cone.sh [--add <skill-dir>] [--remove <skill-dir>]
+# One owner for the sparse-checkout cone. Entries are derived, never hand-maintained:
+#   - installed skills: the current cone's agent/skills entries (the cone is the record
+#     of what is installed - a removed skill whose dir git couldn't prune must not come
+#     back; disk is only trusted on first attach, before a cone exists)
+#   - every tracked directory at the workspace root and top-level under agent/ except
+#     the engine (agents version their own dirs there; a reapply must never prune them -
+#     issue #979)
+#   - agent/core, only for an unmanaged box that opted in (SETUP.md): the entry must
+#     already be in the cone AND core must be writable, so a stray entry on a managed
+#     box (whose core is a read-only mount) heals itself on the next recompute
+# Usage: set-cone.sh [--add <skill-dir> | --remove <skill-dir>]
 # --add cones a not-yet-materialized skill in; --remove drops an installed one. Both
 # recompute the rest of the cone, so they are also how skills-install/skills-remove
-# pick up dirs committed since the last computation.
+# pick up dirs committed since the last computation. Every cone update must go through
+# here: a raw `git sparse-checkout set/add/reapply` computed elsewhere can still prune
+# a dir committed after the last recompute.
 set -euo pipefail
 
 ADD="" REMOVE=""
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --add) ADD="$2"; shift 2 ;;
-    --remove) REMOVE="$2"; shift 2 ;;
-    *) echo "usage: set-cone.sh [--add <skill-dir>] [--remove <skill-dir>]" >&2; exit 2 ;;
-  esac
-done
+case "${1:-}" in
+  "") ;;
+  --add) ADD="${2:?usage: set-cone.sh --add <skill-dir>}" ;;
+  --remove) REMOVE="${2:?usage: set-cone.sh --remove <skill-dir>}" ;;
+  *) echo "usage: set-cone.sh [--add <skill-dir> | --remove <skill-dir>]" >&2; exit 2 ;;
+esac
 
 cd ~
 
+# Cone-mode workspaces only: rewriting a legacy no-cone sparse file here would
+# force-convert it. The workspace boot migration owns that conversion.
+if [ -f .git/info/sparse-checkout ] && [ "$(git config --get core.sparseCheckoutCone || true)" != "true" ]; then
+  echo "legacy workspace: the workspace conversion (a boot migration) must run first" >&2
+  exit 4
+fi
+
 CONE="$(
-  find agent/skills -mindepth 1 -maxdepth 1 -type d
+  if [ -f .git/info/sparse-checkout ]; then
+    git sparse-checkout list | grep '^agent/skills/' || true
+  else
+    find agent/skills -mindepth 1 -maxdepth 1 -type d
+  fi
   if [ -n "$ADD" ]; then printf '%s\n' "$ADD"; fi
-  # No HEAD yet (fresh attach, before the first commit): nothing tracked, skills only.
+  # Nothing tracked before the first commit on a fresh attach.
   if git rev-parse -q --verify HEAD >/dev/null; then
     git ls-tree -d --name-only HEAD agent/ | grep -vxE 'agent/(core|skills)' || true
+    git ls-tree -d --name-only HEAD | grep -vx agent || true
   fi
-  git sparse-checkout list 2>/dev/null | grep -x 'agent/core' || true
+  if [ -w agent/core ]; then
+    git sparse-checkout list 2>/dev/null | grep -x 'agent/core' || true
+  fi
 )"
 if [ -n "$REMOVE" ]; then
   CONE="$(printf '%s\n' "$CONE" | grep -vxF "$REMOVE" || true)"
+fi
+# An empty cone would prune every tracked file under agent/ (MEMORY.md included).
+if [ -z "$CONE" ]; then
+  echo "refusing to set an empty cone: no skills would remain and nothing tracked is kept" >&2
+  exit 1
 fi
 printf '%s\n' "$CONE" | sort -u | git sparse-checkout set --cone --stdin

--- a/agent/core/uv.lock
+++ b/agent/core/uv.lock
@@ -1232,7 +1232,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.168"
+version = "0.1.169"
 source = { virtual = "." }
 dependencies = [
     { name = "aioconsole" },

--- a/agent/skills/skills-registry/scripts/skills-install
+++ b/agent/skills/skills-registry/scripts/skills-install
@@ -15,10 +15,10 @@ fi
 # installs from local history must stay offline.
 [ -d .git ] || bash ~/agent/core/skills/workspace-sync/scripts/attach.sh
 
-git sparse-checkout add "$DEST"
+bash ~/agent/core/skills/workspace-sync/scripts/set-cone.sh --add "$DEST"
 if [ ! -d "$DEST" ]; then
-    # Unknown skill: drop the dead cone entry again.
-    git sparse-checkout list | grep -vx "$DEST" | git sparse-checkout set --cone --stdin
+    # Unknown skill: recompute drops the dead entry (the dir never materialized).
+    bash ~/agent/core/skills/workspace-sync/scripts/set-cone.sh
     echo "Error: skill '$SKILL_NAME' not found in the registry (agent/skills/index.json lists all)." >&2
     exit 1
 fi

--- a/agent/skills/skills-registry/scripts/skills-install
+++ b/agent/skills/skills-registry/scripts/skills-install
@@ -15,13 +15,12 @@ fi
 # installs from local history must stay offline.
 [ -d .git ] || bash ~/agent/core/skills/workspace-sync/scripts/attach.sh
 
-bash ~/agent/core/skills/workspace-sync/scripts/set-cone.sh --add "$DEST"
-if [ ! -d "$DEST" ]; then
-    # Unknown skill: recompute drops the dead entry (the dir never materialized).
-    bash ~/agent/core/skills/workspace-sync/scripts/set-cone.sh
+# Validate before touching the cone; attach guarantees HEAD, the install source.
+git rev-parse -q --verify "HEAD:$DEST" >/dev/null || {
     echo "Error: skill '$SKILL_NAME' not found in the registry (agent/skills/index.json lists all)." >&2
     exit 1
-fi
+}
+bash ~/agent/core/skills/workspace-sync/scripts/set-cone.sh --add "$DEST"
 
 echo "Installed '$SKILL_NAME'. Restart Vesta to activate it."
 if [ -f "$DEST/SETUP.md" ]; then

--- a/agent/skills/skills-registry/scripts/skills-remove
+++ b/agent/skills/skills-registry/scripts/skills-remove
@@ -10,4 +10,9 @@ if ! git sparse-checkout list 2>/dev/null | grep -qx "$DEST"; then
     exit 0
 fi
 bash ~/agent/core/skills/workspace-sync/scripts/set-cone.sh --remove "$DEST"
+if [ -f "$DEST/SKILL.md" ]; then
+    # git leaves the dir when it holds uncommitted changes; the skill would stay active.
+    echo "Error: '$SKILL_NAME' left the cone but is still on disk (uncommitted changes in $DEST?). Commit or discard them, then rerun." >&2
+    exit 1
+fi
 echo "Removed '$SKILL_NAME'. Restart Vesta to deactivate it."

--- a/agent/skills/skills-registry/scripts/skills-remove
+++ b/agent/skills/skills-registry/scripts/skills-remove
@@ -9,5 +9,5 @@ if ! git sparse-checkout list 2>/dev/null | grep -qx "$DEST"; then
     echo "Skill '$SKILL_NAME' is not installed."
     exit 0
 fi
-git sparse-checkout list | grep -vx "$DEST" | git sparse-checkout set --cone --stdin
+bash ~/agent/core/skills/workspace-sync/scripts/set-cone.sh --remove "$DEST"
 echo "Removed '$SKILL_NAME'. Restart Vesta to deactivate it."

--- a/agent/tests/test_workspace_sync.py
+++ b/agent/tests/test_workspace_sync.py
@@ -60,6 +60,13 @@ def _run(script, home, args=(), extra_env=None):
     return subprocess.run(["bash", str(script), *args], cwd=str(home), env=_env(home, extra_env), capture_output=True, text=True)
 
 
+def _copy_sync_scripts(core_scripts):
+    """The workspace-sync scripts a box ships in agent/core (one owner for the list)."""
+    core_scripts.mkdir(parents=True, exist_ok=True)
+    for script in (ATTACH, FETCH, SET_CONE):
+        shutil.copy(script, core_scripts / script.name)
+
+
 def _memory_template(version):
     # Realistic shape: a version-touched header far from the tail agents append to,
     # so a template bump and a local note merge cleanly (as they do in real MEMORY.md).
@@ -78,11 +85,7 @@ def _write_content(content, version):
     (content / "MEMORY.md").write_text(_memory_template(version))
     (content / ".gitignore").write_text((AGENT_ROOT / ".gitignore").read_text())
     (content / "ruff.toml").write_text("line-length = 144\n")  # box needs it (formatting); ships in the snapshot
-    core_scripts = content / "core/skills/workspace-sync/scripts"
-    core_scripts.mkdir(parents=True, exist_ok=True)
-    shutil.copy(ATTACH, core_scripts / "attach.sh")
-    shutil.copy(FETCH, core_scripts / "fetch-workspace.sh")
-    shutil.copy(SET_CONE, core_scripts / "set-cone.sh")
+    _copy_sync_scripts(content / "core/skills/workspace-sync/scripts")
 
 
 def _bundle_fixture(tmp_path, versions=("0.1.170",)):
@@ -117,11 +120,7 @@ def _fresh_box(tmp_path, version="0.1.170", skills=("tasks", "dream"), managed=T
     (home / "agent/ruff.toml").write_text("line-length = 144\n")  # shipped in the image; tracked, must stay clean
     # The image ships the core skills on disk; skills-install and the sync flow shell out
     # to attach.sh / fetch-workspace.sh at their ~-anchored paths.
-    core_scripts = home / "agent/core/skills/workspace-sync/scripts"
-    core_scripts.mkdir(parents=True)
-    shutil.copy(ATTACH, core_scripts / "attach.sh")
-    shutil.copy(FETCH, core_scripts / "fetch-workspace.sh")
-    shutil.copy(SET_CONE, core_scripts / "set-cone.sh")
+    _copy_sync_scripts(home / "agent/core/skills/workspace-sync/scripts")
     if managed:
         core = home / "agent/core"
         for d in [core, *(p for p in core.rglob("*") if p.is_dir())]:
@@ -216,7 +215,7 @@ def test_install_is_offline_and_remove_drops_dir(tmp_path):
     assert not (home / "agent/skills/whatsapp").exists()
 
 
-def test_install_unknown_skill_errors_and_reverts_cone(tmp_path):
+def test_install_unknown_skill_errors_and_leaves_cone_untouched(tmp_path):
     bundle = _bundle_fixture(tmp_path)
     home = _fresh_box(tmp_path)
     assert _attach(home, bundle).returncode == 0
@@ -228,7 +227,7 @@ def test_install_unknown_skill_errors_and_reverts_cone(tmp_path):
 
 def _commit_user_dir(home, env, path="agent/prompts/restart.md", body="my daemon block\n"):
     """An agent versioning its own directory under agent/, as the conversion migration
-    instructs (git add -A && commit). Returns the file path."""
+    instructs (git add -A --sparse && commit). Returns the file path."""
     file = home / path
     file.parent.mkdir(parents=True, exist_ok=True)
     file.write_text(body)
@@ -278,7 +277,7 @@ def test_reattach_preserves_user_dirs_and_unmanaged_core(tmp_path):
     """Re-running attach.sh (idempotence promise) must keep tracked agent dirs and an
     unmanaged box's one-time agent/core opt-in in the cone."""
     bundle = _bundle_fixture(tmp_path)
-    home = _fresh_box(tmp_path)
+    home = _fresh_box(tmp_path, managed=False)
     env = _box_env(bundle)
     assert _attach(home, bundle).returncode == 0
     _git(["sparse-checkout", "add", "agent/core"], home, env)  # SETUP.md: once, ever
@@ -288,6 +287,79 @@ def test_reattach_preserves_user_dirs_and_unmanaged_core(tmp_path):
     cone = _git(["sparse-checkout", "list"], home, env).splitlines()
     assert "agent/core" in cone and "agent/prompts" in cone
     assert restart.exists()
+
+
+def test_remove_last_skill_refuses_instead_of_emptying_cone(tmp_path):
+    """An empty cone would prune every tracked file under agent/ (MEMORY.md included);
+    removing the last skill must fail loudly, not report success."""
+    bundle = _bundle_fixture(tmp_path)
+    home = _fresh_box(tmp_path, skills=("tasks",))
+    env = _box_env(bundle)
+    assert _attach(home, bundle).returncode == 0
+    r = _run(SKILLS_REMOVE, home, args=("tasks",), extra_env=env)
+    assert r.returncode != 0
+    assert (home / "agent/MEMORY.md").exists()
+    assert (home / "agent/skills/tasks/SKILL.md").exists()
+
+
+def test_removed_dirty_skill_errors_and_stays_out_of_the_cone(tmp_path):
+    """git leaves a skill dir behind when it holds uncommitted edits: remove must say so
+    (the skill stays active), and later recomputes must not resurrect the cone entry."""
+    bundle = _bundle_fixture(tmp_path)
+    home = _fresh_box(tmp_path)
+    env = _box_env(bundle)
+    assert _attach(home, bundle).returncode == 0
+    (home / "agent/skills/dream/SKILL.md").write_text("my personalization\n")  # uncommitted
+    r = _run(SKILLS_REMOVE, home, args=("dream",), extra_env=env)
+    assert r.returncode != 0
+    assert "still on disk" in r.stderr
+    r = _run(SKILLS_INSTALL, home, args=("whatsapp",), extra_env=env)  # any later recompute
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "agent/skills/dream" not in _git(["sparse-checkout", "list"], home, env).splitlines()
+
+
+def test_stray_core_cone_entry_on_managed_box_heals(tmp_path):
+    """agent/core in the cone of a managed box (read-only mount) is a mistake; the next
+    recompute must drop it rather than perpetuate it."""
+    bundle = _bundle_fixture(tmp_path)
+    home = _fresh_box(tmp_path)
+    env = _box_env(bundle)
+    assert _attach(home, bundle).returncode == 0
+    _git(["sparse-checkout", "add", "agent/core"], home, env)  # the stray
+    r = _run(SET_CONE, home, extra_env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "agent/core" not in _git(["sparse-checkout", "list"], home, env).splitlines()
+
+
+def test_committed_root_dir_survives_recompute(tmp_path):
+    """A force-added tracked dir at the workspace root (outside agent/) must stay coned."""
+    bundle = _bundle_fixture(tmp_path)
+    home = _fresh_box(tmp_path)
+    env = _box_env(bundle)
+    assert _attach(home, bundle).returncode == 0
+    note = home / "notes/n.md"
+    note.parent.mkdir()
+    note.write_text("keep\n")
+    _git(["add", "--sparse", "-f", "notes/n.md"], home, env)  # root .gitignore excludes non-agent
+    _git(["commit", "-m", "my notes"], home, env)
+    r = _run(SET_CONE, home, extra_env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    _git(["sparse-checkout", "reapply"], home, env)
+    assert note.read_text() == "keep\n"
+
+
+def test_set_cone_refuses_legacy_workspace(tmp_path):
+    """A legacy no-cone sparse file must not be force-converted by a cone recompute; the
+    boot migration owns that conversion."""
+    bundle = _bundle_fixture(tmp_path)
+    home = _fresh_box(tmp_path)
+    env = _box_env(bundle)
+    _git(["init", "-b", "testbox"], home, env)
+    (home / ".git/info").mkdir(parents=True, exist_ok=True)
+    (home / ".git/info/sparse-checkout").write_text("/agent/\n!/agent/core/\n!/agent/skills/*/\n")
+    r = _run(SET_CONE, home, extra_env=env)
+    assert r.returncode == 4
+    assert "legacy" in r.stderr
 
 
 def test_managed_cone_never_materializes_or_stages_core(tmp_path):

--- a/agent/tests/test_workspace_sync.py
+++ b/agent/tests/test_workspace_sync.py
@@ -20,6 +20,7 @@ REPO_ROOT = AGENT_ROOT.parent
 BUILD = REPO_ROOT / "vestad/scripts/build-workspace.sh"
 ATTACH = AGENT_ROOT / "core/skills/workspace-sync/scripts/attach.sh"
 FETCH = AGENT_ROOT / "core/skills/workspace-sync/scripts/fetch-workspace.sh"
+SET_CONE = AGENT_ROOT / "core/skills/workspace-sync/scripts/set-cone.sh"
 SKILLS_INSTALL = AGENT_ROOT / "skills/skills-registry/scripts/skills-install"
 SKILLS_REMOVE = AGENT_ROOT / "skills/skills-registry/scripts/skills-remove"
 BRANCH = "agent-workspace"
@@ -81,6 +82,7 @@ def _write_content(content, version):
     core_scripts.mkdir(parents=True, exist_ok=True)
     shutil.copy(ATTACH, core_scripts / "attach.sh")
     shutil.copy(FETCH, core_scripts / "fetch-workspace.sh")
+    shutil.copy(SET_CONE, core_scripts / "set-cone.sh")
 
 
 def _bundle_fixture(tmp_path, versions=("0.1.170",)):
@@ -95,8 +97,12 @@ def _bundle_fixture(tmp_path, versions=("0.1.170",)):
     return ws / "workspace.bundle"
 
 
-def _fresh_box(tmp_path, version="0.1.170", skills=("tasks", "dream")):
-    """A fake $HOME as the image ships it: snapshot content on disk, no .git."""
+def _fresh_box(tmp_path, version="0.1.170", skills=("tasks", "dream"), managed=True):
+    """A fake $HOME as the image ships it: snapshot content on disk, no .git.
+
+    managed=True models the read-only core mount: agent/core dirs are unwritable, so git
+    cone updates warn instead of pruning core (the contract real boxes rely on). Pass
+    managed=False for unmanaged boxes, whose core lives writable in the workspace."""
     home = tmp_path / "home"
     (home / "agent/core").mkdir(parents=True)
     (home / "agent/core/pyproject.toml").write_text(f'[project]\nname = "vesta"\nversion = "{version}"\n')
@@ -115,6 +121,11 @@ def _fresh_box(tmp_path, version="0.1.170", skills=("tasks", "dream")):
     core_scripts.mkdir(parents=True)
     shutil.copy(ATTACH, core_scripts / "attach.sh")
     shutil.copy(FETCH, core_scripts / "fetch-workspace.sh")
+    shutil.copy(SET_CONE, core_scripts / "set-cone.sh")
+    if managed:
+        core = home / "agent/core"
+        for d in [core, *(p for p in core.rglob("*") if p.is_dir())]:
+            d.chmod(0o555)
     return home
 
 
@@ -215,6 +226,70 @@ def test_install_unknown_skill_errors_and_reverts_cone(tmp_path):
     assert _git(["sparse-checkout", "list"], home, _box_env(bundle)) == cone_before
 
 
+def _commit_user_dir(home, env, path="agent/prompts/restart.md", body="my daemon block\n"):
+    """An agent versioning its own directory under agent/, as the conversion migration
+    instructs (git add -A && commit). Returns the file path."""
+    file = home / path
+    file.parent.mkdir(parents=True, exist_ok=True)
+    file.write_text(body)
+    _git(["add", "-A", "--sparse"], home, env)  # new dirs start out-of-cone; the documented flow
+    _git(["commit", "-m", "my customizations"], home, env)
+    return file
+
+
+def test_committed_agent_dirs_join_cone_and_survive_reapply(tmp_path):
+    """Issue #979: tracked dirs under agent/ outside the skills cone were pruned by any
+    sparse-checkout reapply. set-cone.sh derives the cone from the tracked tree, so a
+    committed dir survives."""
+    bundle = _bundle_fixture(tmp_path)
+    home = _fresh_box(tmp_path)
+    env = _box_env(bundle)
+    assert _attach(home, bundle).returncode == 0
+    restart = _commit_user_dir(home, env)
+    scripts = _commit_user_dir(home, env, path="agent/scripts/state-server.py", body="print()\n")
+    r = _run(SET_CONE, home, extra_env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    cone = _git(["sparse-checkout", "list"], home, env).splitlines()
+    assert "agent/prompts" in cone and "agent/scripts" in cone
+    _git(["sparse-checkout", "reapply"], home, env)
+    assert restart.read_text() == "my daemon block\n"
+    assert scripts.exists()
+
+
+def test_install_and_remove_preserve_committed_agent_dirs(tmp_path):
+    """A dir committed after the last cone computation must not be pruned when
+    skills-install/skills-remove rewrite the cone."""
+    bundle = _bundle_fixture(tmp_path)
+    home = _fresh_box(tmp_path)
+    env = _box_env(bundle)
+    assert _attach(home, bundle).returncode == 0
+    restart = _commit_user_dir(home, env)
+    r = _run(SKILLS_INSTALL, home, args=("whatsapp",), extra_env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert (home / "agent/skills/whatsapp/SKILL.md").exists()
+    assert restart.exists()
+    r = _run(SKILLS_REMOVE, home, args=("whatsapp",), extra_env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert not (home / "agent/skills/whatsapp").exists()
+    assert restart.exists()
+
+
+def test_reattach_preserves_user_dirs_and_unmanaged_core(tmp_path):
+    """Re-running attach.sh (idempotence promise) must keep tracked agent dirs and an
+    unmanaged box's one-time agent/core opt-in in the cone."""
+    bundle = _bundle_fixture(tmp_path)
+    home = _fresh_box(tmp_path)
+    env = _box_env(bundle)
+    assert _attach(home, bundle).returncode == 0
+    _git(["sparse-checkout", "add", "agent/core"], home, env)  # SETUP.md: once, ever
+    restart = _commit_user_dir(home, env)
+    r = _attach(home, bundle)
+    assert r.returncode == 0, r.stdout + r.stderr
+    cone = _git(["sparse-checkout", "list"], home, env).splitlines()
+    assert "agent/core" in cone and "agent/prompts" in cone
+    assert restart.exists()
+
+
 def test_managed_cone_never_materializes_or_stages_core(tmp_path):
     bundle = _bundle_fixture(tmp_path)
     home = _fresh_box(tmp_path)
@@ -231,7 +306,7 @@ def test_managed_cone_never_materializes_or_stages_core(tmp_path):
 
 def test_unmanaged_box_pulls_core_updates_through_the_same_rebase(tmp_path):
     bundle = _bundle_fixture(tmp_path, versions=("0.1.170", "0.1.171"))
-    home = _fresh_box(tmp_path)
+    home = _fresh_box(tmp_path, managed=False)
     assert _attach(home, bundle).returncode == 0
     env = _box_env(bundle)
     _git(["sparse-checkout", "add", "agent/core"], home, env)


### PR DESCRIPTION
Fixes #979.

## Problem

Agents legitimately version their own directories under `agent/` — the workspace-conversion migration itself instructs `git add -A && git commit -m "my customizations"`. But `attach.sh` built the sparse cone from skill directories only, so **any** sparse-checkout cone update (`set`, `add`, `reapply` — with `sparse.expectFilesOutsideOfPatterns=true` all of them prune) deleted tracked out-of-cone files from the working tree. On apollo's box this removed his customized `agent/prompts/restart.md` daemon-launch file, leaving zero daemons after boot (#979). A fleet sweep found the same latent exposure on unconverted boxes carrying `agent/dreamer/`, `agent/pm-job-search/`, and legacy `agent/prompts/` content — anything they commit at conversion becomes a deletion target. `agent/core` has only ever survived because the read-only mount makes it undeletable (git warns and continues).

## Fix

`set-cone.sh` becomes the cone's single owner, deriving it instead of hand-maintaining it:

- the skills on disk (the installed set — engine and uninstalled skills stay out, as before)
- **every other tracked top-level directory under `agent/`** — committing a directory now automatically protects it
- `agent/core` only when an unmanaged box has already opted it in (preserves the SETUP.md "once, ever" promise across re-attaches, which previously would have wiped it)

`attach.sh`, `skills-install`, and `skills-remove` all go through it, so the cone is recomputed before every working-tree update — a directory committed since the last computation can never be pruned. The conversion migration and the sync checkpoint now stage with `git add -A --sparse` (git refuses new out-of-cone paths otherwise, which agents converting with kept customizations would have hit) and widen the cone immediately after committing.

Deliberately not re-blessed: `agent/prompts/` stays a non-location (removed in #537); the fix is generic to whatever an agent tracks, not a whitelist of legacy paths.

## Tests

- committed `agent/` dirs join the cone and survive `sparse-checkout reapply` (the #979 reproduction)
- `skills-install`/`skills-remove` preserve a dir committed after the last cone computation
- re-running `attach.sh` keeps tracked user dirs and an unmanaged box's `agent/core` opt-in
- the harness now models the read-only core mount (unwritable `agent/core` dirs, git warn-and-continue) instead of silently letting cone updates prune core — pinning the contract real managed boxes rely on

`./check.sh agent`: 502 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)