### PR TITLE
feat(voice): production-grade daemon lifecycle

### DIFF
--- a/agent/skills/voice/SETUP.md
+++ b/agent/skills/voice/SETUP.md
@@ -10,14 +10,14 @@ This provides the `voice-server` and `voice-keys` commands.
 
 ## 2. Start the voice server
 
-1. Register with vestad to get a port (see [service](../service/SKILL.md)), then start the server in a background screen session:
+1. Start the daemon:
    ```bash
-   PORT=$(~/agent/skills/service/scripts/register-service voice)
-   SKILL_PORT=$PORT screen -dmS voice voice-server
+   voice-keys daemon start
    ```
+   Idempotent (a running daemon is a no-op) and owns the register-service call (see [service](../service/SKILL.md)) so there is nothing else to wire up. Check with `voice-keys daemon status`.
 2. Add this startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
    ```
-   PORT=$(~/agent/skills/service/scripts/register-service voice) && SKILL_PORT=$PORT screen -dmS voice voice-server
+   voice-keys daemon start
    ```
 
 ## 3. API keys

--- a/agent/skills/voice/SKILL.md
+++ b/agent/skills/voice/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: voice
 description: Voice input/output, transcription, TTS, API keys; manages ~/.voice/voice_config.json.
-serve: PORT=$(~/agent/skills/service/scripts/register-service voice) && SKILL_PORT=$PORT screen -dmS voice voice-server
+serve: voice-keys daemon start
 ---
 
 # Voice setup (STT/TTS)
@@ -35,14 +35,16 @@ Once configured, the user can manage voice settings directly from the **agent se
    voice-keys set-voice --id <voice_id>
    ```
    Let them know they can browse all voices and listen to previews in the app settings later.
-6. **Ensure the voice server is running.** The app fetches config from it. Check with `screen -ls | grep voice`. If it's not running, start it:
+6. **Ensure the voice server is running.** The app fetches config from it.
    ```bash
-   PORT=$(~/agent/skills/service/scripts/register-service voice)
-   SKILL_PORT=$PORT screen -dmS voice voice-server
+   voice-keys daemon start
    ```
+   Idempotent (a running daemon is a no-op) and owns the register-service call, so this is the only command needed. Check with `voice-keys daemon status`.
 7. **Confirm**, e.g. "Voice is ready! You can use the mic button now. You can also change voices, listen to previews, and tweak settings from the settings page in the app."
 
 ## Commands
+
+**Daemon**: `voice-keys daemon start|stop|restart|status`. Start is idempotent (never stacks a duplicate) and owns the register-service call; status reports the port plus each domain's provider and enabled state. Manage the daemon only through these commands, never raw `screen`.
 
 ```bash
 # See current state

--- a/agent/skills/voice/cli/pyproject.toml
+++ b/agent/skills/voice/cli/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
 voice-server = "voice.server:main"
 voice-keys = "voice.voice_keys:main"
 
+[dependency-groups]
+dev = ["pytest>=8.4.0"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/voice"]
 

--- a/agent/skills/voice/cli/src/voice/daemon.py
+++ b/agent/skills/voice/cli/src/voice/daemon.py
@@ -1,0 +1,151 @@
+"""Lifecycle for the voice-server screen daemon.
+
+`start` owns the register-service call (idempotent: vestad returns the same port for a
+given name on every call), so the agent runs one command instead of stitching together
+register-service + screen by hand. Liveness is a TCP connect to the registered port;
+voice-server has no admin socket of its own.
+"""
+
+import os
+import pathlib as pl
+import re
+import shutil
+import socket
+import subprocess
+import time
+import typing as tp
+
+from . import config as vc
+
+SESSION_NAME = "voice"
+START_TIMEOUT_S = 30
+STOP_TIMEOUT_S = 15
+POLL_INTERVAL_S = 1.0
+PORT_CONNECT_TIMEOUT_S = 2.0
+
+REGISTER_SERVICE = pl.Path.home() / "agent" / "skills" / "service" / "scripts" / "register-service"
+
+
+class DaemonError(RuntimeError):
+    pass
+
+
+class AuthEntry(tp.TypedDict):
+    provider: str
+    enabled: bool
+
+
+class LifecycleResult(tp.TypedDict):
+    status: str
+    session: str
+    port: int
+
+
+class StatusResult(tp.TypedDict):
+    running: bool
+    session: str
+    port: int
+    auth: dict[str, AuthEntry | None]
+
+
+def data_dir() -> pl.Path:
+    return pl.Path.home() / ".voice"
+
+
+def screen_output_has_live_session(screen_ls: str, name: str) -> bool:
+    """A LIVE screen session with exactly this name (a "(Dead ???)" corpse does not count)."""
+    pattern = re.compile(r"\d+\." + re.escape(name) + r"\s")
+    for line in screen_ls.splitlines():
+        if pattern.search(line) and "Dead" not in line:
+            return True
+    return False
+
+
+def _screen_session_live(name: str) -> bool:
+    # `screen -ls` exits nonzero when no sessions exist; only the output matters.
+    result = subprocess.run(["screen", "-ls"], capture_output=True, text=True)
+    return screen_output_has_live_session(result.stdout, name)
+
+
+def resolve_port() -> int:
+    result = subprocess.run([str(REGISTER_SERVICE), "voice"], capture_output=True, text=True, timeout=35)
+    if result.returncode != 0 or not result.stdout.strip():
+        raise DaemonError(f"register-service failed: {result.stderr.strip()}")
+    return int(result.stdout.strip())
+
+
+def port_alive(port: int) -> bool:
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=PORT_CONNECT_TIMEOUT_S):
+            return True
+    except OSError:
+        return False
+
+
+def _auth_status() -> dict[str, AuthEntry | None]:
+    cfg = vc.load(data_dir())
+    auth: dict[str, AuthEntry | None] = {}
+    for domain in ("stt", "tts"):
+        entry = cfg[domain]
+        if entry is None or "provider" not in entry:
+            auth[domain] = None
+            continue
+        enabled = entry["enabled"] if "enabled" in entry else False
+        auth[domain] = {"provider": entry["provider"], "enabled": enabled}
+    return auth
+
+
+def start() -> LifecycleResult:
+    port = resolve_port()
+    if port_alive(port):
+        return {"status": "already_running", "session": SESSION_NAME, "port": port}
+
+    binary = shutil.which("voice-server")
+    if binary is None:
+        raise DaemonError("voice-server binary not on PATH; run `uv tool install --editable ~/agent/skills/voice/cli` first")
+
+    env = dict(os.environ)
+    env["SKILL_PORT"] = str(port)
+    launch = subprocess.run(["screen", "-dmS", SESSION_NAME, binary], env=env, capture_output=True, text=True)
+    if launch.returncode != 0:
+        raise DaemonError(f"failed to launch screen session: {launch.stderr.strip()}")
+
+    deadline = time.monotonic() + START_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if port_alive(port):
+            return {"status": "started", "session": SESSION_NAME, "port": port}
+        if not _screen_session_live(SESSION_NAME):
+            raise DaemonError("voice-server exited during startup; run 'voice-server' in the foreground to see the error")
+        time.sleep(POLL_INTERVAL_S)
+    raise DaemonError(f"voice-server did not answer on port {port} within {START_TIMEOUT_S}s")
+
+
+def stop() -> LifecycleResult:
+    port = resolve_port()
+    if not port_alive(port):
+        return {"status": "already_stopped", "session": SESSION_NAME, "port": port}
+
+    subprocess.run(["screen", "-S", SESSION_NAME, "-X", "quit"])
+    deadline = time.monotonic() + STOP_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if not port_alive(port):
+            return {"status": "stopped", "session": SESSION_NAME, "port": port}
+        time.sleep(POLL_INTERVAL_S)
+    raise DaemonError(f"voice-server still answering on port {port} after screen quit; inspect with 'screen -r {SESSION_NAME}'")
+
+
+def restart() -> LifecycleResult:
+    stop()
+    result = start()
+    result["status"] = "restarted"
+    return result
+
+
+def status() -> StatusResult:
+    port = resolve_port()
+    return {
+        "running": port_alive(port),
+        "session": SESSION_NAME,
+        "port": port,
+        "auth": _auth_status(),
+    }

