### PR TITLE
fix(web): keep mobile chat pinned to bottom while typing

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <meta name="color-scheme" content="light dark" />
     <link rel="icon" type="image/png" href="/favicon.png?v=2" />

--- a/apps/web/src/components/Chat/ChatMessageArea/index.tsx
+++ b/apps/web/src/components/Chat/ChatMessageArea/index.tsx
@@ -133,8 +133,11 @@ export function ChatMessageArea({
   }, [chatMessages]);
   const parentRef = useRef<HTMLDivElement>(null);
   // Drives the scroll-to-bottom button: true while pinned near the latest message, false once
-  // the user scrolls up. Recomputed on scroll and on content resize (see below).
+  // the user scrolls up. Recomputed on scroll and on any resize (see below).
   const [atBottom, setAtBottom] = useState(true);
+  // Mirror of atBottom for resize handling: once the container has shrunk, the DOM already
+  // reads as scrolled-away, so re-pinning needs the pre-resize answer.
+  const pinnedRef = useRef(true);
 
   const getItemKey = useCallback(
     (index: number) => decorated[index].key,
@@ -202,6 +205,7 @@ export function ChatMessageArea({
     const atEnd =
       el.scrollHeight - el.scrollTop - el.clientHeight <=
       AT_BOTTOM_THRESHOLD_PX;
+    pinnedRef.current = atEnd;
     setAtBottom(atEnd);
     if (hasMore && !loadingMore && !atEnd && el.scrollTop < LOAD_OLDER_TOP_PX) {
       loadMore();
@@ -211,20 +215,27 @@ export function ChatMessageArea({
   // "At bottom" depends on content height, not just scroll position: after the first paint the
   // virtualizer measures real row heights (vs. the estimates scrollToEnd used), which moves the
   // end without firing a scroll event. Recompute on every content resize so the button doesn't
-  // get stuck showing when we're actually pinned to the latest message.
+  // get stuck showing when we're actually pinned to the latest message. And when the container
+  // itself resizes while pinned (mobile keyboard opening, composer growing a line, window
+  // resize), stay pinned to the latest message instead of letting the bottom slide out of view.
   useLayoutEffect(() => {
     const el = parentRef.current;
     const content = el?.firstElementChild;
     if (!el || !content) return;
-    const ro = new ResizeObserver(() => {
-      setAtBottom(
+    const ro = new ResizeObserver((entries) => {
+      if (pinnedRef.current && entries.some((entry) => entry.target === el)) {
+        virtualizer.scrollToEnd();
+      }
+      const atEnd =
         el.scrollHeight - el.scrollTop - el.clientHeight <=
-          AT_BOTTOM_THRESHOLD_PX,
-      );
+        AT_BOTTOM_THRESHOLD_PX;
+      pinnedRef.current = atEnd;
+      setAtBottom(atEnd);
     });
+    ro.observe(el);
     ro.observe(content);
     return () => ro.disconnect();
-  }, []);
+  }, [virtualizer]);
 
   const items = virtualizer.getVirtualItems();
   const topPad = fullscreen ? navbarHeight + 16 : 32;

--- a/apps/web/src/components/Chat/use-chat-keyboard-focus.test.tsx
+++ b/apps/web/src/components/Chat/use-chat-keyboard-focus.test.tsx
@@ -1,0 +1,103 @@
+import { useRef } from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLayout } from "@/stores/use-layout";
+import { useChatKeyboardFocus } from "./use-chat-keyboard-focus";
+
+vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => true }));
+
+const BASELINE_HEIGHT = 800;
+const KEYBOARD_OPEN_HEIGHT = 500;
+
+interface FakeVisualViewport {
+  height: number;
+  addEventListener: (type: string, listener: () => void) => void;
+  removeEventListener: (type: string, listener: () => void) => void;
+  resizeTo: (height: number) => void;
+}
+
+function installVisualViewport(height: number): FakeVisualViewport {
+  const listeners = new Set<() => void>();
+  const viewport: FakeVisualViewport = {
+    height,
+    addEventListener: (_type, listener) => listeners.add(listener),
+    removeEventListener: (_type, listener) => listeners.delete(listener),
+    resizeTo: (next) => {
+      viewport.height = next;
+      listeners.forEach((listener) => listener());
+    },
+  };
+  Object.defineProperty(window, "visualViewport", {
+    value: viewport,
+    configurable: true,
+  });
+  return viewport;
+}
+
+function Harness() {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  useChatKeyboardFocus(textareaRef);
+  return <textarea ref={textareaRef} />;
+}
+
+let viewport: FakeVisualViewport;
+
+beforeEach(() => {
+  useLayout.setState({ chatKeyboardFocused: false });
+  document.documentElement.style.height = "";
+  viewport = installVisualViewport(BASELINE_HEIGHT);
+  vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+});
+
+afterEach(cleanup);
+
+function openKeyboard() {
+  const view = render(<Harness />);
+  screen.getByRole("textbox").focus();
+  act(() => viewport.resizeTo(KEYBOARD_OPEN_HEIGHT));
+  return view;
+}
+
+describe("useChatKeyboardFocus", () => {
+  it("fits the app to the visual viewport when the keyboard opens over the composer", () => {
+    openKeyboard();
+    expect(useLayout.getState().chatKeyboardFocused).toBe(true);
+    expect(document.documentElement.style.height).toBe(
+      `${KEYBOARD_OPEN_HEIGHT}px`,
+    );
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it("tracks keyboard height changes while composing", () => {
+    openKeyboard();
+    act(() => viewport.resizeTo(KEYBOARD_OPEN_HEIGHT - 40));
+    expect(document.documentElement.style.height).toBe(
+      `${KEYBOARD_OPEN_HEIGHT - 40}px`,
+    );
+    expect(useLayout.getState().chatKeyboardFocused).toBe(true);
+  });
+
+  it("releases the app height when the keyboard closes", () => {
+    openKeyboard();
+    act(() => viewport.resizeTo(BASELINE_HEIGHT));
+    expect(useLayout.getState().chatKeyboardFocused).toBe(false);
+    expect(document.documentElement.style.height).toBe("");
+  });
+
+  it("releases the app height when the composer loses focus", () => {
+    openKeyboard();
+    screen.getByRole("textbox").blur();
+    act(() => viewport.resizeTo(BASELINE_HEIGHT));
+    expect(useLayout.getState().chatKeyboardFocused).toBe(false);
+    expect(document.documentElement.style.height).toBe("");
+  });
+
+  it("releases the app height on unmount", () => {
+    const view = openKeyboard();
+    expect(document.documentElement.style.height).toBe(
+      `${KEYBOARD_OPEN_HEIGHT}px`,
+    );
+    view.unmount();
+    expect(document.documentElement.style.height).toBe("");
+  });
+});

--- a/apps/web/src/components/Chat/use-chat-keyboard-focus.ts
+++ b/apps/web/src/components/Chat/use-chat-keyboard-focus.ts
@@ -42,27 +42,33 @@ export function useChatKeyboardFocus(
       const viewportHeight = viewport.height;
       const baselineHeight = viewportHeightRef.current;
 
+      let focused = false;
       if (!isTextareaActive) {
         viewportHeightRef.current =
           baselineHeight === null
             ? viewportHeight
             : Math.max(baselineHeight, viewportHeight);
-        writeFocused(false);
-        return;
-      }
-
-      if (baselineHeight === null || viewportHeight > baselineHeight) {
+      } else if (baselineHeight === null || viewportHeight > baselineHeight) {
         viewportHeightRef.current = viewportHeight;
-        writeFocused(false);
-        return;
+      } else {
+        focused = baselineHeight - viewportHeight > 120;
       }
 
-      writeFocused(baselineHeight - viewportHeight > 120);
+      writeFocused(focused);
+      // Browsers that ignore interactive-widget=resizes-content (iOS Safari) keep the
+      // layout viewport under the keyboard and pan it to reveal the caret, a pan that
+      // any reflow while typing resets, hiding the composer. While the keyboard is up,
+      // fit the app to the visual viewport instead so nothing ever needs panning.
+      document.documentElement.style.height = focused
+        ? `${viewportHeight}px`
+        : "";
+      if (focused) window.scrollTo(0, 0);
     };
 
     viewport.addEventListener("resize", syncKeyboardFocus);
     return () => {
       viewport.removeEventListener("resize", syncKeyboardFocus);
+      document.documentElement.style.height = "";
     };
   }, [isMobile, setChatKeyboardFocused, textareaRef]);
 }


### PR DESCRIPTION
Fixes #1205

## Problem

On mobile, typing in app-chat scrolls the view up, away from the compose box and the latest messages, forcing a manual scroll back down after nearly every keystroke.

Root cause: the app is a fixed `h-dvh` layout, and mobile browsers default to overlaying the on-screen keyboard on top of it (`interactive-widget=resizes-visual`). The browser then pans the viewport to reveal the caret, and any reflow while composing (textarea autosize, message re-renders, the navbar hiding) resets that pan back to the top of the page, leaving the composer hidden behind the keyboard. On top of that, the chat message list never re-pins to the bottom when its scroll container shrinks, so even a properly resized layout would surface older messages instead of the latest ones.

## Fix

Resize the layout to the keyboard instead of relying on browser panning, and keep the list pinned:

- **`interactive-widget=resizes-content`** in the viewport meta: browsers that support it (Chrome/Edge/Firefox on Android) shrink the layout viewport when the keyboard opens, so the composer sits above the keyboard natively and no panning ever happens.
- **Visual-viewport fit in `useChatKeyboardFocus`**: browsers that ignore the meta (iOS Safari) get the same effect manually. While the chat keyboard is up (the state the hook already tracks), the app root is sized to `visualViewport.height` and the pan is cancelled with `window.scrollTo(0, 0)`; released when the keyboard closes, the composer blurs, or the hook unmounts. On browsers that honor the meta this sets the height to the value it already has, so it is a no-op there.
- **Re-pin on container resize in `ChatMessageArea`**: the ResizeObserver now watches the scroll container as well as its content, and when the container resizes while the view is pinned near the bottom it calls `scrollToEnd()`, so the latest messages stay in view when the keyboard opens, the composer grows a line, or the window resizes. A ref mirrors the pinned state because after the resize the DOM already reads as scrolled-away. Scrolled-up readers are left where they are.

## Tests

- New `use-chat-keyboard-focus.test.tsx` covers the viewport-fit lifecycle: fit + scroll reset when the keyboard opens over the composer, tracking keyboard height changes while composing, and release on keyboard close, blur, and unmount.
- `./check.sh web` green (eslint, prettier, tsc, vitest: 181 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)