### PR TITLE
fix(browser): bound the cdp transport request wait

### DIFF
--- a/agent/skills/browser/cli/src/vesta_browser/cdp_backend.py
+++ b/agent/skills/browser/cli/src/vesta_browser/cdp_backend.py
@@ -47,6 +47,7 @@ _KEY_MAP = {
 _CDP_BUTTON = {0: "left", 1: "middle", 2: "right"}
 _INTERNAL_PREFIXES = ("devtools://", "chrome://", "chrome-extension://")
 _LOAD_TIMEOUT_S = 30.0
+_CDP_RESPONSE_TIMEOUT_S = 60.0
 _DOMAINS = ("Page", "Runtime", "Log", "DOM")
 
 
@@ -104,7 +105,13 @@ class _CdpTransport:
         if session_id is not None:
             frame["sessionId"] = session_id
         await self._ws.send(json.dumps(frame))
-        return await future
+        try:
+            return await asyncio.wait_for(future, timeout=_CDP_RESPONSE_TIMEOUT_S)
+        except TimeoutError:
+            # BidiError, not TimeoutError: the latter is an OSError with an empty str(), which the daemon relays as {"error": ""}.
+            raise BidiError("timeout", f"no response to {method!r} within {_CDP_RESPONSE_TIMEOUT_S}s") from None
+        finally:
+            self._pending.pop(command_id, None)
 
     async def close(self) -> None:
         if self._reader is not None:

--- a/agent/skills/browser/cli/tests/test_cdp_backend.py
+++ b/agent/skills/browser/cli/tests/test_cdp_backend.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+import websockets
 from vesta_browser import cdp_backend
 from vesta_browser.bidi import BidiError
-from vesta_browser.cdp_backend import CdpBackend, _printable_key, _remote_to_bidi, _translate_event
+from vesta_browser.cdp_backend import CdpBackend, _CdpTransport, _printable_key, _remote_to_bidi, _translate_event
 
 
 class FakeTransport:
@@ -223,3 +224,86 @@ def test_unsupported_method_raises_bidi_error():
     backend = _backend()
     with pytest.raises(BidiError, match="unsupported operation"):
         asyncio.run(backend.send("storage.getCookies", {}))
+
+
+# ── Transport-level request bounding ──────────────────────────
+
+CREATE_TARGET = "Target.createTarget"
+TEST_TIMEOUT_S = 0.2
+CANCEL_AFTER_S = 0.1
+HANG_GUARD_S = 5
+
+
+class SilentCdpServer:
+    """Accepts CDP commands and never answers them, as a wedged Chrome does."""
+
+    def __init__(self) -> None:
+        self._server: websockets.Server | None = None
+
+    async def start(self) -> str:
+        self._server = await websockets.serve(self._handle, "127.0.0.1", 0)
+        port = self._server.sockets[0].getsockname()[1]
+        return f"ws://127.0.0.1:{port}/devtools/browser/fake"
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    async def _handle(self, ws: websockets.ServerConnection) -> None:
+        async for _raw in ws:
+            pass
+
+
+async def _unused_event_cb(method: str, params: dict, session_id: str | None) -> None:
+    raise AssertionError(f"a silent server pushes no events, got {method!r}")
+
+
+async def _with_silent_transport(body):
+    server = SilentCdpServer()
+    url = await server.start()
+    transport = _CdpTransport()
+    await transport.connect(url, _unused_event_cb)
+    try:
+        return await asyncio.wait_for(body(transport), timeout=HANG_GUARD_S)
+    finally:
+        await transport.close()
+        await server.stop()
+
+
+def test_withheld_cdp_response_raises_timeout_naming_the_method(monkeypatch):
+    """A Chrome that accepts a command and never answers must error, not hang forever."""
+    monkeypatch.setattr(cdp_backend, "_CDP_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
+
+    async def body(transport):
+        with pytest.raises(BidiError) as excinfo:
+            await transport.send(CREATE_TARGET, {"url": "about:blank"})
+        return excinfo.value
+
+    error = asyncio.run(_with_silent_transport(body))
+    assert error.code == "timeout"
+    assert CREATE_TARGET in error.message
+
+
+def test_timed_out_cdp_request_is_dropped_from_pending(monkeypatch):
+    """The abandoned future is released, so a wedged Chrome cannot accumulate them."""
+    monkeypatch.setattr(cdp_backend, "_CDP_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
+
+    async def body(transport):
+        with pytest.raises(BidiError):
+            await transport.send(CREATE_TARGET, {"url": "about:blank"})
+        return dict(transport._pending)
+
+    assert asyncio.run(_with_silent_transport(body)) == {}
+
+
+def test_cancelled_cdp_request_is_dropped_from_pending():
+    """Cleanup rides a finally, so a caller cancelled while waiting leaks no pending entry either."""
+
+    async def body(transport):
+        # Cancelled from outside well inside the un-patched 60s bound, so only the finally can clear it.
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(transport.send(CREATE_TARGET, {"url": "about:blank"}), timeout=CANCEL_AFTER_S)
+        return dict(transport._pending)
+
+    assert asyncio.run(_with_silent_transport(body)) == {}


### PR DESCRIPTION
Fixes #1333

## Verifying the diagnosis

Every claim in the issue checks out against the code:

- `_CdpTransport.send` (`cdp_backend.py`, line 107 on master, the issue said ~105) does end in an unbounded `return await future`.
- `TimeoutError` is an `OSError` subclass and `str(TimeoutError())` is `""`. The daemon's connection handler catches `(json.JSONDecodeError, ConnectionError, OSError)` and writes `{"error": str(e)}`, so a bare `TimeoutError` really would surface as `{"error": ""}`. `BidiError` instead rides the existing `except BidiError` in `_handle_bidi`, which reaches the CLI with the method named. The daemon holds a `CdpBackend` in its `bidi` slot on the `browser connect <chrome>` path, so that channel is the live one here.
- The leak framing is right. `_read_loop` only pops `_pending` when a response actually arrives, so a withheld response strands the entry permanently. Nothing reaps it.

One correction to the issue's framing, which does not change the fix. The issue says "`admin.py`'s `send()` **now** bounds its socket receive at 90s, so the user-visible hang class is already closed here". That bound is PR #1318, which is still **open**. On master today the CDP path is unbounded end to end, so this is currently a hang *and* a leak; it becomes leak-only once #1318 lands. Either way the fix is the same, and this PR does not depend on #1318 (no overlapping files, so no conflict).

## What changed

Mirrors #1318's shape exactly, on the third wait it left out of scope:

- `_CDP_RESPONSE_TIMEOUT_S = 60.0`, matching the BiDi side's value and this file's `_`-prefixed constant convention (`_LOAD_TIMEOUT_S` next to it).
- The wait runs under `asyncio.wait_for` and raises `BidiError("timeout", "no response to 'Target.createTarget' within 60.0s")`.
- The pending entry is dropped in a `finally`, deliberately: it covers cancellation, not just timeout. On the happy path it is a no-op, since `_read_loop` already popped the entry.

Scope held to the leak. #1305's `open`/`new_tab` root cause is untouched and stays open.

## Fleet impact

None, and no migration. This changes skill CLI code only. It moves, renames, or deletes nothing an agent holds on disk or in config: no data paths, env vars, config keys, command surfaces, or sparse-cone entries. The `SKILL.md` frontmatter is unchanged, so `index.json` is unaffected (guards confirm). Boxes pick the fix up through the normal upstream-sync rebase.

## Tests

Three tests drive the **real** `_CdpTransport` over a `SilentCdpServer`, a websocket server that accepts CDP frames and never answers, reproducing a wedged Chrome. The existing tests in this file swap `_cdp` for a recording fake, which cannot reach the transport at all.

- a withheld response raises `BidiError` with code `timeout`, naming the method
- **the timed-out request is dropped from `_pending`** (the leak itself)
- a request cancelled while waiting is also dropped, pinning the `finally`

Verified red/green by mutation, not assumed: reverting only the bounding logic while keeping the constant makes all three fail, then restoring makes all 25 pass. Each test carries a hang guard (`HANG_GUARD_S`), so the regression fails in ~10s with a clear message rather than hanging the CI job, which is what the unbounded code does.

## Checks

`./check.sh agent` and `./check.sh guards` both pass.