### PR TITLE
feat(email-client): add CLI-owned poll daemon lifecycle

### DIFF
--- a/agent/skills/email-client/SETUP.md
+++ b/agent/skills/email-client/SETUP.md
@@ -124,8 +124,10 @@ If these work, repeat steps 2-3 for each additional account.
 ## 4. Start the poll daemon
 
 ```bash
-screen -dmS email-client bash -c "cd ~/.email-client/runtime && PYTHONUNBUFFERED=1 uv run python3 ~/.email-client/poll_daemon.py --interval 15 > ~/.email-client/poll_daemon.log 2>&1"
+email-client daemon start
 ```
+
+Idempotent (a running daemon is a no-op) and defaults `--interval` to `$EMAIL_CLIENT_POLL_INTERVAL` or 15 seconds. Check with `email-client daemon status`, which reports process state plus per-account auth health in one JSON blob, so there's no need to `screen -X hardcopy` or read the log by hand. `email-client daemon stop` and `email-client daemon restart` are also available; a deliberate stop or restart marks itself intentional first, so it never fires the `daemon_died` notification the agent would otherwise investigate.
 
 The daemon runs one worker per watched `(account, folder)`. Where the server supports IMAP **IDLE** (Gmail, Microsoft, most others) the worker is pushed on new mail in real time; otherwise it polls every `--interval` seconds (the flag is the fallback cadence, not the primary mechanism). It recomputes the watch set as accounts or folders change, so neither adding an account nor changing the watch list needs a restart.
 
@@ -147,7 +149,7 @@ connects out to IMAP and writes notification files, so it needs no inbound port:
 daemon, not a vestad service.
 
 ```
-screen -dmS email-client bash -c "cd ~/.email-client/runtime && PYTHONUNBUFFERED=1 uv run python3 ~/.email-client/poll_daemon.py --interval 15 > ~/.email-client/poll_daemon.log 2>&1"
+running email-client || { email-client daemon start; sleep 1; }
 ```
 
 ## 6. Wire the rules into MEMORY.md
@@ -194,7 +196,7 @@ Repeat for each connected account. Don't rush this. Go through many hundreds of 
 - **Gmail `invalid_grant` on refresh**: access revoked or the refresh token aged out. Run `email-client auth add --account <name> --provider gmail --reauth`.
 - **Yahoo / iCloud `LOGIN failed`**: app password rotated or wrong. Generate a new one and `--reauth`.
 - **Loopback OAuth `bind: Address already in use`**: another process grabbed the port between probe and bind. Re-run; the CLI picks a fresh random port each time.
