### PR TITLE
fix(browser): install Camoufox's headless GTK deps in the agent image

### DIFF
--- a/agent/skills/browser/SETUP.md
+++ b/agent/skills/browser/SETUP.md
@@ -28,9 +28,17 @@ x86_64, ~650 MB) from GitHub, verifies its sha256, and extracts it to
 No Chromium, no Xvfb, no display: Camoufox runs headless and fully fingerprint-spoofed. Check
 state with `browser doctor`.
 
-It does need GTK3, which the image installs (headless still runs GTK init). Without it Camoufox
-exits 255 before BiDi with `libgtk-3.so.0: cannot open shared object file`. On a non-vesta image
-install GTK3: `libgtk-3-0t64` on Debian trixie and later, `libgtk-3-0` on bookworm and earlier.
+## Shared library dependencies
+
+Headless Camoufox is still Gecko, so it dlopens GTK, X, dbus-glib and ALSA at startup. Missing any
+of them, `browser launch` exits 255 before BiDi with an XPCOMGlueLoad error (`libgtk-3.so.0: cannot
+open shared object file`). The Vesta image installs them at build time. `browser doctor` reports
+them under `shared_libs`, and on a box whose image predates that (or any non-vesta image) prints the
+line to fix it:
+
+```bash
+apt-get install -y libgtk-3-0 libgdk-pixbuf-2.0-0 libx11-xcb1 libdbus-glib-1-2 libxtst6 libasound2
+```
 
 ## Handover dependencies
 

--- a/agent/skills/browser/SETUP.md
+++ b/agent/skills/browser/SETUP.md
@@ -30,15 +30,9 @@ state with `browser doctor`.
 
 ## Shared library dependencies
 
-Headless Camoufox is still Gecko, so it dlopens GTK, X, dbus-glib and ALSA at startup. Missing any
-of them, `browser launch` exits 255 before BiDi with an XPCOMGlueLoad error (`libgtk-3.so.0: cannot
-open shared object file`). The Vesta image installs them at build time. `browser doctor` reports
-them under `shared_libs`, and on a box whose image predates that (or any non-vesta image) prints the
-line to fix it:
-
-```bash
-apt-get install -y libgtk-3-0 libgdk-pixbuf-2.0-0 libx11-xcb1 libdbus-glib-1-2 libxtst6 libasound2
-```
+Headless Camoufox is still Gecko, so it dlopens GTK, X, dbus-glib and ALSA at startup; without them
+`browser launch` exits 255 before BiDi. The Vesta image installs them at build time. Anywhere else,
+`browser doctor` reports them under `shared_libs` and prints the apt line for whatever is missing.
 
 ## Handover dependencies
 

--- a/agent/skills/browser/cli/src/vesta_browser/cli.py
+++ b/agent/skills/browser/cli/src/vesta_browser/cli.py
@@ -352,13 +352,14 @@ def cmd_fetch(args: argparse.Namespace) -> int:
 def cmd_doctor(_args: argparse.Namespace) -> int:
     import platform
 
-    from .launcher import CAMOUFOX_RELEASE_TAG, _asset_for_arch, camoufox_home, camoufox_installed
+    from .launcher import CAMOUFOX_RELEASE_TAG, _asset_for_arch, camoufox_home, camoufox_installed, libs_readiness
 
     report: dict = {
         "arch": platform.machine(),
         "camoufox_release": CAMOUFOX_RELEASE_TAG,
         "camoufox_installed": camoufox_installed(),
         "camoufox_home": str(camoufox_home()),
+        "shared_libs": libs_readiness(),
         "sessions": admin.list_sessions(),
         "handover": handover.readiness(),
     }

--- a/agent/skills/browser/cli/src/vesta_browser/launcher.py
+++ b/agent/skills/browser/cli/src/vesta_browser/launcher.py
@@ -71,9 +71,7 @@ def camoufox_installed() -> bool:
     return (camoufox_home() / "camoufox").is_file()
 
 
