### PR TITLE
design(web): pin the wordmark serif to Source Serif 4

### DIFF
--- a/agent/skills/dashboard/app/package-lock.json
+++ b/agent/skills/dashboard/app/package-lock.json
@@ -12,8 +12,10 @@
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@fontsource-variable/outfit": "^5.2.8",
         "@fontsource-variable/public-sans": "^5.2.7",
+        "@fontsource-variable/source-serif-4": "^5.2.9",
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1301,6 +1303,15 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@fontsource-variable/outfit": {
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/outfit/-/outfit-5.2.8.tgz",
@@ -1314,6 +1325,15 @@
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/public-sans/-/public-sans-5.2.7.tgz",
       "integrity": "sha512-4mvade2J3slKkvwRkS+p8T3szet/0vhWoSnuUJTVU81Uo2pRpSZY/Y8bSLRqpSwzIPxjVmRJ53oq6JKP/l/PSg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/source-serif-4": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/source-serif-4/-/source-serif-4-5.2.9.tgz",
+      "integrity": "sha512-PPcxjLFk/fS0WHg79pDM2YNvz61kC+oYZ5cWZZyCS0DHpJncmuYOuiZAsvj4tDxlWPBEvxxcRLQQNmSaRbPkqw==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -4679,6 +4699,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",

--- a/agent/skills/dashboard/app/package.json
+++ b/agent/skills/dashboard/app/package.json
@@ -17,6 +17,7 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/outfit": "^5.2.8",
     "@fontsource-variable/public-sans": "^5.2.7",
+    "@fontsource-variable/source-serif-4": "^5.2.9",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/agent/skills/dashboard/app/src/index.css
+++ b/agent/skills/dashboard/app/src/index.css
@@ -6,6 +6,8 @@
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/public-sans";
 @import "@fontsource-variable/outfit";
+@import "@fontsource-variable/source-serif-4";
+@import "@fontsource-variable/source-serif-4/wght-italic.css";
 @import "@fontsource-variable/jetbrains-mono";
 
 @custom-variant dark (&:is(.dark *));
@@ -145,6 +147,7 @@ html[data-platform="android"] {
 @theme inline {
   --font-sans: "Public Sans Variable", sans-serif;
   --font-heading: "Outfit Variable", sans-serif;
+  --font-serif: "Source Serif 4 Variable", Georgia, serif;
   --font-mono:
     "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Consolas,
     "Liberation Mono", monospace;

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -1169,6 +1169,15 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@fontsource-variable/source-serif-4": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/source-serif-4/-/source-serif-4-5.2.9.tgz",
+      "integrity": "sha512-PPcxjLFk/fS0WHg79pDM2YNvz61kC+oYZ5cWZZyCS0DHpJncmuYOuiZAsvj4tDxlWPBEvxxcRLQQNmSaRbPkqw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -11426,6 +11435,7 @@
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@fontsource-variable/outfit": "^5.2.8",
         "@fontsource-variable/public-sans": "^5.2.7",
+        "@fontsource-variable/source-serif-4": "^5.2.9",
         "@hookform/resolvers": "^5.4.0",
         "@tanstack/react-virtual": "^3.14.5",
         "@tauri-apps/api": "^2.11.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/outfit": "^5.2.8",
     "@fontsource-variable/public-sans": "^5.2.7",
+    "@fontsource-variable/source-serif-4": "^5.2.9",
     "@hookform/resolvers": "^5.4.0",
     "@tanstack/react-virtual": "^3.14.5",
     "@tauri-apps/api": "^2.11.1",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3,6 +3,8 @@
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/public-sans";
 @import "@fontsource-variable/outfit";
+@import "@fontsource-variable/source-serif-4";
+@import "@fontsource-variable/source-serif-4/wght-italic.css";
 @import "@fontsource-variable/jetbrains-mono";
 
 @custom-variant dark (&:is(.dark *));
@@ -142,6 +144,7 @@ html[data-platform="android"] {
 @theme inline {
   --font-sans: "Public Sans Variable", sans-serif;
   --font-heading: "Outfit Variable", sans-serif;
+  --font-serif: "Source Serif 4 Variable", Georgia, serif;
   --font-mono:
     "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Consolas,
     "Liberation Mono", monospace;


### PR DESCRIPTION
## What

`font-serif` was used at nine call sites but `apps/web/src/index.css` (`@theme`) defined no `--font-serif`, so every call fell through to the browser default serif: Georgia on macOS, Times New Roman on Windows, DejaVu on Linux. The brand wordmark and every agent name changed per OS.

Call sites affected: `Logo/LogoText`, `AgentCard`, `AgentIsland/Collapsed`, `AgentIsland/Expanded`, and `AgentSettings/FilesTab/DreamsViewer` (7 uses).

## Decision

Issue #803 laid out two honest fixes and asked for a brand call. The user chose **A — pin a real serif** (the more distinctive option; also the one DreamsViewer's italic journal aesthetic argues for).

## Change

- Add `--font-serif: "Source Serif 4 Variable", Georgia, serif;` to `@theme`.
- Import both the upright (`@fontsource-variable/source-serif-4`) **and** italic (`.../wght-italic.css`) entry points. DreamsViewer relies on `italic` serif heavily; without the real italic face the browser would synthesize a faux-oblique. Georgia remains the fallback.
- Add the `@fontsource-variable/source-serif-4` dependency + lockfile entry.

No call sites changed — they already used `font-serif`; they were just resolving to an accidental typeface.

## Verification

- `./check.sh web` green: eslint (0 errors), prettier clean, `tsc --noEmit` clean, vitest 145/145 passed.
- Production build emits both upright and italic Source Serif 4 woff2 subsets into `dist/`, confirming the imports resolve and bundle.

Fixes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)