### PR TITLE
feat(tasks): add cron reminders and fix recurring DST drift

### DIFF
--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -53,6 +53,11 @@ tasks remind "Bills" --recurring monthly --at "2025-12-15T09:00:00" --tz "Americ
 tasks remind "Birthday" --recurring yearly --at "2025-03-14T12:00:00" --tz "America/New_York"
 tasks remind "Check inbox" --recurring hourly
 
+# Recurring on a custom schedule (standard cron)
+tasks remind "Weekdays 9am" --cron "0 9 * * 1-5" --tz "America/New_York"
+tasks remind "Every 15 min, 9-5" --cron "*/15 9-17 * * *" --tz "America/New_York"
+tasks remind "1st of the month" --cron "0 8 1 * *" --tz "America/New_York"
+
 # List, delete, update
 tasks remind list                        # all active reminders
 tasks remind list --task <id>            # reminders linked to a task
@@ -65,6 +70,8 @@ tasks remind update <id> --message "New message"
 - `--at` + `--tz`: absolute datetime (both required together)
 - `--recurring`: hourly | daily | weekly | monthly | yearly
   - hourly needs no datetime; others require `--at` + `--tz`
+- `--cron "<expr>"`: standard 5-field cron (`min hour day-of-month month day-of-week`) for schedules the presets can't express. Supports `*`, ranges (`1-5`), lists (`1,3,5`), steps (`*/15`), and day-of-week names (`mon-fri`). Day-of-week uses **standard cron numbering** (`0` or `7` = Sunday, `1` = Monday), so `--cron "0 9 * * 1-5"` fires 9am Mon-Fri as expected. Requires `--tz`; cannot combine with `--recurring`/`--at`/`--in-*`.
+  - Both `--recurring` and `--cron` schedules are DST-aware: they store your IANA timezone and keep firing at the same wall-clock time across clock changes.
 - Always use the user's timezone from MEMORY.md section 4, not UTC
 - `--task <id>`: link reminder to a task (optional)
 - `--message`: alternative to positional message argument

--- a/agent/skills/tasks/cli/src/tasks_cli/cli.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/cli.py
@@ -227,6 +227,7 @@ def _main_remind():
             p.add_argument("--in-hours", type=int, default=None)
             p.add_argument("--in-days", type=int, default=None)
             p.add_argument("--recurring", default=None, choices=["hourly", "daily", "weekly", "monthly", "yearly"])
+            p.add_argument("--cron", default=None)
             args = p.parse_args(remind_args)
             message = _require_arg(args.message_pos or args.message, "message", 'tasks remind "message" or tasks remind --message "message"')
             result = commands.remind_set(
@@ -239,6 +240,7 @@ def _main_remind():
                 in_hours=args.in_hours,
                 in_days=args.in_days,
                 recurring=args.recurring,
+                cron=args.cron,
             )
 
         print(json.dumps(result, indent=2))
@@ -258,6 +260,7 @@ Set a reminder (default):
   tasks remind "call mom" --in-minutes 30
   tasks remind "check this" --task <id> --at <datetime> --tz <tz>
   tasks remind "standup" --recurring daily --at <datetime> --tz <tz>
+  tasks remind "weekdays 9am" --cron "0 9 * * 1-5" --tz <tz>
 
 options:
   --message MSG         Message (alternative to positional)
@@ -268,6 +271,7 @@ options:
   --in-hours N          Fire in N hours
   --in-days N           Fire in N days
   --recurring TYPE      hourly|daily|weekly|monthly|yearly
+  --cron EXPR           Standard 5-field cron "min hour dom month dow" (requires --tz)
 
 subcommands:
   list                  List active reminders

--- a/agent/skills/tasks/cli/src/tasks_cli/commands.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/commands.py
@@ -12,10 +12,6 @@ from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 from apscheduler.schedulers.background import BackgroundScheduler
 
-# trigger_data stores UTC hour/minute, so CronTrigger must be interpreted in UTC.
-# Without timezone=, APScheduler uses the scheduler's local TZ, which mis-fires by the local-UTC offset.
-_UTC_ZI = ZoneInfo("UTC")
-
 from .config import Config
 from . import db
 from .scheduler import write_reminder_notification
@@ -30,13 +26,10 @@ logger = logging.getLogger(__name__)
 
 class TriggerData(TypedDict, total=False):
     type: str
-    run_date: str
-    month: int
-    day: int
-    day_of_week: str
-    hour: int
-    minute: int
-    hours: int
+    run_date: str  # "date": one-shot ISO-8601 UTC instant
+    expr: str  # "cron": normalized 5-field cron expression (day-of-week as an APScheduler name list)
+    tz: str  # "cron": IANA timezone the expression is interpreted in (DST-aware)
+    hours: int  # "interval": fixed hour spacing
 
 
 # Overdue pending tasks (past due_date) always float to the top, ordered by most
@@ -54,14 +47,70 @@ def _now_utc() -> datetime:
 
 
 def _cron_trigger_from_data(trigger_data: TriggerData) -> CronTrigger:
