### PR TITLE
fix(vestad): stop exporting UV_PROJECT_ENVIRONMENT so skill uv runs cannot clobber the engine venv

### DIFF
--- a/agent/skills/skills-registry/SKILL.md
+++ b/agent/skills/skills-registry/SKILL.md
@@ -38,12 +38,11 @@ your edits and upstream updates take effect on the command's next run:
 uv tool install --editable ~/agent/skills/<name>/cli
 ```
 
-Never install a skill's CLI with `uv pip install -e` or `pip install -e`. You run
-with the engine venv active (`VIRTUAL_ENV=~/agent/.venv`), so an editable pip
-install drops the skill's command into `~/agent/.venv/bin`, which sits ahead of
-`~/.local/bin` on PATH and shadows the real tool: the command and its daemon then
-break with an import error. `uv tool install` keeps the CLI isolated and on
-`~/.local/bin`, so use it every time.
+Never install a skill's CLI with `uv pip install -e` or `pip install -e`. Run from
+`~/agent` those resolve the engine venv, dropping the skill's command into
+`~/agent/.venv/bin`, which leads your PATH and shadows the real tool: the command
+and its daemon then break with an import error. `uv tool install` keeps the CLI
+isolated and on `~/.local/bin`, so use it every time.
 
 ## Notes
 

--- a/agent/skills/upstream-pr/SKILL.md
+++ b/agent/skills/upstream-pr/SKILL.md
@@ -113,14 +113,7 @@ upstream-pr --token-only
 
 ## Running a skill's tests
 
-Each skill CLI is its own uv project, so run its tests from its own directory: `cd ~/agent/skills/<name>/cli && uv run pytest`. uv builds a `.venv` there (gitignored) and leaves the engine venv at `~/agent/.venv` alone.
-
-If uv ever prints `Removed virtual environment at: /root/agent/.venv`, it retargeted the engine venv instead (something exported `UV_PROJECT_ENVIRONMENT`). The running agent survives on already-imported modules, so nothing looks wrong until the next restart fails. Repair it before you restart, and re-run the tests with `uv run --isolated`:
-
-```bash
-UV_PROJECT_ENVIRONMENT=~/agent/.venv uv sync --frozen --project ~/agent/core
-cd ~/agent && .venv/bin/python3 -c "import core.main"   # verify the restart path
-```
+Each skill CLI is its own uv project, so run its tests from its own directory: `cd ~/agent/skills/<name>/cli && uv run pytest`. uv builds a local `.venv` there and leaves the engine venv at `~/agent/.venv` alone.
 
 ## Formatting Python before pushing
 

--- a/agent/skills/upstream-pr/SKILL.md
+++ b/agent/skills/upstream-pr/SKILL.md
@@ -111,9 +111,20 @@ upstream-pr --title "..." --branch my-branch --base master
 upstream-pr --token-only
 ```
 
+## Running a skill's tests
+
+Each skill CLI is its own uv project, so run its tests from its own directory: `cd ~/agent/skills/<name>/cli && uv run pytest`. uv builds a `.venv` there (gitignored) and leaves the engine venv at `~/agent/.venv` alone.
+
+If uv ever prints `Removed virtual environment at: /root/agent/.venv`, it retargeted the engine venv instead (something exported `UV_PROJECT_ENVIRONMENT`). The running agent survives on already-imported modules, so nothing looks wrong until the next restart fails. Repair it before you restart, and re-run the tests with `uv run --isolated`:
+
+```bash
+UV_PROJECT_ENVIRONMENT=~/agent/.venv uv sync --frozen --project ~/agent/core
+cd ~/agent && .venv/bin/python3 -c "import core.main"   # verify the restart path
+```
+
 ## Formatting Python before pushing
 
-Before pushing changed `.py`, format from `~/agent` so the pinned ruff and config match CI's `guards` ruff pass: `cd ~/agent && uv run --project core ruff format <path> && uv run --project core ruff check <path>`. Run `uv run --project core ruff` from that dir, never `uvx ruff` or another cwd: those ignore the lock (`agent/core/uv.lock`) and config (`agent/ruff.toml`) and can fail CI's `--check` on otherwise-correct code.
+Before pushing changed `.py`, format from `~/agent` so the pinned ruff and config match CI's `guards` ruff pass: `cd ~/agent && ruff format <path> && ruff check <path>`. Plain `ruff` from that dir is the engine venv's pinned ruff (its bin leads your PATH), never `uvx ruff` or another cwd: those ignore the lock (`agent/core/uv.lock`) and config (`agent/ruff.toml`) and can fail CI's `--check` on otherwise-correct code.
 
 ## No em/en dashes in markdown
 

