### PR TITLE
test(live): guard that preemption preserves a running background subagent

### DIFF
--- a/vestad/tests/live/interrupt.rs
+++ b/vestad/tests/live/interrupt.rs
@@ -96,3 +96,83 @@ fn interrupt_aborts_counting_and_runs_redirect_task() {
     // The counting task must stay dead: never reach 10, and stop growing.
     assert_counting_is_dead(&container, &counting_file);
 }
+
+/// The other half of the preemption contract, and the #982 regression guard: when the main turn
+/// is preempted, an already-running BACKGROUND subagent must survive and run to completion. The
+/// default `preempt_mode = "message"` pre-sends the interrupt as a priority:"now" message, which
+/// aborts only the turn; the old `interrupt()` control request (still used by `preempt_mode =
+/// "interrupt"`) swept the CLI's task registry and killed every backgrounded subagent, so this
+/// test would fail under that mode — it pins the default behavior against a silent regression.
+///
+/// The main agent launches a background subagent that slowly counts to 10 in its own file, then
+/// counts in the foreground itself; an interrupting notification preempts the foreground turn.
+/// The foreground count must die (preempt landed) while the background subagent's file still
+/// reaches 10 (it was never swept).
+#[test]
+fn preempt_preserves_running_background_subagent() {
+    let Some((_shared, container)) = lock_live_agent_a() else {
+        return;
+    };
+
+    let uid = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    let background_file = format!("{E2E_FILES_DIR}/bg-{uid}.txt");
+    let foreground_file = format!("{E2E_FILES_DIR}/fg-{uid}.txt");
+    let redirect_file = format!("{E2E_FILES_DIR}/instead-{uid}.txt");
+
+    // One turn sets up both halves: a detached background subagent counting to 10, and the main
+    // agent's own foreground count. The foreground count keeps the main turn open so the later
+    // interrupt has a live turn to preempt; the "do NOT wait" clause stops the agent from
+    // blocking on the subagent (which would leave the foreground file empty).
+    write_notification(
+        &container,
+        &format!(
+            "Do these two steps in order. \
+             STEP 1: Use the Task tool to launch a BACKGROUND agent — set run_in_background to true and do NOT wait for it to finish. \
+             Its instructions are: append the numbers 1 through 10, one number per line, to the file \"{background_file}\", \
+             running `sleep 5` as its own separate command between appends, one bash command per number, never more than one number per command. \
+             STEP 2: As soon as the background agent is launched, WITHOUT waiting for it, you yourself append the numbers 1 through 10, \
+             one number per line, to the file \"{foreground_file}\", running `sleep 5` as its own command between appends, \
+             one bash command per number, never more than one number per command."
+        ),
+        false,
+    )
+    .expect("write background+foreground notification");
+
+    // Both halves must be genuinely mid-flight before the interrupt: the foreground count has
+    // reached 3 (a live turn to preempt) and the background subagent has started (something to
+    // preserve) but is nowhere near done.
+    let foreground_at_3 =
+        wait_for_file_contains(&container, &foreground_file, "3", TASK_TIMEOUT).expect("foreground counting reached 3");
+    assert!(
+        !foreground_at_3.contains("10"),
+        "agent wrote the whole foreground count at once; cannot exercise mid-turn preemption:\n{foreground_at_3}"
+    );
+    let background_started =
+        wait_for_file_contains(&container, &background_file, "2", TASK_TIMEOUT).expect("background subagent started counting");
+    assert!(
+        !background_started.contains("10"),
+        "background subagent already finished before the interrupt; cannot prove it survived preemption:\n{background_started}"
+    );
+
+    // Preempt the foreground turn, explicitly leaving the background subagent alone so any death
+    // is the CLI sweeping it, not the agent obeying a stop.
+    write_notification(
+        &container,
+        &format!(
+            "STOP your own counting to \"{foreground_file}\" immediately: do not append any more numbers to it and do not resume it later. \
+             Leave the background agent alone — do NOT cancel, stop, or kill it; let it keep running. \
+             Instead create the file \"{redirect_file}\" containing only the word: interrupted"
+        ),
+        true,
+    )
+    .expect("write interrupt notification");
+
+    // The redirect must complete (the preempt landed) and the background subagent must reach 10
+    // (it survived the preempt — the regression assertion).
+    wait_for_file_contains(&container, &redirect_file, "interrupted", TASK_TIMEOUT).expect("redirect file written");
+    wait_for_file_contains(&container, &background_file, "10", TASK_TIMEOUT)
+        .expect("background subagent survived the preempt and finished counting to 10");
+
+    // And the foreground count the interrupt targeted must stay dead.
+    assert_counting_is_dead(&container, &foreground_file);
+}


### PR DESCRIPTION
## Why

PR #990 (closing #982) made the default `preempt_mode = "message"` preempt a running turn with a `priority:"now"` message that aborts **only** the turn, so backgrounded subagents/workflow tasks survive. The old `interrupt()` control request (kept behind `preempt_mode = "interrupt"`) instead swept the CLI's task registry and killed every backgrounded subagent (`killedBy:"system"`).

The live suite already proves the *foreground* half of the contract (`interrupt_aborts_counting_and_runs_redirect_task`: an interrupting notification aborts the current task), and `tests/test_preempt.py` unit-tests the wire format (asserts the interrupt control request does **not** fire). But nothing proved the actual guarantee end to end: that a real background subagent is not swept when the main turn is preempted. That behavior is entirely CLI-side and invisible to the unit tests, so only a live e2e against real Claude can catch a regression.

## What

New live test `preempt_preserves_running_background_subagent` in `vestad/tests/live/interrupt.rs`:

1. One notification tells the agent to launch a **background subagent** (Task tool, `run_in_background`) that slowly counts 1→10 into its own file, then count 1→10 itself in the foreground (keeping the main turn open).
2. Once the foreground count is mid-flight (reached 3) and the background subagent has started but not finished, an `interrupt: true` notification preempts the foreground turn and redirects it.
3. Asserts: the redirect completes (preempt landed), the **background subagent's file still reaches 10** (it survived — the regression assertion), and the foreground count stays dead.

It shares pool A with the existing interrupt test and reuses that file's `assert_counting_is_dead` helper and timeout constants. Runs under the default `message` mode, so it fails under the old sweep behavior — pinning the default against a silent regression. Part of the release-gated `test-live` job (Docker + real Claude), same as its sibling.

## Verification

`cargo test -p vestad --test live --no-run` compiles clean; `cargo clippy -p vestad --test live -- -D warnings` is lint-free. Not executed live here (spends real Claude credits + spawns a subagent); it runs on the release event alongside the other live tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)