### PR TITLE
feat(onboarding): suggest 200K context for non-Max Claude plans

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -31,7 +31,7 @@ import pydantic as pyd
 from aiohttp import web
 
 from .events import ChatEvent, EventBus, SnapshotChat, SnapshotEvent, UserEvent, VestaEvent
-from .config import VestaConfig, load_notification_rules, stored_config, update_config_store, validate_config_updates
+from .config import ClaudeConfig, VestaConfig, load_notification_rules, stored_config, update_config_store, validate_config_updates
 from .helpers import get_memory_path
 from .models import State
 from .provider import ProviderAuthState, UsageError, clear_provider, get_usage, set_claude, set_openrouter
@@ -272,6 +272,10 @@ async def _provider_get_handler(request: web.Request) -> web.Response:
     provider = stored_config(config)["provider"]
     body = dict(provider) if isinstance(provider, dict) else {}
     body["authed"] = status is not None and status.state == ProviderAuthState.AUTHENTICATED
+    # The Claude plan tier (from the on-disk OAuth blob, excluded from stored_config) so the context
+    # picker can restrict >200K windows to Max, the only plan entitled to the 1M-context beta.
+    if isinstance(config.provider, ClaudeConfig) and config.provider.oauth is not None:
+        body["plan"] = config.provider.oauth.subscriptionType
     return web.json_response(body)
 
 

--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -159,6 +159,9 @@ class ClaudeOAuth(pyd.BaseModel):
     accessToken: str | None = None  # noqa: N815  (mirrors the on-disk camelCase verbatim)
     refreshToken: str | None = None  # noqa: N815
     expiresAt: int | None = None  # noqa: N815
+    # The plan tier ("free" | "pro" | "max"); drives the context-window presets the picker offers,
+    # since the 1M-context beta is a Max-only entitlement.
+    subscriptionType: str | None = None  # noqa: N815
 
 
 def _read_claude_oauth() -> "ClaudeOAuth | None":

--- a/agent/core/manifest.json
+++ b/agent/core/manifest.json
@@ -8,9 +8,10 @@
       "default_model": "opus",
       "context": {
         "default": 1000000,
+        "defaults_by_plan": { "max": 1000000, "pro": 200000, "free": 200000 },
         "presets": [
-          { "tokens": 1000000, "label": "1M", "note": "most context" },
-          { "tokens": 500000, "label": "500K", "note": "balanced" },
+          { "tokens": 1000000, "label": "1M", "note": "most context", "plans": ["max"] },
+          { "tokens": 500000, "label": "500K", "note": "balanced", "plans": ["max"] },
           { "tokens": 200000, "label": "200K", "note": "cheapest prompt-cache reads, compacts soonest" }
         ]
       }

--- a/agent/tests/test_api.py
+++ b/agent/tests/test_api.py
@@ -331,6 +331,26 @@ async def test_status_reports_readiness_separate_from_provider(config):
 
 
 @pytest.mark.anyio
+async def test_provider_get_surfaces_claude_plan_tier():
+    # The context picker gates >200K windows on the Max entitlement, so /provider surfaces the plan
+    # tier read from the on-disk OAuth blob (which stored_config otherwise strips).
+    import core.api as api_mod
+    from core.config import ClaudeConfig, ClaudeOAuth
+    from core.provider import ProviderAuthState, ProviderStatus
+
+    cfg = vm.VestaConfig.model_construct(provider=ClaudeConfig(oauth=ClaudeOAuth(subscriptionType="pro")))
+    state = vm.State()
+    state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
+
+    class _Req:
+        app = {"state": state, "config": cfg}
+
+    resp = await api_mod._provider_get_handler(typing.cast("web.Request", _Req()))
+    body = json.loads(typing.cast("str", resp.text))
+    assert body["plan"] == "pro"
+
+
+@pytest.mark.anyio
 async def test_status_reports_unprovisioned_distinct_from_unauthenticated(config):
     # A fresh agent (no provider chosen) reports provider_configured=False, so vestad can show
     # "needs first sign-in" rather than "re-authenticate".

--- a/agent/tests/test_manifest.py
+++ b/agent/tests/test_manifest.py
@@ -41,3 +41,14 @@ def test_provider_shape_invariants():
     assert "key" not in ClaudeConfig.model_fields  # claude has no key
     assert "thinking" in ClaudeConfig.model_fields  # claude carries the thinking knob
     assert "thinking" not in OpenRouterConfig.model_fields  # openrouter can't set thinking
