### PR TITLE
fix(agent): stop proactive-check skip from spamming logs every tick

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -486,6 +486,8 @@ async def _notification_watcher(notify: asyncio.Event, *, notifications_dir: pl.
 
 async def monitor_loop(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.State, config: cfg.VestaConfig) -> None:
     last_proactive = _now()
+    # Log a busy-deferral once per due window, not every 2s tick while the agent stays busy.
+    proactive_defer_logged = False
     # Init one hour back so the first dreamer check runs on the first tick after boot.
     last_dreamer_check = _now() - dt.timedelta(hours=1)
     pending_snoozed: list[Notification] = []
@@ -513,9 +515,12 @@ async def monitor_loop(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.State, 
 
             if (now - last_proactive).total_seconds() >= config.proactive_check_interval * 60:
                 if state.processor_busy or not queue.empty():
-                    logger.debug("Proactive check skipped: agent is busy, retrying next tick")
+                    if not proactive_defer_logged:
+                        logger.debug("Proactive check deferred: agent busy, will run when idle")
+                        proactive_defer_logged = True
                 else:
                     last_proactive = now
+                    proactive_defer_logged = False
                     check_proactive_task(config=config)
 
             if (now - last_dreamer_check).total_seconds() >= 3600:


### PR DESCRIPTION
## What

`monitor_loop` logged `Proactive check skipped: agent is busy, retrying next tick` on **every** 2-second tick for as long as the agent stayed busy after a proactive check came due, flooding DEBUG logs (~1800 lines/hour).

## Why

The due condition `(now - last_proactive) >= proactive_check_interval` stays true until the check actually runs, and the busy-skip branch deliberately does not advance `last_proactive` (so it retries once idle). Combined with the 2s `monitor_tick_interval`, that means a log line every tick while busy.

## Fix

Log the busy deferral once per due window via a `proactive_defer_logged` flag, reset when the check runs. No change to proactive-check timing or any observable behavior beyond log volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)