### PR TITLE
fix(web): red means recording, one selection device

### DIFF
--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -94,7 +94,7 @@ export function ChatComposer({
             ? "bg-card shadow-md ring-1 ring-foreground/5 dark:ring-foreground/10"
             : "bg-secondary",
           isRecording &&
-            "ring-2 ring-destructive has-[[data-slot=input-group-control]:focus-visible]:border-transparent has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-destructive",
+            "ring-2 ring-red-500 has-[[data-slot=input-group-control]:focus-visible]:border-transparent has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-red-500",
         )}
       >
         <InputGroupTextarea
@@ -142,7 +142,7 @@ export function ChatComposer({
               {...voiceButtonHandlers}
               className={cn(
                 "size-12 rounded-full [&_svg]:size-5",
-                isRecording && "bg-destructive text-background",
+                isRecording && "bg-red-500 text-white hover:bg-red-600",
               )}
             >
               {isRecording ? <Square fill="currentColor" /> : <Mic />}

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -94,7 +94,7 @@ export function ChatComposer({
             ? "bg-card shadow-md ring-1 ring-foreground/5 dark:ring-foreground/10"
             : "bg-secondary",
           isRecording &&
-            "ring-2 ring-red-500 has-[[data-slot=input-group-control]:focus-visible]:border-transparent has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-red-500",
+            "ring-2 ring-destructive has-[[data-slot=input-group-control]:focus-visible]:border-transparent has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-destructive",
         )}
       >
         <InputGroupTextarea
@@ -136,10 +136,14 @@ export function ChatComposer({
             <Button
               type="button"
               size="icon"
+              variant="secondary"
               disabled={inputDisabled}
               aria-label={isRecording ? "Stop recording" : "Start recording"}
               {...voiceButtonHandlers}
-              className="size-12 rounded-full bg-red-500 text-white hover:bg-red-600 [&_svg]:size-5"
+              className={cn(
+                "size-12 rounded-full [&_svg]:size-5",
+                isRecording && "bg-destructive text-background",
+              )}
             >
               {isRecording ? <Square fill="currentColor" /> : <Mic />}
             </Button>

--- a/apps/web/src/components/NewAgent/Steps/PersonalityStep/index.tsx
+++ b/apps/web/src/components/NewAgent/Steps/PersonalityStep/index.tsx
@@ -43,7 +43,7 @@ export function PersonalityStep({
                 aria-pressed={isSelected}
                 className={`group flex h-full flex-col items-center gap-2 rounded-2xl border p-4 text-center transition-all cursor-pointer ${
                   isSelected
-                    ? "border-primary/60 bg-primary/5 ring-2 ring-ring"
+                    ? "border-primary bg-primary/10"
                     : "border-border bg-input/30 hover:bg-input/60 hover:border-border/80"
                 }`}
               >


### PR DESCRIPTION
## Summary

Two state-semantics fixes, both net-deletions of color values.

- **ChatComposer mic button** (`apps/web/src/components/Chat/ChatComposer/index.tsx`): the idle mic was a permanent off-palette `bg-red-500` disc, the loudest pixel on the chat screen, which muted the meaning red is supposed to signal (recording in progress). Idle now uses `variant="secondary"` (quiet, matches the ghost send button next to it); the disc turns `bg-destructive text-background` and the InputGroup ring turns `ring-destructive` only while `isRecording` is true, using the theme's destructive token instead of a raw Tailwind red.
- **PersonalityStep card selection** (`apps/web/src/components/NewAgent/Steps/PersonalityStep/index.tsx`): the selected card stacked three emphasis devices across two hues (`border-primary/60`, `bg-primary/5`, and a grey `ring-2 ring-ring`), i.e. redundant signaling of the same state. Collapsed to one device: `border-primary bg-primary/10`. The ring is reserved for `focus-visible` as intended by the design system.

**Principle cited**: CLAUDE.md's elegance north star, "Subtraction beats addition: prefer removing a step, state, concept, or layer over adding one." Both changes remove color values (an off-palette always-red bg, a redundant ring + double hue) rather than add new ones, and route through the existing `destructive`/`primary` theme tokens rather than raw Tailwind color scales.

## Test plan

- [x] `./check.sh web` (eslint, prettier, tsc, vitest) passes clean; 0 errors, only pre-existing unrelated warnings.
- [x] Manual read of the diff confirms `isRecording` still drives both the button fill and the InputGroup ring together, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqetpDe893MPymiFbKrNuu