### PR TITLE
feat(release): require whats-new message, add unrelease, cascade promote

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,7 +4,9 @@ name: Promote
 # only opted-in beta clients follow; this workflow does the stable half once the beta
 # has soaked: move the agent image :latest tag, flip the GitHub release to latest, and
 # advance the production branch. No rebuild happens here, the exact artifacts that beta
-# users tested become stable.
+# users tested become stable. Promotion also cascades: every non-draft prerelease older
+# than the target is flipped to stable too (never marked latest), so no beta is ever
+# left behind below the new stable.
 
 on:
   workflow_dispatch:
@@ -42,6 +44,33 @@ jobs:
             exit 1
           fi
           echo "✓ $TAG is a prerelease, promoting to stable"
+
+      # Cascade: flip every non-draft prerelease older than the target to stable,
+      # oldest first, so no beta lingers as a prerelease below the new stable. Only
+      # the target (below) gets --latest, the :latest image move, and the production
+      # push; cascaded releases are explicitly not marked latest.
+      - name: Promote older prereleases
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          RELEASE_LIST_LIMIT=100
+          TARGET_VERSION="${TAG#v}"
+          PRERELEASE_TAGS=$(gh release list --repo "$GITHUB_REPOSITORY" --limit "$RELEASE_LIST_LIMIT" \
+            --json tagName,isPrerelease,isDraft \
+            --jq '.[] | select(.isPrerelease and (.isDraft | not)) | .tagName')
+          for OLDER_TAG in $(printf '%s\n' "$PRERELEASE_TAGS" | sort -V); do
+            OLDER_VERSION="${OLDER_TAG#v}"
+            if [ "$OLDER_VERSION" = "$TARGET_VERSION" ]; then
+              continue
+            fi
+            NEWEST=$(printf '%s\n%s\n' "$OLDER_VERSION" "$TARGET_VERSION" | sort -V | tail -n 1)
+            if [ "$NEWEST" != "$TARGET_VERSION" ]; then
+              continue
+            fi
+            echo "Cascading: flipping older beta $OLDER_TAG to stable"
+            gh release edit "$OLDER_TAG" --repo "$GITHUB_REPOSITORY" --prerelease=false --latest=false
+          done
 
       # Full history: the production push is a force-push of the tag's commit, and a
       # shallow checkout can be rejected with "shallow update not allowed".

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
           - patch
           - minor
           - major
+      message:
+        description: 'User-facing "What''s new" summary shown in the app and on the changelog'
+        type: string
+        required: true
 
 permissions:
   contents: write
@@ -98,12 +102,19 @@ jobs:
           git commit -m "Bump version to ${NEW}"
           git push origin master
 
+      # With both --notes and --generate-notes, gh prepends the provided notes above
+      # the auto-generated ones, so the marked whats-new block stays extractable at
+      # the top of the release body (the app and landing page parse it).
       - name: Create GitHub prerelease
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           TAG: ${{ steps.bump.outputs.tag }}
+          MESSAGE: ${{ inputs.message }}
         run: |
-          gh release create "$TAG" --title "$TAG" --generate-notes --target master --prerelease
+          BODY="<!-- whats-new -->
+          ${MESSAGE}
+          <!-- /whats-new -->"
+          gh release create "$TAG" --title "$TAG" --notes "$BODY" --generate-notes --target master --prerelease
           echo "Created prerelease $TAG"
 
       - name: Cleanup on failure