-    return CronTrigger(
-        month=trigger_data["month"] if "month" in trigger_data else None,
-        day=trigger_data["day"] if "day" in trigger_data else None,
-        day_of_week=trigger_data["day_of_week"] if "day_of_week" in trigger_data else None,
-        hour=trigger_data["hour"] if "hour" in trigger_data else None,
-        minute=trigger_data["minute"] if "minute" in trigger_data else None,
-        timezone=_UTC_ZI,
-    )
+    return CronTrigger.from_crontab(trigger_data["expr"], timezone=ZoneInfo(trigger_data["tz"]))
+
+
+# Standard cron numbers the day-of-week field 0-7 with 0 and 7 both Sunday (1=Mon .. 6=Sat) and is
+# what every crontab, doc, and LLM assumes. APScheduler's from_crontab instead uses 0=Mon .. 6=Sun and
+# rejects 7, so "* * * * 1-5" would silently fire Tue-Sat. We normalize the day-of-week field to an
+# unambiguous list of APScheduler weekday names, which both dialects agree on, before handing it over.
+_VIXIE_DOW_NAMES = ("sun", "mon", "tue", "wed", "thu", "fri", "sat")  # index = standard-cron number, 0=Sunday
+_DOW_NAME_TO_INDEX = {name: i for i, name in enumerate(_VIXIE_DOW_NAMES)}
+_APSCHEDULER_DOW_ORDER = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+
+def _dow_single(token: str) -> int:
+    tok = token.strip().lower()
+    if tok in _DOW_NAME_TO_INDEX:
+        return _DOW_NAME_TO_INDEX[tok]
+    if not tok.isdigit():
+        raise ValueError(f"Invalid day-of-week value: '{token}' (use 0-7 or sun-sat)")
+    number = int(tok)
+    if number == 7:
+        return 0
+    if 0 <= number <= 6:
+        return number
+    raise ValueError(f"Invalid day-of-week value: '{token}' (use 0-7 or sun-sat)")
+
+
+def _dow_part_to_indices(part: str) -> list[int]:
+    """Expand one comma-separated piece of a standard-cron day-of-week field to indices (0=Sun .. 6=Sat)."""
+    step = 1
+    if "/" in part:
+        part, _, step_str = part.partition("/")
+        if not step_str.isdigit() or int(step_str) <= 0:
+            raise ValueError(f"Invalid day-of-week step: '{step_str}'")
+        step = int(step_str)
+
+    if part.strip() in ("*", "?"):
+        low, high = 0, 6
+    elif "-" in part:
+        low_str, _, high_str = part.partition("-")
+        low, high = _dow_single(low_str), _dow_single(high_str)
+    else:
+        low = high = _dow_single(part)
+
+    span = (high - low) % 7  # standard cron allows wrap-around ranges like fri-mon
+    return [(low + offset) % 7 for offset in range(0, span + 1, step)]
+
+
+def _normalize_dow(field: str) -> str:
+    if field.strip() in ("*", "?"):
+        return "*"
+    indices: set[int] = set()
+    for part in field.split(","):
+        indices.update(_dow_part_to_indices(part))
+    names = sorted((_VIXIE_DOW_NAMES[i] for i in indices), key=_APSCHEDULER_DOW_ORDER.index)
+    return ",".join(names)
+
+
+def _normalize_cron_expr(expr: str) -> str:
+    """Validate a 5-field cron expression and rewrite its day-of-week field to standard-cron semantics."""
+    fields = expr.split()
+    if len(fields) != 5:
+        raise ValueError(f"Cron expression must have 5 fields (min hour day month dow), got {len(fields)}: '{expr}'")
+    fields[4] = _normalize_dow(fields[4])
+    return " ".join(fields)
 
 
 def _parse_local_dt(datetime_str: str, timezone_str: str) -> datetime:
@@ -514,41 +563,52 @@ def remind_set(
     in_hours: int | None = None,
     in_days: int | None = None,
     recurring: str | None = None,
+    cron: str | None = None,
     notif_dir: Path | None = None,
 ) -> dict:
     reminder_id = str(uuid.uuid4())[:8]
     trigger_data = None
 
-    if recurring == "hourly":
+    if cron is not None:
+        if recurring or scheduled_datetime or in_minutes or in_hours or in_days:
+            raise ValueError("--cron cannot be combined with --recurring, --at, or --in-* options")
+        if not tz:
+            raise ValueError("tz is required when cron is provided")
+        expr = _normalize_cron_expr(cron)
+        trigger = CronTrigger.from_crontab(expr, timezone=ZoneInfo(tz))
+        schedule_info = f"cron: {cron} ({tz})"
+        trigger_data = {"type": "cron", "expr": expr, "tz": tz}
+        next_run = trigger.get_next_fire_time(None, _now_utc())
+    elif recurring == "hourly":
         schedule_info = "hourly"
         trigger_data = {"type": "interval", "hours": 1}
         next_run = None
     elif recurring in ("daily", "weekly", "monthly", "yearly"):
         if not scheduled_datetime or not tz:
             raise ValueError(f"scheduled_datetime and tz are required for {recurring} reminders")
+        # Build the cron expression from the user's wall-clock time and store the IANA tz alongside it,
+        # so APScheduler recomputes the correct UTC instant on every fire and the reminder holds its
+        # wall-clock time across DST transitions instead of drifting by the offset.
         local_dt = _parse_local_dt(scheduled_datetime, tz)
-        utc_dt = local_dt.astimezone(UTC)
-        h, m = utc_dt.hour, utc_dt.minute
-        local_h, local_m = local_dt.hour, local_dt.minute
+        h, m = local_dt.hour, local_dt.minute
 
         if recurring == "daily":
-            trigger = CronTrigger(hour=h, minute=m, timezone=_UTC_ZI)
-            schedule_info = f"daily at {local_h:02d}:{local_m:02d} {tz}"
-            trigger_data = {"type": "cron", "hour": h, "minute": m}
+            expr = f"{m} {h} * * *"
+            schedule_info = f"daily at {h:02d}:{m:02d} {tz}"
         elif recurring == "weekly":
-            day_name = utc_dt.strftime("%a").lower()
-            local_day_name = local_dt.strftime("%a").lower()
-            trigger = CronTrigger(day_of_week=day_name, hour=h, minute=m, timezone=_UTC_ZI)
-            schedule_info = f"weekly on {local_day_name} at {local_h:02d}:{local_m:02d} {tz}"
-            trigger_data = {"type": "cron", "day_of_week": day_name, "hour": h, "minute": m}
+            dow = local_dt.strftime("%a").lower()
+            expr = f"{m} {h} * * {dow}"
+            schedule_info = f"weekly on {dow} at {h:02d}:{m:02d} {tz}"
         elif recurring == "monthly":
-            trigger = CronTrigger(day=utc_dt.day, hour=h, minute=m, timezone=_UTC_ZI)
-            schedule_info = f"monthly on day {local_dt.day} at {local_h:02d}:{local_m:02d} {tz}"
-            trigger_data = {"type": "cron", "day": utc_dt.day, "hour": h, "minute": m}
+            expr = f"{m} {h} {local_dt.day} * *"
+            schedule_info = f"monthly on day {local_dt.day} at {h:02d}:{m:02d} {tz}"
         else:  # yearly
