### PR TITLE
feat(recall): add --snippet flag for windowed excerpts

### DIFF
--- a/agent/skills/recall/SKILL.md
+++ b/agent/skills/recall/SKILL.md
@@ -19,6 +19,7 @@ uv tool install --editable ~/agent/skills/recall/cli
 recall "meeting notes"
 recall "sched*" --limit 5
 recall "wifi password" --snippet
+recall "wifi password" --snippet 10
 ```
 
 Results are ranked by relevance with a recency boost, so recent conversations surface higher.
@@ -26,7 +27,7 @@ Results are ranked by relevance with a recency boost, so recent conversations su
 ## Flags
 
 - `--limit N`: max results (default 20).
-- `--snippet`: return a short windowed excerpt around each match instead of the whole message. Use it to scan many hits cheaply when you just need to locate the right conversation; omit it when you need the full text of a message. The window is centered on the first matched term and elided with `…` on either trimmed side.
+- `--snippet [WORDS]`: return a windowed excerpt instead of the whole message, `WORDS` words on each side of the match (default 24). Use it to scan many hits cheaply when you just need to locate the right conversation, and pass a smaller `WORDS` to compress harder; omit the flag entirely when you need the full text. The window is centered on the first matched term and elided with `…` on either trimmed side.
 
 ## Query syntax (FTS5)
 

--- a/agent/skills/recall/SKILL.md
+++ b/agent/skills/recall/SKILL.md
@@ -18,9 +18,15 @@ uv tool install --editable ~/agent/skills/recall/cli
 ```bash
 recall "meeting notes"
 recall "sched*" --limit 5