--- a/vestad/Dockerfile
+++ b/vestad/Dockerfile
@@ -62,9 +62,11 @@ RUN for d in agent/skills/*/; do \
       grep -qx "$name" agent/core/default-skills.txt || rm -rf "$d"; \
     done
 
-ENV UV_PROJECT_ENVIRONMENT=/root/agent/.venv
 WORKDIR /root/agent
-RUN uv sync --frozen --no-install-project --project core
+# Scoped to this command, never a persistent ENV: an inherited UV_PROJECT_ENVIRONMENT retargets
+# every uv project, so `uv run` in a skill's cli/ would re-sync the engine venv out from under
+# the running agent. The entrypoint puts the venv on PATH instead.
+RUN UV_PROJECT_ENVIRONMENT=/root/agent/.venv uv sync --frozen --no-install-project --project core
 
 # Install Claude Code on PATH. claude_agent_sdk would otherwise fall back to its own bundled CLI
 # (deep in site-packages), but skills shell out to `claude` directly (e.g. video-use), so it must

--- a/vestad/Dockerfile
+++ b/vestad/Dockerfile
@@ -63,9 +63,8 @@ RUN for d in agent/skills/*/; do \
     done
 
 WORKDIR /root/agent
-# Scoped to this command, never a persistent ENV: an inherited UV_PROJECT_ENVIRONMENT retargets
-# every uv project, so `uv run` in a skill's cli/ would re-sync the engine venv out from under
-# the running agent. The entrypoint puts the venv on PATH instead.
+# Scoped, never a persistent ENV: an exported UV_PROJECT_ENVIRONMENT retargets every uv project,
+# so `uv run` in a skill's cli/ would re-sync the engine venv. The entrypoint puts it on PATH.
 RUN UV_PROJECT_ENVIRONMENT=/root/agent/.venv uv sync --frozen --no-install-project --project core
 
 # Install Claude Code on PATH. claude_agent_sdk would otherwise fall back to its own bundled CLI

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -113,11 +113,11 @@ pub(crate) const MOUNT_DESTS: &[&str] = &[
 ];
 
 pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
-    let steps: [String; 11] = [
-        "export PATH=\"/root/.local/bin:/root/.claude/local/bin:$PATH\"".into(),
-        // The venv must live outside the read-only core mount (uv would default to
-        // /root/agent/core/.venv, inside it).
-        "export UV_PROJECT_ENVIRONMENT=/root/agent/.venv".into(),
+    let steps: [String; 10] = [
+        // The engine venv's bin leads PATH: it carries the interpreter and the pinned tools
+        // (ruff, pytest) that the agent and its skills reach as plain commands. This is how the
+        // engine venv is exposed; UV_PROJECT_ENVIRONMENT is never exported (see the sync step).
+        "export PATH=\"/root/agent/.venv/bin:/root/.local/bin:/root/.claude/local/bin:$PATH\"".into(),
         ". /run/vestad-env".into(),
         ". ~/.bashrc || true".into(),
         // LEGACY(remove-when: fleet converged to vestad-served workspaces, whose branch never
@@ -137,10 +137,14 @@ pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
         // network) once tmux is on PATH, and the next snapshot captures the install so it
         // persists across future rebuilds. `|| true` so a failed install never aborts boot.
         "command -v tmux >/dev/null 2>&1 || (apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq tmux) || true".into(),
-        // LEGACY(remove-when: unmanaged boxes have pulled a post-engine-move snapshot):
-        // unmanaged boxes keep the old layout (pyproject at /root/agent) until they rebase
-        // onto an agent-v* snapshot; tolerate both so they never crash-loop.
-        "if [ -f /root/agent/core/pyproject.toml ]; then uv sync --frozen --project /root/agent/core; else uv sync --frozen --project /root/agent; fi".into(),
+        // UV_PROJECT_ENVIRONMENT is scoped to this command, never exported: it retargets EVERY
+        // uv project, so an exported value makes `uv run` in a skill's cli/ re-sync the engine
+        // venv, deleting it outright when the skill pins another Python. Core needs it because
+        // uv would default to /root/agent/core/.venv, inside the read-only mount.
+        // LEGACY(remove-when: unmanaged boxes have pulled a post-engine-move snapshot): the old
+        // layout (pyproject at /root/agent) already defaults to the engine venv, so it needs no
+        // override; tolerate both so unmanaged boxes never crash-loop.
+        "if [ -f /root/agent/core/pyproject.toml ]; then UV_PROJECT_ENVIRONMENT=/root/agent/.venv uv sync --frozen --project /root/agent/core; else uv sync --frozen --project /root/agent; fi".into(),
         // ~/.claude/skills is a real directory of per-skill symlinks. Both
         // /root/agent/skills/ and /root/agent/core/skills/ are flattened in;
         // core entries are linked last so they win any name collision. Reset
@@ -148,7 +152,10 @@ pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
         "rm -rf ~/.claude/skills && mkdir -p ~/.claude/skills".into(),
         "for d in /root/agent/skills/*/SKILL.md /root/agent/core/skills/*/SKILL.md; do [ -f \"$d\" ] || continue; s=$(dirname \"$d\"); ln -sfn \"$s\" ~/.claude/skills/$(basename \"$s\"); done".into(),
         "test -f ~/.claude/settings.json || printf '{\"permissions\":{\"allow\":[]}}\\n' > ~/.claude/settings.json".into(),
-        "cd /root/agent && if [ -f core/pyproject.toml ]; then exec uv run --frozen --project core python -m core.main; else exec uv run --frozen python -m core.main; fi".into(),
+        // Launch the engine interpreter directly. `uv run` would have to carry
+        // UV_PROJECT_ENVIRONMENT to resolve core, and the agent, plus every shell it spawns,
+        // inherits it. cwd is what makes `core` importable; the sync step above owns the venv.
+        "cd /root/agent && exec .venv/bin/python -m core.main".into(),
     ];
     vec!["sh".into(), "-c".into(), steps.join("; \\\n")]
 }
