### PR TITLE
feat(notifications): flag group-chat messages so the agent decides whether to engage

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -126,13 +126,20 @@ _REPLY_SKILLS = frozenset({"app-chat", "whatsapp", "telegram"})
 
 
 def _format_one(notif: vm.Notification) -> str:
-    """Embed a reply hint inside the <channel> element so the model sees them as one unit.
+    """Embed hints inside the <channel> element so the model sees them as one unit.
 
-    The hint points the model at the originating channel's reply skill instead of copying its CLI syntax."""
+    A reply hint points the model at the originating channel's reply skill instead of copying its CLI
+    syntax. A group-chat message (a `chat_name` attribute is present) also gets a note that it may not
+    be addressed to the agent, so the model decides whether to engage rather than always replying."""
     body = notif.format_for_display()
     if notif.type != "message" or notif.source not in _REPLY_SKILLS:
         return body
-    hint = f"\n[Reply using the `{notif.source}` skill]"
+    extras = notif.model_extra or {}
+    hints = []
+    if "chat_name" in extras and extras["chat_name"]:
+        hints.append("[This message is from a group chat and may not be for you; decide whether to chip in or stay out]")
+    hints.append(f"[Reply using the `{notif.source}` skill]")
+    hint = "\n" + "\n".join(hints)
     return body.replace("</channel>", f"{hint}\n</channel>")
 
 

--- a/agent/core/prompts/notification_suffix.md
+++ b/agent/core/prompts/notification_suffix.md
@@ -1,3 +1,1 @@
 Check MEMORY.md Learned Patterns before responding.
-
-A chat_name means a group message that may not be for you, so weigh chipping in versus staying out.

--- a/agent/core/prompts/notification_suffix.md
+++ b/agent/core/prompts/notification_suffix.md
@@ -1,1 +1,3 @@
 Check MEMORY.md Learned Patterns before responding.
+
+When a notification shows a chat_name it is a group chat where the message may not be directed at you, so weigh whether to chip in or stay out.

--- a/agent/core/prompts/notification_suffix.md
+++ b/agent/core/prompts/notification_suffix.md
@@ -1,3 +1,3 @@
 Check MEMORY.md Learned Patterns before responding.
 
-When a notification shows a chat_name it is a group chat where the message may not be directed at you, so weigh whether to chip in or stay out.
+A chat_name means a group message that may not be for you, so weigh chipping in versus staying out.

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -301,6 +301,30 @@ def test_batch_no_hint_for_non_message_type():
     assert "Reply using" not in formatted
 
 
+def test_group_message_flagged_maybe_not_for_you():
+    notif = vm.Notification.model_validate(
+        {
+            "timestamp": "2025-01-01T00:00:00",
+            "source": "whatsapp",
+            "type": "message",
+            "chat_name": "Bride squad",
+            "sender": "bob",
+            "message": "hi",
+        }
+    )
+    formatted = format_notification_batch([notif])
+    assert "from a group chat" in formatted
+    assert "chip in or stay out" in formatted
+
+
+def test_direct_message_not_flagged_as_group():
+    notif = vm.Notification.model_validate(
+        {"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "message", "contact_name": "Alice", "message": "hi"}
+    )
+    formatted = format_notification_batch([notif])
+    assert "from a group chat" not in formatted
+
+
 # --- process_batch ---
 
 


### PR DESCRIPTION
## What

When a message notification comes from a **group chat**, embed a note directly in its `<channel>` element:

> [This message is from a group chat and may not be for you; decide whether to chip in or stay out]

## Why explicitly on the notification (not the suffix)

An earlier take put this in the batch-level notification suffix, but that suffix is appended once to the whole batch, which can mix group and direct messages, so it could not truthfully say "*this* message is from a group." Putting the note on the notification itself (next to the existing reply hint in `_format_one`) states it explicitly and only on actual group messages, and leaves direct messages and the shared suffix untouched.

## How it scopes to groups

Keyed on the `chat_name` attribute, set **only** for non-direct chats by the whatsapp and telegram skills (whatsapp writes `ChatName` when `!IsDirectChat`; telegram for group/supergroup). Read via `notif.model_extra`, so it's inert for DMs and app-chat.

## Tests

`test_group_message_flagged_maybe_not_for_you` (group note present) and `test_direct_message_not_flagged_as_group` (absent for a DM). `test_notifications.py` green (56 passed); ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZxz49Ju4KnJLVqDNmPsEq
