### PR TITLE
fix(release): re-lock the core project on version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           (cd cli && cargo check --quiet) &
           (cd apps/desktop/src-tauri && cargo check --quiet) &
           (cd apps/mobile/src-tauri && cargo check --quiet) &
-          (cd agent && uv lock --quiet) &
+          (cd agent && uv lock --project core --quiet) &
           wait
 
       - name: Commit and push

--- a/agent/core/uv.lock
+++ b/agent/core/uv.lock
@@ -1250,7 +1250,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.169"
+version = "0.1.170"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The 0.1.170 release (`cb4ca4a6`) bumped `agent/core/pyproject.toml` to 0.1.170 but left `agent/core/uv.lock` pinned to 0.1.169. Because the `lockfile` freshness job only runs on PRs (`if: github.event_name == 'pull_request'`), master's push went unchecked — and every PR opened since then fails the check on the inherited merge commit.

## Root cause

`release.yml`'s "Refresh lockfiles" step ran `(cd agent && uv lock --quiet)`. But `agent/` has no `pyproject.toml` — the engine project lives at `agent/core/`. That invocation errors ("no pyproject.toml found"), and since it runs backgrounded under `wait`, the error is swallowed and the step still succeeds. So `agent/core/uv.lock` was never refreshed at bump time.

## Fix

- Point the refresh at the core project: `uv lock --project core` (matching `check.sh` and `scripts/prepare-for-pr.sh`), so future bumps re-lock correctly and can't recur.
- Sync `agent/core/uv.lock` to 0.1.170 now, unblocking the `lockfile` check on all open PRs.

Diff is exactly the one workflow line plus the lock's `vesta` version 0.1.169 → 0.1.170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)