### PR TITLE
feat(skills): add cooking-hacks, a text-only kitchen technique reference

### DIFF
--- a/agent/skills/cooking-hacks/SKILL.md
+++ b/agent/skills/cooking-hacks/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: cooking-hacks
+description: Hands-on kitchen and cooking technique hacks across prep and tools, produce and herbs, eggs, sauces and stocks, meat, fish, baking and pastry, and frying. Use when the user wants a cooking tip, a better way to do a kitchen task, or how a technique works.
+---
+
+# Cooking Hacks
+
+A reference of practical cooking and kitchen techniques, grouped by area. Surface the relevant hack when the user is cooking, prepping, or asking how to do a kitchen task better.
+
+## Kitchen setup, tools & workflow
+
+**Anchor a mixing bowl with a cloth**
+Drape or fold a cloth over a saucepan or work surface and nest the bowl on it. The cloth grips the bowl so it stays still while you whisk mayonnaise or another emulsion.
+
+**Fix a ragged roll of aluminum foil with a foil ball**
+Lightly rub a crumpled ball of foil across the torn edge of the roll. It catches and lifts the uneven layers until one clean sheet remains.
+
+**Use a spoon to open many pull-tab tins**
+Slide the end or handle of a spoon through the pull ring and lever it backward. This is faster and easier on your fingers when opening multiple tins.
+
+**Use labeled timers for cooking and resting**
+Assign separate labeled timers to different meats or dishes. Tracking both cook time and rest time prevents expensive proteins from being forgotten or carved too early.
+
+**Create a vortex to empty bottles faster**
+Hold the bottle near its base and swirl it as you pour. The vortex lets air enter continuously, so thick sauces leave the bottle more smoothly.
+
+**Stabilize a cutting board with rubber jar seals**
+Place a nonslip mat, or two rubber sealing rings from clip-top jars, under the board. They grip the counter without wasting damp paper towel.
+
+**Lower hot-oil temperature by adding room-temperature oil**
+Take the pan off the heat and carefully add room-temperature neutral oil in small amounts, checking the temperature as you go. This can bring oil down quickly to a confit temperature; never add water to hot oil.
+
+**Refill a squeeze bottle by suction**
+Squeeze the empty bottle to expel the air, submerge only the tip in the sauce, and release. The bottle sucks up the liquid; tap it down, repeat, and fit the lid.
+
+**Batch-cut identical parchment sheets**
+Fold one sheet to the desired size, then accordion-fold the roll or stack to match that length. Cut both sides once to produce multiple equal sheets.
+
+**Make a parchment cartouche**
+Cut parchment slightly larger than the pan, fold it repeatedly into a narrow wedge, measure from the center to the inner rim, trim the end, and snip a small center vent. Unfold it into a fitted lid that limits evaporation while protecting the surface.
+
+## Produce, herbs & pantry
+
+**Zest lemons in long top-to-bottom strokes**
+Run the zester from one end of the lemon to the other, rotate the fruit, and repeat. This gives even zest and makes it easier to stop before reaching the bitter white pith.
+
+**Blowtorch tomato skins instead of blanching**
+Briefly blister the skin with a blowtorch on a heatproof surface, then wipe it away with paper towel. The tomato stays cold and firm instead of becoming soft around the outside.
+
+**Soak garlic in hot water before peeling**
+Separate the cloves, cover them with hot tap water, and leave them for about 25 minutes. The softened skins peel away much more easily.
+
+**Freeze ginger before grating**
+Freeze the ginger, then grate it straight from frozen. Freezing weakens the fibers, producing fine ginger "snow" instead of stringy strands clogging the grater; peeling is optional.
+
+**Make quick pickles in the microwave**
+Microwave sliced cucumber in its pickling liquor for a couple of minutes, then chill it for a few hours. The heat rapidly starts the pickling process.
+
+**Open a pepper into one flat sheet**
+Top and tail the pepper, make one vertical slit, then guide the knife just above the inner membrane while rolling the pepper open. The seeds and ribs come away together, leaving a flat sheet for julienne.
+
+**Peel carrots with overlapping strokes**
+Elevate the carrot over a container for stability and overlap each peeler stroke with the previous one. This avoids harsh ridges; a clean food-only scrub pad can smooth small missed areas.
+
+**Wrap chives before slicing**
+Wrap the chive bundle gently in a damp kitchen towel, leaving only the cutting end exposed. The towel holds the stalks together so the cuts stay fine and uniform.
+
+**Wrap fresh herbs in a damp towel**
+Wrap the bunch in absorbent towel, secure it loosely with an elastic band, dampen the towel, and refrigerate. The controlled moisture helps prevent herbs from drying out.
+
+**Add water to speed caramelized onions**
+Add a splash of water and salt, cover the onions with a parchment cartouche, and let the steam soften them quickly. Once broken down, remove the paper and raise the heat to caramelize.
+
+**Rinse raw onion in cold water**
+Rinse cut onion under cold running water, then drain and dry it. This washes away some of the harsh sulfur compounds while retaining crunch and onion flavor.
+
+**Use a julienne peeler instead of a fine mandoline**
+A julienne peeler makes thin vegetable strips with less risk to your fingers. As a bonus, stack the strands and cut across them for a fine brunoise-style dice.
+
+**Microwave onion before peeling it into layers**
+Place a halved onion cut-side down and microwave until just soft. Keep the root intact, peel away whole cooked layers, and use them as a garnish or place them directly into pickle liquor.
+
+**Rinse berries in diluted vinegar**
+Briefly submerge berries in one part vinegar to four parts water, then drain and dry them completely before refrigerating. The rinse is intended to reduce surface mold spores and extend freshness.
+
+**Microwave clumped sugar briefly**
+Heat lumpy sugar in short microwave intervals and stir between them. Gentle heat drives off trapped moisture and loosens the clumps; stop before the sugar begins to melt.
+
+**Turn tired herbs into green herb oil**
+Blend usable but wilted herbs with roughly twice their volume of oil until the mixture reaches about 70-80°C and turns deep green. Strain through absorbent paper to separate the bright oil from the pulp; do not use spoiled herbs.
+
+**Freeze thyme before stripping the leaves**
+Freeze the thyme, then twist or rub the sprigs between your hands. The brittle frozen leaves fall off rapidly, which is useful when processing a large bunch.
+
+**Keep salad leaves cold in a perforated tray over ice**
+Set a steamer tray or colander over ice water and hold the leaves in it. They stay cold without becoming mixed with loose ice, and the whole batch can be lifted out and drained at once.
+
+**Cut limes across the equator for more juice**
+Slice the lime perpendicular to the stem-to-tip axis so the cut exposes all the segments. The opened segment structure releases juice more easily when squeezed.
+
+**Halve cherry tomatoes between two lids**
+Arrange the tomatoes in one layer on a flat lid, place a second lid upside down on top, press lightly, and run a serrated knife horizontally between them.
+
+## Eggs, sauces & stocks
+
+**Bake eggs for consistent fried-egg results**
+Lightly oil a tray, crack in the eggs, and bake with a little humidity. The video uses about 160°C for 2½ minutes; a small pan of water can add humidity in a home oven.
+
+**Use warm milk for béchamel**
+Bring the milk close to the temperature of the roux before whisking them together. Similar temperatures prevent the starch from seizing into lumps and speed up the sauce.
+
+**Make mayonnaise with a stick blender**
+Put the egg, mustard, salt, and all the oil into a tall narrow container. Start the blender on the bottom and raise it very slowly as the emulsion forms.
+
+**Sieve an egg before poaching**
+Crack the egg into a fine sieve and let the watery outer white drain away. Lower the remaining yolk and thick white into barely simmering water for a compact poached egg without feathery strands.
+
+**Batch-prep blended garlic**
+Blend peeled garlic with a little oil, stir in lemon juice to slow browning, transfer to a clean container, and cover the surface with more oil and cling film. Keep it refrigerated and use it promptly.
+
+**Skim stock with an ice-filled ladle**
+Fill a ladle with ice and move its cold underside just over the stock's surface. Fat solidifies on the outside of the ladle and can be wiped away without removing much stock.
+
+**Use a peeled potato as a last-resort fix for excess salt**
+Simmer a peeled potato in an oversalted stock or sauce for roughly 10 minutes, then remove it before it breaks apart. It may take the edge off the saltiness, though dilution is usually more predictable.
+
+**Rescue split mayonnaise with a fresh yolk**
+Put a fresh egg yolk and a pinch of salt in a clean bowl. Slowly whisk the split mayonnaise into the new yolk until the emulsion becomes thick and glossy again.
+
+**Chill stock overnight to remove fat**
+Refrigerate the stock until the fat forms a solid cap, lift it off, and pass the stock through a fine chinois. It will need far less skimming when reheated and reduced.
+
+**Add acidity at the end of a sauce**
+Finish a rich sauce with a few drops of vinegar or citrus just before serving. Adding it late preserves the fresh, bright flavor that prolonged cooking can dull.
+
+**Crack eggs on a flat surface**
+Tap the egg on the counter rather than the rim of a bowl. The shell is less likely to be driven inward and scatter fragments into the egg.
+
+**Mount a sauce with ice-cold butter**
+Warm the sauce gently, then swirl in cubes of butter kept in ice water, one at a time. The cold butter melts gradually and forms a smooth, glossy emulsion; avoid boiling afterward.
+
+**Clarify butter in the microwave**
+Microwave butter in short bursts, about 20 seconds at a time, until the clear fat separates from the milk solids. Carefully pour off the clear layer and leave the solids behind.
+
+**Use sparkling water to lighten an emulsion**
+When hollandaise or a similar butter sauce becomes too thick or looks close to splitting, whisk in a small splash of sparkling water. The bubbles help disperse the fat and make the sauce lighter.
+
+## Meat & poultry
+
+**Wet your hands before handling sticky mixtures**
+Dip your hands in water before shaping mince. The same trick also helps with sticky glucose and dough.
+
+**Season steak with an even layer of fine salt**
+Spread a thin bed of fine salt, press each side of the steak into it, and shake off excess. Fine salt gives more uniform seasoning and better pan contact than large flakes.
+
+**Carve meat against the grain**
+Find the direction of the muscle fibers and cut perpendicular to them. Shortening the fibers makes each slice easier to chew.
+
+**French lamb bones with kitchen string**
+Cut down both sides of each bone, tie string around the base, place the rack at the edge of the board, and pull firmly. The string strips away meat and sinew much faster than scraping.
+
+**Rest meat in butter paper or parchment**
+Wrap or tent resting meat with butter paper or baking parchment rather than reflective foil. It retains some warmth while reducing the risk of excessive carryover cooking and a gray exterior.
+
+**Score pork or duck skin with a depth-controlled blade**
+Use a clean, food-only utility knife with only enough blade exposed to cut through skin and fat, not meat. A foil boat around the meat can catch rendered fat while leaving the skin exposed to crisp.
+
+**Add bicarbonate of soda to chicken brine for browning**
+The video uses 6 g of bicarbonate of soda per 450 g of meat in a wet brine. Raising the skin's surface pH speeds the Maillard reaction, producing deeper color and crisper skin.
+
+**Reshape a chicken breast for even cooking**
+Remove the tenderloin and sinew, reposition the tenderloin at the thin tail end, then roll the breast tightly in cling film and twist the ends. Chill to set the shape, then unwrap before cooking.
+
+**Temper steaks briefly before cooking**
+Let steaks sit out for a limited period so the center is less refrigerator-cold and the fat softens, then cook them immediately. The video demonstrates roughly 35-45 minutes, which promotes more even cooking and faster browning.
+
+**Semi-freeze tender meat for a precise dice**
+Chill beef, tuna, or another soft ingredient until firm but not solid. It stops stretching and sliding, allowing uniform slices and cubes with less waste.
+
+## Fish & shellfish
+
+**Remove a prawn vein with a toothpick**
+Insert a toothpick just under the dark vein along the prawn's back, lift it, and pull gently. This removes the vein while leaving the shell and prawn intact.
+
+**Use a thin mayonnaise coating to stop fish sticking**
+Spread a paper-thin layer of mayonnaise on the cooking side of the fish. Its egg and oil create a barrier that improves browning and helps the fish release cleanly.
+
+**Dry fish uncovered for crisper skin**
+Leave skin-on fish uncovered in the refrigerator for several hours, then oil and season it before cooking. Dry skin browns more deeply; a light weight keeps the fillet flat in the pan.
+
+**Create a grip point when filleting slippery salmon**
+Make a small incision or hole through the skin near the end of the fillet. Hook a finger into it for traction while guiding the knife between flesh and skin.
+
+**Purge clams in a 3% saline bath**
+Dissolve salt in water to make a 3% solution and place live clams in a perforated container set above the bottom of a tray. Refrigerate for 1½-2 hours so expelled sand falls below and is not taken back in.
+
+## Baking, pastry & bread
+
+**Warm the knife for clean tart slices**
+Warm the blade in hot water, or very lightly with a blowtorch, then dry it, slice, and wipe the blade before the next cut. A warm knife passes through filling without dragging it.
+
+**Use ice to create oven steam for bread**
+Place ice on a sturdy preheated tray at the bottom of the oven when the loaf goes in. The slower release of steam improves oven spring, crust development, and even coloring.
+
+**Shape cookie dough in a parchment log**
+Roll fresh cookie dough tightly in parchment to form an even cylinder, freeze or chill it until firm, and slice equal discs. A few drops of water under the tray parchment will keep it from sliding.
+
+**Round cookies while they are still warm**
+Place a ring cutter around each just-baked cookie and swirl it in a small circle. The warm cookie is still flexible, so the edge resets into a neat round shape.
+
+**Use a warm spoon for an ice-cream rocher**
+Warm the spoon, wipe it dry, and carve through the ice cream in one confident motion. Hesitation makes the ice cream stick and produces an uneven shape.
+
+**Fold a piping bag over your hand before filling**
+Open the bag fully and turn the top down over your hand like a cuff. Use the edge of your hand to scrape the mixture into the bag, keeping the outside clean.
+
+**Push piping-bag filling down with a pastry scraper**
+Hold a flexible pastry or bowl scraper against the outside of the bag and sweep the filling toward the nozzle. It clears the upper bag cleanly and reduces trapped air.
+
+**Snip and tie the top of a piping bag**
+Make a small cut at the center of the open top to create two tails, then knot them together. The closed bag is easier and safer to handle during a busy service.
+
+**Grate frozen butter into chilled flour for shortcrust**
+Chill the flour in the freezer for about an hour and freeze the butter, then grate the butter directly into the flour. The small cold pieces combine quickly without melting from overhandling.
+
+**Semi-freeze stale bread for ultra-thin croutons**
+Freeze an older loaf just until firm, slice it very thinly, and bake the slices between two trays for about 15 minutes. The partial freeze prevents the soft crumb from tearing or sticking to the knife.
+
+**Wet your hands before folding sticky bread dough**
+Keep a bowl of water beside you and dampen your hands before each fold. The dough releases more cleanly and less of it sticks to your fingers.
+
+**Rub flour over doughy hands before washing**
+Rub a little dry flour between your hands to lift off large sticky dough pieces. Remove those pieces first, then wash normally.
+
+**Make a piping cone from parchment**
+Cut a parchment triangle, roll it into a cone, lock the outer flap, fill it, fold the top closed, and snip a tiny opening. It works well for chocolate writing and fine plating.
+
+## Frying, batters & service prep
+
+**Use vinegar in the coating for crisp sweet-potato fries**
+Make a coating or batter with cornflour, rice flour, and plain flour, using equal parts vinegar and water for the liquid. The vinegar slows surface browning while the mixed flours create a crisp shell.
+
+**Add a little oil to wing batter**
+Mix a small amount of oil into the batter. It interrupts the batter structure, encouraging airy bubbles and a lighter, more intricate crisp coating.
+
+**Blanch vegetables ahead, then reheat to serve**
+Cook and chill vegetables such as beans in advance to lock in color and doneness. At service, season and reheat them gently in a butter emulsion instead of recooking from raw.

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -28,6 +28,10 @@
     "description": "The people Vesta knows, a living address book and CRM. Who they are, how they communicate, what you know about them, and the history. Use whenever a person comes up, someone new appears, or you learn something about anyone in the user's world. Read a contact before reaching out to them; update it after."
   },
   {
+    "name": "cooking-hacks",
+    "description": "Hands-on kitchen and cooking technique hacks across prep and tools, produce and herbs, eggs, sauces and stocks, meat, fish, baking and pastry, and frying. Use when the user wants a cooking tip, a better way to do a kitchen task, or how a technique works."
+  },
+  {
     "name": "dashboard",
     "description": "Build or modify the user's dashboard: widgets, pages, layouts, or custom UI."
   },


### PR DESCRIPTION
## What

Adds `cooking-hacks`, a **non-default**, **text-only** skill: a curated reference of practical cooking and kitchen techniques grouped by area (kitchen setup & tools, produce & herbs, eggs/sauces/stocks, meat & poultry, fish & shellfish, baking & pastry, frying & batters). No `cli/` — just `SKILL.md` frontmatter + body.

## Notes

- **Non-default**: not added to `core/default-skills.txt`, so the Dockerfile prunes it from the shipped image and it installs on a box on demand via sparse-checkout.
- The `description` is written as discovery/trigger text so the agent surfaces it when the user wants a cooking tip or a better way to do a kitchen task.
- Content is dash-clean for CI: em dashes rewritten to commas, en-dash ranges to hyphens (`70-80°C`, `35-45 minutes`, `1½-2 hours`).
- Regenerated `skills/index.json` (only the new entry added).

`test_deployment.py` green (7 passed): frontmatter valid, name matches dir, in index, no em/en dashes, no ` - ` separators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZxz49Ju4KnJLVqDNmPsEq