### PR TITLE
fix(microsoft): only advance the monitor watermark across successfully polled windows

### DIFF
--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -1,7 +1,9 @@
 import json
 import re
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+from functools import partial
 from pathlib import Path
 from typing import NotRequired, TypedDict
 from zoneinfo import ZoneInfo
@@ -57,13 +59,11 @@ def _read_state(path: Path, now: datetime) -> MonitorState:
         parsed = json.loads(raw)
     except json.JSONDecodeError:
         return MonitorState(last_cycle=raw, units={})
-    if not isinstance(parsed, dict) or "last_cycle" not in parsed or "units" not in parsed:
-        raise ValueError(f"Malformed monitor state in {path}: {raw[:100]}")
-    last_cycle = parsed["last_cycle"]
-    units = parsed["units"]
-    if not isinstance(last_cycle, str) or not isinstance(units, dict):
-        raise ValueError(f"Malformed monitor state in {path}: {raw[:100]}")
-    return MonitorState(last_cycle=last_cycle, units={str(unit): str(watermark) for unit, watermark in units.items()})
+    match parsed:
+        case {"last_cycle": str(last_cycle), "units": dict(units)}:
+            return MonitorState(last_cycle=last_cycle, units={str(unit): str(watermark) for unit, watermark in units.items()})
+        case _:
+            raise ValueError(f"Malformed monitor state in {path}: {raw[:100]}")
 
 
 def _write_state(path: Path, state: MonitorState) -> None:
@@ -72,22 +72,17 @@ def _write_state(path: Path, state: MonitorState) -> None:
     tmp.rename(path)
 
 
-def _unit_window(ctx: MicrosoftContext, state: MonitorState, unit: str, new_check_time: datetime) -> tuple[datetime, bool]:
-    """Start of the window this unit still has to read, and whether that window is a catch-up."""
+def _poll_unit(ctx: MicrosoftContext, state: MonitorState, unit: str, new_check_time: datetime, poll: Callable[[datetime, bool], bool]) -> None:
+    """Poll a unit over the window it still owes, then advance its watermark only if the poll read
+    that window. A failed poll parks it at the window it still owes, so the next healthy cycle re-reads
+    instead of skipping the mail it never fetched; _MAX_CATCHUP bounds how far a long-dead unit re-reads."""
     units = state["units"]
-    last_iso = units[unit] if unit in units else state["last_cycle"]
-    last_dt = max(datetime.fromisoformat(last_iso), new_check_time - _MAX_CATCHUP)
+    last_dt = max(datetime.fromisoformat(units[unit] if unit in units else state["last_cycle"]), new_check_time - _MAX_CATCHUP)
     gap_seconds = (new_check_time - last_dt).total_seconds()
     catching_up = gap_seconds > _CATCHUP_GAP_SECONDS
     if catching_up:
         ctx.monitor_logger.info("Catching up %s from %s, %.0fs behind", unit, last_dt.isoformat(), gap_seconds)
-    return last_dt, catching_up
-
-
-def _record_poll(state: MonitorState, unit: str, last_dt: datetime, new_check_time: datetime, polled: bool) -> None:
-    """Advance a unit's watermark only across a window it actually read. A failed poll parks it at
-    the window it still owes, so the next healthy cycle re-reads that window instead of skipping it."""
-    state["units"][unit] = new_check_time.isoformat() if polled else last_dt.isoformat()
+    units[unit] = new_check_time.isoformat() if poll(last_dt, catching_up) else last_dt.isoformat()
 
 
 class EmailAddress(TypedDict):
@@ -266,8 +261,8 @@ def _poll_owa_rest_calendar(
     ctx: MicrosoftContext,
     config: Config,
     account_email: str,
-    last_dt: datetime,
     new_check_time: datetime,
+    last_dt: datetime,
     catching_up: bool,
 ) -> bool:
     """Emit a locked-tenant OWA REST account's calendar reminders, True when the calendar was read."""
