### PR TITLE
feat(telegram): notify on edited messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
               - 'check.sh'
             go:
               - 'agent/skills/whatsapp/cli/**'
+              - 'agent/skills/telegram/cli/**'
               - '.github/workflows/ci.yml'
               - 'check.sh'
 
@@ -184,7 +185,7 @@ jobs:
       - name: Run agent checks
         run: ./check.sh agent
 
-  # ── Go checks (whatsapp CLI) ──────────────────────────────────────────
+  # ── Go checks (whatsapp + telegram CLIs) ──────────────────────────────
   go-checks:
     needs: detect-changes
     if: github.event_name != 'pull_request' || needs.detect-changes.outputs.go == 'true'
@@ -206,6 +207,9 @@ jobs:
 
       - name: Run whatsapp checks
         run: ./check.sh whatsapp
+
+      - name: Run telegram checks
+        run: ./check.sh telegram
 
   # ── Windows install script guard ──────────────────────────────────────
   install-script-check:

--- a/agent/core/notification_interrupt_policy.py
+++ b/agent/core/notification_interrupt_policy.py
@@ -31,7 +31,7 @@ from .notification import CORE_SOURCE, Notification
 # satisfies the op. This is the single place cross-source field-name knowledge lives — a new source's
 # new field is targetable by its concrete name with no code change.
 _IDENTITY_FIELDS = ("sender", "contact_name", "handle", "from", "author")
-_BODY_FIELDS = ("body", "message", "content", "text")
+_BODY_FIELDS = ("body", "message", "content")
 _FIELD_ALIASES: dict[str, tuple[str, ...]] = {"sender": _IDENTITY_FIELDS, "text": _BODY_FIELDS}
 
 

--- a/agent/core/notification_interrupt_policy.py
+++ b/agent/core/notification_interrupt_policy.py
@@ -31,7 +31,7 @@ from .notification import CORE_SOURCE, Notification
 # satisfies the op. This is the single place cross-source field-name knowledge lives — a new source's
 # new field is targetable by its concrete name with no code change.
 _IDENTITY_FIELDS = ("sender", "contact_name", "handle", "from", "author")
-_BODY_FIELDS = ("body", "message", "content")
+_BODY_FIELDS = ("body", "message", "content", "text")
 _FIELD_ALIASES: dict[str, tuple[str, ...]] = {"sender": _IDENTITY_FIELDS, "text": _BODY_FIELDS}
 
 