+
+
+def test_claude_context_gates_large_windows_by_plan():
+    # The 1M-context beta is a Max-only entitlement, so the picker maps plan -> default and marks the
+    # >200K windows Max-only; the 200K window is offered to every plan.
+    context = _manifest()["providers"]["claude"]["context"]
+    assert context["defaults_by_plan"] == {"max": 1000000, "pro": 200000, "free": 200000}
+    plans_by_tokens = {preset["tokens"]: preset["plans"] for preset in context["presets"] if "plans" in preset}
+    assert plans_by_tokens == {1000000: ["max"], 500000: ["max"]}
+    window_200k = next(preset for preset in context["presets"] if preset["tokens"] == 200000)
+    assert "plans" not in window_200k

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -99,6 +99,9 @@ export interface ProviderInfo {
   model: string | null;
   max_context_tokens: number | null;
   authed: boolean;
+  // Claude plan tier ("free" | "pro" | "max"), null for OpenRouter or when unknown; gates the
+  // context-window presets (the 1M beta is Max-only).
+  plan: string | null;
 }
 
 /// Read an agent's active provider from its `GET /provider`. The agent reports `kind` only when a
@@ -110,12 +113,14 @@ export async function getProvider(name: string): Promise<ProviderInfo> {
     model: string | null;
     max_context_tokens: number | null;
     authed?: boolean;
+    plan?: string | null;
   }>(`/agents/${encodeURIComponent(name)}/provider`);
   return {
     kind: provider.kind ?? "none",
     model: provider.model,
     max_context_tokens: provider.max_context_tokens,
     authed: provider.authed ?? false,
+    plan: provider.plan ?? null,
   };
 }
 

--- a/apps/web/src/api/manifest.ts
+++ b/apps/web/src/api/manifest.ts
@@ -4,11 +4,16 @@ export interface ContextPreset {
   tokens: number;
   label: string;
   note: string;
+  // Plan tiers this preset is offered to; absent means every plan. The 1M/500K Claude windows carry
+  // ["max"] because the 1M-context beta is a Max-only entitlement.
+  plans?: string[];
 }
 
 export interface ProviderContext {
   default: number;
   presets: ContextPreset[];
+  // Per-plan default window; the picker prefers this over `default` when it knows the plan tier.
+  defaults_by_plan?: Record<string, number>;
 }
 
 export interface ProviderEntry {

--- a/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
@@ -38,6 +38,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ProgressBar } from "@/components/ProgressBar";
 import { ModelStep } from "@/components/ProviderPicker/ModelStep";
 import { ContextStep } from "@/components/ProviderPicker/ContextStep";
