### PR TITLE
fix(web): land in fullscreen chat after agent creation

### DIFF
--- a/apps/web/src/components/NewAgent/Steps/CreatingStep/index.tsx
+++ b/apps/web/src/components/NewAgent/Steps/CreatingStep/index.tsx
@@ -92,7 +92,7 @@ export function CreatingStep({
       {done && (
         <Button
           className="mt-2 w-full"
-          onClick={() => navigate(`/agent/${agentName}`)}
+          onClick={() => navigate(`/agent/${agentName}/chat`)}
         >
           say hi
         </Button>


### PR DESCRIPTION
## Problem

After creating an agent in the web app, the "say hi" button navigates to \`/agent/:name\`, the desktop split layout with the dashboard as the main panel and chat squeezed into a 30% side panel. A freshly created agent never has a dashboard service yet, so the user's very first screen is a large empty "your dashboard" placeholder next to the chat they actually came for.

## Fix

Point the button at \`/agent/:name/chat\`, the existing fullscreen chat route. \`DesktopPanelView\` already renders it as plain \`<Chat fullscreen />\` with no dashboard, and \`MobileSwipeView\` already scrolls to the chat page for that path, so both form factors land directly in chat. One line changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)