### PR TITLE
fix(ci): trigger the release workflow on published only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,10 @@ on:
     branches: [master]
   pull_request:
   release:
-    types: [created, published]
+    # published only: gh release create fires created+published together, and two
+    # racing runs each execute test-live (double flake exposure and token spend) while
+    # either one failing deletes the release even when the other fully passed.
+    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

on.release.types is [created, published]. gh release create (what release.sh runs) fires both events, so every release spawns two identical CI runs. Each runs test-live (double live-token spend and double flake exposure), and revert-failed-release in either run deletes the release and tag even when the other run fully passed. That exact race killed the second v0.1.177 attempt: run 29344569677 passed everything including test-live, while its twin 29344569764 failed test-live and deleted the release.

## Fix

Trigger on published only. Draft releases no longer trigger builds either (created fires for drafts; release.sh publishes directly, which fires published exactly once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)