### PR TITLE
refactor(agent): close a 500 path and drop banned/loose typing

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -403,7 +403,7 @@ async def _memory_put_handler(request: web.Request) -> web.Response:
         data = await request.json()
     except (json.JSONDecodeError, TypeError):
         return web.json_response({"error": "invalid json body"}, status=400)
-    if "content" not in data or not isinstance(data["content"], str):
+    if not isinstance(data, dict) or "content" not in data or not isinstance(data["content"], str):
         return web.json_response({"error": "body must be {content: string}"}, status=400)
     path = get_memory_path(config)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -20,7 +20,9 @@ from .loops import (
     monitor_loop,
 )
 from .default_skills import default_skill_sync_turn
+from .events import EventBus
 from .migrations import pending_migration_turns
+from .provider import derive_status
 from .workspace_sync import workspace_sync_turn, vesta_version
 
 
@@ -196,9 +198,6 @@ def init_state(*, config: vm.VestaConfig) -> vm.State:
     persisted = state_store.load_state(config)
     if persisted.session_id:
         logger.init(f"Resuming session {persisted.session_id[:16]}...")
-    from .events import EventBus
-    from .provider import derive_status
-
     event_bus = EventBus(data_dir=config.data_dir)
     provider_status = derive_status(config)
     logger.init(f"Provider: {provider_status.kind} ({provider_status.state.value})")

--- a/agent/core/provider.py
+++ b/agent/core/provider.py
@@ -211,6 +211,14 @@ _CLAUDE_USAGE_METERS = (
 )
 
 
+def _as_float(value: pyd.JsonValue) -> float | None:
+    return value if isinstance(value, int | float) and not isinstance(value, bool) else None
+
+
+def _as_str(value: pyd.JsonValue) -> str | None:
+    return value if isinstance(value, str) else None
+
+
 def _read_oauth_token() -> str | None:
     try:
         data = json.loads(CREDENTIALS_PATH.read_text())
@@ -243,17 +251,25 @@ async def _claude_usage() -> Usage:
     data = await _fetch_usage_json(f"{ANTHROPIC_API_URL}/api/oauth/usage", headers=headers)
     meters = []
     for key, label in _CLAUDE_USAGE_METERS:
-        bucket = data[key] if key in data and isinstance(data[key], dict) else None
+        bucket_raw = data[key] if key in data else None
+        bucket = bucket_raw if isinstance(bucket_raw, dict) else None
         if bucket is not None and "utilization" in bucket:
             meters.append(
-                UsageMeter(label=label, used_pct=bucket["utilization"], resets_at=bucket["resets_at"] if "resets_at" in bucket else None)
+                UsageMeter(
+                    label=label,
+                    used_pct=_as_float(bucket["utilization"]),
+                    resets_at=_as_str(bucket["resets_at"]) if "resets_at" in bucket else None,
+                )
             )
     credits = None
-    extra = data["extra_usage"] if "extra_usage" in data and isinstance(data["extra_usage"], dict) else None
+    extra_raw = data["extra_usage"] if "extra_usage" in data else None
+    extra = extra_raw if isinstance(extra_raw, dict) else None
     if extra is not None and "is_enabled" in extra and extra["is_enabled"]:
         # Anthropic reports extra-usage in cents; normalize to dollars to match OpenRouter's units.
-        used = extra["used_credits"] / 100 if "used_credits" in extra and extra["used_credits"] is not None else None
-        limit = extra["monthly_limit"] / 100 if "monthly_limit" in extra and extra["monthly_limit"] is not None else None
+        used_credits = _as_float(extra["used_credits"]) if "used_credits" in extra else None
+        monthly_limit = _as_float(extra["monthly_limit"]) if "monthly_limit" in extra else None
+        used = used_credits / 100 if used_credits is not None else None
+        limit = monthly_limit / 100 if monthly_limit is not None else None
         credits = UsageCredits(used=used, limit=limit)
     return Usage(meters=meters, credits=credits)
 
@@ -264,13 +280,14 @@ async def _openrouter_usage(config: VestaConfig) -> Usage:
     headers = {"Authorization": f"Bearer {config.provider.key.get_secret_value()}"}
     data = await _fetch_usage_json(OPENROUTER_KEY_URL, headers=headers)
     # OpenRouter wraps the payload in {"data": {...}}; usage and limit are already in dollars.
-    payload = data["data"] if "data" in data and isinstance(data["data"], dict) else {}
-    used = payload["usage"] if "usage" in payload else None
-    limit = payload["limit"] if "limit" in payload else None
+    payload_raw = data["data"] if "data" in data else None
+    payload = payload_raw if isinstance(payload_raw, dict) else {}
+    used = _as_float(payload["usage"]) if "usage" in payload else None
+    limit = _as_float(payload["limit"]) if "limit" in payload else None
     return Usage(meters=[], credits=UsageCredits(used=used, limit=limit))
 
 
-async def _fetch_usage_json(url: str, *, headers: dict[str, str]) -> dict[str, tp.Any]:
+async def _fetch_usage_json(url: str, *, headers: dict[str, str]) -> dict[str, pyd.JsonValue]:
     try:
         async with aiohttp.ClientSession() as session:
             async with session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=_USAGE_TIMEOUT_S)) as resp:

--- a/agent/core/sdk_parsing.py
+++ b/agent/core/sdk_parsing.py
@@ -253,7 +253,7 @@ def make_hooks(state: vm.State) -> dict[HookEvent, list[HookMatcher]]:
         return tp.cast(HookJSONOutput, {})
 
     async def log_compact(input_data: PreCompactHookInput, tool_use_id: str | None, context: HookContext) -> HookJSONOutput:
-        trigger = input_data["trigger"]
+        trigger = input_data["trigger"] if "trigger" in input_data else "unknown"
         state.compacting = True
         logger.client(f"Context compaction starting (trigger={trigger})")
         return tp.cast(HookJSONOutput, {})

--- a/agent/skills/generate-index.py
+++ b/agent/skills/generate-index.py
@@ -19,6 +19,6 @@ if __name__ == "__main__":
         text = skill_md.read_text()
         match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
         fm = dict(re.findall(r"^(\w[\w-]*)\s*:\s*(.+)$", match.group(1), re.MULTILINE)) if match else {}
-        skills.append({"name": fm.get("name", skill_name), "description": fm.get("description", "")})
+        skills.append({"name": fm["name"] if "name" in fm else skill_name, "description": fm["description"] if "description" in fm else ""})
     OUTPUT_FILE.write_text(json.dumps(skills, indent=2) + "\n")
     print(f"Generated {OUTPUT_FILE} with {len(skills)} skills.")

--- a/agent/tests/test_api.py
+++ b/agent/tests/test_api.py
@@ -437,3 +437,18 @@ async def test_history_q_returns_matching_events_in_history_shape(event_bus):
         assert "paris is lovely" in texts and "london is grey" not in texts
     finally:
         await runner.cleanup()
+
+
+@pytest.mark.anyio
+async def test_memory_put_rejects_non_dict_body(event_bus, tmp_path):
+    config = vm.VestaConfig(agent_dir=tmp_path / "agent", ws_port=_pick_port(), agent_token=pyd.SecretStr("test-token"))
+    runner = await start_ws_server(event_bus, config, host="127.0.0.1")
+    base = f"http://127.0.0.1:{config.ws_port}"
+    auth = {"X-Agent-Token": "test-token"}
+
+    try:
+        async with ClientSession() as session:
+            async with session.put(f"{base}/memory", json=42, headers=auth) as resp:
+                assert resp.status == 400
+    finally:
+        await runner.cleanup()


### PR DESCRIPTION
## Summary

Surgical quality pass over agent/core against the repo's own rubric (CLAUDE.md Architecture Principles and CONTRIBUTING conventions). Each change is independent and small.

- `PUT /memory` raised an uncaught TypeError, surfaced by aiohttp as a 500, when the JSON body was not an object (for example a bare number or list): it indexed the body before checking its shape, the one handler that skips the isinstance guard every sibling handler uses. It now returns the same 400 the siblings return.
- `log_compact` in `sdk_parsing.py` read `input_data["trigger"]` directly while every other hook in the same function reads its externally produced payload defensively (`x["k"] if "k" in x else default`). A CLI build omitting the field would raise KeyError inside an async hook; it now matches its siblings.
- `generate-index.py` used `fm.get("name", skill_name)` and `fm.get("description", "")`, the literal banned dict.get() fallback idiom for agent code. Replaced with the `key in dict` idiom used elsewhere in the codebase; regenerated `index.json` is byte-identical.
- `init_state` in `main.py` deferred `from .events import EventBus` and `from .provider import derive_status` inside the function body with no import cycle to justify it (neither module imports main, and models.py already imports both names at module scope). Hoisted to the top-level import block.
- `_fetch_usage_json` in `provider.py` returned `dict[str, tp.Any]`, a banned loose type. Changed to `dict[str, pyd.JsonValue]`; the three usage-extraction call sites (Claude meters, Claude extra credits, OpenRouter payload) now narrow to concrete float/str values at the boundary instead of assuming the upstream shape, with two small helpers (`_as_float`, `_as_str`) to avoid repeating the narrowing.

One planned change was dropped: deleting `delete_notification_files`/`_delete_paths` as a dead second owner. That code no longer exists on master (it has already been consolidated into `_trash_paths`/`trash_notification_files`), so there was nothing left to remove.

Note: this PR targets a fresh branch (`chore/quality-agent-2`) rather than `chore/quality-agent` because that branch name is already in use by open PR #1085 with a different, overlapping scope (unsupervised monitor task, narrow error guards, non-atomic memory write); pushing here avoided clobbering that PR's history. The memory-handler fix in this PR is independent of PR #1085's changes to the adjacent write line and should rebase cleanly either way.

## Test plan

- [x] `./check.sh agent` (ruff check, ruff format --check, ty check, full pytest suite including cc_sdk transport tests): 554 passed
- [x] Added `test_memory_put_rejects_non_dict_body` covering the new 400 path
- [x] Regenerated `agent/skills/index.json`, confirmed no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)