### PR TITLE
fix(dashboard): self-heal build artifacts before vite preview

### DIFF
--- a/agent/core/migrations/2026-07-dashboard-self-heal.md
+++ b/agent/core/migrations/2026-07-dashboard-self-heal.md
@@ -1,0 +1,42 @@
+Your dashboard's startup command runs `vite preview`, which serves the prebuilt
+`app/dist/`. But `dist/` and `node_modules/` are untracked build artifacts: if a
+workspace sparse-checkout prune (or a clean) drops them while the box keeps
+running, `vite preview` serves 404 for every route with no rebuild and no health
+signal. The dashboard skill now ships `scripts/serve`, a launcher that rebuilds
+`node_modules`/`dist` when missing before starting preview, so the service
+self-heals on the next restart instead of serving nothing.
+
+This migration repoints your restart daemon line at that launcher. It only
+matters if you actually set up a dashboard. Safe to run more than once.
+
+### 1. Repoint the dashboard daemon line
+
+Open `~/agent/skills/restart/SKILL.md`. If its `## Daemons` section has no line
+mentioning `dashboard`, you never set one up, skip to the final step.
+
+If a dashboard line exists (it runs `screen -dmS dashboard ... vite preview ...`),
+replace that whole line with:
+
+```
+running dashboard || { screen -dmS dashboard ~/agent/skills/dashboard/scripts/serve; sleep 1; }
+```
+
+If your line already reads exactly that, leave it, there is nothing to change.
+
+### 2. Heal the running dashboard now (only if set up)
+
+So you do not keep serving a possibly-broken build until the next restart,
+relaunch through the new script now (it rebuilds the artifacts if they are
+missing). This no-ops unless a dashboard session is actually running and the new
+script has arrived on disk:
+
+```bash
+if [ -x ~/agent/skills/dashboard/scripts/serve ] && screen -ls | grep -q '\.dashboard[[:space:]]'; then
+  screen -S dashboard -X quit 2>/dev/null
+  screen -dmS dashboard ~/agent/skills/dashboard/scripts/serve
+fi
+```
+
+### 3. Mark this migration applied
+
+Call `mark_migration_applied` with `name="2026-07-dashboard-self-heal"`.

--- a/agent/skills/dashboard/SETUP.md
+++ b/agent/skills/dashboard/SETUP.md
@@ -16,17 +16,17 @@ cd ~/agent/skills/dashboard/app && npx vite build
 
 ## 3. Start the dashboard server
 
-Register with vestad to get a port (see [service](../service/SKILL.md)), then start the server:
+`scripts/serve` registers the service port (see [service](../service/SKILL.md)) and starts the preview, rebuilding `node_modules`/`dist` first if they are missing. Start it, and fetch the port for the check below:
 ```bash
 PORT=$(~/agent/skills/service/scripts/register-service dashboard --public)
-screen -dmS dashboard sh -c "cd ~/agent/skills/dashboard/app && npx vite preview --port $PORT --host 0.0.0.0"
+screen -dmS dashboard ~/agent/skills/dashboard/scripts/serve
 ```
 
 ## 4. Register the service
 
-Add this startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
+Add this guarded startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
 ```
-PORT=$(~/agent/skills/service/scripts/register-service dashboard --public) && screen -dmS dashboard sh -c "cd ~/agent/skills/dashboard/app && npx vite preview --port $PORT --host 0.0.0.0"
+running dashboard || { screen -dmS dashboard ~/agent/skills/dashboard/scripts/serve; sleep 1; }
 ```
 
 ## 5. Check it's alive

--- a/agent/skills/dashboard/SKILL.md
+++ b/agent/skills/dashboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dashboard
 description: Build or modify the user's dashboard: widgets, pages, layouts, or custom UI.
-serve: PORT=$(~/agent/skills/service/scripts/register-service dashboard --public) && screen -dmS dashboard sh -c "cd ~/agent/skills/dashboard/app && npx vite preview --port $PORT --host 0.0.0.0"
+serve: screen -dmS dashboard ~/agent/skills/dashboard/scripts/serve
 ---
 
 # Dashboard
