### PR TITLE
fix(web): one lowercase voice across settings and system screens

### DIFF
--- a/apps/web/src/components/AgentSettings/NotificationsCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationsCard/index.tsx
@@ -160,7 +160,7 @@ export function NotificationsCard() {
                 disabled={loadingMore}
                 onClick={loadMore}
               >
-                {loadingMore ? "loading…" : "load older"}
+                {loadingMore ? "loading..." : "load older"}
               </Button>
             ) : null}
           </div>

--- a/apps/web/src/components/AgentSettings/PreemptModeCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/PreemptModeCard/index.tsx
@@ -78,8 +78,8 @@ export function PreemptModeCard() {
           interrupt handling
         </CardTitle>
         <CardDescription>
-          What happens when an urgent message arrives while {displayName} is
-          busy. Applies after a restart.
+          what happens when an urgent message arrives while {displayName} is
+          busy. applies after a restart.
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
@@ -96,10 +96,10 @@ export function PreemptModeCard() {
             spacing={2}
           >
             <ToggleGroupItem value="message">
-              <MessageSquareDot /> Graceful
+              <MessageSquareDot /> graceful
             </ToggleGroupItem>
             <ToggleGroupItem value="interrupt">
-              <Zap /> Immediate
+              <Zap /> immediate
             </ToggleGroupItem>
           </ToggleGroup>
         )}

--- a/apps/web/src/components/CheckForUpdates/index.tsx
+++ b/apps/web/src/components/CheckForUpdates/index.tsx
@@ -59,10 +59,10 @@ export function CheckForUpdates() {
         />
       )}
       {checking
-        ? "Checking…"
+        ? "checking..."
         : onLatest
-          ? "On latest version already"
-          : "Check for updates"}
+          ? "on the latest version"
+          : "check for updates"}
     </Button>
   );
 }

