### PR TITLE
refactor(microsoft): trim the monitor watermark comments and test prose

### DIFF
--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -16,8 +16,7 @@ _HTML_TAG = re.compile(r"<[^>]+>")
 
 _CATCHUP_GAP_SECONDS = 90
 _FRESH_START_LOOKBACK = timedelta(hours=1)
-# A unit that failed for a long stretch re-reads at most this much history once it heals, so a
-# long-dead account cannot flood the user on recovery.
+# Bounds how much history a long-dead unit re-reads once it heals, so recovery cannot flood the user.
 _MAX_CATCHUP = timedelta(days=7)
 
 
@@ -38,20 +37,16 @@ def strip_fractional(iso: str) -> str:
 
 
 class MonitorState(TypedDict):
-    """Watermarks the monitor resumes from.
-
-    last_cycle: when the monitor last finished a cycle; it seeds a unit polled for the first time.
-    units: poll unit ("mail:<account>", "calendar:<account>", "teams:<account>",
-    "channels:<account>") -> the end of the last window that unit read successfully.
-    """
+    """last_cycle seeds a unit polled for the first time; units maps "<kind>:<account>" to the end of
+    the last window that unit read successfully."""
 
     last_cycle: str
     units: dict[str, str]
 
 
 def _read_state(path: Path, now: datetime) -> MonitorState:
-    """Read the watermarks. A bare-timestamp file (the format before per-unit watermarks) reads as
-    a last_cycle with no units, so every unit resumes from where the old monitor left off."""
+    """A legacy bare-timestamp file reads as a last_cycle with no units, so every unit resumes from
+    where the old monitor left off."""
     raw = path.read_text().strip() if path.exists() else ""
     if not raw:
         return MonitorState(last_cycle=(now - _FRESH_START_LOOKBACK).isoformat(), units={})
@@ -73,9 +68,8 @@ def _write_state(path: Path, state: MonitorState) -> None:
 
 
 def _poll_unit(ctx: MicrosoftContext, state: MonitorState, unit: str, new_check_time: datetime, poll: Callable[[datetime, bool], bool]) -> None:
-    """Poll a unit over the window it still owes, then advance its watermark only if the poll read
-    that window. A failed poll parks it at the window it still owes, so the next healthy cycle re-reads
-    instead of skipping the mail it never fetched; _MAX_CATCHUP bounds how far a long-dead unit re-reads."""
+    """Advance the unit's watermark only across a window the poll actually read, so a failed poll
+    re-reads that window next cycle instead of skipping the mail it never fetched."""
     units = state["units"]
     last_dt = max(datetime.fromisoformat(units[unit] if unit in units else state["last_cycle"]), new_check_time - _MAX_CATCHUP)
     gap_seconds = (new_check_time - last_dt).total_seconds()
