### PR TITLE
test(vestad): guard the crashed-service port reallocation path (#1239)

### DIFF
--- a/vestad/Cargo.lock
+++ b/vestad/Cargo.lock
@@ -3326,6 +3326,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "socket2",
  "tar",
  "tempfile",
  "time",

--- a/vestad/Cargo.toml
+++ b/vestad/Cargo.toml
@@ -78,6 +78,9 @@ jiff = "0.2"
 [dev-dependencies]
 tempfile = "3"
 proptest = "1"
+# Builds the one socket shape std/tokio cannot (bound, never listened on): the crashed
+# service's port corpse the reuse probe must reallocate. Already in the tree via tokio.
+socket2 = "0.6"
 # Integration/live e2e tests live here (in vestad's own tests/) so `cargo test -p vestad
 # --test <name>` builds the vestad binary and exposes its path via CARGO_BIN_EXE_vestad —
 # no separate build step, no stale-binary risk. They reuse the shared harness from vesta-tests.

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -3153,6 +3153,75 @@ mod tests {
         );
     }
 
+    /// A crashed startup leaves its port *held but unserved* (#371, #433): connect is
+    /// refused, yet bind still fails, so nothing inside the container can recover it.
+    /// Model it with a raw socket bound without `SO_REUSEADDR` and never listened on,
+    /// the one shape std/tokio listeners cannot build (they always listen).
+    fn hold_port_unserved(port: u16) -> socket2::Socket {
+        let corpse = socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::STREAM, None)
+            .expect("a raw tcp socket");
+        let addr = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
+        corpse.bind(&addr.into()).expect("bind without listening");
+        corpse
+    }
+
+    // The #371/#433 regression: the port corpse a crash leaves behind answers nothing
+    // but blocks bind, and it is the only condition that must NOT be reused. Reusing it
+    // hands the service a port it can never bind, the crash loop with no recovery path
+    // from inside the container that allocate_service_port exists to break.
+    #[tokio::test]
+    async fn cached_port_is_not_reusable_when_held_but_unserved() {
+        let probe = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = probe.local_addr().unwrap().port();
+        drop(probe);
+        let _corpse = hold_port_unserved(port);
+
+        assert!(
+            !is_cached_port_reusable(port).await,
+            "a port held by a crashed service's corpse must not be reused",
+        );
+    }
+
+    // The recovery half of #371/#433, at the same altitude as the resident-service test
+    // below: a crashed service re-registering must be moved off its dead port and onto
+    // one it can actually bind, without a container or host restart.
+    #[tokio::test]
+    async fn crashed_service_is_reallocated_off_its_dead_port() {
+        use std::collections::HashMap;
+
+        // The registered port, now a corpse the crashed service left holding it. It comes
+        // from the OS rather than allocate_service_port, whose deterministic scan would
+        // hand a parallel test the same port for this one to hold hostage.
+        let probe = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let dead_port = probe.local_addr().unwrap().port();
+        drop(probe);
+        let _corpse = hold_port_unserved(dead_port);
+
+        let mut registry: HashMap<String, HashMap<String, ServiceEntry>> = HashMap::new();
+        registry.entry("agent".into()).or_default().insert(
+            "dashboard".into(),
+            ServiceEntry {
+                port: dead_port,
+                public: false,
+            },
+        );
+
+        // Re-registration, replaying register_service_handler's port decision.
+        let cached = registry
+            .get("agent")
+            .and_then(|services| services.get("dashboard"))
+            .map(|entry| entry.port);
+        let resolved = match cached {
+            Some(port) if is_cached_port_reusable(port).await => port,
+            _ => allocate_service_port(&registry).expect("a port should be free"),
+        };
+
+        assert_ne!(
+            resolved, dead_port,
+            "a crashed service must be moved off its held-but-dead port, not handed it back forever",
+        );
+    }
+
     // Reproduction of vesta#1254. A resident service (voice-server) stays bound to
     // its registered port; re-registration, which is also how consumers resolve the
     // port (whatsapp's resolveVoiceBaseURL, voice's own status/stop/restart), must


### PR DESCRIPTION
Fixes #1239.

## The reported bug is already fixed, at the root cause

#1239 and #1254 are the same bug, reported from two angles on the same version (v0.1.176). #1255 fixed it four days later by restoring connect-or-bind semantics to `is_cached_port_reusable`:

```rust
alive (TCP connect) || free (bind)
```

That is exactly #1239's diagnosis ("`bind()` cannot distinguish my own live service from a squatter") answered at the one place it goes wrong. Replaying #1239's repro against master: the dashboard is alive on X, the status probe re-POSTs, connect(X) succeeds, the reuse arm fires, X is returned and the registry keeps X. The port no longer flip-flops and `http_ok` goes true. `resident_service_keeps_its_port_across_reregistration` already pins this.

So this PR changes no production code. Master's behavior is byte-identical.

## What was actually missing: the other half had no test

#1255 flipped `cached_port_is_not_reusable_when_squatted` into its inverse (`cached_port_is_reusable_when_listening`) and did not replace it. That left the #371/#433 crash-loop recovery path with **zero** coverage, which matters because it is precisely what #1239's own first suggested direction would regress. Implementing "return the cached port unchanged" literally means:

```rust
async fn is_cached_port_reusable(_port: u16) -> bool { true }
```

Mutation-tested on this branch: that version **passes all 12 pre-existing tests**. A crashed service would be handed its dead port forever, with no recovery from inside the container, which is the whole reason #371 and #433 were filed. The guard rail against the tempting fix was missing, so this PR adds it.

## The tests

Two, at the altitudes the neighboring tests already use:

- `cached_port_is_not_reusable_when_held_but_unserved`: the probe verdict.
- `crashed_service_is_reallocated_off_its_dead_port`: replays `register_service_handler`'s port decision and asserts it moves off the dead port.

Both fail against the sticky-port mutation and pass against master, so they discriminate the fix from the regression rather than merely executing the line.

Modeling the corpse is the only fiddly part. It needs the one socket shape `std`/`tokio` cannot build: bound, never listened on, so connect is refused while bind still fails. `socket2` (already in the tree via tokio, added here as a dev-dep only) builds it with no `unsafe` and no lossy casts, which the `libc` alternative would need and which clippy pedantic would reject with no `#[allow]` escape available.

A parallelism trap worth flagging: `allocate_service_port` scans deterministically, so two tests allocating from an empty registry get the **same** port. The corpse socket holding it broke the existing resident test. The dead port therefore comes from the OS ephemeral band, disjoint from the allocator's preferred band above `ip_local_port_range`, the same trick the neighboring probe tests use.

## Why not the idempotent rewrite anyway

CLAUDE.md prefers idempotent no-ops, and re-registration **is** already idempotent for every live service. Making it unconditionally idempotent is not subtraction, it is deleting the recovery path: vestad genuinely cannot tell owner from squatter by port alone, and the connect probe is what buys back idempotency without giving up recovery. Adding a separate renew/heartbeat endpoint would add a concept and a caller contract to solve a problem the probe already solves. One fix per root cause, and it has already landed; the missing piece was the test.

Worth noting separately (not fixed here, out of scope): the handler rewrites `public: body.public` on every re-register, so a resolver POSTing without `--public` silently flips a public service private. Distinct concern from the port drift.

## Checks

`./check.sh vestad` green (208 passed, clippy clean). `./check.sh guards` green. No Docker suite is relevant: production code is unchanged from master, so `vestad-docker` and `integration` cannot be affected by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)