### PR TITLE
fix(vestad): keep a service public when re-registration omits the flag

### DIFF
--- a/agent/skills/vestad/SKILL.md
+++ b/agent/skills/vestad/SKILL.md
@@ -40,7 +40,9 @@ A background process that needs no inbound port is just a daemon: it does not re
 it only goes in the restart skill's `## Daemons` section.
 
 Skills that run a service register it with vestad to get a port, then start it. The
-`register-service` helper does the curl and prints the port (idempotent: same port per name):
+`register-service` helper does the curl and prints the port (idempotent: same port per name,
+and re-registering without `--public` keeps the service's current exposure rather than
+revoking it, so a re-register that only wants the port is safe):
 
 ```bash
 # token-only service

--- a/agent/skills/vestad/scripts/register-service
+++ b/agent/skills/vestad/scripts/register-service
@@ -4,7 +4,10 @@ set -euo pipefail
 # Register a background service with vestad and print the assigned port.
 # Pass --public for services that need a public tunnel route (no token), omit
 # it for token-only services. Registration is idempotent: vestad returns the
-# same port for a given name on every call.
+# same port for a given name on every call, and omitting --public keeps whatever
+# the service is already registered as rather than revoking a publish, so a
+# re-register that only wants the port is safe. To make a public service private,
+# unregister it and register it again.
 #
 # vestad's HTTP API may not be up yet when the restart skill runs this (the
 # daemon block can fire before vestad's API is back). Rather than pipe a refused
@@ -18,9 +21,10 @@ set -euo pipefail
 #   PORT=$(~/agent/skills/vestad/scripts/register-service dashboard --public)
 
 NAME="${1:?Usage: register-service <name> [--public]}"
-PUBLIC="false"
 if [ "${2:-}" = "--public" ]; then
-    PUBLIC="true"
+    REQUEST="{\"name\":\"$NAME\",\"public\":true}"
+else
+    REQUEST="{\"name\":\"$NAME\"}"
 fi
 
 WAIT_SECONDS="${REGISTER_SERVICE_WAIT:-30}"
@@ -30,7 +34,7 @@ DEADLINE=$(( $(date +%s) + WAIT_SECONDS ))
 while :; do
     BODY=$(curl -sk -X POST "$URL" \
         -H "X-Agent-Token: $AGENT_TOKEN" -H 'Content-Type: application/json' \
-        -d "{\"name\":\"$NAME\",\"public\":$PUBLIC}") || BODY=""
+        -d "$REQUEST") || BODY=""
     PORT=$(printf '%s' "$BODY" | python3 -c \
         'import sys, json
 try:

--- a/agent/skills/whatsapp/cli/voice_client.go
+++ b/agent/skills/whatsapp/cli/voice_client.go
@@ -38,6 +38,8 @@ func insecureVestadClient(timeout time.Duration) *http.Client {
 // resolveVoiceBaseURL asks vestad for the voice service's port (idempotent: the same POST
 // register-service uses, so it never disturbs voice's own registration) and health-checks it, so a
 // call only proceeds when the voice backend is actually up. Returns a friendly error otherwise.
+// The body omits "public" so vestad keeps the flag voice registered itself with; sending a value
+// here would make resolving a port silently rewrite the service's exposure.
 func resolveVoiceBaseURL(ctx context.Context) (string, error) {
 	vestadPort := os.Getenv("VESTAD_PORT")
 	agentName := os.Getenv("AGENT_NAME")
@@ -47,7 +49,7 @@ func resolveVoiceBaseURL(ctx context.Context) (string, error) {
 	}
 
 	url := fmt.Sprintf("https://localhost:%s/agents/%s/services", vestadPort, agentName)
-	reqBody := strings.NewReader(`{"name":"voice","public":false}`)
+	reqBody := strings.NewReader(`{"name":"voice"}`)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, reqBody)
 	if err != nil {
 		return "", err

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -1461,7 +1461,7 @@ const SERVICE_PORT_MAX: u16 = 65535;
 struct RegisterServiceBody {
     name: String,
     #[serde(default)]
-    public: bool,
+    public: Option<bool>,
 }
 
 /// Collect all ports in use across all agents in the service registry.
@@ -1541,6 +1541,15 @@ async fn is_cached_port_reusable(port: u16) -> bool {
             .is_ok()
 }
 
+/// `public` is intrinsic to a registration, like the port: an absent field inherits
+/// the cached entry's value, so a re-register that only wants the port (whatsapp's
+/// `resolveVoiceBaseURL`, voice's own status/stop/restart) cannot silently revoke a
+/// deliberate publish. An explicit value always wins, including `false`; a first
+/// registration with nothing cached defaults private.
+fn resolve_public(requested: Option<bool>, cached: Option<ServiceEntry>) -> bool {
+    requested.unwrap_or_else(|| cached.is_some_and(|entry| entry.public))
+}
+
 async fn register_service_handler(
     State(state): State<SharedState>,
     Path(name): Path<String>,
@@ -1567,24 +1576,22 @@ async fn register_service_handler(
 
     let mut settings = state.settings.write().await;
 
-    let cached_port = settings
+    let cached_entry = settings
         .services
         .get(&name)
-        .and_then(|s| s.get(&service_name))
-        .map(|e| e.port);
-    let port = match cached_port {
-        Some(p) if is_cached_port_reusable(p).await => p,
-        Some(p) => {
-            tracing::warn!(agent = %name, service = %service_name, stale_port = p, "cached service port is not bindable, allocating a fresh one");
+        .and_then(|services| services.get(&service_name))
+        .copied();
+    let port = match cached_entry.map(|entry| entry.port) {
+        Some(cached_port) if is_cached_port_reusable(cached_port).await => cached_port,
+        Some(stale_port) => {
+            tracing::warn!(agent = %name, service = %service_name, stale_port, "cached service port is not bindable, allocating a fresh one");
             allocate_service_port(&settings.services).ok_or_else(no_free_ports_err)?
         }
         None => allocate_service_port(&settings.services).ok_or_else(no_free_ports_err)?,
     };
+    let public = resolve_public(body.public, cached_entry);
 
-    let entry = ServiceEntry {
-        port,
-        public: body.public,
-    };
+    let entry = ServiceEntry { port, public };
     settings
         .services
         .entry(name.clone())
@@ -1592,9 +1599,9 @@ async fn register_service_handler(
         .insert(service_name.clone(), entry);
     save_settings(&settings);
     state.agent_status_cache.update_services(&settings.services);
-    tracing::info!(agent = %name, service = %service_name, port, public = body.public, "service registered");
+    tracing::info!(agent = %name, service = %service_name, port, public, "service registered");
     Ok(Json(
-        serde_json::json!({"ok": true, "port": port, "public": body.public}),
+        serde_json::json!({"ok": true, "port": port, "public": public}),
     ))
 }
 
@@ -2914,7 +2921,8 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::{
-        allocate_service_port, ensure_not_rebuilding, is_cached_port_reusable, spawn_pipeline_sse,
+        allocate_service_port, ensure_not_rebuilding, is_cached_port_reusable, resolve_public,
+        spawn_pipeline_sse, RegisterServiceBody,
     };
 
     #[test]
@@ -3250,6 +3258,49 @@ mod tests {
             resolved, p1,
             "a resident service must resolve to its live port {p1}, not a fresh dead one ({resolved})",
         );
+    }
+
+    // Reproduction of vesta#1323. `public` is as durable a choice as the port, and the
+    // caller re-registering is often a resolver that never chose it, so an omitted flag
+    // must inherit the cached one instead of revoking a publish. Drives the real
+    // resolve_public register_service_handler calls.
+    #[test]
+    fn public_flag_survives_a_reregistration_that_omits_it() {
+        let published = Some(ServiceEntry {
+            port: 50000,
+            public: true,
+        });
+        let private = Some(ServiceEntry {
+            port: 50001,
+            public: false,
+        });
+        let cases = [
+            (None, published, true, "omitting public keeps a published service public"),
+            (Some(false), published, false, "an explicit false still demotes a published service"),
+            (None, private, false, "omitting public keeps a private service private"),
+            (Some(true), private, true, "an explicit true still publishes a private service"),
+            (None, None, false, "a first registration with no flag defaults private"),
+            (Some(true), None, true, "a first registration honors an explicit true"),
+        ];
+        for (requested, cached, expected, reason) in cases {
+            assert_eq!(resolve_public(requested, cached), expected, "{reason}");
+        }
+    }
+
+    // The fleet-compat crux of #1323: a pre-fix client sends "public":false explicitly
+    // while a post-fix one omits the field, so the body must tell absent from false.
+    // A null reads as absent, so a client serializing the field as JSON null inherits.
+    #[test]
+    fn register_body_tells_an_absent_public_from_an_explicit_false() {
+        let parse = |body: &str| {
+            serde_json::from_str::<RegisterServiceBody>(body)
+                .expect("a well-formed body should deserialize")
+                .public
+        };
+        assert_eq!(parse(r#"{"name":"dashboard"}"#), None);
+        assert_eq!(parse(r#"{"name":"dashboard","public":null}"#), None);
+        assert_eq!(parse(r#"{"name":"dashboard","public":false}"#), Some(false));
+        assert_eq!(parse(r#"{"name":"dashboard","public":true}"#), Some(true));
     }
 
     // ── API contract fixtures ──────────────────────────────────────────────


### PR DESCRIPTION
Fixes #1323

## Verified diagnosis

The issue's hypothesis is correct, and confirmed against the code. `register_service_handler` rebuilt the whole `ServiceEntry` from the request body on every call (`public: body.public` at `vestad/src/serve.rs:1586`), while `port` was carefully reused from the cached entry via `is_cached_port_reusable` (#1254/#1255). With `#[serde(default)] public: bool`, an omitted field deserialized to `false`, so any re-POST that did not assert `--public` silently downgraded a published service. The request succeeded, the port was unchanged, nothing was logged: only the gateway's exposure changed.

