### PR TITLE
fix(browser): propagate a wedged CDP domain-enable timeout instead of swallowing it

### DIFF
--- a/agent/skills/browser/cli/src/vesta_browser/cdp_backend.py
+++ b/agent/skills/browser/cli/src/vesta_browser/cdp_backend.py
@@ -17,7 +17,6 @@ explicitly handed over, so enabling the CDP domains is fine.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 
 import websockets
@@ -165,9 +164,13 @@ class CdpBackend:
         self._sessions[target_id] = session_id
         self._session_targets[session_id] = target_id
         for domain in _DOMAINS:
-            # A domain a given target lacks must not abort the attach.
-            with contextlib.suppress(BidiError):
+            try:
                 await self._cdp.send(f"{domain}.enable", {}, session_id)
+            except BidiError as e:
+                # A "cdp error" means the target lacks that domain, which must not abort the attach.
+                # Any other error (a withheld "timeout") means a wedged browser and must propagate.
+                if e.code != "cdp error":
+                    raise
         return session_id
 
     # ── BiDi -> CDP command translation ───────────────────────

--- a/agent/skills/browser/cli/tests/test_cdp_backend.py
+++ b/agent/skills/browser/cli/tests/test_cdp_backend.py
@@ -236,10 +236,11 @@ HANG_GUARD_S = 5
 
 
 class SilentCdpServer:
-    """Accepts CDP commands and never answers them, as a wedged Chrome does."""
+    """Accepts CDP commands and never answers, as a wedged Chrome does; an optional answer hook may reply to some before the silence."""
 
-    def __init__(self) -> None:
+    def __init__(self, answer=None) -> None:
         self._server: websockets.Server | None = None
+        self._answer = answer
 
     async def start(self) -> str:
         self._server = await websockets.serve(self._handle, "127.0.0.1", 0)
@@ -252,8 +253,9 @@ class SilentCdpServer:
             await self._server.wait_closed()
 
     async def _handle(self, ws: websockets.ServerConnection) -> None:
-        async for _raw in ws:
-            pass
+        async for raw in ws:
+            if self._answer is not None:
+                await self._answer(ws, json.loads(raw))
 
 
 async def _unused_event_cb(method: str, params: dict, session_id: str | None) -> None:
@@ -272,8 +274,8 @@ async def _with_silent_transport(body):
         await server.stop()
 
 
-async def _with_silent_backend(body):
-    server = SilentCdpServer()
+async def _with_silent_backend(body, server=None):
+    server = server or SilentCdpServer()
     url = await server.start()
     backend = CdpBackend()
     await backend.connect(url)
@@ -336,50 +338,19 @@ def test_cancelled_cdp_request_is_dropped_from_pending():
     assert asyncio.run(_with_silent_transport(body)) == {}
 
 
