### PR TITLE
feat(notifications): temporary silence/trash rules that auto-expire

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -258,7 +258,7 @@ async def _config_get_handler(request: web.Request) -> web.Response:
     config: VestaConfig = request.app["config"]
     data = stored_config(config)
     data.pop("provider", None)
-    data["notification_rules"] = [rule.model_dump() for rule in load_notification_rules()]
+    data["notification_rules"] = [rule.model_dump(mode="json") for rule in load_notification_rules()]
     return web.json_response(data)
 
 

--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -1,4 +1,5 @@
 import copy
+import datetime as dt
 import json
 import os
 import pathlib as pl
@@ -11,7 +12,7 @@ import pydantic_settings as pyd_settings
 from core import logger
 from claude_agent_sdk.types import ThinkingConfigAdaptive, ThinkingConfigDisabled, ThinkingConfigEnabled
 
-from .notification_interrupt_policy import NotificationInterruptRule
+from .notification_interrupt_policy import NotificationInterruptRule, drop_expired
 
 
 _DEFAULT_AGENT_DIR = pl.Path.home() / "agent"
@@ -165,7 +166,7 @@ def load_notification_rules() -> list[NotificationInterruptRule]:
             rules.append(NotificationInterruptRule.model_validate(item))
         except pyd.ValidationError as exc:
             logger.error(f"dropping invalid notification rule {item} — keeping the rest ({exc})")
-    return rules
+    return drop_expired(rules, dt.datetime.now(dt.UTC))
 
 
 class ClaudeOAuth(pyd.BaseModel):
