### PR TITLE
fix(ci): stop cancelling in-progress master runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ permissions:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Only cancel superseded runs on PRs. Master push runs must complete:
+  # cancelling them makes merge-gate-ci report cancelled siblings as a
+  # failure, painting a red X on every merge burst.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Problem

Every merge burst paints red `merge-gate-ci (push)` X's on master. The workflow's concurrency group is shared per ref with `cancel-in-progress: true`, so each merge to master cancels the previous master push run mid-flight. `merge-gate-ci` runs with `if: always()` and deliberately treats cancelled sibling jobs as failure (so a PR run can't be slipped past the required check by cancelling it), which turns every superseded master run into a spurious failure.

## Fix

Scope `cancel-in-progress` to `pull_request` events only. PR runs keep the cancel-superseded-work behavior and the cancelled-counts-as-failure guard; master push runs now always complete, so a red `merge-gate-ci` on master once again means a real failure.

Costs some extra CI minutes during merge bursts, since each master push run finishes instead of being cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)