### PR TITLE
fix(skills): make register-service wait for vestad and fail cleanly

### DIFF
--- a/agent/skills/service/SKILL.md
+++ b/agent/skills/service/SKILL.md
@@ -28,3 +28,8 @@ single line that re-registers and starts, e.g.:
 ```bash
 PORT=$(~/agent/skills/service/scripts/register-service tasks) && screen -dmS tasks tasks serve --notifications-dir ~/agent/notifications --port $PORT
 ```
+
+vestad's API may still be coming up when the daemon block runs, so `register-service` polls
+until vestad answers (up to `REGISTER_SERVICE_WAIT` seconds, default 30) and, if it never does,
+exits non-zero with a stderr message and no port. Keep the `&&` between registration and start:
+a failed registration short-circuits the chain, so the daemon never launches portless.

--- a/agent/skills/service/scripts/register-service
+++ b/agent/skills/service/scripts/register-service
@@ -6,6 +6,13 @@ set -euo pipefail
 # it for token-only services. Registration is idempotent: vestad returns the
 # same port for a given name on every call.
 #
+# vestad's HTTP API may not be up yet when the restart skill runs this (the
+# daemon block can fire before vestad's API is back). Rather than pipe a refused
+# connection's empty body into json (a raw traceback + empty port -> a portless
+# daemon), poll until vestad answers with a port, up to REGISTER_SERVICE_WAIT
+# seconds (default 30). On timeout, exit non-zero with a stderr message and no
+# stdout, so `PORT=$(register-service ...) && start` short-circuits cleanly.
+#
 # Usage: register-service <name> [--public]
 #   PORT=$(~/agent/skills/service/scripts/register-service tasks)
 #   PORT=$(~/agent/skills/service/scripts/register-service dashboard --public)
@@ -16,7 +23,27 @@ if [ "${2:-}" = "--public" ]; then
     PUBLIC="true"
 fi
 
