### PR TITLE
test(live): raise flaky real-Claude probe timeouts to 300s

### DIFF
--- a/vestad/tests/live/interrupt.rs
+++ b/vestad/tests/live/interrupt.rs
@@ -6,7 +6,7 @@ use vesta_tests::exec_in_container;
 use super::common::{lock_live_agent_a, wait_for_file_contains, write_notification, E2E_FILES_DIR};
 
 /// Per-step timeout for the agent to make observable progress.
-const TASK_TIMEOUT: Duration = Duration::from_secs(240);
+const TASK_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Proving the count is dead: the counting task appends a number roughly every 5s, so once the
 /// file is unchanged for COUNT_STABLE_WINDOW (comfortably longer than that cadence) nothing is

--- a/vestad/tests/live/lifecycle.rs
+++ b/vestad/tests/live/lifecycle.rs
@@ -48,6 +48,6 @@ fn agent_restart_vesta_tool_restarts_through_vestad() {
     let uid = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
     let file = format!("{E2E_FILES_DIR}/restarted-{uid}.txt");
     write_notification(&container, &create_file_request(&file, "BACK"), true).expect("write post-restart probe");
-    wait_for_file_contains(&container, &file, "BACK", Duration::from_secs(180))
+    wait_for_file_contains(&container, &file, "BACK", Duration::from_secs(300))
         .expect("agent must process work after the restart");
 }


### PR DESCRIPTION
## Why

The v0.1.171 release was blocked by `test-live`, but it was **flakiness, not a regression**. In one release run, two attempts each failed a *different* single test (the other passed), and both are real-Claude latency timeouts:

| Test | Attempt 1 | Attempt 2 |
|---|---|---|
| `interrupt::preempt_preserves_running_background_subagent` | ✅ ok | ❌ timed out |
| `lifecycle::agent_restart_vesta_tool_restarts_through_vestad` | ❌ timed out | ✅ ok |

Each test passed on one attempt and failed the other — the signature of flakiness, not a deterministic regression. Every test exercising the recent notification changes (#1051/#1053/#1052) passed. Per the testing strategy in CLAUDE.md ("when a flaky test surfaces, quarantine or fix it, do not blanket-rerun"), this hardens the two probes rather than re-rolling the dice.

## What

- `lifecycle.rs:51` post-restart work probe: `180s` → `300s`
- `interrupt.rs:9` `TASK_TIMEOUT`: `240s` → `300s`

Both wait on the agent doing model-driven work; 300s aligns them with the other live probes (e.g. dreamer). No behavior change.

## Verification

`VESTAD_SKIP_APP_BUILD=1 cargo test -p vestad --test live --no-run` compiles. Full live run happens on the next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)