## The part the issue did not cover: vestad alone fixes nothing

I checked every caller. **The CLI never POSTs this endpoint**, so there is no `cli/` change here. The three real callers are agent-side, and two of them hard-code the flag:

| Caller | Sent | Now |
| --- | --- | --- |
| `agent/skills/vestad/scripts/register-service` | `"public":false` whenever `--public` was omitted | omits the field |
| `agent/skills/whatsapp/cli/voice_client.go` (`resolveVoiceBaseURL`) | `"public":false`, always | omits the field |
| `agent/skills/whatsapp/cli/link.go` | `"public":true`, an intentional publish | unchanged |

Because both re-registering clients sent an explicit `false`, making `public` an `Option<bool>` server-side would have changed nothing on its own: `Some(false)` still clobbers, by design. The clients had to stop asserting a value they never chose.

`resolveVoiceBaseURL` is the exact failure the issue predicts ("the caller doing the re-POST is often not the caller that made the original choice to publish"). It is a pure port resolver for `whatsapp call`, and its own doc comment already claimed it is "idempotent ... so it never disturbs voice's own registration" while hard-coding `public:false`. That comment is now true. Voice is private today, so this was latent rather than user-visible.

## Change

- `RegisterServiceBody.public` becomes `Option<bool>`, so "unspecified" and "explicitly false" are distinguishable.
- New `resolve_public(requested, cached)` next to `is_cached_port_reusable`, mirroring the shape `port` established rather than inventing a parallel mechanism: absent inherits the cached entry, an explicit value always wins (including `false`), a first registration with nothing cached defaults private.
- The handler reads the cached entry once (`ServiceEntry` is `Copy`, so `.copied()`, no clone) and both decisions share the lookup. The log line and response now report the resolved value rather than the requested one.
- Demotion stays possible and explicit: pass an explicit `false` on the wire, or unregister and re-register. I did not add a `--private` flag to the script; nothing asked for one and unregister covers it.

