### PR TITLE
fix(agent): evict stalled WS subscribers with one warning instead of an unbounded drop-oldest storm

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -161,14 +161,26 @@ async def _recv_loop(ws: web.WebSocketResponse, event_bus: EventBus, config: Ves
             break
 
 
+# Bound on a single WS send. A half-open socket (peer gone, TCP not yet timed out) blocks
+# send_json indefinitely while the subscriber queue overflows behind it; timing out closes
+# the socket promptly so the client reconnects instead of lingering wedged for minutes.
+_SEND_TIMEOUT_S = 30.0
+
+
 async def _send_loop(ws: web.WebSocketResponse, sub: asyncio.Queue[VestaEvent]) -> None:
-    """Forward all event-bus events to the WS client."""
+    """Forward all event-bus events to the WS client. Exits on the bus's eviction sentinel or a
+    stalled send; the handler then closes the WS so the client reconnects and resyncs."""
     try:
         while True:
             event = await sub.get()
-            await ws.send_json(event)
+            if event["type"] == "evicted":
+                logger.info("subscriber evicted by event bus, closing ws")
+                break
+            await asyncio.wait_for(ws.send_json(event), timeout=_SEND_TIMEOUT_S)
     except asyncio.CancelledError:
         pass
+    except TimeoutError:
+        logger.info("ws send stalled for %.0fs, closing", _SEND_TIMEOUT_S)
     except (ConnectionError, RuntimeError, TypeError) as e:
         logger.info(f"ws send_loop exited: {type(e).__name__}: {e}")
 

--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -15,9 +15,17 @@ EVENTS_DB_FILENAME = "events.db"
 # Upper bound on events buffered per subscriber. A slow-but-alive WS client (phone
 # on a weak link, wedged webview) whose send loop stalls would otherwise grow its
 # queue without limit. 1000 events covers a long burst of streamed text/tool blocks
-# while capping memory; on overflow we drop the oldest event (see emit) so the
+# while capping memory; on overflow we drop the oldest event (see _offer) so the
 # stream stays current rather than replaying a stale backlog.
 SUBSCRIBER_QUEUE_MAXSIZE = 1000
+
+# Consecutive dropped events after which a queue-full subscriber is evicted. A client
+# that far behind (a full queue plus this many straight drops) gets no value from the
+# live stream; endless drop-oldest instead degraded its UI silently and logged one
+# warning per dropped event, a self-sustaining storm while the stalled socket lingered.
+# Eviction hands the subscriber an EvictedEvent so its send loop closes the WS and the
+# client reconnects, resyncing from the connect snapshot.
+SUBSCRIBER_EVICT_AFTER_DROPS = 100
 
 type AgentState = tp.Literal["idle", "thinking"]
 
@@ -158,7 +166,13 @@ class SnapshotEvent(tp.TypedDict):
     notifications: SnapshotNotifications
 
 
-type VestaEvent = StreamEvent | SnapshotEvent
+# Bus-internal: the single item left in an evicted subscriber's queue (see EventBus._offer).
+# The send loop closes the WS on it; never emitted, persisted, or sent to a client.
+class EvictedEvent(_BaseEvent):
+    type: tp.Literal["evicted"]
+
+
+type VestaEvent = StreamEvent | SnapshotEvent | EvictedEvent
 
 PAGE_SIZE = 50
 
@@ -266,7 +280,8 @@ def _quarantine(db_path: pl.Path) -> None:
 
 class EventBus:
     def __init__(self, data_dir: pl.Path | None = None) -> None:
-        self._subscribers: set[asyncio.Queue[VestaEvent]] = set()
+        # queue -> consecutive dropped-event count, the eviction meter (see _offer).
+        self._subscribers: dict[asyncio.Queue[VestaEvent], int] = {}
         self._state: AgentState = "idle"
         self._conn: sqlite3.Connection | None = None
         self._db_path: pl.Path | None = None
@@ -290,12 +305,14 @@ class EventBus:
                 self._conn = _open(self._db_path)
 
     def subscribe(self) -> asyncio.Queue[VestaEvent]:
+        """A live event queue; yields a final EvictedEvent if the bus evicts it (see _offer)."""
         q: asyncio.Queue[VestaEvent] = asyncio.Queue(maxsize=SUBSCRIBER_QUEUE_MAXSIZE)
-        self._subscribers.add(q)
+        self._subscribers[q] = 0
         return q
 
     def unsubscribe(self, q: asyncio.Queue[VestaEvent]) -> None:
-        self._subscribers.discard(q)
+        if q in self._subscribers:
+            del self._subscribers[q]
 
     def emit(self, event: StreamEvent) -> None:
         event["ts"] = dt.datetime.now(dt.UTC).isoformat()
@@ -315,7 +332,7 @@ class EventBus:
                 self._conn.commit()
             except sqlite3.Error as e:
                 logger.warning("event-log write failed, dropping event type=%s: %s", event["type"], e)
-        for q in self._subscribers:
+        for q in list(self._subscribers):
             self._offer(q, event)
 
     def _offer(self, q: asyncio.Queue[VestaEvent], event: StreamEvent) -> None:
@@ -324,15 +341,33 @@ class EventBus:
         A stalled send loop must not pin memory: when the queue is full we evict
         the oldest buffered event to make room for the newest, keeping the live
         stream current. History replay is delivered out-of-band on connect (api.py),
-        never through this queue, so it is unaffected."""
+        never through this queue, so it is unaffected.
+
+        A subscriber that stays full for SUBSCRIBER_EVICT_AFTER_DROPS consecutive
+        drops is evicted: its stale backlog is replaced by an EvictedEvent telling
+        its send loop to close the WS, and the whole stall logs one warning instead
+        of one per dropped event. The client reconnects and resyncs from the connect
+        snapshot; a drained put resets the meter (with the burst's drop count logged)."""
         try:
             q.put_nowait(event)
         except asyncio.QueueFull:
+            drops = self._subscribers[q] + 1
+            if drops >= SUBSCRIBER_EVICT_AFTER_DROPS:
+                del self._subscribers[q]
+                while not q.empty():
+                    q.get_nowait()
+                q.put_nowait(EvictedEvent(type="evicted"))
+                logger.warning("subscriber stalled, evicting after %d consecutive dropped events (latest type=%s)", drops, event["type"])
+                return
+            self._subscribers[q] = drops
             # emit runs on the loop thread, so no other coroutine drains between
             # full and get_nowait: the queue is non-empty here by construction.
-            dropped = q.get_nowait()
-            logger.warning("subscriber queue full, dropped oldest event type=%s", dropped["type"])
+            q.get_nowait()
             q.put_nowait(event)
+            return
+        if self._subscribers[q]:
+            logger.info("subscriber recovered after dropping %d events", self._subscribers[q])
+            self._subscribers[q] = 0
 
     @property
     def state(self) -> AgentState:

--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -15,17 +15,8 @@ EVENTS_DB_FILENAME = "events.db"
 # Upper bound on events buffered per subscriber. A slow-but-alive WS client (phone
 # on a weak link, wedged webview) whose send loop stalls would otherwise grow its
 # queue without limit. 1000 events covers a long burst of streamed text/tool blocks
-# while capping memory; on overflow we drop the oldest event (see _offer) so the
-# stream stays current rather than replaying a stale backlog.
+# while capping memory; a subscriber that overflows it is evicted (see _offer).
 SUBSCRIBER_QUEUE_MAXSIZE = 1000
-
-# Consecutive dropped events after which a queue-full subscriber is evicted. A client
-# that far behind (a full queue plus this many straight drops) gets no value from the
-# live stream; endless drop-oldest instead degraded its UI silently and logged one
-# warning per dropped event, a self-sustaining storm while the stalled socket lingered.
-# Eviction hands the subscriber an EvictedEvent so its send loop closes the WS and the
-# client reconnects, resyncing from the connect snapshot.
-SUBSCRIBER_EVICT_AFTER_DROPS = 100
 
 type AgentState = tp.Literal["idle", "thinking"]
 
@@ -280,8 +271,7 @@ def _quarantine(db_path: pl.Path) -> None:
 
 class EventBus:
     def __init__(self, data_dir: pl.Path | None = None) -> None:
-        # queue -> consecutive dropped-event count, the eviction meter (see _offer).
-        self._subscribers: dict[asyncio.Queue[VestaEvent], int] = {}
+        self._subscribers: set[asyncio.Queue[VestaEvent]] = set()
         self._state: AgentState = "idle"
         self._conn: sqlite3.Connection | None = None
         self._db_path: pl.Path | None = None
@@ -307,12 +297,11 @@ class EventBus:
     def subscribe(self) -> asyncio.Queue[VestaEvent]:
         """A live event queue; yields a final EvictedEvent if the bus evicts it (see _offer)."""
         q: asyncio.Queue[VestaEvent] = asyncio.Queue(maxsize=SUBSCRIBER_QUEUE_MAXSIZE)
-        self._subscribers[q] = 0
+        self._subscribers.add(q)
         return q
 
     def unsubscribe(self, q: asyncio.Queue[VestaEvent]) -> None:
-        if q in self._subscribers:
-            del self._subscribers[q]
+        self._subscribers.discard(q)
 
     def emit(self, event: StreamEvent) -> None:
         event["ts"] = dt.datetime.now(dt.UTC).isoformat()
@@ -336,38 +325,29 @@ class EventBus:
             self._offer(q, event)
 
     def _offer(self, q: asyncio.Queue[VestaEvent], event: StreamEvent) -> None:
-        """Enqueue for one subscriber, dropping its oldest event on overflow.
+        """Enqueue for one subscriber, evicting it on overflow.
 
-        A stalled send loop must not pin memory: when the queue is full we evict
-        the oldest buffered event to make room for the newest, keeping the live
-        stream current. History replay is delivered out-of-band on connect (api.py),
-        never through this queue, so it is unaffected.
-
-        A subscriber that stays full for SUBSCRIBER_EVICT_AFTER_DROPS consecutive
-        drops is evicted: its stale backlog is replaced by an EvictedEvent telling
-        its send loop to close the WS, and the whole stall logs one warning instead
-        of one per dropped event. The client reconnects and resyncs from the connect
-        snapshot; a drained put resets the meter (with the burst's drop count logged)."""
+        A subscriber either receives every event or gets a clean disconnect: one
+        whose send loop stalls long enough to fall a full queue behind is getting
+        no value from the live stream, so on overflow its stale backlog is replaced
+        by a single EvictedEvent (with one warning, not one per event) telling its
+        send loop to close the WS; the client reconnects and resyncs from the
+        connect snapshot. History replay is delivered out-of-band on connect
+        (api.py), never through this queue, so it is unaffected."""
         try:
             q.put_nowait(event)
         except asyncio.QueueFull:
-            drops = self._subscribers[q] + 1
-            if drops >= SUBSCRIBER_EVICT_AFTER_DROPS:
-                del self._subscribers[q]
-                while not q.empty():
-                    q.get_nowait()
-                q.put_nowait(EvictedEvent(type="evicted"))
-                logger.warning("subscriber stalled, evicting after %d consecutive dropped events (latest type=%s)", drops, event["type"])
-                return
-            self._subscribers[q] = drops
+            self._subscribers.discard(q)
             # emit runs on the loop thread, so no other coroutine drains between
-            # full and get_nowait: the queue is non-empty here by construction.
-            q.get_nowait()
-            q.put_nowait(event)
-            return
-        if self._subscribers[q]:
-            logger.info("subscriber recovered after dropping %d events", self._subscribers[q])
-            self._subscribers[q] = 0
+            # full here and the drain below: the queue stays at capacity.
+            while not q.empty():
+                q.get_nowait()
+            q.put_nowait(EvictedEvent(type="evicted"))
+            logger.warning(
+                "subscriber stalled %d events behind, evicting so its client reconnects (latest type=%s)",
+                SUBSCRIBER_QUEUE_MAXSIZE,
+                event["type"],
+            )
 
     @property
     def state(self) -> AgentState:

--- a/agent/tests/test_api.py
+++ b/agent/tests/test_api.py
@@ -257,6 +257,42 @@ async def test_ws_snapshot_failure_cleans_up_subscription(event_bus, monkeypatch
 
 
 @pytest.mark.anyio
+async def test_send_loop_closes_on_eviction_sentinel(event_bus):
+    """When the bus evicts a stalled subscriber (issue #1160) the send loop exits on the
+    EvictedEvent so the handler closes the WS and the client reconnects for a fresh snapshot."""
+    from core.api import _send_loop
+    from core.events import EvictedEvent
+
+    sent = []
+
+    class _Ws:
+        async def send_json(self, event):
+            sent.append(event)
+
+    sub = event_bus.subscribe()
+    sub.put_nowait(EvictedEvent(type="evicted"))
+    await asyncio.wait_for(_send_loop(typing.cast("web.WebSocketResponse", _Ws()), sub), timeout=1.0)
+    assert sent == []
+
+
+@pytest.mark.anyio
+async def test_send_loop_closes_when_send_stalls(event_bus, monkeypatch):
+    """A half-open socket whose send never completes is closed after the send timeout instead of
+    lingering for minutes while its queue overflows (issue #1160)."""
+    from core import api
+
+    monkeypatch.setattr(api, "_SEND_TIMEOUT_S", 0.05)
+
+    class _StalledWs:
+        async def send_json(self, event):
+            await asyncio.Event().wait()
+
+    sub = event_bus.subscribe()
+    event_bus.emit(ChatEvent(type="chat", text="never delivered"))
+    await asyncio.wait_for(api._send_loop(typing.cast("web.WebSocketResponse", _StalledWs()), sub), timeout=1.0)
+
+
+@pytest.mark.anyio
 async def test_memory_put_writes_atomically(tmp_path):
     """PUT /memory lands the full content through the atomic tmp+rename writer, leaving no partial
     or leftover temp file behind."""

--- a/agent/tests/test_eventbus.py
+++ b/agent/tests/test_eventbus.py
@@ -9,7 +9,6 @@ import pytest
 from core.events import (
     _EVENTS_SCHEMA,
     _SCHEMA_VERSION,
-    SUBSCRIBER_EVICT_AFTER_DROPS,
     SUBSCRIBER_QUEUE_MAXSIZE,
     ChatEvent,
     EventBus,
@@ -98,50 +97,15 @@ def test_persists_across_instances(tmp_path):
 # --- Backpressure ---
 
 
-def test_slow_subscriber_queue_is_bounded(event_bus):
-    """A subscriber that never drains stays bounded; the oldest events are dropped."""
+def test_stalled_subscriber_is_evicted_on_overflow(event_bus):
+    """A subscriber that stops draining is evicted at its first overflow: the stale backlog is
+    replaced by a single EvictedEvent telling the send loop to close (the client reconnects and
+    resyncs from the connect snapshot), and further emits no longer reach it. A subscriber
+    either receives every event or gets a clean disconnect; nothing is dropped silently
+    (regression: issue #1160's unbounded drop-oldest storm)."""
     q = event_bus.subscribe()
-    overflow = 50
-    total = SUBSCRIBER_QUEUE_MAXSIZE + overflow
-    for i in range(total):
+    for i in range(SUBSCRIBER_QUEUE_MAXSIZE + 1):
         event_bus.emit(UserEvent(type="user", text=f"msg {i}"))
-
-    assert q.qsize() == SUBSCRIBER_QUEUE_MAXSIZE
-
-    drained = [q.get_nowait() for _ in range(q.qsize())]
-    texts = [tp.cast(tp.Any, e)["text"] for e in drained]
-    # Oldest `overflow` events were evicted; the queue holds the most recent window.
-    assert texts[0] == f"msg {overflow}"
-    assert texts[-1] == f"msg {total - 1}"
-
-
-def test_drop_does_not_affect_other_subscribers(event_bus):
-    """Overflowing one subscriber must not drop events for a healthy one."""
-    slow = event_bus.subscribe()
-    fast = event_bus.subscribe()
-    total = SUBSCRIBER_QUEUE_MAXSIZE + 10
-    for i in range(total):
-        event = UserEvent(type="user", text=f"msg {i}")
-        event_bus.emit(event)
-        fast.get_nowait()  # fast subscriber keeps draining, never overflows
-
-    assert slow.qsize() == SUBSCRIBER_QUEUE_MAXSIZE
-    assert fast.qsize() == 0
-
-
-def _stall_until_evicted(event_bus):
-    """Fill a never-draining subscriber past the eviction threshold, returning its queue."""
-    q = event_bus.subscribe()
-    for i in range(SUBSCRIBER_QUEUE_MAXSIZE + SUBSCRIBER_EVICT_AFTER_DROPS):
-        event_bus.emit(UserEvent(type="user", text=f"msg {i}"))
-    return q
-
-
-def test_stalled_subscriber_is_evicted(event_bus):
-    """A subscriber that stays queue-full for SUBSCRIBER_EVICT_AFTER_DROPS consecutive drops is
-    evicted: its stale backlog is cleared, an EvictedEvent tells the send loop to close, and
-    further emits no longer reach it (regression: issue #1160's unbounded drop storm)."""
-    q = _stall_until_evicted(event_bus)
 
     assert q.qsize() == 1
     assert q.get_nowait()["type"] == "evicted"
@@ -151,36 +115,46 @@ def test_stalled_subscriber_is_evicted(event_bus):
 
 
 def test_eviction_logs_one_warning_not_a_storm(event_bus, caplog):
-    """The overflow storm is coalesced: a stalled subscriber produces exactly one warning (at
-    eviction, with the drop count), not one line per dropped event."""
+    """The overflow storm is coalesced: a stalled subscriber produces exactly one warning at
+    eviction, no matter how many events keep flowing afterwards, not one line per event."""
+    q = event_bus.subscribe()
     with caplog.at_level("WARNING", logger="vesta.events"):
-        _stall_until_evicted(event_bus)
+        for i in range(SUBSCRIBER_QUEUE_MAXSIZE + 200):
+            event_bus.emit(UserEvent(type="user", text=f"msg {i}"))
 
+    assert q.qsize() == 1  # the sentinel; the post-eviction flood never reached it
     warnings = [r for r in caplog.records if r.levelname == "WARNING"]
     assert len(warnings) == 1
-    assert str(SUBSCRIBER_EVICT_AFTER_DROPS) in warnings[0].getMessage()
 
 
-def test_draining_subscriber_recovers_and_is_not_evicted(event_bus, caplog):
-    """A slow-but-alive subscriber that resumes draining resets the eviction counter: two
-    sub-threshold overflow bursts with a drain between never evict, and recovery is logged
-    once with the number of events dropped in the burst."""
+def test_eviction_does_not_affect_other_subscribers(event_bus):
+    """Evicting an overflowing subscriber must not drop events for a healthy one."""
+    slow = event_bus.subscribe()
+    fast = event_bus.subscribe()
+    total = SUBSCRIBER_QUEUE_MAXSIZE + 10
+    delivered = []
+    for i in range(total):
+        event_bus.emit(UserEvent(type="user", text=f"msg {i}"))
+        delivered.append(tp.cast(tp.Any, fast.get_nowait())["text"])  # fast keeps draining
+
+    assert delivered == [f"msg {i}" for i in range(total)]
+    assert slow.qsize() == 1
+    assert slow.get_nowait()["type"] == "evicted"
+
+
+def test_draining_subscriber_is_never_evicted(event_bus):
+    """A subscriber that keeps draining, even one that hovers at the queue bound, receives
+    every event and is never evicted."""
     q = event_bus.subscribe()
-    burst = SUBSCRIBER_EVICT_AFTER_DROPS - 1
-    for i in range(SUBSCRIBER_QUEUE_MAXSIZE + burst):
-        event_bus.emit(UserEvent(type="user", text=f"first {i}"))
-
-    q.get_nowait()
-    with caplog.at_level("INFO", logger="vesta.events"):
-        event_bus.emit(UserEvent(type="user", text="recovered"))
-    assert any(str(burst) in r.getMessage() for r in caplog.records)
-
-    for i in range(burst):
-        event_bus.emit(UserEvent(type="user", text=f"second {i}"))
+    for i in range(SUBSCRIBER_QUEUE_MAXSIZE):
+        event_bus.emit(UserEvent(type="user", text=f"fill {i}"))
+    for i in range(50):
+        q.get_nowait()  # make one slot of room
+        event_bus.emit(UserEvent(type="user", text=f"paced {i}"))
 
     assert q.qsize() == SUBSCRIBER_QUEUE_MAXSIZE
-    drained = [q.get_nowait() for _ in range(q.qsize())]
-    assert all(e["type"] != "evicted" for e in drained)
+    drained = [tp.cast(tp.Any, q.get_nowait())["text"] for _ in range(q.qsize())]
+    assert drained[-1] == "paced 49"
     event_bus.emit(UserEvent(type="user", text="still subscribed"))
     assert tp.cast(tp.Any, q.get_nowait())["text"] == "still subscribed"
 

--- a/agent/tests/test_eventbus.py
+++ b/agent/tests/test_eventbus.py
@@ -9,6 +9,7 @@ import pytest
 from core.events import (
     _EVENTS_SCHEMA,
     _SCHEMA_VERSION,
+    SUBSCRIBER_EVICT_AFTER_DROPS,
     SUBSCRIBER_QUEUE_MAXSIZE,
     ChatEvent,
     EventBus,
@@ -126,6 +127,62 @@ def test_drop_does_not_affect_other_subscribers(event_bus):
 
     assert slow.qsize() == SUBSCRIBER_QUEUE_MAXSIZE
     assert fast.qsize() == 0
+
+
+def _stall_until_evicted(event_bus):
+    """Fill a never-draining subscriber past the eviction threshold, returning its queue."""
+    q = event_bus.subscribe()
+    for i in range(SUBSCRIBER_QUEUE_MAXSIZE + SUBSCRIBER_EVICT_AFTER_DROPS):
+        event_bus.emit(UserEvent(type="user", text=f"msg {i}"))
+    return q
+
+
+def test_stalled_subscriber_is_evicted(event_bus):
+    """A subscriber that stays queue-full for SUBSCRIBER_EVICT_AFTER_DROPS consecutive drops is
+    evicted: its stale backlog is cleared, an EvictedEvent tells the send loop to close, and
+    further emits no longer reach it (regression: issue #1160's unbounded drop storm)."""
+    q = _stall_until_evicted(event_bus)
+
+    assert q.qsize() == 1
+    assert q.get_nowait()["type"] == "evicted"
+
+    event_bus.emit(UserEvent(type="user", text="after eviction"))
+    assert q.qsize() == 0
+
+
+def test_eviction_logs_one_warning_not_a_storm(event_bus, caplog):
+    """The overflow storm is coalesced: a stalled subscriber produces exactly one warning (at
+    eviction, with the drop count), not one line per dropped event."""
+    with caplog.at_level("WARNING", logger="vesta.events"):
+        _stall_until_evicted(event_bus)
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert str(SUBSCRIBER_EVICT_AFTER_DROPS) in warnings[0].getMessage()
+
+
+def test_draining_subscriber_recovers_and_is_not_evicted(event_bus, caplog):
+    """A slow-but-alive subscriber that resumes draining resets the eviction counter: two
+    sub-threshold overflow bursts with a drain between never evict, and recovery is logged
+    once with the number of events dropped in the burst."""
+    q = event_bus.subscribe()
+    burst = SUBSCRIBER_EVICT_AFTER_DROPS - 1
+    for i in range(SUBSCRIBER_QUEUE_MAXSIZE + burst):
+        event_bus.emit(UserEvent(type="user", text=f"first {i}"))
+
+    q.get_nowait()
+    with caplog.at_level("INFO", logger="vesta.events"):
+        event_bus.emit(UserEvent(type="user", text="recovered"))
+    assert any(str(burst) in r.getMessage() for r in caplog.records)
+
+    for i in range(burst):
+        event_bus.emit(UserEvent(type="user", text=f"second {i}"))
+
+    assert q.qsize() == SUBSCRIBER_QUEUE_MAXSIZE
+    drained = [q.get_nowait() for _ in range(q.qsize())]
+    assert all(e["type"] != "evicted" for e in drained)
+    event_bus.emit(UserEvent(type="user", text="still subscribed"))
+    assert tp.cast(tp.Any, q.get_nowait())["text"] == "still subscribed"
 
 
 # --- Pagination ---


### PR DESCRIPTION
Fixes #1160

## Problem

When a WS subscriber's send loop stalls (half-open socket, wedged webview, slow client), its bounded queue fills and every subsequent emit drops the oldest event and logs a warning. One instance logged 88,352 `subscriber queue full` warnings in a 3 minute window (117k+/day in rotated logs). Worse than the log flood: the stalled socket stays technically open for minutes, so the app on the other end shows stale liveness and misses replies until the agent is restarted, which is exactly the "agent not answering until I restarted" symptom.

## Fix

Two mechanisms, one per failure mode:

- **Eviction on overflow (stalled subscriber)**: the 1000-slot queue is the burst tolerance; a subscriber that overflows it is a full queue behind and getting no value from the live stream. Its stale backlog is replaced with a single bus-internal `EvictedEvent` and one warning is logged. The send loop exits on that sentinel, the handler closes the WS, and the client reconnects and resyncs from the connect snapshot. The invariant is now: a subscriber either receives every event or gets a clean disconnect, nothing is dropped silently (the old drop-oldest path could drop events forever without eviction).
- **Send timeout (half-open socket)**: `_send_loop` bounds each `ws.send_json` with a 30s timeout, so a socket whose peer is gone is closed promptly instead of lingering wedged while its queue overflows behind it.

Safe to close sockets: every client (web `reconnecting-ws`, app-chat daemon, CLI) auto-reconnects with backoff and reseeds from the snapshot, and app-chat intake is off-bus so no message delivery is affected.

The `EvictedEvent` sentinel (rather than a `None` sentinel) keeps the subscriber queue element type a uniform event dict, so no consumer needs None narrowing.

## Testing

- New tests: eviction on overflow with the sentinel left behind, exactly one coalesced warning no matter how many events flow after eviction (regression for the storm), a healthy subscriber is unaffected by another's eviction, a draining subscriber hovering at the bound receives everything and is never evicted, send loop exits on the sentinel, send loop closes on a stalled send.
- `./check.sh agent` green (ruff + format + ty + 590 tests).
- E2E verified against a real `start_ws_server`: a client that stops reading is evicted and receives a server-side CLOSE, a concurrent healthy client keeps streaming, a reconnect gets a fresh snapshot, and the whole stall produces exactly 1 warning line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)