+recall "wifi password" --snippet
 ```
 
 Results are ranked by relevance with a recency boost, so recent conversations surface higher.
+
+## Flags
+
+- `--limit N`: max results (default 20).
+- `--snippet`: return a short windowed excerpt around each match instead of the whole message. Use it to scan many hits cheaply when you just need to locate the right conversation; omit it when you need the full text of a message. The window is centered on the first matched term and elided with `…` on either trimmed side.
 
 ## Query syntax (FTS5)
 

--- a/agent/skills/recall/cli/pyproject.toml
+++ b/agent/skills/recall/cli/pyproject.toml
@@ -5,6 +5,11 @@ description = "Full-text recall over the agent's conversation history"
 requires-python = ">=3.11"
 dependencies = []
 
+[dependency-groups]
+dev = [
+    "pytest>=8.4.0",
+]
+
 [project.scripts]
 recall = "recall_cli.cli:main"
 

--- a/agent/skills/recall/cli/src/recall_cli/cli.py
+++ b/agent/skills/recall/cli/src/recall_cli/cli.py
@@ -5,10 +5,15 @@ Standalone, stdlib-only: the agent runs this as a subprocess, so it opens the db
 directly rather than going through core. The query mirrors EventBus.search in
 agent/core/events.py (same FTS5 table, same recency-boosted ranking); keep them
 in step if that ranking ever changes.
+
+Windowing (--snippet) is a CLI-only presentation concern computed in Python:
+events_fts is an external-content table whose backing table has no text_content
+column, so FTS5's own snippet() cannot re-read the source to build one.
 """
 
 import argparse
 import pathlib
+import re
 import sqlite3
 import sys
 
@@ -16,6 +21,12 @@ DB_PATH = pathlib.Path.home() / "agent" / "data" / "events.db"
 RECENCY_DECAY_RATE = 0.01
 MAX_RESULT_CHARS = 50000
 MAX_CONTENT_CHARS = 2000
+SNIPPET_WINDOW_WORDS = 24
+SNIPPET_ELLIPSIS = "…"
+
+# FTS5 query operators, dropped when locating the matched term for --snippet windowing.
+_FTS_OPERATORS = frozenset({"and", "or", "not", "near"})
+_NON_WORD = re.compile(r"[^0-9a-z]")
 
 
 def search(db_path: pathlib.Path, query: str, *, limit: int) -> list[dict[str, str]]:
@@ -40,6 +51,37 @@ def search(db_path: pathlib.Path, query: str, *, limit: int) -> list[dict[str, s
     return [{"timestamp": r[0], "role": r[1], "content": r[2]} for r in rows]
 
 
+def query_terms(query: str) -> list[str]:
+    """The bare search terms of an FTS5 query: its alphanumeric runs, lowercased, with operators
+    dropped. Used only to locate a match for windowing, so approximate parsing is fine."""
+    return [token for token in re.findall(r"[0-9a-z]+", query.lower()) if token not in _FTS_OPERATORS]
+
+
+def _matches(word: str, terms: list[str]) -> bool:
+    cleaned = _NON_WORD.sub("", word.lower())
+    return any(cleaned.startswith(term) for term in terms)
+
+
+def window(content: str, query: str) -> str:
+    """A short excerpt of content centered on the first word matching any query term, marked with
+    SNIPPET_ELLIPSIS on each trimmed side. Falls back to the head of the message when no term can
+    be located (e.g. an operator-only query)."""
+    if not content:
+        return content
+    words = content.split()
+    terms = query_terms(query)
+    hit = next((i for i, candidate in enumerate(words) if _matches(candidate, terms)), None)
+    if hit is None:
+        head = words[: SNIPPET_WINDOW_WORDS * 2]
+        suffix = f" {SNIPPET_ELLIPSIS}" if len(words) > len(head) else ""
+        return " ".join(head) + suffix
+    start = max(0, hit - SNIPPET_WINDOW_WORDS)
+    end = min(len(words), hit + SNIPPET_WINDOW_WORDS + 1)
+    prefix = f"{SNIPPET_ELLIPSIS} " if start > 0 else ""
+    suffix = f" {SNIPPET_ELLIPSIS}" if end < len(words) else ""
+    return prefix + " ".join(words[start:end]) + suffix
+
+
 def format_results(results: list[dict[str, str]]) -> str:
     if not results:
         return "No results found."
@@ -62,6 +104,12 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Recall past conversations via full-text search.")
     parser.add_argument("query", help="FTS5 search query")
     parser.add_argument("--limit", type=int, default=20, help="Max results to return (default 20)")
+    parser.add_argument(
+        "--snippet",
+        action="store_true",
+        help="Return a short windowed excerpt around each match instead of the full message "
+        "(compresses large result sets; omit when you need full fidelity)",
+    )
     args = parser.parse_args()
 
     try:
@@ -69,6 +117,9 @@ def main() -> int:
     except sqlite3.OperationalError as e:
         print(f"Search error: {e}", file=sys.stderr)
         return 1
+    if args.snippet:
+        for r in results:
+            r["content"] = window(r["content"], args.query)
     print(format_results(results))
     return 0
 

--- a/agent/skills/recall/cli/src/recall_cli/cli.py
+++ b/agent/skills/recall/cli/src/recall_cli/cli.py
@@ -62,21 +62,21 @@ def _matches(word: str, terms: list[str]) -> bool:
     return any(cleaned.startswith(term) for term in terms)
 
 
-def window(content: str, query: str) -> str:
-    """A short excerpt of content centered on the first word matching any query term, marked with
-    SNIPPET_ELLIPSIS on each trimmed side. Falls back to the head of the message when no term can
-    be located (e.g. an operator-only query)."""
+def window(content: str, query: str, window_words: int) -> str:
+    """A short excerpt of content with window_words words on each side of the first word matching any
+    query term, marked with SNIPPET_ELLIPSIS on each trimmed side. Falls back to the head of the
+    message when no term can be located (e.g. an operator-only query)."""
     if not content:
         return content
     words = content.split()
     terms = query_terms(query)
     hit = next((i for i, candidate in enumerate(words) if _matches(candidate, terms)), None)
     if hit is None:
-        head = words[: SNIPPET_WINDOW_WORDS * 2]
+        head = words[: window_words * 2]
         suffix = f" {SNIPPET_ELLIPSIS}" if len(words) > len(head) else ""
         return " ".join(head) + suffix
-    start = max(0, hit - SNIPPET_WINDOW_WORDS)
-    end = min(len(words), hit + SNIPPET_WINDOW_WORDS + 1)
+    start = max(0, hit - window_words)
+    end = min(len(words), hit + window_words + 1)
     prefix = f"{SNIPPET_ELLIPSIS} " if start > 0 else ""
     suffix = f" {SNIPPET_ELLIPSIS}" if end < len(words) else ""
     return prefix + " ".join(words[start:end]) + suffix
@@ -106,9 +106,13 @@ def main() -> int:
     parser.add_argument("--limit", type=int, default=20, help="Max results to return (default 20)")
     parser.add_argument(
         "--snippet",
-        action="store_true",
-        help="Return a short windowed excerpt around each match instead of the full message "
-        "(compresses large result sets; omit when you need full fidelity)",
+        nargs="?",
+        type=int,
+        const=SNIPPET_WINDOW_WORDS,
+        default=None,
+        metavar="WORDS",
+        help=f"Return a windowed excerpt of WORDS words on each side of each match (default {SNIPPET_WINDOW_WORDS}) "
+        "instead of the full message; omit for full fidelity",
     )
     args = parser.parse_args()
 
@@ -117,9 +121,9 @@ def main() -> int:
     except sqlite3.OperationalError as e:
         print(f"Search error: {e}", file=sys.stderr)
         return 1
-    if args.snippet:
+    if args.snippet is not None:
         for r in results:
-            r["content"] = window(r["content"], args.query)
+            r["content"] = window(r["content"], args.query, args.snippet)
     print(format_results(results))
     return 0
 

--- a/agent/skills/recall/cli/tests/conftest.py
+++ b/agent/skills/recall/cli/tests/conftest.py
@@ -1,0 +1,34 @@
+import json
+import pathlib
+import sqlite3
+import typing as tp
+
+import pytest
+
+# Mirror of the events.db FTS schema owned by agent/core/events.py: an external-content FTS5 table
+# fed by a trigger that indexes json_extract(data, '$.text') for conversational events only.
+_SCHEMA = """
+CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, ts TEXT NOT NULL, data TEXT NOT NULL);
+CREATE VIRTUAL TABLE events_fts USING fts5(text_content, content='events', content_rowid='id');
+CREATE TRIGGER events_fts_ai AFTER INSERT ON events BEGIN
+    INSERT INTO events_fts(rowid, text_content)
+    SELECT new.id, json_extract(new.data, '$.text')
+    WHERE json_extract(new.data, '$.type') IN ('user', 'assistant', 'chat');
+END;
+"""
+
+Add = tp.Callable[[str, str, str], None]
+
+
+@pytest.fixture
+def events_db(tmp_path: pathlib.Path) -> tp.Iterator[tuple[pathlib.Path, Add]]:
+    path = tmp_path / "events.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(_SCHEMA)
+
+    def add(role: str, text: str, ts: str = "2026-01-01T00:00:00") -> None:
+        conn.execute("INSERT INTO events(ts, data) VALUES (?, ?)", (ts, json.dumps({"type": role, "text": text})))
+        conn.commit()
+
+    yield path, add
+    conn.close()

--- a/agent/skills/recall/cli/tests/test_snippet.py
+++ b/agent/skills/recall/cli/tests/test_snippet.py
@@ -1,4 +1,5 @@
 import pathlib
+import sys
 import typing as tp
 
 import pytest
@@ -30,33 +31,41 @@ def test_query_terms_strips_operators_and_punctuation(query: str, expected: list
 
 def test_window_centers_on_match_with_ellipses_both_sides() -> None:
     content = f"{_LEAD} SENTINEL {_TAIL}"
-    result = cli.window(content, "sentinel")
+    result = cli.window(content, "sentinel", cli.SNIPPET_WINDOW_WORDS)
     assert "SENTINEL" in result
     assert result.startswith(f"{cli.SNIPPET_ELLIPSIS} ")
     assert result.endswith(f" {cli.SNIPPET_ELLIPSIS}")
     assert len(result) < len(content)
 
 
+def test_window_word_count_controls_width() -> None:
+    content = f"{_LEAD} SENTINEL {_TAIL}"
+    narrow = cli.window(content, "sentinel", 3)
+    wide = cli.window(content, "sentinel", cli.SNIPPET_WINDOW_WORDS)
+    assert "SENTINEL" in narrow
+    assert len(narrow) < len(wide)
+
+
 def test_window_no_ellipsis_when_whole_message_fits() -> None:
     content = "the wifi password is hunter2"
-    assert cli.window(content, "wifi") == content
+    assert cli.window(content, "wifi", cli.SNIPPET_WINDOW_WORDS) == content
 
 
 def test_window_matches_prefix_query() -> None:
     content = f"{_LEAD} scheduling the standup {_TAIL}"
-    result = cli.window(content, "sched*")
+    result = cli.window(content, "sched*", cli.SNIPPET_WINDOW_WORDS)
     assert "scheduling" in result
 
 
 def test_window_falls_back_to_head_when_no_term_located() -> None:
     content = f"{_LEAD} {_TAIL}"
-    result = cli.window(content, "nonexistentterm")
+    result = cli.window(content, "nonexistentterm", cli.SNIPPET_WINDOW_WORDS)
     assert result.startswith("lead00 lead01")
     assert result.endswith(f" {cli.SNIPPET_ELLIPSIS}")
 
 
 def test_window_empty_content_is_returned_unchanged() -> None:
-    assert cli.window("", "anything") == ""
+    assert cli.window("", "anything", cli.SNIPPET_WINDOW_WORDS) == ""
 
 
 def test_search_returns_full_content_by_default(events_db: tuple[pathlib.Path, Add]) -> None:
@@ -68,17 +77,52 @@ def test_search_returns_full_content_by_default(events_db: tuple[pathlib.Path, A
     assert results[0]["content"] == long_message
 
 
-def test_snippet_windows_search_results_around_the_match(events_db: tuple[pathlib.Path, Add]) -> None:
-    path, add = events_db
-    long_message = f"{_LEAD} the wifi password is hunter2 {_TAIL}"
-    add("user", long_message, "2026-01-01T00:00:00")
-    results = cli.search(path, "wifi", limit=20)
-    windowed = cli.window(results[0]["content"], "wifi")
-    assert "wifi password is hunter2" in windowed
-    assert len(windowed) < len(long_message)
-
-
 def test_search_ignores_non_conversational_events(events_db: tuple[pathlib.Path, Add]) -> None:
     path, add = events_db
     add("notification", "wifi outage alert", "2026-01-01T00:00:00")
     assert cli.search(path, "wifi", limit=20) == []
+
+
+def test_main_snippet_flag_without_value_windows_with_default(
+    events_db: tuple[pathlib.Path, Add], monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path, add = events_db
+    add("user", f"{_LEAD} the wifi password is hunter2 {_TAIL}", "2026-01-01T00:00:00")
+    monkeypatch.setattr(cli, "DB_PATH", path)
+    monkeypatch.setattr(sys, "argv", ["recall", "wifi", "--snippet"])
+    assert cli.main() == 0
+    out = capsys.readouterr().out
+    assert "wifi password is hunter2" in out
+    assert cli.SNIPPET_ELLIPSIS in out
+    assert "lead00" not in out
+
+
+def test_main_snippet_word_count_compresses_more_than_default(
+    events_db: tuple[pathlib.Path, Add], monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path, add = events_db
+    add("user", f"{_LEAD} the wifi password is hunter2 {_TAIL}", "2026-01-01T00:00:00")
+    monkeypatch.setattr(cli, "DB_PATH", path)
+
+    monkeypatch.setattr(sys, "argv", ["recall", "wifi", "--snippet", "3"])
+    cli.main()
+    narrow = capsys.readouterr().out
+    monkeypatch.setattr(sys, "argv", ["recall", "wifi", "--snippet", "24"])
+    cli.main()
+    wide = capsys.readouterr().out
+
+    assert "wifi" in narrow
+    assert len(narrow) < len(wide)
+
+
+def test_main_without_snippet_returns_full_message(
+    events_db: tuple[pathlib.Path, Add], monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path, add = events_db
+    add("user", f"{_LEAD} the wifi password is hunter2 {_TAIL}", "2026-01-01T00:00:00")
+    monkeypatch.setattr(cli, "DB_PATH", path)
+    monkeypatch.setattr(sys, "argv", ["recall", "wifi"])
+    assert cli.main() == 0
+    out = capsys.readouterr().out
+    assert "lead00" in out
+    assert cli.SNIPPET_ELLIPSIS not in out

--- a/agent/skills/recall/cli/tests/test_snippet.py
+++ b/agent/skills/recall/cli/tests/test_snippet.py
@@ -1,0 +1,84 @@
+import pathlib
+import typing as tp
+
+import pytest
+
+from recall_cli import cli
+
+Add = tp.Callable[[str, str, str], None]
+
+# Both flanks are longer than SNIPPET_WINDOW_WORDS so a centered window trims (and elides) each side.
+_LEAD = " ".join(f"lead{i:02d}" for i in range(30))
+_TAIL = " ".join(f"tail{i:02d}" for i in range(30))
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        ("meeting notes", ["meeting", "notes"]),
+        ('"exact phrase"', ["exact", "phrase"]),
+        ("sched*", ["sched"]),
+        ("cats OR dogs", ["cats", "dogs"]),
+        ("meeting NOT cancelled", ["meeting", "cancelled"]),
+        ("wifi AND password", ["wifi", "password"]),
+        ("NEAR(a b)", ["a", "b"]),
+    ],
+)
+def test_query_terms_strips_operators_and_punctuation(query: str, expected: list[str]) -> None:
+    assert cli.query_terms(query) == expected
+
+
+def test_window_centers_on_match_with_ellipses_both_sides() -> None:
+    content = f"{_LEAD} SENTINEL {_TAIL}"
+    result = cli.window(content, "sentinel")
+    assert "SENTINEL" in result
+    assert result.startswith(f"{cli.SNIPPET_ELLIPSIS} ")
+    assert result.endswith(f" {cli.SNIPPET_ELLIPSIS}")
+    assert len(result) < len(content)
+
+
+def test_window_no_ellipsis_when_whole_message_fits() -> None:
+    content = "the wifi password is hunter2"
+    assert cli.window(content, "wifi") == content
+
+
+def test_window_matches_prefix_query() -> None:
+    content = f"{_LEAD} scheduling the standup {_TAIL}"
+    result = cli.window(content, "sched*")
+    assert "scheduling" in result
+
+
+def test_window_falls_back_to_head_when_no_term_located() -> None:
+    content = f"{_LEAD} {_TAIL}"
+    result = cli.window(content, "nonexistentterm")
+    assert result.startswith("lead00 lead01")
+    assert result.endswith(f" {cli.SNIPPET_ELLIPSIS}")
+
+
+def test_window_empty_content_is_returned_unchanged() -> None:
+    assert cli.window("", "anything") == ""
+
+
+def test_search_returns_full_content_by_default(events_db: tuple[pathlib.Path, Add]) -> None:
+    path, add = events_db
+    long_message = f"{_LEAD} the wifi password is hunter2 {_TAIL}"
+    add("user", long_message, "2026-01-01T00:00:00")
+    results = cli.search(path, "wifi", limit=20)
+    assert len(results) == 1
+    assert results[0]["content"] == long_message
+
+
+def test_snippet_windows_search_results_around_the_match(events_db: tuple[pathlib.Path, Add]) -> None:
+    path, add = events_db
+    long_message = f"{_LEAD} the wifi password is hunter2 {_TAIL}"
+    add("user", long_message, "2026-01-01T00:00:00")
+    results = cli.search(path, "wifi", limit=20)
+    windowed = cli.window(results[0]["content"], "wifi")
+    assert "wifi password is hunter2" in windowed
+    assert len(windowed) < len(long_message)
+
+
+def test_search_ignores_non_conversational_events(events_db: tuple[pathlib.Path, Add]) -> None:
+    path, add = events_db
+    add("notification", "wifi outage alert", "2026-01-01T00:00:00")
+    assert cli.search(path, "wifi", limit=20) == []

--- a/agent/skills/recall/cli/uv.lock
+++ b/agent/skills/recall/cli/uv.lock
@@ -1,0 +1,79 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "recall"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.4.0" }]


### PR DESCRIPTION
## What

Adds a `--snippet` flag to the `recall` skill CLI. With it, each result is a short window centered on the first matched term instead of the whole message. `--snippet` alone uses a 24-word window on each side; `--snippet N` sets the per-side word count so the agent can dial the compression. Without the flag, behavior is unchanged (full message).

```
recall "wifi password" --snippet
[..] user: … filler18 filler19 by the way the wifi password is hunter2 remember that filler00 filler01 …

