### PR TITLE
refactor(microsoft): type Graph Teams payloads as TypedDicts

### DIFF
--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from functools import partial
 from pathlib import Path
-from typing import NotRequired, TypedDict
+from typing import NotRequired, TypedDict, cast
 from zoneinfo import ZoneInfo
 
 from . import auth, capture, folders, graph, notifications, notify, owa_rest, teams
@@ -311,6 +311,65 @@ def _poll_owa_rest_calendar(
     return True
 
 
+class Identity(TypedDict):
+    """A Graph identity (a chatMessage's author, a conversationMember). displayName is nullable:
+    Graph sends null for removed, federated, and anonymous users."""
+
+    id: str
+    displayName: NotRequired[str | None]
+
+
+class IdentitySet(TypedDict):
+    """A chatMessage's `from`: authored by a user or an app, or neither (system events carry
+    `from: null`, so this whole set is nullable at the read)."""
+
+    user: NotRequired[Identity | None]
+    application: NotRequired[Identity | None]
+
+
+class ItemBody(TypedDict):
+    """A message body. content is nullable, so every read must handle the null case."""
+
+    content: NotRequired[str | None]
+
+
+# The shared read-surface of a Graph chatMessage (the channel path) and chatMessageInfo (a chat's
+# lastMessagePreview): different resources, but the poller only ever reads from/body/createdDateTime,
+# and one shape over exactly those fields is what makes conflating them safe. `from` is a keyword, so
+# the functional TypedDict form is the only way to name the key.
+ChatMessage = TypedDict(
+    "ChatMessage",
+    {
+        "from": NotRequired[IdentitySet | None],
+        "body": NotRequired[ItemBody],
+        "createdDateTime": NotRequired[str],
+    },
+)
+
+
+class ConversationMember(TypedDict):
+    """A chat member as the poller reads it: displayName is nullable like every Graph identity."""
+
+    displayName: NotRequired[str | None]
+
+
+class Chat(TypedDict):
+    """A Graph chat as the poller reads it: id, an optional topic, expanded members, and the
+    lastMessagePreview (a chatMessageInfo, nullable for a chat with no messages)."""
+
+    id: str
+    topic: NotRequired[str | None]
+    members: NotRequired[list[ConversationMember]]
+    lastMessagePreview: NotRequired[ChatMessage | None]
+
+
+class ChannelResource(TypedDict):
+    """A Graph team or channel as the poller reads it: an id and a nullable displayName."""
+
+    id: NotRequired[str]
+    displayName: NotRequired[str | None]
+
+
 class TeamsNotifiable(TypedDict):
     """What a Teams notification says about a message: who sent it and its body preview."""
 
@@ -318,23 +377,24 @@ class TeamsNotifiable(TypedDict):
     text: str
 
 
-def _teams_notifiable(message: dict, my_id: str) -> TeamsNotifiable | None:
+def _teams_notifiable(message: ChatMessage, my_id: str) -> TeamsNotifiable | None:
     """Sender + body preview for a Teams message, or None when it must not notify: the user's own
     message, or a system event carrying neither author nor body (member added, chat renamed, meeting
     started). Graph gives those `from: null` and an empty body, leaving nothing to report."""
     sender = message["from"] if "from" in message else None
-    sender_user = (sender["user"] if sender and "user" in sender else None) or {}
-    if "id" in sender_user and sender_user["id"] == my_id:
+    sender_user = sender["user"] if sender and "user" in sender else None
+    if sender_user and "id" in sender_user and sender_user["id"] == my_id:
         return None
-    body = message["body"] if "body" in message else {}
-    text = clean_preview(_HTML_TAG.sub(" ", (body["content"] if "content" in body else None) or ""))[:200]
-    name = (sender_user["displayName"] if "displayName" in sender_user else None) or ""
+    body = message["body"] if "body" in message else None
+    content = body["content"] if body and "content" in body else None
+    text = clean_preview(_HTML_TAG.sub(" ", content or ""))[:200]
+    name = (sender_user["displayName"] if sender_user and "displayName" in sender_user else None) or ""
     if not name and not text:
         return None
     return {"sender": name or "Someone", "text": text}
 
 
-def _arrived_since(message: dict, last_dt: datetime) -> bool:
+def _arrived_since(message: ChatMessage, last_dt: datetime) -> bool:
     """True when the message carries a parseable createdDateTime newer than last_dt."""
     if "createdDateTime" not in message:
         return False
@@ -357,7 +417,7 @@ def _poll_teams_account(ctx: MicrosoftContext, config: Config, account_email: st
         return False
     try:
         my_id = teams._my_id(ctx.http_client, token)
-        chats = teams.list_chats(ctx.http_client, token, limit=50)
+        chats = cast("list[Chat]", teams.list_chats(ctx.http_client, token, limit=50))
     except Exception as e:
         logger.error("Error fetching Teams chats for %s: %s", account_email, e)
         return False
@@ -369,7 +429,8 @@ def _poll_teams_account(ctx: MicrosoftContext, config: Config, account_email: st
         notifiable = _teams_notifiable(preview, my_id)
         if notifiable is None:
             continue  # our own outgoing message, or a contentless system event
-        members = ", ".join(m["displayName"] for m in (chat["members"] if "members" in chat else []) if "displayName" in m)
+        member_list = chat["members"] if "members" in chat else []
+        members = ", ".join(name for m in member_list if (name := m["displayName"] if "displayName" in m else None))
         topic = (chat["topic"] if "topic" in chat else None) or members or None
         logger.info("Writing Teams notification from %s in chat %s", notifiable["sender"], chat["id"])
         notifications.write_notification(
@@ -402,7 +463,7 @@ def _poll_teams_channels_account(ctx: MicrosoftContext, config: Config, account_
         return False
     try:
         my_id = teams._my_id(ctx.http_client, token)
-        teams_list = teams.list_teams(ctx.http_client, token)
+        teams_list = cast("list[ChannelResource]", teams.list_teams(ctx.http_client, token))
     except Exception as e:
         # No channel access (missing ChannelMessage.Read.All / no Graph): degrade to chats-only.
         logger.info("Teams channel messages unavailable for %s, keeping chats-only: %s", account_email, e)
@@ -414,7 +475,7 @@ def _poll_teams_channels_account(ctx: MicrosoftContext, config: Config, account_
             continue
         team_name = (team["displayName"] if "displayName" in team else None) or "Team"
         try:
-            channels = teams.list_channels(ctx.http_client, token, team_id=team_id)
+            channels = cast("list[ChannelResource]", teams.list_channels(ctx.http_client, token, team_id=team_id))
         except Exception as e:
             logger.debug("Skipping Teams channels for team %s (%s): %s", team_name, account_email, e)
             continue
@@ -424,7 +485,9 @@ def _poll_teams_channels_account(ctx: MicrosoftContext, config: Config, account_
                 continue
             channel_name = (channel["displayName"] if "displayName" in channel else None) or "Channel"
             try:
-                messages = teams.list_channel_messages(ctx.http_client, token, team_id=team_id, channel_id=channel_id, limit=20)
+                messages = cast(
+                    "list[ChatMessage]", teams.list_channel_messages(ctx.http_client, token, team_id=team_id, channel_id=channel_id, limit=20)
+                )
             except Exception as e:
                 logger.debug("Skipping Teams channel %s / %s (%s): %s", team_name, channel_name, account_email, e)
                 continue

--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -312,50 +312,47 @@ def _poll_owa_rest_calendar(
 
 
 class Identity(TypedDict):
-    """A Graph identity (a chatMessage's author, a conversationMember). displayName is nullable:
-    Graph sends null for removed, federated, and anonymous users."""
+    """A Graph identity (a chatMessage's author, a conversationMember). Graph sends a null
+    displayName for removed, federated, and anonymous users."""
 
     id: str
     displayName: NotRequired[str | None]
 
 
 class IdentitySet(TypedDict):
-    """A chatMessage's `from`: authored by a user or an app, or neither (system events carry
-    `from: null`, so this whole set is nullable at the read)."""
+    """A chatMessage's `from`: a user, an app, or neither (system events carry `from: null`)."""
 
     user: NotRequired[Identity | None]
     application: NotRequired[Identity | None]
 
 
 class ItemBody(TypedDict):
-    """A message body. content is nullable, so every read must handle the null case."""
+    """A message body."""
 
     content: NotRequired[str | None]
 
 
-# The shared read-surface of a Graph chatMessage (the channel path) and chatMessageInfo (a chat's
-# lastMessagePreview): different resources, but the poller only ever reads from/body/createdDateTime,
-# and one shape over exactly those fields is what makes conflating them safe. `from` is a keyword, so
-# the functional TypedDict form is the only way to name the key.
+# One shape over from/body/createdDateTime covers both a Graph chatMessage (the channel path) and a
+# chatMessageInfo (a chat's lastMessagePreview): the poller reads only those fields, so conflating the
+# two resources is safe. `from` is a keyword, so the functional TypedDict form is the only way to name it.
 ChatMessage = TypedDict(
     "ChatMessage",
     {
         "from": NotRequired[IdentitySet | None],
-        "body": NotRequired[ItemBody],
+        "body": NotRequired[ItemBody | None],
         "createdDateTime": NotRequired[str],
     },
 )
 
 
 class ConversationMember(TypedDict):
-    """A chat member as the poller reads it: displayName is nullable like every Graph identity."""
+    """A chat member as the poller reads it."""
 
     displayName: NotRequired[str | None]
 
 
 class Chat(TypedDict):
-    """A Graph chat as the poller reads it: id, an optional topic, expanded members, and the
-    lastMessagePreview (a chatMessageInfo, nullable for a chat with no messages)."""
+    """A Graph chat as the poller reads it. lastMessagePreview is null for a chat with no messages."""
 
     id: str
     topic: NotRequired[str | None]
@@ -364,7 +361,7 @@ class Chat(TypedDict):
 
 
 class ChannelResource(TypedDict):
-    """A Graph team or channel as the poller reads it: an id and a nullable displayName."""
+    """A Graph team or channel as the poller reads it."""
 
     id: NotRequired[str]
     displayName: NotRequired[str | None]

--- a/agent/skills/microsoft/cli/tests/test_teams.py
+++ b/agent/skills/microsoft/cli/tests/test_teams.py
@@ -631,6 +631,36 @@ def test_poll_teams_reads_null_body_content_as_empty(tmp_path, monkeypatch):
     assert notif["preview"] == ""
 
 
+def test_poll_teams_topic_fallback_skips_null_member_names(tmp_path, monkeypatch):
+    """A topic-less chat falls back to its member names, and Graph declares conversationMember
+    displayName nullable (removed/federated/anonymous members). A null name must be dropped from the
+    join, not crash it: reading the key unguarded would hand `None` to `str.join`."""
+    from datetime import UTC, datetime
+
+    from microsoft_cli import monitor
+
+    chats = [
+        {
+            "id": "chat-1",
+            "members": [{"displayName": None}, {"displayName": "Alice"}],
+            "lastMessagePreview": {
+                "createdDateTime": "2026-07-10T12:00:00Z",
+                "from": {"user": {"id": "other-guid", "displayName": "Alice"}},
+                "body": {"content": "<p>lunch?</p>"},
+            },
+        }
+    ]
+    ctx = _teams_ctx(tmp_path, monkeypatch, chats)
+    last_dt = datetime(2026, 7, 10, 11, 0, tzinfo=UTC)
+    monitor._poll_teams_account(ctx, Config(data_dir=tmp_path), "me@x.com", last_dt, False)
+
+    files = list((tmp_path / "notif").glob("*.json"))
+    assert len(files) == 1
+    notif = json.loads(files[0].read_text())
+    assert notif["topic"] == "Alice"
+    assert "lunch?" in notif["preview"]
+
+
 # ---------------------------------------------------------------------------
 # Monitor: Teams CHANNEL message notification emit + graceful degrade
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`microsoft_cli/monitor.py` typed every Graph Teams payload as a bare `dict` (`_teams_notifiable(message: dict, ...)`, `_arrived_since(message: dict, ...)`, and the `list_chats`/`list_teams`/`list_channels`/`list_channel_messages` results read in the poll loops). A bare `dict` is `dict[Unknown, Unknown]`, the same loose-typing escape hatch CLAUDE.md bans, so every value read out of a Graph response was untyped, which is why the nullable-field bugs #1340/#1345 fixed passed the type checker.

This models the Graph resources the Teams poller actually reads as TypedDicts with nullability modeled honestly, and parses at the boundary so downstream reads are fully typed:

- `Identity` (`id: str`, `displayName: NotRequired[str | None]`)
- `IdentitySet` (`user`/`application`, each `NotRequired[Identity | None]`)
- `ItemBody` (`content: NotRequired[str | None]`)
- `ChatMessage` (the shared read-surface of a `chatMessage` and a `chatMessageInfo`: `from`/`body`/`createdDateTime`, functional-form because `from` is a keyword)
- `ConversationMember` (`displayName: NotRequired[str | None]`)
- `Chat` (`id`, `topic`, `members`, `lastMessagePreview`)
- `ChannelResource` (a team/channel: `id`, `displayName`)

The untyped `teams.py` results are cast to these shapes at the point they enter the monitor (`teams.py` is imported by `monitor.py`, so annotating its returns would introduce an import cycle; casting at the boundary keeps the change inside `monitor.py`).

## Behavior

One intentional behavior delta, otherwise unchanged. The exact null-handling merged in #1340/#1345 is preserved bit-for-bit: a null Teams `from`, a null author `displayName`, and a null `body.content` are all still treated as absent. The single delta is the topic-fallback member join: on master a null member `displayName` was handed to `str.join` and crashed (a latent TypeError), and an empty-string name produced a malformed join; it now skips null/missing/empty names like every other read. This is strictly safer and covered by a new test, but it is a real behavior change, so this is not a pure typing refactor.

## Why the type now has teeth

A probe reading `body.content`, an author `displayName`, or a member `displayName` unguarded now fails `ty` (`expected str, found str | None`), the same class of presence-vs-value error #1345 shipped for. Added `test_poll_teams_topic_fallback_skips_null_member_names` exercising the null-member path; confirmed it fails against the old unguarded join and passes now. The existing null-`from`/null-`displayName`/null-`content` behavioral tests remain green.

## Checks

- `uv run --with ty ty check src/microsoft_cli/monitor.py`: passes
- `uv run pytest skills/microsoft/cli/tests/`: 232 passed
- `./check.sh guards`: passes

Fixes #1351

🤖 Generated with [Claude Code](https://claude.com/claude-code)
