### PR TITLE
fix(skills): install CLIs editable so runtime edits stay fresh

### DIFF
--- a/agent/core/skills/app-chat/SKILL.md
+++ b/agent/core/skills/app-chat/SKILL.md
@@ -8,7 +8,7 @@ description: Reply to notifications with `source=app-chat` via `app-chat send`. 
 ## Setup
 This is a core skill: its CLI lives under `~/agent/core/skills/app-chat/` (read-only mount), not `~/agent/skills/`.
 ```bash
-uv tool install ~/agent/core/skills/app-chat/cli
+uv tool install --editable ~/agent/core/skills/app-chat/cli
 ```
 
 **Background**: `screen -dmS app-chat app-chat serve`

--- a/agent/skills/enable-banking/SETUP.md
+++ b/agent/skills/enable-banking/SETUP.md
@@ -13,7 +13,7 @@
 ## 2. Install CLI
 
 ```bash
-cd ~/agent/skills/enable-banking/cli && uv tool install --force --reinstall .
+cd ~/agent/skills/enable-banking/cli && uv tool install --editable --force --reinstall .
 ```
 
 ## 3. Configure

--- a/agent/skills/exa/SETUP.md
+++ b/agent/skills/exa/SETUP.md
@@ -9,7 +9,7 @@
 ## Step 1: Install the CLI
 
 ```bash
-uv tool install --force --reinstall ~/agent/skills/exa/cli
+uv tool install --editable --force --reinstall ~/agent/skills/exa/cli
 ```
 
 ## Step 2: Configure the API key

--- a/agent/skills/exa/SKILL.md
+++ b/agent/skills/exa/SKILL.md
@@ -77,4 +77,4 @@ Models:
 - Every response includes a `costDollars` field. Mention cost to the user for `research` calls (they can add up).
 - `--text` significantly increases token count. Use `--highlights` or `--summary` when you just need gist.
 - Exa ranks by semantic relevance. For exact-match queries (names, SKUs), pass `--type keyword`.
-- Installed via `uv tool install ~/agent/skills/exa/cli`.
+- Installed via `uv tool install --editable ~/agent/skills/exa/cli`.

--- a/agent/skills/flights/SKILL.md
+++ b/agent/skills/flights/SKILL.md
@@ -193,7 +193,7 @@ flights passenger show myprofile       # show profile
 
 Install with:
 ```bash
-cd ~/agent/skills/flights/cli && uv tool install --force --reinstall .
+cd ~/agent/skills/flights/cli && uv tool install --editable --force --reinstall .
 ```
 
 Duffel API token stored at `~/.config/duffel/token`. Passenger profiles at `~/.config/duffel/passengers.json`.

--- a/agent/skills/flights/cli/src/flights_cli/_freshness.py
+++ b/agent/skills/flights/cli/src/flights_cli/_freshness.py
@@ -5,7 +5,7 @@ pyicloud for iCloud) that track upstream sites which change format without
 notice. A version behind PyPI is how such a skill silently starts returning
 nothing (issue #822). `require_latest` compares the installed version against
 PyPI's latest and exits non-zero when behind, turning silent drift into a
-loud, actionable error that a `uv tool install --force --reinstall .` clears.
+loud, actionable error that a `uv tool install --editable --force --reinstall .` clears.
 
 On any network / PyPI failure staleness cannot be proven, so it warns and
 returns rather than blocking a working install on a transient PyPI outage.
@@ -58,7 +58,7 @@ def require_latest(package: str) -> None:
                     "error": (
                         f"{package} {installed} is behind the latest release {latest}. This skill wraps a "
                         f"reverse-engineered library that breaks when it falls behind upstream; reinstall to "
-                        f"update: cd ~/agent/skills/<skill>/cli && uv tool install --force --reinstall ."
+                        f"update: cd ~/agent/skills/<skill>/cli && uv tool install --editable --force --reinstall ."
                     )
                 }
             ),

--- a/agent/skills/google/SETUP.md
+++ b/agent/skills/google/SETUP.md
@@ -6,7 +6,7 @@
    - Application type: **Desktop app**
    - Download the JSON file
 4. Place the credentials file at `~/.google/credentials.json`
-5. Install: `uv tool install ~/agent/skills/google/cli`
+5. Install: `uv tool install --editable ~/agent/skills/google/cli`
 6. Start background daemon: `screen -dmS google google serve`
 7. Register it for restart (see [service](../service/SKILL.md)) with this startup command:
    ```

--- a/agent/skills/home-assistant/SKILL.md
+++ b/agent/skills/home-assistant/SKILL.md
@@ -41,7 +41,7 @@ ha ping                              # check API connectivity
 #   HASS_TOKEN - long-lived access token from HA
 #   HASS_URL   - HA base URL (default: http://homeassistant.local:8123)
 source /etc/environment
-uv tool install ~/agent/skills/home-assistant/cli
+uv tool install --editable ~/agent/skills/home-assistant/cli
 ```
 
 ## Usage Tips

--- a/agent/skills/icloud-photos/SETUP.md
+++ b/agent/skills/icloud-photos/SETUP.md
@@ -10,7 +10,7 @@
 ## Step 1: Install the CLI
 
 ```bash
-uv tool install --force --reinstall ~/agent/skills/icloud-photos/cli
+uv tool install --editable --force --reinstall ~/agent/skills/icloud-photos/cli
 ```
 
 ## Step 2: Provide credentials

--- a/agent/skills/icloud-photos/SKILL.md
+++ b/agent/skills/icloud-photos/SKILL.md
@@ -84,4 +84,4 @@ Creates one subfolder per shared album. Same `--quality` and `--include-videos` 
 
 ## Installed via
 
