### PR TITLE
fix(dream): scrub known-leaked literals in place so redaction converges

### DIFF
--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -161,7 +161,7 @@ Keep the container's filesystem organized and disk usage under control.
 
 ## Sensitive Data Cleanup
 
-Run `~/agent/skills/dream/scripts/redact_secrets.sh` to scan the event DB for API keys, tokens, passwords, private keys, and connection strings. Review matches (skip false positives), then rerun with `--delete` to purge. When a match is a real leaked value, also append the literal on its own line to `~/agent/data/redact_known.txt`: every run scrubs those literals in place (`[REDACTED]`) across all events, so a value that re-seeds itself through later reasoning about it is caught again automatically. Never quote a leaked value in your summary or anywhere else; refer to it indirectly. Also grep MEMORY.md and dreamer summaries for credentials and remove any you find. Secrets belong in env vars, not in history or files.
+Run `~/agent/skills/dream/scripts/redact_secrets.sh` to scan the event DB for API keys, tokens, passwords, private keys, and connection strings. For each real leak (skip false positives), add the value on its own line to `~/agent/data/redact_known.txt`, then rerun: every run replaces every known literal in place with `[REDACTED]` across all events, so a value that re-seeds itself through later reasoning about it is caught again automatically and redaction converges. Never quote a leaked value in your summary or anywhere else; refer to it indirectly. Also grep MEMORY.md and dreamer summaries for credentials and remove any you find. Secrets belong in env vars, not in history or files.
 
 ## Summary
 

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -161,7 +161,7 @@ Keep the container's filesystem organized and disk usage under control.
 
 ## Sensitive Data Cleanup
 
-Run `~/agent/skills/dream/scripts/redact_secrets.sh` to scan the event DB for API keys, tokens, passwords, private keys, and connection strings. Review matches (skip false positives), then rerun with `--delete` to purge. Also grep MEMORY.md and dreamer summaries for credentials and remove any you find. Secrets belong in env vars, not in history or files.
+Run `~/agent/skills/dream/scripts/redact_secrets.sh` to scan the event DB for API keys, tokens, passwords, private keys, and connection strings. Review matches (skip false positives), then rerun with `--delete` to purge. When a match is a real leaked value, also append the literal on its own line to `~/agent/data/redact_known.txt`: every run scrubs those literals in place (`[REDACTED]`) across all events, so a value that re-seeds itself through later reasoning about it is caught again automatically. Never quote a leaked value in your summary or anywhere else; refer to it indirectly. Also grep MEMORY.md and dreamer summaries for credentials and remove any you find. Secrets belong in env vars, not in history or files.
 
 ## Summary
 

--- a/agent/skills/dream/SKILL.md
+++ b/agent/skills/dream/SKILL.md
@@ -161,7 +161,7 @@ Keep the container's filesystem organized and disk usage under control.
 
 ## Sensitive Data Cleanup
 
-Run `~/agent/skills/dream/scripts/redact_secrets.sh` to scan the event DB for API keys, tokens, passwords, private keys, and connection strings. For each real leak (skip false positives), add the value on its own line to `~/agent/data/redact_known.txt`, then rerun: every run replaces every known literal in place with `[REDACTED]` across all events, so a value that re-seeds itself through later reasoning about it is caught again automatically and redaction converges. Never quote a leaked value in your summary or anywhere else; refer to it indirectly. Also grep MEMORY.md and dreamer summaries for credentials and remove any you find. Secrets belong in env vars, not in history or files.
+Run `~/agent/skills/dream/scripts/redact_secrets.sh` to scan the event DB for API keys, tokens, passwords, private keys, and connection strings. Each hit prints as `event_id|context` with the value itself masked as `[REDACTED]`, so reviewing candidates never re-leaks a live secret into a new event. Judge each from its context, then redact the real leaks in place with `redact_secrets.sh --scrub <id> <id> ...`: it replaces the secret with `[REDACTED]` in those events while keeping their context and the search index intact. The scan runs every dream, so a value that re-seeds itself through later reasoning is simply caught and scrubbed again. Never quote a leaked value in your summary or anywhere else; refer to it indirectly. Also grep MEMORY.md and dreamer summaries for credentials and remove any you find. Secrets belong in env vars, not in history or files.
 
 ## Summary
 

