### PR TITLE
fix(skills): bubble lint rejects any text after a full stop

### DIFF
--- a/agent/core/skills/app-chat/SKILL.md
+++ b/agent/core/skills/app-chat/SKILL.md
@@ -39,6 +39,7 @@ app-chat history --limit 20
 
 ## Notes
 - Always reply to app messages using `app-chat send`, not through any other channel
+- `send` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass
 - Send multiple short messages instead of one long one (like texting)
 - Lowercase, no bullets, keep messages tight — texting feel, not document feel
 - Messages render as markdown: use fenced ``` blocks for code/commands, `[label](url)` for links. Newlines work

--- a/agent/core/skills/app-chat/cli/src/app_chat_cli/bubblelint.py
+++ b/agent/core/skills/app-chat/cli/src/app_chat_cli/bubblelint.py
@@ -19,8 +19,14 @@ BUBBLE_MAX_CHARS = 220  # a genuinely long single bubble
 _URL_RE = re.compile(r"https?://\S+")  # urls
 _DECIMAL_RE = re.compile(r"\b\d+[.,]\d+\b")  # decimals: 8.6, 86,5
 _INITIALISM_RE = re.compile(r"\b(?:[A-Za-z]\.){2,}")  # initialisms: W.A.S.T.E., U.K.
+# Abbreviations, an allowlist, so an unlisted one reads as a full stop. Every entry is a word
+# that is always followed by more, never one that can end a thought: protecting "etc." or "min."
+# would blank the stop in "eggs, milk, etc. also bread" and let the wall through. Dotted forms
+# (e.g., a.m., U.K.) are absent because _INITIALISM_RE already covers them.
 _ABBR_RE = re.compile(
-    r"\b(?:mr|mrs|ms|dr|prof|st|vs|etc|e\.g|i\.e|a\.m|p\.m|u\.k|u\.s|approx|no|fig)\.",
+    r"\b(?:mr|mrs|ms|dr|prof|jr|sr|st|vs|approx|fig"
+    r"|jan|feb|mar|apr|jun|jul|aug|sept|sep|oct|nov|dec"
+    r"|inc|ltd|co|corp|ave|rd|blvd|vol|ch|pp)\.",
     re.IGNORECASE,
 )
 _ELLIPSIS_RE = re.compile(r"\.{3,}")  # ellipsis: a texting beat, not a full stop

--- a/agent/core/skills/app-chat/cli/src/app_chat_cli/bubblelint.py
+++ b/agent/core/skills/app-chat/cli/src/app_chat_cli/bubblelint.py
@@ -15,7 +15,6 @@ import re
 
 # A bubble is "a few words to one line, rarely two" (personality SKILL.md).
 BUBBLE_MAX_CHARS = 220  # a genuinely long single bubble
-BUBBLE_MAX_SENTENCES = 1  # 2+ sentence-enders in one send = a paragraph, split it
 
 _URL_RE = re.compile(r"https?://\S+")  # urls
 _DECIMAL_RE = re.compile(r"\b\d+[.,]\d+\b")  # decimals: 8.6, 86,5
@@ -24,50 +23,51 @@ _ABBR_RE = re.compile(
     r"\b(?:mr|mrs|ms|dr|prof|st|vs|etc|e\.g|i\.e|a\.m|p\.m|u\.k|u\.s|approx|no|fig)\.",
     re.IGNORECASE,
 )
+_ELLIPSIS_RE = re.compile(r"\.{3,}")  # ellipsis: a texting beat, not a full stop
 _ENDER_RE = re.compile(r"[.!?]+")
+
+_SPACE = " \t\r\n\v\f"
 
 
 def _strip_protected(text: str) -> str:
     """Blank out spans whose '.', '?' or '!' are not sentence boundaries."""
-    for rx in (_URL_RE, _DECIMAL_RE, _INITIALISM_RE, _ABBR_RE):
+    for rx in (_URL_RE, _DECIMAL_RE, _INITIALISM_RE, _ABBR_RE, _ELLIPSIS_RE):
         text = rx.sub(" ", text)
     return text
 
 
-def count_sentences(text: str) -> int:
-    """Count sentence-ending runs: terminal punctuation followed by whitespace
-    then an ASCII alphanumeric, or sitting at the end of the text."""
+def text_after_full_stop(text: str) -> bool:
+    """True when a '.', '!' or '?' has anything after it: the tell of a second
+    thought crammed into the same bubble.
+
+    A mark only reads as a full stop when whitespace follows it, so "main.py"
+    and "example.com" stay single thoughts.
+    """
     cleaned = _strip_protected(text).strip()
-    count = 0
     for match in _ENDER_RE.finditer(cleaned):
         rest = cleaned[match.end() :]
-        if rest == "":
-            count += 1
-            continue
-        trimmed = rest.lstrip(" \t\r\n\v\f")
-        if len(trimmed) == len(rest) or trimmed == "":
-            continue  # no whitespace gap, or nothing after it
-        first = trimmed[0]
-        if first.isascii() and first.isalnum():
-            count += 1
-    return count
+        trimmed = rest.lstrip(_SPACE)
+        if trimmed == "" or len(trimmed) == len(rest):
+            continue  # the mark ends the bubble, or no whitespace gap follows it
+        return True
+    return False
 
 
 def bubble_lint_reason(message: str) -> str:
     """Return a non-empty explanation when message is a wall (too many
-    characters, or too many sentences in one bubble), or "" if it passes."""
+    characters, or text carrying on past a full stop), or "" if it passes."""
     n_chars = len(message)
-    n_sent = count_sentences(message)
-    if n_chars <= BUBBLE_MAX_CHARS and n_sent <= BUBBLE_MAX_SENTENCES:
-        return ""
     why = []
     if n_chars > BUBBLE_MAX_CHARS:
         why.append(f"{n_chars} chars")
-    if n_sent > BUBBLE_MAX_SENTENCES:
-        why.append(f"{n_sent} sentences in one bubble")
+    if text_after_full_stop(message):
+        why.append("text after a full stop")
+    if not why:
+        return ""
     return (
-        "bubble lint: this send is a wall (" + ", ".join(why) + "). texting rule: short bubbles, one thought per send. split it into "
-        "several separate send calls, a beat between each, one idea each. if this "
-        "is genuine reference material (a brief, a code block, a list they asked "
-        "for), resend the same command with --longform to bypass."
+        "bubble lint: this send is a wall (" + ", ".join(why) + "). texting rule: short bubbles, one thought per send, and don't use "
+        "full stops at all. split it into several separate send calls, a beat between "
+        "each, one idea each. if this is genuine reference material (a brief, a code "
+        "block, a list they asked for), resend the same command with --longform to "
+        "bypass."
     )

--- a/agent/core/skills/app-chat/cli/tests/test_bubblelint.py
+++ b/agent/core/skills/app-chat/cli/tests/test_bubblelint.py
@@ -1,30 +1,40 @@
 """Mirrors telegram/whatsapp cli/bubblelint_test.go for the app-chat Python port."""
 
-from app_chat_cli.bubblelint import bubble_lint_reason, count_sentences
+from app_chat_cli.bubblelint import bubble_lint_reason, text_after_full_stop
 
 
 def test_bubble_lint_passes():
-    # Short bubbles, one sentence, and protected spans (urls, decimals,
-    # initialisms, abbreviations) whose dots must not read as sentence breaks.
+    # Short bubbles that end at their one mark (or carry none at all), and the
+    # protected spans (urls, decimals, initialisms, abbreviations, ellipses)
+    # whose dots must not read as full stops.
     for msg in [
         "nope, nothing",
         "on it",
         "yep",
         "checked both folders, nothing from them either",
         "running late, see you at 8",
+        "done, anything else?",
+        "one thought.",
         "meet at 8.30 by the door",
         "the W.A.S.T.E. system is down",
         "see https://example.com/a.b.c for the details",
         "call Dr. Smith back today",
-        "done, anything else?",
+        "wait... what",
+        "hmm... ok",
+        "it's in main.py",
+        "check example.com later",
     ]:
         assert bubble_lint_reason(msg) == "", msg
 
 
 def test_bubble_lint_blocks():
     for msg in [
+        "hey. ok",
         "done. anything else?",
         "i checked the first folder. then the second one. nothing in either.",
+        "hey! how are you?",
+        "nice! on it",
+        "wait... what. ok",
         (
             "so the thing about the deploy is that it kept timing out on the build step "
             "and i had to bump the worker memory and also tweak the cache config and re-run "
@@ -34,15 +44,18 @@ def test_bubble_lint_blocks():
         assert bubble_lint_reason(msg) != "", msg
 
 
-def test_count_sentences():
+def test_text_after_full_stop():
     for msg, want in [
-        ("one thought", 0),
-        ("one thought.", 1),
-        ("first. second.", 2),
-        ("first. second. third.", 3),
-        ("meet at 8.30 sharp", 0),
-        ("the U.K. office opens at 9", 0),
-        ("check https://a.com/x.y now", 0),
-        ("e.g. this should not count", 0),
+        ("one thought", False),
+        ("one thought.", False),
+        ("hey. ok", True),
+        ("first. second.", True),
+        ("first. second. third.", True),
+        ("meet at 8.30 sharp", False),
+        ("the U.K. office opens at 9", False),
+        ("check https://a.com/x.y now", False),
+        ("e.g. this should not count", False),
+        ("wait... what", False),
+        ("wait...", False),
     ]:
-        assert count_sentences(msg) == want, msg
+        assert text_after_full_stop(msg) is want, msg

--- a/agent/core/skills/app-chat/cli/tests/test_bubblelint.py
+++ b/agent/core/skills/app-chat/cli/tests/test_bubblelint.py
@@ -19,6 +19,11 @@ def test_bubble_lint_passes():
         "the W.A.S.T.E. system is down",
         "see https://example.com/a.b.c for the details",
         "call Dr. Smith back today",
+        "meet on Jan. 5",
+        "call Acme Inc. tomorrow",
+        "it's on Oxford Ave. somewhere",
+        "ask Jr. about it",
+        "see vol. 3 for that",
         "wait... what",
         "hmm... ok",
         "it's in main.py",
@@ -35,6 +40,11 @@ def test_bubble_lint_blocks():
         "hey! how are you?",
         "nice! on it",
         "wait... what. ok",
+        # An abbreviation that can end a thought would hide these walls, so none is protected.
+        "the answer is no. anyway i tried",
+        "eggs, milk, etc. also bread",
+        "one sec. i'll check",
+        "takes 20 min. i'll wait",
         (
             "so the thing about the deploy is that it kept timing out on the build step "
             "and i had to bump the worker memory and also tweak the cache config and re-run "

--- a/agent/skills/telegram/SKILL.md
+++ b/agent/skills/telegram/SKILL.md
@@ -63,7 +63,7 @@ Notification types written for the agent: `message`, `callback_query` (button ta
 reactions via `react` works). Aliases: `send`/`edit`/`del`/`voice`/`action`/`pin`/`unpin`.
 
 ## Notes
-- `send-message` enforces short-bubble texting: a wall (over ~220 chars, or 3+ sentences in one bubble) is rejected so you re-send as several short calls, one thought each. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. `--message-file` sends are linted too, so `--longform` is the only escape hatch.
+- `send-message` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. `--message-file` sends are linted too, so `--longform` is the only escape hatch.
 - Chat IDs are numeric (e.g., `123456789` for private, `-1001234567890` for groups)
 - Users must `/start` the bot before it can message them
 - Recipients can be resolved by: contact name, @username, or numeric chat ID

--- a/agent/skills/telegram/cli/bubblelint.go
+++ b/agent/skills/telegram/cli/bubblelint.go
@@ -1,26 +1,32 @@
 package main
 
 // Bubble lint: catch wall-of-text chat sends before they reach the recipient.
-// The "text in short bubbles, one thought per send" rule is enforced here at
-// send time rather than left to the personality preset: a rule the agent must
-// remember to apply is the weakest enforcement and regresses into blocks that
-// read like an assistant, not a person. Linting the one place every send passes
-// through makes it structural: a wall is rejected with the reason, so the agent
-// re-sends as several short calls with its own break points. The single bypass
-// is `--longform` (reference material the user asked for); `--message-file` sends are linted too.
+//
+// Why this lives in the CLI: the "text in short bubbles, one thought per send"
+// rule lived only in the personality preset, a rule the agent had to remember to
+// enact on every message, and it kept regressing into one multi-sentence block
+// that reads like an assistant, not a person. A rule that must be remembered is
+// the weakest enforcement. Checking at send time, in the one place every send
+// passes through, makes it structural: a wall is rejected with the reason, so the
+// agent re-sends as several short calls and chooses its own break points (it
+// trains the behaviour rather than mechanically chunking the text).
+//
+// The single bypass is the `--longform` flag, for genuine reference material the
+// user asked for (a brief, a code block, a list). It is deliberately the only
+// escape hatch: routing a wall through `--message-file` is exactly the regression
+// this guards against, so file-sourced sends are linted too.
 
 import (
 	"fmt"
 	"regexp"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 )
 
 // A bubble is "a few words to one line, rarely two" (personality SKILL.md).
 const (
-	bubbleMaxChars     = 220 // a genuinely long single bubble
-	bubbleMaxSentences = 1   // 2+ sentence-enders in one send = a paragraph, split it
+	bubbleMaxChars = 220           // a genuinely long single bubble
+	bubbleSpace    = " \t\r\n\v\f" // the gap that makes a mark read as a full stop
 )
 
 var (
@@ -28,58 +34,54 @@ var (
 	bubbleDecimalRe    = regexp.MustCompile(`\b\d+[.,]\d+\b`)       // decimals: 8.6, 86,5
 	bubbleInitialismRe = regexp.MustCompile(`\b(?:[A-Za-z]\.){2,}`) // initialisms: W.A.S.T.E., U.K.
 	bubbleAbbrRe       = regexp.MustCompile(`(?i)\b(?:mr|mrs|ms|dr|prof|st|vs|etc|e\.g|i\.e|a\.m|p\.m|u\.k|u\.s|approx|no|fig)\.`)
+	bubbleEllipsisRe   = regexp.MustCompile(`\.{3,}`) // ellipsis: a texting beat, not a full stop
 	bubbleEnderRe      = regexp.MustCompile(`[.!?]+`)
 )
 
-// stripProtected blanks out spans whose '.', '?' or '!' are not sentence
-// boundaries, so they do not inflate the sentence count.
+// stripProtected blanks out spans whose '.', '?' or '!' are not full stops, so
+// they cannot trip the lint.
 func stripProtected(text string) string {
-	for _, re := range []*regexp.Regexp{bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe} {
+	for _, re := range []*regexp.Regexp{bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe, bubbleEllipsisRe} {
 		text = re.ReplaceAllString(text, " ")
 	}
 	return text
 }
 
-// countSentences counts sentence-ending runs: terminal punctuation followed by
-// whitespace and then an ASCII alphanumeric, or sitting at the end of the text.
-func countSentences(text string) int {
+// textAfterFullStop reports whether a '.', '!' or '?' has anything after it: the
+// tell of a second thought crammed into the same bubble. A mark only reads as a
+// full stop when whitespace follows it, so "main.py" and "example.com" stay
+// single thoughts.
+func textAfterFullStop(text string) bool {
 	cleaned := strings.TrimSpace(stripProtected(text))
-	count := 0
 	for _, loc := range bubbleEnderRe.FindAllStringIndex(cleaned, -1) {
 		rest := cleaned[loc[1]:]
-		if rest == "" {
-			count++
-			continue
+		trimmed := strings.TrimLeft(rest, bubbleSpace)
+		if trimmed == "" || len(trimmed) == len(rest) {
+			continue // the mark ends the bubble, or no whitespace gap follows it
 		}
-		trimmed := strings.TrimLeft(rest, " \t\r\n\v\f")
-		if len(trimmed) == len(rest) || trimmed == "" {
-			continue // no whitespace gap, or nothing after it
-		}
-		if r := rune(trimmed[0]); r < utf8.RuneSelf && (unicode.IsLetter(r) || unicode.IsDigit(r)) {
-			count++
-		}
+		return true
 	}
-	return count
+	return false
 }
 
 // bubbleLintReason returns a non-empty explanation when message is a wall (too
-// many characters, or too many sentences crammed into one bubble), or "" if it
-// passes. The caller turns a non-empty reason into an error that blocks the send.
+// many characters, or text carrying on past a full stop), or "" if it passes.
+// The caller turns a non-empty reason into an error that blocks the send.
 func bubbleLintReason(message string) string {
 	nChars := utf8.RuneCountInString(message)
-	nSent := countSentences(message)
-	if nChars <= bubbleMaxChars && nSent <= bubbleMaxSentences {
-		return ""
-	}
 	var why []string
 	if nChars > bubbleMaxChars {
 		why = append(why, fmt.Sprintf("%d chars", nChars))
 	}
-	if nSent > bubbleMaxSentences {
-		why = append(why, fmt.Sprintf("%d sentences in one bubble", nSent))
+	if textAfterFullStop(message) {
+		why = append(why, "text after a full stop")
+	}
+	if len(why) == 0 {
+		return ""
 	}
 	return "bubble lint: this send is a wall (" + strings.Join(why, ", ") + "). " +
-		"texting rule: short bubbles, one thought per send. split it into several separate send calls, " +
-		"a beat between each, one idea each. if this is genuine reference material (a brief, a code block, " +
-		"a list they asked for), resend the same command with --longform to bypass."
+		"texting rule: short bubbles, one thought per send, and don't use full stops at all. " +
+		"split it into several separate send calls, a beat between each, one idea each. if this " +
+		"is genuine reference material (a brief, a code block, a list they asked for), resend the " +
+		"same command with --longform to bypass."
 }

--- a/agent/skills/telegram/cli/bubblelint.go
+++ b/agent/skills/telegram/cli/bubblelint.go
@@ -1,20 +1,13 @@
 package main
 
 // Bubble lint: catch wall-of-text chat sends before they reach the recipient.
-//
-// Why this lives in the CLI: the "text in short bubbles, one thought per send"
-// rule lived only in the personality preset, a rule the agent had to remember to
-// enact on every message, and it kept regressing into one multi-sentence block
-// that reads like an assistant, not a person. A rule that must be remembered is
-// the weakest enforcement. Checking at send time, in the one place every send
-// passes through, makes it structural: a wall is rejected with the reason, so the
-// agent re-sends as several short calls and chooses its own break points (it
-// trains the behaviour rather than mechanically chunking the text).
-//
-// The single bypass is the `--longform` flag, for genuine reference material the
-// user asked for (a brief, a code block, a list). It is deliberately the only
-// escape hatch: routing a wall through `--message-file` is exactly the regression
-// this guards against, so file-sourced sends are linted too.
+// The "text in short bubbles, one thought per send" rule is enforced here at
+// send time rather than left to the personality preset: a rule the agent must
+// remember to apply is the weakest enforcement and regresses into blocks that
+// read like an assistant, not a person. Linting the one place every send passes
+// through makes it structural: a wall is rejected with the reason, so the agent
+// re-sends as several short calls with its own break points. The single bypass
+// is `--longform` (reference material the user asked for); `--message-file` sends are linted too.
 
 import (
 	"fmt"
@@ -33,9 +26,15 @@ var (
 	bubbleURLRe        = regexp.MustCompile(`https?://\S+`)         // urls
 	bubbleDecimalRe    = regexp.MustCompile(`\b\d+[.,]\d+\b`)       // decimals: 8.6, 86,5
 	bubbleInitialismRe = regexp.MustCompile(`\b(?:[A-Za-z]\.){2,}`) // initialisms: W.A.S.T.E., U.K.