-curl -sk -X POST "https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services" \
-    -H "X-Agent-Token: $AGENT_TOKEN" -H 'Content-Type: application/json' \
-    -d "{\"name\":\"$NAME\",\"public\":$PUBLIC}" \
-    | python3 -c "import sys,json; print(json.load(sys.stdin)['port'])"
+WAIT_SECONDS="${REGISTER_SERVICE_WAIT:-30}"
+URL="https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services"
+DEADLINE=$(( $(date +%s) + WAIT_SECONDS ))
+
+while :; do
+    BODY=$(curl -sk -X POST "$URL" \
+        -H "X-Agent-Token: $AGENT_TOKEN" -H 'Content-Type: application/json' \
+        -d "{\"name\":\"$NAME\",\"public\":$PUBLIC}") || BODY=""
+    PORT=$(printf '%s' "$BODY" | python3 -c \
+        'import sys, json
+try:
+    print(json.load(sys.stdin)["port"])
+except Exception:
+    sys.exit(1)' 2>/dev/null) || PORT=""
+    if [ -n "$PORT" ]; then
+        printf '%s\n' "$PORT"
+        exit 0
+    fi
+    if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+        echo "register-service: vestad unreachable after ${WAIT_SECONDS}s; service '$NAME' not registered" >&2
+        exit 1
+    fi
+    sleep 1
+done

--- a/agent/tests/test_register_service.py
+++ b/agent/tests/test_register_service.py
@@ -1,0 +1,130 @@
+"""Exercises the REAL register-service script (the helper the restart skill's daemon
+block runs) against a live HTTPS mock and an unreachable port: it must print the port
+on success and, when vestad is down, fail cleanly (non-zero, empty stdout, a stderr
+message, no Python traceback) instead of emitting an empty port that launches a
+portless daemon (issue #960)."""
+
+import http.server
+import pathlib as pl
+import socket
+import ssl
+import subprocess
+import threading
+
+REPO_ROOT = pl.Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "agent/skills/service/scripts/register-service"
+
+
+def _free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _self_signed(tmp_path):
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-keyout",
+            str(key),
+            "-out",
+            str(cert),
+            "-days",
+            "1",
+            "-subj",
+            "/CN=localhost",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cert, key
+
+
+def _run(port, tmp_path, wait="2"):
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "VESTAD_PORT": str(port),
+        "AGENT_NAME": "test-agent",
+        "AGENT_TOKEN": "test-token",
+        "REGISTER_SERVICE_WAIT": wait,
+        "HOME": str(tmp_path),
+    }
+    return subprocess.run(["bash", str(SCRIPT), "tasks"], env=env, capture_output=True, text=True, timeout=30)
+
+
+class _PortHandler(http.server.BaseHTTPRequestHandler):
+    port_value = 45321
+
+    def do_POST(self):
+        length = int(self.headers["Content-Length"])
+        self.rfile.read(length)
+        body = f'{{"port":{self.port_value}}}'.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+def _serve_https(port, cert, key):
+    server = http.server.HTTPServer(("127.0.0.1", port), _PortHandler)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(str(cert), str(key))
+    server.socket = ctx.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def test_prints_port_when_vestad_answers(tmp_path):
+    cert, key = _self_signed(tmp_path)
+    port = _free_port()
+    server = _serve_https(port, cert, key)
+    try:
+        result = _run(port, tmp_path)
+    finally:
+        server.shutdown()
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "45321"
+
+
+def test_fails_cleanly_when_vestad_unreachable(tmp_path):
+    port = _free_port()  # nothing listens here -> connection refused
+    result = _run(port, tmp_path, wait="1")
+    assert result.returncode != 0
+    assert result.stdout.strip() == ""  # no empty/garbage port to launch a portless daemon
+    assert "Traceback" not in result.stderr
+    assert "JSONDecodeError" not in result.stderr
+    assert "vestad unreachable" in result.stderr
+
+
+def test_caller_and_chain_short_circuits_on_failure(tmp_path):
+    """The documented `PORT=$(register-service ...) && start` pattern must not run
+    the start command when registration fails."""
+    port = _free_port()
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "VESTAD_PORT": str(port),
+        "AGENT_NAME": "test-agent",
+        "AGENT_TOKEN": "test-token",
+        "REGISTER_SERVICE_WAIT": "1",
+        "HOME": str(tmp_path),
+    }
+    result = subprocess.run(
+        ["bash", "-c", f'PORT=$("{SCRIPT}" tasks) && echo "STARTED:$PORT"'],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert "STARTED" not in result.stdout

--- a/agent/tests/test_register_service.py
+++ b/agent/tests/test_register_service.py
@@ -72,7 +72,7 @@ class _PortHandler(http.server.BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-    def log_message(self, *args):
+    def log_message(self, format, *args):
         pass
 
 


### PR DESCRIPTION
## Problem

`register-service` piped `curl` straight into `json.load`. During a container restart the restart skill's daemon block can run **before vestad's HTTP API is back up**; the refused connection returns an empty body, `json.load` raises a `JSONDecodeError` (raw traceback, empty stdout), and the caller's `PORT=$(...)` ends up empty. The daemon then launches **portless** and silently fails, so services stay down after a restart with only traceback logs.

Fixes #960.

## Fix

One root-cause change in `agent/skills/service/scripts/register-service`:

- Poll vestad until it answers with a port, up to `REGISTER_SERVICE_WAIT` seconds (default **30**), sleeping 1s between attempts.
- On success: print the port, exit 0 (unchanged happy path, still idempotent).
- On timeout / unreachable: print a clean message to **stderr**, exit **non-zero**, nothing on stdout — no Python traceback.

No per-caller `[ -n "$PORT" ]` guard is added: the documented `PORT=$(register-service ...) && start` chain already short-circuits when the command-substitution assignment carries a non-zero exit, so the daemon never launches portless. Adding a second guard would be redundant belt-and-suspenders (CLAUDE.md: *one fix per root cause*). The service `SKILL.md` documents the wait/clean-exit contract and why the `&&` matters.

## Tests

New `agent/tests/test_register_service.py` drives the real script via subprocess:

- `test_prints_port_when_vestad_answers` — against a local HTTPS mock, prints the assigned port (happy path preserved).
- `test_fails_cleanly_when_vestad_unreachable` — against a closed port: non-zero exit, empty stdout, no `Traceback`/`JSONDecodeError`, a `vestad unreachable` stderr message. **Fails on the old script, passes on the new** (verified).
- `test_caller_and_chain_short_circuits_on_failure` — the documented `&&` chain does not run the start command when registration fails.

```
3 passed in 2.82s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)