### PR TITLE
fix(browser): bound the bidi request path with a timeout

### DIFF
--- a/agent/skills/browser/cli/src/vesta_browser/admin.py
+++ b/agent/skills/browser/cli/src/vesta_browser/admin.py
@@ -18,6 +18,9 @@ from .launcher import RunningCamoufox, launch
 SESSION_FILE_PREFIX = "/tmp/vesta-browser-"
 GRACEFUL_EXIT_POLLS = 25
 GRACEFUL_POLL_INTERVAL_S = 0.2
+# Above the daemon's own per-command bound, so a withheld browser response surfaces as the
+# daemon's error naming the method rather than as a blunter socket timeout out here.
+DAEMON_RESPONSE_TIMEOUT_S = 90.0
 
 
 def _session_name(name: str | None = None) -> str:
@@ -241,18 +244,32 @@ def ensure_daemon(wait_s: float = 30.0, name: str | None = None) -> None:
     raise RuntimeError(f"daemon {session!r} did not come up within {wait_s}s. Last log line: {tail or '(none)'}")
 
 
+def _req_label(req: dict) -> str:
+    """Name a request for error messages: its BiDi method, or its control meta."""
+    if "method" in req:
+        return repr(req["method"])
+    if "meta" in req:
+        return f"meta {req['meta']!r}"
+    return "request"
+
+
 def send(req: dict, name: str | None = None) -> dict:
     """Low-level sync request to the daemon. Raises on error."""
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.connect(socket_path(name))
-    s.sendall((json.dumps(req) + "\n").encode())
-    data = b""
-    while not data.endswith(b"\n"):
-        chunk = s.recv(1 << 20)
-        if not chunk:
-            break
-        data += chunk
-    s.close()
+    s.settimeout(DAEMON_RESPONSE_TIMEOUT_S)
+    try:
+        s.connect(socket_path(name))
+        s.sendall((json.dumps(req) + "\n").encode())
+        data = b""
+        while not data.endswith(b"\n"):
+            chunk = s.recv(1 << 20)
+            if not chunk:
+                break
+            data += chunk
+    except TimeoutError:
+        raise RuntimeError(f"daemon did not respond to {_req_label(req)} within {DAEMON_RESPONSE_TIMEOUT_S}s") from None
+    finally:
+        s.close()
     resp = json.loads(data)
     if "error" in resp:
         raise RuntimeError(resp["error"])

--- a/agent/skills/browser/cli/src/vesta_browser/admin.py
+++ b/agent/skills/browser/cli/src/vesta_browser/admin.py
@@ -18,8 +18,7 @@ from .launcher import RunningCamoufox, launch
 SESSION_FILE_PREFIX = "/tmp/vesta-browser-"
 GRACEFUL_EXIT_POLLS = 25
 GRACEFUL_POLL_INTERVAL_S = 0.2
-# Above the daemon's own per-command bound, so a withheld browser response surfaces as the
-# daemon's error naming the method rather than as a blunter socket timeout out here.
+# Above the daemon's own per-command bound, so its error (which names the method) wins the race.
 DAEMON_RESPONSE_TIMEOUT_S = 90.0
 
 
@@ -244,15 +243,6 @@ def ensure_daemon(wait_s: float = 30.0, name: str | None = None) -> None:
     raise RuntimeError(f"daemon {session!r} did not come up within {wait_s}s. Last log line: {tail or '(none)'}")
 
 
-def _req_label(req: dict) -> str:
-    """Name a request for error messages: its BiDi method, or its control meta."""
-    if "method" in req:
-        return repr(req["method"])
-    if "meta" in req:
-        return f"meta {req['meta']!r}"
-    return "request"
-
-
 def send(req: dict, name: str | None = None) -> dict:
     """Low-level sync request to the daemon. Raises on error."""
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -267,7 +257,8 @@ def send(req: dict, name: str | None = None) -> dict:
                 break
             data += chunk
     except TimeoutError:
