### PR TITLE
fix(copy): purge em dashes and align terminal voice with the app

### DIFF
--- a/apps/web/src/components/Orb/styles.ts
+++ b/apps/web/src/components/Orb/styles.ts
@@ -59,7 +59,10 @@ function resolveStatus(
     case "stopped":
       return { label: "stopped", orbState: "off" };
     case "dead":
-      return { label: "broken — delete and recreate", orbState: "off" };
+      return {
+        label: "broken, delete and recreate it in settings",
+        orbState: "off",
+      };
     default:
       return { label: agent.status, orbState: "off" };
   }

--- a/apps/web/src/lib/pkce.ts
+++ b/apps/web/src/lib/pkce.ts
@@ -139,7 +139,7 @@ export async function completeHostedLogin(
  */
 export async function startNativeLogin(): Promise<void> {
   if (buildPlatform === "ios" || buildPlatform === "android") {
-    throw new Error("mobile sign-in is coming soon — use the web app for now");
+    throw new Error("mobile sign-in is coming soon, use the web app for now");
   }
 
   const { start, onUrl, cancel } =

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -701,8 +701,8 @@ fn prompt_context_window(c: &client::Client) -> Option<u64> {
 /// account (empty input or "1"). Returns true if the user picked OpenRouter.
 fn prompt_use_openrouter() -> bool {
     eprintln!("how should this agent authenticate?");
-    eprintln!("  1) Claude account  — log in with your Claude subscription (default)");
-    eprintln!("  2) OpenRouter      — run on an OpenRouter API key");
+    eprintln!("  1) claude account: log in with your claude subscription (default)");
+    eprintln!("  2) openrouter:     run on an openrouter api key");
     loop {
         match prompt_raw("choice [1]").as_str() {
             "" | "1" => return false,
@@ -769,8 +769,8 @@ fn prompt_openrouter_model(c: &client::Client) -> String {
     eprintln!("top models on OpenRouter this week:");
     for (idx, model) in models.iter().enumerate() {
         match fmt_model_price(model.input_price, model.output_price, model.cache_read_price) {
-            Some(price) => eprintln!("  {:>2}) {} ({}) — {}  [{}]", idx + 1, model.label, model.author, model.slug, price),
-            None => eprintln!("  {:>2}) {} ({}) — {}", idx + 1, model.label, model.author, model.slug),
+            Some(price) => eprintln!("  {:>2}) {} ({}): {}  [{}]", idx + 1, model.label, model.author, model.slug, price),
+            None => eprintln!("  {:>2}) {} ({}): {}", idx + 1, model.label, model.author, model.slug),
         }
     }
     eprintln!("  or type a custom provider/model slug");
@@ -1096,7 +1096,7 @@ fn print_update_available(latest: &str) {
 }
 
 fn print_welcome() {
-    println!("vesta — your personal AI assistant");
+    println!("vesta: your personal AI assistant");
     println!();
     println!("quick start:");
     println!("  vesta setup        create an agent, authenticate, and start");

--- a/install.sh
+++ b/install.sh
@@ -275,22 +275,22 @@ EOF
   esac
 
   echo ""
-  echo "Installed!"
+  echo "installed."
   echo ""
   if [ "$OS" = "linux" ]; then
-    echo "Start your server — this one command does the rest:"
+    echo "start your gateway, one command does the rest:"
     echo ""
     echo "    vestad"
     echo ""
-    echo "It walks you through connecting a domain, then prints your agent's URL."
-    echo "Open that URL in a browser to create your first agent."
+    echo "it walks you through connecting a domain, then prints your agent's URL."
+    echo "open that URL in a browser to create your first agent."
   else
-    echo "Connect to a vestad server:"
+    echo "connect to a vestad server:"
     echo "    vesta connect <connect-link>"
   fi
   if has_gui; then
     echo ""
-    echo "Prefer an app? Open the Vesta app and paste your connect link."
+    echo "prefer an app? open the Vesta app and paste your connect link."
   fi
   if [ -n "$PATH_UPDATED" ]; then
     echo ""

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -266,7 +266,7 @@ fn report_restart_readiness(config: &std::path::Path) {
             None => false,
         };
         if !local_ready {
-            eprintln!("vestad restarted, but its local API did not come up in time — check 'vestad logs'.");
+            eprintln!("vestad restarted, but its local API did not come up in time. check 'vestad logs'.");
             return;
         }
 

--- a/vestad/src/status.rs
+++ b/vestad/src/status.rs
@@ -329,12 +329,12 @@ impl Status {
         let local_url = format!("http://localhost:{}", self.port + 1);
         let tunnel_url = self.tunnel.url();
 
-        // enabled = tunnel up; disabled = --no-tunnel; error — <reason> = a tunnel
+        // enabled = tunnel up; disabled = --no-tunnel; error: <reason> = a tunnel
         // was wanted but couldn't be established (no creds, dead tunnel, API error).
         let tunnel_desc = match &self.tunnel {
             TunnelStatus::Active(_) => "enabled".to_string(),
             TunnelStatus::Disabled => "disabled".to_string(),
-            TunnelStatus::Failed(reason) => format!("error — {}", first_line_truncated(reason, 100)),
+            TunnelStatus::Failed(reason) => format!("error: {}", first_line_truncated(reason, 100)),
         };
         let lan_desc = if self.expose_lan { "enabled" } else { "disabled" }.to_string();
         let lan_url = self.lan_url.as_deref();

--- a/vestad/src/systemd.rs
+++ b/vestad/src/systemd.rs
@@ -76,7 +76,7 @@ WantedBy=default.target
         .status()
         .map_err(|e| format!("failed to run loginctl: {}", e))?;
     if !status.success() {
-        eprintln!("warning: loginctl enable-linger failed — vestad may stop on logout");
+        eprintln!("warning: loginctl enable-linger failed, vestad may stop on logout");
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

CLAUDE.md's brand voice rule is explicit: no em dashes, en dashes, or " - " as a separator in prose or copy anywhere in the repo, use commas, periods, or colons instead. That rule was broken in eight shipped user-facing strings across the terminal onboarding journey (`vesta setup`, `vesta list`, `vestad` status/restart output, `install.sh`) plus two strays in the web app, and the `install.sh` outro was still Sentence-cased and peppy ("Installed!", "Start your server") while the rest of the app has converged on calm, all-lowercase, texting-feel copy.

One sweep, applying the rule to its own letter: em dashes become colons or commas depending on whether the dash was introducing a clause (`:`) or joining two independent clauses (`,`).

## Changes

- `cli/src/main.rs`: welcome banner, the claude/openrouter provider picker, and the openrouter model list all traded em dashes for colons; the provider picker also lowercases "claude account" / "openrouter" to match the CLI's lowercase register and is re-padded so the descriptions still line up.
- `vestad/src/status.rs`: the tunnel-error banner line and its own comment.
- `vestad/src/systemd.rs`: the linger warning.
- `vestad/src/main.rs`: the restart-readiness message.
- `install.sh`: the outro block lowercased to match the app's tone ("installed.", "start your gateway, one command does the rest:", etc.), which also converges the wording on "gateway", the term the app itself uses for vestad (see `apps/web/src/providers/GatewayProvider`).
- `apps/web/src/components/Orb/styles.ts`: the "dead" agent status label. Kept the fix minimal, in-app agent delete/recreate lives in Settings today but there's no in-app *restore* flow, so the copy points at "settings" rather than a restore action that doesn't exist.
- `apps/web/src/lib/pkce.ts`: the mobile sign-in "coming soon" error.

All eight listed changes matched the current code exactly, so nothing was skipped.

## Test plan

- [x] `./check.sh web` (eslint, prettier, tsc, vitest) green; `apps/web/src/components/Orb/styles.ts` needed a `prettier --write` re-wrap after the longer label pushed the line over the print width.
- [x] `cargo check` clean in both `cli/` and `vestad/` (not part of `check.sh web`, but touched Rust files in this PR so verified they still compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqetpDe893MPymiFbKrNuu