### PR TITLE
fix(microsoft): page the mail window instead of capping it at 50 and advancing past the rest

### DIFF
--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -18,8 +18,7 @@ _CATCHUP_GAP_SECONDS = 90
 _FRESH_START_LOOKBACK = timedelta(hours=1)
 # Bounds how much history a long-dead unit re-reads once it heals, so recovery cannot flood the user.
 _MAX_CATCHUP = timedelta(days=7)
-# A cycle drains at most _MAX_WINDOW_MESSAGES per folder, in pages of _MAIL_PAGE_SIZE, so a huge
-# recovery window costs a bounded number of requests; later cycles drain the rest.
+# Bounds a cycle's drain per folder in volume as _MAX_CATCHUP bounds it in time; later cycles drain the rest.
 _MAIL_PAGE_SIZE = 50
 _MAX_WINDOW_MESSAGES = 500
 
@@ -99,9 +98,8 @@ def _earliest(left: datetime | None, right: datetime | None) -> datetime | None:
 
 
 def _window_read_through(messages: list[dict], new_check_time: datetime) -> datetime | None:
-    """How far a fetch honestly read its window: a full-limit response means the window holds more
-    than one cycle drains, so it read only as far as the last (newest) message it fetched. A
-    timestamp that cannot anchor a watermark reports the window unread rather than guessing past it."""
+    """How far a fetch honestly read its window: a full-limit response holds more than one cycle drains, so it
+    read only as far as the last message fetched. An unusable timestamp reports the window unread, not drained."""
     if len(messages) < _MAX_WINDOW_MESSAGES:
         return new_check_time
     newest = messages[-1]
@@ -479,7 +477,7 @@ def _poll_graph_mail(ctx: MicrosoftContext, acc, new_check_time: datetime, last_
                     acc.account_id,
                     params={
                         "$filter": f"receivedDateTime gt {last_dt.isoformat()}",
-                        "$orderby": "receivedDateTime asc",  # oldest first, matching arrival order
+                        "$orderby": "receivedDateTime asc",
                         "$select": "subject,from,bodyPreview,receivedDateTime",
                         "$top": _MAIL_PAGE_SIZE,
                     },

--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -18,6 +18,10 @@ _CATCHUP_GAP_SECONDS = 90
 _FRESH_START_LOOKBACK = timedelta(hours=1)
 # Bounds how much history a long-dead unit re-reads once it heals, so recovery cannot flood the user.
 _MAX_CATCHUP = timedelta(days=7)
+# A cycle drains at most _MAX_WINDOW_MESSAGES per folder, in pages of _MAIL_PAGE_SIZE, so a huge
+# recovery window costs a bounded number of requests; later cycles drain the rest.
+_MAIL_PAGE_SIZE = 50
+_MAX_WINDOW_MESSAGES = 500
 
 
 # Zero-width and bidi / formatting characters that marketing emails use to pad previews with
@@ -67,16 +71,47 @@ def _write_state(path: Path, state: MonitorState) -> None:
     tmp.rename(path)
 
 
-def _poll_unit(ctx: MicrosoftContext, state: MonitorState, unit: str, new_check_time: datetime, poll: Callable[[datetime, bool], bool]) -> None:
-    """Advance the unit's watermark only across a window the poll actually read, so a failed poll
-    re-reads that window next cycle instead of skipping the mail it never fetched."""
+def _poll_unit(
+    ctx: MicrosoftContext, state: MonitorState, unit: str, new_check_time: datetime, poll: Callable[[datetime, bool], datetime | None]
+) -> None:
+    """Advance the unit's watermark only across the window the poll reports reading through, so a
+    failed or part-drained poll re-reads the rest next cycle instead of skipping what it never read."""
     units = state["units"]
     last_dt = max(datetime.fromisoformat(units[unit] if unit in units else state["last_cycle"]), new_check_time - _MAX_CATCHUP)
     gap_seconds = (new_check_time - last_dt).total_seconds()
     catching_up = gap_seconds > _CATCHUP_GAP_SECONDS
     if catching_up:
         ctx.monitor_logger.info("Catching up %s from %s, %.0fs behind", unit, last_dt.isoformat(), gap_seconds)
-    units[unit] = new_check_time.isoformat() if poll(last_dt, catching_up) else last_dt.isoformat()
+    read_through = poll(last_dt, catching_up)
+    units[unit] = last_dt.isoformat() if read_through is None else read_through.isoformat()
+
+
+def _whole_window(new_check_time: datetime, poll: Callable[[datetime, bool], bool]) -> Callable[[datetime, bool], datetime | None]:
+    """Adapt a poll that reads its window in one shot: it read through the whole cycle, or not at all."""
+    return lambda last_dt, catching_up: new_check_time if poll(last_dt, catching_up) else None
+
+
+def _earliest(left: datetime | None, right: datetime | None) -> datetime | None:
+    """A unit read through only as far as its least-drained folder; a folder it could not read wins."""
+    if left is None or right is None:
+        return None
+    return min(left, right)
+
+
+def _window_read_through(messages: list[dict], new_check_time: datetime) -> datetime | None:
+    """How far a fetch honestly read its window: a full-limit response means the window holds more
+    than one cycle drains, so it read only as far as the last (newest) message it fetched. A
+    timestamp that cannot anchor a watermark reports the window unread rather than guessing past it."""
+    if len(messages) < _MAX_WINDOW_MESSAGES:
+        return new_check_time
+    newest = messages[-1]
+    if "receivedDateTime" not in newest:
+        return None
+    try:
+        received = datetime.fromisoformat(newest["receivedDateTime"])
+    except ValueError:
+        return None
+    return received if received.tzinfo else None
 
 
 class EmailAddress(TypedDict):
@@ -222,33 +257,32 @@ def _poll_owa_rest_mail(
     config: Config,
     account_email: str,
     watch_folders: list[str],
+    new_check_time: datetime,
     last_dt: datetime,
     catching_up: bool,
-) -> bool:
-    """Poll a locked-tenant OWA REST account's watched folders for new mail, True when every folder
-    was read. Fetching runs through load_token, so this also keeps the token warm in the background."""
+) -> datetime | None:
+    """Poll a locked-tenant OWA REST account's watched folders for new mail, returning how far its
+    mail was read. Fetching runs through load_token, so this also keeps the token warm."""
     logger = ctx.monitor_logger
