### PR TITLE
feat(tasks): overdue decision loop, adaptive reminder ladder, fuzzed recurring times, low-friction verbs

### DIFF
--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -3,101 +3,65 @@ name: tasks
 description: Tasks, to-dos, reminders, time-based alerts; create and manage. Requires daemon.
 ---
 
-# Tasks + Reminders - CLI: tasks
+# Tasks + Reminders (CLI: tasks)
 
-One CLI, one daemon, one SQLite DB. Tasks are what needs doing; reminders are nudges about when.
+One CLI, one daemon, one SQLite DB. Tasks are what needs doing; reminders are nudges about when. The daemon does the tracking for you: it reminds you before a due date, forces a decision at the due time, and sends a daily digest of anything overdue or stale. Your job is to always resolve those notifications with one of the commands below, never to ignore them.
 
-## Task Commands
+## Tasks
+
 ```bash
-tasks add "Buy groceries"
 tasks add "Submit report" --priority high --due-in-hours 4
-tasks add "Meeting prep" --due-datetime "2025-12-01T10:00:00" --timezone "Europe/London"
-tasks list
-tasks list --show-completed
-tasks search "groceries"
-tasks update <id> --status done
-tasks update <id> --title "Updated title" --priority high
+tasks add "Meeting prep" --due-datetime "2026-12-01T10:00:00" --timezone "Europe/London"
+tasks list                        # pending tasks, overdue first
+tasks done <id>                   # mark done
+tasks postpone <id> --in-days 2   # new due date, measured from now
+tasks search "report"
 tasks get <id>
-tasks get <id> --field status              # just the status, no envelope
-tasks get <id> --field notes --field title # several fields, tab-separated
-tasks delete <id>                          # CASCADE: linked reminders are deleted too
+tasks update <id> --title "..." --priority low --status pending
+tasks delete <id>                 # cascades to linked reminders
 ```
 
-### Task Options
-- `--priority`: low / normal / high (default: normal)
-- `--due-in-minutes`, `--due-in-hours`, `--due-in-days`: relative due date
-- `--due-datetime` + `--timezone`: absolute (both required together)
-- `--show-completed`: include done tasks in list/search
-- `--initial-metadata`: string of metadata to attach when adding a task
-- `tasks list`, `tasks search`, and `tasks remind list` default to a compact tab-separated table; pass `--json` for one-line JSON or `--json-pretty` for indented JSON.
-- `tasks get --field <name>` returns only the named field(s) as raw text. Valid fields: `id`, `title`, `status`, `priority`, `due_date`, `created_at`, `completed_at`, `metadata_path`, `metadata`. Prefer this over `Read`-ing `~/.tasks/metadata/<id>.md` when you only need a specific field. Metadata content is read only when `--field metadata` is requested.
+- Due date: `--due-in-minutes/--due-in-hours/--due-in-days` (relative) or `--due-datetime` + `--timezone` (absolute, both required). `--priority` low/normal/high. `--initial-metadata "..."` attaches notes.
+- `postpone` also takes `--in-minutes/--in-hours` or `--at` + `--tz`, and works on a task with no due date (gives it one).
+- `tasks get <id> --field status` prints just that field (repeat `--field` for several, tab-separated). Valid fields: id, title, status, priority, due_date, created_at, completed_at, metadata_path, metadata. Prefer this over reading the metadata file when you need one value.
+- `list`/`search` print compact tables (`--show-completed` to include done); add `--json` or `--json-pretty` for JSON.
 
-## Reminder Commands
+## Reminders
 
-Reminders take the message as the first positional argument to `tasks remind`. There is no `create` subcommand, so don't reach for one:
+The message is the first argument to `tasks remind`; there is no create/add/set subcommand:
 
 ```bash
-# Set a reminder (the message IS the first argument, no subcommand needed)
 tasks remind "Call mom" --in-minutes 30
-tasks remind "Check report" --in-hours 2
-tasks remind "Weekly review" --in-days 7
-tasks remind "Meeting" --at "2025-12-01T10:00:00" --tz "Europe/London"
-
-# Linked to a task
+tasks remind "Meeting" --at "2026-12-01T10:00:00" --tz "Europe/London"
 tasks remind "Check progress" --task <id> --in-hours 1
-
-# Recurring (hourly needs no datetime; daily/weekly/monthly/yearly take --at + --tz)
-tasks remind "Standup" --recurring daily --at "2025-12-01T10:30:00" --tz "America/New_York"
-tasks remind "Check inbox" --recurring hourly
-
-# Recurring on a custom schedule (standard cron)
+tasks remind "Standup" --recurring daily --at "2026-12-01T09:30:00" --tz "America/New_York"
+tasks remind "Evening check-in" --recurring daily --at "2026-12-01T21:30:00" --tz "Europe/Rome" --fuzz-minutes 75
 tasks remind "Weekdays 9am" --cron "0 9 * * 1-5" --tz "America/New_York"
-tasks remind "Every 15 min, 9-5" --cron "*/15 9-17 * * *" --tz "America/New_York"
-tasks remind "1st of the month" --cron "0 8 1 * *" --tz "America/New_York"
-
-# List, delete, update
-tasks remind list                        # all active reminders
-tasks remind list --task <id>            # reminders linked to a task
-tasks remind delete <id>                 # removes the reminder, task stays
-tasks remind update <id> --message "New message"
+tasks remind list [--task <id>]
+tasks remind snooze <id> --in-hours 4    # push a one-shot back; works on already-fired ones too
+tasks remind update <id> --message "..."
+tasks remind delete <id>
 ```
 
-### Reminder Options
-- `--in-minutes`, `--in-hours`, `--in-days`: relative timing
-- `--at` + `--tz`: absolute datetime (both required together)
-- `--recurring`: hourly | daily | weekly | monthly | yearly
-  - hourly needs no datetime; others require `--at` + `--tz`
-- `--cron "<expr>"`: standard 5-field cron (`min hour day-of-month month day-of-week`) for schedules the presets can't express. Supports `*`, ranges (`1-5`), lists (`1,3,5`), steps (`*/15`), and day-of-week names (`mon-fri`). Day-of-week uses **standard cron numbering** (`0` or `7` = Sunday, `1` = Monday), so `--cron "0 9 * * 1-5"` fires 9am Mon-Fri as expected. Requires `--tz`; cannot combine with `--recurring`/`--at`/`--in-*`.
-  - Both `--recurring` and `--cron` schedules are DST-aware: they store your IANA timezone and keep firing at the same wall-clock time across clock changes.
-- Always use the user's timezone from MEMORY.md section 4, not UTC
-- `--task <id>`: link reminder to a task (optional)
-- `--message`: alternative to positional message argument
+- One-shot: `--in-minutes/--in-hours/--in-days` or `--at` + `--tz`. Always use the user's IANA timezone from MEMORY.md, never UTC.
+- Recurring: `--recurring hourly|daily|weekly|monthly|yearly` (all but hourly need `--at` + `--tz`), or `--cron "min hour dom month dow"` + `--tz` for anything else (standard cron: 0/7 = Sunday, ranges/lists/steps/names supported). Both keep their wall-clock time across DST.
+- `--fuzz-minutes N` (recurring/cron only): each fire lands at a varying point within N minutes either side of the nominal time, so a routine feels natural instead of firing at 09:30:00 sharp every day. Translate vague times yourself: "late evening" is roughly `--at ...T21:30:00 --fuzz-minutes 75`. Use fuzz for human-facing rhythms, never for deadlines; it must fit within half the gap between fires.
+- A recurring reminder's message is an instruction: when it fires, act on it. Recurring reminders double as scheduled automations.
 
-### Recurring Automations
-Recurring reminders double as scheduled automations (see the `--recurring` examples above): the message is delivered as a notification, so when one fires, treat the message as an instruction and act on it.
+## What the daemon does on its own
 
-## Behavior
-
-### Auto-Generated Reminders
-When a task has a due date, 4 auto-generated reminders fire: 1 week, 1 day, 1 hour, and 15 minutes before due.
-
-There is **no at-due fire**: when the due time itself is reached, no notification is emitted. If you want a fire at the exact due time (e.g. user says "remind me at 6pm to X"), set an explicit reminder with `tasks remind "X" --at "..." --tz "..."` instead of relying on `tasks add --due-datetime`.
-
-Skipped if the trigger time is already past. Cleaned up when the task is marked done (`--status done`) or deleted (FK cascade); each can also be deleted individually with `tasks remind delete <id>`.
-
-### Cascade Deletion
-Deleting a task deletes all linked reminders (FK ON DELETE CASCADE); deleting a reminder does NOT affect the linked task.
-
-### Missed Reminders
-When the daemon restarts, any one-time reminders that should have fired while the daemon was down are immediately sent as missed notifications.
-
-### Notification Files
-JSON in the notifications dir: `*-tasks-reminder.json` (type `reminder`), `*-tasks-daemon_died.json` (type `daemon_died`).
+- **Spaced pre-due reminders**: for each due date, checkpoints that halve the remaining time (a task due in 6 months pings at about 3 months, 6 weeks, 3 weeks), then 1 week, 1 day, 1 hour, and 15 minutes before due.
+- **A decision fire at the due time.** When it arrives you must pick one, immediately: do the task and `tasks done <id>`, or `tasks postpone <id> --in-days N`, or tell the user you are dropping it and `tasks delete <id>`. Marking a task done without doing it is never an option.
+- **Daily digest** (`type=task_digest`): one notification per day listing every overdue task and every task pending 2+ weeks with no due date, with the same three choices. It returns every day until the list is empty; work it down, don't acknowledge it.
+- **Missed one-shots**: reminders that should have fired while the daemon was down are sent on restart marked `missed`; missed recurring fires are skipped.
+- Completing or deleting a task cleans up its auto reminders; postponing rebuilds them for the new date.
 
 ## Data
+
 DB `~/.tasks/tasks.db`; metadata `~/.tasks/metadata/<id>.md`; logs `~/.tasks/logs/daemon.log`; PID `~/.tasks/serve.pid`.
 
 ## Setup
+
 ```bash
 uv tool install --editable ~/agent/skills/tasks/cli
 ```