-        raise RuntimeError(f"daemon did not respond to {_req_label(req)} within {DAEMON_RESPONSE_TIMEOUT_S}s") from None
+        label = req["method"] if "method" in req else req["meta"]
+        raise RuntimeError(f"daemon did not respond to {label!r} within {DAEMON_RESPONSE_TIMEOUT_S}s") from None
     finally:
         s.close()
     resp = json.loads(data)

--- a/agent/skills/browser/cli/src/vesta_browser/admin.py
+++ b/agent/skills/browser/cli/src/vesta_browser/admin.py
@@ -18,8 +18,8 @@ from .launcher import RunningCamoufox, launch
 SESSION_FILE_PREFIX = "/tmp/vesta-browser-"
 GRACEFUL_EXIT_POLLS = 25
 GRACEFUL_POLL_INTERVAL_S = 0.2
-# Above the daemon's own per-command bound, so its error (which names the method) wins the race.
-DAEMON_RESPONSE_TIMEOUT_S = 90.0
+# Above the daemon's largest per-command bound (the navigate wait), so its error (which names the method) wins the race.
+DAEMON_RESPONSE_TIMEOUT_S = 120.0
 
 
 def _session_name(name: str | None = None) -> str:

--- a/agent/skills/browser/cli/src/vesta_browser/bidi.py
+++ b/agent/skills/browser/cli/src/vesta_browser/bidi.py
@@ -20,13 +20,11 @@ import json
 
 import websockets
 
-# Generous: the longest legitimate single command (navigate to a slow page, screenshot a
-# large one) stays well inside it, so firing means the browser withheld the response.
 BIDI_RESPONSE_TIMEOUT_S = 60.0
 
 
 class BidiError(Exception):
-    """A BiDi command failed: the server returned {type: "error"}, or withheld its response."""
+    """A BiDi command failed: the server errored or withheld its response."""
 
     def __init__(self, code: str, message: str) -> None:
         super().__init__(f"{code}: {message}")
@@ -99,10 +97,10 @@ class BidiClient:
         try:
             return await asyncio.wait_for(future, timeout=BIDI_RESPONSE_TIMEOUT_S)
         except TimeoutError:
+            # BidiError, not TimeoutError: the latter is an OSError with an empty str(), which the daemon relays as {"error": ""}.
             raise BidiError("timeout", f"no response to {method!r} within {BIDI_RESPONSE_TIMEOUT_S}s") from None
         finally:
-            if command_id in self._pending:
-                del self._pending[command_id]
+            self._pending.pop(command_id, None)
 
     async def new_session(self) -> str:
         """Open a session and return the first top-level browsing-context id."""

--- a/agent/skills/browser/cli/src/vesta_browser/bidi.py
+++ b/agent/skills/browser/cli/src/vesta_browser/bidi.py
@@ -21,6 +21,9 @@ import json
 import websockets
 
 BIDI_RESPONSE_TIMEOUT_S = 60.0
+# Navigate/reload with wait="complete" answer only once the page finishes loading, so a slow load needs more room than a generic command.
+NAVIGATE_RESPONSE_TIMEOUT_S = 90.0
+_WAIT_FOR_LOAD_METHODS = frozenset({"browsingContext.navigate", "browsingContext.reload"})
 
 
 class BidiError(Exception):
@@ -94,11 +97,12 @@ class BidiClient:
         future: asyncio.Future[dict] = asyncio.get_running_loop().create_future()
         self._pending[command_id] = future
         await self._ws.send(json.dumps({"id": command_id, "method": method, "params": params or {}}))
+        timeout = NAVIGATE_RESPONSE_TIMEOUT_S if method in _WAIT_FOR_LOAD_METHODS else BIDI_RESPONSE_TIMEOUT_S
         try:
-            return await asyncio.wait_for(future, timeout=BIDI_RESPONSE_TIMEOUT_S)
+            return await asyncio.wait_for(future, timeout=timeout)
         except TimeoutError:
             # BidiError, not TimeoutError: the latter is an OSError with an empty str(), which the daemon relays as {"error": ""}.
