### PR TITLE
fix(whatsapp): guard add-contact and send against group IDs passed as phone numbers

### DIFF
--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -13,6 +13,21 @@ func (wac *WhatsAppClient) AddContact(name, phone string) (Contact, error) {
 	return wac.store.SaveManualContact(name, phone)
 }
 
+// MaxPhoneDigits is the E.164 ceiling on phone-number length. A WhatsApp
+// group ID renders as a longer all-digit string; sending to one as a user JID
+// makes the server log the device out and destroys the pairing (#1169).
+const MaxPhoneDigits = 15
+
+func errIfGroupIDDigits(digits string) error {
+	if len(digits) <= MaxPhoneDigits {
+		return nil
+	}
+	return fmt.Errorf(
+		"'%s' looks like a WhatsApp group ID, not a phone number (%d digits; phone numbers have at most %d). To message a group, use its group name: send --to '<Group Name>'",
+		digits, len(digits), MaxPhoneDigits,
+	)
+}
+
 func (wac *WhatsAppClient) requireManualContact(jid types.JID) error {
 	if jid.Server != types.DefaultUserServer {
 		return nil
@@ -40,6 +55,19 @@ func (wac *WhatsAppClient) requireManualContact(jid types.JID) error {
 }
 
 func (wac *WhatsAppClient) ResolveRecipient(identifier string) (types.JID, error) {
+	jid, err := wac.resolveRecipientJID(identifier)
+	if err != nil {
+		return types.JID{}, err
+	}
+	if jid.Server == types.DefaultUserServer {
+		if err := errIfGroupIDDigits(jid.User); err != nil {
+			return types.JID{}, err
+		}
+	}
+	return jid, nil
+}
+
+func (wac *WhatsAppClient) resolveRecipientJID(identifier string) (types.JID, error) {
 	if identifier == "" {
 		return types.JID{}, fmt.Errorf("recipient identifier cannot be empty")
 	}

--- a/agent/skills/whatsapp/cli/contacts_test.go
+++ b/agent/skills/whatsapp/cli/contacts_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+// groupIDDigits is a WhatsApp group ID rendered numerically: all digits, but
+// longer than any E.164 phone number.
+const groupIDDigits = "120363419527129553"
+
+func newTestStore(t *testing.T) *MessageStore {
+	t.Helper()
+	store, err := NewMessageStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create message store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestSaveManualContactRejectsGroupIDAsPhone(t *testing.T) {
+	store := newTestStore(t)
+	_, err := store.SaveManualContact("Test Group", "+"+groupIDDigits)
+	if err == nil || !strings.Contains(err.Error(), "group ID") {
+		t.Errorf("saving a group ID as a phone must fail with a group-ID error, got %v", err)
+	}
+}
+
+func TestSaveManualContactAcceptsPhone(t *testing.T) {
+	store := newTestStore(t)
+	contact, err := store.SaveManualContact("Alice", "+15551234567")
+	if err != nil {
+		t.Fatalf("saving a valid phone must succeed, got %v", err)
+	}
+	if contact.PhoneNumber != "+15551234567" {
+		t.Errorf("expected phone +15551234567, got %q", contact.PhoneNumber)
+	}
+}
+
+func TestResolveRecipientRejectsGroupIDAsPhone(t *testing.T) {
+	wac := &WhatsAppClient{}
+	for _, identifier := range []string{
+		"+" + groupIDDigits,
+		groupIDDigits,
+		groupIDDigits + "@s.whatsapp.net",
+	} {
+		_, err := wac.ResolveRecipient(identifier)
+		if err == nil || !strings.Contains(err.Error(), "group ID") {
+			t.Errorf("ResolveRecipient(%q) must fail with a group-ID error, got %v", identifier, err)
+		}
+	}
+}
+
+func TestResolveRecipientAllowsMaxLengthPhone(t *testing.T) {
+	wac := &WhatsAppClient{}
+	jid, err := wac.ResolveRecipient("+123456789012345")
+	if err != nil {
+		t.Fatalf("a 15-digit phone must resolve, got %v", err)
+	}
+	if jid.User != "123456789012345" || jid.Server != types.DefaultUserServer {
+		t.Errorf("expected user JID for 15-digit phone, got %v", jid)
+	}
+}
+
+func TestResolveRecipientAllowsGroupJID(t *testing.T) {
+	wac := &WhatsAppClient{}
+	jid, err := wac.ResolveRecipient(groupIDDigits + "@" + types.GroupServer)
+	if err != nil {
+		t.Fatalf("an explicit group JID must resolve, got %v", err)
+	}
+	if jid.Server != types.GroupServer {
+		t.Errorf("expected group JID, got %v", jid)
+	}
+}
+
+func TestResolveRecipientRejectsSavedGroupIDContact(t *testing.T) {
+	store := newTestStore(t)
+	jid := groupIDDigits + "@" + types.DefaultUserServer
+	if _, err := store.db.Exec(
+		`INSERT INTO contacts (jid, phone_number, name, added_at, updated_at)
+		 VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		jid, "+"+groupIDDigits, "Legacy Bad Contact",
+	); err != nil {
+		t.Fatalf("failed to seed legacy contact: %v", err)
+	}
+
+	wac := &WhatsAppClient{store: store}
+	_, err := wac.ResolveRecipient("Legacy Bad Contact")
+	if err == nil || !strings.Contains(err.Error(), "group ID") {
+		t.Errorf("a previously saved group-ID contact must not resolve to a user JID, got %v", err)
+	}
+}

--- a/agent/skills/whatsapp/cli/storage.go
+++ b/agent/skills/whatsapp/cli/storage.go
@@ -509,6 +509,9 @@ func (ms *MessageStore) SaveManualContact(name, phone string) (Contact, error) {
 	if trimmedName == "" {
 		return Contact{}, fmt.Errorf("contact name cannot be empty")
 	}
+	if err := errIfGroupIDDigits(normalizedDigits); err != nil {
+		return Contact{}, err
+	}
 	jid := fmt.Sprintf("%s@%s", normalizedDigits, types.DefaultUserServer)
 	_, err = ms.db.Exec(`
 		INSERT INTO contacts (jid, phone_number, name, added_at, updated_at)


### PR DESCRIPTION
## Problem

A WhatsApp group ID rendered numerically (e.g. `1203634…`, 17+ digits) is indistinguishable from a phone number to any digit-based check. `add-contact` accepted and saved it, and a later `send` to that contact built a `@s.whatsapp.net` user JID from it; WhatsApp returns 400 on that send and logs the device out server-side, destroying the pairing. Recovery needs a fresh re-scan, which on a young account risks the anti-abuse cooldown/ban.

## Fix

One guard, `errIfGroupIDDigits` in `contacts.go`, built on the E.164 ceiling (phone numbers have at most 15 digits; group IDs render longer), applied at both ends per the issue's suggestion:

- **Persist time**: `SaveManualContact` refuses a group-ID-shaped phone before writing it, so `add-contact` fails fast with an error pointing at `send --to '<Group Name>'`.
- **JID-build time (defense-in-depth)**: `ResolveRecipient` now validates the resolved JID and refuses to return a `@s.whatsapp.net` JID whose user part exceeds 15 digits. This covers `+<digits>`, bare digits, explicit `<digits>@s.whatsapp.net`, and a previously-saved bad contact resolved by name, so even legacy poisoned contacts can no longer trigger the logout. Group JIDs (`@g.us`) and LID JIDs are unaffected.

## Tests

`contacts_test.go`: rejection at save time and via every resolve path (including a seeded legacy bad contact), plus acceptance of a max-length 15-digit phone and an explicit group JID. `./check.sh whatsapp` (gofmt + vet + build + `go test -tags fts5`) passes locally.

Fixes #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)