### PR TITLE
docs: reposition Vesta as an AI guardian angel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ The single guide for Claude Code when working in this repository: how the system
 
 ## Project Overview
 
-Vesta is a personal AI assistant that runs as a persistent daemon in Docker, powered by Claude Code. Vesta monitors notifications, responds to messages, and handles tasks autonomously. The agent drives Claude through the official **Claude Agent SDK** (`claude-agent-sdk`): `core/client.py` builds a `ClaudeAgentOptions`, opens a `ClaudeSDKClient`, and streams response blocks back from the SDK message stream and its native hooks.
+Vesta is an AI guardian angel that runs as a persistent daemon in Docker, powered by Claude Code. Vesta monitors notifications, responds to messages, and handles tasks autonomously. The agent drives Claude through the official **Claude Agent SDK** (`claude-agent-sdk`): `core/client.py` builds a `ClaudeAgentOptions`, opens a `ClaudeSDKClient`, and streams response blocks back from the SDK message stream and its native hooks.
 
 > **cc_sdk is dormant, leave it alone.** `agent/core/cc_sdk/` is an in-repo SDK that drives the interactive `claude` CLI inside tmux and exposes the *same* `ClaudeSDKClient` surface. It is retained deliberately as a drop-in alternative driver in case CLI-driving is ever needed again (e.g. behavior the headless SDK can't reach); it is not imported by `core/` and not on the running agent's path. Do not delete it, tidy it, or wire it back into `core/` without an explicit ask. Its transport tests (`tests/test_cc_sdk.py`, `tests/test_e2e_transport.py`, `tests/test_stop_race.py`) keep it healthy; keep them green.
 
@@ -167,6 +167,7 @@ Run locally on master. Bumps versions, updates lockfiles, commits, pushes, and c
 ## Code conventions
 
 ### Brand voice
+- **Positioning (the single source of truth for Vesta's copy).** Vesta is an **AI guardian angel**. Not a "personal AI", not an "assistant", not a friend or companion. The canonical one-liner, used verbatim wherever a tagline is needed: **"an AI guardian angel that gives you back time and helps you achieve your goals."** Every user-facing surface (README, landing, app strings, prompts, emails, CLI output) draws its positioning from here; never reintroduce "personal AI"/"personal assistant" framing.
 - **Never use a pronoun for Vesta.** In all copy and prose, refer to the agent as **"Vesta"**, or **"they/them/their"** where a pronoun is unavoidable. Never "she/her" or "it/its". This holds across every surface: README, app/notification strings, agent prompts and skills, and the vesta-cloud site and emails. The product is a relationship, not a gadget; one consistent voice keeps each new email or prompt from re-litigating it. (This does not apply to pronouns for other nouns: the daemon, a container, the user, a config object.)
 - **No dashes as separators in prose.** In prose and copy (this file, SKILL.md bodies, prompts, app strings, PR descriptions, emails), never use spaced-hyphen or em-dash separators; use commas, periods, or colons instead.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vesta
 
-A personal AI agent that lives in a Docker container, powered by Claude.
+An AI guardian angel that gives you back time and helps you achieve your goals, living in a Docker container, powered by Claude.
 
 Don't want to run a server? [vesta.run](https://vesta.run) hosts one for you. Invite-only.
 

--- a/agent/core/pyproject.toml
+++ b/agent/core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vesta"
 version = "0.1.174"
-description = "Personal assistant agent that works autonomously on your behalf"
+description = "AI guardian angel that works autonomously on your behalf"
 license = "MIT"
 authors = [
     { name = "elyxlz" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT"
 repository = "https://github.com/elyxlz/vesta"
 authors = ["elyxlz"]
 edition = "2021"
-description = "Vesta CLI for managing personal assistant agents"
+description = "Vesta CLI for managing AI guardian angel agents"
 
 [[bin]]
 name = "vesta"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1110,7 +1110,7 @@ fn print_update_available(latest: &str) {
 }
 
 fn print_welcome() {
-    println!("vesta: your personal AI assistant");
+    println!("vesta: your AI guardian angel");
     println!();
     println!("quick start:");
     println!("  vesta connect <link>   link this machine to your server (from vestad status)");

--- a/vestad/Dockerfile
+++ b/vestad/Dockerfile
@@ -16,7 +16,7 @@ RUN bash /build/build-whisper.sh /opt/whisper.cpp
 FROM debian:trixie-slim
 
 LABEL org.opencontainers.image.title="Vesta" \
-      org.opencontainers.image.description="Personal assistant agent that works autonomously on your behalf" \
+      org.opencontainers.image.description="AI guardian angel that works autonomously on your behalf" \
       org.opencontainers.image.source="https://github.com/elyxlz/vesta" \
       org.opencontainers.image.licenses="MIT"
 

--- a/vestad/src/status.rs
+++ b/vestad/src/status.rs
@@ -434,7 +434,7 @@ impl Status {
             BoxRow::Art(4),
             BoxRow::Art(5),
             BoxRow::Gap,
-            BoxRow::Center(format!("personal AI daemon · v{}", self.version)),
+            BoxRow::Center(format!("AI guardian angel daemon · v{}", self.version)),
             BoxRow::Gap,
             BoxRow::Kv("user".into(), self.user.clone()),
             BoxRow::Kv("port".into(), self.port.to_string()),
@@ -541,7 +541,7 @@ mod tests {
         let rows = vec![
             BoxRow::Gap,
             BoxRow::Art(0),
-            BoxRow::Center("personal AI daemon".into()),
+            BoxRow::Center("AI guardian angel daemon".into()),
             BoxRow::Kv("user".into(), "emi".into()),
             BoxRow::Rule("connection".into()),
             BoxRow::Value("0123456789abcdef0123456789abcdef".into()),


### PR DESCRIPTION
## What

Repositions Vesta as an **AI guardian angel** and retires "personal AI" / "personal assistant" positioning language across the vesta repo. Requested by the repo owner in elyxlz/vesta-cloud#105.

The canonical framing, now codified in CLAUDE.md as the single source of truth for Vesta's copy:

- Vesta is an AI guardian angel. Not a personal AI, not an assistant-as-buddy, not a friend.
- Canonical one-liner: **"an AI guardian angel that gives you back time and helps you achieve your goals."**

## Changes

- **CLAUDE.md**: reworded the Project Overview opener ("personal AI assistant" to "AI guardian angel") without changing the technical meaning; added a new **Positioning** bullet at the top of the Brand voice section stating the guardian-angel framing and the canonical one-liner as the standardized home for Vesta's copy.
- **README.md**: replaced the opening tagline with the canonical one-liner, keeping the technical detail (Docker container, powered by Claude).
- **cli/src/main.rs**: `print_welcome` now prints "vesta: your AI guardian angel".
- **vestad/src/status.rs**: the daemon status box now reads "AI guardian angel daemon" (real display string plus its matching test fixture).
- **vestad/Dockerfile**: OCI image `description` label reworded to "AI guardian angel that works autonomously on your behalf".
- **cli/Cargo.toml** and **agent/core/pyproject.toml**: package/crate `description` product taglines reworded to guardian-angel framing.

All prose follows the brand voice rules (no she/her/it for Vesta; no dash separators).

## Checks

- `cargo build` (cli): passes.
- `cargo test -p vestad --bins status`: 17 passed, including `render_box_lines_share_width_and_are_bordered`.
- `uv lock --check` (agent/core): lock is fresh (the pyproject description is not tracked in uv.lock).

## Left for review (intentionally NOT changed)

- **COMPETITORS.md:19**: "Inflection's conversational personal AI" describes the competitor Pi, not Vesta.
- **.claude/workflows/gtm.js:24**: internal GTM-audit prompt describing the business ("hosted personal AI agent", "a personal AI living in their life"). Not user-facing copy, and it has uncommitted local edits in the shared checkout, so left untouched.
- **agent/core/openrouter_cache.py:52**: incidental code comment ("idle gaps typical of a personal assistant") explaining a cache TTL; technical, not positioning copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)