### PR TITLE
fix(agent): drain deferred compactions on the processor's idle tick

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -411,12 +411,22 @@ async def message_processor(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.St
             try:
                 turn = await asyncio.wait_for(queue.get(), timeout=1.0)
             except TimeoutError:
+                # The one drain site for deferred compactions, on the idle tick rather than
+                # after queue items: a compaction can be requested by a turn the processor
+                # never ran (a delivered preempt executing as its own CLI turn calls
+                # compact_context turnlessly), and /compact needs the whole session idle,
+                # which the bus state tracks across turnless work too.
+                if state.pending_compaction is not None and state.event_bus.state == "idle":
+                    state.processor_busy = True
+                    try:
+                        await drain_compaction_request(state=state, config=config)
+                    finally:
+                        state.processor_busy = False
                 continue
 
             state.processor_busy = True
             try:
                 await _run_messages_with_preempts(turn, queue=queue, state=state, config=config)
-                await drain_compaction_request(state=state, config=config)
             finally:
                 state.processor_busy = False
 

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -367,3 +367,54 @@ async def test_notification_file_deleted_before_processing_is_lost_on_restart(tm
         f"Message queued mid-compact must survive restart (recovered {len(recovered)})."
         f" dying_queue qsize={dying_queue.qsize()} is dropped on restart."
     )
+
+
+# --- the processor drains a turnless compaction request on its idle tick ---
+
+
+@pytest.mark.anyio
+async def test_processor_drains_turnless_compaction_on_idle_tick():
+    """A compaction can be requested by a turn the processor never ran: a delivered preempt
+    executing as its own CLI turn calls compact_context turnlessly while the processor is parked
+    on queue.get(). The idle tick must drain it, and only once the whole session is idle (the
+    bus state tracks turnless work), never mid-stream. Regression: the drain used to fire only
+    after queue items, stranding exactly this request (v0.1.177 release, live dreamer test)."""
+    from claude_agent_sdk import TextBlock
+
+    from core.loops import message_processor
+    from conftest import assistant_msg, make_stream_harness, result_msg
+
+    state, config, mock_client, _, message_queue, _ = make_stream_harness()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    queue: asyncio.Queue = asyncio.Queue()
+
+    with (
+        patch("core.client.ClaudeSDKClient", return_value=mock_client),
+        patch("core.client.build_client_options", return_value=MagicMock()),
+    ):
+        processor = asyncio.create_task(message_processor(queue, state=state, config=config))
+
+        # Turnless CLI work is streaming (a delivered preempt running as its own turn); during
+        # it the tool call lands the request. The bus reads thinking, so the drain must hold.
+        await message_queue.put(assistant_msg([TextBlock("turnless work")]))
+        await wait_for_condition(lambda: state.event_bus.state == "thinking", message="turnless activity never set thinking")
+        state.pending_compaction = vm.PendingCompaction(prompt="curate the open threads", followup=None, restart=False)
+        # Negative assertion: prove the drain does NOT fire mid-stream. Waiting for absence
+        # requires a real time window past the 1s idle tick; this sleep is intentional.
+        await asyncio.sleep(1.5)
+        assert state.pending_compaction is not None, "the drain must not fire while turnless work streams"
+        mock_client.query.assert_not_called()
+
+        # The turnless turn ends: bus flips idle, the next tick drains, /compact goes out.
+        await message_queue.put(result_msg())
+        await wait_for_condition(
+            lambda: any(call.args == ("/compact curate the open threads",) for call in mock_client.query.call_args_list),
+            timeout=5.0,
+            message="idle tick never drained the pending compaction",
+        )
+        await message_queue.put(result_msg())  # closes the compaction turn
+        await wait_for_condition(lambda: state.pending_compaction is None and not state.processor_busy, message="drain never completed")
+
+        state.shutdown_event.set()
+        await asyncio.wait_for(processor, timeout=5)


### PR DESCRIPTION
## Problem

Follow-up regression from #1256 (delivery-is-completion): a delivered preempt that the CLI runs as its own turn calls compact_context with no Vesta queue item behind it. drain_compaction_request fired only after queue-item turns, so the request stranded until an unrelated notification completed a cycle. This is what failed the live dreamer test 3 of 4 times on the v0.1.177 release attempts (the finalize notification is delivered as a preempt when it lands mid-turn; when it lands idle it runs plain and the test passes, matching the observed intermittency). Before #1256 the phantom pre-sent turns accidentally guaranteed a drain after every preempt.

## Fix

Move the drain to the processor's 1-second idle tick, gated on the event-bus activity state being idle (which now tracks turnless CLI work). One drain site instead of one-per-batch; /compact runs at the next moment the whole session is actually quiet, which the old post-batch site did not guarantee either.

## Tests

New processor-level regression test: a turnless compaction request is NOT drained while turnless work streams (bus thinking), and drains within a tick once the stream goes idle. Verified red without the loops.py change, green with it. Full agent suite: 604 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)