### PR TITLE
fix(ci): use free TestFlight submission

### DIFF
--- a/apps/mobile/.eas/workflows/testflight-prerelease.yml
+++ b/apps/mobile/.eas/workflows/testflight-prerelease.yml
@@ -17,13 +17,10 @@ jobs:
       profile: production
       message: ${{ inputs.changelog }}
 
-  testflight:
-    name: Deliver to internal TestFlight
+  submit_ios:
+    name: Upload to TestFlight
     needs: [build_ios]
-    type: testflight
+    type: submit
     params:
       build_id: ${{ needs.build_ios.outputs.build_id }}
       profile: production
-      changelog: ${{ inputs.changelog }}
-      submit_beta_review: false
-      wait_processing_timeout_seconds: 3600


### PR DESCRIPTION
## Summary

- replace the paid EAS TestFlight workflow job with the standard submit job
- keep the production build and submission profiles
- avoid requiring an Expo paid plan for release delivery

## Root cause

The release build succeeded, but EAS refused to start the TestFlight job because submitting an EAS `build_id` through `type: testflight` requires a paid Expo plan.

## Validation

- `eas workflow:validate .eas/workflows/testflight-prerelease.yml`
- CI-equivalent Expo workflow JSON schema validation