### PR TITLE
test(desktop): cover the main process oauth loopback, updater, and connection store

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -5,6 +5,7 @@ directories:
   output: dist
 files:
   - dist-electron/**
+  - "!dist-electron/**/*.test.js"
   - package.json
 extraResources:
   - from: ../web/dist

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,6 +15,7 @@
     "compile": "tsc",
     "check": "tsc --noEmit",
     "lint": "eslint src scripts",
+    "test": "vitest run",
     "build": "npm -w @vesta/web run build && tsc && electron-builder --publish never"
   },
   "dependencies": {
@@ -28,6 +29,7 @@
     "eslint": "^10.7.0",
     "globals": "^17.7.0",
     "typescript": "^7.0.2",
-    "typescript-eslint": "^8.64.0"
+    "typescript-eslint": "^8.64.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/desktop/src/oauth-loopback.test.ts
+++ b/apps/desktop/src/oauth-loopback.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cancelLoopback, startLoopback } from "./oauth-loopback";
+
+const openPorts: number[] = [];
+
+afterEach(() => {
+  for (const port of openPorts.splice(0)) cancelLoopback(port);
+});
+
+describe("oauth loopback", () => {
+  it("reconstructs the full callback url from the incoming request", async () => {
+    const captured: string[] = [];
+    const port = await startLoopback((url) => {
+      captured.push(url);
+    });
+    openPorts.push(port);
+
+    const response = await fetch(
+      `http://127.0.0.1:${String(port)}/callback?code=abc&state=xyz`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("Signed in");
+    expect(captured).toEqual([
+      `http://127.0.0.1:${String(port)}/callback?code=abc&state=xyz`,
+    ]);
+  });
+
+  it("frees the port after cancel", async () => {
+    const port = await startLoopback(() => {
+      /* never called */
+    });
+    cancelLoopback(port);
+    await expect(fetch(`http://127.0.0.1:${String(port)}/`)).rejects.toBeTruthy();
+  });
+});

--- a/apps/desktop/src/store.test.ts
+++ b/apps/desktop/src/store.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearConnection, readConnection, writeConnection } from "./store";
+
+const CONNECTION = {
+  url: "https://box.example",
+  accessToken: "at",
+  refreshToken: "rt",
+  expiresAt: 123,
+};
+
+let userDataDir = "";
+
+beforeEach(async () => {
+  userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), "vesta-store-test-"));
+  process.env.VESTA_TEST_USER_DATA = userDataDir;
+});
+
+afterEach(async () => {
+  delete process.env.VESTA_TEST_USER_DATA;
+  await fs.rm(userDataDir, { recursive: true, force: true });
+});
+
+describe("connection store", () => {
+  it("round-trips a written connection", async () => {
+    await writeConnection(CONNECTION);
+    expect(await readConnection()).toEqual(CONNECTION);
+  });
+
+  it("reads null when nothing has been written", async () => {
+    expect(await readConnection()).toBeNull();
+  });
+
+  it("reads null rather than throwing on a corrupt store file", async () => {
+    await fs.writeFile(
+      path.join(userDataDir, "connection.json"),
+      "{ not json",
+      "utf8",
+    );
+    expect(await readConnection()).toBeNull();
+  });
+
+  it("clears a stored connection", async () => {
+    await writeConnection(CONNECTION);
+    await clearConnection();
+    expect(await readConnection()).toBeNull();
+  });
+
+  it("clears an absent connection without throwing", async () => {
+    await clearConnection();
+    expect(await readConnection()).toBeNull();
+  });
+});