--- a/agent/skills/telegram/SKILL.md
+++ b/agent/skills/telegram/SKILL.md
@@ -23,6 +23,10 @@ telegram send-file --to "<contact_name>" --file-path /path/to/document.pdf
 telegram send-voice --to "<contact_name>" --file-path /path/to/note.ogg
 ```
 
+## Edited messages
+
+People change their minds after they hit send, so a message you already read can change. An edit arrives as an `edit` notification naming the message that changed (`target_message_id`), the text you last saw (`old_text`), and what it says now (`new_text`). The stored message is rewritten, so `list-messages` and search show only the new text. Answer again only if the edit asks something new: a fixed typo needs nothing from you. Deletions are invisible here, Telegram never tells a bot that a message was deleted.
+
 ## Interactive UI (inline buttons + callbacks)
 
 Send tappable buttons, get notified when the owner taps, then answer the tap and/or edit the

--- a/agent/skills/telegram/SKILL.md
+++ b/agent/skills/telegram/SKILL.md
@@ -25,7 +25,7 @@ telegram send-voice --to "<contact_name>" --file-path /path/to/note.ogg
 
 ## Edited messages
 
-People change their minds after they hit send, so a message you already read can change. An edit arrives as an `edit` notification naming the message that changed (`target_message_id`), the text you last saw (`old_text`), and what it says now (`new_text`). The stored message is rewritten, so `list-messages` and search show only the new text. Answer again only if the edit asks something new: a fixed typo needs nothing from you. Deletions are invisible here, Telegram never tells a bot that a message was deleted.
+People change their minds after they hit send, so a message you already read can change. An edit arrives as an `edit` notification naming the message that changed (`target_message_id`), the text you last saw (`old_text`), and what it says now (`text`). The stored message is rewritten, so `list-messages` and search show only the new text. Answer again only if the edit asks something new: a fixed typo needs nothing from you. Deletions are invisible here, Telegram never tells a bot that a message was deleted.
 
 ## Interactive UI (inline buttons + callbacks)
 

--- a/agent/skills/telegram/SKILL.md
+++ b/agent/skills/telegram/SKILL.md
@@ -25,7 +25,7 @@ telegram send-voice --to "<contact_name>" --file-path /path/to/note.ogg
 
 ## Edited messages
 
-People change their minds after they hit send, so a message you already read can change. An edit arrives as an `edit` notification naming the message that changed (`target_message_id`), the text you last saw (`old_text`), and what it says now (`text`). The stored message is rewritten, so `list-messages` and search show only the new text. Answer again only if the edit asks something new: a fixed typo needs nothing from you. Deletions are invisible here, Telegram never tells a bot that a message was deleted.
+People change their minds after they hit send, so a message you already read can change. An edit arrives as an `edit` notification whose body carries what the message says now, just like a plain message, naming the message that changed (`target_message_id`) and the text you last saw (`old_text`). The stored message is rewritten, so `list-messages` and search show only the new text. Answer again only if the edit asks something new: a fixed typo needs nothing from you. Deletions are invisible here, Telegram never tells a bot that a message was deleted.
 
 ## Interactive UI (inline buttons + callbacks)
 

--- a/agent/skills/telegram/cli/edits_test.go
+++ b/agent/skills/telegram/cli/edits_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+const (
+	testChatID    = int64(4242)
+	testMessageID = 77
+	testBotUserID = int64(999)
+	testSenderID  = 4242
+)
+
+// newEditTestClient builds a client wired to a real store and notifications dir. The bot
+// handle stays nil: the edit path never calls Telegram, it only reads the update it was
+// handed.
+func newEditTestClient(t *testing.T) (*TelegramClient, string) {
+	t.Helper()
+	store, err := NewMessageStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	if err := store.StoreChat(testChatID, "Ana", "private", time.Now()); err != nil {
+		t.Fatalf("failed to store chat: %v", err)
+	}
+
+	notifDir := t.TempDir()
+	return &TelegramClient{
+		store:            store,
+		notificationsDir: notifDir,
+		instance:         "personal",
+		skipSenders:      map[string]bool{},
+		botUserID:        testBotUserID,
+	}, notifDir
+}
+
+func storeOriginal(t *testing.T, tc *TelegramClient, content string) {
+	t.Helper()
+	if err := tc.store.StoreMessage(
+		testMessageID, testChatID, "Ana", content, time.Now(), false, "", "", "", 0,
+	); err != nil {
+		t.Fatalf("failed to store message: %v", err)
+	}
+}
+
+func editedMessage(newText string) *tgbotapi.Message {
+	return &tgbotapi.Message{
+		MessageID: testMessageID,
+		From:      &tgbotapi.User{ID: testSenderID, FirstName: "Ana", UserName: "ana"},
+		Chat:      &tgbotapi.Chat{ID: testChatID, Type: "private", FirstName: "Ana"},
+		Text:      newText,
+		Date:      int(time.Now().Unix()),
+	}
+}
+
+func readNotifs(t *testing.T, dir string) []editNotif {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read notifications dir: %v", err)
+	}
+	notifs := make([]editNotif, 0, len(entries))
+	for _, entry := range entries {
+		raw, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			t.Fatalf("failed to read notification: %v", err)
+		}
+		var n editNotif
+		if err := json.Unmarshal(raw, &n); err != nil {
+			t.Fatalf("notification is not valid json: %v", err)
+		}
+		notifs = append(notifs, n)
+	}
+	return notifs
+}
+
+func soleNotif(t *testing.T, dir string) editNotif {
+	t.Helper()
+	notifs := readNotifs(t, dir)
+	if len(notifs) != 1 {
+		t.Fatalf("expected exactly one notification, got %d: %+v", len(notifs), notifs)
+	}
+	return notifs[0]
+}
+
+func TestEditNotifiesWithBothTheOldAndTheNewText(t *testing.T) {
+	tc, notifDir := newEditTestClient(t)
+	storeOriginal(t, tc, "let's meet at 6")
+
+	tc.handleEditedMessage(editedMessage("let's meet at 9"))
+
+	got := soleNotif(t, notifDir)
+	if got.Source != "telegram" || got.Type != "edit" {
+		t.Errorf("source/type = %q/%q, want telegram/edit (not a plain message)", got.Source, got.Type)
+	}
+	if got.OldText != "let's meet at 6" {
+		t.Errorf("old_text = %q, want the pre-edit text", got.OldText)
+	}
+	if got.NewText != "let's meet at 9" {
+		t.Errorf("new_text = %q, want the replacement text", got.NewText)
+	}
+	if got.TargetMessageID != testMessageID {
+		t.Errorf("target_message_id = %d, want the edited message's id", got.TargetMessageID)
+	}
+	if got.Timestamp == "" {
+		t.Error("timestamp is empty")
+	}
+}
+
+func TestEditRewritesStoredContent(t *testing.T) {
+	tc, _ := newEditTestClient(t)
+	storeOriginal(t, tc, "let's meet at 6")
+
+	tc.handleEditedMessage(editedMessage("let's meet at 9"))
+
+	content, err := tc.store.GetMessageContent(testMessageID)
+	if err != nil {
+		t.Fatalf("failed to read content: %v", err)
+	}
+	if content != "let's meet at 9" {
+		t.Errorf("stored content = %q, want the edit applied", content)
+	}
+}
+
+func TestEditKeepsFullTextSearchInSyncWithTheNewText(t *testing.T) {
+	tc, _ := newEditTestClient(t)
+	storeOriginal(t, tc, "let's meet at the harbour")
+
+	tc.handleEditedMessage(editedMessage("let's meet at the airport"))
+
+	if ids := searchIDs(t, tc, "airport"); len(ids) != 1 || ids[0] != testMessageID {
+		t.Errorf("searching the new text returned %v, want exactly the edited message", ids)
+	}
+	if ids := searchIDs(t, tc, "harbour"); len(ids) != 0 {
+		t.Errorf("searching the pre-edit text returned %v, want nothing (the index must not hold stale text)", ids)
+	}
+}
+
+func searchIDs(t *testing.T, tc *TelegramClient, query string) []int64 {
+	t.Helper()
+	rows, err := tc.store.db.Query(`
+		SELECT m.id FROM messages m
+		JOIN messages_fts ON messages_fts.rowid = m.rowid
+		WHERE messages_fts MATCH ?
+	`, query)
+	if err != nil {
+		t.Fatalf("fts query failed: %v", err)
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan failed: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func TestEditOfAMessageWeNeverStoredStillReportsTheNewText(t *testing.T) {
+	tc, notifDir := newEditTestClient(t)
+
+	tc.handleEditedMessage(editedMessage("let's meet at 9"))
+
+	got := soleNotif(t, notifDir)
+	if got.NewText != "let's meet at 9" {
+		t.Errorf("new_text = %q, want the replacement text", got.NewText)
+	}
+	if got.OldText != "" {
+		t.Errorf("old_text = %q, want empty when the original was never stored", got.OldText)
+	}
+}
+
+func TestEditToIdenticalTextIsNotNotified(t *testing.T) {
+	tc, notifDir := newEditTestClient(t)
+	storeOriginal(t, tc, "let's meet at 6")
+
+	tc.handleEditedMessage(editedMessage("let's meet at 6"))
+
+	if notifs := readNotifs(t, notifDir); len(notifs) != 0 {
+		t.Errorf("wrote %d notifications, want none when the text did not actually change", len(notifs))
+	}
+}
+
+func TestOwnEditIsNotNotified(t *testing.T) {
+	tc, notifDir := newEditTestClient(t)
+	storeOriginal(t, tc, "let's meet at 6")
+
+	msg := editedMessage("let's meet at 9")
+	msg.From.ID = int64(testBotUserID)
+	tc.handleEditedMessage(msg)
+
+	if notifs := readNotifs(t, notifDir); len(notifs) != 0 {
+		t.Errorf("wrote %d notifications, want none for our own edit", len(notifs))
+	}
+}
+
+func TestSkippedSenderGetsNoEditNotification(t *testing.T) {
+	tc, notifDir := newEditTestClient(t)
+	storeOriginal(t, tc, "let's meet at 6")
+	tc.skipSenders["ana"] = true
+
+	tc.handleEditedMessage(editedMessage("let's meet at 9"))
+
+	if notifs := readNotifs(t, notifDir); len(notifs) != 0 {
+		t.Errorf("wrote %d notifications, want none for a skipped sender", len(notifs))
+	}
+}
+
+// An edited caption carries its text in Caption, not Text.
+func TestEditOfAMediaCaptionIsReported(t *testing.T) {
+	tc, notifDir := newEditTestClient(t)
+	storeOriginal(t, tc, "old caption")
+
+	msg := editedMessage("")
+	msg.Caption = "new caption"
+	tc.handleEditedMessage(msg)
+
+	got := soleNotif(t, notifDir)
+	if got.NewText != "new caption" || got.OldText != "old caption" {
+		t.Errorf("caption edit not reported: old=%q new=%q", got.OldText, got.NewText)
+	}
+}

--- a/agent/skills/telegram/cli/edits_test.go
+++ b/agent/skills/telegram/cli/edits_test.go
@@ -103,8 +103,8 @@ func TestEditNotifiesWithBothTheOldAndTheNewText(t *testing.T) {
 	if got.OldText != "let's meet at 6" {
 		t.Errorf("old_text = %q, want the pre-edit text", got.OldText)
 	}
-	if got.Text != "let's meet at 9" {
-		t.Errorf("text = %q, want the replacement text", got.Text)
+	if got.Message != "let's meet at 9" {
+		t.Errorf("message = %q, want the replacement text", got.Message)
 	}
 	if got.TargetMessageID != testMessageID {
 		t.Errorf("target_message_id = %d, want the edited message's id", got.TargetMessageID)
@@ -171,8 +171,8 @@ func TestEditOfAMessageWeNeverStoredStillReportsTheNewText(t *testing.T) {
 	tc.handleEditedMessage(editedMessage("let's meet at 9"))
 
 	got := soleNotif(t, notifDir)
-	if got.Text != "let's meet at 9" {
-		t.Errorf("text = %q, want the replacement text", got.Text)
+	if got.Message != "let's meet at 9" {
+		t.Errorf("message = %q, want the replacement text", got.Message)
 	}
 	if got.OldText != "" {
 		t.Errorf("old_text = %q, want empty when the original was never stored", got.OldText)
@@ -225,7 +225,7 @@ func TestEditOfAMediaCaptionIsReported(t *testing.T) {
 	tc.handleEditedMessage(msg)
 
 	got := soleNotif(t, notifDir)
-	if got.Text != "new caption" || got.OldText != "old caption" {
-		t.Errorf("caption edit not reported: old=%q new=%q", got.OldText, got.Text)
+	if got.Message != "new caption" || got.OldText != "old caption" {
+		t.Errorf("caption edit not reported: old=%q new=%q", got.OldText, got.Message)
 	}
 }

--- a/agent/skills/telegram/cli/edits_test.go
+++ b/agent/skills/telegram/cli/edits_test.go
@@ -103,8 +103,8 @@ func TestEditNotifiesWithBothTheOldAndTheNewText(t *testing.T) {
 	if got.OldText != "let's meet at 6" {
 		t.Errorf("old_text = %q, want the pre-edit text", got.OldText)
 	}
-	if got.NewText != "let's meet at 9" {
-		t.Errorf("new_text = %q, want the replacement text", got.NewText)
+	if got.Text != "let's meet at 9" {
+		t.Errorf("text = %q, want the replacement text", got.Text)
 	}
 	if got.TargetMessageID != testMessageID {
 		t.Errorf("target_message_id = %d, want the edited message's id", got.TargetMessageID)
@@ -171,8 +171,8 @@ func TestEditOfAMessageWeNeverStoredStillReportsTheNewText(t *testing.T) {
 	tc.handleEditedMessage(editedMessage("let's meet at 9"))
 
 	got := soleNotif(t, notifDir)
-	if got.NewText != "let's meet at 9" {
-		t.Errorf("new_text = %q, want the replacement text", got.NewText)
+	if got.Text != "let's meet at 9" {
+		t.Errorf("text = %q, want the replacement text", got.Text)
 	}
 	if got.OldText != "" {
 		t.Errorf("old_text = %q, want empty when the original was never stored", got.OldText)
@@ -225,7 +225,7 @@ func TestEditOfAMediaCaptionIsReported(t *testing.T) {
 	tc.handleEditedMessage(msg)
 
 	got := soleNotif(t, notifDir)
-	if got.NewText != "new caption" || got.OldText != "old caption" {
-		t.Errorf("caption edit not reported: old=%q new=%q", got.OldText, got.NewText)
+	if got.Text != "new caption" || got.OldText != "old caption" {
+		t.Errorf("caption edit not reported: old=%q new=%q", got.OldText, got.Text)
 	}
 }

--- a/agent/skills/telegram/cli/notifications.go
+++ b/agent/skills/telegram/cli/notifications.go
@@ -44,9 +44,10 @@ type reactionNotif struct {
 	ContactUnknown  bool   `json:"contact_unknown,omitempty"`
 }
 
-// editNotif is emitted when a sender edits a message the agent has already seen. It names the
-// message that changed plus both texts, so the agent can tell a fixed typo (nothing to do) from
-// a changed question (worth answering again) instead of reading the edit as a brand new message.
+// editNotif is emitted when a sender edits a message the agent has already seen. It carries the
+// current text in message (the same body field a plain message uses) plus old_text, so the agent
+// can tell a fixed typo (nothing to do) from a changed question (worth answering again) instead of
+// reading the edit as a brand new message.
 type editNotif struct {
 	Source          string `json:"source"`
 	Type            string `json:"type"`
@@ -56,7 +57,7 @@ type editNotif struct {
 	ChatName        string `json:"chat_name,omitempty"`
 	Username        string `json:"username,omitempty"`
 	OldText         string `json:"old_text,omitempty"`
-	Text            string `json:"text"`
+	Message         string `json:"message"`
 	Timestamp       string `json:"timestamp"`
 	TargetMessageID int64  `json:"target_message_id"`
 	ContactUnknown  bool   `json:"contact_unknown,omitempty"`
@@ -133,7 +134,7 @@ func WriteEditNotification(
 		ContactName:     contactName,
 		Username:        username,
 		OldText:         oldText,
-		Text:            newText,
+		Message:         newText,
 		Timestamp:       time.Now().Format(time.RFC3339),
 		TargetMessageID: targetMessageID,
 		ContactUnknown:  !contactSaved,

--- a/agent/skills/telegram/cli/notifications.go
+++ b/agent/skills/telegram/cli/notifications.go
@@ -56,7 +56,7 @@ type editNotif struct {
 	ChatName        string `json:"chat_name,omitempty"`
 	Username        string `json:"username,omitempty"`
 	OldText         string `json:"old_text,omitempty"`
-	NewText         string `json:"new_text"`
+	Text            string `json:"text"`
 	Timestamp       string `json:"timestamp"`
 	TargetMessageID int64  `json:"target_message_id"`
 	ContactUnknown  bool   `json:"contact_unknown,omitempty"`
@@ -133,7 +133,7 @@ func WriteEditNotification(
 		ContactName:     contactName,
 		Username:        username,
 		OldText:         oldText,
-		NewText:         newText,
+		Text:            newText,
 		Timestamp:       time.Now().Format(time.RFC3339),
 		TargetMessageID: targetMessageID,
 		ContactUnknown:  !contactSaved,

--- a/agent/skills/telegram/cli/notifications.go
+++ b/agent/skills/telegram/cli/notifications.go
@@ -44,6 +44,25 @@ type reactionNotif struct {
 	ContactUnknown  bool   `json:"contact_unknown,omitempty"`
 }
 
+// editNotif is emitted when a sender edits a message the agent has already seen. It names the
+// message that changed plus both texts, so the agent can tell a fixed typo (nothing to do) from
+// a changed question (worth answering again) instead of reading the edit as a brand new message.
+type editNotif struct {
+	Source          string `json:"source"`
+	Type            string `json:"type"`
+	Instance        string `json:"instance,omitempty"`
+	ContactName     string `json:"contact_name,omitempty"`
+	Sender          string `json:"sender,omitempty"`
+	ChatName        string `json:"chat_name,omitempty"`
+	Username        string `json:"username,omitempty"`
+	OldText         string `json:"old_text,omitempty"`
+	NewText         string `json:"new_text"`
+	Timestamp       string `json:"timestamp"`
+	TargetMessageID int64  `json:"target_message_id"`
+	ContactUnknown  bool   `json:"contact_unknown,omitempty"`
+	ReplyHint       string `json:"reply_hint,omitempty"`
+}
+
 // callbackNotif is emitted when the owner taps an inline-keyboard button. CallbackID is needed to
 // answer the tap (telegram answer-callback --callback-id ...); ChatID+MessageID locate the message
 // to edit in place if updating the UI.
@@ -92,6 +111,47 @@ func WriteCallbackNotification(
 	}
 	filename := fmt.Sprintf("%s-telegram-callback.json", uuid.New().String())
 	return os.WriteFile(filepath.Join(notifDir, filename), out, 0644)
+}
+
+func WriteEditNotification(
+	notifDir string, targetMessageID int64, chatName, contactName, username, instance string,
+	contactSaved, isDirectChat bool,
+	sender, oldText, newText string,
+) error {
+	if notifDir == "" {
+		return nil
+	}
+
+	if err := os.MkdirAll(notifDir, 0755); err != nil {
+		return fmt.Errorf("failed to create notifications dir: %v", err)
+	}
+
+	notif := editNotif{
+		Source:          "telegram",
+		Type:            "edit",
+		Instance:        instance,
+		ContactName:     contactName,
+		Username:        username,
+		OldText:         oldText,
+		NewText:         newText,
+		Timestamp:       time.Now().Format(time.RFC3339),
+		TargetMessageID: targetMessageID,
+		ContactUnknown:  !contactSaved,
+		ReplyHint:       "they changed a message you may have already answered; reply with `telegram send` only if the change asks something new",
+	}
+	if !isDirectChat {
+		notif.ChatName = chatName
+		if sender != chatName {
+			notif.Sender = sender
+		}
+	}
+
+	data, err := json.MarshalIndent(notif, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal edit notification: %v", err)
+	}
+	filename := fmt.Sprintf("%s-telegram-edit.json", uuid.New().String())
+	return os.WriteFile(filepath.Join(notifDir, filename), data, 0644)
 }
 
 func WriteNotification(

--- a/agent/skills/telegram/cli/storage.go
+++ b/agent/skills/telegram/cli/storage.go
@@ -84,6 +84,10 @@ func NewMessageStore(dataDir string) (*MessageStore, error) {
 			DELETE FROM messages_fts WHERE rowid = old.rowid;
 		END;
 
+		CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE OF content ON messages BEGIN
+			UPDATE messages_fts SET content = new.content WHERE rowid = new.rowid;
+		END;
+
 		CREATE TRIGGER IF NOT EXISTS chats_au AFTER UPDATE OF name ON chats BEGIN
 			DELETE FROM messages_fts WHERE rowid IN (
 				SELECT rowid FROM messages WHERE chat_id = new.id
@@ -168,6 +172,31 @@ func (ms *MessageStore) StoreMessage(
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, msgID, chatID, sender, content, timestamp, isFromMe,
 		mediaType, filename, fileID, replyToID)
+	return err
+}
+
+// GetMessageContent returns a message's text, or empty when it was never stored.
+func (ms *MessageStore) GetMessageContent(msgID int64) (string, error) {
+	var content sql.NullString
+	err := ms.db.QueryRow(`SELECT content FROM messages WHERE id = ? LIMIT 1`, msgID).Scan(&content)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return content.String, nil
+}
+
+// UpdateMessageContent rewrites a message's text in place after the sender edited it.
+// An edit changes only the text, so this writes only that and leaves the row's media,
+// reply and timestamp columns as the original message set them, rather than re-deriving
+// every one of them from the edit payload the way a full StoreMessage would.
+func (ms *MessageStore) UpdateMessageContent(msgID, chatID int64, content string) error {
+	_, err := ms.db.Exec(`
+		UPDATE messages SET content = ?
+		WHERE id = ? AND chat_id = ?
+	`, content, msgID, chatID)
 	return err
 }
 

--- a/agent/skills/telegram/cli/telegram.go
+++ b/agent/skills/telegram/cli/telegram.go
@@ -93,7 +93,7 @@ func (tc *TelegramClient) StartPolling() {
 		case update.Message != nil:
 			tc.handleMessage(update.Message)
 		case update.EditedMessage != nil:
-			tc.handleMessage(update.EditedMessage)
+			tc.handleEditedMessage(update.EditedMessage)
 		case update.CallbackQuery != nil:
 			tc.handleCallbackQuery(update.CallbackQuery)
 		}
@@ -131,6 +131,104 @@ func (tc *TelegramClient) handleCallbackQuery(cb *tgbotapi.CallbackQuery) {
 func (tc *TelegramClient) Stop() {
 	tc.bot.StopReceivingUpdates()
 	tc.store.Close()
+}
+
+// notifContext is who an inbound message is from, resolved identically for a new message and
+// for an edit of one.
+type notifContext struct {
+	chatName     string
+	contactName  string
+	username     string
+	sender       string
+	contactSaved bool
+	isDirectChat bool
+}
+
+func chatNameOf(msg *tgbotapi.Message) string {
+	if msg.Chat.Title != "" {
+		return msg.Chat.Title
+	}
+	if msg.Chat.FirstName != "" {
+		return strings.TrimSpace(msg.Chat.FirstName + " " + msg.Chat.LastName)
+	}
+	return ""
+}
+
+// notifContextFor resolves who to name in a notification about msg, and reports false when
+// nothing should be written for it at all: our own message, notifications off, or a skipped
+// sender. Shared so an edit stays exactly as quiet as the message it refers to.
+func (tc *TelegramClient) notifContextFor(msg *tgbotapi.Message) (notifContext, bool) {
+	isFromMe := msg.From != nil && int64(msg.From.ID) == tc.botUserID
+	if tc.notificationsDir == "" || isFromMe {
+		return notifContext{}, false
+	}
+
+	username := ""
+	senderID := ""
+	if msg.From != nil {
+		username = msg.From.UserName
+		senderID = strconv.FormatInt(int64(msg.From.ID), 10)
+	}
+	if tc.skipSenders[senderID] || tc.skipSenders[username] {
+		return notifContext{}, false
+	}
+
+	senderName := formatSenderName(msg.From)
+	contactName := ""
+	contactSaved := false
+	if contact, _ := tc.store.GetManualContact(msg.Chat.ID); contact != nil {
+		contactName = contact.Name
+		contactSaved = true
+	}
+	if contactName == "" {
+		contactName = senderName
+	}
+
+	return notifContext{
+		chatName:     chatNameOf(msg),
+		contactName:  contactName,
+		username:     username,
+		sender:       senderName,
+		contactSaved: contactSaved,
+		isDirectChat: msg.Chat.Type == "private",
+	}, true
+}
+
+// handleEditedMessage reports that a message the agent already read now says something else.
+// Telegram delivers the edit as a whole message carrying the new text under the original's ID,
+// so routing it through handleMessage would store it correctly but announce it as a brand new
+// message, and the agent would answer the same question twice.
+func (tc *TelegramClient) handleEditedMessage(msg *tgbotapi.Message) {
+	newText := msg.Text
+	if newText == "" {
+		newText = msg.Caption
+	}
+	if newText == "" {
+		return
+	}
+
+	// Read the old text before the update overwrites it: it is the whole point of the
+	// notification, and an edit to a message we never stored just reads as empty.
+	oldText, err := tc.store.GetMessageContent(int64(msg.MessageID))
+	if err != nil {
+		log.Printf("Failed to look up edited message %d: %v", msg.MessageID, err)
+	}
+	if err := tc.store.UpdateMessageContent(int64(msg.MessageID), msg.Chat.ID, newText); err != nil {
+		log.Printf("Failed to apply edit to message %d: %v", msg.MessageID, err)
+	}
+	if oldText == newText {
+		return
+	}
+
+	if ctx, ok := tc.notifContextFor(msg); ok {
+		if err := WriteEditNotification(
+			tc.notificationsDir, int64(msg.MessageID), ctx.chatName, ctx.contactName,
+			ctx.username, tc.instance, ctx.contactSaved, ctx.isDirectChat,
+			ctx.sender, oldText, newText,
+		); err != nil {
+			log.Printf("Failed to write edit notification for %d: %v", msg.MessageID, err)
+		}
+	}
 }
 
 func (tc *TelegramClient) handleMessage(msg *tgbotapi.Message) {
@@ -186,19 +284,9 @@ func (tc *TelegramClient) handleMessage(msg *tgbotapi.Message) {
 	}
 
 	senderName := formatSenderName(msg.From)
-	username := ""
-	if msg.From != nil {
-		username = msg.From.UserName
-	}
-
-	chatName := msg.Chat.Title
-	if chatName == "" && msg.Chat.FirstName != "" {
-		chatName = strings.TrimSpace(msg.Chat.FirstName + " " + msg.Chat.LastName)
-	}
-
+	chatName := chatNameOf(msg)
 	chatType := string(msg.Chat.Type)
 	isFromMe := msg.From != nil && int64(msg.From.ID) == tc.botUserID
-	isDirectChat := msg.Chat.Type == "private"
 	timestamp := msg.Time()
 
 	var replyToID int64
@@ -220,38 +308,21 @@ func (tc *TelegramClient) handleMessage(msg *tgbotapi.Message) {
 	}
 
 	// Write notification for incoming messages
-	if tc.notificationsDir != "" && !isFromMe {
-		contactName := ""
-		contactSaved := false
-		if contact, _ := tc.store.GetManualContact(msg.Chat.ID); contact != nil {
-			contactName = contact.Name
-			contactSaved = true
-		}
-		if contactName == "" {
-			contactName = senderName
-		}
-
-		senderPhone := ""
-		if msg.From != nil {
-			senderPhone = strconv.FormatInt(int64(msg.From.ID), 10)
-		}
-
-		if !tc.skipSenders[senderPhone] && !tc.skipSenders[username] {
-			WriteNotification(
-				tc.notificationsDir,
-				int64(msg.MessageID),
-				chatName,
-				contactName,
-				username,
-				tc.instance,
-				contactSaved,
-				isDirectChat,
-				senderName,
-				content,
-				mediaType,
-				replyToID,
-			)
-		}
+	if ctx, ok := tc.notifContextFor(msg); ok {
+		WriteNotification(
+			tc.notificationsDir,
+			int64(msg.MessageID),
+			ctx.chatName,
+			ctx.contactName,
+			ctx.username,
+			tc.instance,
+			ctx.contactSaved,
+			ctx.isDirectChat,
+			ctx.sender,
+			content,
+			mediaType,
+			replyToID,
+		)
 	}
 }
 

--- a/agent/tests/test_notification_rules.py
+++ b/agent/tests/test_notification_rules.py
@@ -183,6 +183,9 @@ def test_match_text_alias_searches_body_and_message():
     rule = _rule(match=[{"field": "text", "op": "regex", "value": "taxes"}], action="snooze")
     assert npn.notif_disposition(_wa(message="ping about taxes"), [rule]) == "snooze"
     assert npn.notif_disposition(_notif(body="taxes due"), [rule]) == "snooze"
+    # A telegram edit carries its current text under `text`, so the text alias must reach it too,
+    # matching the edit's new content the same way it matches a plain message's `message`.
+    assert npn.notif_disposition(_notif(source="telegram", type="edit", text="taxes are due"), [rule]) == "snooze"
 
 
 def test_match_invalid_regex_predicate_is_rejected():

--- a/agent/tests/test_notification_rules.py
+++ b/agent/tests/test_notification_rules.py
@@ -183,9 +183,9 @@ def test_match_text_alias_searches_body_and_message():
     rule = _rule(match=[{"field": "text", "op": "regex", "value": "taxes"}], action="snooze")
     assert npn.notif_disposition(_wa(message="ping about taxes"), [rule]) == "snooze"
     assert npn.notif_disposition(_notif(body="taxes due"), [rule]) == "snooze"
-    # A telegram edit carries its current text under `text`, so the text alias must reach it too,
-    # matching the edit's new content the same way it matches a plain message's `message`.
-    assert npn.notif_disposition(_notif(source="telegram", type="edit", text="taxes are due"), [rule]) == "snooze"
+    # A telegram edit carries its current text in `message`, the same body field a plain message
+    # uses, so a content rule matches an edited message the same way it matches a new one.
+    assert npn.notif_disposition(_notif(source="telegram", type="edit", message="taxes are due"), [rule]) == "snooze"
 
 
 def test_match_invalid_regex_predicate_is_rejected():

--- a/check.sh
+++ b/check.sh
@@ -21,6 +21,7 @@ Suites:
                  dashboard-sync freshness + the vite base check
   whatsapp       gofmt + go vet + go build + go test for the whatsapp skill CLI
                  (builds whisper.cpp static libs to ~/.cache/vesta-whisper on first run)
+  telegram       gofmt + go vet + go build + go test for the telegram skill CLI
   integration    vestad integration tests (needs Docker)
   live           live agent e2e tests, incl. the upgrade gate (needs Docker + ~/.claude/.credentials.json; real Claude)
   upgrade        just the upgrade e2e: create an agent on the previous release, update in place
@@ -173,6 +174,22 @@ check_whatsapp() {
   )
 }
 
+check_telegram() {
+  (
+    cd agent/skills/telegram/cli
+    . ./cgo-env.sh
+    UNFORMATTED=$(gofmt -l .)
+    if [ -n "$UNFORMATTED" ]; then
+      echo "error: unformatted Go files:" >&2
+      echo "$UNFORMATTED" >&2
+      exit 1
+    fi
+    go vet -tags fts5 ./...
+    go build -tags fts5 -o /tmp/telegram-check-build .
+    go test -tags fts5 ./...
+  )
+}
+
 check_integration() {
   (
     cd vestad
@@ -230,6 +247,7 @@ for suite in "$@"; do
     web) check_web ;;
     guards) check_guards ;;
     whatsapp) check_whatsapp ;;
+    telegram) check_telegram ;;
     integration) check_integration ;;
     live) check_live ;;
     all) check_guards && check_agent && check_cli && check_vestad && check_web ;;


### PR DESCRIPTION
Follow-up to #1289 (WhatsApp edits), fixing the same gap on Telegram.

## What

An edited Telegram message now reaches the agent as its own `edit` notification carrying the old and new text, instead of masquerading as a brand new message.

## Why

Telegram's poller already opts into `edited_message`, but `StartPolling` aliased it straight to `handleMessage`:

```go
case update.EditedMessage != nil:
    tc.handleMessage(update.EditedMessage)
