### PR TITLE
fix(app-chat): stop silently dropping WS user messages

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -39,6 +39,11 @@ from .provider import ProviderAuthState, UsageError, clear_provider, get_usage, 
 
 logger = logging.getLogger("vesta.api")
 
+# Ping every connected client on this cadence so a half-open socket (a phone that dropped off the
+# network without a close frame) is detected and torn down promptly, freeing the subscriber and
+# letting the client reconnect and replay, rather than the server buffering to a dead peer for minutes.
+WS_HEARTBEAT_S = 30.0
+
 
 def _pending_notification_ids(config: VestaConfig) -> list[str]:
     """Notification file stems still on disk — received but not yet processed. Seeds the connect
@@ -60,7 +65,7 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
     config: VestaConfig = request.app["config"]
     skip_history = request.query.get("skip_history", "") in ("1", "true")
 
-    ws = web.WebSocketResponse()
+    ws = web.WebSocketResponse(heartbeat=WS_HEARTBEAT_S)
     await ws.prepare(request)
     request.app["websockets"].add(ws)
 

--- a/agent/core/skills/app-chat/cli/src/app_chat_cli/daemon.py
+++ b/agent/core/skills/app-chat/cli/src/app_chat_cli/daemon.py
@@ -20,6 +20,9 @@ import aiohttp
 
 
 RECONNECT_DELAY = 2.0
+# Ping the peer on this cadence so a half-open connection (silent network drop, wedged webview)
+# is detected and closed promptly instead of lingering until the next send fails minutes later.
+WS_HEARTBEAT_S = 30.0
 
 
 @dataclass
@@ -102,7 +105,7 @@ async def _ws_loop(state: DaemonState) -> None:
             if agent_token:
                 sep = "&" if "?" in url else "?"
                 url = f"{url}{sep}agent_token={agent_token}"
-            async with state.session.ws_connect(url) as ws:
+            async with state.session.ws_connect(url, heartbeat=WS_HEARTBEAT_S) as ws:
                 state.ws = ws
                 _log(f"connected to {state.ws_url}")
                 async for msg in ws:
@@ -133,30 +136,37 @@ def _handle_event(state: DaemonState, raw: str) -> None:
         _replay_missed(state, event["chat"]["events"])
         return
 
-    if "ts" in event:
-        _update_last_seen_ts(state, event["ts"])
-
     if event_type == "user" and "text" in event:
         ts = event["ts"] if "ts" in event else None
-        _write_notification(state, event["text"], timestamp=ts)
+        _notify_if_new(state, event["text"], ts)
+
+
+def _notify_if_new(state: DaemonState, text: str, ts: str | None) -> bool:
+    """Write a notification for a user message, unless one at or before `ts` was already notified.
+
+    The dedup watermark advances *only* here, on user messages. Advancing it on assistant/tool/status
+    events (as an earlier version did) let a later event push it past a user message that was never
+    notified — dropped from the bounded live queue or lost on a socket teardown — so on reconnect that
+    message read as 'already seen' and was silently lost. Keying purely on user-message ts closes that
+    gap and makes the snapshot/live overlap on connect idempotent."""
+    if ts is not None and state.last_seen_ts is not None and ts <= state.last_seen_ts:
+        return False
+    _write_notification(state, text, timestamp=ts)
+    if ts is not None:
+        _update_last_seen_ts(state, ts)
+    return True
 
 
 def _replay_missed(state: DaemonState, events: list[dict[str, object]]) -> None:
-    """On reconnect, generate notifications for user messages missed during downtime."""
-    cutoff = state.last_seen_ts
+    """On reconnect, generate notifications for user messages missed during downtime. Snapshot events
+    arrive oldest-first, so the watermark advances in order and only un-notified messages get through."""
     count = 0
     for past in events:
         if "type" not in past or past["type"] != "user" or "text" not in past:
             continue
-        ts = past["ts"] if "ts" in past else None
-        if cutoff and ts and str(ts) <= cutoff:
-            continue
-        _write_notification(state, str(past["text"]), timestamp=str(ts) if ts else None)
-        count += 1
-    for past in reversed(events):
-        if "ts" in past:
-            _update_last_seen_ts(state, str(past["ts"]))
-            break
+        ts = str(past["ts"]) if "ts" in past else None
+        if _notify_if_new(state, str(past["text"]), ts):
+            count += 1
     if count:
         _log(f"replayed {count} missed message(s)")
 

--- a/agent/core/skills/app-chat/cli/tests/test_daemon.py
+++ b/agent/core/skills/app-chat/cli/tests/test_daemon.py
@@ -1,0 +1,110 @@
+"""Tests for the app-chat daemon's notification dedup + reconnect replay.
+
+These pin the fix for silently-lost user messages: the dedup watermark must advance only on user
+messages, so an assistant/tool/status event can never push it past an un-notified message and make
+reconnect replay skip it.
+"""
+
+import json
+import pathlib as pl
+
+import app_chat_cli.daemon as daemon
+
+
+def _state(tmp_path: pl.Path) -> daemon.DaemonState:
+    notifications = tmp_path / "notifications"
+    data = tmp_path / "data"
+    notifications.mkdir(exist_ok=True)
+    data.mkdir(exist_ok=True)
+    return daemon.DaemonState(
+        notifications_dir=notifications,
+        ws_url="ws://x/ws",
+        sock_path=data / "app-chat.sock",
+        data_dir=data,
+    )
+
+
+def _messages(state: daemon.DaemonState) -> list[str]:
+    # Filenames are random uuids, so glob order is arbitrary — sort for deterministic assertions.
+    return sorted(json.loads(p.read_text())["message"] for p in state.notifications_dir.glob("*.json"))
+
+
+def _user(ts: str, text: str) -> str:
+    return json.dumps({"type": "user", "ts": ts, "text": text})
+
+
+def _assistant(ts: str, text: str) -> str:
+    return json.dumps({"type": "assistant", "ts": ts, "text": text})
+
+
+def _snapshot(events: list[dict[str, object]]) -> str:
+    return json.dumps({"type": "snapshot", "chat": {"events": events}})
+
+
+def test_live_user_message_writes_one_notification(tmp_path):
+    state = _state(tmp_path)
+    daemon._handle_event(state, _user("t1", "hello"))
+    assert _messages(state) == ["hello"]
+    assert state.last_seen_ts == "t1"
+
+
+def test_assistant_events_do_not_advance_watermark(tmp_path):
+    state = _state(tmp_path)
+    daemon._handle_event(state, _user("t1", "first"))
+    daemon._handle_event(state, _assistant("t9", "a long streamed reply"))
+    # The watermark tracks the last notified user message, not the latest event of any type.
+    assert state.last_seen_ts == "t1"
+
+
+def test_reconnect_replays_message_that_arrived_during_a_drop(tmp_path):
+    # Regression: a user message (t3) arrives while disconnected; assistant activity (t9) happened
+    # before the drop. If the watermark had advanced to t9, replay would skip t3 and lose it.
+    state = _state(tmp_path)
+    daemon._handle_event(state, _user("t1", "before drop"))
+    daemon._handle_event(state, _assistant("t9", "reply that raced ahead"))
+
+    daemon._handle_event(
+        state,
+        _snapshot(
+            [{"type": "user", "ts": "t3", "text": "sent during drop"}, {"type": "assistant", "ts": "t9", "text": "reply that raced ahead"}]
+        ),
+    )
+
+    assert _messages(state) == ["before drop", "sent during drop"]
+    assert state.last_seen_ts == "t3"
+
+
+def test_replay_skips_already_notified_messages(tmp_path):
+    state = _state(tmp_path)
+    daemon._handle_event(state, _user("t1", "hello"))
+
+    daemon._handle_event(state, _snapshot([{"type": "user", "ts": "t1", "text": "hello"}]))
+
+    assert _messages(state) == ["hello"]
+
+
+def test_snapshot_live_overlap_does_not_double_notify(tmp_path):
+    # The overlap window on connect can deliver the same user message in both the snapshot and live.
+    state = _state(tmp_path)
+    daemon._handle_event(state, _snapshot([{"type": "user", "ts": "t2", "text": "overlap"}]))
+    daemon._handle_event(state, _user("t2", "overlap"))
+
+    assert _messages(state) == ["overlap"]
+
+
+def test_watermark_persists_across_restart(tmp_path):
+    state = _state(tmp_path)
+    daemon._handle_event(state, _user("t5", "hello"))
+
+    reloaded = _state(tmp_path)
+    daemon._load_last_seen_ts(reloaded)
+    assert reloaded.last_seen_ts == "t5"
+    # After restart, the snapshot must not re-notify the already-seen message.
+    daemon._handle_event(reloaded, _snapshot([{"type": "user", "ts": "t5", "text": "hello"}]))
+    assert _messages(reloaded) == ["hello"]
+
+
+def test_message_without_ts_is_notified(tmp_path):
+    state = _state(tmp_path)
+    daemon._handle_event(state, json.dumps({"type": "user", "text": "no ts"}))
+    assert _messages(state) == ["no ts"]


### PR DESCRIPTION
Fixes #1008

## Root cause

The app-chat daemon deduped inbound user messages against a `last_seen_ts` watermark that was advanced by **every** event with a `ts` (assistant, tool, status, …), not just user messages. A later assistant event pushed the watermark past a user message that was never turned into a notification (dropped from the bounded live queue during a stall, or lost when the socket tore down). On reconnect, `_replay_missed` treated that message as `ts <= cutoff` → already-seen → skipped it. The message survived only in server-side history and never surfaced as a notification.

A related latent bug: the live path wrote a notification for every user event with **no** dedup guard, so the snapshot/live overlap window on connect could double-notify.

## Fix

- **Advance the dedup watermark only on user messages**, via a single `_notify_if_new(state, text, ts)` helper shared by the live and replay paths. Assistant/tool/status events can no longer move it, so replay reliably re-notifies any un-notified user message. The shared helper also makes the connect overlap idempotent.
- **WS heartbeat on both sides** (agent server in `api.py`, daemon client in `daemon.py`): a half-open socket (phone off the network with no close frame) is now detected and torn down within the heartbeat interval, so the client reconnects and replays promptly instead of the server buffering to a dead peer for minutes.

### On the suggested per-client send buffer

The issue also suggested a bounded per-client send buffer. Deliberately **not** added: aiohttp already buffers writes at the transport, and the event bus already bounds each subscriber's queue (`SUBSCRIBER_QUEUE_MAXSIZE`, oldest-drop). A third buffer duplicates both and runs against the architecture principle of not stacking bulkheads on this single-tenant daemon. With replay now reliable, a dropped socket is no longer data loss, so the buffer's purpose is moot.

### Fleet impact

No migration needed. The persisted `last_seen_ts` on existing boxes holds the last event seen while connected; new user messages have a strictly later `ts` and still notify, while already-processed ones (`ts <= watermark`) stay suppressed. The watermark self-corrects as new user messages arrive.

## Tests

New `tests/test_daemon.py` drives the real daemon functions against a tmp notifications dir:
- assistant events do not advance the watermark (regression for the core bug)
- a user message that arrives during a drop is replayed on reconnect even after a later assistant event
- replay skips already-notified messages; snapshot/live overlap does not double-notify
- watermark persists across restart; a message without a `ts` is still notified

🤖 Generated with [Claude Code](https://claude.com/claude-code)