### PR TITLE
fix(web): reconnect the gateway socket immediately on tab refocus

### DIFF
--- a/apps/web/src/lib/reconnecting-ws.test.ts
+++ b/apps/web/src/lib/reconnecting-ws.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { connectReconnectingWs } from "./reconnecting-ws";
 
@@ -122,6 +123,44 @@ describe("connectReconnectingWs", () => {
       onMessage: () => {},
     });
     await vi.runAllTimersAsync();
+    expect(FakeSocket.instances).toHaveLength(1);
+  });
+
+  it("reconnects immediately on regaining visibility, consuming the pending backoff", () => {
+    connectReconnectingWs({
+      url: () => "ws://host/a",
+      onMessage: () => {},
+      baseDelayMs: 1000,
+    });
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    // Mobile OS drops the socket while the tab is backgrounded; the deferred
+    // close lands on return and schedules a backoff reconnect.
+    socket.drop();
+    expect(FakeSocket.instances).toHaveLength(1);
+    // Regaining visibility reconnects now instead of waiting out the backoff.
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(FakeSocket.instances).toHaveLength(2);
+    // The pending backoff timer was cleared, so it never spawns a duplicate.
+    vi.advanceTimersByTime(30000);
+    expect(FakeSocket.instances).toHaveLength(2);
+  });
+
+  it("leaves a healthy socket untouched when the tab becomes visible", () => {
+    connectReconnectingWs({ url: () => "ws://host/a", onMessage: () => {} });
+    FakeSocket.instances[0].open();
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(FakeSocket.instances).toHaveLength(1);
+  });
+
+  it("stops listening for visibility once closed", () => {
+    const handle = connectReconnectingWs({
+      url: () => "ws://host/a",
+      onMessage: () => {},
+    });
+    FakeSocket.instances[0].open();
+    handle.close();
+    document.dispatchEvent(new Event("visibilitychange"));
     expect(FakeSocket.instances).toHaveLength(1);
   });
 

--- a/apps/web/src/lib/reconnecting-ws.ts
+++ b/apps/web/src/lib/reconnecting-ws.ts
@@ -1,6 +1,11 @@
 const DEFAULT_BASE_DELAY_MS = 1000;
 const DEFAULT_MAX_DELAY_MS = 30000;
 
+// WebSocket.readyState values, named locally so the health checks read clearly
+// and don't depend on the WebSocket global (tests stub it without the statics).
+const WS_CONNECTING = 0;
+const WS_OPEN = 1;
+
 export interface ReconnectingWsHandle {
   /** The live socket, or null while down/reconnecting. */
   current: () => WebSocket | null;
@@ -40,6 +45,7 @@ export function connectReconnectingWs(
   let cancelled = false;
   let socket: WebSocket | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let connecting = false;
   let delay = baseDelay;
 
   const scheduleReconnect = () => {
@@ -48,41 +54,78 @@ export function connectReconnectingWs(
   };
 
   async function connect() {
-    if (cancelled) return;
-    if (options.beforeConnect) {
-      const verdict = await options.beforeConnect();
-      if (cancelled) return;
-      if (verdict === "stop") {
-        cancelled = true;
+    if (cancelled || connecting) return;
+    connecting = true;
+    try {
+      if (options.beforeConnect) {
+        const verdict = await options.beforeConnect();
+        if (cancelled) return;
+        if (verdict === "stop") {
+          cancelled = true;
+          return;
+        }
+      }
+      let url: string;
+      try {
+        url = options.url();
+      } catch {
+        scheduleReconnect();
         return;
       }
+      const sock = new WebSocket(url);
+      socket = sock;
+      sock.onopen = () => {
+        if (cancelled) return;
+        delay = baseDelay;
+        options.onOpen?.();
+      };
+      sock.onmessage = (event) => {
+        if (cancelled || typeof event.data !== "string") return;
+        options.onMessage(event.data);
+      };
+      sock.onclose = () => {
+        socket = null;
+        if (cancelled) return;
+        options.onClose?.();
+        scheduleReconnect();
+      };
+      sock.onerror = () => {};
+    } finally {
+      connecting = false;
     }
-    let url: string;
-    try {
-      url = options.url();
-    } catch {
-      scheduleReconnect();
-      return;
-    }
-    const sock = new WebSocket(url);
-    socket = sock;
-    sock.onopen = () => {
-      if (cancelled) return;
-      delay = baseDelay;
-      options.onOpen?.();
-    };
-    sock.onmessage = (event) => {
-      if (cancelled || typeof event.data !== "string") return;
-      options.onMessage(event.data);
-    };
-    sock.onclose = () => {
-      socket = null;
-      if (cancelled) return;
-      options.onClose?.();
-      scheduleReconnect();
-    };
-    sock.onerror = () => {};
   }
+
+  // Mobile browsers freeze a backgrounded tab and the OS often drops the socket;
+  // the deferred close only lands on return, then reconnect waits out the full
+  // backoff. On regaining visibility, skip that wait and reconnect now unless a
+  // connect is already in flight or the socket is still healthy.
+  const reconnectNow = () => {
+    if (cancelled || connecting) return;
+    const sock = socket;
+    if (
+      sock &&
+      (sock.readyState === WS_CONNECTING || sock.readyState === WS_OPEN)
+    )
+      return;
+    // A closing socket's onclose is still pending: detach it so it can't
+    // schedule a second reconnect on top of the one we start here.
+    if (sock) {
+      sock.onclose = null;
+      socket = null;
+    }
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    delay = baseDelay;
+    void connect();
+  };
+
+  const hasDocument = typeof document !== "undefined";
+  const onVisible = () => {
+    if (document.visibilityState === "visible") reconnectNow();
+  };
+  if (hasDocument) document.addEventListener("visibilitychange", onVisible);
 
   void connect();
 
@@ -90,6 +133,8 @@ export function connectReconnectingWs(
     current: () => socket,
     close: () => {
       cancelled = true;
+      if (hasDocument)
+        document.removeEventListener("visibilitychange", onVisible);
       if (timer) clearTimeout(timer);
       if (socket) {
         socket.onclose = null;


### PR DESCRIPTION
## Problem

On mobile, switching tabs away from the web app and back flashes the "disconnected from gateway" overlay for ~2 seconds before it reconnects, on every single tab switch.

Mobile browsers freeze a backgrounded tab's JavaScript, and the OS drops the WebSocket while it's frozen. The socket's `close` event is queued but not delivered until the tab returns. When it finally fires, the reconnect loop schedules a retry only **after** the exponential backoff delay (`baseDelayMs` = 1000ms), and then runs `beforeConnect` (token refresh + version fetch) before reopening. That ~1s backoff plus fetch latency exceeds the 750ms `DISCONNECT_GRACE_MS`, so the overlay appears every time and clears once the fresh socket opens ~2s later.

## Fix

The fix lives in the shared `connectReconnectingWs` primitive (the single owner of the reconnect loop, used by the gateway, chat, and notification sockets). It now listens for `visibilitychange` and, when the tab regains visibility with no healthy or in-flight connection, clears the pending backoff timer, resets the delay, and reconnects at once, so the socket is back before the overlay's grace period elapses. The chat and notification sockets get the same instant-refocus behavior for free.

Safety details, since this is the shared primitive:
- A `connecting` guard wraps the whole `connect()` (including the `beforeConnect` await window), so a visibility event can never start a second parallel connect.
- If a still-closing socket's `onclose` hasn't fired yet, its handler is detached before reconnecting, so it can't schedule a duplicate on top of the one we start.
- The listener is `document`-guarded (matching `use-window-focus.ts`) so the primitive stays safe in non-DOM/test environments, and it's removed on `close()`.

## Tests

Added three cases to `reconnecting-ws.test.ts`: immediate reconnect on refocus that consumes the pending backoff without duplicating, a healthy socket left untouched on visibility, and the listener removed after `close()`. Full `./check.sh web` is green (eslint, prettier, tsc, 171 vitest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQRArmeMi7suvFuLXqLsah

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQRArmeMi7suvFuLXqLsah)_