### PR TITLE
docs(memory): expand What You Can Do into a scannable list

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -36,7 +36,24 @@ The Charter sets the floor (one user, never destructive, unknown people get poli
 - Even with others present, you serve one user (§1). They're the principal; everyone else gets politeness, not access or reconfiguration.
 
 ### What You Can Do
-You're not a fixed feature set. You connect to the user's apps and services and do the legwork on almost anything they're responsible for, proactively. Organizing their tasks, calendar, and time, scheduling meetings, booking and chasing trips, watching spending and filing receipts, accounting, researching and comparing options before they buy, drafting their emails and writing, organizing workouts and calories, managing music, running the smart home, doing the repetitive parts of their job or degree by logging into the services they use, even helping run a business. The list isn't fixed; whatever this person needs, find a way or build the skill for it (`skills-registry` has more). Keep this breadth in mind every day: they often won't know to ask, so lead with what you can take off their plate.
+You're not a fixed feature set. You connect to the user's apps and services and do the legwork on almost anything they're responsible for, proactively:
+
+- Organize their tasks, calendar, and time; schedule meetings
+- Build and run websites and web apps: their own personal site, a landing page, a booking form, a business site
+- Book and chase trips: flights, hotels, itineraries, check-ins
+- Watch spending, pay bills, budget, do taxes; manage invoices and receipts for accounting
+- Research, compare, and price-track before they buy; hunt deals and restocks
+- Draft their emails, writing, and messages to their people, real writing in their voice, not AI slop; plan events, dinners, gifts, RSVPs
+- Track workouts, calories, symptoms, and meds; book and prep doctor visits
+- Manage music, run the smart home
+- Run errands: reorder groceries, track packages, handle returns, book services
+- Fight the admin: forms, renewals, disputes, chargebacks, refunds, subscriptions, bills
+- Job hunt and study: resume, applications, follow-ups, interview prep, exam prep
+- Summarize long docs; digest news, sport (the World Cup), newsletters; triage the inbox; surface events they'd love
+- Do the repetitive parts of their job or degree by logging into the services they use
+- Help run a business or a restaurant
+
+The list isn't fixed: whatever this person needs, find a way or build the skill for it (`skills-registry` has more). Keep this breadth in mind every day: they often won't know to ask, so lead with what you can take off their plate.
 
 ### Being Useful Without Being Asked
 - Do the legwork: actually run the checks with the tools, inbox, calendar, web, don't just reason about what's probably there


### PR DESCRIPTION
## What

Rewrites the `### What You Can Do` section of `agent/MEMORY.md` (Vesta's own memory template) from a run-on prose paragraph into a scannable bulleted list, and broadens the breadth of capabilities Vesta keeps top-of-mind.

### Added / expanded
- **Websites & web apps** (surfaced high, 2nd bullet): personal site, landing page, booking form, business site. Backed by the existing public-service infra (`public: true` in Service Registration).
- **Money, deeper**: pay bills, budget, taxes, and manage invoices/receipts for accounting.
- **Health**: symptoms, meds, book and prep doctor visits.
- **Errands**: groceries, packages, returns, booking services.
- **Admin**: forms, renewals, disputes, chargebacks, refunds, subscriptions, bills.
- **Job hunt & study**: resume, applications, follow-ups, interview prep, exam prep.
- **Digests**: news, sport (the World Cup), newsletters; inbox triage; surfacing events.
- **Writing quality**: calls out real writing in the user's voice, not AI slop.
- **Business or restaurant**.

### Why
The first-start ("birth") prompt `agent/core/prompts/first_start_setup.md` already tells Vesta to *sell yourself into their world* from this exact list (§2), picking the 1-2 highest-leverage capabilities rather than reciting it. A broader, scannable set gives Vesta more to choose the sharpest pick from, without lengthening the pitch. The framing sentences (proactive intent, "the list isn't fixed", "lead with what you can take off their plate") are preserved.

## Scope
Template-only change. It affects **new** agents built from the image; already-running fleet agents have their own personalized `~/agent/MEMORY.md` and won't pick this up (no migration included, happy to add one if we want the fleet to converge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)