### PR TITLE
fix(web): host-access copy says "the agent's computer" not "this computer"

### DIFF
--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -247,8 +247,8 @@ export function HostAccessCard() {
           <DialogHeader>
             <DialogTitle>add a folder</DialogTitle>
             <DialogDescription>
-              choose a folder on this computer for {agentName || "the agent"} to
-              open.
+              choose a folder on {agentName || "the agent"}'s computer for them
+              to open.
             </DialogDescription>
           </DialogHeader>
 
@@ -281,7 +281,7 @@ export function HostAccessCard() {
               value={hostPath}
               onChange={(e) => setHostPath(e.target.value)}
               placeholder="/mnt/media"
-              aria-label="folder path on this computer"
+              aria-label={`folder path on ${agentName || "the agent"}'s computer`}
               className="h-8 text-xs"
             />
             {showContainerPath ? (

--- a/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/HostAccessCard/index.tsx
@@ -247,8 +247,8 @@ export function HostAccessCard() {
           <DialogHeader>
             <DialogTitle>add a folder</DialogTitle>
             <DialogDescription>
-              choose a folder on {agentName || "the agent"}'s computer for them
-              to open.
+              choose a folder on {agentName || "the agent"}'s host computer for
+              them to open.
             </DialogDescription>
           </DialogHeader>
 
@@ -281,7 +281,7 @@ export function HostAccessCard() {
               value={hostPath}
               onChange={(e) => setHostPath(e.target.value)}
               placeholder="/mnt/media"
-              aria-label={`folder path on ${agentName || "the agent"}'s computer`}
+              aria-label={`folder path on ${agentName || "the agent"}'s host computer`}
               className="h-8 text-xs"
             />
             {showContainerPath ? (


### PR DESCRIPTION
The host-access card told users to "choose a folder on this computer," but the web app can run on a different device than vestad. The shared folder actually lives on the computer the agent runs on, not the device viewing the app.

Reworded the add-folder dialog description and the path input's aria-label to say "{agent}'s computer" instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)