### PR TITLE
fix(whatsapp): build the CLI on the fly and float whatsmeow to latest

### DIFF
--- a/agent/core/migrations/2026-07-whatsapp-live-build.md
+++ b/agent/core/migrations/2026-07-whatsapp-live-build.md
@@ -1,0 +1,73 @@
+Your `whatsapp` command is a static binary compiled once at setup. It never
+gets rebuilt, so source fixes to the whatsapp skill silently never reach it,
+and its bundled whatsmeow protocol code ages until WhatsApp breaks it
+(issue #1073). The skill now ships a launcher script (`whatsapp` in the skill
+directory) that compiles
+from source on every invocation and pulls the latest whatsmeow before the
+daemon starts. This migration switches you onto that launcher. Every step is
+safe to run more than once.
+
+### 1. Skip if WhatsApp is not set up
+
+If `~/agent/skills/whatsapp` does not exist, you never installed the skill:
+skip to the final step.
+
+### 2. Check the build toolchain is still present
+
+The launcher needs the Go toolchain and the whisper.cpp static libraries that
+were installed when the skill was set up:
+
+```bash
+ls /usr/local/go/bin/go /opt/whisper.cpp/build-static 2>&1
+```
+
+If either is missing, redo steps 1 and 2 of
+`~/agent/skills/whatsapp/SETUP.md` first (install dependencies, build
+whisper.cpp).
+
+### 3. Install the launcher and delete the stale binaries
+
+```bash
+mkdir -p ~/.local/bin
+ln -sf ~/agent/skills/whatsapp/whatsapp ~/.local/bin/whatsapp
+rm -f /usr/local/bin/whatsapp
+```
+
+`ln -sf` also replaces any old static binary sitting at `~/.local/bin/whatsapp`.
+
+### 4. Prime the build, then restart the daemon
+
+Compile before restarting so the daemon is only down for seconds, not for the
+minutes the first compile takes:
+
+```bash
+whatsapp --help
+```
+
+Wait for it to finish (a few minutes on first run). If it fails, fix the
+toolchain per step 2 before touching the daemon. Then, only if a whatsapp
+screen session is actually running, restart it onto the launcher:
+
+```bash
+if screen -ls | grep -q '\.whatsapp[[:space:]]'; then
+  screen -S whatsapp -X quit
+  sleep 2
+  screen -dmS whatsapp whatsapp serve --notifications-dir ~/agent/notifications
+fi
+```
+
+If you run extra instances (e.g. `--instance personal`), restart those screen
+sessions the same way with their original serve flags.
+
+After ~30 seconds, confirm the session survived the restart:
+
+```bash
+whatsapp authenticate
+```
+
+It should report already authenticated. If it does not, tell the user their
+WhatsApp link needs re-pairing and follow SETUP.md's auth section.
+
+### 5. Mark this migration applied
+
+Call `mark_migration_applied` with `name="2026-07-whatsapp-live-build"`.

--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -42,26 +42,22 @@ curl -fSL -o /usr/local/share/ggml-small.bin \
   https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin
 ```
 
-## 4. Build the WhatsApp CLI
+## 4. Install the WhatsApp CLI launcher
+
+**Never `go build` a static whatsapp binary.** A frozen binary silently drifts as the source gets fixes (issue #1073). Instead, `whatsapp` is a launcher script that compiles from source on every invocation (Go's build cache makes repeat runs fast) and pulls the latest whatsmeow before the daemon starts. Install it as a symlink:
 
 ```bash
