### PR TITLE
feat(dashboard): add a CLI-owned daemon lifecycle wrapper

### DIFF
--- a/agent/skills/dashboard/SETUP.md
+++ b/agent/skills/dashboard/SETUP.md
@@ -1,34 +1,22 @@
 # Dashboard setup
 
-## 1. Install dependencies
-
-`node` and `npm` ship in the base image.
-
+`node` and `npm` ship in the base image. Run the one-shot setup script; it installs
+dependencies, builds, starts the daemon, confirms it answers a 200, and appends the
+guarded startup line to the restart skill, all idempotent (safe to re-run):
 ```bash
-cd ~/agent/skills/dashboard/app && npm install
+~/agent/skills/dashboard/scripts/setup.sh
 ```
 
-## 2. Build the dashboard
+It fails loudly on a real problem instead of leaving a half set-up dashboard: don't
+assume success, check its output.
 
-```bash
-cd ~/agent/skills/dashboard/app && npx vite build
-```
+## Manual steps (only if setup.sh can't be used)
 
-## 3. Start the dashboard server
-
-`scripts/serve` registers the service port (see [service](../service/SKILL.md)) and starts the preview, rebuilding `node_modules`/`dist` first if they are missing. Start it, and fetch the port for the check below:
-```bash
-PORT=$(~/agent/skills/service/scripts/register-service dashboard --public)
-screen -dmS dashboard ~/agent/skills/dashboard/scripts/serve
-```
-
-## 4. Register the service
-
-Add this guarded startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
-```
-running dashboard || { screen -dmS dashboard ~/agent/skills/dashboard/scripts/serve; sleep 1; }
-```
-
-## 5. Check it's alive
-
-The build and server run in the background, so confirm the dashboard is actually serving before considering it done, e.g. `curl -fsS localhost:$PORT >/dev/null`. Don't assume success; a failed build or server won't tell you.
+1. **Install dependencies**: `cd ~/agent/skills/dashboard/app && npm install`
+2. **Build**: `cd ~/agent/skills/dashboard/app && npx vite build`
+3. **Start the daemon**: `~/agent/skills/dashboard/scripts/daemon start` (idempotent, never stacks a duplicate)
+4. **Register the restart line**: add this guarded startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
+   ```
+   running dashboard || { ~/agent/skills/dashboard/scripts/daemon start; sleep 1; }
+   ```
+5. **Check it's alive**: `~/agent/skills/dashboard/scripts/daemon status` reports `running`, `port`, and `http_ok` in one JSON blob. Don't assume success; a failed build or server won't tell you otherwise.

--- a/agent/skills/dashboard/SKILL.md
+++ b/agent/skills/dashboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dashboard
 description: Build or modify the user's dashboard: widgets, pages, layouts, or custom UI.
-serve: screen -dmS dashboard ~/agent/skills/dashboard/scripts/serve
+serve: ~/agent/skills/dashboard/scripts/daemon start
 ---
 
 # Dashboard
@@ -124,18 +124,19 @@ import { StarIcon } from "lucide-react"
 
 ## After every change
 