@@ -480,7 +475,7 @@ def _poll_graph_mail(ctx: MicrosoftContext, acc, last_dt: datetime, catching_up:
     return polled
 
 
-def _poll_graph_calendar(ctx: MicrosoftContext, acc, last_dt: datetime, new_check_time: datetime, catching_up: bool) -> bool:
+def _poll_graph_calendar(ctx: MicrosoftContext, acc, new_check_time: datetime, last_dt: datetime, catching_up: bool) -> bool:
     """Emit one MSAL (Graph) account's calendar reminders, True when the calendar was read."""
     logger = ctx.monitor_logger
     conn = graph.GraphConn(ctx.http_client, ctx.cache_file, ctx.scopes, ctx.base_url)
@@ -525,13 +520,8 @@ def run(ctx: MicrosoftContext):
             msal_accounts = auth.list_accounts(ctx.cache_file)
             for acc in msal_accounts:
                 logger.info("Checking account: %s", acc.username)
-                unit = f"mail:{acc.username}"
-                last_dt, catching_up = _unit_window(ctx, state, unit, new_check_time)
-                _record_poll(state, unit, last_dt, new_check_time, _poll_graph_mail(ctx, acc, last_dt, catching_up))
-
-                unit = f"calendar:{acc.username}"
-                last_dt, catching_up = _unit_window(ctx, state, unit, new_check_time)
-                _record_poll(state, unit, last_dt, new_check_time, _poll_graph_calendar(ctx, acc, last_dt, new_check_time, catching_up))
+                _poll_unit(ctx, state, f"mail:{acc.username}", new_check_time, partial(_poll_graph_mail, ctx, acc))
+                _poll_unit(ctx, state, f"calendar:{acc.username}", new_check_time, partial(_poll_graph_calendar, ctx, acc, new_check_time))
 
             # OWA REST accounts (locked tenants) are not in the MSAL cache, so poll them here over
             # OWA REST for anything Graph did not already cover. The fetch runs through load_token,
@@ -543,29 +533,26 @@ def run(ctx: MicrosoftContext):
                     continue
                 logger.info("Checking OWA REST account: %s", account_email)
                 watch_folders = notify.get_notify_folders(ctx.notify_file, account_email) if ctx.notify_file else ["inbox"]
-                unit = f"mail:{account_email}"
-                last_dt, catching_up = _unit_window(ctx, state, unit, new_check_time)
-                polled = _poll_owa_rest_mail(ctx, config, account_email, watch_folders, last_dt, catching_up)
-                _record_poll(state, unit, last_dt, new_check_time, polled)
-
-                unit = f"calendar:{account_email}"
-                last_dt, catching_up = _unit_window(ctx, state, unit, new_check_time)
-                polled = _poll_owa_rest_calendar(ctx, config, account_email, last_dt, new_check_time, catching_up)
-                _record_poll(state, unit, last_dt, new_check_time, polled)
+                _poll_unit(
+                    ctx, state, f"mail:{account_email}", new_check_time, partial(_poll_owa_rest_mail, ctx, config, account_email, watch_folders)
+                )
+                _poll_unit(
+                    ctx,
+                    state,
+                    f"calendar:{account_email}",
+                    new_check_time,
+                    partial(_poll_owa_rest_calendar, ctx, config, account_email, new_check_time),
+                )
 
             # Teams chats: poll every account that has authorized Teams (device or captured token).
             # Channel messages are polled right after with their own cutoff; they degrade to a no-op
             # for accounts that lack channel-read access (default-on where the capability exists).
             for account_email in teams.list_accounts(config):
                 logger.info("Checking Teams account: %s", account_email)
-                unit = f"teams:{account_email}"
-                last_dt, catching_up = _unit_window(ctx, state, unit, new_check_time)
-                _record_poll(state, unit, last_dt, new_check_time, _poll_teams_account(ctx, config, account_email, last_dt, catching_up))
-
-                unit = f"channels:{account_email}"
-                last_dt, catching_up = _unit_window(ctx, state, unit, new_check_time)
-                polled = _poll_teams_channels_account(ctx, config, account_email, last_dt, catching_up)
-                _record_poll(state, unit, last_dt, new_check_time, polled)
+                _poll_unit(ctx, state, f"teams:{account_email}", new_check_time, partial(_poll_teams_account, ctx, config, account_email))
+                _poll_unit(
+                    ctx, state, f"channels:{account_email}", new_check_time, partial(_poll_teams_channels_account, ctx, config, account_email)
+                )
 
             # Keep browser-captured tokens fresh so the user's one sign-in lasts the SSO session.
             _refresh_captured_tokens(ctx, config, refresh_gave_up)

--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -1,6 +1,8 @@
+import json
 import re
 import time
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import NotRequired, TypedDict
 from zoneinfo import ZoneInfo
 
@@ -9,6 +11,12 @@ from .config import Config
 from .context import MicrosoftContext
 
 _HTML_TAG = re.compile(r"<[^>]+>")
+
+_CATCHUP_GAP_SECONDS = 90
+_FRESH_START_LOOKBACK = timedelta(hours=1)
+# A unit that failed for a long stretch re-reads at most this much history once it heals, so a
+# long-dead account cannot flood the user on recovery.
+_MAX_CATCHUP = timedelta(days=7)
 
 
 # Zero-width and bidi / formatting characters that marketing emails use to pad previews with
@@ -25,6 +33,61 @@ def clean_preview(text: str) -> str:
 def strip_fractional(iso: str) -> str:
     """Remove fractional seconds from an ISO-8601 datetime string (Graph returns '.0000000')."""
     return re.sub(r"\.\d+", "", iso)
+
+
+class MonitorState(TypedDict):
+    """Watermarks the monitor resumes from.
+
+    last_cycle: when the monitor last finished a cycle; it seeds a unit polled for the first time.
+    units: poll unit ("mail:<account>", "calendar:<account>", "teams:<account>",
+    "channels:<account>") -> the end of the last window that unit read successfully.
+    """
+
+    last_cycle: str
+    units: dict[str, str]
+
+
+def _read_state(path: Path, now: datetime) -> MonitorState:
+    """Read the watermarks. A bare-timestamp file (the format before per-unit watermarks) reads as
+    a last_cycle with no units, so every unit resumes from where the old monitor left off."""
+    raw = path.read_text().strip() if path.exists() else ""
+    if not raw:
+        return MonitorState(last_cycle=(now - _FRESH_START_LOOKBACK).isoformat(), units={})
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return MonitorState(last_cycle=raw, units={})
+    if not isinstance(parsed, dict) or "last_cycle" not in parsed or "units" not in parsed:
+        raise ValueError(f"Malformed monitor state in {path}: {raw[:100]}")
+    last_cycle = parsed["last_cycle"]
+    units = parsed["units"]
+    if not isinstance(last_cycle, str) or not isinstance(units, dict):
+        raise ValueError(f"Malformed monitor state in {path}: {raw[:100]}")
+    return MonitorState(last_cycle=last_cycle, units={str(unit): str(watermark) for unit, watermark in units.items()})
+
+
+def _write_state(path: Path, state: MonitorState) -> None:
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state))
+    tmp.rename(path)
+
+
+def _unit_window(ctx: MicrosoftContext, state: MonitorState, unit: str, new_check_time: datetime) -> tuple[datetime, bool]:
+    """Start of the window this unit still has to read, and whether that window is a catch-up."""
+    units = state["units"]
+    last_iso = units[unit] if unit in units else state["last_cycle"]
+    last_dt = max(datetime.fromisoformat(last_iso), new_check_time - _MAX_CATCHUP)
+    gap_seconds = (new_check_time - last_dt).total_seconds()
+    catching_up = gap_seconds > _CATCHUP_GAP_SECONDS
+    if catching_up:
+        ctx.monitor_logger.info("Catching up %s from %s, %.0fs behind", unit, last_dt.isoformat(), gap_seconds)
+    return last_dt, catching_up
+
+
+def _record_poll(state: MonitorState, unit: str, last_dt: datetime, new_check_time: datetime, polled: bool) -> None:
+    """Advance a unit's watermark only across a window it actually read. A failed poll parks it at
+    the window it still owes, so the next healthy cycle re-reads that window instead of skipping it."""
+    state["units"][unit] = new_check_time.isoformat() if polled else last_dt.isoformat()
 
 
 class EmailAddress(TypedDict):
