### PR TITLE
fix(web): resume agent onboarding after a page refresh

### DIFF
--- a/apps/web/src/components/NewAgent/index.tsx
+++ b/apps/web/src/components/NewAgent/index.tsx
@@ -9,6 +9,11 @@ import {
 } from "@/api/agents";
 import { stepTransition } from "@/lib/motion";
 import { errorMessage } from "@/lib/utils";
+import {
+  loadOnboarding,
+  saveOnboarding,
+  clearOnboarding,
+} from "@/lib/onboarding-progress";
 import { useOnboarding } from "@/stores/use-onboarding";
 import { NameStep } from "./Steps/NameStep";
 import { ProviderPicker } from "@/components/ProviderPicker";
@@ -22,22 +27,35 @@ const START_TIMEOUT_MS = 10 * 60 * 1000;
 export function NewAgent() {
   const step = useOnboarding((s) => s.step);
   const setStep = useOnboarding((s) => s.setStep);
-  const [agentName, setAgentName] = useState("");
-  const [personality, setPersonality] = useState<string | null>(null);
+  // Refreshing mid-onboarding restores the name and personality (never the credentials, which
+  // stay in memory only); a resumed run re-collects the provider and skips whatever it already has.
+  const [agentName, setAgentName] = useState(
+    () => loadOnboarding()?.agentName ?? "",
+  );
+  const [personality, setPersonality] = useState<string | null>(
+    () => loadOnboarding()?.personality ?? null,
+  );
   // The full provider result from the picker — credentials/key plus the default
   // model and context window, all forwarded verbatim to setProvider.
   const [providerResult, setProviderResult] = useState<ProviderResult | null>(
     null,
   );
   const [createError, setCreateError] = useState<string | null>(null);
-  // Pipeline runs for the current name; a retry treats createAgent's 409 as
-  // phase 1 already done (the failed attempt made the container).
-  const attemptRef = useRef(0);
+  // Pipeline runs for the current name; a retry treats createAgent's 409 as phase 1 already done
+  // (the failed attempt made the container). A resumed refresh is such a retry, since the container
+  // may already exist, so seed the count when the name was restored.
+  const attemptRef = useRef(agentName ? 1 : 0);
 
   useEffect(() => {
-    setStep("name");
+    // No credentials survive a refresh, so a restored name resumes at the provider step; the
+    // pipeline then skips any personality already collected. A fresh visit starts at the name.
+    setStep(agentName ? "provider" : "name");
     return () => setStep(null);
   }, []);
+
+  useEffect(() => {
+    if (agentName) saveOnboarding({ agentName, personality });
+  }, [agentName, personality]);
 
   useEffect(() => {
     if (step !== "creating" || createError !== null) return;
@@ -95,6 +113,7 @@ export function NewAgent() {
         await waitUntilAlive(agentName, START_TIMEOUT_MS);
         if (cancelled) return;
 
+        clearOnboarding();
         setStep("done");
       } catch (e) {
         // Transient failure: stay here with everything collected intact; the

--- a/apps/web/src/lib/onboarding-progress.test.tsx
+++ b/apps/web/src/lib/onboarding-progress.test.tsx
@@ -1,0 +1,51 @@
+// Exercises the real sessionStorage-backed helper, so it runs in the jsdom project (storage
+// present) — hence .test.tsx despite having no JSX. The .test.ts (node) project has no storage.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  loadOnboarding,
+  saveOnboarding,
+  clearOnboarding,
+} from "./onboarding-progress";
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe("onboarding progress", () => {
+  it("returns null when nothing has been saved", () => {
+    expect(loadOnboarding()).toBeNull();
+  });
+
+  it("round-trips the name and personality across a reload", () => {
+    saveOnboarding({ agentName: "luna", personality: "warm" });
+    expect(loadOnboarding()).toEqual({
+      agentName: "luna",
+      personality: "warm",
+    });
+  });
+
+  it("keeps a name saved before a personality is chosen", () => {
+    saveOnboarding({ agentName: "luna", personality: null });
+    expect(loadOnboarding()).toEqual({ agentName: "luna", personality: null });
+  });
+
+  it("clears the saved progress once onboarding finishes", () => {
+    saveOnboarding({ agentName: "luna", personality: "warm" });
+    clearOnboarding();
+    expect(loadOnboarding()).toBeNull();
+  });
+
+  it("treats an entry with no usable name as no progress", () => {
+    sessionStorage.setItem(
+      "vesta:onboarding",
+      JSON.stringify({ agentName: "", personality: "warm" }),
+    );
+    expect(loadOnboarding()).toBeNull();
+  });
+
+  it("ignores a corrupt payload rather than throwing", () => {
+    sessionStorage.setItem("vesta:onboarding", "{not json");
+    expect(loadOnboarding()).toBeNull();
+  });
+});

--- a/apps/web/src/lib/onboarding-progress.ts
+++ b/apps/web/src/lib/onboarding-progress.ts
@@ -1,0 +1,38 @@
+// The non-sensitive inputs collected while creating a new agent, persisted so a page refresh
+// mid-onboarding resumes instead of restarting from the name. The provider result (OAuth blob /
+// API key) is deliberately never stored: a resumed run re-collects the provider, then skips every
+// step it already has. Scoped to sessionStorage so it lives for the tab's onboarding, not forever.
+const STORAGE_KEY = "vesta:onboarding";
+
+export interface OnboardingProgress {
+  agentName: string;
+  personality: string | null;
+}
+
+export function loadOnboarding(): OnboardingProgress | null {
+  if (typeof sessionStorage === "undefined") return null;
+  const raw = sessionStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  let parsed: { agentName?: unknown; personality?: unknown };
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed.agentName !== "string" || !parsed.agentName) return null;
+  return {
+    agentName: parsed.agentName,
+    personality:
+      typeof parsed.personality === "string" ? parsed.personality : null,
+  };
+}
+
+export function saveOnboarding(progress: OnboardingProgress): void {
+  if (typeof sessionStorage === "undefined") return;
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+}
+
+export function clearOnboarding(): void {
+  if (typeof sessionStorage === "undefined") return;
+  sessionStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
## Problem

During agent creation in the web app, refreshing the page mid-onboarding lost all progress and sent the user back to the name step. The wizard kept every collected input (name, provider, personality) in in-memory React state, so a reload reset it to the start.

## Fix

Persist the non-sensitive wizard inputs to `sessionStorage` and rehydrate them on mount, so a refresh resumes instead of restarting.

- New helper `lib/onboarding-progress.ts` (matching the existing `lib/last-agent.ts` pattern) with `load`/`save`/`clear`. Scoped to `sessionStorage`, the natural lifetime for an in-progress wizard.
- `NewAgent` seeds its `agentName`/`personality` state from the saved progress, saves on change, and clears on success.
- On mount, a restored name resumes at the **provider** step rather than the name step.

The provider result (Claude OAuth blob / OpenRouter API key) is deliberately never stored. A resumed run re-collects only the provider, then skips any step it already has (name, personality) via the wizard's existing "skip collected inputs" logic. This keeps credentials out of storage while still recovering everything safe to recover.

To keep the long "creating" phase correct across a refresh, the attempt count is seeded when the name was restored, so a create `409` for an already-built container reads as "already created" (the existing retry semantics) instead of a fresh name clash.

## Behavior after refresh

| Refreshed at | Before | After |
| --- | --- | --- |
| name | back to name | back to name |
| provider | name lost, back to name | name restored, resume at provider |
| personality | everything lost | name + personality restored, re-auth then skip personality |
| creating/done | everything lost | name + personality restored, re-auth, create 409 treated as already-created |

## Tests

- `lib/onboarding-progress.test.tsx`: round-trip, name-only, clear-on-finish, empty-name guard, corrupt-payload guard.
- `./check.sh web` green (eslint 0 errors, prettier, tsc, 174 vitest tests pass). No new lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016DqGrS7hPsJzuj9GPcscJp)_