### PR TITLE
fix(migrations): force one verified workspace resync so stale skills converge

### DIFF
--- a/agent/core/migrations/2026-07-workspace-resync.md
+++ b/agent/core/migrations/2026-07-workspace-resync.md
@@ -1,0 +1,67 @@
+Your installed skills only change when you rebase your workspace onto the stock snapshot
+of the version you run (see `~/agent/core/skills/workspace-sync/SKILL.md`). Some boxes
+skipped or half-finished that sync and are still running old skill copies. One known
+case: an old `notifications` skill whose `notif-interrupt-rules.py` writes rules to
+`~/agent/data/notification_policy.json`, a legacy file the current agent deletes on
+every boot, so those rules silently vanish across restarts.
+
+The workspace-sync skill itself ships with your core, so the copy at
+`~/agent/core/skills/workspace-sync/` is already the current one. Use it now for one
+full, verified sync so every other skill is brought current too. Safe to re-run: an
+already-synced workspace passes step 1 and step 2 becomes a no-op.
+
+### 1. Check where you stand
+
+```bash
+cd ~
+VERSION="$(grep '^version = ' agent/core/pyproject.toml | cut -d'"' -f2)"
+bash agent/core/skills/workspace-sync/scripts/fetch-workspace.sh
+git merge-base --is-ancestor "agent-v$VERSION" HEAD && echo synced || echo needs-sync
+```
+
+- `needs-sync`: continue with step 2.
+- `synced`: your base is current, but stale files can still ride along in your own
+  commits, so do step 3 anyway.
+- The fetch fails or the tag does not exist: Vesta's daemon has no snapshot for your
+  version (an unconverted or unmanaged-core box). Nothing you can do here; mention it
+  to the user and finish.
+
+### 2. Sync
+
+Follow the Sync section of `~/agent/core/skills/workspace-sync/SKILL.md` as written
+(checkpoint commit, rebase onto `agent-v$VERSION`, set-cone.sh, then
+`mark_workspace_synced`), with two adjustments for this pass:
+
+- When a conflict is inside a skill's scripts or code and you never deliberately edited
+  that file, take the stock side. Your own content (filled-in personalization stubs,
+  notes, files you created) stays on top as usual.
+- Skip the `restart_vesta` call for now; step 4 covers the restart.
+
+### 3. Verify the skills actually match stock
+
+```bash
+git -C ~ diff --stat "agent-v$VERSION" -- agent/skills agent/core/skills
+```
+
+Every line must be a change you made on purpose. Anything else is stale stock riding
+along in your commits; make it match stock, per file:
+
+```bash
+git -C ~ checkout "agent-v$VERSION" -- <path>   # stock still ships it: take stock
+git -C ~ rm -r <path>                           # stock deleted it: drop it
+```
+
+Commit what you changed: `git -C ~ add -A && git -C ~ commit -m "drop stale stock"`.
+
+Concrete check for the known case: if you have the `notifications` skill,
+`~/agent/skills/notifications/notif-interrupt-rules.py` must be gone and the skill must
+contain a `cli/` directory. The current skill manages rules through your config API, so
+they survive restarts. If you had interrupt rules through the old script, they were
+lost; re-create the ones you still want with the current skill (your past conversations
+can remind you which rules you had).
+
+### 4. Load the refreshed skills
+
+If step 2 rebased or step 3 committed anything, call `restart_vesta`, but only after
+the final step below has marked this migration applied, so it does not re-run on the
+way back up. If nothing changed, no restart is needed.


### PR DESCRIPTION
## Why

#1076 (rules in `notification_policy.json` vanish on every restart) is skill/core skew: the box runs current core (v0.1.172) but a pre-#950 `notifications` skill that still writes the legacy file, which the current core's one-shot legacy migration deletes at every boot. The version-driven workspace-sync boot turn evidently did not converge that box (marked without a real rebase, or the rebase kept the old skill files), and any box in that state silently loses focus rules on each restart.

## What

Adds one prompt-based migration, `agent/core/migrations/2026-07-workspace-resync.md`, nothing else. On the next upgrade boot every existing box:

1. Checks whether its workspace base is `agent-v<running version>` (fetch + `git merge-base --is-ancestor`), with an explicit finish-and-report branch for boxes whose daemon has no snapshot.
2. If behind, runs the sync exactly as the core-shipped workspace-sync skill specifies (that skill is part of the read-only core mount, so it is already the latest by the time the migration runs), with stock winning conflicts in skill code the agent never deliberately edited.
3. Verifies the result: `git diff --stat agent-v<version> -- agent/skills agent/core/skills` must show only intentional personalization; stale stock is restored or dropped. Includes the concrete check for the known case (`notif-interrupt-rules.py` gone, `cli/` present) and has the agent re-create interrupt rules it lost through the legacy file.
4. Restarts only after the migration is marked applied, so it cannot re-run on the way back up.

Idempotent per the migration contract: a converged box passes step 1, step 2 no-ops, step 3 finds nothing. Sorts after `2026-07-workspace-conversion`, so an unconverted box converts first in the same boot. Fresh agents pre-mark it and never run it.

Fixes #1076

🤖 Generated with [Claude Code](https://claude.com/claude-code)