### PR TITLE
fix(microsoft): stop Teams system messages notifying with no sender or text

### DIFF
--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -279,18 +279,27 @@ def _poll_owa_rest_calendar(
     return True
 
 
-def _teams_sender_name(message: dict, my_id: str) -> str | None:
-    """Sender display name for a Teams message, or None when it is the user's own message."""
+class TeamsNotifiable(TypedDict):
+    """What a Teams notification says about a message: who sent it and its body preview."""
+
+    sender: str
+    text: str
+
+
+def _teams_notifiable(message: dict, my_id: str) -> TeamsNotifiable | None:
+    """Sender + body preview for a Teams message, or None when it must not notify: the user's own
+    message, or a system event carrying neither author nor body (member added, chat renamed, meeting
+    started). Graph gives those `from: null` and an empty body, leaving nothing to report."""
     sender = message["from"] if "from" in message else None
     sender_user = (sender["user"] if sender and "user" in sender else None) or {}
     if "id" in sender_user and sender_user["id"] == my_id:
         return None
-    return sender_user["displayName"] if "displayName" in sender_user else "Someone"
-
-
-def _teams_body_preview(message: dict) -> str:
     body = message["body"] if "body" in message else {}
-    return clean_preview(_HTML_TAG.sub(" ", body["content"] if "content" in body else ""))[:200]
+    text = clean_preview(_HTML_TAG.sub(" ", body["content"] if "content" in body else ""))[:200]
+    named = "displayName" in sender_user
+    if not named and not text:
+        return None
+    return {"sender": sender_user["displayName"] if named else "Someone", "text": text}
 
 
 def _arrived_since(message: dict, last_dt: datetime) -> bool:
@@ -325,20 +334,19 @@ def _poll_teams_account(ctx: MicrosoftContext, config: Config, account_email: st
         preview = chat["lastMessagePreview"] if "lastMessagePreview" in chat else None
         if not preview or not _arrived_since(preview, last_dt):
             continue
-        sender_name = _teams_sender_name(preview, my_id)
-        if sender_name is None:
-            continue  # our own outgoing message
+        notifiable = _teams_notifiable(preview, my_id)
+        if notifiable is None:
+            continue  # our own outgoing message, or a contentless system event
         members = ", ".join(m["displayName"] for m in (chat["members"] if "members" in chat else []) if "displayName" in m)
         topic = (chat["topic"] if "topic" in chat else None) or members or None
-        text = _teams_body_preview(preview)
-        logger.info("Writing Teams notification from %s in chat %s", sender_name, chat["id"])
+        logger.info("Writing Teams notification from %s in chat %s", notifiable["sender"], chat["id"])
         notifications.write_notification(
             ctx.notif_dir,
             "teams",
             interrupt=True,
-            sender=sender_name,
+            sender=notifiable["sender"],
             topic=topic,
-            preview=text,
+            preview=notifiable["text"],
             chat_id=chat["id"],
             account=account_email,
             missed=catching_up or None,
@@ -391,18 +399,17 @@ def _poll_teams_channels_account(ctx: MicrosoftContext, config: Config, account_
             for msg in messages:
                 if not _arrived_since(msg, last_dt):
                     continue
-                sender_name = _teams_sender_name(msg, my_id)
-                if sender_name is None:
-                    continue  # our own channel post
-                text = _teams_body_preview(msg)
-                logger.info("Writing Teams channel notification from %s in %s / %s", sender_name, team_name, channel_name)
+                notifiable = _teams_notifiable(msg, my_id)
+                if notifiable is None:
+                    continue  # our own channel post, or a contentless system event
+                logger.info("Writing Teams channel notification from %s in %s / %s", notifiable["sender"], team_name, channel_name)
                 notifications.write_notification(
                     ctx.notif_dir,
                     "teams",
                     interrupt=False,
-                    sender=sender_name,
+                    sender=notifiable["sender"],
                     topic=f"{team_name} / {channel_name}",
-                    preview=text,
+                    preview=notifiable["text"],
                     team_id=team_id,
                     channel_id=channel_id,
                     account=account_email,

--- a/agent/skills/microsoft/cli/tests/test_teams.py
+++ b/agent/skills/microsoft/cli/tests/test_teams.py
@@ -465,6 +465,89 @@ def test_poll_teams_skips_own_message(tmp_path, monkeypatch):
     assert list((tmp_path / "notif").glob("*.json")) == []
 
 
+def test_poll_teams_skips_authorless_bodyless_system_event(tmp_path, monkeypatch):
+    """Graph gives system messages (member added, chat renamed) `from: null` and an empty body.
+    They carry no sender and no text, so they must never reach the agent, least of all as an
+    interrupt the user's notification rules have no field to match on."""
+    from datetime import UTC, datetime
+
+    from microsoft_cli import monitor
+
+    chats = [
+        {
+            "id": "chat-1",
+            "topic": "IVF 2026",
+            "lastMessagePreview": {
+                "createdDateTime": "2026-07-10T12:00:00Z",
+                "from": None,
+                "body": {"content": ""},
+            },
+        }
+    ]
+    ctx = _teams_ctx(tmp_path, monkeypatch, chats)
+    last_dt = datetime(2026, 7, 10, 11, 0, tzinfo=UTC)
+    monitor._poll_teams_account(ctx, Config(data_dir=tmp_path), "me@x.com", last_dt, False)
+    assert list((tmp_path / "notif").glob("*.json")) == []
+
+
+def test_poll_teams_still_emits_for_authored_message_without_body(tmp_path, monkeypatch):
+    """An image-only post has a real author but strips to an empty preview. It is a real message
+    from a real person, so it still notifies rather than being swallowed with the system events."""
+    from datetime import UTC, datetime
+
+    from microsoft_cli import monitor
+
+    chats = [
+        {
+            "id": "chat-1",
+            "topic": "Standup",
+            "lastMessagePreview": {
+                "createdDateTime": "2026-07-10T12:00:00Z",
+                "from": {"user": {"id": "other-guid", "displayName": "Bob"}},
+                "body": {"content": '<img src="x.png">'},
+            },
+        }
+    ]
+    ctx = _teams_ctx(tmp_path, monkeypatch, chats)
+    last_dt = datetime(2026, 7, 10, 11, 0, tzinfo=UTC)
+    monitor._poll_teams_account(ctx, Config(data_dir=tmp_path), "me@x.com", last_dt, False)
+
+    files = list((tmp_path / "notif").glob("*.json"))
+    assert len(files) == 1
+    notif = json.loads(files[0].read_text())
+    assert notif["sender"] == "Bob"
+    assert notif["preview"] == ""
+
+
+def test_poll_teams_still_emits_for_app_message_with_body(tmp_path, monkeypatch):
+    """A bot/app post carries `from.application` rather than `from.user`, so no display name
+    resolves, but it has real text. Text is the signal: it notifies under the placeholder sender."""
+    from datetime import UTC, datetime
+
+    from microsoft_cli import monitor
+
+    chats = [
+        {
+            "id": "chat-1",
+            "topic": "Builds",
+            "lastMessagePreview": {
+                "createdDateTime": "2026-07-10T12:00:00Z",
+                "from": {"application": {"id": "app-guid", "displayName": "Jenkins"}},
+                "body": {"content": "<p>build 42 failed</p>"},
+            },
+        }
+    ]
+    ctx = _teams_ctx(tmp_path, monkeypatch, chats)
+    last_dt = datetime(2026, 7, 10, 11, 0, tzinfo=UTC)
+    monitor._poll_teams_account(ctx, Config(data_dir=tmp_path), "me@x.com", last_dt, False)
+
+    files = list((tmp_path / "notif").glob("*.json"))
+    assert len(files) == 1
+    notif = json.loads(files[0].read_text())
+    assert notif["sender"] == "Someone"
+    assert "build 42 failed" in notif["preview"]
+
+
 # ---------------------------------------------------------------------------
 # Monitor: Teams CHANNEL message notification emit + graceful degrade
 # ---------------------------------------------------------------------------
@@ -551,6 +634,28 @@ def test_poll_teams_channels_skips_own_message(tmp_path, monkeypatch):
             "createdDateTime": "2026-07-10T12:00:00Z",
             "from": {"user": {"id": "me-guid", "displayName": "Me"}},
             "body": {"content": "my own post"},
+        }
+    ]
+    ctx = _teams_channels_ctx(tmp_path, monkeypatch, teams_list=teams_list, channels=channels, messages=messages)
+    last_dt = datetime(2026, 7, 10, 11, 0, tzinfo=UTC)
+    monitor._poll_teams_channels_account(ctx, Config(data_dir=tmp_path), "me@x.com", last_dt, False)
+    assert list((tmp_path / "notif").glob("*.json")) == []
+
+
+def test_poll_teams_channels_skips_authorless_bodyless_system_event(tmp_path, monkeypatch):
+    """The channel path shares the chat path's extraction, so it drops system events too."""
+    from datetime import UTC, datetime
+
+    from microsoft_cli import monitor
+
+    teams_list = [{"id": "team-1", "displayName": "Engineering"}]
+    channels = [{"id": "chan-1", "displayName": "General"}]
+    messages = [
+        {
+            "id": "msg-1",
+            "createdDateTime": "2026-07-10T12:00:00Z",
+            "from": None,
+            "body": {"content": ""},
         }
     ]
     ctx = _teams_channels_ctx(tmp_path, monkeypatch, teams_list=teams_list, channels=channels, messages=messages)


### PR DESCRIPTION
Fixes #1337

## What was wrong

Confirmed on the real code, with one correction to the issue's diagnosis (below).

Graph returns `from: null` and an empty body for Teams **system messages** (member added/removed, chat renamed, meeting started). Both Teams pollers wrote a notification for them regardless, so the chat path preempted the agent with a payload carrying `sender: "Someone"`, `preview: ""`: nothing to triage, nothing to act on, and no field for the user's own notification rules to match on. The only workaround was snoozing the whole `microsoft/teams` source, which would also silence real DMs.

**Correction to the issue's diagnosis.** The issue (and its line numbers, 245/321) describes the extraction as duplicated inline in `_poll_teams_account` and `_poll_teams_channels_account`. It is not: it was refactored into two helpers, `_teams_sender_name` and `_teams_body_preview`, shared by both paths. The bug itself is exactly as reported, but the suggested fix cannot be applied literally at the call sites, because `sender_user` is no longer visible there. Applying it would mean either leaking `sender_user` out of the helper or duplicating the guard in both paths.

## The fix

Fold both helpers into one `_teams_notifiable`, which owns the whole "should this notify, and with what" decision and returns `None` when it must not. That is one owner for one decision, one guard instead of two, and 2 helpers become 1. Both paths keep their existing dispositions: chats `interrupt=True`, channels `interrupt=False`.

Per the notification-disposition convention, the fix is to **not write** a contentless notification at all, never to downgrade it to `interrupt=False`. No real message's interrupt flag changes.

## Decisions called out in the issue

**Authored-but-bodyless messages still notify.** An image-only post strips to an empty preview but has a real author. It is a real message from a real person, and `sender` is a real field the user's rules can match on, so it is not the pathology reported here. It is not swallowed, and it is covered by a test. I deliberately did **not** render it as `"sent an attachment"`: images, stickers, cards, reactions and bodies of pure markup all collapse to empty text alike, so that string would be a guess the poller cannot substantiate, and inventing it is a feature beyond this bug. The honest empty preview plus a real sender and chat lets the agent fetch the message if it matters.

**The guard is "no author AND no body", not "no author".** This is load-bearing rather than incidental: bot/app posts arrive as `from: {application: {...}}` with no `user` key, so no display name resolves and the sender falls back to `"Someone"`, but the body has real text. Collapsing the condition to "no author" would silently drop every bot notification. Test added.

**The unreachable own-message check is real, and harmless.** `if "id" in sender_user and ...` is indeed False whenever `sender_user == {}`, so it cannot fire for authorless messages. No change needed: an authorless message is never the user's own (our own messages always carry our user id), and these now exit through the new guard before any write.

## Fleet impact

None. This is pure poller logic: no state format, config schema, on-disk path, or notification field changes, and the notification contract is untouched. Nothing a running agent already has on disk or in config moves, so no migration is needed. No `SKILL.md` change, so the skills index is unaffected (`./check.sh guards` confirms).

## Tests

Four added to `test_teams.py`, proving the fix discriminates in both directions:

- authorless + bodyless system event is dropped (chat path, the reported bug)
- same for the channels path
- authored-but-bodyless message still notifies (guards against over-swallowing)
- app/bot message with a body still notifies as `"Someone"` (guards the discriminator)

**Mutation-verified**: with the guard reverted, exactly the two skip tests fail and the other 46 pass; restored, all 48 pass. The two "must not swallow" tests pass in both directions by design, since they cover the opposite failure mode.

`./check.sh agent` and `./check.sh guards` both green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)