### PR TITLE
fix(web): chat tells the truth about agent state

### DIFF
--- a/apps/web/src/components/Chat/ChatBubble/index.tsx
+++ b/apps/web/src/components/Chat/ChatBubble/index.tsx
@@ -6,6 +6,17 @@ import type { VestaEvent } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { ToolCallLabel } from "../ToolCallLabel";
 
+// Coarse relative countdown to a rate-limit reset (unix seconds); minutes/hours/days is
+// plenty of precision for "come back later" copy.
+function formatResetTime(resetsAt: number): string {
+  const minutes = Math.round((resetsAt * 1000 - Date.now()) / 60_000);
+  if (minutes <= 1) return "in a minute";
+  if (minutes < 60) return `in ${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `in ${hours}h`;
+  return `in ${Math.round(hours / 24)}d`;
+}
+
 export const ChatBubble = memo(function ChatBubble({
   event,
   className,
@@ -34,6 +45,22 @@ export const ChatBubble = memo(function ChatBubble({
         input={event.input}
         className={className}
       />
+    );
+  }
+
+  if (event.type === "error" || event.type === "rate_limited") {
+    const text =
+      event.type === "rate_limited"
+        ? event.resets_at
+          ? `rate limited, back ${formatResetTime(event.resets_at)}`
+          : "rate limited, retrying later"
+        : "hit a snag, this may not have gone through";
+    return (
+      <div className={cn("flex justify-center", className)}>
+        <span className="text-[11px] text-muted-foreground/60 select-none">
+          {text}
+        </span>
+      </div>
     );
   }
 

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -17,13 +17,11 @@ import { cn } from "@/lib/utils";
 import { useVoice } from "@/stores/use-voice";
 import { useVoiceActivation } from "@/stores/use-voice-activation";
 import { useIsMobile } from "@/hooks/use-mobile";
-import type { AgentActivityState } from "@/lib/types";
 
 interface ChatComposerProps {
   fullscreen?: boolean;
   connected: boolean;
   notAuthenticated: boolean;
-  agentState: AgentActivityState;
   sttAvailable: boolean;
   isRecording: boolean;
   voiceAutoSend: boolean;
@@ -42,7 +40,6 @@ export function ChatComposer({
   fullscreen,
   connected,
   notAuthenticated,
-  agentState,
   sttAvailable,
   isRecording,
   voiceAutoSend,
@@ -111,9 +108,7 @@ export function ChatComposer({
               ? "listening..."
               : notAuthenticated
                 ? "sign in to chat"
-                : agentState === "thinking"
-                  ? "working... send a message to steer"
-                  : "send a message..."
+                : "send a message..."
           }
           disabled={inputDisabled}
           rows={1}

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -17,11 +17,13 @@ import { cn } from "@/lib/utils";
 import { useVoice } from "@/stores/use-voice";
 import { useVoiceActivation } from "@/stores/use-voice-activation";
 import { useIsMobile } from "@/hooks/use-mobile";
+import type { AgentActivityState } from "@/lib/types";
 
 interface ChatComposerProps {
   fullscreen?: boolean;
   connected: boolean;
   notAuthenticated: boolean;
+  agentState: AgentActivityState;
   sttAvailable: boolean;
   isRecording: boolean;
   voiceAutoSend: boolean;
@@ -40,6 +42,7 @@ export function ChatComposer({
   fullscreen,
   connected,
   notAuthenticated,
+  agentState,
   sttAvailable,
   isRecording,
   voiceAutoSend,
@@ -108,7 +111,9 @@ export function ChatComposer({
               ? "listening..."
               : notAuthenticated
                 ? "sign in to chat"
-                : "send a message..."
+                : agentState === "thinking"
+                  ? "working... send a message to steer"
+                  : "send a message..."
           }
           disabled={inputDisabled}
           rows={1}

--- a/apps/web/src/components/Chat/ChatMessageArea/index.tsx
+++ b/apps/web/src/components/Chat/ChatMessageArea/index.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { CardContent } from "@/components/ui/card";
 import type { VestaEvent } from "@/lib/types";
 import { cn } from "@/lib/utils";
+import { stepTransition } from "@/lib/motion";
 import { ChatBubble } from "../ChatBubble";
 import { buildDecorated } from "./virtual";
 
@@ -176,6 +177,15 @@ export function ChatMessageArea({
     hadRowsRef.current = hasRows;
   }, [count, virtualizer]);
 
+  // Highest row index seen as of the last commit — read during render (holds the prior
+  // value, since this effect hasn't fired yet) to tell a genuine append from a history
+  // page landing or an unrelated re-render, then advanced after commit. Gated on
+  // hadRowsRef so the first page of history never plays the entrance animation.
+  const maxSeenIndexRef = useRef(-1);
+  useLayoutEffect(() => {
+    maxSeenIndexRef.current = count - 1;
+  }, [count]);
+
   const handleScroll = useCallback(() => {
     const el = parentRef.current;
     if (!el) return;
@@ -261,6 +271,8 @@ export function ChatMessageArea({
           {items.map((item) => {
             const row = decorated[item.index];
             const isLast = item.index === count - 1;
+            const isNewAppend =
+              hadRowsRef.current && item.index > maxSeenIndexRef.current;
             return (
               <div
                 key={item.key}
@@ -297,12 +309,27 @@ export function ChatMessageArea({
                       </span>
                     </div>
                   )}
-                  <ChatBubble
-                    event={row.event}
-                    className={row.gap}
-                    fullscreen={fullscreen}
-                    isMobile={isMobile}
-                  />
+                  {isNewAppend ? (
+                    <motion.div
+                      initial={{ opacity: 0, y: 6, scale: 0.98 }}
+                      animate={{ opacity: 1, y: 0, scale: 1 }}
+                      transition={stepTransition.transition}
+                    >
+                      <ChatBubble
+                        event={row.event}
+                        className={row.gap}
+                        fullscreen={fullscreen}
+                        isMobile={isMobile}
+                      />
+                    </motion.div>
+                  ) : (
+                    <ChatBubble
+                      event={row.event}
+                      className={row.gap}
+                      fullscreen={fullscreen}
+                      isMobile={isMobile}
+                    />
+                  )}
                 </div>
                 {isLast && (
                   <div className="px-4 pb-4">

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -45,7 +45,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
 
   const {
     messages,
-    agentState,
     isTyping,
     connected,
     historyLoaded,
@@ -80,14 +79,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
       ),
     [messages, showToolCalls],
   );
-
-  // The pacing drain only flags isTyping once a reply has already arrived, so it fires after
-  // the fact. Fill the real gap (the model is still working) whenever the last visible message
-  // is the user's own and the agent isn't idle; any agent-authored bubble (or tool call) already
-  // shows activity on its own.
-  const lastVisible = chatMessages[chatMessages.length - 1];
-  const showTyping =
-    isTyping || (agentState !== "idle" && lastVisible?.type === "user");
 
   const scrollToBottom = useCallback(() => {
     scrollRef.current?.scrollToBottom();
@@ -152,7 +143,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
           historyLoaded={historyLoaded}
           agentName={name}
           notAuthenticated={notAuthenticated}
-          isTyping={showTyping}
+          isTyping={isTyping}
           isMobile={isMobile}
         />
 
@@ -162,7 +153,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
             fullscreen={fullscreen}
             connected={connected}
             notAuthenticated={notAuthenticated}
-            agentState={agentState}
             sttAvailable={sttAvailable}
             isRecording={isRecording}
             voiceAutoSend={voiceAutoSend}

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -45,6 +45,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
 
   const {
     messages,
+    agentState,
     isTyping,
     connected,
     historyLoaded,
@@ -71,12 +72,22 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
         (m) =>
           m.type === "user" ||
           m.type === "chat" ||
+          m.type === "error" ||
+          m.type === "rate_limited" ||
           (showToolCalls &&
             m.type === "tool_start" &&
             !(m.tool === "Bash" && m.input.includes("app-chat"))),
       ),
     [messages, showToolCalls],
   );
+
+  // The pacing drain only flags isTyping once a reply has already arrived, so it fires after
+  // the fact. Fill the real gap (the model is still working) whenever the last visible message
+  // is the user's own and the agent isn't idle; any agent-authored bubble (or tool call) already
+  // shows activity on its own.
+  const lastVisible = chatMessages[chatMessages.length - 1];
+  const showTyping =
+    isTyping || (agentState !== "idle" && lastVisible?.type === "user");
 
   const scrollToBottom = useCallback(() => {
     scrollRef.current?.scrollToBottom();
@@ -141,7 +152,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
           historyLoaded={historyLoaded}
           agentName={name}
           notAuthenticated={notAuthenticated}
-          isTyping={isTyping}
+          isTyping={showTyping}
           isMobile={isMobile}
         />
 
@@ -151,6 +162,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
             fullscreen={fullscreen}
             connected={connected}
             notAuthenticated={notAuthenticated}
+            agentState={agentState}
             sttAvailable={sttAvailable}
             isRecording={isRecording}
             voiceAutoSend={voiceAutoSend}

--- a/apps/web/src/providers/AgentSocketProvider/index.tsx
+++ b/apps/web/src/providers/AgentSocketProvider/index.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { useAgentSocketState } from "./use-agent-socket";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { useNotifications } from "@/providers/NotificationProvider";
 import { useVoice } from "@/stores/use-voice";
+import { useShowToolCalls } from "@/stores/use-show-tool-calls";
 import { AgentSocketContext, type AgentSocketValue } from "./context";
 
 export { useAgentSocket } from "./context";
@@ -11,7 +12,8 @@ export function AgentSocketProvider({ children }: { children: ReactNode }) {
   const { name, agent, setAgentState } = useSelectedAgent();
   const { speak, prefetch } = useVoice();
   const { notifyAssistant, setChattingAgent } = useNotifications();
-  const [showToolCalls, setShowToolCalls] = useState(false);
+  const showToolCalls = useShowToolCalls((s) => s.showToolCalls);
+  const setShowToolCalls = useShowToolCalls((s) => s.setShowToolCalls);
 
   useEffect(() => {
     setChattingAgent(name);

--- a/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
+++ b/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
@@ -162,6 +162,9 @@ export function useAgentSocketState({
             enqueueChatMessage(event);
           } else {
             setMessages((prev) => capTail([...prev, event]));
+            if (event.type === "error" || event.type === "rate_limited") {
+              resetTyping();
+            }
           }
           if (event.type === "status") {
             setAgentState(event.state);

--- a/apps/web/src/stores/use-show-tool-calls.ts
+++ b/apps/web/src/stores/use-show-tool-calls.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+
+const STORAGE_KEY = "chat-show-tool-calls";
+
+interface ShowToolCallsState {
+  showToolCalls: boolean;
+  setShowToolCalls: (value: boolean | ((prev: boolean) => boolean)) => void;
+}
+
+export const useShowToolCalls = create<ShowToolCallsState>((set, get) => ({
+  showToolCalls: localStorage.getItem(STORAGE_KEY) === "on",
+  setShowToolCalls: (value) => {
+    const next =
+      typeof value === "function" ? value(get().showToolCalls) : value;
+    localStorage.setItem(STORAGE_KEY, next ? "on" : "off");
+    set({ showToolCalls: next });
+  },
+}));


### PR DESCRIPTION
## Rationale

All three changes are surgical uses of signals the socket already streams; nothing new is plumbed in.

- **Errors and rate limits reached no surface.** `error` and `rate_limited` events already exist on `VestaEvent` (`core/client.py`'s SDK classification) but the chat filter dropped them, so a failed turn read as Vesta ignoring the user. They're now included in the filter and rendered by `ChatBubble` as the existing centered muted system-stamp style (matching the day-stamp pattern already in the file, `text-[11px] text-muted-foreground/60`), so the treatment introduces no new visual vocabulary. Also resets the pacing `isTyping` state on these events so the dots can't get stuck mid-turn.
- **The tool-calls toggle silently reset every session.** It lived in `useState` inside `AgentSocketProvider`, discarded on reload. Moved to a tiny zustand + localStorage store (`stores/use-show-tool-calls.ts`), mirroring the existing `use-chat-pacing.ts` pattern exactly, so a user's trust-building "show me what you're doing" choice persists like the other display prefs.
- **Appended bubbles popped in with zero motion.** `ChatMessageArea` now tracks the highest rendered row index in a ref and wraps genuinely new appends (never the initial history page or a load-older prepend) in a `motion.div` using the file's existing spring vocabulary (`lib/motion.ts`'s `stepTransition.transition`, already used elsewhere in the app for entrance motion). The virtualizer's absolutely-positioned outer row is untouched, so virtualization/measurement is unaffected.

(Two further changes, a derived typing-indicator fallback and a state-aware "send a message to steer" composer placeholder, were rejected in review and reverted in c4e4cee5.)

## Test plan
- [x] `./check.sh web` (eslint + prettier + tsc + vitest) green, no new warnings vs. master
- [x] Manual review of the diff for each behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqetpDe893MPymiFbKrNuu
