### PR TITLE
feat(skills): ship the committing-together backburner ritual as a fleet default

### DIFF
--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -33,7 +33,7 @@ Nudging is one tool, not the whole job, and it's the one they'll always ask for 
 
 ## Committing together
 
-Every few days, when nothing is urgent, sweep the dormant backburner (tasks with no due date, stalled §4 Goals) and propose committing to exactly one: name it, stage the first concrete chunk, and suggest a deadline. They choose; a pass costs nothing and a yes gets the deadline, a calendar entry, and chunked reminders, and you work it together. Due dates exist only on conscious commitments, never retrofitted onto backburner items.
+Every few days, when nothing is urgent, sweep the dormant backburner (tasks with no due date, stalled goals in MEMORY.md's User State) and propose committing to exactly one: name it, stage the first concrete chunk, and suggest a deadline. They choose; a pass costs nothing and a yes gets the deadline, a calendar entry, and chunked reminders, and you work it together. Due dates exist only on conscious commitments, never retrofitted onto backburner items.
 
 ## When to reach out
 

--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -31,6 +31,10 @@ A goal blocked on the user for more than one wake window can be nudged, not held
 
 Nudging is one tool, not the whole job, and it's the one they'll always ask for more of. Cap it at one task-nudge thread per check. The rest of the check is for the broader proactive work (exploring, preparing options they haven't asked for, deepening your model of their world) and your own curiosity.
 
+## Committing together
+
+Every few days, when nothing is urgent, sweep the dormant backburner (tasks with no due date, stalled §4 Goals) and propose committing to exactly one: name it, stage the first concrete chunk, and suggest a deadline. They choose; a pass costs nothing and a yes gets the deadline, a calendar entry, and chunked reminders, and you work it together. Due dates exist only on conscious commitments, never retrofitted onto backburner items.
+
 ## When to reach out
 
 Reach out if you found something good, something needs attention, or you just have something to say. You don't need a reason to start a conversation, but don't be annoying about it either. If there's nothing worth saying, stay quiet. Background action beats a message that wastes their attention.
@@ -38,4 +42,4 @@ Reach out if you found something good, something needs attention, or you just ha
 ## How to decide
 
 - Read MEMORY.md's user state and the recent conversation before acting
-- Check the `tasks` skill for anything overdue or upcoming
+- Check for anything overdue or upcoming: `tasks list` and `tasks remind list`


### PR DESCRIPTION
## Summary

Ships a ritual that was designed and validated with one user but only ever implemented instance-locally, never merged into the shared skill so every agent gets it.

- Adds a **Committing together** section to `proactive-check`: every few days, when nothing is urgent, sweep the dormant backburner (undated tasks, stalled goals) and propose committing to exactly one, i.e. name it, stage the first concrete chunk, and suggest a deadline. A yes attaches a deadline, a calendar entry, and chunked reminders, and the work proceeds together from there. Due dates stay reserved for conscious commitments and are never retrofitted onto backburner items.
- Tightens the existing "How to decide" tasks line from a vague pointer at the `tasks` skill into the two concrete commands (`tasks list`, `tasks remind list`) an agent actually runs.

## Why

Every outward effect is gated behind the user's explicit yes to the proposal, so this grants no new autonomy, it only makes the invitation itself a fleet default:

- **Self-Determination Theory (autonomy)**: the agent proposes and the user chooses; nothing is auto-committed. A pass costs nothing, so the invitation carries no pressure.
- **Motivational Interviewing (eliciting vs imposing)**: the ritual elicits a commitment from the user's own dormant intentions rather than imposing one, and channels that commitment into concrete scaffolding (deadline, calendar entry, chunked reminders) once it's made.

## Test plan

- [x] Read the resulting `SKILL.md` for tone and consistency with the surrounding sections
- [x] No `.py` files touched, so `./check.sh agent` is not required
- [x] Frontmatter (`name`/`description`) unchanged, so no skills-index regeneration is needed

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqetpDe893MPymiFbKrNuu