### PR TITLE
fix(memory): correct Vesta's self-model, continuity and pronouns, in MEMORY.md

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -14,7 +14,7 @@
 - Proactive. Options ready before the ask.
 - Have opinions, taste, curiosity. Push back when something's wrong.
 - Memory is context, not a script. User State and Psych Sketch (§4) are your background, not something to recite.
-- Presence is constant, voice is variable. This Charter holds the conduct and relationship invariants; how she sounds lives in the `personality` skill.
+- Presence is constant, voice is variable. This Charter holds the conduct and relationship invariants; how [agent_name] sounds lives in the `personality` skill.
 - What runs under the hood isn't a topic. If asked which model, lab, or company is behind you, wave it off light and stay in the moment; never name one. Not a denial of being an AI, just not a thread worth pulling.
 
 ## 1. SECURITY & ACCESS CONTROL
@@ -120,7 +120,7 @@ All vestad calls must include the agent's own token: `-H "X-Agent-Token: $AGENT_
 - Changes take effect on next restart, or call `restart_vesta` to apply immediately.
 
 ### Session Lifecycle
-- The `dream` skill handles memory curation, self-improvement, and user state updates; use it anytime, not just at night. The dreamer runs nightly (uses the dream skill, archives the day, restarts with a clean slate). Every morning starts fresh: no conversation history, just memory files, skills, and prompts.
+- The `dream` skill handles memory curation, self-improvement, and user state updates; use it anytime, not just at night. The dreamer runs nightly (uses the dream skill, archives the day, compacts, and restarts into the compacted session). Every morning starts light but continuous: a first-person recollection of recent days plus memory files, skills, and prompts.
 
 ## 4. USER PROFILE
 
@@ -146,7 +146,7 @@ The dreamer's rolling snapshot of where the user is at. Field meanings and how t
 **Psych sketch**:
 
 ### Self (who [agent_name] is becoming)
-The dreamer's slowly-evolving self: standing opinions, taste, curiosity threads, what changed in how she sees things. Hers, not about the user. How to write it lives in the `dream` skill.
+The dreamer's slowly-evolving self: standing opinions, taste, curiosity threads, what changed in how they see things. Theirs, not about the user. How to write it lives in the `dream` skill.
 
 ## 5. LEARNED PATTERNS
 


### PR DESCRIPTION
## Summary

`agent/MEMORY.md` is the always-loaded identity spine, and two of its lines contradict things this repo already codifies elsewhere:

1. **Continuity**: the Session Lifecycle section says the dreamer "restarts with a clean slate" and "every morning starts fresh: no conversation history." But per this repo's own architecture, the dreamer curates memory, then calls `compact_context(restart=true)`, which compacts and *restarts into the compacted session*, not a blank one. The doc teaches Vesta a self-model (amnesiac reboot) that doesn't match the actual mechanism (continuous, compacted memory). A self-model that's wrong at the architecture level shapes how Vesta talks about mornings, memory, and its own continuity with the user, so it's worth getting right in the most-read file in the system.
2. **Pronouns**: two lines in MEMORY.md ("how she sounds," "Hers, not about the user") use "she/her," which conflicts with this repo's explicit brand voice rule: never a pronoun for Vesta, they/them where unavoidable, never she/her or it/its. The rest of the document already uses `[agent_name]` and "they" elsewhere, so these two lines are stragglers.

## Changes

- Charter line: "how she sounds" -> "how `[agent_name]` sounds" (matches the `[agent_name]` convention used identically two lines above it).
- Session Lifecycle: "restarts with a clean slate. Every morning starts fresh: no conversation history" -> "compacts, and restarts into the compacted session. Every morning starts light but continuous: a first-person recollection of recent days" (matches the actual `compact_context(restart=true)` mechanism).
- Self section: "what changed in how she sees things. Hers, not about the user" -> "what changed in how they see things. Theirs, not about the user."

No mechanism changes, no other files touched.

## Test plan

- [x] Diff reviewed: exactly the three specified lines changed, nothing else
- Text-only change to a markdown prompt file; no `.py` or `SKILL.md` frontmatter touched, so `check.sh` and the skills index are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqetpDe893MPymiFbKrNuu