-class AttachThenSilentCdpServer:
-    """Answers Target.attachToTarget, then withholds every domain-enable reply, as a Chrome wedged mid-attach does."""
-
-    def __init__(self) -> None:
-        self._server: websockets.Server | None = None
-
-    async def start(self) -> str:
-        self._server = await websockets.serve(self._handle, "127.0.0.1", 0)
-        port = self._server.sockets[0].getsockname()[1]
-        return f"ws://127.0.0.1:{port}/devtools/browser/fake"
-
-    async def stop(self) -> None:
-        if self._server is not None:
-            self._server.close()
-            await self._server.wait_closed()
-
-    async def _handle(self, ws: websockets.ServerConnection) -> None:
-        async for raw in ws:
-            message = json.loads(raw)
-            if message["method"] == "Target.attachToTarget":
-                await ws.send(json.dumps({"id": message["id"], "result": {"sessionId": "S1"}}))
-
-
-async def _with_attach_then_silent_backend(body):
-    server = AttachThenSilentCdpServer()
-    url = await server.start()
-    backend = CdpBackend()
-    await backend.connect(url)
-    try:
-        return await asyncio.wait_for(body(backend), timeout=HANG_GUARD_S)
-    finally:
-        await backend.close()
-        await server.stop()
-
-
 def test_wedged_domain_enable_propagates_timeout_instead_of_being_swallowed(monkeypatch):
     """A withheld domain-enable reply means a wedged browser: the timeout must propagate, not be swallowed as a missing-domain refusal."""
     monkeypatch.setattr(cdp_backend, "_CDP_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
+
+    async def answer_attach(ws, message):
+        if message["method"] == "Target.attachToTarget":
+            await ws.send(json.dumps({"id": message["id"], "result": {"sessionId": "S1"}}))
 
     async def body(backend):
         with pytest.raises(BidiError) as excinfo:
             await backend._session_for("T1")
         return excinfo.value
 
-    error = asyncio.run(_with_attach_then_silent_backend(body))
+    error = asyncio.run(_with_silent_backend(body, SilentCdpServer(answer_attach)))
     assert error.code == "timeout"
     assert ".enable" in error.message

--- a/agent/skills/browser/cli/tests/test_cdp_backend.py
+++ b/agent/skills/browser/cli/tests/test_cdp_backend.py
@@ -7,6 +7,7 @@ translation logic against a recording fake transport so a wrong CDP mapping fail
 from __future__ import annotations
 
 import asyncio
+import json
 
 import pytest
 import websockets
@@ -333,3 +334,52 @@ def test_cancelled_cdp_request_is_dropped_from_pending():
         return dict(transport._pending)
 
     assert asyncio.run(_with_silent_transport(body)) == {}
+
+
+class AttachThenSilentCdpServer:
+    """Answers Target.attachToTarget, then withholds every domain-enable reply, as a Chrome wedged mid-attach does."""
+
+    def __init__(self) -> None:
+        self._server: websockets.Server | None = None
+
+    async def start(self) -> str:
+        self._server = await websockets.serve(self._handle, "127.0.0.1", 0)
+        port = self._server.sockets[0].getsockname()[1]
+        return f"ws://127.0.0.1:{port}/devtools/browser/fake"
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    async def _handle(self, ws: websockets.ServerConnection) -> None:
+        async for raw in ws:
+            message = json.loads(raw)
+            if message["method"] == "Target.attachToTarget":
+                await ws.send(json.dumps({"id": message["id"], "result": {"sessionId": "S1"}}))
+
+
+async def _with_attach_then_silent_backend(body):
+    server = AttachThenSilentCdpServer()
+    url = await server.start()
+    backend = CdpBackend()
+    await backend.connect(url)
+    try:
+        return await asyncio.wait_for(body(backend), timeout=HANG_GUARD_S)
+    finally:
+        await backend.close()
+        await server.stop()
+
+
+def test_wedged_domain_enable_propagates_timeout_instead_of_being_swallowed(monkeypatch):
+    """A withheld domain-enable reply means a wedged browser: the timeout must propagate, not be swallowed as a missing-domain refusal."""
+    monkeypatch.setattr(cdp_backend, "_CDP_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
+
+    async def body(backend):
+        with pytest.raises(BidiError) as excinfo:
+            await backend._session_for("T1")
+        return excinfo.value
+
+    error = asyncio.run(_with_attach_then_silent_backend(body))
+    assert error.code == "timeout"
+    assert ".enable" in error.message


### PR DESCRIPTION
## What

`cdp_backend.py`'s `_session_for` enabled the four CDP domains behind `contextlib.suppress(BidiError)`:

```python
for domain in _DOMAINS:
    # A domain a given target lacks must not abort the attach.
    with contextlib.suppress(BidiError):
        await self._cdp.send(f"{domain}.enable", {}, session_id)
```

That suppress was written when the only `BidiError` from `send` was a browser refusal: a target lacking a domain must not abort the attach. Merged PR #1342 gave `BidiError` a second, unrelated meaning, `BidiError("timeout", ...)` (the browser never answered), and the blanket suppress now eats that too. A wedged Chrome that withholds the four `{domain}.enable` replies costs `4 x _CDP_RESPONSE_TIMEOUT_S` (240s at the shipped 60.0) of completely silent waiting, then `_session_for` returns normally: nothing raised, nothing logged. That is the "No silent exception swallowing" rule in CLAUDE.md, reached through a type widening rather than a new `except`.

## Change

Narrow the handler to swallow only the benign `"cdp error"` refusal and re-raise everything else (including `"timeout"`), mirroring the attach relabel PR #1347 added a few lines above:

```python
for domain in _DOMAINS:
    try:
        await self._cdp.send(f"{domain}.enable", {}, session_id)
    except BidiError as e:
        # A "cdp error" means the target lacks that domain, which must not abort the attach.
        # Any other error (a withheld "timeout") means a wedged browser and must propagate.
        if e.code != "cdp error":
            raise
```

`contextlib` was only used here, so its import is dropped.

## Test

`test_wedged_domain_enable_propagates_timeout_instead_of_being_swallowed` stands up a server that answers `Target.attachToTarget` then withholds every domain-enable reply, and asserts `_session_for` raises `BidiError(code="timeout")` naming a `.enable` method. Confirmed it discriminates: against the unpatched `contextlib.suppress` it fails with "DID NOT RAISE BidiError"; with the fix it passes.

## Scope: partial fix, #1348 stays open

This PR is the surgical half of #1348. It does NOT touch the second defect the issue documents: `self._sessions[target_id] = session_id` and `self._session_targets[session_id] = target_id` are written *before* the enable loop, so even now a half-enabled session is cached before the enables run (the propagated timeout is not caught above `_session_for`, but the cache write already happened). Fixing the cache poisoning means moving those two writes below the loop, which changes which target `_on_cdp_event` resolves for events arriving *during* the enables (the fallback to `self._context` when `_session_targets` lacks the session). That is a real ordering decision with its own test, deliberately deferred to a separate PR.

Refs #1348 (kept open to track the cache-reorder half).

## Checks

- `uv run pytest` (browser skill CLI): 201 passed
- `./check.sh guards`: All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>