### PR TITLE
refactor(notifications): drop the triage suffix from the idle pool pass

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -153,7 +153,6 @@ async def process_batch(
     queue: asyncio.Queue[vm.QueuedTurn],
     state: vm.State,
     config: vm.VestaConfig,
-    external_suffix_name: str = "notification_suffix",
 ) -> None:
     """Render a batch as one prompt and queue it. Internal (`source=core`) notifications skip the external-message suffix; mixed batches render in two sections, system first.
 
@@ -181,7 +180,7 @@ async def process_batch(
     if system:
         await queue_section(system, suffix="")
     if external:
-        await queue_section(external, suffix=load_prompt(external_suffix_name, config) or "")
+        await queue_section(external, suffix=load_prompt("notification_suffix", config) or "")
 
 
 def greeting_turn(*, config: vm.VestaConfig, state: vm.State, reason: str) -> str | None:
@@ -634,7 +633,7 @@ async def monitor_loop(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.State, 
                 await process_batch(interrupt_notifs, queue=queue, state=state, config=config)
 
             # Track how long the agent has been continuously idle; micro-gaps shorter than the
-            # grace never qualify, so a brief breather between turns doesn't trigger a triage pass.
+            # grace never qualify, so a brief breather between turns doesn't flush the pool.
             if state.event_bus.state == "idle":
                 if idle_since is None:
                     idle_since = now
@@ -642,7 +641,7 @@ async def monitor_loop(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.State, 
                 idle_since = None
 
             if pending_passive and idle_since is not None and (now - idle_since).total_seconds() >= config.notif_pool_idle_grace_seconds:
-                await process_batch(pending_passive, queue=queue, state=state, config=config, external_suffix_name="notification_triage")
+                await process_batch(pending_passive, queue=queue, state=state, config=config)
                 pending_passive = []
     finally:
         await _cancel_task(watcher_task)

--- a/agent/core/prompts/notification_triage.md
+++ b/agent/core/prompts/notification_triage.md
@@ -1,1 +1,0 @@
-These notifications came in while you were busy. Read the `notifications` skill and triage them: act on what genuinely needs you now, note anything worth surfacing to the user, and drop the rest. Spend effort proportional to value; you do not need to respond to each one.

--- a/agent/core/uv.lock
+++ b/agent/core/uv.lock
@@ -1250,7 +1250,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.1.169"
+version = "0.1.170"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/agent/tests/test_notif_pool_triage.py
+++ b/agent/tests/test_notif_pool_triage.py
@@ -1,19 +1,8 @@
-"""Config knobs + triage prompt for the pooled-notification triage pass."""
-
-import pathlib as pl
+"""Config knobs for the pooled-notification idle pass."""
 
 from core.config import VestaConfig
-
-AGENT_ROOT = pl.Path(__file__).resolve().parents[1]
 
 
 def test_notif_pool_triage_config_defaults():
     config = VestaConfig()
     assert config.notif_pool_idle_grace_seconds == 30.0
-
-
-def test_notification_triage_prompt_ships_and_points_at_skill():
-    text = (AGENT_ROOT / "core" / "prompts" / "notification_triage.md").read_text()
-    assert text.strip()
-    assert "notifications" in text  # references the comprehensive skill
-    assert "triage" in text.lower()

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -700,21 +700,6 @@ async def test_policy_changes_take_effect_live_on_next_tick(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_process_batch_external_suffix_name_selects_prompt(tmp_path):
-    config = vm.VestaConfig(agent_dir=tmp_path / "agent")
-    config.notifications_dir.mkdir(parents=True, exist_ok=True)
-    state = vm.State()
-    queue: asyncio.Queue = asyncio.Queue()
-    notif = vm.Notification(timestamp=dt.datetime(2025, 1, 1), source="twitter", type="tweet", body="hi")
-
-    with patch("core.loops.load_prompt", side_effect=lambda name, config: f"SUFFIX:{name}"):
-        await process_batch([notif], queue=queue, state=state, config=config, external_suffix_name="notification_triage")
-    prompt, is_user, _, _, _ = await queue.get()
-    assert "SUFFIX:notification_triage" in prompt
-    assert is_user is False
-
-
-@pytest.mark.anyio
 async def test_process_batch_defaults_to_notification_suffix(tmp_path):
     config = vm.VestaConfig(agent_dir=tmp_path / "agent")
     config.notifications_dir.mkdir(parents=True, exist_ok=True)
@@ -786,8 +771,8 @@ async def test_pool_not_flushed_before_grace(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_pool_triage_flushes_once_after_grace_with_triage_framing(tmp_path):
-    """After continuous idle >= grace, the pool is triaged once, framed notification_triage."""
+async def test_pool_flushes_once_after_grace(tmp_path):
+    """After continuous idle >= grace, the pooled notifications are flushed once."""
     config = _passive_config(tmp_path)
     _install_rule(config, action="pool")
     state = vm.State()
@@ -800,9 +785,9 @@ async def test_pool_triage_flushes_once_after_grace_with_triage_framing(tmp_path
         await runner.__anext__()
         try:
             _write_notif(config.notifications_dir, "p")
-            await wait_for_condition(lambda: pb.call_count >= 1, message="pool was never triaged after idle+grace")
-            _, kwargs = pb.call_args
-            assert kwargs["external_suffix_name"] == "notification_triage"
+            await wait_for_condition(lambda: pb.call_count >= 1, message="pool was never flushed after idle+grace")
+            (batch,), _ = pb.call_args
+            assert len(batch) == 1
             await asyncio.sleep(0.1)
             assert pb.call_count == 1  # interval prevents an immediate re-fire
         finally:


### PR DESCRIPTION
## What

Pooled (non-interrupting) notifications flushed at the idle grace point were framed with a dedicated `notification_triage` prompt suffix that told the model to read the `notifications` skill and triage the batch. This drops that special framing: the pooled batch now goes through with the normal `notification_suffix`, exactly like the interrupt path. The notifications themselves are unchanged — they already ride in the same `<notifications>…</notifications>` block on both paths; only the trailing instruction line differed.

Rationale: the model already triages a batch on its own, so the extra prompt is redundant.

## Changes

- `loops.py`: the idle pool flush calls `process_batch` with the default suffix.
- With both `process_batch` call sites now on the default, `external_suffix_name` became single-valued dead flexibility (no speculative flexibility for a single caller) — parameter removed, suffix hardcoded to `notification_suffix`.
- Deleted the orphaned `agent/core/prompts/notification_triage.md`.
- Updated tests: dropped the param-selection and triage-prompt-ships tests, retargeted the idle-flush test to assert the pool is flushed once (no framing assertion).

## Verification

`./check.sh agent` equivalent locally: ruff check + format + ty + full pytest — **539 passed**, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)