recall "wifi password" --snippet 3
[..] user: … way the wifi password is hunter2 remember …
```

## Why

`recall` is Vesta's on-demand backing store behind the always-loaded `MEMORY.md` snapshot (the FTS5 tier). When the agent is scanning many hits just to locate the right conversation, returning whole messages burns context for no benefit. Windowing gives cheap compression the agent opts into, dials with `N`, and keeps full fidelity one flag away. This is the deterministic, no-extra-model version of what a summarizer would do, without the latency, cost, or lossiness of putting a second LLM on the recall hot path.

## How

The window is computed in Python, not via FTS5 `snippet()`. `events_fts` is an external-content table (`content='events'`) whose backing table has no `text_content` column (the triggers inject `json_extract(data,'$.text')`), so `snippet()` cannot re-read the source column to build an excerpt. Instead `window()` splits the message, locates the first word matching any query term (operators/punctuation/prefix-stars stripped for the lookup), keeps `N` words on each side, and elides trimmed sides with `…`. Operator-only queries fall back to the message head. The existing `MAX_CONTENT_CHARS` cap stays as an outer backstop. `--snippet` uses argparse `nargs="?"` so the flag works with or without a value.

Ranking, the DB query, and default output are untouched, so parity with `EventBus.search` in `agent/core/events.py` is preserved.

## Tests

New `skills/recall/cli/tests/` suite (18 tests): `query_terms` parsing across FTS operator forms, windowing (both-side elision, word-count width, no-elision when the message fits, prefix match, head fallback, empty content), and end-to-end `main` on a temp events.db (full-content default, `--snippet` default width, `--snippet N` compresses more, non-conversational events excluded). All pass; ruff + format clean; skills index unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)