### PR TITLE
feat(web): opus-first claude model picker, auto-open oauth, lowercase brand

### DIFF
--- a/agent/core/manifest.json
+++ b/agent/core/manifest.json
@@ -4,7 +4,7 @@
   "providers": {
     "claude": {
       "display": "Claude account",
-      "models": ["opus", "sonnet", "haiku"],
+      "models": ["opus", "sonnet"],
       "default_model": "opus",
       "context": {
         "default": 1000000,

--- a/agent/tests/test_manifest.py
+++ b/agent/tests/test_manifest.py
@@ -19,7 +19,7 @@ def test_manifest_has_both_providers_and_defaults():
     assert manifest["default_provider"] == "claude"
     assert manifest["default_personality"] == "dry"
     assert sorted(manifest["providers"]) == ["claude", "openrouter"]
-    assert manifest["providers"]["claude"]["models"] == ["opus", "sonnet", "haiku"]
+    assert manifest["providers"]["claude"]["models"] == ["opus", "sonnet"]
     assert manifest["providers"]["claude"]["context"]["presets"]  # the picker's curated suggestions
     assert manifest["providers"]["openrouter"]["models"] == "live"  # free-form, fetched separately
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,7 +8,7 @@
     />
     <meta name="color-scheme" content="light dark" />
     <link rel="icon" type="image/png" href="/favicon.png?v=2" />
-    <title>Vesta</title>
+    <title>vesta</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/api/providers/openrouter.ts
+++ b/apps/web/src/api/providers/openrouter.ts
@@ -4,6 +4,9 @@ export interface OpenRouterModelOption {
   slug: string;
   label: string;
   author: string;
+  // Tiny strength hint shown in place of the author/price line (Claude opus vs sonnet). Absent for
+  // OpenRouter models, which show author + context + price instead.
+  note?: string;
   context_length?: number;
   // USD per million prompt/completion/cache-read tokens, when OpenRouter reports it.
   input_price?: number | null;

--- a/apps/web/src/components/AuthFlow/index.tsx
+++ b/apps/web/src/components/AuthFlow/index.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Copy, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ProviderStep } from "@/components/ProviderPicker/ProviderStep";
 import { ClaudeLogo } from "@/components/ProviderPicker/logos";
+import { openExternalUrl } from "@/lib/open-external-url";
 import { errorMessage } from "@/lib/utils";
 
 interface AuthFlowProps {
@@ -25,6 +26,12 @@ export function AuthFlow({
   const [code, setCode] = useState("");
   const [error, setError] = useState("");
   const [copied, setCopied] = useState(false);
+
+  // Open the sign-in link for the user as soon as it's ready. Best-effort: a popup blocker or a
+  // non-user-gesture context can stop it, so the copyable link below stays as the fallback.
+  useEffect(() => {
+    if (authUrl) openExternalUrl(authUrl).catch(() => {});
+  }, [authUrl]);
 
   const copyAuthUrl = async () => {
     try {

--- a/apps/web/src/components/Logo/LogoText/index.tsx
+++ b/apps/web/src/components/Logo/LogoText/index.tsx
@@ -4,7 +4,7 @@ export function LogoText({ className }: { className?: string }) {
       data-tauri-drag-region
       className={`text-[2.1rem] leading-none font-serif font-medium tracking-tight ${className ?? ""}`}
     >
-      Vesta
+      vesta
     </span>
   );
 }

--- a/apps/web/src/components/ProviderPicker/ContextStep/index.tsx
+++ b/apps/web/src/components/ProviderPicker/ContextStep/index.tsx
@@ -25,7 +25,7 @@ export function ContextStep({
     <ProviderStep
       logo={logo}
       title="context window"
-      subtitle="how much the agent keeps in context before it compacts. larger holds more at once; smaller is cheaper and compacts sooner."
+      subtitle="how much vesta keeps in mind before compacting. longer means vesta is less likely to forget things during the day, but uses more of your usage; shorter is cheaper and compacts sooner."
       submitLabel={submitLabel}
       onSubmit={() => onSubmit(selected)}
       onCancel={onCancel}

--- a/apps/web/src/components/ProviderPicker/ModelStep/index.tsx
+++ b/apps/web/src/components/ProviderPicker/ModelStep/index.tsx
@@ -213,17 +213,23 @@ function ModelCard({
       <div className="flex min-w-0 flex-col">
         <span className="truncate text-sm font-medium">{model.label}</span>
         <span className="truncate text-[11px] text-muted-foreground">
-          {model.author}
-          {model.context_length
-            ? ` · ${formatTokens(model.context_length)} ctx`
-            : ""}
-          {formatPrice(
-            model.input_price,
-            model.output_price,
-            model.cache_read_price,
-          )
-            ? ` · ${formatPrice(model.input_price, model.output_price, model.cache_read_price)}`
-            : ""}
+          {model.note ? (
+            model.note
+          ) : (
+            <>
+              {model.author}
+              {model.context_length
+                ? ` · ${formatTokens(model.context_length)} ctx`
+                : ""}
+              {formatPrice(
+                model.input_price,
+                model.output_price,
+                model.cache_read_price,
+              )
+                ? ` · ${formatPrice(model.input_price, model.output_price, model.cache_read_price)}`
+                : ""}
+            </>
+          )}
         </span>
       </div>
     </button>

--- a/apps/web/src/components/VersionMismatchScreen/index.tsx
+++ b/apps/web/src/components/VersionMismatchScreen/index.tsx
@@ -37,7 +37,7 @@ async function updateApp(gatewayVersion: string) {
   // Mobile can't self-update (store-gated); the build comes from the App Store /
   // TestFlight (or Play), so surface that instead of invoking a missing command.
   if (platform === "ios" || platform === "android") {
-    throw new Error("update Vesta from the App Store or TestFlight");
+    throw new Error("update vesta from the App Store or TestFlight");
   }
   const { invoke } = await import("@tauri-apps/api/core");
   const command = platform === "linux" ? "install_update" : "run_update";

--- a/apps/web/src/hooks/use-claude-models.ts
+++ b/apps/web/src/hooks/use-claude-models.ts
@@ -1,13 +1,28 @@
 import { useManifest } from "@/hooks/use-manifest";
 import type { OpenRouterModelOption } from "@/api/providers/openrouter";
 
+// Display label + one-word strength note per Claude slug, so the picker can say what each is for
+// (opus is the strongest, sonnet is faster) instead of showing a bare lowercase slug.
+const CLAUDE_MODEL_META: Record<string, { label: string; note: string }> = {
+  opus: { label: "Claude Opus", note: "strongest" },
+  sonnet: { label: "Claude Sonnet", note: "faster, lighter" },
+};
+
+function claudeOption(slug: string): OpenRouterModelOption {
+  const meta = CLAUDE_MODEL_META[slug];
+  return {
+    slug,
+    label: meta ? meta.label : slug,
+    author: "Anthropic",
+    note: meta?.note,
+  };
+}
+
 // Shown immediately; refined from the manifest (GET /manifest) so a newly added model appears
 // without a code change. claude-code resolves the aliases.
-const CLAUDE_FALLBACK: OpenRouterModelOption[] = [
-  { slug: "opus", label: "Claude Opus", author: "Anthropic" },
-  { slug: "sonnet", label: "Claude Sonnet", author: "Anthropic" },
-  { slug: "haiku", label: "Claude Haiku", author: "Anthropic" },
-];
+const CLAUDE_FALLBACK: OpenRouterModelOption[] = ["opus", "sonnet"].map(
+  claudeOption,
+);
 
 /// The Claude model list as model-card options for the provider card's model switcher, derived from
 /// the manifest's Claude catalog. Starts from the static fallback until the manifest resolves.
@@ -17,5 +32,5 @@ export function useClaudeModels(enabled = true): OpenRouterModelOption[] {
   if (!enabled) return CLAUDE_FALLBACK;
   const models = manifest?.providers["claude"]?.models;
   if (!Array.isArray(models) || models.length === 0) return CLAUDE_FALLBACK;
-  return models.map((slug) => ({ slug, label: slug, author: "Anthropic" }));
+  return models.map(claudeOption);
 }

--- a/apps/web/src/lib/tab-title.ts
+++ b/apps/web/src/lib/tab-title.ts
@@ -1,4 +1,4 @@
-const DEFAULT_BASE = "Vesta";
+const DEFAULT_BASE = "vesta";
 
 export function setTabBaseTitle(base: string): void {
   if (typeof document === "undefined") return;

--- a/apps/web/src/providers/NotificationProvider/index.tsx
+++ b/apps/web/src/providers/NotificationProvider/index.tsx
@@ -193,7 +193,7 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
         : `${agent.name} needs to sign in again`;
       const body = unprovisioned
         ? "Tap to choose a provider and sign in."
-        : "Vesta lost the provider credentials. Tap to re-authenticate.";
+        : "vesta lost the provider credentials. Tap to re-authenticate.";
       try {
         const n = new Notification(title, {
           body,


### PR DESCRIPTION
## What

Reworks the Claude side of the provider model picker and tidies a few brand touches.

- **Opus-first, no Haiku.** Drops `haiku` from the Claude catalog in `agent/core/manifest.json` (the one source vestad re-serves), so Haiku no longer appears anywhere. Each remaining model now carries a one-word strength note on its card:
  - **Claude Opus** — _strongest_
  - **Claude Sonnet** — _faster, lighter_
- **Auto-open the OAuth link.** When the Claude sign-in URL is ready, it opens in a new tab automatically via the existing `openExternalUrl` helper (handles Tauri + browser). Best-effort: a popup blocker or non-gesture context can stop it, so the copyable link stays as the fallback.
- **Context-window copy.** Explains the tradeoff in plain terms: longer context means vesta is less likely to forget things during the day but uses more of your usage; shorter is cheaper and compacts sooner.
- **Lowercase brand.** `vesta` wordmark lowercased across visible app copy (logo, browser tab title, re-auth notification, version-mismatch error, `index.html` title). Type identifiers (`VestaEvent`/`VestaConfig`) and the `Vestad` daemon references are untouched.

## Implementation notes

- Added an optional `note` field to `OpenRouterModelOption`; the model card shows it in place of the author/price line when present (OpenRouter cards unchanged).
- `useClaudeModels` now decorates each slug with its display label + note, applied to both the static fallback and the manifest-derived list.

## Verification

- `tsc` clean, eslint 0 errors, prettier clean.
- `agent/tests/test_manifest.py` updated + passing.
- 109 web tests pass (3 test files error locally only because `jsdom` isn't installed in the sandbox; CI installs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)