### PR TITLE
feat(notifications): add trash disposition to drop notifications entirely

### DIFF
--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -304,6 +304,13 @@ class VestaConfig(pyd_settings.BaseSettings):
         return self.agent_dir / "notifications"
 
     @property
+    def notif_trash_dir(self) -> pl.Path:
+        # Trashed notifications are moved here rather than deleted, so a too-aggressive trash rule stays
+        # recoverable/auditable. A subdir of notifications_dir is safe: the loader globs "*.json"
+        # non-recursively and the watcher is recursive=False, so files parked here are never re-scanned.
+        return self.notifications_dir / "trash"
+
+    @property
     def data_dir(self) -> pl.Path:
         return self.agent_dir / "data"
 

--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -80,7 +80,7 @@ class NotificationEvent(_BaseEvent):
     # so the rule editor + the skill's `facets` can surface what an interrupt rule can match beyond
     # source/type/sender. NotRequired (events predating it, and notifications with no such extras, omit it).
     fields: tp.NotRequired[dict[str, str]]
-    decided: tp.NotRequired[tp.Literal["interrupt", "pool"]]
+    decided: tp.NotRequired[tp.Literal["interrupt", "pool", "trash"]]
     notif_id: tp.NotRequired[str]
 
 

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -618,8 +618,14 @@ async def monitor_loop(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.State, 
 
             # Trashed notifications are recorded in history above but never reach the agent: move the
             # files out of the active dir (recoverable, and so they never re-emit) and create no turn.
+            # They are resolved the moment they arrive, so clear each one's pending marker right away —
+            # the arrival emit carried a notif_id, and without a matching notification_cleared the
+            # history view would show a trashed notification pending forever.
             if trashed:
                 await trash_notification_files(trashed, trash_dir=config.notif_trash_dir)
+                for notif in trashed:
+                    if notif.file_path:
+                        state.event_bus.emit({"type": "notification_cleared", "notif_id": pl.Path(notif.file_path).stem})
 
             queued_paths.update(n.file_path for n, disposition in decisions if disposition != "trash" and n.file_path)
             pending_passive.extend(new_passive)

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -5,6 +5,7 @@ import datetime as dt
 import json
 import pathlib as pl
 import time
+import typing as tp
 
 import pydantic
 from claude_agent_sdk import ClaudeSDKClient, ClaudeSDKError
@@ -71,13 +72,16 @@ def drop_core_notification(*, type_: str, body: str, config: vm.VestaConfig, nam
     return path
 
 
-def _notif_interrupts(notif: vm.Notification, rules: list[notification_interrupt_policy.NotificationInterruptRule]) -> bool:
-    """True if the notification preempts the current turn. Core notifications are exempt from the user's
-    rules — their disposition is control-flow, derived from the type (CORE_POOL_TYPES); everything else
-    goes through the ruleset (first match wins, else the producer's own interrupt default)."""
+def _notif_disposition(
+    notif: vm.Notification, rules: list[notification_interrupt_policy.NotificationInterruptRule]
+) -> tp.Literal["interrupt", "pool", "trash"]:
+    """The notification's effective disposition: `interrupt`, `pool`, or `trash`. Core notifications are
+    exempt from the user's rules — their disposition is control-flow, derived from the type
+    (CORE_POOL_TYPES), and is never trashed; everything else goes through the ruleset (first match wins,
+    else the producer's own interrupt default)."""
     if notif.source == CORE_SOURCE:
-        return notif.type not in CORE_POOL_TYPES
-    return notification_interrupt_policy.should_interrupt(notif, rules)
+        return "pool" if notif.type in CORE_POOL_TYPES else "interrupt"
+    return notification_interrupt_policy.notif_disposition(notif, rules)
 
 
 async def load_notifications(*, config: vm.VestaConfig) -> list[vm.Notification]:
@@ -99,6 +103,23 @@ async def load_notifications(*, config: vm.VestaConfig) -> list[vm.Notification]
 
 async def delete_notification_files(notifications: list[vm.Notification]) -> None:
     _delete_paths([n.file_path for n in notifications if n.file_path])
+
+
+def _trash_paths(file_paths: list[str], trash_dir: pl.Path) -> None:
+    """Move each notification file into the trash dir, replacing any same-named entry. Trashing keeps the
+    file recoverable/auditable instead of deleting it; a parked file is never re-scanned (the loader
+    globs non-recursively and the watcher ignores subdirs)."""
+    if not file_paths:
+        return
+    trash_dir.mkdir(parents=True, exist_ok=True)
+    for path_str in file_paths:
+        source = pl.Path(path_str)
+        if source.exists():
+            source.replace(trash_dir / source.name)
+
+
+async def trash_notification_files(notifications: list[vm.Notification], *, trash_dir: pl.Path) -> None:
+    _trash_paths([n.file_path for n in notifications if n.file_path], trash_dir)
 
 
 _REPLY_SKILLS = frozenset({"app-chat", "whatsapp", "telegram"})
@@ -572,15 +593,16 @@ async def monitor_loop(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.State, 
             notifications = await load_notifications(config=config)
             rules = await asyncio.to_thread(cfg.load_notification_rules, config)
             fresh = [n for n in notifications if not n.file_path or n.file_path not in queued_paths]
-            decisions = [(n, _notif_interrupts(n, rules)) for n in fresh]
-            interrupt_notifs = [n for n, hot in decisions if hot]
-            new_passive = [n for n, hot in decisions if not hot]
+            decisions = [(n, _notif_disposition(n, rules)) for n in fresh]
+            interrupt_notifs = [n for n, disposition in decisions if disposition == "interrupt"]
+            new_passive = [n for n, disposition in decisions if disposition == "pool"]
+            trashed = [n for n, disposition in decisions if disposition == "trash"]
 
             # Emit each genuinely-new notification to the bus exactly once, enriched with structured
-            # facets + the effective interrupt disposition for the history view. load_notifications
-            # re-reads every file each tick, so files kept on disk (e.g. deferred while
-            # unauthenticated) must not re-emit — that was the notification storm.
-            for notif, hot in decisions:
+            # facets + the effective disposition for the history view. load_notifications re-reads every
+            # file each tick, so files kept on disk (e.g. deferred while unauthenticated) must not
+            # re-emit — that was the notification storm.
+            for notif, disposition in decisions:
                 state.event_bus.emit(
                     {
                         "type": "notification",
@@ -589,12 +611,17 @@ async def monitor_loop(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.State, 
                         "notif_type": notif.type,
                         "sender": notification_interrupt_policy.notif_sender(notif) or "",
                         "fields": notification_interrupt_policy.notif_facet_fields(notif),
-                        "decided": "interrupt" if hot else "pool",
+                        "decided": disposition,
                         "notif_id": pl.Path(notif.file_path).stem if notif.file_path else "",
                     }
                 )
 
-            queued_paths.update(n.file_path for n in fresh if n.file_path)
+            # Trashed notifications are recorded in history above but never reach the agent: move the
+            # files out of the active dir (recoverable, and so they never re-emit) and create no turn.
+            if trashed:
+                await trash_notification_files(trashed, trash_dir=config.notif_trash_dir)
+
+            queued_paths.update(n.file_path for n, disposition in decisions if disposition != "trash" and n.file_path)
             pending_passive.extend(new_passive)
 
             if interrupt_notifs:

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -180,7 +180,7 @@ class Notification(pyd.BaseModel):
     source: str
     type: str
     # The producing skill's default disposition, used when no user rule matches (True -> interrupt,
-    # False -> pool). See notification_interrupt_policy.should_interrupt.
+    # False -> pool). See notification_interrupt_policy.notif_disposition.
     interrupt: bool = True
     body: str | None = None
     file_path: str | None = pyd.Field(default=None, exclude=True)

--- a/agent/core/notification_interrupt_policy.py
+++ b/agent/core/notification_interrupt_policy.py
@@ -1,10 +1,12 @@
 """Arrival-time notification interrupt policy.
 
-An ordered ruleset decides whether an incoming notification preempts the agent's current turn
-(`interrupt`) or waits in the passive pool until the agent is idle (`pool`). First matching rule wins;
-with no match the decision falls back to the notification's own `interrupt` flag — the default the
-producing skill ships for its own notifications (whatsapp/chat interrupt, email/finance pool), so a
-fresh agent with no rules already behaves sensibly. The user's rules exist to override those defaults.
+An ordered ruleset decides an incoming notification's disposition: preempt the agent's current turn
+(`interrupt`), wait in the passive pool until the agent is idle (`pool`), or drop without ever reaching
+the agent (`trash`). First matching rule wins; with no match the decision falls back to the
+notification's own `interrupt` flag — the default the producing skill ships for its own notifications
+(whatsapp/chat interrupt, email/finance pool), so a fresh agent with no rules already behaves sensibly.
+A notification is never trashed by default, only by an explicit user rule. The user's rules exist to
+override those defaults.
 The ruleset lives on the agent config
 (`VestaConfig.notification_rules`); both the user (PUT /config) and the agent (the notifications skill,
 via the same config API) edit it, and monitor_loop reads it from the config store each tick, so edits
@@ -89,7 +91,7 @@ class NotificationInterruptRule(pyd.BaseModel):
     source: str | None = None
     type: str | None = None
     match: list[FieldPredicate] = []
-    action: tp.Literal["interrupt", "pool"]
+    action: tp.Literal["interrupt", "pool", "trash"]
 
     @pyd.model_validator(mode="before")
     @classmethod
@@ -218,13 +220,15 @@ def _matches(rule: NotificationInterruptRule, notif: "vm.Notification") -> bool:
     return all(_predicate_matches(predicate, notif) for predicate in rule.match)
 
 
-def should_interrupt(notif: "vm.Notification", rules: list[NotificationInterruptRule]) -> bool:
-    """True -> preempt the agent's current turn; False -> pool until idle.
+def notif_disposition(notif: "vm.Notification", rules: list[NotificationInterruptRule]) -> tp.Literal["interrupt", "pool", "trash"]:
+    """The effective disposition for an arriving notification: `interrupt` (preempt the current turn now),
+    `pool` (wait for the idle triage pass), or `trash` (drop without ever reaching the agent).
 
-    First matching rule wins; with no match the notification's own `interrupt` flag (the producing
-    skill's default) decides. Core notifications never reach here: loops.py decides their disposition
-    from the type."""
+    First matching rule wins and supplies its action; with no match the notification's own `interrupt`
+    flag (the producing skill's default) decides interrupt-vs-pool. A notification is never trashed by
+    default, only by an explicit user rule. Core notifications never reach here: loops.py decides their
+    disposition from the type."""
     for rule in rules:
         if _matches(rule, notif):
-            return rule.action == "interrupt"
-    return notif.interrupt
+            return rule.action
+    return "interrupt" if notif.interrupt else "pool"

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -89,7 +89,7 @@
   },
   {
     "name": "notifications",
-    "description": "Interrupt rules that guard YOUR focus (you, the agent, are the one interrupted, not the user): tune which notifications pull you off your work now vs. wait in the pool for triage. Use when the user says what should or shouldn't interrupt you (\"don't let Twitter interrupt you\", \"always let my wife's messages through right away\"), when guarding deep work, when asked what's currently allowed to interrupt you, or when triaging pooled notifications."
+    "description": "Interrupt rules that guard YOUR focus (you, the agent, are the one interrupted, not the user): tune which notifications pull you off your work now vs. wait in the pool for triage vs. get dropped entirely. Use when the user says what should or shouldn't interrupt you (\"don't let Twitter interrupt you\", \"always let my wife's messages through right away\"), when the user wants a kind of notification ignored/trashed outright so it never reaches you (\"stop showing me WhatsApp status updates\", \"always ignore X\"), when guarding deep work, when asked what's currently allowed to interrupt you, or when triaging pooled notifications."
   },
   {
     "name": "onboard",

--- a/agent/skills/notifications/SKILL.md
+++ b/agent/skills/notifications/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notifications
-description: Interrupt rules that guard YOUR focus (you, the agent, are the one interrupted, not the user): tune which notifications pull you off your work now vs. wait in the pool for triage. Use when the user says what should or shouldn't interrupt you ("don't let Twitter interrupt you", "always let my wife's messages through right away"), when guarding deep work, when asked what's currently allowed to interrupt you, or when triaging pooled notifications.
+description: Interrupt rules that guard YOUR focus (you, the agent, are the one interrupted, not the user): tune which notifications pull you off your work now vs. wait in the pool for triage vs. get dropped entirely. Use when the user says what should or shouldn't interrupt you ("don't let Twitter interrupt you", "always let my wife's messages through right away"), when the user wants a kind of notification ignored/trashed outright so it never reaches you ("stop showing me WhatsApp status updates", "always ignore X"), when guarding deep work, when asked what's currently allowed to interrupt you, or when triaging pooled notifications.
 ---
 
 # Notifications
@@ -8,6 +8,8 @@ description: Interrupt rules that guard YOUR focus (you, the agent, are the one 
 ## What these rules do
 
 These interrupts land on **you, the agent**, not the user. An **interrupt** notification preempts your current turn the moment it arrives; a **pool** one (shown as **"snooze"** in the app) does not touch your current work, it waits and is gathered into a triage pass once you have been idle a little while. Pooling changes *when* you see a notification, never *whether*: nothing is dropped, the rule is reversible anytime, and you decide what to act on or drop when you triage it (below). Each rule is about **timing**, not visibility: "worth dropping everything for right now" vs. "this can wait until I'm free". Being yanked out of hard work by something trivial is a real cost, so these rules keep low-value notifications from breaking your focus while letting what genuinely matters reach you immediately.
+
+A third disposition, **trash**, is different in kind: it drops the notification entirely. It never reaches you, never becomes a turn, never enters the pool, so it changes *whether* you ever see something, not just when. It still shows in the notification history (marked "trashed") and the file is moved to a trash folder rather than deleted, so a too-aggressive rule stays recoverable. Use it only for high-volume noise the user has said to *always* ignore (e.g. WhatsApp status broadcasts) where even a pooled triage glance is wasted attention, so **only add a trash rule when the user has explicitly said to ignore that kind of notification outright**; when unsure, pool instead.
 
 ## Your active role
 
@@ -22,6 +24,7 @@ Tune the rules **with the user** (they judge what's important, you feel what's p
 A rule has two dedicated fields (`source`, `type`) plus any number of `match` conditions over the
 notification's other fields. Every field/condition you set must hold (AND); whatever you omit is ignored.
 
+- `--action` is `interrupt`, `pool`, or `trash` (drop entirely; see the mental model).
 - `source`/`type` are exact (case-insensitive), e.g. `--source whatsapp --type message`.
 - Each `match` targets one field: `--match 'FIELD<op>VALUE'`, ops (case-insensitive):
   - `=` substring, e.g. `--match 'chat_name=Bride squad'`
@@ -63,6 +66,10 @@ notifications add --source email --keyword urgent --action interrupt
 
 # Snooze one busy group chat by name, while 1:1s and other groups still interrupt (target chat_name)
 notifications add --source whatsapp --match 'chat_name=Bride squad' --action pool
+
+# Drop noise the user always wants ignored, so it never costs a turn (here: WhatsApp status broadcasts).
+# Still visible in history (marked "trashed"); only do this when the user has said to ignore it outright.
+notifications add --source whatsapp --match 'chat_name=status' --action trash
 
 # Combine conditions (AND): pool only group chats from whatsapp, leaving DMs alone
 notifications add --source whatsapp --match 'chat_type=group' --action pool

--- a/agent/skills/notifications/cli/src/notifications_cli/cli.py
+++ b/agent/skills/notifications/cli/src/notifications_cli/cli.py
@@ -1,10 +1,11 @@
 """Manage the agent's notification interrupt rules via the config API.
 
-An ordered ruleset routes each incoming notification to 'interrupt' (preempt the agent's current turn)
-or 'pool' (wait until the agent is idle). First matching rule wins; with no match the notification
-interrupts. Rules live on the agent config (VestaConfig.notification_rules) and are read/written through
-the agent's local HTTP API (GET/PUT /config), so a change applies on the next monitor tick with no
-restart. `facets` reads the notification history (events.db) directly to show what values you can target.
+An ordered ruleset routes each incoming notification to 'interrupt' (preempt the agent's current turn),
+'pool' (wait until the agent is idle), or 'trash' (drop it entirely: it never reaches the agent, costs no
+turn). First matching rule wins; with no match the notification interrupts. Rules live on the agent
+config (VestaConfig.notification_rules) and are read/written through the agent's local HTTP API
+(GET/PUT /config), so a change applies on the next monitor tick with no restart. `facets` reads the
+notification history (events.db) directly to show what values you can target.
 """
 
 import argparse
@@ -18,7 +19,7 @@ import urllib.error
 import urllib.request
 import uuid
 
-ACTIONS = ("interrupt", "pool")
+ACTIONS = ("interrupt", "pool", "trash")
 OPS = ("contains", "regex")
 CORE_SOURCE = "core"
 # Facet label -> the field stored on the NotificationEvent in events.db (see core/events.py).
@@ -278,7 +279,12 @@ def main() -> int:
         help="Add a rule. First matching rule wins (top = highest priority). By default a new rule is "
         "placed above broader rules so a narrow exception is not shadowed; use --before/--after to override.",
     )
-    add.add_argument("--action", choices=ACTIONS, required=True, help="interrupt = preempt the current turn; pool = wait until idle.")
+    add.add_argument(
+        "--action",
+        choices=ACTIONS,
+        required=True,
+        help="interrupt = preempt the current turn; pool = wait until idle; trash = drop entirely (never reaches you).",
+    )
     add.add_argument("--source", help="Exact match on notification source (case-insensitive), e.g. twitter, whatsapp.")
     add.add_argument("--type", help="Exact match on notification type (case-insensitive), e.g. message, tweet.")
     add.add_argument("--sender", help="Shortcut: substring match (case-insensitive) on the sender/contact across identity fields.")

--- a/agent/skills/notifications/cli/tests/test_rules.py
+++ b/agent/skills/notifications/cli/tests/test_rules.py
@@ -46,6 +46,16 @@ def test_add_builds_match_predicates_from_shortcuts(monkeypatch, capsys):
     assert "applies next tick" in capsys.readouterr().out
 
 
+def test_add_builds_trash_rule(monkeypatch, capsys):
+    store = _store(monkeypatch)
+    rc = cli.cmd_add(_args(action="trash", source="whatsapp", match=["chat_name=status"]))
+    assert rc == 0
+    rule = store[0]
+    assert rule["action"] == "trash" and rule["source"] == "whatsapp"
+    assert rule["match"] == [{"field": "chat_name", "op": "contains", "value": "status", "negate": False}]
+    assert "-> trash" in capsys.readouterr().out
+
+
 def test_add_rejects_core_source(monkeypatch, capsys):
     _store(monkeypatch)
     assert cli.cmd_add(_args(action="pool", source="core")) == 1

--- a/agent/tests/test_notification_interrupt_rules_api.py
+++ b/agent/tests/test_notification_interrupt_rules_api.py
@@ -59,7 +59,7 @@ async def test_put_then_get_round_trip_and_applies(tmp_path, monkeypatch):
         # Persisted to the store for the loop to read, and it drives the decision.
         loaded = cfg.load_notification_rules(config)
         assert loaded[0].source == "twitter"
-        assert npn.should_interrupt(_notif(), loaded) is False
+        assert npn.notif_disposition(_notif(), loaded) == "pool"
     finally:
         await client.close()
 

--- a/agent/tests/test_notification_rules.py
+++ b/agent/tests/test_notification_rules.py
@@ -23,46 +23,46 @@ def _rule(**fields) -> npn.NotificationInterruptRule:
     return npn.NotificationInterruptRule(**fields)
 
 
-# --- matching + should_interrupt ---
+# --- matching + notif_disposition ---
 
 
 def test_no_rules_defaults_to_interrupt():
-    assert npn.should_interrupt(_notif(), []) is True
+    assert npn.notif_disposition(_notif(), []) == "interrupt"
 
 
 def test_no_rules_honors_producer_pool_default():
     # A skill that ships interrupt=False (email, finance) pools when no rule matches — the fallback is
     # the producer's default, not an unconditional interrupt.
-    assert npn.should_interrupt(_notif(interrupt=False), []) is False
+    assert npn.notif_disposition(_notif(interrupt=False), []) == "pool"
 
 
 def test_matching_rule_overrides_producer_pool_default():
     notif = _notif(source="finance", interrupt=False)
-    assert npn.should_interrupt(notif, [_rule(source="finance", action="interrupt")]) is True
+    assert npn.notif_disposition(notif, [_rule(source="finance", action="interrupt")]) == "interrupt"
 
 
 def test_source_rule_pools():
-    assert npn.should_interrupt(_notif(), [_rule(source="twitter", action="pool")]) is False
+    assert npn.notif_disposition(_notif(), [_rule(source="twitter", action="pool")]) == "pool"
 
 
 def test_source_rule_interrupts():
-    assert npn.should_interrupt(_notif(), [_rule(source="twitter", action="interrupt")]) is True
+    assert npn.notif_disposition(_notif(), [_rule(source="twitter", action="interrupt")]) == "interrupt"
 
 
 def test_source_match_is_case_insensitive():
     notif = _notif(source="Twitter")
-    assert npn.should_interrupt(notif, [_rule(source="twitter", action="pool")]) is False
+    assert npn.notif_disposition(notif, [_rule(source="twitter", action="pool")]) == "pool"
 
 
 def test_type_rule_matches():
-    assert npn.should_interrupt(_notif(type="tweet"), [_rule(type="tweet", action="pool")]) is False
+    assert npn.notif_disposition(_notif(type="tweet"), [_rule(type="tweet", action="pool")]) == "pool"
 
 
 def test_conditions_are_anded_within_a_rule():
     # source matches but type does not -> rule does not apply -> falls back to the default interrupt.
     notif = _notif(source="twitter", type="dm")
     rules = [_rule(source="twitter", type="tweet", action="pool")]
-    assert npn.should_interrupt(notif, rules) is True
+    assert npn.notif_disposition(notif, rules) == "interrupt"
 
 
 def test_sender_substring_over_identity_fields():
@@ -71,36 +71,36 @@ def test_sender_substring_over_identity_fields():
     )
     # A source rule pools whatsapp; a sender rule earlier interrupts alice specifically.
     rules = [_rule(sender="alice", action="interrupt"), _rule(source="whatsapp", action="pool")]
-    assert npn.should_interrupt(notif, rules) is True
+    assert npn.notif_disposition(notif, rules) == "interrupt"
 
 
 def test_keyword_matches_body():
     notif = _notif(body="this is URGENT")
-    assert npn.should_interrupt(notif, [_rule(source="twitter", action="pool"), _rule(keyword="urgent", action="interrupt")]) is False
+    assert npn.notif_disposition(notif, [_rule(source="twitter", action="pool"), _rule(keyword="urgent", action="interrupt")]) == "pool"
 
 
 def test_keyword_matches_message_extra_field():
     notif = vm.Notification.model_validate(
         {"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "message", "message": "ping about taxes"}
     )
-    assert npn.should_interrupt(notif, [_rule(keyword="taxes", action="pool")]) is False
+    assert npn.notif_disposition(notif, [_rule(keyword="taxes", action="pool")]) == "pool"
 
 
 def test_keyword_regex_alternation():
     rule = _rule(keyword="invoice|payment", action="pool")
-    assert npn.should_interrupt(_notif(body="your payment is due"), [rule]) is False
-    assert npn.should_interrupt(_notif(body="nothing relevant"), [rule]) is True
+    assert npn.notif_disposition(_notif(body="your payment is due"), [rule]) == "pool"
+    assert npn.notif_disposition(_notif(body="nothing relevant"), [rule]) == "interrupt"
 
 
 def test_keyword_regex_anchor():
     rule = _rule(keyword=r"^\$\d+", action="pool")
-    assert npn.should_interrupt(_notif(body="$500 received"), [rule]) is False
+    assert npn.notif_disposition(_notif(body="$500 received"), [rule]) == "pool"
     # The anchor requires the amount at the start, so a mid-body match does not count.
-    assert npn.should_interrupt(_notif(body="received $500"), [rule]) is True
+    assert npn.notif_disposition(_notif(body="received $500"), [rule]) == "interrupt"
 
 
 def test_keyword_regex_is_case_insensitive():
-    assert npn.should_interrupt(_notif(body="ALERT: down"), [_rule(keyword="alert", action="pool")]) is False
+    assert npn.notif_disposition(_notif(body="ALERT: down"), [_rule(keyword="alert", action="pool")]) == "pool"
 
 
 def test_invalid_keyword_regex_is_rejected():
@@ -121,68 +121,68 @@ def test_match_targets_a_concrete_extra_field():
     # The whole point: pool one group chat by its chat_name, which is neither sender nor body.
     notif = _wa(chat_name="Bride squad")
     rule = _rule(source="whatsapp", match=[{"field": "chat_name", "value": "bride squad"}], action="pool")
-    assert npn.should_interrupt(notif, [rule]) is False
+    assert npn.notif_disposition(notif, [rule]) == "pool"
 
 
 def test_match_concrete_field_is_substring_and_case_insensitive():
     notif = _wa(chat_name="The Bride Squad 2024")
     rule = _rule(match=[{"field": "chat_name", "value": "bride squad"}], action="pool")
-    assert npn.should_interrupt(notif, [rule]) is False
+    assert npn.notif_disposition(notif, [rule]) == "pool"
 
 
 def test_match_does_not_apply_when_field_absent():
     # A 1:1 message has no chat_name; the group rule must not touch it.
     notif = _wa(contact_name="Alice")
     rule = _rule(match=[{"field": "chat_name", "value": "bride squad"}], action="pool")
-    assert npn.should_interrupt(notif, [rule]) is True
+    assert npn.notif_disposition(notif, [rule]) == "interrupt"
 
 
 def test_match_regex_op_on_concrete_field():
     rule = _rule(match=[{"field": "chat_name", "op": "regex", "value": "^proj-"}], action="pool")
-    assert npn.should_interrupt(_wa(chat_name="proj-vesta"), [rule]) is False
-    assert npn.should_interrupt(_wa(chat_name="my proj-vesta"), [rule]) is True
+    assert npn.notif_disposition(_wa(chat_name="proj-vesta"), [rule]) == "pool"
+    assert npn.notif_disposition(_wa(chat_name="my proj-vesta"), [rule]) == "interrupt"
 
 
 def test_match_negate_inverts():
     # interrupt for everything whose chat_name is NOT the snoozed group; pool the rest via a later rule.
     rules = [_rule(match=[{"field": "chat_name", "value": "bride squad", "negate": True}], action="interrupt"), _rule(action="pool")]
-    assert npn.should_interrupt(_wa(chat_name="Work standup"), rules) is True
-    assert npn.should_interrupt(_wa(chat_name="Bride squad"), rules) is False
+    assert npn.notif_disposition(_wa(chat_name="Work standup"), rules) == "interrupt"
+    assert npn.notif_disposition(_wa(chat_name="Bride squad"), rules) == "pool"
 
 
 def test_match_negate_on_absent_field_counts_as_not_matching():
     # No chat_name -> does not contain "x" -> negated predicate holds.
     rule = _rule(match=[{"field": "chat_name", "value": "x", "negate": True}], action="pool")
-    assert npn.should_interrupt(_wa(), [rule]) is False
+    assert npn.notif_disposition(_wa(), [rule]) == "pool"
 
 
 def test_match_coerces_non_string_fields():
     # is_group is a bool; chat targeting by a bool/int field still works via str-coercion.
     notif = _wa(is_group=True)
     rule = _rule(match=[{"field": "is_group", "value": "true"}], action="pool")
-    assert npn.should_interrupt(notif, [rule]) is False
+    assert npn.notif_disposition(notif, [rule]) == "pool"
 
 
 def test_match_predicates_are_anded():
     notif = _wa(chat_name="Bride squad", is_group=True)
     # Both predicates hold -> pool.
     both = _rule(match=[{"field": "chat_name", "value": "bride"}, {"field": "is_group", "value": "true"}], action="pool")
-    assert npn.should_interrupt(notif, [both]) is False
+    assert npn.notif_disposition(notif, [both]) == "pool"
     # One predicate fails -> rule does not apply -> default interrupt.
     one = _rule(match=[{"field": "chat_name", "value": "bride"}, {"field": "is_group", "value": "false"}], action="pool")
-    assert npn.should_interrupt(notif, [one]) is True
+    assert npn.notif_disposition(notif, [one]) == "interrupt"
 
 
 def test_match_sender_alias_searches_identity_fields():
     notif = _wa(contact_name="Alice Smith")
     rule = _rule(match=[{"field": "sender", "value": "alice"}], action="pool")
-    assert npn.should_interrupt(notif, [rule]) is False
+    assert npn.notif_disposition(notif, [rule]) == "pool"
 
 
 def test_match_text_alias_searches_body_and_message():
     rule = _rule(match=[{"field": "text", "op": "regex", "value": "taxes"}], action="pool")
-    assert npn.should_interrupt(_wa(message="ping about taxes"), [rule]) is False
-    assert npn.should_interrupt(_notif(body="taxes due"), [rule]) is False
+    assert npn.notif_disposition(_wa(message="ping about taxes"), [rule]) == "pool"
+    assert npn.notif_disposition(_notif(body="taxes due"), [rule]) == "pool"
 
 
 def test_match_invalid_regex_predicate_is_rejected():
@@ -220,17 +220,31 @@ def test_legacy_null_sender_keyword_are_dropped_not_predicates():
     assert rule.match == []
 
 
-# --- should_interrupt ordering / catch-all ---
+# --- notif_disposition ordering / catch-all ---
 
 
 def test_first_matching_rule_wins():
     notif = _notif(source="twitter")
     rules = [_rule(source="twitter", action="interrupt"), _rule(source="twitter", action="pool")]
-    assert npn.should_interrupt(notif, rules) is True
+    assert npn.notif_disposition(notif, rules) == "interrupt"
 
 
 def test_empty_conditions_rule_is_catch_all():
-    assert npn.should_interrupt(_notif(), [_rule(action="pool")]) is False
+    assert npn.notif_disposition(_notif(), [_rule(action="pool")]) == "pool"
+
+
+def test_matching_trash_rule_trashes():
+    notif = _notif(source="whatsapp", chat_name="status")
+    assert (
+        npn.notif_disposition(notif, [_rule(source="whatsapp", action="trash", match=[npn.FieldPredicate(field="chat_name", value="status")])])
+        == "trash"
+    )
+
+
+def test_never_trashes_without_a_matching_rule():
+    # trash is only ever an explicit user rule; the producer default is only ever interrupt/pool.
+    assert npn.notif_disposition(_notif(interrupt=True), []) == "interrupt"
+    assert npn.notif_disposition(_notif(interrupt=False), []) == "pool"
 
 
 # --- config store: load_notification_rules ---
@@ -270,27 +284,34 @@ def test_load_round_trips_a_written_store(tmp_path):
     assert loaded[0].source == "twitter"
     assert loaded[0].action == "pool"
     # And the loaded rule drives the decision.
-    assert npn.should_interrupt(_notif(), loaded) is False
+    assert npn.notif_disposition(_notif(), loaded) == "pool"
 
 
-# --- core routing via loops._notif_interrupts ---
+# --- core routing via loops._notif_disposition ---
 
 
 def test_core_type_interrupts_despite_catch_all_pool_rule():
     # A non-pool core type (migration) preempts even under a broad user pool rule.
     notif = _notif(source=vm.CORE_SOURCE, type="migration")
-    assert loops._notif_interrupts(notif, [_rule(action="pool")]) is True
+    assert loops._notif_disposition(notif, [_rule(action="pool")]) == "interrupt"
 
 
 def test_core_pool_type_pools():
     notif = _notif(source=vm.CORE_SOURCE, type=vm.TYPE_PROACTIVE_CHECK)
-    assert loops._notif_interrupts(notif, []) is False
+    assert loops._notif_disposition(notif, []) == "pool"
 
 
 def test_non_core_goes_through_rules():
     notif = _notif(source="twitter")
-    assert loops._notif_interrupts(notif, [_rule(source="twitter", action="pool")]) is False
-    assert loops._notif_interrupts(notif, []) is True
+    assert loops._notif_disposition(notif, [_rule(source="twitter", action="pool")]) == "pool"
+    assert loops._notif_disposition(notif, []) == "interrupt"
+
+
+def test_core_notification_is_never_trashed():
+    # Core disposition is control-flow (type-derived) and exempt from user rules, so a broad trash rule
+    # can't drop a core notification.
+    notif = _notif(source=vm.CORE_SOURCE, type="migration")
+    assert loops._notif_disposition(notif, [_rule(action="trash")]) == "interrupt"
 
 
 # --- notif_sender ---

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -576,6 +576,9 @@ async def test_monitor_loop_trash_rule_drops_file_and_creates_no_turn(tmp_path):
         notifs = [e for e in emitted if e["type"] == "notification"]
         assert len(notifs) == 1, f"trashed notification must still be recorded once, got {len(notifs)}"
         assert notifs[0]["decided"] == "trash", "history must record the trash disposition"
+        # A trashed notification is resolved on arrival, so it must be cleared (no pending dot forever).
+        cleared = [e for e in emitted if e["type"] == "notification_cleared"]
+        assert [e["notif_id"] for e in cleared] == ["status"], "trashed notification must emit a matching notification_cleared"
     finally:
         await runner.aclose()
 

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -548,6 +548,38 @@ async def test_monitor_loop_emits_each_notification_once_across_ticks(tmp_path):
         await runner.aclose()
 
 
+@pytest.mark.anyio
+async def test_monitor_loop_trash_rule_drops_file_and_creates_no_turn(tmp_path):
+    """A trash rule moves the notification into the trash dir, records it in history with decided='trash',
+    and never queues a turn (even when the bus is idle, where a pooled notif would flush)."""
+    config = _passive_config(tmp_path)
+    _install_rule(config, source="test", action="trash")
+    state = vm.State()
+    state.shutdown_event = asyncio.Event()
+    state.event_bus.set_state("idle")
+    queue: asyncio.Queue = asyncio.Queue()
+    sub = state.event_bus.subscribe()
+
+    runner = _run_monitor(queue, state=state, config=config)
+    await runner.__anext__()
+    try:
+        path = _write_notif(config.notifications_dir, "status")
+        moved = config.notif_trash_dir / "status.json"
+        await wait_for_condition(moved.exists, message="trashed notification was never moved to the trash dir")
+
+        assert not path.exists(), "trashed file must leave the active notifications dir"
+        # A trashed notification must never create a turn; give the loop a moment to (not) queue one.
+        await asyncio.sleep(0.05)
+        assert queue.empty(), "a trashed notification must not create a turn"
+
+        emitted = [sub.get_nowait() for _ in range(sub.qsize())]
+        notifs = [e for e in emitted if e["type"] == "notification"]
+        assert len(notifs) == 1, f"trashed notification must still be recorded once, got {len(notifs)}"
+        assert notifs[0]["decided"] == "trash", "history must record the trash disposition"
+    finally:
+        await runner.aclose()
+
+
 # --- _notification_watcher local-stop bridge ---
 
 

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -348,7 +348,7 @@ export interface NotificationInterruptRule {
   // All conditions beyond source/type (sender, keyword, and any arbitrary field) are predicates here,
   // ANDed together. Empty = the rule matches every notification of the given source/type.
   match?: FieldPredicate[];
-  action: "interrupt" | "pool";
+  action: "interrupt" | "pool" | "trash";
 }
 
 /// Read the agent's ordered notification interrupt ruleset from its config (GET /config).

--- a/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.test.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.test.tsx
@@ -51,7 +51,7 @@ describe("NotificationInterruptRulesCard", () => {
     expect(screen.queryByRole("button", { name: /add rule/i })).toBeNull();
   });
 
-  it("cycles a rule's action snooze -> trash and auto-saves", async () => {
+  it("cycles snooze -> trash only after confirming the destructive drop", async () => {
     vi.spyOn(api, "getNotificationInterruptRules").mockResolvedValue([
       { id: "a", source: "twitter", action: "pool" },
     ]);
@@ -59,12 +59,35 @@ describe("NotificationInterruptRulesCard", () => {
       .spyOn(api, "setNotificationInterruptRules")
       .mockResolvedValue([]);
     render(<NotificationInterruptRulesCard />);
-    // pool renders as "snooze"; the action badge cycles interrupt -> snooze -> trash.
+    // pool renders as "snooze"; stepping into trash is destructive, so it must confirm first.
     await userEvent.click(
       await screen.findByRole("button", { name: /action: snooze/i }),
     );
+    // No save yet — the confirm dialog is open.
+    expect(setSpy).not.toHaveBeenCalled();
+    await userEvent.click(
+      await screen.findByRole("button", { name: /trash them/i }),
+    );
     await waitFor(() => expect(setSpy).toHaveBeenCalled());
     expect(setSpy.mock.calls.at(-1)![1][0].action).toBe("trash");
+  });
+
+  it("does not trash when the confirm is cancelled", async () => {
+    vi.spyOn(api, "getNotificationInterruptRules").mockResolvedValue([
+      { id: "a", source: "twitter", action: "pool" },
+    ]);
+    const setSpy = vi
+      .spyOn(api, "setNotificationInterruptRules")
+      .mockResolvedValue([]);
+    render(<NotificationInterruptRulesCard />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /action: snooze/i }),
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: /cancel/i }),
+    );
+    // Cancelling leaves the rule untouched and saves nothing.
+    expect(setSpy).not.toHaveBeenCalled();
   });
 
   it("renders a trash rule and cycles it back to interrupt", async () => {

--- a/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.test.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.test.tsx
@@ -51,7 +51,7 @@ describe("NotificationInterruptRulesCard", () => {
     expect(screen.queryByRole("button", { name: /add rule/i })).toBeNull();
   });
 
-  it("toggles a rule's action and auto-saves", async () => {
+  it("cycles a rule's action snooze -> trash and auto-saves", async () => {
     vi.spyOn(api, "getNotificationInterruptRules").mockResolvedValue([
       { id: "a", source: "twitter", action: "pool" },
     ]);
@@ -59,8 +59,24 @@ describe("NotificationInterruptRulesCard", () => {
       .spyOn(api, "setNotificationInterruptRules")
       .mockResolvedValue([]);
     render(<NotificationInterruptRulesCard />);
+    // pool renders as "snooze"; the action badge cycles interrupt -> snooze -> trash.
     await userEvent.click(
       await screen.findByRole("button", { name: /action: snooze/i }),
+    );
+    await waitFor(() => expect(setSpy).toHaveBeenCalled());
+    expect(setSpy.mock.calls.at(-1)![1][0].action).toBe("trash");
+  });
+
+  it("renders a trash rule and cycles it back to interrupt", async () => {
+    vi.spyOn(api, "getNotificationInterruptRules").mockResolvedValue([
+      { id: "a", source: "whatsapp", action: "trash" },
+    ]);
+    const setSpy = vi
+      .spyOn(api, "setNotificationInterruptRules")
+      .mockResolvedValue([]);
+    render(<NotificationInterruptRulesCard />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /action: trash/i }),
     );
     await waitFor(() => expect(setSpy).toHaveBeenCalled());
     expect(setSpy.mock.calls.at(-1)![1][0].action).toBe("interrupt");

--- a/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.tsx
@@ -1,5 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { GripVertical, ListFilter } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -91,6 +101,10 @@ export function NotificationInterruptRulesCard() {
   const [saveError, setSaveError] = useState<string | null>(null);
   // The rule row currently being dragged, for reordering (null when not dragging).
   const [dragIndex, setDragIndex] = useState<number | null>(null);
+  // Index of the rule a click is about to move into trash, pending confirmation (null = no dialog).
+  const [confirmTrashIndex, setConfirmTrashIndex] = useState<number | null>(
+    null,
+  );
 
   useEffect(() => {
     if (!agentName) return;
@@ -153,12 +167,26 @@ export function NotificationInterruptRulesCard() {
     [save],
   );
 
-  const cycleAction = (index: number) =>
+  const applyAction = (index: number, action: RuleAction) =>
     commit(
       (rules ?? []).map((rule, i) =>
-        i === index ? { ...rule, action: ACTION_CYCLE[rule.action] } : rule,
+        i === index ? { ...rule, action } : rule,
       ),
     );
+
+  const cycleAction = (index: number) => {
+    const rule = (rules ?? [])[index];
+    if (!rule) return;
+    const next = ACTION_CYCLE[rule.action];
+    // Trash drops matching notifications entirely (they never reach the agent) and auto-saves, so
+    // confirm before stepping into it. Every other transition — including downgrading out of trash —
+    // is only a timing change and applies immediately.
+    if (next === "trash") {
+      setConfirmTrashIndex(index);
+      return;
+    }
+    applyAction(index, next);
+  };
 
   const deleteRule = (index: number) =>
     commit((rules ?? []).filter((_, i) => i !== index));
@@ -316,6 +344,37 @@ export function NotificationInterruptRulesCard() {
           )}
         </div>
       </CardContent>
+      <AlertDialog
+        open={confirmTrashIndex !== null}
+        onOpenChange={(next) => {
+          if (!next) setConfirmTrashIndex(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>trash matching notifications?</AlertDialogTitle>
+            <AlertDialogDescription>
+              a trash rule drops every matching notification entirely — they
+              never reach {agentName || "the agent"} and create no turn. they
+              still show in history, and you can change the rule back anytime.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={(e) => {
+                e.preventDefault();
+                if (confirmTrashIndex !== null)
+                  applyAction(confirmTrashIndex, "trash");
+                setConfirmTrashIndex(null);
+              }}
+            >
+              trash them
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
   );
 }

--- a/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationInterruptRulesCard/index.tsx
@@ -29,6 +29,29 @@ import { cn } from "@/lib/utils";
 
 const SAVE_DEBOUNCE_MS = 500;
 
+type RuleAction = NotificationInterruptRule["action"];
+
+// The action badge cycles on click. interrupt/snooze only change *timing*; trash is different in kind:
+// it drops the notification entirely (it never reaches the agent), so it reads as destructive.
+const ACTION_CYCLE: Record<RuleAction, RuleAction> = {
+  interrupt: "pool",
+  pool: "trash",
+  trash: "interrupt",
+};
+const ACTION_LABEL: Record<RuleAction, string> = {
+  interrupt: "interrupt",
+  pool: "snooze",
+  trash: "trash",
+};
+const ACTION_BADGE_VARIANT: Record<
+  RuleAction,
+  "default" | "outline" | "destructive"
+> = {
+  interrupt: "default",
+  pool: "outline",
+  trash: "destructive",
+};
+
 // One predicate -> a read-only badge. The sender/text aliases render under their friendly names;
 // any other field shows its name with a relation hint (~ regex, "not" when negated).
 function predicateBadge(p: FieldPredicate): { label: string; value: string } {
@@ -130,15 +153,10 @@ export function NotificationInterruptRulesCard() {
     [save],
   );
 
-  const toggleAction = (index: number) =>
+  const cycleAction = (index: number) =>
     commit(
       (rules ?? []).map((rule, i) =>
-        i === index
-          ? {
-              ...rule,
-              action: rule.action === "interrupt" ? "pool" : "interrupt",
-            }
-          : rule,
+        i === index ? { ...rule, action: ACTION_CYCLE[rule.action] } : rule,
       ),
     );
 
@@ -246,24 +264,14 @@ export function NotificationInterruptRulesCard() {
                         <ItemActions>
                           <Badge
                             asChild
-                            variant={
-                              rule.action === "interrupt"
-                                ? "default"
-                                : "outline"
-                            }
+                            variant={ACTION_BADGE_VARIANT[rule.action]}
                           >
                             <button
                               type="button"
-                              onClick={() => toggleAction(index)}
-                              aria-label={`action: ${
-                                rule.action === "interrupt"
-                                  ? "interrupt"
-                                  : "snooze"
-                              }, click to toggle`}
+                              onClick={() => cycleAction(index)}
+                              aria-label={`action: ${ACTION_LABEL[rule.action]}, click to change`}
                             >
-                              {rule.action === "interrupt"
-                                ? "interrupt"
-                                : "snooze"}
+                              {ACTION_LABEL[rule.action]}
                             </button>
                           </Badge>
                           <Button

--- a/apps/web/src/components/AgentSettings/NotificationsCard/NotificationRow.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationsCard/NotificationRow.tsx
@@ -113,16 +113,26 @@ function parseFields(content: string): { key: string; value: string }[] {
   }));
 }
 
-// Shows what happened to this notification: the effective decision (interrupt vs snooze).
+// Shows what happened to this notification: the effective decision (interrupt, snooze, or trashed =
+// dropped without ever reaching the agent).
 function Disposition({ event }: { event: NotificationEvent }) {
   const decided = event.decided;
   if (!decided) return null;
+  const label =
+    decided === "interrupt"
+      ? "interrupt"
+      : decided === "trash"
+        ? "trashed"
+        : "snooze";
+  const variant =
+    decided === "interrupt"
+      ? "default"
+      : decided === "trash"
+        ? "destructive"
+        : "outline";
   return (
-    <Badge
-      variant={decided === "interrupt" ? "default" : "outline"}
-      className="w-[4.5rem]"
-    >
-      {decided === "interrupt" ? "interrupt" : "snooze"}
+    <Badge variant={variant} className="w-[4.5rem]">
+      {label}
     </Badge>
   );
 }

--- a/apps/web/src/components/AgentSettings/NotificationsCard/index.test.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationsCard/index.test.tsx
@@ -66,6 +66,29 @@ describe("NotificationsCard", () => {
     expect(screen.getByText("snooze")).toBeTruthy();
   });
 
+  it("renders a trashed notification's disposition", async () => {
+    vi.spyOn(api, "getNotificationHistory").mockResolvedValue({
+      notifications: [
+        {
+          type: "notification",
+          source: "whatsapp",
+          summary:
+            '<notification source="whatsapp" type="message">status update</notification>',
+          notif_type: "message",
+          sender: "someone",
+          decided: "trash",
+          ts: new Date().toISOString(),
+        },
+      ],
+      cursor: null,
+    });
+    render(<NotificationsCard />);
+
+    expect(await screen.findByText("whatsapp")).toBeTruthy();
+    // decided=trash renders the "trashed" disposition badge.
+    expect(screen.getByText("trashed")).toBeTruthy();
+  });
+
   it("loads older notifications when there's a cursor", async () => {
     const spy = vi
       .spyOn(api, "getNotificationHistory")

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -52,7 +52,7 @@ export type VestaEvent =
       notif_type?: string;
       sender?: string;
       fields?: Record<string, string>; // targetable structured extras, e.g. { chat_name: "Bride squad" }
-      decided?: "interrupt" | "pool"; // effective decision given the rules
+      decided?: "interrupt" | "pool" | "trash"; // effective decision given the rules (trash = dropped)
       notif_id?: string; // file stem; pending while its file is on disk, cleared once processed
     })
   | (BaseEvent & {


### PR DESCRIPTION
## What

Adds a third notification disposition, **trash**, to the notifications skill's interrupt ruleset. A rule with `--action trash` drops matching notifications so they **never reach the agent**: no turn, no tokens, no triage pass.

Today rules can only route a notification `interrupt` vs `pool` — both still cost an agent turn eventually. On an account following many contacts, WhatsApp status broadcasts (`chat_name=status`) generate 20+ notifications/day, and even pooling them means a triage glance per post. `trash` lets a standing "always ignore status updates" policy actually cost nothing.

Reframes #981 (which proposed a WhatsApp-specific daemon flag) as the general, source-agnostic mechanism: any notification the user wants ignored outright.

## Behavior

- **Recoverable, not deleted**: trashed files are moved to a `notifications/trash/` folder (safe from re-scan: the loader globs non-recursively, the watcher is `recursive=False`), so a too-aggressive rule can be undone.
- **Still auditable**: the notification is emitted to history with `decided=trash` (a "trashed" badge in the app), so nothing is silently lost — only the agent turn is skipped.
- **Explicit-only**: a notification is never trashed by its producer default; trash comes only from a user rule. Core notifications remain exempt.

## Changes

- **policy** (`notification_interrupt_policy.py`): `action` gains `"trash"`; `should_interrupt` (bool) becomes `notif_disposition` (3-way) as the single decision function.
- **loops** (`loops.py`): `monitor_loop` moves trashed files to `config.notif_trash_dir`, emits `decided=trash`, creates no turn.
- **skill/CLI**: `--action trash`, SKILL.md docs (with the caution that trash is the one action that changes *whether* you see something), and discovery text for "always ignore X".
- **web**: rules-card action badge cycles interrupt → snooze → trash; history renders a "trashed" badge.

## Tests

- Agent: policy 3-way (trash on match, never by default), core-never-trashed, and a `monitor_loop` behavioral test (file moved to trash dir, no turn queued, one `decided=trash` history emit). Full `./check.sh agent` green (544 passed).
- CLI: `add --action trash` builds a trash rule (`./check.sh` skills CLI green).
- Web: rules-card cycle to/through trash, history "trashed" badge. Full `./check.sh web` green (137 passed).

## Fleet impact

Purely additive: existing interrupt/pool rules are unchanged and still valid; no persisted-state or schema change, so no migration is needed. The trash folder is created lazily on first use.

Closes #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)