```

So the edit was stored correctly but announced as an ordinary message. The agent could not tell an edit from a new message, and would answer a question it had already answered. Unlike WhatsApp (where edits were dropped entirely), this one is a *wrong* signal rather than a missing one.

## How

- `edited_message` routes to a new `handleEditedMessage`: rewrite the stored text, notify with `type: "edit"` + `old_text` + `new_text` + `target_message_id`.
- Notification identity (contact/sender/chat lookup, plus the own-message and `--skip-senders` suppressions) moves out of `handleMessage`'s inline block into a shared `notifContextFor`, so an edit stays exactly as quiet as the message it refers to. That extraction is why `telegram.go`'s diff is bigger than the feature: duplicating ~30 lines of sender resolution was the alternative.
- The rewrite is a targeted `UpdateMessageContent`, so an edit writes only the text and leaves the row's media/reply/timestamp columns as the original set them. `messages` had no `AFTER UPDATE` FTS trigger, so search would otherwise keep serving the pre-edit text: adds `messages_au`, in the existing `CREATE TRIGGER IF NOT EXISTS` block that runs on every store open, so existing agents converge on their next daemon start with no migration.

**Deletions are out of scope, permanently:** the Bot API never tells a bot a message was deleted. That is a Telegram limitation, not an omission, and the SKILL.md now says so rather than leaving the agent to wonder.

## Second concern, deliberately included

**The telegram CLI's Go tests ran nowhere in CI.** `go-checks` only ran `./check.sh whatsapp`, path-filtered to `agent/skills/whatsapp/cli/**`, and no `check.sh telegram` existed. Its existing suites (`daemon_test.go`, `markdownv2_test.go`, `bubblelint_test.go`) have never been enforced. Adding tests to a suite CI does not run would be shipping dead tests, so this adds `check.sh telegram` and a `go-checks` step, and extends the `go` path filter. Telegram's `cgo-env.sh` already anticipated it: *"sourced by the launcher (and by any check script)"*. Happy to split this out if you would rather.

## Tests

8 tests driving `handleEditedMessage` against a real SQLite store, asserting on the notification files that land.

I was wrong about something here and the tests caught it. I first justified the targeted UPDATE by claiming `INSERT OR REPLACE` leaves the FTS index doubled up on stale text. Mutation-testing that claim disproved it: fts5 treats an explicit-rowid insert as a replace, so the old path kept search correct. The comment now states the real reason. The `messages_au` trigger is separately mutation-confirmed as load-bearing: removing it fails the search test (stale "harbour" still matches, new "airport" does not).

`./check.sh telegram` and `./check.sh whatsapp` both pass, run in the `vesta:local` image (this box has no Go toolchain).

## Not verified end to end

No real Telegram bot was involved. The handler is driven by synthetic `tgbotapi.Message` values, so a live edit from a real chat has not been observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)