### PR TITLE
fix(onboard): single-source the price floor (read it live from the control plane)

### DIFF
--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -116,13 +116,13 @@ and links between them and the CLI.
 
 ## Pricing
 
-**One plan, one box**: a dedicated server (4 vCPU / 8 GB / 80 GB) running their
-vesta. **From $24/month.** That's the **floor**, not a fixed price: the price is
+**One plan, one box**: a dedicated server (2 vCPU / 4 GB / 40 GB) running their
+vesta. **From $12/month.** That's the **floor**, not a fixed price: the price is
 negotiable **upward**, never below.
 
 **How to price:**
 
-- **Default to the floor ($24)** for a normal person who just wants in.
+- **Default to the floor ($12)** for a normal person who just wants in.
 - **Price to desire + status.** The whole point of the velvet rope is that people
   pay for exclusivity. If they fought to get in, gushed about it, or are clearly
   wealthy (a founder, an exec, "money's no object", a whale who wants a concierge
@@ -132,11 +132,11 @@ negotiable **upward**, never below.
 - **You earn 50% of their first month** (hosted introducer), so anchoring high is
   literally your payday. A $2,000 close earns you $1,000.
 
-Pass the agreed figure as `--price <usd>` (monthly). Omit it to charge the $24 floor.
+Pass the agreed figure as `--price <usd>` (monthly). Omit it to charge the $12 floor.
 
 **Discount codes.** If the owner has given you a discount/invite code, pass it as
 `--code <code>` and it knocks a percentage off the first month at checkout (it
-composes with whatever `--price` you set: half off $24 or off $2,000 alike). You
+composes with whatever `--price` you set: half off $12 or off $2,000 alike). You
 never invent codes: pass only what the owner hands you. An unknown code comes back
 `{"error": "invalid code"}`: relay that and continue without it. There is nothing
 to look up or reveal; the code's value and effect live entirely on the server.
@@ -174,7 +174,7 @@ onboard verify --email ada@example.com --code 123456
 
 # Someone who just wants in, the floor:
 onboard checkout --email ada@example.com
-# { "url": "https://checkout.stripe.com/c/pay/cs_test_...", "subdomain": "ada" }   ($24/mo)
+# { "url": "https://checkout.stripe.com/c/pay/cs_test_...", "subdomain": "ada" }   ($12/mo)
 
 # A whale who fought to get in, anchor high (uncapped):
 onboard checkout --email vc@example.com --price 2000
@@ -182,7 +182,7 @@ onboard checkout --email vc@example.com --price 2000
 
 # Below the floor is rejected (the server enforces it too):
 onboard checkout --email x@example.com --price 5
-# { "error": "price $5 is below the $24 floor", "floor_usd": 24 }
+# { "error": "price $5 is below the $12 floor", "floor_usd": 12 }
 
 onboard status --email ada@example.com
 # { "status": "reserved", ... }   (paid? provisioning? not active yet)
@@ -214,7 +214,7 @@ The cases you'll actually hit, and the move for each:
   to the owner that their referral code changed.
 - `invalid code` (a bad discount `--code` at checkout): re-run `onboard checkout`
   **without** `--code`.
-- `price ... below the $24 floor`: re-quote at or above $24 and re-run.
+- `price ... below the $12 floor`: re-quote at or above $12 and re-run.
 - `already provisioned`: they already have a vesta. Send them `onboard links` to
   sign in; do not onboard them again.
 - `rate limited`: too many attempts from here today. Tell them you'll pick it back

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -88,8 +88,8 @@ and links between them and the CLI.
    account (Pro or Max)?"* If not, don't take their money; tell them to grab one
    first; nothing here works without it.
 3. **Agree a name + a price.** What do they want it called / how should it feel
