### PR TITLE
feat(microsoft): email parity with email-client (folders, forward, move, flag, notify)

### DIFF
--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -73,7 +73,7 @@
   },
   {
     "name": "microsoft",
-    "description": "Outlook email, inbox, calendar, meetings, events via Microsoft. Requires daemon."
+    "description": "Outlook/Microsoft 365 work account via Graph: read/send/reply/forward email, drafts, flag/categorize, move/archive, folders, attachments, block senders, calendar and meetings, and new-mail paging. Requires daemon."
   },
   {
     "name": "nap",

--- a/agent/skills/microsoft/SETUP.md
+++ b/agent/skills/microsoft/SETUP.md
@@ -1,22 +1,32 @@
 # Microsoft Setup
 
-1. Create an Azure App Registration at https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade
-   - Name: anything (e.g. "Vesta")
-   - Supported account types: select the **third option** (multitenant + personal Microsoft accounts), labeled "Accounts in any organizational directory ... and personal Microsoft accounts". Works for both work/school and personal accounts
-   - Redirect URI: leave blank (device flow doesn't need one)
-   - Under "API permissions": click "Add a permission" → "Microsoft Graph" → **"Delegated permissions"** (not Application permissions) → search and add: `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, `MailboxSettings.ReadWrite`
-   - Under "Authentication" (may show as "Authentication (Preview)"): go to the **Settings** tab → toggle "Allow public client flows" to **Yes** → click Save
-2. Copy the **Application (client) ID**
-3. Set environment variable:
-   ```
-   MICROSOFT_MCP_CLIENT_ID=<your-client-id>
-   ```
-4. Install: `uv tool install ~/agent/skills/microsoft/cli`
-5. Start background daemon: `screen -dmS microsoft microsoft serve`
-6. Register it for restart (see [service](../service/SKILL.md)) with this startup command:
+No Azure setup is required. The skill defaults to the **Microsoft Graph Command Line Tools**
+public client (Microsoft-published, multitenant, device-code capable) and requests the delegated
+Graph scopes it needs (`Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`,
+`MailboxSettings.ReadWrite`) via dynamic consent at sign-in. Just install, start the daemon, and
+authenticate:
+
+1. Install: `uv tool install ~/agent/skills/microsoft/cli`
+2. Start background daemon: `screen -dmS microsoft microsoft serve`
+3. Register it for restart (see [service](../service/SKILL.md)) with this startup command:
    ```
    screen -dmS microsoft microsoft serve --notifications-dir ~/agent/notifications
    ```
+
+## Optional: your own Azure app registration
+
+Use your own app only if you need to (e.g. a Conditional Access policy blocks the default client,
+or you want to pin a narrower scope set). Create one at
+https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade:
+
+- Name: anything (e.g. "Vesta")
+- Supported account types: select the **third option** (multitenant + personal Microsoft accounts), labeled "Accounts in any organizational directory ... and personal Microsoft accounts". Works for both work/school and personal accounts
+- Redirect URI: leave blank (device flow doesn't need one)
+- Under "API permissions": click "Add a permission" → "Microsoft Graph" → **"Delegated permissions"** (not Application permissions) → search and add: `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, `MailboxSettings.ReadWrite`
+- Under "Authentication" (may show as "Authentication (Preview)"): go to the **Settings** tab → toggle "Allow public client flows" to **Yes** → click Save
+
+Then copy the **Application (client) ID** and set `MICROSOFT_MCP_CLIENT_ID=<your-client-id>`
+(a custom client uses `.default`, i.e. exactly the permissions you configured above).
 
 ## Authentication
 

--- a/agent/skills/microsoft/SKILL.md
+++ b/agent/skills/microsoft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: microsoft
-description: Outlook email, inbox, calendar, meetings, events via Microsoft. Requires daemon.
+description: Outlook/Microsoft 365 work account via Graph: read/send/reply/forward email, drafts, flag/categorize, move/archive, folders, attachments, block senders, calendar and meetings, and new-mail paging. Requires daemon.
 ---
 
 # Microsoft - CLI: microsoft
@@ -15,8 +15,47 @@ microsoft email list --account user@example.com
 microsoft email get --account user@example.com --id <email_id>
 microsoft email send --account user@example.com --to bob@example.com --subject "Hello" --body "Message"
 microsoft email reply --account user@example.com --id <email_id> --body "Thanks!"
+microsoft email reply --account user@example.com --id <email_id> --body "Thanks all!" --reply-all
+microsoft email forward --account user@example.com --id <email_id> --to bob@example.com --body "fyi, see below"
 microsoft email search --account user@example.com --query "project update"
 ```
+
+`send`, `reply`, and `forward` accept `--attachments file1 file2` and `--html` (treats `--body` as HTML). `forward` requires `--to` and also takes `--cc`.
+
+## Organize messages
+
+```bash
+microsoft email update --account user@example.com --id <email_id> --is-read true      # mark read/unread
+microsoft email update --account user@example.com --id <email_id> --flagged            # flag for follow-up
+microsoft email update --account user@example.com --id <email_id> --unflagged          # clear the flag
+microsoft email update --account user@example.com --id <email_id> --categories Tax Receipts
+microsoft email move --account user@example.com --id <email_id> --to-folder Archive     # any folder (well-known key or display name)
+microsoft email archive --account user@example.com --id <email_id>                      # shortcut for move to Archive
+```
+
+`--to-folder` accepts a well-known key (`inbox`, `sent`, `drafts`, `deleted`, `junk`, `archive`) or a folder's display name (resolved to its id automatically).
+
+## Drafts
+
+```bash
+microsoft email draft --account user@example.com --to bob@example.com --subject "Proposal" --body "rough notes..."
+microsoft email draft --account user@example.com --reply-to <email_id> --body "draft answer for review"    # threaded reply draft
+microsoft email draft --account user@example.com --forward <email_id> --to bob@example.com --body "fyi"      # forward draft
+```
+
+`draft` saves to the Drafts folder without sending. `--reply-to` / `--forward` (mutually exclusive) build a **threaded** draft off an existing message; `--subject` is optional then (inherited). Accepts `--cc`/`--bcc`/`--attachments`.
+
+## Folders
+
+```bash
+microsoft folder list --account user@example.com                                  # every folder + unread/total counts
+microsoft folder status --account user@example.com --folder inbox                 # counts for one folder
+microsoft folder create --account user@example.com --name "Newsletters"           # nest with --parent <folder_id>
+microsoft folder rename --account user@example.com --id <folder_id> --name "News"
+microsoft folder delete --account user@example.com --id <folder_id>
+```
+
+`folder list` also prints each folder's `id` (needed for `--parent`, `rename`, `delete`).
 
 ## Email Block/Unblock
 
@@ -63,14 +102,31 @@ microsoft calendar respond --account user@example.com --id <event_id> --response
 - `--no-attachments` on email get skips attachment metadata
 - `--save-to` on email get overrides the auto-save path for the body
 - **`email get` always saves the body to disk** under `~/.microsoft/emails/<timestamp>_<subject>_<id>.txt` and strips it from the JSON response. The JSON returns `body: {saved_to, length, size_bytes, _note}` plus the legacy `body_saved_to`, `body_saved_size`, `body_length` fields, and a short `preview`. To inspect content, read the file at `body.saved_to`. The full `body.content` field is intentionally never returned inline to keep agent context small. Bodies over 5000 chars also surface a warning telling you to grep/crop before pasting snippets
-- `--categories` on email update accepts multiple space-separated category names
-- `email list`, `email search`, `calendar list`, and `calendar calendars` default to a compact tab-separated table; pass `--json` for one-line JSON or `--json-pretty` for indented JSON. Graph `@odata.*` metadata is stripped from every result.
+- `--categories` on email update accepts multiple space-separated category names; `--flagged`/`--unflagged` set or clear the follow-up flag
+- `email list`, `email search`, `calendar list`, `calendar calendars`, and `folder list` default to a compact tab-separated table; pass `--json` for one-line JSON or `--json-pretty` for indented JSON. Graph `@odata.*` metadata is stripped from every result.
+- `microsoft auth list` shows registered accounts; `microsoft auth remove --account user@example.com` signs one out
 
 ## Email Attachments
 
 ```bash
-microsoft email attachment --account user@example.com --email-id '<email_id>' --attachment-id '<attachment_id>' --save-path /tmp/file.pdf
+microsoft email attachment --account user@example.com --email-id '<email_id>' --list                                   # list attachment metadata
+microsoft email attachment --account user@example.com --email-id '<email_id>' --all                                     # download all (to ~/.microsoft/attachments/<id>)
+microsoft email attachment --account user@example.com --email-id '<email_id>' --all --out-dir /tmp/x                     # download all to a dir
+microsoft email attachment --account user@example.com --email-id '<email_id>' --attachment-id '<attachment_id>' --save-path /tmp/file.pdf  # one
 ```
+
+## Notifications
+
+The `serve` daemon watches each account's inbox by default and writes one notification per new email (source `microsoft`, type `email`, with a `folder` field). To watch more folders (e.g. a folder an inbox rule routes newsletters into), set the per-account watch list; the daemon re-reads it every cycle, no restart:
+
+```bash
+microsoft notify list --account user@example.com                      # show watched folders
+microsoft notify add --account user@example.com --folder Newsletters  # also notify on this folder
+microsoft notify add --account user@example.com --all                 # watch every folder (prune noisy ones after)
+microsoft notify remove --account user@example.com --folder inbox     # stop notifying on inbox
+```
+
+`notify add --folder` validates the folder exists first. Removing every folder mutes the account. The watch list lives in `~/.microsoft/notify.json`. Watching is time-based: it fires on **new arrivals** (including rule-routed mail), not on messages you manually move into a folder.
 
 ### Contact Communication Styles
 [How to communicate with different contacts. Fill in after data gathering: who are the key contacts, what tone/formality for each, language preferences]

--- a/agent/skills/microsoft/cli/src/microsoft_cli/auth.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/auth.py
@@ -47,9 +47,6 @@ def _run_device_flow(app: msal.PublicClientApplication, scopes: list[str], cache
 
 def get_app(cache_file: pl.Path) -> msal.PublicClientApplication:
     settings = get_settings()
-    if not settings.microsoft_mcp_client_id:
-        raise ValueError("MICROSOFT_MCP_CLIENT_ID is required")
-
     authority = f"https://login.microsoftonline.com/{settings.microsoft_mcp_tenant_id}"
 
     cache = msal.SerializableTokenCache()

--- a/agent/skills/microsoft/cli/src/microsoft_cli/auth_commands.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/auth_commands.py
@@ -10,6 +10,23 @@ def list_accounts(config: Config) -> list[dict[str, str]]:
     return [{"email": acc.username, "account_id": acc.account_id} for acc in auth.list_accounts(config.cache_file)]
 
 
+def remove_account(config: Config, *, account_email: str) -> dict[str, str]:
+    app = auth.get_app(config.cache_file)
+    email_lower = account_email.lower()
+    matches = [a for a in app.get_accounts() if (a["username"] if "username" in a else "").lower() == email_lower]
+    if not matches:
+        raise ValueError(f"No account found with email '{account_email}'")
+
+    for account in matches:
+        app.remove_account(account)
+
+    cache = app.token_cache
+    if isinstance(cache, auth.msal.SerializableTokenCache) and cache.has_state_changed:
+        auth._write_cache(config.cache_file, content=cache.serialize())
+
+    return {"status": "removed", "email": account_email}
+
+
 def authenticate_account(config: Config) -> dict[str, str]:
     app = auth.get_app(config.cache_file)
     flow = app.initiate_device_flow(scopes=config.scopes)

--- a/agent/skills/microsoft/cli/src/microsoft_cli/cli.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/cli.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import httpx
 
 from .config import Config
-from . import auth_commands, email, calendar, monitor, notifications, block, format as fmt
+from . import auth_commands, email, calendar, monitor, notifications, block, folders, notify, format as fmt
 from .context import MicrosoftContext
 
 
@@ -60,6 +60,8 @@ def main():
     p_complete = auth_sub.add_parser("complete")
     p_complete.add_argument("--flow-cache", required=True)
     auth_sub.add_parser("list")
+    p_auth_remove = auth_sub.add_parser("remove")
+    p_auth_remove.add_argument("--account", required=True)
 
     # email
     email_parser = group.add_parser("email")
@@ -90,11 +92,14 @@ def main():
     p_draft = email_sub.add_parser("draft")
     p_draft.add_argument("--account", required=True)
     p_draft.add_argument("--to", nargs="+", default=None)
-    p_draft.add_argument("--subject", required=True)
+    p_draft.add_argument("--subject", default=None)
     p_draft.add_argument("--body", required=True)
     p_draft.add_argument("--cc", nargs="+", default=None)
     p_draft.add_argument("--bcc", nargs="+", default=None)
     p_draft.add_argument("--attachments", nargs="+", default=None)
+    p_draft_source = p_draft.add_mutually_exclusive_group()
+    p_draft_source.add_argument("--reply-to", dest="reply_to_id", default=None, help="Draft a threaded reply to this message id")
+    p_draft_source.add_argument("--forward", dest="forward_id", default=None, help="Draft a forward of this message id")
 
     p_reply = email_sub.add_parser("reply")
     p_reply.add_argument("--account", required=True)
@@ -104,11 +109,32 @@ def main():
     p_reply.add_argument("--reply-all", action="store_true")
     p_reply.add_argument("--html", action="store_true")
 
+    p_forward = email_sub.add_parser("forward")
+    p_forward.add_argument("--account", required=True)
+    p_forward.add_argument("--id", required=True, dest="email_id")
+    p_forward.add_argument("--to", nargs="+", required=True)
+    p_forward.add_argument("--body", default="")
+    p_forward.add_argument("--cc", nargs="+", default=None)
+    p_forward.add_argument("--attachments", nargs="+", default=None)
+    p_forward.add_argument("--html", action="store_true")
+
+    p_move = email_sub.add_parser("move")
+    p_move.add_argument("--account", required=True)
+    p_move.add_argument("--id", required=True, dest="email_id")
+    p_move.add_argument("--to-folder", required=True, dest="to_folder")
+
+    p_archive = email_sub.add_parser("archive")
+    p_archive.add_argument("--account", required=True)
+    p_archive.add_argument("--id", required=True, dest="email_id")
+
     p_attachment = email_sub.add_parser("attachment")
     p_attachment.add_argument("--account", required=True)
     p_attachment.add_argument("--email-id", required=True)
-    p_attachment.add_argument("--attachment-id", required=True)
-    p_attachment.add_argument("--save-path", required=True)
+    p_attachment.add_argument("--attachment-id", default=None)
+    p_attachment.add_argument("--save-path", default=None)
+    p_attachment.add_argument("--list", action="store_true", dest="list_only", help="List attachment metadata only")
+    p_attachment.add_argument("--all", action="store_true", dest="download_all", help="Download every attachment to --out-dir")
+    p_attachment.add_argument("--out-dir", default=None, help="Directory for --all downloads (default ~/.microsoft/attachments/<email-id>)")
 
     p_search = email_sub.add_parser("search")
     p_search.add_argument("--account", required=True)
@@ -122,6 +148,9 @@ def main():
     p_update.add_argument("--id", required=True, dest="email_id")
     p_update.add_argument("--is-read", type=lambda x: x.lower() == "true", default=None)
     p_update.add_argument("--categories", nargs="+", default=None)
+    p_update_flag = p_update.add_mutually_exclusive_group()
+    p_update_flag.add_argument("--flagged", dest="flagged", action="store_true", default=None, help="Flag the message for follow-up.")
+    p_update_flag.add_argument("--unflagged", dest="flagged", action="store_false", default=None, help="Clear the follow-up flag.")
 
     p_delete = email_sub.add_parser("delete")
     p_delete.add_argument("--account", required=True)
@@ -139,6 +168,49 @@ def main():
     p_unblock = email_sub.add_parser("unblock")
     p_unblock.add_argument("--account", required=True)
     p_unblock.add_argument("--sender", required=True, help="Email address of sender to unblock")
+
+    # folder
+    folder_parser = group.add_parser("folder")
+    folder_sub = folder_parser.add_subparsers(dest="command", required=True)
+
+    p_folder_list = folder_sub.add_parser("list")
+    p_folder_list.add_argument("--account", required=True)
+    _add_format_flags(p_folder_list)
+
+    p_folder_status = folder_sub.add_parser("status")
+    p_folder_status.add_argument("--account", required=True)
+    p_folder_status.add_argument("--folder", required=True)
+
+    p_folder_create = folder_sub.add_parser("create")
+    p_folder_create.add_argument("--account", required=True)
+    p_folder_create.add_argument("--name", required=True)
+    p_folder_create.add_argument("--parent", default=None, dest="parent_id", help="Parent folder id for a nested folder")
+
+    p_folder_rename = folder_sub.add_parser("rename")
+    p_folder_rename.add_argument("--account", required=True)
+    p_folder_rename.add_argument("--id", required=True, dest="folder_id")
+    p_folder_rename.add_argument("--name", required=True)
+
+    p_folder_delete = folder_sub.add_parser("delete")
+    p_folder_delete.add_argument("--account", required=True)
+    p_folder_delete.add_argument("--id", required=True, dest="folder_id")
+
+    # notify
+    notify_parser = group.add_parser("notify")
+    notify_sub = notify_parser.add_subparsers(dest="command", required=True)
+
+    p_notify_list = notify_sub.add_parser("list")
+    p_notify_list.add_argument("--account", required=True)
+
+    p_notify_add = notify_sub.add_parser("add")
+    p_notify_add.add_argument("--account", required=True)
+    p_notify_add_group = p_notify_add.add_mutually_exclusive_group(required=True)
+    p_notify_add_group.add_argument("--folder", default=None, help="Folder (well-known key or display name) to also notify on")
+    p_notify_add_group.add_argument("--all", action="store_true", dest="all_folders", help="Watch every folder on the server")
+
+    p_notify_remove = notify_sub.add_parser("remove")
+    p_notify_remove.add_argument("--account", required=True)
+    p_notify_remove.add_argument("--folder", required=True)
 
     # calendar
     cal_parser = group.add_parser("calendar")
@@ -221,12 +293,15 @@ def main():
         if args.group == "auth":
             result = _dispatch_auth(args, config)
             print(json.dumps(fmt.strip_odata(result), indent=2))
-        elif args.group in ("email", "calendar"):
+        elif args.group in ("email", "calendar", "folder", "notify"):
             with httpx.Client(timeout=30.0, follow_redirects=True) as client:
-                if args.group == "email":
-                    result = _dispatch_email(args, config, client)
-                else:
-                    result = _dispatch_calendar(args, config, client)
+                dispatchers = {
+                    "email": _dispatch_email,
+                    "calendar": _dispatch_calendar,
+                    "folder": _dispatch_folder,
+                    "notify": _dispatch_notify,
+                }
+                result = dispatchers[args.group](args, config, client)
                 _print_result(args, result)
     except Exception as e:
         print(json.dumps({"error": str(e)}), file=sys.stderr)
@@ -238,6 +313,7 @@ _COMPACT_FORMATTERS = {
     ("email", "search"): fmt.format_email_list,
     ("calendar", "list"): fmt.format_calendar_event_list,
     ("calendar", "calendars"): fmt.format_calendar_name_list,
+    ("folder", "list"): fmt.format_folder_list,
 }
 
 
@@ -269,6 +345,8 @@ def _dispatch_auth(args, config):
         return auth_commands.authenticate_account(config)
     elif args.command == "complete":
         return auth_commands.complete_authentication(config, flow_cache=args.flow_cache)
+    elif args.command == "remove":
+        return auth_commands.remove_account(config, account_email=args.account)
 
 
 def _dispatch_email(args, config, client):
@@ -307,6 +385,8 @@ def _dispatch_email(args, config, client):
             cc=args.cc,
             bcc=args.bcc,
             attachments=args.attachments,
+            reply_to_id=args.reply_to_id,
+            forward_id=args.forward_id,
         )
     elif args.command == "reply":
         return email.reply_to_email(
@@ -319,15 +399,35 @@ def _dispatch_email(args, config, client):
             reply_all=args.reply_all,
             html=args.html,
         )
-    elif args.command == "attachment":
-        return email.get_attachment(
-            config, client, account_email=args.account, email_id=args.email_id, attachment_id=args.attachment_id, save_path=args.save_path
+    elif args.command == "forward":
+        return email.forward_email(
+            config,
+            client,
+            account_email=args.account,
+            email_id=args.email_id,
+            to=args.to,
+            body=args.body,
+            cc=args.cc,
+            attachments=args.attachments,
+            html=args.html,
         )
+    elif args.command == "move":
+        return email.move_email(config, client, account_email=args.account, email_id=args.email_id, to_folder=args.to_folder)
+    elif args.command == "archive":
+        return email.archive_email(config, client, account_email=args.account, email_id=args.email_id)
+    elif args.command == "attachment":
+        return _dispatch_attachment(args, config, client)
     elif args.command == "search":
         return email.search_emails(config, client, account_email=args.account, query=args.query, limit=args.limit, folder=args.folder)
     elif args.command == "update":
         return email.update_email(
-            config, client, account_email=args.account, email_id=args.email_id, is_read=args.is_read, categories=args.categories
+            config,
+            client,
+            account_email=args.account,
+            email_id=args.email_id,
+            is_read=args.is_read,
+            categories=args.categories,
+            flagged=args.flagged,
         )
     elif args.command == "delete":
         return email.delete_email(
@@ -339,6 +439,41 @@ def _dispatch_email(args, config, client):
         return block.block_sender(config, client, account_email=args.account, sender=args.sender)
     elif args.command == "unblock":
         return block.unblock_sender(config, client, account_email=args.account, sender=args.sender)
+
+
+def _dispatch_attachment(args, config, client):
+    if args.list_only:
+        return email.list_attachments(config, client, account_email=args.account, email_id=args.email_id)
+    if args.download_all:
+        out_dir = args.out_dir or str(config.data_dir / "attachments" / args.email_id)
+        return email.download_attachments(config, client, account_email=args.account, email_id=args.email_id, out_dir=out_dir)
+    if not args.attachment_id or not args.save_path:
+        raise ValueError("Provide --attachment-id and --save-path to download one attachment, or use --list / --all")
+    return email.get_attachment(
+        config, client, account_email=args.account, email_id=args.email_id, attachment_id=args.attachment_id, save_path=args.save_path
+    )
+
+
+def _dispatch_folder(args, config, client):
+    if args.command == "list":
+        return folders.list_folders(config, client, account_email=args.account)
+    elif args.command == "status":
+        return folders.folder_status(config, client, account_email=args.account, folder=args.folder)
+    elif args.command == "create":
+        return folders.create_folder(config, client, account_email=args.account, name=args.name, parent_id=args.parent_id)
+    elif args.command == "rename":
+        return folders.rename_folder(config, client, account_email=args.account, folder_id=args.folder_id, name=args.name)
+    elif args.command == "delete":
+        return folders.delete_folder(config, client, account_email=args.account, folder_id=args.folder_id)
+
+
+def _dispatch_notify(args, config, client):
+    if args.command == "list":
+        return notify.list_notify(config, client, account_email=args.account)
+    elif args.command == "add":
+        return notify.add_notify(config, client, account_email=args.account, folder=args.folder, all_folders=args.all_folders)
+    elif args.command == "remove":
+        return notify.remove_notify(config, client, account_email=args.account, folder=args.folder)
 
 
 def _dispatch_calendar(args, config, client):
@@ -432,6 +567,7 @@ def _run_serve(config: Config, notif_dir: Path):
         base_url=config.base_url,
         upload_chunk_size=config.upload_chunk_size,
         folders=config.folders,
+        notify_file=notify.notify_file_for(config),
         calendar_notify_thresholds=config.calendar_notify_thresholds,
     )
 

--- a/agent/skills/microsoft/cli/src/microsoft_cli/config.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/config.py
@@ -1,8 +1,24 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from .settings import get_settings, DEFAULT_CLIENT_ID
 
-SCOPES = ["https://graph.microsoft.com/.default"]
+# Dynamic-consent scopes for the shared default public client (it has no permissions we control,
+# so ".default" would either grant nothing useful or demand admin consent for its whole catalog).
+DEFAULT_CLIENT_SCOPES = [
+    "https://graph.microsoft.com/Mail.ReadWrite",
+    "https://graph.microsoft.com/Mail.Send",
+    "https://graph.microsoft.com/Calendars.ReadWrite",
+    "https://graph.microsoft.com/MailboxSettings.ReadWrite",
+]
+# A user's own app registration: request exactly the delegated permissions it was configured with.
+OWNED_APP_SCOPES = ["https://graph.microsoft.com/.default"]
+
+
+def resolve_scopes() -> list[str]:
+    return list(DEFAULT_CLIENT_SCOPES) if get_settings().microsoft_mcp_client_id == DEFAULT_CLIENT_ID else list(OWNED_APP_SCOPES)
+
+
 BASE_URL = "https://graph.microsoft.com/v1.0"
 UPLOAD_CHUNK_SIZE = 15 * 320 * 1024
 
@@ -20,7 +36,7 @@ FOLDERS = {
 class Config:
     data_dir: Path = Path.home() / ".microsoft"
     log_dir: Path = Path.home() / ".microsoft" / "logs"
-    scopes: list[str] = field(default_factory=lambda: list(SCOPES))
+    scopes: list[str] = field(default_factory=resolve_scopes)
     base_url: str = BASE_URL
     upload_chunk_size: int = UPLOAD_CHUNK_SIZE
     folders: dict[str, str] = field(default_factory=lambda: dict(FOLDERS))

--- a/agent/skills/microsoft/cli/src/microsoft_cli/context.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/context.py
@@ -22,6 +22,7 @@ class MicrosoftContext:
     base_url: str
     upload_chunk_size: int
     folders: dict[str, str]
+    notify_file: Path | None = None
     calendar_notify_thresholds: list[int] | None = None
 
     def get_calendar_notify_thresholds(self) -> list[int]:

--- a/agent/skills/microsoft/cli/src/microsoft_cli/email.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/email.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import httpx
 
-from . import graph, auth
+from . import graph, auth, folders
 from .config import Config
 
 EMAIL_SAVE_SUBDIR = "emails"
@@ -41,6 +41,20 @@ def _read_attachment(file_path: str) -> tuple[bytes, str, int]:
     path = pl.Path(file_path).expanduser().resolve()
     content_bytes = path.read_bytes()
     return content_bytes, path.name, len(content_bytes)
+
+
+def _attach_files(config: Config, client: httpx.Client, message_id: str, attachments: list[str] | None, account_id: str) -> None:
+    """Attach files to an existing draft, small ones inline and large ones via upload session."""
+    if not attachments:
+        return
+    for file_path in attachments:
+        content_bytes, att_name, att_size = _read_attachment(file_path)
+        if att_size < LARGE_ATTACHMENT_THRESHOLD:
+            graph.request_cfg(
+                config, client, "POST", f"/me/messages/{message_id}/attachments", account_id, json=_file_attachment(att_name, content_bytes)
+            )
+        else:
+            graph.upload_mail_attachment_cfg(config, client, message_id, att_name, content_bytes, account_id)
 
 
 def _remove_attachment_bytes(result: dict[str, Any]) -> None:
@@ -224,17 +238,46 @@ def create_email_draft(
     client: httpx.Client,
     *,
     account_email: str,
-    to: list[str] | None = None,
-    subject: str,
     body: str,
+    subject: str | None = None,
+    to: list[str] | None = None,
     cc: list[str] | None = None,
     bcc: list[str] | None = None,
     attachments: list[str] | None = None,
+    reply_to_id: str | None = None,
+    forward_id: str | None = None,
 ) -> dict[str, Any]:
-    if not to and not cc and not bcc:
-        raise ValueError("At least one recipient is required (--to, --cc, or --bcc)")
+    if reply_to_id and forward_id:
+        raise ValueError("Specify at most one of --reply-to or --forward")
 
     account_id = auth.get_account_id_by_email(account_email, config.cache_file)
+
+    if reply_to_id or forward_id:
+        source_id = reply_to_id or forward_id
+        create_endpoint = "createReply" if reply_to_id else "createForward"
+        draft = graph.request_cfg(config, client, "POST", f"/me/messages/{source_id}/{create_endpoint}", account_id)
+        if not draft or "id" not in draft:
+            raise ValueError("Failed to create reply/forward draft")
+        draft_id = draft["id"]
+
+        updates: dict[str, Any] = {"body": {"contentType": "Text", "content": body}}
+        if subject:
+            updates["subject"] = subject
+        if to:
+            updates["toRecipients"] = [{"emailAddress": {"address": addr}} for addr in to]
+        if cc:
+            updates["ccRecipients"] = [{"emailAddress": {"address": addr}} for addr in cc]
+        if bcc:
+            updates["bccRecipients"] = [{"emailAddress": {"address": addr}} for addr in bcc]
+        graph.request_cfg(config, client, "PATCH", f"/me/messages/{draft_id}", account_id, json=updates)
+
+        _attach_files(config, client, draft_id, attachments, account_id)
+        return {"status": "drafted", "id": draft_id, "source_id": source_id}
+
+    if not subject:
+        raise ValueError("--subject is required for a new draft")
+    if not to and not cc and not bcc:
+        raise ValueError("At least one recipient is required (--to, --cc, or --bcc)")
 
     message = {
         "subject": subject,
@@ -400,14 +443,7 @@ def reply_to_email(
             json={"body": {"contentType": "HTML" if html else "Text", "content": body}},
         )
 
-        for file_path in attachments:
-            content_bytes, att_name, att_size = _read_attachment(file_path)
-
-            if att_size < LARGE_ATTACHMENT_THRESHOLD:
-                attachment = _file_attachment(att_name, content_bytes)
-                graph.request_cfg(config, client, "POST", f"/me/messages/{draft_id}/attachments", account_id, json=attachment)
-            else:
-                graph.upload_mail_attachment_cfg(config, client, draft_id, att_name, content_bytes, account_id)
+        _attach_files(config, client, draft_id, attachments, account_id)
 
         graph.request_cfg(config, client, "POST", f"/me/messages/{draft_id}/send", account_id)
         return {"status": "sent"}
@@ -416,6 +452,131 @@ def reply_to_email(
         payload = {"message": {"body": {"contentType": "HTML" if html else "Text", "content": body}}}
         graph.request_cfg(config, client, "POST", endpoint, account_id, json=payload)
         return {"status": "sent"}
+
+
+def forward_email(
+    config: Config,
+    client: httpx.Client,
+    *,
+    account_email: str,
+    email_id: str,
+    to: list[str],
+    body: str = "",
+    cc: list[str] | None = None,
+    attachments: list[str] | None = None,
+    html: bool = False,
+) -> dict[str, str]:
+    if not to:
+        raise ValueError("--to is required to forward")
+
+    account_id = auth.get_account_id_by_email(account_email, config.cache_file)
+    to_recipients = [{"emailAddress": {"address": addr}} for addr in to]
+
+    # cc / html / attachments need the draft path (the one-shot forward action only
+    # takes a plain-text comment + toRecipients); the plain case keeps the quoted original.
+    if attachments or cc or html:
+        draft = graph.request_cfg(config, client, "POST", f"/me/messages/{email_id}/createForward", account_id)
+        if not draft or "id" not in draft:
+            raise ValueError("Failed to create forward draft")
+        draft_id = draft["id"]
+
+        updates: dict[str, Any] = {
+            "body": {"contentType": "HTML" if html else "Text", "content": body},
+            "toRecipients": to_recipients,
+        }
+        if cc:
+            updates["ccRecipients"] = [{"emailAddress": {"address": addr}} for addr in cc]
+        graph.request_cfg(config, client, "PATCH", f"/me/messages/{draft_id}", account_id, json=updates)
+
+        _attach_files(config, client, draft_id, attachments, account_id)
+        graph.request_cfg(config, client, "POST", f"/me/messages/{draft_id}/send", account_id)
+        return {"status": "sent"}
+
+    graph.request_cfg(
+        config, client, "POST", f"/me/messages/{email_id}/forward", account_id, json={"comment": body, "toRecipients": to_recipients}
+    )
+    return {"status": "sent"}
+
+
+def move_email(
+    config: Config,
+    client: httpx.Client,
+    *,
+    account_email: str,
+    email_id: str,
+    to_folder: str,
+) -> dict[str, Any]:
+    account_id = auth.get_account_id_by_email(account_email, config.cache_file)
+    destination = folders.resolve_folder_id_cfg(config, client, account_id, to_folder)
+    result = graph.request_cfg(config, client, "POST", f"/me/messages/{email_id}/move", account_id, json={"destinationId": destination})
+    return {
+        "status": "moved",
+        "email_id": email_id,
+        "to_folder": to_folder,
+        "new_id": result["id"] if result and "id" in result else None,
+    }
+
+
+def archive_email(
+    config: Config,
+    client: httpx.Client,
+    *,
+    account_email: str,
+    email_id: str,
+) -> dict[str, Any]:
+    return move_email(config, client, account_email=account_email, email_id=email_id, to_folder="archive")
+
+
+def list_attachments(
+    config: Config,
+    client: httpx.Client,
+    *,
+    account_email: str,
+    email_id: str,
+) -> list[dict[str, Any]]:
+    account_id = auth.get_account_id_by_email(account_email, config.cache_file)
+    result = graph.request_cfg(
+        config, client, "GET", f"/me/messages/{email_id}/attachments", account_id, params={"$select": "id,name,size,contentType"}
+    )
+    return result["value"] if result and "value" in result else []
+
+
+def download_attachments(
+    config: Config,
+    client: httpx.Client,
+    *,
+    account_email: str,
+    email_id: str,
+    out_dir: str,
+) -> dict[str, Any]:
+    account_id = auth.get_account_id_by_email(account_email, config.cache_file)
+    result = graph.request_cfg(config, client, "GET", f"/me/messages/{email_id}/attachments", account_id)
+    attachments = result["value"] if result and "value" in result else []
+
+    out = pl.Path(out_dir).expanduser().resolve()
+    out.mkdir(parents=True, exist_ok=True)
+
+    saved: list[dict[str, Any]] = []
+    used: set[str] = set()
+    for att in attachments:
+        # item/reference attachments carry no inline bytes; only file attachments are downloadable.
+        if "contentBytes" not in att:
+            continue
+        raw_name = att["name"] if "name" in att else "attachment"
+        stem = pl.Path(raw_name).stem or "attachment"
+        suffix = pl.Path(raw_name).suffix
+        name = f"{stem}{suffix}"
+        counter = 1
+        while name in used:
+            name = f"{stem}_{counter}{suffix}"
+            counter += 1
+        used.add(name)
+
+        path = out / name
+        path.write_bytes(base64.b64decode(att["contentBytes"]))
+        saved.append({"name": raw_name, "saved_to": str(path), "size": att["size"] if "size" in att else 0})
+
+    return {"email_id": email_id, "count": len(saved), "saved": saved}
 
 
 def get_attachment(
@@ -518,17 +679,20 @@ def update_email(
     email_id: str,
     is_read: bool | None = None,
     categories: list[str] | None = None,
+    flagged: bool | None = None,
 ) -> dict[str, Any]:
     account_id = auth.get_account_id_by_email(account_email, config.cache_file)
 
-    updates = {}
+    updates: dict[str, Any] = {}
     if is_read is not None:
         updates["isRead"] = is_read
     if categories is not None:
         updates["categories"] = categories
+    if flagged is not None:
+        updates["flag"] = {"flagStatus": "flagged" if flagged else "notFlagged"}
 
     if not updates:
-        raise ValueError("Must specify at least one field to update (is_read or categories)")
+        raise ValueError("Must specify at least one field to update (is_read, categories, or flagged)")
 
     result = graph.request_cfg(config, client, "PATCH", f"/me/messages/{email_id}", account_id, json=updates)
     return result or {"status": "updated", "email_id": email_id}

--- a/agent/skills/microsoft/cli/src/microsoft_cli/folders.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/folders.py
@@ -1,0 +1,120 @@
+"""Mail-folder commands for Microsoft CLI (list, counts, create/rename/delete).
+
+Folder resolution follows the graph.py primitive/`_cfg` split so the monitor
+thread (which holds raw connection primitives, not a Config) and the command
+modules (which hold a Config) can both resolve a user-supplied folder token to a
+Graph folder path segment.
+"""
+
+from typing import Any
+
+import httpx
+
+from . import graph, auth
+from .config import Config
+
+_FOLDER_FIELDS = ("id", "displayName", "parentFolderId", "totalItemCount", "unreadItemCount")
+_FOLDER_SELECT = ",".join(_FOLDER_FIELDS)
+
+
+def _project(folder: dict[str, Any]) -> dict[str, Any]:
+    return {k: folder[k] for k in _FOLDER_FIELDS if k in folder}
+
+
+def _flatten(raw: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Flatten top-level folders plus one expanded level of child folders."""
+    out: list[dict[str, Any]] = []
+    for folder in raw:
+        out.append(_project(folder))
+        for child in folder["childFolders"] if "childFolders" in folder else []:
+            out.append(_project(child))
+    return out
+
+
+def fetch_folders(
+    client: httpx.Client,
+    cache_file,
+    scopes: list[str],
+    base_url: str,
+    account_id: str,
+) -> list[dict[str, Any]]:
+    result = graph.request(
+        client,
+        cache_file,
+        scopes,
+        base_url,
+        "GET",
+        "/me/mailFolders",
+        account_id,
+        params={"$top": 100, "$expand": "childFolders", "$select": _FOLDER_SELECT},
+    )
+    return _flatten(result["value"] if result and "value" in result else [])
+
+
+def resolve_folder_id(
+    client: httpx.Client,
+    cache_file,
+    scopes: list[str],
+    base_url: str,
+    folders_map: dict[str, str],
+    account_id: str,
+    folder: str,
+) -> str:
+    """Map a well-known key, a display name, or a raw folder id to a path segment."""
+    key = folder.casefold()
+    if key in folders_map:
+        return folders_map[key]
+    for candidate in fetch_folders(client, cache_file, scopes, base_url, account_id):
+        if "displayName" in candidate and candidate["displayName"].casefold() == key:
+            return candidate["id"]
+    return folder
+
+
+def fetch_folders_cfg(config: Config, client: httpx.Client, account_id: str) -> list[dict[str, Any]]:
+    return fetch_folders(client, config.cache_file, config.scopes, config.base_url, account_id)
+
+
+def resolve_folder_id_cfg(config: Config, client: httpx.Client, account_id: str, folder: str) -> str:
+    return resolve_folder_id(client, config.cache_file, config.scopes, config.base_url, config.folders, account_id, folder)
+
+
+def list_folders(config: Config, client: httpx.Client, *, account_email: str) -> list[dict[str, Any]]:
+    account_id = auth.get_account_id_by_email(account_email, config.cache_file)
+    return fetch_folders_cfg(config, client, account_id)
+
+
+def folder_status(config: Config, client: httpx.Client, *, account_email: str, folder: str) -> dict[str, Any]:
+    account_id = auth.get_account_id_by_email(account_email, config.cache_file)
+    folder_id = resolve_folder_id_cfg(config, client, account_id, folder)
+    result = graph.request_cfg(
+        config,
+        client,
+        "GET",
+        f"/me/mailFolders/{folder_id}",
+        account_id,
+        params={"$select": "id,displayName,totalItemCount,unreadItemCount"},
+    )
+    if not result:
+        raise ValueError(f"Folder '{folder}' not found")
+    return result
+
+
+def create_folder(config: Config, client: httpx.Client, *, account_email: str, name: str, parent_id: str | None = None) -> dict[str, Any]:
+    account_id = auth.get_account_id_by_email(account_email, config.cache_file)
+    path = f"/me/mailFolders/{parent_id}/childFolders" if parent_id else "/me/mailFolders"
+    result = graph.request_cfg(config, client, "POST", path, account_id, json={"displayName": name})
+    if not result:
+        raise ValueError(f"Failed to create folder '{name}'")
+    return result
+
+
+def rename_folder(config: Config, client: httpx.Client, *, account_email: str, folder_id: str, name: str) -> dict[str, Any]:
+    account_id = auth.get_account_id_by_email(account_email, config.cache_file)
+    result = graph.request_cfg(config, client, "PATCH", f"/me/mailFolders/{folder_id}", account_id, json={"displayName": name})
+    return result or {"status": "renamed", "id": folder_id, "displayName": name}
+
+
+def delete_folder(config: Config, client: httpx.Client, *, account_email: str, folder_id: str) -> dict[str, Any]:
+    account_id = auth.get_account_id_by_email(account_email, config.cache_file)
+    graph.request_cfg(config, client, "DELETE", f"/me/mailFolders/{folder_id}", account_id)
+    return {"status": "deleted", "id": folder_id}

--- a/agent/skills/microsoft/cli/src/microsoft_cli/format.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/format.py
@@ -57,6 +57,15 @@ def format_calendar_event_list(events: list[dict[str, Any]]) -> str:
     )
 
 
+def format_folder_list(folders: list[dict[str, Any]]) -> str:
+    """One line per folder: unread/total  name  id."""
+    if not folders:
+        return "(no folders)"
+    return "\n".join(
+        f"{_pick(f, 'unreadItemCount')}/{_pick(f, 'totalItemCount')}\t{_trunc(_pick(f, 'displayName'), 40)}\t{_pick(f, 'id')}" for f in folders
+    )
+
+
 def format_calendar_name_list(calendars: list[dict[str, Any]]) -> str:
     """One line per calendar: default-marker  name  id."""
     if not calendars:

--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -2,7 +2,7 @@ import re
 from datetime import datetime, timedelta, UTC
 from typing import TypedDict, NotRequired
 from zoneinfo import ZoneInfo
-from . import graph, auth, notifications
+from . import graph, auth, notifications, notify, folders
 from .context import MicrosoftContext
 
 
@@ -122,59 +122,65 @@ def run(ctx: MicrosoftContext):
             for acc in auth.list_accounts(ctx.cache_file):
                 logger.info(f"Checking account: {acc.username}")
 
-                try:
-                    result = graph.request(
-                        ctx.http_client,
-                        ctx.cache_file,
-                        ctx.scopes,
-                        ctx.base_url,
-                        "GET",
-                        "/me/mailFolders/inbox/messages",
-                        acc.account_id,
-                        params={
-                            "$filter": f"receivedDateTime gt {last_check}",
-                            "$select": "subject,from,bodyPreview,receivedDateTime",
-                            "$top": 50,
-                        },
-                    )
-
-                    if not result or "value" not in result:
-                        logger.warning(f"Unexpected email API response: {result}")
-                        continue
-                    emails = result["value"]
-                    logger.info(f"Found {len(emails)} new emails for {acc.username}")
-
-                    for email in emails:
-                        email_from = email["from"] if "from" in email else None
-                        if not email_from or "emailAddress" not in email_from:
-                            logger.warning(f"Email missing sender info: {email['id'] if 'id' in email else '?'}")
-                            continue
-                        sender = email_from["emailAddress"]
-                        sender_name = sender["name"] if "name" in sender else None
-                        sender_addr = sender["address"] if "address" in sender else None
-                        if not sender_addr:
-                            logger.warning(f"Email sender missing address: {email['id'] if 'id' in email else '?'}")
-                            continue
-
-                        logger.info(f"Writing notification for email from {sender_addr}")
-                        display_name = sender_name or sender_addr
-                        # Only include sender_address when it adds info beyond the display name.
-                        extra_addr = sender_addr if sender_name and sender_name != sender_addr else None
-                        notifications.write_notification(
-                            ctx.notif_dir,
-                            "email",
-                            # Email pools by default (calendar reminders keep interrupting); the user adds
-                            # interrupt rules for the senders/keywords that should reach them right away.
-                            interrupt=False,
-                            sender=display_name,
-                            subject=email["subject"] if "subject" in email else None,
-                            preview=clean_preview(email["bodyPreview"] if "bodyPreview" in email else "")[:200],
-                            sender_address=extra_addr,
-                            account=acc.username,
-                            missed=catching_up or None,
+                watch_folders = notify.get_notify_folders(ctx.notify_file, acc.username) if ctx.notify_file else ["inbox"]
+                for folder_token in watch_folders:
+                    try:
+                        folder_id = folders.resolve_folder_id(
+                            ctx.http_client, ctx.cache_file, ctx.scopes, ctx.base_url, ctx.folders, acc.account_id, folder_token
                         )
-                except Exception as e:
-                    logger.error(f"Error fetching emails for {acc.username}: {e}")
+                        result = graph.request(
+                            ctx.http_client,
+                            ctx.cache_file,
+                            ctx.scopes,
+                            ctx.base_url,
+                            "GET",
+                            f"/me/mailFolders/{folder_id}/messages",
+                            acc.account_id,
+                            params={
+                                "$filter": f"receivedDateTime gt {last_check}",
+                                "$select": "subject,from,bodyPreview,receivedDateTime",
+                                "$top": 50,
+                            },
+                        )
+
+                        if not result or "value" not in result:
+                            logger.warning(f"Unexpected email API response: {result}")
+                            continue
+                        emails = result["value"]
+                        logger.info(f"Found {len(emails)} new emails for {acc.username} in {folder_token}")
+
+                        for email in emails:
+                            email_from = email["from"] if "from" in email else None
+                            if not email_from or "emailAddress" not in email_from:
+                                logger.warning(f"Email missing sender info: {email['id'] if 'id' in email else '?'}")
+                                continue
+                            sender = email_from["emailAddress"]
+                            sender_name = sender["name"] if "name" in sender else None
+                            sender_addr = sender["address"] if "address" in sender else None
+                            if not sender_addr:
+                                logger.warning(f"Email sender missing address: {email['id'] if 'id' in email else '?'}")
+                                continue
+
+                            logger.info(f"Writing notification for email from {sender_addr}")
+                            display_name = sender_name or sender_addr
+                            # Only include sender_address when it adds info beyond the display name.
+                            extra_addr = sender_addr if sender_name and sender_name != sender_addr else None
+                            notifications.write_notification(
+                                ctx.notif_dir,
+                                "email",
+                                # Email pools by default (calendar reminders keep interrupting); the user adds
+                                # interrupt rules for the senders/keywords that should reach them right away.
+                                interrupt=False,
+                                sender=display_name,
+                                subject=email["subject"] if "subject" in email else None,
+                                preview=clean_preview(email["bodyPreview"] if "bodyPreview" in email else "")[:200],
+                                sender_address=extra_addr,
+                                account=acc.username,
+                                folder=folder_token,
+                                missed=catching_up or None,
+                            )
+                    except Exception as e:
+                        logger.error(f"Error fetching emails for {acc.username} folder {folder_token}: {e}")
 
                 try:
                     max_threshold = max(ctx.get_calendar_notify_thresholds())

--- a/agent/skills/microsoft/cli/src/microsoft_cli/notify.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/notify.py
@@ -1,0 +1,85 @@
+"""Per-account notify-folder selection for the monitor.
+
+The watch list lives at ~/.microsoft/notify.json as {"<email>": ["inbox", ...]}.
+When an account has no entry the monitor watches INBOX only, so existing
+installs keep their current behavior with no migration. The monitor re-reads
+this file every cycle, so edits apply without a restart.
+"""
+
+import json
+from pathlib import Path
+
+import httpx
+
+from . import folders, auth
+from .config import Config
+
+DEFAULT_NOTIFY_FOLDERS = ["inbox"]
+
+
+def notify_file_for(config: Config) -> Path:
+    return config.data_dir / "notify.json"
+
+
+def _load(path: Path) -> dict[str, list[str]]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def _save(path: Path, data: dict[str, list[str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2))
+    tmp.replace(path)
+
+
+def get_notify_folders(path: Path, account_email: str) -> list[str]:
+    data = _load(path)
+    return data[account_email] if account_email in data else list(DEFAULT_NOTIFY_FOLDERS)
+
+
+def list_notify(config: Config, client: httpx.Client, *, account_email: str) -> dict[str, object]:
+    auth.get_account_id_by_email(account_email, config.cache_file)
+    return {"account": account_email, "folders": get_notify_folders(notify_file_for(config), account_email)}
+
+
+def add_notify(
+    config: Config, client: httpx.Client, *, account_email: str, folder: str | None = None, all_folders: bool = False
+) -> dict[str, object]:
+    account_id = auth.get_account_id_by_email(account_email, config.cache_file)
+    path = notify_file_for(config)
+    data = _load(path)
+
+    if all_folders:
+        server_folders = folders.fetch_folders_cfg(config, client, account_id)
+        data[account_email] = [f["displayName"] for f in server_folders if "displayName" in f]
+        _save(path, data)
+        return {"account": account_email, "folders": data[account_email]}
+
+    if not folder:
+        raise ValueError("Specify --folder or --all")
+
+    server_folders = folders.fetch_folders_cfg(config, client, account_id)
+    known_names = set(config.folders) | {f["displayName"].casefold() for f in server_folders if "displayName" in f}
+    known_ids = {f["id"] for f in server_folders if "id" in f}
+    if folder.casefold() not in known_names and folder not in known_ids:
+        raise ValueError(f"Folder '{folder}' not found on the server")
+
+    current = data[account_email] if account_email in data else list(DEFAULT_NOTIFY_FOLDERS)
+    if not any(f.casefold() == folder.casefold() for f in current):
+        current.append(folder)
+    data[account_email] = current
+    _save(path, data)
+    return {"account": account_email, "folders": current}
+
+
+def remove_notify(config: Config, client: httpx.Client, *, account_email: str, folder: str) -> dict[str, object]:
+    auth.get_account_id_by_email(account_email, config.cache_file)
+    path = notify_file_for(config)
+    data = _load(path)
+    current = data[account_email] if account_email in data else list(DEFAULT_NOTIFY_FOLDERS)
+    current = [f for f in current if f.casefold() != folder.casefold()]
+    data[account_email] = current
+    _save(path, data)
+    return {"account": account_email, "folders": current}

--- a/agent/skills/microsoft/cli/src/microsoft_cli/settings.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/settings.py
@@ -1,7 +1,13 @@
 from functools import lru_cache
 
-from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Microsoft Graph Command Line Tools: a Microsoft-published, multitenant public client that
+# supports device-code flow. It is the default so the skill works with no Azure setup; users
+# who want their own app registration (e.g. to restrict scopes or clear a Conditional Access
+# block) override it with MICROSOFT_MCP_CLIENT_ID. The default client requests explicit Graph
+# scopes (dynamic consent); a user's own app uses ".default" (its configured permissions).
+DEFAULT_CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e"
 
 
 class MicrosoftSettings(BaseSettings):
@@ -11,17 +17,8 @@ class MicrosoftSettings(BaseSettings):
         extra="ignore",
     )
 
-    microsoft_mcp_client_id: str | None = None
+    microsoft_mcp_client_id: str = DEFAULT_CLIENT_ID
     microsoft_mcp_tenant_id: str = "common"
-
-    @model_validator(mode="after")
-    def _check_client_id(self):
-        if not self.microsoft_mcp_client_id:
-            raise ValueError(
-                "MICROSOFT_MCP_CLIENT_ID environment variable is required. "
-                "Get one from https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade"
-            )
-        return self
 
 
 @lru_cache(maxsize=1)

--- a/agent/skills/microsoft/cli/tests/test_attachments.py
+++ b/agent/skills/microsoft/cli/tests/test_attachments.py
@@ -1,0 +1,44 @@
+"""Unit tests for attachment listing / bulk download (mocked Graph calls)."""
+
+import base64
+
+import pytest
+
+from microsoft_cli import email
+from microsoft_cli.config import Config
+
+_ATTACHMENTS = {
+    "value": [
+        {"id": "a1", "name": "report.pdf", "size": 3, "contentType": "application/pdf", "contentBytes": base64.b64encode(b"pdf").decode()},
+        {"id": "a2", "name": "report.pdf", "size": 3, "contentType": "application/pdf", "contentBytes": base64.b64encode(b"two").decode()},
+        {"id": "a3", "name": "ref-item", "size": 0, "contentType": "message/rfc822"},  # no contentBytes: skipped
+    ]
+}
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    def fake_account_id(account_email, cache_file):
+        return "acct-1"
+
+    def fake_request(client, cache_file, scopes, base_url, method, path, account_id=None, **kwargs):
+        if method == "GET" and path.endswith("/attachments"):
+            return _ATTACHMENTS
+        return None
+
+    monkeypatch.setattr(email.auth, "get_account_id_by_email", fake_account_id)
+    monkeypatch.setattr(email.graph, "request", fake_request)
+
+
+def test_list_attachments(patched):
+    result = email.list_attachments(Config(), None, account_email="me@example.com", email_id="m1")
+    assert [a["name"] for a in result] == ["report.pdf", "report.pdf", "ref-item"]
+
+
+def test_download_all_dedupes_names_and_skips_non_file(patched, tmp_path):
+    result = email.download_attachments(Config(), None, account_email="me@example.com", email_id="m1", out_dir=str(tmp_path))
+    assert result["count"] == 2
+    saved_paths = sorted(p.name for p in tmp_path.iterdir())
+    assert saved_paths == ["report.pdf", "report_1.pdf"]
+    assert (tmp_path / "report.pdf").read_bytes() == b"pdf"
+    assert (tmp_path / "report_1.pdf").read_bytes() == b"two"

--- a/agent/skills/microsoft/cli/tests/test_draft.py
+++ b/agent/skills/microsoft/cli/tests/test_draft.py
@@ -1,0 +1,67 @@
+"""Unit tests for microsoft_cli.email.create_email_draft (mocked Graph calls)."""
+
+import pytest
+
+from microsoft_cli import email
+from microsoft_cli.config import Config
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_account_id(account_email, cache_file):
+        return "acct-1"
+
+    def fake_request(client, cache_file, scopes, base_url, method, path, account_id=None, **kwargs):
+        calls.append({"method": method, "path": path, "json": kwargs["json"] if "json" in kwargs else None})
+        if method == "POST" and path.endswith("/createReply"):
+            return {"id": "reply-draft"}
+        if method == "POST" and path.endswith("/createForward"):
+            return {"id": "fwd-draft"}
+        if method == "POST" and path == "/me/messages":
+            return {"id": "compose-draft"}
+        return None
+
+    monkeypatch.setattr(email.auth, "get_account_id_by_email", fake_account_id)
+    monkeypatch.setattr(email.graph, "request", fake_request)
+    return calls
+
+
+def test_compose_draft(patched):
+    result = email.create_email_draft(Config(), None, account_email="me@example.com", subject="Hi", body="body", to=["bob@x.com"])
+    assert result["id"] == "compose-draft"
+    assert patched[0]["path"] == "/me/messages"
+    assert patched[0]["json"]["subject"] == "Hi"
+
+
+def test_compose_requires_subject(patched):
+    with pytest.raises(ValueError, match="--subject is required"):
+        email.create_email_draft(Config(), None, account_email="me@example.com", body="body", to=["bob@x.com"])
+
+
+def test_compose_requires_recipient(patched):
+    with pytest.raises(ValueError, match="At least one recipient"):
+        email.create_email_draft(Config(), None, account_email="me@example.com", subject="Hi", body="body")
+
+
+def test_reply_draft_is_threaded_and_not_sent(patched):
+    result = email.create_email_draft(Config(), None, account_email="me@example.com", body="thanks", reply_to_id="orig-1")
+    assert result == {"status": "drafted", "id": "reply-draft", "source_id": "orig-1"}
+    assert patched[0]["path"] == "/me/messages/orig-1/createReply"
+    assert patched[1]["method"] == "PATCH"
+    assert patched[1]["path"] == "/me/messages/reply-draft"
+    assert patched[1]["json"]["body"] == {"contentType": "Text", "content": "thanks"}
+    assert not any(c["path"].endswith("/send") for c in patched)
+
+
+def test_forward_draft_with_recipient(patched):
+    result = email.create_email_draft(Config(), None, account_email="me@example.com", body="fyi", forward_id="orig-2", to=["bob@x.com"])
+    assert result["id"] == "fwd-draft"
+    assert patched[0]["path"] == "/me/messages/orig-2/createForward"
+    assert patched[1]["json"]["toRecipients"] == [{"emailAddress": {"address": "bob@x.com"}}]
+
+
+def test_reply_and_forward_mutually_exclusive(patched):
+    with pytest.raises(ValueError, match="at most one"):
+        email.create_email_draft(Config(), None, account_email="me@example.com", body="x", reply_to_id="a", forward_id="b")

--- a/agent/skills/microsoft/cli/tests/test_folders.py
+++ b/agent/skills/microsoft/cli/tests/test_folders.py
@@ -1,0 +1,98 @@
+"""Unit tests for microsoft_cli.folders (mocked Graph calls)."""
+
+import pytest
+
+from microsoft_cli import folders
+from microsoft_cli.config import Config
+
+_FOLDERS_PAGE = {
+    "value": [
+        {
+            "id": "inbox-id",
+            "displayName": "Inbox",
+            "totalItemCount": 10,
+            "unreadItemCount": 2,
+            "childFolders": [{"id": "sub-id", "displayName": "Receipts", "totalItemCount": 3, "unreadItemCount": 1}],
+        },
+        {"id": "news-id", "displayName": "Newsletters", "totalItemCount": 5, "unreadItemCount": 5, "childFolders": []},
+    ]
+}
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_account_id(account_email, cache_file):
+        return "acct-1"
+
+    def fake_request(client, cache_file, scopes, base_url, method, path, account_id=None, **kwargs):
+        calls.append({"method": method, "path": path, "json": kwargs["json"] if "json" in kwargs else None})
+        if method == "GET" and path == "/me/mailFolders":
+            return _FOLDERS_PAGE
+        if method == "GET" and path.startswith("/me/mailFolders/"):
+            return {"id": "inbox-id", "displayName": "Inbox", "totalItemCount": 10, "unreadItemCount": 2}
+        if method == "POST":
+            return {"id": "created-id", "displayName": "New"}
+        return None
+
+    monkeypatch.setattr(folders.auth, "get_account_id_by_email", fake_account_id)
+    monkeypatch.setattr(folders.graph, "request", fake_request)
+    return calls
+
+
+def test_list_folders_flattens_children(patched):
+    result = folders.list_folders(Config(), None, account_email="me@example.com")
+    names = [f["displayName"] for f in result]
+    assert names == ["Inbox", "Receipts", "Newsletters"]
+    assert result[0] == {"id": "inbox-id", "displayName": "Inbox", "totalItemCount": 10, "unreadItemCount": 2}
+
+
+def test_resolve_wellknown_key_skips_lookup(patched):
+    resolved = folders.resolve_folder_id_cfg(Config(), None, "acct-1", "Archive")
+    assert resolved == "archive"
+    assert patched == []  # no folder listing needed for a well-known key
+
+
+def test_resolve_display_name_to_id(patched):
+    resolved = folders.resolve_folder_id_cfg(Config(), None, "acct-1", "Newsletters")
+    assert resolved == "news-id"
+    assert any(c["path"] == "/me/mailFolders" for c in patched)
+
+
+def test_resolve_unknown_returns_token(patched):
+    resolved = folders.resolve_folder_id_cfg(Config(), None, "acct-1", "already-an-id")
+    assert resolved == "already-an-id"
+
+
+def test_folder_status(patched):
+    result = folders.folder_status(Config(), None, account_email="me@example.com", folder="inbox")
+    assert result["totalItemCount"] == 10
+    assert patched[0]["path"] == "/me/mailFolders/inbox"
+
+
+def test_create_folder_root(patched):
+    folders.create_folder(Config(), None, account_email="me@example.com", name="Projects")
+    post = [c for c in patched if c["method"] == "POST"][0]
+    assert post["path"] == "/me/mailFolders"
+    assert post["json"] == {"displayName": "Projects"}
+
+
+def test_create_folder_nested(patched):
+    folders.create_folder(Config(), None, account_email="me@example.com", name="Child", parent_id="parent-id")
+    post = [c for c in patched if c["method"] == "POST"][0]
+    assert post["path"] == "/me/mailFolders/parent-id/childFolders"
+
+
+def test_rename_folder(patched):
+    folders.rename_folder(Config(), None, account_email="me@example.com", folder_id="fid", name="Renamed")
+    patch = [c for c in patched if c["method"] == "PATCH"][0]
+    assert patch["path"] == "/me/mailFolders/fid"
+    assert patch["json"] == {"displayName": "Renamed"}
+
+
+def test_delete_folder(patched):
+    result = folders.delete_folder(Config(), None, account_email="me@example.com", folder_id="fid")
+    assert result == {"status": "deleted", "id": "fid"}
+    delete = [c for c in patched if c["method"] == "DELETE"][0]
+    assert delete["path"] == "/me/mailFolders/fid"

--- a/agent/skills/microsoft/cli/tests/test_message_actions.py
+++ b/agent/skills/microsoft/cli/tests/test_message_actions.py
@@ -1,0 +1,95 @@
+"""Unit tests for forward / move / archive / flag message actions (mocked Graph)."""
+
+import pytest
+
+from microsoft_cli import email
+from microsoft_cli.config import Config
+
+_FOLDERS_PAGE = {
+    "value": [
+        {"id": "news-id", "displayName": "Newsletters", "childFolders": []},
+    ]
+}
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_account_id(account_email, cache_file):
+        return "acct-1"
+
+    def fake_request(client, cache_file, scopes, base_url, method, path, account_id=None, **kwargs):
+        calls.append({"method": method, "path": path, "json": kwargs["json"] if "json" in kwargs else None})
+        if method == "GET" and path == "/me/mailFolders":
+            return _FOLDERS_PAGE
+        if method == "POST" and path.endswith("/createForward"):
+            return {"id": "draft-1"}
+        if method == "POST" and path.endswith("/move"):
+            return {"id": "moved-1"}
+        return None
+
+    monkeypatch.setattr(email.auth, "get_account_id_by_email", fake_account_id)
+    monkeypatch.setattr(email.graph, "request", fake_request)
+    return calls
+
+
+def test_forward_plain_uses_forward_action(patched):
+    result = email.forward_email(Config(), None, account_email="me@example.com", email_id="m1", to=["bob@x.com"], body="fyi")
+    assert result == {"status": "sent"}
+    assert len(patched) == 1
+    assert patched[0]["path"] == "/me/messages/m1/forward"
+    assert patched[0]["json"] == {"comment": "fyi", "toRecipients": [{"emailAddress": {"address": "bob@x.com"}}]}
+
+
+def test_forward_with_cc_uses_draft_path(patched):
+    result = email.forward_email(Config(), None, account_email="me@example.com", email_id="m1", to=["bob@x.com"], body="fyi", cc=["cc@x.com"])
+    assert result == {"status": "sent"}
+    paths = [c["path"] for c in patched]
+    assert paths == ["/me/messages/m1/createForward", "/me/messages/draft-1", "/me/messages/draft-1/send"]
+    patch = patched[1]
+    assert patch["json"]["ccRecipients"] == [{"emailAddress": {"address": "cc@x.com"}}]
+    assert patch["json"]["toRecipients"] == [{"emailAddress": {"address": "bob@x.com"}}]
+
+
+def test_forward_requires_to(patched):
+    with pytest.raises(ValueError, match="--to is required"):
+        email.forward_email(Config(), None, account_email="me@example.com", email_id="m1", to=[])
+
+
+def test_move_to_wellknown_folder(patched):
+    result = email.move_email(Config(), None, account_email="me@example.com", email_id="m1", to_folder="Archive")
+    assert result == {"status": "moved", "email_id": "m1", "to_folder": "Archive", "new_id": "moved-1"}
+    move = [c for c in patched if c["path"].endswith("/move")][0]
+    assert move["json"] == {"destinationId": "archive"}
+
+
+def test_move_to_named_folder_resolves_id(patched):
+    email.move_email(Config(), None, account_email="me@example.com", email_id="m1", to_folder="Newsletters")
+    move = [c for c in patched if c["path"].endswith("/move")][0]
+    assert move["json"] == {"destinationId": "news-id"}
+
+
+def test_archive_moves_to_archive(patched):
+    result = email.archive_email(Config(), None, account_email="me@example.com", email_id="m1")
+    assert result["to_folder"] == "archive"
+    move = [c for c in patched if c["path"].endswith("/move")][0]
+    assert move["json"] == {"destinationId": "archive"}
+
+
+def test_update_flagged(patched):
+    email.update_email(Config(), None, account_email="me@example.com", email_id="m1", flagged=True)
+    patch = [c for c in patched if c["method"] == "PATCH"][0]
+    assert patch["path"] == "/me/messages/m1"
+    assert patch["json"] == {"flag": {"flagStatus": "flagged"}}
+
+
+def test_update_unflagged(patched):
+    email.update_email(Config(), None, account_email="me@example.com", email_id="m1", flagged=False)
+    patch = [c for c in patched if c["method"] == "PATCH"][0]
+    assert patch["json"] == {"flag": {"flagStatus": "notFlagged"}}
+
+
+def test_update_requires_a_field(patched):
+    with pytest.raises(ValueError, match="at least one field"):
+        email.update_email(Config(), None, account_email="me@example.com", email_id="m1")

--- a/agent/skills/microsoft/cli/tests/test_notify.py
+++ b/agent/skills/microsoft/cli/tests/test_notify.py
@@ -1,0 +1,72 @@
+"""Unit tests for microsoft_cli.notify (real temp file, mocked Graph folder lookup)."""
+
+import json
+
+import pytest
+
+from microsoft_cli import notify, folders
+from microsoft_cli.config import Config
+
+_FOLDERS_PAGE = {
+    "value": [
+        {"id": "inbox-id", "displayName": "Inbox", "childFolders": []},
+        {"id": "news-id", "displayName": "Newsletters", "childFolders": []},
+    ]
+}
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    return Config(data_dir=tmp_path)
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    def fake_account_id(account_email, cache_file):
+        return "acct-1"
+
+    def fake_request(client, cache_file, scopes, base_url, method, path, account_id=None, **kwargs):
+        if method == "GET" and path == "/me/mailFolders":
+            return _FOLDERS_PAGE
+        return None
+
+    monkeypatch.setattr(notify.auth, "get_account_id_by_email", fake_account_id)
+    monkeypatch.setattr(folders.graph, "request", fake_request)
+
+
+def test_default_is_inbox_when_absent(cfg, patched):
+    assert notify.get_notify_folders(notify.notify_file_for(cfg), "me@example.com") == ["inbox"]
+
+
+def test_add_valid_folder_appends_and_persists(cfg, patched):
+    result = notify.add_notify(cfg, None, account_email="me@example.com", folder="Newsletters")
+    assert result["folders"] == ["inbox", "Newsletters"]
+    saved = json.loads(notify.notify_file_for(cfg).read_text())
+    assert saved["me@example.com"] == ["inbox", "Newsletters"]
+
+
+def test_add_is_idempotent(cfg, patched):
+    notify.add_notify(cfg, None, account_email="me@example.com", folder="Newsletters")
+    result = notify.add_notify(cfg, None, account_email="me@example.com", folder="newsletters")
+    assert result["folders"] == ["inbox", "Newsletters"]
+
+
+def test_add_unknown_folder_rejected(cfg, patched):
+    with pytest.raises(ValueError, match="not found on the server"):
+        notify.add_notify(cfg, None, account_email="me@example.com", folder="Nonexistent")
+
+
+def test_add_all_replaces_with_every_folder(cfg, patched):
+    result = notify.add_notify(cfg, None, account_email="me@example.com", all_folders=True)
+    assert result["folders"] == ["Inbox", "Newsletters"]
+
+
+def test_remove_folder(cfg, patched):
+    notify.add_notify(cfg, None, account_email="me@example.com", folder="Newsletters")
+    result = notify.remove_notify(cfg, None, account_email="me@example.com", folder="inbox")
+    assert result["folders"] == ["Newsletters"]
+
+
+def test_remove_last_mutes_account(cfg, patched):
+    result = notify.remove_notify(cfg, None, account_email="me@example.com", folder="inbox")
+    assert result["folders"] == []

--- a/agent/skills/microsoft/cli/tests/test_settings.py
+++ b/agent/skills/microsoft/cli/tests/test_settings.py
@@ -1,6 +1,7 @@
 """Locks the single-owner settings accessor: env-derived, read once per process."""
 
-from microsoft_cli.settings import MicrosoftSettings, get_settings
+from microsoft_cli.settings import MicrosoftSettings, get_settings, DEFAULT_CLIENT_ID
+from microsoft_cli.config import resolve_scopes, DEFAULT_CLIENT_SCOPES, OWNED_APP_SCOPES
 
 
 def test_get_settings_reads_env_and_is_memoized(monkeypatch):
@@ -14,4 +15,25 @@ def test_get_settings_reads_env_and_is_memoized(monkeypatch):
     assert first.microsoft_mcp_client_id == "test-client-id"
     assert first is second
 
+    get_settings.cache_clear()
+
+
+def test_defaults_to_graph_cli_client_when_env_absent(monkeypatch):
+    monkeypatch.delenv("MICROSOFT_MCP_CLIENT_ID", raising=False)
+    get_settings.cache_clear()
+    assert get_settings().microsoft_mcp_client_id == DEFAULT_CLIENT_ID
+    get_settings.cache_clear()
+
+
+def test_default_client_uses_dynamic_scopes(monkeypatch):
+    monkeypatch.delenv("MICROSOFT_MCP_CLIENT_ID", raising=False)
+    get_settings.cache_clear()
+    assert resolve_scopes() == DEFAULT_CLIENT_SCOPES
+    get_settings.cache_clear()
+
+
+def test_custom_client_uses_default_scope(monkeypatch):
+    monkeypatch.setenv("MICROSOFT_MCP_CLIENT_ID", "my-own-app")
+    get_settings.cache_clear()
+    assert resolve_scopes() == OWNED_APP_SCOPES
     get_settings.cache_clear()


### PR DESCRIPTION
Brings the `microsoft` skill's email surface up to parity with the `email-client` skill for every feature Microsoft Graph can express.

## New surface

**`folder` group**
- `folder list` — every folder with unread/total counts + ids (list-folders + status)
- `folder status --folder inbox` — counts for one folder
- `folder create/rename/delete`

**`email` message actions**
- `email forward --to … [--cc] [--attachments] [--html]`
- `email move --to-folder <well-known key or display name>`
- `email archive`
- `email update --flagged / --unflagged`

**Drafts**
- `email draft --reply-to <id>` / `--forward <id>` — threaded reply/forward drafts (subject inherited)

**Attachments**
- `email attachment --list` (metadata) / `--all [--out-dir]` (bulk download, de-duped names, skips non-file attachments)

**Notifications**
- `notify list/add/remove` — per-account watch-folder selection persisted at `~/.microsoft/notify.json`, live-reloaded by the monitor each cycle; notifications now carry a `folder` field. Default stays inbox-only, so running agents are unaffected.

**Accounts**
- `auth remove --account <email>`

## Design notes
- New `folders.py` + `notify.py` modules follow the existing `graph.py` primitive/`_cfg` split so the monitor thread (raw primitives) and command modules (Config) share folder resolution.
- Two deliberate Graph limitations, documented in SKILL.md: multi-folder notify is **time-based** (fires on new arrivals incl. rule-routed mail, not manual moves in), and `folder list` covers top-level + one level of children.
- **Dropped** (no Graph equivalent): IMAP `\Answered`/`\Draft` system flags, folder `subscribe`.

## Tests
33 new unit tests (folders, forward/move/archive/flag, draft reply/forward, notify config, attachment list/all) following the mocked-Graph pattern; full skill suite 48 passing. Ruff check + format clean; skills index regenerated.

## Fleet impact
No migration needed: absent `notify.json` ⇒ inbox-only watch (unchanged behavior); the added `folder` field on notifications is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)