### PR TITLE
fix(notifications): reply guidance lives only in the producer reply_hint

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -126,7 +126,7 @@ def _write_app_chat_notification(config: VestaConfig, text: str) -> None:
             "type": "message",
             "message": text,
             "interrupt": True,
-            "reply_hint": "reply with a short message, and think about how you can best show your personality",
+            "reply_hint": "reply with `app-chat send`, and think about how you can best show your personality",
         }
     )
     path = directory / f"{time.time_ns()}-app-chat-message.json"

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -114,33 +114,12 @@ async def trash_notification_files(notifications: list[Notification], *, trash_d
     _trash_paths([n.file_path for n in notifications if n.file_path], trash_dir)
 
 
-_REPLY_SKILLS = frozenset({"app-chat", "whatsapp", "telegram"})
-
-
-def _format_one(notif: Notification) -> str:
-    """Embed hints inside the <channel> element so the model sees them as one unit.
-
-    A reply hint points the model at the originating channel's reply skill instead of copying its CLI
-    syntax. A group-chat message (a `chat_name` attribute is present) also gets a note that it may not
-    be addressed to the agent, so the model decides whether to engage rather than always replying."""
-    body = notif.format_for_display()
-    if notif.type != "message" or notif.source not in _REPLY_SKILLS:
-        return body
-    extras = notif.model_extra or {}
-    hints = []
-    if "chat_name" in extras and extras["chat_name"]:
-        hints.append("[This message is from a group chat and may not be for you; decide whether to chip in or stay out]")
-    hints.append(f"[Reply using the `{notif.source}` skill]")
-    hint = "\n" + "\n".join(hints)
-    return body.replace("</channel>", f"{hint}\n</channel>")
-
-
 def format_notification_batch(notifications: list[Notification]) -> str:
     """Join the batch as newline-separated <channel> elements, matching how Claude Code delivers
     several native channel events together on one turn. No wrapper element: each <channel> is
-    self-contained. Any read-time guidance is carried per-notification by the producer (e.g. the
-    `reply_hint` attribute), not appended as a global suffix here."""
-    return "\n".join(_format_one(n) for n in notifications)
+    self-contained. All read-time guidance (the reply command, the group-chat caveat) is the
+    producer's, carried in its `reply_hint` attribute; core injects nothing."""
+    return "\n".join(n.format_for_display() for n in notifications)
 
 
 async def process_batch(

--- a/agent/skills/telegram/cli/notifications.go
+++ b/agent/skills/telegram/cli/notifications.go
@@ -120,11 +120,11 @@ func WriteNotification(
 		Timestamp:      time.Now().Format(time.RFC3339),
 		MessageID:      messageID,
 		ContactUnknown: !contactSaved,
-		ReplyHint:      "reply with a short message, and think about how you can best show your personality",
+		ReplyHint:      "reply with `telegram send`, and think about how you can best show your personality",
 	}
 	if !isDirectChat {
 		notif.ChatName = chatName
-		notif.ReplyHint = "reply with a short message, and think about how you can best show your personality; this is a group chat, so it may not be expecting a reply from you"
+		notif.ReplyHint = "reply with `telegram send`, and think about how you can best show your personality; this is a group chat, so it may not be expecting a reply from you"
 		if sender != chatName {
 			notif.Sender = sender
 		}

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -105,11 +105,11 @@ func WriteNotification(
 		Timestamp:       time.Now().Format(time.RFC3339),
 		MessageID:       messageID,
 		ContactUnknown:  !ctx.ContactSaved,
-		ReplyHint:       "reply with a short message, and think about how you can best show your personality",
+		ReplyHint:       "reply with `whatsapp send`, and think about how you can best show your personality",
 	}
 	if !ctx.IsDirectChat {
 		n.ChatName = ctx.ChatName
-		n.ReplyHint = "reply with a short message, and think about how you can best show your personality; this is a group chat, so it may not be expecting a reply from you"
+		n.ReplyHint = "reply with `whatsapp send`, and think about how you can best show your personality; this is a group chat, so it may not be expecting a reply from you"
 		// Drop Sender when it's just the same JID as the chat (happens for unsaved group participants).
 		if ctx.Sender != ctx.ChatName {
 			n.Sender = ctx.Sender

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -251,57 +251,7 @@ def test_format_for_display_strips_timestamp_microseconds():
     assert 'timestamp="2025-01-01T12:34:56+00:00"' in display
 
 
-@pytest.mark.parametrize(
-    "payload,expected_substr",
-    [
-        (
-            {"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "message", "contact_name": "Alice", "message": "hi"},
-            "Reply using the `whatsapp` skill",
-        ),
-        (
-            {
-                "timestamp": "2025-01-01T00:00:00",
-                "source": "whatsapp",
-                "type": "message",
-                "chat_name": "Group",
-                "sender": "bob",
-                "message": "hi",
-            },
-            "Reply using the `whatsapp` skill",
-        ),
-        (
-            {"timestamp": "2025-01-01T00:00:00", "source": "telegram", "type": "message", "contact_name": "Carol", "message": "hi"},
-            "Reply using the `telegram` skill",
-        ),
-        (
-            {"timestamp": "2025-01-01T00:00:00", "source": "app-chat", "type": "message", "message": "hi"},
-            "Reply using the `app-chat` skill",
-        ),
-    ],
-    ids=["whatsapp-direct", "whatsapp-group", "telegram-direct", "app-chat"],
-)
-def test_batch_includes_reply_hint(payload, expected_substr):
-    notif = Notification.model_validate(payload)
-    formatted = format_notification_batch([notif])
-    assert "Reply using" in formatted
-    assert expected_substr in formatted
-
-
-def test_batch_no_hint_for_unknown_source():
-    notif = Notification.model_validate({"timestamp": "2025-01-01T00:00:00", "source": "email", "type": "message", "sender": "alice"})
-    formatted = format_notification_batch([notif])
-    assert "Reply using" not in formatted
-
-
-def test_batch_no_hint_for_non_message_type():
-    notif = Notification.model_validate(
-        {"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "reaction", "contact_name": "Alice", "emoji": "👍"}
-    )
-    formatted = format_notification_batch([notif])
-    assert "Reply using" not in formatted
-
-
-def test_group_message_flagged_maybe_not_for_you():
+def test_batch_reply_guidance_appears_only_in_producer_reply_hint():
     notif = Notification.model_validate(
         {
             "timestamp": "2025-01-01T00:00:00",
@@ -310,19 +260,14 @@ def test_group_message_flagged_maybe_not_for_you():
             "chat_name": "Bride squad",
             "sender": "bob",
             "message": "hi",
+            "reply_hint": "reply with `whatsapp send`; this is a group chat, so it may not be expecting a reply from you",
         }
     )
     formatted = format_notification_batch([notif])
-    assert "from a group chat" in formatted
-    assert "chip in or stay out" in formatted
-
-
-def test_direct_message_not_flagged_as_group():
-    notif = Notification.model_validate(
-        {"timestamp": "2025-01-01T00:00:00", "source": "whatsapp", "type": "message", "contact_name": "Alice", "message": "hi"}
-    )
-    formatted = format_notification_batch([notif])
-    assert "from a group chat" not in formatted
+    assert formatted.count("group chat") == 1
+    assert formatted.count("whatsapp send") == 1
+    assert "[Reply using" not in formatted
+    assert "chip in or stay out" not in formatted
 
 
 # --- process_batch ---


### PR DESCRIPTION
## Problem

Since #1209 made read-time guidance producer-owned, group-chat messages carried the same guidance twice: the producer's `reply_hint` attribute already says "this is a group chat, so it may not be expecting a reply from you", and core's `_format_one` (loops.py) still injected its own `[This message is from a group chat and may not be for you; decide whether to chip in or stay out]` plus `[Reply using the X skill]` lines into the body. Two owners for one piece of guidance:

```
<channel source="whatsapp" ... reply_hint="reply with a short message, and think about how you can best show your personality; this is a group chat, so it may not be expecting a reply from you">2 topi e un uccellino oggi.... [This message is from a group chat and may not be for you; decide whether to chip in or stay out] [Reply using the whatsapp skill] </channel>
```

## Fix

The producer's `reply_hint` is now the single owner of all read-time guidance; core injects nothing into the body (`_format_one` and `_REPLY_SKILLS` are deleted, `format_notification_batch` just joins the rendered elements). The producers (whatsapp, telegram, app-chat) carry the reply command itself in the hint ("reply with `whatsapp send`, and think about how you can best show your personality", with the group-chat caveat appended on group messages), and "with a short message" is dropped from the hint. Regression test asserts a group message renders the group-chat guidance and the reply command exactly once, with no core-injected brackets.

## Testing

- `./check.sh agent` green (597 core tests + skill CLI suites)
- `./check.sh guards` green
- Go changes are string literals only; validated by the `go-checks` CI job (no local Go toolchain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)