### PR TITLE
feat(web): widen chat bubble gap after a 5-minute conversational pause

### DIFF
--- a/apps/web/src/components/Chat/ChatMessageArea/virtual.test.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/virtual.test.ts
@@ -42,6 +42,30 @@ describe("buildDecorated", () => {
     expect(keys[0]).toBe("2026-06-08T10:00:00Z-user");
   });
 
+  it("keeps a tight gap between same-sender messages sent close together", () => {
+    const rows = buildDecorated([
+      userMsg("2026-06-08T10:00:00Z"),
+      userMsg("2026-06-08T10:04:00Z"),
+    ]);
+    expect(rows[1]?.gap).toBe("mt-1.5");
+  });
+
+  it("widens the gap between same-sender messages resumed after >= 5 minutes", () => {
+    const rows = buildDecorated([
+      userMsg("2026-06-08T10:00:00Z"),
+      userMsg("2026-06-08T10:05:00Z"),
+    ]);
+    expect(rows[1]?.gap).toBe("mt-5");
+  });
+
+  it("keeps the tight gap when a timestamp is unparseable", () => {
+    const rows = buildDecorated([
+      userMsg("2026-06-08T10:00:00Z"),
+      userMsg("not-a-date"),
+    ]);
+    expect(rows[1]?.gap).toBe("mt-1.5");
+  });
+
   it("uses a tight gap between consecutive tool calls", () => {
     const rows = buildDecorated([
       {

--- a/apps/web/src/components/Chat/ChatMessageArea/virtual.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/virtual.ts
@@ -14,6 +14,21 @@ export function rowKey(event: VestaEvent, idxFallback: number): string {
   return event.ts ? `${event.ts}-${event.type}` : `i-${String(idxFallback)}`;
 }
 
+// A same-sender run resumed after this long reads as a new beat, so it gets the
+// wider alternating-style gap instead of the tight same-sender one.
+const TIME_GAP_THRESHOLD_MS = 5 * 60 * 1000;
+
+function elapsedAtLeastThreshold(
+  msg: VestaEvent,
+  prev: VestaEvent | undefined,
+): boolean {
+  if (!msg.ts || !prev?.ts) return false;
+  const now = Date.parse(msg.ts);
+  const before = Date.parse(prev.ts);
+  if (Number.isNaN(now) || Number.isNaN(before)) return false;
+  return now - before >= TIME_GAP_THRESHOLD_MS;
+}
+
 function rowGap(
   msg: VestaEvent,
   prev: VestaEvent | undefined,
@@ -26,7 +41,8 @@ function rowGap(
   const prevIsTool = prev?.type === "tool_start";
   if (isTool && prevIsTool) return "mt-1";
   if (isTool || prevIsTool) return "mt-2";
-  return prev?.type === msg.type ? "mt-1.5" : "mt-5";
+  if (prev?.type !== msg.type) return "mt-5";
+  return elapsedAtLeastThreshold(msg, prev) ? "mt-5" : "mt-1.5";
 }
 
 export function buildDecorated(chatMessages: VestaEvent[]): DecoratedRow[] {


### PR DESCRIPTION
## What

On the web SPA chat, consecutive same-sender bubbles now get the wider alternating-style top margin (`mt-5`) once at least five minutes separate a message from the previous one, so a conversation resumed after a pause reads as a new beat instead of one long run. Bubbles sent close together keep the tight `mt-1.5`, alternating bubbles are unchanged, and an absent or unparseable `ts` falls back to the existing tight spacing (never throws).

Implemented in `apps/web/src/components/Chat/ChatMessageArea/virtual.ts`: a `TIME_GAP_THRESHOLD_MS` constant (5 min) and an `elapsedAtLeastThreshold` helper gate the same-type branch of `rowGap`.

## Tests

Added three cases to `virtual.test.ts` proving the discrimination: a >= 5 min gap between same-type messages yields `mt-5`, a < 5 min gap stays `mt-1.5`, and an unparseable timestamp stays `mt-1.5`.

## Scope

Web half only. The native Expo half (`apps/mobile/src/agent/chat-list-model.ts`) is deferred to the mobile branch, which is not on master. Using `Refs #1370` so the issue stays open for the native half.

Refs #1370

🤖 Generated with [Claude Code](https://claude.com/claude-code)