### PR TITLE
fix(skills): unify poll-daemon lifecycle correctness across skills

### DIFF
--- a/agent/core/skills/app-chat/cli/src/app_chat_cli/daemon.py
+++ b/agent/core/skills/app-chat/cli/src/app_chat_cli/daemon.py
@@ -232,6 +232,11 @@ def cmd_daemon_start(args: argparse.Namespace) -> None:
         _print({"error": "app-chat is not on PATH; install it per SKILL.md first"})
         sys.exit(1)
 
+    # A stop marker can outlive its daemon (a stop that raced the process's death, or a failed
+    # quit), so clear it before launching; this fresh daemon's own unexpected death then still
+    # fires daemon_died instead of silently consuming the stale marker.
+    data_dir.mkdir(parents=True, exist_ok=True)
+    _stop_marker_path(data_dir).unlink(missing_ok=True)
     subprocess.run([screen_bin, "-dmS", SESSION_NAME, app_chat_bin, "serve"], check=False)
 
     deadline = time.monotonic() + DAEMON_START_TIMEOUT

--- a/agent/core/skills/app-chat/cli/tests/test_daemon.py
+++ b/agent/core/skills/app-chat/cli/tests/test_daemon.py
@@ -146,6 +146,33 @@ def test_daemon_start_launches_and_waits_for_the_socket(tmp_path, monkeypatch, c
     assert calls["launched"] is True
 
 
+def test_daemon_start_clears_a_leaked_stop_marker_before_launching(tmp_path, monkeypatch, capsys):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    daemon._stop_marker_path(data_dir).write_text("")
+
+    calls = {"launched": False}
+
+    def fake_alive(sock_path):
+        return calls["launched"]
+
+    def fake_run(cmd, check):
+        calls["launched"] = True
+        # the leaked marker must be gone before the fresh daemon is launched, so its own
+        # unexpected death still reports daemon_died rather than silently consuming the marker
+        assert not daemon._stop_marker_path(data_dir).exists()
+
+    monkeypatch.setattr(daemon, "daemon_alive", fake_alive)
+    monkeypatch.setattr(daemon.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(daemon.subprocess, "run", fake_run)
+    monkeypatch.setattr(daemon.time, "sleep", lambda seconds: None)
+
+    daemon.cmd_daemon_start(_args(tmp_path))
+
+    assert json.loads(capsys.readouterr().out) == {"status": "started", "session": "app-chat"}
+    assert not daemon._stop_marker_path(data_dir).exists()
+
+
 def test_daemon_stop_is_idempotent_when_already_stopped(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(daemon, "daemon_alive", lambda sock_path: False)
 


### PR DESCRIPTION
## What

Audits every skill that runs a CLI-owned poll/background daemon for the three daemon-lifecycle correctness fixes landed in #1094 (email-client), and applies the one genuine gap that audit found.

The three fixes from #1094:
1. **refuse-start-when-live**: a live legacy daemon is detected so `start` never stacks a second process.
2. **clear-stale-marker-on-start**: a leaked stop marker is cleared by `start`, so an unintentional death still reports `daemon_died`.
3. **clear-marker-on-died-before-SIGTERM**: the stop path clears the marker when the process was already gone.

## Audit

- **app-chat** (core skill): same CLI-owned lifecycle shape (`daemon start|stop|restart|status`, a `stop-requested` marker, a `daemon_died` notification). It already HAS fix 1 (its `daemon_alive` socket check makes `start` idempotent and refuses to stack). It LACKED **fix 2**: `cmd_daemon_start` never cleared the stop marker, so a leaked marker (a stop that raced the daemon's death, or a failed quit) was inherited by the next daemon, whose own unexpected death then silently consumed the marker and skipped `daemon_died`. Fix 3's stop-path orphan does not arise in app-chat (its `stop` early-returns before writing a marker when the daemon is already dead), and any residual leak is fully closed by fix 2, so per the repo's "one fix per root cause" rule fix 2 is the single correct fix. **Applied fix 2, with a test.**
- **tasks, google, microsoft**: only a raw `serve` command started under a user-managed `screen -dmS` line, with no CLI-owned `daemon start|stop|restart|status` and no `stop-requested` marker (they write `daemon_died` on every shutdown, intentional SIGTERM included). The three fixes presuppose a CLI-owned lifecycle these skills do not have; adding one would be a new feature, not a correctness fix. Out of scope.
- **voice (#1092), dashboard (#1090)**: their daemon lifecycles are being added by open sibling PRs; excluded to avoid duplication or conflict.
- Other daemon-bearing skills (browser, whatsapp, discord, slack, spotify, telegram, twitter, enable-banking) do not use the `stop-requested` marker + `daemon_died` lifecycle, so the fixes do not apply.

## Change

`app-chat` `cmd_daemon_start` now unlinks the `stop-requested` marker before launching a fresh daemon, mirroring email-client's `daemon_start`. New test `test_daemon_start_clears_a_leaked_stop_marker_before_launching` mirrors the email-client regression test.

Origin: #1094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)