-            trigger = CronTrigger(month=utc_dt.month, day=utc_dt.day, hour=h, minute=m, timezone=_UTC_ZI)
-            schedule_info = f"yearly on {local_dt.month}/{local_dt.day} at {local_h:02d}:{local_m:02d} {tz}"
-            trigger_data = {"type": "cron", "month": utc_dt.month, "day": utc_dt.day, "hour": h, "minute": m}
+            expr = f"{m} {h} {local_dt.day} {local_dt.month} *"
+            schedule_info = f"yearly on {local_dt.month}/{local_dt.day} at {h:02d}:{m:02d} {tz}"
+
+        expr = _normalize_cron_expr(expr)
+        trigger = CronTrigger.from_crontab(expr, timezone=ZoneInfo(tz))
+        trigger_data = {"type": "cron", "expr": expr, "tz": tz}
         next_run = trigger.get_next_fire_time(None, _now_utc())
     elif scheduled_datetime:
         if not tz:

--- a/agent/skills/tasks/cli/src/tasks_cli/db.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/db.py
@@ -159,6 +159,33 @@ def _migrate_v1_to_v2(data_dir: Path, conn: sqlite3.Connection):
     logger.info("Migrated schema v1 -> v2")
 
 
+def _migrate_v2_to_v3(conn: sqlite3.Connection):
+    """v2 -> v3: rewrite legacy cron reminders from UTC-baked fields to the {expr, tz} form.
+
+    Old recurring reminders stored a fixed UTC hour/minute (plus optional day/month/day_of_week)
+    with no timezone, so they silently drifted by an hour across every DST transition. Rewrite each
+    to an equivalent cron expression tagged tz='UTC', which preserves their exact current firing
+    instants; reminders created after this upgrade carry the user's real IANA timezone and stay put
+    across DST. Idempotent: rows already in {expr, tz} form are skipped."""
+    rows = conn.execute("SELECT id, trigger_data FROM reminders WHERE trigger_data IS NOT NULL").fetchall()
+    migrated = 0
+    for row in rows:
+        data = json.loads(row["trigger_data"])
+        if "type" not in data or data["type"] != "cron" or "expr" in data:
+            continue
+        minute = data["minute"] if "minute" in data else "*"
+        hour = data["hour"] if "hour" in data else "*"
+        day = data["day"] if "day" in data else "*"
+        month = data["month"] if "month" in data else "*"
+        dow = data["day_of_week"] if "day_of_week" in data else "*"
+        new_data = {"type": "cron", "expr": f"{minute} {hour} {day} {month} {dow}", "tz": "UTC"}
+        conn.execute("UPDATE reminders SET trigger_data = ? WHERE id = ?", (json.dumps(new_data), row["id"]))
+        migrated += 1
+    if migrated:
+        logger.info(f"Migrated {migrated} legacy cron reminders to tz-aware form")
+    logger.info("Migrated schema v2 -> v3")
+
+
 AUTO_REMINDER_WINDOWS = [
     ("1 week", timedelta(weeks=1)),
     ("1 day", timedelta(days=1)),
@@ -242,6 +269,11 @@ def init_db(data_dir: Path):
         if version < 2:
             _migrate_v1_to_v2(data_dir, conn)
             conn.execute("UPDATE schema_version SET version = 2")
+            version = 2
+
+        if version < 3:
+            _migrate_v2_to_v3(conn)
+            conn.execute("UPDATE schema_version SET version = 3")
 
         conn.commit()
 

--- a/agent/skills/tasks/cli/tests/test_e2e.py
+++ b/agent/skills/tasks/cli/tests/test_e2e.py
@@ -176,18 +176,18 @@ class TestAddTask:
 class TestListTasks:
     def test_list_returns_tasks(self, shared_env):
         home, _, _ = shared_env
-        items = parse(tasks_cli(home, "list"))
+        items = parse(tasks_cli(home, "list", "--json"))
         assert isinstance(items, list)
         assert len(items) >= 1
 
     def test_list_has_metadata_path(self, shared_env):
         home, _, _ = shared_env
-        items = parse(tasks_cli(home, "list"))
+        items = parse(tasks_cli(home, "list", "--json"))
         assert all("metadata_path" in i for i in items)
 
     def test_list_sorted_by_priority(self, shared_env):
         home, _, _ = shared_env
-        items = parse(tasks_cli(home, "list"))
+        items = parse(tasks_cli(home, "list", "--json"))
         priorities = [i["priority"] for i in items]
         assert priorities == sorted(priorities, reverse=True)
 
@@ -305,7 +305,7 @@ class TestDeleteTask:
         home, _, _ = shared_env
         added = parse(tasks_cli(home, "add", "delete me 2"))
         tasks_cli(home, "delete", added["id"])
-        items = parse(tasks_cli(home, "list"))
+        items = parse(tasks_cli(home, "list", "--json"))
         assert not any(i["id"] == added["id"] for i in items)
 
     def test_delete_removes_metadata_file(self, shared_env):
@@ -337,18 +337,18 @@ class TestSearchTasks:
     def test_search_finds_match(self, shared_env):
         home, _, _ = shared_env
         parse(tasks_cli(home, "add", "unique_searchterm_xyz"))
-        items = parse(tasks_cli(home, "search", "unique_searchterm_xyz"))
+        items = parse(tasks_cli(home, "search", "unique_searchterm_xyz", "--json"))
         assert len(items) >= 1
         assert any("unique_searchterm_xyz" in i["title"] for i in items)
 
     def test_search_no_match(self, shared_env):
         home, _, _ = shared_env
-        items = parse(tasks_cli(home, "search", "zzznonexistent999"))
+        items = parse(tasks_cli(home, "search", "zzznonexistent999", "--json"))
         assert items == []
 
     def test_search_via_flag(self, shared_env):
         home, _, _ = shared_env
-        items = parse(tasks_cli(home, "search", "--query", "unique_searchterm_xyz"))
+        items = parse(tasks_cli(home, "search", "--query", "unique_searchterm_xyz", "--json"))
         assert len(items) >= 1
 
     def test_search_requires_query(self, shared_env):
@@ -360,12 +360,12 @@ class TestSearchTasks:
         home, _, _ = shared_env
         added = parse(tasks_cli(home, "add", "searchdone_abc"))
         tasks_cli(home, "update", added["id"], "--status", "done")
-        items = parse(tasks_cli(home, "search", "searchdone_abc"))
+        items = parse(tasks_cli(home, "search", "searchdone_abc", "--json"))
         assert not any(i["id"] == added["id"] for i in items)
 
     def test_search_show_completed(self, shared_env):
         home, _, _ = shared_env
-        items = parse(tasks_cli(home, "search", "searchdone_abc", "--show-completed"))
+        items = parse(tasks_cli(home, "search", "searchdone_abc", "--show-completed", "--json"))
         assert any("searchdone_abc" in i["title"] for i in items)
 
 
@@ -374,12 +374,12 @@ class TestCompletedFiltering:
         home, _, _ = shared_env
         added = parse(tasks_cli(home, "add", "will complete"))
         tasks_cli(home, "update", added["id"], "--status", "done")
-        items = parse(tasks_cli(home, "list"))
+        items = parse(tasks_cli(home, "list", "--json"))
         assert not any(i["id"] == added["id"] for i in items)
 
     def test_list_show_completed(self, shared_env):
         home, _, _ = shared_env
-        items = parse(tasks_cli(home, "list", "--show-completed"))
+        items = parse(tasks_cli(home, "list", "--show-completed", "--json"))
         assert any(i["status"] == "done" for i in items)
 
 
@@ -477,7 +477,7 @@ class TestRemindSetRecurring:
 class TestRemindList:
     def test_list_returns_items(self, shared_env):
         home, _, _ = shared_env
-        items = parse(tasks_cli(home, "remind", "list"))
+        items = parse(tasks_cli(home, "remind", "list", "--json"))
         assert isinstance(items, list)
         assert len(items) >= 1
 
@@ -486,12 +486,12 @@ class TestRemindList:
         task = parse(tasks_cli(home, "add", "filter task"))
         parse(tasks_cli(home, "remind", "linked reminder", "--task", task["id"], "--in-hours", "2"))
         parse(tasks_cli(home, "remind", "unlinked reminder", "--in-hours", "2"))
-        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"]))
+        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         assert all(i["task_id"] == task["id"] for i in items)
 
     def test_list_has_auto_generated_field(self, shared_env):
         home, _, _ = shared_env
-        items = parse(tasks_cli(home, "remind", "list"))
+        items = parse(tasks_cli(home, "remind", "list", "--json"))
         assert all("auto_generated" in i for i in items)
 
 
@@ -506,7 +506,7 @@ class TestRemindDelete:
         home, _, _ = shared_env
         s = parse(tasks_cli(home, "remind", "bye2", "--in-minutes", "60"))
         tasks_cli(home, "remind", "delete", s["id"])
-        items = parse(tasks_cli(home, "remind", "list"))
+        items = parse(tasks_cli(home, "remind", "list", "--json"))
         assert not any(i["id"] == s["id"] for i in items)
 
     def test_delete_nonexistent(self, shared_env):
@@ -550,7 +550,7 @@ class TestCascadeDeletion:
 
         tasks_cli(home, "delete", task["id"])
 
-        items = parse(tasks_cli(home, "remind", "list"))
+        items = parse(tasks_cli(home, "remind", "list", "--json"))
         ids = [i["id"] for i in items]
         assert r1["id"] not in ids
         assert r2["id"] not in ids
@@ -564,7 +564,7 @@ class TestAutoReminders:
         home, _, _ = shared_env
         future = (datetime.now(UTC) + timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%S")
         task = parse(tasks_cli(home, "add", "auto reminder task", "--due-datetime", future, "--timezone", "UTC"))
-        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"]))
+        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         auto = [i for i in items if i["auto_generated"]]
         # Should have reminders for 1 week, 1 day, 1 hour, 15 min before
         assert len(auto) >= 3  # at least 1 week, 1 day, 1 hour (15 min depends on timing)
@@ -574,7 +574,7 @@ class TestAutoReminders:
         # Due in 30 minutes: only 15-min auto-reminder should be created (others are in the past)
         future = (datetime.now(UTC) + timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%S")
         task = parse(tasks_cli(home, "add", "soon task", "--due-datetime", future, "--timezone", "UTC"))
-        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"]))
+        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         auto = [i for i in items if i["auto_generated"]]
         assert len(auto) == 1
         assert "15 minutes" in auto[0]["message"]
@@ -584,12 +584,12 @@ class TestAutoReminders:
         future = (datetime.now(UTC) + timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%S")
         task = parse(tasks_cli(home, "add", "done cleanup", "--due-datetime", future, "--timezone", "UTC"))
         # Verify auto reminders exist
-        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"]))
+        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         assert any(i["auto_generated"] for i in items)
         # Mark done
         tasks_cli(home, "update", task["id"], "--status", "done")
         # Auto reminders should be gone
-        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"]))
+        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         auto = [i for i in items if i["auto_generated"]]
         assert len(auto) == 0
 
@@ -597,11 +597,11 @@ class TestAutoReminders:
         home, _, _ = shared_env
         future = (datetime.now(UTC) + timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%S")
         task = parse(tasks_cli(home, "add", "cascade auto", "--due-datetime", future, "--timezone", "UTC"))
-        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"]))
+        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         assert len(items) >= 1
         tasks_cli(home, "delete", task["id"])
         # All reminders for this task should be gone
-        all_items = parse(tasks_cli(home, "remind", "list"))
+        all_items = parse(tasks_cli(home, "remind", "list", "--json"))
         assert not any(i["task_id"] == task["id"] for i in all_items)
 
 
@@ -641,7 +641,7 @@ class TestDaemonNotifications:
             s = parse(tasks_cli(home, "remind", "hourly check", "--recurring", "hourly"))
             rid = s["id"]
             time.sleep(2)
-            items = parse(tasks_cli(home, "remind", "list"))
+            items = parse(tasks_cli(home, "remind", "list", "--json"))
             assert any(i["id"] == rid for i in items)
         finally:
             stop_daemon(proc)
@@ -693,10 +693,10 @@ class TestMissedReminders:
             notif_files = list(notif_dir.glob("*-tasks-reminder.json"))
             assert len(notif_files) >= 1
             data = json.loads(notif_files[0].read_text())
-            assert data["message"] == "you missed this"
+            assert data["message"].splitlines()[0] == "you missed this"
             assert data["missed"] is True
 
-            items = parse(tasks_cli(home, "remind", "list"))
+            items = parse(tasks_cli(home, "remind", "list", "--json"))
             assert not any(i["id"] == "pastdue01" for i in items)
         finally:
             stop_daemon(proc)
@@ -716,7 +716,7 @@ class TestMissedReminders:
         try:
             time.sleep(3)
             # Recurring reminder should be active, not marked completed or missed
-            items = parse(tasks_cli(home, "remind", "list"))
+            items = parse(tasks_cli(home, "remind", "list", "--json"))
             assert any(i["id"] == "recur01" for i in items)
             # No missed notification should be written for recurring reminders
             notif_files = list(notif_dir.glob("*-tasks-reminder.json"))
@@ -795,7 +795,7 @@ class TestRecurringNextRun:
         original_time = (datetime.now(UTC) - timedelta(days=1)).isoformat()
         conn.execute(
             "INSERT INTO reminders (id, message, schedule_type, scheduled_time, completed, trigger_data) VALUES (?, ?, ?, ?, 0, ?)",
-            ("cron01", "daily standup", "daily at 10:30 UTC", original_time, json.dumps({"type": "cron", "hour": 10, "minute": 30})),
+            ("cron01", "daily standup", "daily at 10:30 UTC", original_time, json.dumps({"type": "cron", "expr": "30 10 * * *", "tz": "UTC"})),
         )
         conn.commit()
         conn.close()
@@ -987,7 +987,7 @@ class TestRecurringNextRun:
                 "friday review",
                 "weekly on fri at 17:00 UTC",
                 original_time,
-                json.dumps({"type": "cron", "day_of_week": "fri", "hour": 17, "minute": 0}),
+                json.dumps({"type": "cron", "expr": "0 17 * * fri", "tz": "UTC"}),
             ),
         )
         conn.commit()
@@ -1020,7 +1020,7 @@ class TestRecurringNextRun:
                 "pay bills",
                 "monthly on day 15 at 09:00 UTC",
                 original_time,
-                json.dumps({"type": "cron", "day": 15, "hour": 9, "minute": 0}),
+                json.dumps({"type": "cron", "expr": "0 9 15 * *", "tz": "UTC"}),
             ),
         )
         conn.commit()
@@ -1089,7 +1089,7 @@ class TestRecurringNextRun:
 
         notif_files = list(notif_dir.glob("*-tasks-reminder.json"))
         data = next(json.loads(f.read_text()) for f in notif_files if json.loads(f.read_text())["reminder_id"] == "msg01")
-        assert data["message"] == "db message"
+        assert data["message"].splitlines()[0] == "db message"
 
     def test_empty_db_message_falls_back_to_kwarg(self, test_home):
         """If DB message is empty string, the kwarg message should be used."""
@@ -1108,7 +1108,7 @@ class TestRecurringNextRun:
 
         notif_files = list(notif_dir.glob("*-tasks-reminder.json"))
         data = next(json.loads(f.read_text()) for f in notif_files if json.loads(f.read_text())["reminder_id"] == "msg02")
-        assert data["message"] == "fallback msg"
+        assert data["message"].splitlines()[0] == "fallback msg"
 
 
 # === Daemon lifecycle ===

--- a/agent/skills/tasks/cli/tests/test_remind_schedule.py
+++ b/agent/skills/tasks/cli/tests/test_remind_schedule.py
@@ -1,12 +1,14 @@
-"""Unit tests for remind_set schedule label rendering across timezones."""
+"""Unit tests for recurring reminder scheduling: preset + cron triggers, DST safety, and migration."""
 
 import json
+import sqlite3
 from contextlib import closing
-from datetime import datetime, UTC
+from datetime import datetime, timedelta, UTC
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
+from apscheduler.triggers.cron import CronTrigger
 
 from tasks_cli import commands, db
 from tasks_cli.config import Config
@@ -26,104 +28,271 @@ def _trigger_data(config: Config, reminder_id: str) -> dict:
     return json.loads(row["trigger_data"])
 
 
-def _expected_utc(local_iso: str, tz_name: str) -> datetime:
-    return datetime.fromisoformat(local_iso).replace(tzinfo=ZoneInfo(tz_name)).astimezone(UTC)
+def _fire_days(expr: str, tz: str, start: str, count: int) -> list[str]:
+    """Weekday abbreviations of the next `count` fire times of a cron expression."""
+    trigger = CronTrigger.from_crontab(expr, timezone=ZoneInfo(tz))
+    base = datetime.fromisoformat(start).replace(tzinfo=ZoneInfo(tz))
+    out = []
+    for _ in range(count):
+        nxt = trigger.get_next_fire_time(None, base)
+        out.append(nxt.strftime("%a").lower())
+        base = nxt + timedelta(seconds=1)
+    return out
 
 
-def test_daily_label_uses_local_tz(tmp_config: Config):
-    result = commands.remind_set(
-        tmp_config,
-        message="standup",
-        scheduled_datetime="2026-04-26T10:30:00",
-        tz="Europe/London",
-        recurring="daily",
-    )
+# ---------------------------------------------------------------------------
+# Preset recurring reminders: local wall-clock semantics + {expr, tz} storage
+# ---------------------------------------------------------------------------
+
+
+def test_daily_stores_local_cron_expr_and_tz(tmp_config: Config):
+    result = commands.remind_set(tmp_config, message="standup", scheduled_datetime="2026-04-26T10:30:00", tz="Europe/London", recurring="daily")
     assert result["schedule"] == "daily at 10:30 Europe/London"
-    expected_utc = _expected_utc("2026-04-26T10:30:00", "Europe/London")
-    data = _trigger_data(tmp_config, result["id"])
-    assert (data["hour"], data["minute"]) == (expected_utc.hour, expected_utc.minute)
+    assert _trigger_data(tmp_config, result["id"]) == {"type": "cron", "expr": "30 10 * * *", "tz": "Europe/London"}
 
 
-def test_weekly_label_uses_local_tz_and_day(tmp_config: Config):
+def test_weekly_uses_local_day_of_week(tmp_config: Config):
+    # 2026-04-26 23:30 New York is a Sunday locally (03:30 UTC Monday), so the weekly reminder must fire Sunday.
     result = commands.remind_set(
-        tmp_config,
-        message="review",
-        scheduled_datetime="2026-04-26T23:30:00",
-        tz="America/New_York",
-        recurring="weekly",
+        tmp_config, message="review", scheduled_datetime="2026-04-26T23:30:00", tz="America/New_York", recurring="weekly"
     )
     assert result["schedule"] == "weekly on sun at 23:30 America/New_York"
-    expected_utc = _expected_utc("2026-04-26T23:30:00", "America/New_York")
-    data = _trigger_data(tmp_config, result["id"])
-    assert (data["hour"], data["minute"]) == (expected_utc.hour, expected_utc.minute)
-    assert data["day_of_week"] == expected_utc.strftime("%a").lower()
+    assert _trigger_data(tmp_config, result["id"]) == {"type": "cron", "expr": "30 23 * * sun", "tz": "America/New_York"}
 
 
-def test_monthly_label_uses_local_tz(tmp_config: Config):
+def test_monthly_uses_local_day(tmp_config: Config):
     result = commands.remind_set(
-        tmp_config,
-        message="bills",
-        scheduled_datetime="2026-04-15T23:30:00",
-        tz="America/New_York",
-        recurring="monthly",
+        tmp_config, message="bills", scheduled_datetime="2026-04-15T23:30:00", tz="America/New_York", recurring="monthly"
     )
     assert result["schedule"] == "monthly on day 15 at 23:30 America/New_York"
-    expected_utc = _expected_utc("2026-04-15T23:30:00", "America/New_York")
-    data = _trigger_data(tmp_config, result["id"])
-    assert (data["day"], data["hour"], data["minute"]) == (
-        expected_utc.day,
-        expected_utc.hour,
-        expected_utc.minute,
-    )
+    assert _trigger_data(tmp_config, result["id"]) == {"type": "cron", "expr": "30 23 15 * *", "tz": "America/New_York"}
 
 
-def test_yearly_label_uses_local_tz(tmp_config: Config):
+def test_yearly_uses_local_month_and_day(tmp_config: Config):
     result = commands.remind_set(
-        tmp_config,
-        message="birthday",
-        scheduled_datetime="2026-12-31T23:30:00",
-        tz="America/New_York",
-        recurring="yearly",
+        tmp_config, message="birthday", scheduled_datetime="2026-12-31T23:30:00", tz="America/New_York", recurring="yearly"
     )
     assert result["schedule"] == "yearly on 12/31 at 23:30 America/New_York"
-    expected_utc = _expected_utc("2026-12-31T23:30:00", "America/New_York")
+    assert _trigger_data(tmp_config, result["id"]) == {"type": "cron", "expr": "30 23 31 12 *", "tz": "America/New_York"}
+
+
+def test_hourly_stays_interval(tmp_config: Config):
+    result = commands.remind_set(tmp_config, message="ping", recurring="hourly")
+    assert result["schedule"] == "hourly"
+    assert _trigger_data(tmp_config, result["id"]) == {"type": "interval", "hours": 1}
+
+
+# ---------------------------------------------------------------------------
+# DST safety: the whole point of storing {expr, tz} instead of a frozen UTC hour
+# ---------------------------------------------------------------------------
+
+
+def test_daily_preset_holds_wall_clock_across_dst(tmp_config: Config):
+    """A 09:00 Europe/London daily reminder must fire at 09:00 local in both winter (UTC+0)
+    and summer (UTC+1) — i.e. it must NOT drift by the DST offset."""
+    result = commands.remind_set(tmp_config, message="standup", scheduled_datetime="2026-06-15T09:00:00", tz="Europe/London", recurring="daily")
     data = _trigger_data(tmp_config, result["id"])
-    assert (data["month"], data["day"], data["hour"], data["minute"]) == (
-        expected_utc.month,
-        expected_utc.day,
-        expected_utc.hour,
-        expected_utc.minute,
-    )
+    trigger = CronTrigger.from_crontab(data["expr"], timezone=ZoneInfo(data["tz"]))
+    london = ZoneInfo("Europe/London")
+
+    winter = trigger.get_next_fire_time(None, datetime(2026, 1, 10, tzinfo=london))
+    summer = trigger.get_next_fire_time(None, datetime(2026, 7, 10, tzinfo=london))
+
+    # Local wall-clock is 09:00 on both sides of the DST boundary.
+    assert winter.astimezone(london).hour == 9
+    assert summer.astimezone(london).hour == 9
+    # And the underlying UTC instant shifts with the offset (09:00 UTC winter, 08:00 UTC summer).
+    assert winter.astimezone(UTC).hour == 9
+    assert summer.astimezone(UTC).hour == 8
 
 
-def test_daily_label_utc_tz_unchanged(tmp_config: Config):
-    result = commands.remind_set(
-        tmp_config,
-        message="standup",
-        scheduled_datetime="2026-04-26T10:30:00",
-        tz="UTC",
-        recurring="daily",
-    )
-    assert result["schedule"] == "daily at 10:30 UTC"
+# ---------------------------------------------------------------------------
+# Day-of-week normalization: standard cron numbering (0/7=Sun) not APScheduler's (0=Mon)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field,expected",
+    [
+        ("*", "*"),
+        ("?", "*"),
+        ("0", "sun"),
+        ("7", "sun"),
+        ("1", "mon"),
+        ("6", "sat"),
+        ("1-5", "mon,tue,wed,thu,fri"),
+        ("0,6", "sat,sun"),
+        ("mon-fri", "mon,tue,wed,thu,fri"),
+        ("fri-mon", "mon,fri,sat,sun"),
+        ("*/2", "tue,thu,sat,sun"),
+        ("sun", "sun"),
+        ("MON", "mon"),
+    ],
+)
+def test_normalize_dow(field: str, expected: str):
+    assert commands._normalize_dow(field) == expected
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        ("0 9 * * 1-5", "0 9 * * mon,tue,wed,thu,fri"),
+        ("*/15 9-17 * * *", "*/15 9-17 * * *"),
+        ("0 8 1 * *", "0 8 1 * *"),
+        ("0 9 * * 0", "0 9 * * sun"),
+    ],
+)
+def test_normalize_cron_expr(expr: str, expected: str):
+    assert commands._normalize_cron_expr(expr) == expected
+
+
+@pytest.mark.parametrize("expr", ["0 9 * *", "0 9 * * * *", "", "0 9 * * 9", "0 9 * * abc"])
+def test_normalize_cron_expr_rejects_bad(expr: str):
+    with pytest.raises(ValueError):
+        commands._normalize_cron_expr(expr)
+
+
+# ---------------------------------------------------------------------------
+# Raw --cron reminders
+# ---------------------------------------------------------------------------
+
+
+def test_cron_weekdays_use_standard_numbering(tmp_config: Config):
+    """`1-5` must mean Mon-Fri (standard cron), not Tue-Sat (raw APScheduler numbering)."""
+    result = commands.remind_set(tmp_config, message="weekday standup", cron="0 9 * * 1-5", tz="America/New_York")
     data = _trigger_data(tmp_config, result["id"])
