### PR TITLE
fix(ci): give the macOS release build headroom for slow notarization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -687,7 +687,10 @@ jobs:
       needs.detect-changes.outputs.app == 'true'
       )
     runs-on: macos-latest
-    timeout-minutes: 60
+    # Release builds sign and notarize; Apple's notarytool can wait well past an
+    # hour during notary-service backlogs, so give it the headroom the mobile
+    # delivery job already has. PR builds are unsigned and finish in minutes.
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Problem

In the `v0.1.179` release, `Desktop · Build (macOS universal)` ran for exactly 60m00s and was cancelled while waiting on Apple `notarytool` (job log ends at `Terminate orphan process: notarytool`). That cancellation failed `merge-gate-ci` and cascaded the whole release to `cancelled`, triggering the auto-revert.

The job's `timeout-minutes: 60` is too tight for the release path, which signs **and** notarizes. Apple's notary service latency is variable and can exceed an hour during backlogs.

## Fix

Raise `build-electron-macos`'s `timeout-minutes` to 120 (matching the mobile delivery job). PR builds take the unsigned path and finish in minutes, so they're unaffected. Verified with `actionlint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)