### PR TITLE
feat(skills): production-grade daemon lifecycle for telegram, default notifications dir for tasks

### DIFF
--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -107,15 +107,19 @@ uv tool install --editable ~/agent/skills/tasks/cli
 Register with vestad to get a port (see [service](../service/SKILL.md)), then start:
 ```bash
 PORT=$(~/agent/skills/service/scripts/register-service tasks)
-screen -dmS tasks tasks serve --notifications-dir ~/agent/notifications --port $PORT
+screen -dmS tasks tasks serve --port $PORT
 ```
+
+`--notifications-dir` defaults to `~/agent/notifications`; pass it only to override.
 
 One daemon handles everything, both task due-date monitoring and reminder scheduling. No separate reminder daemon needed.
 
 **Restart**: Add this startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
 ```
-PORT=$(~/agent/skills/service/scripts/register-service tasks) && screen -dmS tasks tasks serve --notifications-dir ~/agent/notifications --port $PORT
+PORT=$(~/agent/skills/service/scripts/register-service tasks) && screen -dmS tasks tasks serve --port $PORT
 ```
+
+`--notifications-dir` defaults to `~/agent/notifications`; pass it only to override.
 
 ### Reminder Patterns
 [User's common reminder types and preferences]

--- a/agent/skills/tasks/cli/src/tasks_cli/cli.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/cli.py
@@ -86,7 +86,7 @@ def main():
 
     # serve
     p_serve = sub.add_parser("serve", help="Run background daemon (scheduler + reminder engine)")
-    p_serve.add_argument("--notifications-dir", required=True)
+    p_serve.add_argument("--notifications-dir", default=str(Path.home() / "agent" / "notifications"))
     p_serve.add_argument("--port", type=int, required=True, help="HTTP server port (allocated by vestad)")
 
     # add

--- a/agent/skills/tasks/cli/tests/test_serve_defaults.py
+++ b/agent/skills/tasks/cli/tests/test_serve_defaults.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import tasks_cli.cli as cli
+
+
+def test_serve_notifications_dir_defaults_to_agent_notifications(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    captured: dict[str, Path] = {}
+
+    def fake_run_serve(config, notif_dir, *, port):
+        captured["notif_dir"] = notif_dir
+
+    monkeypatch.setattr(cli, "_run_serve", fake_run_serve)
+    monkeypatch.setattr("sys.argv", ["tasks", "serve", "--port", "1"])
+    cli.main()
+
+    assert captured["notif_dir"] == tmp_path / "agent" / "notifications"

--- a/agent/skills/telegram/SETUP.md
+++ b/agent/skills/telegram/SETUP.md
@@ -21,21 +21,20 @@
      ```
 4. Start the daemon:
    ```bash
-   screen -dmS telegram telegram serve --notifications-dir ~/agent/notifications
+   telegram daemon start
    ```
+   Idempotent (a running daemon is a no-op) and defaults `--notifications-dir` to `~/agent/notifications`. Check with `telegram daemon status`.
 5. **Important**: The user must `/start` the bot from their Telegram account before Vesta can send them messages. After that first interaction, Vesta can message them anytime (including autonomously, e.g., morning reports).
-6. Add to the `## Services` section of `~/agent/skills/restart/SKILL.md`:
+6. Add to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
    ```
-   screen -dmS telegram telegram serve --notifications-dir ~/agent/notifications
-   screen -dmS telegram-watchdog bash ~/agent/skills/telegram/telegram-watchdog.sh
+   running telegram || { telegram daemon start; sleep 1; }
+   running telegram-watchdog || { screen -dmS telegram-watchdog bash ~/agent/skills/telegram/telegram-watchdog.sh; sleep 1; }
    ```
    The watchdog (`telegram-watchdog.sh`) runs in its own screen session and restarts the daemon
    if it dies, independent of the agent loop, so the channel self-heals even while the agent is
    busy or mid-restart. It is rate-limited (backs off after repeated restarts) and drops a
    notification when it acts. Especially important when Telegram is the primary/only channel.
 
-   **Deploying a new binary:** quit the watchdog FIRST, then the daemon, then swap the binary and
-   restart both (`screen -S telegram-watchdog -X quit; screen -S telegram -X quit; ...build...;
-   screen -dmS telegram ...; screen -dmS telegram-watchdog ...`). If you restart the daemon while
-   the watchdog is live, the watchdog races you and you end up with two daemons (two pollers →
-   Telegram 409 Conflict).
+   **Deploying a new binary:** build it, then `telegram daemon restart`. The restart quits the
+   watchdog first, restarts the daemon, and brings the watchdog back, so the watchdog can never
+   race you into two daemons (two pollers, Telegram 409 Conflict).

--- a/agent/skills/telegram/SKILL.md
+++ b/agent/skills/telegram/SKILL.md
@@ -6,7 +6,7 @@ description: Telegram: send/receive messages; reply to source=telegram notificat
 # Telegram - CLI: telegram
 
 **Setup**: See [SETUP.md](SETUP.md)
-**Background**: `screen -dmS telegram telegram serve --notifications-dir ~/agent/notifications`
+**Daemon**: `telegram daemon start|stop|restart|status`. Start is idempotent (never stacks a duplicate) and defaults `--notifications-dir` to `~/agent/notifications`; stop/restart quit the watchdog first so it cannot race a manual restart into two daemons, then restart brings it back; status reports daemon, watchdog, and auth state in one place. Manage the daemon only through these commands, never raw `screen` or signals.
 
 ## Quick Reference
 ```bash

--- a/agent/skills/telegram/cli/cli.go
+++ b/agent/skills/telegram/cli/cli.go
@@ -151,8 +151,7 @@ func runServe() {
 
 	notifDir := extractNotificationsDir()
 	if notifDir == "" {
-		fmt.Fprintln(os.Stderr, "error: --notifications-dir is required for serve")
-		os.Exit(1)
+		notifDir = defaultNotificationsDir()
 	}
 
 	var err error
@@ -160,6 +159,7 @@ func runServe() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+	writeDaemonInfo(dataDir, os.Args[1:])
 	if err = os.MkdirAll(notifDir, 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -202,7 +202,11 @@ func runServe() {
 	sig := <-sigChan
 
 	fmt.Fprintf(os.Stderr, "Shutting down (signal: %v)...\n", sig)
-	writeDeathNotification(notifDir, sig.String())
+	if _, statErr := os.Stat(stopRequestedPath(dataDir)); statErr == nil {
+		os.Remove(stopRequestedPath(dataDir))
+	} else {
+		writeDeathNotification(notifDir, sig.String())
+	}
 	if listener != nil {
 		stopSocketServer(listener, sockPath)
 	}
@@ -233,7 +237,7 @@ func runOneShot(command string) {
 	sockPath := getSocketPath()
 	output, exitCode, connected := trySocketCommand(sockPath, command, stripGlobalFlags(os.Args[1:]))
 	if !connected {
-		printJSON(map[string]interface{}{"error": "daemon not running — start with: screen -dmS telegram telegram serve --notifications-dir ~/agent/notifications"})
+		printJSON(map[string]interface{}{"error": "daemon not running; start with: telegram daemon start"})
 		os.Exit(1)
 	}
 	fmt.Println(string(output))

--- a/agent/skills/telegram/cli/cli.go
+++ b/agent/skills/telegram/cli/cli.go
@@ -195,10 +195,10 @@ func runServe() {
 	// Start polling in background
 	go tc.StartPolling()
 
-	signal.Ignore(syscall.SIGHUP)
-
+	// SIGHUP is how `screen -X quit` (daemon stop/restart) kills the daemon,
+	// so it must reach the graceful shutdown path, matching whatsapp's serve.
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	sig := <-sigChan
 
 	fmt.Fprintf(os.Stderr, "Shutting down (signal: %v)...\n", sig)

--- a/agent/skills/telegram/cli/daemon.go
+++ b/agent/skills/telegram/cli/daemon.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	DaemonStartTimeout = 30 * time.Second
+	DaemonStopTimeout  = 15 * time.Second
+	DaemonPollInterval = time.Second
+	SocketDialTimeout  = 2 * time.Second
+
+	daemonInfoFile  = "daemon-info.json"
+	watchdogSession = "telegram-watchdog"
+)
+
+type daemonInfo struct {
+	Args      []string  `json:"args"`
+	PID       int       `json:"pid"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+func defaultNotificationsDir() string {
+	return filepath.Join(os.Getenv("HOME"), "agent", "notifications")
+}
+
+func stopRequestedPath(dataDir string) string {
+	return filepath.Join(dataDir, "stop-requested")
+}
+
+func sessionName() string {
+	if instance := extractInstance(); instance != "" {
+		return "telegram-" + instance
+	}
+	return "telegram"
+}
+
+func daemonAlive(sockPath string) bool {
+	conn, err := net.DialTimeout("unix", sockPath, SocketDialTimeout)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// screenOutputHasLiveSession reports whether `screen -ls` output contains a
+// LIVE session with exactly this name (a "(Dead ???)" corpse does not count,
+// and `telegram` must not match `telegram-watchdog`).
+func screenOutputHasLiveSession(screenLs, name string) bool {
+	sessionPattern := regexp.MustCompile(`[0-9]+\.` + regexp.QuoteMeta(name) + `\s`)
+	for _, line := range strings.Split(screenLs, "\n") {
+		if sessionPattern.MatchString(line) && !strings.Contains(line, "Dead") {
+			return true
+		}
+	}
+	return false
+}
+
+func screenSessionLive(name string) bool {
+	// screen -ls exits nonzero when no sessions exist; only the output matters.
+	output, _ := exec.Command("screen", "-ls").CombinedOutput()
+	return screenOutputHasLiveSession(string(output), name)
+}
+
+func writeDaemonInfo(dataDir string, serveArgs []string) {
+	info := daemonInfo{Args: serveArgs, PID: os.Getpid(), StartedAt: time.Now().UTC()}
+	data, err := json.Marshal(info)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to marshal daemon info: %v\n", err)
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, daemonInfoFile), data, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to write daemon info: %v\n", err)
+	}
+}
+
+func readDaemonInfo(dataDir string) (daemonInfo, error) {
+	var info daemonInfo
+	data, err := os.ReadFile(filepath.Join(dataDir, daemonInfoFile))
+	if err != nil {
+		return info, err
+	}
+	if err := json.Unmarshal(data, &info); err != nil {
+		return info, err
+	}
+	return info, nil
+}
+
+func runDaemon() {
+	if len(os.Args) < 2 {
+		printJSON(map[string]interface{}{"error": "usage: telegram daemon <start|stop|restart|status> [serve flags]"})
+		os.Exit(1)
+	}
+	sub := os.Args[1]
+	os.Args = append(os.Args[:1], os.Args[2:]...)
+	switch sub {
+	case "start":
+		daemonStart(os.Args[1:])
+	case "stop":
+		daemonStop()
+	case "restart":
+		daemonRestart()
+	case "status":
+		daemonStatus()
+	default:
+		printJSON(map[string]interface{}{"error": fmt.Sprintf("unknown daemon subcommand %q (use start|stop|restart|status)", sub)})
+		os.Exit(1)
+	}
+}
+
+// startDaemonProcess launches `telegram serve` under screen and waits for the
+// socket. Idempotent: an already-answering daemon is a no-op.
+func startDaemonProcess(serveArgs []string) error {
+	sockPath := getSocketPath()
+	if daemonAlive(sockPath) {
+		return nil
+	}
+	binary, err := exec.LookPath("telegram")
+	if err != nil {
+		return fmt.Errorf("telegram binary not on PATH; build it per SETUP.md first")
+	}
+	screenArgs := append([]string{"-dmS", sessionName(), binary, "serve"}, serveArgs...)
+	if err := exec.Command("screen", screenArgs...).Run(); err != nil {
+		return fmt.Errorf("failed to launch screen session: %v", err)
+	}
+	deadline := time.Now().Add(DaemonStartTimeout)
+	for time.Now().Before(deadline) {
+		if daemonAlive(sockPath) {
+			return nil
+		}
+		if !screenSessionLive(sessionName()) {
+			return fmt.Errorf("daemon exited during startup; run 'telegram serve' in the foreground to see the error")
+		}
+		time.Sleep(DaemonPollInterval)
+	}
+	return fmt.Errorf("daemon did not answer on %s within %s", sockPath, DaemonStartTimeout)
+}
+
+func daemonStart(serveArgs []string) {
+	if daemonAlive(getSocketPath()) {
+		printJSON(map[string]interface{}{"status": "already_running", "session": sessionName()})
+		return
+	}
+	if err := startDaemonProcess(serveArgs); err != nil {
+		printJSON(map[string]interface{}{"error": err.Error()})
+		os.Exit(1)
+	}
+	printJSON(map[string]interface{}{"status": "started", "session": sessionName()})
+}
+
+// stopWatchdogIfLive quits the watchdog screen session first so it cannot race
+// the stop and respawn a second daemon (the documented two-daemons footgun).
+// Returns whether the watchdog was running, so restart can bring it back.
+func stopWatchdogIfLive() bool {
+	if !screenSessionLive(watchdogSession) {
+		return false
+	}
+	if err := exec.Command("screen", "-S", watchdogSession, "-X", "quit").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to quit watchdog session: %v\n", err)
+	}
+	return true
+}
+
+func startWatchdog() {
+	script := filepath.Join(os.Getenv("HOME"), "agent", "skills", "telegram", "telegram-watchdog.sh")
+	if _, err := os.Stat(script); err != nil {
+		return
+	}
+	if screenSessionLive(watchdogSession) {
+		return
+	}
+	if err := exec.Command("screen", "-dmS", watchdogSession, "bash", script).Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to start watchdog session: %v\n", err)
+	}
+}
+
+func stopDaemonProcess() error {
+	dataDir, _ := parseStateDir()
+	// Mark the stop intentional so serve's shutdown skips the daemon_died
+	// notification the agent would otherwise investigate.
+	if err := os.WriteFile(stopRequestedPath(dataDir), []byte{}, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not mark stop as intentional: %v\n", err)
+	}
+	if err := exec.Command("screen", "-S", sessionName(), "-X", "quit").Run(); err != nil {
+		return fmt.Errorf("screen quit failed: %v", err)
+	}
+	deadline := time.Now().Add(DaemonStopTimeout)
+	for time.Now().Before(deadline) {
+		if !daemonAlive(getSocketPath()) {
+			return nil
+		}
+		time.Sleep(DaemonPollInterval)
+	}
+	return fmt.Errorf("daemon still answering after screen quit; inspect with 'screen -r %s'", sessionName())
+}
+
+func daemonStop() {
+	if !daemonAlive(getSocketPath()) {
+		stopWatchdogIfLive()
+		printJSON(map[string]interface{}{"status": "already_stopped", "session": sessionName()})
+		return
+	}
+	watchdogWasLive := stopWatchdogIfLive()
+	if err := stopDaemonProcess(); err != nil {
+		printJSON(map[string]interface{}{"error": err.Error()})
+		os.Exit(1)
+	}
+	printJSON(map[string]interface{}{"status": "stopped", "session": sessionName(), "watchdog_stopped": watchdogWasLive})
+}
+
+func daemonRestart() {
+	dataDir, _ := parseStateDir()
+	serveArgs := []string{}
+	if info, err := readDaemonInfo(dataDir); err == nil {
+		serveArgs = info.Args
+	}
+	watchdogWasLive := stopWatchdogIfLive()
+	if daemonAlive(getSocketPath()) {
+		if err := stopDaemonProcess(); err != nil {
+			printJSON(map[string]interface{}{"error": err.Error()})
+			os.Exit(1)
+		}
+	}
+	if err := startDaemonProcess(serveArgs); err != nil {
+		printJSON(map[string]interface{}{"error": err.Error()})
+		os.Exit(1)
+	}
+	if watchdogWasLive {
+		startWatchdog()
+	}
+	printJSON(map[string]interface{}{"status": "restarted", "session": sessionName(), "watchdog_restarted": watchdogWasLive, "serve_args": serveArgs})
+}
+
+func daemonStatus() {
+	dataDir, _ := parseStateDir()
+	result := map[string]interface{}{
+		"running":          daemonAlive(getSocketPath()),
+		"session":          sessionName(),
+		"watchdog_running": screenSessionLive(watchdogSession),
+		"auth":             readAuthStatus(dataDir),
+	}
+	if info, err := readDaemonInfo(dataDir); err == nil {
+		result["started_at"] = info.StartedAt
+		result["serve_args"] = info.Args
+	}
+	printJSON(result)
+}