-    assert (data["hour"], data["minute"]) == (10, 30)
+    assert data == {"type": "cron", "expr": "0 9 * * mon,tue,wed,thu,fri", "tz": "America/New_York"}
+    assert result["schedule"] == "cron: 0 9 * * 1-5 (America/New_York)"
+    assert result["next_run"] is not None
+
+    days = set(_fire_days(data["expr"], data["tz"], "2026-06-01T00:00:00", 10))
+    assert days == {"mon", "tue", "wed", "thu", "fri"}
 
 
-def test_daily_next_run_is_at_expected_utc_moment(tmp_config: Config):
-    """Regression: remind_set computes next_run from the same CronTrigger the daemon will
-    fire from. trigger_data stores UTC hour/minute, so the trigger must be interpreted in
-    UTC regardless of the daemon's local timezone. Without an explicit timezone=UTC on the
-    CronTrigger, APScheduler falls back to tzlocal() and next_run drifts by the local-UTC
-    offset, so the reminder fires at the wrong moment."""
-    from datetime import datetime, UTC
+def test_cron_step_expression(tmp_config: Config):
+    result = commands.remind_set(tmp_config, message="quarter-hourly", cron="*/15 9-17 * * *", tz="UTC")
+    data = _trigger_data(tmp_config, result["id"])
+    assert data == {"type": "cron", "expr": "*/15 9-17 * * *", "tz": "UTC"}
+    trigger = CronTrigger.from_crontab(data["expr"], timezone=ZoneInfo("UTC"))
+    first = trigger.get_next_fire_time(None, datetime(2026, 6, 1, 8, 50, tzinfo=UTC))
+    assert (first.hour, first.minute) == (9, 0)
 
