### PR TITLE
refactor(dream): drop two redundant restatements, no behavior change

### DIFF
--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -81,7 +81,7 @@ Simulating it yourself tends to approve your own fixes, so for a failure that ha
 
 Read `upstream-pr` and follow it. It can be a no-op; don't invent work to fill it. Note in the summary what was filed (or that it was a no-op, and why).
 
-**Test the channel before you call it blocked.** A blocker you can disprove in one command is not a blocker, it is a deferral wearing a costume. `upstream-pr` authenticates via a GitHub App (`uv run ~/agent/skills/upstream-pr/pr.py --token-only`), which is INDEPENDENT of the `gh` CLI's stored token. So "gh auth is broken / 401 / token expired" does NOT block upstreaming; it only blocks `gh`-CLI status checks. Before ever writing "upstream blocked on auth", actually run `pr.py --token-only`: if it prints a token, the channel works and filing is possible right now. Only a failure of `pr.py` itself (e.g. a missing App key) is a real auth blocker.
+**Test the channel before you call it blocked.** A blocker you can disprove in one command is not a blocker, it is a deferral wearing a costume. So "gh auth is broken / 401 / token expired" does NOT block upstreaming; it only blocks `gh`-CLI status checks. Before ever writing "upstream blocked on auth", actually run `pr.py --token-only`: if it prints a token, the channel works and filing is possible right now. Only a failure of `pr.py` itself (e.g. a missing App key) is a real auth blocker.
 
 **Keep an upstream queue and drain it.** Maintain a persistent queue file (e.g. `~/agent/upstream-queue.md`): every generalizable fix, bug, or learning gets appended the moment it is found. Each dream must, for every queued item, either file the PR (then remove it) or record a hard blocker actually tested this pass (not "next quiet window"). An item sitting unfiled across multiple dreams while `pr.py --token-only` works is a failure to flag, not a defer. "It's risky at 4am" is not a blocker for a single-file change that CI gates: file it and let CI catch errors.
 
@@ -170,8 +170,6 @@ Keep the container's filesystem organized and disk usage under control.
 - Kill orphaned screen sessions that are no longer needed (`screen -ls`, `screen -S name -X quit`)
 - Remove unused packages or build caches if they're taking significant space (`uv cache clean`, `apt clean`)
 
-The goal: a tidy workspace where everything has a purpose. If something is left over from a one-off task, remove it.
-
 ## Sensitive Data Cleanup
 
 Run `~/agent/skills/dream/scripts/redact_secrets.sh` to scan the event DB for API keys, tokens, passwords, private keys, and connection strings. Review matches (skip false positives), then rerun with `--delete` to purge. Also grep MEMORY.md and dreamer summaries for credentials and remove any you find. Secrets belong in env vars, not in history or files.
@@ -184,8 +182,6 @@ Write what you changed and why to `~/agent/dreamer/YYYY-MM-DDTHHMM.md` (e.g. `20
 - Whether each validated or not
 - Upstream contributions: PRs created, issues filed, what was synced
 - Anything left unresolved
-
-Keep it terse. Future you will grep these. The point is a trail, not a journal.
 
 ## Compaction on completion
 


### PR DESCRIPTION
Minimal, conservative trim to `agent/skills/dream/SKILL.md`, the single most behavior-shaping file in the repo. Removes exactly two redundant restatements and nothing else. No behavior change.

## The two cuts (3 removed lines total)

1. **§5 Upstream** — removed one mechanical restatement sentence describing how `upstream-pr` authenticates via a GitHub App and that this is independent of the `gh` CLI token. Those mechanics are owned by the `upstream-pr` skill, which the section already tells the agent to "Read `upstream-pr` and follow it." The dream-specific behavioral guidance is untouched: the "**Test the channel before you call it blocked**" / "deferral wearing a costume" framing stays, the actionable "actually run `pr.py --token-only` before writing 'blocked'" instruction stays, and the `queue_gate.py` completion-gate paragraph is untouched.

2. **Two purely motivational restatement lines** removed, each of which just re-states the section it sits under:
   - Workspace Cleanup: "The goal: a tidy workspace where everything has a purpose. If something is left over from a one-off task, remove it."
   - Summary: "Keep it terse. Future you will grep these. The point is a trail, not a journal."

## Untouched (verified)

All anti-deferral / anti-churn machinery and the retrospective grade vocabulary are intact: the meta-retrospective grades (**real** / **churn** / **light**), the commitment audit, the executable completion gate (`queue_gate.py`), the "corrected assumption is a SKILL edit not a MEMORY bullet" rule, the absolute-dates rule, the 30k-char MEMORY cap, all of User State, and the personality-drift instructions. Frontmatter is unchanged, so `index.json` is not touched. No em/en dashes introduced.

Line count: 210 -> 206.