### PR TITLE
feat(vestad): let agents trigger gateway update and read version; fix agent-token auth on gateway logs

### DIFF
--- a/vestad/src/auth.rs
+++ b/vestad/src/auth.rs
@@ -85,6 +85,42 @@ pub async fn auth_middleware_api_or_agent_token(
     unauthorized()
 }
 
+/// Accepts either the API key or a valid `X-Agent-Token` belonging to any agent on this
+/// host. Gateway-scoped routes (`/version`, `/gateway/...`) have no agent name in the
+/// path to scope a token to: the token proves the caller is one of this host's agents,
+/// the right tier for host-global reads and the self-update action.
+pub async fn auth_middleware_api_or_any_agent_token(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    request: Request,
+    next: Next,
+) -> Response {
+    if request.method() == axum::http::Method::OPTIONS {
+        return next.run(request).await;
+    }
+
+    if has_valid_api_auth(&headers, request.uri(), &state.api_key) {
+        return next.run(request).await;
+    }
+
+    if let Some(provided) = headers.get("x-agent-token").and_then(|v| v.to_str().ok()) {
+        if any_agent_token_matches(provided, &state.env_config.agents_dir) {
+            return next.run(request).await;
+        }
+    }
+    let path = request.uri().path().to_string();
+    tracing::warn!(path = %path, "client auth failed (neither api-key nor any agent-token accepted)");
+    unauthorized()
+}
+
+/// True when the provided token matches the `AGENT_TOKEN` of any agent env file on this host.
+fn any_agent_token_matches(provided: &str, agents_dir: &std::path::Path) -> bool {
+    crate::docker::env_file_names(agents_dir).iter().any(|name| {
+        let (_, expected) = crate::docker::read_agent_port_and_token(name, agents_dir);
+        expected.is_some_and(|expected| expected == provided)
+    })
+}
+
 fn check_agent_token(
     headers: &HeaderMap,
     agent_name: &str,
@@ -475,5 +511,44 @@ mod verify_token_tests {
     #[test]
     fn same_length_non_matching_key_does_not_verify() {
         assert!(!verify_token("the-api-kex", "the-api-key"));
+    }
+}
+
+#[cfg(test)]
+mod any_agent_token_tests {
+    use super::any_agent_token_matches;
+
+    #[test]
+    fn matches_the_token_of_any_agent_env_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("alpha.env"),
+            "WS_PORT=4001\nAGENT_TOKEN=tok-alpha\n",
+        )
+        .expect("write alpha env");
+        std::fs::write(
+            tmp.path().join("beta.env"),
+            "export WS_PORT=4002\nexport AGENT_TOKEN=tok-beta\n",
+        )
+        .expect("write beta env");
+        assert!(any_agent_token_matches("tok-alpha", tmp.path()));
+        assert!(any_agent_token_matches("tok-beta", tmp.path()));
+    }
+
+    #[test]
+    fn rejects_an_unknown_token() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("alpha.env"),
+            "WS_PORT=4001\nAGENT_TOKEN=tok-alpha\n",
+        )
+        .expect("write alpha env");
+        assert!(!any_agent_token_matches("tok-other", tmp.path()));
+    }
+
+    #[test]
+    fn rejects_when_no_agents_exist() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!any_agent_token_matches("tok-alpha", tmp.path()));
     }
 }

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2251,9 +2251,6 @@ pub fn build_router(state: SharedState) -> Router {
         // for a registered, rotating refresh token — so the box never mints a
         // refresh token for an unauthenticated caller.
         .route("/auth/exchange", post(auth::exchange_session_handler))
-        .route("/version", get(version))
-        .route("/version/check", post(version_check))
-        .route("/gateway/update", post(gateway_update_handler))
         .route("/gateway/restart", post(restart_gateway_handler))
         .route("/gateway/info", get(gateway_info_handler))
         .route(
@@ -2428,17 +2425,34 @@ pub fn build_router(state: SharedState) -> Router {
         ))
         .with_state(state.clone());
 
-    // Gateway logs: accepts either API key or the agent's token (agent self-diagnosis)
+    // Gateway self-update surface, shared with agents: the agent reads /version to see
+    // whether an update exists and POSTs /gateway/update to apply it (the vestad skill's
+    // flow). These paths carry no agent name, so the middleware accepts any of this
+    // host's agent tokens. Update is host-global: it restarts vestad, which stops and
+    // restarts every agent on the host, the caller included.
+    let gateway_agent_shared = Router::new()
+        .route("/version", get(version))
+        .route("/version/check", post(version_check))
+        .route("/gateway/update", post(gateway_update_handler))
+        .layer(control_timeout_layer())
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::auth_middleware_api_or_any_agent_token,
+        ));
+
+    // Gateway logs: accepts either API key or any agent's token (agent self-diagnosis;
+    // no agent name in the path, so the self-scoped middleware cannot apply here)
     let gateway_logs = Router::new()
         .route("/gateway/logs", get(gateway_logs_handler))
         .layer(middleware::from_fn_with_state(
             state.clone(),
-            auth::auth_middleware_api_or_agent_token,
+            auth::auth_middleware_api_or_any_agent_token,
         ))
         .with_state(state.clone());
 
     Router::new()
         .merge(vestad_public)
+        .merge(gateway_agent_shared)
         .merge(vestad_protected_timed)
         .merge(vestad_protected_longrun)
         .merge(vestad_protected_streaming)


### PR DESCRIPTION
Agents could not reach `POST /gateway/update` (API-key only), and the documented agent-token access to `GET /gateway/logs` was dead code: `auth_middleware_api_or_agent_token` scopes the token via the `/agents/{name}` path segment, which gateway-scoped paths do not have, so the agent branch never fired.

This adds `auth_middleware_api_or_any_agent_token`: accepts the API key or an `X-Agent-Token` matching any agent env file on the host. Gateway-scoped routes have no agent name to scope to; the token proves the caller is one of this host's agents, which is the right tier for host-global reads and the self-update action.

Applied to:
- `POST /gateway/update` (new for agents): an agent can now update vestad when the user asks. Update is host-global, it restarts vestad and therefore every agent on the host, the caller included.
- `GET /version` and `POST /version/check` (new for agents): without these the agent cannot know an update exists.
- `GET /gateway/logs` (fix): restores the self-diagnosis flow MEMORY.md already documents.

Unit tests cover the any-agent token matcher (match across multiple env files, unknown token, empty agents dir). `./check.sh vestad` green.

A follow-up PR centralizes all vestad interaction docs into a `vestad` skill (absorbing the `service` skill) and documents this endpoint there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V478Pk3tTqBQLd36sVctLL