-    # 08:00 Europe/London on a BST date (UTC+1) -> 07:00 UTC expected.
-    result = commands.remind_set(
-        tmp_config,
-        message="standup",
-        scheduled_datetime="2026-06-15T08:00:00",
-        tz="Europe/London",
-        recurring="daily",
+
+def test_cron_requires_tz(tmp_config: Config):
+    with pytest.raises(ValueError, match="tz is required"):
+        commands.remind_set(tmp_config, message="x", cron="0 9 * * *")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"recurring": "daily", "scheduled_datetime": "2026-01-01T09:00:00"},
+        {"scheduled_datetime": "2026-01-01T09:00:00"},
+        {"in_minutes": 30},
+    ],
+)
+def test_cron_conflicts_with_other_modes(tmp_config: Config, kwargs: dict):
+    with pytest.raises(ValueError, match="cannot be combined"):
+        commands.remind_set(tmp_config, message="x", cron="0 9 * * *", tz="UTC", **kwargs)
+
+
+def test_cron_invalid_expression_rejected(tmp_config: Config):
+    with pytest.raises(ValueError):
+        commands.remind_set(tmp_config, message="x", cron="99 9 * * *", tz="UTC")
+
+
+def test_cron_reminder_restores_into_scheduler(tmp_config: Config):
+    from tasks_cli.scheduler import create_scheduler
+
+    result = commands.remind_set(tmp_config, message="weekday standup", cron="0 9 * * 1-5", tz="America/New_York")
+    scheduler = create_scheduler()
+    commands.restore_all_jobs(tmp_config, scheduler, notif_dir=None)
+    assert {job.id for job in scheduler.get_jobs()} == {result["id"]}
+
+
+# ---------------------------------------------------------------------------
+# Migration v2 -> v3: legacy UTC-baked cron rows become {expr, tz:"UTC"}
+# ---------------------------------------------------------------------------
+
+
+def _make_v2_db(data_dir: Path) -> sqlite3.Connection:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(data_dir / "tasks.db")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+    conn.execute("INSERT INTO schema_version (version) VALUES (2)")
+    conn.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT NOT NULL, status TEXT, priority INTEGER, "
+        "due_date TEXT, created_at TEXT, completed_at TEXT)"
     )
