### PR TITLE
fix(release): unbreak and harden the delivery pipeline

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
   packages: read
+  # ci.yml (called below) requests pull-requests: read; a reusable workflow
+  # cannot request more than its caller grants, so grant it here too.
+  pull-requests: read
 
 concurrency:
   group: release-pipeline-${{ github.event.release.tag_name }}

--- a/release.sh
+++ b/release.sh
@@ -51,6 +51,42 @@ RUN_ID=$(gh run list --workflow=release.yml --limit=1 --json databaseId --jq '.[
 echo "Watching run ${RUN_ID}..."
 gh run watch "$RUN_ID" --exit-status
 
+# The prerelease is published; release-pipeline.yml now fires on that event to
+# build and deliver. It reverts its own runtime failures, but a run rejected at
+# validation never schedules jobs, so that in-pipeline revert can't fire and the
+# broken tag would linger. Watch the pipeline through startup and pull the beta
+# here if it never launches.
+TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+echo
+echo "Prerelease ${TAG} created. Confirming the delivery pipeline launches..."
+
+PIPELINE_ID=""
+for _ in $(seq 1 30); do
+  PIPELINE_ID=$(gh run list --workflow=release-pipeline.yml --event=release --limit 10 \
+    --json databaseId,displayTitle \
+    --jq "map(select(.displayTitle == \"${TAG}\")) | .[0].databaseId // empty")
+  [ -n "$PIPELINE_ID" ] && break
+  sleep 4
+done
+
+if [ -z "$PIPELINE_ID" ]; then
+  echo "Warning: no release-pipeline run found for ${TAG} yet; watch it in Actions."
+else
+  while true; do
+    read -r STATUS CONCLUSION <<<"$(gh run view "$PIPELINE_ID" --json status,conclusion --jq '"\(.status) \(.conclusion // "")"')"
+    if [ "$STATUS" = "completed" ] && [ "$CONCLUSION" = "startup_failure" ]; then
+      echo "The release pipeline for ${TAG} failed at startup, so its own cleanup never ran."
+      echo "Pulling the broken beta..."
+      gh workflow run unrelease.yml -f tag="$TAG"
+      echo "Fix the workflow, then re-run ./release.sh."
+      exit 1
+    fi
+    [ "$STATUS" = "queued" ] || break
+    sleep 5
+  done
+  echo "Pipeline launched for ${TAG}; it owns delivery and cleanup from here."
+fi
+
 cat <<'EOF'
 
 This ships a BETA (prerelease). Only opted-in beta clients receive it; stable users


### PR DESCRIPTION
## Problem

The `Release pipeline` (added in #1355) failed at **startup** on its first-ever release run (`v0.1.178`), so no delivery jobs ran, and neither did the pipeline's own auto-revert:

> `.github/workflows/release-pipeline.yml (Line: 44): Error calling workflow 'ci.yml'. The workflow is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.`

`release-pipeline.yml` calls `ci.yml` as a reusable workflow, but its top-level `permissions` granted only `contents: read` + `packages: read`. `ci.yml` declares `pull-requests: read`, and a reusable workflow cannot request more permission than its caller grants, so GitHub rejects the whole run before any job starts.

Worse, the safety net that should have caught this lives *inside* the workflow that couldn't parse: `revert-failed-release` has `if: failure()`, but a `startup_failure` never schedules jobs, so it can't fire. The result was a published `v0.1.178` beta with zero artifacts and an unreverted version bump on master. `release.sh` compounded it by watching only the prerelease-creation run and then printing "shipped a BETA".

## Fix (two commits, one concern: delivery-pipeline reliability)

1. **`release-pipeline.yml`**: add `pull-requests: read` to top-level `permissions` so the `ci.yml` call validates. (`live-tests.yml`, also called, only needs `contents`+`packages`, already granted.) Verified with `actionlint`.
2. **`release.sh`**: after the prerelease is published, watch the delivery pipeline through startup. If it never launches (`startup_failure`), pull the beta via the unrelease workflow and exit non-zero, instead of silently reporting success. This closes the structural gap an in-pipeline revert cannot cover: a workflow can't guard its own parse. Verified with `shellcheck -S warning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)