### PR TITLE
fix(vestad): supervisor owns the tunnel lifecycle end to end

### DIFF
--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -423,6 +423,21 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
             let (port, http_listener) = bind_http_atomically(port, &config).await;
             serve::write_port_file(&config, port);
 
+            // Best-effort convergence before the surfaces below read
+            // tunnel.json: create a missing tunnel (fresh BYOK box) or
+            // reconcile a changed pinned subdomain, so agent env files, /info,
+            // and the banner get the right identity URL on first boot. Failure
+            // is fine here; the supervisor keeps converging after boot.
+            if !no_tunnel
+                && !is_cloud_managed()
+                && tunnel::has_cf_creds(&config)
+                && !tunnel::has_declined_tunnel(&config)
+            {
+                if let Err(e) = tunnel::ensure_tunnel(&config) {
+                    tracing::warn!("boot tunnel converge failed (supervisor will retry): {e}");
+                }
+            }
+
             // Boot renders no verdict on tunnel health: the supervisor owns
             // establish/verify/repair and mirrors sustained state into
             // status.json via on_tunnel_up. Boot only decides whether a tunnel
@@ -430,7 +445,7 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
             let tunnel_intended = !no_tunnel
                 && (is_cloud_managed()
                     || tunnel::get_tunnel_config(&config).is_some()
-                    || tunnel::has_cf_creds(&config));
+                    || (tunnel::has_cf_creds(&config) && !tunnel::has_declined_tunnel(&config)));
             let tunnel_url = tunnel_intended
                 .then(|| {
                     tunnel::get_tunnel_config(&config)
@@ -484,6 +499,14 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
             // Keep status.json honest: on a SUSTAINED tunnel outage the supervisor
             // flips the tunnel field to an error and back to enabled on recovery.
             // Transient blips it recovers from on its own don't change it.
+            // Recovery guidance differs by who owns the tunnel: a managed
+            // (vesta.run) tunnel is the control plane's to fix, a self-hosted
+            // one is re-created by `vestad connect`.
+            let tunnel_down_hint = if is_cloud_managed() {
+                "tunnel down 2+ min; the vesta.run control plane owns it and should recover it"
+            } else {
+                "tunnel down 2+ min; if it persists, run vestad connect"
+            };
             let status = std::sync::Arc::new(std::sync::Mutex::new(status));
             let on_tunnel_up: std::sync::Arc<dyn Fn(bool) + Send + Sync> = {
                 let status = status.clone();
@@ -491,10 +514,10 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
                 let tunnel_url = tunnel_url.clone();
                 std::sync::Arc::new(move |up: bool| {
                     let next = if up {
-                        match tunnel_url.clone().or_else(|| {
-                            tunnel::get_tunnel_config(&config)
-                                .map(|tc| format!("https://{}", tc.hostname))
-                        }) {
+                        match tunnel::get_tunnel_config(&config)
+                            .map(|tc| format!("https://{}", tc.hostname))
+                            .or_else(|| tunnel_url.clone())
+                        {
                             Some(url) => TunnelStatus::Active(url),
                             None => return, // can't name the URL; leave the field as-is
                         }
@@ -503,9 +526,7 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
                         // TUNNEL_DOWN_SUSTAINED_SECS, whatever the failure mode
                         // (wedged connector, fast-exiting cloudflared, dead
                         // config): a general recovery hint, not revoked-specific.
-                        TunnelStatus::Failed(
-                            "tunnel down 2+ min — if it persists, run vestad connect".to_string(),
-                        )
+                        TunnelStatus::Failed(tunnel_down_hint.to_string())
                     };
                     if let Ok(mut s) = status.lock() {
                         s.set_tunnel(next);
@@ -887,6 +908,12 @@ fn main() {
                 }
                 TunnelAction::Destroy => {
                     tunnel::destroy_tunnel(&config).unwrap_or_else(|e| die(e));
+                    if let Err(e) = tunnel::decline_tunnel(&config) {
+                        eprintln!(
+                            "warning: tunnel destroyed but failed to persist the no-tunnel preference: {}",
+                            e
+                        );
+                    }
                     eprintln!("✓ tunnel removed");
                 }
             }

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -499,11 +499,10 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
                             None => return, // can't name the URL; leave the field as-is
                         }
                     } else {
-                        // Fired only after TUNNEL_DOWN_SUSTAINED_SECS with a live
-                        // cloudflared whose edge stayed unregistered (a wedged
-                        // connector). A revoked/deleted tunnel exits too fast to
-                        // reach this path and keeps its boot-time failure reason,
-                        // so this is a general recovery hint, not revoked-specific.
+                        // Fired once the tunnel has been unregistered for
+                        // TUNNEL_DOWN_SUSTAINED_SECS, whatever the failure mode
+                        // (wedged connector, fast-exiting cloudflared, dead
+                        // config): a general recovery hint, not revoked-specific.
                         TunnelStatus::Failed(
                             "tunnel down 2+ min — if it persists, run vestad connect".to_string(),
                         )

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -428,11 +428,9 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
             // reconcile a changed pinned subdomain, so agent env files, /info,
             // and the banner get the right identity URL on first boot. Failure
             // is fine here; the supervisor keeps converging after boot.
-            if !no_tunnel
-                && !is_cloud_managed()
-                && tunnel::has_cf_creds(&config)
-                && !tunnel::has_declined_tunnel(&config)
-            {
+            let byok_tunnel_wanted =
+                tunnel::has_cf_creds(&config) && !tunnel::has_declined_tunnel(&config);
+            if !no_tunnel && !is_cloud_managed() && byok_tunnel_wanted {
                 if let Err(e) = tunnel::ensure_tunnel(&config) {
                     tracing::warn!("boot tunnel converge failed (supervisor will retry): {e}");
                 }
@@ -441,17 +439,12 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
             // Boot renders no verdict on tunnel health: the supervisor owns
             // establish/verify/repair and mirrors sustained state into
             // status.json via on_tunnel_up. Boot only decides whether a tunnel
-            // is intended and advertises the identity URL from tunnel.json.
-            let tunnel_intended = !no_tunnel
-                && (is_cloud_managed()
-                    || tunnel::get_tunnel_config(&config).is_some()
-                    || (tunnel::has_cf_creds(&config) && !tunnel::has_declined_tunnel(&config)));
-            let tunnel_url = tunnel_intended
-                .then(|| {
-                    tunnel::get_tunnel_config(&config)
-                        .map(|tc| format!("https://{}", tc.hostname))
-                })
-                .flatten();
+            // is intended and advertises the identity URL from tunnel.json
+            // (read after the converge above, which may have just created it).
+            let saved_url = tunnel::get_tunnel_config(&config).map(|tc| tc.url());
+            let tunnel_intended =
+                !no_tunnel && (is_cloud_managed() || saved_url.is_some() || byok_tunnel_wanted);
+            let tunnel_url = if tunnel_intended { saved_url } else { None };
             let tunnel_status = if no_tunnel {
                 TunnelStatus::Disabled
             } else if tunnel_intended {
@@ -515,7 +508,7 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
                 std::sync::Arc::new(move |up: bool| {
                     let next = if up {
                         match tunnel::get_tunnel_config(&config)
-                            .map(|tc| format!("https://{}", tc.hostname))
+                            .map(|tc| tc.url())
                             .or_else(|| tunnel_url.clone())
                         {
                             Some(url) => TunnelStatus::Active(url),
@@ -844,8 +837,7 @@ fn main() {
                         eprintln!("creating agent '{}'...", name);
                         let config = config_dir();
                         let vestad_port = read_port_file(&config).unwrap_or(0);
-                        let vestad_tunnel = tunnel::get_tunnel_config(&config)
-                            .map(|tc| format!("https://{}", tc.hostname));
+                        let vestad_tunnel = tunnel::get_tunnel_config(&config).map(|tc| tc.url());
                         let env_config = docker::AgentEnvConfig {
                             config_dir: config.clone(),
                             agents_dir: config.join("agents"),

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -391,158 +391,6 @@ async fn bind_http_atomically(
     unreachable!()
 }
 
-/// How many times startup tries to bring the tunnel up before giving up and
-/// starting anyway (with the failure shown in the banner). Absorbs a tunnel that
-/// is slow to register right after boot (DNS-readiness is handled separately by
-/// wait_for_dns_ready, so these retries are for a slow first registration).
-const TUNNEL_STARTUP_ATTEMPTS: u32 = 3;
-const TUNNEL_STARTUP_RETRY_DELAY_SECS: u64 = 5;
-
-/// A stable Cloudflare host whose resolution signals the local resolver is
-/// actually serving. Right after boot systemd-resolved can be up-but-not-ready
-/// and answer "server misbehaving"; cloudflared's edge discovery then fails
-/// fast and burns every tunnel retry in seconds. Waiting for one successful
-/// lookup first removes that race at its source.
-const DNS_READY_HOST: &str = "api.cloudflare.com:443";
-/// Bounded so a genuinely-offline box still finishes booting — the tunnel
-/// supervisor keeps retrying afterward — yet long enough to outlast a slow boot.
-const DNS_READY_MAX_WAIT_SECS: u64 = 60;
-const DNS_READY_POLL_SECS: u64 = 2;
-
-/// Wait (bounded) for DNS to resolve before the tunnel attempts. Returns as soon
-/// as a lookup succeeds, or after DNS_READY_MAX_WAIT_SECS regardless (the tunnel
-/// attempt and its supervisor handle a still-down resolver from there).
-async fn wait_for_dns_ready() {
-    let deadline =
-        tokio::time::Instant::now() + std::time::Duration::from_secs(DNS_READY_MAX_WAIT_SECS);
-    loop {
-        if let Ok(mut addrs) = tokio::net::lookup_host(DNS_READY_HOST).await {
-            if addrs.next().is_some() {
-                return;
-            }
-        }
-        if tokio::time::Instant::now() >= deadline {
-            tracing::warn!("DNS still not resolving after {DNS_READY_MAX_WAIT_SECS}s; attempting tunnel anyway");
-            return;
-        }
-        tokio::time::sleep(std::time::Duration::from_secs(DNS_READY_POLL_SECS)).await;
-    }
-}
-
-/// Bring the tunnel up at startup, retrying before giving up. On success the
-/// banner advertises the live URL and the supervisor keeps it alive; if every
-/// attempt fails, vestad starts ANYWAY (local access + agents) with the error
-/// surfaced in the banner — a broken tunnel must not block the rest of the box.
-///
-/// The /ready pre-flight is credential-free, so this works even on a box that
-/// can't reach the Cloudflare API. Managed (vesta.run) boxes are exempt: the
-/// control plane owns the tunnel, so we trust the seeded config and let the
-/// supervisor (re)connect rather than pre-flighting.
-///
-/// Whether a failed boot setup should discard the saved `tunnel.json`. Only
-/// forget when the box could rebuild it — i.e. it holds its own Cloudflare creds
-/// (the same predicate that gates the recreate path in `try_establish_tunnel`).
-/// Forgetting a config the box CANNOT rebuild turns a transient boot failure into
-/// a permanent outage. Managed boxes never forget (the control plane owns it).
-fn should_forget_failed_tunnel(failed: bool, managed: bool, has_creds: bool) -> bool {
-    failed && !managed && has_creds
-}
-
-async fn setup_and_verify_tunnel(config: &std::path::Path, port: u16) -> TunnelStatus {
-    // Managed boxes don't pre-flight cloudflared at boot (they trust the seeded
-    // config), so only the self-hosted pre-flight path needs a ready resolver.
-    if !is_cloud_managed() {
-        wait_for_dns_ready().await;
-    }
-    let status = retry_tunnel(
-        TUNNEL_STARTUP_ATTEMPTS,
-        std::time::Duration::from_secs(TUNNEL_STARTUP_RETRY_DELAY_SECS),
-        |attempt| async move {
-            let result = try_establish_tunnel(config, port).await;
-            if let Err(reason) = &result {
-                tracing::warn!(
-                    attempt,
-                    attempts = TUNNEL_STARTUP_ATTEMPTS,
-                    "tunnel not up: {reason}"
-                );
-            }
-            result
-        },
-    )
-    .await;
-
-    // Gave up. Drop the saved config ONLY when this box could recreate it (has its
-    // own Cloudflare creds). On a creds-less box (e.g. a legacy vesta.run tunnel) a
-    // merely-transient boot failure — DNS not ready yet — would otherwise orphan a
-    // still-valid tunnel forever AND suppress the supervisor, which keys off
-    // tunnel.json existing. Keeping the config lets the supervisor respawn
-    // cloudflared and self-heal once DNS is up; a genuinely revoked tunnel just
-    // loops with its reason in `vestad logs` (recovery is `vestad connect`).
-    if should_forget_failed_tunnel(
-        matches!(status, TunnelStatus::Failed(_)),
-        is_cloud_managed(),
-        tunnel::has_cf_creds(config),
-    ) {
-        tunnel::forget_tunnel(config);
-    }
-    status
-}
-
-/// Retry an async tunnel attempt up to `attempts` times, sleeping `delay` between
-/// tries. Returns `Active` with the first URL that comes up, or `Failed` carrying
-/// the last error once every attempt has failed.
-async fn retry_tunnel<F, Fut>(
-    attempts: u32,
-    delay: std::time::Duration,
-    mut attempt: F,
-) -> TunnelStatus
-where
-    F: FnMut(u32) -> Fut,
-    Fut: std::future::Future<Output = Result<String, String>>,
-{
-    let mut reason = "tunnel could not be established".to_string();
-    for n in 1..=attempts {
-        match attempt(n).await {
-            Ok(url) => return TunnelStatus::Active(url),
-            Err(e) => {
-                reason = e;
-                if n < attempts {
-                    tokio::time::sleep(delay).await;
-                }
-            }
-        }
-    }
-    TunnelStatus::Failed(reason)
-}
-
-/// One attempt to bring up and verify the tunnel. `Ok(url)` once it registers an
-/// edge connection; `Err(reason)` describes why this attempt failed.
-async fn try_establish_tunnel(config: &std::path::Path, port: u16) -> Result<String, String> {
-    let tc = tunnel::ensure_cloudflared(config).and_then(|_| tunnel::ensure_tunnel(config))?;
-
-    if is_cloud_managed() {
-        return Ok(format!("https://{}", tc.hostname));
-    }
-
-    if tunnel::preflight_tunnel(config, port).await {
-        return Ok(format!("https://{}", tc.hostname));
-    }
-    tracing::warn!(hostname = %tc.hostname, "saved tunnel failed to register");
-
-    // With our own creds the tunnel may be fixable — recreate it from scratch
-    // (new tunnel + token + DNS) and re-verify.
-    if tunnel::has_cf_creds(config) {
-        let subdomain = tc.hostname.split('.').next().unwrap_or("");
-        let fresh = tunnel::setup_tunnel(config, subdomain)?;
-        if tunnel::preflight_tunnel(config, port).await {
-            tracing::info!(hostname = %fresh.hostname, "tunnel recreated and registered");
-            return Ok(format!("https://{}", fresh.hostname));
-        }
-        return Err("recreated tunnel still could not register".to_string());
-    }
-    Err("saved tunnel could not register".to_string())
-}
-
 fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
     let config = config_dir();
 
@@ -575,12 +423,29 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
             let (port, http_listener) = bind_http_atomically(port, &config).await;
             serve::write_port_file(&config, port);
 
+            // Boot renders no verdict on tunnel health: the supervisor owns
+            // establish/verify/repair and mirrors sustained state into
+            // status.json via on_tunnel_up. Boot only decides whether a tunnel
+            // is intended and advertises the identity URL from tunnel.json.
+            let tunnel_intended = !no_tunnel
+                && (is_cloud_managed()
+                    || tunnel::get_tunnel_config(&config).is_some()
+                    || tunnel::has_cf_creds(&config));
+            let tunnel_url = tunnel_intended
+                .then(|| {
+                    tunnel::get_tunnel_config(&config)
+                        .map(|tc| format!("https://{}", tc.hostname))
+                })
+                .flatten();
             let tunnel_status = if no_tunnel {
                 TunnelStatus::Disabled
+            } else if tunnel_intended {
+                TunnelStatus::Connecting(tunnel_url.clone())
             } else {
-                setup_and_verify_tunnel(&config, port).await
+                TunnelStatus::Failed(
+                    "no tunnel configured: run `vestad connect` to connect a domain".to_string(),
+                )
             };
-            let tunnel_url = tunnel_status.url().map(str::to_string);
 
             docker::update_all_agent_env_files(&config.join("agents"), port, tunnel_url.as_deref());
             // Only advertise a LAN address when the API is actually bound to the
@@ -615,15 +480,6 @@ fn run_server_foreground(port: Option<u16>, no_tunnel: bool, expose_lan: bool) {
             );
             status.persist(&config);
             status.print_banner(&api_key);
-
-            // Supervise whenever a tunnel is INTENDED, not only when boot-time
-            // setup succeeded: a managed box whose tunnel.json the control plane
-            // is still seeding, or a transient ensure_tunnel failure, must not
-            // leave the daemon tunnel-less until a manual restart. The supervisor
-            // re-reads tunnel.json on every respawn, so late config is picked up.
-            let tunnel_intended = tunnel_url.is_some()
-                || (!no_tunnel
-                    && (is_cloud_managed() || tunnel::get_tunnel_config(&config).is_some()));
 
             // Keep status.json honest: on a SUSTAINED tunnel outage the supervisor
             // flips the tunnel field to an error and back to enabled on recovery.
@@ -1126,66 +982,6 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn forget_failed_tunnel_only_when_the_box_can_recreate_it() {
-        // Transient boot failure on a creds-less box: keep the config so the
-        // supervisor can self-heal. Forgetting would permanently orphan it.
-        assert!(!should_forget_failed_tunnel(true, false, false));
-        // Failed WITH own creds: the recreate path already tried and failed, so
-        // dropping the dead config is safe — a fresh boot / connect rebuilds it.
-        assert!(should_forget_failed_tunnel(true, false, true));
-        // Managed boxes never forget — the control plane owns tunnel.json.
-        assert!(!should_forget_failed_tunnel(true, true, true));
-        // A tunnel that came up is never forgotten.
-        assert!(!should_forget_failed_tunnel(false, false, true));
-    }
-
-    #[tokio::test]
-    async fn retry_tunnel_succeeds_without_retrying_when_first_attempt_works() {
-        let calls = std::cell::Cell::new(0u32);
-        let status = retry_tunnel(3, std::time::Duration::ZERO, |_| {
-            calls.set(calls.get() + 1);
-            async { Ok::<String, String>("https://host".to_string()) }
-        })
-        .await;
-        assert!(matches!(status, TunnelStatus::Active(url) if url == "https://host"));
-        assert_eq!(calls.get(), 1, "should not retry once an attempt succeeds");
-    }
-
-    #[tokio::test]
-    async fn retry_tunnel_retries_until_an_attempt_succeeds() {
-        let calls = std::cell::Cell::new(0u32);
-        let status = retry_tunnel(3, std::time::Duration::ZERO, |attempt| {
-            calls.set(calls.get() + 1);
-            async move {
-                if attempt < 3 {
-                    Err(format!("not up yet (attempt {attempt})"))
-                } else {
-                    Ok("https://up".to_string())
-                }
-            }
-        })
-        .await;
-        assert!(matches!(status, TunnelStatus::Active(url) if url == "https://up"));
-        assert_eq!(calls.get(), 3);
-    }
-
-    #[tokio::test]
-    async fn retry_tunnel_gives_up_with_the_last_error_after_all_attempts() {
-        let calls = std::cell::Cell::new(0u32);
-        let status = retry_tunnel(3, std::time::Duration::ZERO, |attempt| {
-            calls.set(calls.get() + 1);
-            async move { Err::<String, String>(format!("boom {attempt}")) }
-        })
-        .await;
-        assert!(matches!(status, TunnelStatus::Failed(reason) if reason == "boom 3"));
-        assert_eq!(
-            calls.get(),
-            3,
-            "should try exactly `attempts` times before giving up"
-        );
-    }
 
     #[test]
     fn local_health_url_targets_http_port_plus_one() {

--- a/vestad/src/status.rs
+++ b/vestad/src/status.rs
@@ -274,7 +274,9 @@ fn agent_rows(agents: &[AgentEntry]) -> Vec<BoxRow> {
 #[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub enum TunnelStatus {
     Disabled,       // --no-tunnel
-    Active(String), // reachable https URL
+    Active(String), // reachable https URL, verified by the supervisor's edge probe
+    // supervisor still converging; identity URL from tunnel.json when one exists
+    Connecting(Option<String>),
     Failed(String), // wanted, but couldn't be established — concise reason
 }
 
@@ -282,6 +284,18 @@ impl TunnelStatus {
     pub fn url(&self) -> Option<&str> {
         match self {
             TunnelStatus::Active(url) => Some(url),
+            _ => None,
+        }
+    }
+
+    /// The URL worth advertising to a human: a verified Active URL, or the
+    /// identity URL of a tunnel the supervisor is still connecting (live within
+    /// seconds on a healthy network, so the banner shows it rather than hiding
+    /// the address).
+    pub fn advertised_url(&self) -> Option<&str> {
+        match self {
+            TunnelStatus::Active(url) => Some(url),
+            TunnelStatus::Connecting(Some(url)) => Some(url),
             _ => None,
         }
     }
@@ -400,12 +414,14 @@ impl Status {
     /// in rather than persisted, so the secret never lands in `status.json`.
     pub fn print_banner(&self, api_key: &str) {
         let local_url = format!("http://localhost:{}", self.port + 1);
-        let tunnel_url = self.tunnel.url();
+        let tunnel_url = self.tunnel.advertised_url();
 
-        // enabled = tunnel up; disabled = --no-tunnel; error: <reason> = a tunnel
-        // was wanted but couldn't be established (no creds, dead tunnel, API error).
+        // enabled = tunnel verified up; connecting… = supervisor converging;
+        // disabled = --no-tunnel; error: <reason> = a tunnel was wanted but
+        // couldn't be established (no creds, dead tunnel, API error).
         let tunnel_desc = match &self.tunnel {
             TunnelStatus::Active(_) => "enabled".to_string(),
+            TunnelStatus::Connecting(_) => "connecting…".to_string(),
             TunnelStatus::Disabled => "disabled".to_string(),
             TunnelStatus::Failed(reason) => format!("error: {}", first_line_truncated(reason, 100)),
         };
@@ -590,6 +606,8 @@ mod tests {
         for tunnel in [
             TunnelStatus::Disabled,
             TunnelStatus::Active("https://host.example/".into()),
+            TunnelStatus::Connecting(Some("https://host.example/".into())),
+            TunnelStatus::Connecting(None),
             TunnelStatus::Failed("invalid token".into()),
         ] {
             let status = Status::new(
@@ -635,6 +653,25 @@ mod tests {
         let json = serde_json::to_string(&status).expect("serialize");
         let back: Status = serde_json::from_str(&json).expect("deserialize");
         assert!(back.agents == agents);
+    }
+
+    #[test]
+    fn advertised_url_covers_active_and_connecting_with_url() {
+        let url = "https://fox.example";
+        assert_eq!(
+            TunnelStatus::Active(url.into()).advertised_url(),
+            Some(url)
+        );
+        assert_eq!(
+            TunnelStatus::Connecting(Some(url.into())).advertised_url(),
+            Some(url)
+        );
+        assert_eq!(TunnelStatus::Connecting(None).advertised_url(), None);
+        assert_eq!(TunnelStatus::Disabled.advertised_url(), None);
+        assert_eq!(
+            TunnelStatus::Failed("x".into()).advertised_url(),
+            None
+        );
     }
 
     #[test]

--- a/vestad/src/status.rs
+++ b/vestad/src/status.rs
@@ -281,13 +281,6 @@ pub enum TunnelStatus {
 }
 
 impl TunnelStatus {
-    pub fn url(&self) -> Option<&str> {
-        match self {
-            TunnelStatus::Active(url) => Some(url),
-            _ => None,
-        }
-    }
-
     /// The URL worth advertising to a human: a verified Active URL, or the
     /// identity URL of a tunnel the supervisor is still connecting (live within
     /// seconds on a healthy network, so the banner shows it rather than hiding

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -55,6 +55,13 @@ pub fn has_declined_tunnel(config_dir: &Path) -> bool {
     no_tunnel_marker_path(config_dir).exists()
 }
 
+/// Persist "the user does not want a tunnel" (written by `vestad tunnel
+/// destroy` and the skipped first-run prompt) so neither boot nor the
+/// supervisor recreates one until `vestad connect` clears it.
+pub fn decline_tunnel(config_dir: &Path) -> Result<(), String> {
+    write_secret_file(&no_tunnel_marker_path(config_dir), "", "no-tunnel preference")
+}
+
 /// Write `contents` to `path` 0600, creating the parent dir. Single owner of the
 /// "persist a secret config file" pattern; `what` names the file in write errors.
 fn write_secret_file(path: &Path, contents: &str, what: &str) -> Result<(), String> {
@@ -201,6 +208,7 @@ pub fn setup_cf_creds_interactive(config_dir: &Path) -> Result<(), String> {
             zone_id,
         },
     )?;
+    std::fs::remove_file(no_tunnel_marker_path(config_dir)).ok();
     eprintln!("  \x1b[32m✓\x1b[0m connected to {}", domain);
     eprintln!();
     Ok(())
@@ -516,10 +524,9 @@ pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
             return Ok(tc);
         }
         tracing::info!(old = %current, new = %preferred, "tunnel subdomain changed, recreating");
-        if let Err(e) = destroy_tunnel(config_dir) {
-            tracing::warn!("failed to destroy old tunnel: {e}");
-            std::fs::remove_file(tunnel_config_path(config_dir)).ok();
-        }
+        destroy_tunnel(config_dir).map_err(|e| {
+            format!("could not destroy the old tunnel to recreate it (keeping the saved config): {e}")
+        })?;
     }
 
     // setup_tunnel calls delete_tunnel_if_exists, so stale tunnels with our
@@ -531,18 +538,18 @@ pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
 
 /// Supervisor establish: converge tunnel.json without ever rewriting an
 /// existing config. An existing config is authoritative here, whatever its
-/// subdomain (reconciling a changed subdomain belongs to `vestad connect`);
-/// a missing one is created from BYOK creds, and a managed box keeps
-/// erroring until the control plane seeds it.
+/// subdomain (reconciling a changed subdomain belongs to `vestad connect`
+/// and the boot converge); a tunnel the user declined or destroyed stays
+/// down; everything else (managed seed wait, BYOK creation) delegates to
+/// ensure_tunnel.
 fn establish_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
-    if crate::is_cloud_managed() {
-        return get_tunnel_config(config_dir)
-            .ok_or_else(|| "managed mode: no tunnel.json seeded by the control plane".to_string());
-    }
     if let Some(saved) = get_tunnel_config(config_dir) {
         return Ok(saved);
     }
-    setup_tunnel(config_dir, &preferred_subdomain())
+    if has_declined_tunnel(config_dir) {
+        return Err("tunnel declined by the user: run `vestad connect` to enable one".to_string());
+    }
+    ensure_tunnel(config_dir)
 }
 
 pub fn setup_tunnel(config_dir: &Path, subdomain: &str) -> Result<TunnelConfig, String> {
@@ -806,11 +813,12 @@ fn alloc_loopback_port() -> Result<u16, String> {
 // live session through it. /ready measures exactly the thing a restart fixes.
 // The supervisor owns the whole lifecycle: it converges tunnel.json before each
 // run (establish_tunnel: an existing config is used as-is, one is created from
-// BYOK creds when missing, or it waits for the managed seed), and
-// after a run that never registered it recreates the tunnel from scratch on a
-// BYOK box (repair_tunnel), so config-level death (tunnel deleted server-side,
-// token revoked) self-heals when the box holds creds. A creds-less box keeps
-// retrying with the reason in `vestad logs`; recovery there is `vestad connect`.
+// BYOK creds when missing, or it waits for the managed seed), and once an
+// outage is sustained enough to be reported down it recreates the tunnel from
+// scratch on a BYOK box (repair_tunnel), so config-level death (tunnel
+// deleted server-side, token revoked) self-heals when the box holds creds. A
+// creds-less box keeps retrying with the reason in `vestad logs`; recovery
+// there is `vestad connect`.
 // Nothing here ever deletes tunnel.json: only explicit user action does.
 
 /// Respawn backoff. A respawn whose run reconnects to the edge (a transient blip
@@ -832,6 +840,11 @@ const READY_PROBE_MAX_FAILURES: u32 = 3;
 /// down to status.json. Longer than a normal restart-recovery cycle, so transient
 /// blips the supervisor heals on its own keep the status showing "enabled".
 const TUNNEL_DOWN_SUSTAINED_SECS: u64 = 120;
+/// How long shutdown waits for the supervisor task before aborting it. The
+/// task can be inside a blocking Cloudflare API sequence (establish or
+/// repair); aborting is safe, cloudflared children are kill_on_drop and the
+/// curl at worst runs out its own --max-time detached.
+const TUNNEL_SHUTDOWN_MAX_WAIT_SECS: u64 = 10;
 
 pub struct TunnelSupervisor {
     shutdown: tokio::sync::watch::Sender<bool>,
@@ -839,10 +852,20 @@ pub struct TunnelSupervisor {
 }
 
 impl TunnelSupervisor {
-    /// Kill the current cloudflared and stop supervising (graceful shutdown).
+    /// Kill the current cloudflared and stop supervising (graceful shutdown,
+    /// bounded by TUNNEL_SHUTDOWN_MAX_WAIT_SECS).
     pub async fn shutdown(self) {
         self.shutdown.send(true).ok();
-        self.task.await.ok();
+        let mut task = self.task;
+        if tokio::time::timeout(
+            std::time::Duration::from_secs(TUNNEL_SHUTDOWN_MAX_WAIT_SECS),
+            &mut task,
+        )
+        .await
+        .is_err()
+        {
+            task.abort();
+        }
     }
 }
 
@@ -928,11 +951,6 @@ pub fn supervise_tunnel(
                         if registered {
                             repaired_since_registered = false;
                         }
-                        if should_attempt_repair(registered, has_cf_creds(&config_dir), repaired_since_registered)
-                            && repair_tunnel(&config_dir).await
-                        {
-                            repaired_since_registered = true;
-                        }
                     }
                     Err(e) => {
                         // start_tunnel never reached the edge, so this counts as a run
@@ -951,6 +969,14 @@ pub fn supervise_tunnel(
             if let Some(report) = edge_report(reported, false, sustained_down) {
                 on_tunnel_up(report);
                 reported = Some(report);
+            }
+            if should_attempt_repair(reported, has_cf_creds(&config_dir), repaired_since_registered)
+                && repair_tunnel(&config_dir).await
+            {
+                repaired_since_registered = true;
+                // A fresh tunnel deserves a prompt first run, not the grown
+                // failure backoff.
+                respawn_delay_secs = TUNNEL_RESPAWN_BASE_DELAY_SECS;
             }
             tokio::select! {
                 _ = shutdown_rx.changed() => return,
@@ -1067,13 +1093,13 @@ fn edge_report(reported: Option<bool>, ok: bool, sustained_down: bool) -> Option
     None
 }
 
-/// Whether a finished run warrants recreating the tunnel from scratch: only
-/// when it never registered an edge connection (a run that registered failed
-/// transiently and a plain respawn recovers it), the box holds its own
-/// Cloudflare creds to rebuild with, and no recreate has already succeeded in
-/// this down-period (a run that registers clears the latch).
-fn should_attempt_repair(registered: bool, has_creds: bool, repaired_since_registered: bool) -> bool {
-    !registered && has_creds && !repaired_since_registered
+/// Whether to recreate the tunnel from scratch: only once the outage is
+/// sustained enough to have been reported down (a pre-report failure is
+/// routinely transient: a boot-time resolver race, a brief edge blip), only
+/// with our own Cloudflare creds to rebuild with, and only once per
+/// down-period (a run that registers clears the latch).
+fn should_attempt_repair(reported: Option<bool>, has_creds: bool, repaired_since_registered: bool) -> bool {
+    reported == Some(false) && has_creds && !repaired_since_registered
 }
 
 /// Recreate the saved tunnel from scratch (same subdomain, fresh tunnel + token +
@@ -1191,21 +1217,20 @@ mod tests {
     }
 
     #[test]
-    fn repair_runs_only_for_unregistered_runs_on_byok_boxes() {
-        // A run that never registered, on a box holding its own creds, no prior
-        // repair this down-period: repair.
-        assert!(should_attempt_repair(false, true, false));
-        // A run that registered failed transiently; the tunnel itself is fine.
-        assert!(!should_attempt_repair(true, true, false));
-        // No creds (managed / legacy): nothing to rebuild with.
-        assert!(!should_attempt_repair(false, false, false));
-        assert!(!should_attempt_repair(true, false, false));
+    fn repair_waits_for_a_reported_sustained_outage_and_runs_once() {
+        // Reported down, holding our own creds, no prior repair this
+        // down-period: repair.
+        assert!(should_attempt_repair(Some(false), true, false));
         // A repair already succeeded this down-period: don't recreate again
         // every cycle while the outage continues.
-        assert!(!should_attempt_repair(false, true, true));
-        assert!(!should_attempt_repair(true, true, true));
-        assert!(!should_attempt_repair(false, false, true));
-        assert!(!should_attempt_repair(true, false, true));
+        assert!(!should_attempt_repair(Some(false), true, true));
+        // No creds (managed / legacy): nothing to rebuild with.
+        assert!(!should_attempt_repair(Some(false), false, false));
+        // Reported up: the tunnel is fine, nothing to repair.
+        assert!(!should_attempt_repair(Some(true), true, false));
+        // Not yet reported down (a pre-report failure is routinely
+        // transient): wait for the sustained-outage report before repairing.
+        assert!(!should_attempt_repair(None, true, false));
     }
 
     #[test]
@@ -1267,6 +1292,52 @@ mod tests {
         assert!(path.exists(), "tunnel.json must still exist");
         assert_eq!(
             std::fs::read_to_string(&path).expect("read back after establish"),
+            original_contents,
+            "tunnel.json content must be unchanged"
+        );
+    }
+
+    #[test]
+    fn establish_tunnel_errors_when_the_user_declined_and_nothing_is_saved() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(no_tunnel_marker_path(dir.path()), "").expect("write no_tunnel marker");
+
+        let err = match establish_tunnel(dir.path()) {
+            Err(e) => e,
+            Ok(_) => panic!("a declined tunnel must not be established"),
+        };
+
+        assert!(err.contains("declined"), "error should mention the decline: {err}");
+    }
+
+    #[test]
+    fn ensure_tunnel_keeps_the_saved_config_when_reconcile_fails_without_creds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A saved config whose subdomain does NOT match preferred_subdomain(),
+        // and no cloudflare.json / CLOUDFLARE_* env: the reconcile attempt
+        // fails at cf_env before any curl, so it must never touch the saved
+        // tunnel.json.
+        let preferred = preferred_subdomain();
+        let stale = TunnelConfig {
+            tunnel_id: "stale-tunnel-id".to_string(),
+            tunnel_token: "stale-token".to_string(),
+            hostname: format!("{preferred}-stale.example.com"),
+            dns_record_id: Some("stale-record-id".to_string()),
+        };
+        let path = tunnel_config_path(dir.path());
+        std::fs::write(&path, serde_json::to_string_pretty(&stale).unwrap())
+            .expect("write tunnel.json");
+        let original_contents = std::fs::read_to_string(&path).expect("read back");
+
+        let result = ensure_tunnel(dir.path());
+
+        assert!(
+            result.is_err(),
+            "no cloudflare.json and no CLOUDFLARE_* env: reconcile cannot succeed"
+        );
+        assert!(path.exists(), "tunnel.json must still exist after a failed reconcile");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read back after ensure_tunnel"),
             original_contents,
             "tunnel.json content must be unchanged"
         );

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -314,14 +314,6 @@ pub fn get_tunnel_config(config_dir: &Path) -> Option<TunnelConfig> {
     serde_json::from_str(&data).ok()
 }
 
-/// Drop the saved tunnel config WITHOUT touching Cloudflare. Used when the box
-/// can't manage the remote tunnel (no creds — e.g. an orphaned `*.vesta.run`
-/// tunnel left behind on a now-self-hosted box) so future boots stop retrying a
-/// tunnel that can never register.
-pub fn forget_tunnel(config_dir: &Path) {
-    std::fs::remove_file(tunnel_config_path(config_dir)).ok();
-}
-
 const ANIMALS: &[&str] = &[
     "alpaca",
     "badger",
@@ -775,64 +767,6 @@ fn alloc_loopback_port() -> Result<u16, String> {
         .local_addr()
         .map_err(|e| format!("failed to read metrics port: {}", e))?;
     Ok(addr.port())
-}
-
-/// How long boot-time pre-flight waits for cloudflared to register an edge
-/// connection before declaring the saved tunnel dead. Generous enough to absorb
-/// a slow first connect, short enough not to stall startup.
-const PREFLIGHT_READY_TIMEOUT_SECS: u64 = 20;
-const PREFLIGHT_POLL_INTERVAL_MS: u64 = 500;
-
-/// Credential-free boot check that the saved tunnel can actually register.
-///
-/// Spawns one short-lived cloudflared and polls its /ready endpoint until it
-/// reports a registered edge connection, then kills it (the supervisor owns the
-/// long-lived child). Returns `false` if cloudflared exits early — e.g.
-/// "Unauthorized: Tunnel not found" when the tunnel was deleted server-side or
-/// its token revoked — or never registers within PREFLIGHT_READY_TIMEOUT_SECS.
-/// This relies only on cloudflared's local /ready, so it works on a box that
-/// holds no Cloudflare credentials and can't query the API.
-pub async fn preflight_tunnel(config_dir: &Path, port: u16) -> bool {
-    let (mut child, metrics_port) = match start_tunnel(config_dir, port).await {
-        Ok(pair) => pair,
-        Err(e) => {
-            tracing::warn!("tunnel pre-flight could not start cloudflared: {e}");
-            return false;
-        }
-    };
-    let probe_client = match reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(READY_PROBE_TIMEOUT_SECS))
-        .build()
-    {
-        Ok(client) => client,
-        Err(e) => {
-            tracing::warn!("tunnel pre-flight probe client unavailable: {e}");
-            child.kill().await.ok();
-            return false;
-        }
-    };
-    let probe_url = format!("http://127.0.0.1:{metrics_port}/ready");
-    let deadline =
-        tokio::time::Instant::now() + std::time::Duration::from_secs(PREFLIGHT_READY_TIMEOUT_SECS);
-    let ready = loop {
-        // cloudflared gave up on its own (dead tunnel / revoked token).
-        if matches!(child.try_wait(), Ok(Some(_))) {
-            break false;
-        }
-        let registered = match probe_client.get(&probe_url).send().await {
-            Ok(resp) => resp.status().is_success(),
-            Err(_) => false,
-        };
-        if registered {
-            break true;
-        }
-        if tokio::time::Instant::now() >= deadline {
-            break false;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(PREFLIGHT_POLL_INTERVAL_MS)).await;
-    };
-    child.kill().await.ok();
-    ready
 }
 
 // --- Tunnel supervision ---

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -5,6 +5,12 @@ const CLOUDFLARED_DOWNLOAD_BASE: &str =
     "https://github.com/cloudflare/cloudflared/releases/latest/download";
 const CF_API_BASE: &str = "https://api.cloudflare.com/client/v4";
 
+/// Bound every Cloudflare API curl so a stalled connection can never wedge the
+/// caller: the tunnel supervisor runs these calls in its loop and vestad's
+/// shutdown awaits that loop.
+const CF_API_CONNECT_TIMEOUT_SECS: u64 = 10;
+const CF_API_MAX_TIME_SECS: u64 = 60;
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct TunnelConfig {
     pub tunnel_id: String,
@@ -208,6 +214,10 @@ fn cf_request(
 ) -> Result<serde_json::Value, String> {
     let mut cmd = std::process::Command::new("curl");
     cmd.args(["-sS", "-X", method, url])
+        .arg("--connect-timeout")
+        .arg(CF_API_CONNECT_TIMEOUT_SECS.to_string())
+        .arg("--max-time")
+        .arg(CF_API_MAX_TIME_SECS.to_string())
         .arg("-H")
         .arg(format!("Authorization: Bearer {}", api_token))
         .arg("-H")

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -839,11 +839,13 @@ pub async fn preflight_tunnel(config_dir: &Path, port: u16) -> bool {
 // Cloudflare edge would conflate probe-path failures (host DNS/egress, an edge
 // incident) with a wedged connector and kill a healthy tunnel — dropping every
 // live session through it. /ready measures exactly the thing a restart fixes.
-// Config-level death (tunnel deleted server-side, token revoked) is not fixed by
-// a restart: cloudflared keeps exiting with the reason, so the respawn backoff
-// stretches toward its cap and the failure lands in `vestad logs` via the stderr
-// forwarder; recovery is `vestad connect`. It still self-heals for free if the
-// cause turns out to be transient (a slow resolver at boot).
+// The supervisor owns the whole lifecycle: it converges tunnel.json before each
+// run (ensure_tunnel: create from BYOK creds, or wait for the managed seed), and
+// after a run that never registered it recreates the tunnel from scratch on a
+// BYOK box (repair_tunnel), so config-level death (tunnel deleted server-side,
+// token revoked) self-heals when the box holds creds. A creds-less box keeps
+// retrying with the reason in `vestad logs`; recovery there is `vestad connect`.
+// Nothing here ever deletes tunnel.json: only explicit user action does.
 
 /// Respawn backoff. A respawn whose run reconnects to the edge (a transient blip
 /// on a working tunnel) resets to BASE for prompt recovery; a run that never
@@ -916,35 +918,53 @@ pub fn supervise_tunnel(
         let mut last_registered = tokio::time::Instant::now();
         let mut respawn_delay_secs = TUNNEL_RESPAWN_BASE_DELAY_SECS;
         loop {
-            match start_tunnel(&config_dir, port).await {
-                Ok((mut child, metrics_port)) => {
-                    let (reason, registered) = tokio::select! {
-                        _ = shutdown_rx.changed() => {
-                            child.kill().await.ok();
-                            return;
-                        }
-                        outcome = run_until_unhealthy(
-                            &mut child,
-                            probe_client.as_ref(),
-                            metrics_port,
-                            on_tunnel_up.as_ref(),
-                            &mut reported,
-                            &mut last_registered,
-                        ) => outcome,
-                    };
-                    child.kill().await.ok();
-                    respawn_delay_secs = next_respawn_delay_secs(respawn_delay_secs, registered);
-                    tracing::warn!(
-                        delay_secs = respawn_delay_secs,
-                        "tunnel unhealthy ({reason}), restarting cloudflared"
-                    );
-                }
+            // Establish before each run: converge tunnel.json. Idempotent when
+            // the saved config already matches; created from BYOK creds when
+            // missing; a managed box keeps erroring here until the control
+            // plane seeds it. The Cloudflare API call goes through blocking
+            // curl, so it runs off the async runtime.
+            let ensure_dir = config_dir.clone();
+            let established = tokio::task::spawn_blocking(move || ensure_tunnel(&ensure_dir))
+                .await
+                .unwrap_or_else(|join_err| Err(format!("ensure_tunnel task failed: {join_err}")));
+            match established {
                 Err(e) => {
-                    // start_tunnel never reached the edge, so this counts as a run
-                    // that did not register — back off.
                     respawn_delay_secs = next_respawn_delay_secs(respawn_delay_secs, false);
-                    tracing::warn!(delay_secs = respawn_delay_secs, "tunnel start failed: {e}");
+                    tracing::warn!(delay_secs = respawn_delay_secs, "tunnel not establishable: {e}");
                 }
+                Ok(_) => match start_tunnel(&config_dir, port).await {
+                    Ok((mut child, metrics_port)) => {
+                        let (reason, registered) = tokio::select! {
+                            _ = shutdown_rx.changed() => {
+                                child.kill().await.ok();
+                                return;
+                            }
+                            outcome = run_until_unhealthy(
+                                &mut child,
+                                probe_client.as_ref(),
+                                metrics_port,
+                                on_tunnel_up.as_ref(),
+                                &mut reported,
+                                &mut last_registered,
+                            ) => outcome,
+                        };
+                        child.kill().await.ok();
+                        respawn_delay_secs = next_respawn_delay_secs(respawn_delay_secs, registered);
+                        tracing::warn!(
+                            delay_secs = respawn_delay_secs,
+                            "tunnel unhealthy ({reason}), restarting cloudflared"
+                        );
+                        if should_attempt_repair(registered, has_cf_creds(&config_dir)) {
+                            repair_tunnel(&config_dir).await;
+                        }
+                    }
+                    Err(e) => {
+                        // start_tunnel never reached the edge, so this counts as a run
+                        // that did not register — back off.
+                        respawn_delay_secs = next_respawn_delay_secs(respawn_delay_secs, false);
+                        tracing::warn!(delay_secs = respawn_delay_secs, "tunnel start failed: {e}");
+                    }
+                },
             }
             tokio::select! {
                 _ = shutdown_rx.changed() => return,
@@ -1061,6 +1081,33 @@ fn edge_report(reported: Option<bool>, ok: bool, sustained_down: bool) -> Option
     None
 }
 
+/// Whether a finished run warrants recreating the tunnel from scratch: only when
+/// it never registered an edge connection (a run that registered failed
+/// transiently and a plain respawn recovers it) and the box holds its own
+/// Cloudflare creds to rebuild with.
+fn should_attempt_repair(registered: bool, has_creds: bool) -> bool {
+    !registered && has_creds
+}
+
+/// Recreate the saved tunnel from scratch (same subdomain, fresh tunnel + token +
+/// DNS record) after a run that never registered. During a network outage the
+/// API call fails fast and changes nothing; with a live network and a revoked or
+/// deleted tunnel this restores it. Never deletes the saved config on failure.
+async fn repair_tunnel(config_dir: &Path) {
+    let Some(saved) = get_tunnel_config(config_dir) else {
+        return; // nothing saved yet; the establish step owns creation
+    };
+    let subdomain = saved.hostname.split('.').next().unwrap_or("").to_string();
+    let repair_dir = config_dir.to_path_buf();
+    match tokio::task::spawn_blocking(move || setup_tunnel(&repair_dir, &subdomain)).await {
+        Ok(Ok(fresh)) => {
+            tracing::info!(hostname = %fresh.hostname, "tunnel recreated after a run that never registered")
+        }
+        Ok(Err(e)) => tracing::warn!("tunnel repair failed: {e}"),
+        Err(join_err) => tracing::warn!("tunnel repair task failed: {join_err}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1145,6 +1192,17 @@ mod tests {
         assert_eq!(edge_report(None, false, true), Some(false));
         // Boot, not yet sustained: silent.
         assert_eq!(edge_report(None, false, false), None);
+    }
+
+    #[test]
+    fn repair_runs_only_for_unregistered_runs_on_byok_boxes() {
+        // A run that never registered, on a box holding its own creds: repair.
+        assert!(should_attempt_repair(false, true));
+        // A run that registered failed transiently; the tunnel itself is fine.
+        assert!(!should_attempt_repair(true, true));
+        // No creds (managed / legacy): nothing to rebuild with.
+        assert!(!should_attempt_repair(false, false));
+        assert!(!should_attempt_repair(true, false));
     }
 
     #[test]

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -483,6 +483,15 @@ pub fn connect_interactive(config_dir: &Path) -> Result<TunnelConfig, String> {
     ensure_tunnel(config_dir)
 }
 
+/// The subdomain this box wants: VESTA_SUBDOMAIN when set, else <animal>-<hostname>.
+fn preferred_subdomain() -> String {
+    std::env::var("VESTA_SUBDOMAIN")
+        .ok()
+        .map(|s| sanitize(&s))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| generate_subdomain(0))
+}
+
 pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
     // Managed (vesta.run) VMs: the control plane creates the tunnel + DNS and
     // SEEDS tunnel.json into the config dir. vestad holds no Cloudflare account
@@ -498,11 +507,7 @@ pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
     // Self-hosted deployments pin an exact subdomain via VESTA_SUBDOMAIN only when
     // set; otherwise keep the generated <animal>-<hostname>. Creation uses the
     // BYOK creds in cloudflare.json (see cf_env / setup_cf_creds_interactive).
-    let preferred = std::env::var("VESTA_SUBDOMAIN")
-        .ok()
-        .map(|s| sanitize(&s))
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| generate_subdomain(0));
+    let preferred = preferred_subdomain();
 
     // Reuse existing tunnel if it matches our preferred subdomain
     if let Some(tc) = get_tunnel_config(config_dir) {
@@ -522,6 +527,22 @@ pub fn ensure_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
     // different animal.
     tracing::info!(subdomain = %preferred, "creating tunnel");
     setup_tunnel(config_dir, &preferred)
+}
+
+/// Supervisor establish: converge tunnel.json without ever rewriting an
+/// existing config. An existing config is authoritative here, whatever its
+/// subdomain (reconciling a changed subdomain belongs to `vestad connect`);
+/// a missing one is created from BYOK creds, and a managed box keeps
+/// erroring until the control plane seeds it.
+fn establish_tunnel(config_dir: &Path) -> Result<TunnelConfig, String> {
+    if crate::is_cloud_managed() {
+        return get_tunnel_config(config_dir)
+            .ok_or_else(|| "managed mode: no tunnel.json seeded by the control plane".to_string());
+    }
+    if let Some(saved) = get_tunnel_config(config_dir) {
+        return Ok(saved);
+    }
+    setup_tunnel(config_dir, &preferred_subdomain())
 }
 
 pub fn setup_tunnel(config_dir: &Path, subdomain: &str) -> Result<TunnelConfig, String> {
@@ -784,7 +805,8 @@ fn alloc_loopback_port() -> Result<u16, String> {
 // incident) with a wedged connector and kill a healthy tunnel — dropping every
 // live session through it. /ready measures exactly the thing a restart fixes.
 // The supervisor owns the whole lifecycle: it converges tunnel.json before each
-// run (ensure_tunnel: create from BYOK creds, or wait for the managed seed), and
+// run (establish_tunnel: an existing config is used as-is, one is created from
+// BYOK creds when missing, or it waits for the managed seed), and
 // after a run that never registered it recreates the tunnel from scratch on a
 // BYOK box (repair_tunnel), so config-level death (tunnel deleted server-side,
 // token revoked) self-heals when the box holds creds. A creds-less box keeps
@@ -861,16 +883,21 @@ pub fn supervise_tunnel(
         let mut reported: Option<bool> = None;
         let mut last_registered = tokio::time::Instant::now();
         let mut respawn_delay_secs = TUNNEL_RESPAWN_BASE_DELAY_SECS;
+        // Latches once a repair (tunnel recreated from scratch) succeeds, so a
+        // sustained API-reachable/edge-unreachable incident doesn't recreate the
+        // tunnel + DNS every cycle; a run that registers clears it.
+        let mut repaired_since_registered = false;
         loop {
-            // Establish before each run: converge tunnel.json. Idempotent when
-            // the saved config already matches; created from BYOK creds when
-            // missing; a managed box keeps erroring here until the control
-            // plane seeds it. The Cloudflare API call goes through blocking
-            // curl, so it runs off the async runtime.
+            // Establish before each run: an existing tunnel.json is used as-is
+            // (subdomain reconciliation is `vestad connect`'s job, never the
+            // supervisor's); a missing one is created from BYOK creds; a
+            // managed box keeps erroring here until the control plane seeds
+            // it. The Cloudflare API call goes through blocking curl, so it
+            // runs off the async runtime.
             let ensure_dir = config_dir.clone();
-            let established = tokio::task::spawn_blocking(move || ensure_tunnel(&ensure_dir))
+            let established = tokio::task::spawn_blocking(move || establish_tunnel(&ensure_dir))
                 .await
-                .unwrap_or_else(|join_err| Err(format!("ensure_tunnel task failed: {join_err}")));
+                .unwrap_or_else(|join_err| Err(format!("establish_tunnel task failed: {join_err}")));
             match established {
                 Err(e) => {
                     respawn_delay_secs = next_respawn_delay_secs(respawn_delay_secs, false);
@@ -898,8 +925,13 @@ pub fn supervise_tunnel(
                             delay_secs = respawn_delay_secs,
                             "tunnel unhealthy ({reason}), restarting cloudflared"
                         );
-                        if should_attempt_repair(registered, has_cf_creds(&config_dir)) {
-                            repair_tunnel(&config_dir).await;
+                        if registered {
+                            repaired_since_registered = false;
+                        }
+                        if should_attempt_repair(registered, has_cf_creds(&config_dir), repaired_since_registered)
+                            && repair_tunnel(&config_dir).await
+                        {
+                            repaired_since_registered = true;
                         }
                     }
                     Err(e) => {
@@ -909,6 +941,16 @@ pub fn supervise_tunnel(
                         tracing::warn!(delay_secs = respawn_delay_secs, "tunnel start failed: {e}");
                     }
                 },
+            }
+            // A cycle that ends without a registered edge (fast cloudflared
+            // exit, establish or start failure) never reaches a probe tick, so
+            // evaluate the sustained window here too. edge_report latches via
+            // `reported`, so this fires at most once per sustained outage.
+            let sustained_down = last_registered.elapsed()
+                >= std::time::Duration::from_secs(TUNNEL_DOWN_SUSTAINED_SECS);
+            if let Some(report) = edge_report(reported, false, sustained_down) {
+                on_tunnel_up(report);
+                reported = Some(report);
             }
             tokio::select! {
                 _ = shutdown_rx.changed() => return,
@@ -1025,30 +1067,40 @@ fn edge_report(reported: Option<bool>, ok: bool, sustained_down: bool) -> Option
     None
 }
 
-/// Whether a finished run warrants recreating the tunnel from scratch: only when
-/// it never registered an edge connection (a run that registered failed
-/// transiently and a plain respawn recovers it) and the box holds its own
-/// Cloudflare creds to rebuild with.
-fn should_attempt_repair(registered: bool, has_creds: bool) -> bool {
-    !registered && has_creds
+/// Whether a finished run warrants recreating the tunnel from scratch: only
+/// when it never registered an edge connection (a run that registered failed
+/// transiently and a plain respawn recovers it), the box holds its own
+/// Cloudflare creds to rebuild with, and no recreate has already succeeded in
+/// this down-period (a run that registers clears the latch).
+fn should_attempt_repair(registered: bool, has_creds: bool, repaired_since_registered: bool) -> bool {
+    !registered && has_creds && !repaired_since_registered
 }
 
 /// Recreate the saved tunnel from scratch (same subdomain, fresh tunnel + token +
 /// DNS record) after a run that never registered. During a network outage the
 /// API call fails fast and changes nothing; with a live network and a revoked or
 /// deleted tunnel this restores it. Never deletes the saved config on failure.
-async fn repair_tunnel(config_dir: &Path) {
+/// Returns true only on a successful recreate, so the caller can latch and stop
+/// repairing until a run registers again.
+async fn repair_tunnel(config_dir: &Path) -> bool {
     let Some(saved) = get_tunnel_config(config_dir) else {
-        return; // nothing saved yet; the establish step owns creation
+        return false; // nothing saved yet; the establish step owns creation
     };
     let subdomain = saved.hostname.split('.').next().unwrap_or("").to_string();
     let repair_dir = config_dir.to_path_buf();
     match tokio::task::spawn_blocking(move || setup_tunnel(&repair_dir, &subdomain)).await {
         Ok(Ok(fresh)) => {
-            tracing::info!(hostname = %fresh.hostname, "tunnel recreated after a run that never registered")
+            tracing::info!(hostname = %fresh.hostname, "tunnel recreated after a run that never registered");
+            true
         }
-        Ok(Err(e)) => tracing::warn!("tunnel repair failed: {e}"),
-        Err(join_err) => tracing::warn!("tunnel repair task failed: {join_err}"),
+        Ok(Err(e)) => {
+            tracing::warn!("tunnel repair failed: {e}");
+            false
+        }
+        Err(join_err) => {
+            tracing::warn!("tunnel repair task failed: {join_err}");
+            false
+        }
     }
 }
 
@@ -1140,13 +1192,20 @@ mod tests {
 
     #[test]
     fn repair_runs_only_for_unregistered_runs_on_byok_boxes() {
-        // A run that never registered, on a box holding its own creds: repair.
-        assert!(should_attempt_repair(false, true));
+        // A run that never registered, on a box holding its own creds, no prior
+        // repair this down-period: repair.
+        assert!(should_attempt_repair(false, true, false));
         // A run that registered failed transiently; the tunnel itself is fine.
-        assert!(!should_attempt_repair(true, true));
+        assert!(!should_attempt_repair(true, true, false));
         // No creds (managed / legacy): nothing to rebuild with.
-        assert!(!should_attempt_repair(false, false));
-        assert!(!should_attempt_repair(true, false));
+        assert!(!should_attempt_repair(false, false, false));
+        assert!(!should_attempt_repair(true, false, false));
+        // A repair already succeeded this down-period: don't recreate again
+        // every cycle while the outage continues.
+        assert!(!should_attempt_repair(false, true, true));
+        assert!(!should_attempt_repair(true, true, true));
+        assert!(!should_attempt_repair(false, false, true));
+        assert!(!should_attempt_repair(true, false, true));
     }
 
     #[test]
@@ -1182,5 +1241,34 @@ mod tests {
     fn alloc_loopback_port_returns_a_usable_port() {
         let port = alloc_loopback_port().expect("allocation succeeds");
         assert_ne!(port, 0);
+    }
+
+    #[test]
+    fn supervisor_establish_never_rewrites_an_existing_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A saved config whose subdomain does NOT match preferred_subdomain()
+        // (simulates legacy creds-less box / hostname drift): the supervisor
+        // must use it as-is, never destroy or recreate it.
+        let mismatched = TunnelConfig {
+            tunnel_id: "existing-tunnel-id".to_string(),
+            tunnel_token: "existing-token".to_string(),
+            hostname: "definitely-not-preferred.example.com".to_string(),
+            dns_record_id: Some("existing-record-id".to_string()),
+        };
+        let path = tunnel_config_path(dir.path());
+        std::fs::write(&path, serde_json::to_string_pretty(&mismatched).unwrap())
+            .expect("write tunnel.json");
+        let original_contents = std::fs::read_to_string(&path).expect("read back");
+
+        let result = establish_tunnel(dir.path()).expect("establish succeeds from saved config");
+
+        assert_eq!(result.hostname, mismatched.hostname);
+        assert_eq!(result.tunnel_id, mismatched.tunnel_id);
+        assert!(path.exists(), "tunnel.json must still exist");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read back after establish"),
+            original_contents,
+            "tunnel.json content must be unchanged"
+        );
     }
 }

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -19,6 +19,13 @@ pub struct TunnelConfig {
     pub dns_record_id: Option<String>,
 }
 
+impl TunnelConfig {
+    /// The public https URL this tunnel serves.
+    pub fn url(&self) -> String {
+        format!("https://{}", self.hostname)
+    }
+}
+
 /// Self-hosted (BYOK) Cloudflare credentials, persisted to `cloudflare.json`.
 ///
 /// The public vestad binary ships **no** Cloudflare token — a self-hoster brings
@@ -60,6 +67,12 @@ pub fn has_declined_tunnel(config_dir: &Path) -> bool {
 /// supervisor recreates one until `vestad connect` clears it.
 pub fn decline_tunnel(config_dir: &Path) -> Result<(), String> {
     write_secret_file(&no_tunnel_marker_path(config_dir), "", "no-tunnel preference")
+}
+
+/// Clear the declined-tunnel preference: a successful `vestad connect` means
+/// the user wants a tunnel again.
+fn clear_declined_tunnel(config_dir: &Path) {
+    std::fs::remove_file(no_tunnel_marker_path(config_dir)).ok();
 }
 
 /// Write `contents` to `path` 0600, creating the parent dir. Single owner of the
@@ -159,11 +172,7 @@ pub fn setup_cf_creds_interactive(config_dir: &Path) -> Result<(), String> {
     let domain =
         prompt("  your domain (press enter to skip, local network only): ")?.to_lowercase();
     if domain.is_empty() {
-        write_secret_file(
-            &no_tunnel_marker_path(config_dir),
-            "",
-            "no-tunnel preference",
-        )?;
+        decline_tunnel(config_dir)?;
         eprintln!();
         eprintln!(
             "  no public URL yet. your agent works on this machine and your LAN. \
@@ -208,7 +217,7 @@ pub fn setup_cf_creds_interactive(config_dir: &Path) -> Result<(), String> {
             zone_id,
         },
     )?;
-    std::fs::remove_file(no_tunnel_marker_path(config_dir)).ok();
+    clear_declined_tunnel(config_dir);
     eprintln!("  \x1b[32m✓\x1b[0m connected to {}", domain);
     eprintln!();
     Ok(())
@@ -918,58 +927,51 @@ pub fn supervise_tunnel(
             // it. The Cloudflare API call goes through blocking curl, so it
             // runs off the async runtime.
             let ensure_dir = config_dir.clone();
-            let established = tokio::task::spawn_blocking(move || establish_tunnel(&ensure_dir))
+            let attempt = match tokio::task::spawn_blocking(move || establish_tunnel(&ensure_dir))
                 .await
-                .unwrap_or_else(|join_err| Err(format!("establish_tunnel task failed: {join_err}")));
-            match established {
-                Err(e) => {
-                    respawn_delay_secs = next_respawn_delay_secs(respawn_delay_secs, false);
-                    tracing::warn!(delay_secs = respawn_delay_secs, "tunnel not establishable: {e}");
-                }
-                Ok(_) => match start_tunnel(&config_dir, port).await {
-                    Ok((mut child, metrics_port)) => {
-                        let (reason, registered) = tokio::select! {
-                            _ = shutdown_rx.changed() => {
-                                child.kill().await.ok();
-                                return;
-                            }
-                            outcome = run_until_unhealthy(
-                                &mut child,
-                                probe_client.as_ref(),
-                                metrics_port,
-                                on_tunnel_up.as_ref(),
-                                &mut reported,
-                                &mut last_registered,
-                            ) => outcome,
-                        };
-                        child.kill().await.ok();
-                        respawn_delay_secs = next_respawn_delay_secs(respawn_delay_secs, registered);
-                        tracing::warn!(
-                            delay_secs = respawn_delay_secs,
-                            "tunnel unhealthy ({reason}), restarting cloudflared"
-                        );
-                        if registered {
-                            repaired_since_registered = false;
+                .unwrap_or_else(|join_err| Err(format!("establish_tunnel task failed: {join_err}")))
+            {
+                Ok(_) => start_tunnel(&config_dir, port).await,
+                Err(e) => Err(e),
+            };
+            match attempt {
+                Ok((mut child, metrics_port)) => {
+                    let (reason, registered) = tokio::select! {
+                        _ = shutdown_rx.changed() => {
+                            child.kill().await.ok();
+                            return;
                         }
+                        outcome = run_until_unhealthy(
+                            &mut child,
+                            probe_client.as_ref(),
+                            metrics_port,
+                            on_tunnel_up.as_ref(),
+                            &mut reported,
+                            &mut last_registered,
+                        ) => outcome,
+                    };
+                    child.kill().await.ok();
+                    respawn_delay_secs = next_respawn_delay_secs(respawn_delay_secs, registered);
+                    tracing::warn!(
+                        delay_secs = respawn_delay_secs,
+                        "tunnel unhealthy ({reason}), restarting cloudflared"
+                    );
+                    if registered {
+                        repaired_since_registered = false;
                     }
-                    Err(e) => {
-                        // start_tunnel never reached the edge, so this counts as a run
-                        // that did not register — back off.
-                        respawn_delay_secs = next_respawn_delay_secs(respawn_delay_secs, false);
-                        tracing::warn!(delay_secs = respawn_delay_secs, "tunnel start failed: {e}");
-                    }
-                },
+                }
+                Err(e) => {
+                    // Establish or start never reached the edge, so this counts
+                    // as a run that did not register — back off.
+                    respawn_delay_secs = next_respawn_delay_secs(respawn_delay_secs, false);
+                    tracing::warn!(delay_secs = respawn_delay_secs, "tunnel not up: {e}");
+                }
             }
             // A cycle that ends without a registered edge (fast cloudflared
             // exit, establish or start failure) never reaches a probe tick, so
-            // evaluate the sustained window here too. edge_report latches via
-            // `reported`, so this fires at most once per sustained outage.
-            let sustained_down = last_registered.elapsed()
-                >= std::time::Duration::from_secs(TUNNEL_DOWN_SUSTAINED_SECS);
-            if let Some(report) = edge_report(reported, false, sustained_down) {
-                on_tunnel_up(report);
-                reported = Some(report);
-            }
+            // evaluate the sustained window here too; the report latches via
+            // `reported`, firing at most once per sustained outage.
+            report_sustained_edge(&mut reported, false, last_registered, on_tunnel_up.as_ref());
             if should_attempt_repair(reported, has_cf_creds(&config_dir), repaired_since_registered)
                 && repair_tunnel(&config_dir).await
             {
@@ -1040,12 +1042,7 @@ async fn run_until_unhealthy(
                 }
                 // Mirror health into status.json on sustained edges only: "up" the
                 // moment it registers, "down" only after a sustained outage.
-                let sustained_down = last_registered.elapsed()
-                    >= std::time::Duration::from_secs(TUNNEL_DOWN_SUSTAINED_SECS);
-                if let Some(report) = edge_report(*reported, ok, sustained_down) {
-                    on_tunnel_up(report);
-                    *reported = Some(report);
-                }
+                report_sustained_edge(reported, ok, *last_registered, on_tunnel_up);
                 let (failures, restart) = record_probe(consecutive_failures, ok);
                 consecutive_failures = failures;
                 if !ok {
@@ -1077,6 +1074,23 @@ fn record_probe(consecutive_failures: u32, ok: bool) -> (u32, bool) {
     }
     let failures = consecutive_failures + 1;
     (failures, failures >= READY_PROBE_MAX_FAILURES)
+}
+
+/// Evaluate one health observation against the sustained-down window and report
+/// a debounced edge transition at most once (see `edge_report`), latching what
+/// was reported into `reported`.
+fn report_sustained_edge(
+    reported: &mut Option<bool>,
+    ok: bool,
+    last_registered: tokio::time::Instant,
+    on_tunnel_up: &(dyn Fn(bool) + Send + Sync),
+) {
+    let sustained_down =
+        last_registered.elapsed() >= std::time::Duration::from_secs(TUNNEL_DOWN_SUSTAINED_SECS);
+    if let Some(report) = edge_report(*reported, ok, sustained_down) {
+        on_tunnel_up(report);
+        *reported = Some(report);
+    }
 }
 
 /// Pure edge accounting for status.json: which sustained transition (if any) to

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -883,11 +883,11 @@ impl TunnelSupervisor {
 /// `next_respawn_delay_secs`).
 ///
 /// `on_tunnel_up(bool)` is invoked on SUSTAINED edge changes (debounced) so the
-/// caller can mirror tunnel health into status.json: `true` as soon as the tunnel
-/// re-registers, `false` only after it has been unregistered for
-/// `TUNNEL_DOWN_SUSTAINED_SECS` (so transient blips the supervisor heals don't
-/// flip status). Kept as a plain `Fn(bool)` to keep this module free of caller
-/// types.
+/// caller can mirror tunnel health into status.json: `true` when the tunnel
+/// registers (including the first registration after boot), `false` only after
+/// it has been unregistered for `TUNNEL_DOWN_SUSTAINED_SECS` (so transient blips
+/// the supervisor heals don't flip status). Kept as a plain `Fn(bool)` to keep
+/// this module free of caller types.
 pub fn supervise_tunnel(
     config_dir: PathBuf,
     port: u16,
@@ -908,10 +908,11 @@ pub fn supervise_tunnel(
                 None
             }
         };
-        // Edge state for status.json, carried across cloudflared restarts. The
-        // supervisor only runs once the tunnel was verified up, so we start
-        // "reported up" with `now` as the last registered time.
-        let mut reported_up = true;
+        // Edge state for status.json, carried across cloudflared restarts.
+        // Nothing is reported at spawn (boot shows "connecting…"), so the first
+        // registered probe reports up, and a boot that never registers reports
+        // down once the outage is sustained.
+        let mut reported: Option<bool> = None;
         let mut last_registered = tokio::time::Instant::now();
         let mut respawn_delay_secs = TUNNEL_RESPAWN_BASE_DELAY_SECS;
         loop {
@@ -927,7 +928,7 @@ pub fn supervise_tunnel(
                             probe_client.as_ref(),
                             metrics_port,
                             on_tunnel_up.as_ref(),
-                            &mut reported_up,
+                            &mut reported,
                             &mut last_registered,
                         ) => outcome,
                     };
@@ -962,13 +963,13 @@ pub fn supervise_tunnel(
 /// /ready failing READY_PROBE_MAX_FAILURES times in a row; the `registered` flag
 /// drives the respawn backoff (a run that reconnected resets it, one that never
 /// did lets it grow). Drives the debounced `on_tunnel_up` edge callback via
-/// `reported_up`/`last_registered`, which persist across restarts.
+/// `reported`/`last_registered`, which persist across restarts.
 async fn run_until_unhealthy(
     child: &mut tokio::process::Child,
     probe_client: Option<&reqwest::Client>,
     metrics_port: u16,
     on_tunnel_up: &(dyn Fn(bool) + Send + Sync),
-    reported_up: &mut bool,
+    reported: &mut Option<bool>,
     last_registered: &mut tokio::time::Instant,
 ) -> (String, bool) {
     let probe_url = format!("http://127.0.0.1:{metrics_port}/ready");
@@ -1001,20 +1002,17 @@ async fn run_until_unhealthy(
                     Ok(resp) => resp.status().is_success(),
                     Err(_) => false,
                 };
-                // Mirror health into status.json on sustained edges only: "up" the
-                // moment it re-registers, "down" only after a sustained outage.
                 if ok {
                     registered = true;
                     *last_registered = tokio::time::Instant::now();
-                    if !*reported_up {
-                        on_tunnel_up(true);
-                        *reported_up = true;
-                    }
-                } else if *reported_up
-                    && last_registered.elapsed() >= std::time::Duration::from_secs(TUNNEL_DOWN_SUSTAINED_SECS)
-                {
-                    on_tunnel_up(false);
-                    *reported_up = false;
+                }
+                // Mirror health into status.json on sustained edges only: "up" the
+                // moment it registers, "down" only after a sustained outage.
+                let sustained_down = last_registered.elapsed()
+                    >= std::time::Duration::from_secs(TUNNEL_DOWN_SUSTAINED_SECS);
+                if let Some(report) = edge_report(*reported, ok, sustained_down) {
+                    on_tunnel_up(report);
+                    *reported = Some(report);
                 }
                 let (failures, restart) = record_probe(consecutive_failures, ok);
                 consecutive_failures = failures;
@@ -1047,6 +1045,20 @@ fn record_probe(consecutive_failures: u32, ok: bool) -> (u32, bool) {
     }
     let failures = consecutive_failures + 1;
     (failures, failures >= READY_PROBE_MAX_FAILURES)
+}
+
+/// Pure edge accounting for status.json: which sustained transition (if any) to
+/// report given what was last reported (`None` = nothing yet, at boot). Reports
+/// up on the first successful probe after boot or a reported outage; reports
+/// down once the edge has been unregistered for the sustained window.
+fn edge_report(reported: Option<bool>, ok: bool, sustained_down: bool) -> Option<bool> {
+    if ok && reported != Some(true) {
+        return Some(true);
+    }
+    if !ok && sustained_down && reported != Some(false) {
+        return Some(false);
+    }
+    None
 }
 
 #[cfg(test)]
@@ -1113,6 +1125,26 @@ mod tests {
         let (count, restart) = record_probe(failures, false);
         assert_eq!(count, READY_PROBE_MAX_FAILURES);
         assert!(restart, "restart at the threshold");
+    }
+
+    #[test]
+    fn edge_report_reports_each_sustained_transition_once() {
+        // Boot, nothing reported yet: first success reports up.
+        assert_eq!(edge_report(None, true, false), Some(true));
+        // Already up: further successes are silent.
+        assert_eq!(edge_report(Some(true), true, false), None);
+        // Up, blip not yet sustained: silent.
+        assert_eq!(edge_report(Some(true), false, false), None);
+        // Up, outage sustained: reports down once.
+        assert_eq!(edge_report(Some(true), false, true), Some(false));
+        assert_eq!(edge_report(Some(false), false, true), None);
+        // Down, recovers: reports up.
+        assert_eq!(edge_report(Some(false), true, false), Some(true));
+        // Boot, never registers, sustained: reports down so status.json gets
+        // the recovery hint instead of showing connecting forever.
+        assert_eq!(edge_report(None, false, true), Some(false));
+        // Boot, not yet sustained: silent.
+        assert_eq!(edge_report(None, false, false), None);
     }
 
     #[test]


### PR DESCRIPTION
## Incident

A power cut rebooted a multi-user host before its network was up. Every vestad booted into a DNS blackout: the 60s DNS-ready wait expired, all 3 boot preflight attempts failed (cloudflared could not resolve argotunnel.com, the recreate fallback could not resolve api.cloudflare.com), and because these are BYOK boxes the failure branch deleted tunnel.json. The tunnel supervisor is gated on tunnel.json existing, so it never started: zero cloudflared processes on the box, every agent hostname serving Cloudflare error 1033 until manual restarts.

## Why this class survived five fixes

#621 (force HTTP/2), #812 (supervise cloudflared), #847 (boot preflight + retry + forget-on-failure), #1067 (gate forget on creds), and #1074 (respawn backoff) each narrowed a window or gated a branch. None removed the structural cause: two owners of one decision. Boot rendered a one-shot verdict on tunnel health during the worst possible window (right after boot, network still converging), and that verdict could both destroy durable state (tunnel.json) and decide whether the self-healing loop existed at all. Any boot outage longer than the boot budget re-triggered the class.

## Design

Boot renders no tunnel verdict. It computes one bit (tunnel intended: managed, or tunnel.json exists, or BYOK creds exist), advertises the identity URL from tunnel.json as the new `Connecting` status, and starts the supervisor. The supervision loop owns the whole lifecycle:

- **Establish**: `establish_tunnel` before every spawn. An existing tunnel.json is authoritative and never rewritten (subdomain reconciliation belongs to `vestad connect`, its one owner); a missing one is created from BYOK creds; a managed box keeps erroring until the control plane seeds it.
- **Verify + report**: the existing /ready probing feeds a pure tri-state `edge_report`, so status.json flips Connecting to Active on first registration, and to the recovery-hint Failed after a sustained (2 min) outage, including fast-exit failures (revoked tunnel) that never reach a probe tick.
- **Repair**: a run that never registered, on a box holding creds, triggers one same-subdomain recreate per down-period (latched until a run registers again). A runtime-revoked tunnel now self-heals; today it loops forever.
- **Nothing auto-deletes tunnel.json.** Only explicit user action (`vestad connect`, `tunnel destroy`) touches it.

Deleted: `wait_for_dns_ready`, boot retry/preflight/forget machinery (`setup_and_verify_tunnel`, `retry_tunnel`, `try_establish_tunnel`, `should_forget_failed_tunnel`, `preflight_tunnel`, `forget_tunnel`) and their tests. Added: `TunnelStatus::Connecting(Option<String>)` + `advertised_url()`, `establish_tunnel`, `edge_report`, repair latch, and bounded (`--connect-timeout 10 --max-time 60`) Cloudflare API curls so a stalled connection cannot wedge shutdown.

Net: the failure class (any outage outlasting a boot-time budget) is unrepresentable rather than re-narrowed; boot orchestration shrinks by ~200 lines.

## Testing

`./check.sh vestad` green (clippy -D warnings, 198 passed). New behavioral coverage: `supervisor_establish_never_rewrites_an_existing_config`, `edge_report_reports_each_sustained_transition_once`, `advertised_url_covers_active_and_connecting_with_url`, extended `repair_runs_only_for_unregistered_runs_on_byok_boxes` and status round-trip with both `Connecting` shapes.

Fleet: tunnel.json shape, env-file contract, and `/info.tunnel_url` are unchanged; no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)