### PR TITLE
feat(web): deepen agent log scrollback to the 5000 lines the viewer already keeps

### DIFF
--- a/apps/web/src/api/logs.ts
+++ b/apps/web/src/api/logs.ts
@@ -1,4 +1,5 @@
 import { getConnection } from "@/lib/connection";
+import { replayTailLines } from "@/lib/log-stream-policy";
 import type { LogEvent } from "@/lib/types";
 import { openLogStream } from "./log-stream";
 
@@ -16,12 +17,11 @@ export function streamLogs(
       return;
     }
 
-    // A fresh stream replays the recent tail; a reconnect after a transport drop
-    // passes tail=0 so the server follows new lines only and we don't re-append
-    // the same block as duplicates.
-    const replay = opts?.replay ?? true;
-    const tailParam = replay ? "" : "&tail=0";
-    const url = `${conn.url}/agents/${encodeURIComponent(name)}/logs?token=${encodeURIComponent(conn.accessToken)}${tailParam}`;
+    const params = new URLSearchParams({
+      token: conn.accessToken,
+      tail: String(replayTailLines(opts?.replay ?? true)),
+    });
+    const url = `${conn.url}/agents/${encodeURIComponent(name)}/logs?${params.toString()}`;
     logSources.get(name)?.close();
     logSources.set(
       name,

--- a/apps/web/src/components/Console/index.tsx
+++ b/apps/web/src/components/Console/index.tsx
@@ -10,11 +10,14 @@ import { useLayout } from "@/stores/use-layout";
 import { streamLogs, stopLogs } from "@/api";
 import { stripAnsi } from "@/lib/ansi";
 import { linkify } from "@/lib/linkify";
-import { logStreamAction, isAgentContainerUp } from "@/lib/log-stream-policy";
+import {
+  logStreamAction,
+  isAgentContainerUp,
+  LOG_SCROLLBACK_LINES,
+} from "@/lib/log-stream-policy";
 import type { AgentStatus } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-const MAX_LINES = 5000;
 const RECONNECT_BASE = 1000;
 const RECONNECT_MAX = 30000;
 // One mono line is ~19px; wrapped lines measure taller (measureElement corrects).
@@ -167,7 +170,9 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
     const buffered = bufferRef.current;
     bufferRef.current = [];
     setLines(
-      buffered.length > MAX_LINES ? buffered.slice(-MAX_LINES) : buffered,
+      buffered.length > LOG_SCROLLBACK_LINES
+        ? buffered.slice(-LOG_SCROLLBACK_LINES)
+        : buffered,
     );
   }, []);
 
@@ -217,7 +222,9 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
               }
               setLines((prev) => {
                 const next = [...prev, line];
-                return next.length > MAX_LINES ? next.slice(-MAX_LINES) : next;
+                return next.length > LOG_SCROLLBACK_LINES
+                  ? next.slice(-LOG_SCROLLBACK_LINES)
+                  : next;
               });
               break;
             }
@@ -304,7 +311,7 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
     estimateSize: () => ESTIMATED_LINE_HEIGHT,
     getItemKey,
     // End-anchored stream: stick to the bottom on new lines (unless the user scrolled up),
-    // and stay anchored when old lines drop off the front at the MAX_LINES cap.
+    // and stay anchored when old lines drop off the front at the LOG_SCROLLBACK_LINES cap.
     anchorTo: "end",
     followOnAppend: true,
     scrollEndThreshold: AT_BOTTOM_THRESHOLD_PX,

