### PR TITLE
fix(web): connect screen answers every paste

### DIFF
--- a/apps/web/src/components/Connect/index.tsx
+++ b/apps/web/src/components/Connect/index.tsx
@@ -27,7 +27,14 @@ const connectEntrance = {
 } as const;
 
 function ConnectHeader() {
-  return <LogoText />;
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <LogoText />
+      <p className="text-sm leading-none text-muted-foreground">
+        your unfair advantage
+      </p>
+    </div>
+  );
 }
 
 export function Connect() {

--- a/apps/web/src/components/Connect/index.tsx
+++ b/apps/web/src/components/Connect/index.tsx
@@ -27,14 +27,7 @@ const connectEntrance = {
 } as const;
 
 function ConnectHeader() {
-  return (
-    <div className="flex flex-col items-center gap-1.5">
-      <LogoText />
-      <p className="text-sm leading-none text-muted-foreground">
-        your unfair advantage
-      </p>
-    </div>
-  );
+  return <LogoText />;
 }
 
 export function Connect() {
@@ -85,6 +78,9 @@ export function Connect() {
     if (busy) return;
     const link = parseConnectLink(value);
     if (!link) {
+      setError(
+        "that doesn't look like a connect link. paste the whole link vestad printed.",
+      );
       inputRef.current?.focus();
       return;
     }
@@ -218,11 +214,14 @@ export function Connect() {
               ref={inputRef}
               id="connect-link"
               type="text"
-              placeholder="paste your gateway connect link"
+              placeholder="paste your connect link"
               autoComplete="off"
               autoFocus
               value={value}
-              onChange={(e) => setValue(e.target.value)}
+              onChange={(e) => {
+                setValue(e.target.value);
+                setError("");
+              }}
               className="text-center"
             />
           </Field>


### PR DESCRIPTION
## Summary

The first in-app interaction of the self-host connect journey had two rough edges, both subtraction or reuse of existing UI:

- **A silent no-op on a bad paste.** `handleConnect` refocused the input but never surfaced why, leaving the user to guess. It now reuses the existing `role=alert` error slot (already wired for the connect-failure case) to say plainly what's wrong, and clears on the next keystroke so the message doesn't linger past a correction.
- **"Gateway" is a term the terminal journey never named.** The placeholder said "paste your gateway connect link" while `cli/src/main.rs:1672` and `install.sh:293` (the actual sources the user copies the link from) both say "connect link". Matches the file's own comment above `handleConnect`, which already calls it "the connect link".

Cited principle: elegance is the north star, subtraction beats addition. Both changes remove a rough edge rather than adding a new concept.

(A third change, removing the ConnectHeader tagline, was rejected in review and reverted in a3705eb7.)

## Test plan
- [x] `./check.sh web` (eslint, prettier, tsc, vitest) passes locally, 146/146 tests green, 0 lint errors (pre-existing warnings elsewhere untouched).
- [ ] Manual: paste garbage into the connect field and confirm the new error message appears and clears on the next keystroke.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqetpDe893MPymiFbKrNuu