@@ -110,16 +74,12 @@ PORT=$(~/agent/skills/vestad/scripts/register-service tasks)
 screen -dmS tasks tasks serve --port $PORT
 ```
 
-`--notifications-dir` defaults to `~/agent/notifications`; pass it only to override.
-
-One daemon handles everything, both task due-date monitoring and reminder scheduling. No separate reminder daemon needed.
+One daemon handles everything: task due-date monitoring, reminder scheduling, and the daily digest. `--notifications-dir` defaults to `~/agent/notifications`; pass it only to override.
 
 **Restart**: Add this startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
 ```
 PORT=$(~/agent/skills/vestad/scripts/register-service tasks) && screen -dmS tasks tasks serve --port $PORT
 ```
-
-`--notifications-dir` defaults to `~/agent/notifications`; pass it only to override.
 
 ### Reminder Patterns
 [User's common reminder types and preferences]

--- a/agent/skills/tasks/cli/src/tasks_cli/cli.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/cli.py
@@ -55,22 +55,31 @@ def _require_daemon(config):
 
 
 def _sync_jobs(config: Config, scheduler, notif_dir: Path):
-    """Sync scheduler jobs with DB state: remove stale, add new."""
-    scheduled_ids = {job.id for job in scheduler.get_jobs()}
-
+    """Sync scheduler jobs with DB state: remove stale, add new, re-add moved one-shots (snooze)."""
     with closing(db.get_db(config.data_dir)) as conn:
-        cursor = conn.execute("SELECT id FROM reminders WHERE completed = 0 AND trigger_data IS NOT NULL")
-        db_ids = {row["id"] for row in cursor}
+        cursor = conn.execute("SELECT id, scheduled_time, trigger_data FROM reminders WHERE completed = 0 AND trigger_data IS NOT NULL")
+        rows = {row["id"]: (row["scheduled_time"], row["trigger_data"]) for row in cursor}
 
-    for sid in scheduled_ids - db_ids:
+    jobs = {job.id: job for job in scheduler.get_jobs()}
+    for sid in set(jobs) - set(rows):
         try:
             scheduler.remove_job(sid)
         except Exception as e:
             logging.getLogger(__name__).warning(f"Failed to remove stale job {sid}: {e}")
 
-    missing = db_ids - scheduled_ids
-    if missing:
-        commands.restore_jobs_by_ids(config, scheduler, missing, notif_dir=notif_dir)
+    to_restore = set(rows) - set(jobs)
+    for jid, (scheduled_time, trigger_data) in rows.items():
+        if jid not in jobs or scheduled_time is None or jobs[jid].next_run_time is None:
+            continue
+        if abs((jobs[jid].next_run_time - db.parse_datetime(scheduled_time)).total_seconds()) <= commands.STALE_FIRE_SLACK.total_seconds():
+            continue
+        # Only one-shot ("date") triggers move underneath a live job (remind snooze rewrites them
+        # in place); recurring jobs recompute their own next fire and must not be reset here.
+        data = json.loads(trigger_data)
+        if "type" in data and data["type"] == "date":
+            to_restore.add(jid)
+    if to_restore:
+        commands.restore_jobs_by_ids(config, scheduler, to_restore, notif_dir=notif_dir)
 
 
 def main():
@@ -130,6 +139,21 @@ def main():
     p_update.add_argument("--due-in-minutes", type=int, default=None)
     p_update.add_argument("--due-in-hours", type=int, default=None)
     p_update.add_argument("--due-in-days", type=int, default=None)
+
+    # done
+    p_done = sub.add_parser("done", help="Mark a task done")
+    p_done.add_argument("id_pos", nargs="?", default=None, metavar="id")
+    p_done.add_argument("--id", default=None, dest="task_id")
+
+    # postpone
+    p_postpone = sub.add_parser("postpone", help="Set a new due date measured from now (also gives undated tasks one)")
+    p_postpone.add_argument("id_pos", nargs="?", default=None, metavar="id")
+    p_postpone.add_argument("--id", default=None, dest="task_id")
+    p_postpone.add_argument("--in-minutes", type=int, default=None)
+    p_postpone.add_argument("--in-hours", type=int, default=None)
+    p_postpone.add_argument("--in-days", type=int, default=None)
+    p_postpone.add_argument("--at", default=None)
+    p_postpone.add_argument("--tz", default=None)
 
     # delete
     p_delete = sub.add_parser("delete", help="Delete a task")
@@ -216,6 +240,26 @@ def _main_remind():
             args = p.parse_args(remind_args[1:])
             reminder_id = _require_arg(args.id_pos or args.reminder_id, "id", "tasks remind update <id> or tasks remind update --id <id>")
             result = commands.remind_update(config, reminder_id=reminder_id, message=args.message)
+        elif subcmd == "snooze":
+            p = argparse.ArgumentParser(prog="tasks remind snooze", add_help=False)
+            p.add_argument("id_pos", nargs="?", default=None, metavar="id")
+            p.add_argument("--id", default=None, dest="reminder_id")
+            p.add_argument("--in-minutes", type=int, default=None)
+            p.add_argument("--in-hours", type=int, default=None)
+            p.add_argument("--in-days", type=int, default=None)
+            p.add_argument("--at", default=None)
+            p.add_argument("--tz", default=None)
+            args = p.parse_args(remind_args[1:])
+            reminder_id = _require_arg(args.id_pos or args.reminder_id, "id", "tasks remind snooze <id> --in-hours N")
+            result = commands.remind_snooze(
+                config,
+                reminder_id=reminder_id,
+                in_minutes=args.in_minutes,
+                in_hours=args.in_hours,
+                in_days=args.in_days,
+                at=args.at,
+                tz=args.tz,
+            )
         else:
             p = argparse.ArgumentParser(prog="tasks remind", add_help=False)
             p.add_argument("message_pos", nargs="?", default=None, metavar="message")
@@ -228,6 +272,7 @@ def _main_remind():
             p.add_argument("--in-days", type=int, default=None)
             p.add_argument("--recurring", default=None, choices=["hourly", "daily", "weekly", "monthly", "yearly"])
             p.add_argument("--cron", default=None)
+            p.add_argument("--fuzz-minutes", type=int, default=None)
             args = p.parse_args(remind_args)
             message = _require_arg(args.message_pos or args.message, "message", 'tasks remind "message" or tasks remind --message "message"')
             result = commands.remind_set(
@@ -241,6 +286,7 @@ def _main_remind():
                 in_days=args.in_days,
                 recurring=args.recurring,
                 cron=args.cron,
+                fuzz_minutes=args.fuzz_minutes,
             )
 
         print(json.dumps(result, indent=2))
@@ -253,6 +299,7 @@ def _main_remind():
 def _print_remind_help():
     print("""usage: tasks remind <message> [options]
        tasks remind list [--task <id>] [--limit N]
+       tasks remind snooze <id> --in-hours N
        tasks remind delete <id>
        tasks remind update <id> --message <msg>
 
@@ -260,6 +307,7 @@ Set a reminder (default):
   tasks remind "call mom" --in-minutes 30
   tasks remind "check this" --task <id> --at <datetime> --tz <tz>
   tasks remind "standup" --recurring daily --at <datetime> --tz <tz>
+  tasks remind "wind down" --recurring daily --at <datetime> --tz <tz> --fuzz-minutes 75
   tasks remind "weekdays 9am" --cron "0 9 * * 1-5" --tz <tz>
 
 options:
@@ -272,9 +320,11 @@ options:
   --in-days N           Fire in N days
   --recurring TYPE      hourly|daily|weekly|monthly|yearly
   --cron EXPR           Standard 5-field cron "min hour dom month dow" (requires --tz)
+  --fuzz-minutes N      Recurring/cron only: each fire lands within +/-N minutes of the nominal time
 
 subcommands:
   list                  List active reminders
+  snooze                Push a one-shot reminder back (works on fired ones too)
   delete                Delete a reminder
   update                Update a reminder message""")
 
@@ -319,6 +369,20 @@ def _handle_task(args, config: Config):
             due_in_minutes=args.due_in_minutes,
             due_in_hours=args.due_in_hours,
             due_in_days=args.due_in_days,
+        )
+    elif args.command == "done":
+        task_id = _require_arg(args.id_pos or args.task_id, "id", "tasks done <id> or tasks done --id <id>")
+        result = commands.update_task(config, task_id=task_id, status="done")
+    elif args.command == "postpone":
+        task_id = _require_arg(args.id_pos or args.task_id, "id", "tasks postpone <id> --in-days N")
+        result = commands.postpone_task(
+            config,
+            task_id=task_id,
+            due_datetime=args.at,
+            timezone=args.tz,
+            in_minutes=args.in_minutes,
+            in_hours=args.in_hours,
+            in_days=args.in_days,
         )
     elif args.command == "delete":
         task_id = _require_arg(args.id_pos or args.task_id, "id", "tasks delete <id> or tasks delete --id <id>")
@@ -390,7 +454,12 @@ def _run_serve(config: Config, notif_dir: Path, *, port: int):
     try:
         while not stop:
             time.sleep(sync_interval)
-            _sync_jobs(config, scheduler, notif_dir)
+            try:
+                _sync_jobs(config, scheduler, notif_dir)
+                commands.maybe_send_digest(config, notif_dir)
+            except Exception:
+                # A bad tick (locked db, malformed row) must not kill the daemon; retry next tick.
+                logging.getLogger(__name__).exception("serve tick failed")
     finally:
         http_server.should_exit = True
         write_notification(notif_dir, "daemon_died", reason=shutdown_reason)

--- a/agent/skills/tasks/cli/src/tasks_cli/commands.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/commands.py
@@ -5,6 +5,7 @@ from typing import Any, TypedDict
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import json
 import logging
+import random
 import uuid
 
 from apscheduler.triggers.date import DateTrigger
@@ -14,7 +15,8 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 from .config import Config
 from . import db
-from .scheduler import write_reminder_notification
+from .format import PRIORITY_LABEL, rel_delta
+from .scheduler import write_notification, write_reminder_notification
 
 logger = logging.getLogger(__name__)
 
@@ -30,14 +32,16 @@ class TriggerData(TypedDict, total=False):
     expr: str  # "cron": normalized 5-field cron expression (day-of-week as an APScheduler name list)
     tz: str  # "cron": IANA timezone the expression is interpreted in (DST-aware)
     hours: int  # "interval": fixed hour spacing
+    fuzz_minutes: int  # "cron": each fire shifts by a deterministic sample in [-fuzz, +fuzz]
 
 
-# Overdue pending tasks (past due_date) always float to the top, ordered by most
-# overdue first. Non-overdue tasks keep their existing priority/due/created order.
+# Overdue pending tasks (past due_date) always float to the top, ordered by most overdue first.
+# datetime() normalizes the ISO 'T'/offset form to SQLite's space-separated form so the
+# comparison is chronological, not lexicographic. Non-overdue tasks keep priority/due/created order.
 _TASK_ORDER_BY = (
     " ORDER BY"
-    " CASE WHEN status = 'pending' AND due_date IS NOT NULL AND due_date < datetime('now') THEN 0 ELSE 1 END ASC,"
-    " CASE WHEN status = 'pending' AND due_date IS NOT NULL AND due_date < datetime('now') THEN due_date END ASC,"
+    " CASE WHEN status = 'pending' AND due_date IS NOT NULL AND datetime(due_date) < datetime('now') THEN 0 ELSE 1 END ASC,"
+    " CASE WHEN status = 'pending' AND due_date IS NOT NULL AND datetime(due_date) < datetime('now') THEN datetime(due_date) END ASC,"
     " priority DESC, due_date ASC NULLS LAST, created_at DESC"
 )
 
@@ -46,8 +50,60 @@ def _now_utc() -> datetime:
     return datetime.now(UTC)
 
 
+# A one-shot job whose DB run_date moved further than this into the future was snoozed after the
+# job was armed; the fire is stale and the job sync re-arms it at the new time.
+STALE_FIRE_SLACK = timedelta(seconds=60)
+
+# A past-due one-shot younger than this is most likely firing right now in a scheduler worker
+# (the job leaves the scheduler before completed=1 commits), not missed during downtime.
+MISSED_GRACE = timedelta(seconds=30)
+
+# How many upcoming fires to sample when bounding fuzz to half the smallest gap.
+FUZZ_VALIDATION_FIRES = 26
+
+
+def _relative_offset(minutes: int | None, hours: int | None, days: int | None) -> timedelta | None:
+    """Validated offset from --in-*/--due-in-* flags; None when no flag was given."""
+    for name, val in [("minutes", minutes), ("hours", hours), ("days", days)]:
+        if val is not None and val <= 0:
+            raise ValueError(f"in_{name} must be positive")
+    offset = timedelta(minutes=minutes or 0, hours=hours or 0, days=days or 0)
+    return offset if offset.total_seconds() > 0 else None
+
+
 def _cron_trigger_from_data(trigger_data: TriggerData) -> CronTrigger:
     return CronTrigger.from_crontab(trigger_data["expr"], timezone=ZoneInfo(trigger_data["tz"]))
+
+
+def _validate_fuzz(fuzz_minutes: int, trigger: CronTrigger):
+    if fuzz_minutes <= 0:
+        raise ValueError("fuzz_minutes must be positive")
+    # Bound against the smallest gap over the next fires, not just the first one: a weekday cron
+    # validated across a weekend, or a monthly one across a long month, would otherwise accept a
+    # fuzz whose windows overlap the schedule's short gaps and drop fires.
+    fires: list[datetime] = []
+    next_fire = trigger.get_next_fire_time(None, _now_utc())
+    while next_fire is not None and len(fires) < FUZZ_VALIDATION_FIRES:
+        fires.append(next_fire)
+        next_fire = trigger.get_next_fire_time(next_fire, next_fire + timedelta(seconds=1))
+    gaps = [later - earlier for earlier, later in zip(fires, fires[1:])]
+    if not gaps or timedelta(minutes=fuzz_minutes) > min(gaps) / 2:
+        raise ValueError("fuzz_minutes must be at most half the gap between fires")
+
+
+def fuzzed_next_fire(reminder_id: str, trigger_data: TriggerData, after: datetime) -> datetime:
+    """Next fire instant for a fuzzed cron reminder: the nominal cron fire shifted by an offset
+    sampled deterministically per (reminder, nominal instant). A daemon restart recomputes the
+    identical instant, so fuzz can neither double-fire nor drift across restarts."""
+    trigger = _cron_trigger_from_data(trigger_data)
+    fuzz = timedelta(minutes=trigger_data["fuzz_minutes"])
+    nominal = trigger.get_next_fire_time(None, after - fuzz)
+    while True:
+        offset = random.Random(f"{reminder_id}@{nominal.isoformat()}").uniform(-1.0, 1.0)
+        fire = nominal + fuzz * offset
+        if fire > after:
+            return fire
+        nominal = trigger.get_next_fire_time(nominal, nominal + timedelta(seconds=1))
 
 
 # Standard cron numbers the day-of-week field 0-7 with 0 and 7 both Sunday (1=Mon .. 6=Sat) and is
@@ -159,16 +215,8 @@ def _compute_due_date(
             raise ValueError("timezone is required when due_datetime is provided")
         return _to_utc(due_datetime, timezone_str)
 
-    for name, val in [("due_in_minutes", due_in_minutes), ("due_in_hours", due_in_hours), ("due_in_days", due_in_days)]:
-        if val is not None and val <= 0:
-            raise ValueError(f"{name} must be positive")
-
-    offset = timedelta(
-        minutes=due_in_minutes or 0,
-        hours=due_in_hours or 0,
-        days=due_in_days or 0,
-    )
-    if offset.total_seconds() > 0:
+    offset = _relative_offset(due_in_minutes, due_in_hours, due_in_days)
+    if offset is not None:
         return (_now_utc() + offset).isoformat()
 
     return None
@@ -243,7 +291,7 @@ def add_task(
             (task_id, title, priority, due_date),
         )
         if due_date:
-            db.create_auto_reminders(conn, task_id, title, due_date, priority)
+            db.create_auto_reminders(conn, task_id, title, due_date)
         conn.commit()
 
     if initial_metadata:
@@ -314,7 +362,7 @@ def update_task(
                 if not due_date_changed:
                     old_due = result["due_date"]
                     if old_due:
-                        db.create_auto_reminders(conn, task_id, result["title"], old_due, result["priority"])
+                        db.create_auto_reminders(conn, task_id, result["title"], old_due)
 
         for field, value in [("title", title), ("priority", priority)]:
             if value is not None:
@@ -326,13 +374,12 @@ def update_task(
             params.append(new_due_date)
             db.delete_auto_reminders(conn, task_id)
             if new_due_date:
-                # Use updated title/priority if provided in the same call, else existing.
+                # Use the updated title if provided in the same call, else existing.
                 reminder_title = title if title is not None else result["title"]
-                reminder_priority = priority if priority is not None else result["priority"]
                 # Only create reminders if the task is (or will be) pending.
                 effective_status = status if status is not None else result["status"]
                 if effective_status == "pending":
-                    db.create_auto_reminders(conn, task_id, reminder_title, new_due_date, reminder_priority)
+                    db.create_auto_reminders(conn, task_id, reminder_title, new_due_date)
 
         if updates:
             params.append(task_id)
@@ -342,6 +389,31 @@ def update_task(
 
         cursor = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,))
         return _task_with_metadata(config.data_dir, dict(cursor.fetchone()), include_content=True)
+
+
+def postpone_task(
+    config: Config,
+    *,
+    task_id: str,
+    due_datetime: str | None = None,
+    timezone: str | None = None,
+    in_minutes: int | None = None,
+    in_hours: int | None = None,
+    in_days: int | None = None,
+) -> dict:
+    """Set a new due date measured from now (or an absolute one) and rebuild the auto reminders.
+    Also gives a due date to a task that never had one."""
+    if due_datetime is None and not (in_minutes or in_hours or in_days):
+        raise ValueError("Say when: tasks postpone <id> --in-days N (or --in-minutes/--in-hours, or --at + --tz)")
+    return update_task(
+        config,
+        task_id=task_id,
+        due_datetime=due_datetime,
+        timezone=timezone,
+        due_in_minutes=in_minutes,
+        due_in_hours=in_hours,
+        due_in_days=in_days,
+    )
 
 
 def get_task(config: Config, *, task_id: str) -> dict:
@@ -408,6 +480,79 @@ def search_tasks(config: Config, *, query: str, show_completed: bool = False) ->
 
 
 # ---------------------------------------------------------------------------
+# Daily digest (overdue + stale tasks)
+# ---------------------------------------------------------------------------
+
+DIGEST_TYPE = "task_digest"
+DIGEST_MIN_GAP = timedelta(hours=24)
+STALE_AFTER = timedelta(days=14)
+_DIGEST_META_KEY = "last_digest_at"
+
+_OVERDUE_HEADER = (
+    "Overdue tasks. Resolve every one right now: do it and `tasks done <id>`, or postpone it "
+    "(`tasks postpone <id> --in-days N`), or tell the user you are dropping it and `tasks delete <id>`. "
+    "Never leave a task sitting overdue."
+)
+_STALE_HEADER = (
+    "Stale tasks, pending 2+ weeks with no due date. Give each a deadline (`tasks postpone <id> --in-days N`), "
+    "do it now, or drop it with the user's knowledge."
+)
+
+
+def build_digest(config: Config, *, now: datetime | None = None) -> str | None:
+    """The daily digest message, or None when nothing needs attention."""
+    now = now or _now_utc()
+    with closing(db.get_db(config.data_dir)) as conn:
+        pending = conn.execute("SELECT id, title, priority, due_date, created_at FROM tasks WHERE status = 'pending'").fetchall()
+
+    overdue: list[tuple[dict, datetime]] = []
+    stale: list[tuple[dict, datetime]] = []
+    for row in pending:
+        if row["due_date"]:
+            due = db.parse_datetime(row["due_date"])
+            if due < now:
+                overdue.append((dict(row), due))
+        else:
+            created = db.parse_datetime(row["created_at"])
+            if now - created > STALE_AFTER:
+                stale.append((dict(row), created))
+
+    if not overdue and not stale:
+        return None
+
+    lines: list[str] = []
+    if overdue:
+        overdue.sort(key=lambda pair: pair[1])
+        lines.append(_OVERDUE_HEADER)
+        lines += [f'- {t["id"]} "{t["title"]}" ({PRIORITY_LABEL[t["priority"]]}, overdue {rel_delta(now - due)})' for t, due in overdue]
+    if stale:
+        if overdue:
+            lines.append("")
+        lines.append(_STALE_HEADER)
+        lines += [f'- {t["id"]} "{t["title"]}" (created {rel_delta(now - created)} ago)' for t, created in stale]
+    return "\n".join(lines)
+
+
+def maybe_send_digest(config: Config, notif_dir: Path, *, now: datetime | None = None) -> bool:
+    """Emit at most one task digest per day, and only when something needs attention."""
+    now = now or _now_utc()
+    with closing(db.get_db(config.data_dir)) as conn:
+        last = db.get_meta(conn, _DIGEST_META_KEY)
+    if last is not None and now - db.parse_datetime(last) < DIGEST_MIN_GAP:
+        return False
+
+    message = build_digest(config, now=now)
+    if message is None:
+        return False
+
+    write_notification(notif_dir, DIGEST_TYPE, message=message)
+    with closing(db.get_db(config.data_dir)) as conn:
+        db.set_meta(conn, _DIGEST_META_KEY, now.isoformat())
+        conn.commit()
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Reminder job callback
 # ---------------------------------------------------------------------------
 
@@ -419,12 +564,19 @@ def send_reminder_job(reminder_id: str, *, message: str, data_dir: str, notif_di
     if notif_dir:
         task_id = None
         with closing(db.get_db(data_dir)) as conn:
-            cursor = conn.execute("SELECT task_id, message, trigger_data FROM reminders WHERE id = ?", (reminder_id,))
+            cursor = conn.execute("SELECT task_id, message, trigger_data, auto_generated FROM reminders WHERE id = ?", (reminder_id,))
             row = cursor.fetchone()
             if row:
                 task_id = row["task_id"]
                 message = row["message"] or message
                 trigger_data = json.loads(row["trigger_data"]) if row["trigger_data"] else {}
+                trigger_type = trigger_data["type"] if "type" in trigger_data else None
+
+                if trigger_type == "date" and "run_date" in trigger_data:
+                    run_date = db.parse_datetime(trigger_data["run_date"])
+                    if run_date > _now_utc() + STALE_FIRE_SLACK:
+                        logger.info("Reminder %s was snoozed to %s; skipping stale fire", reminder_id, trigger_data["run_date"])
+                        return
 
                 logger.info(f"Firing reminder {reminder_id}: {message[:50]}")
 
@@ -433,13 +585,16 @@ def send_reminder_job(reminder_id: str, *, message: str, data_dir: str, notif_di
                     reminder_id,
                     message,
                     task_id=task_id,
+                    snooze_hint=trigger_type == "date" and not row["auto_generated"],
                 )
 
-                trigger_type = trigger_data["type"] if "type" in trigger_data else None
                 if trigger_type == "date":
                     conn.execute("UPDATE reminders SET completed = 1 WHERE id = ?", (reminder_id,))
                     conn.commit()
-                elif trigger_type == "cron":
+                elif trigger_type == "cron" and "fuzz_minutes" not in trigger_data:
+                    # Fuzzed cron rows run as chained one-shots; the job sync's restore computes
+                    # their next fuzzed fire and advances scheduled_time, so only plain cron
+                    # (whose job stays armed) updates it here.
                     next_fire = _cron_trigger_from_data(trigger_data).get_next_fire_time(None, _now_utc())
                     if next_fire is not None:
                         conn.execute(
@@ -475,6 +630,10 @@ def _restore_row(scheduler: BackgroundScheduler, row, now: datetime, notif_dir: 
                 return False
             run_date = db.parse_datetime(trigger_data["run_date"])
             if run_date < now:
+                if run_date > now - MISSED_GRACE:
+                    # Probably firing right now in a scheduler worker; a later tick either finds
+                    # it completed or declares it missed for real.
+                    return False
                 logger.info(f"Reminder {reminder_id}: past due, sending missed notification")
                 if notif_dir:
                     write_reminder_notification(
@@ -483,13 +642,21 @@ def _restore_row(scheduler: BackgroundScheduler, row, now: datetime, notif_dir: 
                         row["message"],
                         task_id=row["task_id"],
                         extra={"missed": True},
+                        snooze_hint=not row["auto_generated"],
                     )
                 conn.execute("UPDATE reminders SET completed = 1 WHERE id = ?", (reminder_id,))
                 return True
             trigger = DateTrigger(run_date=run_date)
 
         elif trigger_type == "cron":
-            trigger = _cron_trigger_from_data(trigger_data)
+            if "fuzz_minutes" in trigger_data:
+                # Fuzzed reminders run as chained one-shots: this job fires once at the fuzzed
+                # instant, then the serve loop's job sync restores the next one the same way.
+                fire = fuzzed_next_fire(reminder_id, trigger_data, now)
+                conn.execute("UPDATE reminders SET scheduled_time = ? WHERE id = ?", (fire.isoformat(), reminder_id))
+                trigger = DateTrigger(run_date=fire)
+            else:
+                trigger = _cron_trigger_from_data(trigger_data)
 
         elif trigger_type == "interval":
             trigger = IntervalTrigger(hours=trigger_data["hours"] if "hours" in trigger_data else 1)
@@ -527,7 +694,9 @@ def restore_all_jobs(config: Config, scheduler: BackgroundScheduler, *, notif_di
     Past-due one-time reminders fire missed notifications immediately."""
     now = _now_utc()
     with closing(db.get_db(config.data_dir)) as conn:
-        cursor = conn.execute("SELECT id, task_id, message, trigger_data FROM reminders WHERE completed = 0 AND trigger_data IS NOT NULL")
+        cursor = conn.execute(
+            "SELECT id, task_id, message, trigger_data, auto_generated FROM reminders WHERE completed = 0 AND trigger_data IS NOT NULL"
+        )
         for row in cursor:
             _restore_row(scheduler, row, now, notif_dir, conn, config)
         conn.commit()
@@ -539,7 +708,8 @@ def restore_jobs_by_ids(config: Config, scheduler: BackgroundScheduler, ids: set
     placeholders = ",".join("?" for _ in ids)
     with closing(db.get_db(config.data_dir)) as conn:
         cursor = conn.execute(
-            f"SELECT id, task_id, message, trigger_data FROM reminders WHERE completed = 0 AND trigger_data IS NOT NULL AND id IN ({placeholders})",
+            f"SELECT id, task_id, message, trigger_data, auto_generated FROM reminders"
+            f" WHERE completed = 0 AND trigger_data IS NOT NULL AND id IN ({placeholders})",
             list(ids),
         )
         for row in cursor:
@@ -550,6 +720,14 @@ def restore_jobs_by_ids(config: Config, scheduler: BackgroundScheduler, ids: set
 # ---------------------------------------------------------------------------
 # Reminder commands (CRUD)
 # ---------------------------------------------------------------------------
+
+
+def _apply_fuzz(
+    reminder_id: str, trigger_data: TriggerData, trigger: CronTrigger, schedule_info: str, fuzz_minutes: int
+) -> tuple[str, datetime]:
+    _validate_fuzz(fuzz_minutes, trigger)
+    trigger_data["fuzz_minutes"] = fuzz_minutes
+    return f"{schedule_info}, fuzz {fuzz_minutes}m", fuzzed_next_fire(reminder_id, trigger_data, _now_utc())
 
 
 def remind_set(
@@ -564,10 +742,14 @@ def remind_set(
     in_days: int | None = None,
     recurring: str | None = None,
     cron: str | None = None,
+    fuzz_minutes: int | None = None,
     notif_dir: Path | None = None,
 ) -> dict:
     reminder_id = str(uuid.uuid4())[:8]
     trigger_data = None
+
+    if fuzz_minutes is not None and cron is None and recurring not in ("daily", "weekly", "monthly", "yearly"):
+        raise ValueError("fuzz_minutes needs a daily/weekly/monthly/yearly or cron schedule")
 
     if cron is not None:
         if recurring or scheduled_datetime or in_minutes or in_hours or in_days:
@@ -579,6 +761,8 @@ def remind_set(
         schedule_info = f"cron: {cron} ({tz})"
         trigger_data = {"type": "cron", "expr": expr, "tz": tz}
         next_run = trigger.get_next_fire_time(None, _now_utc())
+        if fuzz_minutes is not None:
+            schedule_info, next_run = _apply_fuzz(reminder_id, trigger_data, trigger, schedule_info, fuzz_minutes)
     elif recurring == "hourly":
         schedule_info = "hourly"
         trigger_data = {"type": "interval", "hours": 1}
@@ -610,6 +794,8 @@ def remind_set(
         trigger = CronTrigger.from_crontab(expr, timezone=ZoneInfo(tz))
         trigger_data = {"type": "cron", "expr": expr, "tz": tz}
         next_run = trigger.get_next_fire_time(None, _now_utc())
+        if fuzz_minutes is not None:
+            schedule_info, next_run = _apply_fuzz(reminder_id, trigger_data, trigger, schedule_info, fuzz_minutes)
     elif scheduled_datetime:
         if not tz:
             raise ValueError("tz is required when scheduled_datetime is provided")
@@ -618,11 +804,8 @@ def remind_set(
         trigger_data = {"type": "date", "run_date": utc_dt.isoformat()}
         next_run = utc_dt
     else:
-        for name, val in [("in_minutes", in_minutes), ("in_hours", in_hours), ("in_days", in_days)]:
-            if val is not None and val <= 0:
-                raise ValueError(f"{name} must be positive")
-        offset = timedelta(minutes=in_minutes or 0, hours=in_hours or 0, days=in_days or 0)
-        if not offset.total_seconds():
+        offset = _relative_offset(in_minutes, in_hours, in_days)
+        if offset is None:
             raise ValueError("Must specify when to send reminder")
         run_time = _now_utc() + offset
         parts = [f"{v} {u}" for v, u in [(in_days, "days"), (in_hours, "hours"), (in_minutes, "minutes")] if v]
@@ -700,6 +883,45 @@ def remind_delete(config: Config, *, reminder_id: str) -> dict:
         conn.commit()
 
     return {"status": "deleted", "id": reminder_id}
+
+
+def remind_snooze(
+    config: Config,
+    *,
+    reminder_id: str,
+    in_minutes: int | None = None,
+    in_hours: int | None = None,
+    in_days: int | None = None,
+    at: str | None = None,
+    tz: str | None = None,
+) -> dict:
+    """Reschedule a one-shot reminder for later; works on already-fired reminders too."""
+    with closing(db.get_db(config.data_dir)) as conn:
+        row = conn.execute("SELECT * FROM reminders WHERE id = ?", (reminder_id,)).fetchone()
+        if not row:
+            raise ValueError(f"Reminder '{reminder_id}' not found. Use 'tasks remind list' to see active reminders.")
+        trigger_data = json.loads(row["trigger_data"]) if row["trigger_data"] else {}
+        if "type" in trigger_data and trigger_data["type"] != "date":
+            raise ValueError("Recurring reminders fire again on their own; snooze only works on one-shot reminders (delete if unwanted)")
+
+        if at is not None:
+            if not tz:
+                raise ValueError("tz is required when at is provided")
+            run_time = _to_utc_dt(at, tz)
+        else:
+            offset = _relative_offset(in_minutes, in_hours, in_days)
+            if offset is None:
+                raise ValueError("Say when: tasks remind snooze <id> --in-hours N (or --in-minutes/--in-days, or --at + --tz)")
+            run_time = _now_utc() + offset
+
+        new_data = {"type": "date", "run_date": run_time.isoformat()}
+        conn.execute(
+            "UPDATE reminders SET completed = 0, trigger_data = ?, scheduled_time = ? WHERE id = ?",
+            (json.dumps(new_data), run_time.isoformat(), reminder_id),
+        )
+        conn.commit()
+
+    return {"id": reminder_id, "message": row["message"], "next_run": run_time.isoformat(), "status": "snoozed"}
 
 
 def remind_update(config: Config, *, reminder_id: str, message: str) -> dict:

--- a/agent/skills/tasks/cli/src/tasks_cli/db.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/db.py
@@ -186,12 +186,20 @@ def _migrate_v2_to_v3(conn: sqlite3.Connection):
     logger.info("Migrated schema v2 -> v3")
 
 
-AUTO_REMINDER_WINDOWS = [
+AUTO_REMINDER_TAIL = [
     ("1 week", timedelta(weeks=1)),
     ("1 day", timedelta(days=1)),
     ("1 hour", timedelta(hours=1)),
     ("15 minutes", timedelta(minutes=15)),
 ]
+
+CHECKPOINT_FLOOR = timedelta(weeks=2)
+
+DUE_NOW_MESSAGE = (
+    'Task "{title}" ({task_id}) is due now. Decide immediately: do it and run `tasks done {task_id}`, '
+    "or postpone it (`tasks postpone {task_id} --in-days N`), or tell the user you are dropping it and run "
+    "`tasks delete {task_id}`. Never leave a task sitting overdue."
+)
 
 
 def parse_datetime(s: str) -> datetime:
@@ -199,24 +207,45 @@ def parse_datetime(s: str) -> datetime:
     return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
 
 
-def create_auto_reminders(conn: sqlite3.Connection, task_id: str, title: str, due_date_str: str, priority: int):
+def _humanize_delta(delta: timedelta) -> str:
+    days = round(delta.total_seconds() / 86400)
+    if days >= 60:
+        return f"about {round(days / 30)} months"
+    return f"about {round(days / 7)} weeks"
+
+
+def auto_reminder_deltas(lead: timedelta) -> list[tuple[str, timedelta]]:
+    """Lead-time offsets for a task's auto reminders: checkpoints that halve the remaining lead
+    while they stay more than two weeks out, then the fixed 1w/1d/1h/15m tail."""
+    checkpoints = []
+    half = lead / 2
+    while half > CHECKPOINT_FLOOR:
+        checkpoints.append((_humanize_delta(half), half))
+        half = half / 2
+    return checkpoints + AUTO_REMINDER_TAIL
+
+
+def _insert_auto_reminder(conn: sqlite3.Connection, task_id: str, message: str, schedule_type: str, fire_time: datetime):
+    trigger_data = {"type": "date", "run_date": fire_time.isoformat()}
+    conn.execute(
+        """INSERT INTO reminders (id, task_id, message, schedule_type, scheduled_time, completed, trigger_data, auto_generated)
+           VALUES (?, ?, ?, ?, ?, 0, ?, 1)""",
+        (str(uuid.uuid4())[:8], task_id, message, schedule_type, fire_time.isoformat(), json.dumps(trigger_data)),
+    )
+
+
+def create_auto_reminders(conn: sqlite3.Connection, task_id: str, title: str, due_date_str: str):
     now = datetime.now(UTC)
     due_dt = parse_datetime(due_date_str)
 
-    for label, delta in AUTO_REMINDER_WINDOWS:
+    for label, delta in auto_reminder_deltas(due_dt - now):
         fire_time = due_dt - delta
         if fire_time <= now:
             continue
+        _insert_auto_reminder(conn, task_id, f"Task due in {label}: {title}", f"auto: {label} before due", fire_time)
 
-        reminder_id = str(uuid.uuid4())[:8]
-        trigger_data = {"type": "date", "run_date": fire_time.isoformat()}
-        message = f"Task due in {label}: {title}"
-
-        conn.execute(
-            """INSERT INTO reminders (id, task_id, message, schedule_type, scheduled_time, completed, trigger_data, auto_generated)
-               VALUES (?, ?, ?, ?, ?, 0, ?, 1)""",
-            (reminder_id, task_id, message, f"auto: {label} before due", fire_time.isoformat(), json.dumps(trigger_data)),
-        )
+    if due_dt > now:
+        _insert_auto_reminder(conn, task_id, DUE_NOW_MESSAGE.format(title=title, task_id=task_id), "auto: at due", due_dt)
 
 
 def delete_auto_reminders(conn: sqlite3.Connection, task_id: str):
@@ -225,13 +254,34 @@ def delete_auto_reminders(conn: sqlite3.Connection, task_id: str):
 
 def _create_auto_reminders_for_existing(conn: sqlite3.Connection):
     """Create auto-generated reminders for all pending tasks with due dates."""
-    tasks = conn.execute("SELECT id, title, due_date, priority FROM tasks WHERE due_date IS NOT NULL AND status='pending'").fetchall()
+    tasks = conn.execute("SELECT id, title, due_date FROM tasks WHERE due_date IS NOT NULL AND status='pending'").fetchall()
     created = 0
     for task in tasks:
-        create_auto_reminders(conn, task["id"], task["title"], task["due_date"], task["priority"])
+        create_auto_reminders(conn, task["id"], task["title"], task["due_date"])
         created += 1
     if created:
         logger.info(f"Created auto-generated reminders for {created} tasks")
+
+
+def _migrate_v3_to_v4(conn: sqlite3.Connection):
+    """v3 -> v4: add the meta key-value table (digest bookkeeping) and regenerate pending auto
+    reminders so existing tasks pick up the at-due decision fire and the spaced checkpoints."""
+    conn.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)")
+    conn.execute("DELETE FROM reminders WHERE auto_generated = 1 AND completed = 0")
+    _create_auto_reminders_for_existing(conn)
+    logger.info("Migrated schema v3 -> v4")
+
+
+def get_meta(conn: sqlite3.Connection, key: str) -> str | None:
+    row = conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+    return row["value"] if row else None
+
+
+def set_meta(conn: sqlite3.Connection, key: str, value: str):
+    conn.execute(
+        "INSERT INTO meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, value),
+    )
 
 
 def init_db(data_dir: Path):
@@ -274,6 +324,11 @@ def init_db(data_dir: Path):
         if version < 3:
             _migrate_v2_to_v3(conn)
             conn.execute("UPDATE schema_version SET version = 3")
+            version = 3
+
+        if version < 4:
+            _migrate_v3_to_v4(conn)
+            conn.execute("UPDATE schema_version SET version = 4")
 
         conn.commit()
 

--- a/agent/skills/tasks/cli/src/tasks_cli/format.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/format.py
@@ -1,8 +1,11 @@
 """Compact text formatters for tasks CLI output."""
 
+from datetime import datetime, UTC, timedelta
 from typing import Any
 
-_PRIORITY_LABEL = {1: "low", 2: "norm", 3: "high"}
+from .db import parse_datetime
+
+PRIORITY_LABEL = {1: "low", 2: "norm", 3: "high"}
 
 
 def _trunc(value: Any, width: int) -> str:
@@ -15,33 +18,66 @@ def _pick(d: dict, k: str, default: Any = "") -> Any:
 
 
 def _prio(p: Any) -> str:
-    return _PRIORITY_LABEL[p] if p in _PRIORITY_LABEL else (str(p) if p is not None else "-")
+    return PRIORITY_LABEL[p] if p in PRIORITY_LABEL else (str(p) if p is not None else "-")
 
 
-def format_task_list(tasks: list[dict[str, Any]]) -> str:
+def rel_delta(delta: timedelta) -> str:
+    """A duration as one coarse unit: 45m, 3h, 2d, 3w."""
+    seconds = max(int(delta.total_seconds()), 0)
+    if seconds < 5400:
+        return f"{max(seconds // 60, 1)}m"
+    if seconds < 129600:
+        return f"{round(seconds / 3600)}h"
+    if seconds < 1209600:
+        return f"{round(seconds / 86400)}d"
+    return f"{round(seconds / 604800)}w"
+
+
+def rel_time(iso: str | None, now: datetime) -> str:
+    """An instant relative to now: 'in 3h', '2d ago', '-' when unset."""
+    if not iso:
+        return "-"
+    instant = parse_datetime(iso)
+    if instant >= now:
+        return f"in {rel_delta(instant - now)}"
+    return f"{rel_delta(now - instant)} ago"
+
+
+def _due_col(iso: str | None, now: datetime) -> str:
+    if not iso:
+        return "-"
+    due = parse_datetime(iso)
+    if due >= now:
+        return f"due in {rel_delta(due - now)}"
+    return f"OVERDUE {rel_delta(now - due)}"
+
+
+def format_task_list(tasks: list[dict[str, Any]], now: datetime | None = None) -> str:
     """One line per task: status  prio  due  id  title."""
     if not tasks:
         return "(no tasks)"
+    now = now or datetime.now(UTC)
     return "\n".join(
         f"{_trunc(_pick(t, 'status', '-'), 8)}\t"
         f"{_prio(_pick(t, 'priority', None))}\t"
-        f"{_trunc(_pick(t, 'due_date', None), 20)}\t"
+        f"{_due_col(_pick(t, 'due_date', None), now)}\t"
         f"{_pick(t, 'id')}\t"
         f"{_trunc(_pick(t, 'title'), 80)}"
         for t in tasks
     )
 
 
-def format_reminder_list(reminders: list[dict[str, Any]]) -> str:
+def format_reminder_list(reminders: list[dict[str, Any]], now: datetime | None = None) -> str:
     """One line per reminder: next_run  id  schedule  message (task=<id> if linked; * if auto)."""
     if not reminders:
         return "(no reminders)"
+    now = now or datetime.now(UTC)
     rows = []
     for r in reminders:
         auto = " *" if _pick(r, "auto_generated", False) else ""
         suffix = f"\ttask={r['task_id']}" if _pick(r, "task_id", None) else ""
         rows.append(
-            f"{_trunc(_pick(r, 'next_run', None), 25)}\t"
+            f"{rel_time(_pick(r, 'next_run', None), now)}\t"
             f"{_pick(r, 'id')}\t"
             f"{_trunc(_pick(r, 'schedule', None), 40)}\t"
             f"{_trunc(_pick(r, 'message'), 80)}{auto}{suffix}"

--- a/agent/skills/tasks/cli/src/tasks_cli/scheduler.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/scheduler.py
@@ -21,10 +21,7 @@ def create_scheduler() -> BackgroundScheduler:
     )
 
 
-_REARM_HINT = (
-    "Tip: if no action is taken on this reminder, rearm it for a later date"
-    " via `tasks remind delete {rid}` followed by a new `tasks remind ... --at ...`."
-)
+_SNOOZE_HINT = "Not actionable right now? Push it back: `tasks remind snooze {rid} --in-hours N`."
 
 
 def write_notification(notif_dir: Path, type_: str, **fields: object) -> None:
@@ -50,10 +47,12 @@ def write_reminder_notification(
     *,
     task_id: str | None = None,
     extra: dict | None = None,
+    snooze_hint: bool = False,
 ):
-    """Write a reminder notification JSON file."""
+    """Write a reminder notification JSON file. `snooze_hint` appends the snooze tip; set it for
+    one-shot user reminders only (recurring ones fire again anyway, auto ones carry their own menu)."""
     if not reminder_id or not message:
         raise ValueError("reminder_id and message required")
 
-    full_message = f"{message}\n{_REARM_HINT.format(rid=reminder_id)}"
+    full_message = f"{message}\n{_SNOOZE_HINT.format(rid=reminder_id)}" if snooze_hint else message
     write_notification(notif_dir, "reminder", message=full_message, reminder_id=reminder_id, task_id=task_id, **(extra or {}))

--- a/agent/skills/tasks/cli/src/tasks_cli/server.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/server.py
@@ -30,6 +30,11 @@ class UpdateTaskBody(BaseModel):
     status: Literal["pending", "done"] | None = None
     title: str | None = None
     priority: str | int | None = None
+    due_datetime: str | None = None
+    timezone: str | None = None
+    due_in_minutes: int | None = None
+    due_in_hours: int | None = None
+    due_in_days: int | None = None
 
 
 class SetReminderBody(BaseModel):
@@ -41,10 +46,20 @@ class SetReminderBody(BaseModel):
     in_hours: int | None = None
     in_days: int | None = None
     recurring: Literal["hourly", "daily", "weekly", "monthly", "yearly"] | None = None
+    cron: str | None = None
+    fuzz_minutes: int | None = None
 
 
 class UpdateReminderBody(BaseModel):
     message: str
+
+
+class SnoozeReminderBody(BaseModel):
+    in_minutes: int | None = None
+    in_hours: int | None = None
+    in_days: int | None = None
+    at: str | None = None
+    tz: str | None = None
 
 
 # --- App factory ---
@@ -87,7 +102,18 @@ def _create_app(config: Config) -> FastAPI:
 
     @app.patch("/tasks/{task_id}")
     def update_task(task_id: str, body: UpdateTaskBody):
-        return commands.update_task(config, task_id=task_id, status=body.status, title=body.title, priority=body.priority)
+        return commands.update_task(
+            config,
+            task_id=task_id,
+            status=body.status,
+            title=body.title,
+            priority=body.priority,
+            due_datetime=body.due_datetime,
+            timezone=body.timezone,
+            due_in_minutes=body.due_in_minutes,
+            due_in_hours=body.due_in_hours,
+            due_in_days=body.due_in_days,
+        )
 
     @app.delete("/tasks/{task_id}")
     def delete_task(task_id: str):
@@ -111,11 +137,25 @@ def _create_app(config: Config) -> FastAPI:
             in_hours=body.in_hours,
             in_days=body.in_days,
             recurring=body.recurring,
+            cron=body.cron,
+            fuzz_minutes=body.fuzz_minutes,
         )
 
     @app.patch("/reminders/{reminder_id}")
     def update_reminder(reminder_id: str, body: UpdateReminderBody):
         return commands.remind_update(config, reminder_id=reminder_id, message=body.message)
+
+    @app.post("/reminders/{reminder_id}/snooze")
+    def snooze_reminder(reminder_id: str, body: SnoozeReminderBody):
+        return commands.remind_snooze(
+            config,
+            reminder_id=reminder_id,
+            in_minutes=body.in_minutes,
+            in_hours=body.in_hours,
+            in_days=body.in_days,
+            at=body.at,
+            tz=body.tz,
+        )
 
     @app.delete("/reminders/{reminder_id}")
     def delete_reminder(reminder_id: str):

--- a/agent/skills/tasks/cli/tests/conftest.py
+++ b/agent/skills/tasks/cli/tests/conftest.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import pytest
+
+from tasks_cli import db
+from tasks_cli.config import Config
+
+
+@pytest.fixture
+def tmp_config(tmp_path: Path) -> Config:
+    cfg = Config(data_dir=tmp_path / "tasks", log_dir=tmp_path / "tasks" / "logs")
+    cfg.data_dir.mkdir(parents=True, exist_ok=True)
+    db.init_db(cfg.data_dir)
+    return cfg

--- a/agent/skills/tasks/cli/tests/test_e2e.py
+++ b/agent/skills/tasks/cli/tests/test_e2e.py
@@ -571,13 +571,27 @@ class TestAutoReminders:
 
     def test_auto_reminders_skipped_if_past(self, shared_env):
         home, _, _ = shared_env
-        # Due in 30 minutes: only 15-min auto-reminder should be created (others are in the past)
+        # Due in 30 minutes: only the 15-min pre-due reminder plus the at-due decision fire remain
         future = (datetime.now(UTC) + timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%S")
         task = parse(tasks_cli(home, "add", "soon task", "--due-datetime", future, "--timezone", "UTC"))
         items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         auto = [i for i in items if i["auto_generated"]]
-        assert len(auto) == 1
-        assert "15 minutes" in auto[0]["message"]
+        assert len(auto) == 2
+        messages = sorted(i["message"] for i in auto)
+        assert "is due now" in messages[0]
+        assert "15 minutes" in messages[1]
+
+    def test_at_due_reminder_carries_decision_menu(self, shared_env):
+        home, _, _ = shared_env
+        future = (datetime.now(UTC) + timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%S")
+        task = parse(tasks_cli(home, "add", "decision task", "--due-datetime", future, "--timezone", "UTC"))
+        items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
+        at_due = [i for i in items if i["schedule"] == "auto: at due"]
+        assert len(at_due) == 1
+        message = at_due[0]["message"]
+        assert f"tasks done {task['id']}" in message
+        assert f"tasks postpone {task['id']}" in message
+        assert f"tasks delete {task['id']}" in message
 
     def test_done_status_cleans_auto_reminders(self, shared_env):
         home, _, _ = shared_env
@@ -605,6 +619,35 @@ class TestAutoReminders:
         assert not any(i["task_id"] == task["id"] for i in all_items)
 
 
+# === Low-friction verbs ===
+
+
+class TestVerbs:
+    def test_done_marks_task_done(self, shared_env):
+        home, _, _ = shared_env
+        task = parse(tasks_cli(home, "add", "verb done"))
+        data = parse(tasks_cli(home, "done", task["id"]))
+        assert data["status"] == "done"
+
+    def test_postpone_sets_new_due_from_now(self, shared_env):
+        home, _, _ = shared_env
+        task = parse(tasks_cli(home, "add", "verb postpone"))
+        data = parse(tasks_cli(home, "postpone", task["id"], "--in-days", "2"))
+        assert data["due_date"] is not None
+
+    def test_postpone_without_timing_errors(self, shared_env):
+        home, _, _ = shared_env
+        task = parse(tasks_cli(home, "add", "verb postpone bad"))
+        r = tasks_cli(home, "postpone", task["id"])
+        assert r.returncode != 0
+
+    def test_remind_snooze_moves_one_shot(self, shared_env):
+        home, _, _ = shared_env
+        s = parse(tasks_cli(home, "remind", "snooze me", "--in-hours", "1"))
+        data = parse(tasks_cli(home, "remind", "snooze", s["id"], "--in-hours", "5"))
+        assert data["status"] == "snoozed"
+
+
 # === Daemon / Notification tests ===
 
 
@@ -625,8 +668,7 @@ class TestDaemonNotifications:
                 data = json.loads(f.read_text())
                 if data.get("reminder_id") == rid:
                     assert data["message"].startswith("fire soon")
-                    assert "rearm" in data["message"]
-                    assert f"tasks remind delete {rid}" in data["message"]
+                    assert f"tasks remind snooze {rid}" in data["message"]
                     assert data["source"] == "tasks"
                     found = True
                     break
@@ -643,6 +685,49 @@ class TestDaemonNotifications:
             time.sleep(2)
             items = parse(tasks_cli(home, "remind", "list", "--json"))
             assert any(i["id"] == rid for i in items)
+        finally:
+            stop_daemon(proc)
+
+    def test_snoozed_reminder_fires_at_new_time(self, test_home):
+        home, notif_dir = test_home
+        proc = start_daemon(home, notif_dir)
+        try:
+            far = (datetime.now(UTC) + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S")
+            s = parse(tasks_cli(home, "remind", "snooze fire", "--at", far, "--tz", "UTC"))
+            time.sleep(2)  # let the daemon schedule the original far-off job
+            soon = (datetime.now(UTC) + timedelta(seconds=3)).strftime("%Y-%m-%dT%H:%M:%S")
+            snoozed = parse(tasks_cli(home, "remind", "snooze", s["id"], "--at", soon, "--tz", "UTC"))
+            assert snoozed["status"] == "snoozed"
+
+            deadline = time.time() + 15
+            found = False
+            while time.time() < deadline and not found:
+                found = any(json.loads(f.read_text())["reminder_id"] == s["id"] for f in notif_dir.glob("*-tasks-reminder.json"))
+                time.sleep(0.5)
+            assert found, "snoozed reminder did not fire at its new time"
+        finally:
+            stop_daemon(proc)
+
+    def test_digest_fires_for_overdue_task(self, test_home):
+        home, notif_dir = test_home
+        proc = start_daemon(home, notif_dir)
+        try:
+            task = parse(tasks_cli(home, "add", "already late", "--due-in-minutes", "5"))
+            past = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+            conn = sqlite3.connect(home / ".tasks" / "tasks.db")
+            conn.execute("UPDATE tasks SET due_date = ? WHERE id = ?", (past, task["id"]))
+            conn.commit()
+            conn.close()
+
+            deadline = time.time() + 15
+            digest_files = []
+            while time.time() < deadline and not digest_files:
+                digest_files = list(notif_dir.glob("*-tasks-task_digest.json"))
+                time.sleep(0.5)
+            assert digest_files, "daemon did not emit a digest for the overdue task"
+            payload = json.loads(digest_files[0].read_text())
+            assert task["id"] in payload["message"]
+            assert "tasks postpone <id>" in payload["message"]
         finally:
             stop_daemon(proc)
 

--- a/agent/skills/tasks/cli/tests/test_fuzz.py
+++ b/agent/skills/tasks/cli/tests/test_fuzz.py
@@ -1,0 +1,74 @@
+"""Unit tests for fuzzed recurring reminders: deterministic sampling, window bounds, restart safety."""
+
+from datetime import datetime, timedelta, UTC
+import pytest
+
+from tasks_cli import commands, db
+from tasks_cli.config import Config
+
+
+DAILY_1030 = {"type": "cron", "expr": "30 10 * * *", "tz": "UTC", "fuzz_minutes": 60}
+
+
+def test_fuzz_stored_and_next_run_within_window(tmp_config: Config):
+    result = commands.remind_set(
+        tmp_config, message="wind down", scheduled_datetime="2026-04-26T21:30:00", tz="UTC", recurring="daily", fuzz_minutes=45
+    )
+    assert result["schedule"] == "daily at 21:30 UTC, fuzz 45m"
+
+    # A 45m fuzz around 21:30 stays inside the same date, so the nominal is next_run's own 21:30.
+    next_run = db.parse_datetime(result["next_run"])
+    nominal = next_run.replace(hour=21, minute=30, second=0, microsecond=0)
+    assert abs((next_run - nominal).total_seconds()) <= 45 * 60
+
+
+def test_fuzz_requires_a_recurring_or_cron_schedule(tmp_config: Config):
+    with pytest.raises(ValueError, match="fuzz_minutes needs"):
+        commands.remind_set(tmp_config, message="one shot", in_hours=1, fuzz_minutes=30)
+    with pytest.raises(ValueError, match="fuzz_minutes needs"):
+        commands.remind_set(tmp_config, message="hourly", recurring="hourly", fuzz_minutes=30)
+
+
+def test_fuzz_bounded_by_smallest_gap_not_first(tmp_config: Config):
+    # Weekday cron: the weekend gap is 3 days but the weekday gap is 24h, so 800m (> 720m half) is
+    # rejected no matter which gap comes next.
+    with pytest.raises(ValueError, match="half the gap"):
+        commands.remind_set(tmp_config, message="weekdays", cron="0 9 * * 1-5", tz="UTC", fuzz_minutes=800)
+
+
+def test_fuzz_must_fit_in_half_the_period(tmp_config: Config):
+    with pytest.raises(ValueError, match="half the gap"):
+        commands.remind_set(
+            tmp_config, message="too wide", scheduled_datetime="2026-04-26T10:30:00", tz="UTC", recurring="daily", fuzz_minutes=800
+        )
+    with pytest.raises(ValueError, match="positive"):
+        commands.remind_set(
+            tmp_config, message="negative", scheduled_datetime="2026-04-26T10:30:00", tz="UTC", recurring="daily", fuzz_minutes=-5
+        )
+
+
+def test_fuzzed_next_fire_is_deterministic_and_bounded():
+    after = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    first = commands.fuzzed_next_fire("rem1", DAILY_1030, after)
+    again = commands.fuzzed_next_fire("rem1", DAILY_1030, after)
+    assert first == again
+
+    nominal = datetime(2026, 1, 1, 10, 30, tzinfo=UTC)
+    assert abs((first - nominal).total_seconds()) <= 60 * 60
+
+    other = commands.fuzzed_next_fire("rem2", DAILY_1030, after)
+    assert other != first  # distinct reminders sample distinct offsets
+
+
+def test_fuzzed_next_fire_never_double_fires_across_restarts():
+    after = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    fire = commands.fuzzed_next_fire("rem1", DAILY_1030, after)
+
+    # A restart moments before the fire recomputes the identical instant.
+    assert commands.fuzzed_next_fire("rem1", DAILY_1030, fire - timedelta(minutes=1)) == fire
+
+    # A restart (or the post-fire resync) right after the fire moves to the next day,
+    # even while today's nominal 10:30 may still be ahead of the clock.
+    following = commands.fuzzed_next_fire("rem1", DAILY_1030, fire)
+    assert following > fire
+    assert following - fire > timedelta(hours=12)

--- a/agent/skills/tasks/cli/tests/test_overdue_loop.py
+++ b/agent/skills/tasks/cli/tests/test_overdue_loop.py
@@ -1,0 +1,287 @@
+"""Unit tests for the overdue pressure loop: adaptive reminder ladder, at-due decision fire,
+postpone/snooze verbs, the daily digest, and overdue ordering."""
+
+import json
+from contextlib import closing
+from datetime import datetime, timedelta, UTC
+from pathlib import Path
+
+import pytest
+
+from tasks_cli import commands, db
+from tasks_cli.config import Config
+from tasks_cli.scheduler import create_scheduler
+
+
+def _auto_reminders(config: Config, task_id: str) -> list[dict]:
+    with closing(db.get_db(config.data_dir)) as conn:
+        rows = conn.execute("SELECT * FROM reminders WHERE task_id = ? AND auto_generated = 1", (task_id,)).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _add_task_due_in(config: Config, title: str, delta: timedelta) -> dict:
+    due = (datetime.now(UTC) + delta).strftime("%Y-%m-%dT%H:%M:%S")
+    return commands.add_task(config, title=title, due_datetime=due, timezone="UTC")
+
+
+def _force_due_date(config: Config, task_id: str, due: datetime):
+    with closing(db.get_db(config.data_dir)) as conn:
+        conn.execute("UPDATE tasks SET due_date = ? WHERE id = ?", (due.isoformat(), task_id))
+        conn.commit()
+
+
+def _force_created_at(config: Config, task_id: str, created: datetime):
+    with closing(db.get_db(config.data_dir)) as conn:
+        conn.execute("UPDATE tasks SET created_at = ? WHERE id = ?", (created.strftime("%Y-%m-%d %H:%M:%S"), task_id))
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Adaptive auto-reminder ladder
+# ---------------------------------------------------------------------------
+
+
+def test_far_future_due_gets_halving_checkpoints(tmp_config: Config):
+    task = _add_task_due_in(tmp_config, "far future", timedelta(days=180))
+    schedules = {r["schedule_type"] for r in _auto_reminders(tmp_config, task["id"])}
+    assert schedules == {
+        "auto: about 3 months before due",
+        "auto: about 6 weeks before due",
+        "auto: about 3 weeks before due",
+        "auto: 1 week before due",
+        "auto: 1 day before due",
+        "auto: 1 hour before due",
+        "auto: 15 minutes before due",
+        "auto: at due",
+    }
+
+
+def test_near_due_has_no_checkpoints_and_skips_past_rungs(tmp_config: Config):
+    task = _add_task_due_in(tmp_config, "near", timedelta(days=3))
+    schedules = {r["schedule_type"] for r in _auto_reminders(tmp_config, task["id"])}
+    assert schedules == {
+        "auto: 1 day before due",
+        "auto: 1 hour before due",
+        "auto: 15 minutes before due",
+        "auto: at due",
+    }
+
+
+def test_at_due_reminder_fires_at_due_time_with_decision_menu(tmp_config: Config):
+    task = _add_task_due_in(tmp_config, "decide", timedelta(days=3))
+    at_due = [r for r in _auto_reminders(tmp_config, task["id"]) if r["schedule_type"] == "auto: at due"]
+    assert len(at_due) == 1
+    assert db.parse_datetime(at_due[0]["scheduled_time"]) == db.parse_datetime(commands.get_task(tmp_config, task_id=task["id"])["due_date"])
+    for command in (f"tasks done {task['id']}", f"tasks postpone {task['id']}", f"tasks delete {task['id']}"):
+        assert command in at_due[0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Postpone
+# ---------------------------------------------------------------------------
+
+
+def test_postpone_overdue_task_moves_due_forward_and_rebuilds_reminders(tmp_config: Config):
+    task = _add_task_due_in(tmp_config, "late", timedelta(minutes=30))
+    _force_due_date(tmp_config, task["id"], datetime.now(UTC) - timedelta(days=3))
+
+    updated = commands.postpone_task(tmp_config, task_id=task["id"], in_days=2)
+
+    assert db.parse_datetime(updated["due_date"]) > datetime.now(UTC) + timedelta(days=1)
+    schedules = {r["schedule_type"] for r in _auto_reminders(tmp_config, task["id"])}
+    assert "auto: at due" in schedules
+
+
+def test_postpone_gives_undated_task_a_due_date(tmp_config: Config):
+    task = commands.add_task(tmp_config, title="undated")
+    updated = commands.postpone_task(tmp_config, task_id=task["id"], in_hours=6)
+    assert updated["due_date"] is not None
+    assert {r["schedule_type"] for r in _auto_reminders(tmp_config, task["id"])} == {
+        "auto: 1 hour before due",
+        "auto: 15 minutes before due",
+        "auto: at due",
+    }
+
+
+def test_postpone_requires_timing(tmp_config: Config):
+    task = commands.add_task(tmp_config, title="no timing")
+    with pytest.raises(ValueError, match="Say when"):
+        commands.postpone_task(tmp_config, task_id=task["id"])
+
+
+# ---------------------------------------------------------------------------
+# Reminder snooze
+# ---------------------------------------------------------------------------
+
+
+def test_snooze_moves_a_pending_one_shot(tmp_config: Config):
+    reminder = commands.remind_set(tmp_config, message="one shot", in_hours=1)
+    result = commands.remind_snooze(tmp_config, reminder_id=reminder["id"], in_hours=4)
+
+    new_run = db.parse_datetime(result["next_run"])
+    assert new_run > datetime.now(UTC) + timedelta(hours=3)
+    with closing(db.get_db(tmp_config.data_dir)) as conn:
+        row = conn.execute("SELECT completed, trigger_data FROM reminders WHERE id = ?", (reminder["id"],)).fetchone()
+    assert row["completed"] == 0
+    assert db.parse_datetime(json.loads(row["trigger_data"])["run_date"]) == new_run
+
+
+def test_snooze_reactivates_a_fired_reminder(tmp_config: Config):
+    reminder = commands.remind_set(tmp_config, message="already fired", in_hours=1)
+    with closing(db.get_db(tmp_config.data_dir)) as conn:
+        conn.execute("UPDATE reminders SET completed = 1 WHERE id = ?", (reminder["id"],))
+        conn.commit()
+
+    commands.remind_snooze(tmp_config, reminder_id=reminder["id"], in_minutes=30)
+
+    with closing(db.get_db(tmp_config.data_dir)) as conn:
+        row = conn.execute("SELECT completed FROM reminders WHERE id = ?", (reminder["id"],)).fetchone()
+    assert row["completed"] == 0
+
+
+def test_snooze_rejects_recurring(tmp_config: Config):
+    reminder = commands.remind_set(tmp_config, message="daily", scheduled_datetime="2026-04-26T10:30:00", tz="UTC", recurring="daily")
+    with pytest.raises(ValueError, match="one-shot"):
+        commands.remind_snooze(tmp_config, reminder_id=reminder["id"], in_hours=1)
+
+
+def test_snooze_requires_timing(tmp_config: Config):
+    reminder = commands.remind_set(tmp_config, message="one shot", in_hours=1)
+    with pytest.raises(ValueError, match="Say when"):
+        commands.remind_snooze(tmp_config, reminder_id=reminder["id"])
+
+
+def test_stale_fire_after_snooze_is_skipped_not_completed(tmp_config: Config, tmp_path: Path):
+    """A job armed before a snooze must not fire against the snoozed row (the snooze-race guard)."""
+    notif_dir = tmp_path / "notifications"
+    notif_dir.mkdir()
+    reminder = commands.remind_set(tmp_config, message="imminent", in_minutes=1)
+    commands.remind_snooze(tmp_config, reminder_id=reminder["id"], in_hours=4)
+
+    commands.send_reminder_job(reminder["id"], message="imminent", data_dir=str(tmp_config.data_dir), notif_dir=str(notif_dir))
+
+    assert list(notif_dir.glob("*.json")) == []
+    with closing(db.get_db(tmp_config.data_dir)) as conn:
+        assert conn.execute("SELECT completed FROM reminders WHERE id = ?", (reminder["id"],)).fetchone()["completed"] == 0
+
+
+def test_just_fired_one_shot_is_not_replayed_as_missed(tmp_config: Config, tmp_path: Path):
+    """Restore must not declare a seconds-old one-shot missed (it is likely mid-fire), but a
+    genuinely stale one still replays."""
+    notif_dir = tmp_path / "notifications"
+    notif_dir.mkdir()
+    scheduler = create_scheduler()
+    reminder = commands.remind_set(tmp_config, message="racing", in_minutes=1)
+
+    def rewind_run_date(seconds_ago: int):
+        run_date = (datetime.now(UTC) - timedelta(seconds=seconds_ago)).isoformat()
+        with closing(db.get_db(tmp_config.data_dir)) as conn:
+            conn.execute(
+                "UPDATE reminders SET trigger_data = ?, scheduled_time = ? WHERE id = ?",
+                (json.dumps({"type": "date", "run_date": run_date}), run_date, reminder["id"]),
+            )
+            conn.commit()
+
+    rewind_run_date(5)
+    commands.restore_jobs_by_ids(tmp_config, scheduler, {reminder["id"]}, notif_dir=notif_dir)
+    assert list(notif_dir.glob("*.json")) == []
+    with closing(db.get_db(tmp_config.data_dir)) as conn:
+        assert conn.execute("SELECT completed FROM reminders WHERE id = ?", (reminder["id"],)).fetchone()["completed"] == 0
+
+    rewind_run_date(120)
+    commands.restore_jobs_by_ids(tmp_config, scheduler, {reminder["id"]}, notif_dir=notif_dir)
+    missed = list(notif_dir.glob("*-tasks-reminder.json"))
+    assert len(missed) == 1
+    assert json.loads(missed[0].read_text())["missed"] is True
+    with closing(db.get_db(tmp_config.data_dir)) as conn:
+        assert conn.execute("SELECT completed FROM reminders WHERE id = ?", (reminder["id"],)).fetchone()["completed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Daily digest
+# ---------------------------------------------------------------------------
+
+
+def test_digest_lists_overdue_and_stale_with_commands(tmp_config: Config):
+    overdue = _add_task_due_in(tmp_config, "overdue task", timedelta(minutes=30))
+    _force_due_date(tmp_config, overdue["id"], datetime.now(UTC) - timedelta(days=2))
+    stale = commands.add_task(tmp_config, title="stale task")
+    _force_created_at(tmp_config, stale["id"], datetime.now(UTC) - timedelta(days=20))
+    fresh = commands.add_task(tmp_config, title="fresh task")
+
+    message = commands.build_digest(tmp_config)
+
+    assert message is not None
+    assert overdue["id"] in message and "overdue 2d" in message
+    assert stale["id"] in message and "created 3w ago" in message
+    assert fresh["id"] not in message
+    for command in ("tasks done <id>", "tasks postpone <id> --in-days N", "tasks delete <id>"):
+        assert command in message
+
+
+def test_digest_is_none_when_nothing_needs_attention(tmp_config: Config):
+    commands.add_task(tmp_config, title="fresh")
+    _add_task_due_in(tmp_config, "future", timedelta(days=3))
+    assert commands.build_digest(tmp_config) is None
+
+
+def test_digest_emits_at_most_once_per_day(tmp_config: Config, tmp_path: Path):
+    notif_dir = tmp_path / "notifications"
+    notif_dir.mkdir()
+    overdue = _add_task_due_in(tmp_config, "still overdue", timedelta(minutes=30))
+    _force_due_date(tmp_config, overdue["id"], datetime.now(UTC) - timedelta(days=1))
+
+    now = datetime.now(UTC)
+    assert commands.maybe_send_digest(tmp_config, notif_dir, now=now) is True
+    assert commands.maybe_send_digest(tmp_config, notif_dir, now=now + timedelta(hours=6)) is False
+    assert commands.maybe_send_digest(tmp_config, notif_dir, now=now + timedelta(hours=24)) is True
+
+    files = list(notif_dir.glob("*-tasks-task_digest.json"))
+    assert len(files) == 2
+    payload = json.loads(files[0].read_text())
+    assert payload["type"] == "task_digest"
+    assert overdue["id"] in payload["message"]
+
+
+def test_digest_skips_quietly_when_clean_and_does_not_stamp(tmp_config: Config, tmp_path: Path):
+    notif_dir = tmp_path / "notifications"
+    notif_dir.mkdir()
+    assert commands.maybe_send_digest(tmp_config, notif_dir) is False
+    assert list(notif_dir.glob("*.json")) == []
+    # Nothing stamped: the moment something goes overdue, the next check emits immediately.
+    overdue = _add_task_due_in(tmp_config, "now overdue", timedelta(minutes=30))
+    _force_due_date(tmp_config, overdue["id"], datetime.now(UTC) - timedelta(hours=1))
+    assert commands.maybe_send_digest(tmp_config, notif_dir) is True
+
+
+# ---------------------------------------------------------------------------
+# Overdue ordering + migration
+# ---------------------------------------------------------------------------
+
+
+def test_overdue_today_floats_to_top(tmp_config: Config):
+    high = _add_task_due_in(tmp_config, "high future", timedelta(days=1))
+    commands.update_task(tmp_config, task_id=high["id"], priority=3)
+    overdue = _add_task_due_in(tmp_config, "overdue an hour ago", timedelta(minutes=30))
+    _force_due_date(tmp_config, overdue["id"], datetime.now(UTC) - timedelta(hours=1))
+
+    listed = commands.list_tasks(tmp_config)
+    assert listed[0]["id"] == overdue["id"]
+
+
+def test_migration_v4_regenerates_auto_reminders_and_creates_meta(tmp_config: Config):
+    task = _add_task_due_in(tmp_config, "legacy task", timedelta(days=5))
+    with closing(db.get_db(tmp_config.data_dir)) as conn:
+        # Rewind to a v3-shaped db: no meta table, no at-due reminder.
+        conn.execute("DELETE FROM reminders WHERE schedule_type = 'auto: at due'")
+        conn.execute("DROP TABLE meta")
+        conn.execute("UPDATE schema_version SET version = 3")
+        conn.commit()
+
+    db.init_db(tmp_config.data_dir)
+
+    schedules = {r["schedule_type"] for r in _auto_reminders(tmp_config, task["id"])}
+    assert "auto: at due" in schedules
+    with closing(db.get_db(tmp_config.data_dir)) as conn:
+        assert conn.execute("SELECT version FROM schema_version").fetchone()["version"] == 4
+        assert db.get_meta(conn, "anything") is None

--- a/agent/skills/tasks/cli/tests/test_remind_schedule.py
+++ b/agent/skills/tasks/cli/tests/test_remind_schedule.py
@@ -14,14 +14,6 @@ from tasks_cli import commands, db
 from tasks_cli.config import Config
 
 
-@pytest.fixture
-def tmp_config(tmp_path: Path) -> Config:
-    cfg = Config(data_dir=tmp_path / "tasks", log_dir=tmp_path / "tasks" / "logs")
-    cfg.data_dir.mkdir(parents=True, exist_ok=True)
-    db.init_db(cfg.data_dir)
-    return cfg
-
-
 def _trigger_data(config: Config, reminder_id: str) -> dict:
     with closing(db.get_db(config.data_dir)) as conn:
         row = conn.execute("SELECT trigger_data FROM reminders WHERE id = ?", (reminder_id,)).fetchone()
@@ -261,7 +253,7 @@ def test_migration_v2_to_v3_rewrites_legacy_cron(tmp_path: Path):
     assert _read_trigger(data_dir, "interval1") == {"type": "interval", "hours": 1}  # non-cron untouched
     assert _read_trigger(data_dir, "date1") == {"type": "date", "run_date": "2026-01-01T00:00:00+00:00"}
     with closing(db.get_db(data_dir)) as conn:
-        assert conn.execute("SELECT version FROM schema_version").fetchone()["version"] == 3
+        assert conn.execute("SELECT version FROM schema_version").fetchone()["version"] == 4
 
 
 def test_migration_preserves_firing_instant(tmp_path: Path):


### PR DESCRIPTION
## What

Re-engineers the tasks skill so the agent stays on top of things by construction instead of by discipline.

**Overdue pressure loop.** Every pressure point now forces a decision instead of informing:
- A new at-due auto reminder fires at the due instant with a closed menu: do it now (`tasks done <id>`), postpone (`tasks postpone <id> --in-days N`), or tell the user you are dropping it and delete. Marking done without doing it is explicitly not an option.
- A daily `task_digest` notification (state-based sweep, emitted only when non-empty, at most once per 24h, restart-proof via a new `meta` table) lists every overdue task with age and every task pending 2+ weeks with no due date, with the same three choices. Consolidated on purpose: one nag per day regardless of how many tasks are overdue, so pressure stays persistent without training alarm fatigue.
- The undated-task loophole (avoid due dates, avoid nags) is closed by the stale section.

**Adaptive reminder ladder.** Auto reminders scale to lead time: checkpoints that halve the remaining time while more than two weeks out (due in 6 months → ~3 months, ~6 weeks, ~3 weeks), then the existing 1w/1d/1h/15m tail, then the at-due fire. Schema v4 regenerates auto reminders for existing pending tasks so the fleet converges on first boot after sync.

**Low-friction verbs.** `tasks done <id>`, `tasks postpone <id> --in-days N` (sets due measured from now; gives undated tasks a date; rebuilds the ladder), `tasks remind snooze <id> --in-hours N` (works on already-fired reminders; replaces the delete-and-recreate rearm hint). The honest action is always one short command.

**Fuzzed recurring times.** `--fuzz-minutes N` on recurring/cron reminders lands each fire within ±N minutes of the nominal time ("late evening" ≈ `--at 21:30 --fuzz-minutes 75`). Offsets are sampled deterministically per (reminder, nominal instant), so a daemon restart recomputes the identical instant: no double fires, no drift, unit-testable. Fuzz is validated against half the smallest gap across upcoming fires. Implemented as chained one-shot DateTriggers re-armed by the existing job sync.

**Presentation.** Task/reminder tables show relative times (`due in 3d`, `OVERDUE 2d`, `in 3h`); exact instants stay in `--json`/`get`. SKILL.md rewritten as a compact cheat sheet with a "what the daemon does on its own" section. Overdue tasks now actually float to the top of `tasks list` (the old ordering string-compared mixed datetime formats and missed same-day overdue).

## Review hardening (full multi-agent code review, 10 findings, all confirmed ones fixed)

- Stale-fire guard in `send_reminder_job`: a snooze racing an armed job can no longer fire-and-complete the snoozed row; the DB run_date is authoritative.
- Missed-grace window in `_restore_row`: a one-shot mid-fire is no longer replayed as a duplicate "missed" notification by the job sync (APScheduler removes date jobs from the store before the callback commits).
- Serve tick wrapped so a bad tick (locked db, malformed row) logs and retries instead of killing the daemon.
- Digest gap 23h → 24h (no backward time-of-day drift), fuzz bounded by min gap not first gap, overdue tie-break compares datetimes, per-tick json parsing gated behind the cheap timestamp check, shared `_relative_offset` helper replaces three copies of the timing validation, dead `priority` param removed, shared test fixture moved to conftest.

Known accepted trade-off: a fuzzed reminder whose fire lands inside daemon downtime is skipped (documented in SKILL.md); plain cron keeps its 1h misfire grace.

## Fleet impact

All changes live inside the skill directory: boxes pick them up through the normal upstream sync, the editable install exposes the new verbs immediately, and the versioned in-skill schema migration (v4) converges existing DBs on the daemon's next boot. No agent-core changes, no prompt migration needed.

## Testing

- 173 tasks-CLI tests pass (`uv run pytest skills/tasks/cli/tests/`), including new suites for the ladder, postpone/snooze, digest gating and content, deterministic fuzz (restart-identity, no-double-fire), both race guards, and the v4 migration.
- `./check.sh agent` fully green (ruff, ty, all agent + skill suites).
- Daemon-level e2e: snoozed reminder fires at its new time through the live job sync; digest emitted by a real daemon for an overdue task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)