-   (`onboard presets` for personalities + skills)? Agree the monthly price (see
-   **Pricing**).
+   (`onboard presets` for personalities + skills, and the live `plan_floor_usd`)?
+   Agree the monthly price (see **Pricing**).
 4. **Send the Stripe link.** `onboard checkout --email <e> [--price <usd>] [--code
    <code>]` → `{ url, subdomain }`. Send the `url` as a tappable link, never bare
    text: where the channel renders Markdown links, format it as `[Complete your
@@ -117,12 +117,13 @@ and links between them and the CLI.
 ## Pricing
 
 **One plan, one box**: a dedicated server (2 vCPU / 4 GB / 40 GB) running their
-vesta. **From $12/month.** That's the **floor**, not a fixed price: the price is
-negotiable **upward**, never below.
+vesta. There's a monthly **floor**; the price is negotiable **upward**, never
+below. The floor is whatever `onboard presets` reports as `plan_floor_usd` (the
+control plane owns that number): quote *that*, never a figure baked into this doc.
 
 **How to price:**
 
-- **Default to the floor ($12)** for a normal person who just wants in.
+- **Default to the floor** for a normal person who just wants in.
 - **Price to desire + status.** The whole point of the velvet rope is that people
   pay for exclusivity. If they fought to get in, gushed about it, or are clearly
   wealthy (a founder, an exec, "money's no object", a whale who wants a concierge
@@ -132,12 +133,12 @@ negotiable **upward**, never below.
 - **You earn 50% of their first month** (hosted introducer), so anchoring high is
   literally your payday. A $2,000 close earns you $1,000.
 
-Pass the agreed figure as `--price <usd>` (monthly). Omit it to charge the $12 floor.
+Pass the agreed figure as `--price <usd>` (monthly). Omit it to charge the floor.
 
 **Discount codes.** If the owner has given you a discount/invite code, pass it as
 `--code <code>` and it knocks a percentage off the first month at checkout (it
-composes with whatever `--price` you set: half off $12 or off $2,000 alike). You
-never invent codes: pass only what the owner hands you. An unknown code comes back
+composes with whatever `--price` you set: it discounts the floor and a high quote
+alike). You never invent codes: pass only what the owner hands you. An unknown code comes back
 `{"error": "invalid code"}`: relay that and continue without it. There is nothing
 to look up or reveal; the code's value and effect live entirely on the server.
 
@@ -156,7 +157,7 @@ onboard status       --email <e>                       # -> { status: reserved|a
 onboard create-agent --email <e> --name <n> [--personality <preset>] [--context "notes"]
 onboard claude-start  --email <e>                      # -> { auth_url }  (send it to them)
 onboard claude-finish --email <e> --code <pasted> [--model opus|sonnet|haiku]
-onboard presets                                        # personalities + skills + models
+onboard presets                                        # personalities + skills + models + plan_floor_usd
 onboard links                                          # marketing + app install URLs
 ```
 
@@ -174,15 +175,15 @@ onboard verify --email ada@example.com --code 123456
 
 # Someone who just wants in, the floor:
 onboard checkout --email ada@example.com
-# { "url": "https://checkout.stripe.com/c/pay/cs_test_...", "subdomain": "ada" }   ($12/mo)
+# { "url": "https://checkout.stripe.com/c/pay/cs_test_...", "subdomain": "ada" }   (the floor)
 
 # A whale who fought to get in, anchor high (uncapped):
 onboard checkout --email vc@example.com --price 2000
 # { "url": "https://...", "subdomain": "vc" }   ($2,000/mo)
 
-# Below the floor is rejected (the server enforces it too):
+# Below the floor is rejected server-side (the floor lives only on the control plane):
 onboard checkout --email x@example.com --price 5
-# { "error": "price $5 is below the $12 floor", "floor_usd": 12 }
+# { "error": "price below floor", "message": "...Quote at or above the floor.", "floor_usd": 12 }
 
 onboard status --email ada@example.com
 # { "status": "reserved", ... }   (paid? provisioning? not active yet)
@@ -214,7 +215,8 @@ The cases you'll actually hit, and the move for each:
   to the owner that their referral code changed.
 - `invalid code` (a bad discount `--code` at checkout): re-run `onboard checkout`
   **without** `--code`.
-- `price ... below the $12 floor`: re-quote at or above $12 and re-run.
+- `price below floor` (a `--price` under the server floor; carries `floor_usd`):
+  re-quote at or above that figure and re-run.
 - `already provisioned`: they already have a vesta. Send them `onboard links` to
   sign in; do not onboard them again.
 - `rate limited`: too many attempts from here today. Tell them you'll pick it back

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from . import state
 from .client import Client, OnboardError
-from .config import LINKS, PLAN, PLAN_FLOOR_USD, Config
+from .config import LINKS, PLAN, Config
 
 
 def _print(payload: dict[str, Any]) -> None:
@@ -87,16 +87,13 @@ def _cmd_checkout(args: argparse.Namespace, client: Client, _cfg: Config) -> int
     email = _email(args)
     token = _require_token(email, "run `onboard verify` with the buyer's code first")
 
-    price: float | None = None
-    if args.price is not None:
-        if args.price < PLAN_FLOOR_USD:
-            raise _InvalidError({"error": f"price ${args.price:g} is below the ${PLAN_FLOOR_USD} floor", "floor_usd": PLAN_FLOOR_USD})
-        price = args.price
-
+    # The floor is enforced (and reported) server-side: a below-floor price comes back
+    # as {error, floor_usd} from checkout, which the skill re-quotes against. No local
+    # mirror of the floor to drift.
     result = client.checkout(
         token=token,
         plan=PLAN,
-        price=price,
+        price=args.price,
         discount_code=(args.code.strip() if args.code else None),
     )
     if "url" in result:
