### PR TITLE
refactor(stripe-pay): trim SKILL.md, no functionality change

### DIFF
--- a/agent/skills/stripe-pay/SKILL.md
+++ b/agent/skills/stripe-pay/SKILL.md
@@ -7,24 +7,11 @@ description: Use when the user wants the agent to make a payment on their behalf
 
 Lets the agent spend on the user's behalf through Stripe's "Link Wallet for Agents" + "Issuing for Agents" APIs (April 2026 release).
 
-Two commands. No history viewer, no spend-cap config (caps live in Stripe Link), no auto-approve.
+Two commands: `stripe-pay authorize` (one-time OAuth setup) and `stripe-pay charge` (see below). No history viewer, no spend-cap config (caps live in Stripe Link), no auto-approve.
 
-```bash
-stripe-pay authorize                                          # one-time OAuth setup
-stripe-pay charge --amount 12.50 --currency USD \
-                  --merchant "Some Shop" --reason "domain renewal"
-```
+## Trigger / Skip
 
-## Trigger
-
-Invoke this skill when:
-- The user asks the agent to buy something for them ("order me X", "pay this invoice", "renew my domain")
-- The user explicitly mentions Stripe / Link wallet / agent wallet
-- A workflow needs to spend money on the user's behalf at a merchant that takes cards
-
-## Skip
-
-Not for sending money to people (merchants only, not P2P) or read-only expense logging (use the `enable-banking` skill). If `stripe-pay authorize` has not run, `charge` errors clearly and you tell the user to set up first.
+Use when the user asks the agent to buy something ("order me X", "pay this invoice", "renew my domain"), mentions Stripe / Link wallet, or a workflow needs to spend at a card-taking merchant. Not for P2P sends (merchants only) or read-only expense logging (use the `enable-banking` skill). If `stripe-pay authorize` has not run, `charge` errors clearly and you tell the user to set up first.
 
 ## Setup
 
@@ -50,17 +37,10 @@ stripe-pay charge \
 ```
 
 Flow:
-1. The CLI sends an approval prompt to the user via their **primary channel**
-   (auto-detected from `MEMORY.md` Primary Channel default; falls back to WhatsApp).
-   The prompt includes amount, currency, merchant, reason, and a 5-minute deadline.
-2. The CLI blocks waiting for the user's reply. Approval keywords: `yes`, `y`,
-   `go`, `confirm`, `ok`, or a thumbs-up / check-mark emoji. Rejection keywords:
-   `no`, `n`, `stop`, `cancel`.
-3. On approval the CLI calls Stripe Issuing-for-Agents to mint a single-use
-   virtual card scoped to that amount + merchant, and prints the card details
-   to stdout as JSON. It also logs the transaction to `~/.stripe-pay/history.jsonl`.
-4. On rejection / timeout the CLI exits non-zero, logs the abort, and the agent
-   tells the user.
+1. The CLI sends an approval prompt to the user via their **primary channel** (auto-detected from `MEMORY.md` Primary Channel default; falls back to WhatsApp). The prompt includes amount, currency, merchant, reason, and a 5-minute deadline.
+2. The CLI blocks waiting for the user's reply. Approval keywords: `yes`, `y`, `go`, `confirm`, `ok`, or a thumbs-up / check-mark emoji. Rejection keywords: `no`, `n`, `stop`, `cancel`.
+3. On approval the CLI calls Stripe Issuing-for-Agents to mint a single-use virtual card scoped to that amount + merchant, and prints the card details to stdout as JSON. It also logs the transaction to `~/.stripe-pay/history.jsonl`.
+4. On rejection / timeout the CLI exits non-zero, logs the abort, and the agent tells the user.
 
 ### Output (success)
 
@@ -80,31 +60,20 @@ Flow:
 }
 ```
 
-The agent can hand this card detail to a browser/checkout flow, or use Stripe's
-Buy-with-Link merchant integration if the merchant supports it.
+The agent can hand this card detail to a browser/checkout flow, or use Stripe's Buy-with-Link merchant integration if the merchant supports it.
 
 ### Output (rejected / timed out)
 
-```json
-{ "status": "rejected", "reason": "user_declined" }
-{ "status": "timeout",  "reason": "no_reply_in_5_minutes" }
-```
+Rejected: `{ "status": "rejected", "reason": "user_declined" }`. Timeout: `{ "status": "timeout", "reason": "no_reply_in_5_minutes" }`.
 
 ## Caveats
 
-- **Always asks the user. Never silent.** This is a hard rule. Do not try to
-  bypass the approval prompt.
-- **Charges do NOT create vesta tasks.** They log to `~/.stripe-pay/history.jsonl`
-  only. Don't write a task for a charge.
-- **If Stripe's Link-side cap is exceeded**, Stripe forces a Link-app approval on
-  top of ours. The CLI surfaces that requirement in the channel prompt.
-- **Card details are ephemeral.** The skill never persists raw card numbers,
-  they live in stdout for one process lifetime. The agent should pass them
-  straight to the merchant flow, not save them.
-- **Currency** uses ISO 4217 codes (`USD`, `EUR`, `GBP`, ...). Amounts are in
-  major units (e.g. `24.99` not `2499`).
-- **One charge at a time.** Don't fan out parallel `stripe-pay charge` calls,
-  the user will get multiple WhatsApp prompts and approvals will get tangled.
+- **Always asks the user. Never silent.** This is a hard rule. Do not try to bypass the approval prompt.
+- **Charges do NOT create vesta tasks.** They log to `~/.stripe-pay/history.jsonl` only. Don't write a task for a charge.
+- **If Stripe's Link-side cap is exceeded**, Stripe forces a Link-app approval on top of ours. The CLI surfaces that requirement in the channel prompt.
+- **Card details are ephemeral.** The skill never persists raw card numbers, they live in stdout for one process lifetime. The agent should pass them straight to the merchant flow, not save them.
+- **Currency** uses ISO 4217 codes (`USD`, `EUR`, `GBP`, ...). Amounts are in major units (e.g. `24.99` not `2499`).
+- **One charge at a time.** Don't fan out parallel `stripe-pay charge` calls, the user will get multiple WhatsApp prompts and approvals will get tangled.
 
 ## Logs
 


### PR DESCRIPTION
Trims `agent/skills/stripe-pay/SKILL.md` from 122 to 91 lines with no loss of function.

## Cuts
- Removed the duplicate `charge` command example from the header quick-ref; kept the single full example under "Making a charge".
- Inlined the trivial reject / timeout output JSON blocks to one line each.
- Compressed the "Trigger" and "Skip" sections (which restated the frontmatter description) into a single "Trigger / Skip" paragraph.
- Reflowed the Flow steps and Caveats bullets to one line each (pure reflow, no word changes).

All safety caveats retained; no command surface removed.