### PR TITLE
fix(ci): check out the repo in the unrelease workflow

### DIFF
--- a/.github/workflows/unrelease.yml
+++ b/.github/workflows/unrelease.yml
@@ -28,6 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # The "Delete ghcr image tag" step runs scripts/delete-ghcr-tag.sh, so the
+      # repo must be checked out or that step exits 127 and aborts the cleanup.
+      - uses: actions/checkout@v7
+
       - name: Validate tag is an existing prerelease
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
## Problem

`./unrelease.sh v0.1.178` failed: the `Unrelease` job's "Delete ghcr image tag" step exited **127** (`scripts/delete-ghcr-tag.sh` not found), which aborted the job and skipped the actual "Delete release and git tag" step, so the broken beta stayed published.

Root cause: `unrelease.yml` (rewritten in #1355) has **no `actions/checkout` step**, so the repo's scripts aren't on the runner. The step's comment says failures should "only warn", but it lacks `continue-on-error`, so a `127` is fatal.

## Fix

Add `actions/checkout@v7` as the job's first step so `scripts/delete-ghcr-tag.sh` is present. No `continue-on-error` needed: the script is already best-effort (it `exit 0`s on every failure path, including no-image-found), so with the checkout in place the step succeeds even when there's nothing to clean.

Verified with `actionlint`.

Note: `v0.1.178` was already pulled manually (release + tag deleted; no GHCR image existed) to unblock the re-release. This fixes the tool for next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)