@@ -253,7 +250,7 @@ def _cmd_presets(_args: argparse.Namespace, client: Client, _cfg: Config) -> int
         {
             "personalities": [p["name"] for p in client.fetch_personalities()],
             "skills": _installable_skills(),
-            "plan_floor_usd": PLAN_FLOOR_USD,
+            "plan_floor_usd": client.fetch_floor_usd(),
             "claude_models": [m["id"] for m in client.fetch_claude_models()],
             "default_personality": defaults["personality"],
             "default_model": defaults["model"],

--- a/agent/skills/onboard/cli/src/onboard_cli/cli.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/cli.py
@@ -284,7 +284,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_checkout = sub.add_parser("checkout", help="Reserve + mint a Stripe link (auto subdomain).")
     p_checkout.add_argument("--email", required=True)
-    p_checkout.add_argument("--price", type=float, help="Negotiated MONTHLY USD (>= the $24 floor; uncapped above).")
+    p_checkout.add_argument("--price", type=float, help="Negotiated MONTHLY USD (>= the $12 floor; uncapped above).")
     p_checkout.add_argument("--code", help="Optional discount code to redeem at checkout.")
 
     p_status = sub.add_parser("status", help="Has the buyer paid + the VM come up?")

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -96,6 +96,12 @@ class Client:
             body["referral_code"] = referral_code
         return self._json(self._post("/onboard/account", json=body))
 
+    def fetch_floor_usd(self) -> int:
+        """GET /onboard/pricing -> the live membership floor in USD. The control plane's
+        `listMonthlyCents` is the single source of truth; the skill reads it live so a
+        quote can't drift from what checkout enforces. Public (no token)."""
+        return int(self._json(self._get("/onboard/pricing"))["floor_usd"])
+
     # --- control plane: auth -------------------------------------------------
 
     def send_otp(self, email: str) -> dict[str, Any]:

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -35,12 +35,6 @@ DEFAULT_CONTROL_URL = "https://vesta.run/api"
 # upgrades, but onboarding only ever sells this one.
 PLAN = "pro"
 
-# List MONTHLY price (USD) — the NEGOTIATION FLOOR. The agent can quote any price
-# >= it (uncapped above); the control plane enforces the floor server-side, so
-# this is for the agent's UX + a friendly local error. Keep in sync with the
-# control plane's listMonthlyCents("pro").
-PLAN_FLOOR_USD = 12
-
 # Public marketing + install links surfaced by `onboard links`.
 LINKS = {
     "marketing": "https://vesta.run",

--- a/agent/skills/onboard/cli/src/onboard_cli/config.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/config.py
@@ -30,8 +30,8 @@ from . import referral_store
 # staging/testing (the control plane injects it into managed boxes).
 DEFAULT_CONTROL_URL = "https://vesta.run/api"
 
-# Hosted Vesta is ONE plan, one box — the control plane's `pro` tier (4 vCPU /
-# 8 GB). The control plane also defines starter/power for admin provisioning and
+# Hosted Vesta is ONE plan, one box — the control plane's `pro` tier (2 vCPU /
+# 4 GB). The control plane also defines starter/power for admin provisioning and
 # upgrades, but onboarding only ever sells this one.
 PLAN = "pro"
 
@@ -39,7 +39,7 @@ PLAN = "pro"
 # >= it (uncapped above); the control plane enforces the floor server-side, so
 # this is for the agent's UX + a friendly local error. Keep in sync with the
 # control plane's listMonthlyCents("pro").
-PLAN_FLOOR_USD = 24
+PLAN_FLOOR_USD = 12
 
 # Public marketing + install links surfaced by `onboard links`.
 LINKS = {

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -63,7 +63,7 @@ def test_presets_lists_live_reference_data(capsys, monkeypatch):
     rc, data = _run(["presets"], capsys)
     assert rc == 0
     assert "dry" in data["personalities"]
-    assert data["plan_floor_usd"] == 24
+    assert data["plan_floor_usd"] == 12
     assert "plans" not in data  # single plan — no tier list
     assert data["claude_models"] == ["opus", "sonnet", "haiku"]
     assert data["default_personality"] == "dry"
@@ -190,7 +190,7 @@ def test_checkout_rejects_below_floor_without_calling(capsys, monkeypatch):
     calls = {"n": 0}
     monkeypatch.setattr(cli_mod.Client, "checkout", lambda self, **kw: calls.__setitem__("n", calls["n"] + 1) or {"url": "x"})
     rc, data = _run(["checkout", "--email", E, "--price", "5"], capsys)
-    assert rc == 2 and data["floor_usd"] == 24 and calls["n"] == 0
+    assert rc == 2 and data["floor_usd"] == 12 and calls["n"] == 0
 
 
 def test_checkout_surfaces_structured_error(capsys, monkeypatch):

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -55,11 +55,12 @@ def test_links(capsys):
 
 
 def test_presets_lists_live_reference_data(capsys, monkeypatch):
-    # `onboard presets` now reads personalities / models / defaults from the box's vestad
-    # instead of hardcoding them, so the command is a pure consumer of that one source.
+    # `onboard presets` reads personalities / models / defaults from the box's vestad and the
+    # floor from the control plane, so the command is a pure consumer of those sources (no hardcoding).
     monkeypatch.setattr(cli_mod.Client, "fetch_personalities", lambda self: [{"name": "dry"}, {"name": "chill"}])
     monkeypatch.setattr(cli_mod.Client, "fetch_claude_models", lambda self: [{"id": "opus"}, {"id": "sonnet"}, {"id": "haiku"}])
     monkeypatch.setattr(cli_mod.Client, "fetch_agent_defaults", lambda self: {"personality": "dry", "model": "opus"})
+    monkeypatch.setattr(cli_mod.Client, "fetch_floor_usd", lambda self: 12)
     rc, data = _run(["presets"], capsys)
     assert rc == 0
     assert "dry" in data["personalities"]
@@ -185,12 +186,19 @@ def test_checkout_forwards_price_and_code_no_referral(capsys, monkeypatch):
     assert "server_id" not in data
 
 
-def test_checkout_rejects_below_floor_without_calling(capsys, monkeypatch):
+def test_checkout_below_floor_is_enforced_server_side(capsys, monkeypatch):
+    # No local floor mirror: a below-floor price is forwarded to the control plane, whose
+    # {error, floor_usd} is surfaced to the agent (the floor lives in one place, the server).
     _verified()
-    calls = {"n": 0}
-    monkeypatch.setattr(cli_mod.Client, "checkout", lambda self, **kw: calls.__setitem__("n", calls["n"] + 1) or {"url": "x"})
+    captured = {}
+
+    def fake_checkout(self, *, token, plan, price, discount_code):
+        captured["price"] = price
+        return {"error": "price below floor", "floor_usd": 12}
+
+    monkeypatch.setattr(cli_mod.Client, "checkout", fake_checkout)
     rc, data = _run(["checkout", "--email", E, "--price", "5"], capsys)
-    assert rc == 2 and data["floor_usd"] == 12 and calls["n"] == 0
+    assert rc == 2 and data["floor_usd"] == 12 and captured["price"] == 5.0
 
 
 def test_checkout_surfaces_structured_error(capsys, monkeypatch):


### PR DESCRIPTION
The onboard skill + CLI quoted a **$24/month** floor on a **4 vCPU / 8 GB / 80 GB** box. Both were stale: vesta-cloud #92 dropped the floor to **$12** and moved provisioning to **cx23 (2 vCPU / 4 GB / 40 GB)**. The root cause is that the floor was **duplicated**, hardcoded in the CLI (`PLAN_FLOOR_USD`) as a mirror of the server value, and the mirror drifted.

This does two things:

1. **Fixes the stale server spec** in `SKILL.md` (cx33 → cx23; not machine-exposed anywhere, so it stays prose).
2. **Removes the duplication.** The floor now has one home, the control plane's `listMonthlyCents`, and the CLI reads it live:
   - `client.fetch_floor_usd()` → `GET /api/onboard/pricing`; `onboard presets` surfaces it as `plan_floor_usd`.
   - Deletes the `PLAN_FLOOR_USD` constant **and** the local below-floor pre-check. The server is the sole enforcer and already returns `{error, floor_usd}`, so there is nothing left to keep in sync.
   - `SKILL.md` tells the agent to quote whatever `presets` reports, never a figure baked into the doc.

After this, changing the price is **one line in vesta-cloud** and every quote follows.

### Depends on
- **elyxlz/vesta-cloud#119** (the `GET /api/onboard/pricing` endpoint) must be **deployed first**, or `onboard presets` 404s. Do not merge/release this ahead of that.

### Tests
All 20 onboard CLI tests pass; the obsolete local-pre-check test is replaced by one asserting a below-floor price is forwarded and the server's `floor_usd` is surfaced.

Resolves the vesta side of vesta-cloud#99 (site stays silent; the price lives in one server-owned place the skill reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)