@@ -131,7 +131,7 @@ Rebuild, re-register with vestad, restart the preview server, and notify the Ves
 cd ~/agent/skills/dashboard/app && { [ -d node_modules ] || npm install; } && npx vite build
 PORT=$(~/agent/skills/service/scripts/register-service dashboard --public)
 screen -S dashboard -X quit 2>/dev/null
-screen -dmS dashboard sh -c "cd ~/agent/skills/dashboard/app && npx vite preview --port $PORT --host 0.0.0.0"
+screen -dmS dashboard ~/agent/skills/dashboard/scripts/serve
 # Wait for the server to be ready
 for i in $(seq 1 20); do curl -s -o /dev/null http://localhost:$PORT && break; sleep 0.5; done
 # Smoke test: fetch the page and check for runtime errors

--- a/agent/skills/dashboard/scripts/serve
+++ b/agent/skills/dashboard/scripts/serve
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Self-healing dashboard launcher. `vite preview` serves the prebuilt app, but
+# node_modules/ and dist/ are untracked build artifacts: a workspace
+# sparse-checkout prune (or a clean) can drop them while the box keeps running,
+# leaving `vite preview` to serve 404s with no rebuild. Ensuring both exist here,
+# before every launch, lets the service rebuild itself on the next restart
+# instead of serving nothing. Idempotent: on a normal restart both dirs are
+# present and this goes straight to `vite preview`.
+cd ~/agent/skills/dashboard/app
+[ -d node_modules ] || npm install
+[ -d dist ] || npx vite build
+PORT=$(~/agent/skills/service/scripts/register-service dashboard --public)
+exec npx vite preview --port "$PORT" --host 0.0.0.0


### PR DESCRIPTION
## Problem

Fixes #1007. The dashboard runs `vite preview`, which serves the prebuilt `app/dist/`. Both `dist/` and `node_modules/` are untracked build artifacts (not in git). If they are lost while the service keeps running (a workspace `git sparse-checkout` change, a clean, any re-materialization that prunes the skill dir), the already-running `vite preview` silently serves HTTP 404 for every route: no rebuild, no health signal, service still shows "up".

## Fix

Extract `agent/skills/dashboard/scripts/serve`, a self-healing launcher:

```sh
cd ~/agent/skills/dashboard/app
[ -d node_modules ] || npm install
[ -d dist ] || npx vite build
PORT=$(~/agent/skills/service/scripts/register-service dashboard --public)
exec npx vite preview --port "$PORT" --host 0.0.0.0
```

It rebuilds the missing artifacts before launching preview, so the service self-heals on the next restart instead of serving nothing. Idempotent: on a normal restart both dirs exist and it goes straight to `vite preview`.

The serve command was duplicated across the `serve:` frontmatter, `SETUP.md`, and each box's agent-authored restart daemon line. The launcher becomes the single owner; frontmatter, SETUP, and the after-change restart block now all call it. The after-change block still builds explicitly (source changed) before handing off to the launcher.

Per one-fix-per-root-cause, the optional 404 health-check poller is intentionally skipped: the startup preflight is the correct single layer.

## Fleet impact

No code consumes the `serve:` frontmatter (it's a convention the agent copies into `restart/SKILL.md`), so a repo-only change would not reach running boxes. Migration `2026-07-dashboard-self-heal.md` (conditional + idempotent) repoints the existing dashboard daemon line at the launcher and, if a dashboard session is live and the script has arrived, relaunches it in place to heal immediately. Boxes that never set up a dashboard no-op. Fresh agents pre-mark it.

## Verification

- Hermetic harness (stubbed `npm`/`npx`/`register-service`): cold start runs `npm install` -> `vite build` -> `vite preview --port <p>`; warm start skips straight to `vite preview --port <p>`. Correct port threaded through.
- `sh -n` clean on the launcher and the migration heal snippet.
- Skills index regenerated (unchanged; name/description untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)