### PR TITLE
fix(browser): report a wedged cdp attach as a timeout, not a missing frame

### DIFF
--- a/agent/skills/browser/cli/src/vesta_browser/cdp_backend.py
+++ b/agent/skills/browser/cli/src/vesta_browser/cdp_backend.py
@@ -157,7 +157,10 @@ class CdpBackend:
         try:
             attach = await self._cdp.send("Target.attachToTarget", {"targetId": target_id, "flatten": True})
         except BidiError as e:
-            raise BidiError("no such frame", e.message) from e
+            # Only a refusal means the target is gone. Relabelling a withheld response sends the daemon to re-derive and retry a wedged browser.
+            if e.code == "cdp error":
+                raise BidiError("no such frame", e.message) from e
+            raise
         session_id = attach["sessionId"]
         self._sessions[target_id] = session_id
         self._session_targets[session_id] = target_id

--- a/agent/skills/browser/cli/tests/test_cdp_backend.py
+++ b/agent/skills/browser/cli/tests/test_cdp_backend.py
@@ -271,6 +271,18 @@ async def _with_silent_transport(body):
         await server.stop()
 
 
+async def _with_silent_backend(body):
+    server = SilentCdpServer()
+    url = await server.start()
+    backend = CdpBackend()
+    await backend.connect(url)
+    try:
+        return await asyncio.wait_for(body(backend), timeout=HANG_GUARD_S)
+    finally:
+        await backend.close()
+        await server.stop()
+
+
 def test_withheld_cdp_response_raises_timeout_naming_the_method(monkeypatch):
     """A Chrome that accepts a command and never answers must error, not hang forever."""
     monkeypatch.setattr(cdp_backend, "_CDP_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
@@ -295,6 +307,20 @@ def test_timed_out_cdp_request_is_dropped_from_pending(monkeypatch):
         return dict(transport._pending)
 
     assert asyncio.run(_with_silent_transport(body)) == {}
+
+
+def test_wedged_attach_reports_timeout_not_a_retryable_frame_error(monkeypatch):
+    """A withheld attach means the browser is wedged; reporting 'no such frame' would send the daemon to re-derive and replay it."""
+    monkeypatch.setattr(cdp_backend, "_CDP_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
+
+    async def body(backend):
+        with pytest.raises(BidiError) as excinfo:
+            await backend.send("browsingContext.navigate", {"context": "T1", "url": "about:blank"})
+        return excinfo.value
+
+    error = asyncio.run(_with_silent_backend(body))
+    assert error.code == "timeout"
+    assert "Target.attachToTarget" in error.message
 
 
 def test_cancelled_cdp_request_is_dropped_from_pending():


### PR DESCRIPTION
Found while reviewing merged PR #1342.

#1342 correctly bounded `_CdpTransport.send` and taught it to raise `BidiError("timeout", ...)`. That new error class then flows into a pre-existing handler that was written when the only `BidiError` from `send` was a refusal from the browser, and that handler misreads it.

## The defect

`_session_for` wrapped **every** `BidiError` from `Target.attachToTarget` into `BidiError("no such frame")`:

```python
except BidiError as e:
    raise BidiError("no such frame", e.message) from e
```

`"no such frame"` is the one code the daemon treats as retryable (`daemon.py:227`):

```python
if e.code in ("no such frame", "no such node") and await self._rederive_context():
    ...  # replay the whole command
```

So a browser that accepts the attach and never answers now produces exactly the wrong response: the daemon re-derives the context (another CDP send, another response bound) and **replays the command against a browser that is already wedged**. Retrying a wedge is the one thing that cannot help.

It also defeats #1342's own goal. The point of raising `BidiError` rather than `TimeoutError` was that the CLI reaches the user with the method named. On this path the relabel burns a second and third response bound (attach 60s, then `browsingContext.getTree` 60s), so the daemon replies at ~120s, right at `admin.py`'s `DAEMON_RESPONSE_TIMEOUT_S` (120.0). The user races into the blunt socket error instead, and if `_rederive_context` succeeds the replay adds another 60s on top.

Verified against the real code before writing the fix, not inferred:

```
FINDING1: code='no such frame'  message="no response to 'Target.attachToTarget' within 0.2s"
FINDING1: daemon _handle_bidi would retry? True
```

## The fix

Only a refusal from the browser means the target is gone, so only `"cdp error"` (the code `_read_loop` sets for a genuine error response) is relabelled. Anything else propagates untouched. Failing closed on an unknown code is deliberate: a future code that does not mean "target gone" will surface as itself rather than be laundered into the retry path.

Scope is one handler. #1305's `open`/`new_tab` root cause stays untouched and open.

## Tests

One test, driving the **real** `CdpBackend` over the `SilentCdpServer` #1342 introduced: a withheld attach reports `code == "timeout"` naming `Target.attachToTarget`, not a retryable frame error.

Proven by mutation, not assumed:
- Reverting only this fix: `AssertionError: assert 'no such frame' == 'timeout'`.
- Reverting #1342's bounding logic (keeping the constant): all four transport tests fail, its three plus this one, so this PR does not weaken the coverage it builds on.
- `26 passed` with both in place.

## Fleet impact

None, and no migration. Skill CLI code only; no data paths, env vars, config keys, command surfaces, or sparse-cone entries move. `SKILL.md` frontmatter is unchanged, so `index.json` is unaffected. Boxes pick this up through the normal upstream-sync rebase.

## Checks

`./check.sh agent` and `./check.sh guards` both pass (exit 0).

## Not fixed here

Two further findings from the same review are filed separately rather than widening this PR: the domain-enable loop's `contextlib.suppress(BidiError)` silently swallowing the same timeout, and #1342's declared cancellation gap on `await self._ws.send(...)`.