### PR TITLE
fix(microsoft): treat a null Teams displayName or body as absent

### DIFF
--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -295,11 +295,11 @@ def _teams_notifiable(message: dict, my_id: str) -> TeamsNotifiable | None:
     if "id" in sender_user and sender_user["id"] == my_id:
         return None
     body = message["body"] if "body" in message else {}
-    text = clean_preview(_HTML_TAG.sub(" ", body["content"] if "content" in body else ""))[:200]
-    named = "displayName" in sender_user
-    if not named and not text:
+    text = clean_preview(_HTML_TAG.sub(" ", (body["content"] if "content" in body else None) or ""))[:200]
+    name = (sender_user["displayName"] if "displayName" in sender_user else None) or ""
+    if not name and not text:
         return None
-    return {"sender": sender_user["displayName"] if named else "Someone", "text": text}
+    return {"sender": name or "Someone", "text": text}
 
 
 def _arrived_since(message: dict, last_dt: datetime) -> bool:

--- a/agent/skills/microsoft/cli/tests/test_teams.py
+++ b/agent/skills/microsoft/cli/tests/test_teams.py
@@ -548,6 +548,89 @@ def test_poll_teams_still_emits_for_app_message_with_body(tmp_path, monkeypatch)
     assert "build 42 failed" in notif["preview"]
 
 
+def test_poll_teams_skips_nameless_author_with_empty_body(tmp_path, monkeypatch):
+    """Graph declares displayName nullable, and sends null for removed, federated and anonymous
+    users. A null name plus an empty body is as contentless as `from: null`, so it must not notify:
+    testing the key's presence rather than its value would write the very payload #1337 reported."""
+    from datetime import UTC, datetime
+
+    from microsoft_cli import monitor
+
+    chats = [
+        {
+            "id": "chat-1",
+            "topic": "IVF 2026",
+            "lastMessagePreview": {
+                "createdDateTime": "2026-07-10T12:00:00Z",
+                "from": {"user": {"id": "other-guid", "displayName": None}},
+                "body": {"content": ""},
+            },
+        }
+    ]
+    ctx = _teams_ctx(tmp_path, monkeypatch, chats)
+    last_dt = datetime(2026, 7, 10, 11, 0, tzinfo=UTC)
+    monitor._poll_teams_account(ctx, Config(data_dir=tmp_path), "me@x.com", last_dt, False)
+    assert list((tmp_path / "notif").glob("*.json")) == []
+
+
+def test_poll_teams_still_emits_for_nameless_author_with_body(tmp_path, monkeypatch):
+    """A null display name is only half the test: with real text there is still something to report,
+    so it notifies under the placeholder sender rather than being swallowed with the system events."""
+    from datetime import UTC, datetime
+
+    from microsoft_cli import monitor
+
+    chats = [
+        {
+            "id": "chat-1",
+            "topic": "IVF 2026",
+            "lastMessagePreview": {
+                "createdDateTime": "2026-07-10T12:00:00Z",
+                "from": {"user": {"id": "other-guid", "displayName": None}},
+                "body": {"content": "<p>are we still on for 3pm</p>"},
+            },
+        }
+    ]
+    ctx = _teams_ctx(tmp_path, monkeypatch, chats)
+    last_dt = datetime(2026, 7, 10, 11, 0, tzinfo=UTC)
+    monitor._poll_teams_account(ctx, Config(data_dir=tmp_path), "me@x.com", last_dt, False)
+
+    files = list((tmp_path / "notif").glob("*.json"))
+    assert len(files) == 1
+    notif = json.loads(files[0].read_text())
+    assert notif["sender"] == "Someone"
+    assert "are we still on for 3pm" in notif["preview"]
+
+
+def test_poll_teams_reads_null_body_content_as_empty(tmp_path, monkeypatch):
+    """Graph declares itemBody.content nullable too. The poll loop sits outside the request's
+    try/except, so handing null to the HTML strip would take down the whole cycle for one message."""
+    from datetime import UTC, datetime
+
+    from microsoft_cli import monitor
+
+    chats = [
+        {
+            "id": "chat-1",
+            "topic": "Standup",
+            "lastMessagePreview": {
+                "createdDateTime": "2026-07-10T12:00:00Z",
+                "from": {"user": {"id": "other-guid", "displayName": "Bob"}},
+                "body": {"content": None},
+            },
+        }
+    ]
+    ctx = _teams_ctx(tmp_path, monkeypatch, chats)
+    last_dt = datetime(2026, 7, 10, 11, 0, tzinfo=UTC)
+    monitor._poll_teams_account(ctx, Config(data_dir=tmp_path), "me@x.com", last_dt, False)
+
+    files = list((tmp_path / "notif").glob("*.json"))
+    assert len(files) == 1
+    notif = json.loads(files[0].read_text())
+    assert notif["sender"] == "Bob"
+    assert notif["preview"] == ""
+
+
 # ---------------------------------------------------------------------------
 # Monitor: Teams CHANNEL message notification emit + graceful degrade
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Found while reviewing merged PR #1340 (which fixed #1337). This is a live defect on master, not a PR nit: #1340's guard has a hole that writes the very notification the guard exists to prevent.

