### PR TITLE
feat(web): whats-new dialog fed by release notes

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,7 @@ import { AuthProvider, useAuth } from "@/providers/AuthProvider";
 import { GatewayProvider, useGateway } from "@/providers/GatewayProvider";
 import { NotificationProvider } from "@/providers/NotificationProvider";
 import { InsetFrame } from "@/components/InsetFrame";
+import { WhatsNewDialog } from "@/components/WhatsNew";
 import { isTauri } from "@/lib/env";
 import { cn } from "@/lib/utils";
 import { router } from "@/router";
@@ -34,6 +35,7 @@ function AppContent() {
           transition={{ duration: 0.3 }}
         >
           <RouterProvider router={router} />
+          <WhatsNewDialog />
         </motion.div>
       )}
     </AnimatePresence>

--- a/apps/web/src/components/WhatsNew/index.tsx
+++ b/apps/web/src/components/WhatsNew/index.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState } from "react";
+import { Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { useGateway } from "@/providers/GatewayProvider";
+import { useWhatsNew } from "@/stores/use-whats-new";
+import { filterReleaseNotes, fetchReleaseNotes } from "@/lib/whats-new";
+import type { ReleaseNote } from "@/lib/whats-new";
+import { useWhatsNewAutoOpen } from "./use-whats-new-auto-open";
+
+function formatReleaseDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function WhatsNewButton() {
+  const { reachable } = useGateway();
+  const setOpen = useWhatsNew((s) => s.setOpen);
+
+  if (!reachable) return null;
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="xs"
+      onClick={() => setOpen(true)}
+      className="text-muted-foreground"
+    >
+      <Sparkles data-icon="inline-start" className="size-3.5" />
+      What's new
+    </Button>
+  );
+}
+
+// Mounted once at the app root so the post-update auto-open works on any page;
+// the settings navbar button opens the same instance via the store.
+export function WhatsNewDialog() {
+  const { gatewayVersion, gatewayChannel } = useGateway();
+  const open = useWhatsNew((s) => s.open);
+  const setOpen = useWhatsNew((s) => s.setOpen);
+  const [notes, setNotes] = useState<ReleaseNote[] | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  const handleAutoOpen = useCallback(
+    (visible: ReleaseNote[]) => {
+      setNotes(visible);
+      setOpen(true);
+    },
+    [setOpen],
+  );
+  useWhatsNewAutoOpen(handleAutoOpen);
+
+  useEffect(() => {
+    if (!open || notes !== null) return;
+    let cancelled = false;
+    void fetchReleaseNotes().then((fetched) => {
+      if (cancelled) return;
+      setFailed(fetched === null);
+      if (fetched === null) return;
+      setNotes(
+        filterReleaseNotes(fetched, {
+          version: gatewayVersion,
+          channel: gatewayChannel,
+        }),
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, notes, gatewayVersion, gatewayChannel]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-h-[70vh] gap-5 overflow-y-auto sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>What's new</DialogTitle>
+          <DialogDescription className="sr-only">
+            Recent Vesta release notes
+          </DialogDescription>
+        </DialogHeader>
+        {failed ? (
+          <p className="text-sm text-muted-foreground">
+            Couldn't load release notes
+          </p>
+        ) : notes === null ? (
+          <Spinner className="mx-auto my-2" />
+        ) : notes.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Nothing to show yet, check back after the next update.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {notes.map((entry) => (
+              <div key={entry.version} className="flex flex-col gap-1">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-sm font-semibold">
+                    v{entry.version}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {formatReleaseDate(entry.date)}
+                  </span>
+                </div>
+                <p className="text-sm whitespace-pre-line text-muted-foreground">
+                  {entry.message}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/WhatsNew/use-whats-new-auto-open.ts
+++ b/apps/web/src/components/WhatsNew/use-whats-new-auto-open.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from "react";
+import { useGateway } from "@/providers/GatewayProvider";
+import { compareVersions } from "@/lib/version";
+import {
+  fetchReleaseNotes,
+  filterReleaseNotes,
+  type ReleaseNote,
+} from "@/lib/whats-new";
+
+const LAST_SEEN_VERSION_KEY = "vesta:whats-new-last-seen";
+
+/**
+ * Open the dialog once after a vestad update: when the connected version
+ * differs from the last one this browser saw and that version has a visible
+ * release note. A fresh install just records the current version silently.
+ * Checks at most once per app load; the fetched notes are handed to the
+ * caller so opening does not refetch.
+ */
+export function useWhatsNewAutoOpen(
+  onAutoOpen: (notes: ReleaseNote[]) => void,
+) {
+  const { reachable, gatewayVersion, gatewayChannel } = useGateway();
+  const checkedRef = useRef(false);
+
+  useEffect(() => {
+    if (checkedRef.current || !reachable || !gatewayVersion) return;
+    checkedRef.current = true;
+
+    const lastSeen = localStorage.getItem(LAST_SEEN_VERSION_KEY);
+    if (lastSeen === null) {
+      localStorage.setItem(LAST_SEEN_VERSION_KEY, gatewayVersion);
+      return;
+    }
+    if (lastSeen === gatewayVersion) return;
+
+    let cancelled = false;
+    void fetchReleaseNotes().then((fetched) => {
+      if (cancelled || fetched === null) return;
+      const visible = filterReleaseNotes(fetched, {
+        version: gatewayVersion,
+        channel: gatewayChannel,
+      });
+      const hasCurrent = visible.some(
+        (entry) => compareVersions(entry.version, gatewayVersion) === 0,
+      );
+      if (!hasCurrent) return;
+      localStorage.setItem(LAST_SEEN_VERSION_KEY, gatewayVersion);
+      onAutoOpen(visible);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [reachable, gatewayVersion, gatewayChannel, onAutoOpen]);
+}

--- a/apps/web/src/lib/whats-new.test.ts
+++ b/apps/web/src/lib/whats-new.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractWhatsNew,
+  parseReleaseNotes,
+  filterReleaseNotes,
+  type ReleaseNote,
+} from "@/lib/whats-new";
+
+function release(
+  tag: string,
+  overrides: Partial<{
+    published_at: string;
+    prerelease: boolean;
+    body: string;
+  }> = {},
+) {
+  return {
+    tag_name: tag,
+    published_at: "2026-07-01T00:00:00Z",
+    prerelease: false,
+    body: "<!-- whats-new -->Something shipped.<!-- /whats-new -->",
+    ...overrides,
+  };
+}
+
+function note(version: string, prerelease = false): ReleaseNote {
+  return {
+    version,
+    date: "2026-07-01T00:00:00Z",
+    prerelease,
+    message: "Something shipped.",
+  };
+}
+
+describe("extractWhatsNew", () => {
+  it("extracts the trimmed copy between the markers", () => {
+    expect(
+      extractWhatsNew(
+        "release blurb\n<!-- whats-new -->\nVesta now naps.\n<!-- /whats-new -->\nchangelog",
+      ),
+    ).toBe("Vesta now naps.");
+  });
+
+  it("returns null when no markers are present", () => {
+    expect(extractWhatsNew("plain old release body")).toBeNull();
+  });
+
+  it("returns null when the closing marker is missing", () => {
+    expect(extractWhatsNew("<!-- whats-new -->half a block")).toBeNull();
+  });
+
+  it("returns null when the block is empty", () => {
+    expect(
+      extractWhatsNew("<!-- whats-new -->  \n<!-- /whats-new -->"),
+    ).toBeNull();
+  });
+});
+
+describe("parseReleaseNotes", () => {
+  it("parses releases and strips the leading v from tags", () => {
+    expect(parseReleaseNotes([release("v0.3.1")])).toEqual([note("0.3.1")]);
+  });
+
+  it("skips releases without a well-formed block", () => {
+    expect(
+      parseReleaseNotes([
+        release("v0.3.2", { body: "no markers here" }),
+        release("v0.3.1"),
+        release("v0.3.0", { body: "<!-- whats-new -->dangling" }),
+      ]),
+    ).toEqual([note("0.3.1")]);
+  });
+
+  it("skips entries missing the expected fields", () => {
+    expect(
+      parseReleaseNotes([{ tag_name: "v0.3.1" }, "junk", null, 42]),
+    ).toEqual([]);
+  });
+
+  it("returns empty for non-array JSON", () => {
+    expect(parseReleaseNotes({ message: "rate limited" })).toEqual([]);
+    expect(parseReleaseNotes(null)).toEqual([]);
+  });
+
+  it("sorts newest version first, comparing numerically", () => {
+    const parsed = parseReleaseNotes([
+      release("v0.1.9"),
+      release("v0.1.154"),
+      release("v0.1.20"),
+    ]);
+    expect(parsed.map((entry) => entry.version)).toEqual([
+      "0.1.154",
+      "0.1.20",
+      "0.1.9",
+    ]);
+  });
+});
+
+describe("filterReleaseNotes", () => {
+  it("keeps only versions at or below the connected vestad", () => {
+    const notes = [note("0.4.0"), note("0.3.1"), note("0.3.0")];
+    expect(
+      filterReleaseNotes(notes, { version: "0.3.1", channel: "stable" }),
+    ).toEqual([note("0.3.1"), note("0.3.0")]);
+  });
+
+  it("compares versions numerically, not lexicographically", () => {
+    expect(
+      filterReleaseNotes([note("0.1.154")], {
+        version: "0.1.20",
+        channel: "stable",
+      }),
+    ).toEqual([]);
+  });
+
+  it("hides prereleases on the stable channel", () => {
+    const notes = [note("0.3.2", true), note("0.3.1")];
+    expect(
+      filterReleaseNotes(notes, { version: "0.3.2", channel: "stable" }),
+    ).toEqual([note("0.3.1")]);
+  });
+
+  it("shows prereleases on the beta channel", () => {
+    const notes = [note("0.3.2", true), note("0.3.1")];
+    expect(
+      filterReleaseNotes(notes, { version: "0.3.2", channel: "beta" }),
+    ).toEqual([note("0.3.2", true), note("0.3.1")]);
+  });
+});

--- a/apps/web/src/lib/whats-new.ts
+++ b/apps/web/src/lib/whats-new.ts
@@ -1,0 +1,98 @@
+import { compareVersions } from "@/lib/version";
+import type { ReleaseChannel } from "@/lib/types";
+
+// Marketing summaries live in each GitHub release body between these markers
+// (written by the release pipeline); releases without a well-formed block are
+// old and carry no user-facing copy, so they are skipped.
+const WHATS_NEW_BLOCK_RE =
+  /<!--\s*whats-new\s*-->([\s\S]*?)<!--\s*\/whats-new\s*-->/;
+
+const RELEASES_URL =
+  "https://api.github.com/repos/elyxlz/vesta/releases?per_page=20";
+
+const RELEASES_FETCH_TIMEOUT_MS = 10000;
+
+export interface ReleaseNote {
+  version: string;
+  date: string;
+  prerelease: boolean;
+  message: string;
+}
+
+interface GithubRelease {
+  tag_name: string;
+  published_at: string;
+  prerelease: boolean;
+  body: string;
+}
+
+function isGithubRelease(value: unknown): value is GithubRelease {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "tag_name" in value &&
+    typeof value.tag_name === "string" &&
+    "published_at" in value &&
+    typeof value.published_at === "string" &&
+    "prerelease" in value &&
+    typeof value.prerelease === "boolean" &&
+    "body" in value &&
+    typeof value.body === "string"
+  );
+}
+
+export function extractWhatsNew(body: string): string | null {
+  const match = WHATS_NEW_BLOCK_RE.exec(body);
+  if (!match) return null;
+  const message = match[1].trim();
+  return message.length > 0 ? message : null;
+}
+
+/** Parse a GitHub release-list response into notes, newest version first. */
+export function parseReleaseNotes(json: unknown): ReleaseNote[] {
+  if (!Array.isArray(json)) return [];
+  const releases: unknown[] = json;
+  const notes: ReleaseNote[] = [];
+  for (const release of releases) {
+    if (!isGithubRelease(release)) continue;
+    const message = extractWhatsNew(release.body);
+    if (message === null) continue;
+    notes.push({
+      version: release.tag_name.replace(/^v/, ""),
+      date: release.published_at,
+      prerelease: release.prerelease,
+      message,
+    });
+  }
+  return notes.sort((a, b) => compareVersions(b.version, a.version));
+}
+
+/**
+ * Keep only notes the connected vestad has actually shipped: versions at or
+ * below the running one, with prereleases visible only on the beta channel.
+ */
+export function filterReleaseNotes(
+  notes: ReleaseNote[],
+  connected: { version: string; channel: ReleaseChannel },
+): ReleaseNote[] {
+  return notes.filter(
+    (note) =>
+      compareVersions(note.version, connected.version) <= 0 &&
+      (connected.channel === "beta" || !note.prerelease),
+  );
+}
+
+/** Fetch and parse the release list; null on any network or HTTP failure. */
+export async function fetchReleaseNotes(): Promise<ReleaseNote[] | null> {
+  try {
+    const response = await fetch(RELEASES_URL, {
+      headers: { Accept: "application/vnd.github+json" },
+      signal: AbortSignal.timeout(RELEASES_FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    const json: unknown = await response.json();
+    return parseReleaseNotes(json);
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/pages/AppSettings/index.tsx
+++ b/apps/web/src/pages/AppSettings/index.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { Home } from "lucide-react";
 import { AppSettings } from "@/components/Settings";
 import { CheckForUpdates } from "@/components/CheckForUpdates";
+import { WhatsNewButton } from "@/components/WhatsNew";
 import { LogoText } from "@/components/Logo/LogoText";
 import { Navbar } from "@/components/Navbar";
 import { SettingsScrollArea } from "@/components/SettingsScrollArea";
@@ -30,6 +31,7 @@ export function AppSettingsPage() {
         trailing={
           <div className="flex items-center gap-2">
             <StatusPill showHostname={false} />
+            <WhatsNewButton />
             <CheckForUpdates />
           </div>
         }

--- a/apps/web/src/stores/use-whats-new.ts
+++ b/apps/web/src/stores/use-whats-new.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+
+// Open state for the What's new dialog. A store (not lifted state) because the
+// dialog mounts once at the app root (so the post-update auto-open works on any
+// page) while the trigger button lives in the settings navbar.
+interface WhatsNewState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+export const useWhatsNew = create<WhatsNewState>((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+}));


### PR DESCRIPTION
## What

Adds the app-side "What's new" surface: a dialog listing the marketing summary of each shipped release, fed directly from the public GitHub releases API.

- **`apps/web/src/lib/whats-new.ts`**: pure, fully typed parsing and filtering. Extracts the copy between `<!-- whats-new -->` and `<!-- /whats-new -->` in each release body (releases without a well-formed block are skipped), keeps only versions at or below the connected vestad (numeric dotted compare via the existing `compareVersions`), and includes prereleases only when the daemon runs the beta channel. Vitest coverage for marker present/absent/malformed/empty, field validation, version ordering, and channel gating.
- **`apps/web/src/components/WhatsNew/`**: the dialog (existing ui dialog primitives), newest first, version + date + message per entry. Fetches only when it opens, never polls; on failure it shows a quiet "Couldn't load release notes" line.
- **Entry points**: a ghost/xs "What's new" button in the settings navbar next to Check for updates, and a one-shot auto-open after a vestad update. The auto-open hook (`use-whats-new-auto-open.ts`, colocated with the component) persists the last-seen version in localStorage: fresh installs just record the current version silently; when the connected version differs and a visible release note exists for it, the dialog opens once with the already-fetched notes and the stored version advances. The dialog mounts once at the app root so the auto-open works on any page; a small zustand store shares its open state with the settings button.

## Channel sourcing

No vestad change was needed: `/version` already reports `channel` ("stable" | "beta") and GatewayProvider already surfaces it as `gatewayChannel` on `useGateway`, so the beta gating rides the existing payload.

## Marker contract

This depends on the sibling release-pipeline PR that writes the `<!-- whats-new -->...<!-- /whats-new -->` block into each GitHub release body. Until that lands and a release ships with markers, every existing release is skipped and the dialog shows an empty state (and the auto-open never fires), which is the intended behavior for pre-marker releases.

## Verify

`./check.sh web` green (eslint, prettier, tsc, vitest; 159 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
