### PR TITLE
refactor(whatsapp): name a saved contact without restating their number

### DIFF
--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -71,6 +71,17 @@ type callNotif struct {
 	Timestamp    string `json:"timestamp"`
 }
 
+// notifPhone is the number to name in a notification, and only an unsaved contact gets one.
+// For a saved contact the name is what `whatsapp send --to` takes, so carrying the number too
+// just restates the name on every notification; when a name is ambiguous, send's own error
+// lists the candidates with their numbers.
+func notifPhone(ctx NotifContext) string {
+	if ctx.ContactSaved {
+		return ""
+	}
+	return ctx.ContactPhone
+}
+
 func writeNotificationFile(notifDir string, data any, notifType string) error {
 	if notifDir == "" {
 		return nil
@@ -97,7 +108,7 @@ func WriteNotification(
 		Instance:        ctx.Instance,
 		ContactName:     ctx.ContactName,
 		Message:         content,
-		ContactPhone:    ctx.ContactPhone,
+		ContactPhone:    notifPhone(ctx),
 		MediaType:       mediaType,
 		IsForwarded:     isForwarded,
 		QuotedMessageID: quotedMessageID,
@@ -128,7 +139,7 @@ func WriteReactionNotification(
 		Instance:        ctx.Instance,
 		ContactName:     ctx.ContactName,
 		Emoji:           emoji,
-		ContactPhone:    ctx.ContactPhone,
+		ContactPhone:    notifPhone(ctx),
 		IsRemoved:       isRemoved,
 		Timestamp:       time.Now().Format(time.RFC3339),
 		TargetMessageID: targetMessageID,

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func savedCtx(dir string) NotifContext {
+	return NotifContext{
+		NotifDir: dir, Instance: "personal", ChatName: "Ana",
+		ContactName: "Ana", ContactPhone: "+15551234567",
+		ContactSaved: true, IsDirectChat: true, Sender: "Ana",
+	}
+}
+
+func unsavedCtx(dir string) NotifContext {
+	return NotifContext{
+		NotifDir: dir, Instance: "personal", ChatName: "+15559998888",
+		ContactName: "", ContactPhone: "+15559998888",
+		ContactSaved: false, IsDirectChat: true, Sender: "+15559998888",
+	}
+}
+
+// soleNotifFields decodes the one notification in dir as a field map, so a test can assert
+// that a key is absent rather than merely empty.
+func soleNotifFields(t *testing.T, dir string) map[string]json.RawMessage {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read notifications dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly one notification, got %d", len(entries))
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("failed to read notification: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("notification is not valid json: %v", err)
+	}
+	return fields
+}
+
+func TestSavedContactIsNamedWithoutRestatingTheirNumber(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteNotification(savedCtx(dir), "3EB0A1", "are you coming", "", false, "", ""); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	fields := soleNotifFields(t, dir)
+	if _, present := fields["contact_phone"]; present {
+		t.Errorf("contact_phone is present for a saved contact; the name is what `send --to` takes")
+	}
+	var name string
+	if err := json.Unmarshal(fields["contact_name"], &name); err != nil || name != "Ana" {
+		t.Errorf("contact_name = %q, want Ana (the saved contact must still be named)", name)
+	}
+}
+
+func TestUnsavedContactIsIdentifiedByNumber(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteNotification(unsavedCtx(dir), "3EB0A1", "hello", "", false, "", ""); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	fields := soleNotifFields(t, dir)
+	var phone string
+	if err := json.Unmarshal(fields["contact_phone"], &phone); err != nil || phone != "+15559998888" {
+		t.Errorf("contact_phone = %q, want the number: it is the only way to reply to someone unsaved", phone)
+	}
+	if _, present := fields["contact_name"]; present {
+		t.Errorf("contact_name is present for an unsaved contact, want it absent")
+	}
+	if _, present := fields["contact_unknown"]; !present {
+		t.Errorf("contact_unknown is absent for an unsaved contact, want it flagged")
+	}
+}
+
+func TestSavedContactReactionAlsoOmitsTheNumber(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteReactionNotification(savedCtx(dir), "3EB0A1", "❤️", false); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	if _, present := soleNotifFields(t, dir)["contact_phone"]; present {
+		t.Errorf("contact_phone is present on a saved contact's reaction, want it omitted")
+	}
+}
+
+func TestUnsavedContactReactionKeepsTheNumber(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteReactionNotification(unsavedCtx(dir), "3EB0A1", "❤️", false); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	fields := soleNotifFields(t, dir)
+	var phone string
+	if err := json.Unmarshal(fields["contact_phone"], &phone); err != nil || phone != "+15559998888" {
+		t.Errorf("contact_phone = %q, want the number for an unsaved reactor", phone)
+	}
+}
+
+// The primary account runs without --instance, so it never labels its notifications; a second
+// named account is the only thing that does.
+func TestPrimaryAccountDoesNotLabelItsInstance(t *testing.T) {
+	dir := t.TempDir()
+	ctx := savedCtx(dir)
+	ctx.Instance = ""
+
+	if err := WriteNotification(ctx, "3EB0A1", "are you coming", "", false, "", ""); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	if _, present := soleNotifFields(t, dir)["instance"]; present {
+		t.Errorf("instance is present for the unnamed primary account, want it omitted")
+	}
+}


### PR DESCRIPTION
## What

A WhatsApp notification now carries whichever field actually identifies the sender, not both:

- **saved contact** -> `contact_name` only (`whatsapp send --to 'Ana'` is what you reply with)
- **unsaved** -> `contact_phone` only (there is no name, and the number is the only way to reply)

## Why

Every notification about a saved contact carried both, and the number just restated the name:

```xml
<channel source="whatsapp" type="message" ... contact_name="Ana" contact_phone="+15551234567" ...>
```

`send --to` resolves saved contacts by name, so the number was never the thing the agent reached for. The unsaved case was already correct (no name exists, so only the number was carried); this only drops the redundant half of the saved case.

**Nothing is lost on the ambiguous-name path.** If two saved contacts share a name, `resolveFromContacts` already fails with an error listing the candidates *and their numbers*, so the escape hatch survives without spending the field on every notification.

## On `instance`

Also checked, and **it already behaves as wanted, so this PR does not touch it**. `--instance` names a *second* account; the primary line runs plain `whatsapp serve`, leaving `instance` empty, which `omitempty` drops. So a single-account user never sees the field, and it appears only to disambiguate a second account. Added a test pinning that (`TestPrimaryAccountDoesNotLabelItsInstance`) so it stays true.

## Tests

The notification writers and their `omitempty` behaviour had **no coverage at all**; these are the first. Five tests asserting on field *absence* (not emptiness), decoded as a raw field map so `omitempty` is genuinely exercised.

Mutation-checked: making `notifPhone` unconditionally return the number (the old behaviour) fails both saved-contact tests, while the unsaved ones correctly stay green.

`./check.sh whatsapp` passes, run in the `vesta:local` image (this box has no Go toolchain).

## Follow-up

#1289 adds `edit`/`revoke` notifications whose writers use `ctx.ContactPhone` directly. Whichever of the two lands second needs a one-line change to route through `notifPhone`; I will do that on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)