-    polled = True
+    read_through: datetime | None = new_check_time
     for folder_token in watch_folders:
         try:
-            messages = owa_rest.list_messages(ctx.http_client, account_email, config, folder=folder_token, limit=50)
-            new_messages = []
-            for message in messages:
-                if "receivedDateTime" not in message:
-                    continue
-                try:
-                    received = datetime.fromisoformat(message["receivedDateTime"])
-                except ValueError:
-                    continue
-                if received > last_dt:
-                    new_messages.append(message)
-            logger.info("OWA REST: %d new emails for %s in %s", len(new_messages), account_email, folder_token)
-            for message in reversed(new_messages):  # oldest first, matching arrival order
+            messages = owa_rest.list_messages_since(
+                ctx.http_client,
+                account_email,
+                config,
+                folder=folder_token,
+                since_utc=last_dt.isoformat().replace("+00:00", "Z"),
+                limit=_MAX_WINDOW_MESSAGES,
+            )
+            logger.info("OWA REST: %d new emails for %s in %s", len(messages), account_email, folder_token)
+            for message in messages:  # oldest first, matching arrival order
                 _emit_email_notification(ctx, message, account_email, folder_token, catching_up)
+            read_through = _earliest(read_through, _window_read_through(messages, new_check_time))
         except Exception as e:
             logger.error("Error fetching OWA REST emails for %s folder %s: %s", account_email, folder_token, e)
