### PR TITLE
refactor(web): IO-boundary hygiene

### DIFF
--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -65,20 +65,12 @@ export async function setProvider(
             ? { max_context_tokens: result.maxContextTokens }
             : {}),
         };
-  await apiFetch(`/agents/${enc}/provider`, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  await apiFetch(`/agents/${enc}/provider`, jsonInit("PUT", body));
   const prefs: Record<string, string> = {};
   if (personality) prefs.agent_personality = personality;
   if (timezone) prefs.timezone = timezone;
   if (Object.keys(prefs).length > 0) {
-    await apiFetch(`/agents/${enc}/config`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(prefs),
-    });
+    await apiFetch(`/agents/${enc}/config`, jsonInit("PUT", prefs));
   }
   await restartAgent(name);
 }
@@ -129,11 +121,10 @@ async function patchProvider(
   name: string,
   patch: Record<string, unknown>,
 ): Promise<void> {
-  await apiFetch(`/agents/${encodeURIComponent(name)}/provider`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(patch),
-  });
+  await apiFetch(
+    `/agents/${encodeURIComponent(name)}/provider`,
+    jsonInit("PATCH", patch),
+  );
   await restartAgent(name);
 }
 
@@ -153,11 +144,7 @@ export async function setContextWindow(
 /// Create an empty agent container. Credentials and preferences (provider, model, personality,
 /// context, timezone) are sent once it's up, via `setProvider`.
 export async function createAgent(name: string): Promise<void> {
-  await apiJson("/agents", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name }),
-  });
+  await apiJson("/agents", jsonInit("POST", { name }));
 }
 
 /// Coarse, ordered stages of first-time agent creation reported by vestad while
@@ -190,6 +177,30 @@ export async function getBuildPhase(name: string): Promise<BuildPhase | null> {
   return resp.phase;
 }
 
+/// Poll /agents/{name} until its status settles into one of `ready` (resolve) or `failed` (throw);
+/// anything else (still starting up) keeps polling until `timeoutMs` elapses.
+async function waitForStatus(
+  name: string,
+  timeoutMs: number,
+  pollIntervalMs: number,
+  ready: readonly string[],
+  failed: readonly string[],
+  timeoutLabel: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const resp = await apiJson<{ status: string }>(
+      `/agents/${encodeURIComponent(name)}`,
+    );
+    if (ready.includes(resp.status)) return;
+    if (failed.includes(resp.status)) {
+      throw new Error(`${name}: ${resp.status}`);
+    }
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+  throw new Error(`${name}: ${timeoutLabel}`);
+}
+
 /// Poll /agents/{name} until it reports a settled HTTP-up status. A brand-new empty agent boots into
 /// "unprovisioned" (no provider chosen) until provisioned; a re-auth case reports "not_authenticated".
 export async function waitUntilRunning(
@@ -197,27 +208,14 @@ export async function waitUntilRunning(
   timeoutMs: number,
   pollIntervalMs = 500,
 ): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const resp = await apiJson<{ status: string }>(
-      `/agents/${encodeURIComponent(name)}`,
-    );
-    if (
-      resp.status === "alive" ||
-      resp.status === "not_authenticated" ||
-      resp.status === "unprovisioned"
-    )
-      return;
-    if (
-      resp.status === "dead" ||
-      resp.status === "stopped" ||
-      resp.status === "not_found"
-    ) {
-      throw new Error(`${name}: ${resp.status}`);
-    }
-    await new Promise((r) => setTimeout(r, pollIntervalMs));
-  }
-  throw new Error(`${name}: timed out waiting for HTTP server`);
+  await waitForStatus(
+    name,
+    timeoutMs,
+    pollIntervalMs,
+    ["alive", "not_authenticated", "unprovisioned"],
+    ["dead", "stopped", "not_found"],
+    "timed out waiting for HTTP server",
+  );
 }
 
 export async function waitUntilAlive(
@@ -225,24 +223,14 @@ export async function waitUntilAlive(
   timeoutMs: number,
   pollIntervalMs = 500,
 ): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const resp = await apiJson<{ status: string }>(
-      `/agents/${encodeURIComponent(name)}`,
-    );
-    if (resp.status === "alive") return;
-    if (
-      resp.status === "dead" ||
-      resp.status === "stopped" ||
-      resp.status === "not_found" ||
-      resp.status === "not_authenticated" ||
-      resp.status === "unprovisioned"
-    ) {
-      throw new Error(`${name}: ${resp.status}`);
-    }
-    await new Promise((r) => setTimeout(r, pollIntervalMs));
-  }
-  throw new Error(`${name}: timed out waiting to become alive`);
+  await waitForStatus(
+    name,
+    timeoutMs,
+    pollIntervalMs,
+    ["alive"],
+    ["dead", "stopped", "not_found", "not_authenticated", "unprovisioned"],
+    "timed out waiting to become alive",
+  );
 }
 
 export async function startAgent(name: string): Promise<void> {
@@ -373,11 +361,10 @@ export async function setNotificationInterruptRules(
   name: string,
   rules: NotificationInterruptRule[],
 ): Promise<NotificationInterruptRule[]> {
-  await apiFetch(`/agents/${encodeURIComponent(name)}/config`, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ notification_rules: rules }),
-  });
+  await apiFetch(
+    `/agents/${encodeURIComponent(name)}/config`,
+    jsonInit("PUT", { notification_rules: rules }),
+  );
   return rules;
 }
 
