### PR TITLE
feat(vestad): report a rebuilding agent status instead of stopped during container rebuilds

### DIFF
--- a/apps/web/src/components/Orb/styles.test.ts
+++ b/apps/web/src/components/Orb/styles.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { getAgentVisualStatus } from "./styles";
+
+describe("getAgentVisualStatus", () => {
+  it("shows a busy updating orb for a server-side rebuilding agent", () => {
+    const { label, orbState } = getAgentVisualStatus(
+      { status: "rebuilding" },
+      "idle",
+      "",
+      "idle",
+    );
+    expect(label).toBe("updating...");
+    expect(orbState).toBe("busy");
+  });
+});

--- a/apps/web/src/components/Orb/styles.ts
+++ b/apps/web/src/components/Orb/styles.ts
@@ -56,6 +56,8 @@ function resolveStatus(
       return { label: "not set up", orbState: "busy" };
     case "restarting":
       return { label: "restarting...", orbState: "busy" };
+    case "rebuilding":
+      return { label: "updating...", orbState: "busy" };
     case "stopped":
       return { label: "stopped", orbState: "off" };
     case "dead":

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -5,6 +5,7 @@ export type AgentStatus =
   | "not_authenticated"
   | "unprovisioned"
   | "restarting"
+  | "rebuilding"
   | "stopped"
   | "dead"
   | "not_found";

--- a/apps/web/src/lib/vestad-api-fixtures.ts
+++ b/apps/web/src/lib/vestad-api-fixtures.ts
@@ -14,6 +14,7 @@ export const vestadApiFixtures = {
     "starting",
     "not_authenticated",
     "unprovisioned",
+    "rebuilding",
     "stopped",
     "dead",
     "not_found"

--- a/cli/tests/fixtures/vestad-api.json
+++ b/cli/tests/fixtures/vestad-api.json
@@ -11,6 +11,7 @@
     "starting",
     "not_authenticated",
     "unprovisioned",
+    "rebuilding",
     "stopped",
     "dead",
     "not_found"

--- a/vestad/src/agent_status.rs
+++ b/vestad/src/agent_status.rs
@@ -18,14 +18,20 @@ pub async fn get_status(
     http_client: &reqwest::Client,
     name: &str,
     agents_dir: &std::path::Path,
+    rebuilding: &docker::RebuildTracker,
 ) -> Result<docker::StatusJson, docker::DockerError> {
     docker::validate_name(name)?;
     let cname = docker::container_name(name);
     let info = docker::inspect_container(docker, &cname, Some(agents_dir)).await;
 
+    let status = if rebuilding.is_rebuilding(name) {
+        docker::AgentStatus::Rebuilding
+    } else {
+        combined_status(http_client, agents_dir, &cname, &info).await
+    };
     Ok(docker::StatusJson {
         name: name.to_string(),
-        status: combined_status(http_client, agents_dir, &cname, &info).await,
+        status,
         id: info.id,
         ws_port: info.port.unwrap_or(0),
     })
@@ -35,6 +41,7 @@ pub async fn list_agents(
     docker: &Docker,
     http_client: &reqwest::Client,
     agents_dir: &std::path::Path,
+    rebuilding: &docker::RebuildTracker,
 ) -> Vec<ListEntry> {
     let agents = docker::list_managed_agents(docker).await;
     let mut entries = Vec::new();
@@ -46,6 +53,26 @@ pub async fn list_agents(
             ws_port: info.port.unwrap_or(0),
             started_at: info.started_at.clone(),
         });
+    }
+    apply_rebuilding(entries, rebuilding.names())
+}
+
+/// Overlay live rebuild state onto the docker-derived listing: a mid-rebuild agent reports
+/// `Rebuilding`, and one whose container is momentarily removed (between the rebuild's remove
+/// and create steps) stays listed instead of vanishing. Names are sorted so the merged list is
+/// deterministic across polls (the watch channel diffs on equality).
+fn apply_rebuilding(mut entries: Vec<ListEntry>, mut rebuilding: Vec<String>) -> Vec<ListEntry> {
+    rebuilding.sort();
+    for name in rebuilding {
+        match entries.iter_mut().find(|entry| entry.name == name) {
+            Some(entry) => entry.status = docker::AgentStatus::Rebuilding,
+            None => entries.push(ListEntry {
+                name,
+                status: docker::AgentStatus::Rebuilding,
+                ws_port: 0,
+                started_at: None,
+            }),
+        }
     }
     entries
 }
@@ -198,6 +225,7 @@ pub fn spawn_agent_status_task(
     http_client: reqwest::Client,
     agents_dir: PathBuf,
     on_agents_changed: OnAgentsChanged,
+    rebuilding: docker::RebuildTracker,
 ) {
     tokio::spawn(async move {
         let mut agent_ws_handles: HashMap<String, AgentWsHandle> = HashMap::new();
@@ -206,7 +234,7 @@ pub fn spawn_agent_status_task(
 
         loop {
             // Poll agent list via async bollard
-            let agents = list_agents(&docker, &http_client, &agents_dir).await;
+            let agents = list_agents(&docker, &http_client, &agents_dir, &rebuilding).await;
 
             // Update the agents watch channel (only notifies if changed)
             let changed = cache.agents_tx.send_if_modified(|current| {
@@ -356,6 +384,37 @@ async fn agent_activity_listener(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn apply_rebuilding_overrides_status_and_keeps_missing_agents_listed() {
+        let entries = vec![
+            ListEntry {
+                name: "apollo".into(),
+                status: docker::AgentStatus::Stopped,
+                ws_port: 4200,
+                started_at: None,
+            },
+            ListEntry {
+                name: "hera".into(),
+                status: docker::AgentStatus::Alive,
+                ws_port: 4201,
+                started_at: Some("2026-01-01T00:00:00Z".into()),
+            },
+        ];
+        // apollo is mid-rebuild with its container still present; zeus is mid-rebuild
+        // with its container removed (it dropped out of the docker listing entirely).
+        let merged = apply_rebuilding(entries, vec!["apollo".into(), "zeus".into()]);
+        assert_eq!(merged.len(), 3);
+        assert_eq!(merged[0].name, "apollo");
+        assert_eq!(merged[0].status, docker::AgentStatus::Rebuilding);
+        assert_eq!(merged[0].ws_port, 4200);
+        assert_eq!(merged[1].name, "hera");
+        assert_eq!(merged[1].status, docker::AgentStatus::Alive);
+        assert_eq!(merged[2].name, "zeus");
+        assert_eq!(merged[2].status, docker::AgentStatus::Rebuilding);
+        assert_eq!(merged[2].ws_port, 0);
+        assert_eq!(merged[2].started_at, None);
+    }
 
     #[test]
     fn status_from_readiness_distinguishes_unprovisioned_from_unauthenticated() {

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -196,6 +196,10 @@ pub enum AgentStatus {
     /// Reachable, but no provider is chosen yet (fresh agent, or signed out) — needs first sign-in,
     /// distinct from `NotAuthenticated` (a chosen provider whose credential is invalid/expired).
     Unprovisioned,
+    /// Container is being rebuilt (post-update reconcile, user rebuild, or a grant recreate).
+    /// The snapshot takes minutes and the container is briefly removed, so without this state
+    /// the agent would read as `Stopped`/gone and invite a manual restart mid-rebuild.
+    Rebuilding,
     Stopped,
     Dead,
     NotFound,
@@ -211,9 +215,65 @@ impl AgentStatus {
             AgentStatus::Starting => "starting",
             AgentStatus::NotAuthenticated => "not authenticated",
             AgentStatus::Unprovisioned => "unprovisioned",
+            AgentStatus::Rebuilding => "rebuilding",
             AgentStatus::Stopped => "stopped",
             AgentStatus::Dead => "dead",
             AgentStatus::NotFound => "not found",
+        }
+    }
+}
+
+/// Live registry of agents whose container is mid-rebuild (stop → snapshot → remove → create).
+/// `rebuild_agent` holds a mark for its duration and the boot reconcile pre-marks its whole
+/// batch, so status derivation reports `Rebuilding` instead of `Stopped`/`NotFound` and the
+/// mutating handlers can refuse to race the recreate. Marks are counted per agent, so the
+/// reconcile's batch mark and `rebuild_agent`'s own mark nest safely.
+#[derive(Debug, Clone, Default)]
+pub struct RebuildTracker(std::sync::Arc<std::sync::Mutex<HashMap<String, u32>>>);
+
+impl RebuildTracker {
+    pub fn mark(&self, name: &str) -> RebuildMark {
+        let mut counts = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        *counts.entry(name.to_string()).or_insert(0) += 1;
+        RebuildMark {
+            tracker: self.clone(),
+            name: name.to_string(),
+        }
+    }
+
+    pub fn is_rebuilding(&self, name: &str) -> bool {
+        self.0
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(name)
+    }
+
+    pub fn names(&self) -> Vec<String> {
+        self.0
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .keys()
+            .cloned()
+            .collect()
+    }
+}
+
+/// RAII mark: dropping it (rebuild finished, failed, or abandoned) clears the agent's
+/// rebuilding state, so no error path can leave an agent stuck reporting `Rebuilding`.
+#[derive(Debug)]
+pub struct RebuildMark {
+    tracker: RebuildTracker,
+    name: String,
+}
+
+impl Drop for RebuildMark {
+    fn drop(&mut self) {
+        let mut counts = self.tracker.0.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(count) = counts.get_mut(&self.name) {
+            *count -= 1;
+            if *count == 0 {
+                counts.remove(&self.name);
+            }
         }
     }
 }
@@ -1870,6 +1930,7 @@ pub async fn restart_agent(
     env_config: &AgentEnvConfig,
     user_mounts: &[crate::mounts::HostMount],
     reason: Option<String>,
+    rebuilding: &RebuildTracker,
 ) -> Result<(), DockerError> {
     validate_name(name)?;
     let cname = container_name(name);
@@ -1898,7 +1959,7 @@ pub async fn restart_agent(
             // A caller-supplied reason wins; else describe the grant delta the rebuild applies.
             let effective =
                 crate::mounts::effective_restart_reason(reason, &actual_mounts, user_mounts);
-            rebuild_agent(docker, name, env_config, user_mounts).await?;
+            rebuild_agent(docker, name, env_config, user_mounts, rebuilding).await?;
             // Written into the freshly created container AFTER the rebuild: a write before it
             // would survive a failed rebuild in the old container, claiming access that was
             // never applied (and would bake the reason into the rebuild snapshot).
@@ -1966,6 +2027,7 @@ pub async fn reconcile_containers(
     manages_core_code: &(dyn Fn(&str) -> bool + Send + Sync),
     wants_running: &(dyn Fn(&str) -> bool + Send + Sync),
     mounts_for: &(dyn Fn(&str) -> Vec<crate::mounts::HostMount> + Send + Sync),
+    rebuilding: &RebuildTracker,
 ) {
     let agents = list_managed_agents(docker).await;
     if agents.is_empty() {
@@ -2022,8 +2084,22 @@ pub async fn reconcile_containers(
 
     // Phase 2: rebuild containers with wrong config (skipped when disk is critically full — see the
     // guard above). Uses container-derived mount topology (not settings) so a stale settings.json
-    // can't redirect the rebuild into wiping bind-mounted core code.
-    let mut agent_code_ok = false;
+    // can't redirect the rebuild into wiping bind-mounted core code. The whole batch is determined
+    // and marked as rebuilding up front: rebuilds run serially and take minutes each, so agents
+    // waiting their turn must already report `Rebuilding`, not `Stopped`.
+    struct PendingRebuild<'a> {
+        name: &'a str,
+        cname: &'a str,
+        raw: bollard::models::ContainerInspectResponse,
+        desired_mounts: Vec<crate::mounts::HostMount>,
+        has_core_mounts: bool,
+        // Held for the agent's place in the queue; a rebuilt agent's mark is kept until
+        // reconcile ends (phase 3 has started it), so it never dips back to `Stopped`
+        // while a later agent's rebuild runs. Dropped early only when the batch is
+        // abandoned, clearing the never-rebuilt agents' `Rebuilding` status truthfully.
+        mark: RebuildMark,
+    }
+    let mut pending = Vec::new();
     for ManagedAgent {
         cname,
         agent_name: name,
@@ -2056,7 +2132,19 @@ pub async fn reconcile_containers(
             continue;
         }
         tracing::info!(agent = %name, "rebuild needed");
-        if has_core_mounts && !agent_code_ok {
+        pending.push(PendingRebuild {
+            name,
+            cname,
+            raw,
+            desired_mounts,
+            has_core_mounts,
+            mark: rebuilding.mark(name),
+        });
+    }
+    let mut agent_code_ok = false;
+    let mut rebuilt_marks = Vec::new();
+    for item in pending {
+        if item.has_core_mounts && !agent_code_ok {
             match crate::agent_code::ensure_agent_code(&env_config.config_dir) {
                 Ok(_) => agent_code_ok = true,
                 Err(e) => {
@@ -2065,16 +2153,19 @@ pub async fn reconcile_containers(
                 }
             }
         }
-        match rebuild_agent(docker, name, env_config, &desired_mounts).await {
+        match rebuild_agent(docker, item.name, env_config, &item.desired_mounts, rebuilding).await {
             Ok(()) => {
-                tracing::info!(agent = %name, "rebuild complete");
+                tracing::info!(agent = %item.name, "rebuild complete");
                 // Grants can also land here (restart_agent defers to reconcile when disk is low or
                 // inspect fails); tell the agent about the delta, same as the restart path would.
-                let mount_reason =
-                    crate::mounts::mount_change_reason(&actual_user_mounts(&raw), &desired_mounts);
-                write_boot_reason(docker, name, cname, mount_reason).await;
+                let mount_reason = crate::mounts::mount_change_reason(
+                    &actual_user_mounts(&item.raw),
+                    &item.desired_mounts,
+                );
+                write_boot_reason(docker, item.name, item.cname, mount_reason).await;
+                rebuilt_marks.push(item.mark);
             }
-            Err(e) => tracing::error!(agent = %name, error = %e, "rebuild failed"),
+            Err(e) => tracing::error!(agent = %item.name, error = %e, "rebuild failed"),
         }
     }
 
@@ -2336,8 +2427,10 @@ pub async fn rebuild_agent(
     name: &str,
     env_config: &AgentEnvConfig,
     user_mounts: &[crate::mounts::HostMount],
+    rebuilding: &RebuildTracker,
 ) -> Result<(), DockerError> {
     validate_name(name)?;
+    let _mark = rebuilding.mark(name);
     let cname = container_name(name);
     let raw = docker
         .inspect_container(&cname, None)
@@ -2504,6 +2597,45 @@ pub async fn rename_agent(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rebuild_tracker_marks_agent_while_guard_held() {
+        let tracker = RebuildTracker::default();
+        assert!(!tracker.is_rebuilding("apollo"));
+        let mark = tracker.mark("apollo");
+        assert!(tracker.is_rebuilding("apollo"));
+        drop(mark);
+        assert!(!tracker.is_rebuilding("apollo"));
+    }
+
+    #[test]
+    fn rebuild_tracker_nested_marks_clear_only_when_all_dropped() {
+        let tracker = RebuildTracker::default();
+        let outer = tracker.mark("apollo");
+        let inner = tracker.mark("apollo");
+        drop(inner);
+        assert!(tracker.is_rebuilding("apollo"));
+        drop(outer);
+        assert!(!tracker.is_rebuilding("apollo"));
+    }
+
+    #[test]
+    fn rebuild_tracker_names_lists_each_marked_agent_once() {
+        let tracker = RebuildTracker::default();
+        let _a1 = tracker.mark("apollo");
+        let _a2 = tracker.mark("apollo");
+        let _b = tracker.mark("hera");
+        let mut names = tracker.names();
+        names.sort();
+        assert_eq!(names, vec!["apollo".to_string(), "hera".to_string()]);
+    }
+
+    #[test]
+    fn rebuilding_status_serializes_snake_case() {
+        let json = serde_json::to_string(&AgentStatus::Rebuilding).expect("serialize");
+        assert_eq!(json, "\"rebuilding\"");
+        assert_eq!(AgentStatus::Rebuilding.human_text(), "rebuilding");
+    }
 
     #[test]
     fn removable_snapshot_only_matches_our_throwaway_namespaces() {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -154,6 +154,22 @@ async fn agent_write_guard(state: &AppState, name: &str) -> tokio::sync::OwnedRw
     state.agent_lock(name).await.write_owned().await
 }
 
+/// Refuse a container-mutating operation while the agent's container is mid-rebuild: the rebuild
+/// (boot reconcile included, which doesn't hold the per-agent write lock) removes and recreates
+/// the container, so a concurrent start/restart/destroy would race the recreate.
+fn ensure_not_rebuilding(
+    rebuilding: &docker::RebuildTracker,
+    name: &str,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    if rebuilding.is_rebuilding(name) {
+        return Err(err_response(
+            StatusCode::CONFLICT,
+            &format!("agent '{name}' is updating (container rebuild in progress); wait for it to finish"),
+        ));
+    }
+    Ok(())
+}
+
 /// Run a container-mutating operation on a detached task and await its single result over a oneshot
 /// channel. Load-bearing invariant for a self-restart: the request's client is the agent inside the
 /// very container the operation stops, so the loopback connection drops the instant the container
@@ -413,7 +429,7 @@ async fn gateway_update_handler(
 async fn list_agents_handler(
     State(state): State<SharedState>,
 ) -> impl IntoResponse {
-    let agents = agent_status::list_agents(&state.docker, &state.http_client, &state.env_config.agents_dir).await;
+    let agents = agent_status::list_agents(&state.docker, &state.http_client, &state.env_config.agents_dir, &state.rebuilding).await;
     Json(agents)
 }
 
@@ -503,7 +519,7 @@ async fn agent_status_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
 ) -> Result<Json<docker::StatusJson>, (StatusCode, Json<serde_json::Value>)> {
-    let status = agent_status::get_status(&state.docker, &state.http_client, &name, &state.env_config.agents_dir)
+    let status = agent_status::get_status(&state.docker, &state.http_client, &name, &state.env_config.agents_dir, &state.rebuilding)
         .await
         .map_err(map_docker_err)?;
     Ok(Json(status))
@@ -514,6 +530,7 @@ async fn start_agent_handler(
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     tracing::info!(name = %name, "starting agent");
+    ensure_not_rebuilding(&state.rebuilding, &name)?;
     let _guard = agent_write_guard(&state, &name).await;
 
     {
@@ -563,6 +580,7 @@ async fn stop_agent_handler(
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     tracing::info!(name = %name, "stopping agent");
+    ensure_not_rebuilding(&state.rebuilding, &name)?;
     let _guard = agent_write_guard(&state, &name).await;
 
     {
@@ -607,6 +625,7 @@ async fn restart_agent_handler(
     body: axum::body::Bytes,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     tracing::info!(name = %name, "restarting agent");
+    ensure_not_rebuilding(&state.rebuilding, &name)?;
     let reason =
         parse_restart_reason(&body).map_err(|msg| err_response(StatusCode::BAD_REQUEST, &msg))?;
     // Detached from this request's connection: a self-restart's client is the agent inside the very
@@ -635,6 +654,7 @@ async fn restart_agent_handler(
             &state.env_config,
             &user_mounts,
             reason,
+            &state.rebuilding,
         )
         .await
         .map_err(map_docker_err)?;
@@ -648,6 +668,7 @@ async fn destroy_agent_handler(
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     tracing::info!(name = %name, "destroying agent");
+    ensure_not_rebuilding(&state.rebuilding, &name)?;
     let _guard = agent_write_guard(&state, &name).await;
 
     docker::destroy_agent(&state.docker, &name, &state.env_config.agents_dir)
@@ -669,13 +690,14 @@ async fn rebuild_agent_handler(
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     tracing::info!(name = %name, "rebuilding agent");
+    ensure_not_rebuilding(&state.rebuilding, &name)?;
     let _guard = agent_write_guard(&state, &name).await;
 
     let user_mounts = {
         let settings = state.settings.read().await;
         settings.agent_mounts(&name)
     };
-    docker::rebuild_agent(&state.docker, &name, &state.env_config, &user_mounts)
+    docker::rebuild_agent(&state.docker, &name, &state.env_config, &user_mounts, &state.rebuilding)
         .await
         .map_err(map_docker_err)?;
     // A rebuild ends by starting the agent, so record it as desired-running for boot-start.
@@ -2724,6 +2746,7 @@ pub async fn run_server(cfg: ServerConfig) {
     // snapshots each container's filesystem (minutes), and awaiting it would leave vestad unreachable.
     let reconcile_docker = docker.clone();
     let reconcile_env = state.env_config.clone();
+    let reconcile_rebuilding = state.rebuilding.clone();
     tokio::spawn(async move {
         docker::reconcile_containers(
             &reconcile_docker,
@@ -2741,6 +2764,7 @@ pub async fn run_server(cfg: ServerConfig) {
             // Mount grants are also read LIVE so a grant added/removed during the reconcile window
             // (or via a later `vesta restart`) is reflected without needing a fresh vestad boot.
             &|name| load_settings().agent_mounts(name),
+            &reconcile_rebuilding,
         )
         .await;
     });
@@ -2753,6 +2777,7 @@ pub async fn run_server(cfg: ServerConfig) {
         state.http_client.clone(),
         state.env_config.agents_dir.clone(),
         on_agents_changed,
+        state.rebuilding.clone(),
     );
     let app = build_router(state.clone());
     spawn_auto_backup_task(state.clone());
@@ -2845,7 +2870,16 @@ async fn shutdown_signal() {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_cached_port_reusable, spawn_pipeline_sse};
+    use super::{ensure_not_rebuilding, is_cached_port_reusable, spawn_pipeline_sse};
+
+    #[test]
+    fn mutating_agent_ops_conflict_while_rebuilding() {
+        let rebuilding = crate::docker::RebuildTracker::default();
+        assert!(ensure_not_rebuilding(&rebuilding, "apollo").is_ok());
+        let _mark = rebuilding.mark("apollo");
+        let err = ensure_not_rebuilding(&rebuilding, "apollo").expect_err("expected 409 while rebuilding");
+        assert_eq!(err.0, axum::http::StatusCode::CONFLICT);
+    }
 
     // ── SSE cancellation safety ───────────────────────────────────
     //
@@ -3090,6 +3124,7 @@ mod tests {
             AgentStatus::Starting,
             AgentStatus::NotAuthenticated,
             AgentStatus::Unprovisioned,
+            AgentStatus::Rebuilding,
             AgentStatus::Stopped,
             AgentStatus::Dead,
             AgentStatus::NotFound,

--- a/vestad/src/state.rs
+++ b/vestad/src/state.rs
@@ -101,6 +101,9 @@ pub struct AppState {
     pub(crate) settings: RwLock<Settings>,
     pub(crate) dev_mode: bool,
     pub(crate) agent_status_cache: Arc<agent_status::AgentStatusCache>,
+    /// Agents whose container is mid-rebuild; shared with the boot reconcile and the
+    /// status poll so they report `Rebuilding` and mutating handlers refuse to race it.
+    pub(crate) rebuilding: docker::RebuildTracker,
     pub(crate) https_port: u16,
     /// LAN exposure facts captured at startup (read-only; surfaced by /gateway/info).
     /// `expose_lan` mirrors the `--expose-lan` flag; `lan_url` is the advertised
@@ -148,6 +151,7 @@ impl AppState {
             settings: RwLock::new(settings),
             dev_mode,
             agent_status_cache: Arc::new(agent_status::AgentStatusCache::new()),
+            rebuilding: docker::RebuildTracker::default(),
             https_port,
             expose_lan,
             lan_url,


### PR DESCRIPTION
## Problem

After updating vestad from the app, agents show gray and "stopped" while their containers are rebuilt (the post-update reconcile recreates any container whose entrypoint or mounts drifted). The snapshot takes minutes and the container is briefly removed, so the agent reads as stopped, or drops out of the agent list entirely, which invites the user to restart the agent mid-rebuild. There was no server-side notion of "rebuilding": the web app's "rebuilding..." label only fired for a rebuild the same client initiated.

## Fix

Rebuild-in-progress is now a first-class, server-derived agent status.

- `RebuildTracker` (`docker.rs`): a shared registry of mid-rebuild agents with RAII counted marks, so no error path can leave an agent stuck reporting rebuilding. `rebuild_agent` holds a mark for its duration, covering the boot reconcile, user-initiated rebuilds, and grant-drift recreates.
- The boot reconcile pre-marks its whole rebuild batch up front and keeps each rebuilt agent's mark until the start phase has run, so with several agents none of them dips back to "stopped" while another one's rebuild runs.
- Status derivation (`agent_status.rs`): a marked agent reports `rebuilding`, and one whose container is momentarily removed stays in the `GET /agents` list instead of vanishing.
- Container-mutating handlers (start, stop, restart, rebuild, destroy) return 409 with a clear message while a rebuild is in flight. The boot reconcile does not hold the per-agent write lock, so this closes a real race: a manual restart could previously interleave with the remove/recreate steps.
- Web: the new status renders as a busy orb labeled "updating...", replacing the gray "stopped" orb that tempted manual restarts.
- API contract fixtures regenerated (web + cli); the CLI parses status as a plain string, so it needs no code change.

## Tests

TDD throughout: tracker mark/drop/nesting semantics, the list overlay (override + keep-listed), the 409 gate, snake_case wire serialization, and the web orb mapping, plus the regenerated cross-language contract fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)