### PR TITLE
fix(image): base agent image on debian trixie for git >=2.42

### DIFF
--- a/vestad/Dockerfile
+++ b/vestad/Dockerfile
@@ -1,4 +1,8 @@
-FROM debian:bookworm-slim
+# Debian 13 (trixie) for git >=2.42. On git 2.39 (bookworm) `git sparse-checkout set` deletes an
+# out-of-cone directory that holds untracked files, taking the agent's untracked
+# ~/.claude/.credentials.json with it and de-authing the agent on a skills-install. git >=2.42
+# refuses to delete a directory containing untracked files, closing that hole at the root.
+FROM debian:trixie-slim
 
 LABEL org.opencontainers.image.title="Vesta" \
       org.opencontainers.image.description="Personal assistant agent that works autonomously on your behalf" \


### PR DESCRIPTION
## Why

The v0.1.170 release was blocked by a failing `test-live` gate. The second failure — `upgrade::upgrade_from_previous_release_converges_migrations_and_keeps_agent_healthy` — is a **real credential-loss bug**, newly exposed because 0.1.170 ships two new default skills (`nap`, `vesta-cloud-account`).

On upgrade the boot runs a default-skill-sync `skills-install` → `set-cone.sh` → `git sparse-checkout set --cone`. On the image's **git 2.39** (`debian:bookworm-slim`), `set` reloads the index from HEAD, re-adds the `.claude` entry the entrypoint guard force-removed, then sparsifies it — **deleting the untracked `~/.claude/.credentials.json`** alongside the tracked `.claude` file. The agent boots `not_authenticated`, idles forever, and the test times out at `upgrade.rs:182`. This matches the `.claude`-never-tracked invariant in CLAUDE.md and would de-auth real legacy-checkout boxes on upgrade.

## What

Base the agent image on **`debian:trixie-slim`** (Debian 13 stable, git 2.47) instead of `debian:bookworm-slim` (git 2.39). git ≥2.42 refuses to delete a directory containing untracked files, so `sparse-checkout set` can no longer take the credentials — the hole is closed at the root rather than guarded.

> Note: bookworm-backports carries no newer git (only 2.39.5 exists on Debian 12), so the base bump is the clean route to a modern git.

The index-only entrypoint guard in `vestad/src/docker.rs` and its git-2.39 comment are left in place (they still protect legacy monorepo-checkout boxes); retiring them is a separate follow-up once the whole fleet is on the new image.

## Verification

- Image builds cleanly on trixie: claude, uv, nodesource all install on Debian 13.
- `docker run vesta git --version` → `2.47.3`.
- Repro of the exact failing flow (tracked `.claude/settings.json`, untracked `.credentials.json`, then a sparsifying `git sparse-checkout set --cone`): on this image git **warns** about the untracked directory and **keeps the credentials** (`PASS: creds survived`). On git 2.39 the same flow deletes them.
- Full live `upgrade` run happens on the release re-cut (`test-live` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)