--- a/agent/skills/telegram/cli/daemon.go
+++ b/agent/skills/telegram/cli/daemon.go
@@ -117,6 +117,21 @@ func runDaemon() {
 	}
 }
 
+// ensureNotificationsDirArg prepends the default --notifications-dir when
+// serveArgs lacks one, so the default daemon's cmdline always starts with the
+// flag the watchdog's liveness pgrep pattern matches on. Instance daemons are
+// left as-is: the watchdog only guards the default instance, and their cmdline
+// must not match its pattern (that would hide a dead default daemon).
+func ensureNotificationsDirArg(serveArgs []string) []string {
+	for _, arg := range serveArgs {
+		if arg == "--notifications-dir" || arg == "--instance" ||
+			strings.HasPrefix(arg, "--notifications-dir=") || strings.HasPrefix(arg, "--instance=") {
+			return serveArgs
+		}
+	}
+	return append([]string{"--notifications-dir", defaultNotificationsDir()}, serveArgs...)
+}
+
 // startDaemonProcess launches `telegram serve` under screen and waits for the
 // socket. Idempotent: an already-answering daemon is a no-op.
 func startDaemonProcess(serveArgs []string) error {
@@ -128,7 +143,7 @@ func startDaemonProcess(serveArgs []string) error {
 	if err != nil {
 		return fmt.Errorf("telegram binary not on PATH; build it per SETUP.md first")
 	}
-	screenArgs := append([]string{"-dmS", sessionName(), binary, "serve"}, serveArgs...)
+	screenArgs := append([]string{"-dmS", sessionName(), binary, "serve"}, ensureNotificationsDirArg(serveArgs)...)
 	if err := exec.Command("screen", screenArgs...).Run(); err != nil {
 		return fmt.Errorf("failed to launch screen session: %v", err)
 	}
@@ -159,8 +174,13 @@ func daemonStart(serveArgs []string) {
 
 // stopWatchdogIfLive quits the watchdog screen session first so it cannot race
 // the stop and respawn a second daemon (the documented two-daemons footgun).
-// Returns whether the watchdog was running, so restart can bring it back.
+// The watchdog only guards the default instance, so instance-scoped commands
+// leave it alone. Returns whether the watchdog was running, so restart can
+// bring it back.
 func stopWatchdogIfLive() bool {
+	if extractInstance() != "" {
+		return false
+	}
 	if !screenSessionLive(watchdogSession) {
 		return false
 	}
@@ -171,6 +191,9 @@ func stopWatchdogIfLive() bool {
 }
 
 func startWatchdog() {
+	if extractInstance() != "" {
+		return
+	}
 	script := filepath.Join(os.Getenv("HOME"), "agent", "skills", "telegram", "telegram-watchdog.sh")
 	if _, err := os.Stat(script); err != nil {
 		return
@@ -190,7 +213,10 @@ func stopDaemonProcess() error {
 	if err := os.WriteFile(stopRequestedPath(dataDir), []byte{}, 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not mark stop as intentional: %v\n", err)
 	}
+	// A failed stop leaves the daemon running; clear the marker so a later
+	// genuine death still writes the daemon_died notification.
 	if err := exec.Command("screen", "-S", sessionName(), "-X", "quit").Run(); err != nil {
+		os.Remove(stopRequestedPath(dataDir))
 		return fmt.Errorf("screen quit failed: %v", err)
 	}
 	deadline := time.Now().Add(DaemonStopTimeout)
@@ -200,6 +226,7 @@ func stopDaemonProcess() error {
 		}
 		time.Sleep(DaemonPollInterval)
 	}
+	os.Remove(stopRequestedPath(dataDir))
 	return fmt.Errorf("daemon still answering after screen quit; inspect with 'screen -r %s'", sessionName())
 }
 

--- a/agent/skills/telegram/cli/daemon_test.go
+++ b/agent/skills/telegram/cli/daemon_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -72,5 +73,52 @@ func TestDefaultNotificationsDir(t *testing.T) {
 	want := filepath.Join(os.Getenv("HOME"), "agent", "notifications")
 	if got := defaultNotificationsDir(); got != want {
 		t.Errorf("defaultNotificationsDir() = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureNotificationsDirArg(t *testing.T) {
+	defaultDir := defaultNotificationsDir()
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty args get the default prepended", nil, []string{"--notifications-dir", defaultDir}},
+		{"other flags keep the dir first on the cmdline", []string{"--read-only"}, []string{"--notifications-dir", defaultDir, "--read-only"}},
+		{"explicit dir is untouched", []string{"--notifications-dir", "/tmp/n"}, []string{"--notifications-dir", "/tmp/n"}},
+		{"explicit dir= is untouched", []string{"--notifications-dir=/tmp/n"}, []string{"--notifications-dir=/tmp/n"}},
+		{"instance daemons are untouched", []string{"--instance", "foo"}, []string{"--instance", "foo"}},
+		{"instance= daemons are untouched", []string{"--instance=foo"}, []string{"--instance=foo"}},
+	}
+	for _, testCase := range cases {
+		if got := ensureNotificationsDirArg(testCase.in); !reflect.DeepEqual(got, testCase.want) {
+			t.Errorf("%s: ensureNotificationsDirArg(%v) = %v, want %v", testCase.name, testCase.in, got, testCase.want)
+		}
+	}
+}
+
+func TestStopWatchdogSkipsInstanceScopedCommands(t *testing.T) {
+	origArgs := os.Args
+	t.Cleanup(func() { os.Args = origArgs })
+	os.Args = []string{"telegram", "--instance", "foo"}
+	if stopWatchdogIfLive() {
+		t.Error("stopWatchdogIfLive() must be a no-op for instance-scoped commands")
+	}
+}
+
+func TestFailedStopClearsStopMarker(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	origArgs := os.Args
+	t.Cleanup(func() { os.Args = origArgs })
+	os.Args = []string{"telegram", "--instance", "stoptest"}
+	dataDir, _ := parseStateDir()
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := stopDaemonProcess(); err == nil {
+		t.Fatal("expected stopDaemonProcess to fail with no daemon running")
+	}
+	if _, err := os.Stat(stopRequestedPath(dataDir)); !os.IsNotExist(err) {
+		t.Error("stop-requested marker not cleared after a failed stop")
 	}
 }

--- a/agent/skills/telegram/cli/daemon_test.go
+++ b/agent/skills/telegram/cli/daemon_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUsageListsLifecycleCommands(t *testing.T) {
+	var buf bytes.Buffer
+	printUsage(&buf)
+	out := buf.String()
+	for _, want := range []string{"daemon", "serve", "authenticate", "send-message"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("usage output missing %q", want)
+		}
+	}
+}
+
+func TestIsHelpArg(t *testing.T) {
+	cases := map[string]bool{"--help": true, "-h": true, "help": true, "send": false, "serve": false}
+	for arg, want := range cases {
+		if got := isHelpArg(arg); got != want {
+			t.Errorf("isHelpArg(%q) = %v, want %v", arg, got, want)
+		}
+	}
+}
+
+func TestScreenOutputHasLiveSession(t *testing.T) {
+	live := "There are screens on:\n\t12345.telegram\t(Detached)\n\t99.telegram-watchdog\t(Detached)\n2 Sockets in /run/screen/S-root.\n"
+	dead := "There are screens on:\n\t12345.telegram\t(Dead ???)\nRemove dead screens with 'screen -wipe'.\n"
+	cases := []struct {
+		session string
+		output  string
+		want    bool
+	}{
+		{"telegram", live, true},
+		{"telegram-watchdog", live, true},
+		{"telegram", dead, false},
+		{"telegram", "No Sockets found in /run/screen/S-root.\n", false},
+		{"telegram-other", live, false},
+	}
+	for _, testCase := range cases {
+		if got := screenOutputHasLiveSession(testCase.output, testCase.session); got != testCase.want {
+			t.Errorf("screenOutputHasLiveSession(session=%q) = %v, want %v", testCase.session, got, testCase.want)
+		}
+	}
+}
+
+func TestDaemonInfoRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	writeDaemonInfo(dir, []string{"--notifications-dir", "/tmp/n"})
+	info, err := readDaemonInfo(dir)
+	if err != nil {
+		t.Fatalf("readDaemonInfo: %v", err)
+	}
+	if len(info.Args) != 2 || info.Args[0] != "--notifications-dir" {
+		t.Errorf("args round-trip failed: %v", info.Args)
+	}
+	if info.PID != os.Getpid() {
+		t.Errorf("pid = %d, want %d", info.PID, os.Getpid())
+	}
+	if time.Since(info.StartedAt) > time.Minute {
+		t.Errorf("started_at not recent: %v", info.StartedAt)
+	}
+}
+
+func TestDefaultNotificationsDir(t *testing.T) {
+	want := filepath.Join(os.Getenv("HOME"), "agent", "notifications")
+	if got := defaultNotificationsDir(); got != want {
+		t.Errorf("defaultNotificationsDir() = %q, want %q", got, want)
+	}
+}

--- a/agent/skills/telegram/cli/main.go
+++ b/agent/skills/telegram/cli/main.go
@@ -2,25 +2,37 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
 
+func isHelpArg(arg string) bool {
+	return arg == "--help" || arg == "-h" || arg == "help"
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage: telegram <command> [args] [flags]")
+	fmt.Fprintln(w, "Lifecycle:")
+	fmt.Fprintln(w, "  daemon <start|stop|restart|status>   manage the background daemon (idempotent start; stop/restart also handle the watchdog)")
+	fmt.Fprintln(w, "  serve                                run the daemon in the foreground")
+	fmt.Fprintln(w, "  authenticate                         save the bot token / print auth status")
+	fmt.Fprintln(w, "Commands (short aliases in parentheses):")
+	fmt.Fprintln(w, "  send-message (send) [to] [message]   send-file (file) [to] [path]")
+	fmt.Fprintln(w, "    send-message flags: --buttons 'L1=d1,L2=d2;L3=d3'  --reply-to <id>  --message-file <path>")
+	fmt.Fprintln(w, "  edit-message [to] [message-id] [message] (--buttons)  delete-message (del) [to] [message-id]")
+	fmt.Fprintln(w, "  answer-callback [callback-id] (--text --alert)   send-voice [to] [file-path]")
+	fmt.Fprintln(w, "  send-chat-action [to] [action]       pin-message [to] [message-id]   unpin-message [to] [message-id]")
+	fmt.Fprintln(w, "  send-reaction (react) [to] [id] [emoji]")
+	fmt.Fprintln(w, "  list-messages (messages) [to]        list-chats (chats)")
+	fmt.Fprintln(w, "  list-contacts (contacts)             list-groups (groups)")
+	fmt.Fprintln(w, "  add-contact [name] [chat-id]         remove-contact [identifier]")
+}
+
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "Usage: telegram <command> [args] [flags]")
-		fmt.Fprintln(os.Stderr, "Commands (short aliases in parentheses):")
-		fmt.Fprintln(os.Stderr, "  send-message (send) [to] [message]   send-file (file) [to] [path]")
-		fmt.Fprintln(os.Stderr, "    send-message flags: --buttons 'L1=d1,L2=d2;L3=d3'  --reply-to <id>  --message-file <path>")
-		fmt.Fprintln(os.Stderr, "  edit-message [to] [message-id] [message] (--buttons)  delete-message (del) [to] [message-id]")
-		fmt.Fprintln(os.Stderr, "  answer-callback [callback-id] (--text --alert)   send-voice [to] [file-path]")
-		fmt.Fprintln(os.Stderr, "  send-chat-action [to] [action]       pin-message [to] [message-id]   unpin-message [to] [message-id]")
-		fmt.Fprintln(os.Stderr, "  send-reaction (react) [to] [id] [emoji]")
-		fmt.Fprintln(os.Stderr, "  list-messages (messages) [to]        list-chats (chats)")
-		fmt.Fprintln(os.Stderr, "  list-contacts (contacts)             list-groups (groups)")
-		fmt.Fprintln(os.Stderr, "  add-contact [name] [chat-id]         remove-contact [identifier]")
-		fmt.Fprintln(os.Stderr, "  serve  authenticate")
-		os.Exit(1)
+	if len(os.Args) < 2 || isHelpArg(os.Args[1]) {
+		printUsage(os.Stdout)
+		os.Exit(0)
 	}
 
 	command := os.Args[1]
@@ -86,6 +98,8 @@ func main() {
 		runServe()
 	case "authenticate":
 		runAuthenticate()
+	case "daemon":
+		runDaemon()
 	default:
 		runOneShot(command)
 	}


### PR DESCRIPTION
Transplants the whatsapp production-grade lifecycle learnings to the other channel/daemon skills, per the same principle: every documented ritual that exists because software misbehaves becomes enforced behavior, then the prose dies.

## telegram
- New `telegram daemon start|stop|restart|status` subcommands. Start is idempotent via socket detection (kills the duplicate-daemon class from #867); stop/restart quit the watchdog FIRST and restart brings it back, making the documented two-daemons race (watchdog vs manual restart, Telegram 409 Conflict) unrepresentable; status reports daemon + watchdog + auth in one place.
- `serve` defaults `--notifications-dir` to `~/agent/notifications` (the required-flag trap is gone).
- Intentional stops write a stop marker so serve's shutdown skips the `daemon_died` notification (the agent no longer investigates its own deliberate stops).
- `telegram --help` / bare invocation print usage and exit 0.
- `daemon not running` errors now point at `telegram daemon start` instead of a raw screen incantation.
- SKILL.md/SETUP.md rewritten accordingly (deploy-a-new-binary recipe is now just `telegram daemon restart`).

## tasks
- `tasks serve --notifications-dir` defaults to `~/agent/notifications` instead of `required=True`; docs updated.

Tests: telegram Go tests (usage, screen -ls parsing incl. Dead-corpse and prefix-collision cases, daemon-info round-trip, notifications default) and a tasks parser-default test. Pre-existing tasks e2e failures in the sandbox (daemon spawn) are unchanged with/without this diff (verified via stash).

Fleet impact: no migration needed. Existing restart-skill lines (`screen -dmS telegram telegram serve --notifications-dir ...`) keep working unchanged; the new subcommands are additive, and boxes pick them up with the next workspace sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)