### PR TITLE
feat(web): let password managers save the connect link

### DIFF
--- a/apps/web/src/components/Connect/index.tsx
+++ b/apps/web/src/components/Connect/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Navigate } from "react-router-dom";
 import { AnimatePresence, motion } from "motion/react";
+import { Eye, EyeOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Field, FieldLabel, FieldDescription } from "@/components/ui/field";
@@ -44,6 +45,7 @@ export function Connect() {
   const [value, setValue] = useState("");
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
+  const [revealed, setRevealed] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   // In the desktop app (and any vesta-account surface) we lead with "continue
   // with vesta account"; `selfHost` flips to the connect-link form for people
@@ -219,20 +221,35 @@ export function Connect() {
             <FieldLabel htmlFor="connect-link" className="sr-only">
               Connect link
             </FieldLabel>
-            <Input
-              ref={inputRef}
-              id="connect-link"
-              type="text"
-              placeholder="paste your connect link"
-              autoComplete="off"
-              autoFocus
-              value={value}
-              onChange={(e) => {
-                setValue(e.target.value);
-                setError("");
-              }}
-              className="text-center"
-            />
+            <div className="relative">
+              <Input
+                ref={inputRef}
+                id="connect-link"
+                name="connect-link"
+                type={revealed ? "text" : "password"}
+                placeholder="paste your connect link"
+                autoComplete="current-password"
+                autoFocus
+                value={value}
+                onChange={(e) => {
+                  setValue(e.target.value);
+                  setError("");
+                }}
+                className="px-9 text-center"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => setRevealed((shown) => !shown)}
+                aria-label={
+                  revealed ? "hide connect link" : "show connect link"
+                }
+                className="absolute inset-y-0 right-0.5 my-auto text-muted-foreground hover:bg-transparent hover:text-foreground"
+              >
+                {revealed ? <EyeOff /> : <Eye />}
+              </Button>
+            </div>
           </Field>
 
           <Button


### PR DESCRIPTION
## What

The connect-link input on the web app now triggers the password manager: masked by default with a reveal toggle, so 1Password/Chrome offer to save it on connect and fill it next time.

## Why

`autoComplete="off"` on the field is an explicit instruction to browsers and password managers to stay away, so the connect link had to be re-pasted by hand on every new device. It is the one credential you legitimately re-enter across devices, which is exactly what a password manager is for.

## Changes

All in `apps/web/src/components/Connect/index.tsx`:

- `autoComplete="off"` to `"current-password"`. This was the actual blocker.
- `type="text"` to `type={revealed ? "text" : "password"}`. The reliable trigger for save/fill.
- Added `name="connect-link"` so managers have a stable field identity to key the saved entry on.
- Added a ghost Eye/EyeOff reveal toggle inside the field, `type="button"` so it cannot submit the form. A connect link is a long URL whose common failure is a truncated paste, so it stays eyeball-checkable.
- Padding `px-3` to `px-9`, symmetric so the centered text stays centered rather than sitting off-center against the toggle.

The `<form onSubmit>` + `type="submit"` structure was already correct, which is what makes the save prompt fire on connect.

## Note on the deliberate inconsistency

The sibling OpenRouter API key field (`ProviderPicker/KeyStep`) does the opposite on purpose: it stays `type="text"`, masks via `WebkitTextSecurity`, and carries `data-1p-ignore` / `data-lpignore` / `data-form-type="other"` to keep managers out entirely. That split is intentional and left as-is: a connect link is re-entered per device, an API key is pasted once at setup and never again.

## Verification

`./check.sh web` passes (exit 0, 185 tests). The markup is verified; whether 1Password actually offers to save and fill needs a real browser with the extension installed and has not been confirmed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)