-Rebuild, re-register with vestad, restart the preview server, and notify the Vesta app:
+Rebuild, restart the daemon, confirm it is actually serving, and notify the Vesta app:
 
 ```bash
 # First build only: node_modules is not baked into the image, so install deps once.
 cd ~/agent/skills/dashboard/app && { [ -d node_modules ] || npm install; } && npx vite build
-PORT=$(~/agent/skills/service/scripts/register-service dashboard --public)
-screen -S dashboard -X quit 2>/dev/null
-screen -dmS dashboard ~/agent/skills/dashboard/scripts/serve
-# Wait for the server to be ready
-for i in $(seq 1 20); do curl -s -o /dev/null http://localhost:$PORT && break; sleep 0.5; done
+~/agent/skills/dashboard/scripts/daemon stop
+~/agent/skills/dashboard/scripts/daemon start
+# Status carries a port + HTTP 200 probe: don't assume success, check it.
+STATUS=$(~/agent/skills/dashboard/scripts/daemon status)
+echo "$STATUS"
+PORT=$(echo "$STATUS" | python3 -c 'import sys, json; print(json.load(sys.stdin)["port"])')
 # Smoke test: fetch the page and check for runtime errors
-SMOKE=$(curl -s http://localhost:$PORT/ | head -50)
+SMOKE=$(curl -s "http://localhost:$PORT/" | head -50)
 if ! echo "$SMOKE" | grep -q '<div id="root"'; then
   echo "ERROR: Dashboard failed to load. Check the build output."
 fi
@@ -149,12 +150,10 @@ curl -sk -X POST https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services/dash
 - **Cloudflare caches 404 responses for ~4 hours via the public tunnel.** If you accidentally serve a broken build that 404s on assets, even after fixing the build, the tunnel will keep serving the cached 404 until either (a) the URL changes, (b) the cache expires, or (c) you bust with a `?v=...` query. Vite's content hashes change automatically when source changes, so normally this isn't an issue. If you ever get a stuck 404 with no source change, temporarily add `Date.now()` to `entryFileNames` in `vite.config.ts`, rebuild, then revert.
 
 ## Troubleshooting
-*   **Dashboard not showing?** `screen -ls | grep dashboard`
-*   **Check registration:** `curl -sk https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services`
+*   **Dashboard not showing?** `~/agent/skills/dashboard/scripts/daemon status`, it reports `running`, `port`, and `http_ok` in one JSON blob.
 *   **Restart server:** Run the rebuild/restart block above.
 *   **Build failed or blank after deploy?** Run `cd ~/agent/skills/dashboard/app && { [ -d node_modules ] || npm install; } && npx vite build` and fix reported errors; confirm `app/dist/` exists before starting preview. `UNRESOLVED_IMPORT` / "Cannot find package" means deps were never installed, run `npm install` first.
-*   **Iframe stuck on an old build?** After a successful build and preview restart, run the `.../services/dashboard/invalidate` `curl` from the block above (the parent app keeps the iframe until invalidated).
-*   **Preview errors or 404?** Attach to logs with `screen -r dashboard`, then detach with Ctrl+A then `d`. If the session is wedged, `screen -S dashboard -X quit` and rerun the restart line from the block above.
-*   **No port from vestad?** Run the `POST .../services` `curl` alone and inspect the body; the `python3` one-liner errors on bad JSON. Verify `VESTAD_PORT`, `AGENT_NAME`, and `AGENT_TOKEN`.
+*   **Iframe stuck on an old build?** After a successful build and daemon restart, run the `.../services/dashboard/invalidate` `curl` from the block above (the parent app keeps the iframe until invalidated).
+*   **Preview errors or `http_ok: false`?** Attach to logs with `screen -r dashboard`, then detach with Ctrl+A then `d`. If the session is wedged, `~/agent/skills/dashboard/scripts/daemon stop` and rerun the restart line from the block above.
 *   **Widgets or API calls failing?** Use devtools on the dashboard (network tab): wrong `apiFetch` paths, skill server down, or auth not ready yet (`waitForAuth` in `parent-bridge.ts`).
 *   **Wrong or missing shadcn styles?** Shared UI components are updated via workspace sync. Check that the latest release tag has been merged.

--- a/agent/skills/dashboard/scripts/daemon
+++ b/agent/skills/dashboard/scripts/daemon
@@ -1,0 +1,90 @@
+#!/bin/sh
+set -u
+
+# Dashboard daemon lifecycle: start|stop|status. Wraps the self-healing
+# `serve` script (which rebuilds node_modules/dist if a sparse-checkout prune
+# dropped them) under a screen session, so the agent manages the dashboard
+# through one command instead of raw screen incantations.
+
+SESSION="dashboard"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() {
+  echo "Usage: daemon <start|stop|status>"
+}
+
+# True iff a LIVE screen session named $SESSION exists. A "(Dead ???)" corpse
+# left behind by a restart that preserves /run does not count; wipe first so
+# it can't be mistaken for a live session.
+running() {
+  screen -wipe >/dev/null 2>&1 || true
+  test -n "$(screen -ls 2>/dev/null | grep -E "[0-9]+\.${SESSION}[[:space:]]" | grep -v "Dead")"
+}
+
+daemon_start() {
+  if running; then
+    echo '{"status":"already_running"}'
+    return 0
+  fi
+  screen -dmS "$SESSION" "$DIR/serve"
+  i=0
+  while [ "$i" -lt 60 ]; do
+    running && break
+    sleep 0.5
+    i=$((i + 1))
+  done
+  if ! running; then
+    echo '{"error":"dashboard exited during startup; run scripts/serve in the foreground to see the error"}' >&2
+    return 1
+  fi
+  echo '{"status":"started"}'
+}
+
+daemon_stop() {
+  if ! running; then
+    echo '{"status":"already_stopped"}'
+    return 0
+  fi
+  screen -S "$SESSION" -X quit
+  i=0
+  while [ "$i" -lt 30 ]; do
+    running || break
+    sleep 0.5
+    i=$((i + 1))
+  done
+  if running; then
+    echo '{"error":"dashboard still running after screen quit; inspect with: screen -r dashboard"}' >&2
+    return 1
+  fi
+  echo '{"status":"stopped"}'
+}
+
+daemon_status() {
+  running_flag="false"
+  running && running_flag="true"
+
+  port=""
+  http_ok="false"
+  if [ "$running_flag" = "true" ]; then
+    port=$(~/agent/skills/service/scripts/register-service dashboard --public 2>/dev/null) || port=""
+    if [ -n "$port" ] && curl -fsS -o /dev/null "http://localhost:$port"; then
+      http_ok="true"
+    fi
+  fi
+
+  if [ -n "$port" ]; then
+    port_json="\"$port\""
+  else
+    port_json="null"
+  fi
+
+  printf '{"running":%s,"session":"%s","port":%s,"http_ok":%s}\n' "$running_flag" "$SESSION" "$port_json" "$http_ok"
+}
+
+case "${1:-}" in
+  start) daemon_start ;;
+  stop) daemon_stop ;;
+  status) daemon_status ;;
+  ""|-h|--help|help) usage; exit 0 ;;
+  *) usage >&2; exit 1 ;;
+esac

--- a/agent/skills/dashboard/scripts/daemon
+++ b/agent/skills/dashboard/scripts/daemon
@@ -21,23 +21,46 @@ running() {
   test -n "$(screen -ls 2>/dev/null | grep -E "[0-9]+\.${SESSION}[[:space:]]" | grep -v "Dead")"
 }
 
+# Port registered with vestad; empty when vestad is unreachable.
+service_port() {
+  ~/agent/skills/service/scripts/register-service dashboard --public 2>/dev/null || true
+}
+
+# True iff the dashboard answers a 200 on port $1.
+answers_http() {
+  [ -n "$1" ] && curl -fsS -o /dev/null "http://localhost:$1" 2>/dev/null
+}
+
+# Blocks until the server actually answers a 200, so callers can probe
+# immediately after start; the session existing is not readiness (serve may
+# still be installing deps or building before vite binds the port).
 daemon_start() {
   if running; then
     echo '{"status":"already_running"}'
     return 0
   fi
   screen -dmS "$SESSION" "$DIR/serve"
+  seen="false"
   i=0
   while [ "$i" -lt 60 ]; do
-    running && break
+    if running; then
+      seen="true"
+      if answers_http "$(service_port)"; then
+        echo '{"status":"started"}'
+        return 0
+      fi
+    elif [ "$seen" = "true" ]; then
+      break
+    fi
     sleep 0.5
     i=$((i + 1))
   done
-  if ! running; then
+  if running; then
+    echo '{"error":"dashboard is up but never answered a 200 on its port; inspect with: screen -r dashboard"}' >&2
+  else
     echo '{"error":"dashboard exited during startup; run scripts/serve in the foreground to see the error"}' >&2
-    return 1
   fi
-  echo '{"status":"started"}'
+  return 1
 }
 
 daemon_stop() {
@@ -66,10 +89,8 @@ daemon_status() {
   port=""
   http_ok="false"
   if [ "$running_flag" = "true" ]; then
-    port=$(~/agent/skills/service/scripts/register-service dashboard --public 2>/dev/null) || port=""
-    if [ -n "$port" ] && curl -fsS -o /dev/null "http://localhost:$port"; then
-      http_ok="true"
-    fi
+    port=$(service_port)
+    answers_http "$port" && http_ok="true"
   fi
 
   if [ -n "$port" ]; then

--- a/agent/skills/dashboard/scripts/setup.sh
+++ b/agent/skills/dashboard/scripts/setup.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+# Idempotent one-shot dashboard setup: installs deps, builds, starts the
+# daemon, confirms it is actually serving, and appends the guarded
+# restart-skill daemon line once. Safe to re-run; every step is a no-op when
+# already done, and a real failure exits loudly instead of leaving a half
+# set-up dashboard that looks fine until the next restart.
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cd "$DIR/../app"
+
+if [ ! -d node_modules ]; then
+  echo "Installing dependencies..."
+  npm install
+fi
+
+if [ ! -d dist ]; then
+  echo "Building dashboard..."
+  npx vite build
+fi
+
+echo "Starting daemon..."
+"$DIR/daemon" start
+
+STATUS=$("$DIR/daemon" status)
+echo "$STATUS"
+case "$STATUS" in
+  *'"http_ok":true'*) ;;
+  *)
+    echo "ERROR: dashboard did not answer a 200 after start; see 'screen -r dashboard'" >&2
+    exit 1
+    ;;
+esac
+
+RESTART_SKILL=~/agent/skills/restart/SKILL.md
+LINE='running dashboard || { ~/agent/skills/dashboard/scripts/daemon start; sleep 1; }'
+if [ -f "$RESTART_SKILL" ] && ! grep -qF "$LINE" "$RESTART_SKILL"; then
+  printf '\n```bash\n%s\n```\n' "$LINE" >> "$RESTART_SKILL"
+  echo "Appended dashboard daemon line to restart skill."
+fi
+
+echo "Dashboard setup complete."

--- a/agent/tests/test_dashboard_daemon.py
+++ b/agent/tests/test_dashboard_daemon.py
@@ -4,6 +4,7 @@ screen/curl/register-service, mirroring the telegram/tasks lifecycle transplant.
 import json
 import os
 import pathlib as pl
+import shutil
 import subprocess
 
 REPO_ROOT = pl.Path(__file__).resolve().parents[2]
@@ -32,6 +33,14 @@ esac
 """
 
 FAKE_CURL = """#!/bin/sh
+# Counts calls in $SCREEN_STATE_DIR/curl-calls; fails the first
+# $FAKE_CURL_FAIL_FIRST calls so tests can pin readiness polling.
+count_file="$SCREEN_STATE_DIR/curl-calls"
+count=$(($(cat "$count_file" 2>/dev/null || echo 0) + 1))
+echo "$count" > "$count_file"
+if [ "$count" -le "${FAKE_CURL_FAIL_FIRST:-0}" ]; then
+  exit 7
+fi
 exit "${FAKE_CURL_EXIT:-0}"
 """
 
@@ -81,6 +90,15 @@ def test_daemon_start_is_idempotent(tmp_path):
     second = _run(DAEMON, ["start"], env)
     assert second.returncode == 0
     assert json.loads(second.stdout) == {"status": "already_running"}
+
+
+def test_daemon_start_polls_until_the_server_answers(tmp_path):
+    env = _rig(tmp_path)
+    env["FAKE_CURL_FAIL_FIRST"] = "3"
+    result = _run(DAEMON, ["start"], env)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout) == {"status": "started"}
+    assert int((tmp_path / "screen-state/curl-calls").read_text()) == 4
 
 
 def test_daemon_status_reports_running_port_and_http(tmp_path):
@@ -141,26 +159,26 @@ def test_unknown_subcommand_exits_nonzero(tmp_path):
 
 def test_setup_starts_daemon_and_appends_restart_line_once(tmp_path):
     env = _rig(tmp_path)
-    app_dir = REPO_ROOT / "agent/skills/dashboard/app"
-    # node_modules/dist are untracked build artifacts; pre-seed real paths so the
-    # test never shells out to npm/vite, only exercises the lifecycle+append logic.
-    (app_dir / "node_modules").mkdir(exist_ok=True)
-    (app_dir / "dist").mkdir(exist_ok=True)
-    try:
-        restart_skill = pl.Path(env["HOME"]) / "agent/skills/restart/SKILL.md"
-        restart_skill.write_text("# Restart\n\n## Daemons\n")
+    # Copy the skill scripts into tmp_path (preserving the scripts/../app layout)
+    # and pre-seed the app build artifacts there, so setup.sh never shells out to
+    # npm/vite and the test never touches the real checkout.
+    skill_dir = tmp_path / "dashboard"
+    shutil.copytree(SETUP.parent, skill_dir / "scripts")
+    (skill_dir / "app/node_modules").mkdir(parents=True)
+    (skill_dir / "app/dist").mkdir(parents=True)
+    setup = skill_dir / "scripts/setup.sh"
 
-        first = subprocess.run(["sh", str(SETUP)], env=env, capture_output=True, text=True)
-        assert first.returncode == 0, first.stdout + first.stderr
-        assert json.loads(_run(DAEMON, ["status"], env).stdout)["running"] is True
+    restart_skill = pl.Path(env["HOME"]) / "agent/skills/restart/SKILL.md"
+    restart_skill.write_text("# Restart\n\n## Daemons\n")
 
-        line = "running dashboard || { ~/agent/skills/dashboard/scripts/daemon start; sleep 1; }"
-        content_after_first = restart_skill.read_text()
-        assert content_after_first.count(line) == 1
+    first = subprocess.run(["sh", str(setup)], env=env, capture_output=True, text=True)
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert json.loads(_run(DAEMON, ["status"], env).stdout)["running"] is True
 
-        second = subprocess.run(["sh", str(SETUP)], env=env, capture_output=True, text=True)
-        assert second.returncode == 0, second.stdout + second.stderr
-        assert restart_skill.read_text().count(line) == 1
-    finally:
-        (app_dir / "node_modules").rmdir()
-        (app_dir / "dist").rmdir()
+    line = "running dashboard || { ~/agent/skills/dashboard/scripts/daemon start; sleep 1; }"
+    content_after_first = restart_skill.read_text()
+    assert content_after_first.count(line) == 1
+
+    second = subprocess.run(["sh", str(setup)], env=env, capture_output=True, text=True)
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert restart_skill.read_text().count(line) == 1

--- a/agent/tests/test_dashboard_daemon.py
+++ b/agent/tests/test_dashboard_daemon.py
@@ -1,0 +1,166 @@
+"""Exercises the REAL dashboard scripts/daemon and scripts/setup.sh against a fake
+screen/curl/register-service, mirroring the telegram/tasks lifecycle transplant."""
+
+import json
+import os
+import pathlib as pl
+import subprocess
+
+REPO_ROOT = pl.Path(__file__).resolve().parents[2]
+DAEMON = REPO_ROOT / "agent/skills/dashboard/scripts/daemon"
+SETUP = REPO_ROOT / "agent/skills/dashboard/scripts/setup.sh"
+
+FAKE_SCREEN = """#!/bin/sh
+# Tracks a "live session" as a marker file under $SCREEN_STATE_DIR.
+case "$1" in
+  -ls)
+    if [ -f "$SCREEN_STATE_DIR/dashboard.live" ]; then
+      echo "There are screens on:"
+      printf '\\t12345.dashboard\\t(Detached)\\n'
+    else
+      echo "No Sockets found in /run/screen/S-root."
+    fi
+    ;;
+  -wipe) ;;
+  -dmS)
+    touch "$SCREEN_STATE_DIR/$2.live"
+    ;;
+  -S)
+    rm -f "$SCREEN_STATE_DIR/$2.live"
+    ;;
+esac
+"""
+
+FAKE_CURL = """#!/bin/sh
+exit "${FAKE_CURL_EXIT:-0}"
+"""
+
+FAKE_REGISTER_SERVICE = """#!/bin/sh
+echo "${FAKE_DASHBOARD_PORT:-4321}"
+"""
+
+
+def _rig(tmp_path):
+    """Builds a fake $HOME plus a fake screen/curl on PATH, returns the env for subprocess."""
+    home = tmp_path / "home"
+    (home / "agent/skills/service/scripts").mkdir(parents=True)
+    (home / "agent/skills/restart").mkdir(parents=True)
+    register_service = home / "agent/skills/service/scripts/register-service"
+    register_service.write_text(FAKE_REGISTER_SERVICE)
+    register_service.chmod(0o755)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    screen = bin_dir / "screen"
+    screen.write_text(FAKE_SCREEN)
+    screen.chmod(0o755)
+    curl = bin_dir / "curl"
+    curl.write_text(FAKE_CURL)
+    curl.chmod(0o755)
+
+    screen_state = tmp_path / "screen-state"
+    screen_state.mkdir()
+
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["SCREEN_STATE_DIR"] = str(screen_state)
+    return env
+
+
+def _run(script, args, env):
+    return subprocess.run([str(script), *args], env=env, capture_output=True, text=True)
+
+
+def test_daemon_start_is_idempotent(tmp_path):
+    env = _rig(tmp_path)
+    first = _run(DAEMON, ["start"], env)
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert json.loads(first.stdout) == {"status": "started"}
+
+    second = _run(DAEMON, ["start"], env)
+    assert second.returncode == 0
+    assert json.loads(second.stdout) == {"status": "already_running"}
+
+
+def test_daemon_status_reports_running_port_and_http(tmp_path):
+    env = _rig(tmp_path)
+    env["FAKE_DASHBOARD_PORT"] = "9999"
+    _run(DAEMON, ["start"], env)
+
+    status = _run(DAEMON, ["status"], env)
+    assert status.returncode == 0, status.stdout + status.stderr
+    body = json.loads(status.stdout)
+    assert body == {"running": True, "session": "dashboard", "port": "9999", "http_ok": True}
+
+
+def test_daemon_status_when_stopped_reports_no_port(tmp_path):
+    env = _rig(tmp_path)
+    status = _run(DAEMON, ["status"], env)
+    assert status.returncode == 0
+    assert json.loads(status.stdout) == {"running": False, "session": "dashboard", "port": None, "http_ok": False}
+
+
+def test_daemon_status_running_but_probe_failing_is_not_http_ok(tmp_path):
+    env = _rig(tmp_path)
+    _run(DAEMON, ["start"], env)
+    env["FAKE_CURL_EXIT"] = "22"
+
+    status = _run(DAEMON, ["status"], env)
+    body = json.loads(status.stdout)
+    assert body["running"] is True
+    assert body["http_ok"] is False
+
+
+def test_daemon_stop_is_idempotent(tmp_path):
+    env = _rig(tmp_path)
+    already = _run(DAEMON, ["stop"], env)
+    assert already.returncode == 0
+    assert json.loads(already.stdout) == {"status": "already_stopped"}
+
+    _run(DAEMON, ["start"], env)
+    stopped = _run(DAEMON, ["stop"], env)
+    assert stopped.returncode == 0
+    assert json.loads(stopped.stdout) == {"status": "stopped"}
+    assert json.loads(_run(DAEMON, ["status"], env).stdout)["running"] is False
+
+
+def test_bare_invocation_and_help_print_usage_and_exit_zero(tmp_path):
+    env = _rig(tmp_path)
+    for args in ([], ["--help"], ["-h"], ["help"]):
+        result = _run(DAEMON, args, env)
+        assert result.returncode == 0, f"{args}: {result.stdout + result.stderr}"
+        assert "Usage" in result.stdout
+
+
+def test_unknown_subcommand_exits_nonzero(tmp_path):
+    env = _rig(tmp_path)
+    result = _run(DAEMON, ["bogus"], env)
+    assert result.returncode != 0
+
+
+def test_setup_starts_daemon_and_appends_restart_line_once(tmp_path):
+    env = _rig(tmp_path)
+    app_dir = REPO_ROOT / "agent/skills/dashboard/app"
+    # node_modules/dist are untracked build artifacts; pre-seed real paths so the
+    # test never shells out to npm/vite, only exercises the lifecycle+append logic.
+    (app_dir / "node_modules").mkdir(exist_ok=True)
+    (app_dir / "dist").mkdir(exist_ok=True)
+    try:
+        restart_skill = pl.Path(env["HOME"]) / "agent/skills/restart/SKILL.md"
+        restart_skill.write_text("# Restart\n\n## Daemons\n")
+
+        first = subprocess.run(["sh", str(SETUP)], env=env, capture_output=True, text=True)
+        assert first.returncode == 0, first.stdout + first.stderr
+        assert json.loads(_run(DAEMON, ["status"], env).stdout)["running"] is True
+
+        line = "running dashboard || { ~/agent/skills/dashboard/scripts/daemon start; sleep 1; }"
+        content_after_first = restart_skill.read_text()
+        assert content_after_first.count(line) == 1
+
+        second = subprocess.run(["sh", str(SETUP)], env=env, capture_output=True, text=True)
+        assert second.returncode == 0, second.stdout + second.stderr
+        assert restart_skill.read_text().count(line) == 1
+    finally:
+        (app_dir / "node_modules").rmdir()
+        (app_dir / "dist").rmdir()


### PR DESCRIPTION
## What changed

Applies the production-grade daemon-lifecycle pattern from #1083 to the `dashboard` skill (items 1, 5, 6 from the checklist; the dashboard is a script-based daemon with no death-notification mechanism, so item 4 does not apply).

- **`agent/skills/dashboard/scripts/daemon`** (new): a `start|stop|status` wrapper around the existing self-healing `scripts/serve`. `start` is idempotent (a live screen session is a no-op, never stacks a duplicate). `status` reports `running`, `session`, `port`, and `http_ok` (an actual HTTP probe against the registered port) in one JSON blob, so the agent never has to diagnose via `screen -X hardcopy` or raw `screen -ls` parsing. Bare invocation and `--help` print usage and exit 0.
- **`agent/skills/dashboard/scripts/setup.sh`** (new): idempotent one-shot setup, installs deps and builds only if missing, starts the daemon, confirms it answers a 200, and appends the guarded restart-skill line itself (no-op if already present). Fails loudly on a real problem.
- **`SKILL.md`** / **`SETUP.md`**: point at `scripts/daemon`/`scripts/setup.sh` instead of raw `screen -dmS`/`screen -S ... -X quit` incantations. The `serve:` frontmatter value (informational only, not parsed into `index.json`) now points at `daemon start`. `name`/`description` are untouched.

`scripts/serve` itself is unchanged: it keeps its existing self-heal behavior (rebuilding `node_modules`/`dist` if a sparse-checkout prune dropped them) and is now just what `daemon start` launches under `screen`.

## Checklist items covered (from #1083)

- [x] 1. CLI-owned daemon lifecycle: `scripts/daemon start|stop|status`, idempotent start, status reports process + health in one JSON blob.
- [x] 5. Idempotent one-script setup: `scripts/setup.sh`, no-op when already done, appends the guarded restart-skill line itself.
- [x] 6. Docs shrink: SKILL.md/SETUP.md point at the lifecycle commands, not raw screen incantations.
- [x] 7. Tests ship with the logic: `agent/tests/test_dashboard_daemon.py` runs the real `daemon`/`setup.sh` scripts against a faked `screen`/`curl`/`register-service`, covering idempotent start/stop, status (running, stopped, probe-failing), usage/help exit codes, unknown subcommands, and the setup script's one-time restart-line append.
- Not applicable: item 4 (intentional-stop marker) — dashboard has no `daemon_died` notification path to suppress; its self-heal is the artifact rebuild in `scripts/serve`, which is unchanged.

## Fleet impact

Additive only. Existing restart-skill daemon lines already on live boxes (`screen -dmS dashboard ~/agent/skills/dashboard/scripts/serve`) keep working unchanged: `scripts/serve` is untouched. `scripts/daemon` and `scripts/setup.sh` are new files that arrive via the normal workspace-sync rebase; no path moved, no config/state shape changed, so no migration is needed. A box only starts using the new lifecycle commands when the agent (or the user, re-running setup) opts in by calling `scripts/daemon`/`scripts/setup.sh`, or after re-running dashboard setup, at which point `setup.sh` appends the new guarded line to the box's own `~/agent/skills/restart/SKILL.md` (idempotent, so re-running it is safe).

## Test plan

- [x] `agent/tests/test_dashboard_daemon.py` (8 new tests, all passing)
- [x] `./check.sh agent` (565 tests passing, ruff + ty clean)
- [x] `uv run python agent/skills/generate-index.py` produces no diff (frontmatter `name`/`description` untouched)

Part of #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGjjUkGBUinjiZa1MJzoKb