### PR TITLE
feat(skills): fail loudly when a scraper dependency is stale

### DIFF
--- a/agent/skills/flights/cli/src/flights_cli/_freshness.py
+++ b/agent/skills/flights/cli/src/flights_cli/_freshness.py
@@ -1,0 +1,67 @@
+"""Preflight guard against running on a stale scraper dependency.
+
+Some skills wrap reverse-engineered libraries (fli for Google Flights,
+pyicloud for iCloud) that track upstream sites which change format without
+notice. A version behind PyPI is how such a skill silently starts returning
+nothing (issue #822). `require_latest` compares the installed version against
+PyPI's latest and exits non-zero when behind, turning silent drift into a
+loud, actionable error that a `uv tool install --force --reinstall .` clears.
+
+On any network / PyPI failure staleness cannot be proven, so it warns and
+returns rather than blocking a working install on a transient PyPI outage.
+"""
+
+import json
+import sys
+import urllib.request
+from importlib.metadata import PackageNotFoundError, version
+
+PYPI_TIMEOUT_SECS = 5
+
+
+def _release_tuple(raw: str) -> tuple[int, ...]:
+    """Numeric release segments of a version, ignoring any pre/post suffix."""
+    segments = []
+    for segment in raw.split("."):
+        digits = ""
+        for ch in segment:
+            if not ch.isdigit():
+                break
+            digits += ch
+        segments.append(int(digits) if digits else 0)
+    return tuple(segments)
+
+
+def require_latest(package: str) -> None:
+    """Exit non-zero if `package` is behind its latest PyPI release.
+
+    Prints the error and warnings to stderr so they never contaminate the
+    JSON a command writes to stdout.
+    """
+    try:
+        installed = version(package)
+    except PackageNotFoundError:
+        print(json.dumps({"error": f"{package} is not installed"}), file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with urllib.request.urlopen(f"https://pypi.org/pypi/{package}/json", timeout=PYPI_TIMEOUT_SECS) as resp:
+            latest = json.load(resp)["info"]["version"]
+    except Exception as exc:
+        print(f"warning: could not verify {package} is current against PyPI: {exc}", file=sys.stderr)
+        return
+
+    if _release_tuple(installed) < _release_tuple(latest):
+        print(
+            json.dumps(
+                {
+                    "error": (
+                        f"{package} {installed} is behind the latest release {latest}. This skill wraps a "
+                        f"reverse-engineered library that breaks when it falls behind upstream; reinstall to "
+                        f"update: cd ~/agent/skills/<skill>/cli && uv tool install --force --reinstall ."
+                    )
+                }
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/agent/skills/flights/cli/src/flights_cli/cli.py
+++ b/agent/skills/flights/cli/src/flights_cli/cli.py
@@ -804,6 +804,13 @@ def main():
     p_passenger.set_defaults(func=cmd_passenger)
 
     args = parser.parse_args()
+    # The search/dates/cheapest commands scrape Google Flights via fli; a stale
+    # fli silently returns nothing (issue #822). The Duffel commands use a
+    # stable API and are exempt.
+    if args.command in ("search", "dates", "cheapest"):
+        from ._freshness import require_latest
+
+        require_latest("flights")
     args.func(args)
 
 

--- a/agent/skills/icloud-photos/cli/src/icloud_cli/_freshness.py
+++ b/agent/skills/icloud-photos/cli/src/icloud_cli/_freshness.py
@@ -1,0 +1,67 @@
+"""Preflight guard against running on a stale scraper dependency.
+
+Some skills wrap reverse-engineered libraries (fli for Google Flights,
+pyicloud for iCloud) that track upstream sites which change format without
+notice. A version behind PyPI is how such a skill silently starts returning
+nothing (issue #822). `require_latest` compares the installed version against
+PyPI's latest and exits non-zero when behind, turning silent drift into a
+loud, actionable error that a `uv tool install --force --reinstall .` clears.
+
+On any network / PyPI failure staleness cannot be proven, so it warns and
+returns rather than blocking a working install on a transient PyPI outage.
+"""
+
+import json
+import sys
+import urllib.request
+from importlib.metadata import PackageNotFoundError, version
+
+PYPI_TIMEOUT_SECS = 5
+
+
+def _release_tuple(raw: str) -> tuple[int, ...]:
+    """Numeric release segments of a version, ignoring any pre/post suffix."""
+    segments = []
+    for segment in raw.split("."):
+        digits = ""
+        for ch in segment:
+            if not ch.isdigit():
+                break
+            digits += ch
+        segments.append(int(digits) if digits else 0)
+    return tuple(segments)
+
+
+def require_latest(package: str) -> None:
+    """Exit non-zero if `package` is behind its latest PyPI release.
+
+    Prints the error and warnings to stderr so they never contaminate the
+    JSON a command writes to stdout.
+    """
+    try:
+        installed = version(package)
+    except PackageNotFoundError:
+        print(json.dumps({"error": f"{package} is not installed"}), file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with urllib.request.urlopen(f"https://pypi.org/pypi/{package}/json", timeout=PYPI_TIMEOUT_SECS) as resp:
+            latest = json.load(resp)["info"]["version"]
+    except Exception as exc:
+        print(f"warning: could not verify {package} is current against PyPI: {exc}", file=sys.stderr)
+        return
+
+    if _release_tuple(installed) < _release_tuple(latest):
+        print(
+            json.dumps(
+                {
+                    "error": (
+                        f"{package} {installed} is behind the latest release {latest}. This skill wraps a "
+                        f"reverse-engineered library that breaks when it falls behind upstream; reinstall to "
+                        f"update: cd ~/agent/skills/<skill>/cli && uv tool install --force --reinstall ."
+                    )
+                }
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/agent/skills/icloud-photos/cli/src/icloud_cli/cli.py
+++ b/agent/skills/icloud-photos/cli/src/icloud_cli/cli.py
@@ -844,6 +844,14 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
+    # pyicloud reverse-engineers iCloud and breaks when it falls behind Apple's
+    # changes; a stale version fails silently. Guard every user command. The
+    # internal _worker runs in a subprocess the parent already guarded, so it is
+    # exempt to avoid a duplicate PyPI check.
+    if args.command != "_worker":
+        from ._freshness import require_latest
+
+        require_latest("pyicloud")
     args.func(args)
 
 

--- a/agent/skills/icloud-photos/cli/tests/test_freshness.py
+++ b/agent/skills/icloud-photos/cli/tests/test_freshness.py
@@ -1,0 +1,76 @@
+"""Tests for the stale-dependency guard shared by scraper skills."""
+
+import json
+
+import pytest
+
+from icloud_cli import _freshness
+
+
+class _FakeResp:
+    def __init__(self, latest: str) -> None:
+        self._body = json.dumps({"info": {"version": latest}}).encode()
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _patch(monkeypatch, installed: str, latest: str | None, *, offline: bool = False) -> None:
+    monkeypatch.setattr(_freshness, "version", lambda _pkg: installed)
+    if offline:
+
+        def _boom(*_a, **_k):
+            raise OSError("no network")
+
+        monkeypatch.setattr(_freshness.urllib.request, "urlopen", _boom)
+    else:
+        monkeypatch.setattr(_freshness.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(latest))
+
+
+def test_stale_exits_nonzero_with_error(monkeypatch, capsys):
+    _patch(monkeypatch, installed="2.5.0", latest="2.6.0")
+    with pytest.raises(SystemExit) as exc:
+        _freshness.require_latest("pyicloud")
+    assert exc.value.code == 1
+    err = json.loads(capsys.readouterr().err)
+    assert "2.5.0" in err["error"] and "2.6.0" in err["error"]
+
+
+def test_current_proceeds(monkeypatch):
+    _patch(monkeypatch, installed="2.6.0", latest="2.6.0")
+    _freshness.require_latest("pyicloud")  # no SystemExit
+
+
+def test_newer_local_build_proceeds(monkeypatch):
+    _patch(monkeypatch, installed="2.7.0", latest="2.6.0")
+    _freshness.require_latest("pyicloud")  # a local build ahead of PyPI is fine
+
+
+def test_offline_warns_and_proceeds(monkeypatch, capsys):
+    _patch(monkeypatch, installed="2.5.0", latest=None, offline=True)
+    _freshness.require_latest("pyicloud")  # no SystemExit
+    assert "could not verify" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("installed", "latest", "stale"),
+    [
+        ("0.8.4", "0.9.0", True),
+        ("0.9.0", "0.9.0", False),
+        ("0.10.0", "0.9.0", False),
+        ("0.9.0rc1", "0.9.0", False),
+    ],
+)
+def test_release_ordering(monkeypatch, installed, latest, stale):
+    _patch(monkeypatch, installed=installed, latest=latest)
+    if stale:
+        with pytest.raises(SystemExit):
+            _freshness.require_latest("pyicloud")
+    else:
+        _freshness.require_latest("pyicloud")


### PR DESCRIPTION
## Why

Follow-up to #1019 (which bumped `fli` to 0.9.0 for #822). That fixed the immediate breakage, but the underlying failure mode remains: skills that wrap **reverse-engineered / scraper libraries** break *silently* whenever they fall behind upstream. `fli` (Google Flights) and `pyicloud` (iCloud) track sites that change format without notice, so a version behind PyPI returns nothing with exit 0. For these, *being current is functionality* — unlike the stable official SDKs the other skills use (google-api, stripe, msal, spotipy…), which don't break a release behind.

The #1019 fli bump was auto-merged before this guard commit landed on the branch, so it needs its own PR.

## What

A small stdlib-only preflight, `require_latest(package)`, carried by each scraper skill (Vesta duplicates small shapes rather than sharing a lib across skills). It compares the installed version to PyPI's latest and exits non-zero with an actionable reinstall message when behind. A PyPI outage can't prove staleness, so it **warns and proceeds** rather than blocking a working install on a transient outage.

Wired into:
- **flights**: the fli-backed `search` / `dates` / `cheapest` commands (the Duffel path is a stable API and exempt).
- **icloud-photos** (`pyicloud`, also reverse-engineered): every command except the internal `_worker` subprocess, which the parent already guarded.

Stable-SDK skills are intentionally left untouched — force-latest there would fail spuriously on every compatible release and add a needless PyPI round-trip per command.

## Verification

- Hermetic tests (`icloud-photos/cli/tests/test_freshness.py`): stale → exit 1 with error; current → proceeds; newer-local-build → proceeds; offline → warns + proceeds; plus release-ordering (`0.8.4<0.9.0`, `0.10.0>0.9.0`, rc suffix). 8 passing.
- `check.sh agent` gates (ruff check, ruff format, ty check) pass.
- Live smoke: `flights search` with an up-to-date fli runs normally (guard silent); simulated stale/offline paths behave as above.

## Fleet note

Running agents pick this up on the next `uv tool install --force --reinstall .` (Setup section of each skill's `SKILL.md`); the skill files reach boxes via the normal workspace sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)