### PR TITLE
fix(telegram): setup uses the baked image toolchain, no Go download or apt-get

### DIFF
--- a/agent/skills/telegram/SETUP.md
+++ b/agent/skills/telegram/SETUP.md
@@ -1,13 +1,9 @@
 # Telegram Setup
 
-1. Install dependencies (gcc for CGO and Go from https://go.dev/dl/, NOT the system package manager):
-   ```bash
-   apt-get install -y gcc
-   ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
-   curl -fsSL "https://go.dev/dl/$(curl -fsSL 'https://go.dev/VERSION?m=text' | head -1).linux-${ARCH}.tar.gz" | tar -C /usr/local -xz
-   export PATH="/usr/local/go/bin:$PATH"
-   ```
-2. Install the launcher on PATH. It compiles `cli/` from source on every invocation, so no
+Everything the build needs (Go, gcc) ships in the agent image; install nothing,
+download nothing.
+
+1. Install the launcher on PATH. It compiles `cli/` from source on every invocation, so no
    stale binary can ever drift (the send-message handler and its bubble lint run inside the
    daemon; a static binary left the daemon executing weeks-old code after the source changed).
    CGO/FTS5 build flags live in `cli/cgo-env.sh`, sourced by the launcher.
@@ -16,7 +12,7 @@
    telegram --help >/dev/null   # warm the build cache; a compile error surfaces HERE, loudly
    ```
    Never `go build` a static binary onto PATH; the launcher is the only entry point.
-3. Create a Telegram bot and authenticate:
+2. Create a Telegram bot and authenticate:
    - Tell the user to message [@BotFather](https://t.me/BotFather) on Telegram
    - Send `/newbot` and follow the prompts to create a bot
    - Copy the bot token (looks like `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`)
@@ -24,13 +20,13 @@
      ```bash
      telegram authenticate --token "<BOT_TOKEN>"
      ```
-4. Start the daemon:
+3. Start the daemon:
    ```bash
    telegram daemon start
    ```
    Idempotent (a running daemon is a no-op) and defaults `--notifications-dir` to `~/agent/notifications`. Check with `telegram daemon status`.
-5. Then have them open the bot and send any message (hitting Start counts). Wait for that first inbound notification and confirm back on the new channel before declaring it live: the channel does not exist until you have replied to them on it.
-6. Add to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
+4. Then have them open the bot and send any message (hitting Start counts). Wait for that first inbound notification and confirm back on the new channel before declaring it live: the channel does not exist until you have replied to them on it.
+5. Add to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
    ```
    running telegram || { telegram daemon start; sleep 1; }
    running telegram-watchdog || { screen -dmS telegram-watchdog bash ~/agent/skills/telegram/telegram-watchdog.sh; sleep 1; }

--- a/agent/skills/telegram/telegram
+++ b/agent/skills/telegram/telegram
@@ -8,7 +8,7 @@ set -euo pipefail
 
 CLI_DIR="$(dirname "$(readlink -f "$0")")/cli"
 
-# The box install puts Go at /usr/local/go without linking it onto PATH.
+# Go lives at /usr/local/go; not every environment links it onto PATH.
 if ! command -v go >/dev/null; then export PATH="/usr/local/go/bin:$PATH"; fi
 . "$CLI_DIR/cgo-env.sh"
 


### PR DESCRIPTION
Since #1096 the agent image bakes Go 1.26.5, gcc/g++ and ffmpeg, but telegram's SETUP.md step 1 still instructed the agent to `apt-get install gcc` and download the full Go toolchain from go.dev: several minutes of dead air (and ~150MB of redundant download) during first-conversation channel setup, exactly the activation moment #1147 is about. This rewrites the setup doc to the same posture as whatsapp's: everything the build needs ships in the image, setup is symlink + warm compile + BotFather flow. Also retires the launcher comment that attributed `/usr/local/go` to a box-side install (the PATH fallback itself stays: legacy boxes that installed Go manually never linked it onto PATH).

Measured on a cold cache, the remaining first-invoke compile (go-sqlite3 CGO) is ~8s wall / ~25s CPU with a 20MB module download, so no image-side build-cache baking or birth-time background pre-build is warranted; that resolves the remaining fork in #1147 (rationale recorded on the issue).

Doc + comment change only; no on-disk agent state moves, no migration needed. Already-set-up boxes are unaffected.

Fixes #1147

🤖 Generated with [Claude Code](https://claude.com/claude-code)