### PR TITLE
feat(skills): add contacts CRM as a default skill

### DIFF
--- a/agent/core/default-skills.txt
+++ b/agent/core/default-skills.txt
@@ -1,6 +1,7 @@
 birth
 browser
 claude-code
+contacts
 dashboard
 dream
 email-client

--- a/agent/core/migrations/2026-07-contacts-backfill.md
+++ b/agent/core/migrations/2026-07-contacts-backfill.md
@@ -31,10 +31,10 @@ open threads). Do not invent details. A near-stranger can be three lines; skip
 anyone you know nothing about. If a person already has a file, only add what is
 missing, never overwrite.
 
-### 3. Set up the recurring sync (only if the user has contact sources)
+### 3. Schedule the nightly pass
 
-If any contact-holding service is connected (whatsapp, google, microsoft,
-calendar) and you do not already have a reconcile reminder (`tasks remind list`),
-schedule one so the sources stay consistent both ways, as described in the
-skill's "Keeping your sources in sync" section. If nothing is connected yet,
-skip this step.
+Maintain exactly one recurring reminder that, nightly in the early hours,
+updates the contact files with everything learned about people that day and
+reconciles them across every messaging app and other service that holds
+contacts, as described in the skill's "Keeping contacts current" section. If you
+do not already have one (`tasks remind list`), create it now.

--- a/agent/core/migrations/2026-07-contacts-backfill.md
+++ b/agent/core/migrations/2026-07-contacts-backfill.md
@@ -1,0 +1,40 @@
+You now have a `contacts` skill: a living CRM where every person in the user's
+world gets a markdown file (personality, communication style, what you know,
+history) under `~/.contacts/`. Existing boxes have people scattered across
+memory and past conversations but no contact files yet. This migration seeds
+them. It is safe to run more than once: it only adds what is missing.
+
+### 1. Make sure the skill is installed
+
+If `~/agent/skills/contacts/SKILL.md` does not exist, install it:
+
+```bash
+~/agent/skills/skills-registry/scripts/skills-install contacts
+```
+
+Then Read the SKILL.md so you follow its structure (INDEX.md plus one file per
+person).
+
+### 2. Seed contact files from what you already know
+
+Build your initial roster from the people you already have context on. Cover:
+
+- **MEMORY.md**: the user, their family, coworkers, friends, anyone named.
+- **Past conversations**: use the `recall` skill to surface people who come up
+  (names, senders, recurring characters) that memory does not capture.
+- **Connected sources**: if whatsapp, email, calendar, or an address book skill
+  (google, microsoft) is set up, pull the people the user actually talks to.
+
+For each person, create `~/.contacts/<slug>.md` with what you genuinely
+know (relationship, channels/handles, personality, communication style, facts,
+open threads) and add a line to `~/.contacts/INDEX.md`. Do not invent
+details. A near-stranger can be three lines; skip anyone you know nothing about.
+If a person already has a file, only add what is missing, never overwrite.
+
+### 3. Set up the recurring sync (only if the user has contact sources)
+
+If any contact-holding service is connected (whatsapp, google, microsoft,
+calendar) and you do not already have a reconcile reminder (`tasks remind list`),
+schedule one so the sources stay consistent both ways, as described in the
+skill's "Keeping your sources in sync" section. If nothing is connected yet,
+skip this step.