+import { planContextOptions } from "@/components/ProviderPicker/context-plan";
 import { providerMeta } from "@/components/ProviderPicker/providers";
 import {
   setModel,
@@ -419,18 +420,20 @@ export function ProviderCard() {
             </div>
           ) : (
             <div className="flex flex-col items-center gap-4 py-2">
-              <ContextStep
-                presets={
-                  manifest.providers[provider.kind]?.context.presets ?? []
-                }
-                initial={
-                  provider.max_context_tokens ??
-                  manifest.providers[provider.kind]?.context.default ??
-                  0
-                }
-                submitLabel="apply"
-                onSubmit={(tokens) => void applyContext(tokens)}
-              />
+              {(() => {
+                const context = manifest.providers[provider.kind]?.context;
+                const { presets, initial } = context
+                  ? planContextOptions(context, provider.plan)
+                  : { presets: [], initial: 0 };
+                return (
+                  <ContextStep
+                    presets={presets}
+                    initial={provider.max_context_tokens ?? initial}
+                    submitLabel="apply"
+                    onSubmit={(tokens) => void applyContext(tokens)}
+                  />
+                );
+              })()}
               {error && (
                 <p className="text-xs text-destructive text-center">{error}</p>
               )}

--- a/apps/web/src/components/ProviderPicker/context-plan.test.ts
+++ b/apps/web/src/components/ProviderPicker/context-plan.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderContext } from "@/api/manifest";
+import { planContextOptions, planFromCredentials } from "./context-plan";
+
+const claudeContext: ProviderContext = {
+  default: 1000000,
+  defaults_by_plan: { max: 1000000, pro: 200000, free: 200000 },
+  presets: [
+    { tokens: 1000000, label: "1M", note: "most context", plans: ["max"] },
+    { tokens: 500000, label: "500K", note: "balanced", plans: ["max"] },
+    { tokens: 200000, label: "200K", note: "cheapest" },
+  ],
+};
+
+describe("planContextOptions", () => {
+  it("offers every window and defaults to 1M for max", () => {
+    const { presets, initial } = planContextOptions(claudeContext, "max");
+    expect(presets.map((preset) => preset.tokens)).toEqual([
+      1000000, 500000, 200000,
+    ]);
+    expect(initial).toBe(1000000);
+  });
+
+  it("hides >200K windows and defaults to 200K for pro", () => {
+    const { presets, initial } = planContextOptions(claudeContext, "pro");
+    expect(presets.map((preset) => preset.tokens)).toEqual([200000]);
+    expect(initial).toBe(200000);
+  });
+
+  it("hides >200K windows and defaults to 200K for free", () => {
+    const { presets, initial } = planContextOptions(claudeContext, "free");
+    expect(presets.map((preset) => preset.tokens)).toEqual([200000]);
+    expect(initial).toBe(200000);
+  });
+
+  it("is permissive when the plan is unknown", () => {
+    const { presets, initial } = planContextOptions(claudeContext, null);
+    expect(presets.map((preset) => preset.tokens)).toEqual([
+      1000000, 500000, 200000,
+    ]);
+    expect(initial).toBe(1000000);
+  });
+
+  it("leaves an ungated provider unchanged", () => {
+    const openrouter: ProviderContext = {
+      default: 200000,
+      presets: [
+        { tokens: 200000, label: "200K", note: "full window" },
+        { tokens: 64000, label: "64K", note: "cheapest" },
+      ],
+    };
+    const { presets, initial } = planContextOptions(openrouter, null);
+    expect(presets.map((preset) => preset.tokens)).toEqual([200000, 64000]);
+    expect(initial).toBe(200000);
+  });
+});
+
+describe("planFromCredentials", () => {
+  it("reads subscriptionType from a claude OAuth blob", () => {
+    expect(
+      planFromCredentials(
+        JSON.stringify({ claudeAiOauth: { subscriptionType: "max" } }),
+      ),
+    ).toBe("max");
+  });
+
+  it("returns null when the field, blob, or JSON is absent", () => {
+    expect(
+      planFromCredentials(JSON.stringify({ claudeAiOauth: {} })),
+    ).toBeNull();
+    expect(planFromCredentials(JSON.stringify({}))).toBeNull();
+    expect(planFromCredentials("not json")).toBeNull();
+  });
+});

--- a/apps/web/src/components/ProviderPicker/context-plan.ts
+++ b/apps/web/src/components/ProviderPicker/context-plan.ts
@@ -1,0 +1,61 @@
+import type { ContextPreset, ProviderContext } from "@/api/manifest";
+
+// The Claude plan tier drives which context windows the picker offers: the 1M-context beta is a
+// Max-only entitlement, so a Pro/Free agent that selects a >200K window would send an unentitled
+// beta header and fail on its first turn. We gate the presets and default off the plan instead.
+
+// The plan tier from a raw `.credentials.json` OAuth blob, or null when absent/unparseable. During
+// onboarding the blob is only ever client-side (standalone OAuth, not yet bound to an agent), so the
+// wizard reads the plan straight from it; the settings screen gets the plan from GET /provider.
+export function planFromCredentials(credentials: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(credentials);
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      "claudeAiOauth" in parsed
+    ) {
+      const oauth = (parsed as { claudeAiOauth: unknown }).claudeAiOauth;
+      if (
+        oauth !== null &&
+        typeof oauth === "object" &&
+        "subscriptionType" in oauth
+      ) {
+        const plan = (oauth as { subscriptionType: unknown }).subscriptionType;
+        return typeof plan === "string" ? plan : null;
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+// A preset is offered when it carries no plan restriction, or the known plan is in its allowlist. A
+// null plan (unknown tier) is permissive: we only hide a window when we know the plan can't use it.
+function presetAllowed(preset: ContextPreset, plan: string | null): boolean {
+  return (
+    preset.plans === undefined || plan === null || preset.plans.includes(plan)
+  );
+}
+
+// The presets to offer and the initial selection for a context step, given the known plan (or null).
+export function planContextOptions(
+  context: ProviderContext,
+  plan: string | null,
+): { presets: ContextPreset[]; initial: number } {
+  const presets = context.presets.filter((preset) =>
+    presetAllowed(preset, plan),
+  );
+  const preferred =
+    plan === null ? undefined : context.defaults_by_plan?.[plan];
+  const inPresets = (tokens: number) =>
+    presets.some((preset) => preset.tokens === tokens);
+  const initial =
+    preferred !== undefined && inPresets(preferred)
+      ? preferred
+      : inPresets(context.default)
+        ? context.default
+        : (presets[presets.length - 1]?.tokens ?? context.default);
+  return { presets, initial };
+}

--- a/apps/web/src/components/ProviderPicker/index.tsx
+++ b/apps/web/src/components/ProviderPicker/index.tsx
@@ -8,6 +8,7 @@ import { ChoiceStep } from "./ChoiceStep";
 import { KeyStep } from "./KeyStep";
 import { ModelStep } from "./ModelStep";
 import { ContextStep } from "./ContextStep";
+import { planContextOptions, planFromCredentials } from "./context-plan";
 import { AuthStep } from "./AuthStep";
 import { ClaudeLogo, OpenRouterLogo } from "./logos";
 import type { ProviderMode } from "./types";
@@ -195,15 +196,28 @@ export function ProviderPicker({
             onCancel={cancelToChoice}
           />
         )}
-        {step === "context" && provider && (
-          <ContextStep
-            presets={manifest.providers[provider]?.context.presets ?? []}
-            initial={manifest.providers[provider]?.context.default ?? 0}
-            onSubmit={handleContextSubmit}
-            logo={stepLogo}
-            onCancel={cancelToChoice}
-          />
-        )}
+        {step === "context" &&
+          provider &&
+          (() => {
+            const context = manifest.providers[provider]?.context;
+            // Claude gates >200K windows on the plan tier, read from the stashed OAuth blob.
+            const plan =
+              provider === "claude" && credentials !== null
+                ? planFromCredentials(credentials)
+                : null;
+            const { presets, initial } = context
+              ? planContextOptions(context, plan)
+              : { presets: [], initial: 0 };
+            return (
+              <ContextStep
+                presets={presets}
+                initial={initial}
+                onSubmit={handleContextSubmit}
+                logo={stepLogo}
+                onCancel={cancelToChoice}
+              />
+            );
+          })()}
       </div>
     </div>
   );


### PR DESCRIPTION
## Why

When a user signs in with Claude during onboarding, the context picker defaults to **1M** for everyone. But the 1M-context beta (`context-1m-2025-08-07`) is a **Max-only** entitlement. A Pro (\$20) or Free user who takes that default sends an unentitled beta header and their agent **errors on its first turn** (`client.py` enables the beta whenever the window exceeds 200K, regardless of plan).

## What

Detect the plan tier and gate the context picker off it. The plan is already on disk: the Claude OAuth blob (`.credentials.json` → `claudeAiOauth.subscriptionType`) carries `"free" | "pro" | "max"`.

- **Max** → sees 1M / 500K / 200K, default **1M** (unchanged).
- **Pro / Free** → sees only **200K**, default 200K.
- **Unknown plan** (legacy blob without `subscriptionType`) → permissive, unchanged behavior.

Gating (not just a soft default) so neither onboarding nor the settings dialog can reopen a window the plan can't use — an unentitled 1M choice is unrepresentable.

### Changes
- `config.py`: model `subscriptionType` on `ClaudeOAuth`.
- `api.py`: `GET /provider` surfaces `plan` (read from the in-memory OAuth blob, which `stored_config` otherwise strips).
- `manifest.json`: claude `context` gains `defaults_by_plan` + a per-preset `plans` allowlist (`["max"]` on 1M/500K). `manifest.rs` serves it as passthrough — no Rust change.
- web: new pure helper `planContextOptions` / `planFromCredentials`, wired into onboarding (plan from the stashed OAuth blob, available before the context step) and the settings context dialog (plan from `GET /provider`).

## Fleet impact
No migration: the plan is read live from credentials, no on-disk state changes. Existing agents are unaffected; a Pro agent stuck at 1M (already broken) gets nudged to 200K next time they open the settings dialog.

## Tests
- `test_manifest.py`: manifest carries `defaults_by_plan` + Max-only presets.
- `test_api.py`: `GET /provider` surfaces the plan tier.
- `context-plan.test.ts`: preset gating + default resolution across max/pro/free/unknown/ungated.

Green locally: agent (ruff + ty + pytest), web (tsc + eslint + prettier + vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)