--- a/.github/workflows/unrelease.yml
+++ b/.github/workflows/unrelease.yml
@@ -1,0 +1,76 @@
+name: Unrelease
+
+# Pull a broken beta (prerelease) so no new client picks it up: delete the GitHub
+# release, its git tag, and the ghcr image tag. Refuses to touch a stable release,
+# a promoted release must never be unreleased. The version-bump commit on master
+# stays; the version number is burned. Boxes already on the beta stay on it
+# (updates are forward-only), so ship a fixed release right after.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Prerelease tag to pull (e.g. v0.1.156)"
+        type: string
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: unrelease
+  cancel-in-progress: false
+
+jobs:
+  unrelease:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Validate tag is an existing prerelease
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          case "$TAG" in
+            v*) ;;
+            *) echo "::error::tag must look like vX.Y.Z (got '$TAG')"; exit 1 ;;
+          esac
+          if ! IS_PRERELEASE=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease'); then
+            echo "::error::release $TAG does not exist"
+            exit 1
+          fi
+          if [ "$IS_PRERELEASE" != "true" ]; then
+            echo "::error::$TAG is stable; a promoted release must never be unreleased"
+            exit 1
+          fi
+          echo "✓ $TAG is a prerelease, pulling it"
+
+      # Best effort: an orphaned image is harmless, so a failure here only warns.
+      - name: Delete ghcr image tag
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set +e
+          PACKAGE_NAME="${GITHUB_REPOSITORY#*/}"
+          VERSION_ID=$(gh api "users/${GITHUB_REPOSITORY_OWNER}/packages/container/${PACKAGE_NAME}/versions" \
+            --paginate --jq ".[] | select(.metadata.container.tags | index(\"${TAG}\")) | .id" | head -n 1)
+          if [ -z "$VERSION_ID" ]; then
+            echo "::warning::no ghcr image version tagged ${TAG} found, skipping image cleanup"
+            exit 0
+          fi
+          if gh api --method DELETE "users/${GITHUB_REPOSITORY_OWNER}/packages/container/${PACKAGE_NAME}/versions/${VERSION_ID}"; then
+            echo "✓ deleted ghcr.io/${GITHUB_REPOSITORY}:${TAG} (package version ${VERSION_ID})"
+          else
+            echo "::warning::failed to delete ghcr image version ${VERSION_ID}; an orphaned image is harmless"
+          fi
+          exit 0
+
+      - name: Delete release and git tag
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag
+          echo "✓ deleted release and tag $TAG"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,10 +155,12 @@ On iOS, install the resulting .ipa to a paired device without the Xcode GUI: `xc
 ### Releasing
 
 ```bash
