### PR TITLE
feat(skills): make microsoft a default skill and codify provider routing

### DIFF
--- a/agent/core/default-skills.txt
+++ b/agent/core/default-skills.txt
@@ -5,6 +5,7 @@ contacts
 dashboard
 dream
 email-client
+microsoft
 nap
 notifications
 onboard

--- a/agent/skills/email-client/SKILL.md
+++ b/agent/skills/email-client/SKILL.md
@@ -11,7 +11,7 @@ Provider-agnostic IMAP/SMTP for the user's email accounts, any number side by si
 
 Use it for a uniform IMAP/SMTP interface across one or many personal accounts: read, send, reply, forward, manage, and get notified on new mail.
 
-Google Calendar is also available here for Gmail accounts (see "Calendar" below): one Gmail sign-in grants both mail and calendar, so a lightweight calendar surface lives in this skill. Do not use it when the user wants the full Gmail API surface or Google contacts/Meet (use the `google` skill), a non-Google calendar or Graph/M365 *work* mail with IMAP/SMTP disabled (use the `microsoft` skill; M365 work *with* IMAP enabled works here, see SETUP.md "Microsoft 365 with a custom domain"), or an agent-owned inbox instead of personal mail (use `agentmail`).
+Google Calendar is also available here for Gmail accounts (see "Calendar" below): one Gmail sign-in grants both mail and calendar, so a lightweight calendar surface lives in this skill. For Microsoft accounts (personal or work: Outlook.com, Hotmail, Live, Microsoft 365) prefer the `microsoft` skill (Graph) over this one; fall back here only when Graph is unavailable and IMAP is enabled (see SETUP.md "Microsoft 365 with a custom domain"). The `google` skill is only for Google-native APIs (full Gmail API, Contacts, Meet) and requires the user's own Google OAuth client. For an agent-owned inbox instead of personal mail, use `agentmail`.
 
 ## Notes & rules
 

--- a/agent/skills/index.json
+++ b/agent/skills/index.json
@@ -93,7 +93,7 @@
   },
   {
     "name": "microsoft",
-    "description": "Outlook/Microsoft 365 work account via Graph: read/send/reply/forward email, drafts, flag/categorize, move/archive, folders, attachments, block senders, calendar and meetings, new-mail paging, and Microsoft Teams (chats, channels, presence, plus new-message notifications). Requires daemon."
+    "description": "Use for any Microsoft account, personal or work (Outlook.com, Hotmail, Live, Microsoft 365); preferred over email-client for Microsoft accounts. Graph-based mail (read/send/reply/forward, drafts, flag/categorize, move/archive, folders, attachments, block senders), calendar and meetings, Microsoft Teams (chats, channels, presence), and new-mail/Teams notifications. Requires daemon."
   },
   {
     "name": "nap",

--- a/agent/skills/microsoft/SKILL.md
+++ b/agent/skills/microsoft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: microsoft
-description: Outlook/Microsoft 365 work account via Graph: read/send/reply/forward email, drafts, flag/categorize, move/archive, folders, attachments, block senders, calendar and meetings, new-mail paging, and Microsoft Teams (chats, channels, presence, plus new-message notifications). Requires daemon.
+description: Use for any Microsoft account, personal or work (Outlook.com, Hotmail, Live, Microsoft 365); preferred over email-client for Microsoft accounts. Graph-based mail (read/send/reply/forward, drafts, flag/categorize, move/archive, folders, attachments, block senders), calendar and meetings, Microsoft Teams (chats, channels, presence), and new-mail/Teams notifications. Requires daemon.
 ---
 
 # Microsoft - CLI: microsoft


### PR DESCRIPTION
## What

- Adds `microsoft` to `agent/core/default-skills.txt` (alphabetical slot between `email-client` and `nap`), so every Vesta ships the Microsoft (Graph) skill by default.
- Codifies the skill-routing decision in the discovery text:
  - `email-client/SKILL.md` "When to use this skill" now states that for Microsoft accounts (personal or work: Outlook.com, Hotmail, Live, Microsoft 365) the `microsoft` skill is preferred over email-client (fall back to IMAP only when Graph is unavailable and IMAP is enabled), and that the `google` skill is only for Google-native APIs and requires the user's own Google OAuth client.
  - `microsoft/SKILL.md` frontmatter `description` rewritten as when-to-use triggers (Outlook.com/Hotmail/Live/M365 mail, calendar, Teams; preferred over email-client for Microsoft accounts) so discovery routes Microsoft-account tasks there.
- Regenerates `agent/skills/index.json`.

## Why the routing

`email-client` (IMAP/SMTP/CalDAV) stays the default cross-provider surface. For Microsoft accounts the Graph-based `microsoft` skill is strictly richer (categories, calendar, Teams, block senders, works on tenants with IMAP disabled), so it is preferred whenever the account is Microsoft. The `google` skill is reserved for Google-native API needs and requires the user's own Google OAuth client (handled in a separate PR).

## Why no migration

`reconcile_default_skills` (`agent/core/default_skills.py`) is stateless and self-healing: every boot it reads `core/default-skills.txt` from the read-only core mount and queues an install turn for any default skill missing on disk, so existing boxes converge on their next boot with no migration file. Fresh images get the directory automatically: the Dockerfile prune step keeps exactly the skills listed in `default-skills.txt`, so no Dockerfile change is needed either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)