### PR TITLE
refactor(vestad): fold the port-corpse test setup into one helper

### DIFF
--- a/vestad/Cargo.toml
+++ b/vestad/Cargo.toml
@@ -78,8 +78,8 @@ jiff = "0.2"
 [dev-dependencies]
 tempfile = "3"
 proptest = "1"
-# Builds the one socket shape std/tokio cannot (bound, never listened on): the crashed
-# service's port corpse the reuse probe must reallocate. Already in the tree via tokio.
+# The port-reuse tests' corpse socket: bound, never listened on, the one shape std/tokio
+# cannot build. Already in the tree via tokio.
 socket2 = "0.6"
 # Integration/live e2e tests live here (in vestad's own tests/) so `cargo test -p vestad
 # --test <name>` builds the vestad binary and exposes its path via CARGO_BIN_EXE_vestad —

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -3153,50 +3153,36 @@ mod tests {
         );
     }
 
-    /// A crashed startup leaves its port *held but unserved* (#371, #433): connect is
-    /// refused, yet bind still fails, so nothing inside the container can recover it.
-    /// Model it with a raw socket bound without `SO_REUSEADDR` and never listened on,
-    /// the one shape std/tokio listeners cannot build (they always listen).
-    fn hold_port_unserved(port: u16) -> socket2::Socket {
+    /// A port a crashed startup left *held but unserved* (#371, #433), and the corpse
+    /// holding it: connect is refused, yet bind still fails. Only a raw socket bound
+    /// without `SO_REUSEADDR` and never listened on models that; std/tokio listeners
+    /// always listen. The port is OS-ephemeral rather than from `allocate_service_port`,
+    /// whose deterministic scan would hand the same port to a parallel test.
+    fn dead_port_with_corpse() -> (u16, socket2::Socket) {
+        let probe = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("an ephemeral port");
+        let port = probe.local_addr().expect("the probe's address").port();
+        drop(probe);
         let corpse = socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::STREAM, None)
             .expect("a raw tcp socket");
         let addr = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
         corpse.bind(&addr.into()).expect("bind without listening");
-        corpse
+        (port, corpse)
     }
 
-    // The #371/#433 regression: the port corpse a crash leaves behind answers nothing
-    // but blocks bind, and it is the only condition that must NOT be reused. Reusing it
-    // hands the service a port it can never bind, the crash loop with no recovery path
-    // from inside the container that allocate_service_port exists to break.
     #[tokio::test]
     async fn cached_port_is_not_reusable_when_held_but_unserved() {
-        let probe = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
-        let port = probe.local_addr().unwrap().port();
-        drop(probe);
-        let _corpse = hold_port_unserved(port);
-
+        let (port, _corpse) = dead_port_with_corpse();
         assert!(
             !is_cached_port_reusable(port).await,
             "a port held by a crashed service's corpse must not be reused",
         );
     }
 
-    // The recovery half of #371/#433, at the same altitude as the resident-service test
-    // below: a crashed service re-registering must be moved off its dead port and onto
-    // one it can actually bind, without a container or host restart.
+    // The recovery half of #371/#433: a crashed service re-registering must land on a
+    // port it can actually bind, without a container or host restart.
     #[tokio::test]
     async fn crashed_service_is_reallocated_off_its_dead_port() {
-        use std::collections::HashMap;
-
-        // The registered port, now a corpse the crashed service left holding it. It comes
-        // from the OS rather than allocate_service_port, whose deterministic scan would
-        // hand a parallel test the same port for this one to hold hostage.
-        let probe = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
-        let dead_port = probe.local_addr().unwrap().port();
-        drop(probe);
-        let _corpse = hold_port_unserved(dead_port);
-
+        let (dead_port, _corpse) = dead_port_with_corpse();
         let mut registry: HashMap<String, HashMap<String, ServiceEntry>> = HashMap::new();
         registry.entry("agent".into()).or_default().insert(
             "dashboard".into(),


### PR DESCRIPTION
Follow-up to #1317, which merged before this trimming pass reached it. Test-only, like its parent: **production code is byte-identical to master**.

## What this cuts

#1317 landed the two regression tests guarding the #371/#433 crash-loop recovery path. Both opened with the same four-line dance (bind an ephemeral port, read it back, drop the listener, hand the port to `hold_port_unserved`), and both carried comments restating what the test name and the assert message already say.

`dead_port_with_corpse()` returns the port *and* the socket holding it, so each test now opens with one line. Net **-14** (+16/-30).

What stays, because the code cannot show it:
- the socket-corpse mechanic (bound without `SO_REUSEADDR`, never listened on, the one shape std/tokio cannot build, so connect is refused while bind still fails),
- why the port comes from the OS ephemeral band rather than `allocate_service_port`, whose deterministic scan would hand the same port to a parallel test.

Both now live on the helper, next to the code they explain, instead of being split across a doc comment and a duplicated inline note.

## Coverage is unchanged, and verified so

The whole value of #1317 is that these two tests are the only thing stopping someone from "simplifying" the connect probe into `async fn is_cached_port_reusable(_port: u16) -> bool { true }` and shipping a service that keeps its dead port forever. A trim that quietly cost them that would be worse than no trim, so the mutation was applied and run both before and after:

| | result |
|---|---|
| mutation, pre-trim | `cached_port_is_not_reusable_when_held_but_unserved` FAILED, `crashed_service_is_reallocated_off_its_dead_port` FAILED (16 passed, 2 failed) |
| mutation, post-trim | same two FAILED, and only those two (207 passed, 2 failed) |

The pre-trim run also re-confirms #1317's premise from the other side: every other port test, including `resident_service_keeps_its_port_across_reregistration`, passes happily against the sticky-port mutation. These two are the only guards.

`socket2` stays a dev-dep: it builds the corpse with no `unsafe` and no lossy casts, which the `libc` alternative needs and clippy pedantic rejects with no `#[allow]` escape available.

## Checks

`./check.sh vestad` green (209 passed, clippy clean). `./check.sh guards` green. No Docker suite is relevant: production code is unchanged from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)