### PR TITLE
refactor(keeper): trim SKILL.md, no functionality change

### DIFF
--- a/agent/skills/keeper/SKILL.md
+++ b/agent/skills/keeper/SKILL.md
@@ -22,20 +22,13 @@ keeper "search dropbox login"            # search by partial words
 keeper "search aws --format json"        # JSON output
 ```
 
-### View a Record
+### View a Record / Reveal a Password
 ```bash
 keeper "get <UID>"                       # display record details
-keeper "get <UID> --unmask"              # show passwords in plain text
+keeper "get <UID> --unmask"              # show full record with passwords in plain text
 keeper "get <UID> --format json"         # JSON output
 keeper "get <UID> --format password"     # show only the password
-```
-
-### Reveal a Password
-
-To reveal a stored password, use one of these working commands:
-```bash
 keeper "find-password <UID>"             # print just the password
-keeper "get <UID> --unmask"              # print the full record with passwords in plain text
 ```
 
 Note: `unmask` is NOT a subcommand. `keeper "unmask <UID> password"` does not exist and will fail. Unmasking is the `--unmask` flag on `get`, or use `find-password` to get the password on its own.


### PR DESCRIPTION
Trims `agent/skills/keeper/SKILL.md` from 123 to 116 lines with no loss of function.

## Cuts
- Merged the two overlapping password blocks ("View a Record" and "Reveal a Password") into a single "View a Record / Reveal a Password" block. Both previously duplicated `get <UID> --unmask` and shared `--format password`; the merged block keeps every unique command: `get`, `get --unmask`, `get --format json`, `get --format password`, `find-password`.

No command surface, gotchas, or [Fill in] stubs removed. The `unmask` is NOT a subcommand gotcha, record-types list, `$GEN` syntax, TOTP, sharing, generation, and the Learned Patterns personalization stubs are all preserved.