-# Gecko dlopens these at startup even headless; one missing and Camoufox exits 255 before BiDi with
-# an XPCOMGlueLoad error. The Vesta image bakes them in, so this names the gap on a box whose image
-# predates that. The apt names are the ones that resolve on both bookworm and trixie.
+# Gecko dlopens these at startup even headless; one missing and Camoufox exits 255 before BiDi.
 CAMOUFOX_SHARED_LIBS = (
     "libgtk-3.so.0",
     "libgdk_pixbuf-2.0.so.0",
@@ -86,8 +84,6 @@ CAMOUFOX_LIBS_INSTALL = "apt-get install -y libgtk-3-0 libgdk-pixbuf-2.0-0 libx1
 
 
 def libs_readiness() -> dict[str, bool | list[str] | str]:
-    """Report the Camoufox shared libs the dynamic loader cannot resolve, for `browser doctor` to
-    surface the gap by name rather than as an exit-255 launch failure to decode."""
     missing: list[str] = []
     for soname in CAMOUFOX_SHARED_LIBS:
         try:

--- a/agent/skills/browser/cli/src/vesta_browser/launcher.py
+++ b/agent/skills/browser/cli/src/vesta_browser/launcher.py
@@ -13,6 +13,7 @@ file the detached process can always write to and tail it for the URL.
 from __future__ import annotations
 
 import contextlib
+import ctypes
 import os
 import platform
 import re
@@ -68,6 +69,35 @@ def camoufox_home() -> Path:
 
 def camoufox_installed() -> bool:
     return (camoufox_home() / "camoufox").is_file()
+
+
+# Gecko dlopens these at startup even headless; one missing and Camoufox exits 255 before BiDi with
+# an XPCOMGlueLoad error. The Vesta image bakes them in, so this names the gap on a box whose image
+# predates that. The apt names are the ones that resolve on both bookworm and trixie.
+CAMOUFOX_SHARED_LIBS = (
+    "libgtk-3.so.0",
+    "libgdk_pixbuf-2.0.so.0",
+    "libX11-xcb.so.1",
+    "libdbus-glib-1.so.2",
+    "libXtst.so.6",
+    "libasound.so.2",
+)
+CAMOUFOX_LIBS_INSTALL = "apt-get install -y libgtk-3-0 libgdk-pixbuf-2.0-0 libx11-xcb1 libdbus-glib-1-2 libxtst6 libasound2"
+
+
+def libs_readiness() -> dict[str, bool | list[str] | str]:
+    """Report the Camoufox shared libs the dynamic loader cannot resolve, for `browser doctor` to
+    surface the gap by name rather than as an exit-255 launch failure to decode."""
+    missing: list[str] = []
+    for soname in CAMOUFOX_SHARED_LIBS:
+        try:
+            ctypes.CDLL(soname)
+        except OSError:
+            missing.append(soname)
+    report: dict[str, bool | list[str] | str] = {"ready": not missing, "missing": missing}
+    if missing:
+        report["install"] = CAMOUFOX_LIBS_INSTALL
+    return report
 
 
 def _verify_sha256(path: Path, expected: str) -> None:

--- a/agent/skills/browser/cli/tests/test_launcher.py
+++ b/agent/skills/browser/cli/tests/test_launcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ctypes.util
 import hashlib
 import zipfile
 
@@ -27,6 +28,19 @@ def test_asset_for_arch_unknown(monkeypatch):
     monkeypatch.setattr(launcher.platform, "machine", lambda: "sparc64")
     with pytest.raises(RuntimeError, match="no Camoufox build"):
         launcher._asset_for_arch()
+
+
+def test_libs_readiness_is_ready_when_every_soname_loads(monkeypatch):
+    libc = ctypes.util.find_library("c")
+    assert libc is not None
+    monkeypatch.setattr(launcher, "CAMOUFOX_SHARED_LIBS", (libc,))
+    assert launcher.libs_readiness() == {"ready": True, "missing": []}
+
+
+def test_libs_readiness_names_the_missing_lib_and_how_to_install_it(monkeypatch):
+    monkeypatch.setattr(launcher, "CAMOUFOX_SHARED_LIBS", ("libvesta-absent.so.9",))
+    report = launcher.libs_readiness()
+    assert report == {"ready": False, "missing": ["libvesta-absent.so.9"], "install": launcher.CAMOUFOX_LIBS_INSTALL}
 
 
 def test_camoufox_home_uses_release_tag():

--- a/agent/skills/browser/cli/tests/test_launcher.py
+++ b/agent/skills/browser/cli/tests/test_launcher.py
@@ -39,8 +39,7 @@ def test_libs_readiness_is_ready_when_every_soname_loads(monkeypatch):
 
 def test_libs_readiness_names_the_missing_lib_and_how_to_install_it(monkeypatch):
     monkeypatch.setattr(launcher, "CAMOUFOX_SHARED_LIBS", ("libvesta-absent.so.9",))
-    report = launcher.libs_readiness()
-    assert report == {"ready": False, "missing": ["libvesta-absent.so.9"], "install": launcher.CAMOUFOX_LIBS_INSTALL}
+    assert launcher.libs_readiness() == {"ready": False, "missing": ["libvesta-absent.so.9"], "install": launcher.CAMOUFOX_LIBS_INSTALL}
 
 
 def test_camoufox_home_uses_release_tag():

--- a/vestad/Dockerfile
+++ b/vestad/Dockerfile
@@ -20,10 +20,9 @@ LABEL org.opencontainers.image.title="Vesta" \
       org.opencontainers.image.source="https://github.com/elyxlz/vesta" \
       org.opencontainers.image.licenses="MIT"
 
-# The browser skill's OS dependencies: headless Camoufox is still Gecko, which dlopens GTK, X,
-# dbus-glib and ALSA at startup, so without them every `browser launch` exits 255 before BiDi with
-# `libgtk-3.so.0: cannot open shared object file`. The t64 names are trixie's time_t rename; GTK3
-# pulls gdk-pixbuf and the core X libs itself. `browser doctor` checks the matching sonames.
+# The browser skill's OS deps: headless Camoufox is still Gecko and dlopens these at startup, so
+# without them every `browser launch` exits 255 before BiDi. The t64 names are trixie's time_t
+# rename; gdk-pixbuf comes in via GTK3.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl git ca-certificates tzdata gnupg screen tmux \
     libgtk-3-0t64 libx11-xcb1 libdbus-glib-1-2 libxtst6 libasound2t64 && \

--- a/vestad/Dockerfile
+++ b/vestad/Dockerfile
@@ -20,11 +20,13 @@ LABEL org.opencontainers.image.title="Vesta" \
       org.opencontainers.image.source="https://github.com/elyxlz/vesta" \
       org.opencontainers.image.licenses="MIT"
 
-# libgtk-3-0t64 is the browser skill's one OS dependency: headless Camoufox still runs GTK init,
-# so without it every `browser launch` exits 255 before BiDi with `libgtk-3.so.0: cannot open
-# shared object file`. The t64 name is trixie's time_t rename; plain libgtk-3-0 does not exist here.
+# The browser skill's OS dependencies: headless Camoufox is still Gecko, which dlopens GTK, X,
+# dbus-glib and ALSA at startup, so without them every `browser launch` exits 255 before BiDi with
+# `libgtk-3.so.0: cannot open shared object file`. The t64 names are trixie's time_t rename; GTK3
+# pulls gdk-pixbuf and the core X libs itself. `browser doctor` checks the matching sonames.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl git ca-certificates tzdata gnupg screen tmux libgtk-3-0t64 && \
+    curl git ca-certificates tzdata gnupg screen tmux \
+    libgtk-3-0t64 libx11-xcb1 libdbus-glib-1-2 libxtst6 libasound2t64 && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #1245

## What

Headless Camoufox is still Gecko: it dlopens GTK, X, dbus-glib and ALSA at startup, so on a minimal image every `browser launch` exits 255 before BiDi with `XPCOMGlueLoad error ... libgtk-3.so.0: cannot open shared object file`.

Three parts:

1. **Image** (`vestad/Dockerfile`): the existing apt layer already carried `libgtk-3-0t64` (#1306); it now also carries `libx11-xcb1 libdbus-glib-1-2 libxtst6 libasound2t64`, the four the reporter's set leaves unresolved on this base. Names verified against the actual base (trixie): `libasound2t64` is the real package (`libasound2` is transitional), and GTK3 pulls gdk-pixbuf plus the core X libs itself, so those need no explicit entry.
2. **Doctor** (`launcher.libs_readiness`, surfaced as `shared_libs` in `browser doctor`): tries `ctypes.CDLL` on each of the six sonames Gecko needs, which is exactly what the loader does at launch. Reports `{ready, missing}`, plus an `install` line naming the apt one-liner when anything is missing. Mirrors the existing `handover.readiness()` shape.
3. **Docs** (`agent/skills/browser/SETUP.md`): the "It does need GTK3" paragraph understated the dependency; replaced with a `Shared library dependencies` section naming the full set, the failure mode, and the apt line.

The doctor hint and SETUP.md deliberately use the reporter's package names (`libgtk-3-0`, `libgdk-pixbuf-2.0-0`, ..., `libasound2`), verified to install on both bookworm and trixie, so the printed line works on whatever base the box happens to be on. The Dockerfile uses the exact trixie names since it only ever builds against trixie.

## Fleet impact

**Existing containers do not get the new layer.** The Dockerfile change only reaches a box when its container is recreated from a rebuilt image; a vestad update alone does not recreate containers, and upstream-sync ships the agent's code, never the image. So every already-running box with a browser stays broken until it is recreated.

**The doctor check is the bridge, and a migration is not warranted here.** The gap is an OS package inside a container, not agent state: nothing on disk was moved, renamed, or deleted, so there is no drift for a migration to converge. A migration would also be a poor fit in practice: it would need to shell out to `apt-get` on every boot until it is marked, and its effect is erased the moment the container is recreated (which is also the moment the image fix lands and makes it redundant). What an affected box needs is to know what is wrong, which is precisely what `browser doctor` now answers by name, with the apt line to unblock itself right now:

```
"shared_libs": {
  "ready": false,
  "missing": ["libX11-xcb.so.1", "libdbus-glib-1.so.2", "libXtst.so.6", "libasound.so.2"],
  "install": "apt-get install -y libgtk-3-0 libgdk-pixbuf-2.0-0 libx11-xcb1 libdbus-glib-1-2 libxtst6 libasound2"
}
```

That apt install is not durable across a container recreate, but it does not need to be: a recreate is exactly what brings in the baked-in libs.

## Verification

Verified:
- `./check.sh agent` and `./check.sh guards`, both green.
- The image builds from this Dockerfile (`docker build -f vestad/Dockerfile`, arm64), and all six sonames resolve inside the built image.
- `libs_readiness()` run inside the built image returns `{"ready": true, "missing": []}`.
- Package-name resolution probed on real `debian:trixie-slim`: with GTK3 alone, the four added sonames are genuinely missing; the reporter's names also install there.
- New unit tests cover both branches of `libs_readiness`.

Not verified: an actual `browser launch` driving real Camoufox (the ~650 MB fetch is out of scope for a local check; the reporter confirmed this package set fixes launch on x86_64), and the x86_64 image build (built arm64 locally; CI builds amd64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)