### PR TITLE
fix(vestad): make auto-backup scheduling DST-safe and tz-consistent

### DIFF
--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -232,7 +232,7 @@ export function AppSettings() {
                   </FieldContent>
                   <span className="shrink-0 text-sm text-muted-foreground">
                     {gatewaySetup.settings.auto_backup.enabled
-                      ? `daily at ${String(gatewaySetup.settings.auto_backup.hour).padStart(2, "0")}:00`
+                      ? `daily at ${String(gatewaySetup.settings.auto_backup.hour).padStart(2, "0")}:00 server time`
                       : "disabled"}
                   </span>
                 </Field>

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -73,6 +73,14 @@ pub fn now_timestamp_from_epoch(epoch_secs: u64) -> String {
     dt.format(&fmt).expect("timestamp format never fails")
 }
 
+/// Parse a compact `YYYYMMDD-HHMMSS` UTC timestamp (the `created_at` format) back to epoch seconds.
+/// Inverse of `now_timestamp_from_epoch`; returns None on malformed input.
+pub fn parse_compact_utc_epoch(created_at: &str) -> Option<u64> {
+    let fmt = time::macros::format_description!("[year][month][day]-[hour][minute][second]");
+    let dt = time::PrimitiveDateTime::parse(created_at.trim(), &fmt).ok()?;
+    u64::try_from(dt.assume_utc().unix_timestamp()).ok()
+}
+
 /// Returns the container's age in seconds, or None if unknown.
 pub async fn container_age_secs(docker: &Docker, name: &str) -> Option<u64> {
     let cname = container_name(name);
@@ -473,6 +481,19 @@ mod tests {
     fn retention_empty_list() {
         let to_delete = compute_backups_to_delete(&[], &DEFAULT_RETENTION);
         assert!(to_delete.is_empty());
+    }
+
+    #[test]
+    fn parse_compact_utc_epoch_roundtrips() {
+        let epoch = 1_780_000_000u64;
+        let ts = now_timestamp_from_epoch(epoch);
+        assert_eq!(parse_compact_utc_epoch(&ts), Some(epoch));
+    }
+
+    #[test]
+    fn parse_compact_utc_epoch_rejects_malformed() {
+        assert_eq!(parse_compact_utc_epoch("not-a-timestamp"), None);
+        assert_eq!(parse_compact_utc_epoch(""), None);
     }
 
     #[test]

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2460,14 +2460,26 @@ pub fn build_router(state: SharedState) -> Router {
 
 // --- Auto-backup background task ---
 
-fn local_hour() -> u8 {
-    let epoch = crate::time_utils::now_epoch_secs() as libc::time_t;
+fn local_tm(epoch_secs: u64) -> libc::tm {
+    let epoch = epoch_secs as libc::time_t;
     // SAFETY: libc::tm is a plain-integer C struct for which an all-zero bit pattern is valid.
     let mut tm: libc::tm = unsafe { std::mem::zeroed() };
     // SAFETY: &epoch and &mut tm are valid, non-overlapping, properly aligned pointers for the
     // duration of the call.
     unsafe { libc::localtime_r(&epoch, &mut tm) };
-    tm.tm_hour as u8
+    tm
+}
+
+fn local_hour() -> u8 {
+    local_tm(crate::time_utils::now_epoch_secs()).tm_hour as u8
+}
+
+/// Host-local calendar date (YYYYMMDD) for an epoch. Keying the once-per-day backup dedup to this
+/// same wall clock as the firing window avoids the UTC-vs-local day-boundary mismatch that could
+/// otherwise double or skip a daily near midnight.
+fn local_date_of_epoch(epoch_secs: u64) -> String {
+    let tm = local_tm(epoch_secs);
+    format!("{:04}{:02}{:02}", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday)
 }
 
 fn spawn_auto_backup_task(state: SharedState) {
@@ -2485,10 +2497,14 @@ fn spawn_auto_backup_task(state: SharedState) {
                 continue;
             }
 
+            // Fire on or after the configured local hour rather than only during that exact hour,
+            // then let the per-type dedup below make the work idempotent (one daily per local day,
+            // etc.). This way a spring-forward DST jump that skips the target hour still triggers a
+            // backup on the next cycle, and a daemon that was down through the hour catches up.
             let target_hour = backup_settings.hour;
             let current_hour = local_hour();
-            if current_hour != target_hour {
-                tracing::debug!(current_hour, target_hour, "auto-backup: not in backup window, skipping");
+            if current_hour < target_hour {
+                tracing::debug!(current_hour, target_hour, "auto-backup: before daily window, skipping");
                 continue;
             }
 
@@ -2502,7 +2518,7 @@ fn spawn_auto_backup_task(state: SharedState) {
             tracing::info!(agent_count = agents.len(), "auto-backup: starting cycle");
 
             let now_epoch = crate::time_utils::now_epoch_secs();
-            let today_date = &backup::now_timestamp()[..8];
+            let today_local = local_date_of_epoch(now_epoch);
             let seven_days_ago = backup::now_timestamp_from_epoch(now_epoch - 7 * 86400);
             let thirty_days_ago = backup::now_timestamp_from_epoch(now_epoch - 30 * 86400);
 
@@ -2535,7 +2551,7 @@ fn spawn_auto_backup_task(state: SharedState) {
 
                 let has_daily_today = backups.iter().any(|b| {
                     b.backup_type == crate::types::BackupType::Daily
-                        && b.created_at.starts_with(today_date)
+                        && backup::parse_compact_utc_epoch(&b.created_at).map(local_date_of_epoch).as_deref() == Some(today_local.as_str())
                 });
                 if !has_daily_today {
                     needed.push(crate::types::BackupType::Daily);


### PR DESCRIPTION
Follow-up to #1033. Fixes the three auto-backup timezone issues surfaced by that PR's repo-wide audit.

## The bugs

The auto-backup task (`serve.rs`, `spawn_auto_backup_task`) fired only during the **single local hour** equal to `backup.hour`, but deduped dailies against a **UTC** calendar date (`today_date = &now_timestamp()[..8]`). Mixing the two clocks caused:

1. **Spring-forward skip.** The window is one hour, checked hourly. On the spring-forward DST day the local clock jumps 01:59 → 03:00, so if `backup.hour` is the skipped hour (`2` in most US/EU zones) `local_hour()` never returns it and that day's backup is missed.
2. **Local-vs-UTC day boundary.** The firing window is local but the daily dedup keys on a UTC date. For a host far from UTC with `backup.hour` near the UTC midnight boundary, the two can name different calendar days, so the "has today's daily run?" check is off by a day: an extra or a skipped daily at the edge.
3. **Web UI ambiguity.** Settings showed `daily at 03:00` with no timezone, and that hour is the *server's* local tz — misleading for the macOS/Windows app talking to a remote Linux vestad.

Neither 1 nor 2 is the frozen-wall-clock bug from #1033: `local_hour()` is recomputed each cycle so it tracks DST. These are a skipped-hour edge and a day-labeling seam.

## The fix

One structural change collapses 1 and 2: **fire on or after `backup.hour`** (`current_hour < target_hour` skips) and let the existing per-type dedup make the work idempotent (one daily per local day). A skipped hour or a brief daemon outage then still produces the day's backup on the next cycle. The daily dedup is keyed to the **host-local calendar date**, converting each backup's UTC `created_at` with a new `parse_compact_utc_epoch` helper, so the firing clock and the dedup clock agree. Weekly/monthly are unchanged (rolling windows, already correct).

Issue 3 is a one-word label: `daily at 03:00 server time`.

## Tests

`vestad --bins` green, `clippy -D warnings` clean. New unit tests cover `parse_compact_utc_epoch` (roundtrip + malformed). The scheduling loop itself has no unit harness (needs Docker + a timer); this matches the file's existing test depth, and the behavior change is small and reasoned in the diff comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)