### PR TITLE
fix(contacts): make the roster grep robust to an empty or missing store

### DIFF
--- a/agent/skills/contacts/SKILL.md
+++ b/agent/skills/contacts/SKILL.md
@@ -16,7 +16,7 @@ Keep it plain. The whole thing is markdown you edit with Read, Write, Glob, and 
 To see who you know, derive the roster from the files instead of keeping a separate list (nothing to fall out of sync):
 
 ```bash
-grep -H "^# \|^Relationship:" ~/.contacts/*.md   # name + relationship for everyone, one call
+grep -rHs "^# \|^Relationship:" ~/.contacts/   # name + relationship for everyone; empty until you add people
 ```
 
 `Glob ~/.contacts/*.md` lists everyone; `Grep` across the dir finds who said what or who works where.


### PR DESCRIPTION
## What

The contacts skill documents a one-line roster command:

```bash
grep -H "^# \|^Relationship:" ~/.contacts/*.md
```

On a fresh box (empty or absent `~/.contacts/`) the `*.md` glob doesn't expand, so bash passes the literal `~/.contacts/*.md` to grep, which errors:

```
grep: /root/.contacts/*.md: No such file or directory
```

The agent runs this right after the contacts-backfill migration (before any contact file exists) and sees an error instead of an empty roster, so it may conclude the store is broken.

## Fix

Grep across the directory (`-r`) and suppress no-file errors (`-s`):

```bash
grep -rHs "^# \|^Relationship:" ~/.contacts/
```

Verified:
- empty store → clean empty output (exit 1, no message)
- missing store → clean, no error message
- populated store → the same `file:name` / `file:relationship` roster as before

Doc-only change to the skill body; frontmatter is untouched so `index.json` is unchanged.

## Note

The review that surfaced this also flagged the contacts-backfill migration for "never calling `mark_migration_applied`" — that one is a **false positive**: `migrations.py` (`pending_migration_turns`) auto-appends the mark step to every pending migration, so the backfill does not re-fire. No migration change is needed (and shipped migrations are append-only regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)