### PR TITLE
chore(deps): stop dependabot bumping Expo-managed mobile packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,11 @@ updates:
         patterns: ["*"]
 
   # Mobile is deliberately not an npm workspace under /apps and owns a
-  # separate lockfile, so it needs its own update source.
+  # separate lockfile, so it needs its own update source. Expo SDK owns the
+  # versions of its managed packages (react, react-native, the expo-* and
+  # @expo/* families, typescript); `expo install --check` pins them to the
+  # SDK's matrix, so bumping past it only yields red PRs. Ignore that set here;
+  # community deps (zod, tanstack, vitest, eslint) still get bumped.
   - package-ecosystem: npm
     directory: /apps/mobile
     schedule:
@@ -41,6 +45,19 @@ updates:
     groups:
       mobile-node-deps:
         patterns: ["*"]
+    ignore:
+      - dependency-name: "expo"
+      - dependency-name: "expo-*"
+      - dependency-name: "@expo/*"
+      - dependency-name: "@expo-google-fonts/*"
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "react-native"
+      - dependency-name: "react-native-*"
+      - dependency-name: "@react-native/*"
+      - dependency-name: "@react-native-async-storage/*"
+      - dependency-name: "typescript"
+      - dependency-name: "@types/react"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Why

Dependency PR #1361 (the `mobile-node-deps` group) bumped 13 Expo-SDK-managed packages (`react`, `react-dom`, the `react-native-*` family, `@react-native-async-storage/async-storage`, `typescript`) past the versions Expo SDK 57 pins. CI's `expo install --check` (in `check.sh web`) validates the installed set against the SDK's compatibility matrix and fails on any divergence, so that PR could never go green without reverting nearly every bump. This is structural: Expo owns these versions, dependabot shouldn't touch them.

## What

Adds an `ignore` list to the `/apps/mobile` dependabot source covering the Expo-managed families (`expo`, `expo-*`, `@expo/*`, `@expo-google-fonts/*`, `react`, `react-dom`, `react-native`, `react-native-*`, `@react-native/*`, `@react-native-async-storage/*`, `typescript`, `@types/react`). Community deps in the mobile app (`zod`, `@tanstack/react-query`, `vitest`, `eslint`, `patch-package`, `eslint-import-resolver-typescript`) still get bumped as before. Expo-managed packages now move only via `expo install` / an SDK upgrade.

Closes #1361 (superseded: that PR's bumps are exactly the set Expo pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)