--- a/apps/web/src/lib/log-stream-policy.test.ts
+++ b/apps/web/src/lib/log-stream-policy.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { logStreamAction, isAgentContainerUp } from "./log-stream-policy";
+import {
+  logStreamAction,
+  isAgentContainerUp,
+  replayTailLines,
+  LOG_SCROLLBACK_LINES,
+} from "./log-stream-policy";
 import type { AgentStatus } from "./types";
 
 describe("logStreamAction", () => {
@@ -38,5 +43,15 @@ describe("isAgentContainerUp", () => {
 
   it.each(down)("treats %s as down (no live logs)", (status) => {
     expect(isAgentContainerUp(status)).toBe(false);
+  });
+});
+
+describe("replayTailLines", () => {
+  it("asks a fresh stream to replay the full scrollback the viewer keeps", () => {
+    expect(replayTailLines(true)).toBe(LOG_SCROLLBACK_LINES);
+  });
+
+  it("asks a reconnect for no replay, so the tail is not re-appended", () => {
+    expect(replayTailLines(false)).toBe(0);
   });
 });

--- a/apps/web/src/lib/log-stream-policy.ts
+++ b/apps/web/src/lib/log-stream-policy.ts
@@ -34,3 +34,16 @@ const CONTAINER_DOWN_STATUSES: ReadonlySet<AgentStatus> = new Set<AgentStatus>([
 export function isAgentContainerUp(status: AgentStatus): boolean {
   return !CONTAINER_DOWN_STATUSES.has(status);
 }
+
+// How far back the viewer can scroll: the lines a fresh stream asks the server to
+// replay, and the lines the Console keeps before dropping the oldest. One number so
+// the two agree; a request deeper than the buffer would drop lines on arrival, a
+// buffer deeper than the request would reserve scrollback that never fills.
+export const LOG_SCROLLBACK_LINES = 5000;
+
+// The `tail` a stream requests: the full scrollback on a fresh connect, none on a
+// reconnect after a transport drop, where the replayed block is already on screen
+// and would re-append as duplicates.
+export function replayTailLines(replay: boolean): number {
+  return replay ? LOG_SCROLLBACK_LINES : 0;
+}


### PR DESCRIPTION
## What

The agent logs view only scrolled back 500 lines. The Console already allocates a 5000 line buffer, but a fresh stream never sent a `tail` param, so vestad fell back to its `DEFAULT_LOG_TAIL_LINES = 500` and 90% of the buffer sat empty. Scrollback is now the full 5000 lines.

## How

The two sides of the same decision were set independently: `api/logs.ts` chose the replay depth, `Console` chose the buffer cap. Rather than bump one number to match the other, the depth is now a single constant in `lib/log-stream-policy.ts` (already "the single owner of how the log viewer reacts to the stream"), read by both. A request deeper than the buffer would drop lines on arrival; a buffer deeper than the request leaves scrollback that never fills. One constant makes both unrepresentable.

`replayTailLines(replay)` keeps the existing reconnect semantics: a transport drop still asks for `tail=0` so the already-rendered block is not re-appended as duplicates.

The query string moves to `URLSearchParams` to match the sibling `api/gateway.ts`, which also satisfies the `restrict-template-expressions` lint rule that bans interpolating a number into a template literal.

## Verification

- `./check.sh web` green: 0 errors, 203 tests pass. The 56 remaining warnings are pre-existing and identical on master (confirmed by linting a clean master).
- New unit tests cover both branches of `replayTailLines`.
- Measured the docker side against a realistic 20k line / 2.2MB `vesta.log` in a `vesta:local` container: `tail -n 5000` returns exactly 5000 lines in 26ms, so the deeper opening burst (~560KB) stays well inside the Console's 1500ms initial fill cap on a local gateway. On a slow tunnel the cap may fire mid burst, in which case the remainder appends incrementally and `followOnAppend` keeps it pinned, the same path a chatty agent already takes today.

Server side is unchanged: the endpoint already accepts an arbitrary `tail` (the CLI passes `--tail N`), and `DEFAULT_LOG_TAIL_LINES` stays as the fallback for callers that omit it.

## Note

This raises the ceiling rather than removing it. True infinite scrollback would need a paginated log API (vestad serves `tail -n N -f`, which has no offset), a much larger change. 5000 lines looked like the 90% for 10%, but say the word if you want the paginated version.