### PR TITLE
feat(agent): render notifications as native <channel> elements

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -126,20 +126,23 @@ _REPLY_SKILLS = frozenset({"app-chat", "whatsapp", "telegram"})
 
 
 def _format_one(notif: vm.Notification) -> str:
-    """Embed a reply hint inside the <notification> element so the model sees them as one unit.
+    """Embed a reply hint inside the <channel> element so the model sees them as one unit.
 
     The hint points the model at the originating channel's reply skill instead of copying its CLI syntax."""
     body = notif.format_for_display()
     if notif.type != "message" or notif.source not in _REPLY_SKILLS:
         return body
     hint = f"\n[Reply using the `{notif.source}` skill]"
-    return body.replace("</notification>", f"{hint}\n</notification>")
+    return body.replace("</channel>", f"{hint}\n</channel>")
 
 
 def format_notification_batch(notifications: list[vm.Notification], *, suffix: str = "") -> str:
+    """Join the batch as newline-separated <channel> elements, matching how Claude Code delivers
+    several native channel events together on one turn. No wrapper element: each <channel> is
+    self-contained."""
     suffix_str = f"\n\n{suffix}" if suffix else ""
     inner = "\n".join(_format_one(n) for n in notifications)
-    return f"<notifications>\n{inner}\n</notifications>{suffix_str}"
+    return f"{inner}{suffix_str}"
 
 
 def _delete_paths(file_paths: list[str]) -> None:

--- a/agent/core/models.py
+++ b/agent/core/models.py
@@ -4,6 +4,7 @@ import dataclasses as dc
 import datetime as dt
 import time
 import typing as tp
+import xml.sax.saxutils as xml_utils
 
 import pydantic as pyd
 from aiohttp.web import AppRunner
@@ -173,6 +174,13 @@ class State:
     context_warning_active: bool = False
 
 
+# Fields promoted to the <channel> element's inner body (the message), in priority order.
+# Everything else on a notification renders as an attribute. Skills that carry a human-readable
+# message use one of these keys (whatsapp/app-chat write `message`); metadata-only notifications
+# (email, reactions) have none and render as attributes with an empty body.
+_CONTENT_FIELDS = ("message", "text", "content")
+
+
 class Notification(pyd.BaseModel):
     model_config = pyd.ConfigDict(extra="allow")
 
@@ -186,10 +194,13 @@ class Notification(pyd.BaseModel):
     file_path: str | None = pyd.Field(default=None, exclude=True)
 
     def format_for_display(self) -> str:
-        """Render the notification as an XML element for unambiguous parsing.
+        """Render the notification as a <channel> element: routing metadata as attributes, the
+        message as the inner body. This mirrors the shape Claude Code injects for native channel
+        events, so the model reads Vesta notifications in a structure it already handles well.
 
-        When `body` is set it becomes the inner text (used by multi-line system prompts).
-        Otherwise the remaining fields render as `key=value` attributes.
+        A multi-line `body` (core/system notifications) becomes the inner text directly. Otherwise
+        the first present content field (message/text/content) becomes the body and every other
+        field renders as an attribute.
 
         Drops empty strings, False bools, empty lists, and None since they cost tokens without
         carrying information. Booleans should be named so True is the interesting case
