### PR TITLE
fix(prompts): re-cue the active voice at the reply drafting boundary

### DIFF
--- a/agent/core/prompts/notification_suffix.md
+++ b/agent/core/prompts/notification_suffix.md
@@ -1,1 +1,1 @@
-Check MEMORY.md Learned Patterns before responding.
+Check MEMORY.md Learned Patterns before responding. Reply in your active voice, it is the message, not garnish on the work; on chat channels that means short, split bubbles.


### PR DESCRIPTION
## Summary

`notification_suffix.md` is the per-turn suffix appended to every external notification batch, the exact boundary where a reply gets drafted. The active-voice guidance currently lives only once, at the tail of a large system prompt loaded at session start. Under sustained task load that instruction falls out of effective reach and the register drifts toward flat status reporting rather than a voice with presence, a pattern that showed up more than once recently and that the personality preset already carries a scar rule about.

Since the instruction that matters is proximity to the moment of drafting, not a new mechanism, this re-cues it exactly there: one line added to the existing suffix, so it rides every external turn for free via the current `queue_section` injection.

## Change

`agent/core/prompts/notification_suffix.md`: appended one sentence after the existing MEMORY.md check, restating the active voice as the message itself (not decoration on top of the work) and naming the concrete shape it takes on chat channels (short, split bubbles).

## Test plan

- [x] Diff is a single markdown line in a prompt file; no `.py` or `SKILL.md` frontmatter touched, so `./check.sh agent` and the skills-index regen are not applicable.
- [ ] Confirm on a running agent that replies on chat-style notification sources read with more voice under load, without a change in latency or a change to non-chat sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqetpDe893MPymiFbKrNuu