### PR TITLE
fix(upstream-sync): stop the managed-core rebase re-fire loop

### DIFF
--- a/agent/core/skills/upstream-sync/SKILL.md
+++ b/agent/core/skills/upstream-sync/SKILL.md
@@ -22,19 +22,16 @@ The version you are running: `grep '^version = ' ~/agent/core/pyproject.toml`
 bash ~/agent/core/skills/upstream-sync/scripts/sync.sh
 ```
 
-That is the whole procedure: it checkpoints your work, fetches, fixes the cone, and rebases
-you onto the snapshot for the version you run. It is idempotent, and it exits 0 saying
-"already synced" when there is nothing to do. Exit 5 means the rebase stopped on a conflict
-and needs you; anything else it prints is the reason it could not proceed. Do not hand-run
-the porcelain instead: on a managed box the engine is a read-only mount, and the script is
-what keeps git from trying to rewrite it.
+The whole procedure, idempotent. Run it, never the porcelain by hand: it is what keeps git
+off the read-only engine mount. Exit 5 means it stopped on a conflict, which is yours:
 
 - Conflicts: ALWAYS resolve by hand, and the default is to keep BOTH sides, your change
   AND the stock change, not pick a winner. Do NOT reflexively `git checkout --ours/--theirs`
   or blanket-take one side: that silently drops real work. Even a file you upstreamed comes
   back genericized, so take stock's form and re-apply your local specifics on top rather
   than discarding either. Edit each conflicted file so both sides survive, `git add <file>`,
-  then `git rebase --continue`. `git rebase --abort` restores exactly the pre-sync state.
+  then `git rebase --continue` and re-run sync.sh to finish. `git rebase --abort` restores
+  exactly the pre-sync state.
 - Paused but `git diff --diff-filter=U` lists no files? Not a conflict: the rebase stopped
   on a commit that's now empty (its changes are already in the new stock) or mode-only.
   Run `git add -A` then `git rebase --continue`; if git says the commit is empty, run

--- a/agent/core/skills/upstream-sync/SKILL.md
+++ b/agent/core/skills/upstream-sync/SKILL.md
@@ -19,12 +19,15 @@ The version you are running: `grep '^version = ' ~/agent/core/pyproject.toml`
 ## Sync (after an upgrade, when the boot turn asks)
 
 ```bash
