### PR TITLE
docs(vestad): document how to make a registered service private

### DIFF
--- a/agent/skills/vestad/SKILL.md
+++ b/agent/skills/vestad/SKILL.md
@@ -66,10 +66,13 @@ a failed registration short-circuits the chain, so the daemon never launches por
 whole line in the `running <name> ||` guard the Daemons block defines, so re-running it (crash
 recovery re-enters the block) never stacks a duplicate daemon.
 
-List registrations, or tell connected clients to reload after changing what a service serves:
+List registrations, unregister a service (also how you make a public service private: drop the
+registration, then register it again without `--public`), or tell connected clients to reload
+after changing what a service serves:
 
 ```bash
 curl -sk https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services -H "X-Agent-Token: $AGENT_TOKEN"
+curl -sk -X DELETE https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services/<name> -H "X-Agent-Token: $AGENT_TOKEN"
 curl -sk -X POST https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services/<name>/invalidate -H "X-Agent-Token: $AGENT_TOKEN"
 ```
 

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -3260,10 +3260,9 @@ mod tests {
         );
     }
 
-    // Reproduction of vesta#1323. `public` is as durable a choice as the port, and the
-    // caller re-registering is often a resolver that never chose it, so an omitted flag
-    // must inherit the cached one instead of revoking a publish. Drives the real
-    // resolve_public register_service_handler calls.
+    // Reproduction of vesta#1323: the caller re-registering is often a resolver that never
+    // chose the flag, so an omitted one must inherit the cached value instead of revoking a
+    // publish. Drives the real `resolve_public` that `register_service_handler` calls.
     #[test]
     fn public_flag_survives_a_reregistration_that_omits_it() {
         let published = Some(ServiceEntry {


### PR DESCRIPTION
Found while reviewing merged PR #1341.

## Review outcome: the fix is correct

I reviewed `40aab51a` for a live defect on master, with attention to the two directions the author flagged as unverified. **No bug found.** Recording what I checked, since the value here is the verification, not the diff:

- **Caller inventory is complete.** I swept every POST to `/agents/{name}/services` repo-wide, not just the three the PR body names. The full set is `register-service` (the helper behind tasks / voice / dashboard / file-host / browser), `whatsapp/cli/link.go`, `whatsapp/cli/voice_client.go`, and agentmail's printed setup snippet. `vestad/scripts/health` hits the same path but is a GET, so it never clobbers. **No caller sends an explicit `false` any more**, which is what makes the client-side half of the fix load-bearing and complete.
- **`resolve_public` is mutation-proven.** Reverting it to `requested.unwrap_or(false)` fails `public_flag_survives_a_reregistration_that_omits_it` on `omitting public keeps a published service public` (left: false, right: true). The three-way distinction is doing real work.
- **No unintended-exposure hole.** `public` can only be inherited from the same agent+service's own cached entry. `stop_agent_handler` and `destroy_agent_handler` both wipe `settings.services` for the agent, and `rename_agent_handler` carries it across, so a stale entry can never publish a fresh service.
- **The serde reasoning holds**, with one unstated caveat (below).

## Serde nuance the PR body did not cover

I probed the old and new DTOs against a real `serde_json` rather than reasoning from the contract:

| body | new vestad | old vestad (shipped) |
| --- | --- | --- |
| `{"name":"d"}` | `None` (inherit) | `false` |
| `{"name":"d","public":null}` | `None` (inherit) | **422** `invalid type: null, expected a boolean` |
| `{"name":"d","public":false}` | `Some(false)` | `false` |

`#[serde(default)]` covers a *missing* field, not a *null* one, so `null` is only safe against the new vestad. The PR's null claim is scoped to the new binary and is correct; the new client omits the field rather than nulling it, so nothing bites. Worth knowing before anyone "helpfully" makes a client serialize `public: null`.

Separately: `#[serde(default)]` on the new `Option<bool>` is inert (serde already defaults `Option<T>` to `None` on a missing field; I confirmed the attribute changes no case). Fleet safety for new-client to old-vestad comes from the *old* binary's own attribute, which is already compiled and shipped. **Left as-is deliberately**, it documents intent and guards a future type change.

## What this PR changes

Two small things, no behavior change:

- **The demotion path is undocumented where the agent reads.** #1341 correctly removed the accidental demotion the fleet had (re-register without `--public`) and documented the replacement, unregister then re-register, in the `register-service` script header. But `agent/skills/vestad/SKILL.md`, the surface the agent actually loads, now says re-registering keeps exposure and never says how to drop it. `DELETE /agents/{name}/services/{service}` exists and is agent-token authed, but an agent asked to unpublish a dashboard would have to read vestad's Rust source to find it. Added it to the SKILL.md's existing services curl block.
- **A dropped word** left the test's comment unparseable ("Drives the real resolve_public register_service_handler calls"). Fixed, and trimmed to the two lines carrying intent.

Coverage untouched; re-proved by the same mutation after the edit.

## Checks

`./check.sh vestad` (211 passed, 0 failed) and `./check.sh guards` both green locally. Skills index regenerated, unchanged (body-only edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)