-            polled = False
-    return polled
+            read_through = None
+    return read_through
 
 
 def _poll_owa_rest_calendar(
@@ -427,42 +461,40 @@ def _refresh_captured_tokens(ctx: MicrosoftContext, config: Config, gave_up: set
             notifications.write_notification(ctx.notif_dir, "auth_needed", interrupt=False, account=account, message=str(e))
 
 
-def _poll_graph_mail(ctx: MicrosoftContext, acc, last_dt: datetime, catching_up: bool) -> bool:
-    """Poll one MSAL (Graph) account's watched folders for new mail, True when every folder was read."""
+def _poll_graph_mail(ctx: MicrosoftContext, acc, new_check_time: datetime, last_dt: datetime, catching_up: bool) -> datetime | None:
+    """Poll one MSAL (Graph) account's watched folders for new mail, returning how far its mail was read."""
     logger = ctx.monitor_logger
     conn = graph.GraphConn(ctx.http_client, ctx.cache_file, ctx.scopes, ctx.base_url)
     watch_folders = notify.get_notify_folders(ctx.notify_file, acc.username) if ctx.notify_file else ["inbox"]
-    polled = True
+    read_through: datetime | None = new_check_time
     for folder_token in watch_folders:
         try:
             folder_id = folders.resolve_folder_id(
                 ctx.http_client, ctx.cache_file, ctx.scopes, ctx.base_url, ctx.folders, acc.account_id, folder_token
             )
-            result = graph.request(
-                conn,
-                "GET",
-                f"/me/mailFolders/{folder_id}/messages",
-                acc.account_id,
-                params={
-                    "$filter": f"receivedDateTime gt {last_dt.isoformat()}",
-                    "$select": "subject,from,bodyPreview,receivedDateTime",
-                    "$top": 50,
-                },
+            emails = list(
+                graph.request_paginated(
+                    conn,
+                    f"/me/mailFolders/{folder_id}/messages",
+                    acc.account_id,
+                    params={
+                        "$filter": f"receivedDateTime gt {last_dt.isoformat()}",
+                        "$orderby": "receivedDateTime asc",  # oldest first, matching arrival order
+                        "$select": "subject,from,bodyPreview,receivedDateTime",
+                        "$top": _MAIL_PAGE_SIZE,
+                    },
+                    limit=_MAX_WINDOW_MESSAGES,
+                )
             )
-
-            if not result or "value" not in result:
-                logger.warning("Unexpected email API response: %s", result)
-                polled = False
-                continue
-            emails = result["value"]
             logger.info("Found %d new emails for %s in %s", len(emails), acc.username, folder_token)
 
             for email in emails:
                 _emit_email_notification(ctx, email, acc.username, folder_token, catching_up)
+            read_through = _earliest(read_through, _window_read_through(emails, new_check_time))
         except Exception as e:
             logger.error("Error fetching emails for %s folder %s: %s", acc.username, folder_token, e)
-            polled = False
-    return polled
+            read_through = None
+    return read_through
 
 
 def _poll_graph_calendar(ctx: MicrosoftContext, acc, new_check_time: datetime, last_dt: datetime, catching_up: bool) -> bool:
@@ -510,8 +542,14 @@ def run(ctx: MicrosoftContext):
             msal_accounts = auth.list_accounts(ctx.cache_file)
             for acc in msal_accounts:
                 logger.info("Checking account: %s", acc.username)
-                _poll_unit(ctx, state, f"mail:{acc.username}", new_check_time, partial(_poll_graph_mail, ctx, acc))
-                _poll_unit(ctx, state, f"calendar:{acc.username}", new_check_time, partial(_poll_graph_calendar, ctx, acc, new_check_time))
+                _poll_unit(ctx, state, f"mail:{acc.username}", new_check_time, partial(_poll_graph_mail, ctx, acc, new_check_time))
+                _poll_unit(
+                    ctx,
+                    state,
+                    f"calendar:{acc.username}",
+                    new_check_time,
+                    _whole_window(new_check_time, partial(_poll_graph_calendar, ctx, acc, new_check_time)),
+                )
 
             # OWA REST accounts (locked tenants) are not in the MSAL cache, so poll them separately
             # for anything Graph did not already cover.
@@ -522,22 +560,36 @@ def run(ctx: MicrosoftContext):
                 logger.info("Checking OWA REST account: %s", account_email)
                 watch_folders = notify.get_notify_folders(ctx.notify_file, account_email) if ctx.notify_file else ["inbox"]
                 _poll_unit(
-                    ctx, state, f"mail:{account_email}", new_check_time, partial(_poll_owa_rest_mail, ctx, config, account_email, watch_folders)
+                    ctx,
+                    state,
+                    f"mail:{account_email}",
+                    new_check_time,
+                    partial(_poll_owa_rest_mail, ctx, config, account_email, watch_folders, new_check_time),
                 )
                 _poll_unit(
                     ctx,
                     state,
                     f"calendar:{account_email}",
                     new_check_time,
-                    partial(_poll_owa_rest_calendar, ctx, config, account_email, new_check_time),
+                    _whole_window(new_check_time, partial(_poll_owa_rest_calendar, ctx, config, account_email, new_check_time)),
                 )
 
             # Teams chats: every account that has authorized Teams (device or captured token).
             for account_email in teams.list_accounts(config):
                 logger.info("Checking Teams account: %s", account_email)
-                _poll_unit(ctx, state, f"teams:{account_email}", new_check_time, partial(_poll_teams_account, ctx, config, account_email))
                 _poll_unit(
-                    ctx, state, f"channels:{account_email}", new_check_time, partial(_poll_teams_channels_account, ctx, config, account_email)
+                    ctx,
+                    state,
+                    f"teams:{account_email}",
+                    new_check_time,
+                    _whole_window(new_check_time, partial(_poll_teams_account, ctx, config, account_email)),
+                )
+                _poll_unit(
+                    ctx,
+                    state,
+                    f"channels:{account_email}",
+                    new_check_time,
+                    _whole_window(new_check_time, partial(_poll_teams_channels_account, ctx, config, account_email)),
                 )
 
             # Keep browser-captured tokens fresh so the user's one sign-in lasts the SSO session.

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
@@ -289,14 +289,13 @@ def list_messages(client: httpx.Client, account_email: str, config, *, folder: s
     params = {
         "$select": _MSG_SELECT,
         "$orderby": "ReceivedDateTime desc",
-        "$top": str(min(limit, 100)),
+        "$top": str(min(limit, _MAX_PAGE_SIZE)),
     }
     return _paginate(client, token, f"/me/mailfolders/{fid}/messages", params, limit)
 
 
 def list_messages_since(client: httpx.Client, account_email: str, config, *, folder: str, since_utc: str, limit: int) -> list[dict]:
-    """Messages received after ``since_utc``, oldest first, paged up to ``limit``. Ascending order
-    makes a truncated read a resumable prefix of the window rather than its newest slice."""
+    """Ascending order makes a truncated read a resumable prefix of the window, not its newest slice."""
     token = load_token(account_email, config)
     fid = _folder_id(folder)
     params = {

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
@@ -270,6 +270,8 @@ _MSG_SELECT = (
     "id,subject,receivedDateTime,sentDateTime,isRead,hasAttachments,from,toRecipients,ccRecipients,categories,conversationId,bodyPreview"
 )
 
+_MAX_PAGE_SIZE = 100
+
 
 def _folder_id(name: str | None) -> str:
     key = (name or "inbox").casefold()
@@ -288,6 +290,20 @@ def list_messages(client: httpx.Client, account_email: str, config, *, folder: s
         "$select": _MSG_SELECT,
         "$orderby": "ReceivedDateTime desc",
         "$top": str(min(limit, 100)),
+    }
+    return _paginate(client, token, f"/me/mailfolders/{fid}/messages", params, limit)
+
+
+def list_messages_since(client: httpx.Client, account_email: str, config, *, folder: str, since_utc: str, limit: int) -> list[dict]:
+    """Messages received after ``since_utc``, oldest first, paged up to ``limit``. Ascending order
+    makes a truncated read a resumable prefix of the window rather than its newest slice."""
+    token = load_token(account_email, config)
+    fid = _folder_id(folder)
+    params = {
+        "$select": _MSG_SELECT,
+        "$filter": f"ReceivedDateTime gt {since_utc}",
+        "$orderby": "ReceivedDateTime asc",
+        "$top": str(min(limit, _MAX_PAGE_SIZE)),
     }
     return _paginate(client, token, f"/me/mailfolders/{fid}/messages", params, limit)
 

--- a/agent/skills/microsoft/cli/tests/test_monitor.py
+++ b/agent/skills/microsoft/cli/tests/test_monitor.py
@@ -71,6 +71,18 @@ def _email(addr, name, received):
     }
 
 
+def _mailbox(*emails):
+    """A fake OWA REST fetch honoring the real one's contract: newer than since_utc, oldest first,
+    capped at limit."""
+
+    def fetch(_client, _account, _config, *, folder, since_utc, limit):
+        since = datetime.fromisoformat(since_utc)
+        window = [email for email in emails if datetime.fromisoformat(email["receivedDateTime"]) > since]
+        return sorted(window, key=lambda email: datetime.fromisoformat(email["receivedDateTime"]))[:limit]
+
+    return fetch
+
+
 def test_emit_email_notification_writes_with_sender(tmp_path, monkeypatch):
     calls = []
     monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
@@ -85,22 +97,24 @@ def test_poll_owa_rest_notifies_only_new_mail(tmp_path, monkeypatch):
     monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
     monkeypatch.setattr(
         monitor.owa_rest,
-        "list_messages",
-        lambda *a, **k: [
-            _email("new@x.com", "New Sender", "2026-07-08T13:00:00Z"),
-            _email("old@x.com", "Old Sender", "2026-07-08T11:00:00Z"),
-        ],
+        "list_messages_since",
+        _mailbox(
+            _email("new@x.com", "New Sender", "2026-07-08T13:00:00+00:00"),
+            _email("old@x.com", "Old Sender", "2026-07-08T11:00:00+00:00"),
+        ),
     )
     last_dt = datetime(2026, 7, 8, 12, 0, tzinfo=UTC)
-    assert monitor._poll_owa_rest_mail(_fake_ctx(tmp_path), None, "me@x.com", ["inbox"], last_dt, False) is True
+    new_check = datetime(2026, 7, 8, 14, 0, tzinfo=UTC)
+    assert monitor._poll_owa_rest_mail(_fake_ctx(tmp_path), None, "me@x.com", ["inbox"], new_check, last_dt, False) == new_check
     assert len(calls) == 1
     assert calls[0]["sender"] == "New Sender"
 
 
 def test_poll_owa_rest_mail_reports_a_folder_it_could_not_read(tmp_path, monkeypatch):
-    monkeypatch.setattr(monitor.owa_rest, "list_messages", _raise(httpx.ConnectError("boom")))
+    monkeypatch.setattr(monitor.owa_rest, "list_messages_since", _raise(httpx.ConnectError("boom")))
     last_dt = datetime(2026, 7, 8, 12, 0, tzinfo=UTC)
-    assert monitor._poll_owa_rest_mail(_fake_ctx(tmp_path), None, "me@x.com", ["inbox"], last_dt, False) is False
+    new_check = datetime(2026, 7, 8, 14, 0, tzinfo=UTC)
+    assert monitor._poll_owa_rest_mail(_fake_ctx(tmp_path), None, "me@x.com", ["inbox"], new_check, last_dt, False) is None
 
 
 def test_poll_owa_rest_fires_calendar_reminder(tmp_path, monkeypatch):
@@ -172,13 +186,13 @@ def test_failed_poll_leaves_the_window_for_the_next_cycle_to_recover(tmp_path, m
 
     cycle = {"n": 0}
 
-    def list_messages(*_args, **_kwargs):
+    def list_messages_since(*_args, **_kwargs):
         cycle["n"] += 1
         if cycle["n"] == 1:
             raise httpx.ConnectError("Server disconnected without sending a response.")
         return [arrived]
 
-    monkeypatch.setattr(monitor.owa_rest, "list_messages", list_messages)
+    monkeypatch.setattr(monitor.owa_rest, "list_messages_since", list_messages_since)
     monitor.run(ctx)
 
     assert [call["sender"] for call in calls] == ["Manager"]
@@ -200,12 +214,14 @@ def test_broken_account_does_not_make_a_healthy_one_renotify(tmp_path, monkeypat
     ctx.monitor_state_file.write_text(parked_at.isoformat())
     delivered = _email("colleague@x.com", "Colleague", delivered_at.isoformat())
 
-    def list_messages(_client, account_email, *_args, **_kwargs):
+    healthy = _mailbox(delivered)
+
+    def list_messages_since(client, account_email, config, **kwargs):
         if account_email == "broken@x.com":
             raise httpx.ConnectError("token is dead")
-        return [delivered]
+        return healthy(client, account_email, config, **kwargs)
 
-    monkeypatch.setattr(monitor.owa_rest, "list_messages", list_messages)
+    monkeypatch.setattr(monitor.owa_rest, "list_messages_since", list_messages_since)
     monitor.run(ctx)
 
     assert [call["sender"] for call in calls] == ["Colleague"]
@@ -224,11 +240,11 @@ def test_recovery_reads_at_most_the_max_catchup_window(tmp_path, monkeypatch):
     ctx.monitor_state_file.write_text(json.dumps(stale))
     monkeypatch.setattr(
         monitor.owa_rest,
-        "list_messages",
-        lambda *a, **k: [
+        "list_messages_since",
+        _mailbox(
             _email("ancient@x.com", "Ancient", (now - timedelta(days=20)).isoformat()),
             _email("recent@x.com", "Recent", (now - timedelta(hours=1)).isoformat()),
-        ],
+        ),
     )
     monitor.run(ctx)
 
@@ -246,12 +262,81 @@ def test_legacy_bare_timestamp_state_is_read_as_the_starting_watermark(tmp_path,
     ctx.monitor_state_file.write_text((now - timedelta(minutes=5)).isoformat())
     monkeypatch.setattr(
         monitor.owa_rest,
-        "list_messages",
-        lambda *a, **k: [
+        "list_messages_since",
+        _mailbox(
             _email("before@x.com", "Before", (now - timedelta(minutes=10)).isoformat()),
             _email("after@x.com", "After", (now - timedelta(minutes=2)).isoformat()),
-        ],
+        ),
     )
     monitor.run(ctx)
 
     assert [call["sender"] for call in calls] == ["After"]
+
+
+def _oversized_window(now: datetime, count: int) -> list[dict]:
+    """`count` emails arriving one second apart, oldest first, all inside the last cycle's window."""
+    return [_email(f"s{i}@x.com", f"S{i}", (now - timedelta(seconds=count - i)).isoformat()) for i in range(count)]
+
+
+def test_a_window_over_the_drain_limit_parks_the_watermark_at_the_last_message_read(tmp_path, monkeypatch):
+    """The cap and the watermark are one decision: a full-limit fetch cannot advance past the mail it
+    never fetched, which is what silently dropped everything older than the newest 50."""
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    _single_owa_account(monkeypatch)
+
+    now = datetime.now(UTC)
+    over_limit = monitor._MAX_WINDOW_MESSAGES + 100
+    mailbox = _oversized_window(now, over_limit)
+    ctx = _run_ctx(tmp_path, cycles=1)
+    ctx.monitor_state_file.write_text((now - timedelta(seconds=over_limit + 1)).isoformat())
+    monkeypatch.setattr(monitor.owa_rest, "list_messages_since", _mailbox(*mailbox))
+    monitor.run(ctx)
+
+    drained = mailbox[: monitor._MAX_WINDOW_MESSAGES]
+    assert [call["sender"] for call in calls] == [call["from"]["emailAddress"]["name"] for call in drained]
+    assert _watermark(ctx, "mail:me@x.com") == datetime.fromisoformat(drained[-1]["receivedDateTime"])
+    assert _watermark(ctx, "mail:me@x.com") < datetime.fromisoformat(mailbox[monitor._MAX_WINDOW_MESSAGES]["receivedDateTime"])
+
+
+def test_the_rest_of_an_oversized_window_is_drained_by_the_following_cycle(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    _single_owa_account(monkeypatch)
+
+    now = datetime.now(UTC)
+    over_limit = monitor._MAX_WINDOW_MESSAGES + 100
+    mailbox = _oversized_window(now, over_limit)
+    ctx = _run_ctx(tmp_path, cycles=2)
+    ctx.monitor_state_file.write_text((now - timedelta(seconds=over_limit + 1)).isoformat())
+    monkeypatch.setattr(monitor.owa_rest, "list_messages_since", _mailbox(*mailbox))
+    monitor.run(ctx)
+
+    # every message exactly once, in arrival order: nothing dropped, nothing re-notified
+    assert [call["sender"] for call in calls] == [email["from"]["emailAddress"]["name"] for email in mailbox]
+
+
+def test_graph_mail_pages_a_bounded_window_and_parks_at_the_last_message_read(tmp_path, monkeypatch):
+    """The Graph path caps the same way, so it pages the window oldest-first under one bound."""
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    monkeypatch.setattr(monitor.folders, "resolve_folder_id", lambda *a, **k: "inbox-id")
+
+    now = datetime.now(UTC)
+    mailbox = _oversized_window(now, monitor._MAX_WINDOW_MESSAGES)
+    asked = {}
+
+    def request_paginated(_conn, path, _account_id=None, params=None, limit=None, extra_prefer=None):
+        asked.update(path=path, params=params, limit=limit)
+        return iter(mailbox[:limit])
+
+    monkeypatch.setattr(monitor.graph, "request_paginated", request_paginated)
+    ctx = _run_ctx(tmp_path, cycles=1)
+    acc = types.SimpleNamespace(username="me@x.com", account_id="acct-1")
+
+    read_through = monitor._poll_graph_mail(ctx, acc, now, now - timedelta(hours=1), False)
+
+    assert asked["params"]["$orderby"] == "receivedDateTime asc"
+    assert asked["limit"] == monitor._MAX_WINDOW_MESSAGES
+    assert len(calls) == monitor._MAX_WINDOW_MESSAGES
+    assert read_through == datetime.fromisoformat(mailbox[-1]["receivedDateTime"])

--- a/agent/skills/microsoft/cli/tests/test_monitor.py
+++ b/agent/skills/microsoft/cli/tests/test_monitor.py
@@ -279,8 +279,7 @@ def _oversized_window(now: datetime, count: int) -> list[dict]:
 
 
 def test_a_window_over_the_drain_limit_parks_the_watermark_at_the_last_message_read(tmp_path, monkeypatch):
-    """The cap and the watermark are one decision: a full-limit fetch cannot advance past the mail it
-    never fetched, which is what silently dropped everything older than the newest 50."""
+    """The cap and the watermark are one decision: a full-limit fetch cannot advance past mail it never fetched."""
     calls = []
     monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
     _single_owa_account(monkeypatch)
@@ -312,12 +311,10 @@ def test_the_rest_of_an_oversized_window_is_drained_by_the_following_cycle(tmp_p
     monkeypatch.setattr(monitor.owa_rest, "list_messages_since", _mailbox(*mailbox))
     monitor.run(ctx)
 
-    # every message exactly once, in arrival order: nothing dropped, nothing re-notified
     assert [call["sender"] for call in calls] == [email["from"]["emailAddress"]["name"] for email in mailbox]
 
 
 def test_graph_mail_pages_a_bounded_window_and_parks_at_the_last_message_read(tmp_path, monkeypatch):
-    """The Graph path caps the same way, so it pages the window oldest-first under one bound."""
     calls = []
     monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
     monkeypatch.setattr(monitor.folders, "resolve_folder_id", lambda *a, **k: "inbox-id")


### PR DESCRIPTION
Fixes #1335

## The bug (verified, and the issue's diagnosis holds with one correction)

Both mail paths capped a single window at 50 messages and then advanced the watermark across the **whole** window regardless. A window holding more than 50 messages kept only the newest 50; the rest were dropped permanently, and nothing reported it.

The issue's diagnosis is right on the behaviour and on the sharp edge: the cap and the watermark advance were decided independently, and nothing noticed a fetch coming back exactly at its limit. One correction to the mechanics: the OWA path was not literally unpaged. `owa_rest.list_messages` already pages via `_paginate`, but it asks for `ReceivedDateTime desc` and stops at `limit=50`, so the effect is identical (newest 50, oldest silently dropped). The Graph path was genuinely unpaged: a single `$top: 50` with the `@odata.nextLink` never followed.

Not a regression, as the issue says: pre-existing, and #1311 strictly improved matters. It matters more now only because #1311 makes recovery windows normal.

## The fix: page the window, per #1311's own invariant

Both paths now page the window **oldest-first**, bounded by `_MAX_WINDOW_MESSAGES` (500) per folder per cycle in pages of `_MAIL_PAGE_SIZE` (50). Both backends already had the paging primitive (`graph.request_paginated`, `owa_rest._paginate`); the mail polls simply were not using them.

The cap and the watermark are now one decision. A poll reports **the instant it genuinely read through** rather than a bare success bool, and `_poll_unit` advances the watermark only that far:

- fetch came back under the limit, the window is drained, read through the cycle's instant
- fetch came back **at** the limit (the cheap "probably truncated" signal), read only as far as the last message actually fetched, so the next cycle drains the remainder
- fetch failed, window unread, watermark parks where #1311 left it

**Ascending order is what makes the bound safe**, and is the reason paging was workable on both backends rather than falling back to the issue's stated minimum. Oldest-first makes a truncated read a resumable *prefix* of the window: park at the last message read and the rest is picked up next cycle, with nothing dropped and nothing re-notified. Newest-first cannot do this: the unread remainder sits in the middle of the window, so parking would re-notify everything already emitted, every cycle, forever, and never reach the old mail. That is why the ordering changed rather than just the page count.

Paging the OWA path oldest-first needs a server-side window, so `owa_rest.list_messages_since` adds `$filter=ReceivedDateTime gt <since>` with `$orderby ReceivedDateTime asc`. The monitor's client-side "is this newer than last_dt" filter is deleted in favour of it: one owner for the window. `list_messages` (the `email list` command's path) is untouched.

Bounding: `_MAX_CATCHUP` (7 days) still bounds the window in time; `_MAX_WINDOW_MESSAGES` now bounds it in volume, so a huge recovery window costs at most 10 requests per folder per cycle and drains over the cycles that follow. It cannot spin: each cycle strictly advances the watermark past the messages it read.

## Fleet impact: `state.txt` format is unchanged

Deliberately not touched, given #1336 (the format is already one-way and a downgrade stalls the monitor forever). Same `{"last_cycle", "units"}` shape, same unit keys, same value type: an ISO instant. The only change is that a unit's watermark may now hold a message's received time rather than a cycle time, which every reader, old or new, treats identically. No migration needed, and nothing new to downgrade through.

## Tests

`skills/microsoft/cli/tests/test_monitor.py`, driving the real `run()` loop over a real state file:
- a window over the drain limit notifies the oldest first and parks the watermark at the last message read, strictly behind the first message it did not read
- the following cycle drains the remainder: every message exactly once, in arrival order, nothing dropped and nothing re-notified
- the Graph path pages the same bounded window oldest-first and parks the same way (this path had no monitor coverage at all before)

Both discriminating tests were confirmed red by mutation (restoring "a full-limit fetch claims it read the whole window") and green with the fix restored.

The existing OWA fakes now honour the real fetch contract (newer than `since_utc`, oldest first, capped at `limit`) instead of returning a fixed list, which is what a real backend does now that filtering is server-side. That is what turned up one honest wrinkle: with a fake that ignored `since_utc`, a healthy account re-notified its window every cycle. The faithful fake proves it does not.

## Two things a reviewer should know

- Folders within an account share one watermark (#1311's granularity, unchanged). If one folder truncates while another is drained, the drained folder's tail is re-read next cycle and can re-notify. Only reachable in the pathological >500-in-7-days case, and per #1311 a duplicate notification beats losing mail. Fixing it properly means a per-folder unit key, which is exactly the `state.txt` change this PR declines to make.
- `$filter`/`$orderby` on `ReceivedDateTime` against OWA REST v2.0 is unverified against a live locked tenant (see below).

`./check.sh agent` and `./check.sh guards` pass.
