### PR TITLE
fix(agent): frame interrupted-tool "user rejected" results as cancellations, not refusals

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -465,11 +465,26 @@ async def compact_session(*, state: vm.State, prompt: str | None = None) -> None
         _close_turn(state, turn)
 
 
+# The CLI stamps every tool call still in flight when a turn is interrupted (preempt_mode="interrupt",
+# or the silence-timeout/auth-loss interrupts) with a synthesized "The user doesn't want to proceed with
+# this tool use" rejection that never goes through can_use_tool, so the model reads a human refusal that
+# never happened and halts (issue #915). Headless with bypassPermissions, that message is always such an
+# artifact; this standing note keeps the model from treating it as a real decision.
+_TOOL_CANCELLATION_NOTE = (
+    "# Canceled tool calls\n\n"
+    "You run headless: every tool call is auto-approved and your user never sees a permission dialog. "
+    'A tool result claiming a rejection or denial ("The user doesn\'t want to proceed with this tool use") '
+    "is never a real decision by your user; it is the runtime canceling in-flight tool calls when a turn is "
+    "interrupted or times out. Treat it as a canceled call: re-run the tool if you still need it, and do not "
+    "stop to wait for the user because of it."
+)
+
+
 def build_client_options(config: vm.VestaConfig, state: vm.State) -> ClaudeAgentOptions:
     memory_path = get_memory_path(config)
     if not memory_path.exists():
         raise FileNotFoundError(f"MEMORY.md not found at {memory_path}, cannot start agent without it")
-    system_prompt = memory_path.read_text()
+    system_prompt = f"{memory_path.read_text()}\n\n{_TOOL_CANCELLATION_NOTE}"
 
     # Constitution: a user-authored charter set from vestad and bind-mounted read-only,
     # so the agent cannot edit it. Prepend it ahead of MEMORY.md when non-empty.

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -465,18 +465,16 @@ async def compact_session(*, state: vm.State, prompt: str | None = None) -> None
         _close_turn(state, turn)
 
 
-# The CLI stamps every tool call still in flight when a turn is interrupted (preempt_mode="interrupt",
-# or the silence-timeout/auth-loss interrupts) with a synthesized "The user doesn't want to proceed with
-# this tool use" rejection that never goes through can_use_tool, so the model reads a human refusal that
-# never happened and halts (issue #915). Headless with bypassPermissions, that message is always such an
-# artifact; this standing note keeps the model from treating it as a real decision.
+# The CLI stamps tool calls canceled by a turn interrupt with a synthesized "user rejected" tool_result
+# that never goes through can_use_tool, so the model reads a refusal no human made and halts (issue #915).
 _TOOL_CANCELLATION_NOTE = (
-    "# Canceled tool calls\n\n"
+    "# Runtime note: canceled tool calls\n\n"
     "You run headless: every tool call is auto-approved and your user never sees a permission dialog. "
-    'A tool result claiming a rejection or denial ("The user doesn\'t want to proceed with this tool use") '
-    "is never a real decision by your user; it is the runtime canceling in-flight tool calls when a turn is "
-    "interrupted or times out. Treat it as a canceled call: re-run the tool if you still need it, and do not "
-    "stop to wait for the user because of it."
+    "A tool result claiming the user rejected or declined a tool use (\"The user doesn't want to proceed "
+    'with this tool use") is never a real decision by your user; it is the runtime canceling in-flight '
+    "calls when a turn is interrupted or times out. Do not stop to wait for the user because of it. A "
+    "canceled call may still have taken effect and a timed-out call may hang again, so check before "
+    "re-running anything with side effects and change approach if the same call keeps getting canceled."
 )
 
 

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -871,3 +871,23 @@ async def test_converse_flips_auth_on_result_api_error_status(config):
         await asyncio.wait_for(converse("test prompt", state=state, config=config, show_output=False), timeout=5.0)
 
     assert state.provider_status.state == ProviderAuthState.NOT_AUTHENTICATED
+
+
+# --- Interrupted-tool rejection framing (issue #915) ---
+
+
+def test_system_prompt_frames_interrupted_tool_rejections_as_cancellations(tmp_path, state):
+    """An interrupted turn's in-flight tools come back as "The user doesn't want to proceed with
+    this tool use" tool_results synthesized by the CLI without ever consulting can_use_tool; the
+    system prompt must keep the model from reading that as a real human refusal (issue #915)."""
+    from core.client import build_client_options
+    from core.config import ClaudeConfig
+
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent", provider=ClaudeConfig())
+    config.agent_dir.mkdir(parents=True, exist_ok=True)
+    (config.agent_dir / "MEMORY.md").write_text("my memory body")
+
+    prompt = build_client_options(config, state).system_prompt
+    assert isinstance(prompt, str)
+    assert "The user doesn't want to proceed with this tool use" in prompt
+    assert "never a real decision by your user" in prompt

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -876,18 +876,23 @@ async def test_converse_flips_auth_on_result_api_error_status(config):
 # --- Interrupted-tool rejection framing (issue #915) ---
 
 