--- a/apps/desktop/src/updater.test.ts
+++ b/apps/desktop/src/updater.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { selectLinuxAsset } from "./updater";
+
+const RELEASE_ASSETS = [
+  {
+    name: "Vesta_0.1.176_amd64.deb",
+    browser_download_url: "https://example.test/Vesta_0.1.176_amd64.deb",
+  },
+  {
+    name: "Vesta_0.1.176_arm64.deb",
+    browser_download_url: "https://example.test/Vesta_0.1.176_arm64.deb",
+  },
+  {
+    name: "Vesta_0.1.176_x86_64.rpm",
+    browser_download_url: "https://example.test/Vesta_0.1.176_x86_64.rpm",
+  },
+  {
+    name: "Vesta_0.1.176_aarch64.rpm",
+    browser_download_url: "https://example.test/Vesta_0.1.176_aarch64.rpm",
+  },
+  {
+    name: "Vesta_0.1.176_universal.dmg",
+    browser_download_url: "https://example.test/Vesta_0.1.176_universal.dmg",
+  },
+];
+
+const NO_DEB_ASSETS = [
+  {
+    name: "Vesta_0.1.176_x86_64.rpm",
+    browser_download_url: "https://example.test/Vesta_0.1.176_x86_64.rpm",
+  },
+  {
+    name: "Vesta_0.1.176_universal.dmg",
+    browser_download_url: "https://example.test/Vesta_0.1.176_universal.dmg",
+  },
+];
+
+const FOREIGN_ARCH_ASSETS = [
+  {
+    name: "Vesta_0.1.176_armv7l.deb",
+    browser_download_url: "https://example.test/Vesta_0.1.176_armv7l.deb",
+  },
+];
+
+describe("linux release asset selection", () => {
+  it.each([
+    { arch: "arm64", extension: ".deb", expected: "Vesta_0.1.176_arm64.deb" },
+    { arch: "x64", extension: ".deb", expected: "Vesta_0.1.176_amd64.deb" },
+    { arch: "arm64", extension: ".rpm", expected: "Vesta_0.1.176_aarch64.rpm" },
+    { arch: "x64", extension: ".rpm", expected: "Vesta_0.1.176_x86_64.rpm" },
+  ])("picks $expected for $arch asking $extension", ({
+    arch,
+    extension,
+    expected,
+  }) => {
+    expect(selectLinuxAsset(RELEASE_ASSETS, arch, extension)?.name).toBe(
+      expected,
+    );
+  });
+
+  it("returns the asset's download url alongside its name", () => {
+    expect(selectLinuxAsset(RELEASE_ASSETS, "x64", ".deb")).toEqual({
+      name: "Vesta_0.1.176_amd64.deb",
+      browser_download_url: "https://example.test/Vesta_0.1.176_amd64.deb",
+    });
+  });
+
+  it.each([
+    { arch: "arm64", extension: ".deb" },
+    { arch: "x64", extension: ".deb" },
+  ])(
+    "returns undefined for $arch when the release ships no $extension",
+    ({ arch, extension }) => {
+      expect(selectLinuxAsset(NO_DEB_ASSETS, arch, extension)).toBeUndefined();
+    },
+  );
+
+  it("returns undefined when no asset matches the arch", () => {
+    expect(selectLinuxAsset(FOREIGN_ARCH_ASSETS, "arm64", ".deb")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty asset list", () => {
+    expect(selectLinuxAsset([], "x64", ".deb")).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/updater.ts
+++ b/apps/desktop/src/updater.ts
@@ -61,7 +61,22 @@ interface ReleaseAsset {
   browser_download_url: string;
 }
 
-/** Pick this arch's .deb or .rpm from the release's asset list by name. */
+/** Pick an arch's .deb or .rpm out of a release's asset list by name. */
+export function selectLinuxAsset(
+  assets: ReleaseAsset[],
+  arch: string,
+  extension: string,
+): ReleaseAsset | undefined {
+  const archTokens =
+    arch === "arm64" ? ["arm64", "aarch64"] : ["x64", "amd64", "x86_64"];
+  return assets.find(
+    (candidate) =>
+      candidate.name.endsWith(extension) &&
+      archTokens.some((token) => candidate.name.includes(token)),
+  );
+}
+
+/** Resolve this arch's package download url from the release's assets. */
 async function findLinuxAsset(
   version: string,
   extension: string,
@@ -74,15 +89,7 @@ async function findLinuxAsset(
     release !== null && typeof release === "object" && "assets" in release
       ? (release as { assets: ReleaseAsset[] }).assets
       : [];
-  const archTokens =
-    process.arch === "arm64"
-      ? ["arm64", "aarch64"]
-      : ["x64", "amd64", "x86_64"];
-  const asset = assets.find(
-    (candidate) =>
-      candidate.name.endsWith(extension) &&
-      archTokens.some((token) => candidate.name.includes(token)),
-  );
+  const asset = selectLinuxAsset(assets, process.arch, extension);
   if (!asset)
     throw new Error(
       `no ${extension} for ${process.arch} in release v${version}`,

--- a/apps/desktop/test/electron-stub.ts
+++ b/apps/desktop/test/electron-stub.ts
@@ -1,0 +1,13 @@
+import os from "node:os";
+import path from "node:path";
+
+// Stands in for the `electron` module under vitest (aliased in vitest.config.ts).
+// store.ts resolves its path on every call, so a test points userData at its own
+// temp dir through VESTA_TEST_USER_DATA.
+export const app = {
+  getPath: (name: string): string =>
+    name === "temp"
+      ? os.tmpdir()
+      : (process.env.VESTA_TEST_USER_DATA ??
+        path.join(os.tmpdir(), "vesta-test-userdata")),
+};

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    alias: {
+      // The sources under test import `app` from electron; the stub keeps a real
+      // Electron runtime out of the unit tests.
+      electron: path.resolve(__dirname, "test/electron-stub.ts"),
+    },
+  },
+});

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -25,7 +25,8 @@
         "eslint": "^10.7.0",
         "globals": "^17.7.0",
         "typescript": "^7.0.2",
-        "typescript-eslint": "^8.64.0"
+        "typescript-eslint": "^8.64.0",
+        "vitest": "^4.1.10"
       }
     },
     "desktop/node_modules/typescript": {

--- a/check.sh
+++ b/check.sh
@@ -16,7 +16,7 @@ Suites:
   vestad         cargo clippy -p vestad -D warnings + cargo test -p vestad
   vestad-docker  vestad #[ignore] Docker tests (needs Docker + an agent image:
                  set VESTAD_AGENT_IMAGE or docker pull ghcr.io/elyxlz/vesta:latest)
-  web            eslint + prettier --check + tsc + vitest (web) and eslint + tsc (desktop)
+  web            eslint + prettier --check + tsc + vitest (web) and eslint + tsc + vitest (desktop)
   guards         repo-wide ruff check + format, convention guards (lint escapes,
                  comment length, import cycles), shellcheck, skills index, uv.lock,
                  and dashboard-sync freshness + the vite base check
@@ -110,6 +110,7 @@ check_web() {
     npm -w @vesta/web run test
     npm -w @vesta/desktop run lint
     npm -w @vesta/desktop run check
+    npm -w @vesta/desktop run test
   )
 }
 


### PR DESCRIPTION
Fixes #1242

`apps/desktop` shipped with no test runner at all, so the Electron main process was verified only by rebuilding and launching the app. This adds vitest and covers the three files that hold real, silently regressable logic.

## Harness

vitest (node env, `^4.1.10`, the version `@vesta/web` already pins, so the lockfile gains a dependency reference and no new packages). `vitest.config.ts` aliases the `electron` module to `test/electron-stub.ts`, which stubs `app.getPath`, so importing the sources under test never pulls in a real Electron runtime. The stub resolves `userData` through an env var, and `store.ts` resolves its path on every call, which lets each store test point at its own `mkdtemp` dir and stay hermetic and order independent.

## Coverage

- **oauth-loopback**: drives a real http server on an ephemeral port. Asserts the callback url is reconstructed exactly (path and query preserved), that `onUrl` fires once, that the response is a 200 serving the "Signed in" page, and that `cancelLoopback` frees the port.
- **updater**: table-driven over a realistic asset list across the four arch/extension combinations, plus the undefined cases (no asset of the asked extension, no arch match, empty list). `selectLinuxAsset` is extracted as a pure helper per the issue; `findLinuxAsset` calls it with `process.arch` and keeps its existing error, so behavior is unchanged.
- **store**: round-trip, `null` on an absent file, `null` rather than a throw on corrupt JSON, and `clearConnection` both removing the file and no-oping when already absent.

Out of scope per the issue: `window.ts`, `main.ts`, and `preload.ts` are Electron-runtime wiring with no branch-worthy logic, so they remain manual-verify.

## CI runs it

`./check.sh web` now runs `npm -w @vesta/desktop run test`, so the existing `test-frontend` job executes the suite. No new top-level CI job. That job's path filter already covers `apps/**` and `check.sh`, so the suite runs on this PR and on any future desktop change.

## Notes

`tsc` emits the `src/*.test.ts` files into `dist-electron`, which electron-builder packages via `dist-electron/**`. Keeping the tests in `src/` is what gets them typechecked by the existing `check` and linted by the existing `lint`, so the tests stay there and `electron-builder.yml` excludes the emitted test JS from the bundle instead.

## Verification

- `npm -w @vesta/desktop run test`: 16 passed across 3 files
- `./check.sh web`: green (web 185 tests, desktop 16, plus both lint/typecheck passes)
- `./check.sh guards`: green
- Mutation-checked the suite rather than trusting a green run: breaking the arch token match, dropping the extension filter, dropping the loopback query string, and making the store rethrow on corrupt JSON each fail the relevant test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)