### PR TITLE
refactor(skills): fold the nightly contacts pass into the dream

### DIFF
--- a/agent/core/migrations/2026-07-contacts-reminder-to-dream.md
+++ b/agent/core/migrations/2026-07-contacts-reminder-to-dream.md
@@ -1,0 +1,31 @@
+The nightly contacts pass (capture everyone who came up today, then reconcile
+the sources) is now owned by the `dream`, not a standalone reminder. Earlier
+boxes created a dedicated recurring reminder for it: the old `contacts` skill
+and the `2026-07-contacts-backfill` migration both set one up. This migration
+removes that reminder so the pass does not run twice a night. It is safe to run
+more than once and is a no-op if you never had one.
+
+### 1. Delete the standalone contacts reminder
+
+If the `tasks` skill is set up, list your recurring reminders:
+
+```bash
+tasks remind list
+```
+
+Find the one whose message is about updating contacts and reconciling them
+across services (the old wording was roughly "Update contacts with everything
+learned today, then reconcile them across every messaging app..."). If it
+exists, delete it by id:
+
+```bash
+tasks remind delete <id>
+```
+
+If there is no such reminder, or the `tasks` CLI is not installed, there is
+nothing to remove. Either way the `dream` now runs this pass nightly in its
+"User State" step, so nothing is lost.
+
+### 2. Mark this migration applied
+
+Call `mark_migration_applied` with `name="2026-07-contacts-reminder-to-dream"`.

--- a/agent/skills/contacts/SKILL.md
+++ b/agent/skills/contacts/SKILL.md
@@ -65,13 +65,7 @@ People don't live in one place, and you learn about them all day long. Two thing
 - **Capture the day**: go back over the day's conversations and activity and fold everything you learned about anyone into their file, a new fact, a mood, a plan, something they're going through, a handle you saw. Anyone who came up for the first time gets a file.
 - **Reconcile the sources**: the same person is a thread in one messaging app, an address in another, a guest on a calendar, a row in an address book. Contacts is the hub of truth that ties them together. Pull new people and facts in from everywhere that holds contacts, and push your canonical fields (name, number, email) back out to the services that can be written to. Non-destructive: fill gaps and fix what's clearly stale, never bulk-overwrite a service's data.
 
-Always keep this running. Maintain exactly **one** recurring reminder that triggers the pass:
-
-```bash
-tasks remind "Update contacts with everything learned today, then reconcile them across every messaging app and every other service that holds contacts" --recurring daily --at "2026-01-05T04:00:00" --tz "$TZ"
-```
-
-When it fires, do both: sweep the day's activity into the files, then work out which sources are worth reconciling this time and bring them in line. Check `tasks remind list` first so you never stack duplicates.
+The nightly `dream` runs this pass, so there's no separate reminder to maintain. On that pass, do both: sweep the day's activity into the files, then work out which sources are worth reconciling this time and bring them in line.
 
 ## [Your setup]
 

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -15,7 +15,7 @@ description: Self-improvement and memory curation; used nightly by the dreamer o
 
 0. **Curiosity**: spend a real moment on yourself before the retrospective.
 1. **Self-improvement**: retrospective, review, fix, validate, upstream, recurrence sweep
-2. **User State**: update the snapshot in MEMORY.md
+2. **User State**: update the MEMORY.md snapshot and the contacts files
 3. **Memory curation**: prune, consolidate, move things out
 4. **Workspace cleanup**: keep the filesystem clean and disk usage manageable
 5. **Sensitive data cleanup**: purge secrets from history and files
@@ -110,6 +110,8 @@ Update the "User State" section, your working model of where they're at. Write w
 - Self: update the Self subsection in MEMORY.md. One honest pass: did you form or change an opinion today, notice a recurring curiosity, or decide something about how you want to handle a kind of moment? Write the few lines tomorrow-you needs to still be the same person, not start blank. Slowly evolving, not rewritten on one day. If you disagreed with the user on substance today (taste, plan, priority, not just facts), keep the view, do not dissolve it into a verification rule. A peer is allowed to just think the user is wrong.
 
 Replace rather than append. It's a snapshot, not a log. Be honest but not dramatic, like "seemed tired" rather than "experiencing significant fatigue." If things got tense between you, write down what happened and what you'd do differently. Don't pretend it didn't happen.
+
+**Contacts.** The people-half of your model lives in `~/.contacts/`, a separate store, not MEMORY.md. Read the `contacts` skill and do its nightly pass: fold everyone who came up today into their file (anyone new gets one), then reconcile the sources worth bringing in line this time. This is the write pass the deeper-context mining above is deliberately barred from doing.
 
 ## Memory Curation
 


### PR DESCRIPTION
## What

The `contacts` skill told each agent to maintain its own daily `tasks remind` cron (04:00) to trigger the nightly capture + reconcile pass. That duplicates the **dream**, which already runs a nightly memory + User State pass at the same early hour. This drives the contacts pass from the dream instead of a competing standalone reminder.

## Changes

- **`contacts` skill**: drop the "maintain exactly one recurring reminder" block. The capture + reconcile description stays; only the trigger moves.
- **`dream` skill**: add a **Contacts** step to the User State phase, read the contacts skill and run its nightly pass. It's the natural write pass complementing the User State "deeper context" mining, which is explicitly *read-only* into `~/.contacts/`.
- **Migration `2026-07-contacts-reminder-to-dream`**: delete the old standalone reminder on boxes that created one (both the old skill and the released `2026-07-contacts-backfill` migration set one up). Idempotent, no-op if none exists. Named to sort **after** `contacts-backfill` so an agent running both on one boot creates-then-removes cleanly.

## Scope / fleet

- Body-only skill edits + one new migration, so `index.json` needs no regen (descriptions unchanged, verified).
- Existing boxes: the migration removes the duplicate 04:00 reminder; the dream takes over. Fresh boxes are born converged (all migrations pre-marked) and never create the reminder.
- The released `contacts-backfill` migration is left untouched (append-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)