### PR TITLE
fix(ci): unset empty Apple signing env on the unsigned electron-macos path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -742,6 +742,11 @@ jobs:
             npx electron-builder --mac dmg zip --universal --publish never
           else
             echo "No signing certificate configured; building unsigned."
+            # The empty secrets above still define the env vars: electron-builder resolves an
+            # empty CSC_LINK against the project dir and dies with "not a file" on non-PR
+            # events (PR builds skip signing wholesale, so only push/release hit it). Unset
+            # them so the unsigned path is genuinely unsigned.
+            unset CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
             CSC_IDENTITY_AUTO_DISCOVERY=false \
               npx electron-builder --mac dmg zip --universal --publish never -c.mac.notarize=false
           fi


### PR DESCRIPTION
## Problem

build-electron-macos fails on every non-PR event (all master pushes and the v0.1.177 release attempt) with:

    • empty password will be used for code signing  reason=CSC_KEY_PASSWORD is not defined
    ⨯ /Users/runner/work/vesta/vesta/apps/desktop not a file

The job env unconditionally sets CSC_LINK from the unset APPLE_CERT_P12 secret, leaving an empty-but-defined env var. electron-builder skips signing wholesale on pull_request events (why PR builds pass), but on push/release it resolves the empty CSC_LINK against the project dir and dies. This is what failed the v0.1.177 release (its revert-failed-release then pulled the release and tag).

## Fix

In the unsigned branch, unset the five Apple env vars before invoking electron-builder, so the unsigned path is genuinely unsigned. The signed path is untouched and engages unchanged once real secrets are added.

## Verification

The failing path only runs on non-PR events, so the PR run cannot exercise it; the post-merge master push run is the verification. Current master is red on this job on every push since #1224 (e7452c5c, 9a2ec5f5, 01e9fbd0), so the delta is unambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)