### PR TITLE
fix(ci): drop stale notification_suffix assertion; run check-vesta on embedded agent paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,13 @@ jobs:
             cli:
               - 'cli/**'
               - 'vestad/**'
+              # vestad embeds the agent home (build.rs EMBED_DIRS/EMBED_FILES), so
+              # agent-only changes can break check-vesta and must trigger it on PRs.
+              - 'agent/core/**'
+              - 'agent/skills/**'
+              - 'agent/MEMORY.md'
+              - 'agent/.gitignore'
+              - 'agent/ruff.toml'
               - '.github/workflows/ci.yml'
               - 'check.sh'
             app:

--- a/vestad/src/agent_code.rs
+++ b/vestad/src/agent_code.rs
@@ -140,7 +140,6 @@ mod tests {
         // Non-.py files under core/ (prompts, skill manifests) must also be embedded
         // — the agent's prompt loader depends on them at runtime.
         assert!(dir.join("core/prompts/nightly_dream.md").is_file());
-        assert!(dir.join("core/prompts/notification_suffix.md").is_file());
         // The full home ships now: skills, the MEMORY template, and the agent .gitignore
         // all feed build-upstream.sh.
         assert!(dir.join("skills/skills-registry/SKILL.md").is_file());


### PR DESCRIPTION
## Problem

Master is red: `check-vesta` fails on the merge of #1209 with

```
agent_code::tests::ensure_extracts_expected_files_and_is_idempotent
assertion failed: dir.join("core/prompts/notification_suffix.md").is_file()
```

#1209 deleted `agent/core/prompts/notification_suffix.md` but the vestad test still asserted the embedded agent home contains it.

The PR merged green because `check-vesta` is path-filtered on PRs to `cli/**` + `vestad/**` only; an agent-only PR skips it, even though vestad embeds the agent home (build.rs `EMBED_DIRS`/`EMBED_FILES`) and its tests can depend on agent files. The failure only surfaced on the push to master, where filters don't apply.

## Fix

- Drop the stale assertion (the "non-.py files under core/ are embedded" behavior stays covered by the `nightly_dream.md` assertion on the line above).
- Add the embedded agent paths (`agent/core/**`, `agent/skills/**`, `agent/MEMORY.md`, `agent/.gitignore`, `agent/ruff.toml`) to the `cli` filter so agent PRs run `check-vesta` and this class of breakage is caught pre-merge.

Verified locally: `cargo test -p vestad --bin vestad agent_code` passes, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)