-cd ~/agent/skills/whatsapp/cli
-
-C_INCLUDE_PATH=/opt/whisper.cpp/include:/opt/whisper.cpp/ggml/include \
-LIBRARY_PATH=/opt/whisper.cpp/build-static/src:/opt/whisper.cpp/build-static/ggml/src \
-CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" \
-CGO_LDFLAGS="-lwhisper -lggml -lggml-base -lggml-cpu -lm -lstdc++ -fopenmp" \
-PATH="/usr/local/go/bin:$PATH" \
-go build -tags "fts5" -o /usr/local/bin/whatsapp .
+mkdir -p ~/.local/bin
+ln -sf ~/agent/skills/whatsapp/whatsapp ~/.local/bin/whatsapp
 ```
 
-| Variable | Purpose |
-|---|---|
-| `C_INCLUDE_PATH` | Points to whisper.cpp and ggml headers |
-| `LIBRARY_PATH` | Points to the static `.a` libraries |
-| `CGO_CFLAGS` | Enables SQLite FTS5 for message search |
-| `CGO_LDFLAGS` | Links whisper, ggml, and C++ runtime |
-| `-tags "fts5"` | Activates the FTS5 build tag for go-sqlite3 |
+The launcher owns the CGO build environment (whisper.cpp include/library paths, FTS5 flags); read the `whatsapp` script in this skill directory if the build fails. The first invocation compiles everything and can take a few minutes; later invocations reuse the build cache. At `serve` time it runs `go get go.mau.fi/whatsmeow@latest` so the daemon always compiles against current whatsmeow; if the module proxy is unreachable it warns and serves the source already on disk. Only whatsmeow floats: the whisper.cpp binding pin in `go.mod` is deliberate, never bump it to master.
+
+Verify the launcher works before continuing (expect a wait on first compile):
+
+```bash
+whatsapp --help
+```
 
 ## 5. Start the daemon and authenticate
 

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -99,6 +99,9 @@ The agent can read/search that account on demand (`whatsapp list-chats --instanc
 - **Before sending to an unknown phone number, save it first with `add-contact`.**
   *Why:* Sending to a raw JID with no saved contact row triggers the `requireManualContact` guard and blocks the send.
 
