### PR TITLE
fix(ci): install mobile deps before the TestFlight delivery reads the config

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -256,6 +256,13 @@ jobs:
           packager: npm
           token: ${{ secrets.EXPO_TOKEN }}
 
+      # eas workflow:run reads apps/mobile/app.config.ts locally, which needs the
+      # workspace's TypeScript toolchain installed or the read fails.
+      - name: Install mobile deps
+        run: |
+          npm --prefix apps ci
+          npm --prefix apps/mobile ci
+
       - name: Build and deliver the tagged app to TestFlight
         working-directory: apps/mobile
         env:


### PR DESCRIPTION
## Problem

The first release to actually exercise mobile delivery (`v0.1.179`) failed in the `Mobile · Build and upload to TestFlight` job:

```
Error reading Expo config at apps/mobile/app.config.ts:
Cannot read properties of undefined (reading 'CommonJS')
Error: workflow:run command failed.
```

`eas workflow:run` reads `apps/mobile/app.config.ts` **locally** to resolve the project before submitting to EAS. The `mobile-testflight` job sets up EAS and immediately runs it with **no dependency install**, so the workspace's TypeScript toolchain is absent and the config read throws. This path had never run before (mobile was just added in #1267; delivery wired in #1355).

## Fix

Install the workspace deps before the eas step, matching the working compile job in `mobile-build.yml` (`npm --prefix apps ci` + `npm --prefix apps/mobile ci`). Verified with `actionlint`.

> Note: I can't run EAS end-to-end from here, so this fixes the confirmed config-read failure but can't prove the full TestFlight submission succeeds. Separately, the same release saw the macOS universal desktop build hit its 60-min timeout while waiting on Apple `notarytool` (likely transient Apple-side latency), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)