## The bug

PR #1340 added `_teams_notifiable`, whose job is to return `None` when a Teams message has nothing to say. Its guard reads:

```python
named = "displayName" in sender_user
if not named and not text:
    return None
```

`named` tests the key's **presence**. Graph declares `from.user.displayName` **nullable** and sends null for removed, federated and anonymous users. A null name is therefore "named", the compound guard does not fire, and `_teams_notifiable` returns `{"sender": None, "text": ""}`. `write_notification` filters `None` values out of the payload, so the chat path writes this, reproduced end to end against merged master:

```json
{
  "source": "microsoft", "type": "teams", "interrupt": true,
  "topic": "IVF 2026", "preview": "", "chat_id": "chat-1", "account": "me@x.com"
}
```

That is issue #1337's exact pathology, and strictly worse than the `sender: "Someone"` it reported: the `sender` key is gone, so the user's notification rules have no field left to match on. It also makes `TeamsNotifiable.sender: str` a lie; `ty` cannot catch it because `message: dict` erases the value type.

The same presence-vs-value error sits on the next line: null `body.content` passes the `in` check and reaches `_HTML_TAG.sub`, raising `TypeError: expected string or bytes-like object`. The poll loop sits outside the request's try/except and `_poll_unit` does not catch, so one such message takes down the whole cycle. That line predates #1340 (it moved in from `_teams_body_preview`), but it is the same root cause in the same four-line function, so it is fixed here rather than left as a known crash.

## The fix

Read both fields with the `or` fallback **the surrounding code already uses for this exact Graph field**: `or "Team"` (L383), `or "Channel"` (L393), `or members or None` (L341). Line 299 was the odd one out. Net **0 LOC** in source, 4 lines changed in place.

The guard stays **compound**, and every decision #1340 called out is preserved:

- **Bot/app posts still notify.** They carry `from.application` and no `user` key, so no name resolves but the text does: `not name and not text` is False, notifies as `"Someone"`. Unchanged.
- **Authored-but-bodyless posts still notify.** A real display name makes `not name` False. Unchanged. No `"sent an attachment"` invented.
- **`interrupt=True` on chats, `interrupt=False` on channels.** Untouched. A contentless notification is not written, never downgraded.
- **The unreachable own-message check.** Left alone; no second guard stacked.

Behavior changes only for a present-but-falsy `displayName`, in three ways, all strictly better and none swallowing a real message:

| input | before | after |
|---|---|---|
| null name + empty body | writes interrupt with no `sender` | skipped |
| null name + real text | writes with `sender` dropped | writes `sender: "Someone"` |
| null `body.content` | TypeError kills the cycle | read as empty body |

## Tests

Three added, covering both directions so the guard cannot be fixed by over-swallowing:

- null name + empty body is dropped (the bug)
- null name + **real text still notifies** as `"Someone"`
- null `body.content` reads as an empty body instead of crashing

**Mutation-verified.** Reverted the fix to a byte-identical copy of master (empty `git diff` on the source file), ran the suite: exactly the 3 new tests fail, the other 48 pass. Restored: 51 pass. The 48 include #1340's own 4 tests (bot notifies, authored-bodyless notifies, system events dropped on both paths), which pass both with and without my change, proving the compound guard and the bot path are intact.

`uv run pytest tests/` in the skill CLI: 228 passed. `./check.sh guards`: green. Skills index regenerated identically, no `SKILL.md` change.

## Fleet impact

None. Pure poller logic: no state format, config schema, on-disk path, or notification field changes, so no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)