### PR TITLE
refactor(onboard): send referral_code / discount_code by name to the control plane

### DIFF
--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -59,12 +59,12 @@ def _cmd_verify_send(args: argparse.Namespace, client: Client, cfg: Config) -> i
     # Public onboarding (issue #79): record the invitee's pending intent, attributed
     # to our referral code, then send their OTP. The account is created when they
     # verify (below). Self-hosted boxes can onboard too, no server-identity gate.
-    code = (args.referral.strip() if getattr(args, "referral", None) else None) or cfg.referral_code
-    resp = client.create_account(email, code)
+    referral_code = (args.referral.strip() if getattr(args, "referral", None) else None) or cfg.referral_code
+    resp = client.create_account(email, referral_code)
     if "error" in resp:
         raise _Invalid(resp)  # e.g. a malformed email
     client.send_otp(email)
-    _print({"sent": True, "email": email, "code_applied": bool(resp.get("code_applied"))})
+    _print({"sent": True, "email": email, "referral_code_applied": bool(resp.get("referral_code_applied"))})
     return 0
 
 
@@ -97,7 +97,7 @@ def _cmd_checkout(args: argparse.Namespace, client: Client, cfg: Config) -> int:
         token=token,
         plan=PLAN,
         price=price,
-        code=(args.code.strip() if args.code else None),
+        discount_code=(args.code.strip() if args.code else None),
     )
     if "url" in result:
         # Stash the assigned subdomain + server id (both returned by checkout) so

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -82,17 +82,18 @@ class Client:
 
     # --- control plane: account pre-create (authed as THIS vesta) ------------
 
-    def create_account(self, email: str, code: str | None = None) -> dict[str, Any]:
-        """POST /onboard/account -> {ok, email, code_applied}.
+    def create_account(self, email: str, referral_code: str | None = None) -> dict[str, Any]:
+        """POST /onboard/account -> {ok, email, referral_code_applied}.
 
         Public (issue #79): no server-identity token. Records a pending onboard
-        intent and, when `code` is given, attributes it; the account itself is
-        created when the invitee verifies their OTP. An unknown/revoked code never
-        blocks signup (code_applied:false). A 4xx body carries {error} to surface.
+        intent and, when `referral_code` is given, attributes it; the account itself
+        is created when the invitee verifies their OTP. An unknown/revoked code never
+        blocks signup (referral_code_applied:false). A 4xx body carries {error} to
+        surface. This is the REFERRAL code (attribution), not the checkout discount.
         """
         body: dict[str, Any] = {"email": email}
-        if code:
-            body["code"] = code
+        if referral_code:
+            body["referral_code"] = referral_code
         return self._json(self._post("/onboard/account", json=body))
 
     # --- control plane: auth -------------------------------------------------
@@ -132,18 +133,20 @@ class Client:
         token: str,
         plan: str,
         price: float | None,
-        code: str | None,
+        discount_code: str | None,
     ) -> dict[str, Any]:
         """POST /onboard/checkout -> {url, subdomain, server_id}. Auto-assigns the subdomain.
 
-        Referral attribution no longer rides checkout (issue #79): it is bound at
-        account-create from the buyer's signup code, so no X-Vesta-Referral header.
+        `discount_code` is the DISCOUNT code (a Stripe coupon off month 1), distinct
+        from the referral code the buyer signed up with. Referral attribution no
+        longer rides checkout (issue #79): it is bound at account-create from the
+        buyer's signup code, so no X-Vesta-Referral header.
         """
         body: dict[str, Any] = {"plan": plan}
         if price is not None:
             body["price"] = price  # negotiated monthly USD; floor enforced server-side
-        if code:
-            body["code"] = code  # discount code; unknown -> {"error": "invalid code"}
+        if discount_code:
+            body["discount_code"] = discount_code  # unknown -> {"error": "invalid code"}
         return self._json(self._post("/onboard/checkout", json=body, headers=self._auth(token)))
 
     def me(self, token: str) -> dict[str, Any]:

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -79,7 +79,7 @@ def _mock_precreate(monkeypatch, result=None):
     monkeypatch.setattr(
         cli_mod.Client,
         "create_account",
-        lambda self, email, code=None: result if result is not None else {"ok": True, "email": email, "code_applied": bool(code)},
+        lambda self, email, code=None: result if result is not None else {"ok": True, "email": email, "referral_code_applied": bool(code)},
     )
 
 
@@ -98,7 +98,7 @@ def test_verify_send_records_intent_then_sends(capsys, monkeypatch):
 
     def _create(self, email, code=None):
         calls["create"] = (email, code)
-        return {"ok": True, "email": email, "code_applied": bool(code)}
+        return {"ok": True, "email": email, "referral_code_applied": bool(code)}
 
     def _send(self, email):
         calls["send"] = email
@@ -120,12 +120,12 @@ def test_verify_send_sends_referral_code_from_shared_file(capsys, monkeypatch):
 
     def _create(self, email, code=None):
         calls["code"] = code
-        return {"ok": True, "email": email, "code_applied": bool(code)}
+        return {"ok": True, "email": email, "referral_code_applied": bool(code)}
 
     monkeypatch.setattr(cli_mod.Client, "create_account", _create)
     monkeypatch.setattr(cli_mod.Client, "send_otp", lambda self, email: {"success": True})
     rc, data = _run(["verify-send", "--email", E], capsys)
-    assert rc == 0 and data["code_applied"] is True
+    assert rc == 0 and data["referral_code_applied"] is True
     assert calls["code"] == "abc123"
 
 
@@ -173,14 +173,14 @@ def test_checkout_forwards_price_and_code_no_referral(capsys, monkeypatch):
 
     # checkout no longer takes/sends a referral (issue #79): attribution is bound
     # at account-create, so its signature has no referral_code and no X-Vesta-Referral.
-    def fake_checkout(self, *, token, plan, price, code):
-        captured.update(token=token, plan=plan, price=price, code=code)
+    def fake_checkout(self, *, token, plan, price, discount_code):
+        captured.update(token=token, plan=plan, price=price, discount_code=discount_code)
         return {"url": "https://checkout.stripe.com/x", "subdomain": "ada", "server_id": "srv1"}
 
     monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
     rc, data = _run(["checkout", "--email", E, "--price", "200", "--code", " friend50 "], capsys)
     assert rc == 0 and data["url"].startswith("https://checkout.stripe.com/")
-    assert captured == {"token": "TOK", "plan": "pro", "price": 200.0, "code": "friend50"}
+    assert captured == {"token": "TOK", "plan": "pro", "price": 200.0, "discount_code": "friend50"}
     # server_id is stashed for later steps but kept out of the agent-facing output.
     assert state_mod.load(E)["server_id"] == "srv1"
     assert "server_id" not in data


### PR DESCRIPTION
## Why

Companion to **elyxlz/vesta-cloud#94**. The control plane renamed its two onboarding code fields so they can't be confused: the **referral** code (attribution) and the checkout **discount** code are no longer both called `code`. This updates the `onboard` skill's HTTP client to match.

## What

`agent/skills/onboard/cli/src/onboard_cli/client.py`:
- `create_account` -> POSTs `referral_code`, reads `referral_code_applied`
- `checkout` -> POSTs `discount_code`

`cli.py` call sites and `tests/test_cli.py` follow. **CLI flags are unchanged** (`onboard checkout --code` still means the discount code).

## Lockstep

There are **no live users**, so there is no back-compat: this must merge together with vesta-cloud#94. Old field names stop working the moment the control plane deploys.

## Verification

- onboard CLI tests: 20/20 pass (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)