### PR TITLE
chore: remove converged 0.1.161 legacy paths

### DIFF
--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -424,10 +424,9 @@ def load_config() -> tuple[VestaConfig, list[str]]:
     fall back to a default claude provider.
 
     Legacy convergence runs first (before the config is built), so the loaded config reflects the
-    migrated nested provider rather than a stale default. This makes load_config the single owner of
-    "what config does the agent run on" — there is no separate boot step to sequence wrongly.
+    migrated store rather than a stale default. This makes load_config the single owner of "what
+    config does the agent run on" — there is no separate boot step to sequence wrongly.
     """
-    migrate_legacy_config_to_store()
     migrate_notification_policy_file()
     issues: list[str] = []
     dropped: set[str] = set()
@@ -461,83 +460,6 @@ def load_config() -> tuple[VestaConfig, list[str]]:
                     ),
                     issues,
                 )
-
-
-_LEGACY_PROVIDER_ENV = pl.Path.home() / ".claude" / "vesta-provider.env"
-_LEGACY_FLAT_KEYS = ("agent_model", "agent_provider", "openrouter_key", "max_context_tokens", "thinking")
-
-
-def _parse_legacy_export(content: str, key: str) -> str | None:
-    """Read a `[export ]KEY=value` line from a shell env file, unquoting once; None if absent/empty."""
-    for raw_line in content.splitlines():
-        line = raw_line.strip().removeprefix("export ")
-        name, _, value = line.partition("=")
-        if "=" not in line or name.strip() != key:
-            continue
-        value = value.strip()
-        if len(value) >= 2 and value.startswith("'") and value.endswith("'"):
-            value = value[1:-1]
-        return value or None
-    return None
-
-
-def migrate_legacy_config_to_store() -> None:
-    """Relocate a legacy agent's flat provider config into the nested `provider` object, draining the
-    old flat config.json keys, the legacy env vars, and vesta-provider.env. Idempotent: once the store
-    has a `provider` and no flat keys, it's a no-op. This is the only place flat->nested lives.
-
-    LEGACY(remove-when: no fleet agent boots with flat provider keys in config.json): this function,
-    its boot call site, _parse_legacy_export, and _LEGACY_FLAT_KEYS.
-    """
-    store = read_config_store()
-    content = _LEGACY_PROVIDER_ENV.read_text() if _LEGACY_PROVIDER_ENV.is_file() else ""
-    changed = False
-
-    def legacy(env_key: str, store_key: str) -> str | None:  # old flat store key wins, then env, then file
-        if store_key in store and store[store_key] not in (None, ""):
-            return str(store[store_key])
-        env = os.environ[env_key] if env_key in os.environ else ""
-        return env or _parse_legacy_export(content, env_key)
-
-    if "provider" not in store:
-        kind = legacy("AGENT_PROVIDER", "agent_provider")
-        model = legacy("AGENT_MODEL", "agent_model")
-        key = legacy("ANTHROPIC_AUTH_TOKEN", "openrouter_key")
-        ctx_raw = legacy("MAX_CONTEXT_TOKENS", "max_context_tokens")
-        ctx = int(ctx_raw) if ctx_raw and ctx_raw.isdigit() else None
-        provider: dict[str, pyd.JsonValue] | None = None
-        if kind == "openrouter" and key and model:
-            provider = {"kind": "openrouter", "model": model, "key": key}
-            if ctx is not None:
-                provider["max_context_tokens"] = ctx
-        elif model or kind == "claude":
-            provider = {"kind": "claude", "model": model or "opus"}
-            if ctx is not None:
-                provider["max_context_tokens"] = ctx
-            if "thinking" in store and store["thinking"] is not None:
-                provider["thinking"] = store["thinking"]
-        if provider is not None:
-            store["provider"] = provider
-            changed = True
-
-    for flat in _LEGACY_FLAT_KEYS:
-        if flat in store:
-            store.pop(flat, None)
-            changed = True
-
-    personality = os.environ["AGENT_PERSONALITY"] if "AGENT_PERSONALITY" in os.environ else _parse_legacy_export(content, "AGENT_PERSONALITY")
-    if personality and "agent_personality" not in store:
-        store["agent_personality"] = personality
-        changed = True
-    tz = os.environ["TZ"] if "TZ" in os.environ else None
-    if tz and tz != "UTC" and "timezone" not in store:
-        store["timezone"] = tz
-        changed = True
-
-    if changed:
-        logger.startup("migrated legacy flat config into the nested provider store")
-        _write_config_store(store)
-    _LEGACY_PROVIDER_ENV.unlink(missing_ok=True)
 
 
 _LEGACY_POLICY_FILE = "notification_policy.json"

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -9,7 +9,7 @@ import pydantic as pyd
 from aiohttp.web import AppRunner
 from claude_agent_sdk import ClaudeSDKClient
 
-from .config import ClaudeConfig, OpenRouterConfig, Provider, VestaConfig, load_config, migrate_legacy_config_to_store
+from .config import ClaudeConfig, OpenRouterConfig, Provider, VestaConfig, load_config
 from .events import EventBus
 from .notification_interrupt_policy import CORE_SOURCE
 from .provider import ProviderStatus
@@ -25,7 +25,6 @@ __all__ = [
     "PersistedState",
     "CORE_SOURCE",
     "load_config",
-    "migrate_legacy_config_to_store",
 ]
 
 # Notification `type` values for the `source=core` notifications that remain notifications (periodic

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -11,7 +11,6 @@ from core.config import (
     config_store_path,
     load_config,
     load_notification_rules,
-    migrate_legacy_config_to_store,
     migrate_notification_policy_file,
     read_config_store,
     update_config_store,
@@ -43,7 +42,6 @@ def test_default_provider_is_none_when_unprovisioned(agentdir, monkeypatch, tmp_
     from core import config as config_mod
 
     monkeypatch.setattr(config_mod, "CREDENTIALS_PATH", tmp_path / ".credentials.json")
-    monkeypatch.setattr(config_mod, "_LEGACY_PROVIDER_ENV", tmp_path / "absent.env")
     config, _ = config_mod.load_config()
     assert config.provider is None
 
@@ -128,7 +126,6 @@ def test_loads_shipped_defaults_with_no_env_or_store(agentdir, monkeypatch, tmp_
     from core import config as config_mod
 
     monkeypatch.setattr(config_mod, "CREDENTIALS_PATH", tmp_path / ".credentials.json")
-    monkeypatch.setattr(config_mod, "_LEGACY_PROVIDER_ENV", tmp_path / "absent.env")
     config, issues = load_config()
     assert config.provider is None
     assert config.agent_personality == "dry"
@@ -161,7 +158,6 @@ def test_corrupt_store_does_not_crash_load(agentdir, monkeypatch, tmp_path):
     from core import config as config_mod
 
     monkeypatch.setattr(config_mod, "CREDENTIALS_PATH", tmp_path / ".credentials.json")
-    monkeypatch.setattr(config_mod, "_LEGACY_PROVIDER_ENV", tmp_path / "absent.env")
     config_store_path().write_text("{ not json")
     assert read_config_store() == {}
     config, _ = load_config()
@@ -173,116 +169,8 @@ def test_stored_config_serializes_null_provider(agentdir, monkeypatch, tmp_path)
     from core.config import stored_config
 
     monkeypatch.setattr(config_mod, "CREDENTIALS_PATH", tmp_path / ".credentials.json")
-    monkeypatch.setattr(config_mod, "_LEGACY_PROVIDER_ENV", tmp_path / "absent.env")
     config, _ = config_mod.load_config()
     assert stored_config(config)["provider"] is None
-
-
-# --- Legacy fleet convergence: flat -> nested provider ---
-
-
-def test_migrate_drains_flat_env_into_nested_provider(agentdir, monkeypatch):
-    monkeypatch.setenv("AGENT_MODEL", "sonnet")
-    monkeypatch.setenv("AGENT_PERSONALITY", "warm")
-    monkeypatch.setenv("MAX_CONTEXT_TOKENS", "500000")
-    monkeypatch.delenv("TZ", raising=False)
-    migrate_legacy_config_to_store()
-    assert read_config_store() == {
-        "provider": {"kind": "claude", "model": "sonnet", "max_context_tokens": 500000},
-        "agent_personality": "warm",
-    }
-
-
-def test_migrate_drains_legacy_tz_into_store(agentdir, monkeypatch):
-    monkeypatch.setenv("TZ", "America/New_York")
-    migrate_legacy_config_to_store()
-    assert read_config_store()["timezone"] == "America/New_York"
-
-
-def test_migrate_skips_utc_default_tz(agentdir, monkeypatch):
-    monkeypatch.setenv("TZ", "UTC")
-    migrate_legacy_config_to_store()
-    assert "timezone" not in read_config_store()
-
-
-def test_migrate_does_not_overwrite_existing_store_and_is_idempotent(agentdir, monkeypatch):
-    update_config_store({"provider": {"kind": "claude", "model": "haiku"}})  # a prior choice
-    monkeypatch.setenv("AGENT_MODEL", "sonnet")  # legacy env says otherwise
-    migrate_legacy_config_to_store()
-    assert read_config_store()["provider"] == {"kind": "claude", "model": "haiku"}  # choice preserved
-    migrate_legacy_config_to_store()  # second run is a no-op
-    assert read_config_store()["provider"] == {"kind": "claude", "model": "haiku"}
-
-
-def test_migrate_ignores_nonnumeric_context(agentdir, monkeypatch):
-    monkeypatch.setenv("AGENT_MODEL", "opus")
-    monkeypatch.delenv("AGENT_PERSONALITY", raising=False)
-    monkeypatch.setenv("MAX_CONTEXT_TOKENS", "lots")
-    migrate_legacy_config_to_store()
-    assert read_config_store()["provider"] == {"kind": "claude", "model": "opus"}
-
-
-def test_migrate_drains_legacy_provider_file_into_nested(agentdir, monkeypatch, tmp_path):
-    from core import config as config_mod
-
-    for key in ("AGENT_MODEL", "AGENT_PERSONALITY", "MAX_CONTEXT_TOKENS", "AGENT_PROVIDER"):
-        monkeypatch.delenv(key, raising=False)
-    legacy = tmp_path / "vesta-provider.env"
-    legacy.write_text(
-        "export AGENT_PROVIDER=openrouter\n"
-        "export AGENT_MODEL='deepseek/deepseek-v4-flash'\n"
-        "export ANTHROPIC_AUTH_TOKEN='sk-or-v1-secret'\n"
-        "export MAX_CONTEXT_TOKENS=200000\n"
-    )
-    monkeypatch.setattr(config_mod, "_LEGACY_PROVIDER_ENV", legacy)
-
-    config_mod.migrate_legacy_config_to_store()
-    provider = config_mod.read_config_store()["provider"]
-    assert provider == {
-        "kind": "openrouter",
-        "model": "deepseek/deepseek-v4-flash",
-        "key": "sk-or-v1-secret",
-        "max_context_tokens": 200000,
-    }
-    assert not legacy.exists()  # the legacy file is retired after draining
-
-
-def test_migrate_legacy_claude_file_carries_no_key(agentdir, monkeypatch, tmp_path):
-    from core import config as config_mod
-
-    for key in ("AGENT_MODEL", "AGENT_PERSONALITY", "MAX_CONTEXT_TOKENS", "AGENT_PROVIDER"):
-        monkeypatch.delenv(key, raising=False)
-    legacy = tmp_path / "vesta-provider.env"
-    legacy.write_text("export AGENT_PROVIDER=claude\nexport ANTHROPIC_AUTH_TOKEN=\n")
-    monkeypatch.setattr(config_mod, "_LEGACY_PROVIDER_ENV", legacy)
-
-    config_mod.migrate_legacy_config_to_store()
-    assert config_mod.read_config_store()["provider"] == {"kind": "claude", "model": "opus"}
-    assert not legacy.exists()
-
-
-def test_load_config_converges_legacy_provider_file_first(agentdir, monkeypatch, tmp_path):
-    """A legacy OpenRouter agent stores its provider only in vesta-provider.env. load_config must
-    drain it into the store BEFORE building the config, so the returned config is the OpenRouter
-    provider — not the default (which would derive not_authenticated and defer all work)."""
-    from core import config as config_mod
-    from core.config import OpenRouterConfig
-
-    for key in ("AGENT_MODEL", "AGENT_PROVIDER", "MAX_CONTEXT_TOKENS", "AGENT_PERSONALITY", "ANTHROPIC_AUTH_TOKEN"):
-        monkeypatch.delenv(key, raising=False)
-    monkeypatch.setattr(config_mod, "CREDENTIALS_PATH", tmp_path / ".credentials.json")
-    legacy = tmp_path / "vesta-provider.env"
-    legacy.write_text(
-        "export AGENT_PROVIDER=openrouter\nexport AGENT_MODEL='deepseek/deepseek-v4-flash'\nexport ANTHROPIC_AUTH_TOKEN='sk-or-v1-secret'\n"
-    )
-    monkeypatch.setattr(config_mod, "_LEGACY_PROVIDER_ENV", legacy)
-
-    config, _ = config_mod.load_config()
-
-    assert isinstance(config.provider, OpenRouterConfig)
-    assert config.provider.model == "deepseek/deepseek-v4-flash"
-    assert config.provider.key.get_secret_value() == "sk-or-v1-secret"
-    assert not legacy.exists()  # convergence ran and retired the legacy file
 
 
 # --- PUT /config (prefs) + PATCH /provider validation ---

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1063,11 +1063,6 @@ pub fn update_all_agent_env_files(agents_dir: &std::path::Path, vestad_port: u16
     for name in env_file_names(agents_dir) {
         let path = agents_dir.join(format!("{name}.env"));
         let Ok(content) = std::fs::read_to_string(&path) else { continue };
-        // LEGACY(remove-when: no agent env file carries AGENT_SEED_PERSONALITY): rename it to
-        // AGENT_PERSONALITY in place, value-preserving, so the agent keeps the chosen voice.
-        let has_new_personality = content
-            .lines()
-            .any(|line| line.strip_prefix("export ").unwrap_or(line).starts_with("AGENT_PERSONALITY="));
         let mut new_lines: Vec<String> = content
             .lines()
             .filter_map(|line| {
@@ -1077,12 +1072,6 @@ pub fn update_all_agent_env_files(agents_dir: &std::path::Path, vestad_port: u16
                 // fetch a bundle from vestad; no branch name needed) - strip stale keys.
                 if stripped.starts_with("VESTAD_PORT=") || stripped.starts_with("VESTAD_TUNNEL=") || stripped.starts_with("VESTA_WORKSPACE_REF=") || stripped.starts_with("VESTA_UPSTREAM_REF=") {
                     return None; // re-appended below with the current values
-                }
-                if stripped.starts_with("AGENT_SEED_PERSONALITY=") {
-                    if has_new_personality {
-                        return None; // already migrated; drop the stale duplicate
-                    }
-                    return Some(line.replacen("AGENT_SEED_PERSONALITY=", "AGENT_PERSONALITY=", 1));
                 }
                 Some(line.to_string())
             })
@@ -2562,33 +2551,6 @@ mod tests {
         let path2 = write_agent_env_file(&cfg, "agent2", 3, "tok2").expect("write env file 2");
         let content2 = std::fs::read_to_string(&path2).expect("read env file 2");
         assert!(!content2.contains("VESTA_CLOUD_CONTROL_URL"), "absent when unset: {content2}");
-    }
-
-    #[test]
-    fn update_env_renames_legacy_personality_var_preserving_value() {
-        // The agent dropped the AGENT_SEED_PERSONALITY env alias; the startup normalizer must
-        // rename it to AGENT_PERSONALITY in existing files so a legacy non-default voice survives.
-        let dir = tempfile::TempDir::new().expect("tempdir");
-        let env_path = dir.path().join("vesta.env");
-        std::fs::write(&env_path, "export AGENT_TOKEN=t\nexport AGENT_SEED_PERSONALITY=warm\nexport VESTAD_PORT=1\n").expect("write");
-        update_all_agent_env_files(dir.path(), 39565, None);
-        let content = std::fs::read_to_string(&env_path).expect("read");
-        assert!(content.contains("export AGENT_PERSONALITY=warm"), "renamed, value preserved: {content}");
-        assert!(!content.contains("AGENT_SEED_PERSONALITY"), "legacy var removed: {content}");
-        assert!(content.contains("export AGENT_TOKEN=t"), "identity preserved");
-    }
-
-    #[test]
-    fn update_env_drops_legacy_personality_when_new_one_present() {
-        // If a file already has the new var, the stale legacy duplicate is dropped, not re-added.
-        let dir = tempfile::TempDir::new().expect("tempdir");
-        let env_path = dir.path().join("vesta.env");
-        std::fs::write(&env_path, "export AGENT_PERSONALITY=dry\nexport AGENT_SEED_PERSONALITY=warm\n").expect("write");
-        update_all_agent_env_files(dir.path(), 39565, None);
-        let content = std::fs::read_to_string(&env_path).expect("read");
-        assert!(content.contains("export AGENT_PERSONALITY=dry"));
-        assert!(!content.contains("AGENT_SEED_PERSONALITY"));
-        assert!(!content.contains("warm"));
     }
 
     #[test]

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -3045,7 +3045,7 @@ mod tests {
         let long = client.post(format!("http://127.0.0.1:{}/longrun", port)).send().await.unwrap();
         assert_eq!(long.status(), reqwest::StatusCode::OK);
 
-        assert!(super::LONGRUN_REQUEST_TIMEOUT_SECS > super::CONTROL_REQUEST_TIMEOUT_SECS);
+        const { assert!(super::LONGRUN_REQUEST_TIMEOUT_SECS > super::CONTROL_REQUEST_TIMEOUT_SECS) };
         handle.abort();
     }
 

--- a/vestad/tests-integration/src/client.rs
+++ b/vestad/tests-integration/src/client.rs
@@ -314,36 +314,12 @@ impl Client {
         Ok(())
     }
 
-    /// LEGACY(remove-when: the upgrade e2e's from-version (`previous_released_tag`) >= 0.1.161 —
-    /// the first release speaking the current PUT `/provider` + `{kind,model,key}` contract; true
-    /// once 0.1.160 is no longer an upgrade-from target): sign in against a pre-0.1.161 daemon,
-    /// which serves `POST /agents/{name}/provider` and whose agent core expects
-    /// `{openrouter_key, openrouter_model}`. The upgrade test provisions on the previous released
-    /// daemon before upgrading, so it must speak whatever contract that daemon shipped.
-    pub fn sign_in_openrouter_legacy_pre_put(&self, name: &str, key: &str, model: &str) -> Result<(), String> {
-        self.wait_until_running(name, 60)?;
-        let body = serde_json::json!({"openrouter_key": key, "openrouter_model": model});
-        self.post_json(&format!("/agents/{}/provider", name), &body)?;
-        Ok(())
-    }
-
     /// Sign an agent in with a Claude OAuth credentials blob + model via `PUT /provider`. The write
     /// doesn't restart; callers restart afterwards. The agent must be running to receive the call.
     pub fn sign_in_claude(&self, name: &str, credentials: &str, model: &str) -> Result<(), String> {
         self.wait_until_running(name, 60)?;
         let body = serde_json::json!({"kind": "claude", "credentials": credentials, "model": model});
         self.put_json(&format!("/agents/{}/provider", name), &body)?;
-        Ok(())
-    }
-
-    /// LEGACY(remove-when: the upgrade e2e's from-version (`previous_released_tag`) >= 0.1.161): sign
-    /// a pre-0.1.161 daemon in with Claude credentials. It serves `POST /agents/{name}/provider` and
-    /// its agent core expects just `{credentials}` (model comes from the `AGENT_MODEL` env the caller
-    /// sets). The upgrade test provisions the previous released daemon, so it must speak that contract.
-    pub fn sign_in_claude_legacy_pre_put(&self, name: &str, credentials: &str) -> Result<(), String> {
-        self.wait_until_running(name, 60)?;
-        let body = serde_json::json!({"credentials": credentials});
-        self.post_json(&format!("/agents/{}/provider", name), &body)?;
         Ok(())
     }
 

--- a/vestad/tests/live/common.rs
+++ b/vestad/tests/live/common.rs
@@ -4,7 +4,7 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
-use vesta_tests::{SERVER, TestAgent, docker_cmd, dump_agent_diagnostics, exec_in_container, parse_release_tag};
+use vesta_tests::{SERVER, TestAgent, docker_cmd, dump_agent_diagnostics, exec_in_container};
 
 type SharedAgent = Option<(TestAgent<'static>, String)>;
 
@@ -202,62 +202,25 @@ pub fn wait_until_alive_or_die(client: &vesta_tests::client::Client, name: &str,
     }
 }
 
-/// First release whose provider sign-in is the current `PUT /provider` + `{kind,model,key}`
-/// contract; every earlier release serves `POST /provider` + `{openrouter_key, openrouter_model}`.
-/// LEGACY(remove-when: `previous_released_tag` >= 0.1.161 — i.e. once 0.1.160 is no longer an
-/// upgrade-from target, which holds after the 0.1.161 release): delete this, `LegacyPrePut`, and
-/// `for_daemon_tag`, leaving the upgrade test on `ProviderApi::Current`.
-const PROVIDER_PUT_CONTRACT_SINCE: [u64; 3] = [0, 1, 161];
-
-/// Which provider sign-in contract `provision_and_settle` uses. The live pool always talks to the
-/// current daemon; the upgrade e2e provisions against the previous released daemon, whose sign-in
-/// may predate the current contract — so it derives the variant from that daemon's version rather
-/// than hardcoding one, keeping the test correct for any upgrade-from version.
-#[derive(Clone, Copy)]
-pub enum ProviderApi {
-    Current,
-    /// LEGACY(remove-when: see `PROVIDER_PUT_CONTRACT_SINCE`): pre-0.1.161 sign-in shape.
-    LegacyPrePut,
-}
-
-impl ProviderApi {
-    /// The sign-in contract a daemon released as `tag` speaks. Unparseable/newer tags default to
-    /// the current contract.
-    pub fn for_daemon_tag(tag: &str) -> ProviderApi {
-        match parse_release_tag(tag) {
-            Some(parts) if parts.as_slice() < &PROVIDER_PUT_CONTRACT_SINCE[..] => ProviderApi::LegacyPrePut,
-            _ => ProviderApi::Current,
-        }
-    }
-}
-
 /// Provision a freshly-created agent for live e2e (Claude provider on `live_model()`, test memory,
 /// real credentials) and block until it has fully settled after first-start. Shared by the live
 /// agent pool and the upgrade e2e test, both of which need a real, idle agent. Panics with
 /// diagnostics on failure, matching the pool's fail-fast behavior. Callers must have already
 /// confirmed the credentials exist (via `host_credentials_path`).
-pub fn provision_and_settle(client: &vesta_tests::client::Client, name: &str, container: &str, api: ProviderApi) {
+pub fn provision_and_settle(client: &vesta_tests::client::Client, name: &str, container: &str) {
     let credentials_path = host_credentials_path().expect("CLAUDE_CREDENTIALS present (caller checked)");
     let credentials = fs::read_to_string(&credentials_path).unwrap_or_else(|e| panic!("read {}: {e}", credentials_path.display()));
     let model = live_model();
 
     wait_for_container_running(container, Duration::from_secs(60)).expect("container running");
 
-    // The legacy (pre-0.1.161) sign-in carries no model — that agent reads AGENT_MODEL from env. Set
-    // it so the old upgrade agent runs on `model` too; the current agent takes the model from the PUT.
-    exec_in_container(container, &format!("echo 'export AGENT_MODEL={model}' >> ~/.bashrc")).expect("set AGENT_MODEL");
-
     exec_in_container(container, &format!("mkdir -p {E2E_FILES_DIR}")).expect("create e2e dir");
     exec_in_container(container, &format!("cat > {MEMORY_PATH} <<'EOF'\n{TEST_MEMORY}\nEOF"))
         .expect("write test memory");
 
-    match api {
-        ProviderApi::Current => client.sign_in_claude(name, &credentials, &model),
-        ProviderApi::LegacyPrePut => client.sign_in_claude_legacy_pre_put(name, &credentials),
-    }
-    .expect("sign in with Claude");
-    // Restart after sign-in so the agent boots with the Claude provider (and AGENT_MODEL) applied:
-    // vestad applies a provider write only on the next boot, so first-start runs on the chosen model.
+    client.sign_in_claude(name, &credentials, &model).expect("sign in with Claude");
+    // Restart after sign-in so the agent boots with the Claude provider applied: vestad applies a
+    // provider write only on the next boot, so first-start runs on the chosen model.
     client.restart_agent(name).expect("restart agent to apply provider");
 
     wait_until_alive_or_die(client, name, container);
@@ -299,6 +262,6 @@ fn setup_live_agent(name: &str) -> Option<(TestAgent<'static>, String)> {
     let status = client.agent_status(&agent.name).unwrap();
     let container = status.id.unwrap_or_else(|| panic!("agent {} has no container id", agent.name));
 
-    provision_and_settle(client, &agent.name, &container, ProviderApi::Current);
+    provision_and_settle(client, &agent.name, &container);
     Some((agent, container))
 }

--- a/vestad/tests/live/upgrade.rs
+++ b/vestad/tests/live/upgrade.rs
@@ -29,7 +29,6 @@ use vesta_tests::{
 
 use super::common::{
     create_file_request, host_credentials_path, provision_and_settle, wait_for_file_contains, wait_until_alive_or_die, write_notification,
-    ProviderApi,
 };
 
 const AGENT_NAME: &str = "upgrade";
@@ -132,7 +131,7 @@ fn upgrade_from_previous_release_converges_migrations_and_keeps_agent_healthy() 
     // Stream the agent's own log to the test output for the whole run; survives every restart.
     let _log_stream = AgentLogStream::start(&container);
 
-    provision_and_settle(&old_client, &agent_name, &container, ProviderApi::for_daemon_tag(&previous_tag));
+    provision_and_settle(&old_client, &agent_name, &container);
     let pre_applied = applied_migrations(&container);
     eprintln!("upgrade e2e: setup complete on {previous_tag}; {} migration(s) pre-applied", pre_applied.len());
 


### PR DESCRIPTION
## What

Removes `LEGACY(...)`-marked convergence code whose `remove-when` condition has fired. The user confirmed the fleet floor is **past 0.1.161**, so any migration/self-heal introduced at or before 0.1.161 has run on every agent and is now dead.

Enumerated every marker with `rg 'LEGACY\('` and mapped each to its introducing release via `git blame`:

| Marker | Introduced | Action |
|---|---|---|
| provider pre-0.1.161 sign-in (live/upgrade e2e + client helpers) | 0.1.161 (test-only, condition met independent of fleet) | **removed** |
| `docker.rs` `AGENT_SEED_PERSONALITY` → `AGENT_PERSONALITY` env rename | 0.1.161 | **removed** |
| `config.py` flat → nested provider migration | 0.1.161 | **removed** |
| `docker.rs` `.claude` untrack self-heal | 0.1.168 | kept (needs 168 floor) |
| `docker.rs` unmanaged old-layout tolerance | 0.1.168 | kept |
| `docker.rs` strip `VESTA_*_REF` | 0.1.168 | kept |
| `config.py` `notification_policy.json` fold | 0.1.168 | kept |
| `notification_interrupt_policy.py` flat `sender`/`keyword` | 0.1.168 | kept |

The 0.1.168-gated markers are tracked for removal once the fleet floor reaches 0.1.168 (see #1025).

## Details

- **Provider legacy (tests):** the upgrade e2e always upgrades from the highest release below current (now ≫ 0.1.161), so `ProviderApi` / `LegacyPrePut` / `for_daemon_tag` and the `sign_in_openrouter_legacy_pre_put` / `sign_in_claude_legacy_pre_put` client helpers are unreachable. `provision_and_settle` drops its `api` param and its AGENT_MODEL-for-legacy dance.
- **Env rename (vestad):** `update_all_agent_env_files` no longer renames the legacy personality var; the two rename tests go with it. The `VESTA_*_REF` strip in the same function stays (0.1.168).
- **Config migration (agent):** verified this was safe to remove wholesale — vestad no longer writes `AGENT_PERSONALITY` to env (`docker.rs`: "env carries only identity; the agent owns … personality"), and `timezone` reads `TZ` directly via its field alias, so the personality/timezone seeding inside the migration was legacy-only convergence. Removed the function, `_parse_legacy_export`, `_LEGACY_FLAT_KEYS`, `_LEGACY_PROVIDER_ENV`, the boot call site, the `models.py` re-export, and the legacy test block.
- **Incidental:** fixed a newer-clippy `assertions-on-constants` lint in `serve.rs` (wrapped the compile-time invariant in a `const { … }` block).

## Verification

- `agent`: ruff check + `ruff format --check` + ty + pytest (`test_config.py`, `test_notification_rules.py` — 81 passed) ✅
- `vestad`: `cargo clippy -p vestad --all-targets -D warnings` ✅ (covers `docker.rs`, `serve.rs`, and the live-test targets that link `client.rs` / `common.rs` / `upgrade.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)