## Fleet impact

**No on-disk format change.** `Option<bool>` is only on the request DTO. The persisted `ServiceEntry` in `settings.json` is untouched (still `port` + `public: bool`, with its existing legacy-tolerant `Deserialize`), so this is not the one-way format change class that bit the microsoft monitor in #1336. Nothing to migrate, and a downgrade reads the same settings file.

Both wire directions are safe, and serde's missing/null/false handling is the crux:

- **Old client → new vestad**: sends `"public":false` explicitly, reads as `Some(false)`, sets false. Identical to today. No regression, and no fix either until the agent picks up the new script via upstream-sync. Correct and expected: the fix arrives with the client.
- **New client → old vestad**: omits the field. Old vestad's `#[serde(default)] public: bool` reads a missing field as `false`, which is exactly what the old script sent anyway. Same behavior, no 422. This only works because the old field carried `#[serde(default)]`; a required `bool` would have rejected the body.
- `null` reads as absent (inherit), so a client serializing the field as JSON null does not clobber either.

No prompt migration is needed: no path, command, env var, or on-disk state moves. The script keeps its exact CLI (`register-service <name> [--public]`), so no caller in the fleet breaks.

## Tests

Two new tests in `vestad/src/serve.rs`, next to the existing port tests and consistent with their `public: false` / `public: true` fixtures:

- `public_flag_survives_a_reregistration_that_omits_it` table-drives the real `resolve_public` the handler calls.
- `register_body_tells_an_absent_public_from_an_explicit_false` pins the serde contract above (absent/null/false/true), which is what makes the fleet-compat reasoning checkable rather than asserted.

**Mutation-verified**: reverting `resolve_public` to the buggy semantics (`requested.unwrap_or(false)`, keeping the signature so this is a behavior mutation and not a compile error) fails the first test with `omitting public keeps a published service public: left: false, right: true`. Restored, and it passes.

`./check.sh vestad` (211 passed), `./check.sh guards` (shellcheck covers the script, skills index unaffected since the `description` frontmatter is unchanged), and `./check.sh whatsapp` (gofmt/vet/build/test) all pass locally. `cli` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)