--- a/apps/web/src/components/DisconnectedOverlay/index.tsx
+++ b/apps/web/src/components/DisconnectedOverlay/index.tsx
@@ -30,13 +30,13 @@ export function DisconnectedOverlay() {
           <Spinner className="size-6" />
           <EmptyTitle>disconnected from gateway</EmptyTitle>
           <EmptyDescription>
-            attempting to reconnect to {hostname}…
+            attempting to reconnect to {hostname}...
           </EmptyDescription>
         </EmptyHeader>
         <EmptyContent>
-          <Button variant="destructive" onClick={() => disconnect()}>
+          <Button variant="outline" onClick={() => disconnect()}>
             <LogOut data-icon="inline-start" />
-            Disconnect
+            disconnect
           </Button>
         </EmptyContent>
       </Empty>

--- a/apps/web/src/components/ErrorBoundary/index.tsx
+++ b/apps/web/src/components/ErrorBoundary/index.tsx
@@ -56,9 +56,9 @@ export function RouteErrorBoundary() {
     return (
       <ErrorFallback
         error={
-          new Error(`${error.status} — ${error.statusText || "Page not found"}`)
+          new Error(`${error.status}: ${error.statusText || "page not found"}`)
         }
-        title={error.status === 404 ? "Page not found" : "Something went wrong"}
+        title={error.status === 404 ? "page not found" : "something went wrong"}
         description={
           error.status === 404
             ? "The page you're looking for doesn't exist or has been moved."
@@ -85,8 +85,8 @@ interface ErrorFallbackProps {
 
 function ErrorFallback({
   error,
-  title = "Something went wrong",
-  description = "An unexpected error occurred. You can try again or go back home.",
+  title = "something went wrong",
+  description = "this shouldn't have happened. try again, or head back home.",
   onReset,
 }: ErrorFallbackProps) {
   const [detailsOpen, setDetailsOpen] = useState(false);
@@ -152,14 +152,14 @@ function ErrorFallback({
             className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground shadow-sm transition-all hover:opacity-90 active:scale-[0.97]"
           >
             <RotateCcw className="h-4 w-4" />
-            Try again
+            try again
           </button>
           <button
             onClick={handleGoHome}
             className="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2.5 text-sm font-medium text-foreground shadow-sm transition-all hover:bg-accent active:scale-[0.97]"
           >
             <Home className="h-4 w-4" />
-            Go home
+            go home
           </button>
         </div>
 
@@ -174,7 +174,7 @@ function ErrorFallback({
             >
               <ChevronDown className="h-3.5 w-3.5" />
             </motion.div>
-            Error details
+            error details
           </button>
 
           <AnimatePresence>

--- a/apps/web/src/components/Home/index.tsx
+++ b/apps/web/src/components/Home/index.tsx
@@ -57,7 +57,7 @@ function SkeletonList() {
         <SkeletonCard key={i} index={i} opacity={1 - i / SKELETON_COUNT} />
       ))}
       <p className="absolute bottom-12 left-0 right-0 text-center text-sm text-muted-foreground">
-        loading agents…
+        loading agents...
       </p>
     </motion.div>
   );

--- a/apps/web/src/components/Navbar/AgentNavbar/index.tsx
+++ b/apps/web/src/components/Navbar/AgentNavbar/index.tsx
@@ -133,7 +133,7 @@ export function AgentNavbar({
                     className={restarting ? "animate-spin" : undefined}
                   />
                   {!isMobile &&
-                    (restarting ? "restarting…" : "restart to apply")}
+                    (restarting ? "restarting..." : "restart to apply")}
                 </Button>
               )}
               {!isMobile && needsAuth && (

--- a/apps/web/src/components/Settings/KeybindsSection/index.tsx
+++ b/apps/web/src/components/Settings/KeybindsSection/index.tsx
@@ -52,7 +52,7 @@ export function KeybindsCard() {
   return (
     <Card size="sm">
       <CardContent>
-        <MenuSection title="Keybinds">
+        <MenuSection title="keybinds">
           <div className="flex flex-col gap-1.5">
             {keybinds.map((bind) => (
               <div key={bind.label}>

--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -59,7 +59,7 @@ export function AppSettings() {
     <div className="mx-auto mt-4 grid w-full max-w-5xl grid-cols-1 gap-4 pb-6 md:auto-rows-min md:grid-cols-2">
       <Card size="sm">
         <CardContent>
-          <MenuSection title="Appearance">
+          <MenuSection title="appearance">
             <ToggleGroup
               type="single"
               value={theme}
@@ -71,14 +71,14 @@ export function AppSettings() {
             >
               {!isTauri && (
                 <ToggleGroupItem value="system">
-                  <Monitor /> System
+                  <Monitor /> system
                 </ToggleGroupItem>
               )}
               <ToggleGroupItem value="light">
-                <Sun /> Light
+                <Sun /> light
               </ToggleGroupItem>
               <ToggleGroupItem value="dark">
-                <Moon /> Dark
+                <Moon /> dark
               </ToggleGroupItem>
             </ToggleGroup>
           </MenuSection>
@@ -87,7 +87,7 @@ export function AppSettings() {
 
       <Card size="sm">
         <CardContent>
-          <MenuSection title="Chat">
+          <MenuSection title="chat">
             <Field
               orientation="horizontal"
               className="items-center justify-between"
@@ -109,7 +109,7 @@ export function AppSettings() {
 
       <Card size="sm">
         <CardContent>
-          <MenuSection title="App">
+          <MenuSection title="app">
             <Field
               orientation="horizontal"
               className="items-center justify-between"
@@ -143,7 +143,7 @@ export function AppSettings() {
       <Card size="sm" className="md:col-span-2">
         <CardContent>
           <MenuSection
-            title="Gateway"
+            title="gateway"
             trailing={
               (gatewayVersion || gatewayBranch) && (
                 <span className="shrink-0 text-xs font-medium text-muted-foreground">
@@ -159,7 +159,7 @@ export function AppSettings() {
                 <StatusPill showHostname={false} />
                 <span className="flex min-w-0 flex-1 items-baseline gap-1">
                   <span className="shrink-0 text-muted-foreground">
-                    {reachable ? "Connected to" : "Cannot reach"}
+                    {reachable ? "connected to" : "can't reach"}
                   </span>
                   <span className="min-w-0 truncate font-medium text-foreground">
                     {hostname}
@@ -173,7 +173,7 @@ export function AppSettings() {
                   onClick={() => setShowLogs(true)}
                 >
                   <ScrollText data-icon="inline-start" />
-                  View logs
+                  view logs
                 </Button>
               )}
               <Button
@@ -182,7 +182,7 @@ export function AppSettings() {
                 onClick={() => disconnect()}
               >
                 <LogOut data-icon="inline-start" />
-                Disconnect
+                disconnect
               </Button>
             </div>
             <ConnectionControls />
@@ -217,7 +217,7 @@ export function AppSettings() {
                     </FieldDescription>
                   </FieldContent>
                   <span className="min-w-0 shrink-0 truncate text-sm text-muted-foreground">
-                    {gatewaySetup.info.tunnel_url ?? "—"}
+                    {gatewaySetup.info.tunnel_url ?? "not set"}
                   </span>
                 </Field>
                 <Field
@@ -247,14 +247,14 @@ export function AppSettings() {
       {reachable && managed && (
         <Card size="sm">
           <CardContent>
-            <MenuSection title="Account">
+            <MenuSection title="account">
               <Button
                 variant="outline"
                 className="w-full justify-start"
                 onClick={() => openExternalUrl(ACCOUNT_URL)}
               >
                 <CreditCard data-icon="inline-start" />
-                Manage account &amp; billing
+                manage account &amp; billing
                 <ExternalLink data-icon="inline-end" className="ml-auto" />
               </Button>
             </MenuSection>

--- a/apps/web/src/components/VersionMismatchScreen/index.tsx
+++ b/apps/web/src/components/VersionMismatchScreen/index.tsx
@@ -106,7 +106,7 @@ export function VersionMismatchScreen({
         <div className="mt-4 flex w-full max-w-sm flex-col gap-3">
           <Button variant="destructive" onClick={() => disconnect()}>
             <LogOut data-icon="inline-start" />
-            Disconnect
+            disconnect
           </Button>
           <ConnectionControls />
         </div>


### PR DESCRIPTION
## Summary

Half the settings surface and every system screen spoke Title Case beside sibling labels that were already lowercase, mixed two ellipsis glyphs (`…` and `...`) for the same busy state, and the crash screen built an em-dash string. Pure string normalization to the app's own dominant convention, plus one variant demotion so the reconnect overlay's only action stops reading as destructive.

**Principle**: CLAUDE.md, brand voice: "UI + agent copy is intentionally all-lowercase, texting-feel, terse" and "No dashes as separators in prose... use commas, periods, or colons." Both rules were already the convention in the majority of the app (e.g. `AgentSettings/NotificationsCard`, `NotificationInterruptRulesCard` descriptions, the `detail level` toggle right next to the one this PR fixes); this PR converges the remaining holdouts rather than introducing a new rule.

## Changes

- `Settings/index.tsx`: `MenuSection` titles (`appearance`/`chat`/`app`/`gateway`/`account`), theme toggle labels (`system`/`light`/`dark`), gateway status copy (`connected to`/`can't reach`), `view logs`, `disconnect`, `manage account & billing`, and the tunnel-url placeholder `—` → `not set` (matches the sibling `lan access`/`backups` fields, which already use words, not glyphs, for the empty state)
- `Settings/KeybindsSection/index.tsx`: `Keybinds` → `keybinds`
- `AgentSettings/PreemptModeCard/index.tsx`: `Graceful`/`Immediate` toggle labels and the card description lowercased to match every sibling `CardDescription` in `AgentSettings/`
- `CheckForUpdates/index.tsx`: busy/idle copy lowercased and the ellipsis glyph swapped for `...`, matching the ~30 existing ASCII-ellipsis sites
- `DisconnectedOverlay/index.tsx`: `Disconnect` → `disconnect`, ellipsis glyph → `...`, and the button demoted from `variant="destructive"` to `variant="outline"`. Disconnecting the app from a gateway it's actively trying to reconnect to isn't a destructive action in the way a data-loss action is; the spinner + "attempting to reconnect" copy stay the visual focus, this is just an escape hatch
- `VersionMismatchScreen/index.tsx`: `Disconnect` → `disconnect`
- `ErrorBoundary/index.tsx`: `${error.status} — ${...}` → `${error.status}: ${...}`, `Something went wrong`/`Try again`/`Go home`/`Error details`/`Page not found` lowercased, and the generic default description reworded to match the app's terse voice
- Ellipsis sweep: `AgentNavbar` (`restarting...`), `Home` (`loading agents...`), `NotificationsCard` (`loading...`) switched from `…` to the ASCII `...` already used everywhere else in the app

Kept `disconnect` as the label everywhere rather than renaming to `log out`: connect/disconnect is the app's established terminology pair (`ConnectionControls`, `AuthProvider`), and swapping vocabulary on one screen would be a net addition, not a subtraction.

## Test plan

- [x] `./check.sh web` (eslint, prettier, tsc, vitest) green: 0 lint errors (37 pre-existing, unrelated warnings), prettier clean, tsc clean, 146/146 tests passing
- [x] Manual read-through of every touched string against its surrounding siblings for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqetpDe893MPymiFbKrNuu