@@ -165,18 +228,18 @@ def _emit_calendar_reminders(
             )
 
 
-def _poll_owa_rest_account(
+def _poll_owa_rest_mail(
     ctx: MicrosoftContext,
     config: Config,
     account_email: str,
     watch_folders: list[str],
     last_dt: datetime,
-    new_check_time: datetime,
     catching_up: bool,
-) -> None:
-    """Poll a locked-tenant OWA REST account for new mail and calendar reminders. Fetching also
-    triggers the token auto-refresh in load_token, so this keeps the token warm in the background."""
+) -> bool:
+    """Poll a locked-tenant OWA REST account's watched folders for new mail, True when every folder
+    was read. Fetching runs through load_token, so this also keeps the token warm in the background."""
     logger = ctx.monitor_logger
+    polled = True
     for folder_token in watch_folders:
         try:
             messages = owa_rest.list_messages(ctx.http_client, account_email, config, folder=folder_token, limit=50)
@@ -195,7 +258,20 @@ def _poll_owa_rest_account(
                 _emit_email_notification(ctx, message, account_email, folder_token, catching_up)
         except Exception as e:
             logger.error("Error fetching OWA REST emails for %s folder %s: %s", account_email, folder_token, e)
+            polled = False
+    return polled
 
+
+def _poll_owa_rest_calendar(
+    ctx: MicrosoftContext,
+    config: Config,
+    account_email: str,
+    last_dt: datetime,
+    new_check_time: datetime,
+    catching_up: bool,
+) -> bool:
+    """Emit a locked-tenant OWA REST account's calendar reminders, True when the calendar was read."""
+    logger = ctx.monitor_logger
     try:
         max_threshold = max(ctx.get_calendar_notify_thresholds())
         window_end = new_check_time + timedelta(minutes=max_threshold + 60)
@@ -210,6 +286,8 @@ def _poll_owa_rest_account(
         _emit_calendar_reminders(ctx, events, account_email, last_dt, new_check_time, catching_up)
     except Exception as e:
         logger.error("Error fetching OWA REST calendar for %s: %s", account_email, e)
+        return False
+    return True
 
 
 def _teams_sender_name(message: dict, my_id: str) -> str | None:
@@ -237,21 +315,22 @@ def _arrived_since(message: dict, last_dt: datetime) -> bool:
     return created > last_dt
 
 
-def _poll_teams_account(ctx: MicrosoftContext, config: Config, account_email: str, last_dt: datetime, catching_up: bool) -> None:
+def _poll_teams_account(ctx: MicrosoftContext, config: Config, account_email: str, last_dt: datetime, catching_up: bool) -> bool:
     """Emit a notification per chat whose latest message arrived since last_dt (excluding the user's
-    own messages). One /me/chats request per cycle carries every chat's last-message preview."""
+    own messages), True when the chats were read. One /me/chats request per cycle carries every
+    chat's last-message preview."""
     logger = ctx.monitor_logger
     try:
         token = teams.resolve_token(config, account_email)
     except teams.TeamsError as e:
         logger.info("Teams token unavailable for %s: %s", account_email, e)
-        return
+        return False
     try:
         my_id = teams._my_id(ctx.http_client, token)
         chats = teams.list_chats(ctx.http_client, token, limit=50)
     except Exception as e:
         logger.error("Error fetching Teams chats for %s: %s", account_email, e)
-        return
+        return False
 
     for chat in chats:
         preview = chat["lastMessagePreview"] if "lastMessagePreview" in chat else None
@@ -275,9 +354,10 @@ def _poll_teams_account(ctx: MicrosoftContext, config: Config, account_email: st
             account=account_email,
             missed=catching_up or None,
         )
+    return True
 
 
-def _poll_teams_channels_account(ctx: MicrosoftContext, config: Config, account_email: str, last_dt: datetime, catching_up: bool) -> None:
+def _poll_teams_channels_account(ctx: MicrosoftContext, config: Config, account_email: str, last_dt: datetime, catching_up: bool) -> bool:
     """Emit a non-interrupting notification per Teams CHANNEL message since last_dt (excluding the
     user's own). Channels are broadcast, so a message per channel would be noisy — hence interrupt=False,
     unlike chats which stay interrupt=True.
@@ -285,21 +365,23 @@ def _poll_teams_channels_account(ctx: MicrosoftContext, config: Config, account_
     GRACEFUL DEGRADE: reading channel messages needs the admin-only ChannelMessage.Read.All scope plus
     Graph access that many accounts (browser-capture / OWA-REST-only) do NOT have. If enumerating teams
     fails for ANY reason (permission 403/401, GraphUnavailableError, TeamsError, ...), log once at info and
-    return — the account silently keeps working with chats only. A failure on a single team/channel is
-    logged at debug and skipped, never fatal."""
+    report the window read — the account silently keeps working with chats only, and parking the watermark
+    would only flood it if access ever appeared. A failure on a single team/channel is logged at debug and
+    skipped, never fatal. Only a missing token, which loses messages the account can otherwise read,
+    reports the window unread."""
     logger = ctx.monitor_logger
     try:
         token = teams.resolve_token(config, account_email)
     except teams.TeamsError as e:
         logger.info("Teams token unavailable for %s: %s", account_email, e)
-        return
+        return False
     try:
         my_id = teams._my_id(ctx.http_client, token)
         teams_list = teams.list_teams(ctx.http_client, token)
     except Exception as e:
         # No channel access (missing ChannelMessage.Read.All / no Graph): degrade to chats-only.
         logger.info("Teams channel messages unavailable for %s, keeping chats-only: %s", account_email, e)
-        return
+        return True
 
     for team in teams_list:
         team_id = team["id"] if "id" in team else None
@@ -341,6 +423,7 @@ def _poll_teams_channels_account(ctx: MicrosoftContext, config: Config, account_
                     account=account_email,
                     missed=catching_up or None,
                 )
+    return True
 
 
 def _refresh_captured_tokens(ctx: MicrosoftContext, config: Config, gave_up: set[str]) -> None:
@@ -359,11 +442,12 @@ def _refresh_captured_tokens(ctx: MicrosoftContext, config: Config, gave_up: set
             notifications.write_notification(ctx.notif_dir, "auth_needed", interrupt=False, account=account, message=str(e))
 
 
-def _poll_graph_account(ctx: MicrosoftContext, acc, last_check: str, last_dt: datetime, new_check_time: datetime, catching_up: bool) -> None:
-    """Poll one MSAL (Graph) account for new mail in its watched folders and upcoming calendar events."""
+def _poll_graph_mail(ctx: MicrosoftContext, acc, last_dt: datetime, catching_up: bool) -> bool:
+    """Poll one MSAL (Graph) account's watched folders for new mail, True when every folder was read."""
     logger = ctx.monitor_logger
     conn = graph.GraphConn(ctx.http_client, ctx.cache_file, ctx.scopes, ctx.base_url)
     watch_folders = notify.get_notify_folders(ctx.notify_file, acc.username) if ctx.notify_file else ["inbox"]
+    polled = True
     for folder_token in watch_folders:
         try:
             folder_id = folders.resolve_folder_id(
@@ -375,7 +459,7 @@ def _poll_graph_account(ctx: MicrosoftContext, acc, last_check: str, last_dt: da
                 f"/me/mailFolders/{folder_id}/messages",
                 acc.account_id,
                 params={
-                    "$filter": f"receivedDateTime gt {last_check}",
+                    "$filter": f"receivedDateTime gt {last_dt.isoformat()}",
                     "$select": "subject,from,bodyPreview,receivedDateTime",
                     "$top": 50,
                 },
@@ -383,6 +467,7 @@ def _poll_graph_account(ctx: MicrosoftContext, acc, last_check: str, last_dt: da
 
             if not result or "value" not in result:
                 logger.warning("Unexpected email API response: %s", result)
+                polled = False
                 continue
             emails = result["value"]
             logger.info("Found %d new emails for %s in %s", len(emails), acc.username, folder_token)
@@ -391,7 +476,14 @@ def _poll_graph_account(ctx: MicrosoftContext, acc, last_check: str, last_dt: da
                 _emit_email_notification(ctx, email, acc.username, folder_token, catching_up)
         except Exception as e:
             logger.error("Error fetching emails for %s folder %s: %s", acc.username, folder_token, e)
+            polled = False
+    return polled
 
+
+def _poll_graph_calendar(ctx: MicrosoftContext, acc, last_dt: datetime, new_check_time: datetime, catching_up: bool) -> bool:
+    """Emit one MSAL (Graph) account's calendar reminders, True when the calendar was read."""
+    logger = ctx.monitor_logger
+    conn = graph.GraphConn(ctx.http_client, ctx.cache_file, ctx.scopes, ctx.base_url)
     try:
         max_threshold = max(ctx.get_calendar_notify_thresholds())
         window_end = new_check_time + timedelta(minutes=max_threshold + 60)
@@ -409,75 +501,77 @@ def _poll_graph_account(ctx: MicrosoftContext, acc, last_check: str, last_dt: da
 
         if not cal_result or "value" not in cal_result:
             logger.warning("Unexpected calendar API response: %s", cal_result)
-            return
+            return False
         events = cal_result["value"]
         logger.info("Found %d upcoming calendar events for %s", len(events), acc.username)
         _emit_calendar_reminders(ctx, events, acc.username, last_dt, new_check_time, catching_up)
     except Exception as e:
         logger.error("Error fetching calendar for %s: %s", acc.username, e)
+        return False
+    return True
 
 
 def run(ctx: MicrosoftContext):
     logger = ctx.monitor_logger
     logger.info("Monitor thread started")
-    first_run = True
-    catching_up = False
     refresh_gave_up: set[str] = set()
 
     while not ctx.monitor_stop_event.is_set():
         try:
-            last_check = (
-                ctx.monitor_state_file.read_text().strip()
-                if ctx.monitor_state_file.exists()
-                else (datetime.now(UTC) - timedelta(hours=1)).isoformat()
-            )
-            catching_up = False
-
-            if first_run:
-                last_check_dt = datetime.fromisoformat(last_check)
-                gap_seconds = (datetime.now(UTC) - last_check_dt).total_seconds()
-                if gap_seconds > 90:
-                    logger.info("Detected offline period of %.0fs, catching up from %s", gap_seconds, last_check)
-                    catching_up = True
-            first_run = False
-
-            logger.info("Checking for updates since %s", last_check)
-            last_dt = datetime.fromisoformat(last_check)
-
             new_check_time = datetime.now(UTC)
+            state = _read_state(ctx.monitor_state_file, new_check_time)
+            config = Config(data_dir=ctx.cache_file.parent)
 
             msal_accounts = auth.list_accounts(ctx.cache_file)
             for acc in msal_accounts:
                 logger.info("Checking account: %s", acc.username)
-                _poll_graph_account(ctx, acc, last_check, last_dt, new_check_time, catching_up)
+                unit = f"mail:{acc.username}"
+                last_dt, catching_up = _unit_window(ctx, state, unit, new_check_time)
+                _record_poll(state, unit, last_dt, new_check_time, _poll_graph_mail(ctx, acc, last_dt, catching_up))
+
+                unit = f"calendar:{acc.username}"
+                last_dt, catching_up = _unit_window(ctx, state, unit, new_check_time)
+                _record_poll(state, unit, last_dt, new_check_time, _poll_graph_calendar(ctx, acc, last_dt, new_check_time, catching_up))
 
             # OWA REST accounts (locked tenants) are not in the MSAL cache, so poll them here over
             # OWA REST for anything Graph did not already cover. The fetch runs through load_token,
             # which silently re-mints an expiring token from the signed-in browser profile, so this
             # also keeps the token warm in the background.
-            config = Config(data_dir=ctx.cache_file.parent)
             msal_usernames = {acc.username.casefold() for acc in msal_accounts}
             for account_email in owa_rest.list_accounts(config):
                 if account_email.casefold() in msal_usernames:
                     continue
                 logger.info("Checking OWA REST account: %s", account_email)
                 watch_folders = notify.get_notify_folders(ctx.notify_file, account_email) if ctx.notify_file else ["inbox"]
-                _poll_owa_rest_account(ctx, config, account_email, watch_folders, last_dt, new_check_time, catching_up)
+                unit = f"mail:{account_email}"
+                last_dt, catching_up = _unit_window(ctx, state, unit, new_check_time)
+                polled = _poll_owa_rest_mail(ctx, config, account_email, watch_folders, last_dt, catching_up)
+                _record_poll(state, unit, last_dt, new_check_time, polled)
+
+                unit = f"calendar:{account_email}"
+                last_dt, catching_up = _unit_window(ctx, state, unit, new_check_time)
+                polled = _poll_owa_rest_calendar(ctx, config, account_email, last_dt, new_check_time, catching_up)
+                _record_poll(state, unit, last_dt, new_check_time, polled)
 
             # Teams chats: poll every account that has authorized Teams (device or captured token).
-            # Channel messages are polled right after with the same cutoff; they degrade to a no-op
+            # Channel messages are polled right after with their own cutoff; they degrade to a no-op
             # for accounts that lack channel-read access (default-on where the capability exists).
             for account_email in teams.list_accounts(config):
                 logger.info("Checking Teams account: %s", account_email)
-                _poll_teams_account(ctx, config, account_email, last_dt, catching_up)
-                _poll_teams_channels_account(ctx, config, account_email, last_dt, catching_up)
+                unit = f"teams:{account_email}"
+                last_dt, catching_up = _unit_window(ctx, state, unit, new_check_time)
+                _record_poll(state, unit, last_dt, new_check_time, _poll_teams_account(ctx, config, account_email, last_dt, catching_up))
+
+                unit = f"channels:{account_email}"
+                last_dt, catching_up = _unit_window(ctx, state, unit, new_check_time)
+                polled = _poll_teams_channels_account(ctx, config, account_email, last_dt, catching_up)
+                _record_poll(state, unit, last_dt, new_check_time, polled)
 
             # Keep browser-captured tokens fresh so the user's one sign-in lasts the SSO session.
             _refresh_captured_tokens(ctx, config, refresh_gave_up)
 
-            tmp = ctx.monitor_state_file.with_suffix(".tmp")
-            tmp.write_text(new_check_time.isoformat())
-            tmp.rename(ctx.monitor_state_file)
+            state["last_cycle"] = new_check_time.isoformat()
+            _write_state(ctx.monitor_state_file, state)
             logger.info("Completed check cycle, sleeping for 45 seconds")
             if ctx.monitor_stop_event.wait(45):
                 break

--- a/agent/skills/microsoft/cli/tests/test_monitor.py
+++ b/agent/skills/microsoft/cli/tests/test_monitor.py
@@ -117,7 +117,7 @@ def test_poll_owa_rest_fires_calendar_reminder(tmp_path, monkeypatch):
     # the 60-minute reminder (trigger 12:00) falls in this cycle's window
     last_dt = datetime(2026, 7, 8, 11, 59, tzinfo=UTC)
     new_check = datetime(2026, 7, 8, 12, 0, 30, tzinfo=UTC)
-    assert monitor._poll_owa_rest_calendar(_fake_ctx(tmp_path), None, "me@x.com", last_dt, new_check, False) is True
+    assert monitor._poll_owa_rest_calendar(_fake_ctx(tmp_path), None, "me@x.com", new_check, last_dt, False) is True
     assert len(calls) == 1
     assert calls[0]["subject"] == "Standup"
 
@@ -126,7 +126,7 @@ def test_poll_owa_rest_calendar_reports_a_calendar_it_could_not_read(tmp_path, m
     monkeypatch.setattr(monitor.owa_rest, "list_events", _raise(httpx.ConnectError("boom")))
     last_dt = datetime(2026, 7, 8, 11, 59, tzinfo=UTC)
     new_check = datetime(2026, 7, 8, 12, 0, 30, tzinfo=UTC)
-    assert monitor._poll_owa_rest_calendar(_fake_ctx(tmp_path), None, "me@x.com", last_dt, new_check, False) is False
+    assert monitor._poll_owa_rest_calendar(_fake_ctx(tmp_path), None, "me@x.com", new_check, last_dt, False) is False
 
 
 # ---------------------------------------------------------------------------

--- a/agent/skills/microsoft/cli/tests/test_monitor.py
+++ b/agent/skills/microsoft/cli/tests/test_monitor.py
@@ -1,11 +1,20 @@
 """Unit tests for microsoft_cli.monitor preview / timestamp helpers and OWA REST polling."""
 
+import json
 import logging
 import types
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
+import httpx
 from microsoft_cli import monitor
 from microsoft_cli.monitor import clean_preview, strip_fractional
+
+
+def _raise(exc: Exception):
+    def fail(*_args, **_kwargs):
+        raise exc
+
+    return fail
 
 
 def test_clean_preview_strips_zero_width_and_bidi():
@@ -82,18 +91,22 @@ def test_poll_owa_rest_notifies_only_new_mail(tmp_path, monkeypatch):
             _email("old@x.com", "Old Sender", "2026-07-08T11:00:00Z"),
         ],
     )
-    monkeypatch.setattr(monitor.owa_rest, "list_events", lambda *a, **k: [])
     last_dt = datetime(2026, 7, 8, 12, 0, tzinfo=UTC)
-    new_check = datetime(2026, 7, 8, 13, 30, tzinfo=UTC)
-    monitor._poll_owa_rest_account(_fake_ctx(tmp_path), None, "me@x.com", ["inbox"], last_dt, new_check, False)
+    assert monitor._poll_owa_rest_mail(_fake_ctx(tmp_path), None, "me@x.com", ["inbox"], last_dt, False) is True
     assert len(calls) == 1
     assert calls[0]["sender"] == "New Sender"
+
+
+def test_poll_owa_rest_mail_reports_a_folder_it_could_not_read(tmp_path, monkeypatch):
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: None)
+    monkeypatch.setattr(monitor.owa_rest, "list_messages", _raise(httpx.ConnectError("boom")))
+    last_dt = datetime(2026, 7, 8, 12, 0, tzinfo=UTC)
+    assert monitor._poll_owa_rest_mail(_fake_ctx(tmp_path), None, "me@x.com", ["inbox"], last_dt, False) is False
 
 
 def test_poll_owa_rest_fires_calendar_reminder(tmp_path, monkeypatch):
     calls = []
     monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
-    monkeypatch.setattr(monitor.owa_rest, "list_messages", lambda *a, **k: [])
     monkeypatch.setattr(
         monitor.owa_rest,
         "list_events",
@@ -104,6 +117,152 @@ def test_poll_owa_rest_fires_calendar_reminder(tmp_path, monkeypatch):
     # the 60-minute reminder (trigger 12:00) falls in this cycle's window
     last_dt = datetime(2026, 7, 8, 11, 59, tzinfo=UTC)
     new_check = datetime(2026, 7, 8, 12, 0, 30, tzinfo=UTC)
-    monitor._poll_owa_rest_account(_fake_ctx(tmp_path), None, "me@x.com", ["inbox"], last_dt, new_check, False)
+    assert monitor._poll_owa_rest_calendar(_fake_ctx(tmp_path), None, "me@x.com", last_dt, new_check, False) is True
     assert len(calls) == 1
     assert calls[0]["subject"] == "Standup"
+
+
+def test_poll_owa_rest_calendar_reports_a_calendar_it_could_not_read(tmp_path, monkeypatch):
+    monkeypatch.setattr(monitor.owa_rest, "list_events", _raise(httpx.ConnectError("boom")))
+    last_dt = datetime(2026, 7, 8, 11, 59, tzinfo=UTC)
+    new_check = datetime(2026, 7, 8, 12, 0, 30, tzinfo=UTC)
+    assert monitor._poll_owa_rest_calendar(_fake_ctx(tmp_path), None, "me@x.com", last_dt, new_check, False) is False
+
+
+# ---------------------------------------------------------------------------
+# The watermark only advances across a window that was actually read: a poll
+# that failed (dead token, network) must not skip the mail it never fetched.
+# ---------------------------------------------------------------------------
+
+
+def _run_ctx(tmp_path, cycles: int):
+    """A context whose stop event ends run() after `cycles` iterations."""
+    remaining = {"cycles": cycles}
+
+    def wait(_timeout):
+        remaining["cycles"] -= 1
+        return remaining["cycles"] <= 0
+
+    ctx = _fake_ctx(tmp_path)
+    ctx.monitor_state_file = tmp_path / "state.txt"
+    ctx.monitor_stop_event = types.SimpleNamespace(is_set=lambda: False, wait=wait)
+    ctx.notify_file = None
+    ctx.scopes = []
+    ctx.base_url = "https://graph.invalid/v1.0"
+    ctx.folders = {"inbox": "inbox"}
+    return ctx
+
+
+def _single_owa_account(monkeypatch, account: str = "me@x.com"):
+    """Only one OWA REST account exists: no MSAL, no Teams, no token refresh."""
+    monkeypatch.setattr(monitor.auth, "list_accounts", lambda *a, **k: [])
+    monkeypatch.setattr(monitor.teams, "list_accounts", lambda *a, **k: [])
+    monkeypatch.setattr(monitor.capture, "due_accounts", lambda *a, **k: [])
+    monkeypatch.setattr(monitor.owa_rest, "list_accounts", lambda *a, **k: [account])
+    monkeypatch.setattr(monitor.owa_rest, "list_events", lambda *a, **k: [])
+
+
+def _watermark(ctx, unit: str) -> datetime:
+    return datetime.fromisoformat(json.loads(ctx.monitor_state_file.read_text())["units"][unit])
+
+
+def test_failed_poll_leaves_the_window_for_the_next_cycle_to_recover(tmp_path, monkeypatch):
+    """The bug: a cycle whose poll failed used to advance the watermark, dropping the mail forever."""
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    _single_owa_account(monkeypatch)
+
+    now = datetime.now(UTC)
+    ctx = _run_ctx(tmp_path, cycles=2)
+    ctx.monitor_state_file.write_text((now - timedelta(seconds=60)).isoformat())
+    arrived_at = now - timedelta(seconds=30)
+    arrived = _email("boss@x.com", "Manager", arrived_at.isoformat())
+
+    cycle = {"n": 0}
+
+    def list_messages(*_args, **_kwargs):
+        cycle["n"] += 1
+        if cycle["n"] == 1:
+            raise httpx.ConnectError("Server disconnected without sending a response.")
+        return [arrived]
+
+    monkeypatch.setattr(monitor.owa_rest, "list_messages", list_messages)
+    monitor.run(ctx)
+
+    assert [call["sender"] for call in calls] == ["Manager"]
+    assert _watermark(ctx, "mail:me@x.com") > arrived_at
+
+
+def test_broken_account_does_not_make_a_healthy_one_renotify(tmp_path, monkeypatch):
+    """Per-account watermarks: a dead account parks its own window only, so the healthy account
+    keeps advancing instead of re-reading and re-notifying the same mail every cycle."""
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    _single_owa_account(monkeypatch)
+    monkeypatch.setattr(monitor.owa_rest, "list_accounts", lambda *a, **k: ["broken@x.com", "healthy@x.com"])
+
+    now = datetime.now(UTC)
+    parked_at = now - timedelta(seconds=60)
+    delivered_at = now - timedelta(seconds=30)
+    ctx = _run_ctx(tmp_path, cycles=2)
+    ctx.monitor_state_file.write_text(parked_at.isoformat())
+    delivered = _email("colleague@x.com", "Colleague", delivered_at.isoformat())
+
+    def list_messages(_client, account_email, *_args, **_kwargs):
+        if account_email == "broken@x.com":
+            raise httpx.ConnectError("token is dead")
+        return [delivered]
+
+    monkeypatch.setattr(monitor.owa_rest, "list_messages", list_messages)
+    monitor.run(ctx)
+
+    assert [call["sender"] for call in calls] == ["Colleague"]
+    assert _watermark(ctx, "mail:broken@x.com") == parked_at
+    assert _watermark(ctx, "mail:healthy@x.com") > delivered_at
+
+
+def test_recovery_reads_at_most_the_max_catchup_window(tmp_path, monkeypatch):
+    """A long-dead account cannot flood the user on recovery: only _MAX_CATCHUP of mail comes back."""
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    _single_owa_account(monkeypatch)
+
+    now = datetime.now(UTC)
+    ctx = _run_ctx(tmp_path, cycles=1)
+    stale = {"last_cycle": now.isoformat(), "units": {"mail:me@x.com": (now - timedelta(days=30)).isoformat()}}
+    ctx.monitor_state_file.write_text(json.dumps(stale))
+    monkeypatch.setattr(
+        monitor.owa_rest,
+        "list_messages",
+        lambda *a, **k: [
+            _email("ancient@x.com", "Ancient", (now - timedelta(days=20)).isoformat()),
+            _email("recent@x.com", "Recent", (now - timedelta(hours=1)).isoformat()),
+        ],
+    )
+    monitor.run(ctx)
+
+    assert [call["sender"] for call in calls] == ["Recent"]
+    assert calls[0]["missed"] is True
+
+
+def test_legacy_bare_timestamp_state_is_read_as_the_starting_watermark(tmp_path, monkeypatch):
+    """Boxes on the old format carry a bare ISO timestamp: it seeds every unit, so an update
+    neither re-notifies an hour of mail nor skips what arrived since that timestamp."""
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    _single_owa_account(monkeypatch)
+
+    now = datetime.now(UTC)
+    ctx = _run_ctx(tmp_path, cycles=1)
+    ctx.monitor_state_file.write_text((now - timedelta(minutes=5)).isoformat())
+    monkeypatch.setattr(
+        monitor.owa_rest,
+        "list_messages",
+        lambda *a, **k: [
+            _email("before@x.com", "Before", (now - timedelta(minutes=10)).isoformat()),
+            _email("after@x.com", "After", (now - timedelta(minutes=2)).isoformat()),
+        ],
+    )
+    monitor.run(ctx)
+
+    assert [call["sender"] for call in calls] == ["After"]


### PR DESCRIPTION
Fixes #1311

## The bug

`monitor.py` wrote `new_check_time` as the last-check watermark at the end of **every** cycle, including cycles whose polls fetched nothing because auth was broken. The poll helpers swallowed their own exceptions (`except Exception as e: logger.error(...)`), so a failed poll never reached the outer handler: the loop committed the watermark as if the window had been read, and the next cycle's `receivedDateTime gt <advanced watermark>` skipped the unread window forever. The daemon logged `Completed check cycle` throughout. On a real box this silently dropped two emails that needed a reply during a 26h token outage.

The `first_run` catch-up did not help: it only fires against a stale state file, i.e. only when the process was down. While the process is alive and auth is broken, the watermark is diligently advanced the whole time.

## The fix

The invariant: a watermark only advances across a window that was actually read. Poll helpers now return whether they read their window, and the loop records `new_check_time` only for the polls that succeeded; a failed poll parks its watermark so the next healthy cycle re-reads the window.

## Granularity: per (account, source), not one global watermark

Each poll unit (`mail:<account>`, `calendar:<account>`, `teams:<account>`, `channels:<account>`) carries its own watermark.

A single global watermark is simpler, but `notifications.write_notification` does **not** dedupe by message id, so re-reading is not free: with one global watermark, one broken account parks the watermark for everyone, and every healthy account re-reads and re-notifies its window every 45s until the broken one heals. That trades silent mail loss for a notification storm. Per-account keeps a dead account's window parked without touching a healthy account's.

Mail and calendar are separate units within an account for the same reason: they are separate endpoints with separate failure modes, and a permanently failing calendar (a missing `Calendars.Read` scope 403s forever) would otherwise re-notify that account's mail on every cycle.

Two deliberate non-failures, both preserving documented behavior:
- Teams **channel enumeration** failure keeps reporting the window read. It is the documented graceful degrade for the many accounts with no channel access, and parking there would only flood them if access ever appeared. A missing token, which loses messages the account can otherwise read, does report the window unread.
- A single team/channel failure after successful enumeration stays best-effort ("never fatal"), since a private channel the user cannot read would otherwise park the whole unit permanently.

## Bounded recovery

A unit's re-read window is clamped to `_MAX_CATCHUP` (7 days), so a long-dead account cannot flood the user when it heals. The clamp is persisted on each failed poll, so staleness cannot grow without bound. The issue's 26h outage recovers in full.

Catch-up is now intrinsic: `catching_up` is derived per unit from its own gap (`_CATCHUP_GAP_SECONDS`), which deletes the `first_run` flag and means recovered mail is tagged `missed` whether the process was down **or** the token was dead. The old flag could only ever see the former.

## Fleet impact

`state.txt` becomes `{"last_cycle": iso, "units": {...}}`. A box on the old format holds a bare ISO timestamp, which reads as `last_cycle` with no units, so every unit resumes from exactly where the old monitor left off: no migration, no re-notify burst on update, and the offline catch-up still works. The path is unchanged.

## Tests

`skills/microsoft/cli/tests/test_monitor.py`, driving the real `run()` loop over a real state file:
- a cycle whose poll failed does not advance the watermark, and the next successful cycle re-reads the window and produces the notification that was previously dropped (the issue's exact case)
- a broken account does not make a healthy one re-notify, and the healthy account's watermark keeps advancing
- recovery reads at most the catch-up window, and the recovered mail is tagged `missed`
- a legacy bare-timestamp state file is honored as the starting watermark
- the mail and calendar polls each report a window they could not read

Both watermark tests were confirmed red against the old unconditional-advance behavior.

`./check.sh agent` and `./check.sh guards` pass.