-    next_run = datetime.fromisoformat(result["next_run"]).astimezone(UTC)
-    assert (next_run.hour, next_run.minute) == (7, 0), f"expected next_run at 07:00 UTC (08:00 BST), got {next_run.isoformat()}"
+    conn.execute(
+        "CREATE TABLE reminders (id TEXT PRIMARY KEY, task_id TEXT, message TEXT NOT NULL, schedule_type TEXT, "
+        "scheduled_time TEXT, completed INTEGER DEFAULT 0, created_at TEXT DEFAULT CURRENT_TIMESTAMP, "
+        "trigger_data TEXT, auto_generated INTEGER DEFAULT 0)"
+    )
+    return conn
+
+
+def _read_trigger(data_dir: Path, rid: str) -> dict:
+    with closing(db.get_db(data_dir)) as conn:
+        return json.loads(conn.execute("SELECT trigger_data FROM reminders WHERE id = ?", (rid,)).fetchone()["trigger_data"])
+
+
+def test_migration_v2_to_v3_rewrites_legacy_cron(tmp_path: Path):
+    data_dir = tmp_path / "tasks"
+    conn = _make_v2_db(data_dir)
+    legacy = [
+        ("daily1", {"type": "cron", "hour": 9, "minute": 0}),
+        ("weekly1", {"type": "cron", "day_of_week": "fri", "hour": 17, "minute": 0}),
+        ("monthly1", {"type": "cron", "day": 15, "hour": 9, "minute": 0}),
+        ("interval1", {"type": "interval", "hours": 1}),
+        ("date1", {"type": "date", "run_date": "2026-01-01T00:00:00+00:00"}),
+    ]
+    for rid, data in legacy:
+        conn.execute("INSERT INTO reminders (id, message, trigger_data) VALUES (?, ?, ?)", (rid, rid, json.dumps(data)))
+    conn.commit()
+    conn.close()
+
+    db.init_db(data_dir)
+
+    assert _read_trigger(data_dir, "daily1") == {"type": "cron", "expr": "0 9 * * *", "tz": "UTC"}
+    assert _read_trigger(data_dir, "weekly1") == {"type": "cron", "expr": "0 17 * * fri", "tz": "UTC"}
+    assert _read_trigger(data_dir, "monthly1") == {"type": "cron", "expr": "0 9 15 * *", "tz": "UTC"}
+    assert _read_trigger(data_dir, "interval1") == {"type": "interval", "hours": 1}  # non-cron untouched
+    assert _read_trigger(data_dir, "date1") == {"type": "date", "run_date": "2026-01-01T00:00:00+00:00"}
+    with closing(db.get_db(data_dir)) as conn:
+        assert conn.execute("SELECT version FROM schema_version").fetchone()["version"] == 3
+
+
+def test_migration_preserves_firing_instant(tmp_path: Path):
+    """A migrated legacy cron reminder must fire at the exact same UTC instant it did before."""
+    data_dir = tmp_path / "tasks"
+    conn = _make_v2_db(data_dir)
+    conn.execute(
+        "INSERT INTO reminders (id, message, trigger_data) VALUES (?, ?, ?)",
+        ("daily1", "standup", json.dumps({"type": "cron", "hour": 9, "minute": 30})),
+    )
+    conn.commit()
+    conn.close()
+
+    db.init_db(data_dir)
+    data = _read_trigger(data_dir, "daily1")
+    trigger = CronTrigger.from_crontab(data["expr"], timezone=ZoneInfo(data["tz"]))
+    nxt = trigger.get_next_fire_time(None, datetime(2026, 6, 1, 0, 0, tzinfo=UTC)).astimezone(UTC)
+    assert (nxt.hour, nxt.minute) == (9, 30)
+
+
+def test_migration_is_idempotent(tmp_path: Path):
+    data_dir = tmp_path / "tasks"
+    conn = _make_v2_db(data_dir)
+    conn.execute(
+        "INSERT INTO reminders (id, message, trigger_data) VALUES (?, ?, ?)",
+        ("daily1", "standup", json.dumps({"type": "cron", "hour": 9, "minute": 0})),
+    )
+    conn.commit()
+    conn.close()
+
+    db.init_db(data_dir)
+    first = _read_trigger(data_dir, "daily1")
+    db.init_db(data_dir)  # second run must not touch already-migrated rows
+    assert _read_trigger(data_dir, "daily1") == first == {"type": "cron", "expr": "0 9 * * *", "tz": "UTC"}


