### PR TITLE
fix(vestad): expose the engine venv on the image PATH and trim the venv comments

### DIFF
--- a/vestad/Dockerfile
+++ b/vestad/Dockerfile
@@ -63,9 +63,10 @@ RUN for d in agent/skills/*/; do \
     done
 
 WORKDIR /root/agent
-# Scoped, never a persistent ENV: an exported UV_PROJECT_ENVIRONMENT retargets every uv project,
-# so `uv run` in a skill's cli/ would re-sync the engine venv. The entrypoint puts it on PATH.
+# Scoped, never ENV: exported, UV_PROJECT_ENVIRONMENT retargets every uv project, so a skill's
+# `uv run` would re-sync the engine venv. PATH exposes the venv instead.
 RUN UV_PROJECT_ENVIRONMENT=/root/agent/.venv uv sync --frozen --no-install-project --project core
+ENV PATH="/root/agent/.venv/bin:${PATH}"
 
 # Install Claude Code on PATH. claude_agent_sdk would otherwise fall back to its own bundled CLI
 # (deep in site-packages), but skills shell out to `claude` directly (e.g. video-use), so it must

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -114,8 +114,10 @@ pub(crate) const MOUNT_DESTS: &[&str] = &[
 
 pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
     let steps: [String; 10] = [
-        // The engine venv's bin leads PATH so the agent and skills reach the interpreter and its
-        // pinned tools (ruff, pytest) as plain commands. UV_PROJECT_ENVIRONMENT is never exported.
+        // The engine venv is reached via PATH, never an exported UV_PROJECT_ENVIRONMENT (nor `uv
+        // run`, which exports it): exported, it retargets every uv project, so a skill's `uv run`
+        // re-syncs and can delete the engine venv. The core sync gets it scoped, since uv would
+        // otherwise default to core/.venv, inside the read-only mount.
         "export PATH=\"/root/agent/.venv/bin:/root/.local/bin:/root/.claude/local/bin:$PATH\"".into(),
         ". /run/vestad-env".into(),
         ". ~/.bashrc || true".into(),
@@ -136,10 +138,6 @@ pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
         // network) once tmux is on PATH, and the next snapshot captures the install so it
         // persists across future rebuilds. `|| true` so a failed install never aborts boot.
         "command -v tmux >/dev/null 2>&1 || (apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq tmux) || true".into(),
-        // UV_PROJECT_ENVIRONMENT stays scoped to this command: exported, it retargets every uv
-        // project, so `uv run` in a skill's cli/ would re-sync (and can delete) the engine venv
-        // under the running agent. Core needs the override or uv defaults to core/.venv, inside
-        // the read-only mount.
         // LEGACY(remove-when: unmanaged boxes have pulled a post-engine-move snapshot): the old
         // layout (pyproject at /root/agent) defaults to the engine venv, so it needs no override.
         "if [ -f /root/agent/core/pyproject.toml ]; then UV_PROJECT_ENVIRONMENT=/root/agent/.venv uv sync --frozen --project /root/agent/core; else uv sync --frozen --project /root/agent; fi".into(),
@@ -150,8 +148,6 @@ pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
         "rm -rf ~/.claude/skills && mkdir -p ~/.claude/skills".into(),
         "for d in /root/agent/skills/*/SKILL.md /root/agent/core/skills/*/SKILL.md; do [ -f \"$d\" ] || continue; s=$(dirname \"$d\"); ln -sfn \"$s\" ~/.claude/skills/$(basename \"$s\"); done".into(),
         "test -f ~/.claude/settings.json || printf '{\"permissions\":{\"allow\":[]}}\\n' > ~/.claude/settings.json".into(),
-        // Launch the engine interpreter directly: `uv run` would carry UV_PROJECT_ENVIRONMENT
-        // into the agent and every shell it spawns. cwd makes `core` importable.
         "cd /root/agent && exec .venv/bin/python -m core.main".into(),
     ];
     vec!["sh".into(), "-c".into(), steps.join("; \\\n")]
@@ -2821,9 +2817,6 @@ mod tests {
 
     #[test]
     fn entrypoint_never_exports_uv_project_environment_into_the_agent() {
-        // Exported, UV_PROJECT_ENVIRONMENT retargets every uv project, so `uv run` in a skill's
-        // cli/ re-syncs and can delete the engine venv. It stays scoped to the core sync, and the
-        // engine launches without `uv run`, which would propagate it.
         let cmd = agent_container_entrypoint_cmd();
         let script = cmd.last().expect("entrypoint script");
         assert!(


### PR DESCRIPTION
Follow-up to #1320 (already merged), applying the review findings from that change.

## The `vesta shell` regression (caused by #1320)

#1320 correctly scoped `UV_PROJECT_ENVIRONMENT` to the engine's own `uv sync`, but the image previously carried it as `ENV`, and the replacement (the venv's bin on PATH) is exported **only by the entrypoint**. `docker exec` does not inherit that: `vesta shell` runs `docker exec -it <c> bash` (`main.rs:752`), `/root/.bashrc` is truncated (`Dockerfile:82`), and `create_container` supplies no `env`.

So on a fresh-image container, a shell now has neither the variable nor the venv on PATH:

* plain `ruff` is not found
* `uv run --project core ruff` defaults the project env into the read-only `/root/agent/core` mount and dies with `Permission denied (os error 13)`

`ENV PATH="/root/agent/.venv/bin:${PATH}"` restores it, matching the entrypoint's precedence (`.venv/bin` ahead of `/root/.local/bin`). This is safe and cannot reintroduce the clobbering #1320 fixed: it does not set `UV_PROJECT_ENVIRONMENT`, and PATH does not make uv adopt the venv as a project target, which is the verified basis of #1320. Nothing in the venv shadows a later Dockerfile step (`claude --version` still resolves; there is no `claude` in the venv).

Only fresh-image containers regressed: rebuilt ones (`docker export|import`) already lost the `ENV`.

## Comment trim

The rationale was stated four times (`docker.rs` x3, `Dockerfile` x1): +25 comment lines on a ~4 line code delta, which CLAUDE.md calls out directly ("Minimize comments; a long comment is a code smell").

* States the mechanic **once**, terse, at the entrypoint's PATH export, keeping the genuinely non-obvious knowledge: why PATH instead of the variable, and why the core sync still needs it scoped.
* Drops the launch-step and test preambles (the test name and its three assertion messages already say it).
* Unwelds `LEGACY(remove-when:)` from the general rationale so a future grep-and-delete takes only the transitional branch.
* Fixes the false antecedent in the Dockerfile comment ("The entrypoint puts **it** on PATH" read as putting the env var on PATH).

## No behavior change to the boot path

No entrypoint shell string changed, only comments: the boot sequence is byte-identical. Verified: `git diff origin/master -- vestad/src/docker.rs | grep -E "^[-+]\s+\""` returns nothing.

The regression guard `entrypoint_never_exports_uv_project_environment_into_the_agent` is kept.

## Checks

`./check.sh vestad` (209 passed), `./check.sh agent` (173 passed + skill suites), `./check.sh guards` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)