-	bubbleAbbrRe       = regexp.MustCompile(`(?i)\b(?:mr|mrs|ms|dr|prof|st|vs|etc|e\.g|i\.e|a\.m|p\.m|u\.k|u\.s|approx|no|fig)\.`)
-	bubbleEllipsisRe   = regexp.MustCompile(`\.{3,}`) // ellipsis: a texting beat, not a full stop
-	bubbleEnderRe      = regexp.MustCompile(`[.!?]+`)
+	// Abbreviations, an allowlist, so an unlisted one reads as a full stop. Every entry is a word
+	// that is always followed by more, never one that can end a thought: protecting "etc." or "min."
+	// would blank the stop in "eggs, milk, etc. also bread" and let the wall through. Dotted forms
+	// (e.g., a.m., U.K.) are absent because bubbleInitialismRe already covers them.
+	bubbleAbbrRe = regexp.MustCompile(`(?i)\b(?:mr|mrs|ms|dr|prof|jr|sr|st|vs|approx|fig` +
+		`|jan|feb|mar|apr|jun|jul|aug|sept|sep|oct|nov|dec` +
+		`|inc|ltd|co|corp|ave|rd|blvd|vol|ch|pp)\.`)
+	bubbleEllipsisRe = regexp.MustCompile(`\.{3,}`) // ellipsis: a texting beat, not a full stop
+	bubbleEnderRe    = regexp.MustCompile(`[.!?]+`)
 )
 
 // stripProtected blanks out spans whose '.', '?' or '!' are not full stops, so

