### PR TITLE
ci: free runner disk before the integration suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,24 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The integration suite exports multi-GB agent containers, streams them into
+      # restic, and re-imports them, up to 8 tests in parallel (--test-threads=8). On a
+      # stock ubuntu runner (~14 GB free on /) that exhausts the disk: docker
+      # export/import, restic, and the mounted-repo git fetch fail with "no space left
+      # on device", and the backup/rename tests stall until the step times out.
+      # Reclaim the tens of GB of preinstalled toolchains this job never uses, and prune
+      # the runner's seeded Docker images. This runs before the agent image is built, so
+      # nothing the tests need is removed. Best-effort: cleanup never fails the job.
+      - name: Free runner disk space
+        run: |
+          echo "Disk before cleanup:"
+          df -h /
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /usr/share/swift || true
+          docker system prune --all --force || true
+          echo "Disk after cleanup:"
+          df -h /
+
       - name: Install Rust
         uses: ./.github/actions/install-rust
 


### PR DESCRIPTION
## Symptom

`test-integration` (the `./check.sh integration` Docker suite) has been failing across master and many open PRs. Each failing job runs ~25 minutes and reports `Attempt 1 failed. Reason: Timeout of 1080000ms hit` (the 18-minute step cap), then a fast-failing retry.

## Root cause: runner disk exhaustion, not the timeout

I pulled the raw logs for the failing master job (run 29509541348) and two failing PR jobs (runs 29521051137, 29518435566). All three show the identical shape:

- Attempt 1: the disk-heavy tests (`backup::*`, `rename::*`, `upstream::agent_attaches_to_the_upstream_through_the_mounted_repo`) log "has been running for over 60 seconds" and never finish, stalling the whole attempt until it trips `Timeout of 1080000ms hit` at 18 minutes.
- Attempt 2: the same tests fail immediately with explicit disk errors:
  - `docker export failed`
  - `docker import failed: Error response from daemon: write /root/.cache/uv/... : no space left on device`
  - `image sanity check failed: docker: ... no space left on device`
  - `attach succeeds through the mounted upstream repo: ... failed: fatal: write error: No space left on device`

Final result each time: `test result: FAILED. 41 passed; 10 failed`.

The suite (`server` + `multi_user` + `oauth`, `--test-threads=8`) exports multi-GB agent containers into restic, re-imports them, and fetches into the mounted upstream repo, up to 8 tests in parallel. On a stock `ubuntu-latest` runner (~14 GB free on `/`), that exhausts the disk. When it does, docker/restic operations stall (attempt 1 hangs to the timeout) and then fail fast (attempt 2). The retry across attempts compounds it: attempt 1 leaves images/exports behind, so attempt 2 starts with even less space.

The 18-minute cap is **not** the problem. Healthy integration jobs finish in ~9 minutes total (the test step itself in ~5.5 minutes), far under the cap. This is intermittent: runs that land on a runner with enough headroom pass; runs that fill the disk fail. Master is red because enough master runs land on the failing side.

## The fix

Add one best-effort **Free runner disk space** step to `test-integration`, before the agent image is built. It removes the large preinstalled toolchains this job never uses (Android SDK, .NET, Haskell/GHC, CodeQL, Swift) and prunes the runner's seeded Docker images, reclaiming tens of GB. It runs before `Build agent image from checkout`, so nothing the tests need is removed, and it is guarded with `|| true` so cleanup can never fail the job (same philosophy as the `continue-on-error` on the cache step). `df -h /` is printed before and after so the reclaimed space is visible in the log.

## What this deliberately does NOT change

- **The 18-minute step timeout stays.** It is not the root cause; healthy runs finish in ~5.5 minutes. Raising it would only let the disk-starved attempt 1 hang longer before failing.
- **No tests disabled, removed, or weakened**, and `--test-threads=8` is unchanged. Freeing disk is the single root-cause fix; throttling parallelism would be a second, overlapping fix for the same cause.
- **Scoped to `test-integration` only.** The `check-vesta` job's `vestad-docker` step (`#[ignore]` Docker tests) also builds the agent image and could in principle hit the same wall; it is not currently the reported failure, so per one-concern-per-PR it is left alone. If it starts showing `no space left on device`, the same step transplants cleanly.
- The intermittent `rustup install failed after 3 attempts` and cache-service blips seen occasionally are separate transient infra flake already handled by the install-rust retry and `continue-on-error` cache; this PR does not touch them.

🤖 Generated with Claude Code