### PR TITLE
fix(web): keep back-button history clean (no self-push, replace on deep-link fallback)

### DIFF
--- a/apps/web/src/components/AgentMenu/index.tsx
+++ b/apps/web/src/components/AgentMenu/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { MoreVertical } from "lucide-react";
 import {
   Dialog,
@@ -20,6 +20,13 @@ import { DesktopMenu } from "./DesktopMenu";
 
 export function AgentMenu() {
   const navigate = useNavigate();
+  const location = useLocation();
+  // Re-selecting the current page must not push a duplicate history entry:
+  // the navbar's back button pops one entry per press, and a duplicate makes
+  // the first press a visible no-op.
+  const goTo = (path: string) => {
+    if (location.pathname !== path) navigate(path);
+  };
   const { name, agent, isBusy, start, stop, restart, backup } =
     useSelectedAgent();
   const { setDeleteDialogOpen, handleOpenAuth } = useModals();
@@ -43,11 +50,10 @@ export function AgentMenu() {
     isBusy,
     showToolCalls,
     onToggle: () => void (isRunning ? stop() : start()),
-    onLogs: () => navigate(`/agent/${encodeURIComponent(name)}/logs`),
+    onLogs: () => goTo(`/agent/${encodeURIComponent(name)}/logs`),
     onToolCalls: () => setShowToolCalls((v) => !v),
     onAppSettings: () => navigate("/settings"),
-    onAgentSettings: () =>
-      navigate(`/agent/${encodeURIComponent(name)}/settings`),
+    onAgentSettings: () => goTo(`/agent/${encodeURIComponent(name)}/settings`),
     onRestart: () => void restart(),
     onBackup: () => void backup(),
     onAuthenticate: gateway.reachable ? () => handleOpenAuth() : undefined,

--- a/apps/web/src/components/Navbar/AgentNavbar/index.tsx
+++ b/apps/web/src/components/Navbar/AgentNavbar/index.tsx
@@ -75,12 +75,12 @@ export function AgentNavbar({
   const hideMobileNavbar = isMobile && !!chatMatch && chatKeyboardFocused;
   // Subpages go back to wherever they were opened from (chat or dashboard); a
   // deep link has no in-app history (location.key === "default"), so fall back
-  // to the dashboard.
+  // to the dashboard, replacing the entry so browser back still exits the app.
   const showBack = !!logsMatch || !!settingsMatch;
   const showDashboardBack = !isMobile && !!chatMatch;
   const goBack = () => {
     if (location.key === "default") {
-      navigate(`/agent/${encodeURIComponent(name)}`);
+      navigate(`/agent/${encodeURIComponent(name)}`, { replace: true });
     } else {
       navigate(-1);
     }


### PR DESCRIPTION
## Summary
Follow-up to #1193 (merged before its code-review findings were applied). Two confirmed history-hygiene bugs in the new back button:

- **Menu self-push**: re-selecting "logs" or "agent settings" from the agent menu while already on that page pushed a duplicate history entry, making the back button's first press a visible no-op. The menu now skips navigation when already on the target path.
- **Deep-link fallback**: backing out of a deep-linked subpage pushed the dashboard on top of the subpage entry, so browser/hardware back returned the user to the page they had just left. The fallback now uses `replace: true`, so browser back exits the app cleanly.

## Verification
Drove the real SPA with Playwright against a stubbed vestad API:
- re-selected logs twice from the menu on the logs page → still one back press straight to chat ✔
- deep link to logs → in-app back → dashboard; browser back exits the app instead of re-showing logs ✔
- full original probe suite (desktop back, mobile back-to-chat, settings, deep-link fallback) still green ✔

`./check.sh web` green (174 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)