--- a/agent/skills/telegram/cli/bubblelint_test.go
+++ b/agent/skills/telegram/cli/bubblelint_test.go
@@ -3,20 +3,26 @@ package main
 import "testing"
 
 // TestBubbleLintPasses pins the sends that must reach the recipient untouched:
-// short bubbles, one sentence, and the protected spans (urls, decimals,
-// initialisms, abbreviations) whose dots must not read as sentence breaks.
+// short bubbles that end at their one mark (or carry none at all), and the
+// protected spans (urls, decimals, initialisms, abbreviations, ellipses) whose
+// dots must not read as full stops.
 func TestBubbleLintPasses(t *testing.T) {
 	cases := []string{
 		"nope, nothing",
 		"on it",
 		"yep",
 		"checked both folders, nothing from them either",
-		"running late, see you at 8",                    // a decimal-free single thought
-		"meet at 8.30 by the door",                      // decimal must not split into two sentences
+		"running late, see you at 8",
+		"done, anything else?",                          // a trailing mark ends the bubble
+		"one thought.",                                  // a trailing full stop ends the bubble
+		"meet at 8.30 by the door",                      // decimal must not read as a full stop
 		"the W.A.S.T.E. system is down",                 // initialism protected
 		"see https://example.com/a.b.c for the details", // url protected
 		"call Dr. Smith back today",                     // abbreviation protected
-		"done, anything else?",                          // single sentence is allowed
+		"wait... what",                                  // ellipsis is a beat, not a full stop
+		"hmm... ok",                                     // ellipsis is a beat, not a full stop
+		"it's in main.py",                               // no whitespace gap, so not a full stop
+		"check example.com later",                       // no whitespace gap, so not a full stop
 	}
 	for _, msg := range cases {
 		if reason := bubbleLintReason(msg); reason != "" {
@@ -26,14 +32,18 @@ func TestBubbleLintPasses(t *testing.T) {
 }
 
 // TestBubbleLintBlocks pins the walls that must be rejected so the agent re-sends
-// as several short bubbles.
+// as several short bubbles. Anything past a full stop is a second thought.
 func TestBubbleLintBlocks(t *testing.T) {
 	cases := []struct {
 		name string
 		msg  string
 	}{
+		{"text after a full stop", "hey. ok"},
 		{"two sentences in one bubble", "done. anything else?"},
 		{"three sentences in one bubble", "i checked the first folder. then the second one. nothing in either."},
+		{"text after a question mark", "hey! how are you?"},
+		{"text after an exclamation mark", "nice! on it"},
+		{"ellipsis does not license a later full stop", "wait... what. ok"},
 		{"long single sentence", "so the thing about the deploy is that it kept timing out on the build step and i had to bump the worker memory and also tweak the cache config and re-run it twice and then clear the layer cache before it finally went green for us this afternoon"},
 	}
 	for _, c := range cases {
@@ -43,25 +53,28 @@ func TestBubbleLintBlocks(t *testing.T) {
 	}
 }
 
-// TestCountSentences pins the sentence counter directly, including the protected
-// spans that must not inflate the count.
-func TestCountSentences(t *testing.T) {
+// TestTextAfterFullStop pins the detector directly, including the protected
+// spans that must not read as full stops.
+func TestTextAfterFullStop(t *testing.T) {
 	cases := []struct {
 		msg  string
-		want int
+		want bool
 	}{
-		{"one thought", 0},
-		{"one thought.", 1},
-		{"first. second.", 2},
-		{"first. second. third.", 3},
-		{"meet at 8.30 sharp", 0},
-		{"the U.K. office opens at 9", 0},
-		{"check https://a.com/x.y now", 0},
-		{"e.g. this should not count", 0},
+		{"one thought", false},
+		{"one thought.", false},
+		{"hey. ok", true},
+		{"first. second.", true},
+		{"first. second. third.", true},
+		{"meet at 8.30 sharp", false},
+		{"the U.K. office opens at 9", false},
+		{"check https://a.com/x.y now", false},
+		{"e.g. this should not count", false},
+		{"wait... what", false},
+		{"wait...", false},
 	}
 	for _, c := range cases {
-		if got := countSentences(c.msg); got != c.want {
-			t.Errorf("countSentences(%q) = %d, want %d", c.msg, got, c.want)
+		if got := textAfterFullStop(c.msg); got != c.want {
+			t.Errorf("textAfterFullStop(%q) = %v, want %v", c.msg, got, c.want)
 		}
 	}
 }

--- a/agent/skills/telegram/cli/bubblelint_test.go
+++ b/agent/skills/telegram/cli/bubblelint_test.go
@@ -19,6 +19,11 @@ func TestBubbleLintPasses(t *testing.T) {
 		"the W.A.S.T.E. system is down",                 // initialism protected
 		"see https://example.com/a.b.c for the details", // url protected
 		"call Dr. Smith back today",                     // abbreviation protected
+		"meet on Jan. 5",                                // month abbreviation protected
+		"call Acme Inc. tomorrow",                       // company abbreviation protected
+		"it's on Oxford Ave. somewhere",                 // street abbreviation protected
+		"ask Jr. about it",                              // name suffix protected
+		"see vol. 3 for that",                           // reference abbreviation protected
 		"wait... what",                                  // ellipsis is a beat, not a full stop
 		"hmm... ok",                                     // ellipsis is a beat, not a full stop
 		"it's in main.py",                               // no whitespace gap, so not a full stop
@@ -44,6 +49,11 @@ func TestBubbleLintBlocks(t *testing.T) {
 		{"text after a question mark", "hey! how are you?"},
 		{"text after an exclamation mark", "nice! on it"},
 		{"ellipsis does not license a later full stop", "wait... what. ok"},
+		// An abbreviation that can end a thought would hide these walls, so none is protected.
+		{"no. is not protected", "the answer is no. anyway i tried"},
+		{"etc. is not protected", "eggs, milk, etc. also bread"},
+		{"sec. is not protected", "one sec. i'll check"},
+		{"min. is not protected", "takes 20 min. i'll wait"},
 		{"long single sentence", "so the thing about the deploy is that it kept timing out on the build step and i had to bump the worker memory and also tweak the cache config and re-run it twice and then clear the layer cache before it finally went green for us this afternoon"},
 	}
 	for _, c := range cases {

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -15,7 +15,7 @@ description: WhatsApp messages, contacts, groups, and live voice calls (place/an
 - Flags for a specific subcommand: `whatsapp <subcommand> --help`. The top-level `whatsapp` with no args prints the command list.
 - Names for `--to` / `--chat-id` / `--group`: contact name, phone (`+E.164`), group name, or JID - the CLI resolves them.
 - For `send-message`, prefer `--message-file <path>` (or `--message-file -` / `--message -` to read from stdin) when the body contains apostrophes, quotes, backticks, `$(...)`, or multiple lines: an inline `--message 'text'` lets the shell mangle or even evaluate it.
-- `send-message` enforces short-bubble texting: a wall (over ~220 chars, or 3+ sentences in one bubble) is rejected so you re-send as several short calls, one thought each. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. This applies to `--message-file` sends too, so `--longform` is the only escape hatch.
+- `send-message` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. This applies to `--message-file` sends too, so `--longform` is the only escape hatch.
 
 ## Reply / Quote
 ```bash

--- a/agent/skills/whatsapp/cli/bubblelint.go
+++ b/agent/skills/whatsapp/cli/bubblelint.go
@@ -1,26 +1,32 @@
 package main
 
 // Bubble lint: catch wall-of-text chat sends before they reach the recipient.
-// The "text in short bubbles, one thought per send" rule is enforced here at
-// send time rather than left to the personality preset: a rule the agent must
-// remember to apply is the weakest enforcement and regresses into blocks that
-// read like an assistant, not a person. Linting the one place every send passes
-// through makes it structural: a wall is rejected with the reason, so the agent
-// re-sends as several short calls with its own break points. The single bypass
-// is `--longform` (reference material the user asked for); `--message-file` sends are linted too.
+//
+// Why this lives in the CLI: the "text in short bubbles, one thought per send"
+// rule lived only in the personality preset, a rule the agent had to remember to
+// enact on every message, and it kept regressing into one multi-sentence block
+// that reads like an assistant, not a person. A rule that must be remembered is
+// the weakest enforcement. Checking at send time, in the one place every send
+// passes through, makes it structural: a wall is rejected with the reason, so the
+// agent re-sends as several short calls and chooses its own break points (it
+// trains the behaviour rather than mechanically chunking the text).
+//
+// The single bypass is the `--longform` flag, for genuine reference material the
+// user asked for (a brief, a code block, a list). It is deliberately the only
+// escape hatch: routing a wall through `--message-file` is exactly the regression
+// this guards against, so file-sourced sends are linted too.
 
 import (
 	"fmt"
 	"regexp"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 )
 
 // A bubble is "a few words to one line, rarely two" (personality SKILL.md).
 const (
-	bubbleMaxChars     = 220 // a genuinely long single bubble
-	bubbleMaxSentences = 1   // 2+ sentence-enders in one send = a paragraph, split it
+	bubbleMaxChars = 220           // a genuinely long single bubble
+	bubbleSpace    = " \t\r\n\v\f" // the gap that makes a mark read as a full stop
 )
 
 var (
@@ -28,58 +34,54 @@ var (
 	bubbleDecimalRe    = regexp.MustCompile(`\b\d+[.,]\d+\b`)       // decimals: 8.6, 86,5
 	bubbleInitialismRe = regexp.MustCompile(`\b(?:[A-Za-z]\.){2,}`) // initialisms: W.A.S.T.E., U.K.
 	bubbleAbbrRe       = regexp.MustCompile(`(?i)\b(?:mr|mrs|ms|dr|prof|st|vs|etc|e\.g|i\.e|a\.m|p\.m|u\.k|u\.s|approx|no|fig)\.`)
+	bubbleEllipsisRe   = regexp.MustCompile(`\.{3,}`) // ellipsis: a texting beat, not a full stop
 	bubbleEnderRe      = regexp.MustCompile(`[.!?]+`)
 )
 
-// stripProtected blanks out spans whose '.', '?' or '!' are not sentence
-// boundaries, so they do not inflate the sentence count.
+// stripProtected blanks out spans whose '.', '?' or '!' are not full stops, so
+// they cannot trip the lint.
 func stripProtected(text string) string {
-	for _, re := range []*regexp.Regexp{bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe} {
+	for _, re := range []*regexp.Regexp{bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe, bubbleEllipsisRe} {
 		text = re.ReplaceAllString(text, " ")
 	}
 	return text
 }
 
-// countSentences counts sentence-ending runs: terminal punctuation followed by
-// whitespace and then an ASCII alphanumeric, or sitting at the end of the text.
-func countSentences(text string) int {
+// textAfterFullStop reports whether a '.', '!' or '?' has anything after it: the
+// tell of a second thought crammed into the same bubble. A mark only reads as a
+// full stop when whitespace follows it, so "main.py" and "example.com" stay
+// single thoughts.
+func textAfterFullStop(text string) bool {
 	cleaned := strings.TrimSpace(stripProtected(text))
-	count := 0
 	for _, loc := range bubbleEnderRe.FindAllStringIndex(cleaned, -1) {
 		rest := cleaned[loc[1]:]
-		if rest == "" {
-			count++
-			continue
+		trimmed := strings.TrimLeft(rest, bubbleSpace)
+		if trimmed == "" || len(trimmed) == len(rest) {
+			continue // the mark ends the bubble, or no whitespace gap follows it
 		}
-		trimmed := strings.TrimLeft(rest, " \t\r\n\v\f")
-		if len(trimmed) == len(rest) || trimmed == "" {
-			continue // no whitespace gap, or nothing after it
-		}
-		if r := rune(trimmed[0]); r < utf8.RuneSelf && (unicode.IsLetter(r) || unicode.IsDigit(r)) {
-			count++
-		}
+		return true
 	}
-	return count
+	return false
 }
 
 // bubbleLintReason returns a non-empty explanation when message is a wall (too
-// many characters, or too many sentences crammed into one bubble), or "" if it
-// passes. The caller turns a non-empty reason into an error that blocks the send.
+// many characters, or text carrying on past a full stop), or "" if it passes.
+// The caller turns a non-empty reason into an error that blocks the send.
 func bubbleLintReason(message string) string {
 	nChars := utf8.RuneCountInString(message)
-	nSent := countSentences(message)
-	if nChars <= bubbleMaxChars && nSent <= bubbleMaxSentences {
-		return ""
-	}
 	var why []string
 	if nChars > bubbleMaxChars {
 		why = append(why, fmt.Sprintf("%d chars", nChars))
 	}
-	if nSent > bubbleMaxSentences {
-		why = append(why, fmt.Sprintf("%d sentences in one bubble", nSent))
+	if textAfterFullStop(message) {
+		why = append(why, "text after a full stop")
+	}
+	if len(why) == 0 {
+		return ""
 	}
 	return "bubble lint: this send is a wall (" + strings.Join(why, ", ") + "). " +
-		"texting rule: short bubbles, one thought per send. split it into several separate send calls, " +
-		"a beat between each, one idea each. if this is genuine reference material (a brief, a code block, " +
-		"a list they asked for), resend the same command with --longform to bypass."
+		"texting rule: short bubbles, one thought per send, and don't use full stops at all. " +
+		"split it into several separate send calls, a beat between each, one idea each. if this " +
+		"is genuine reference material (a brief, a code block, a list they asked for), resend the " +
+		"same command with --longform to bypass."
 }

--- a/agent/skills/whatsapp/cli/bubblelint.go
+++ b/agent/skills/whatsapp/cli/bubblelint.go
@@ -1,20 +1,13 @@
 package main
 
 // Bubble lint: catch wall-of-text chat sends before they reach the recipient.
-//
-// Why this lives in the CLI: the "text in short bubbles, one thought per send"
-// rule lived only in the personality preset, a rule the agent had to remember to
-// enact on every message, and it kept regressing into one multi-sentence block
-// that reads like an assistant, not a person. A rule that must be remembered is
-// the weakest enforcement. Checking at send time, in the one place every send
-// passes through, makes it structural: a wall is rejected with the reason, so the
-// agent re-sends as several short calls and chooses its own break points (it
-// trains the behaviour rather than mechanically chunking the text).
-//
-// The single bypass is the `--longform` flag, for genuine reference material the
-// user asked for (a brief, a code block, a list). It is deliberately the only
-// escape hatch: routing a wall through `--message-file` is exactly the regression
-// this guards against, so file-sourced sends are linted too.
+// The "text in short bubbles, one thought per send" rule is enforced here at
+// send time rather than left to the personality preset: a rule the agent must
+// remember to apply is the weakest enforcement and regresses into blocks that
+// read like an assistant, not a person. Linting the one place every send passes
+// through makes it structural: a wall is rejected with the reason, so the agent
+// re-sends as several short calls with its own break points. The single bypass
+// is `--longform` (reference material the user asked for); `--message-file` sends are linted too.
 
 import (
 	"fmt"
@@ -33,9 +26,15 @@ var (
 	bubbleURLRe        = regexp.MustCompile(`https?://\S+`)         // urls
 	bubbleDecimalRe    = regexp.MustCompile(`\b\d+[.,]\d+\b`)       // decimals: 8.6, 86,5
 	bubbleInitialismRe = regexp.MustCompile(`\b(?:[A-Za-z]\.){2,}`) // initialisms: W.A.S.T.E., U.K.
-	bubbleAbbrRe       = regexp.MustCompile(`(?i)\b(?:mr|mrs|ms|dr|prof|st|vs|etc|e\.g|i\.e|a\.m|p\.m|u\.k|u\.s|approx|no|fig)\.`)
-	bubbleEllipsisRe   = regexp.MustCompile(`\.{3,}`) // ellipsis: a texting beat, not a full stop
-	bubbleEnderRe      = regexp.MustCompile(`[.!?]+`)
+	// Abbreviations, an allowlist, so an unlisted one reads as a full stop. Every entry is a word
+	// that is always followed by more, never one that can end a thought: protecting "etc." or "min."
+	// would blank the stop in "eggs, milk, etc. also bread" and let the wall through. Dotted forms
+	// (e.g., a.m., U.K.) are absent because bubbleInitialismRe already covers them.
+	bubbleAbbrRe = regexp.MustCompile(`(?i)\b(?:mr|mrs|ms|dr|prof|jr|sr|st|vs|approx|fig` +
+		`|jan|feb|mar|apr|jun|jul|aug|sept|sep|oct|nov|dec` +
+		`|inc|ltd|co|corp|ave|rd|blvd|vol|ch|pp)\.`)
+	bubbleEllipsisRe = regexp.MustCompile(`\.{3,}`) // ellipsis: a texting beat, not a full stop
+	bubbleEnderRe    = regexp.MustCompile(`[.!?]+`)
 )
 
 // stripProtected blanks out spans whose '.', '?' or '!' are not full stops, so

--- a/agent/skills/whatsapp/cli/bubblelint_test.go
+++ b/agent/skills/whatsapp/cli/bubblelint_test.go
@@ -3,20 +3,26 @@ package main
 import "testing"
 
 // TestBubbleLintPasses pins the sends that must reach the recipient untouched:
-// short bubbles, one sentence, and the protected spans (urls, decimals,
-// initialisms, abbreviations) whose dots must not read as sentence breaks.
+// short bubbles that end at their one mark (or carry none at all), and the
+// protected spans (urls, decimals, initialisms, abbreviations, ellipses) whose
+// dots must not read as full stops.
 func TestBubbleLintPasses(t *testing.T) {
 	cases := []string{
 		"nope, nothing",
 		"on it",
 		"yep",
 		"checked both folders, nothing from them either",
-		"running late, see you at 8",                    // a decimal-free single thought
-		"meet at 8.30 by the door",                      // decimal must not split into two sentences
+		"running late, see you at 8",
+		"done, anything else?",                          // a trailing mark ends the bubble
+		"one thought.",                                  // a trailing full stop ends the bubble
+		"meet at 8.30 by the door",                      // decimal must not read as a full stop
 		"the W.A.S.T.E. system is down",                 // initialism protected
 		"see https://example.com/a.b.c for the details", // url protected
 		"call Dr. Smith back today",                     // abbreviation protected
-		"done, anything else?",                          // single sentence is allowed
+		"wait... what",                                  // ellipsis is a beat, not a full stop
+		"hmm... ok",                                     // ellipsis is a beat, not a full stop
+		"it's in main.py",                               // no whitespace gap, so not a full stop
+		"check example.com later",                       // no whitespace gap, so not a full stop
 	}
 	for _, msg := range cases {
 		if reason := bubbleLintReason(msg); reason != "" {
@@ -26,14 +32,18 @@ func TestBubbleLintPasses(t *testing.T) {
 }
 
 // TestBubbleLintBlocks pins the walls that must be rejected so the agent re-sends
-// as several short bubbles.
+// as several short bubbles. Anything past a full stop is a second thought.
 func TestBubbleLintBlocks(t *testing.T) {
 	cases := []struct {
 		name string
 		msg  string
 	}{
+		{"text after a full stop", "hey. ok"},
 		{"two sentences in one bubble", "done. anything else?"},
 		{"three sentences in one bubble", "i checked the first folder. then the second one. nothing in either."},
+		{"text after a question mark", "hey! how are you?"},
+		{"text after an exclamation mark", "nice! on it"},
+		{"ellipsis does not license a later full stop", "wait... what. ok"},
 		{"long single sentence", "so the thing about the deploy is that it kept timing out on the build step and i had to bump the worker memory and also tweak the cache config and re-run it twice and then clear the layer cache before it finally went green for us this afternoon"},
 	}
 	for _, c := range cases {
@@ -43,25 +53,28 @@ func TestBubbleLintBlocks(t *testing.T) {
 	}
 }
 
-// TestCountSentences pins the sentence counter directly, including the protected
-// spans that must not inflate the count.
-func TestCountSentences(t *testing.T) {
+// TestTextAfterFullStop pins the detector directly, including the protected
+// spans that must not read as full stops.
+func TestTextAfterFullStop(t *testing.T) {
 	cases := []struct {
 		msg  string
-		want int
+		want bool
 	}{
-		{"one thought", 0},
-		{"one thought.", 1},
-		{"first. second.", 2},
-		{"first. second. third.", 3},
-		{"meet at 8.30 sharp", 0},
-		{"the U.K. office opens at 9", 0},
-		{"check https://a.com/x.y now", 0},
-		{"e.g. this should not count", 0},
+		{"one thought", false},
+		{"one thought.", false},
+		{"hey. ok", true},
+		{"first. second.", true},
+		{"first. second. third.", true},
+		{"meet at 8.30 sharp", false},
+		{"the U.K. office opens at 9", false},
+		{"check https://a.com/x.y now", false},
+		{"e.g. this should not count", false},
+		{"wait... what", false},
+		{"wait...", false},
 	}
 	for _, c := range cases {
-		if got := countSentences(c.msg); got != c.want {
-			t.Errorf("countSentences(%q) = %d, want %d", c.msg, got, c.want)
+		if got := textAfterFullStop(c.msg); got != c.want {
+			t.Errorf("textAfterFullStop(%q) = %v, want %v", c.msg, got, c.want)
 		}
 	}
 }

--- a/agent/skills/whatsapp/cli/bubblelint_test.go
+++ b/agent/skills/whatsapp/cli/bubblelint_test.go
@@ -19,6 +19,11 @@ func TestBubbleLintPasses(t *testing.T) {
 		"the W.A.S.T.E. system is down",                 // initialism protected
 		"see https://example.com/a.b.c for the details", // url protected
 		"call Dr. Smith back today",                     // abbreviation protected
+		"meet on Jan. 5",                                // month abbreviation protected
+		"call Acme Inc. tomorrow",                       // company abbreviation protected
+		"it's on Oxford Ave. somewhere",                 // street abbreviation protected
+		"ask Jr. about it",                              // name suffix protected
+		"see vol. 3 for that",                           // reference abbreviation protected
 		"wait... what",                                  // ellipsis is a beat, not a full stop
 		"hmm... ok",                                     // ellipsis is a beat, not a full stop
 		"it's in main.py",                               // no whitespace gap, so not a full stop
@@ -44,6 +49,11 @@ func TestBubbleLintBlocks(t *testing.T) {
 		{"text after a question mark", "hey! how are you?"},
 		{"text after an exclamation mark", "nice! on it"},
 		{"ellipsis does not license a later full stop", "wait... what. ok"},
+		// An abbreviation that can end a thought would hide these walls, so none is protected.
+		{"no. is not protected", "the answer is no. anyway i tried"},
+		{"etc. is not protected", "eggs, milk, etc. also bread"},
+		{"sec. is not protected", "one sec. i'll check"},
+		{"min. is not protected", "takes 20 min. i'll wait"},
 		{"long single sentence", "so the thing about the deploy is that it kept timing out on the build step and i had to bump the worker memory and also tweak the cache config and re-run it twice and then clear the layer cache before it finally went green for us this afternoon"},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
## What this PR does

Chat sends go through a bubble lint (`app-chat`, `telegram`, `whatsapp`) that rejects walls so the agent texts in short bubbles instead of assistant-style paragraphs. This PR closes a hole in it and tightens the rule to "one full stop, at the end, or none."

**The hole:** the lint counted sentence-enders and capped at one, which punished the *closing* full stop rather than the mid-bubble one:

- `hey. ok` scored **1** (only the `.` counts; `ok` carries no punctuation) and **passed**
- `hey. ok.` scored **2** and was blocked

So two thoughts in one bubble sailed through whenever the second ended bare, which is exactly how the agent texts.

**The change:** a `.`, `!` or `?` may only **close** a bubble, never carry text after it. `count_sentences`/`countSentences` and `BUBBLE_MAX_SENTENCES` are gone, replaced by `text_after_full_stop`. The 220-char cap is unchanged. The reason string now tells the agent not to use full stops at all.

All three CLIs stay in lockstep, and the docs now describe the lint identically (app-chat documented it nowhere; telegram/whatsapp both still said "3+ sentences in one bubble", stale since #1241 lowered the cap to 1).

---

## ⚠️ Open design question (please weigh in)

**This rule is fighting its own design, and I don't think this PR is the final form.** Writing it up here so the decision is visible rather than buried in a thread.

### The core tension

Every exception in this lint exists to answer one question: *is this dot a sentence boundary?* And that question only exists because we want to **allow** abbreviations like `Dr. Smith`. But `Dr. Smith` and `hey. ok` are structurally identical: word, dot, space, word. Nothing but a dictionary tells them apart.

So the moment we decide abbreviations must pass, we've signed up for a dictionary, and a dictionary is:

- **permanently incomplete** (`Jan.` works, `Aug.` works, the next one someone types won't), and
- **permanently hole-punching** (any entry that can *end a thought* hides a wall: protecting `no.` lets `the answer is no. anyway i tried` through).

That is not a bug in the list. It is the shape of the boundary-detection approach.

### What this PR settled for

I reshaped the allowlist around one criterion, **an entry earns its place only if it can never end a thought**, which is the best you can do *within* boundary detection:

- **Added** always-followed-by-more abbreviations the agent actually uses: months, `inc/ltd/co/corp`, `jr/sr`, `ave/rd/blvd`, `vol/ch/pp`.
- **Removed** the hole-punchers that shipped in the original list: `no`, `etc`, `min`, `hr`, `sec` now read as real stops, so `the answer is no. anyway i tried` is finally blocked.
- **Removed** `e.g/i.e/a.m/p.m/u.k/u.s`: the initialism regex already covers them (verified), so they were dead weight.

Net: 4 regexes + a ~27-token list, with no entry that can hide a wall. It works for every preset. But the list is still incomplete by construction and still needs maintenance forever.

### The alternative I'd lean toward (not in this PR)

**Invert the rule: ban full stops instead of detecting boundaries.** Young people don't write `Dr. Smith`, they write `dr smith`. If we never need to *allow* an abbreviation, we never need to *detect* a boundary, and the entire apparatus collapses to:

```python
_ELLIPSIS_RE  = re.compile(r"\.{2,}")       # a beat, not a stop
_FULL_STOP_RE = re.compile(r"\.(?:\s|$)")   # a dot with only space after it
# block if _FULL_STOP_RE matches after blanking ellipses
```

Two regexes, one exception (ellipsis), zero allowlist. `main.py`, `8.30`, `example.com`, URLs all pass for free (their dots aren't followed by a space). Every current hole closes for free (nothing is exempt). This is the literal reading of "text like young people do."

**Why it is not in this PR:** the lint is fleet-wide and preset-blind, but two shipped presets are *defined* by the register it would ban:

- `classic`: "Full punctuation: periods, commas, exclamation marks, question marks"
- `polished`: "Sentence case, proper punctuation"

Banning full stops makes **every send from those two presets fail**. The simple rule and those presets cannot coexist. Resolving that (rework or drop classic/polished, or make the lint preset-aware) is a product call bigger than this PR, so I've kept this PR to the safe-allowlist version and am flagging the fork.

### The three options on the table

| Option | Cost | Benefit |
|---|---|---|
| **A. Ban full stops** (2 regexes, no list) | Breaks `classic` + `polished` presets; needs a follow-up | Exactly "text like young people"; every hole closes for free; nothing to maintain |
| **B. Safe allowlist** (this PR) | ~27-token list, incomplete forever, needs upkeep | Works for every preset today; no false blocks on real abbreviations |
| **C. Char cap only** (delete the stop rule) | Stops enforcing one-thought-per-send (undoes the original ask) | Zero regexes, zero exceptions, zero holes |

My recommendation: **merge B now** (it strictly improves on master, closes the original hole, and unbreaks nothing), then decide A vs status quo separately once the preset question is settled.

---

## Behavior (verified by running the lint)

| Passes | Blocked |
|---|---|
| `on it` | `hey. ok` **(the hole, now closed)** |
| `nope, nothing` | `done. anything else?` |
| `done, anything else?` | `hey! how are you?` |
| `one thought.` | `nice! on it` |
| `wait, what?!` | `the answer is no. anyway i tried` **(new)** |
| `wait... what`, `hmm... ok` | `eggs, milk, etc. also bread` **(new)** |
| `it's in main.py` | `one sec. i'll check` **(new)** |
| `meet on Jan. 5`, `call Acme Inc. tomorrow` | `done. 👍` **(new)** |
| `call Dr. Smith back today` | `wait... what. ok` |
| `the U.K. office opens at 9`, `8 a.m. tomorrow` | a 244-char single sentence |
| `see https://example.com/a.b.c for it` | |

Newly rejected vs master: `hey. ok` (the point of the PR); the hole-puncher walls (`no.`/`etc.`/`sec.`/`min.`); and `done. 👍` / `hey. :)` (the old rule only counted a stop before an *alphanumeric*, so an emoji after a stop didn't register). All fix to the voice we want anyway.

## A mark only reads as a stop when whitespace follows it

`main.py`, `example.com`, `8.30` and URLs pass without any dedicated url/decimal rule involvement, because their dots have no following space. Ellipses are exempted (`wait... what`) as a texting beat.

## Scope

- `agent/core/skills/app-chat/` (Python) + its SKILL.md (lint was undocumented here)
- `agent/skills/telegram/cli/` (Go) + SKILL.md (was stale)
- `agent/skills/whatsapp/cli/` (Go) + SKILL.md (was stale)

## Testing

Rebased onto master (was 97 commits behind; conflicted in all six lint files, resolved). Tests in all three pin the new rule, the ellipsis exemption, the no-whitespace-gap cases, the added abbreviations, and the now-closed hole-puncher walls.

- `./check.sh agent` green (includes the app-chat CLI suite)
- `./check.sh whatsapp` green
- `./check.sh guards` green
- telegram `go test -tags fts5 ./...` green (telegram has no check.sh entry; note: its CLI is unit-tested but not wired into CI, unlike whatsapp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)