### PR TITLE
fix(app): clear "restart to apply" once the agent actually restarts

### DIFF
--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -281,7 +281,7 @@ export function FilesTab() {
       await writeFile(agentName, loadedFile.path, editorContent);
       setLoadedFile({ ...loadedFile, content: editorContent });
       setStatus({ kind: "saved" });
-      markRestartPending(agentName, "files");
+      markRestartPending(agentName, "files", agent.startedAt);
     } catch (e) {
       setStatus({ kind: "error", message: errorMessage(e, "save failed") });
     }

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -40,7 +40,7 @@ function folderName(path: string): string {
 // can-edit toggle); an "add a folder" cell opens a dialog for the add flow (suggestions +
 // path). PUTs the whole list on every change.
 export function HostAccessCard() {
-  const { name: agentName } = useSelectedAgent();
+  const { name: agentName, agent } = useSelectedAgent();
   const markRestartPending = useRestartPending((s) => s.markPending);
   const [mounts, setMounts] = useState<HostMount[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -96,7 +96,8 @@ export function HostAccessCard() {
     try {
       const result = await setAgentMounts(agentName, next);
       setMounts(result.mounts);
-      if (result.restartRequired) markRestartPending(agentName, "host-access");
+      if (result.restartRequired)
+        markRestartPending(agentName, "host-access", agent.startedAt);
       return true;
     } catch (e) {
       setSaveError(errorMessage(e, "failed to update host access"));

--- a/apps/web/src/components/AgentSettings/PreemptModeCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/PreemptModeCard/index.tsx
@@ -26,7 +26,7 @@ const MODE_HINT: Record<PreemptMode, (agent: string) => string> = {
 // Toggling back to the mode that was loaded withdraws this card's flag — the loaded value is the
 // best available stand-in for what the running agent applied.
 export function PreemptModeCard() {
-  const { name: agentName } = useSelectedAgent();
+  const { name: agentName, agent } = useSelectedAgent();
   const markRestartPending = useRestartPending((s) => s.markPending);
   const clearRestartReason = useRestartPending((s) => s.clearReason);
   const [mode, setMode] = useState<PreemptMode | null>(null);
@@ -62,7 +62,7 @@ export function PreemptModeCard() {
     setPreemptMode(agentName, next)
       .then(() => {
         if (next === appliedMode) clearRestartReason(agentName, "preempt-mode");
-        else markRestartPending(agentName, "preempt-mode");
+        else markRestartPending(agentName, "preempt-mode", agent.startedAt);
       })
       .catch((e: unknown) => {
         setMode(previous);

--- a/apps/web/src/components/Navbar/AgentNavbar/index.tsx
+++ b/apps/web/src/components/Navbar/AgentNavbar/index.tsx
@@ -44,7 +44,7 @@ export function AgentNavbar({
   const isMobile = useIsMobile();
   const chatKeyboardFocused = useLayout((s) => s.chatKeyboardFocused);
   const restartPending = useRestartPending((s) =>
-    Boolean(name && s.pending[name]?.length),
+    Boolean(name && s.pending[name]?.reasons.length),
   );
   const [restarting, setRestarting] = useState(false);
   // Route through the provider's restart so clearing the pending flag has a single owner (the

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -19,6 +19,9 @@ export interface AgentInfo {
   status: AgentStatus;
   activityState: AgentActivityState;
   services: Record<string, ServiceInfo>;
+  // Container start time (RFC3339), absent for an agent that has never started. Changes on every
+  // restart, so it is the signal that clears a "restart to apply" flag (see use-restart-pending).
+  startedAt?: string;
 }
 
 export type AgentActivityState = "idle" | "thinking";

--- a/apps/web/src/lib/vestad-api-fixtures.ts
+++ b/apps/web/src/lib/vestad-api-fixtures.ts
@@ -30,6 +30,7 @@ export const vestadApiFixtures = {
             "rev": 3
           }
         },
+        "startedAt": "2026-01-01T00:00:00Z",
         "status": "alive",
         "ws_port": 4200
       },

--- a/apps/web/src/providers/GatewayProvider/index.tsx
+++ b/apps/web/src/providers/GatewayProvider/index.tsx
@@ -20,6 +20,7 @@ import type {
   GatewayVersionInfo,
   ReleaseChannel,
 } from "@/lib/types";
+import { useRestartPending } from "@/stores/use-restart-pending";
 import { GatewayContext, disconnectedValue } from "./context";
 
 export { useGateway } from "./context";
@@ -166,8 +167,11 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
               break;
             }
             case "agents": {
-              setAgents(msg.agents ?? []);
+              const agents: AgentInfo[] = msg.agents ?? [];
+              setAgents(agents);
               setAgentsFetched(true);
+              // Clear any "restart to apply" flag whose agent has since restarted (by any path).
+              useRestartPending.getState().reconcile(agents);
               break;
             }
           }

--- a/apps/web/src/providers/SelectedAgentProvider/index.tsx
+++ b/apps/web/src/providers/SelectedAgentProvider/index.tsx
@@ -60,8 +60,12 @@ export function SelectedAgentProvider({
   const start = op("starting", () => startAgent(name), "start failed");
   const stop = op("stopping", () => stopAgent(name), "stop failed");
   // A restart/rebuild applies any pending saved changes, so clear the "restart to apply" reminder on
-  // success (the run callback throws on failure, so a failed op keeps the reminder). This is the single
-  // owner of clearing it, whichever surface (navbar button, agent menu) triggers the op.
+  // success (the run callback throws on failure, so a failed op keeps the reminder). For most reasons
+  // reconcile (use-restart-pending) is the owner — it clears the flag once the agent is observed to
+  // restart by any path — and this optimistic clear only hides the ~3s status-poll latency so the
+  // button vanishes immediately instead of flickering back. For host-access, which reconcile leaves
+  // alone (its mount needs a recreate a boot-time change can't confirm), this button IS the owner:
+  // it runs restartAgent, which recreates on mount drift and thus actually applies the grant.
   const applyPending = (
     operation: AgentOperation,
     run: () => Promise<unknown>,

--- a/apps/web/src/stores/use-restart-pending.test.tsx
+++ b/apps/web/src/stores/use-restart-pending.test.tsx
@@ -1,0 +1,138 @@
+// Exercises the real persisted store, so it runs in the jsdom project (localStorage present) —
+// hence .test.tsx despite having no JSX. The .test.ts (node) project has no localStorage.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  migrateRestartPending,
+  useRestartPending,
+} from "./use-restart-pending";
+
+const BOOT_T0 = "2026-07-07T10:00:00Z";
+const BOOT_T1 = "2026-07-07T11:00:00Z";
+
+beforeEach(() => {
+  localStorage.clear();
+  useRestartPending.setState({ pending: {} });
+});
+
+describe("useRestartPending", () => {
+  it("captures the agent's boot time when a change is flagged", () => {
+    useRestartPending.getState().markPending("ada", "files", BOOT_T0);
+    const entry = useRestartPending.getState().pending["ada"];
+    expect(entry.reasons).toEqual(["files"]);
+    expect(entry.since).toBe(BOOT_T0);
+  });
+
+  it("clears the flag once the agent is observed booting with a newer start time", () => {
+    useRestartPending.getState().markPending("ada", "files", BOOT_T0);
+    useRestartPending
+      .getState()
+      .reconcile([{ name: "ada", startedAt: BOOT_T1 }]);
+    expect(useRestartPending.getState().pending["ada"]).toBeUndefined();
+  });
+
+  it("keeps the flag while the agent has not restarted", () => {
+    useRestartPending.getState().markPending("ada", "files", BOOT_T0);
+    useRestartPending
+      .getState()
+      .reconcile([{ name: "ada", startedAt: BOOT_T0 }]);
+    expect(useRestartPending.getState().pending["ada"].reasons).toEqual([
+      "files",
+    ]);
+  });
+
+  it("adopts a baseline for a flag with no captured boot time, then clears on the next restart", () => {
+    // Mirrors a flag carried over from before this fix shipped (since unknown).
+    useRestartPending.setState({
+      pending: { ada: { reasons: ["settings"], since: null } },
+    });
+    useRestartPending
+      .getState()
+      .reconcile([{ name: "ada", startedAt: BOOT_T0 }]);
+    // First sighting only pins the baseline; the flag must survive.
+    expect(useRestartPending.getState().pending["ada"].since).toBe(BOOT_T0);
+    useRestartPending
+      .getState()
+      .reconcile([{ name: "ada", startedAt: BOOT_T1 }]);
+    expect(useRestartPending.getState().pending["ada"]).toBeUndefined();
+  });
+
+  it("ignores agents with no reported boot time", () => {
+    useRestartPending.getState().markPending("ada", "files", BOOT_T0);
+    useRestartPending.getState().reconcile([{ name: "ada" }]);
+    expect(useRestartPending.getState().pending["ada"].reasons).toEqual([
+      "files",
+    ]);
+  });
+
+  it("withdraws one reason without dropping another or losing the boot time", () => {
+    useRestartPending.getState().markPending("ada", "files", BOOT_T0);
+    useRestartPending.getState().markPending("ada", "preempt-mode", BOOT_T0);
+    useRestartPending.getState().clearReason("ada", "files");
+    const entry = useRestartPending.getState().pending["ada"];
+    expect(entry.reasons).toEqual(["preempt-mode"]);
+    expect(entry.since).toBe(BOOT_T0);
+  });
+
+  it("keeps a known baseline when a later reason is flagged with no boot time", () => {
+    useRestartPending.getState().markPending("ada", "files", BOOT_T0);
+    useRestartPending.getState().markPending("ada", "preempt-mode", undefined);
+    expect(useRestartPending.getState().pending["ada"].since).toBe(BOOT_T0);
+  });
+
+  it("keeps a host-access flag across a restart, since a mount needs a recreate", () => {
+    // A plain/crash restart reuses the container with the old mounts; only a recreate (the app
+    // restart button) applies a new grant, so reconcile must not drop it on a boot change.
+    useRestartPending.getState().markPending("ada", "host-access", BOOT_T0);
+    useRestartPending
+      .getState()
+      .reconcile([{ name: "ada", startedAt: BOOT_T1 }]);
+    expect(useRestartPending.getState().pending["ada"].reasons).toEqual([
+      "host-access",
+    ]);
+  });
+
+  it("clears restart-applied reasons but keeps host-access on the same restart", () => {
+    useRestartPending.getState().markPending("ada", "files", BOOT_T0);
+    useRestartPending.getState().markPending("ada", "host-access", BOOT_T0);
+    useRestartPending
+      .getState()
+      .reconcile([{ name: "ada", startedAt: BOOT_T1 }]);
+    expect(useRestartPending.getState().pending["ada"].reasons).toEqual([
+      "host-access",
+    ]);
+  });
+});
+
+describe("migrateRestartPending", () => {
+  it("carries v1 reason lists over with an unknown boot time", () => {
+    const migrated = migrateRestartPending(
+      { pending: { ada: ["files", "host-access"] } },
+      1,
+    );
+    expect(migrated.pending["ada"]).toEqual({
+      reasons: ["files", "host-access"],
+      since: null,
+    });
+  });
+
+  it("carries a v0 boolean flag over as the generic reason", () => {
+    const migrated = migrateRestartPending({ pending: { ada: true } }, 0);
+    expect(migrated.pending["ada"]).toEqual({
+      reasons: ["settings"],
+      since: null,
+    });
+  });
+
+  it("drops a malformed v1 value that is not an array of known reasons", () => {
+    const migrated = migrateRestartPending(
+      { pending: { ada: "files", bob: ["files", "bogus"] } },
+      1,
+    );
+    expect(migrated.pending["ada"]).toBeUndefined();
+    expect(migrated.pending["bob"]).toEqual({
+      reasons: ["files"],
+      since: null,
+    });
+  });
+});

--- a/apps/web/src/stores/use-restart-pending.ts
+++ b/apps/web/src/stores/use-restart-pending.ts
@@ -1,74 +1,166 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
+import type { AgentInfo } from "@/lib/types";
+
 // Tracks agents that have a saved change which only applies after a restart. Features flag their
 // agent here (each under its own reason key) instead of rendering their own "restart to apply"
 // hint, so the navbar can offer a single restart action. Per-reason tracking lets a feature
 // withdraw its own flag when its setting is toggled back to the applied value, without wiping
 // another feature's legitimate reminder. Persisted to localStorage so a page reload keeps the
 // reminder — the change is already saved server-side, and a lost reminder means the user never
-// restarts and the edit stays silently inert. Cleared when the agent is restarted (see
-// SelectedAgentProvider).
-// The reason vocabulary is the withdraw contract: clearReason only matches an identical key,
-// so the store owns the spelling. "settings" only labels flags migrated from the un-keyed v0 store.
-export type RestartReason =
-  "host-access" | "files" | "preempt-mode" | "settings";
+// restarts and the edit stays silently inert.
+// The flag is cleared by observing the agent actually restart: markPending stamps the agent's boot
+// time (`since`), and reconcile drops the flag once a different boot time is seen (see reconcile), so
+// a restart by any path — the navbar button, the CLI, another tab/device, a crash, the nightly
+// dreamer — clears it, not only a restart this browser triggered. The exception is host-access: a
+// new bind mount needs a container *recreate*, which a boot-time change can't distinguish from a
+// plain/crash restart that reused the old mounts, so reconcile leaves those reasons for the app
+// restart button's clear (which does recreate) rather than risk dropping a still-inert grant.
+
+// ALL_REASONS is the single source for the reason vocabulary: it's the withdraw contract
+// (clearReason matches an identical key, so the store owns the spelling) and the runtime allowlist
+// migrate narrows untrusted persisted data against; RestartReason derives from it so the two never
+// drift. "settings" only labels flags migrated from the un-keyed v0 store.
+const ALL_REASONS = [
+  "host-access",
+  "files",
+  "preempt-mode",
+  "settings",
+] as const;
+export type RestartReason = (typeof ALL_REASONS)[number];
+
+// Reasons reconcile must not clear on a boot-time change — they need a container recreate, not a
+// mere restart (see the header). host-access qualifies: bind mounts are fixed at container create.
+const RECREATE_ONLY_REASONS: readonly RestartReason[] = ["host-access"];
+
+// `since` is the agent's container start time (AgentInfo.startedAt) captured when the change was
+// saved; null when it wasn't known. Only the restart-applied reasons consult it — host-access
+// threads it too (so a later mixed entry has a baseline) but clears via the button regardless.
+interface PendingEntry {
+  reasons: RestartReason[];
+  since: string | null;
+}
+
+// A restart observation: the subset of AgentInfo reconcile needs, kept coupled to the wire type.
+type AgentBoot = Pick<AgentInfo, "name" | "startedAt">;
 
 interface RestartPendingState {
-  pending: Record<string, RestartReason[]>;
-  markPending: (agent: string, reason: RestartReason) => void;
+  pending: Record<string, PendingEntry>;
+  markPending: (
+    agent: string,
+    reason: RestartReason,
+    startedAt: string | undefined,
+  ) => void;
   clearReason: (agent: string, reason: RestartReason) => void;
   clearPending: (agent: string) => void;
+  reconcile: (agents: AgentBoot[]) => void;
 }
 
 function without(
-  pending: Record<string, RestartReason[]>,
+  pending: Record<string, PendingEntry>,
   agent: string,
-): Record<string, RestartReason[]> {
+): Record<string, PendingEntry> {
   const next = { ...pending };
   delete next[agent];
   return next;
+}
+
+export function migrateRestartPending(
+  persisted: unknown,
+  version: number,
+): { pending: Record<string, PendingEntry> } {
+  const state = persisted as { pending?: Record<string, unknown> };
+  const pending: Record<string, PendingEntry> = {};
+  for (const [agent, value] of Object.entries(state.pending ?? {})) {
+    if (version === 0) {
+      // v0 stored Record<string, boolean>; carry the reminder over under a generic reason.
+      if (value === true)
+        pending[agent] = { reasons: ["settings"], since: null };
+    } else if (Array.isArray(value)) {
+      // v1 stored Record<string, RestartReason[]>; no boot time was captured back then. Narrow
+      // rather than trust the persisted shape — drop anything that isn't a known reason.
+      const reasons = value.filter(
+        (r): r is RestartReason =>
+          typeof r === "string" &&
+          (ALL_REASONS as readonly string[]).includes(r),
+      );
+      if (reasons.length) pending[agent] = { reasons, since: null };
+    }
+  }
+  return { pending };
 }
 
 export const useRestartPending = create<RestartPendingState>()(
   persist(
     (set) => ({
       pending: {},
-      markPending: (agent, reason) =>
+      markPending: (agent, reason, startedAt) =>
         set((state) => {
-          const reasons = state.pending[agent] ?? [];
-          if (reasons.includes(reason)) return state;
+          const entry = state.pending[agent];
+          if (entry?.reasons.includes(reason)) return state;
+          // Advance the baseline to this save's boot when it's known, else keep the prior one — a
+          // transient undefined (agent not yet loaded) must not erase a good baseline down to null.
+          const reasons = entry ? [...entry.reasons, reason] : [reason];
           return {
-            pending: { ...state.pending, [agent]: [...reasons, reason] },
+            pending: {
+              ...state.pending,
+              [agent]: { reasons, since: startedAt ?? entry?.since ?? null },
+            },
           };
         }),
       clearReason: (agent, reason) =>
         set((state) => {
-          const reasons = state.pending[agent];
-          if (!reasons?.includes(reason)) return state;
-          const remaining = reasons.filter((r) => r !== reason);
+          const entry = state.pending[agent];
+          if (!entry?.reasons.includes(reason)) return state;
+          const remaining = entry.reasons.filter((r) => r !== reason);
           if (remaining.length === 0)
             return { pending: without(state.pending, agent) };
-          return { pending: { ...state.pending, [agent]: remaining } };
+          return {
+            pending: {
+              ...state.pending,
+              [agent]: { ...entry, reasons: remaining },
+            },
+          };
         }),
       clearPending: (agent) =>
         set((state) => {
           if (!state.pending[agent]) return state;
           return { pending: without(state.pending, agent) };
         }),
+      // Retire reasons once the agent is observed running a different container start than the one
+      // the change was saved against — the restart applied them, whoever triggered it. Recreate-only
+      // reasons survive (see RECREATE_ONLY_REASONS). A flag whose boot time is unknown (migrated)
+      // pins the current boot as its baseline on first sighting, so it clears on the next restart
+      // rather than lingering forever.
+      reconcile: (agents) =>
+        set((state) => {
+          let pending = state.pending;
+          for (const { name, startedAt } of agents) {
+            const entry = pending[name];
+            if (!entry || !startedAt) continue;
+            if (entry.since === null) {
+              pending = { ...pending, [name]: { ...entry, since: startedAt } };
+            } else if (startedAt !== entry.since) {
+              const survivors = entry.reasons.filter((r) =>
+                RECREATE_ONLY_REASONS.includes(r),
+              );
+              pending =
+                survivors.length === 0
+                  ? without(pending, name)
+                  : {
+                      ...pending,
+                      [name]: { reasons: survivors, since: startedAt },
+                    };
+            }
+          }
+          return pending === state.pending ? state : { pending };
+        }),
     }),
     {
       name: "vesta-restart-pending",
-      version: 1,
-      // v0 stored Record<string, boolean>; carry the reminder over under a generic reason.
-      migrate: (persisted: unknown) => {
-        const state = persisted as { pending?: Record<string, unknown> };
-        const pending: Record<string, RestartReason[]> = {};
-        for (const [agent, value] of Object.entries(state.pending ?? {})) {
-          if (value === true) pending[agent] = ["settings"];
-        }
-        return { pending };
-      },
+      version: 2,
+      migrate: migrateRestartPending,
     },
   ),
 );

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -228,6 +228,10 @@ pub struct ListEntry {
     pub name: String,
     pub status: AgentStatus,
     pub ws_port: u16,
+    // Container start time; the web app watches it change to retire a "restart to apply" flag.
+    // camelCase on the wire to match the web's AgentInfo; omitted when the agent has never started.
+    #[serde(rename = "startedAt", skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
 }
 
 // --- Docker connection ---
@@ -430,7 +434,13 @@ pub struct ContainerInfo {
     pub status: ContainerStatus,
     pub port: Option<u16>,
     pub id: Option<String>,
+    /// Container start time (RFC3339 from Docker `State.StartedAt`), `None` for one that has never
+    /// started. Changes on every restart, so the web app uses it to retire a "restart to apply" flag.
+    pub started_at: Option<String>,
 }
+
+// The Go zero time Docker reports for a container that has never started; not a real boot.
+const NEVER_STARTED_AT: &str = "0001-01-01T00:00:00Z";
 
 pub async fn combined_status(
     http_client: &reqwest::Client,
@@ -505,7 +515,10 @@ pub(crate) fn container_info_from(cname: &str, info: &bollard::models::Container
         .unwrap_or_else(|| name_from_cname(cname));
     let port = agents_dir.and_then(|dir| read_env_value(dir, &name, "WS_PORT"))
         .and_then(|v| v.parse().ok());
-    ContainerInfo { status, port, id }
+    let started_at = info.state.as_ref()
+        .and_then(|s| s.started_at.clone())
+        .filter(|t| !t.is_empty() && t != NEVER_STARTED_AT);
+    ContainerInfo { status, port, id, started_at }
 }
 
 pub(crate) async fn inspect_container(docker: &Docker, cname: &str, agents_dir: Option<&std::path::Path>) -> ContainerInfo {
@@ -515,6 +528,7 @@ pub(crate) async fn inspect_container(docker: &Docker, cname: &str, agents_dir: 
             status: ContainerStatus::NotFound,
             port: None,
             id: None,
+            started_at: None,
         },
     }
 }
@@ -1720,6 +1734,7 @@ pub async fn list_agents(
             name: agent_name.clone(),
             status: combined_status(http_client, agents_dir, cname, &info).await,
             ws_port: info.port.unwrap_or(0),
+            started_at: info.started_at.clone(),
         });
     }
     entries
@@ -2456,6 +2471,33 @@ mod tests {
         assert!(mounts_have_core_code(&single));
         assert!(mounts_have_core_code(&legacy));
         assert!(!mounts_have_core_code(&none));
+    }
+
+    fn inspect_with_started_at(started_at: Option<&str>) -> bollard::models::ContainerInspectResponse {
+        bollard::models::ContainerInspectResponse {
+            state: Some(bollard::models::ContainerState {
+                status: Some(bollard::models::ContainerStateStatusEnum::RUNNING),
+                started_at: started_at.map(str::to_string),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn container_info_from_surfaces_container_start_time() {
+        // The web app clears a "restart to apply" flag by watching this value change, so a running
+        // container must report its StartedAt while a never-started container reports nothing.
+        let running = container_info_from("vesta-bot", &inspect_with_started_at(Some("2026-07-07T10:00:00.5Z")), None);
+        assert_eq!(running.started_at.as_deref(), Some("2026-07-07T10:00:00.5Z"));
+
+        // Docker returns the Go zero time for a container that has never started; treat it as absent
+        // so it never reads as a real boot on the wire.
+        let never = container_info_from("vesta-bot", &inspect_with_started_at(Some("0001-01-01T00:00:00Z")), None);
+        assert_eq!(never.started_at, None);
+
+        let missing = container_info_from("vesta-bot", &inspect_with_started_at(None), None);
+        assert_eq!(missing.started_at, None);
     }
 
     #[test]

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -3099,8 +3099,8 @@ mod tests {
 
         // The control WS "agents" message, built by the production code path.
         let agents = vec![
-            ListEntry { name: "sample-agent".into(), status: AgentStatus::Alive, ws_port: 4200 },
-            ListEntry { name: "stopped-agent".into(), status: AgentStatus::Stopped, ws_port: 4201 },
+            ListEntry { name: "sample-agent".into(), status: AgentStatus::Alive, ws_port: 4200, started_at: Some("2026-01-01T00:00:00Z".into()) },
+            ListEntry { name: "stopped-agent".into(), status: AgentStatus::Stopped, ws_port: 4201, started_at: None },
         ];
         let mut activity = HashMap::new();
         activity.insert("sample-agent".to_string(), "thinking".to_string());


### PR DESCRIPTION
## Problem

The "restart to apply" button stayed lit permanently even after the agent had already restarted. The reminder lives only in browser `localStorage` and was cleared by a **single** optimistic path that fires only when *this* browser triggers the restart. Any other route — a model/context change, a CLI restart, a restart from another tab or device, a crash restart, or the nightly dreamer — never cleared it, so the button got stuck on.

## Root cause

The flag never reconciled against the agent actually restarting. And the frontend had **no** per-agent signal that reliably changes on a restart (the served status only ever passes through `starting → alive`, on a 3s poll that can miss the window). So a purely-client fix can't observe restarts that happen while a tab is closed.

## Fix

Surface the container start time as ground truth and reconcile against it:

- **vestad** reads Docker's `State.StartedAt` in `container_info_from` (normalizing the Go zero-time to absent), threads it through `ContainerInfo` → `ListEntry`, and serializes it as `startedAt` on the control-WS `agents` message. No extra Docker calls — the inspect was already in hand.
- **web**: `AgentInfo.startedAt`; the `use-restart-pending` store stamps the agent's boot time when a change is saved and `reconcile(agents)` (called from the single agents-message ingress) drops the flag once a **different** boot is observed — so a restart by *any* path clears it. The optimistic clear stays only to hide the ~3s poll latency on the local path.

### One deliberate exception: `host-access`

A new bind mount is only applied by a container **recreate**, which a boot-time change can't distinguish from a plain/crash restart that reused the old mounts. So `reconcile` leaves `host-access` for the app restart button's clear (which recreates on mount drift) rather than risk silently dropping a still-inert grant. The precise per-reason (container-id) / backend-owned handling is tracked in #1003.

## Testing

- TDD throughout. New store tests cover: boot-time capture, clear-on-restart, keep-while-not-restarted, the migrated/unknown-baseline adoption, host-access survival, per-reason clearing, and the v0→v2 migration incl. malformed-value narrowing. A vestad unit test covers `StartedAt` extraction + zero-time normalization.
- `apps/web`: `tsc` clean, all vitest green (incl. the cross-language contract test now validating the `startedAt` fixture). vestad is Linux-only and couldn't be compiled on the dev Mac (no cross toolchain) — its build/test rely on CI.

## Reviews run before opening

- `/code-review` at high effort: found the initial reconcile cleared too eagerly (host-access on a crash restart; a stale-baseline race). Fixed by scoping auto-clear to restart-applied reasons and excluding host-access; the residual precise/backend-owned handling is #1003.
- `/simplify`: collapsed duplicated `markPending` branches, dropped repeated `?? null` at call sites, coupled `AgentBoot` to `AgentInfo` via `Pick`, and made `ALL_REASONS` the single source deriving `RestartReason`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)