### PR DESCRIPTION
## What

Adds a `--cron` interface to `tasks remind` and fixes a DST-drift bug in the existing recurring reminders.

```bash
tasks remind "Weekdays 9am"      --cron "0 9 * * 1-5"    --tz "America/New_York"
tasks remind "Every 15 min, 9-5" --cron "*/15 9-17 * * *" --tz "America/New_York"
```

## The DST bug (fixed)

Recurring reminders (`--recurring daily|weekly|monthly|yearly`) converted the user's wall-clock time to a **fixed UTC hour/minute at creation time** and stored only that. After a DST transition the frozen UTC value no longer maps to the same wall clock, so a "9am London" reminder silently starts firing at 8am (or 10am) for half the year.

The fix stores the cron expression **plus the IANA timezone** (`{expr, tz}`) and reconstructs the trigger with `CronTrigger.from_crontab(expr, timezone=ZoneInfo(tz))`, so APScheduler recomputes the correct UTC instant on every fire. The wall-clock time now holds across DST for both `--cron` and the presets (which are now thin sugar over the same model). This also deletes the old local→UTC conversion dance.

## Day-of-week correctness

APScheduler's `from_crontab` uses `0=Mon..6=Sun` and rejects `7` — so `0 9 * * 1-5` would silently fire **Tue–Sat**. Everyone (and every LLM) means standard cron (`0/7=Sun, 1=Mon`). The day-of-week field is normalized to an unambiguous APScheduler weekday-name list (handling `*`, ranges incl. wrap-around, lists, steps, and names) before it's handed over.

## Migration

A `v2 → v3` db migration rewrites existing UTC-baked cron reminders to `{expr, tz:"UTC"}`, preserving their **exact current firing instants** (they were UTC-baked, so tagging them UTC is behavior-preserving). New reminders carry the real timezone and are DST-correct. Idempotent.

## Tests

`skills/tasks/cli/tests/` — 141 pass. New coverage: DST regression (winter vs summer fire), day-of-week normalization table, `--cron` parsing/validation/conflicts, scheduler restore, and migration fidelity + idempotency.

**Note:** while adding these I found the tasks skill test suite is **not run by `check.sh`** (it only runs `agent/tests/`, not `skills/*/cli/tests/`), so it had rotted — `list`/`search` switched to a table default and a rearm hint was added without the tests being updated (25 pre-existing failures on master). This PR also repairs that rot (tests request `--json`; message asserts compare the first line). Wiring the skill suites into CI is worth a follow-up but is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)