-./release.sh         # Patch release (0.1.0 -> 0.1.1)
-./release.sh minor   # Minor release (0.1.0 -> 0.2.0)
-./release.sh major   # Major release (0.1.0 -> 1.0.0)
+./release.sh "<message>"         # Patch release (0.1.0 -> 0.1.1)
+./release.sh minor "<message>"   # Minor release (0.1.0 -> 0.2.0)
+./release.sh major "<message>"   # Major release (0.1.0 -> 1.0.0)
 ```
+
+The message is required: user-facing "What's new" marketing copy embedded in the release body (the app and changelog parse it). Pull a broken beta with `./unrelease.sh vX.Y.Z`; promote a soaked one with `./promote.sh vX.Y.Z`.
 
 Run locally on master. Bumps versions, updates lockfiles, commits, pushes, and creates the GitHub release. CI then builds artifacts and publishes. Do NOT bump versions in PRs: `release.sh` handles version bumps at release time.
 

--- a/promote.sh
+++ b/promote.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 # Promote a beta (prerelease) to stable for everyone. Run after ./release.sh has
 # shipped a beta and it has soaked. Moves the agent image :latest tag, flips the
-# GitHub release to latest, and advances production. No rebuild happens.
+# GitHub release to latest, and advances production. No rebuild happens. Older
+# betas cascade: every prerelease older than the target is flipped to stable too,
+# so no beta is left behind.
 
 TAG="${1:-}"
 

--- a/release.sh
+++ b/release.sh
@@ -5,12 +5,19 @@ usage() {
   cat <<'EOF'
 Usage: ./release.sh [patch|minor|major] "<message>"
 
-The message is required: user-facing marketing copy for the changelog
-("What's new"), shown to users in the app and on the changelog.
+The message is required: user-facing "What's new" copy shown in the app and on
+the changelog. Style:
+
+  * Two or three short sentences in plain user language.
+  * Name the headline features with a little texture; drop minor items.
+  * Describe only what actually changed: a fix or backend improvement reads as
+    "more reliable" or "now works with X", never as a brand-new capability.
+  * Refer to the agent as Vesta or they/them, never it. No dashes as separators.
+  * Internal-only release: an honest one-liner like "Small fixes under the hood."
 
 Examples:
-  ./release.sh "Faster startup and smoother chat scrolling."
-  ./release.sh minor "Vesta can now manage your calendar."
+  ./release.sh "Vesta can now shop online, and hand you their browser when a site needs your login."
+  ./release.sh minor "Any email account now works: full IMAP support with instant new-mail push."
 EOF
   exit 1
 }

--- a/release.sh
+++ b/release.sh
@@ -1,15 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BUMP="${1:-patch}"
+usage() {
+  cat <<'EOF'
+Usage: ./release.sh [patch|minor|major] "<message>"
 
-case "$BUMP" in
-  patch|minor|major) ;;
-  *) echo "Usage: ./release.sh [patch|minor|major]"; exit 1 ;;
+The message is required: user-facing marketing copy for the changelog
+("What's new"), shown to users in the app and on the changelog.
+
+Examples:
+  ./release.sh "Faster startup and smoother chat scrolling."
+  ./release.sh minor "Vesta can now manage your calendar."
+EOF
+  exit 1
+}
+
+BUMP="patch"
+case "${1:-}" in
+  patch|minor|major) BUMP="$1"; MESSAGE="${2:-}" ;;
+  *) MESSAGE="${1:-}" ;;
 esac
 
+[ -n "$MESSAGE" ] || usage
+
 echo "Triggering Release workflow (bump=${BUMP})..."
-gh workflow run release.yml -f bump="$BUMP"
+gh workflow run release.yml -f bump="$BUMP" -f message="$MESSAGE"
 
 sleep 3
 RUN_ID=$(gh run list --workflow=release.yml --limit=1 --json databaseId --jq '.[0].databaseId')
@@ -22,5 +37,9 @@ This ships a BETA (prerelease). Only opted-in beta clients receive it; stable us
 are unaffected. Once it has soaked and you are happy, promote it to everyone with:
 
   ./promote.sh vX.Y.Z
+
+If the beta turns out broken, pull it with:
+
+  ./unrelease.sh vX.Y.Z
 
 EOF

--- a/unrelease.sh
+++ b/unrelease.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pull a broken beta (prerelease). Deletes the GitHub release, its git tag, and the
+# ghcr image tag; refuses to touch a promoted (stable) release. The version-bump
+# commit on master stays, the version number is burned.
+
+TAG="${1:-}"
+
+case "$TAG" in
+  v*) ;;
+  *) echo "Usage: ./unrelease.sh vX.Y.Z"; exit 1 ;;
+esac
+
+echo "Triggering Unrelease workflow (tag=${TAG})..."
+gh workflow run unrelease.yml -f tag="$TAG"
+
+sleep 3
+RUN_ID=$(gh run list --workflow=unrelease.yml --limit=1 --json databaseId --jq '.[0].databaseId')
+echo "Watching run ${RUN_ID}..."
+gh run watch "$RUN_ID" --exit-status
+
+cat <<'EOF'
+
+Pulled. Boxes already on this beta stay on it (updates are forward-only), so ship a
+fixed release right after:
+
+  ./release.sh "<message>"
+
+EOF


### PR DESCRIPTION
Release pipeline upgrades: every release now carries user-facing marketing copy, a broken beta can be pulled, and promotion never strands an older beta.

## 1. Releases require a "What's new" message

`./release.sh [patch|minor|major] "<message>"`: the message is required marketing copy for the changelog. If the first argument is not a bump type, the bump defaults to patch and the first argument is the message. A missing message prints usage and exits 1.

`release.yml` gains a required `message` dispatch input (passed through `env:`, never interpolated into the run script) and embeds it in the release body inside a marked, extractable block ABOVE the auto-generated notes:

```
<!-- whats-new -->
<message>
<!-- /whats-new -->
```

This block is the contract the app and landing page parse to show "What's new" to users. Ordering is guaranteed by `gh release create --notes "$BODY" --generate-notes`, which per gh's documented behavior prepends the provided notes before the generated ones.

## 2. Unrelease: pull a broken beta

New `./unrelease.sh vX.Y.Z` + `.github/workflows/unrelease.yml` (mirrors promote's shape):

- Refuses unless the tag is an existing prerelease (`gh release view --json isPrerelease`); a promoted release must never be unreleased.
- Best-effort deletes the `ghcr.io/elyxlz/vesta:vX.Y.Z` image via the packages API; failure only emits a `::warning::` (an orphaned image is harmless).
- `gh release delete --yes --cleanup-tag` removes the release and the git tag. The version-bump commit on master stays; the version number is burned.

Boxes already on the pulled beta stay on it (updates are forward-only), so the script tells you to ship a fixed release right after.

## 3. Promote cascades to older betas

`promote.yml` now flips every non-draft prerelease OLDER than the target (numeric semver compare, oldest first) to stable with `--prerelease=false --latest=false` before the existing steps run. Only the target gets `--latest`, the `:latest` image move, and the production branch push. No beta is ever left behind below the new stable.

Also updates the stale `./release.sh` usage in CLAUDE.md's Releasing section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
