### PR TITLE
fix(browser): handover provisions its own Xvfb instead of grabbing the desktop seat

### DIFF
--- a/agent/skills/browser/cli/src/vesta_browser/handover.py
+++ b/agent/skills/browser/cli/src/vesta_browser/handover.py
@@ -110,6 +110,18 @@ def _free_port(start: int) -> int:
     raise RuntimeError(f"no free port in range {start}-{start + 200}")
 
 
+def _free_display(start: int = 99) -> str:
+    """A display number with no X server yet, so handover always provisions its OWN Xvfb.
+
+    Reusing the ambient DISPLAY breaks on a real desktop seat: x11vnc cannot X_GetImage a live
+    Wayland/Xorg screen (it fails BadMatch), so noVNC hangs on connect. A dedicated Xvfb is always
+    grabbable, and on a headless box (the container) picking a free number lands on :99 as before."""
+    for n in range(start, start + 100):
+        if not Path(f"/tmp/.X11-unix/X{n}").exists():
+            return f":{n}"
+    raise RuntimeError(f"no free X display in range :{start}-:{start + 100}")
+
+
 def _alive(pid: int | None) -> bool:
     if pid is None:
         return False
@@ -202,12 +214,13 @@ def start(*, url: str | None, port: int | None, user_data_dir: str | None) -> di
     for lock in ("lock", ".parentlock"):
         (profile / lock).unlink(missing_ok=True)
 
-    # Pin the display so x11vnc mirrors the exact screen Camoufox renders on. On a Wayland host,
-    # x11vnc and Firefox both prefer the ambient Wayland session over our Xvfb X11 display (x11vnc
-    # 0.9.x exits outright when WAYLAND_DISPLAY is set), so drop it and force Firefox onto X11 with
-    # MOZ_ENABLE_WAYLAND=0: handover owns a dedicated X11 display. Harmless where WAYLAND_DISPLAY
-    # is unset (e.g. the container).
-    display = os.environ["DISPLAY"] if "DISPLAY" in os.environ else ":99"
+    # Handover owns a dedicated Xvfb display, never the ambient one: x11vnc can grab a fresh Xvfb
+    # but not a live desktop seat (a real :0 fails X_GetImage BadMatch, hanging noVNC), and a
+    # desktop's DISPLAY=:0 would also render the headed browser onto the user's own monitor. On a
+    # Wayland host x11vnc and Firefox both prefer the ambient Wayland session over our X11 display
+    # (x11vnc 0.9.x exits outright when WAYLAND_DISPLAY is set), so drop it and force Firefox onto
+    # X11 with MOZ_ENABLE_WAYLAND=0. Harmless where WAYLAND_DISPLAY is unset (e.g. the container).
+    display = _free_display()
     os.environ["DISPLAY"] = display
     os.environ.pop("WAYLAND_DISPLAY", None)
     os.environ["MOZ_ENABLE_WAYLAND"] = "0"

--- a/agent/skills/browser/cli/tests/test_handover.py
+++ b/agent/skills/browser/cli/tests/test_handover.py
@@ -146,6 +146,19 @@ def test_free_port_returns_a_bindable_port():
         s.close()
 
 
+def test_free_display_skips_existing_seats(monkeypatch):
+    # A real desktop seat (:0/:1) already has an X socket; handover must never pick it, else x11vnc
+    # grabs the live seat and noVNC hangs. Pretend :99 and :100 are taken; it must land on :101.
+    taken = {"/tmp/.X11-unix/X99", "/tmp/.X11-unix/X100"}
+    monkeypatch.setattr(handover.Path, "exists", lambda self: str(self) in taken)
+    assert handover._free_display() == ":101"
+
+
+def test_free_display_returns_base_when_free(monkeypatch):
+    monkeypatch.setattr(handover.Path, "exists", lambda self: False)
+    assert handover._free_display() == ":99"
+
+
 def test_alive_false_for_none_and_dead_pid():
     assert handover._alive(None) is False
     # PID 2**31-1 is not a running process on any sane system.


### PR DESCRIPTION
## Problem

`browser handover` hung forever on "Waking vesta's computer" on a real desktop.

`handover.py` chose its display as `os.environ["DISPLAY"] if "DISPLAY" in os.environ else ":99"`, so whenever `DISPLAY` was set (a desktop seat, e.g. `:0`) it **reused the live seat** instead of provisioning its own Xvfb. `_ensure_xvfb(":0")` sees the seat already up and creates nothing, then x11vnc tries to mirror it and fails:

```
Xlib:  extension "DPMS" missing on display ":0".
X Error of failed request:  BadMatch
  Major opcode of failed request:  73 (X_GetImage)
```

x11vnc cannot `X_GetImage` a live Wayland/Xorg seat, so noVNC connects to websockify but never gets a framebuffer and hangs on the loading screen. (Reusing `:0` would also have rendered the headed browser onto the user's own monitor.) It only ever worked in the container because `DISPLAY` is unset there, falling through to `:99`.

## Fix

`handover` now always picks a display number with no X server yet (`_free_display`, scanning `/tmp/.X11-unix`) and provisions its own Xvfb there, matching the docstring's stated intent ("handover owns a dedicated X11 display"). x11vnc can always grab a fresh Xvfb. On a headless box (`DISPLAY` unset) it still lands on `:99`, so container behavior is unchanged.

Verified live on a Wayland desktop (`:0` seat): before, x11vnc logged `BadMatch` and noVNC hung; after, handover comes up on `:99`, x11vnc serves it cleanly ("The VNC desktop is: localhost:0", no BadMatch), and the sign-in page renders and is viewable.

## Tests

`_free_display` skips already-present seats and returns the base when free (`test_handover.py`). Full handover suite green (20 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)