@@ -416,7 +417,7 @@ def validate_config_updates(config: "VestaConfig", data: object) -> dict[str, py
         for rule in validated.notification_rules:
             if not rule.id:
                 rule.id = uuid.uuid4().hex
-        updates["notification_rules"] = [rule.model_dump() for rule in validated.notification_rules]
+        updates["notification_rules"] = [rule.model_dump(mode="json") for rule in validated.notification_rules]
     return updates
 
 

--- a/agent/core/notification_interrupt_policy.py
+++ b/agent/core/notification_interrupt_policy.py
@@ -87,6 +87,17 @@ class NotificationInterruptRule(pyd.BaseModel):
     type: str | None = None
     match: list[FieldPredicate] = []
     action: tp.Literal["interrupt", "snooze", "trash"]
+    # When set, the rule stops applying once this instant passes (a temporary silence/trash), so
+    # notifications flow by their default again with no one having to remember to remove it. Filtered
+    # out of the live ruleset by drop_expired at the load boundary, then pruned on the next rule write.
+    expires_at: dt.datetime | None = None
+
+    def is_expired(self, now: dt.datetime) -> bool:
+        if self.expires_at is None:
+            return False
+        # A naive stored value (older write, hand edit) is read as UTC so the comparison never raises.
+        expiry = self.expires_at if self.expires_at.tzinfo is not None else self.expires_at.replace(tzinfo=dt.UTC)
+        return now >= expiry
 
     @pyd.model_validator(mode="before")
     @classmethod
@@ -226,6 +237,13 @@ def _matches(rule: NotificationInterruptRule, notif: Notification) -> bool:
     if rule.type is not None and rule.type.lower() != notif.type.lower():
         return False
     return all(_predicate_matches(predicate, notif) for predicate in rule.match)
+
+
+def drop_expired(rules: list[NotificationInterruptRule], now: dt.datetime) -> list[NotificationInterruptRule]:
+    """The live subset of a ruleset: temporary rules whose `expires_at` has passed are gone. Applied at
+    the load boundary (load_notification_rules) so matching, the GET /config view, and the skill's `list`
+    all see only active rules, and an expired rule is pruned the next time the ruleset is written."""
+    return [rule for rule in rules if not rule.is_expired(now)]
 
 
 def notif_disposition(notif: Notification, rules: list[NotificationInterruptRule]) -> tp.Literal["interrupt", "snooze", "trash"]:

--- a/agent/skills/notifications/SKILL.md
+++ b/agent/skills/notifications/SKILL.md
@@ -25,6 +25,12 @@ A rule has two dedicated fields (`source`, `type`) plus any number of `match` co
 notification's other fields. Every field/condition you set must hold (AND); whatever you omit is ignored.
 
 - `--action` is `interrupt`, `snooze`, or `trash` (drop entirely; see the mental model).
+- `--for <duration>` makes any rule **temporary**: it auto-expires (and is then removed) after that long, so
+  notifications flow by their default again with nothing to remember. Pairs with any action, so a
+  temporary silence is `--action snooze --for 2h` and a temporary trash is `--action trash --for 1d`.
+  Duration is `s`/`m`/`h`/`d` chunks: `30m`, `2h`, `1h30m`, `1d`. A permanent rule (no `--for`) stays
+  until you remove it. Prefer a temporary rule whenever the reason is time-bounded (deep work, a noisy
+  event that ends), so a suppression can never outlive its purpose.
 - `source`/`type` are exact (case-insensitive), e.g. `--source whatsapp --type message`.
 - Each `match` targets one field: `--match 'FIELD<op>VALUE'`, ops (case-insensitive):
   - `=` substring, e.g. `--match 'chat_name=Bride squad'`
@@ -60,6 +66,12 @@ notifications list
 # Snooze low-value distractions so they wait until you are idle
 notifications add --source twitter --action snooze
 
+# Temporary silence: mute a source for a few hours, then it flows again on its own (no cleanup needed)
+notifications add --source whatsapp --action snooze --for 2h
+
+# Temporary trash: drop a source that is noisy only for today (an event, a live thread), auto-expires
+notifications add --source twitter --match 'chat_name=World Cup' --action trash --for 1d
+
 # Let what genuinely matters reach you immediately (auto-placed above broader snooze rules)
 notifications add --source whatsapp --sender "wife" --action interrupt
 notifications add --source email --keyword urgent --action interrupt
@@ -90,7 +102,7 @@ notifications clear
 
 ## Guarding a hard task
 
-Before deep work you don't want broken, add a broad `--action snooze` rule (with narrower `interrupt` rules above it for the few things that should still reach you), then **remove it when you're done**: a forgotten snooze rule keeps holding back interrupts after the session is over.
+Before deep work you don't want broken, add a broad `--action snooze` rule (with narrower `interrupt` rules above it for the few things that should still reach you). If you know roughly how long the work will take, add `--for <duration>` (e.g. `--for 90m`) so the rule lifts itself and you can't forget it. Otherwise **remove it when you're done**: a forgotten permanent snooze rule keeps holding back interrupts after the session is over.
 
 ## Working through snoozed notifications
 

--- a/agent/skills/notifications/cli/src/notifications_cli/cli.py
+++ b/agent/skills/notifications/cli/src/notifications_cli/cli.py
@@ -9,6 +9,7 @@ notification history (events.db) directly to show what values you can target.
 """
 
 import argparse
+import datetime as dt
 import json
 import os
 import pathlib
@@ -68,6 +69,28 @@ def _predicate(field: str, op: str, value: str, negate: bool = False) -> dict[st
     """The canonical match-predicate shape core's FieldPredicate accepts. One builder so the sender/text
     alias predicates and parsed --match predicates can't drift in shape."""
     return {"field": field, "op": op, "value": value, "negate": negate}
+
+
+_DURATION_GRAMMAR = re.compile(r"(\d+)\s*([smhd])", re.IGNORECASE)
+_DURATION_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+def _parse_duration(spec: str) -> dt.timedelta:
+    """Parse a duration like '2h', '30m', '1h30m', '45s', '1d' into a timedelta, summing each
+    <int><unit> chunk (s/m/h/d). Rejects a spec with no chunk or any leftover text, so a typo like
+    '2x' fails loudly instead of silently expiring immediately."""
+    chunks = list(_DURATION_GRAMMAR.finditer(spec))
+    stripped = re.sub(r"\s+", "", spec)
+    if not chunks or "".join(chunk.group(0) for chunk in chunks).replace(" ", "") != stripped:
+        raise ValueError(f"--for must be a duration like 2h, 30m, 1h30m, 1d: {spec!r}")
+    seconds = sum(int(chunk.group(1)) * _DURATION_UNIT_SECONDS[chunk.group(2).lower()] for chunk in chunks)
+    if seconds <= 0:
+        raise ValueError(f"--for must be a positive duration: {spec!r}")
+    return dt.timedelta(seconds=seconds)
 
 
 _MATCH_GRAMMAR = re.compile(r"^(?P<field>[^=!~]+)(?P<op>!?~?=)(?P<value>.*)$", re.DOTALL)
@@ -171,6 +194,12 @@ def cmd_add(args: argparse.Namespace) -> int:
             print(f"error: {e}", file=sys.stderr)
             return 1
     rule: dict[str, object] = {"id": uuid.uuid4().hex, "source": args.source, "type": args.type, "match": predicates, "action": args.action}
+    if args.for_duration is not None:
+        try:
+            rule["expires_at"] = (_utcnow() + _parse_duration(args.for_duration)).isoformat()
+        except ValueError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 1
     rules = get_rules()
     try:
         index = _placement_index(rules, rule, args.before, args.after)
@@ -180,7 +209,8 @@ def cmd_add(args: argparse.Namespace) -> int:
     rules.insert(index, rule)
     put_rules(rules)
     where = "" if index == len(rules) - 1 else f" at position {index + 1} of {len(rules)}"
-    print(f"Added rule {rule['id']}: {_describe_scope(rule)} -> {args.action}{where}. Now {len(rules)} rule(s); applies next tick.")
+    expiry = f" (expires in {args.for_duration}, then auto-removed)" if args.for_duration is not None else ""
+    print(f"Added rule {rule['id']}: {_describe_scope(rule)} -> {args.action}{expiry}{where}. Now {len(rules)} rule(s); applies next tick.")
     return 0
 
 
@@ -299,6 +329,15 @@ def main() -> int:
         help="Match ANY notification field (run `facets` to see them). Ops: '=' substring, '~=' regex, "
         "'!=' not, '!~=' not-regex. Repeatable (all must match). e.g. --match 'chat_name=Bride squad', "
         "--match 'chat_type!=group', --match 'chat_name~=^proj-'. Case-insensitive.",
+    )
+    add.add_argument(
+        "--for",
+        dest="for_duration",
+        metavar="DURATION",
+        help="Make the rule temporary: it auto-expires (and is then removed) after this long, so "
+        "notifications flow normally again with nothing to remember. Works with any --action, e.g. a "
+        "temporary silence (--action snooze --for 2h) or temporary trash (--action trash --for 1d). "
+        "Duration is s/m/h/d chunks: 30m, 2h, 1h30m, 1d.",
     )
     add_pos = add.add_mutually_exclusive_group()
     add_pos.add_argument("--before", metavar="ID", help="Place the new rule directly above this rule id (higher priority).")