-            raise BidiError("timeout", f"no response to {method!r} within {BIDI_RESPONSE_TIMEOUT_S}s") from None
+            raise BidiError("timeout", f"no response to {method!r} within {timeout}s") from None
         finally:
             self._pending.pop(command_id, None)
 

--- a/agent/skills/browser/cli/src/vesta_browser/bidi.py
+++ b/agent/skills/browser/cli/src/vesta_browser/bidi.py
@@ -20,9 +20,13 @@ import json
 
 import websockets
 
+# Generous: the longest legitimate single command (navigate to a slow page, screenshot a
+# large one) stays well inside it, so firing means the browser withheld the response.
+BIDI_RESPONSE_TIMEOUT_S = 60.0
+
 
 class BidiError(Exception):
-    """A BiDi command returned {type: "error"}."""
+    """A BiDi command failed: the server returned {type: "error"}, or withheld its response."""
 
     def __init__(self, code: str, message: str) -> None:
         super().__init__(f"{code}: {message}")
@@ -92,7 +96,13 @@ class BidiClient:
         future: asyncio.Future[dict] = asyncio.get_running_loop().create_future()
         self._pending[command_id] = future
         await self._ws.send(json.dumps({"id": command_id, "method": method, "params": params or {}}))
-        return await future
+        try:
+            return await asyncio.wait_for(future, timeout=BIDI_RESPONSE_TIMEOUT_S)
+        except TimeoutError:
+            raise BidiError("timeout", f"no response to {method!r} within {BIDI_RESPONSE_TIMEOUT_S}s") from None
+        finally:
+            if command_id in self._pending:
+                del self._pending[command_id]
 
     async def new_session(self) -> str:
         """Open a session and return the first top-level browsing-context id."""

--- a/agent/skills/browser/cli/tests/fake_bidi.py
+++ b/agent/skills/browser/cli/tests/fake_bidi.py
@@ -23,8 +23,7 @@ class FakeBidiServer:
     def __init__(self, snapshot_nodes: list[dict] | None = None, withhold: set[str] | None = None) -> None:
         self.navigations: list[str] = []
         self.snapshot_nodes = snapshot_nodes or []
-        # Methods the server accepts and never answers, as Camoufox does for
-        # browsingContext.create (issue #1305).
+        # Methods accepted and never answered, as Camoufox does to browsingContext.create (issue #1305).
         self.withhold = withhold or set()
         self._server: websockets.Server | None = None
         self.url = ""
@@ -47,10 +46,10 @@ class FakeBidiServer:
 
     async def _respond(self, ws: websockets.ServerConnection, message: dict) -> None:
         method = message["method"]
-        params = message["params"]
-        command_id = message["id"]
         if method in self.withhold:
             return
+        params = message["params"]
+        command_id = message["id"]
         if method == "session.new":
             result = {"sessionId": "fake-session", "capabilities": {}}
         elif method == "session.subscribe":

