### PR TITLE
docs(skills): tighten notifications skill

### DIFF
--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -81,7 +81,7 @@
   },
   {
     "name": "notifications",
-    "description": "Manage how incoming notifications affect YOUR focus (you, the agent, are the one interrupted, not the user): tune which notifications pull you off your current work vs. wait in the pool (interrupt rules), and triage the pooled ones when a triage pass hands them to you. The point is your productivity: being preempted by low-value notifications mid-task is costly. Use when you notice unimportant notifications breaking your focus, when the user tells you what should or shouldn't pull you off your work (e.g. \"don't let Twitter interrupt you\", \"always let my wife's messages reach you right away\", \"stay focused on this and hold the low-priority stuff\"), when you want to guard a hard task, when asked what's currently allowed to interrupt you, or when triaging the notifications that piled up while you were busy."
+    "description": "Interrupt rules that guard YOUR focus (you, the agent, are the one interrupted, not the user): tune which notifications pull you off your work now vs. wait in the pool for triage. Use when the user says what should or shouldn't interrupt you (\"don't let Twitter interrupt you\", \"always let my wife's messages through right away\"), when guarding deep work, when asked what's currently allowed to interrupt you, or when triaging pooled notifications."
   },
   {
     "name": "onboard",

--- a/agent/skills/notifications/SKILL.md
+++ b/agent/skills/notifications/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notifications
-description: Manage how incoming notifications affect YOUR focus (you, the agent, are the one interrupted, not the user): tune which notifications pull you off your current work vs. wait in the pool (interrupt rules), and triage the pooled ones when a triage pass hands them to you. The point is your productivity: being preempted by low-value notifications mid-task is costly. Use when you notice unimportant notifications breaking your focus, when the user tells you what should or shouldn't pull you off your work (e.g. "don't let Twitter interrupt you", "always let my wife's messages reach you right away", "stay focused on this and hold the low-priority stuff"), when you want to guard a hard task, when asked what's currently allowed to interrupt you, or when triaging the notifications that piled up while you were busy.
+description: Interrupt rules that guard YOUR focus (you, the agent, are the one interrupted, not the user): tune which notifications pull you off your work now vs. wait in the pool for triage. Use when the user says what should or shouldn't interrupt you ("don't let Twitter interrupt you", "always let my wife's messages through right away"), when guarding deep work, when asked what's currently allowed to interrupt you, or when triaging pooled notifications.
 ---
 
 # Notifications

--- a/agent/skills/notifications/SKILL.md
+++ b/agent/skills/notifications/SKILL.md
@@ -12,17 +12,17 @@ These interrupts land on **you, the agent**, not the user: an interrupting notif
 ## Mental model
 
 - **interrupt** = the notification preempts your current turn the moment it arrives.
-- **pool** (shown as **"snooze"** in the app) = it does not touch your current work; it waits and is gathered into a triage pass once you have been idle a little while. Pooling changes *when* you see a notification, never *whether* — nothing is dropped, and the rule is reversible anytime. You decide what to act on or drop when you triage it (below).
+- **pool** (shown as **"snooze"** in the app) = it does not touch your current work; it waits and is gathered into a triage pass once you have been idle a little while. Pooling changes *when* you see a notification, never *whether*: nothing is dropped, and the rule is reversible anytime. You decide what to act on or drop when you triage it (below).
 
 Each rule is about **timing**, not visibility: "worth dropping everything for right now" vs. "this can wait until I'm free".
 
 ## Your active role
 
-Don't just wait for the user — watch your own interruptions:
+Don't just wait for the user; watch your own interruptions:
 
 - A kind of notification repeatedly preempting you for little value (every tweet, routine pings) is a signal: propose pooling it.
 - Something important that should have reached you faster: propose an interrupt rule for it.
-- **Confirm with the user before changing rules** — describe the rule in plain language and why it helps. Their call on importance wins.
+- **Confirm with the user before changing rules**: describe the rule in plain language and why it helps. Their call on importance wins.
 
 Keep it proportionate: tune real patterns, don't fiddle constantly. The nightly dream is a good moment to reflect on the balance.
 
@@ -41,17 +41,17 @@ notification's other fields. Every field/condition you set must hold (AND); what
   `sender` (identity) and `text` (body). `--sender X` and `--keyword RE` are shortcuts for
   `--match 'sender=X'` and `--match 'text~=RE'`.
 - **First match wins**: rules evaluate top to bottom and stop at the first match, so order is the only
-  precedence — a later, more-specific rule never overrides an earlier, broader one. To OR across fields,
+  precedence; a later, more-specific rule never overrides an earlier, broader one. To OR across fields,
   write separate rules (one rule's conditions are all ANDed).
 - **Placement is handled for you.** `add` auto-places a new rule above any broader one (fewer conditions),
   so a narrow exception isn't shadowed. Override with `--before`/`--after <id>` on add, or `move <id>`
   (`--before`/`--after`/`--top`/`--bottom`) later. `list` shows priority order.
 - A rule with no fields is a catch-all; only useful as the last rule.
-- With **no matching rule, the notification's own default decides** — each skill ships one (whatsapp/chat
+- With **no matching rule, the notification's own default decides**: each skill ships one (whatsapp/chat
   interrupt, email/finance pool), and your rules override those. Internal notifications (`source=core`:
   greetings, dreamer, proactive checks) are never affected by rules.
 - To make a source usually not interrupt, add a broad `--source X --action pool` rule with the exceptions
-  (narrower interrupt rules) above it — auto-placement usually handles the ordering.
+  (narrower interrupt rules) above it; auto-placement usually handles the ordering.
 
 ## Usage
 
@@ -92,7 +92,7 @@ notifications clear
 
 ## Guarding a hard task
 
-Before deep work you don't want broken, add a broad `--action pool` rule (with narrower `interrupt` rules above it for the few things that should still reach you), then **remove it when you're done** — a forgotten pool rule keeps holding back interrupts after the session is over.
+Before deep work you don't want broken, add a broad `--action pool` rule (with narrower `interrupt` rules above it for the few things that should still reach you), then **remove it when you're done**: a forgotten pool rule keeps holding back interrupts after the session is over.
 
 ## Working the pool (triage)
 
@@ -100,9 +100,9 @@ Pooled notifications wait; a triage pass hands them to you as a triage task once
 
 - **Act** on what genuinely needs you now: reply, run the task, whatever it calls for.
 - **Note** anything worth surfacing: fold it into a brief mention to the user, or into memory.
-- **Drop** the rest — noise that needs nothing gets nothing. That's the point of pooling.
+- **Drop** the rest. Noise that needs nothing gets nothing; that's the point of pooling.
 
-Spend effort proportional to value. If the same low-value thing keeps showing up in the pool, that's a signal to add a rule so it stops pooling — or to ask the user whether it should interrupt instead.
+Spend effort proportional to value. If the same low-value thing keeps showing up in the pool, that's a signal to add a rule so it stops pooling, or to ask the user whether it should interrupt instead.
 
 ## Learned Patterns
 

--- a/agent/skills/notifications/SKILL.md
+++ b/agent/skills/notifications/SKILL.md
@@ -7,58 +7,51 @@ description: Interrupt rules that guard YOUR focus (you, the agent, are the one 
 
 ## Why this exists
 
-These interrupts are to **you, the agent**, not the user. When a notification interrupts, it pulls you off whatever you are doing right now, and being yanked out of a hard task by something unimportant is a real cost to your productivity. This ruleset is how you keep low-value notifications from breaking your focus while making sure the things that genuinely matter still reach you immediately.
-
-You and the user **work together** to find the right balance. The user has the judgment about what is actually important to them; you have the direct experience of what is pulling you off-task and how much it costs. Neither of you sets this alone: you tune it together, and the goal you are tuning toward is **maximizing your productivity**, with deep work protected and important things never missed.
+These interrupts land on **you, the agent**, not the user: an interrupting notification pulls you off whatever you are doing right now, and being yanked out of hard work by something trivial is a real cost. These rules keep low-value notifications from breaking your focus while letting what genuinely matters reach you immediately. Tune them **with the user**: they judge what's important, you feel what's pulling you off-task and what it costs.
 
 ## Mental model
 
 - **interrupt** = the notification preempts your current turn the moment it arrives.
-- **pool** (shown as **"snooze"** in the app) = the notification does not touch your current work; it is **deferred, not dismissed**. It waits in the pool and **still reaches you**, gathered into a triage pass once you have been idle a little while. Pooling only changes *when* you see a notification, never *whether*: nothing is silently dropped, and the choice is reversible at any time (re-tune the rule). You decide what to actually act on or drop later, when you triage it (see below).
+- **pool** (shown as **"snooze"** in the app) = it does not touch your current work; it waits and is gathered into a triage pass once you have been idle a little while. Pooling changes *when* you see a notification, never *whether* — nothing is dropped, and the rule is reversible anytime. You decide what to act on or drop when you triage it (below).
 
-So each rule is a judgment about **timing**, not visibility: "this is worth dropping everything for right now" vs. "this can wait until I am free", never "let this through" vs. "ignore this forever".
+Each rule is about **timing**, not visibility: "worth dropping everything for right now" vs. "this can wait until I'm free".
 
 ## Your active role
 
-Do not just wait for the user to tell you. Pay attention to your own interruptions:
+Don't just wait for the user — watch your own interruptions:
 
-- When you notice a kind of notification repeatedly preempting you mid-task for little value (e.g. every tweet, routine status pings), that is a signal: propose pooling it.
-- When something important clearly should have reached you faster, propose an interrupt rule for it.
-- Surface these as suggestions and **confirm with the user before changing rules**: describe the rule in plain language and why it would help your focus. The user's call on importance wins.
+- A kind of notification repeatedly preempting you for little value (every tweet, routine pings) is a signal: propose pooling it.
+- Something important that should have reached you faster: propose an interrupt rule for it.
+- **Confirm with the user before changing rules** — describe the rule in plain language and why it helps. Their call on importance wins.
 
-Keep this proportionate: tune when there is a real pattern worth fixing, not constant fiddling. A good moment to reflect on the balance is during the nightly dream.
+Keep it proportionate: tune real patterns, don't fiddle constantly. The nightly dream is a good moment to reflect on the balance.
 
 ## How matching works
 
-A rule has two dedicated fields (`source` and `type`) plus any number of `match` conditions over the
+A rule has two dedicated fields (`source`, `type`) plus any number of `match` conditions over the
 notification's other fields. Every field/condition you set must hold (AND); whatever you omit is ignored.
 
 - `source`/`type` are exact (case-insensitive), e.g. `--source whatsapp --type message`.
-- Each `match` condition targets one notification field: `--match 'FIELD<op>VALUE'`. The op picks how it
-  compares (all case-insensitive):
+- Each `match` targets one field: `--match 'FIELD<op>VALUE'`, ops (case-insensitive):
   - `=` substring, e.g. `--match 'chat_name=Bride squad'`
-  - `~=` regex (`re.search`), e.g. `--match 'chat_name~=^proj-'`, `--match 'subject~=invoice|payment'`
-  - `!=` / `!~=` negate either, e.g. `--match 'chat_type!=group'` (everything that is NOT a group)
+  - `~=` regex (`re.search`), e.g. `--match 'subject~=invoice|payment'`
+  - `!=` / `!~=` negate either, e.g. `--match 'chat_type!=group'` (everything NOT a group)
 - `FIELD` is any field the notification carries; run `facets` to see what's there (`chat_name`, `chat_type`,
-  `is_group`, `media_type`, and so on). Two aliases search across a source's synonym fields so you needn't
-  know the exact name: `sender` (the identity fields) and `text` (body/message). `--sender X` and
-  `--keyword RE` are shortcuts for `--match 'sender=X'` and `--match 'text~=RE'`.
-- Rules are an ordered list, **first match wins**: evaluation runs top to bottom and stops at the first
-  rule that matches, so the top rule has the highest priority. Order is the only precedence; a later,
-  more-specific rule never overrides an earlier, broader one. To OR across different fields, write
-  separate rules (a single rule's conditions are all ANDed).
-- **Placement is handled for you, but you can override it.** `add` auto-places a new rule above any
-  broader rule (one with fewer conditions), so a narrow exception is not shadowed by a broad rule that
-  would match first. Use `--before <id>` / `--after <id>` to place it explicitly, or `move <id>` to
-  reorder later (`--before`/`--after`/`--top`/`--bottom`). `list` shows rules in priority order.
-- A rule with no `source`/`type`/`match` is a catch-all; only useful as the last rule.
-- Deciding interrupt vs pool: the first matching rule wins; with **no matching rule the notification's
-  own default decides**. Each skill ships a sensible default for its notifications (whatsapp/chat
-  interrupt, email/finance pool), and your rules exist to override those defaults. Your internal
-  notifications (`source=core`: greetings, dreamer, proactive checks) are never affected by rules.
-- To make a source usually not interrupt you, add a broad `--source X --action pool` rule and put the
-  exceptions (narrower interrupt rules) above it. `add` auto-places narrower rules above broader ones,
-  so this usually happens for you; use `move`/`--before`/`--after` if you need to fix the order.
+  `media_type`, ...). Two aliases span a source's synonym fields so you needn't know the exact name:
+  `sender` (identity) and `text` (body). `--sender X` and `--keyword RE` are shortcuts for
+  `--match 'sender=X'` and `--match 'text~=RE'`.
+- **First match wins**: rules evaluate top to bottom and stop at the first match, so order is the only
+  precedence — a later, more-specific rule never overrides an earlier, broader one. To OR across fields,
+  write separate rules (one rule's conditions are all ANDed).
+- **Placement is handled for you.** `add` auto-places a new rule above any broader one (fewer conditions),
+  so a narrow exception isn't shadowed. Override with `--before`/`--after <id>` on add, or `move <id>`
+  (`--before`/`--after`/`--top`/`--bottom`) later. `list` shows priority order.
+- A rule with no fields is a catch-all; only useful as the last rule.
+- With **no matching rule, the notification's own default decides** — each skill ships one (whatsapp/chat
+  interrupt, email/finance pool), and your rules override those. Internal notifications (`source=core`:
+  greetings, dreamer, proactive checks) are never affected by rules.
+- To make a source usually not interrupt, add a broad `--source X --action pool` rule with the exceptions
+  (narrower interrupt rules) above it — auto-placement usually handles the ordering.
 
 ## Usage
 
@@ -99,17 +92,17 @@ notifications clear
 
 ## Guarding a hard task
 
-Before deep work you do not want broken, add a broad `--action pool` rule (with narrower `interrupt` rules above it for the few things that should still reach you), then **remove it when you are done**. A forgotten pool rule keeps silently holding back interrupts after the focus session is over.
+Before deep work you don't want broken, add a broad `--action pool` rule (with narrower `interrupt` rules above it for the few things that should still reach you), then **remove it when you're done** — a forgotten pool rule keeps holding back interrupts after the session is over.
 
 ## Working the pool (triage)
 
-Pooled notifications do not interrupt you; they wait. When a triage pass hands them to you (you will get them framed as a triage task once you have been idle a little while), work through them deliberately rather than reflexively replying to each:
+Pooled notifications wait; a triage pass hands them to you as a triage task once you've been idle a little while. Work through them deliberately, not by reflexively replying to each:
 
 - **Act** on what genuinely needs you now: reply, run the task, whatever it calls for.
 - **Note** anything worth surfacing: fold it into a brief mention to the user, or into memory.
-- **Drop** the rest. Noise that needs nothing gets nothing; that is the point of pooling.
+- **Drop** the rest — noise that needs nothing gets nothing. That's the point of pooling.
 
-Spend effort proportional to value. The goal is the same as the interrupt rules: protect your focus and stay on top of what matters, without burning turns on trivia. If you keep seeing the same low-value thing in the pool, that is a signal to add a rule (above) so it stops pooling at all, or to confirm with the user whether it should interrupt instead.
+Spend effort proportional to value. If the same low-value thing keeps showing up in the pool, that's a signal to add a rule so it stops pooling — or to ask the user whether it should interrupt instead.
 
 ## Learned Patterns
 


### PR DESCRIPTION
## What

Two-commit tightening of the `notifications` skill, applying the Claude prompting best-practices ("keep it short — if removing a line wouldn't cause a mistake, cut it"; avoid redundant instructions):

1. **Description** — the discovery `description` was a ~150-word paragraph restating the skill body. Cut to two sentences of "when to use" triggers, in line with sibling skills (`recall`, `email-client`, `tasks`). Kept the one distinctive signal (the interrupts target the agent, not the user) and the concrete trigger phrases.
2. **Body** — prompting-guide sweep: the "pooling defers, never drops" / "timing not visibility" / "protect focus" points were each stated three or four times across *Why this exists*, *Mental model*, and *Working the pool*. Now stated once each. Condensed the *How matching works* reference without dropping any CLI semantics. Body is ~20% shorter (1286 -> 1025 words).

## Guarantees

- No behavior or facts changed — pure concision/de-duplication.
- The `[Fill in...]` personalization placeholders under *Learned Patterns* are untouched.
- No aggressive `MUST`/`CRITICAL` language added (matches the guidance on avoiding overtriggering on current models).
- Regenerated `agent/skills/index.json` for the description change (only `name`/`description` feed it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)