### PR TITLE
fix(web): don't auto-open the claude sign-in link during agent creation

### DIFF
--- a/apps/web/src/components/AuthFlow/index.tsx
+++ b/apps/web/src/components/AuthFlow/index.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Copy, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ProviderStep } from "@/components/ProviderPicker/ProviderStep";
 import { ClaudeLogo } from "@/components/ProviderPicker/logos";
-import { openExternalUrl } from "@/lib/open-external-url";
 import { errorMessage } from "@/lib/utils";
 
 interface AuthFlowProps {
@@ -26,12 +25,6 @@ export function AuthFlow({
   const [code, setCode] = useState("");
   const [error, setError] = useState("");
   const [copied, setCopied] = useState(false);
-
-  // Open the sign-in link for the user as soon as it's ready. Best-effort: a popup blocker or a
-  // non-user-gesture context can stop it, so the copyable link below stays as the fallback.
-  useEffect(() => {
-    if (authUrl) openExternalUrl(authUrl).catch(() => {});
-  }, [authUrl]);
 
   const copyAuthUrl = async () => {
     try {


### PR DESCRIPTION
## What

During Claude OAuth agent creation, `AuthFlow` opened the sign-in link automatically via an effect the moment the `authUrl` was ready. This removes that behavior so the user opens the link themselves.

## Why

Auto-opening a browser tab (or attempting to) during the sign-in step is intrusive and unreliable: popup blockers and non-user-gesture contexts already made it best-effort, and the copyable link plus copy button already cover the flow. Letting the user initiate the open keeps the step predictable.

## Changes

- Remove the `useEffect` in `apps/web/src/components/AuthFlow/index.tsx` that called `openExternalUrl(authUrl)` on mount.
- Drop the now-unused `openExternalUrl` import and switch the React import from `useEffect, useState` to `useState`.

The visible link, copy button, and the "open the link, sign in, then paste the code below" subtitle remain unchanged, so the user still has a clear one-tap path.

## Verification

- `tsc --noEmit` clean
- `eslint` clean
- `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpAEbh2uEXVdxZPaupF9DW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpAEbh2uEXVdxZPaupF9DW)_