--- a/agent/skills/dream/scripts/redact_secrets.py
+++ b/agent/skills/dream/scripts/redact_secrets.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Scan events DB for secrets and scrub known-leaked literals. Usage: redact_secrets.py"""
+"""Scan the events DB for secrets, then scrub the real leaks in place by event id.
+Usage: redact_secrets.py            # scan, printing each hit with the value masked
+       redact_secrets.py --scrub ID [ID ...]   # redact every secret in those events
+"""
 
 import os
 import re
@@ -7,11 +10,6 @@ import sqlite3
 import sys
 
 DB = os.path.expanduser("~/agent/data/events.db")
-# One known-leaked literal per line (# comments allowed). Lives in the gitignored data dir so the
-# literals never reach tracked source or the upstream snapshot. Scrubbed in place on every run:
-# a leaked secret re-seeds itself (the agent reasons about it in later events), so a one-time
-# delete never converges; the standing scrub does.
-KNOWN_FILE = os.path.expanduser("~/agent/data/redact_known.txt")
 REDACTED = "[REDACTED]"
 # Event types indexed by events_fts (mirrors the triggers in core/events.py). The schema has
 # insert/delete triggers only, so an in-place UPDATE must resync the index itself: otherwise the
@@ -34,43 +32,19 @@ PATTERNS = [
 REGEX = re.compile("|".join(PATTERNS), re.IGNORECASE)
 
 
-def read_known() -> list[str]:
-    if not os.path.isfile(KNOWN_FILE):
-        return []
-    with open(KNOWN_FILE) as f:
-        return [line.strip() for line in f if line.strip() and not line.lstrip().startswith("#")]
-
-
-def scrub_known(conn: sqlite3.Connection) -> int:
-    """Replace every occurrence of each known-leaked literal in place, keeping events_fts in sync."""
-    scrubbed_ids: set[int] = set()
-    type_marks = ",".join("?" * len(FTS_TYPES))
-    for literal in read_known():
-        ids = [row[0] for row in conn.execute("SELECT id FROM events WHERE instr(data, ?) > 0", (literal,))]
-        if not ids:
-            continue
-        id_marks = ",".join("?" * len(ids))
-        fts_where = f"id IN ({id_marks}) AND json_extract(data, '$.type') IN ({type_marks}) AND json_extract(data, '$.text') IS NOT NULL"
-        conn.execute(
-            "INSERT INTO events_fts(events_fts, rowid, text_content) "
-            f"SELECT 'delete', id, json_extract(data, '$.text') FROM events WHERE {fts_where}",
-            (*ids, *FTS_TYPES),
-        )
-        conn.execute(f"UPDATE events SET data = REPLACE(data, ?, ?) WHERE id IN ({id_marks})", (literal, REDACTED, *ids))
-        conn.execute(
-            f"INSERT INTO events_fts(rowid, text_content) SELECT id, json_extract(data, '$.text') FROM events WHERE {fts_where}",
-            (*ids, *FTS_TYPES),
-        )
-        scrubbed_ids.update(ids)
-    conn.commit()
-    return len(scrubbed_ids)
+def mask(match: re.Match[str]) -> str:
+    """Replace a real hit with the placeholder; leave an already-scrubbed span untouched so the
+    scan and scrub are both idempotent (a re-run never re-flags or mangles `password=[REDACTED]`)."""
+    return match.group(0) if REDACTED in match.group(0) else REDACTED
 
 
 def scan(conn: sqlite3.Connection) -> list[tuple[int, str]]:
-    """All pattern hits as (event id, context snippet): every match per event, not just the first,
-    so a benign first hit can't mask a real secret later in the same event. Scans the FULL event:
-    secrets often sit deep inside long bash commands / tool payloads (an old PAT once survived
-    weeks because substr(data,1,200) never saw it). Already-scrubbed values are skipped."""
+    """Every pattern hit as (event id, masked context snippet). The secret itself is replaced with
+    [REDACTED] in the snippet, so reviewing candidates never re-leaks the value into a new event
+    (the old redaction loop's self-reseeding). Reports every match per event, not just the first,
+    so a benign first hit can't mask a real secret later on. Scans the FULL event: secrets often sit
+    deep inside long bash commands / tool payloads (an old PAT once survived weeks because
+    substr(data,1,200) never saw it)."""
     matches = []
     for row_id, data in conn.execute("SELECT id, data FROM events"):
         if not data:
@@ -78,10 +52,41 @@ def scan(conn: sqlite3.Connection) -> list[tuple[int, str]]:
         for m in REGEX.finditer(data):
             if REDACTED in m.group(0):
                 continue
-            start = max(0, m.start() - 40)
-            snippet = data[start : m.end() + 40].replace("\n", " ")
-            matches.append((row_id, snippet))
+            window = data[max(0, m.start() - 40) : m.end() + 40]
+            matches.append((row_id, REGEX.sub(mask, window).replace("\n", " ")))
     return matches
+
+
+def scrub(conn: sqlite3.Connection, ids: list[int]) -> int:
+    """Redact every pattern hit in the given events in place, keeping their context and events_fts.
+    Regex-driven and keyed by id, so the caller never has to pass (and thereby re-leak) the literal."""
+    changed: dict[int, str] = {}
+    for row_id in ids:
+        row = conn.execute("SELECT data FROM events WHERE id = ?", (row_id,)).fetchone()
+        if row is None or not row[0]:
+            continue
+        new_data = REGEX.sub(mask, row[0])
+        if new_data != row[0]:
+            changed[row_id] = new_data
+    if not changed:
+        return 0
+    changed_ids = list(changed)
+    id_marks = ",".join("?" * len(changed_ids))
+    type_marks = ",".join("?" * len(FTS_TYPES))
+    fts_where = f"id IN ({id_marks}) AND json_extract(data, '$.type') IN ({type_marks}) AND json_extract(data, '$.text') IS NOT NULL"
+    conn.execute(
+        "INSERT INTO events_fts(events_fts, rowid, text_content) "
+        f"SELECT 'delete', id, json_extract(data, '$.text') FROM events WHERE {fts_where}",
+        (*changed_ids, *FTS_TYPES),
+    )
+    for row_id, new_data in changed.items():
+        conn.execute("UPDATE events SET data = ? WHERE id = ?", (new_data, row_id))
+    conn.execute(
+        f"INSERT INTO events_fts(rowid, text_content) SELECT id, json_extract(data, '$.text') FROM events WHERE {fts_where}",
+        (*changed_ids, *FTS_TYPES),
+    )
+    conn.commit()
+    return len(changed)
 
 
 def main() -> int:
@@ -89,24 +94,27 @@ def main() -> int:
         print(f"No database at {DB}")
         return 1
 
+    args = sys.argv[1:]
     conn = sqlite3.connect(DB)
     try:
-        scrubbed = scrub_known(conn)
-        if scrubbed:
-            print(f"Scrubbed {scrubbed} events containing known-leaked literals in place.")
+        if args[:1] == ["--scrub"]:
+            scrubbed = scrub(conn, [int(arg) for arg in args[1:]])
+            print(f"Scrubbed secrets in {scrubbed} event(s) in place.")
+            return 0
+
         matches = scan(conn)
+        if not matches:
+            print("No secrets found.")
+            return 0
+
+        ids = sorted({row_id for row_id, _ in matches})
+        print(f"Found {len(ids)} event(s) with potential secrets (value masked below).")
+        print("Review the context, then redact the real leaks: redact_secrets.sh --scrub <id> <id> ...")
+        for row_id, snippet in matches[:20]:
+            print(f"{row_id}|{snippet}")
+        return 0
     finally:
         conn.close()
-
-    if not matches:
-        print("No secrets found.")
-        return 0
-
-    ids = sorted({row_id for row_id, _ in matches})
-    print(f"Found {len(ids)} events with potential secrets. Add each real leak to {KNOWN_FILE} and rerun to scrub it in place:")
-    for row_id, snippet in matches[:20]:
-        print(f"{row_id}|{snippet}")
-    return 0
 
 
 if __name__ == "__main__":

--- a/agent/skills/dream/scripts/redact_secrets.py
+++ b/agent/skills/dream/scripts/redact_secrets.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Scan events DB for secrets and scrub known-leaked literals. Usage: redact_secrets.py [--delete]"""
+"""Scan events DB for secrets and scrub known-leaked literals. Usage: redact_secrets.py"""
 
 import os
 import re
@@ -89,7 +89,6 @@ def main() -> int:
         print(f"No database at {DB}")
         return 1
 
-    delete = "--delete" in sys.argv[1:]
     conn = sqlite3.connect(DB)
     try:
         scrubbed = scrub_known(conn)
@@ -104,20 +103,9 @@ def main() -> int:
         return 0
 
     ids = sorted({row_id for row_id, _ in matches})
-    print(f"Found {len(ids)} events with potential secrets:")
+    print(f"Found {len(ids)} events with potential secrets. Add each real leak to {KNOWN_FILE} and rerun to scrub it in place:")
     for row_id, snippet in matches[:20]:
         print(f"{row_id}|{snippet}")
-
-    if delete:
-        conn = sqlite3.connect(DB)
-        try:
-            placeholders = ",".join("?" * len(ids))
-            conn.execute(f"DELETE FROM events WHERE id IN ({placeholders})", ids)
-            conn.commit()
-        finally:
-            conn.close()
-        print(f"Deleted {len(ids)} events.")
-
     return 0
 
 

--- a/agent/skills/dream/scripts/redact_secrets.py
+++ b/agent/skills/dream/scripts/redact_secrets.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Scan events DB for secrets. Usage: redact_secrets.py [--delete]"""
+"""Scan events DB for secrets and scrub known-leaked literals. Usage: redact_secrets.py [--delete]"""
 
 import os
 import re
@@ -7,6 +7,16 @@ import sqlite3
 import sys
 
 DB = os.path.expanduser("~/agent/data/events.db")
+# One known-leaked literal per line (# comments allowed). Lives in the gitignored data dir so the
+# literals never reach tracked source or the upstream snapshot. Scrubbed in place on every run:
+# a leaked secret re-seeds itself (the agent reasons about it in later events), so a one-time
+# delete never converges; the standing scrub does.
+KNOWN_FILE = os.path.expanduser("~/agent/data/redact_known.txt")
+REDACTED = "[REDACTED]"
+# Event types indexed by events_fts (mirrors the triggers in core/events.py). The schema has
+# insert/delete triggers only, so an in-place UPDATE must resync the index itself: otherwise the
+# old text (with the secret) stays searchable and a later delete corrupts the external-content index.
+FTS_TYPES = ("user", "assistant", "chat")
 
 PATTERNS = [
     r"sk-[a-zA-Z0-9_-]{20,}",
@@ -24,6 +34,56 @@ PATTERNS = [
 REGEX = re.compile("|".join(PATTERNS), re.IGNORECASE)
 
 
+def read_known() -> list[str]:
+    if not os.path.isfile(KNOWN_FILE):
+        return []
+    with open(KNOWN_FILE) as f:
+        return [line.strip() for line in f if line.strip() and not line.lstrip().startswith("#")]
+
+
+def scrub_known(conn: sqlite3.Connection) -> int:
+    """Replace every occurrence of each known-leaked literal in place, keeping events_fts in sync."""
+    scrubbed_ids: set[int] = set()
+    type_marks = ",".join("?" * len(FTS_TYPES))
+    for literal in read_known():
+        ids = [row[0] for row in conn.execute("SELECT id FROM events WHERE instr(data, ?) > 0", (literal,))]
+        if not ids:
+            continue
+        id_marks = ",".join("?" * len(ids))
+        fts_where = f"id IN ({id_marks}) AND json_extract(data, '$.type') IN ({type_marks}) AND json_extract(data, '$.text') IS NOT NULL"
+        conn.execute(
+            "INSERT INTO events_fts(events_fts, rowid, text_content) "
+            f"SELECT 'delete', id, json_extract(data, '$.text') FROM events WHERE {fts_where}",
+            (*ids, *FTS_TYPES),
+        )
+        conn.execute(f"UPDATE events SET data = REPLACE(data, ?, ?) WHERE id IN ({id_marks})", (literal, REDACTED, *ids))
+        conn.execute(
+            f"INSERT INTO events_fts(rowid, text_content) SELECT id, json_extract(data, '$.text') FROM events WHERE {fts_where}",
+            (*ids, *FTS_TYPES),
+        )
+        scrubbed_ids.update(ids)
+    conn.commit()
+    return len(scrubbed_ids)
+
+
+def scan(conn: sqlite3.Connection) -> list[tuple[int, str]]:
+    """All pattern hits as (event id, context snippet): every match per event, not just the first,
+    so a benign first hit can't mask a real secret later in the same event. Scans the FULL event:
+    secrets often sit deep inside long bash commands / tool payloads (an old PAT once survived
+    weeks because substr(data,1,200) never saw it). Already-scrubbed values are skipped."""
+    matches = []
+    for row_id, data in conn.execute("SELECT id, data FROM events"):
+        if not data:
+            continue
+        for m in REGEX.finditer(data):
+            if REDACTED in m.group(0):
+                continue
+            start = max(0, m.start() - 40)
+            snippet = data[start : m.end() + 40].replace("\n", " ")
+            matches.append((row_id, snippet))
+    return matches
+
+
 def main() -> int:
     if not os.path.isfile(DB):
         print(f"No database at {DB}")
@@ -32,19 +92,10 @@ def main() -> int:
     delete = "--delete" in sys.argv[1:]
     conn = sqlite3.connect(DB)
     try:
-        # Scan the FULL event, not just the first 200 chars: secrets often sit
-        # deep inside long bash commands / tool payloads (an old PAT once survived
-        # weeks because substr(data,1,200) never saw it). Show a window around the hit.
-        cursor = conn.execute("SELECT id, data FROM events")
-        matches = []
-        for row_id, data in cursor:
-            if not data:
-                continue
-            m = REGEX.search(data)
-            if m:
-                start = max(0, m.start() - 40)
-                snippet = data[start : m.end() + 40].replace("\n", " ")
-                matches.append((row_id, snippet))
+        scrubbed = scrub_known(conn)
+        if scrubbed:
+            print(f"Scrubbed {scrubbed} events containing known-leaked literals in place.")
+        matches = scan(conn)
     finally:
         conn.close()
 

--- a/agent/skills/dream/scripts/redact_secrets.sh
+++ b/agent/skills/dream/scripts/redact_secrets.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-# Scan events DB for secrets and scrub known-leaked literals. Usage: redact_secrets.sh
-exec uv run python3 "$(dirname "$0")/redact_secrets.py"
+# Scan events DB for secrets; scrub the real leaks in place. Usage: redact_secrets.sh [--scrub ID ...]
+exec uv run python3 "$(dirname "$0")/redact_secrets.py" "$@"

--- a/agent/skills/dream/scripts/redact_secrets.sh
+++ b/agent/skills/dream/scripts/redact_secrets.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-# Scan events DB for secrets. Usage: redact_secrets.sh [--delete]
-exec uv run python3 "$(dirname "$0")/redact_secrets.py" "$@"
+# Scan events DB for secrets and scrub known-leaked literals. Usage: redact_secrets.sh
+exec uv run python3 "$(dirname "$0")/redact_secrets.py"

--- a/agent/tests/test_redact_secrets.py
+++ b/agent/tests/test_redact_secrets.py
@@ -102,17 +102,19 @@ def test_scan_skips_scrubbed_values(event_bus, db_conn, known_file):
     assert redact.scan(db_conn) == []
 
 
-def test_main_delete_purges_flagged_events(tmp_path, event_bus, db_conn, known_file, monkeypatch, capsys):
+def test_main_reports_candidates_and_scrubs_known(tmp_path, event_bus, db_conn, known_file, monkeypatch, capsys):
     event_bus.emit(ChatEvent(type="chat", text="my key is AKIAABCDEFGHIJKLMNOP"))
-    event_bus.emit(ChatEvent(type="chat", text="nothing sensitive here"))
+    event_bus.emit(ChatEvent(type="chat", text=f"and the password {SECRET} too"))
+    known_file.write_text(f"{SECRET}\n")
     monkeypatch.setattr(redact, "DB", str(tmp_path / "events.db"))
-    monkeypatch.setattr("sys.argv", ["redact_secrets.py", "--delete"])
+    monkeypatch.setattr("sys.argv", ["redact_secrets.py"])
 
     assert redact.main() == 0
 
     out = capsys.readouterr().out
+    assert "Scrubbed 1 events" in out
     assert "Found 1 events" in out
-    assert "Deleted 1 events." in out
-    remaining = [row[0] for row in db_conn.execute("SELECT data FROM events")]
-    assert len(remaining) == 1
-    assert "nothing sensitive" in remaining[0]
+    rows = [row[0] for row in db_conn.execute("SELECT data FROM events")]
+    assert len(rows) == 2
+    assert all(SECRET not in data for data in rows)
+    assert any("AKIAABCDEFGHIJKLMNOP" in data for data in rows)

--- a/agent/tests/test_redact_secrets.py
+++ b/agent/tests/test_redact_secrets.py
@@ -1,0 +1,118 @@
+"""Tests for the dream skill's redact_secrets script: known-literal scrub + pattern scan."""
+
+import importlib.util
+import pathlib as pl
+import sqlite3
+
+import pytest
+
+from core.events import ChatEvent, UserEvent
+
+SCRIPT = pl.Path(__file__).resolve().parents[1] / "skills" / "dream" / "scripts" / "redact_secrets.py"
+
+spec = importlib.util.spec_from_file_location("redact_secrets", SCRIPT)
+assert spec is not None and spec.loader is not None
+redact = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(redact)
+
+SECRET = "hunter2secret9000"
+
+
+@pytest.fixture
+def known_file(tmp_path, monkeypatch):
+    path = tmp_path / "redact_known.txt"
+    monkeypatch.setattr(redact, "KNOWN_FILE", str(path))
+    return path
+
+
+@pytest.fixture
+def db_conn(tmp_path, event_bus):
+    conn = sqlite3.connect(str(tmp_path / "events.db"))
+    yield conn
+    conn.close()
+
+
+def test_scrub_replaces_literal_in_every_event_and_keeps_context(event_bus, db_conn, known_file):
+    event_bus.emit(ChatEvent(type="chat", text=f"the password is {SECRET} for gmail"))
+    event_bus.emit(UserEvent(type="user", text=f"I found {SECRET} again while cleaning up"))
+    known_file.write_text(f"{SECRET}\n")
+
+    assert redact.scrub_known(db_conn) == 2
+
+    rows = [row[0] for row in db_conn.execute("SELECT data FROM events")]
+    assert all(SECRET not in data for data in rows)
+    assert any("the password is [REDACTED] for gmail" in data for data in rows)
+
+
+def test_scrub_keeps_fts_in_sync(event_bus, db_conn, known_file):
+    event_bus.emit(ChatEvent(type="chat", text=f"leaked {SECRET} during backup"))
+    known_file.write_text(f"{SECRET}\n")
+
+    redact.scrub_known(db_conn)
+
+    assert event_bus.search(SECRET) == []
+    hits = event_bus.search("backup")
+    assert len(hits) == 1
+    assert "[REDACTED]" in hits[0]["text"]
+
+    db_conn.execute("DELETE FROM events")
+    db_conn.commit()
+    assert event_bus.search("backup") == []
+
+
+def test_scrub_converges_when_secret_reseeds(event_bus, db_conn, known_file):
+    event_bus.emit(ChatEvent(type="chat", text=f"original leak {SECRET}"))
+    known_file.write_text(f"{SECRET}\n")
+    assert redact.scrub_known(db_conn) == 1
+
+    event_bus.emit(ChatEvent(type="chat", text=f"last night I redacted {SECRET} from history"))
+    assert redact.scrub_known(db_conn) == 1
+    rows = [row[0] for row in db_conn.execute("SELECT data FROM events")]
+    assert all(SECRET not in data for data in rows)
+
+
+def test_scrub_without_known_file_is_noop(event_bus, db_conn, known_file):
+    event_bus.emit(ChatEvent(type="chat", text=f"leak {SECRET}"))
+    assert redact.scrub_known(db_conn) == 0
+
+
+def test_scrub_ignores_comments_and_blank_lines(event_bus, db_conn, known_file):
+    event_bus.emit(ChatEvent(type="chat", text=f"leak {SECRET}"))
+    known_file.write_text(f"# known leaked literals\n\n{SECRET}\n")
+    assert redact.scrub_known(db_conn) == 1
+
+
+def test_scan_reports_every_match_in_an_event(event_bus, db_conn):
+    event_bus.emit(ChatEvent(type="chat", text="first AKIAABCDEFGHIJKLMNOP then xoxb-1234-abcdef in one message"))
+
+    matches = redact.scan(db_conn)
+
+    snippets = [snippet for _, snippet in matches]
+    assert len(matches) == 2
+    assert any("AKIAABCDEFGHIJKLMNOP" in snippet for snippet in snippets)
+    assert any("xoxb-1234-abcdef" in snippet for snippet in snippets)
+
+
+def test_scan_skips_scrubbed_values(event_bus, db_conn, known_file):
+    event_bus.emit(ChatEvent(type="chat", text=f"password={SECRET}"))
+    known_file.write_text(f"{SECRET}\n")
+
+    assert len(redact.scan(db_conn)) == 1
+    redact.scrub_known(db_conn)
+    assert redact.scan(db_conn) == []
+
+
+def test_main_delete_purges_flagged_events(tmp_path, event_bus, db_conn, known_file, monkeypatch, capsys):
+    event_bus.emit(ChatEvent(type="chat", text="my key is AKIAABCDEFGHIJKLMNOP"))
+    event_bus.emit(ChatEvent(type="chat", text="nothing sensitive here"))
+    monkeypatch.setattr(redact, "DB", str(tmp_path / "events.db"))
+    monkeypatch.setattr("sys.argv", ["redact_secrets.py", "--delete"])
+
+    assert redact.main() == 0
+
+    out = capsys.readouterr().out
+    assert "Found 1 events" in out
+    assert "Deleted 1 events." in out
+    remaining = [row[0] for row in db_conn.execute("SELECT data FROM events")]
+    assert len(remaining) == 1
+    assert "nothing sensitive" in remaining[0]

--- a/agent/tests/test_redact_secrets.py
+++ b/agent/tests/test_redact_secrets.py
@@ -1,4 +1,4 @@
-"""Tests for the dream skill's redact_secrets script: known-literal scrub + pattern scan."""
+"""Tests for the dream skill's redact_secrets script: masked pattern scan + in-place scrub by id."""
 
 import importlib.util
 import pathlib as pl
@@ -15,14 +15,7 @@ assert spec is not None and spec.loader is not None
 redact = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(redact)
 
-SECRET = "hunter2secret9000"
-
-
-@pytest.fixture
-def known_file(tmp_path, monkeypatch):
-    path = tmp_path / "redact_known.txt"
-    monkeypatch.setattr(redact, "KNOWN_FILE", str(path))
-    return path
+SECRET = "AKIAABCDEFGHIJKLMNOP"
 
 
 @pytest.fixture
@@ -32,23 +25,42 @@ def db_conn(tmp_path, event_bus):
     conn.close()
 
 
-def test_scrub_replaces_literal_in_every_event_and_keeps_context(event_bus, db_conn, known_file):
-    event_bus.emit(ChatEvent(type="chat", text=f"the password is {SECRET} for gmail"))
-    event_bus.emit(UserEvent(type="user", text=f"I found {SECRET} again while cleaning up"))
-    known_file.write_text(f"{SECRET}\n")
+def test_scan_masks_the_secret_but_keeps_context(event_bus, db_conn):
+    event_bus.emit(ChatEvent(type="chat", text=f"the aws key is {SECRET} for backups"))
 
-    assert redact.scrub_known(db_conn) == 2
+    matches = redact.scan(db_conn)
 
-    rows = [row[0] for row in db_conn.execute("SELECT data FROM events")]
-    assert all(SECRET not in data for data in rows)
-    assert any("the password is [REDACTED] for gmail" in data for data in rows)
+    assert len(matches) == 1
+    _, snippet = matches[0]
+    assert SECRET not in snippet
+    assert "[REDACTED]" in snippet
+    assert "the aws key is" in snippet and "for backups" in snippet
 
 
-def test_scrub_keeps_fts_in_sync(event_bus, db_conn, known_file):
+def test_scan_reports_every_match_in_an_event(event_bus, db_conn):
+    event_bus.emit(ChatEvent(type="chat", text="first AKIAABCDEFGHIJKLMNOP then xoxb-1234-abcdef in one message"))
+
+    matches = redact.scan(db_conn)
+
+    assert len(matches) == 2
+    assert all("AKIA" not in snippet and "xoxb-1234" not in snippet for _, snippet in matches)
+
+
+def test_scrub_redacts_the_secret_in_place_and_keeps_context(event_bus, db_conn):
     event_bus.emit(ChatEvent(type="chat", text=f"leaked {SECRET} during backup"))
-    known_file.write_text(f"{SECRET}\n")
+    ids = sorted({row_id for row_id, _ in redact.scan(db_conn)})
 
-    redact.scrub_known(db_conn)
+    assert redact.scrub(db_conn, ids) == 1
+
+    data = db_conn.execute("SELECT data FROM events").fetchone()[0]
+    assert SECRET not in data
+    assert "leaked [REDACTED] during backup" in data
+
+
+def test_scrub_keeps_fts_in_sync(event_bus, db_conn):
+    event_bus.emit(ChatEvent(type="chat", text=f"leaked {SECRET} during backup"))
+
+    redact.scrub(db_conn, [row_id for row_id, _ in redact.scan(db_conn)])
 
     assert event_bus.search(SECRET) == []
     hits = event_bus.search("backup")
@@ -60,61 +72,63 @@ def test_scrub_keeps_fts_in_sync(event_bus, db_conn, known_file):
     assert event_bus.search("backup") == []
 
 
-def test_scrub_converges_when_secret_reseeds(event_bus, db_conn, known_file):
+def test_scrub_only_touches_the_given_events(event_bus, db_conn):
+    event_bus.emit(ChatEvent(type="chat", text=f"real leak {SECRET}"))
+    event_bus.emit(ChatEvent(type="chat", text=f"benign discussion of {SECRET} to keep"))
+    rows = list(db_conn.execute("SELECT id FROM events ORDER BY id"))
+    keep_id = rows[1][0]
+
+    redact.scrub(db_conn, [rows[0][0]])
+
+    kept = db_conn.execute("SELECT data FROM events WHERE id = ?", (keep_id,)).fetchone()[0]
+    assert SECRET in kept
+
+
+def test_scan_and_scrub_converge_when_secret_reseeds(event_bus, db_conn):
     event_bus.emit(ChatEvent(type="chat", text=f"original leak {SECRET}"))
-    known_file.write_text(f"{SECRET}\n")
-    assert redact.scrub_known(db_conn) == 1
+    redact.scrub(db_conn, [row_id for row_id, _ in redact.scan(db_conn)])
+    assert redact.scan(db_conn) == []
 
     event_bus.emit(ChatEvent(type="chat", text=f"last night I redacted {SECRET} from history"))
-    assert redact.scrub_known(db_conn) == 1
-    rows = [row[0] for row in db_conn.execute("SELECT data FROM events")]
-    assert all(SECRET not in data for data in rows)
+    reseeded = redact.scan(db_conn)
+    assert len(reseeded) == 1
+    redact.scrub(db_conn, [row_id for row_id, _ in reseeded])
+    assert redact.scan(db_conn) == []
+    assert all(SECRET not in row[0] for row in db_conn.execute("SELECT data FROM events"))
 
 
-def test_scrub_without_known_file_is_noop(event_bus, db_conn, known_file):
-    event_bus.emit(ChatEvent(type="chat", text=f"leak {SECRET}"))
-    assert redact.scrub_known(db_conn) == 0
+def test_scrub_is_noop_on_events_without_secrets(event_bus, db_conn):
+    event_bus.emit(ChatEvent(type="chat", text="nothing sensitive here"))
+    row_id = db_conn.execute("SELECT id FROM events").fetchone()[0]
+
+    assert redact.scrub(db_conn, [row_id]) == 0
 
 
-def test_scrub_ignores_comments_and_blank_lines(event_bus, db_conn, known_file):
-    event_bus.emit(ChatEvent(type="chat", text=f"leak {SECRET}"))
-    known_file.write_text(f"# known leaked literals\n\n{SECRET}\n")
-    assert redact.scrub_known(db_conn) == 1
-
-
-def test_scan_reports_every_match_in_an_event(event_bus, db_conn):
-    event_bus.emit(ChatEvent(type="chat", text="first AKIAABCDEFGHIJKLMNOP then xoxb-1234-abcdef in one message"))
-
-    matches = redact.scan(db_conn)
-
-    snippets = [snippet for _, snippet in matches]
-    assert len(matches) == 2
-    assert any("AKIAABCDEFGHIJKLMNOP" in snippet for snippet in snippets)
-    assert any("xoxb-1234-abcdef" in snippet for snippet in snippets)
-
-
-def test_scan_skips_scrubbed_values(event_bus, db_conn, known_file):
+def test_scan_skips_already_redacted_values(event_bus, db_conn):
     event_bus.emit(ChatEvent(type="chat", text=f"password={SECRET}"))
-    known_file.write_text(f"{SECRET}\n")
+    ids = [row_id for row_id, _ in redact.scan(db_conn)]
 
-    assert len(redact.scan(db_conn)) == 1
-    redact.scrub_known(db_conn)
+    redact.scrub(db_conn, ids)
+
     assert redact.scan(db_conn) == []
 
 
-def test_main_reports_candidates_and_scrubs_known(tmp_path, event_bus, db_conn, known_file, monkeypatch, capsys):
-    event_bus.emit(ChatEvent(type="chat", text="my key is AKIAABCDEFGHIJKLMNOP"))
-    event_bus.emit(ChatEvent(type="chat", text=f"and the password {SECRET} too"))
-    known_file.write_text(f"{SECRET}\n")
+def test_main_scan_then_scrub_end_to_end(tmp_path, event_bus, db_conn, monkeypatch, capsys):
+    event_bus.emit(ChatEvent(type="chat", text=f"my key is {SECRET}"))
+    event_bus.emit(UserEvent(type="user", text="just a normal message"))
     monkeypatch.setattr(redact, "DB", str(tmp_path / "events.db"))
+
     monkeypatch.setattr("sys.argv", ["redact_secrets.py"])
-
     assert redact.main() == 0
-
     out = capsys.readouterr().out
-    assert "Scrubbed 1 events" in out
-    assert "Found 1 events" in out
+    assert "Found 1 event(s)" in out
+    assert SECRET not in out
+    leak_id = int(out.splitlines()[-1].split("|", 1)[0])
+
+    monkeypatch.setattr("sys.argv", ["redact_secrets.py", "--scrub", str(leak_id)])
+    assert redact.main() == 0
+    assert "Scrubbed secrets in 1 event(s)" in capsys.readouterr().out
+
     rows = [row[0] for row in db_conn.execute("SELECT data FROM events")]
     assert len(rows) == 2
     assert all(SECRET not in data for data in rows)
-    assert any("AKIAABCDEFGHIJKLMNOP" in data for data in rows)


### PR DESCRIPTION
## Problem

Fixes #1210.

`redact_secrets.py --delete` removed whole events, but a leaked secret is self-perpetuating: during the nightly dream the agent reasons about the value (thinking, summary, the SQL used to hunt it) and each mention lands as a new event containing the literal again. Delete N events one night, the secret reappears the next; it never converges. The re-seeder was largely the tool itself: the old scan printed the raw secret in its output, the agent read it while "reviewing matches," and re-logged it. A second bug: `REGEX.search` reported only the first match per event, so a benign first hit masked a real secret later in the same event.

## Fix

One converging mechanism, no sidecar state:

- **Masked scan.** Each hit prints as `event_id|context` with the value itself replaced by `[REDACTED]` (every secret in the context window, not just the primary match). Reviewing candidates can no longer re-leak a live secret into a new event. `finditer` reports every match per event, so a benign first hit can't mask a real one.
- **Scrub in place by id.** `redact_secrets.sh --scrub <id> <id> ...` redacts every pattern hit in those events, keeping their surrounding context. It is regex-driven and keyed by event id, so the caller never has to pass (and thereby re-leak) the literal.
- **Convergence by re-detection.** The scan runs every dream, so a re-seeded pattern secret is simply caught and scrubbed again the next night. No persistent list, no `--delete`, no extra concept or file for the agent to curate.
- **FTS stays consistent.** `events_fts` is an external-content FTS5 table with insert/delete triggers only, so a bare `UPDATE` would leave the secret searchable and corrupt the index on a later delete. The scrub resyncs per row (FTS delete with the old text, `UPDATE`, FTS insert with the new text), mirroring the trigger conditions in `core/events.py`.

The scan reads the full event (secrets often sit deep inside long bash commands / tool payloads); already-`[REDACTED]` spans are skipped so scrubbed events don't re-flag.

**Tradeoff:** detection is regex-only, so a word-shaped secret that no pattern matches relies on the agent catching it the night it leaks. Nearly every real secret is pattern-shaped (keys, tokens, app-passwords, connection strings), and the "never quote a leaked value" rule plus env-var discipline cover the rest. Worth it to drop the file.

## Tests

`agent/tests/test_redact_secrets.py` (9 tests) drives the real EventBus schema: masked scan (secret absent, context present), multi-match reporting, in-place scrub with context preserved, FTS consistency after scrub (secret unsearchable, context still searchable, clean delete afterward), scrub scoped to the given ids only, convergence on re-seed, no-op on clean events, already-redacted skip, and the scan→`--scrub` end-to-end path.

Fleet impact: content ships via the normal upstream-sync snapshot; no new on-disk state, no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