@@ -354,16 +348,12 @@ def _poll_teams_account(ctx: MicrosoftContext, config: Config, account_email: st
 
 def _poll_teams_channels_account(ctx: MicrosoftContext, config: Config, account_email: str, last_dt: datetime, catching_up: bool) -> bool:
     """Emit a non-interrupting notification per Teams CHANNEL message since last_dt (excluding the
-    user's own). Channels are broadcast, so a message per channel would be noisy — hence interrupt=False,
-    unlike chats which stay interrupt=True.
+    user's own), True when the window was read. Channels are broadcast, so a message per channel would
+    be noisy: interrupt=False, unlike chats.
 
-    GRACEFUL DEGRADE: reading channel messages needs the admin-only ChannelMessage.Read.All scope plus
-    Graph access that many accounts (browser-capture / OWA-REST-only) do NOT have. If enumerating teams
-    fails for ANY reason (permission 403/401, GraphUnavailableError, TeamsError, ...), log once at info and
-    report the window read — the account silently keeps working with chats only, and parking the watermark
-    would only flood it if access ever appeared. A failure on a single team/channel is logged at debug and
-    skipped, never fatal. Only a missing token, which loses messages the account can otherwise read,
-    reports the window unread."""
+    Enumerating teams needs channel-read access many accounts lack, so a failure there reports the
+    window read and degrades to chats-only; parking would flood them if access ever appeared. A single
+    team/channel failure is skipped, never fatal. Only a missing token reports the window unread."""
     logger = ctx.monitor_logger
     try:
         token = teams.resolve_token(config, account_email)
@@ -523,10 +513,8 @@ def run(ctx: MicrosoftContext):
                 _poll_unit(ctx, state, f"mail:{acc.username}", new_check_time, partial(_poll_graph_mail, ctx, acc))
                 _poll_unit(ctx, state, f"calendar:{acc.username}", new_check_time, partial(_poll_graph_calendar, ctx, acc, new_check_time))
 
-            # OWA REST accounts (locked tenants) are not in the MSAL cache, so poll them here over
-            # OWA REST for anything Graph did not already cover. The fetch runs through load_token,
-            # which silently re-mints an expiring token from the signed-in browser profile, so this
-            # also keeps the token warm in the background.
+            # OWA REST accounts (locked tenants) are not in the MSAL cache, so poll them separately
+            # for anything Graph did not already cover.
             msal_usernames = {acc.username.casefold() for acc in msal_accounts}
             for account_email in owa_rest.list_accounts(config):
                 if account_email.casefold() in msal_usernames:
@@ -544,9 +532,7 @@ def run(ctx: MicrosoftContext):
                     partial(_poll_owa_rest_calendar, ctx, config, account_email, new_check_time),
                 )
 
-            # Teams chats: poll every account that has authorized Teams (device or captured token).
-            # Channel messages are polled right after with their own cutoff; they degrade to a no-op
-            # for accounts that lack channel-read access (default-on where the capability exists).
+            # Teams chats: every account that has authorized Teams (device or captured token).
             for account_email in teams.list_accounts(config):
                 logger.info("Checking Teams account: %s", account_email)
                 _poll_unit(ctx, state, f"teams:{account_email}", new_check_time, partial(_poll_teams_account, ctx, config, account_email))

--- a/agent/skills/microsoft/cli/tests/test_monitor.py
+++ b/agent/skills/microsoft/cli/tests/test_monitor.py
@@ -98,7 +98,6 @@ def test_poll_owa_rest_notifies_only_new_mail(tmp_path, monkeypatch):
 
 
 def test_poll_owa_rest_mail_reports_a_folder_it_could_not_read(tmp_path, monkeypatch):
-    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: None)
     monkeypatch.setattr(monitor.owa_rest, "list_messages", _raise(httpx.ConnectError("boom")))
     last_dt = datetime(2026, 7, 8, 12, 0, tzinfo=UTC)
     assert monitor._poll_owa_rest_mail(_fake_ctx(tmp_path), None, "me@x.com", ["inbox"], last_dt, False) is False
@@ -127,12 +126,6 @@ def test_poll_owa_rest_calendar_reports_a_calendar_it_could_not_read(tmp_path, m
     last_dt = datetime(2026, 7, 8, 11, 59, tzinfo=UTC)
     new_check = datetime(2026, 7, 8, 12, 0, 30, tzinfo=UTC)
     assert monitor._poll_owa_rest_calendar(_fake_ctx(tmp_path), None, "me@x.com", new_check, last_dt, False) is False
-
-
-# ---------------------------------------------------------------------------
-# The watermark only advances across a window that was actually read: a poll
-# that failed (dead token, network) must not skip the mail it never fetched.
-# ---------------------------------------------------------------------------
 
 
 def _run_ctx(tmp_path, cycles: int):
@@ -167,7 +160,6 @@ def _watermark(ctx, unit: str) -> datetime:
 
 
 def test_failed_poll_leaves_the_window_for_the_next_cycle_to_recover(tmp_path, monkeypatch):
-    """The bug: a cycle whose poll failed used to advance the watermark, dropping the mail forever."""
     calls = []
     monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
     _single_owa_account(monkeypatch)
@@ -194,8 +186,8 @@ def test_failed_poll_leaves_the_window_for_the_next_cycle_to_recover(tmp_path, m
 
 
 def test_broken_account_does_not_make_a_healthy_one_renotify(tmp_path, monkeypatch):
-    """Per-account watermarks: a dead account parks its own window only, so the healthy account
-    keeps advancing instead of re-reading and re-notifying the same mail every cycle."""
+    """Guards the per-account granularity: one global watermark would re-notify every healthy
+    account's window each cycle until the broken one heals."""
     calls = []
     monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
     _single_owa_account(monkeypatch)
@@ -222,7 +214,6 @@ def test_broken_account_does_not_make_a_healthy_one_renotify(tmp_path, monkeypat
 
 
 def test_recovery_reads_at_most_the_max_catchup_window(tmp_path, monkeypatch):
-    """A long-dead account cannot flood the user on recovery: only _MAX_CATCHUP of mail comes back."""
     calls = []
     monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
     _single_owa_account(monkeypatch)
@@ -246,8 +237,6 @@ def test_recovery_reads_at_most_the_max_catchup_window(tmp_path, monkeypatch):
 
 
 def test_legacy_bare_timestamp_state_is_read_as_the_starting_watermark(tmp_path, monkeypatch):
-    """Boxes on the old format carry a bare ISO timestamp: it seeds every unit, so an update
-    neither re-notifies an hour of mail nor skips what arrived since that timestamp."""
     calls = []
     monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
     _single_owa_account(monkeypatch)


### PR DESCRIPTION
Follow-up to #1321, which merged before this review pass finished. Since a merged PR cannot take new commits, the trim lands here against master instead. The monitor files on master are byte-identical to #1321's head, so this applies exactly on top of it.

## What this cuts

Comments and docstrings that restated the code or narrated the fix, per the repo rule "Minimize comments; a long comment is a code smell" and "present tense: what the code does now, never how it used to be":

- `MonitorState` (6-line field-by-field docstring), `_poll_unit`, `_read_state`, `_MAX_CATCHUP`: trimmed to the non-obvious constraint each one actually carries.
- `_poll_teams_channels_account`: an 11-line docstring down to 6, keeping both deliberate non-failures (channel-enumeration failure reports the window read; a single team/channel failure stays best-effort) and dropping an em dash separator.
- `run()`: two inline comment blocks that duplicated the helper docstrings they sit above.
- Tests: a banner comment block, docstrings the test names already carry, and a `write_notification` stub in a test whose call raises before anything is written.

Net **+17/-42** across the two files.

## What is deliberately untouched

- Per-(account, source) granularity: not over-engineering. `write_notification` does not dedupe by message id, so one global watermark would make a single broken account re-notify every healthy account's window every 45s.
- The `_MAX_CATCHUP` clamp and the legacy bare-timestamp state-file compatibility.
- Both deliberate Teams non-failures.

## Verification

`./check.sh agent` and `./check.sh guards` pass; all 15 monitor tests pass.

Coverage is unchanged, and the red property was re-verified rather than assumed, which surfaced a nuance worth recording:

- `test_failed_poll_leaves_the_window_for_the_next_cycle_to_recover` is red against the old monitor for the right reason (`calls == []` vs `["Manager"]`): the mail really was dropped. A true regression test for the issue's case.
- `test_broken_account_does_not_make_a_healthy_one_renotify` gets **past** its behavioral assertion against the old code and only fails at `_watermark()` on a JSON parse. It is not a regression test for the old bug; it is a design guard against a future collapse to a global watermark. Its docstring now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)