@@ -2806,16 +2813,34 @@ mod tests {
         let cmd = agent_container_entrypoint_cmd();
         let script = cmd.last().expect("entrypoint script");
         assert!(
-            script.contains("UV_PROJECT_ENVIRONMENT=/root/agent/.venv"),
-            "entrypoint must pin the venv outside core: {script}"
-        );
-        assert!(
-            script.contains("--project /root/agent/core"),
-            "entrypoint must sync the core project when present: {script}"
+            script.contains("UV_PROJECT_ENVIRONMENT=/root/agent/.venv uv sync --frozen --project /root/agent/core"),
+            "entrypoint must pin the core sync's venv outside core: {script}"
         );
         assert!(
             script.contains("python -m core.main"),
             "entrypoint must launch core.main: {script}"
+        );
+    }
+
+    #[test]
+    fn entrypoint_never_exports_uv_project_environment_into_the_agent() {
+        // An inherited UV_PROJECT_ENVIRONMENT retargets EVERY uv project, so `uv run` in a
+        // skill's cli/ re-syncs the engine venv and deletes it when the skill pins another
+        // Python, bricking the next restart. It stays scoped to the core sync, and the engine
+        // is launched without `uv run`, which would carry the variable into the agent's env.
+        let cmd = agent_container_entrypoint_cmd();
+        let script = cmd.last().expect("entrypoint script");
+        assert!(
+            !script.contains("export UV_PROJECT_ENVIRONMENT"),
+            "UV_PROJECT_ENVIRONMENT must never be exported: {script}"
+        );
+        assert!(
+            !script.contains("uv run"),
+            "the engine must launch without `uv run`, which propagates UV_PROJECT_ENVIRONMENT: {script}"
+        );
+        assert!(
+            script.contains("export PATH=\"/root/agent/.venv/bin:"),
+            "the engine venv must lead PATH so its tools resolve without uv: {script}"
         );
     }
 

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -114,9 +114,8 @@ pub(crate) const MOUNT_DESTS: &[&str] = &[
 
 pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
     let steps: [String; 10] = [
-        // The engine venv's bin leads PATH: it carries the interpreter and the pinned tools
-        // (ruff, pytest) that the agent and its skills reach as plain commands. This is how the
-        // engine venv is exposed; UV_PROJECT_ENVIRONMENT is never exported (see the sync step).
+        // The engine venv's bin leads PATH so the agent and skills reach the interpreter and its
+        // pinned tools (ruff, pytest) as plain commands. UV_PROJECT_ENVIRONMENT is never exported.
         "export PATH=\"/root/agent/.venv/bin:/root/.local/bin:/root/.claude/local/bin:$PATH\"".into(),
         ". /run/vestad-env".into(),
         ". ~/.bashrc || true".into(),
@@ -137,13 +136,12 @@ pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
         // network) once tmux is on PATH, and the next snapshot captures the install so it
         // persists across future rebuilds. `|| true` so a failed install never aborts boot.
         "command -v tmux >/dev/null 2>&1 || (apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq tmux) || true".into(),
-        // UV_PROJECT_ENVIRONMENT is scoped to this command, never exported: it retargets EVERY
-        // uv project, so an exported value makes `uv run` in a skill's cli/ re-sync the engine
-        // venv, deleting it outright when the skill pins another Python. Core needs it because
-        // uv would default to /root/agent/core/.venv, inside the read-only mount.
+        // UV_PROJECT_ENVIRONMENT stays scoped to this command: exported, it retargets every uv
+        // project, so `uv run` in a skill's cli/ would re-sync (and can delete) the engine venv
+        // under the running agent. Core needs the override or uv defaults to core/.venv, inside
+        // the read-only mount.
         // LEGACY(remove-when: unmanaged boxes have pulled a post-engine-move snapshot): the old
-        // layout (pyproject at /root/agent) already defaults to the engine venv, so it needs no
-        // override; tolerate both so unmanaged boxes never crash-loop.
+        // layout (pyproject at /root/agent) defaults to the engine venv, so it needs no override.
         "if [ -f /root/agent/core/pyproject.toml ]; then UV_PROJECT_ENVIRONMENT=/root/agent/.venv uv sync --frozen --project /root/agent/core; else uv sync --frozen --project /root/agent; fi".into(),
         // ~/.claude/skills is a real directory of per-skill symlinks. Both
         // /root/agent/skills/ and /root/agent/core/skills/ are flattened in;
@@ -152,9 +150,8 @@ pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
         "rm -rf ~/.claude/skills && mkdir -p ~/.claude/skills".into(),
         "for d in /root/agent/skills/*/SKILL.md /root/agent/core/skills/*/SKILL.md; do [ -f \"$d\" ] || continue; s=$(dirname \"$d\"); ln -sfn \"$s\" ~/.claude/skills/$(basename \"$s\"); done".into(),
         "test -f ~/.claude/settings.json || printf '{\"permissions\":{\"allow\":[]}}\\n' > ~/.claude/settings.json".into(),
-        // Launch the engine interpreter directly. `uv run` would have to carry
-        // UV_PROJECT_ENVIRONMENT to resolve core, and the agent, plus every shell it spawns,
-        // inherits it. cwd is what makes `core` importable; the sync step above owns the venv.
+        // Launch the engine interpreter directly: `uv run` would carry UV_PROJECT_ENVIRONMENT
+        // into the agent and every shell it spawns. cwd makes `core` importable.
         "cd /root/agent && exec .venv/bin/python -m core.main".into(),
     ];
     vec!["sh".into(), "-c".into(), steps.join("; \\\n")]
@@ -2824,10 +2821,9 @@ mod tests {
 
     #[test]
     fn entrypoint_never_exports_uv_project_environment_into_the_agent() {
-        // An inherited UV_PROJECT_ENVIRONMENT retargets EVERY uv project, so `uv run` in a
-        // skill's cli/ re-syncs the engine venv and deletes it when the skill pins another
-        // Python, bricking the next restart. It stays scoped to the core sync, and the engine
-        // is launched without `uv run`, which would carry the variable into the agent's env.
+        // Exported, UV_PROJECT_ENVIRONMENT retargets every uv project, so `uv run` in a skill's
+        // cli/ re-syncs and can delete the engine venv. It stays scoped to the core sync, and the
+        // engine launches without `uv run`, which would propagate it.
         let cmd = agent_container_entrypoint_cmd();
         let script = cmd.last().expect("entrypoint script");
         assert!(


### PR DESCRIPTION
Fixes #1310

## Root cause: `UV_PROJECT_ENVIRONMENT`, not `VIRTUAL_ENV`

The issue fingers `VIRTUAL_ENV`. It is a red herring, and removing it would have fixed nothing. Verified both against uv 0.11.3:

* `VIRTUAL_ENV` is **ignored** by uv for project commands. It warns `does not match the project environment path .venv and will be ignored` and the skill correctly gets its own `.venv`. Nothing in this repo ever exported it: it appears in the agent's env because `uv run` sets it for its child, which is why it was visible on the box.
* `UV_PROJECT_ENVIRONMENT=/root/agent/.venv` is the destroyer. It retargets **every** uv project, so `uv run` in a skill's `cli/` adopts the engine venv and re-syncs it, deleting and recreating it whenever the skill pins another Python. It was exported in two places: `ENV` in `vestad/Dockerfile` and `export` in `agent_container_entrypoint_cmd`.

Reproduced in a container with a read-only core mount, old entrypoint:

```
engine venv: version_info = 3.14
-- agent runs the skill's tests (the encouraged action) --
Removed virtual environment at: /root/agent/.venv
engine venv now: version_info = 3.11
-- next restart: --
ModuleNotFoundError: No module named 'rich'      # stands in for claude_agent_sdk
```

## Why the export existed (verified, not assumed)

Removing it outright would have made the bricking worse. `/root/agent/core` is a **read-only** bind mount, so without the variable uv defaults the engine's project env to `/root/agent/core/.venv` and dies:

```
error: failed to create directory `.../engine/.venv`: Permission denied (os error 13)
```

So the variable is genuinely needed, but only by the engine's own uv commands. It was exported globally because ad hoc `uv run --project core <tool>` also had to resolve the engine venv.

## The fix

* Scope `UV_PROJECT_ENVIRONMENT` to the engine's own `uv sync` (entrypoint + Dockerfile `RUN`), never exported.
* Put `/root/agent/.venv/bin` first on PATH. `uv run` was already doing this implicitly; making it explicit is what replaces the global export. `ruff`, `pytest`, `ty` and `python` are engine deps, so they still resolve as plain commands, and PATH does **not** make uv adopt the venv as its target (verified).
* Launch the engine with `.venv/bin/python -m core.main` rather than `uv run`, which would carry the variable straight back into the agent's env and every shell it spawns. This also collapses the legacy layout branch, since both layouts put the venv at the same path.

Same scenario, new entrypoint:

```
agent env: UV_PROJECT_ENVIRONMENT=[] VIRTUAL_ENV=[]
Creating virtual environment at: .venv     # the skill's own
engine venv now: version_info = 3.14       # untouched
python -> /root/agent/.venv/bin/python     # pinned tools still resolve
-- next restart: --
ENGINE BOOTED OK
```

## Existing boxes: no migration needed

The export lives only in vestad-owned places, never on the agent's disk. `/root/.bashrc` is truncated by the image and nothing writes the variable there, so there is no persisted per-agent state to converge:

* The entrypoint is the container's `cmd`, and `container_needs_rebuild` compares it against `agent_container_entrypoint_cmd()`. This change drifts every existing container, so reconcile snapshots and recreates each one.
* A rebuild goes through `docker export | docker import`, which drops image `ENV`, and `create_container` supplies no `env`. Verified directly: the imported container's `UV_PROJECT_ENVIRONMENT` is empty and PATH resets to the daemon default. That is also why the entrypoint re-exports PATH. So no box can inherit a stale value from its old image, and no `unset` guard is warranted.
* Already-damaged boxes repair themselves: the boot `uv sync --frozen --project core` restores a clobbered venv (verified), which is the same command the issue documents as recovery.

## Also updated

Two skill docs stated commands that this change would otherwise break or make false:

* `upstream-pr`: `uv run --project core ruff` would now hard-fail against the read-only mount, so it becomes plain `ruff` from `~/agent` (still the pinned ruff, via PATH). Adds the terse hazard plus recovery where it tells agents to run a skill's tests, per the issue's mitigation (3).
* `skills-registry`: cited `VIRTUAL_ENV=~/agent/.venv` as the reason for its `uv pip install -e` warning. The advice stands; the mechanism is now PATH.

Fix (2) from the issue is deliberately skipped: per-skill venvs are what (1) produces for free, and `.venv/` is already gitignored at any depth, so no box gets a dirty tree.

## Checks

`./check.sh vestad` (207 passed), `./check.sh agent`, `./check.sh guards` all green. Adds `entrypoint_never_exports_uv_project_environment_into_the_agent` as the regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)