### PR TITLE
feat: remove the user-facing rebuild action and its vestad endpoint

### DIFF
--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -257,12 +257,6 @@ export async function deleteAgent(name: string): Promise<void> {
   });
 }
 
-export async function rebuildAgent(name: string): Promise<void> {
-  await apiJson(`/agents/${encodeURIComponent(name)}/rebuild`, {
-    method: "POST",
-  });
-}
-
 export interface BackupInfo {
   id: string;
   agent_name: string;

--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -4,7 +4,6 @@ export {
   stopAgent,
   restartAgent,
   deleteAgent,
-  rebuildAgent,
   createBackup,
   listBackups,
   restoreBackup,

--- a/apps/web/src/components/AgentMenu/AgentActions.tsx
+++ b/apps/web/src/components/AgentMenu/AgentActions.tsx
@@ -11,7 +11,6 @@ import {
   Square,
   Trash2,
   Wrench,
-  Hammer,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { MenuSection } from "@/components/ui/menu-section";
@@ -25,7 +24,6 @@ export interface AgentActionsInput {
   onToolCalls: () => void;
   onToggle: () => void;
   onRestart: () => void;
-  onRebuild: () => void;
   onBackup: () => void;
   onAuthenticate?: () => void;
   isAuthenticated?: boolean;
@@ -84,22 +82,13 @@ export function buildActionSections(input: AgentActionsInput): ActionSection[] {
     },
   ];
   if (input.isRunning) {
-    controlItems.push(
-      {
-        key: "restart",
-        icon: <RefreshCw data-icon="inline-start" />,
-        label: "restart",
-        onClick: input.onRestart,
-        disabled: input.isBusy,
-      },
-      {
-        key: "rebuild",
-        icon: <Hammer data-icon="inline-start" />,
-        label: "rebuild",
-        onClick: input.onRebuild,
-        disabled: input.isBusy,
-      },
-    );
+    controlItems.push({
+      key: "restart",
+      icon: <RefreshCw data-icon="inline-start" />,
+      label: "restart",
+      onClick: input.onRestart,
+      disabled: input.isBusy,
+    });
   }
   controlItems.push({
     key: "backup",

--- a/apps/web/src/components/AgentMenu/DesktopMenu.tsx
+++ b/apps/web/src/components/AgentMenu/DesktopMenu.tsx
@@ -18,7 +18,6 @@ export function DesktopMenu({ state, open, onOpenChange, trigger }: MenuProps) {
     onToolCalls: state.onToolCalls,
     onToggle: state.onToggle,
     onRestart: state.onRestart,
-    onRebuild: state.onRebuild,
     onBackup: state.onBackup,
     onAppSettings: state.onAppSettings,
     onAgentSettings: state.onAgentSettings,

--- a/apps/web/src/components/AgentMenu/MobileMenu.tsx
+++ b/apps/web/src/components/AgentMenu/MobileMenu.tsx
@@ -42,7 +42,6 @@ export function MobileMenu({ state, open, onOpenChange, trigger }: MenuProps) {
             onToolCalls={state.onToolCalls}
             onToggle={state.onToggle}
             onRestart={state.onRestart}
-            onRebuild={state.onRebuild}
             onBackup={state.onBackup}
             onAppSettings={state.onAppSettings}
             onAgentSettings={state.onAgentSettings}

--- a/apps/web/src/components/AgentMenu/index.tsx
+++ b/apps/web/src/components/AgentMenu/index.tsx
@@ -20,7 +20,7 @@ import { DesktopMenu } from "./DesktopMenu";
 
 export function AgentMenu() {
   const navigate = useNavigate();
-  const { name, agent, isBusy, start, stop, restart, rebuild, backup } =
+  const { name, agent, isBusy, start, stop, restart, backup } =
     useSelectedAgent();
   const { setDeleteDialogOpen, handleOpenAuth } = useModals();
   const { showToolCalls, setShowToolCalls } = useAgentSocket();
@@ -49,7 +49,6 @@ export function AgentMenu() {
     onAgentSettings: () =>
       navigate(`/agent/${encodeURIComponent(name)}/settings`),
     onRestart: () => void restart(),
-    onRebuild: () => void rebuild(),
     onBackup: () => void backup(),
     onAuthenticate: gateway.reachable ? () => handleOpenAuth() : undefined,
     isAuthenticated: Boolean(

--- a/apps/web/src/components/AgentMenu/types.ts
+++ b/apps/web/src/components/AgentMenu/types.ts
@@ -10,7 +10,6 @@ export interface MenuState {
   onAppSettings: () => void;
   onAgentSettings: () => void;
   onRestart: () => void;
-  onRebuild: () => void;
   onBackup: () => void;
   onAuthenticate?: () => void;
   isAuthenticated?: boolean;

--- a/apps/web/src/components/AgentSettings/ActionsCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ActionsCard/index.tsx
@@ -18,7 +18,6 @@ export function ActionsCard() {
     start,
     stop,
     restart,
-    rebuild,
     backup,
   } = useSelectedAgent();
   const { handleOpenAuth, setDeleteDialogOpen } = useModals();
@@ -68,7 +67,6 @@ export function ActionsCard() {
           onToolCalls={() => setShowToolCalls((value) => !value)}
           onToggle={() => void (isRunning ? stop() : start())}
           onRestart={() => void restart()}
-          onRebuild={() => void rebuild()}
           onBackup={() => void backup()}
           onDelete={() => setDeleteDialogOpen(true)}
         />

--- a/apps/web/src/components/Orb/styles.ts
+++ b/apps/web/src/components/Orb/styles.ts
@@ -31,8 +31,6 @@ function resolveStatus(
       return { label: "signing in...", orbState: "busy" };
     case "deleting":
       return { label: "deleting...", orbState: "deleting" };
-    case "rebuilding":
-      return { label: "rebuilding...", orbState: "busy" };
     case "backing-up":
       return { label: "backing up...", orbState: "alive" };
     case "restoring":

--- a/apps/web/src/providers/SelectedAgentProvider/context.ts
+++ b/apps/web/src/providers/SelectedAgentProvider/context.ts
@@ -24,7 +24,6 @@ export interface SelectedAgentContextValue {
   start: () => void;
   stop: () => void;
   restart: () => Promise<void>;
-  rebuild: () => void;
   backup: () => void;
   backups: BackupInfo[];
   refreshBackups: () => Promise<void>;

--- a/apps/web/src/providers/SelectedAgentProvider/index.tsx
+++ b/apps/web/src/providers/SelectedAgentProvider/index.tsx
@@ -3,7 +3,6 @@ import {
   startAgent,
   stopAgent,
   restartAgent,
-  rebuildAgent,
   createBackup,
   listBackups,
   restoreBackup,
@@ -59,7 +58,7 @@ export function SelectedAgentProvider({
 
   const start = op("starting", () => startAgent(name), "start failed");
   const stop = op("stopping", () => stopAgent(name), "stop failed");
-  // A restart/rebuild applies any pending saved changes, so clear the "restart to apply" reminder on
+  // A restart applies any pending saved changes, so clear the "restart to apply" reminder on
   // success (the run callback throws on failure, so a failed op keeps the reminder). For most reasons
   // reconcile (use-restart-pending) is the owner — it clears the flag once the agent is observed to
   // restart by any path — and this optimistic clear only hides the ~3s status-poll latency so the
@@ -84,12 +83,6 @@ export function SelectedAgentProvider({
     () => restartAgent(name),
     "restart failed",
   );
-  const rebuild = applyPending(
-    "rebuilding",
-    () => rebuildAgent(name),
-    "rebuild failed",
-  );
-
   const [backups, setBackups] = useState<BackupInfo[]>([]);
 
   const refreshBackups = async () => {
@@ -163,7 +156,6 @@ export function SelectedAgentProvider({
     start,
     stop,
     restart,
-    rebuild,
     backup,
     backups,
     refreshBackups,

--- a/apps/web/src/stores/use-agent-ops.ts
+++ b/apps/web/src/stores/use-agent-ops.ts
@@ -7,7 +7,6 @@ export type AgentOperation =
   | "starting"
   | "authenticating"
   | "deleting"
-  | "rebuilding"
   | "backing-up"
   | "restoring";
 
@@ -87,8 +86,6 @@ export function getOpLabel(op: AgentOperation): string {
       return "stopping...";
     case "deleting":
       return "deleting...";
-    case "rebuilding":
-      return "rebuilding...";
     case "backing-up":
       return "backing up...";
     case "restoring":

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -570,17 +570,6 @@ impl Client {
         Ok(())
     }
 
-    pub fn rebuild_agent(&self, name: &str) -> Result<(), String> {
-        // A rebuild may pull a fresh agent image before responding, same as create_agent.
-        let request = self
-            .authorized(self.agent.post(self.url(&format!("/agents/{name}/rebuild"))))
-            .config()
-            .timeout_recv_response(None)
-            .build();
-        self.finish(request.send_empty())?;
-        Ok(())
-    }
-
     /// Poll until status is `alive`, `not_authenticated`, or `unprovisioned`. Used right after
     /// `create_agent` to know the agent's HTTP server is up and ready to accept
     /// `PUT /agents/{name}/config` — a brand-new empty agent reports `unprovisioned`

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -223,11 +223,6 @@ enum Command {
         /// Agent name
         name: String,
     },
-    /// Snapshot, destroy, recreate, restore auth
-    Rebuild {
-        /// Agent name
-        name: String,
-    },
     /// Wait for agent to become ready
     WaitReady {
         /// Agent name
@@ -1654,12 +1649,6 @@ fn run(cli: Cli) {
             let c = get_client(host_ref, token_ref);
             c.destroy_agent(&name).or_die();
             eprintln!("{name}: destroyed");
-        }
-
-        Command::Rebuild { name } => {
-            let c = get_client(host_ref, token_ref);
-            c.rebuild_agent(&name).or_die();
-            eprintln!("{name}: rebuilt and running");
         }
 
         Command::WaitReady { name, timeout } => {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -25,14 +25,14 @@ const GATEWAY_RESTART_DELAY_MS: u64 = 200;
 // streams (logs tail -f, backup create/restore progress, agent proxy), which must stay open.
 const CONTROL_REQUEST_TIMEOUT_SECS: u64 = 120;
 
-// Agent create and rebuild build/pull the image (minutes on a cold cache), which the 120s control
+// Agent create builds/pulls the image (minutes on a cold cache), which the 120s control
 // deadline would 408 mid-progress. A generous deadline that still bounds a truly-hung build.
 const LONGRUN_REQUEST_TIMEOUT_SECS: u64 = 1800;
 
 const API_KEY_BYTES: usize = 32;
 
 const RESERVED_SERVICE_NAMES: &[&str] = &[
-    "start", "stop", "restart", "destroy", "rebuild", "auth", "logs", "tree", "file", "backups",
+    "start", "stop", "restart", "destroy", "auth", "logs", "tree", "file", "backups",
     "settings", "services",
 ];
 const DEFAULT_LOG_TAIL_LINES: u64 = 500;
@@ -682,37 +682,6 @@ async fn destroy_agent_handler(
         save_settings(&settings);
     }
 
-    Ok(ok_json())
-}
-
-async fn rebuild_agent_handler(
-    State(state): State<SharedState>,
-    Path(name): Path<String>,
-) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    tracing::info!(name = %name, "rebuilding agent");
-    ensure_not_rebuilding(&state.rebuilding, &name)?;
-    let _guard = agent_write_guard(&state, &name).await;
-
-    let user_mounts = {
-        let settings = state.settings.read().await;
-        settings.agent_mounts(&name)
-    };
-    docker::rebuild_agent(&state.docker, &name, &state.env_config, &user_mounts, &state.rebuilding)
-        .await
-        .map_err(map_docker_err)?;
-    // A rebuild ends by starting the agent, so record it as desired-running for boot-start.
-    {
-        let mut settings = state.settings.write().await;
-        settings
-            .agents
-            .entry(name.clone())
-            .or_default()
-            .user_desired = UserDesired::Running;
-        save_settings(&settings);
-    }
-    docker::start_agent(&state.docker, &name)
-        .await
-        .map_err(map_docker_err)?;
     Ok(ok_json())
 }
 
@@ -2335,10 +2304,9 @@ pub fn build_router(state: SharedState) -> Router {
             auth::auth_middleware,
         ));
 
-    // Create and rebuild run image builds; the longrun deadline keeps them from 408ing (see the const).
+    // Create runs an image build; the longrun deadline keeps it from 408ing (see the const).
     let vestad_protected_longrun = Router::new()
         .route("/agents", post(create_agent_handler))
-        .route("/agents/{name}/rebuild", post(rebuild_agent_handler))
         .layer(longrun_timeout_layer())
         .layer(middleware::from_fn_with_state(
             state.clone(),
@@ -2400,7 +2368,7 @@ pub fn build_router(state: SharedState) -> Router {
     // how the agent's restart_vesta/stop_vesta tools reach vestad (it then does the docker action).
     // Stop is quick (control tier); restart can trigger a full snapshot+recreate when host-folder
     // grants drifted (docker export|import), which for a multi-GB agent exceeds the control deadline —
-    // so it rides the longrun timeout like the rebuild route, not the control tier.
+    // so it rides the longrun timeout like the create route, not the control tier.
     let agents_self_stop = Router::new()
         .route("/agents/{name}/stop", post(stop_agent_handler))
         .layer(control_timeout_layer())
@@ -3046,7 +3014,7 @@ mod tests {
     #[tokio::test]
     async fn longrun_layer_allows_a_request_past_the_control_deadline() {
         // A handler slower than a control-class deadline must survive under the longrun layer —
-        // the mechanism that keeps agent create/rebuild (multi-minute image builds) from 408ing.
+        // the mechanism that keeps agent create (a multi-minute image build) from 408ing.
         let slow = || async {
             tokio::time::sleep(std::time::Duration::from_millis(250)).await;
             "ok"

--- a/vestad/tests-integration/README.md
+++ b/vestad/tests-integration/README.md
@@ -23,7 +23,7 @@ vestad/tests/                   (the actual suites — run via `cargo test -p ve
     backup.rs       create/list/restore/delete, safety snapshots
     websocket.rs    WS connect, auth rejection
     ports.rs        port uniqueness, env files, agent tokens
-    agent_code.rs   manage_agent_code mounts, rebuild
+    agent_code.rs   manage_agent_code mounts
     layout.rs       fresh agent container filesystem structure
 
   multi_user/     multi-user isolation (6 tests)

--- a/vestad/tests-integration/src/client.rs
+++ b/vestad/tests-integration/src/client.rs
@@ -266,11 +266,6 @@ impl Client {
         Ok(())
     }
 
-    pub fn rebuild_agent(&self, name: &str) -> Result<(), String> {
-        self.post(&format!("/agents/{}/rebuild", name))?;
-        Ok(())
-    }
-
     pub fn rename_agent(&self, name: &str, new_name: &str) -> Result<String, String> {
         let body = serde_json::json!({"new_name": new_name});
         let resp = self.patch_json(&format!("/agents/{}", name), &body)?;

--- a/vestad/tests/server/agent_code.rs
+++ b/vestad/tests/server/agent_code.rs
@@ -1,6 +1,5 @@
 use vesta_tests::{
-    agent_container_name, docker_cmd, inject_fake_token, mark_first_start_done, unique_agent,
-    TestAgent, SERVER,
+    agent_container_name, docker_cmd, mark_first_start_done, unique_agent, TestAgent, SERVER,
 };
 
 fn assert_agent_core_paths_permissions(
@@ -56,30 +55,4 @@ fn manage_agent_code_false_reaches_ready() {
     let container = agent_container_name(&agent.name);
     assert_agent_core_paths_permissions(&container, false)
         .expect("core paths should be writable from image");
-}
-
-#[test]
-fn rebuild_preserves_auth() {
-    let c = SERVER.client();
-    let agent = TestAgent::create(&c, &unique_agent("rebuild")).unwrap();
-    inject_fake_token(&c, &agent.name);
-    c.start_agent(&agent.name).unwrap();
-
-    c.rebuild_agent(&agent.name).unwrap();
-
-    // A rebuild must not wipe the user's credentials. Assert the credentials file
-    // itself survives — not the agent's auth *status*: a fake token's first upstream
-    // call 401s and flips the status to not_authenticated even though the file is
-    // intact, so status is no longer a reliable proxy for "auth preserved".
-    c.wait_until_running(&agent.name, 180)
-        .expect("agent should come up after rebuild");
-    let container = agent_container_name(&agent.name);
-    docker_cmd(&[
-        "exec",
-        &container,
-        "test",
-        "-f",
-        "/root/.claude/.credentials.json",
-    ])
-    .expect("credentials file should survive rebuild");
 }


### PR DESCRIPTION
## What

Removes rebuild entirely as an externally reachable operation:

- **CLI**: drops the `vesta rebuild <name>` subcommand and the `rebuild_agent` client method.
- **Web app**: drops the rebuild button from the agent menu (desktop dropdown + mobile drawer) and the agent settings actions card, plus the now unused `rebuildAgent` API function, the `rebuild` context action, and the `rebuilding` op state (with its orb/status labels).
- **vestad**: drops the `POST /agents/{name}/rebuild` endpoint, its handler, "rebuild" from the reserved service names, the integration test client's `rebuild_agent`, and the endpoint-only `rebuild_preserves_auth` test.

## What stays

The internal `docker::rebuild_agent` machinery is untouched: boot-time `reconcile_containers` still rebuilds containers on config drift (entrypoint/mount changes), and restart still recreates on mount drift. Coverage for the snapshot/recreate state-preservation behavior remains via `rename_preserves_in_container_state` (same snapshot + recreate machinery), the `docker.rs` ordering unit tests (`rebuild_agent_stops_running_container_before_snapshot`, `rebuild_agent_confirms_removal_before_create`), and the release-gating live upgrade e2e (real cross-version reconcile rebuild).

## Verification

- `./check.sh cli` green (clippy + tests)
- `./check.sh web` green (eslint, prettier, tsc, 167 vitest tests)
- `./check.sh vestad` green (clippy + 189 tests)
- `cargo check -p vesta-tests --tests` green (integration crate compiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3zTE3H6Xznp8ZzJuk5u9f