### PR TITLE
feat(promote): flip older stranded prereleases to stable on every promotion

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -2,9 +2,9 @@ name: Promote
 
 # Promote a beta (prerelease) to stable. Every ./release.sh ships a prerelease that
 # only opted-in beta clients follow; this workflow does the stable half once the beta
-# has soaked: move the agent image :latest tag, flip the GitHub release to latest, and
-# advance the production branch. No rebuild happens here, the exact artifacts that beta
-# users tested become stable.
+# has soaked: flip every older stranded prerelease to stable, move the agent image
+# :latest tag, flip the GitHub release to latest, and advance the production branch.
+# No rebuild happens here, the exact artifacts that beta users tested become stable.
 
 on:
   workflow_dispatch:
@@ -42,6 +42,24 @@ jobs:
             exit 1
           fi
           echo "✓ $TAG is a prerelease, promoting to stable"
+
+      # Stable history has no gaps: every prerelease older than the promoted tag flips
+      # to stable too (ascending, --latest=false so none steals the latest pointer).
+      # :latest and production only ever track the promoted tag itself.
+      - name: Promote older stranded prereleases
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          gh release list --repo "$GITHUB_REPOSITORY" --limit 200 --json tagName,isPrerelease \
+            --jq '.[] | select(.isPrerelease) | .tagName' | sort -V |
+            while read -r OLDER_TAG; do
+              NEWEST=$(printf '%s\n%s\n' "$OLDER_TAG" "$TAG" | sort -V | tail -n1)
+              if [ "$OLDER_TAG" != "$TAG" ] && [ "$NEWEST" = "$TAG" ]; then
+                gh release edit "$OLDER_TAG" --repo "$GITHUB_REPOSITORY" --prerelease=false --latest=false
+                echo "✓ $OLDER_TAG flipped to stable"
+              fi
+            done
 
       # Full history: the production push is a force-push of the tag's commit, and a
       # shallow checkout can be rejected with "shallow update not allowed".

--- a/promote.sh
+++ b/promote.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 # Promote a beta (prerelease) to stable for everyone. Run after ./release.sh has
-# shipped a beta and it has soaked. Moves the agent image :latest tag, flips the
-# GitHub release to latest, and advances production. No rebuild happens.
+# shipped a beta and it has soaked. Flips every older stranded prerelease to stable,
+# moves the agent image :latest tag, flips the GitHub release to latest, and
+# advances production. No rebuild happens.
 
 TAG="${1:-}"
 


### PR DESCRIPTION
Promoting vX.Y.Z now also flips every prerelease older than it to stable, so promoted history has no gaps.

## What changed

promote.yml gets one step after tag validation: list all prereleases, keep those semver-older than the promoted tag (sort -V), and \`gh release edit --prerelease=false --latest=false\` each in ascending order. \`--latest=false\` guarantees none of them steals the latest pointer; the image \`:latest\` tag, the GitHub latest alias, and the production branch still track only the promoted tag itself. Prereleases newer than the promoted tag stay untouched (still soaking).

## Why

Skipping a beta during promotion left it stranded as a prerelease forever (12 had accumulated below the current stable). Stable clients follow the releases/latest alias, so flipping older releases is purely a history cleanup and safe.

## Verification

Loop logic simulated locally against the edge cases: mixed older+newer prereleases (only older flipped, ascending), target as the only prerelease (clean no-op exit, the case a naive \`grep -vx\` pipeline would fail under pipefail), and 2- vs 3-digit patch versions (sort -V orders correctly). Workflow YAML parses. The equivalent manual pass was just run against the real repo (12 releases flipped, latest pointer unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)