@@ -397,11 +384,10 @@ export async function setPreemptMode(
   name: string,
   mode: PreemptMode,
 ): Promise<void> {
-  await apiFetch(`/agents/${encodeURIComponent(name)}/config`, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ preempt_mode: mode }),
-  });
+  await apiFetch(
+    `/agents/${encodeURIComponent(name)}/config`,
+    jsonInit("PUT", { preempt_mode: mode }),
+  );
 }
 
 /// One page of received notifications, newest first (GET /history?channel=notifications). Pass the

--- a/apps/web/src/components/AgentMenu/AgentActions.tsx
+++ b/apps/web/src/components/AgentMenu/AgentActions.tsx
@@ -15,7 +15,6 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { MenuSection } from "@/components/ui/menu-section";
-import type { MenuState } from "./types";
 
 export interface AgentActionsInput {
   isRunning: boolean;
@@ -34,26 +33,6 @@ export interface AgentActionsInput {
   onAgentSettings?: () => void;
   onDelete?: () => void;
   onDebugInfo?: () => void;
-}
-
-// The subset of MenuState the menus expose. Both the desktop dropdown and mobile drawer
-// deliberately drop delete/authenticate (those live elsewhere), so the projection lives
-// here once instead of being respelled in each menu.
-export function menuActionsInput(state: MenuState): AgentActionsInput {
-  return {
-    isRunning: state.isRunning,
-    showAliveActions: state.showAliveActions,
-    isBusy: state.isBusy,
-    showToolCalls: state.showToolCalls,
-    onLogs: state.onLogs,
-    onToolCalls: state.onToolCalls,
-    onToggle: state.onToggle,
-    onRestart: state.onRestart,
-    onRebuild: state.onRebuild,
-    onBackup: state.onBackup,
-    onOpenSettings: state.onOpenSettings,
-    onDebugInfo: state.onDebugInfo,
-  };
 }
 
 export interface ActionItem {

--- a/apps/web/src/components/AgentSettings/FilesTab/index.tsx
+++ b/apps/web/src/components/AgentSettings/FilesTab/index.tsx
@@ -231,9 +231,19 @@ export function FilesTab() {
       return;
     }
     setTreeError(null);
+    let cancelled = false;
     fetchFileTree(agentName)
-      .then(setEntries)
-      .catch((e: Error) => setTreeError(e.message));
+      .then((entries) => {
+        if (cancelled) return;
+        setEntries(entries);
+      })
+      .catch((e: Error) => {
+        if (cancelled) return;
+        setTreeError(e.message);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [agentName, isAlive]);
 
   useEffect(() => {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -105,3 +105,9 @@ export interface GatewayVersionInfo {
   channel?: ReleaseChannel;
   auto_update?: boolean;
 }
+
+// The gateway control WS's own frames (distinct from the per-agent VestaEvent stream): a version
+// handshake on connect, then agent-list snapshots on every roster change.
+export type ControlWsMessage =
+  | { type: "hello"; version?: string; port?: number }
+  | { type: "agents"; agents?: AgentInfo[] };

--- a/apps/web/src/lib/voice.ts
+++ b/apps/web/src/lib/voice.ts
@@ -366,6 +366,7 @@ export class Transcriber {
       if (this.active) {
         this.active = false;
         this.opts.onError("Transcription connection closed unexpectedly");
+        this.cleanup();
       }
     };
 

--- a/apps/web/src/providers/GatewayProvider/index.tsx
+++ b/apps/web/src/providers/GatewayProvider/index.tsx
@@ -17,6 +17,7 @@ import { VersionMismatchScreen } from "@/components/VersionMismatchScreen";
 import { DisconnectedOverlay } from "@/components/DisconnectedOverlay";
 import type {
   AgentInfo,
+  ControlWsMessage,
   GatewayVersionInfo,
   ReleaseChannel,
 } from "@/lib/types";
@@ -158,7 +159,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
       onOpen: () => setReachable(true),
       onMessage: (data) => {
         try {
-          const msg = JSON.parse(data);
+          const msg = JSON.parse(data) as ControlWsMessage;
           switch (msg.type) {
             case "hello": {
               setGatewayVersion(msg.version ?? "");
@@ -167,7 +168,7 @@ function ConnectedGateway({ children }: { children: ReactNode }) {
               break;
             }
             case "agents": {
-              const agents: AgentInfo[] = msg.agents ?? [];
+              const agents = msg.agents ?? [];
               setAgents(agents);
               setAgentsFetched(true);
               // Clear any "restart to apply" flag whose agent has since restarted (by any path).


### PR DESCRIPTION
## What
Six surgical cleanups in the web IO boundary:

- Delete `menuActionsInput` (AgentActions.tsx), an unused MenuState projection that doesn't typecheck: it reads `state.onOpenSettings`, a field that exists on neither `MenuState` nor `AgentActionsInput`. DesktopMenu and MobileMenu build their own projections inline (mobile's differs by conditionally forwarding onAuthenticate/isAuthenticated), so there was no real dedup to preserve.
- Release the microphone and AudioContext when the transcription socket closes unexpectedly (voice.ts). Previously only `onerror` called `stop()`; an unexpected `onclose` (server or proxy closing the connection) flipped `active` false without releasing hardware, leaving the mic indicator stuck on until a page reload.
- Guard the FilesTab file tree fetch against stale responses (FilesTab/index.tsx), mirroring the sibling `readFile` effect's cancellation flag. Two quick agent switches could otherwise resolve out of order and pin the wrong agent's file list.
- Type the GatewayProvider control WS frame as a discriminated union (`ControlWsMessage` in lib/types.ts) instead of an implicit any from `JSON.parse`, matching the pattern already used for the per-agent event socket.
- Route every hand-spelled JSON request body in api/agents.ts through the existing `jsonInit` helper so the request envelope (headers + JSON.stringify) has one owner, matching the sibling `setAgentMounts` call.
- Collapse `waitUntilRunning`/`waitUntilAlive` onto one shared `waitForStatus` polling loop; the two functions differed only in which agent statuses count as ready versus failed.

## Why
Each of these is a concrete correctness or one-owner violation caught by reading the code against the repo's IO-boundary and typing rules, not a style preference: dead/broken code, a resource leak, a race on stale async responses, an untyped WS frame, and a duplicated request-envelope/polling pattern.

## Test plan
- [x] `./check.sh web` passes (eslint, prettier --check, tsc, vitest: 146 tests, 23 files)
- [x] No behavior change to exported signatures; `waitUntilRunning`/`waitUntilAlive` keep their existing call sites untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)