-`uv tool install ~/agent/skills/icloud-photos/cli`
+`uv tool install --editable ~/agent/skills/icloud-photos/cli`

--- a/agent/skills/icloud-photos/cli/src/icloud_cli/_freshness.py
+++ b/agent/skills/icloud-photos/cli/src/icloud_cli/_freshness.py
@@ -5,7 +5,7 @@ pyicloud for iCloud) that track upstream sites which change format without
 notice. A version behind PyPI is how such a skill silently starts returning
 nothing (issue #822). `require_latest` compares the installed version against
 PyPI's latest and exits non-zero when behind, turning silent drift into a
-loud, actionable error that a `uv tool install --force --reinstall .` clears.
+loud, actionable error that a `uv tool install --editable --force --reinstall .` clears.
 
 On any network / PyPI failure staleness cannot be proven, so it warns and
 returns rather than blocking a working install on a transient PyPI outage.
@@ -58,7 +58,7 @@ def require_latest(package: str) -> None:
                     "error": (
                         f"{package} {installed} is behind the latest release {latest}. This skill wraps a "
                         f"reverse-engineered library that breaks when it falls behind upstream; reinstall to "
-                        f"update: cd ~/agent/skills/<skill>/cli && uv tool install --force --reinstall ."
+                        f"update: cd ~/agent/skills/<skill>/cli && uv tool install --editable --force --reinstall ."
                     )
                 }
             ),

--- a/agent/skills/microsoft/SETUP.md
+++ b/agent/skills/microsoft/SETUP.md
@@ -6,7 +6,7 @@ Graph scopes it needs (`Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`,
 `MailboxSettings.ReadWrite`) via dynamic consent at sign-in. Just install, start the daemon, and
 authenticate:
 
-1. Install: `uv tool install ~/agent/skills/microsoft/cli`
+1. Install: `uv tool install --editable ~/agent/skills/microsoft/cli`
 2. Start background daemon: `screen -dmS microsoft microsoft serve`
 3. Register it for restart (see [service](../service/SKILL.md)) with this startup command:
    ```

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -290,5 +290,5 @@ playing doorman can turn it off; then decline warmly and point them at `vesta.ru
 The CLI is bundled; install it once (the agent does this on first use):
 
 ```bash
-uv tool install ~/agent/skills/onboard/cli
+uv tool install --editable ~/agent/skills/onboard/cli
 ```

--- a/agent/skills/spotify/SETUP.md
+++ b/agent/skills/spotify/SETUP.md
@@ -19,7 +19,7 @@
 ## Step 2: Install the CLI
 
 ```bash
-uv tool install <path-to-this-skill>/cli
+uv tool install --editable <path-to-this-skill>/cli
 ```
 
 ## Step 3: Configure credentials

--- a/agent/skills/spotify/SKILL.md
+++ b/agent/skills/spotify/SKILL.md
@@ -156,5 +156,5 @@ spotify playback transfer --device-id <ID> --play
 ## Notes
 - Playback control requires Spotify Premium + at least one Spotify client open
 - All output is JSON
-- Install via: `uv tool install <path-to-skill>/cli`
+- Install via: `uv tool install --editable <path-to-skill>/cli`
 - To delete/unfollow a playlist, use the Spotify API directly via spotipy (no CLI command yet, use `sp.current_user_unfollow_playlist(id)`)

--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -99,7 +99,7 @@ DB `~/.tasks/tasks.db`; metadata `~/.tasks/metadata/<id>.md`; logs `~/.tasks/log
 
 ## Setup
 ```bash
-uv tool install ~/agent/skills/tasks/cli
+uv tool install --editable ~/agent/skills/tasks/cli
 ```
 
 ## Background Daemon

--- a/agent/skills/zoom/SETUP.md
+++ b/agent/skills/zoom/SETUP.md
@@ -6,5 +6,5 @@
 4. Note down the **Account ID**, **Client ID**, and **Client Secret**
 5. Under "Scopes", add: `meeting:write:admin`, `meeting:read:admin`
 6. Activate the app
-7. Install: `uv tool install ~/agent/skills/zoom/cli`
+7. Install: `uv tool install --editable ~/agent/skills/zoom/cli`
 8. Run: `zoom setup` and enter the 3 credentials when prompted


### PR DESCRIPTION
## Problem

Every skill CLI is a `[project.scripts]` package the agent installs with `uv tool install <path>`. That **copies** the source into a tool venv, so once installed, an agent's runtime edits to a skill's own CLI source were **not** reflected until a manual reinstall. Agents editing skill CLIs could then run stale code.

`browser` already solved this with `uv tool install --editable`, which links the entrypoint to the source checkout so the next call picks up edits with no reinstall.

## Change

Add `--editable` to every path-based `uv tool install` across `SKILL.md` and `SETUP.md`:

app-chat, enable-banking, exa, flights, google, home-assistant, icloud-photos, microsoft, onboard, spotify, tasks, zoom.

- The `--force --reinstall` skills (exa, icloud-photos, enable-banking, flights) keep those flags for their reverse-engineered PyPI deps — `--editable` composes with them. The two flights/icloud freshness-recovery hints in `_freshness.py` are updated to match.
- `keeper` is left as-is: it installs the third-party `keepercommander` PyPI package, not local skill source, so `--editable` doesn't apply.
- The `uv run script.py` skills (recall, upstream-pr, voice, what-day, samsung-tv, timezone) already run source directly and needed no change.

## Verification

Installed the exa CLI editable into a throwaway tool dir, ran it, edited the source, and re-ran without reinstalling — the edit was reflected on the next invocation. Confirmed the mechanism end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)