--- a/agent/skills/notifications/cli/tests/test_rules.py
+++ b/agent/skills/notifications/cli/tests/test_rules.py
@@ -8,7 +8,7 @@ from notifications_cli import cli
 
 
 def _args(**kwargs) -> argparse.Namespace:
-    base = {"source": None, "type": None, "sender": None, "keyword": None, "match": None, "before": None, "after": None}
+    base = {"source": None, "type": None, "sender": None, "keyword": None, "match": None, "before": None, "after": None, "for_duration": None}
     base.update(kwargs)
     return argparse.Namespace(**base)
 
@@ -54,6 +54,41 @@ def test_add_builds_trash_rule(monkeypatch, capsys):
     assert rule["action"] == "trash" and rule["source"] == "whatsapp"
     assert rule["match"] == [{"field": "chat_name", "op": "contains", "value": "status", "negate": False}]
     assert "-> trash" in capsys.readouterr().out
+
+
+def test_parse_duration_sums_chunks():
+    assert cli._parse_duration("2h") == __import__("datetime").timedelta(hours=2)
+    assert cli._parse_duration("30m") == __import__("datetime").timedelta(minutes=30)
+    assert cli._parse_duration("1h30m") == __import__("datetime").timedelta(minutes=90)
+    assert cli._parse_duration("1d") == __import__("datetime").timedelta(days=1)
+
+
+@pytest.mark.parametrize("spec", ["", "2x", "2h5x", "0m", "abc"])
+def test_parse_duration_rejects_bad(spec):
+    with pytest.raises(ValueError):
+        cli._parse_duration(spec)
+
+
+def test_add_temporary_rule_stamps_expiry(monkeypatch):
+    import datetime as _dt
+
+    store = _store(monkeypatch)
+    fixed = _dt.datetime(2026, 1, 1, tzinfo=_dt.UTC)
+    monkeypatch.setattr(cli, "_utcnow", lambda: fixed)
+    assert cli.cmd_add(_args(action="snooze", source="twitter", for_duration="2h")) == 0
+    assert store[0]["expires_at"] == (fixed + _dt.timedelta(hours=2)).isoformat()
+
+
+def test_add_permanent_rule_has_no_expiry(monkeypatch):
+    store = _store(monkeypatch)
+    assert cli.cmd_add(_args(action="snooze", source="twitter")) == 0
+    assert "expires_at" not in store[0]
+
+
+def test_add_rejects_bad_duration(monkeypatch, capsys):
+    _store(monkeypatch)
+    assert cli.cmd_add(_args(action="snooze", source="twitter", for_duration="soon")) == 1
+    assert "--for must be a duration" in capsys.readouterr().err
 
 
 def test_add_rejects_core_source(monkeypatch, capsys):