+- **Never `go build` a static whatsapp binary or run one directly.** `whatsapp` must stay the launcher symlink (`~/.local/bin/whatsapp` -> `~/agent/skills/whatsapp/whatsapp`), which compiles from source on every invocation and updates whatsmeow at daemon start.
+  *Why:* A frozen binary silently drifts from the source as fixes land (issue #1073), and stale whatsmeow protocol code is what WhatsApp breaks and bans.
+
 - **Right after first-pair auth, `database is locked` can occur transiently during history backfill.**
   *Why:* WhatsApp pushes up to 2 years of history; each conversation is persisted in a short transaction that can briefly exceed the 5s busy-timeout on large chats. If a write fails with "database is locked" within the first minute or two after authentication, wait 10-20 seconds and retry; do not treat it as a real failure. This does not occur on subsequent runs.
 
@@ -110,18 +113,19 @@ The agent can read/search that account on demand (`whatsapp list-chats --instanc
 
 ## Developing & Testing Changes
 
-The WhatsApp CLI runs as a **daemon** via `screen`. One-shot commands (send, list, etc.) connect to the daemon over a Unix socket. This means:
+The WhatsApp CLI runs as a **daemon** via `screen`. One-shot commands (send, list, etc.) connect to the daemon over a Unix socket. The `whatsapp` command is a launcher (the `whatsapp` script in this skill directory) that compiles from source on every invocation, so there is no rebuild step and never a static binary to manage:
 
-1. **Rebuild**: `cd ~/agent/skills/whatsapp/cli && CGO_ENABLED=1 go build -tags "fts5" -o ~/.local/bin/whatsapp .`
-2. **Restart daemon**: The running daemon uses the old binary. Restart it to pick up changes:
+1. **Restart daemon**: The running daemon is still the old build. Restart it to pick up source changes:
    ```bash
    screen -S whatsapp -X quit
    sleep 1
    screen -dmS whatsapp whatsapp serve --notifications-dir ~/agent/notifications
    ```
-3. **Test**: Send a message and verify the new behavior. The daemon handles all command execution, so changes won't take effect until step 2.
+2. **Test**: Send a message and verify the new behavior. The daemon handles all command execution, so changes won't take effect until step 1.
 
-**Common mistake**: rebuilding the binary and testing immediately without restarting the daemon. The CLI client just forwards commands to the daemon over the socket, so the daemon process must be running the new binary.
+**Common mistake**: editing source and testing immediately without restarting the daemon. The CLI client just forwards commands to the daemon over the socket, so the daemon process must be restarted to run the new code.
+
+**If the daemon won't start after a change** (screen session dies immediately), run any foreground command, e.g. `whatsapp --help`: the launcher recompiles and the compile error prints to your terminal. A daemon start also pulls the latest whatsmeow first, so an upstream breaking change surfaces the same way; fix the source against the new API rather than pinning back.
 
 ### Contact Preferences
 [How the user prefers to communicate with different contacts]

--- a/agent/skills/whatsapp/whatsapp
+++ b/agent/skills/whatsapp/whatsapp
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Launcher for the whatsapp CLI. Compiles cli/ from source on every invocation
+# so no stale binary can drift (issue #1073), and pulls the latest whatsmeow
+# before the daemon starts (WhatsApp breaks old protocol code). Installed as a
+# symlink at ~/.local/bin/whatsapp; never `go build` a static binary somewhere.
+set -euo pipefail
+
+CLI_DIR="$(dirname "$(readlink -f "$0")")/cli"
+
+# The box install puts Go at /usr/local/go without linking it onto PATH.
+if ! command -v go >/dev/null; then export PATH="/usr/local/go/bin:$PATH"; fi
+export CGO_ENABLED=1
+export C_INCLUDE_PATH="/opt/whisper.cpp/include:/opt/whisper.cpp/ggml/include"
+export LIBRARY_PATH="/opt/whisper.cpp/build-static/src:/opt/whisper.cpp/build-static/ggml/src"
+export CGO_CFLAGS="-DSQLITE_ENABLE_FTS5"
+export CGO_LDFLAGS="-lwhisper -lggml -lggml-base -lggml-cpu -lm -lstdc++ -fopenmp"
+
+# Only whatsmeow is floated to latest; the whisper.cpp binding pin in go.mod is
+# deliberate (master breaks it). Offline is not stale: on network failure we
+# warn and serve whatever source is on disk.
+if [ "${1:-}" = "serve" ]; then
+  if ! (cd "$CLI_DIR" && timeout 120 go get go.mau.fi/whatsmeow@latest); then
+    echo "whatsapp launcher: could not update whatsmeow to latest (offline?); serving current source" >&2
+  fi
+fi
+
+# Build to a temp path then rename: writing over the binary the running daemon
+# executes would fail with ETXTBSY, and rename keeps the old inode alive for it.
+BIN_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/whatsapp"
+mkdir -p "$BIN_DIR"
+BIN="$BIN_DIR/whatsapp"
+TMP="$BIN.$$"
+(cd "$CLI_DIR" && go build -tags fts5 -o "$TMP" .)
+mv -f "$TMP" "$BIN"
+exec "$BIN" "$@"

--- a/agent/tests/test_whatsapp_launcher.py
+++ b/agent/tests/test_whatsapp_launcher.py
@@ -1,0 +1,72 @@
+"""Exercises the REAL whatsapp launcher (agent/skills/whatsapp/whatsapp) against a
+fake `go` toolchain: build-on-every-invocation + exec, whatsmeow update on serve only,
+and the offline fallback."""
+
+import os
+import pathlib as pl
+import subprocess
+
+REPO_ROOT = pl.Path(__file__).resolve().parents[2]
+LAUNCHER = REPO_ROOT / "agent/skills/whatsapp/whatsapp"
+
+FAKE_GO = """#!/bin/bash
+echo "$@" >> "$GO_LOG"
+case "$1" in
+  get) exit "${GO_GET_EXIT:-0}" ;;
+  build)
+    out=""; prev=""
+    for a in "$@"; do [ "$prev" = "-o" ] && out="$a"; prev="$a"; done
+    printf '#!/bin/bash\\necho "$@" > "$RUN_LOG"\\n' > "$out"
+    chmod +x "$out"
+    ;;
+esac
+"""
+
+
+def _run(tmp_path, args, go_get_exit=0):
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir(exist_ok=True)
+    (fakebin / "go").write_text(FAKE_GO)
+    (fakebin / "go").chmod(0o755)
+    env = os.environ | {
+        "PATH": f"{fakebin}:{os.environ['PATH']}",
+        "XDG_CACHE_HOME": str(tmp_path / "cache"),
+        "GO_LOG": str(tmp_path / "go.log"),
+        "RUN_LOG": str(tmp_path / "run.log"),
+        "GO_GET_EXIT": str(go_get_exit),
+    }
+    result = subprocess.run(["bash", str(LAUNCHER), *args], env=env, capture_output=True, text=True, cwd=tmp_path)
+    go_log = (tmp_path / "go.log").read_text() if (tmp_path / "go.log").exists() else ""
+    run_log = (tmp_path / "run.log").read_text() if (tmp_path / "run.log").exists() else ""
+    return result, go_log, run_log
+
+
+def test_serve_updates_whatsmeow_then_builds_and_execs(tmp_path):
+    result, go_log, run_log = _run(tmp_path, ["serve", "--notifications-dir", "/tmp/notif"])
+    assert result.returncode == 0, result.stderr
+    go_calls = go_log.splitlines()
+    assert go_calls[0] == "get go.mau.fi/whatsmeow@latest"
+    assert go_calls[1].startswith("build -tags fts5 -o ")
+    assert run_log.strip() == "serve --notifications-dir /tmp/notif"
+
+
+def test_one_shot_commands_skip_the_whatsmeow_update(tmp_path):
+    result, go_log, run_log = _run(tmp_path, ["send", "Alice", "hi there"])
+    assert result.returncode == 0, result.stderr
+    assert "get " not in go_log
+    assert run_log.strip() == "send Alice hi there"
+
+
+def test_failed_whatsmeow_update_warns_and_serves_current_source(tmp_path):
+    result, go_log, run_log = _run(tmp_path, ["serve", "--notifications-dir", "/tmp/notif"], go_get_exit=1)
+    assert result.returncode == 0, result.stderr
+    assert "could not update whatsmeow" in result.stderr
+    assert run_log.strip() == "serve --notifications-dir /tmp/notif"
+
+
+def test_rebuild_replaces_the_cached_binary_without_leftover_temps(tmp_path):
+    _run(tmp_path, ["list-chats"])
+    result, _, run_log = _run(tmp_path, ["list-chats"])
+    assert result.returncode == 0, result.stderr
+    assert run_log.strip() == "list-chats"
+    assert sorted(p.name for p in (tmp_path / "cache" / "whatsapp").iterdir()) == ["whatsapp"]


### PR DESCRIPTION
## Summary

The `whatsapp` command was a static binary hand-built once at setup; source fixes never reached running agents and the bundled whatsmeow protocol code aged until WhatsApp broke it (the luna group-contacts incident in #1073). This PR makes the whatsapp skill impossible to freeze:

- **Launcher instead of a binary** (`agent/skills/whatsapp/whatsapp`, symlinked to `~/.local/bin/whatsapp`): compiles `cli/` from source on every invocation (Go build cache keeps repeat runs fast) and owns the whole CGO/whisper build environment, which previously lived as copy-paste env vars in SETUP.md. It builds to a temp path and renames so the running daemon's binary is never written over (ETXTBSY).
- **Always-latest whatsmeow**: at `serve` time the launcher runs `go get go.mau.fi/whatsmeow@latest` before building, so the daemon always compiles against current upstream. If the module proxy is unreachable it warns and serves the source on disk (a boot DNS blip must not take WhatsApp down); if upstream breaks compilation the daemon refuses to start, and SKILL.md documents how the compile error is surfaced (run any foreground command). Only whatsmeow floats: the whisper.cpp binding pin is deliberate and stays.
- **Docs**: SETUP.md step 4 installs the symlink and forbids static builds; SKILL.md drops the rebuild step and gains a never-static-binary rule.
- **Fleet migration** (`2026-07-whatsapp-live-build`): existing agents check the toolchain, install the symlink, delete the stale static binaries, prime the build, then restart the daemon and verify auth survived. Idempotent; skips cleanly when the skill isn't installed. The registered service command resolves `whatsapp` through PATH, so it needs no change.
- **Tests** (`agent/tests/test_whatsapp_launcher.py`): drives the real launcher against a fake `go` toolchain: serve updates whatsmeow then builds and execs, one-shots skip the network, a failed update falls back with a warning, rebuilds leave no temp files.

Part of #1073 (the confirmed whatsapp case). The telegram skill has the same static `go build` pattern and can follow the same launcher shape in a follow-up.

## Test plan
- [x] `./check.sh agent` green locally (546 passed, incl. 4 new launcher tests)
- [ ] CI merge-gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)