-def test_system_prompt_frames_interrupted_tool_rejections_as_cancellations(tmp_path, state):
-    """An interrupted turn's in-flight tools come back as "The user doesn't want to proceed with
-    this tool use" tool_results synthesized by the CLI without ever consulting can_use_tool; the
-    system prompt must keep the model from reading that as a real human refusal (issue #915)."""
-    from core.client import build_client_options
+def test_system_prompt_frames_interrupted_tool_rejections_as_cancellations(tmp_path, state, monkeypatch):
+    """The CLI synthesizes "The user doesn't want to proceed with this tool use" tool_results for
+    calls canceled by a turn interrupt; the system prompt must frame those as cancellations, not a
+    real human refusal (issue #915)."""
+    from core.client import _TOOL_CANCELLATION_NOTE, build_client_options
     from core.config import ClaudeConfig
 
-    config = vm.VestaConfig(agent_dir=tmp_path / "agent", provider=ClaudeConfig())
+    # Like conftest's config fixture: drive agent_dir through AGENT_DIR so config_store_path()
+    # stays inside the tmp dir instead of reading the host's real ~/agent store.
+    monkeypatch.setenv("AGENT_DIR", str(tmp_path / "agent"))
+    config = vm.VestaConfig(provider=ClaudeConfig())
     config.agent_dir.mkdir(parents=True, exist_ok=True)
     (config.agent_dir / "MEMORY.md").write_text("my memory body")
+    (config.agent_dir / "constitution.md").write_text("Always tell the truth.")
 
     prompt = build_client_options(config, state).system_prompt
     assert isinstance(prompt, str)
-    assert "The user doesn't want to proceed with this tool use" in prompt
-    assert "never a real decision by your user" in prompt
+    assert "The user doesn't want to proceed with this tool use" in _TOOL_CANCELLATION_NOTE
+    assert _TOOL_CANCELLATION_NOTE in prompt
+    assert prompt.index("my memory body") < prompt.index(_TOOL_CANCELLATION_NOTE)


### PR DESCRIPTION
## Root cause (found by reading the bundled CLI code, then reproduced live)

When a turn is interrupted, the Claude Code CLI synthesizes a `tool_result` for every tool call still queued or executing: `is_error: true`, `toolDenialKind: "user-rejected"`, text "The user doesn't want to proceed with this tool use. The tool use was rejected... STOP what you are doing and wait for the user to tell you how to proceed." This path (`createSyntheticErrorMessage("user_interrupted")` and `cancelAndAbort` in the CLI bundle, verified on 2.1.205) never consults `permission_mode` or `can_use_tool`, so `bypassPermissions` plus an always-allow callback cannot prevent it.

In Vesta the producers of that interrupt are our own `attempt_interrupt` calls: the silence/query timeout and auth-loss failure paths, and routine preemption in `preempt_mode="interrupt"`. The default priority:"now" preempt drains in-flight tools gracefully and does not produce it (verified live), which is why the issue's `interrupt=False` notification repros came back negative.

Reproduced deterministically with a minimal SDK script: three parallel Bash sleeps, `client.interrupt()` mid-flight, `bypassPermissions` + always-allow `can_use_tool` wired. All three tools came back with exactly the issue's rejection text and `can_use_tool` was never called. The incident fits the timeout chain: turn goes silent past `response_timeout`, `attempt_interrupt` fires, the pending `Read` is stamped rejected, the agent restarts and resumes the session, and the model then reads a fabricated human refusal in its history and halts. The retry 14 minutes later hit no interrupt and succeeded.

Upstream references for the same synthesized-rejection confusion: anthropics/claude-code#23350, anthropics/claude-code#29499, anthropics/claude-code#29238.

## Fix

The interrupts themselves are correct and necessary, and the CLI's text is not ours to change. What is wrong is the model believing the message. In this system the message is always a lie: the agent runs headless with every tool auto-approved, so no permission dialog exists for a user to decline. The fix is one standing note in the system prompt (`_TOOL_CANCELLATION_NOTE` in `core/client.py`) telling the model that this rejection text is the runtime canceling in-flight tool calls on an interrupted or timed-out turn, never a real user decision: treat it as a canceled call, re-run if still needed, do not stop and wait.

One owner (system-prompt assembly in `build_client_options`), no new state, covers every producer at once: failure-path interrupts, interrupt-mode preemption, and upstream CLI aborts we do not control.

## Fleet impact

Core code only, picked up on each agent's next restart through the read-only core mount. No on-disk or config state moves, so no migration.

## Testing

- New regression test in `agent/tests/test_interrupts.py` asserting the system prompt carries the corrective framing.
- `./check.sh agent` green locally (ruff, format, ty, 558 tests).

Fixes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)