--- a/agent/skills/voice/cli/src/voice/voice_keys.py
+++ b/agent/skills/voice/cli/src/voice/voice_keys.py
@@ -26,6 +26,7 @@ import sys
 import urllib.request
 
 from . import config as vc
+from . import daemon
 from . import providers
 
 
@@ -180,9 +181,49 @@ def cmd_set_eot(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_daemon_start(_args: argparse.Namespace) -> int:
+    try:
+        result = daemon.start()
+    except daemon.DaemonError as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def cmd_daemon_stop(_args: argparse.Namespace) -> int:
+    try:
+        result = daemon.stop()
+    except daemon.DaemonError as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def cmd_daemon_restart(_args: argparse.Namespace) -> int:
+    try:
+        result = daemon.restart()
+    except daemon.DaemonError as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def cmd_daemon_status(_args: argparse.Namespace) -> int:
+    try:
+        result = daemon.status()
+    except daemon.DaemonError as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
-    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub = parser.add_subparsers(dest="cmd")
 
     sub.add_parser("status").set_defaults(func=cmd_status)
 
@@ -236,7 +277,17 @@ def main(argv: list[str] | None = None) -> int:
     p_set_eot.add_argument("--timeout-ms", type=int, default=None)
     p_set_eot.set_defaults(func=cmd_set_eot)
 
+    p_daemon = sub.add_parser("daemon", help="Manage the voice-server background daemon")
+    daemon_sub = p_daemon.add_subparsers(dest="daemon_cmd", required=True)
+    daemon_sub.add_parser("start", help="Register a port and start voice-server (idempotent)").set_defaults(func=cmd_daemon_start)
+    daemon_sub.add_parser("stop", help="Stop voice-server").set_defaults(func=cmd_daemon_stop)
+    daemon_sub.add_parser("restart", help="Stop then start voice-server").set_defaults(func=cmd_daemon_restart)
+    daemon_sub.add_parser("status", help="Report daemon + provider auth state").set_defaults(func=cmd_daemon_status)
+
     args = parser.parse_args(argv)
+    if args.cmd is None:
+        parser.print_help()
+        return 0
     return args.func(args)
 
 

--- a/agent/skills/voice/cli/tests/test_cli_usage.py
+++ b/agent/skills/voice/cli/tests/test_cli_usage.py
@@ -1,0 +1,28 @@
+import pytest
+
+import voice.voice_keys as voice_keys
+
+
+def test_bare_invocation_prints_usage_and_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    code = voice_keys.main([])
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "daemon" in out
+
+
+def test_help_flag_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        voice_keys.main(["--help"])
+
+    assert exc.value.code == 0
+
+
+def test_daemon_subcommands_are_registered(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        voice_keys.main(["daemon", "--help"])
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    for want in ("start", "stop", "restart", "status"):
+        assert want in out

--- a/agent/skills/voice/cli/tests/test_daemon.py
+++ b/agent/skills/voice/cli/tests/test_daemon.py
@@ -1,0 +1,76 @@
+import pathlib as pl
+
+import pytest
+
+import voice.config as vc
+import voice.daemon as daemon
+
+
+LIVE_LS = "There are screens on:\n\t12345.voice\t(Detached)\n1 Socket in /run/screen/S-root.\n"
+DEAD_LS = "There are screens on:\n\t12345.voice\t(Dead ???)\nRemove dead screens with 'screen -wipe'.\n"
+NONE_LS = "No Sockets found in /run/screen/S-root.\n"
+COLLIDING_LS = "There are screens on:\n\t12345.voice-other\t(Detached)\n1 Socket in /run/screen/S-root.\n"
+
+
+@pytest.mark.parametrize(
+    "screen_ls,want",
+    [
+        (LIVE_LS, True),
+        (DEAD_LS, False),
+        (NONE_LS, False),
+        (COLLIDING_LS, False),
+    ],
+)
+def test_screen_output_has_live_session(screen_ls: str, want: bool) -> None:
+    assert daemon.screen_output_has_live_session(screen_ls, "voice") == want
+
+
+def test_auth_status_reports_none_when_unconfigured(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(daemon, "data_dir", lambda: tmp_path)
+    assert daemon._auth_status() == {"stt": None, "tts": None}
+
+
+def test_auth_status_reports_provider_and_enabled(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(daemon, "data_dir", lambda: tmp_path)
+    vc.set_key(tmp_path, "stt", "deepgram", "k")
+    vc.set_enabled(tmp_path, "tts", True)
+    vc.set_key(tmp_path, "tts", "elevenlabs", "k2")
+
+    auth = daemon._auth_status()
+
+    assert auth["stt"] == {"provider": "deepgram", "enabled": True}
+    assert auth["tts"] == {"provider": "elevenlabs", "enabled": True}
+
+
+def test_start_is_idempotent_when_port_already_alive(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(daemon, "resolve_port", lambda: 4242)
+    monkeypatch.setattr(daemon, "port_alive", lambda port: True)
+
+    result = daemon.start()
+
+    assert result == {"status": "already_running", "session": "voice", "port": 4242}
+
+
+def test_stop_is_idempotent_when_already_stopped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(daemon, "resolve_port", lambda: 4242)
+    monkeypatch.setattr(daemon, "port_alive", lambda port: False)
+
+    result = daemon.stop()
+
+    assert result == {"status": "already_stopped", "session": "voice", "port": 4242}
+
+
+def test_status_reports_running_port_and_auth(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(daemon, "data_dir", lambda: tmp_path)
+    monkeypatch.setattr(daemon, "resolve_port", lambda: 4242)
+    monkeypatch.setattr(daemon, "port_alive", lambda port: True)
+    vc.set_key(tmp_path, "stt", "deepgram", "k")
+
+    result = daemon.status()
+
+    assert result == {
+        "running": True,
+        "session": "voice",
+        "port": 4242,
+        "auth": {"stt": {"provider": "deepgram", "enabled": True}, "tts": None},
+    }


### PR DESCRIPTION
## Summary

Applies the daemon-lifecycle pattern from #1082 (telegram/tasks) to the voice skill, per checklist items 1, 3, 6 in #1083.

- New `voice-keys daemon start|stop|restart|status`. `start` owns the `register-service` call itself (registration is idempotent, vestad returns the same port for the same name every time), so the agent runs one command instead of stitching `register-service` + `screen` by hand; `start` is also idempotent against an already-answering port (the #867 duplicate-daemon class). `stop`/`restart` quit the screen session and poll until the port stops answering. `status` reports the port plus each domain's (`stt`/`tts`) provider and enabled state in one JSON blob, so the agent never has to `screen -ls | grep voice` or read `~/.voice/voice_config.json` by hand.
- Bare `voice-keys` and `voice-keys --help` now print usage and exit 0 instead of erroring through `required=True` subparsers.
- SKILL.md and SETUP.md rewritten to the single `voice-keys daemon start` command (the frontmatter `serve:` line, the setup walkthrough, and the restart-skill snippet all point at it now); the raw `PORT=$(register-service voice) && SKILL_PORT=$PORT screen -dmS voice voice-server` incantation and the `screen -ls | grep voice` liveness check are gone from the docs.
- No feature changes to voice's STT/TTS behavior; `voice-server` itself is untouched.

## Fleet impact

Additive only. Existing boxes carry the old `PORT=$(...) && SKILL_PORT=$PORT screen -dmS voice voice-server` line in their own `~/agent/skills/restart/SKILL.md` (a per-box file the agent edits, not shipped by this repo) and that line keeps working unchanged, since neither `voice-server`'s env contract nor the screen session name changed. The new `voice-keys daemon` subcommands arrive via the next workspace sync; a box adopts them only when the agent (or user) next edits its restart snippet to the new one-liner. No migration needed: nothing on disk moved, no path or contract changed.

## Test plan

- [x] `uv run pytest skills/voice/cli/tests/` (new: screen-output parsing incl. dead/collision cases, auth-status building from `~/.voice/voice_config.json`, start/stop idempotency, status shape) — 12 passed
- [x] `uv run pytest tests/` (full agent suite, unaffected) — 557 passed
- [x] `uv run ruff check` / `ruff format --check` on `skills/voice`
- [x] `uv run python skills/generate-index.py` — `index.json` unchanged (frontmatter name/description untouched)

Part of #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGjjUkGBUinjiZa1MJzoKb