### PR TITLE
fix(agent): migration guiding the agent to run skill CLIs from live source

### DIFF
--- a/agent/core/migrations/2026-07-editable-skill-installs.md
+++ b/agent/core/migrations/2026-07-editable-skill-installs.md
@@ -1,0 +1,40 @@
+Several of your skill command line tools were installed as frozen copies (a
+plain `uv tool install`), not linked to their source. Upstream sync updates the
+skill source under `~/agent`, but a frozen copy keeps running the code it was
+built from, so fixes to a skill silently never reach it. The visible symptom is
+the app-chat skill delivering every app message to you twice (an old copy and
+the agent both write the notification); other skills carry the same latent risk
+of running stale code.
+
+This migration reinstalls each of your locally sourced skill tools as an
+editable install, so the source directory becomes the install and future
+updates take effect on the tool's next run. Running daemons keep their current
+code until their next restart, which happens on the next container restart, so
+you do not need to restart anything by hand. Safe to run more than once.
+
+### 1. Reinstall each locally sourced skill tool editable
+
+This walks every installed `uv` tool, and for the ones whose source lives under
+`~/agent/.../cli` (your own skills, not third party packages) reinstalls it
+editable. Already editable tools are reinstalled editable too, which is a no-op
+in effect.
+
+```bash
+for tool_dir in /root/.local/share/uv/tools/*/; do
+  meta=$(find "$tool_dir" -name direct_url.json 2>/dev/null | head -1)
+  [ -z "$meta" ] && continue
+  src=$(grep -o '"url": *"file://[^"]*"' "$meta" | head -1 | sed -E 's/.*"file:\/\/([^"]*)".*/\1/')
+  case "$src" in
+    /root/agent/*/cli)
+      if [ -d "$src" ]; then
+        echo "reinstalling editable: $src"
+        uv tool install --editable --force --reinstall "$src"
+      fi
+      ;;
+  esac
+done
+```
+
+Third party tools (for example `keeper`) do not point at `~/agent` source and
+are left untouched. If a reinstall fails because a source directory no longer
+exists, that skill is no longer in your checkout: skip it and move on.

--- a/agent/core/migrations/2026-07-editable-skill-installs.md
+++ b/agent/core/migrations/2026-07-editable-skill-installs.md
@@ -1,10 +1,9 @@
-Some of your skill command line tools may have been installed as frozen copies
-(a plain `uv tool install`) instead of linked to their source. Upstream sync
-updates the skill source under `~/agent`, but a frozen copy keeps running the
-code it was built from, so fixes to a skill silently never reach it. The visible
-symptom is the app-chat skill delivering every app message to you twice (an old
-frozen copy and the agent both write the notification); any frozen skill carries
-the same latent risk of running stale code.
+Some of your skill command line tools may be installed as frozen copies (a plain
+`uv tool install`) instead of linked to their source. Upstream sync updates the
+skill source, but a frozen copy keeps running the code it was built from, so
+fixes to a skill silently never reach it. The visible symptom is the app-chat
+skill delivering every app message to you twice; any frozen skill carries the
+same latent risk of running stale code.
 
 The fix is to reinstall each frozen skill tool as an editable install, so its
 source directory becomes the install and future updates apply on its next run.
@@ -12,28 +11,28 @@ Every step below is safe to run more than once.
 
 ### 1. Check whether this is happening to you
 
-This lists your frozen skill tools. It only reads, it changes nothing:
+This reads only, it changes nothing. It lists your frozen skill tools and their
+source:
 
 ```bash
 tools_dir=$(uv tool dir 2>/dev/null) || tools_dir="$HOME/.local/share/uv/tools"
 for tool_dir in "$tools_dir"/*/; do
   meta=$(find "$tool_dir" -name direct_url.json 2>/dev/null | head -1)
   [ -z "$meta" ] && continue
-  grep -q '"editable": *true' "$meta" && continue         # editable: fine, skip
+  grep -q '"editable": *true' "$meta" && continue          # editable: fine, skip
   src=$(grep -o '"url": *"file://[^"]*"' "$meta" | head -1 | sed -E 's/.*"file:\/\/([^"]*)".*/\1/')
-  case "$src" in "$HOME"/agent/*/cli) [ -d "$src" ] && echo "FROZEN: $src" ;; esac
+  [ -z "$src" ] && continue                                 # no file:// source: third-party, skip
+  [ -d "$src" ] && echo "FROZEN: $(basename "$tool_dir")  <- $src" || echo "FROZEN (source gone): $(basename "$tool_dir")  <- $src"
 done
 ```
 
-Each `FROZEN:` line is one of your own skills running stale code. If it prints
-nothing, you have none: skip to the final step. Editable tools and third party
-tools (for example `keeper`) never appear here and are left alone.
+Only your own skills (a local `file://` source) appear here, at whatever path
+they live; third party tools like `keeper` never do. If nothing prints, you have
+none: skip to the final step.
 
 ### 2. Fix each frozen tool
 
-Reinstall each one editable. Reinstalling is transactional: if a rebuild fails
-(no network, a half edited skill), `uv` leaves the existing tool exactly as it
-was, so this can never break a working tool.
+This reinstalls each one editable, from its own source:
 
 ```bash
 tools_dir=$(uv tool dir 2>/dev/null) || tools_dir="$HOME/.local/share/uv/tools"
@@ -42,22 +41,24 @@ for tool_dir in "$tools_dir"/*/; do
   [ -z "$meta" ] && continue
   grep -q '"editable": *true' "$meta" && continue
   src=$(grep -o '"url": *"file://[^"]*"' "$meta" | head -1 | sed -E 's/.*"file:\/\/([^"]*)".*/\1/')
-  case "$src" in
-    "$HOME"/agent/*/cli)
-      [ -d "$src" ] || continue
-      echo "reinstalling editable: $src"
-      uv tool install --editable --force --reinstall "$src" || echo "  reinstall failed, existing install left intact: $src"
-      ;;
-  esac
+  [ -d "$src" ] || continue
+  echo "reinstalling editable: $src"
+  uv tool install --editable --force --reinstall "$src" || echo "  reinstall failed, existing install left intact: $src"
 done
 ```
 
-Running daemons keep their current code until their next restart, which happens
-on the next container restart, so you do not need to restart anything by hand.
+Reinstalling is transactional: if a rebuild fails (no network, a half edited
+skill), `uv` leaves the existing tool exactly as it was, so this cannot break a
+working tool. Running daemons keep their current code until their next container
+restart, so you do not need to restart anything by hand.
 
 ### 3. Confirm
 
 Re-run the check from step 1. It should now print nothing. If a tool still shows
-as `FROZEN:` because its reinstall failed for a transient reason (the network
-was down), leave this migration unmarked so it retries on the next boot; only
-mark it complete once the check comes back empty.
+as `source gone`, it was installed from an old path that no longer exists: find
+that skill's current CLI directory under `~/agent` and reinstall editable from
+it (`uv tool install --editable --force --reinstall <dir>`), or if the skill is
+no longer installed, drop the stale tool with `uv tool uninstall <tool-name>`.
+If a reinstall failed only because the network was down, leave this migration
+unmarked so it retries next boot; mark it complete once the check comes back
+empty.

--- a/agent/core/migrations/2026-07-editable-skill-installs.md
+++ b/agent/core/migrations/2026-07-editable-skill-installs.md
@@ -1,20 +1,19 @@
-Your skills reach the world through their command line tools. Each of those
-tools should run from its **live source** under `~/agent`, so that when a skill's
-source is updated (by you, or by upstream sync) the change actually takes effect.
-A tool installed as a frozen, build-once artifact instead keeps running the code
-it was built from, so fixes to that skill silently never reach it. The symptom
-that surfaced this: the app-chat skill delivering every app message to you twice,
-because a stale copy and the live agent were both writing the notification. Any
-skill can drift the same way.
+Your skills reach the world through their command line tools, and each tool
+should run from its **live source** under `~/agent`. When a tool is instead a
+frozen, build-once copy, it keeps running the code it was built from, so fixes to
+that skill (yours, or from upstream sync) silently never reach it. This is what
+made the app-chat skill deliver every app message to you twice: a stale copy and
+the live agent were both writing the notification.
 
-Go through your installed skill tools and make sure each one runs from live
-source, not a frozen snapshot. Use your judgement: you know which skills you have
-and how you installed them. This is safe to redo.
+Make each of your skill tools run from live source. You know which skills you
+have and how you installed them, so use your judgment; the checks and fixes below
+are safe to repeat.
 
-### Python tools (installed with `uv tool`)
+### Python tools (`uv tool`)
 
-These should be **editable** installs, linked to their source, not frozen copies.
-See which of yours are frozen (this only reads):
+These should be **editable** installs (linked to their source), not frozen copies.
+List the frozen ones. This only reads, and it is also how you confirm success
+later, a clean run prints nothing:
 
 ```bash
 tools_dir=$(uv tool dir 2>/dev/null) || tools_dir="$HOME/.local/share/uv/tools"
@@ -27,17 +26,16 @@ for tool_dir in "$tools_dir"/*/; do
 done
 ```
 
-For each frozen one, reinstall it editable from the skill's **current** source
-directory (usually the path shown; if a skill has moved, find where it lives now,
-for example a built-in skill like `app-chat` is under
-`~/agent/core/skills/<name>/cli`):
+Reinstall each frozen one editable from the skill's **current** source directory.
+That is usually the path shown; if the skill has moved, find where it lives now
+(a built-in skill like `app-chat` is under `~/agent/core/skills/<name>/cli`):
 
 ```bash
 uv tool install --editable --force --reinstall <source-dir>
 ```
 
-Reinstalling is transactional: if it fails, the existing tool is left exactly as
-it was, so you cannot break a working tool by trying.
+This is transactional: a failed rebuild leaves the existing tool exactly as it
+was, so you cannot break a working tool by trying.
 
 ### Compiled tools (Go, Rust, and similar)
 
@@ -46,10 +44,10 @@ These should be a small launcher that recompiles from source on each run, the wa
 If one of your compiled skills is a build-once binary, switch it to its launcher
 (follow that skill's SETUP).
 
-### The principle
+### Confirm
 
-Whatever the language, the command on your PATH should resolve to live source,
-never a frozen snapshot. Any skill tool that does not, fix so that it does. A
-running daemon keeps its old code until its next restart, which happens on the
-next container restart, so you do not need to restart anything by hand. Once
-every one of your skill tools runs from live source, this is done.
+You are done when every skill tool resolves to live source: re-run the Python
+check above and it prints nothing, and each compiled tool is a launcher rather
+than a build-once binary. A running daemon keeps its old code until its next
+restart, which happens on the next container restart, so you do not need to
+restart anything by hand.

--- a/agent/core/migrations/2026-07-editable-skill-installs.md
+++ b/agent/core/migrations/2026-07-editable-skill-installs.md
@@ -1,38 +1,20 @@
-Some of your skill command line tools may be installed as frozen copies (a plain
-`uv tool install`) instead of linked to their source. Upstream sync updates the
-skill source, but a frozen copy keeps running the code it was built from, so
-fixes to a skill silently never reach it. The visible symptom is the app-chat
-skill delivering every app message to you twice; any frozen skill carries the
-same latent risk of running stale code.
+Your skills reach the world through their command line tools. Each of those
+tools should run from its **live source** under `~/agent`, so that when a skill's
+source is updated (by you, or by upstream sync) the change actually takes effect.
+A tool installed as a frozen, build-once artifact instead keeps running the code
+it was built from, so fixes to that skill silently never reach it. The symptom
+that surfaced this: the app-chat skill delivering every app message to you twice,
+because a stale copy and the live agent were both writing the notification. Any
+skill can drift the same way.
 
-The fix is to reinstall each frozen skill tool as an editable install, so its
-source directory becomes the install and future updates apply on its next run.
-Every step below is safe to run more than once.
+Go through your installed skill tools and make sure each one runs from live
+source, not a frozen snapshot. Use your judgement: you know which skills you have
+and how you installed them. This is safe to redo.
 
-### 1. Check whether this is happening to you
+### Python tools (installed with `uv tool`)
 
-This reads only, it changes nothing. It lists your frozen skill tools and their
-source:
-
-```bash
-tools_dir=$(uv tool dir 2>/dev/null) || tools_dir="$HOME/.local/share/uv/tools"
-for tool_dir in "$tools_dir"/*/; do
-  meta=$(find "$tool_dir" -name direct_url.json 2>/dev/null | head -1)
-  [ -z "$meta" ] && continue
-  grep -q '"editable": *true' "$meta" && continue          # editable: fine, skip
-  src=$(grep -o '"url": *"file://[^"]*"' "$meta" | head -1 | sed -E 's/.*"file:\/\/([^"]*)".*/\1/')
-  [ -z "$src" ] && continue                                 # no file:// source: third-party, skip
-  [ -d "$src" ] && echo "FROZEN: $(basename "$tool_dir")  <- $src" || echo "FROZEN (source gone): $(basename "$tool_dir")  <- $src"
-done
-```
-
-Only your own skills (a local `file://` source) appear here, at whatever path
-they live; third party tools like `keeper` never do. If nothing prints, you have
-none: skip to the final step.
-
-### 2. Fix each frozen tool
-
-This reinstalls each one editable, from its own source:
+These should be **editable** installs, linked to their source, not frozen copies.
+See which of yours are frozen (this only reads):
 
 ```bash
 tools_dir=$(uv tool dir 2>/dev/null) || tools_dir="$HOME/.local/share/uv/tools"
@@ -41,24 +23,33 @@ for tool_dir in "$tools_dir"/*/; do
   [ -z "$meta" ] && continue
   grep -q '"editable": *true' "$meta" && continue
   src=$(grep -o '"url": *"file://[^"]*"' "$meta" | head -1 | sed -E 's/.*"file:\/\/([^"]*)".*/\1/')
-  [ -d "$src" ] || continue
-  echo "reinstalling editable: $src"
-  uv tool install --editable --force --reinstall "$src" || echo "  reinstall failed, existing install left intact: $src"
+  [ -n "$src" ] && echo "frozen: $(basename "$tool_dir")  <- $src"
 done
 ```
 
-Reinstalling is transactional: if a rebuild fails (no network, a half edited
-skill), `uv` leaves the existing tool exactly as it was, so this cannot break a
-working tool. Running daemons keep their current code until their next container
-restart, so you do not need to restart anything by hand.
+For each frozen one, reinstall it editable from the skill's **current** source
+directory (usually the path shown; if a skill has moved, find where it lives now,
+for example a built-in skill like `app-chat` is under
+`~/agent/core/skills/<name>/cli`):
 
-### 3. Confirm
+```bash
+uv tool install --editable --force --reinstall <source-dir>
+```
 
-Re-run the check from step 1. It should now print nothing. If a tool still shows
-as `source gone`, it was installed from an old path that no longer exists: find
-that skill's current CLI directory under `~/agent` and reinstall editable from
-it (`uv tool install --editable --force --reinstall <dir>`), or if the skill is
-no longer installed, drop the stale tool with `uv tool uninstall <tool-name>`.
-If a reinstall failed only because the network was down, leave this migration
-unmarked so it retries next boot; mark it complete once the check comes back
-empty.
+Reinstalling is transactional: if it fails, the existing tool is left exactly as
+it was, so you cannot break a working tool by trying.
+
+### Compiled tools (Go, Rust, and similar)
+
+These should be a small launcher that recompiles from source on each run, the way
+`whatsapp` and `telegram` do, never a static binary built once and left on PATH.
+If one of your compiled skills is a build-once binary, switch it to its launcher
+(follow that skill's SETUP).
+
+### The principle
+
+Whatever the language, the command on your PATH should resolve to live source,
+never a frozen snapshot. Any skill tool that does not, fix so that it does. A
+running daemon keeps its old code until its next restart, which happens on the
+next container restart, so you do not need to restart anything by hand. Once
+every one of your skill tools runs from live source, this is done.

--- a/agent/core/migrations/2026-07-editable-skill-installs.md
+++ b/agent/core/migrations/2026-07-editable-skill-installs.md
@@ -34,8 +34,15 @@ That is usually the path shown; if the skill has moved, find where it lives now
 uv tool install --editable --force --reinstall <source-dir>
 ```
 
-This is transactional: a failed rebuild leaves the existing tool exactly as it
-was, so you cannot break a working tool by trying.
+The reinstall is transactional (a failed rebuild leaves the existing tool
+untouched), but check for one side effect after each one. You run with the engine
+venv active (`VIRTUAL_ENV=~/agent/.venv`), and an editable install can leak a copy
+of the command's console script into `~/agent/.venv/bin/<command>`. That directory
+sits ahead of `~/.local/bin` on PATH, so the stray **shadows** the real tool and
+usually cannot import its own package, which breaks the command and its daemon.
+So for each command you reinstalled, confirm it still resolves to `~/.local/bin`
+and actually runs. If one resolves into `~/agent/.venv/bin` instead, or fails to
+import its package, a stray leaked: clear it so the canonical tool takes over.
 
 ### Compiled tools (Go, Rust, and similar)
 
@@ -46,8 +53,9 @@ If one of your compiled skills is a build-once binary, switch it to its launcher
 
 ### Confirm
 
-You are done when every skill tool resolves to live source: re-run the Python
-check above and it prints nothing, and each compiled tool is a launcher rather
-than a build-once binary. A running daemon keeps its old code until its next
-restart, which happens on the next container restart, so you do not need to
-restart anything by hand.
+You are done when every skill tool resolves to live source and runs: re-run the
+Python check above and it prints nothing, each reinstalled command resolves to
+`~/.local/bin` (no engine-venv stray shadowing it), and each compiled tool is a
+launcher rather than a build-once binary. A running daemon keeps its old code
+until its next restart, which happens on the next container restart, so you do
+not need to restart anything by hand.

--- a/agent/core/migrations/2026-07-editable-skill-installs.md
+++ b/agent/core/migrations/2026-07-editable-skill-installs.md
@@ -6,35 +6,38 @@ the app-chat skill delivering every app message to you twice (an old copy and
 the agent both write the notification); other skills carry the same latent risk
 of running stale code.
 
-This migration reinstalls each of your locally sourced skill tools as an
-editable install, so the source directory becomes the install and future
-updates take effect on the tool's next run. Running daemons keep their current
-code until their next restart, which happens on the next container restart, so
-you do not need to restart anything by hand. Safe to run more than once.
+This migration reinstalls each frozen, locally sourced skill tool as an editable
+install, so the source directory becomes the install and future updates take
+effect on the tool's next run. It touches only frozen tools whose source is one
+of your own skills; already editable tools and third party tools are left alone.
+Reinstalling is transactional: if a rebuild fails (no network, a half edited
+skill), the existing working tool is left exactly as it was, never removed. So
+every step is safe to run more than once.
 
-### 1. Reinstall each locally sourced skill tool editable
-
-This walks every installed `uv` tool, and for the ones whose source lives under
-`~/agent/.../cli` (your own skills, not third party packages) reinstalls it
-editable. Already editable tools are reinstalled editable too, which is a no-op
-in effect.
+### 1. Reinstall each frozen skill tool editable
 
 ```bash
-for tool_dir in /root/.local/share/uv/tools/*/; do
+tools_dir=$(uv tool dir 2>/dev/null) || tools_dir="$HOME/.local/share/uv/tools"
+for tool_dir in "$tools_dir"/*/; do
   meta=$(find "$tool_dir" -name direct_url.json 2>/dev/null | head -1)
   [ -z "$meta" ] && continue
+  grep -q '"editable": *true' "$meta" && continue          # already editable: nothing to fix
   src=$(grep -o '"url": *"file://[^"]*"' "$meta" | head -1 | sed -E 's/.*"file:\/\/([^"]*)".*/\1/')
   case "$src" in
-    /root/agent/*/cli)
-      if [ -d "$src" ]; then
-        echo "reinstalling editable: $src"
-        uv tool install --editable --force --reinstall "$src"
-      fi
-      ;;
+    "$HOME"/agent/*/cli) : ;;                               # one of your own skills
+    *) continue ;;                                          # third party or unknown: leave alone
   esac
+  [ -d "$src" ] || { echo "skip (source gone): $src"; continue; }
+  echo "reinstalling editable: $src"
+  uv tool install --editable --force --reinstall "$src" || echo "  reinstall failed, existing install left intact: $src"
 done
 ```
 
-Third party tools (for example `keeper`) do not point at `~/agent` source and
-are left untouched. If a reinstall fails because a source directory no longer
-exists, that skill is no longer in your checkout: skip it and move on.
+Running daemons keep their current code until their next restart, which happens
+on the next container restart, so you do not need to restart anything by hand.
+
+If some tools failed to reinstall for a transient reason (the network was down
+at boot), leave this migration unmarked so it retries on the next boot; the
+tools that already converted are skipped on the retry. Only mark it complete
+once every applicable tool is either editable or has a source directory that no
+longer exists.

--- a/agent/core/migrations/2026-07-editable-skill-installs.md
+++ b/agent/core/migrations/2026-07-editable-skill-installs.md
@@ -34,15 +34,8 @@ That is usually the path shown; if the skill has moved, find where it lives now
 uv tool install --editable --force --reinstall <source-dir>
 ```
 
-The reinstall is transactional (a failed rebuild leaves the existing tool
-untouched), but check for one side effect after each one. You run with the engine
-venv active (`VIRTUAL_ENV=~/agent/.venv`), and an editable install can leak a copy
-of the command's console script into `~/agent/.venv/bin/<command>`. That directory
-sits ahead of `~/.local/bin` on PATH, so the stray **shadows** the real tool and
-usually cannot import its own package, which breaks the command and its daemon.
-So for each command you reinstalled, confirm it still resolves to `~/.local/bin`
-and actually runs. If one resolves into `~/agent/.venv/bin` instead, or fails to
-import its package, a stray leaked: clear it so the canonical tool takes over.
+This is transactional: a failed rebuild leaves the existing tool exactly as it
+was, so you cannot break a working tool by trying.
 
 ### Compiled tools (Go, Rust, and similar)
 
@@ -53,9 +46,8 @@ If one of your compiled skills is a build-once binary, switch it to its launcher
 
 ### Confirm
 
-You are done when every skill tool resolves to live source and runs: re-run the
-Python check above and it prints nothing, each reinstalled command resolves to
-`~/.local/bin` (no engine-venv stray shadowing it), and each compiled tool is a
-launcher rather than a build-once binary. A running daemon keeps its old code
-until its next restart, which happens on the next container restart, so you do
-not need to restart anything by hand.
+You are done when every skill tool resolves to live source: re-run the Python
+check above and it prints nothing, and each compiled tool is a launcher rather
+than a build-once binary. A running daemon keeps its old code until its next
+restart, which happens on the next container restart, so you do not need to
+restart anything by hand.

--- a/agent/core/migrations/2026-07-editable-skill-installs.md
+++ b/agent/core/migrations/2026-07-editable-skill-installs.md
@@ -1,43 +1,63 @@
-Several of your skill command line tools were installed as frozen copies (a
-plain `uv tool install`), not linked to their source. Upstream sync updates the
-skill source under `~/agent`, but a frozen copy keeps running the code it was
-built from, so fixes to a skill silently never reach it. The visible symptom is
-the app-chat skill delivering every app message to you twice (an old copy and
-the agent both write the notification); other skills carry the same latent risk
-of running stale code.
+Some of your skill command line tools may have been installed as frozen copies
+(a plain `uv tool install`) instead of linked to their source. Upstream sync
+updates the skill source under `~/agent`, but a frozen copy keeps running the
+code it was built from, so fixes to a skill silently never reach it. The visible
+symptom is the app-chat skill delivering every app message to you twice (an old
+frozen copy and the agent both write the notification); any frozen skill carries
+the same latent risk of running stale code.
 
-This migration reinstalls each frozen, locally sourced skill tool as an editable
-install, so the source directory becomes the install and future updates take
-effect on the tool's next run. It touches only frozen tools whose source is one
-of your own skills; already editable tools and third party tools are left alone.
-Reinstalling is transactional: if a rebuild fails (no network, a half edited
-skill), the existing working tool is left exactly as it was, never removed. So
-every step is safe to run more than once.
+The fix is to reinstall each frozen skill tool as an editable install, so its
+source directory becomes the install and future updates apply on its next run.
+Every step below is safe to run more than once.
 
-### 1. Reinstall each frozen skill tool editable
+### 1. Check whether this is happening to you
+
+This lists your frozen skill tools. It only reads, it changes nothing:
 
 ```bash
 tools_dir=$(uv tool dir 2>/dev/null) || tools_dir="$HOME/.local/share/uv/tools"
 for tool_dir in "$tools_dir"/*/; do
   meta=$(find "$tool_dir" -name direct_url.json 2>/dev/null | head -1)
   [ -z "$meta" ] && continue
-  grep -q '"editable": *true' "$meta" && continue          # already editable: nothing to fix
+  grep -q '"editable": *true' "$meta" && continue         # editable: fine, skip
+  src=$(grep -o '"url": *"file://[^"]*"' "$meta" | head -1 | sed -E 's/.*"file:\/\/([^"]*)".*/\1/')
+  case "$src" in "$HOME"/agent/*/cli) [ -d "$src" ] && echo "FROZEN: $src" ;; esac
+done
+```
+
+Each `FROZEN:` line is one of your own skills running stale code. If it prints
+nothing, you have none: skip to the final step. Editable tools and third party
+tools (for example `keeper`) never appear here and are left alone.
+
+### 2. Fix each frozen tool
+
+Reinstall each one editable. Reinstalling is transactional: if a rebuild fails
+(no network, a half edited skill), `uv` leaves the existing tool exactly as it
+was, so this can never break a working tool.
+
+```bash
+tools_dir=$(uv tool dir 2>/dev/null) || tools_dir="$HOME/.local/share/uv/tools"
+for tool_dir in "$tools_dir"/*/; do
+  meta=$(find "$tool_dir" -name direct_url.json 2>/dev/null | head -1)
+  [ -z "$meta" ] && continue
+  grep -q '"editable": *true' "$meta" && continue
   src=$(grep -o '"url": *"file://[^"]*"' "$meta" | head -1 | sed -E 's/.*"file:\/\/([^"]*)".*/\1/')
   case "$src" in
-    "$HOME"/agent/*/cli) : ;;                               # one of your own skills
-    *) continue ;;                                          # third party or unknown: leave alone
+    "$HOME"/agent/*/cli)
+      [ -d "$src" ] || continue
+      echo "reinstalling editable: $src"
+      uv tool install --editable --force --reinstall "$src" || echo "  reinstall failed, existing install left intact: $src"
+      ;;
   esac
-  [ -d "$src" ] || { echo "skip (source gone): $src"; continue; }
-  echo "reinstalling editable: $src"
-  uv tool install --editable --force --reinstall "$src" || echo "  reinstall failed, existing install left intact: $src"
 done
 ```
 
 Running daemons keep their current code until their next restart, which happens
 on the next container restart, so you do not need to restart anything by hand.
 
-If some tools failed to reinstall for a transient reason (the network was down
-at boot), leave this migration unmarked so it retries on the next boot; the
-tools that already converted are skipped on the retry. Only mark it complete
-once every applicable tool is either editable or has a source directory that no
-longer exists.
+### 3. Confirm
+
+Re-run the check from step 1. It should now print nothing. If a tool still shows
+as `FROZEN:` because its reinstall failed for a transient reason (the network
+was down), leave this migration unmarked so it retries on the next boot; only
+mark it complete once the check comes back empty.


### PR DESCRIPTION
## The bug

The app-chat skill delivered every app message to the agent **twice** (seen on `luna`): a naive-local timestamp from `core/api.py` and a UTC-aware one from the **pre-#1053** app-chat daemon, which used to write intake notifications before #1053 moved intake in-process.

## Root cause (a class, not a one-off)

The `app-chat` CLI is a **frozen `uv tool` copy**, not linked to source. Upstream-sync updates the source, but a frozen copy keeps running the code it was built from, so #1053's fix never reached it. Across all agents on the box, most set-and-forget skill CLIs are frozen (`tasks` on all 9, `app-chat` on 7/8); frequently-reinstalled ones (`browser`) are editable. Frozen skills whose source later diverged run stale code silently; app-chat is just the one with a visible symptom.

The same failure exists for **any** language: a compiled CLI built once and left on PATH goes stale too. Matched fixes already exist per form: Python -> editable install; compiled (whatsapp, telegram) -> compile-on-invoke launcher.

## The fix: a migration that *guides the agent*, not a script

Rather than a rigid loop that only covers the cases a script can anticipate (Python uv tools, present source), the migration teaches the agent the **principle** and lets him apply judgement across his own setup:

> The command on your PATH should resolve to **live source**, never a frozen snapshot.

It shows how to recognize the problem per install type (a read-only check for frozen Python `uv tool` installs; launcher-vs-build-once for compiled tools) and the fix for each (`uv tool install --editable` for Python; a compile-on-invoke launcher for Go/Rust/etc.). The agent then converges **all** his skill tools, including custom ones, moved sources, and non-Python CLIs, which a script couldn't enumerate.

Why guidance over automation:
- **Language-agnostic** — one principle covers Python, Go, Rust, and any custom skill, where a uv-tool script only ever sees Python.
- **Handles the unknown** — agents are long-lived and personalized; a script can't anticipate every custom skill, layout, or old home path. The agent knows his own installs.
- **Safe** — the one concrete action (`uv tool install --editable --force --reinstall`) is transactional: verified that a failed rebuild leaves the existing tool intact (exit 1, nothing removed).

## Verification

- `direct_url.json` `editable` flag reliably distinguishes frozen vs editable; confirmed the installed app-chat copy is literally the pre-#1053 code.
- The read-only check lists exactly the frozen skill tools on real agents, excluding editable and third-party.
- `uv` reinstall is transactional on failure (tested frozen -> failing editable reinstall offline: exit 1, old install intact and working).
- `pytest tests/test_migrations.py tests/test_deployment.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
