### PR TITLE
fix(skills): document the correct way to install a skill's CLI

### DIFF
--- a/agent/skills/skills-registry/SKILL.md
+++ b/agent/skills/skills-registry/SKILL.md
@@ -28,6 +28,23 @@ After installing, restart yourself with the `restart_vesta` tool to load the new
 ls ~/agent/skills/
 ```
 
+## Installing or updating a skill's CLI
+
+Many skills ship a command line tool in `cli/`. Install it, or reinstall it after
+you edit it, as an editable `uv` tool. That links the command to its source, so
+your edits and upstream updates take effect on the command's next run:
+
+```bash
+uv tool install --editable ~/agent/skills/<name>/cli
+```
+
+Never install a skill's CLI with `uv pip install -e` or `pip install -e`. You run
+with the engine venv active (`VIRTUAL_ENV=~/agent/.venv`), so an editable pip
+install drops the skill's command into `~/agent/.venv/bin`, which sits ahead of
+`~/.local/bin` on PATH and shadows the real tool: the command and its daemon then
+break with an import error. `uv tool install` keeps the CLI isolated and on
+`~/.local/bin`, so use it every time.
+
 ## Notes
 
 - Skills are installed via git sparse checkout from the upstream repo


### PR DESCRIPTION
## Problem

Skill CLIs can end up with a stray console script in the engine venv (`~/agent/.venv/bin/<command>`) that sits ahead of `~/.local/bin` on PATH, shadows the real tool, and breaks the command and its daemon with a ModuleNotFoundError. This is the failure #1211 tried to clean up at boot.

## Root cause (reproduced)

The strays do **not** come from `uv tool install --editable` (the documented install). Reproduced on the uv versions the fleet runs (0.11.7, 0.11.24), with `VIRTUAL_ENV=<venv>` active:

| Command | Leaks a shim into the active venv bin? |
|---|---|
| `uv tool install --editable <cli>` | **No** (isolated, goes to `~/.local/bin`) |
| `uv pip install -e <cli>` | **Yes** |

The repo never documents `uv pip install -e` for a skill, and the engine venv has no skill deps, so the strays come from **ad-hoc agent behavior**: an agent editing/testing a skill and reaching for `uv pip install -e` instead of `uv tool install --editable`.

## Fix

Prevention at the source, in the skills-registry skill (the skill-management meta-skill): document that a skill's CLI is installed/reinstalled with `uv tool install --editable`, and explicitly that `uv pip install -e` / `pip install -e` must not be used because it leaks a shadowing shim into the engine venv. This removes the cause rather than sweeping up after it each boot.

## Relationship to #1211

This supersedes #1211. #1211's diagnosis is incorrect (it blames `uv tool install --editable`, which does not leak), and its cleanup loop keys on the uv tool's package/dir name (`vesta-browser`) while the stray is named after the console script (`browser`), so it misses browser/app-chat/exa/flights/enablebanking, including the `browser` case it names. With the cause prevented, the boot-time janitor is unnecessary. Recommend closing #1211.

## Verification

- Reproduced the leak (and its absence for `uv tool install`) on uv 0.11.7 and 0.11.24 in isolated temp envs.
- No strays currently exist on any agent on the box.
- Skills index unchanged (frontmatter untouched); `test_deployment` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