-cd ~
-git add -A && git commit -m checkpoint    # only if `git status` shows changes
-bash ~/agent/core/skills/upstream-sync/scripts/fetch-upstream.sh
-git rebase agent-vX.Y.Z                   # X.Y.Z = the version you are running (see top)
-bash ~/agent/core/skills/upstream-sync/scripts/set-cone.sh   # cone covers your tracked dirs
+bash ~/agent/core/skills/upstream-sync/scripts/sync.sh
 ```
+
+That is the whole procedure: it checkpoints your work, fetches, fixes the cone, and rebases
+you onto the snapshot for the version you run. It is idempotent, and it exits 0 saying
+"already synced" when there is nothing to do. Exit 5 means the rebase stopped on a conflict
+and needs you; anything else it prints is the reason it could not proceed. Do not hand-run
+the porcelain instead: on a managed box the engine is a read-only mount, and the script is
+what keeps git from trying to rewrite it.
 
 - Conflicts: ALWAYS resolve by hand, and the default is to keep BOTH sides, your change
   AND the stock change, not pick a winner. Do NOT reflexively `git checkout --ours/--theirs`
@@ -39,7 +42,7 @@ bash ~/agent/core/skills/upstream-sync/scripts/set-cone.sh   # cone covers your 
 - `git add -A` refusing paths "outside of your sparse-checkout definition" means you
   created a new directory: stage it deliberately with `git add --sparse <dir>` (never
   a blanket `add -A --sparse`, which would also stage engine files from the core
-  mount); the set-cone.sh step covers it once committed.
+  mount); sync.sh's cone step covers it once committed.
 - For `agent/MEMORY.md`, keep your accumulated knowledge and adopt the stock structure.
 - Then call `mark_upstream_synced`. If the rebase brought changes, call `restart_vesta`
   (after marking) so the new skills load.

--- a/agent/core/skills/upstream-sync/scripts/set-cone.sh
+++ b/agent/core/skills/upstream-sync/scripts/set-cone.sh
@@ -59,3 +59,12 @@ if [ -z "$CONE" ]; then
   exit 1
 fi
 printf '%s\n' "$CONE" | sort -u | git sparse-checkout set --cone --stdin
+
+# A managed box's agent/core is vestad's read-only mount. Leaving it out of the cone is not
+# enough to keep git out of it: sparsifying a path means deleting it from the worktree, the
+# mount forbids that, so git keeps the entry present and worktree-live and every later
+# checkout tries to rewrite the mount (issue #1280). Set the bit straight in the index,
+# which needs no worktree write.
+if [ ! -w agent/core ] && git rev-parse -q --verify HEAD >/dev/null; then
+  git ls-files -z -- agent/core | xargs -0r git update-index --skip-worktree --
+fi

--- a/agent/core/skills/upstream-sync/scripts/set-cone.sh
+++ b/agent/core/skills/upstream-sync/scripts/set-cone.sh
@@ -60,11 +60,8 @@ if [ -z "$CONE" ]; then
 fi
 printf '%s\n' "$CONE" | sort -u | git sparse-checkout set --cone --stdin
 
-# A managed box's agent/core is vestad's read-only mount. Leaving it out of the cone is not
-# enough to keep git out of it: sparsifying a path means deleting it from the worktree, the
-# mount forbids that, so git keeps the entry present and worktree-live and every later
-# checkout tries to rewrite the mount (issue #1280). Set the bit straight in the index,
-# which needs no worktree write.
-if [ ! -w agent/core ] && git rev-parse -q --verify HEAD >/dev/null; then
+# Sparsifying agent/core means deleting the read-only mount, which git can't do, so it leaves
+# the entry worktree-live and every later checkout rewrites the mount (#1280); pin it in the index.
+if [ ! -w agent/core ]; then
   git ls-files -z -- agent/core | xargs -0r git update-index --skip-worktree --
 fi

--- a/agent/core/skills/upstream-sync/scripts/status.sh
+++ b/agent/core/skills/upstream-sync/scripts/status.sh
@@ -7,14 +7,11 @@ TAG="agent-v$VERSION"
 bash ~/agent/core/skills/upstream-sync/scripts/fetch-upstream.sh
 echo "== running core: v$VERSION (snapshot $TAG)"
 if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-  # merge-base is the authoritative answer: `$TAG..HEAD` lists commits either way, so it
-  # reads like a finished sync even when the rebase never landed (issue #1280).
+  # `$TAG..HEAD` lists my commits either way, so only merge-base says whether the rebase landed.
   if git merge-base --is-ancestor "$TAG" HEAD; then
-    echo "== synced: $TAG is in my history"
-    echo "== my changes on top of $TAG:"
+    echo "== synced: my changes on top of $TAG:"
   else
-    echo "== NOT synced: $TAG is not in my history - run sync.sh"
-    echo "== my commits since $(git describe --tags --match 'agent-v*' --abbrev=0 HEAD 2>/dev/null || echo 'my base'):"
+    echo "== NOT synced: $TAG is not in my history, run sync.sh. My commits:"
   fi
   git log --oneline "$TAG..HEAD" || true
 else

--- a/agent/core/skills/upstream-sync/scripts/status.sh
+++ b/agent/core/skills/upstream-sync/scripts/status.sh
@@ -7,7 +7,15 @@ TAG="agent-v$VERSION"
 bash ~/agent/core/skills/upstream-sync/scripts/fetch-upstream.sh
 echo "== running core: v$VERSION (snapshot $TAG)"
 if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-  echo "== my changes on top of $TAG:"
+  # merge-base is the authoritative answer: `$TAG..HEAD` lists commits either way, so it
+  # reads like a finished sync even when the rebase never landed (issue #1280).
+  if git merge-base --is-ancestor "$TAG" HEAD; then
+    echo "== synced: $TAG is in my history"
+    echo "== my changes on top of $TAG:"
+  else
+    echo "== NOT synced: $TAG is not in my history - run sync.sh"
+    echo "== my commits since $(git describe --tags --match 'agent-v*' --abbrev=0 HEAD 2>/dev/null || echo 'my base'):"
+  fi
   git log --oneline "$TAG..HEAD" || true
 else
   echo "== snapshot $TAG not in the upstream repo"

--- a/agent/core/skills/upstream-sync/scripts/sync.sh
+++ b/agent/core/skills/upstream-sync/scripts/sync.sh
@@ -1,27 +1,24 @@
 #!/usr/bin/env bash
 # One owner for the upgrade sync: put $HOME on the snapshot matching the core it now runs,
-# with local work rebased on top. Mechanical steps only - a conflict is the agent's call and
-# stops the script.
-#
-# On a managed box agent/core is vestad's read-only mount: the engine already runs the target
-# version, so the rebase has nothing to do there and must not try. set-cone.sh pins those
-# paths out of the worktree, and local commits carrying engine paths (a legacy in-cone box, a
-# blanket `add -A --sparse`) are collapsed away first - replaying them would fail unlinking a
-# read-only file, and the mount owns that content anyway (issue #1280).
-#
-# Exit: 0 synced (or already synced); 3 snapshot tag for the running version is missing;
+# with local work rebased on top. Mechanical steps only - a conflict is the agent's call.
+# Exit: 0 synced (or already synced); 3 no snapshot tag for the running version;
 # 5 the rebase stopped and needs conflicts resolved by hand.
 set -euo pipefail
 cd ~
 
+SCRIPTS=~/agent/core/skills/upstream-sync/scripts
 VERSION="$(grep '^version = ' agent/core/pyproject.toml | cut -d'"' -f2)"
 TAG="agent-v$VERSION"
 
-bash ~/agent/core/skills/upstream-sync/scripts/fetch-upstream.sh
+bash "$SCRIPTS/fetch-upstream.sh"
 git rev-parse -q --verify "refs/tags/$TAG" >/dev/null || {
   echo "snapshot $TAG not in the upstream repo - is vestad on a different version?" >&2
   exit 3
 }
+
+# The cone is computed from HEAD, so recompute it whenever HEAD may have moved. It also pins
+# the engine mount out of the worktree, which the rebase below depends on.
+bash "$SCRIPTS/set-cone.sh"
 
 # The authoritative question, and the one the boot turn re-fires on.
 if git merge-base --is-ancestor "$TAG" HEAD; then
@@ -29,24 +26,25 @@ if git merge-base --is-ancestor "$TAG" HEAD; then
   exit 0
 fi
 
-# Cone first: on a managed box this is what makes the rebase's checkout of $TAG update the
-# index alone instead of rewriting the engine mount.
-bash ~/agent/core/skills/upstream-sync/scripts/set-cone.sh
-
 if [ -n "$(git status --porcelain)" ]; then
   git add -A
   git commit -q -m checkpoint
 fi
 
-BASE="$(git describe --tags --match 'agent-v*' --abbrev=0 HEAD)"
-if [ ! -w agent/core ] && [ -n "$(git log --oneline "$BASE..HEAD" -- agent/core)" ]; then
-  git reset -q --soft "$BASE"
-  git reset -q "$BASE" -- agent/core   # index-only: engine paths back to stock, mount untouched
-  git diff --cached --quiet || git commit -q -m "my customizations"
+# A managed box's engine is a read-only mount already running $TAG, so replaying a commit
+# that touches agent/core would fail to unlink it, and the mount owns that content anyway.
+if [ ! -w agent/core ]; then
+  BASE="$(git describe --tags --match 'agent-v*' --abbrev=0 HEAD)"
+  if [ -n "$(git log --oneline "$BASE..HEAD" -- agent/core)" ]; then
+    git reset -q --soft "$BASE"
+    git reset -q "$BASE" -- agent/core   # index-only: engine back to stock, mount untouched
+    git diff --cached --quiet || git commit -q -m "my customizations"
+  fi
 fi
 
 if ! git rebase "$TAG"; then
-  echo "rebase stopped: resolve each conflict keeping BOTH sides, git add them, then git rebase --continue" >&2
+  echo "rebase stopped: resolve each conflict keeping BOTH sides, git add them, git rebase --continue, then re-run me" >&2
   exit 5
 fi
+bash "$SCRIPTS/set-cone.sh"   # HEAD moved
 echo "synced onto $TAG"

--- a/agent/core/skills/upstream-sync/scripts/sync.sh
+++ b/agent/core/skills/upstream-sync/scripts/sync.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# One owner for the upgrade sync: put $HOME on the snapshot matching the core it now runs,
+# with local work rebased on top. Mechanical steps only - a conflict is the agent's call and
+# stops the script.
+#
+# On a managed box agent/core is vestad's read-only mount: the engine already runs the target
+# version, so the rebase has nothing to do there and must not try. set-cone.sh pins those
+# paths out of the worktree, and local commits carrying engine paths (a legacy in-cone box, a
+# blanket `add -A --sparse`) are collapsed away first - replaying them would fail unlinking a
+# read-only file, and the mount owns that content anyway (issue #1280).
+#
+# Exit: 0 synced (or already synced); 3 snapshot tag for the running version is missing;
+# 5 the rebase stopped and needs conflicts resolved by hand.
+set -euo pipefail
+cd ~
+
+VERSION="$(grep '^version = ' agent/core/pyproject.toml | cut -d'"' -f2)"
+TAG="agent-v$VERSION"
+
+bash ~/agent/core/skills/upstream-sync/scripts/fetch-upstream.sh
+git rev-parse -q --verify "refs/tags/$TAG" >/dev/null || {
+  echo "snapshot $TAG not in the upstream repo - is vestad on a different version?" >&2
+  exit 3
+}
+
+# The authoritative question, and the one the boot turn re-fires on.
+if git merge-base --is-ancestor "$TAG" HEAD; then
+  echo "already synced: $TAG is in HEAD's history"
+  exit 0
+fi
+
+# Cone first: on a managed box this is what makes the rebase's checkout of $TAG update the
+# index alone instead of rewriting the engine mount.
+bash ~/agent/core/skills/upstream-sync/scripts/set-cone.sh
+
+if [ -n "$(git status --porcelain)" ]; then
+  git add -A
+  git commit -q -m checkpoint
+fi
+
+BASE="$(git describe --tags --match 'agent-v*' --abbrev=0 HEAD)"
+if [ ! -w agent/core ] && [ -n "$(git log --oneline "$BASE..HEAD" -- agent/core)" ]; then
+  git reset -q --soft "$BASE"
+  git reset -q "$BASE" -- agent/core   # index-only: engine paths back to stock, mount untouched
+  git diff --cached --quiet || git commit -q -m "my customizations"
+fi
+
+if ! git rebase "$TAG"; then
+  echo "rebase stopped: resolve each conflict keeping BOTH sides, git add them, then git rebase --continue" >&2
+  exit 5
+fi
+echo "synced onto $TAG"

--- a/agent/core/upstream_sync.py
+++ b/agent/core/upstream_sync.py
@@ -54,8 +54,9 @@ def upstream_sync_turn(*, state: vm.State, config: cfg.VestaConfig, first_start:
     return (
         "[Upstream sync]\n\n"
         f"Vesta was upgraded (now v{running}). Read `~/agent/core/skills/upstream-sync/SKILL.md` "
-        f"and follow it to sync your workspace to this version: rebase your changes "
-        f"onto `agent-v{running}`, resolving any conflicts. Then call `mark_upstream_synced`. "
+        f"and follow it to sync your workspace to this version: run its `sync.sh`, which rebases "
+        f"your changes onto `agent-v{running}`, and resolve any conflicts it stops on. "
+        f"Then call `mark_upstream_synced`. "
         "If the rebase brought changes, call `restart_vesta` afterward so the new skills load; "
         "if it was a no-op, no restart is needed. If it fails, tell the user what blocked it."
     )

--- a/agent/tests/test_upstream_sync.py
+++ b/agent/tests/test_upstream_sync.py
@@ -99,14 +99,18 @@ def _write_content(content, version):
     _copy_sync_scripts(content / "core/skills")
 
 
-def _upstream_fixture(tmp_path, versions=("0.1.170",)):
+def _upstream_fixture(tmp_path, versions=("0.1.170",), new_dir=None):
     """Build an upstream repo with the REAL build-upstream.sh, one snapshot per version.
     Returns the bare repo path (what a box's fetch-upstream.sh consumes; on real boxes it
-    is bind-mounted at /run/vesta-upstream/upstream.git)."""
+    is bind-mounted at /run/vesta-upstream/upstream.git). new_dir models a release adding a
+    tracked dir under agent/: it lands in the last version's snapshot only."""
     content = tmp_path / "agent-code"
     ws = tmp_path / "upstream"
     for version in versions:
         _write_content(content, version)
+        if new_dir is not None and version == versions[-1]:
+            (content / new_dir).mkdir(parents=True, exist_ok=True)
+            (content / new_dir / "stock.md").write_text(f"{new_dir} at {version}\n")
         r = subprocess.run(
             ["bash", str(BUILD), str(content), str(ws), version], env=_env(tmp_path), capture_output=True, text=True, check=False
         )
@@ -144,12 +148,8 @@ def _fresh_box(tmp_path, version="0.1.170", skills=("tasks", "dream"), managed=T
 
 def _upgrade_core_mount(home, version):
     """vestad swapping a managed box's engine: the core mount now carries the new version,
-    still read-only. Inside the box an upgrade changes nothing else.
-
-    The read-only mount is modelled with chmod, so git's unlink fails EACCES where a real
-    bind mount gives EROFS. Both are the same "git cannot write the engine" failure, and
-    nothing here keys on the errno.
-    """
+    still read-only (modelled with chmod, so git's unlink fails EACCES where a real bind
+    mount gives EROFS; nothing under test keys on the errno)."""
     core = home / "agent/core"
     dirs = [core, *(p for p in core.rglob("*") if p.is_dir())]
     for d in dirs:
@@ -234,11 +234,11 @@ def test_sync_conflict_stops_and_continues(tmp_path):
     assert "both sides survive" in (home / "agent/skills/tasks/SKILL.md").read_text()
 
 
-def _legacy_managed_box(tmp_path):
+def _legacy_managed_box(tmp_path, new_dir=None):
     """A managed box in the shape issue #1280 reports: the engine is a read-only mount, but
     agent/core is in the cone and its own commits carry engine paths (how pre-mount boxes
     converged). Every later checkout then wants to rewrite the mount."""
-    source = _upstream_fixture(tmp_path, versions=("0.1.170", "0.1.171"))
+    source = _upstream_fixture(tmp_path, versions=("0.1.170", "0.1.171"), new_dir=new_dir)
     home = _fresh_box(tmp_path)
     env = _box_env(source)
     assert _attach(home, source).returncode == 0
@@ -261,15 +261,21 @@ def test_managed_sync_lands_when_history_carries_engine_paths(tmp_path):
     _source, home, env = _legacy_managed_box(tmp_path)
     r = _run(SYNC, home, extra_env=env)
     assert r.returncode == 0, r.stdout + r.stderr
-    # The authoritative check the boot turn keys on: unset before, true after.
-    synced = subprocess.run(["git", "merge-base", "--is-ancestor", "agent-v0.1.171", "HEAD"], cwd=str(home), env=_env(home, env), check=False)
-    assert synced.returncode == 0
+    _git(["merge-base", "--is-ancestor", "agent-v0.1.171", "HEAD"], home, env)  # what the boot turn re-fires on
     assert "my personal notes" in (home / "agent/MEMORY.md").read_text()  # my work survives
     assert "0.1.171" in (home / "agent/skills/tasks/SKILL.md").read_text()  # stock moved
     # The mount is untouched, and git now records stock's engine rather than the stale edit.
     assert (home / "agent/core/loops.py").read_text() == "# core at 0.1.171\n"
     tracked_engine = _git(["ls-tree", "-r", "HEAD", "--", "agent/core"], home, env)
     assert tracked_engine == _git(["ls-tree", "-r", "agent-v0.1.171", "--", "agent/core"], home, env)
+
+
+def test_managed_sync_materializes_a_dir_the_new_snapshot_adds(tmp_path):
+    """The cone is computed from HEAD, so set-cone.sh has to run after the rebase too: a dir
+    the upgrade adds is only coned in, and written to disk, once the rebase has landed it."""
+    _source, home, env = _legacy_managed_box(tmp_path, new_dir="prompts")
+    assert _run(SYNC, home, extra_env=env).returncode == 0
+    assert (home / "agent/prompts/stock.md").read_text() == "prompts at 0.1.171\n"
 
 
 def test_managed_sync_is_idempotent_once_synced(tmp_path):

--- a/agent/tests/test_upstream_sync.py
+++ b/agent/tests/test_upstream_sync.py
@@ -21,6 +21,8 @@ BUILD = REPO_ROOT / "vestad/scripts/build-upstream.sh"
 ATTACH = AGENT_ROOT / "core/skills/upstream-sync/scripts/attach.sh"
 FETCH = AGENT_ROOT / "core/skills/upstream-sync/scripts/fetch-upstream.sh"
 SET_CONE = AGENT_ROOT / "core/skills/upstream-sync/scripts/set-cone.sh"
+SYNC = AGENT_ROOT / "core/skills/upstream-sync/scripts/sync.sh"
+STATUS = AGENT_ROOT / "core/skills/upstream-sync/scripts/status.sh"
 SKILLS_INSTALL = AGENT_ROOT / "skills/skills-registry/scripts/skills-install"
 SKILLS_REMOVE = AGENT_ROOT / "skills/skills-registry/scripts/skills-remove"
 BRANCH = "agent-upstream"
@@ -68,7 +70,7 @@ def _copy_sync_scripts(core_skills):
     plus the forwarding workspace-sync shims at their old paths."""
     scripts = core_skills / "upstream-sync/scripts"
     scripts.mkdir(parents=True, exist_ok=True)
-    for script in (ATTACH, FETCH, SET_CONE):
+    for script in (ATTACH, FETCH, SET_CONE, SYNC, STATUS):
         shutil.copy(script, scripts / script.name)
     forwarding = core_skills / "workspace-sync/scripts"
     forwarding.mkdir(parents=True, exist_ok=True)
@@ -138,6 +140,24 @@ def _fresh_box(tmp_path, version="0.1.170", skills=("tasks", "dream"), managed=T
         for d in [core, *(p for p in core.rglob("*") if p.is_dir())]:
             d.chmod(0o555)
     return home
+
+
+def _upgrade_core_mount(home, version):
+    """vestad swapping a managed box's engine: the core mount now carries the new version,
+    still read-only. Inside the box an upgrade changes nothing else.
+
+    The read-only mount is modelled with chmod, so git's unlink fails EACCES where a real
+    bind mount gives EROFS. Both are the same "git cannot write the engine" failure, and
+    nothing here keys on the errno.
+    """
+    core = home / "agent/core"
+    dirs = [core, *(p for p in core.rglob("*") if p.is_dir())]
+    for d in dirs:
+        d.chmod(0o755)
+    (core / "pyproject.toml").write_text(f'[project]\nname = "vesta"\nversion = "{version}"\n')
+    (core / "loops.py").write_text(f"# core at {version}\n")
+    for d in dirs:
+        d.chmod(0o555)
 
 
 def _box_env(source):
@@ -212,6 +232,101 @@ def test_sync_conflict_stops_and_continues(tmp_path):
     _git(["add", "agent/skills/tasks/SKILL.md"], home, env)
     _git(["rebase", "--continue"], home, env)
     assert "both sides survive" in (home / "agent/skills/tasks/SKILL.md").read_text()
+
+
+def _legacy_managed_box(tmp_path):
+    """A managed box in the shape issue #1280 reports: the engine is a read-only mount, but
+    agent/core is in the cone and its own commits carry engine paths (how pre-mount boxes
+    converged). Every later checkout then wants to rewrite the mount."""
+    source = _upstream_fixture(tmp_path, versions=("0.1.170", "0.1.171"))
+    home = _fresh_box(tmp_path)
+    env = _box_env(source)
+    assert _attach(home, source).returncode == 0
+    _git(["sparse-checkout", "add", "agent/core"], home, env)
+    engine = home / "agent/core/loops.py"
+    engine.chmod(0o644)
+    engine.write_text("# core at 0.1.170\n# a stale engine edit my history carries\n")
+    memory = home / "agent/MEMORY.md"
+    memory.write_text(memory.read_text() + "my personal notes\n")
+    _git(["add", "-A"], home, env)
+    _git(["commit", "-m", "checkpoint"], home, env)
+    _upgrade_core_mount(home, "0.1.171")
+    return source, home, env
+
+
+def test_managed_sync_lands_when_history_carries_engine_paths(tmp_path):
+    """Issue #1280: rebasing engine paths onto the new snapshot fails because the core mount
+    is read-only, so the sync never completed and the boot turn re-fired forever. sync.sh
+    drops the mount-owned paths from the local delta, so the rebase lands."""
+    _source, home, env = _legacy_managed_box(tmp_path)
+    r = _run(SYNC, home, extra_env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    # The authoritative check the boot turn keys on: unset before, true after.
+    synced = subprocess.run(["git", "merge-base", "--is-ancestor", "agent-v0.1.171", "HEAD"], cwd=str(home), env=_env(home, env), check=False)
+    assert synced.returncode == 0
+    assert "my personal notes" in (home / "agent/MEMORY.md").read_text()  # my work survives
+    assert "0.1.171" in (home / "agent/skills/tasks/SKILL.md").read_text()  # stock moved
+    # The mount is untouched, and git now records stock's engine rather than the stale edit.
+    assert (home / "agent/core/loops.py").read_text() == "# core at 0.1.171\n"
+    tracked_engine = _git(["ls-tree", "-r", "HEAD", "--", "agent/core"], home, env)
+    assert tracked_engine == _git(["ls-tree", "-r", "agent-v0.1.171", "--", "agent/core"], home, env)
+
+
+def test_managed_sync_is_idempotent_once_synced(tmp_path):
+    """The re-fire loop's cost was re-running a rebase that could not work. A second sync is
+    a no-op that reports the authoritative answer instead."""
+    _source, home, env = _legacy_managed_box(tmp_path)
+    assert _run(SYNC, home, extra_env=env).returncode == 0
+    head = _git(["rev-parse", "HEAD"], home, env)
+    r = _run(SYNC, home, extra_env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "already synced" in r.stdout
+    assert _git(["rev-parse", "HEAD"], home, env) == head
+
+
+def test_managed_cone_pins_engine_out_of_the_worktree(tmp_path):
+    """The mechanism: git cannot sparsify the engine (that means deleting read-only files),
+    so set-cone.sh sets skip-worktree straight in the index. Without it every checkout of a
+    new snapshot tries to rewrite the mount."""
+    _source, home, env = _legacy_managed_box(tmp_path)
+    assert _run(SET_CONE, home, extra_env=env).returncode == 0
+    flags = _git(["ls-files", "-v", "--", "agent/core"], home, env).splitlines()
+    assert flags and all(line.startswith("S ") for line in flags), flags
+    assert _git(["status", "--porcelain"], home, env) == ""  # mount drift is invisible to git
+
+
+def test_unmanaged_core_still_rebases_through_the_cone(tmp_path):
+    """--no-manage-core-code boxes own agent/core in the workspace and legitimately pull the
+    engine through the rebase: it must stay worktree-live, never pinned."""
+    source = _upstream_fixture(tmp_path, versions=("0.1.170", "0.1.171"))
+    home = _fresh_box(tmp_path, managed=False)
+    env = _box_env(source)
+    assert _attach(home, source).returncode == 0
+    _git(["sparse-checkout", "add", "agent/core"], home, env)  # SETUP.md: the one-time opt-in
+    assert _run(SET_CONE, home, extra_env=env).returncode == 0
+    flags = _git(["ls-files", "-v", "--", "agent/core"], home, env).splitlines()
+    assert flags and not any(line.startswith("S ") for line in flags), flags
+    memory = home / "agent/MEMORY.md"
+    memory.write_text(memory.read_text() + "my personal notes\n")
+    _git(["add", "-A"], home, env)
+    _git(["commit", "-m", "checkpoint"], home, env)
+    assert _run(FETCH, home, extra_env=env).returncode == 0
+    _git(["rebase", "agent-v0.1.171"], home, env)
+    assert (home / "agent/core/loops.py").read_text() == "# core at 0.1.171\n"  # engine advanced on disk
+    assert "my personal notes" in memory.read_text()
+
+
+def test_status_reports_the_authoritative_sync_answer(tmp_path):
+    """status.sh grouped commits under "my changes on top of <tag>" either way, which reads
+    like a finished sync when the rebase never landed (issue #1280)."""
+    _source, home, env = _legacy_managed_box(tmp_path)
+    r = _run(STATUS, home, extra_env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "NOT synced" in r.stdout
+    assert _run(SYNC, home, extra_env=env).returncode == 0
+    r = _run(STATUS, home, extra_env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "NOT synced" not in r.stdout and "== synced" in r.stdout
 
 
 def test_install_is_offline_and_remove_drops_dir(tmp_path):


### PR DESCRIPTION
Fixes #1280

## What was happening

On a managed-core (Path A) box, `git rebase agent-vX.Y.Z` failed every boot trying to unlink `agent/core/*`, which is vestad's read-only bind mount. The functional sync was already complete (the mount runs the target version), but `git merge-base --is-ancestor agent-vX.Y.Z HEAD` stayed false, so `last_synced` never advanced and the boot turn re-fired forever. Worse, the loop fed itself: each pass ran the SKILL.md checkpoint step, which committed the drifted engine content, so every boot added another engine-carrying commit for the next rebase to choke on.

## Root cause

Keeping `agent/core` out of the sparse cone is not enough to keep git out of it. Sparsifying a path means **deleting it from the worktree**, the read-only mount forbids that, so git leaves the entry present and worktree-live rather than setting `skip-worktree`. From then on every checkout of a new snapshot wants to rewrite the mount.

I verified the two halves separately in the harness:

- Pinning `skip-worktree` alone fixes the initial checkout of the tag (index-only, `git status` clean) but the rebase **still** dies replaying a commit that touches `agent/core`: merge-ort un-sparsifies a path it must modify. That matches the report's `Rebasing (1/6) error: unable to unlink old 'agent/core/*'`.
- So both halves are needed: pin the engine out of the worktree **and** keep engine paths out of the commits being replayed.

## Direction chosen

The issue offered two directions. I took **direction 1 (exempt `agent/core/**` from the rebase)**, not direction 2 (record `last_synced` from the mounted core version).

Direction 2 records success from the engine version alone, which is only one of the things a sync does. The rest of the workspace (skills, MEMORY.md, prompts) still needs the rebase to take stock's changes, so marking synced off the mount would declare victory while silently never pulling those, and the drift would compound release over release. It stops the noise by making the marker mean less. Direction 1 makes the rebase actually land, so the marker keeps meaning "the documented procedure completed", which is also what removes the pressure on the agent to call `mark_upstream_synced` dishonestly (gotcha 2 in the issue).

## The fix

- `set-cone.sh` (already the one owner of what git materializes) sets `skip-worktree` straight in the index for tracked `agent/core` paths when core is unwritable. Index-only, so it needs no worktree write.
- New `sync.sh` owns the whole mechanical procedure: fetch, the authoritative already-synced check, cone, checkpoint, then on a managed box whose history carries engine paths, collapse the local delta and reset those paths back to stock before rebasing. Conflicts still stop for the agent's judgment (exit 5); the script only owns what must be mechanical. This is the scripts-first shape CLAUDE.md asks for, replacing the raw porcelain the SKILL.md used to spell out.
- `status.sh` now reports the authoritative `merge-base --is-ancestor` answer. It grouped commits under `== my changes on top of <tag>` either way, which reads like a finished sync when the rebase never landed (gotcha 1).
- The boot-turn prompt points at `sync.sh` rather than describing the porcelain.

Both new behaviors are gated on `! -w agent/core`, so unmanaged (`--no-manage-core-code`) boxes keep pulling core through the rebase. There is a test holding that line.

## Fleet impact

Stuck boxes converge on their next boot with no manual intervention. The fix ships in `agent/core`, which is exactly the read-only mount vestad already swapped to the new version, so a stuck box is running this code the moment it boots. Its upstream-sync turn re-fires as it does today, the agent runs `sync.sh`, and the script heals the accumulated state itself: it pins the engine, collapses the engine-carrying checkpoint commits the loop created, and rebases. `mark_upstream_synced` then records a sync that genuinely completed, and the loop stops. No migration is needed because the re-firing turn is itself the delivery mechanism.

## Tests

Added to `agent/tests/test_upstream_sync.py`, which already drives the real scripts against real git repos in a fake `$HOME`:

- `test_managed_sync_lands_when_history_carries_engine_paths` reproduces the issue's shape (engine in cone, engine-carrying commits, upgraded mount) and asserts `is-ancestor` is true afterwards, local work survives, stock moved, the mount is unwritten, and git now records stock's engine.
- `test_managed_sync_is_idempotent_once_synced`, `test_managed_cone_pins_engine_out_of_the_worktree`, `test_status_reports_the_authoritative_sync_answer`.
- `test_unmanaged_core_still_rebases_through_the_cone` holds the `--no-manage-core-code` line.

I confirmed the regression test earns its keep: with the fix disabled it fails with the issue's exact error (`unable to unlink 'agent/core/...'`), and passes with it.

### What I did NOT verify

**The harness models the read-only core mount with `chmod 0555`, not a real read-only bind mount.** Git's unlink therefore fails `EACCES` ("Permission denied") where a real mount gives `EROFS` ("Read-only file system"). I did not exercise a real ro bind mount.

This is a faithful stand-in **because nothing in the fix keys on the errno or on the message text**. The fix is preventive: it keys on `[ ! -w agent/core ]` (a permission probe true under both `chmod 0555` and a real ro mount) and makes git never attempt the write. There is no error-handling path that parses git's output, so the EACCES/EROFS distinction cannot change behavior. The stand-in would be load-bearing if the fix caught and matched on the failure, and it does not.

The real ro-mount path is covered by the Docker-gated integration suite (`vestad/tests/server/upstream.rs`), which I did not run here.

## Checks

`./check.sh agent` and `./check.sh guards` both pass. Skills index regenerated and unchanged (the SKILL.md `name`/`description` did not change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)