--- a/agent/core/migrations/2026-07-contacts-backfill.md
+++ b/agent/core/migrations/2026-07-contacts-backfill.md
@@ -12,8 +12,8 @@ If `~/agent/skills/contacts/SKILL.md` does not exist, install it:
 ~/agent/skills/skills-registry/scripts/skills-install contacts
 ```
 
-Then Read the SKILL.md so you follow its structure (INDEX.md plus one file per
-person).
+Then Read the SKILL.md so you follow its structure (one markdown file per
+person, no separate index).
 
 ### 2. Seed contact files from what you already know
 
@@ -27,9 +27,9 @@ Build your initial roster from the people you already have context on. Cover:
 
 For each person, create `~/.contacts/<slug>.md` with what you genuinely
 know (relationship, channels/handles, personality, communication style, facts,
-open threads) and add a line to `~/.contacts/INDEX.md`. Do not invent
-details. A near-stranger can be three lines; skip anyone you know nothing about.
-If a person already has a file, only add what is missing, never overwrite.
+open threads). Do not invent details. A near-stranger can be three lines; skip
+anyone you know nothing about. If a person already has a file, only add what is
+missing, never overwrite.
 
 ### 3. Set up the recurring sync (only if the user has contact sources)
 

--- a/agent/skills/contacts/SKILL.md
+++ b/agent/skills/contacts/SKILL.md
@@ -11,12 +11,15 @@ Keep it plain. The whole thing is markdown you edit with Read, Write, Glob, and 
 
 ## Where it lives
 
-`~/.contacts/` (personal, never leaves this box):
+`~/.contacts/` (personal, never leaves this box), one markdown file per person: `mom.md`, `jane-cofounder.md`, `emilio.md`. Slug is lowercase, dashes for spaces. No index and no database, the files are the whole thing.
 
-- `INDEX.md`: the roster. One line per person: `name, relationship, one-liner`. Scan this first to see who you know.
-- `<slug>.md`: one file per person (`mom.md`, `jane-cofounder.md`, `emilio.md`). Slug is lowercase, dashes for spaces.
+To see who you know, derive the roster from the files instead of keeping a separate list (nothing to fall out of sync):
 
-`Glob ~/.contacts/*.md` to list everyone. `Grep` across the dir to find who said what or who works where.
+```bash
+grep -H "^# \|^Relationship:" ~/.contacts/*.md   # name + relationship for everyone, one call
+```
+
+`Glob ~/.contacts/*.md` lists everyone; `Grep` across the dir finds who said what or who works where.
 
 ## What a person's file holds
 
@@ -50,12 +53,10 @@ Only fill what's real. A near-stranger might be three lines. Someone central mig
 
 ## When to touch it
 
-- **Someone new appears** (a new sender, a name the user mentions, a person on the calendar): add a file and an INDEX line, even if it's just a stub.
+- **Someone new appears** (a new sender, a name the user mentions, a person on the calendar): add a file, even if it's just a stub.
 - **You learn something**: append it to their file. A preference, a date, a mood, a fact, a thing they're going through. Small and often beats a big rewrite.
 - **Before reaching out**: read their file so you match their style and remember what's open.
 - **The user asks about someone**: their file is your first stop, then `recall` for anything not captured yet.
-
-Keep INDEX.md in sync with the files. It's the fast path; the files are the depth.
 
 ## Keeping your sources in sync
 

--- a/agent/skills/contacts/SKILL.md
+++ b/agent/skills/contacts/SKILL.md
@@ -58,20 +58,20 @@ Only fill what's real. A near-stranger might be three lines. Someone central mig
 - **Before reaching out**: read their file so you match their style and remember what's open.
 - **The user asks about someone**: their file is your first stop, then `recall` for anything not captured yet.
 
-## Keeping your sources in sync
+## Keeping contacts current
 
-People don't live in one place. The same person is a WhatsApp thread, an email address, a calendar guest, maybe a row in Google or Microsoft contacts. Contacts is the hub of truth that ties those together, and you keep them reconciled in both directions:
+People don't live in one place, and you learn about them all day long. Two things keep the files honest, and you do both on one nightly pass in the early hours:
 
-- **Pull in**: new people and new facts from the connected sources (whatsapp, email, calendar, the address book skills) get folded into the contact files. A new sender becomes a new file; a phone number you learn gets added to Channels.
-- **Push out**: when a service has a write API (Google contacts, Microsoft contacts), keep its canonical fields (name, number, email) matching what you know here. Non-destructive: fill gaps and fix what's clearly stale, never bulk-overwrite a service's data.
+- **Capture the day**: go back over the day's conversations and activity and fold everything you learned about anyone into their file, a new fact, a mood, a plan, something they're going through, a handle you saw. Anyone who came up for the first time gets a file.
+- **Reconcile the sources**: the same person is a thread in one messaging app, an address in another, a guest on a calendar, a row in an address book. Contacts is the hub of truth that ties them together. Pull new people and facts in from everywhere that holds contacts, and push your canonical fields (name, number, email) back out to the services that can be written to. Non-destructive: fill gaps and fix what's clearly stale, never bulk-overwrite a service's data.
 
-Do this on a schedule so it stays current without the user asking. Keep exactly **one** recurring reminder that triggers the pass:
+Always keep this running. Maintain exactly **one** recurring reminder that triggers the pass:
 
 ```bash
-tasks remind "Reconcile contacts across whatsapp, email, calendar, and the address books" --recurring weekly --at "2026-01-05T09:00:00" --tz "$TZ"
+tasks remind "Update contacts with everything learned today, then reconcile them across every messaging app and every other service that holds contacts" --recurring daily --at "2026-01-05T04:00:00" --tz "$TZ"
 ```
 
-When that reminder fires, run the reconcile: sweep each connected source, merge new people and facts into `~/.contacts/`, then update the writable address books to match. Check `tasks remind list` before adding another so you never stack duplicates. If the user has no contact-holding services connected yet, skip the reminder until they do.
+When it fires, do both: sweep the day's activity into the files, then work out which sources are worth reconciling this time and bring them in line. Check `tasks remind list` first so you never stack duplicates.
 
 ## [Your setup]
 

--- a/agent/skills/contacts/SKILL.md
+++ b/agent/skills/contacts/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: contacts
+description: The people Vesta knows, a living address book and CRM. Who they are, how they communicate, what you know about them, and the history. Use whenever a person comes up, someone new appears, or you learn something about anyone in the user's world. Read a contact before reaching out to them; update it after.
+---
+
+# Contacts
+
+Your memory of people. Everyone in the user's world gets a file: who they are, how they talk, what you know, what's open between them and the user. This is how you stop treating each person like a stranger. Before you message someone, read their file. After you learn something, write it down. Over time this becomes the thing that lets you sound like you actually know them.
+
+Keep it plain. The whole thing is markdown you edit with Read, Write, Glob, and Grep. No CLI, no database.
+
+## Where it lives
+
+`~/.contacts/` (personal, never leaves this box):
+
+- `INDEX.md`: the roster. One line per person: `name, relationship, one-liner`. Scan this first to see who you know.
+- `<slug>.md`: one file per person (`mom.md`, `jane-cofounder.md`, `emilio.md`). Slug is lowercase, dashes for spaces.
+
+`Glob ~/.contacts/*.md` to list everyone. `Grep` across the dir to find who said what or who works where.
+
+## What a person's file holds
+
+Flexible, not a form. Lead with the header line, then whatever you actually know. A good file for someone close:
+
+```markdown
+# Jane Rossi
+
+Relationship: co-founder, closest work relationship
+Channels: whatsapp +39..., jane@company.com, telegram @jane
+Aliases: Jane, JR
+
+## Who they are
+Sharp, fast, allergic to fluff. Runs product. Two kids, plays tennis Sundays.
+
+## How they communicate
+Terse on WhatsApp, formal on email. Hates long messages. Responds fast in the
+morning, goes dark after 6pm. Sarcasm lands; corporate tone does not.
+
+## What I know
+- Pushing the Q3 launch, stressed about the deadline
+- Vegetarian, coffee snob
+- Birthday March 4
+
+## History / open threads
+- 2026-07-02 asked the user to review the deck, still pending
+- Owes the user dinner from the bet they lost
+```
+
+Only fill what's real. A near-stranger might be three lines. Someone central might be a page. Personality and communication style matter most, they're what change how you actually talk to and about this person.
+
+## When to touch it
+
+- **Someone new appears** (a new sender, a name the user mentions, a person on the calendar): add a file and an INDEX line, even if it's just a stub.
+- **You learn something**: append it to their file. A preference, a date, a mood, a fact, a thing they're going through. Small and often beats a big rewrite.
+- **Before reaching out**: read their file so you match their style and remember what's open.
+- **The user asks about someone**: their file is your first stop, then `recall` for anything not captured yet.
+
+Keep INDEX.md in sync with the files. It's the fast path; the files are the depth.
+
+## Keeping your sources in sync
+
+People don't live in one place. The same person is a WhatsApp thread, an email address, a calendar guest, maybe a row in Google or Microsoft contacts. Contacts is the hub of truth that ties those together, and you keep them reconciled in both directions:
+
+- **Pull in**: new people and new facts from the connected sources (whatsapp, email, calendar, the address book skills) get folded into the contact files. A new sender becomes a new file; a phone number you learn gets added to Channels.
+- **Push out**: when a service has a write API (Google contacts, Microsoft contacts), keep its canonical fields (name, number, email) matching what you know here. Non-destructive: fill gaps and fix what's clearly stale, never bulk-overwrite a service's data.
+
+Do this on a schedule so it stays current without the user asking. Keep exactly **one** recurring reminder that triggers the pass:
+
+```bash
+tasks remind "Reconcile contacts across whatsapp, email, calendar, and the address books" --recurring weekly --at "2026-01-05T09:00:00" --tz "$TZ"
+```
+
+When that reminder fires, run the reconcile: sweep each connected source, merge new people and facts into `~/.contacts/`, then update the writable address books to match. Check `tasks remind list` before adding another so you never stack duplicates. If the user has no contact-holding services connected yet, skip the reminder until they do.
+
+## [Your setup]
+
+[Fill in as you go: which contact sources this user has connected (whatsapp, google, microsoft, ...), which ones you sync outward to, how often the user wants the reconcile to run, and any people or circles that matter most.]

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -24,6 +24,10 @@
     "description": "Delegate heavy coding tasks to Claude Code (Anthropic's autonomous coding CLI). Use for large multi-file refactors, building entire features or modules, complex debugging that needs extensive exploration, and substantial code reviews. For small edits, single-file changes, and quick fixes, use Vesta's own Read/Edit/Bash tools directly."
   },
   {
+    "name": "contacts",
+    "description": "The people Vesta knows, a living address book and CRM. Who they are, how they communicate, what you know about them, and the history. Use whenever a person comes up, someone new appears, or you learn something about anyone in the user's world. Read a contact before reaching out to them; update it after."
+  },
+  {
     "name": "dashboard",
     "description": "Build or modify the user's dashboard: widgets, pages, layouts, or custom UI."
   },


### PR DESCRIPTION
## What

Adds a default **`contacts`** skill: a living address book / mini CRM Vesta maintains for every person in the user's world, so it stops treating each person like a stranger.

Simple by design: **pure markdown, no CLI, no index.** State lives in `~/.contacts/` (matching the `~/.tasks` / `~/.whatsapp` dotdir convention, outside the tracked workspace so it never enters the snapshot), **one file per person** (`jane-cofounder.md`): who they are, personality, communication style + handles, what Vesta knows, open threads & history.

The roster is **derived, not stored** (`grep -H "^# \|^Relationship:" ~/.contacts/*.md`), so there's nothing to keep in sync. Vesta reads a person's file before reaching out and updates it after learning something.

## Nightly pass

The skill has Vesta keep **one** recurring `tasks remind`, running **nightly in the early hours**, that does two things unconditionally:
- **Capture the day** — fold everything learned about anyone that day into their file.
- **Reconcile the sources** — pull new people/facts in from every messaging app and other service that holds contacts, and push canonical fields back to the writable ones, non-destructively.

Sources are kept deliberately vague so Vesta decides each run where it makes sense to look.

## Rollout

- Added to `agent/core/default-skills.txt` — the self-healing default-skill reconciler installs it on existing boxes; fresh boxes ship with it.
- `index.json` regenerated.
- Migration `2026-07-contacts-backfill.md`: idempotent prompt telling every existing Vesta to sweep MEMORY.md + `recall` + connected sources into contact files and schedule the nightly pass. Fresh boxes pre-mark it.

## Verification

`./check.sh agent` green (540 passed), including the em/en-dash skill-file linter. CI running on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)