--- a/agent/skills/browser/cli/tests/fake_bidi.py
+++ b/agent/skills/browser/cli/tests/fake_bidi.py
@@ -20,9 +20,12 @@ _PNG_1X1 = base64.b64encode(
 
 
 class FakeBidiServer:
-    def __init__(self, snapshot_nodes: list[dict] | None = None) -> None:
+    def __init__(self, snapshot_nodes: list[dict] | None = None, withhold: set[str] | None = None) -> None:
         self.navigations: list[str] = []
         self.snapshot_nodes = snapshot_nodes or []
+        # Methods the server accepts and never answers, as Camoufox does for
+        # browsingContext.create (issue #1305).
+        self.withhold = withhold or set()
         self._server: websockets.Server | None = None
         self.url = ""
 
@@ -46,6 +49,8 @@ class FakeBidiServer:
         method = message["method"]
         params = message["params"]
         command_id = message["id"]
+        if method in self.withhold:
+            return
         if method == "session.new":
             result = {"sessionId": "fake-session", "capabilities": {}}
         elif method == "session.subscribe":

--- a/agent/skills/browser/cli/tests/test_admin.py
+++ b/agent/skills/browser/cli/tests/test_admin.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import os
 import signal
+import socket
+import threading
 
 from vesta_browser import admin, daemon
+
+# Bounds the send under test so an unbounded regression fails here rather than hanging CI.
+HANG_GUARD_S = 5
 
 
 def test_session_name_default(monkeypatch):
@@ -136,3 +141,44 @@ def test_read_mode_falls_back_on_garbage(tmp_path, monkeypatch):
         assert admin.read_mode() == "a11y"
     finally:
         admin._session_file(None, "mode").unlink(missing_ok=True)
+
+
+def test_send_times_out_when_the_daemon_never_replies(tmp_path, monkeypatch):
+    """A daemon that accepts the request and goes quiet must surface an error, not hang."""
+    monkeypatch.setattr(admin, "DAEMON_RESPONSE_TIMEOUT_S", 0.3)
+    sock_path = str(tmp_path / "silent.sock")
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(sock_path)
+    listener.listen(1)
+    monkeypatch.setattr(admin, "socket_path", lambda name=None: sock_path)
+
+    held: list[socket.socket] = []
+
+    def accept_and_stay_silent() -> None:
+        conn, _ = listener.accept()
+        held.append(conn)
+
+    # send() runs off-thread so an unbounded regression trips the join guard below
+    # rather than hanging the suite forever.
+    raised: list[BaseException] = []
+
+    def call_send() -> None:
+        try:
+            admin.send({"method": "browsingContext.create", "params": {"type": "tab"}})
+        except BaseException as e:
+            raised.append(e)
+
+    accepter = threading.Thread(target=accept_and_stay_silent, daemon=True)
+    accepter.start()
+    caller = threading.Thread(target=call_send, daemon=True)
+    caller.start()
+    try:
+        caller.join(timeout=HANG_GUARD_S)
+        assert not caller.is_alive(), "admin.send() hung: the daemon socket read is unbounded"
+        assert isinstance(raised[0], RuntimeError)
+        assert "did not respond to 'browsingContext.create' within 0.3s" in str(raised[0])
+    finally:
+        accepter.join(timeout=2)
+        for conn in held:
+            conn.close()
+        listener.close()

--- a/agent/skills/browser/cli/tests/test_admin.py
+++ b/agent/skills/browser/cli/tests/test_admin.py
@@ -9,7 +9,6 @@ import threading
 
 from vesta_browser import admin, daemon
 
-# Bounds the send under test so an unbounded regression fails here rather than hanging CI.
 HANG_GUARD_S = 5
 
 
@@ -152,14 +151,6 @@ def test_send_times_out_when_the_daemon_never_replies(tmp_path, monkeypatch):
     listener.listen(1)
     monkeypatch.setattr(admin, "socket_path", lambda name=None: sock_path)
 
-    held: list[socket.socket] = []
-
-    def accept_and_stay_silent() -> None:
-        conn, _ = listener.accept()
-        held.append(conn)
-
-    # send() runs off-thread so an unbounded regression trips the join guard below
-    # rather than hanging the suite forever.
     raised: list[BaseException] = []
 
     def call_send() -> None:
@@ -168,8 +159,6 @@ def test_send_times_out_when_the_daemon_never_replies(tmp_path, monkeypatch):
         except BaseException as e:
             raised.append(e)
 
-    accepter = threading.Thread(target=accept_and_stay_silent, daemon=True)
-    accepter.start()
     caller = threading.Thread(target=call_send, daemon=True)
     caller.start()
     try:
@@ -178,7 +167,4 @@ def test_send_times_out_when_the_daemon_never_replies(tmp_path, monkeypatch):
         assert isinstance(raised[0], RuntimeError)
         assert "did not respond to 'browsingContext.create' within 0.3s" in str(raised[0])
     finally:
-        accepter.join(timeout=2)
-        for conn in held:
-            conn.close()
         listener.close()

--- a/agent/skills/browser/cli/tests/test_bidi.py
+++ b/agent/skills/browser/cli/tests/test_bidi.py
@@ -66,6 +66,7 @@ def test_event_lands_on_queue():
 
 
 CREATE = "browsingContext.create"
+NAVIGATE = "browsingContext.navigate"
 TEST_TIMEOUT_S = 0.2
 HANG_GUARD_S = 5
 
@@ -109,6 +110,21 @@ def test_a_withheld_response_does_not_block_later_commands(monkeypatch):
         await client.new_session()
         with pytest.raises(BidiError):
             await _create_tab(client)
-        return await client.send("browsingContext.navigate", {"context": "ctx-1", "url": "https://a.test"})
+        return await client.send(NAVIGATE, {"context": "ctx-1", "url": "https://a.test"})
 
     assert asyncio.run(_with_client(body, withhold={CREATE}))["url"] == "https://a.test"
+
+
+def test_navigate_gets_the_longer_wait_for_load_bound(monkeypatch):
+    """A wait-for-load navigation is bounded by the navigate timeout, not the shorter generic one."""
+    monkeypatch.setattr(bidi_module, "BIDI_RESPONSE_TIMEOUT_S", 0.01)
+    monkeypatch.setattr(bidi_module, "NAVIGATE_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
+
+    async def body(_server, client):
+        await client.new_session()
+        return await asyncio.wait_for(client.send(NAVIGATE, {"url": "https://slow.test"}), timeout=HANG_GUARD_S)
+
+    with pytest.raises(BidiError) as excinfo:
+        asyncio.run(_with_client(body, withhold={NAVIGATE}))
+    assert excinfo.value.code == "timeout"
+    assert f"within {TEST_TIMEOUT_S}s" in excinfo.value.message

--- a/agent/skills/browser/cli/tests/test_bidi.py
+++ b/agent/skills/browser/cli/tests/test_bidi.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from vesta_browser import bidi as bidi_module
 from vesta_browser.bidi import BidiClient, BidiError
 
 from .fake_bidi import FakeBidiServer
 
 
-async def _with_client(body, snapshot_nodes=None):
-    server = FakeBidiServer(snapshot_nodes)
+async def _with_client(body, snapshot_nodes=None, withhold=None):
+    server = FakeBidiServer(snapshot_nodes, withhold=withhold)
     url = await server.start()
     client = BidiClient()
     await client.connect(url)
@@ -62,3 +63,53 @@ def test_event_lands_on_queue():
 
     event = asyncio.run(_with_client(body))
     assert event["url"] == "https://a.test"
+
+
+CREATE = "browsingContext.create"
+TEST_TIMEOUT_S = 0.2
+# Bounds the send under test so an unbounded regression fails here rather than hanging CI.
+HANG_GUARD_S = 5
+
+
+async def _create_tab(client):
+    return await asyncio.wait_for(client.send(CREATE, {"type": "tab"}), timeout=HANG_GUARD_S)
+
+
+def test_withheld_response_raises_timeout_naming_the_method(monkeypatch):
+    """A browser that accepts a command and never answers must error, not hang forever."""
+    monkeypatch.setattr(bidi_module, "BIDI_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
+
+    async def body(_server, client):
+        await client.new_session()
+        return await _create_tab(client)
+
+    with pytest.raises(BidiError) as excinfo:
+        asyncio.run(_with_client(body, withhold={CREATE}))
+    assert excinfo.value.code == "timeout"
+    assert CREATE in excinfo.value.message
+
+
+def test_timed_out_request_is_dropped_from_pending(monkeypatch):
+    """The abandoned future is released, so a wedged browser cannot accumulate them."""
+    monkeypatch.setattr(bidi_module, "BIDI_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
+
+    async def body(_server, client):
+        await client.new_session()
+        with pytest.raises(BidiError):
+            await _create_tab(client)
+        return dict(client._pending)
+
+    assert asyncio.run(_with_client(body, withhold={CREATE})) == {}
+
+
+def test_a_withheld_response_does_not_block_later_commands(monkeypatch):
+    """Each request is bounded on its own; one silent command must not wedge the client."""
+    monkeypatch.setattr(bidi_module, "BIDI_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
+
+    async def body(_server, client):
+        await client.new_session()
+        with pytest.raises(BidiError):
+            await _create_tab(client)
+        return await client.send("browsingContext.navigate", {"context": "ctx-1", "url": "https://a.test"})
+
+    assert asyncio.run(_with_client(body, withhold={CREATE}))["url"] == "https://a.test"

--- a/agent/skills/browser/cli/tests/test_bidi.py
+++ b/agent/skills/browser/cli/tests/test_bidi.py
@@ -67,7 +67,6 @@ def test_event_lands_on_queue():
 
 CREATE = "browsingContext.create"
 TEST_TIMEOUT_S = 0.2
-# Bounds the send under test so an unbounded regression fails here rather than hanging CI.
 HANG_GUARD_S = 5
 
 


### PR DESCRIPTION
Refs #1305

## Scope

This lands **fix 1 only** from the issue: a timeout in the bidi/send path, so a withheld BiDi response surfaces as a diagnosable error instead of an unbounded hang. It is correct regardless of why the browser goes quiet.

It deliberately does **not** attempt fix 2, the `open`/`new_tab` root cause. The issue is explicit that the root cause is not established: it lives in Camoufox's compiled Firefox fork, and the correlation with the patched window-open path is unverified. Guessing at a mechanism there would be inventing one.

So this closes the unbounded-hang class. `browsingContext.create` will now fail in about 60s with a message naming the method, rather than blocking forever. **The `open`/`new_tab` root cause stays open**, which is why the issue is referenced, not closed. `browser navigate` remains the working path for navigation.

## What changed

Both waits in the request path were unbounded, in two different processes:

- `bidi.py`: `send()` awaited its response future with no bound. It now awaits under a named `BIDI_RESPONSE_TIMEOUT_S` (60s) and raises `BidiError("timeout", "no response to 'browsingContext.create' within 60.0s")`. Raising `BidiError` rather than a bare `TimeoutError` is load-bearing: a bare `TimeoutError` is an `OSError` subclass whose `str()` is empty, so it would have surfaced through the daemon as `{"error": ""}`. `BidiError` instead rides the daemon's existing `except BidiError` channel and reaches the CLI with the method named.
- `admin.py`: `send()` built a socket and looped on `s.recv()` with no `settimeout`, the one function in that file that did not. It now calls `s.settimeout(DAEMON_RESPONSE_TIMEOUT_S)`, matching the pattern its neighbours already use, and converts the timeout into a `RuntimeError` naming the request.

The abandoned future is dropped from the pending map in a `finally`, so a wedged browser cannot accumulate them.

### On the two timeout values

60s / 90s, generous by design. `goto()` issues `browsingContext.navigate` with `wait="complete"`, so one legitimate command can cover a full page load; the skill's own `wait_for_load` default is 15s and the CDP backend's internal load bound is 30s, so 60s leaves real headroom and only fires when the browser has genuinely gone silent.

The socket bound sits **above** the daemon's own per-command bound on purpose. The daemon's error names the method, so letting it win the race surfaces the better message; a CLI-side timeout firing first would mask it with a blunter one.

## Tests

`tests/fake_bidi.py` gains a `withhold` set: methods the fake server accepts and never answers, reproducing exactly what Camoufox does to `browsingContext.create`. That keeps the high-fidelity fake faithful instead of reaching for a mock.

- a withheld response raises `BidiError` with code `timeout`, naming the method
- the timed-out request is dropped from the pending map
- one silent command does not wedge later commands on the same client
- `admin.send` surfaces a `RuntimeError` when the daemon accepts and stays quiet

Verified these are real red/green tests, not vacuous: reverting only the bounding logic while keeping the constants makes all four fail. Each test carries its own hang guard (an outer `wait_for`; a thread join for the socket path), so that regression fails in seconds with a clear message rather than hanging the CI job, which is what the unbounded code does today.

## Checks

`./check.sh agent` and `./check.sh guards` both pass.