### PR TITLE
fix(microsoft): honour --user-timezone on the owa-rest calendar backend

### DIFF
--- a/agent/skills/microsoft/cli/src/microsoft_cli/calendar.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/calendar.py
@@ -19,7 +19,6 @@ def _validate_timezone(timezone: str) -> None:
 
 
 def resolve_timezone(user_timezone: str | None) -> str:
-    """Resolve the IANA timezone a calendar read reports its times in, defaulting to the local zone."""
     timezone = user_timezone if user_timezone is not None else graph.get_default_iana_timezone()
     _validate_timezone(timezone)
     return timezone

--- a/agent/skills/microsoft/cli/src/microsoft_cli/calendar.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/calendar.py
@@ -18,6 +18,13 @@ def _validate_timezone(timezone: str) -> None:
         raise ValueError(f"Invalid timezone: '{timezone}'. Use IANA names like 'Europe/London' or 'America/New_York'.") from e
 
 
+def resolve_timezone(user_timezone: str | None) -> str:
+    """Resolve the IANA timezone a calendar read reports its times in, defaulting to the local zone."""
+    timezone = user_timezone if user_timezone is not None else graph.get_default_iana_timezone()
+    _validate_timezone(timezone)
+    return timezone
+
+
 def _get_calendar_day_range(
     days_ahead: int,
     days_back: int,
@@ -66,9 +73,7 @@ def list_events(
     include_details: bool = True,
     user_timezone: str | None = None,
 ) -> list[dict[str, Any]]:
-    if user_timezone is None:
-        user_timezone = graph.get_default_iana_timezone()
-    _validate_timezone(user_timezone)
+    user_timezone = resolve_timezone(user_timezone)
     extra_prefer = [f'outlook.timezone="{user_timezone}"']
 
     try:
@@ -121,9 +126,7 @@ def get_event(
 ) -> dict[str, Any]:
     account_id = auth.get_account_id_by_email(account_email, config.cache_file)
 
-    if user_timezone is None:
-        user_timezone = graph.get_default_iana_timezone()
-    _validate_timezone(user_timezone)
+    user_timezone = resolve_timezone(user_timezone)
     extra_prefer = [f'outlook.timezone="{user_timezone}"']
 
     result = graph.request_cfg(config, client, "GET", f"/me/events/{event_id}", account_id, extra_prefer=extra_prefer)

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest_commands.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest_commands.py
@@ -189,16 +189,10 @@ def delete_folder(config: Config, client, *, account_email: str, folder_id: str)
 
 
 def _localize_event(event: dict, timezone: str) -> dict:
-    """Report a UTC-stored event's start/end as wall-clock time in ``timezone`` (IANA).
-
-    The OWA REST calendar endpoints always answer in UTC, so the Graph path's
-    ``Prefer: outlook.timezone`` equivalent is applied here on read. All-day boundaries
-    already read as local midnight, so they are relabelled without shifting; converting
-    them would move the event onto a neighbouring date.
-    """
+    """Report a UTC-stored event's start/end in ``timezone``. All-day boundaries are relabelled, not shifted: shifting moves the date."""
     localized = dict(event)
     for slot in ("start", "end"):
-        stored = dt.datetime.fromisoformat(localized[slot]["dateTime"].replace("Z", "")).replace(microsecond=0)
+        stored = dt.datetime.fromisoformat(event[slot]["dateTime"].replace("Z", "")).replace(microsecond=0)
         moment = stored if event["isAllDay"] else stored.replace(tzinfo=dt.UTC).astimezone(ZoneInfo(timezone)).replace(tzinfo=None)
         localized[slot] = {"dateTime": moment.isoformat(), "timeZone": timezone}
     return localized

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest_commands.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest_commands.py
@@ -16,6 +16,7 @@ import datetime as dt
 import pathlib as pl
 from zoneinfo import ZoneInfo
 
+from . import calendar as calendar_mod
 from . import email as email_mod
 from . import owa_rest
 from .config import Config
@@ -187,6 +188,22 @@ def delete_folder(config: Config, client, *, account_email: str, folder_id: str)
 # ---------------------------------------------------------------------------
 
 
+def _localize_event(event: dict, timezone: str) -> dict:
+    """Report a UTC-stored event's start/end as wall-clock time in ``timezone`` (IANA).
+
+    The OWA REST calendar endpoints always answer in UTC, so the Graph path's
+    ``Prefer: outlook.timezone`` equivalent is applied here on read. All-day boundaries
+    already read as local midnight, so they are relabelled without shifting; converting
+    them would move the event onto a neighbouring date.
+    """
+    localized = dict(event)
+    for slot in ("start", "end"):
+        stored = dt.datetime.fromisoformat(localized[slot]["dateTime"].replace("Z", "")).replace(microsecond=0)
+        moment = stored if event["isAllDay"] else stored.replace(tzinfo=dt.UTC).astimezone(ZoneInfo(timezone)).replace(tzinfo=None)
+        localized[slot] = {"dateTime": moment.isoformat(), "timeZone": timezone}
+    return localized
+
+
 def list_events(
     config: Config,
     client,
@@ -199,8 +216,8 @@ def list_events(
     user_timezone: str | None = None,
 ) -> list[dict]:
     del calendar_name, include_details  # Graph-only knobs; the OWA REST view has no calendar or detail selection
-    tz = user_timezone or "UTC"
-    now = dt.datetime.now(ZoneInfo(tz)) if tz != "UTC" else dt.datetime.now(dt.UTC)
+    tz = calendar_mod.resolve_timezone(user_timezone)
+    now = dt.datetime.now(ZoneInfo(tz))
     start_of_today = now.replace(hour=0, minute=0, second=0, microsecond=0)
     start = (start_of_today - dt.timedelta(days=days_back)).astimezone(dt.UTC)
     end = (start_of_today + dt.timedelta(days=days_ahead + 1)).astimezone(dt.UTC)
@@ -208,7 +225,8 @@ def list_events(
     def z(d: dt.datetime) -> str:
         return d.replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
-    return owa_rest.list_events(client, account_email, config, start_utc=z(start), end_utc=z(end), limit=100)
+    events = owa_rest.list_events(client, account_email, config, start_utc=z(start), end_utc=z(end), limit=100)
+    return [_localize_event(event, tz) for event in events]
 
 
 def list_calendars(config: Config, client, *, account_email: str) -> list[dict]:
@@ -216,8 +234,8 @@ def list_calendars(config: Config, client, *, account_email: str) -> list[dict]:
 
 
 def get_event(config: Config, client, *, account_email: str, event_id: str, user_timezone: str | None = None) -> dict:
-    del user_timezone  # Graph-only knob; OWA REST returns event times as stored
-    return owa_rest.get_event(client, account_email, config, event_id=event_id)
+    tz = calendar_mod.resolve_timezone(user_timezone)
+    return _localize_event(owa_rest.get_event(client, account_email, config, event_id=event_id), tz)
 
 
 def create_event(config: Config, client, *, account_email: str, event: EventFields) -> dict:

--- a/agent/skills/microsoft/cli/tests/test_calendar_timezone.py
+++ b/agent/skills/microsoft/cli/tests/test_calendar_timezone.py
@@ -1,14 +1,10 @@
-"""Timezone reporting for calendar reads.
-
-The OWA REST calendar endpoints always answer in UTC, so `--user-timezone` is applied on
-read; the Graph path pushes the same request upstream through a Prefer header. Both
-backends resolve the default zone and reject an invalid one through `resolve_timezone`.
-"""
+"""Timezone reporting for calendar reads."""
 
 from __future__ import annotations
 
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import httpx
@@ -18,21 +14,13 @@ from microsoft_cli import calendar, owa_rest, owa_rest_commands
 ACCOUNT = "user@example.com"
 
 
-class _FakeConfig:
-    """Minimal config stand-in with a data_dir."""
-
-    def __init__(self, tmp_path: Path) -> None:
-        self.data_dir = tmp_path
-
-
-def _cfg(tmp_path: Path) -> _FakeConfig:
-    cfg = _FakeConfig(tmp_path)
+def _cfg(tmp_path: Path) -> SimpleNamespace:
+    cfg = SimpleNamespace(data_dir=tmp_path)
     owa_rest.save_token(ACCOUNT, cfg, token="test-tok", expires_at=time.time() + 7200)
     return cfg
 
 
 def _client(json_response: dict) -> httpx.Client:
-    """Return a mock httpx.Client whose get() returns the given JSON."""
     mock = MagicMock(spec=httpx.Client)
     resp = MagicMock(spec=httpx.Response)
     resp.status_code = 200
@@ -42,8 +30,7 @@ def _client(json_response: dict) -> httpx.Client:
     return mock
 
 
-def _stored_event(start: str, end: str, *, all_day: bool = False) -> dict:
-    """An event as the OWA REST endpoint returns it: Pascal-cased, always in UTC."""
+def _stored_event(start: str = "2026-08-15T12:00:00Z", end: str = "2026-08-15T13:00:00Z", *, all_day: bool = False) -> dict:
     return {
         "Id": "e1",
         "Subject": "Standup",
@@ -53,31 +40,25 @@ def _stored_event(start: str, end: str, *, all_day: bool = False) -> dict:
     }
 
 
-def test_owa_rest_list_events_reports_a_utc_event_in_the_requested_timezone(tmp_path):
-    client = _client({"value": [_stored_event("2026-08-15T12:00:00Z", "2026-08-15T13:00:00Z")]})
-    events = owa_rest_commands.list_events(_cfg(tmp_path), client, account_email=ACCOUNT, user_timezone="Europe/Rome")
-    assert events[0]["start"] == {"dateTime": "2026-08-15T14:00:00", "timeZone": "Europe/Rome"}
-    assert events[0]["end"] == {"dateTime": "2026-08-15T15:00:00", "timeZone": "Europe/Rome"}
-
-
 @pytest.mark.parametrize(
-    ("timezone", "expected"),
+    ("timezone", "start", "end"),
     [
-        ("UTC", "2026-08-15T12:00:00"),
-        ("Europe/Rome", "2026-08-15T14:00:00"),
-        ("Asia/Tokyo", "2026-08-15T21:00:00"),
-        ("America/Los_Angeles", "2026-08-15T05:00:00"),
+        ("UTC", "2026-08-15T12:00:00", "2026-08-15T13:00:00"),
+        ("Europe/Rome", "2026-08-15T14:00:00", "2026-08-15T15:00:00"),
+        ("Asia/Tokyo", "2026-08-15T21:00:00", "2026-08-15T22:00:00"),
+        ("America/Los_Angeles", "2026-08-15T05:00:00", "2026-08-15T06:00:00"),
     ],
 )
-def test_owa_rest_list_events_start_tracks_the_requested_timezone(tmp_path, timezone, expected):
-    client = _client({"value": [_stored_event("2026-08-15T12:00:00Z", "2026-08-15T13:00:00Z")]})
+def test_owa_rest_list_events_reports_a_utc_event_in_the_requested_timezone(tmp_path, timezone, start, end):
+    client = _client({"value": [_stored_event()]})
     events = owa_rest_commands.list_events(_cfg(tmp_path), client, account_email=ACCOUNT, user_timezone=timezone)
-    assert events[0]["start"] == {"dateTime": expected, "timeZone": timezone}
+    assert events[0]["start"] == {"dateTime": start, "timeZone": timezone}
+    assert events[0]["end"] == {"dateTime": end, "timeZone": timezone}
 
 
 def test_owa_rest_list_events_defaults_to_the_local_timezone(tmp_path, monkeypatch):
     monkeypatch.setenv("TZ", "Asia/Tokyo")
-    client = _client({"value": [_stored_event("2026-08-15T12:00:00Z", "2026-08-15T13:00:00Z")]})
+    client = _client({"value": [_stored_event()]})
     events = owa_rest_commands.list_events(_cfg(tmp_path), client, account_email=ACCOUNT)
     assert events[0]["start"] == {"dateTime": "2026-08-15T21:00:00", "timeZone": "Asia/Tokyo"}
 
@@ -90,23 +71,22 @@ def test_owa_rest_list_events_keeps_all_day_events_on_their_own_date(tmp_path):
 
 
 def test_owa_rest_list_events_preserves_the_other_event_fields(tmp_path):
-    client = _client({"value": [_stored_event("2026-08-15T12:00:00Z", "2026-08-15T13:00:00Z")]})
+    client = _client({"value": [_stored_event()]})
     events = owa_rest_commands.list_events(_cfg(tmp_path), client, account_email=ACCOUNT, user_timezone="Europe/Rome")
     assert events[0]["id"] == "e1"
     assert events[0]["subject"] == "Standup"
 
 
 def test_owa_rest_get_event_reports_times_in_the_requested_timezone(tmp_path):
-    client = _client(_stored_event("2026-08-15T12:00:00Z", "2026-08-15T13:00:00Z"))
+    client = _client(_stored_event())
     event = owa_rest_commands.get_event(_cfg(tmp_path), client, account_email=ACCOUNT, event_id="e1", user_timezone="Europe/Rome")
     assert event["start"] == {"dateTime": "2026-08-15T14:00:00", "timeZone": "Europe/Rome"}
     assert event["end"] == {"dateTime": "2026-08-15T15:00:00", "timeZone": "Europe/Rome"}
 
 
 def test_owa_rest_list_events_rejects_an_unknown_timezone(tmp_path):
-    client = _client({"value": []})
     with pytest.raises(ValueError, match="Invalid timezone"):
-        owa_rest_commands.list_events(_cfg(tmp_path), client, account_email=ACCOUNT, user_timezone="Mars/Olympus")
+        owa_rest_commands.list_events(_cfg(tmp_path), _client({"value": []}), account_email=ACCOUNT, user_timezone="Mars/Olympus")
 
 
 def test_resolve_timezone_rejects_an_unknown_timezone():

--- a/agent/skills/microsoft/cli/tests/test_calendar_timezone.py
+++ b/agent/skills/microsoft/cli/tests/test_calendar_timezone.py
@@ -1,0 +1,119 @@
+"""Timezone reporting for calendar reads.
+
+The OWA REST calendar endpoints always answer in UTC, so `--user-timezone` is applied on
+read; the Graph path pushes the same request upstream through a Prefer header. Both
+backends resolve the default zone and reject an invalid one through `resolve_timezone`.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from microsoft_cli import calendar, owa_rest, owa_rest_commands
+
+ACCOUNT = "user@example.com"
+
+
+class _FakeConfig:
+    """Minimal config stand-in with a data_dir."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _cfg(tmp_path: Path) -> _FakeConfig:
+    cfg = _FakeConfig(tmp_path)
+    owa_rest.save_token(ACCOUNT, cfg, token="test-tok", expires_at=time.time() + 7200)
+    return cfg
+
+
+def _client(json_response: dict) -> httpx.Client:
+    """Return a mock httpx.Client whose get() returns the given JSON."""
+    mock = MagicMock(spec=httpx.Client)
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = json_response
+    resp.raise_for_status = MagicMock()
+    mock.get.return_value = resp
+    return mock
+
+
+def _stored_event(start: str, end: str, *, all_day: bool = False) -> dict:
+    """An event as the OWA REST endpoint returns it: Pascal-cased, always in UTC."""
+    return {
+        "Id": "e1",
+        "Subject": "Standup",
+        "IsAllDay": all_day,
+        "Start": {"DateTime": start, "TimeZone": "UTC"},
+        "End": {"DateTime": end, "TimeZone": "UTC"},
+    }
+
+
+def test_owa_rest_list_events_reports_a_utc_event_in_the_requested_timezone(tmp_path):
+    client = _client({"value": [_stored_event("2026-08-15T12:00:00Z", "2026-08-15T13:00:00Z")]})
+    events = owa_rest_commands.list_events(_cfg(tmp_path), client, account_email=ACCOUNT, user_timezone="Europe/Rome")
+    assert events[0]["start"] == {"dateTime": "2026-08-15T14:00:00", "timeZone": "Europe/Rome"}
+    assert events[0]["end"] == {"dateTime": "2026-08-15T15:00:00", "timeZone": "Europe/Rome"}
+
+
+@pytest.mark.parametrize(
+    ("timezone", "expected"),
+    [
+        ("UTC", "2026-08-15T12:00:00"),
+        ("Europe/Rome", "2026-08-15T14:00:00"),
+        ("Asia/Tokyo", "2026-08-15T21:00:00"),
+        ("America/Los_Angeles", "2026-08-15T05:00:00"),
+    ],
+)
+def test_owa_rest_list_events_start_tracks_the_requested_timezone(tmp_path, timezone, expected):
+    client = _client({"value": [_stored_event("2026-08-15T12:00:00Z", "2026-08-15T13:00:00Z")]})
+    events = owa_rest_commands.list_events(_cfg(tmp_path), client, account_email=ACCOUNT, user_timezone=timezone)
+    assert events[0]["start"] == {"dateTime": expected, "timeZone": timezone}
+
+
+def test_owa_rest_list_events_defaults_to_the_local_timezone(tmp_path, monkeypatch):
+    monkeypatch.setenv("TZ", "Asia/Tokyo")
+    client = _client({"value": [_stored_event("2026-08-15T12:00:00Z", "2026-08-15T13:00:00Z")]})
+    events = owa_rest_commands.list_events(_cfg(tmp_path), client, account_email=ACCOUNT)
+    assert events[0]["start"] == {"dateTime": "2026-08-15T21:00:00", "timeZone": "Asia/Tokyo"}
+
+
+def test_owa_rest_list_events_keeps_all_day_events_on_their_own_date(tmp_path):
+    client = _client({"value": [_stored_event("2026-08-15T00:00:00Z", "2026-08-16T00:00:00Z", all_day=True)]})
+    events = owa_rest_commands.list_events(_cfg(tmp_path), client, account_email=ACCOUNT, user_timezone="America/Los_Angeles")
+    assert events[0]["start"] == {"dateTime": "2026-08-15T00:00:00", "timeZone": "America/Los_Angeles"}
+    assert events[0]["end"] == {"dateTime": "2026-08-16T00:00:00", "timeZone": "America/Los_Angeles"}
+
+
+def test_owa_rest_list_events_preserves_the_other_event_fields(tmp_path):
+    client = _client({"value": [_stored_event("2026-08-15T12:00:00Z", "2026-08-15T13:00:00Z")]})
+    events = owa_rest_commands.list_events(_cfg(tmp_path), client, account_email=ACCOUNT, user_timezone="Europe/Rome")
+    assert events[0]["id"] == "e1"
+    assert events[0]["subject"] == "Standup"
+
+
+def test_owa_rest_get_event_reports_times_in_the_requested_timezone(tmp_path):
+    client = _client(_stored_event("2026-08-15T12:00:00Z", "2026-08-15T13:00:00Z"))
+    event = owa_rest_commands.get_event(_cfg(tmp_path), client, account_email=ACCOUNT, event_id="e1", user_timezone="Europe/Rome")
+    assert event["start"] == {"dateTime": "2026-08-15T14:00:00", "timeZone": "Europe/Rome"}
+    assert event["end"] == {"dateTime": "2026-08-15T15:00:00", "timeZone": "Europe/Rome"}
+
+
+def test_owa_rest_list_events_rejects_an_unknown_timezone(tmp_path):
+    client = _client({"value": []})
+    with pytest.raises(ValueError, match="Invalid timezone"):
+        owa_rest_commands.list_events(_cfg(tmp_path), client, account_email=ACCOUNT, user_timezone="Mars/Olympus")
+
+
+def test_resolve_timezone_rejects_an_unknown_timezone():
+    with pytest.raises(ValueError, match="Invalid timezone"):
+        calendar.resolve_timezone("Mars/Olympus")
+
+
+def test_resolve_timezone_defaults_to_the_local_timezone(monkeypatch):
+    monkeypatch.setenv("TZ", "Europe/Rome")
+    assert calendar.resolve_timezone(None) == "Europe/Rome"


### PR DESCRIPTION
Fixes #1309

## Problem

`microsoft calendar list --user-timezone <TZ>` was accepted then silently ignored on the `owa-rest` backend. `owa_rest_commands.list_events` used `user_timezone` only to compute the query day-range window; the events themselves came straight back from the endpoint in UTC, labelled `"timeZone": "UTC"`. The `graph` backend honours the flag via a `Prefer: outlook.timezone` header, so identical commands returned different times depending on which backend an account resolved to, with no warning. An agent reads the raw times as local and reports every meeting wrong (2h off for a Europe/Rome user in summer).

## Fix

Option 2 from the issue, converting on read in the backend that has the problem. The `Prefer` header route was not taken: it is unverified against the OWA endpoint and not checkable without a live work account, whereas conversion is guaranteed and backend-local.

- `_localize_event` converts each event's `start`/`end` into the requested zone and sets `timeZone` to match. `list_events` and `get_event` both route through it, so `calendar get` stops disagreeing across backends too (the CLI already leaves its `user_timezone` at the default there).
- All-day boundaries are relabelled without shifting. Converting a UTC midnight would move an all-day event onto a neighbouring date for any negative-offset zone (Aug 15 read in `America/Los_Angeles` would become Aug 14), which trades one silent wrong answer for another.
- Timezone resolution now has one owner: `calendar.resolve_timezone` applies the default zone and the existing `_validate_timezone`, and both backends call it. So `--user-timezone` defaults to the local zone and rejects an invalid zone identically on either path. No import cycle: `owa_rest_commands` already imports the graph `email` module, and `calendar` imports nothing that reaches back.

## Tests

New `tests/test_calendar_timezone.py`, including the issue's reproduce case (a UTC-stored 12:00 event reading back as 14:00 Europe/Rome), the three-zone table that previously returned byte-identical values, all-day date preservation, `get_event`, default resolution, and invalid-zone rejection. Verified as genuine regression coverage: 11 of the 12 fail on the pre-fix code and all pass after.

## Checks

`./check.sh agent` and `./check.sh guards` both pass locally.