--- a/agent/tests/test_notification_interrupt_rules_api.py
+++ b/agent/tests/test_notification_interrupt_rules_api.py
@@ -65,6 +65,31 @@ async def test_put_then_get_round_trip_and_applies(tmp_path, monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_temporary_rule_round_trips_and_expired_one_is_dropped(tmp_path, monkeypatch):
+    client, _ = await _client(tmp_path, monkeypatch)
+    try:
+        future = (dt.datetime.now(dt.UTC) + dt.timedelta(hours=1)).isoformat()
+        past = (dt.datetime.now(dt.UTC) - dt.timedelta(hours=1)).isoformat()
+        resp = await client.put(
+            "/config",
+            json={
+                "notification_rules": [
+                    {"source": "twitter", "action": "snooze", "expires_at": future},
+                    {"source": "email", "action": "trash", "expires_at": past},
+                ]
+            },
+        )
+        assert resp.status == 200
+
+        # The live temporary rule survives (datetime serialized fine); the already-expired one is gone.
+        rules = (await (await client.get("/config")).json())["notification_rules"]
+        assert [rule["source"] for rule in rules] == ["twitter"]
+        assert dt.datetime.fromisoformat(rules[0]["expires_at"]) == dt.datetime.fromisoformat(future)
+    finally:
+        await client.close()
+
+
+@pytest.mark.anyio
 async def test_put_legacy_pool_action_is_stored_as_snooze(tmp_path, monkeypatch):
     # LEGACY: pre-rename clients still send action="pool"; it validates and persists as "snooze".
     client, _ = await _client(tmp_path, monkeypatch)

--- a/agent/tests/test_notification_rules.py
+++ b/agent/tests/test_notification_rules.py
@@ -289,6 +289,48 @@ def test_load_round_trips_a_written_store(tmp_path, monkeypatch):
     assert npn.notif_disposition(_notif(), loaded) == "snooze"
 
 
+# --- temporary rules: expires_at / drop_expired ---
+
+
+def test_rule_without_expiry_never_expires():
+    assert _rule(source="twitter", action="snooze").is_expired(dt.datetime(2026, 1, 1, tzinfo=dt.UTC)) is False
+
+
+def test_rule_is_expired_only_after_its_instant():
+    expiry = dt.datetime(2026, 1, 1, 12, tzinfo=dt.UTC)
+    rule = _rule(source="twitter", action="snooze", expires_at=expiry)
+    assert rule.is_expired(dt.datetime(2026, 1, 1, 11, tzinfo=dt.UTC)) is False
+    assert rule.is_expired(dt.datetime(2026, 1, 1, 13, tzinfo=dt.UTC)) is True
+
+
+def test_naive_expiry_is_read_as_utc():
+    rule = _rule(source="twitter", action="snooze", expires_at=dt.datetime(2026, 1, 1, 12))
+    assert rule.is_expired(dt.datetime(2026, 1, 1, 13, tzinfo=dt.UTC)) is True
+
+
+def test_drop_expired_keeps_only_live_rules():
+    now = dt.datetime(2026, 1, 1, 12, tzinfo=dt.UTC)
+    live = _rule(id="live", source="a", action="snooze", expires_at=now + dt.timedelta(hours=1))
+    dead = _rule(id="dead", source="b", action="snooze", expires_at=now - dt.timedelta(hours=1))
+    forever = _rule(id="forever", source="c", action="snooze")
+    assert [rule.id for rule in npn.drop_expired([live, dead, forever], now)] == ["live", "forever"]
+
+
+def test_load_drops_expired_rule(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENT_DIR", str(tmp_path / "agent"))
+    config = cfg.VestaConfig()
+    past = (dt.datetime.now(dt.UTC) - dt.timedelta(hours=1)).isoformat()
+    future = (dt.datetime.now(dt.UTC) + dt.timedelta(hours=1)).isoformat()
+    _write_rules_store(
+        config,
+        [
+            {"id": "expired", "source": "twitter", "action": "snooze", "expires_at": past},
+            {"id": "live", "source": "whatsapp", "action": "snooze", "expires_at": future},
+        ],
+    )
+    assert [rule.id for rule in cfg.load_notification_rules()] == ["live"]
+
+
 # --- core routing via loops._notif_disposition ---
 
 


### PR DESCRIPTION
## What

Adds a `--for <duration>` flag to `notifications add`, making any rule **temporary**: it auto-expires after the given time and is then pruned, so notifications flow by their default again with nothing to remember. This directly closes the footgun the skill already warned about ("a forgotten snooze rule keeps holding back interrupts after the session is over").

It pairs with any action, so:
- **Temporary silence:** `notifications add --source whatsapp --action snooze --for 2h`
- **Temporary trash:** `notifications add --source twitter --match 'chat_name=World Cup' --action trash --for 1d`

Duration is `s`/`m`/`h`/`d` chunks: `30m`, `2h`, `1h30m`, `1d`.

## How

- `NotificationInterruptRule` gains an optional `expires_at: datetime`, with an `is_expired(now)` helper (a naive stored value is read as UTC so comparison never raises).
- `drop_expired(rules, now)` in the policy module is the one place expiry is applied, called from `load_notification_rules` (the single live-rules boundary). So matching (monitor tick), the `GET /config` view, and the skill's `list` all see only active rules, and any `add`/`move`/`remove` reads the already-pruned set and writes it back, pruning expired rules from disk. The matcher stays a pure, time-unaware function.
- Two `model_dump()` calls that persist/serialize rules switch to `mode="json"` so the new datetime field serializes to ISO (no-op for the existing all-JSON-native fields).
- The CLI parses the duration, stamps `expires_at`, and documents the flag; SKILL.md gains the mental model, examples, and a note in "Guarding a hard task".

## Fleet impact

Purely additive: existing rules have no `expires_at` (defaults to `None` = permanent), and the model already tolerates the field on read. No migration needed.

## Tests

- CLI: duration parsing (sums chunks, rejects typos like `2x`), expiry stamping, permanent rule has no expiry, bad-duration rejection.
- Core: `is_expired` before/after the instant, naive-as-UTC, `drop_expired` keeps only live rules, `load_notification_rules` drops an expired rule.
- API: a temporary rule round-trips through PUT/GET (datetime serialization) and an already-expired one is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)