@@ -197,14 +208,20 @@ class Notification(pyd.BaseModel):
         datetime field.
         """
         if self.body is not None:
-            return f'<notification source="{self.source}" type="{self.type}">\n{self.body.strip()}\n</notification>'
+            return f'<channel source="{self.source}" type="{self.type}">\n{self.body.strip()}\n</channel>'
         data = self.model_dump(exclude={"file_path", "type", "source", "body", "interrupt"})
-        parts = []
+        content = ""
+        for field in _CONTENT_FIELDS:
+            if field in data and isinstance(data[field], str) and data[field].strip():
+                content = xml_utils.escape(data.pop(field).strip())
+                break
+        attrs = [f'source="{self.source}"', f'type="{self.type}"']
         for key, value in data.items():
             if value is None or value == "" or value is False or value == []:
                 continue
             if isinstance(value, dt.datetime):
                 value = value.replace(microsecond=0).isoformat()
-            parts.append(f"{key}={value}")
-        body = ", ".join(parts)
-        return f'<notification source="{self.source}" type="{self.type}">{body}</notification>'
+            if value is True:
+                value = "true"
+            attrs.append(f"{key}={xml_utils.quoteattr(str(value))}")
+        return f"<channel {' '.join(attrs)}>{content}</channel>"

--- a/agent/skills/email-client/SETUP.md
+++ b/agent/skills/email-client/SETUP.md
@@ -169,7 +169,7 @@ EOF
 A notification arrives to you looking like this, so your rules can match on `from` / `subject` / `folder`:
 
 ```
-<notification source="email-client" type="email">account=personal, folder=INBOX, from=Jane Doe <jane@example.com>, subject=Q2 budget review, date=..., uid=12345</notification>
+<channel source="email-client" type="email" account="personal" folder="INBOX" from="Jane Doe &lt;jane@example.com&gt;" subject="Q2 budget review" date="..." uid="12345"></channel>
 ```
 
 Without this line you still handle email on request, but standing rules (especially "stay silent" / auto-handle rules) may not fire on their own.

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -162,9 +162,9 @@ async def test_delete_handles_already_deleted(tmp_path):
 def test_batch_single():
     notif = vm.Notification(timestamp=dt.datetime(2025, 1, 1), source="test", type="message")
     formatted = format_notification_batch([notif])
-    assert "<notifications>" in formatted
-    assert '<notification source="test" type="message">' in formatted
-    assert "</notifications>" in formatted
+    assert '<channel source="test" type="message"' in formatted
+    assert formatted.rstrip().endswith("</channel>")
+    assert "<notifications>" not in formatted
 
 
 def test_batch_multiple():
@@ -173,11 +173,11 @@ def test_batch_multiple():
         vm.Notification(timestamp=dt.datetime(2025, 1, 1, 0, 0, 1), source="test", type="alert"),
     ]
     formatted = format_notification_batch(notifs)
-    assert formatted.count("<notification ") == 2
-    assert '<notification source="test" type="message">' in formatted
-    assert '<notification source="test" type="alert">' in formatted
-    assert formatted.startswith("<notifications>\n")
-    assert formatted.endswith("</notifications>")
+    assert formatted.count("<channel ") == 2
+    assert '<channel source="test" type="message"' in formatted
+    assert '<channel source="test" type="alert"' in formatted
+    assert formatted.startswith("<channel ")
+    assert "<notifications>" not in formatted
 
 
 def test_batch_with_suffix():
@@ -189,9 +189,9 @@ def test_batch_with_suffix():
 def test_notification_format_for_display():
     notif = vm.Notification.model_validate({"timestamp": "2025-01-01T00:00:00", "source": "email", "type": "message", "sender": "alice"})
     display = notif.format_for_display()
-    assert display.startswith('<notification source="email" type="message">')
-    assert display.endswith("</notification>")
-    assert "sender=alice" in display
+    assert display.startswith('<channel source="email" type="message"')
+    assert display.endswith("</channel>")
+    assert 'sender="alice"' in display
 
 
 def test_format_for_display_drops_empty_and_false_fields():
@@ -212,11 +212,11 @@ def test_format_for_display_drops_empty_and_false_fields():
         }
     )
     display = notif.format_for_display()
-    assert "contact_name=Alice" in display
-    assert "message=hi" in display
-    assert "contact_unknown=True" in display  # True bool kept (interesting case)
-    assert "chat_name=" not in display
-    assert "media_type=" not in display
+    assert 'contact_name="Alice"' in display
+    assert ">hi</channel>" in display  # message promoted to the element body
+    assert 'contact_unknown="true"' in display  # True bool kept (interesting case)
+    assert "chat_name" not in display
+    assert "media_type" not in display
     assert "is_forwarded" not in display
     assert "quoted_text" not in display
     assert "tags" not in display
@@ -234,7 +234,7 @@ def test_format_for_display_keeps_integer_zero():
         }
     )
     display = notif.format_for_display()
-    assert "minutes_until=0" in display
+    assert 'minutes_until="0"' in display
 
 
 def test_format_for_display_strips_timestamp_microseconds():
@@ -248,7 +248,7 @@ def test_format_for_display_strips_timestamp_microseconds():
     )
     display = notif.format_for_display()
     assert ".123456" not in display
-    assert "timestamp=2025-01-01T12:34:56+00:00" in display
+    assert 'timestamp="2025-01-01T12:34:56+00:00"' in display
 
 
 @pytest.mark.parametrize(
@@ -320,7 +320,7 @@ async def test_process_batch_queues_prompt(tmp_path):
 
     assert not queue.empty()
     prompt, is_user, file_paths, _, _ = await queue.get()
-    assert '<notification source="test" type="message">' in prompt
+    assert '<channel source="test" type="message"' in prompt
     assert is_user is False
 
 
@@ -432,7 +432,7 @@ async def test_monitor_loop_interrupt_queued_while_not_idle(tmp_path):
         await wait_for_condition(lambda: not queue.empty(), message="interrupt notification was never queued")
 
         prompt, is_user, file_paths, _, _ = await queue.get()
-        assert '<notification source="test" type="message">' in prompt
+        assert '<channel source="test" type="message"' in prompt
         assert is_user is False
         assert state.event_bus.state == "thinking", "interrupt routing must not depend on idle state"
     finally:
@@ -464,7 +464,7 @@ async def test_monitor_loop_passive_held_until_idle_then_flushed_once(tmp_path):
         await wait_for_condition(lambda: not queue.empty(), message="passive batch never flushed after idle")
 
         prompt, is_user, file_paths, _, _ = await queue.get()
-        assert '<notification source="test" type="message">' in prompt
+        assert '<channel source="test" type="message"' in prompt
         assert is_user is False
 
         # Exactly once: file stays on disk (deleted only after processing), but nothing re-queues.
@@ -667,7 +667,7 @@ async def test_policy_interrupts_a_notification(tmp_path):
         _write_notif(config.notifications_dir, "now-urgent")
         await wait_for_condition(lambda: not queue.empty(), message="interrupt rule did not queue the notif while busy")
         prompt, is_user, _, _, _ = await queue.get()
-        assert '<notification source="test" type="message">' in prompt
+        assert '<channel source="test" type="message"' in prompt
         assert is_user is False
     finally:
         await runner.aclose()


### PR DESCRIPTION
## What

Format Vesta's injected notifications to match the shape Claude Code uses for its own **native channel events**, so the model reads them in a structure it already handles well.

Follow-up to the research in #36: native channels themselves are still not adoptable for Vesta (custom channels are stuck behind `--dangerously-load-development-channels`, OpenRouter agents can't authenticate to them, and personal-account gating is buggy upstream). This PR takes the cheap, safe win from that research: the **format**, without the transport.

### Before
```
<notifications>
<notification source="whatsapp" type="message">instance=main, contact_name=John, message=hey are you around?, timestamp=2026-07-08T14:03:00, contact_unknown=True</notification>
</notifications>
```
The real message competes for attention with `instance` and `message_id` in a flat CSV.

### After
```
<channel source="whatsapp" type="message" contact_name="John" timestamp="2026-07-08T14:03:00" contact_unknown="true">hey are you around?
[Reply using the `whatsapp` skill]</channel>
```
Routing metadata as attributes, the message as the element body: identical in shape to what Claude Code injects natively.

## How

- `Notification.format_for_display` promotes the first content field (`message`/`text`/`content`) to the inner body and renders every other field as an XML attribute, escaped via `xml.sax.saxutils`. Metadata-only notifications (email, reactions) render attribute-only with an empty body.
- `format_notification_batch` drops the `<notifications>` wrapper and emits newline-separated `<channel>` elements, matching how Claude Code delivers several native channel events on one turn.
- The core/system multi-line `body` path and the reply-skill hint move to the same `<channel>` tag.

## Scope / safety

Purely presentation. The notification-interrupt-policy ruleset, batching, preemption, and EventBus history all match on notification **fields**, not the rendered string, so they are untouched. No change to the notification transport or the file-poll flow.

## Testing

- `test_notifications.py` assertions updated to the new format (54 passing).
- Related suites green: `test_processor.py`, `test_interrupts.py`, `test_preempt.py`, `test_crash_recovery.py` (79 passing).
- ruff + ty clean.
- Verified end-to-end by rendering real whatsapp/reaction/email/core payloads, including XML escaping of `<`, `>`, and quotes in attribute values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)