-- **Notifications don't appear**: confirm `~/agent/notifications/` is the agent's path (it's the standard one) and the daemon shows in `screen -ls`.
+- **Notifications don't appear**: confirm `~/agent/notifications/` is the agent's path (it's the standard one) and `email-client daemon status` shows `"running": true`. A `daemon_died` notification with a `reason` field means it crashed or was killed outside the CLI; restart with `email-client daemon start`.
 - **`list --limit 200` is slow on a huge mailbox**: expected; IMAP `SEARCH ALL` + `FETCH` is O(n). Scope with `search --query 'SINCE <date>'`.
 - **`unknown account 'foo'`**: run `email-client auth list`; add the missing one with `email-client auth add --account foo`.
 - **Microsoft 365 custom domain** (`you@yourcompany.com`): use `--provider microsoft-work`. See "Microsoft 365 with a custom domain" below for the four org-side blockers (`AADSTS50020` / admin consent, IMAP disabled, SMTP AUTH disabled, Conditional Access).
@@ -213,6 +215,9 @@ $EMAIL_CLIENT_DIR/                # default ~/.email-client
       high_uid.txt                # INBOX watermark
       high_uid_Archive.txt        # per-folder watermark (one per extra watched folder)
     work/ ...
+  daemon.pid                      # poll daemon pid; owned by `email-client daemon start|stop|restart|status`
+  daemon-info.json                # {"interval", "started_at"} of the running daemon, for `daemon restart`
+  stop-requested                  # marker `daemon stop`/`restart` writes so a deliberate exit skips daemon_died
 ```
 
 `token.json` always carries a `provider` key alongside the credential (access/refresh token for OAuth, `app_password` otherwise), so the daemon knows the auth strategy even if env vars change later.

--- a/agent/skills/email-client/SKILL.md
+++ b/agent/skills/email-client/SKILL.md
@@ -184,7 +184,9 @@ The first added account becomes the default. To change it, edit `default` in `$E
 
 ## Notifications
 
-Start the poll daemon (see SETUP.md). It runs one worker per **(account, folder)** being watched, each holding a persistent IMAP connection. Where the server advertises **IDLE** (Gmail, Microsoft, most others), the worker gets pushed on new mail in real time; otherwise it falls back to polling every `--interval` seconds (default 15). Either way it writes one JSON per new email into `~/agent/notifications/`. Each notification has source `email-client`, type `email`, `account` and `folder` fields, and `from`, `subject`, `date`, `uid`. The agent picks it up like any other notification source.
+Start the poll daemon with `email-client daemon start` (see SETUP.md); manage it only through `email-client daemon start|stop|restart|status`, never raw `screen` or signals. Start is idempotent (never stacks a duplicate daemon); `daemon status` reports process state and per-account auth health in one JSON blob, so there's no need to `screen -X hardcopy` or read the log by hand.
+
+The daemon runs one worker per **(account, folder)** being watched, each holding a persistent IMAP connection. Where the server advertises **IDLE** (Gmail, Microsoft, most others), the worker gets pushed on new mail in real time; otherwise it falls back to polling every `--interval` seconds (default 15). Either way it writes one JSON per new email into `~/agent/notifications/`. Each notification has source `email-client`, type `email`, `account` and `folder` fields, and `from`, `subject`, `date`, `uid`. The agent picks it up like any other notification source. If the daemon dies unexpectedly it writes a `daemon_died` notification with a `reason`; a deliberate `daemon stop`/`restart` never does.
 
 ### Choosing which folders notify
 

--- a/agent/skills/email-client/daemon_lifecycle.py
+++ b/agent/skills/email-client/daemon_lifecycle.py
@@ -155,6 +155,11 @@ def daemon_start(
     running, pid = daemon_running(state_dir)
     if running:
         return {"status": "already_running", "pid": pid, "session": SESSION_NAME}
+    if screen_session_live():
+        # A pidfile-less daemon (launched by a raw screen line before this CLI existed)
+        # is still running; `screen -dmS` would stack a second poller next to it.
+        return {"error": f"a live '{SESSION_NAME}' screen session has no pidfile; quit it with `screen -S {SESSION_NAME} -X quit`, then retry"}
+    stop_requested_path(state_dir).unlink(missing_ok=True)
     command = f"cd {runtime_dir} && PYTHONUNBUFFERED=1 uv run python3 {poll_daemon_path} --interval {interval} > {log_path} 2>&1"
     subprocess.run(["screen", "-dmS", SESSION_NAME, "bash", "-c", command], check=True)
     deadline = time.monotonic() + START_TIMEOUT_SECS
@@ -177,6 +182,7 @@ def daemon_stop(*, state_dir: pathlib.Path) -> dict:
     try:
         os.kill(pid, signal.SIGTERM)
     except ProcessLookupError:
+        stop_requested_path(state_dir).unlink(missing_ok=True)
         remove_pid(state_dir)
         return {"status": "already_stopped", "session": SESSION_NAME}
     deadline = time.monotonic() + STOP_TIMEOUT_SECS

--- a/agent/skills/email-client/daemon_lifecycle.py
+++ b/agent/skills/email-client/daemon_lifecycle.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Poll-daemon lifecycle: pidfile, stop-requested marker, daemon-info.
+
+Owns the on-disk contract the `email-client daemon start|stop|restart|status`
+subcommand and ``poll_daemon.py`` share, so the 130-char screen invocation
+lives in exactly one place (``daemon_start``) instead of being copy-pasted
+across SETUP.md. The stop-requested marker is how a deliberate ``daemon
+stop``/``restart`` tells the daemon's own shutdown not to fire the
+``daemon_died`` notification the agent would otherwise investigate.
+
+Has no dependency on ``imap_tools``/``msal`` so its logic (pidfile parsing,
+screen-session parsing, auth-summary assembly) can be unit tested without the
+account skill's runtime environment. ``daemon_start``/``stop``/``restart``
+shell out to ``screen`` and are exercised on a real box.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import signal
+import subprocess
+import time
+from datetime import UTC, datetime
+
+SESSION_NAME = "email-client"
+DEFAULT_POLL_INTERVAL_SECS = 15
+START_TIMEOUT_SECS = 20
+STOP_TIMEOUT_SECS = 15
+POLL_INTERVAL_SECS = 0.5
+
+
+def pid_path(state_dir: pathlib.Path) -> pathlib.Path:
+    return state_dir / "daemon.pid"
+
+
+def daemon_info_path(state_dir: pathlib.Path) -> pathlib.Path:
+    return state_dir / "daemon-info.json"
+
+
+def stop_requested_path(state_dir: pathlib.Path) -> pathlib.Path:
+    return state_dir / "stop-requested"
+
+
+def write_pid(state_dir: pathlib.Path) -> None:
+    pid_path(state_dir).write_text(str(os.getpid()))
+
+
+def remove_pid(state_dir: pathlib.Path) -> None:
+    pid_path(state_dir).unlink(missing_ok=True)
+
+
+def read_pid(state_dir: pathlib.Path) -> int | None:
+    p = pid_path(state_dir)
+    if not p.exists():
+        return None
+    raw = p.read_text().strip()
+    if not raw.isdigit():
+        return None
+    return int(raw)
+
+
+def process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def daemon_running(state_dir: pathlib.Path) -> tuple[bool, int | None]:
+    """Return ``(running, pid)``, cleaning up a stale pidfile left by a crash."""
+    pid = read_pid(state_dir)
+    if pid is None:
+        return False, None
+    if process_alive(pid):
+        return True, pid
+    remove_pid(state_dir)
+    return False, None
+
+
+def write_daemon_info(state_dir: pathlib.Path, interval: int) -> None:
+    info = {"interval": interval, "started_at": datetime.now(UTC).replace(microsecond=0).isoformat()}
+    daemon_info_path(state_dir).write_text(json.dumps(info))
+
+
+def read_daemon_info(state_dir: pathlib.Path) -> dict | None:
+    p = daemon_info_path(state_dir)
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except json.JSONDecodeError:
+        return None
+
+
+def mark_stop_requested(state_dir: pathlib.Path) -> None:
+    stop_requested_path(state_dir).write_text("")
+
+
+def consume_stop_requested(state_dir: pathlib.Path) -> bool:
+    """Return True and clear the marker if the exit was requested via `daemon stop`/`restart`."""
+    p = stop_requested_path(state_dir)
+    if not p.exists():
+        return False
+    p.unlink(missing_ok=True)
+    return True
+
+
+def screen_output_has_live_session(screen_ls: str, name: str) -> bool:
+    """True iff ``screen -ls`` output has a LIVE session named exactly ``name``.
+
+    A "(Dead ???)" corpse from a previous boot does not count, and ``email-client``
+    must not match a differently-named session that merely starts with it.
+    """
+    pattern = re.compile(r"[0-9]+\." + re.escape(name) + r"\s")
+    for line in screen_ls.splitlines():
+        if pattern.search(line) and "Dead" not in line:
+            return True
+    return False
+
+
+def screen_session_live(name: str = SESSION_NAME) -> bool:
+    # `screen -ls` exits nonzero when no sessions exist; only the output matters.
+    result = subprocess.run(["screen", "-ls"], capture_output=True, text=True, check=False)
+    return screen_output_has_live_session(result.stdout, name)
+
+
+def account_auth_summary(account: str, cfg: dict, tok: dict | None, provider: str) -> dict:
+    """Assemble one account's auth health from already-loaded config/token dicts.
+
+    Pure and network-free: reports whether a usable credential is on disk
+    (an app password or an OAuth refresh token), not a live IMAP login.
+    """
+    if tok is None:
+        return {"account": account, "provider": provider, "user": cfg["user"] if "user" in cfg else None, "auth_configured": False}
+    auth_configured = bool(tok["app_password"]) if "app_password" in tok else bool(tok["refresh_token"]) if "refresh_token" in tok else False
+    user = cfg["user"] if "user" in cfg else (tok["user"] if "user" in tok else None)
+    return {"account": account, "provider": provider, "user": user, "auth_configured": auth_configured}
+
+
+def daemon_start(
+    *,
+    state_dir: pathlib.Path,
+    runtime_dir: pathlib.Path,
+    poll_daemon_path: pathlib.Path,
+    log_path: pathlib.Path,
+    interval: int,
+) -> dict:
+    """Launch the poll daemon under screen. Idempotent: a live daemon is a no-op."""
+    running, pid = daemon_running(state_dir)
+    if running:
+        return {"status": "already_running", "pid": pid, "session": SESSION_NAME}
+    command = f"cd {runtime_dir} && PYTHONUNBUFFERED=1 uv run python3 {poll_daemon_path} --interval {interval} > {log_path} 2>&1"
+    subprocess.run(["screen", "-dmS", SESSION_NAME, "bash", "-c", command], check=True)
+    deadline = time.monotonic() + START_TIMEOUT_SECS
+    while time.monotonic() < deadline:
+        running, pid = daemon_running(state_dir)
+        if running:
+            return {"status": "started", "pid": pid, "session": SESSION_NAME}
+        if not screen_session_live():
+            return {"error": f"daemon exited during startup; check {log_path}"}
+        time.sleep(POLL_INTERVAL_SECS)
+    return {"error": f"daemon did not report a pid within {START_TIMEOUT_SECS}s"}
+
+
+def daemon_stop(*, state_dir: pathlib.Path) -> dict:
+    """Stop the poll daemon: mark the stop intentional, then SIGTERM and wait for exit."""
+    running, pid = daemon_running(state_dir)
+    if not running:
+        return {"status": "already_stopped", "session": SESSION_NAME}
+    mark_stop_requested(state_dir)
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        remove_pid(state_dir)
+        return {"status": "already_stopped", "session": SESSION_NAME}
+    deadline = time.monotonic() + STOP_TIMEOUT_SECS
+    while time.monotonic() < deadline:
+        still_running, _ = daemon_running(state_dir)
+        if not still_running:
+            return {"status": "stopped", "pid": pid, "session": SESSION_NAME}
+        time.sleep(POLL_INTERVAL_SECS)
+    return {"error": f"daemon still running {STOP_TIMEOUT_SECS}s after SIGTERM (pid={pid})"}
+
+
+def daemon_restart(
+    *,
+    state_dir: pathlib.Path,
+    runtime_dir: pathlib.Path,
+    poll_daemon_path: pathlib.Path,
+    log_path: pathlib.Path,
+    interval: int | None,
+) -> dict:
+    """Stop then start, reusing the daemon's last ``--interval`` unless overridden."""
+    use_interval = interval
+    if use_interval is None:
+        info = read_daemon_info(state_dir)
+        use_interval = info["interval"] if info is not None else DEFAULT_POLL_INTERVAL_SECS
+    stop_result = daemon_stop(state_dir=state_dir)
+    if "error" in stop_result:
+        return stop_result
+    return daemon_start(
+        state_dir=state_dir,
+        runtime_dir=runtime_dir,
+        poll_daemon_path=poll_daemon_path,
+        log_path=log_path,
+        interval=use_interval,
+    )
+
+
+def daemon_status(*, state_dir: pathlib.Path, accounts: list[dict]) -> dict:
+    running, pid = daemon_running(state_dir)
+    info = read_daemon_info(state_dir)
+    result: dict = {"running": running, "pid": pid, "session": SESSION_NAME, "accounts": accounts}
+    if info is not None:
+        result["interval"] = info["interval"]
+        result["started_at"] = info["started_at"]
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit("daemon_lifecycle.py is a library; run the `email-client daemon` subcommand instead")

--- a/agent/skills/email-client/imap_client.py
+++ b/agent/skills/email-client/imap_client.py
@@ -40,13 +40,17 @@ import urllib.request
 
 from imap_tools import AND, MailBox, MailMessageFlags
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# realpath (not abspath) so this resolves through the ~/.email-client/*.py symlinks
+# SETUP.md creates back to the skill's real directory: new sibling modules (e.g.
+# daemon_lifecycle) become importable without adding a new symlink for each one.
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 from providers import (  # noqa: E402
     apply_env_overrides,
     detect_provider,
     get_profile,
     resolve_provider,
 )
+import daemon_lifecycle  # noqa: E402
 
 
 def _env(name: str, default: str | None = None, *, required: bool = False) -> str:
@@ -736,6 +740,68 @@ def cmd_notify_remove(args):
     _save_notify_folders(acc, [f for f in notify_folders(acc) if f != args.folder])
 
 
+# -- daemon lifecycle (start/stop/restart/status of poll_daemon.py) -
+
+
+def _daemon_layout() -> tuple[pathlib.Path, pathlib.Path, pathlib.Path, pathlib.Path]:
+    """Return (state_dir, runtime_dir, poll_daemon_path, log_path) per SETUP.md's install layout."""
+    state_dir = _state_dir()
+    return state_dir, state_dir / "runtime", state_dir / "poll_daemon.py", state_dir / "poll_daemon.log"
+
+
+def _print_daemon_result(result: dict) -> None:
+    print(json.dumps(result, indent=2))
+    if "error" in result:
+        sys.exit(1)
+
+
+def cmd_daemon_start(args):
+    state_dir, runtime_dir, poll_daemon_path, log_path = _daemon_layout()
+    interval = (
+        args.interval
+        if args.interval is not None
+        else int(_env("EMAIL_CLIENT_POLL_INTERVAL", str(daemon_lifecycle.DEFAULT_POLL_INTERVAL_SECS)))
+    )
+    _print_daemon_result(
+        daemon_lifecycle.daemon_start(
+            state_dir=state_dir,
+            runtime_dir=runtime_dir,
+            poll_daemon_path=poll_daemon_path,
+            log_path=log_path,
+            interval=interval,
+        )
+    )
+
+
+def cmd_daemon_stop(args):
+    state_dir, _, _, _ = _daemon_layout()
+    _print_daemon_result(daemon_lifecycle.daemon_stop(state_dir=state_dir))
+
+
+def cmd_daemon_restart(args):
+    state_dir, runtime_dir, poll_daemon_path, log_path = _daemon_layout()
+    _print_daemon_result(
+        daemon_lifecycle.daemon_restart(
+            state_dir=state_dir,
+            runtime_dir=runtime_dir,
+            poll_daemon_path=poll_daemon_path,
+            log_path=log_path,
+            interval=args.interval,
+        )
+    )
+
+
+def cmd_daemon_status(args):
+    state_dir, _, _, _ = _daemon_layout()
+    accounts = []
+    for acc in list_accounts():
+        cfg = load_config(acc)
+        tok = load_token(acc)
+        provider, _ = account_profile(acc)
+        accounts.append(daemon_lifecycle.account_auth_summary(acc, cfg, tok, provider))
+    print(json.dumps(daemon_lifecycle.daemon_status(state_dir=state_dir, accounts=accounts), indent=2))
+
+
 # -- auth subcommands (multi-account management) -------------------
 
 
@@ -952,6 +1018,24 @@ def main():
     pa_rm = asub.add_parser("remove", help="delete an account dir")
     pa_rm.add_argument("--account", required=True)
 
+    pd = sub.add_parser("daemon", help="manage the poll daemon: start|stop|restart|status")
+    dsub = pd.add_subparsers(dest="daemon_cmd", required=True)
+    pd_start = dsub.add_parser("start", help="start the poll daemon if not already running (idempotent)")
+    pd_start.add_argument(
+        "--interval",
+        type=int,
+        default=None,
+        help="poll seconds fallback (default $EMAIL_CLIENT_POLL_INTERVAL or 15)",
+    )
+    dsub.add_parser("stop", help="stop the poll daemon (marks the stop intentional first)")
+    pd_restart = dsub.add_parser("restart", help="stop then start, reusing the last --interval unless overridden")
+    pd_restart.add_argument("--interval", type=int, default=None)
+    dsub.add_parser("status", help="daemon process state plus per-account auth health, in one JSON blob")
+
+    if len(sys.argv) == 1:
+        ap.print_help()
+        sys.exit(0)
+
     args = ap.parse_args()
 
     if args.cmd == "auth":
@@ -987,6 +1071,15 @@ def main():
             "add": cmd_notify_add,
             "remove": cmd_notify_remove,
         }[args.notify_cmd](args)
+        return
+
+    if args.cmd == "daemon":
+        {
+            "start": cmd_daemon_start,
+            "stop": cmd_daemon_stop,
+            "restart": cmd_daemon_restart,
+            "status": cmd_daemon_status,
+        }[args.daemon_cmd](args)
         return
 
     {

--- a/agent/skills/email-client/poll_daemon.py
+++ b/agent/skills/email-client/poll_daemon.py
@@ -28,6 +28,7 @@ import json
 import os
 import pathlib
 import re
+import signal
 import sys
 import threading
 import time
@@ -35,19 +36,25 @@ import uuid
 
 from imap_tools import AND
 
-# Reuse imap_client helpers.
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Reuse imap_client helpers. realpath (not abspath) so this resolves through the
+# ~/.email-client/poll_daemon.py symlink back to the skill's real directory.
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 from imap_client import (  # noqa: E402
     _env,
     _from_full,
+    _state_dir,
     _to_full,
     account_dir,
     connect,
     list_accounts,
     notify_folders,
 )
+import daemon_lifecycle  # noqa: E402
 
 NOTIF_DIR = pathlib.Path.home() / "agent" / "notifications"
+# Bounded wait for worker threads to notice a stop_event and exit, so shutdown
+# on SIGTERM cannot hang forever on a wedged IMAP connection.
+WORKER_JOIN_TIMEOUT_SECS = 5
 
 # Re-issue IDLE well under the 29-minute RFC 2177 ceiling; this also bounds
 # how quickly a worker notices a shutdown request.
@@ -200,6 +207,21 @@ def folder_worker(account: str, folder: str, interval: int, log, stop_event: thr
     log(f"[{account}:{folder}] worker stopped")
 
 
+def write_daemon_died_notification(reason: str) -> None:
+    NOTIF_DIR.mkdir(parents=True, exist_ok=True)
+    notif = {
+        "source": "email-client",
+        "type": "daemon_died",
+        "reason": reason,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime()),
+    }
+    fname = f"email-client-daemon_died-{int(time.time() * 1000)}-{uuid.uuid4().hex[:6]}.json"
+    final = NOTIF_DIR / fname
+    tmp = NOTIF_DIR / f"{fname}.tmp"
+    tmp.write_text(json.dumps(notif, ensure_ascii=False, indent=2))
+    os.replace(tmp, final)
+
+
 def desired_workers() -> set[tuple[str, str]]:
     """The set of ``(account, folder)`` pairs that should be watched now."""
     wanted: set[tuple[str, str]] = set()
@@ -214,10 +236,12 @@ def main():
     ap.add_argument(
         "--interval",
         type=int,
-        default=int(_env("EMAIL_CLIENT_POLL_INTERVAL", "15")),
+        default=int(_env("EMAIL_CLIENT_POLL_INTERVAL", str(daemon_lifecycle.DEFAULT_POLL_INTERVAL_SECS))),
         help="poll seconds (fallback only; servers with IDLE push in real time)",
     )
     args = ap.parse_args()
+
+    state_dir = _state_dir()
 
     log_lock = threading.Lock()
 
@@ -225,43 +249,72 @@ def main():
         with log_lock:
             print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
 
+    shutdown_event = threading.Event()
+    shutdown_reason = "unknown"
+
+    def handle_signal(signum, frame):
+        nonlocal shutdown_reason
+        shutdown_reason = signal.Signals(signum).name
+        shutdown_event.set()
+
+    # SIGHUP fires when the controlling screen session quits; ignored so only an
+    # explicit `daemon stop`/`restart` (SIGTERM) or Ctrl-C (SIGINT) triggers shutdown.
+    signal.signal(signal.SIGHUP, signal.SIG_IGN)
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
     workers: dict[tuple[str, str], tuple[threading.Thread, threading.Event]] = {}
     last_desired: set[tuple[str, str]] | None = None
 
-    while True:
-        try:
-            wanted = desired_workers()
-        except Exception as e:
-            log(f"could not read accounts: {e}")
-            time.sleep(INDEX_CHECK_SECS)
-            continue
-        if wanted != last_desired:
-            last_desired = wanted
-            log(f"watching: {sorted(wanted)}")
-        for key in list(workers):
-            thread, _ = workers[key]
-            if not thread.is_alive():
-                workers.pop(key)
-                log(f"[{key[0]}:{key[1]}] worker died; restarting")
-        for key in wanted:
-            if key not in workers:
-                account, folder = key
-                stop_event = threading.Event()
-                thread = threading.Thread(
-                    target=folder_worker,
-                    args=(account, folder, args.interval, log, stop_event),
-                    name=f"{account}:{folder}",
-                    daemon=True,
-                )
-                workers[key] = (thread, stop_event)
-                thread.start()
-                log(f"[{account}:{folder}] worker started")
-        for key in list(workers):
-            if key not in wanted:
-                _, stop_event = workers.pop(key)
-                stop_event.set()
-                log(f"[{key[0]}:{key[1]}] worker stopping")
-        time.sleep(INDEX_CHECK_SECS)
+    daemon_lifecycle.write_pid(state_dir)
+    daemon_lifecycle.write_daemon_info(state_dir, args.interval)
+
+    try:
+        while not shutdown_event.is_set():
+            try:
+                wanted = desired_workers()
+            except Exception as e:
+                log(f"could not read accounts: {e}")
+                shutdown_event.wait(INDEX_CHECK_SECS)
+                continue
+            if wanted != last_desired:
+                last_desired = wanted
+                log(f"watching: {sorted(wanted)}")
+            for key in list(workers):
+                thread, _ = workers[key]
+                if not thread.is_alive():
+                    workers.pop(key)
+                    log(f"[{key[0]}:{key[1]}] worker died; restarting")
+            for key in wanted:
+                if key not in workers:
+                    account, folder = key
+                    stop_event = threading.Event()
+                    thread = threading.Thread(
+                        target=folder_worker,
+                        args=(account, folder, args.interval, log, stop_event),
+                        name=f"{account}:{folder}",
+                        daemon=True,
+                    )
+                    workers[key] = (thread, stop_event)
+                    thread.start()
+                    log(f"[{account}:{folder}] worker started")
+            for key in list(workers):
+                if key not in wanted:
+                    _, stop_event = workers.pop(key)
+                    stop_event.set()
+                    log(f"[{key[0]}:{key[1]}] worker stopping")
+            shutdown_event.wait(INDEX_CHECK_SECS)
+    finally:
+        for _, stop_event in workers.values():
+            stop_event.set()
+        for thread, _ in workers.values():
+            thread.join(timeout=WORKER_JOIN_TIMEOUT_SECS)
+        if daemon_lifecycle.consume_stop_requested(state_dir):
+            log(f"intentional stop ({shutdown_reason}); skipping daemon_died notification")
+        else:
+            log(f"shutting down ({shutdown_reason}); writing daemon_died notification")
+            write_daemon_died_notification(shutdown_reason)
+        daemon_lifecycle.remove_pid(state_dir)
 
 
 if __name__ == "__main__":

--- a/agent/skills/email-client/tests/conftest.py
+++ b/agent/skills/email-client/tests/conftest.py
@@ -1,0 +1,6 @@
+import pathlib
+import sys
+
+# daemon_lifecycle.py has no dependency on imap_tools/msal, so it can be
+# imported directly for pure-logic tests without the skill's on-box venv.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))

--- a/agent/skills/email-client/tests/test_daemon_lifecycle.py
+++ b/agent/skills/email-client/tests/test_daemon_lifecycle.py
@@ -1,0 +1,250 @@
+import os
+import pathlib
+import subprocess
+import threading
+
+import pytest
+
+import daemon_lifecycle as dl
+
+
+def test_pid_roundtrip(tmp_path: pathlib.Path):
+    assert dl.read_pid(tmp_path) is None
+    dl.write_pid(tmp_path)
+    assert dl.read_pid(tmp_path) == os.getpid()
+    dl.remove_pid(tmp_path)
+    assert dl.read_pid(tmp_path) is None
+
+
+def test_remove_pid_is_idempotent(tmp_path: pathlib.Path):
+    dl.remove_pid(tmp_path)
+    dl.remove_pid(tmp_path)
+
+
+def test_read_pid_ignores_non_numeric_content(tmp_path: pathlib.Path):
+    dl.pid_path(tmp_path).write_text("not-a-pid")
+    assert dl.read_pid(tmp_path) is None
+
+
+def test_process_alive_for_self_and_a_dead_pid():
+    assert dl.process_alive(os.getpid()) is True
+    # A pid far past any plausible live process on a test box.
+    assert dl.process_alive(2**30) is False
+
+
+def test_daemon_running_cleans_up_a_stale_pidfile(tmp_path: pathlib.Path):
+    dl.pid_path(tmp_path).write_text(str(2**30))
+    running, pid = dl.daemon_running(tmp_path)
+    assert running is False
+    assert pid is None
+    assert dl.read_pid(tmp_path) is None
+
+
+def test_daemon_running_true_for_a_live_pid(tmp_path: pathlib.Path):
+    dl.write_pid(tmp_path)
+    running, pid = dl.daemon_running(tmp_path)
+    assert running is True
+    assert pid == os.getpid()
+
+
+def test_daemon_info_roundtrip(tmp_path: pathlib.Path):
+    assert dl.read_daemon_info(tmp_path) is None
+    dl.write_daemon_info(tmp_path, 42)
+    info = dl.read_daemon_info(tmp_path)
+    assert info is not None
+    assert info["interval"] == 42
+    assert "started_at" in info
+
+
+def test_read_daemon_info_returns_none_on_corrupt_json(tmp_path: pathlib.Path):
+    dl.daemon_info_path(tmp_path).write_text("{not json")
+    assert dl.read_daemon_info(tmp_path) is None
+
+
+def test_stop_requested_marker_roundtrip(tmp_path: pathlib.Path):
+    assert dl.consume_stop_requested(tmp_path) is False
+    dl.mark_stop_requested(tmp_path)
+    assert dl.consume_stop_requested(tmp_path) is True
+    # Consuming clears the marker: a second read finds nothing.
+    assert dl.consume_stop_requested(tmp_path) is False
+
+
+@pytest.mark.parametrize(
+    "screen_ls,name,expected",
+    [
+        ("There are screens on:\n\t123.email-client\t(Detached)\n1 Socket in /run/screen.\n", "email-client", True),
+        ("There are screens on:\n\t123.email-client\t(Dead ???)\nRemove dead screens with 'screen -wipe'.\n", "email-client", False),
+        ("No Sockets found in /run/screen/S-root.\n", "email-client", False),
+        ("There are screens on:\n\t123.email-client-other\t(Detached)\n1 Socket in /run/screen.\n", "email-client", False),
+        ("There are screens on:\n\t123.email-client\t(Detached)\n\t456.email-client-watchdog\t(Detached)\n2 Sockets.\n", "email-client", True),
+    ],
+)
+def test_screen_output_has_live_session(screen_ls: str, name: str, expected: bool):
+    assert dl.screen_output_has_live_session(screen_ls, name) is expected
+
+
+@pytest.mark.parametrize(
+    "cfg,tok,provider,expected",
+    [
+        (
+            {"user": "a@example.com"},
+            None,
+            "gmail",
+            {"account": "personal", "provider": "gmail", "user": "a@example.com", "auth_configured": False},
+        ),
+        (
+            {"user": "a@example.com"},
+            {"app_password": "secret"},
+            "generic",
+            {"account": "personal", "provider": "generic", "user": "a@example.com", "auth_configured": True},
+        ),
+        (
+            {"user": "a@example.com"},
+            {"refresh_token": "rt"},
+            "gmail",
+            {"account": "personal", "provider": "gmail", "user": "a@example.com", "auth_configured": True},
+        ),
+        (
+            {},
+            {"user": "token-user@example.com"},
+            "microsoft-personal",
+            {"account": "personal", "provider": "microsoft-personal", "user": "token-user@example.com", "auth_configured": False},
+        ),
+        (
+            {"user": "a@example.com"},
+            {"app_password": ""},
+            "generic",
+            {"account": "personal", "provider": "generic", "user": "a@example.com", "auth_configured": False},
+        ),
+    ],
+)
+def test_account_auth_summary(cfg: dict, tok: dict | None, provider: str, expected: dict):
+    assert dl.account_auth_summary("personal", cfg, tok, provider) == expected
+
+
+def test_daemon_status_without_running_daemon_or_info(tmp_path: pathlib.Path):
+    status = dl.daemon_status(state_dir=tmp_path, accounts=[])
+    assert status["running"] is False
+    assert status["pid"] is None
+    assert status["session"] == dl.SESSION_NAME
+    assert status["accounts"] == []
+    assert "interval" not in status
+    assert "started_at" not in status
+
+
+def test_daemon_status_includes_interval_and_started_at_when_present(tmp_path: pathlib.Path):
+    dl.write_pid(tmp_path)
+    dl.write_daemon_info(tmp_path, 30)
+    accounts = [{"account": "personal", "provider": "gmail", "user": "a@example.com", "auth_configured": True}]
+    status = dl.daemon_status(state_dir=tmp_path, accounts=accounts)
+    assert status["running"] is True
+    assert status["pid"] == os.getpid()
+    assert status["interval"] == 30
+    assert status["accounts"] == accounts
+
+
+def test_daemon_start_is_idempotent_and_never_shells_out_when_already_running(tmp_path: pathlib.Path, monkeypatch):
+    dl.write_pid(tmp_path)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("subprocess.run should not be called when the daemon is already running")
+
+    monkeypatch.setattr(subprocess, "run", fail_if_called)
+    result = dl.daemon_start(
+        state_dir=tmp_path,
+        runtime_dir=tmp_path / "runtime",
+        poll_daemon_path=tmp_path / "poll_daemon.py",
+        log_path=tmp_path / "poll_daemon.log",
+        interval=15,
+    )
+    assert result == {"status": "already_running", "pid": os.getpid(), "session": dl.SESSION_NAME}
+
+
+def test_daemon_stop_is_idempotent_when_already_stopped(tmp_path: pathlib.Path):
+    result = dl.daemon_stop(state_dir=tmp_path)
+    assert result == {"status": "already_stopped", "session": dl.SESSION_NAME}
+
+
+def test_daemon_stop_marks_stop_requested_and_sends_sigterm_to_a_live_pid(tmp_path: pathlib.Path):
+    proc = subprocess.Popen(["sleep", "30"])
+    try:
+        dl.pid_path(tmp_path).write_text(str(proc.pid))
+        result_holder: dict = {}
+
+        def run_stop():
+            result_holder["result"] = dl.daemon_stop(state_dir=tmp_path)
+
+        # daemon_stop polls os.kill(pid, 0) for liveness, which reports a terminated
+        # child as still alive until this process (its parent) reaps it; run the stop
+        # on a thread so the main thread's proc.wait() can reap it as soon as it exits.
+        stopper = threading.Thread(target=run_stop)
+        stopper.start()
+        proc.wait(timeout=5)
+        stopper.join(timeout=5)
+
+        result = result_holder["result"]
+        assert result["status"] == "stopped"
+        assert result["pid"] == proc.pid
+        # `sleep 30` never consumes the marker itself (only poll_daemon.py's own
+        # shutdown does), so it is still there for the real daemon to read.
+        assert dl.consume_stop_requested(tmp_path) is True
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def test_daemon_restart_reuses_the_last_interval_when_not_overridden(tmp_path: pathlib.Path, monkeypatch):
+    dl.write_daemon_info(tmp_path, 45)
+    started_with = {}
+
+    def fake_start(**kwargs):
+        started_with["interval"] = kwargs["interval"]
+        return {"status": "started", "pid": 1, "session": dl.SESSION_NAME}
+
+    monkeypatch.setattr(dl, "daemon_start", fake_start)
+    result = dl.daemon_restart(
+        state_dir=tmp_path,
+        runtime_dir=tmp_path / "runtime",
+        poll_daemon_path=tmp_path / "poll_daemon.py",
+        log_path=tmp_path / "poll_daemon.log",
+        interval=None,
+    )
+    assert result["status"] == "started"
+    assert started_with["interval"] == 45
+
+
+def test_daemon_restart_prefers_an_explicit_interval_override(tmp_path: pathlib.Path, monkeypatch):
+    dl.write_daemon_info(tmp_path, 45)
+    started_with = {}
+
+    def fake_start(**kwargs):
+        started_with["interval"] = kwargs["interval"]
+        return {"status": "started", "pid": 1, "session": dl.SESSION_NAME}
+
+    monkeypatch.setattr(dl, "daemon_start", fake_start)
+    dl.daemon_restart(
+        state_dir=tmp_path,
+        runtime_dir=tmp_path / "runtime",
+        poll_daemon_path=tmp_path / "poll_daemon.py",
+        log_path=tmp_path / "poll_daemon.log",
+        interval=5,
+    )
+    assert started_with["interval"] == 5
+
+
+def test_daemon_restart_propagates_a_stop_failure_without_starting(tmp_path: pathlib.Path, monkeypatch):
+    monkeypatch.setattr(dl, "daemon_stop", lambda *, state_dir: {"error": "still running"})
+
+    def fail_if_called(**kwargs):
+        raise AssertionError("daemon_start should not run when stop failed")
+
+    monkeypatch.setattr(dl, "daemon_start", fail_if_called)
+    result = dl.daemon_restart(
+        state_dir=tmp_path,
+        runtime_dir=tmp_path / "runtime",
+        poll_daemon_path=tmp_path / "poll_daemon.py",
+        log_path=tmp_path / "poll_daemon.log",
+        interval=None,
+    )
+    assert result == {"error": "still running"}

--- a/agent/skills/email-client/tests/test_daemon_lifecycle.py
+++ b/agent/skills/email-client/tests/test_daemon_lifecycle.py
@@ -160,6 +160,45 @@ def test_daemon_start_is_idempotent_and_never_shells_out_when_already_running(tm
     assert result == {"status": "already_running", "pid": os.getpid(), "session": dl.SESSION_NAME}
 
 
+def test_daemon_start_refuses_to_stack_on_a_live_legacy_screen_session(tmp_path: pathlib.Path, monkeypatch):
+    monkeypatch.setattr(dl, "screen_session_live", lambda: True)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("subprocess.run should not be called when a legacy screen session is live")
+
+    monkeypatch.setattr(subprocess, "run", fail_if_called)
+    result = dl.daemon_start(
+        state_dir=tmp_path,
+        runtime_dir=tmp_path / "runtime",
+        poll_daemon_path=tmp_path / "poll_daemon.py",
+        log_path=tmp_path / "poll_daemon.log",
+        interval=15,
+    )
+    assert "error" in result
+    assert dl.SESSION_NAME in result["error"]
+
+
+def test_daemon_start_clears_a_leaked_stop_marker_before_launching(tmp_path: pathlib.Path, monkeypatch):
+    dl.mark_stop_requested(tmp_path)
+    monkeypatch.setattr(dl, "screen_session_live", lambda: False)
+
+    def fake_screen(*args, **kwargs):
+        dl.pid_path(tmp_path).write_text(str(os.getpid()))
+
+    monkeypatch.setattr(subprocess, "run", fake_screen)
+    result = dl.daemon_start(
+        state_dir=tmp_path,
+        runtime_dir=tmp_path / "runtime",
+        poll_daemon_path=tmp_path / "poll_daemon.py",
+        log_path=tmp_path / "poll_daemon.log",
+        interval=15,
+    )
+    assert result["status"] == "started"
+    # The fresh daemon never inherits the leaked marker, so an unintentional
+    # death still fires the daemon_died notification.
+    assert dl.consume_stop_requested(tmp_path) is False
+
+
 def test_daemon_stop_is_idempotent_when_already_stopped(tmp_path: pathlib.Path):
     result = dl.daemon_stop(state_dir=tmp_path)
     assert result == {"status": "already_stopped", "session": dl.SESSION_NAME}
@@ -192,6 +231,17 @@ def test_daemon_stop_marks_stop_requested_and_sends_sigterm_to_a_live_pid(tmp_pa
         if proc.poll() is None:
             proc.kill()
             proc.wait(timeout=5)
+
+
+def test_daemon_stop_clears_the_marker_when_the_process_died_before_sigterm(tmp_path: pathlib.Path, monkeypatch):
+    # The liveness poll says running but the process is gone by the SIGTERM,
+    # so os.kill raises ProcessLookupError; the stop marker must not leak.
+    dl.pid_path(tmp_path).write_text(str(2**30))
+    monkeypatch.setattr(dl, "process_alive", lambda pid: True)
+    result = dl.daemon_stop(state_dir=tmp_path)
+    assert result == {"status": "already_stopped", "session": dl.SESSION_NAME}
+    assert dl.consume_stop_requested(tmp_path) is False
+    assert dl.read_pid(tmp_path) is None
 
 
 def test_daemon_restart_reuses_the_last_interval_when_not_overridden(tmp_path: pathlib.Path, monkeypatch):


### PR DESCRIPTION
## Summary

Applies the production-grade daemon-lifecycle pattern (issue #1083, transplanted from #1082's telegram/tasks work) to the email-client skill's poll daemon, the checklist item #1083 calls out as the worst offender: a 130-char `screen -dmS email-client bash -c "cd ~/.email-client/runtime && ... poll_daemon.py --interval 15 > ...log 2>&1"` duplicated twice in SETUP.md.

- **`email-client daemon start|stop|restart|status`** (new `daemon_lifecycle.py` + a `daemon` subcommand wired into `imap_client.py`) now owns that invocation in one place.
  - `start` is idempotent: detects a live daemon via its pidfile + `os.kill(pid, 0)` liveness check and never stacks a duplicate.
  - `stop` marks the exit intentional (a `stop-requested` marker file) before sending `SIGTERM`, so a deliberate stop/restart never fires the `daemon_died` notification the agent would otherwise investigate. `poll_daemon.py` now writes that notification only when it wasn't asked to stop.
  - `restart` reuses the daemon's last `--interval` (persisted in `daemon-info.json`) unless overridden.
  - `status` reports process state (`running`, `pid`, `session`) plus per-account IMAP auth health (provider, user, whether a usable credential is on disk) in one JSON blob, so the agent never has to `screen -X hardcopy` or read the log by hand.
- **Bare `email-client` invocation** now prints usage and exits 0 (previously argparse exited 2).
- **SETUP.md/SKILL.md** consolidated: both copies of the raw screen line become `email-client daemon start` / `running email-client || { email-client daemon start; sleep 1; }`; troubleshooting and state-layout sections updated to match.
- `daemon_lifecycle.py` has no dependency on `imap_tools`/`msal` so its pure logic (pidfile parsing, screen-session parsing, auth-summary assembly) is unit-testable without the skill's on-box venv.

## Fleet impact

Additive only, no feature changes:

- Existing boxes' `~/agent/skills/restart/SKILL.md` still has the old raw `screen -dmS email-client ...` line pasted in from a previous setup; it keeps working unchanged (nothing about `poll_daemon.py`'s command-line contract or state layout moved).
- The new `daemon` subcommand and `daemon_lifecycle.py` module arrive on a box via the normal workspace-sync content update, no migration needed.
- The one thing that could have broken an already-onboarded box: `daemon_lifecycle.py` is a *new* sibling module that `poll_daemon.py`/`imap_client.py` import, but those two entry points are only reachable on a box via the `~/.email-client/*.py` symlinks SETUP.md's step 1 creates (a box's `sys.path` insert previously resolved to that symlink directory, not the real skill directory, so a brand-new module without its own new symlink would 404 on import). Rather than requiring a new migration to add that symlink retroactively, `imap_client.py`/`poll_daemon.py` now compute their `sys.path` entry via `os.path.realpath(__file__)` instead of `os.path.abspath(__file__)`, resolving *through* the existing symlinks back to the real `~/agent/skills/email-client/` directory. Verified end-to-end: running `imap_client.py` from a symlinked runtime dir with no `daemon_lifecycle.py` symlink present still resolves the import and exposes the `daemon` subcommand. No migration required.

## Checklist coverage (issue #1083, items 1-7)

1. CLI-owned daemon lifecycle: done (`daemon start|stop|restart|status`).
2. Defaults over required flags: `--interval` already defaulted via `$EMAIL_CLIENT_POLL_INTERVAL`/15; unchanged, now shared as `daemon_lifecycle.DEFAULT_POLL_INTERVAL_SECS`.
3. Honest exit codes: bare invocation and `--help` now exit 0.
4. Intentional-stop marker: done (`stop-requested` file consumed by `poll_daemon.py`'s shutdown).
5. Idempotent one-script setup: SETUP.md's daemon start step is now the idempotent `email-client daemon start`; the restart-skill line is guarded (`running email-client || ...`).
6. Docs shrink: both copies of the raw screen line collapse to one command; troubleshooting points at `daemon status` instead of `screen -ls`/log spelunking.
7. Tests: `agent/skills/email-client/tests/test_daemon_lifecycle.py`, 27 pure-logic + light-integration tests (pidfile/marker/daemon-info roundtrips, screen-output parsing, auth-summary assembly, start/stop/restart idempotency and interval-reuse).

## Test plan

- [x] `uv run pytest skills/email-client/tests/` (27 passed)
- [x] `./check.sh agent` (557 passed, ruff + ty clean)
- [x] `uv run python agent/skills/generate-index.py` produces no diff (SKILL.md frontmatter untouched)
- [x] Manual end-to-end smoke test: symlinked `imap_client.py` into a fake `~/.email-client/`-style runtime dir without a `daemon_lifecycle.py` symlink, confirmed `daemon status` and bare-invocation-exits-0 both work through the `realpath` fix

Part of #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGjjUkGBUinjiZa1MJzoKb