### PR TITLE
refactor(vestad): surface swallowed lifecycle failures and stop logging credentials

### DIFF
--- a/vestad/src/agent_proxy.rs
+++ b/vestad/src/agent_proxy.rs
@@ -160,7 +160,7 @@ async fn ws_proxy(client_ws: axum::extract::ws::WebSocket, agent_port: u16, path
     let agent_ws = match tokio_tungstenite::connect_async(&url).await {
         Ok((ws, _)) => ws,
         Err(e) => {
-            tracing::warn!(url = %url, error = %e, "agent websocket not reachable");
+            tracing::warn!(port = agent_port, error = %e, "agent websocket not reachable");
             let mut client_ws = client_ws;
             let _ = client_ws
                 .send(AxumMsg::Close(Some(axum::extract::ws::CloseFrame {

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -4,7 +4,7 @@ use bollard::Docker;
 
 use crate::docker::{
     container_created, container_name, container_size_root_fs, container_size_rw, container_status, create_container,
-    inspect_container, remove_container_force, start_container, stop_container_with_timeout, validate_name,
+    ensure_container_removed, inspect_container, start_container, stop_container_with_timeout, validate_name,
     write_pending_restart_reason, AgentEnvConfig, ContainerStatus, DockerError,
 };
 use crate::types::{BackupInfo, BackupType, RetentionPolicy};
@@ -127,7 +127,9 @@ where
         if let Err(err) = write_pending_restart_reason(docker, &cname, resume_reason).await {
             tracing::warn!(agent = %name, error = %err, "failed to write restart reason");
         }
-        start_container(docker, &cname).await;
+        if !start_container(docker, &cname).await {
+            tracing::error!(agent = %name, "failed to restart agent after backup");
+        }
     }
     result
 }
@@ -291,7 +293,15 @@ pub async fn restore_backup(
         }
         return Err(DockerError::Failed(format!("pre-restore safety backup failed: {e}")));
     }
-    remove_container_force(docker, &cname).await.ok();
+    // Confirm it's actually gone (don't swallow): docker rm can return before the name frees,
+    // and a create colliding on the name would delete the env file while the old container
+    // still exists. The pre-restore safety backup is already taken, so restart and bail.
+    if let Err(e) = ensure_container_removed(docker, &cname).await {
+        if info.status == ContainerStatus::Running {
+            start_container(docker, &cname).await;
+        }
+        return Err(e);
+    }
 
     let port = info
         .port

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -469,6 +469,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn restore_backup_confirms_removal_before_create() {
+        // restore_backup recreates under the SAME name, so the old container must be confirmed
+        // gone before create. A best-effort `remove_container_force(...).await.ok()` could let
+        // the create collide on the name after the env file was already rewritten (docker rm can
+        // return before the name frees, or fail transiently), same failure mode as rebuild_agent.
+        let src = include_str!("backup.rs");
+        let restore_start = src.find("pub async fn restore_backup").expect("restore_backup present");
+        let delete_start = src.find("pub async fn delete_backup").expect("delete_backup present");
+        assert!(restore_start < delete_start, "restore_backup must appear before delete_backup for this test to slice correctly");
+        let restore_body = &src[restore_start..delete_start];
+
+        let remove_pos = restore_body
+            .find("ensure_container_removed")
+            .expect("restore_backup must confirm the old container is gone via ensure_container_removed before recreating");
+        let create_pos = restore_body.find("create_container").expect("create_container must be called in restore_backup");
+        assert!(remove_pos < create_pos, "restore_backup must remove the old container before creating the new one");
+        assert!(
+            !restore_body.contains("remove_container_force"),
+            "restore_backup must use ensure_container_removed (confirms gone), not the best-effort remove_container_force"
+        );
+    }
+
     // ── Retention policy tests ────────────────────────────────────
 
     const DEFAULT_RETENTION: RetentionPolicy = RetentionPolicy {

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -2090,7 +2090,9 @@ pub async fn reconcile_containers(
         if wants_running(name) {
             if !running {
                 tracing::info!(agent = %name, "starting (desired running)");
-                start_container(docker, cname).await;
+                if !start_container(docker, cname).await {
+                    tracing::error!(agent = %name, "boot-start failed");
+                }
             } else if agent_code_changed && has_core_mount {
                 // vestad re-extracted the embedded core this boot. A running agent still holds the
                 // old code in memory and its core mount points at the now-replaced dir, so restart
@@ -2353,7 +2355,10 @@ pub async fn rename_agent(
     snapshot_container(docker, &old_cname, &snapshot_tag, &[]).await?;
 
     tracing::info!(agent = %old_name, "[3/4] removing old container and env file...");
-    remove_container_force(docker, &old_cname).await.ok();
+    // Confirm it's actually gone (don't swallow): the snapshot is safely captured and the env
+    // file and constitution are still untouched, so failing here leaves the old agent fully
+    // intact instead of leaving a live container squatting on the WS port under the old name.
+    ensure_container_removed(docker, &old_cname).await?;
     // Carry the constitution across the rename before the new container is created, so its
     // bind mount resolves to the existing content rather than a fresh empty file.
     let old_constitution = read_constitution(&env_config.agents_dir, old_name).unwrap_or_default();
@@ -2901,6 +2906,21 @@ mod tests {
         assert!(
             !rebuild_body.contains("remove_container_force"),
             "rebuild_agent must use ensure_container_removed (confirms gone), not the best-effort remove_container_force"
+        );
+
+        // rename_agent has the same shape (snapshot, remove, create) and the same failure mode:
+        // a surviving old container keeps the same baked-in WS_PORT while its env file and
+        // constitution are deleted, and the next reconcile boot-starts it alongside the new one.
+        let tests_start = src.find("#[cfg(test)]").expect("test module present");
+        let rename_body = &src[rename_start..tests_start];
+        let rename_remove_pos = rename_body
+            .find("ensure_container_removed")
+            .expect("rename_agent must confirm the old container is gone via ensure_container_removed before recreating");
+        let rename_create_pos = rename_body.find("create_container").expect("create_container must be called in rename_agent");
+        assert!(rename_remove_pos < rename_create_pos, "rename_agent must remove the old container before creating the new one");
+        assert!(
+            !rename_body.contains("remove_container_force"),
+            "rename_agent must use ensure_container_removed (confirms gone), not the best-effort remove_container_force"
         );
     }
 

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -483,10 +483,9 @@ async fn gateway_update_handler(
     }
     let channel = effective_channel(&state).await;
     tracing::info!(channel = channel.as_str(), "gateway update requested via API");
-    let result = tokio::task::spawn_blocking(move || self_update::perform_update(channel))
-        .await
-        .unwrap();
+    let join = tokio::task::spawn_blocking(move || self_update::perform_update(channel)).await;
     state.updating.store(false, std::sync::atomic::Ordering::SeqCst);
+    let result = join.map_err(|e| err_response(StatusCode::INTERNAL_SERVER_ERROR, &format!("update task panicked: {e}")))?;
     match result {
         Ok(outcome) => Ok(Json(serde_json::json!({
             "ok": true,
@@ -2446,7 +2445,7 @@ pub fn build_router(state: SharedState) -> Router {
                         let is_noisy = request.method() == axum::http::Method::OPTIONS
                             || path.ends_with("/logs");
                         if !is_noisy {
-                            tracing::info!(method = %request.method(), path = %request.uri(), "request");
+                            tracing::info!(method = %request.method(), path = %path, "request");
                         }
                     },
                 )

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2438,14 +2438,17 @@ pub fn build_router(state: SharedState) -> Router {
         )
         .layer(
             tower_http::trace::TraceLayer::new_for_http()
-                .make_span_with(tower_http::trace::DefaultMakeSpan::new().level(tracing::Level::INFO))
+                // Custom span: DefaultMakeSpan records the full URI, and ?token= carries the live
+                // API key on browser WS connects; the span prefix lands in persisted logs.
+                .make_span_with(|request: &axum::http::Request<_>| {
+                    tracing::info_span!("request", method = %request.method(), path = %request.uri().path())
+                })
                 .on_request(
                     |request: &axum::http::Request<_>, _span: &tracing::Span| {
-                        let path = request.uri().path();
                         let is_noisy = request.method() == axum::http::Method::OPTIONS
-                            || path.ends_with("/logs");
+                            || request.uri().path().ends_with("/logs");
                         if !is_noisy {
-                            tracing::info!(method = %request.method(), path = %path, "request");
+                            tracing::info!("request");
                         }
                     },
                 )


### PR DESCRIPTION
Quality pass over vestad against the CLAUDE.md rubric: no unwrap on fallible paths, no silent exception swallowing, and no credentials in logs. Six surgical fixes, no behavior changes beyond error surfacing.

## What and why

**gateway_update_handler no longer unwraps the spawn_blocking join** (serve.rs). If perform_update panicked, the unwrap panicked the handler before the updating flag was reset, so every later POST /gateway/update returned 409 until vestad restarted. The join result is now bound first, the flag reset unconditionally, and a panic maps to a 500.

**rename_agent confirms container removal** (docker.rs). rebuild_agent was already hardened to ensure_container_removed, but rename_agent kept the best-effort remove_container_force(...).ok(). If removal lagged, the old container survived with the same baked-in WS_PORT while its env file and constitution were deleted, and the next reconcile boot-started it alongside the new one. The snapshot is captured and the env file untouched at that point, so failing early leaves the old agent fully intact. The existing source-slicing test now covers rename_agent too.

**restore_backup confirms container removal** (backup.rs). Same race: docker rm can return before the name frees, the follow-up create collides, and create_container's error path deletes the agent's env file while the old container still exists. On removal failure the previously-running agent is restarted and the restore bails; the pre-restore safety backup already exists, so the old container staying intact is the best failure mode.

**Request trace no longer logs the query string** (serve.rs). The on_request closure logged the full URI, and auth deliberately accepts ?token= for browser WS clients, so every /ws connect wrote a live root credential into persisted logs that GET /gateway/logs serves back out. The trace now logs only the path.

**ws_proxy no longer logs the upstream URL on connect failure** (agent_proxy.rs). The assembled URL carries the agent token (and, via the forwarded query, possibly the client's ?token=), and agent WS being briefly unreachable is routine during restarts. The warning now logs the port and error only.

**start_container failures are logged instead of discarded** (backup.rs, docker.rs). The post-backup restart and the boot-reconcile start both dropped the returned bool, so a failed start reported success while the agent stayed down. Both now log an error, giving the reconcile summary a loud precursor when an agent lands in the stopped list.

Note: this branch name previously carried the merged PR #633; the stale remote branch was force-replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwBH5747T9nff6FSEANs3t