### PR TITLE
ci: build unsigned macOS app when no signing cert is present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -722,9 +722,12 @@ jobs:
         working-directory: apps
         run: npm -w @vesta/web run build
 
-      # Signing/notarization env is empty on PRs; electron-builder then skips
-      # both and produces unsigned artifacts, which is exactly what PR
-      # validation needs.
+      # electron-builder auto-skips signing on pull_request builds, but on a
+      # push it attempts to sign and fails when no cert is configured. Key the
+      # signed path on the cert being present: with a cert, sign + notarize;
+      # without one, force an unsigned build so master stays green until the
+      # Apple secrets are added, after which the signed path engages with no
+      # further change.
       - name: Build Electron app
         working-directory: apps/desktop
         env:
@@ -735,7 +738,13 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           npx tsc
-          npx electron-builder --mac dmg zip --universal --publish never
+          if [ -n "$CSC_LINK" ]; then
+            npx electron-builder --mac dmg zip --universal --publish never
+          else
+            echo "No signing certificate configured; building unsigned."
+            CSC_IDENTITY_AUTO_DISCOVERY=false \
+              npx electron-builder --mac dmg zip --universal --publish never -c.mac.notarize=false
+          fi
 
       - name: Collect artifacts
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Why master is red

`build-electron-macos` fails on every push to master (since #1224, the Tauri→Electron port) with:

```
⨯ /Users/runner/work/vesta/vesta/apps/desktop not a file
```

On a `push`, electron-builder attempts macOS code signing, but the repo has **no Apple signing secrets** configured, so the universal build's signing step dies. PRs never caught this because electron-builder **auto-skips signing on `pull_request` builds** (`Current build is a part of pull request, code signing will be skipped`), so the failing path is literally unreachable on a PR. `merge-gate-ci` is just the aggregate gate, so it goes red with it.

## Fix

Gate the signed path on the cert being present (`CSC_LINK`):
- **cert present** → sign + notarize (unchanged behavior).
- **no cert** → force `CSC_IDENTITY_AUTO_DISCOVERY=false` + `-c.mac.notarize=false`, producing an unsigned build.

This keeps master green now and **self-heals**: once the `APPLE_CERT_P12` / `APPLE_CERT_PASSWORD` / `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` secrets are added, the signed path engages automatically with no further change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)