### PR TITLE
refactor(agent): delete the dead defensive layers around the SDK seam and notification lifecycle

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -23,7 +23,6 @@ from .client import (
     build_client_options,
     attempt_interrupt,
     send_preempt,
-    persist_session_id,
     resolve_openrouter_max_tokens,
     compact_session,
     consume_stream,
@@ -101,10 +100,6 @@ async def load_notifications(*, config: vm.VestaConfig) -> list[vm.Notification]
     return notifications
 
 
-async def delete_notification_files(notifications: list[vm.Notification]) -> None:
-    _delete_paths([n.file_path for n in notifications if n.file_path])
-
-
 def _trash_paths(file_paths: list[str], trash_dir: pl.Path) -> None:
     """Move each notification file into the trash dir, replacing any same-named entry. Trashing keeps the
     file recoverable/auditable instead of deleting it; a parked file is never re-scanned (the loader
@@ -150,11 +145,6 @@ def format_notification_batch(notifications: list[vm.Notification], *, suffix: s
     suffix_str = f"\n\n{suffix}" if suffix else ""
     inner = "\n".join(_format_one(n) for n in notifications)
     return f"{inner}{suffix_str}"
-
-
-def _delete_paths(file_paths: list[str]) -> None:
-    for path_str in file_paths:
-        pl.Path(path_str).unlink(missing_ok=True)
 
 
 async def process_batch(
@@ -266,16 +256,6 @@ async def _run_messages_with_interrupts(
             raise
         except (ClaudeSDKError, OSError, RuntimeError, ValueError, TimeoutError) as e:
             error_msg = "Response timed out" if isinstance(e, TimeoutError) else (str(e) or type(e).__name__)
-            if not state.persisted.session_id and state.client:
-                # Belt-and-suspenders: sdk_parsing already persists the session_id from the init
-                # message. The official claude_agent_sdk client has no session_id attribute, so this
-                # very-early-crash fallback degrades to None rather than AttributeError-ing here.
-                try:
-                    sid = state.client.session_id  # ty: ignore[unresolved-attribute]
-                except AttributeError:
-                    sid = None
-                if sid:
-                    persist_session_id(sid, state=state, config=config)
             exit_code, stderr_tail = format_crash_detail(e, state.stderr_buffer, fallback="")
             detail = f"Error processing message: {error_msg} | exit_code={exit_code}"
             if stderr_tail:

--- a/agent/core/provider.py
+++ b/agent/core/provider.py
@@ -170,18 +170,6 @@ def _check_claude_oauth(oauth: ClaudeOAuth) -> bool:
     return False
 
 
-def _check_claude_auth(content: str) -> bool:
-    """The disk-boundary entry: parse a `.credentials.json` blob and delegate to _check_claude_oauth."""
-    try:
-        creds = json.loads(content)
-    except (json.JSONDecodeError, TypeError):
-        return False
-    oauth = creds["claudeAiOauth"] if isinstance(creds, dict) and "claudeAiOauth" in creds else None
-    if not isinstance(oauth, dict):
-        return False
-    return _check_claude_oauth(ClaudeOAuth.model_validate(oauth))
-
-
 # --- Plan usage (provider-agnostic) ---
 #
 # Each provider reports usage in its own upstream shape — Claude as time-windowed rate-limit buckets

--- a/agent/core/sdk_parsing.py
+++ b/agent/core/sdk_parsing.py
@@ -132,31 +132,19 @@ def parse_sdk_message(msg: Message) -> tuple[list[str], list[ThinkingBlock], str
     message. Tool-use blocks carry no output here: tool/subagent activity is surfaced via the native
     hooks in make_hooks, so they are ignored. Non-assistant messages just log and return empties."""
     if isinstance(msg, ResultMessage):
-        session_id: str | None = None
-        try:
-            session_id = msg.session_id
-        except AttributeError:
-            pass
-        try:
-            usage_data = msg.usage or {}
-            cost = msg.total_cost_usd
-            duration_s = msg.duration_ms / 1000 if msg.duration_ms is not None else None
-            parts = []
-            if usage_data:
-                input_tok = usage_data["input_tokens"] if "input_tokens" in usage_data else 0
-                output_tok = usage_data["output_tokens"] if "output_tokens" in usage_data else 0
-                cache_read = usage_data["cache_read_input_tokens"] if "cache_read_input_tokens" in usage_data else 0
-                cache_create = usage_data["cache_creation_input_tokens"] if "cache_creation_input_tokens" in usage_data else 0
-                parts.append(f"in={input_tok} out={output_tok} cache_read={cache_read} cache_write={cache_create}")
-            if cost is not None:
-                parts.append(f"cost=${cost:.4f}")
-            if duration_s is not None:
-                parts.append(f"duration={duration_s:.1f}s")
-            if parts:
-                logger.usage(" | ".join(parts))
-        except (AttributeError, TypeError, KeyError):
-            pass
-        return [], [], session_id
+        usage_data = msg.usage or {}
+        parts = []
+        if usage_data:
+            input_tok = usage_data["input_tokens"] if "input_tokens" in usage_data else 0
+            output_tok = usage_data["output_tokens"] if "output_tokens" in usage_data else 0
+            cache_read = usage_data["cache_read_input_tokens"] if "cache_read_input_tokens" in usage_data else 0
+            cache_create = usage_data["cache_creation_input_tokens"] if "cache_creation_input_tokens" in usage_data else 0
+            parts.append(f"in={input_tok} out={output_tok} cache_read={cache_read} cache_write={cache_create}")
+        if msg.total_cost_usd is not None:
+            parts.append(f"cost=${msg.total_cost_usd:.4f}")
+        parts.append(f"duration={msg.duration_ms / 1000:.1f}s")
+        logger.usage(" | ".join(parts))
+        return [], [], msg.session_id
 
     if isinstance(msg, RateLimitEvent):
         info = msg.rate_limit_info
@@ -185,7 +173,7 @@ def parse_sdk_message(msg: Message) -> tuple[list[str], list[ThinkingBlock], str
         return [], [], None
 
     if not isinstance(msg, AssistantMessage):
-        return ([msg] if isinstance(msg, str) else []), [], None
+        return [], [], None
 
     texts = []
     thinking_blocks = []

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -62,6 +62,10 @@ def result_msg():
 
     msg = MagicMock(spec=ResultMessage)
     msg.content = []
+    msg.usage = None
+    msg.total_cost_usd = None
+    msg.duration_ms = 0
+    msg.session_id = None  # no persist: harness configs point at the real home, not a tmp dir
     return msg
 
 

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -7,11 +7,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 import core.models as vm
+from core.events import EventBus
+from core.helpers import clear_notifications
 from core.loops import (
     _is_new_json,
     _load_notification_files,
     _notification_watcher,
-    delete_notification_files,
     format_notification_batch,
     greeting_turn,
     load_notifications,
@@ -123,37 +124,40 @@ async def test_load_notifications_partial_success(tmp_path):
     assert not bad_file.exists()
 
 
-# --- delete_notification_files ---
+# --- clear_notifications ---
 
 
 @pytest.mark.anyio
-async def test_delete_notification_files(tmp_path):
-    f1 = tmp_path / "a.json"
-    f2 = tmp_path / "b.json"
-    f1.write_text("x")
-    f2.write_text("y")
+async def test_clear_notifications_unlinks_and_emits_cleared(tmp_path):
+    bus = EventBus(data_dir=tmp_path / "data")
+    try:
+        state = vm.State()
+        state.event_bus = bus
+        sub = bus.subscribe()
+        f1 = tmp_path / "a.json"
+        f2 = tmp_path / "b.json"
+        f1.write_text("x")
+        f2.write_text("y")
 
-    notifs = [
-        vm.Notification(timestamp=dt.datetime(2025, 1, 1), source="t", type="m", file_path=str(f1)),
-        vm.Notification(timestamp=dt.datetime(2025, 1, 1), source="t", type="m", file_path=str(f2)),
-    ]
-    await delete_notification_files(notifs)
+        clear_notifications(state, [str(f1), str(f2)])
 
-    assert not f1.exists()
-    assert not f2.exists()
-
-
-@pytest.mark.anyio
-async def test_delete_ignores_none_paths():
-    notif = vm.Notification(timestamp=dt.datetime(2025, 1, 1), source="t", type="m")
-    assert notif.file_path is None
-    await delete_notification_files([notif])  # should not raise
+        assert not f1.exists()
+        assert not f2.exists()
+        events = [sub.get_nowait() for _ in range(sub.qsize())]
+        assert [e["notif_id"] for e in events if e["type"] == "notification_cleared"] == ["a", "b"]
+    finally:
+        bus.close()
 
 
 @pytest.mark.anyio
-async def test_delete_handles_already_deleted(tmp_path):
-    notif = vm.Notification(timestamp=dt.datetime(2025, 1, 1), source="t", type="m", file_path=str(tmp_path / "gone.json"))
-    await delete_notification_files([notif])  # missing_ok=True, should not raise
+async def test_clear_notifications_handles_already_deleted(tmp_path):
+    bus = EventBus(data_dir=tmp_path / "data")
+    try:
+        state = vm.State()
+        state.event_bus = bus
+        clear_notifications(state, [str(tmp_path / "gone.json")])  # missing_ok=True, should not raise
+    finally:
+        bus.close()
 
 
 # --- format_notification_batch ---

--- a/agent/tests/test_provider.py
+++ b/agent/tests/test_provider.py
@@ -12,7 +12,7 @@ from core.provider import (
     ProviderAuthState,
     UsageCredits,
     UsageError,
-    _check_claude_auth,
+    _check_claude_oauth,
     _derive_kind_and_auth,
     clear_provider,
     derive_status,
@@ -77,18 +77,15 @@ def test_is_terminal_auth_error(error, expected):
 
 
 @pytest.mark.parametrize(
-    "creds,expected",
+    "oauth,expected",
     [
-        (json.dumps({"claudeAiOauth": {"accessToken": "a", "expiresAt": 2**62}}), True),  # valid, unexpired
-        (json.dumps({"claudeAiOauth": {"accessToken": "a", "expiresAt": 0, "refreshToken": "r"}}), True),  # expired but refreshable
-        (json.dumps({"claudeAiOauth": {"accessToken": "a", "expiresAt": 0}}), False),  # expired, no refresh
-        ("not json", False),
-        ("{}", False),
-        (json.dumps({"claudeAiOauth": None}), False),
+        ({"accessToken": "a", "expiresAt": 2**62}, True),  # valid, unexpired
+        ({"accessToken": "a", "expiresAt": 0, "refreshToken": "r"}, True),  # expired but refreshable
+        ({"accessToken": "a", "expiresAt": 0}, False),  # expired, no refresh
     ],
 )
-def test_claude_auth(creds, expected):
-    assert _check_claude_auth(creds) is expected
+def test_claude_auth(oauth, expected):
+    assert _check_claude_oauth(ClaudeOAuth.model_validate(oauth)) is expected
 
 
 # --- State transitions (free functions) ---


### PR DESCRIPTION
## What

Removes five pieces of dead defensive armor clustered around the SDK seam and the notification lifecycle, each a second owner of a decision that already has a real owner. 92 lines removed, 53 added, net 39 fewer.

- loops.py: the session_id crash fallback that probed `state.client.session_id` inside try/except AttributeError. The official ClaudeSDKClient has no such attribute, so the block always no-oped; sdk_parsing's init-message persistence is the single owner of session resume.
- loops.py: `delete_notification_files` and `_delete_paths`, which had zero production callers. `helpers.clear_notifications` is the real deletion owner (unlink plus the notification_cleared emit).
- sdk_parsing.py: the try/except AttributeError around `msg.session_id` and the banned silent `except (AttributeError, TypeError, KeyError): pass` around the usage logging. ResultMessage is a dataclass whose fields always exist, and every dict access already uses `in` checks.
- sdk_parsing.py: the `[msg] if isinstance(msg, str) else []` branch for a str the typed Message stream never yields.
- provider.py: `_check_claude_auth`, a parallel disk-boundary credentials parser called only by its own test. The live path is config.py's hydrate into `ClaudeOAuth` followed by `_check_claude_oauth`.

## Why

These blocks guard impossible states, so they mislead readers of the hottest error path into thinking the states are possible, and two of them violate the repo's no-silent-swallow rule. Each deleted branch is verified unreachable or uncalled; one fix per root cause means the real owner keeps the job and the shadow copies go.

The one genuine thing the swallowed TypeError was hiding: the conftest `result_msg()` fake (MagicMock spec'd on ResultMessage) lacked the no-default dataclass fields and could not be format-spec'd. The fake now pins `usage`, `total_cost_usd`, `duration_ms`, and `session_id` to concrete values, so the parse path runs honestly in tests instead of erroring into a silent except.

Tests retarget to the real owners: the delete tests now assert `clear_notifications` behavior (unlink plus cleared events), and the credentials parametrize now drives `_check_claude_oauth` with `ClaudeOAuth` models.

## Verification

`./check.sh agent` green: ruff check, ruff format, ty, and 553 passing tests including test_crash_recovery.py (session persistence), test_notifications.py, test_provider.py, and the stream-harness suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwBH5747T9nff6FSEANs3t