### PR TITLE
fix(microsoft): re-scan the boundary second of a truncated mail window

### DIFF
--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -109,9 +109,8 @@ def _window_read_through(messages: list[dict], new_check_time: datetime) -> date
         received = datetime.fromisoformat(newest["receivedDateTime"])
     except ValueError:
         return None
-    # Park one second before the newest, so a same-second tie the truncation split (message 501 sharing
-    # the 500th's second-precision receivedDateTime) is re-scanned next cycle instead of lost to strict
-    # `gt`. The boundary second re-notifies (there is no id-level dedup), a bounded duplicate over a drop.
+    # Park a second back so a same-second tie split off the truncated window is re-scanned next cycle,
+    # not lost to strict `gt`; the boundary second re-notifies (no id-level dedup), a bounded dup over a drop.
     return received - timedelta(seconds=1) if received.tzinfo else None
 
 

--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -109,7 +109,10 @@ def _window_read_through(messages: list[dict], new_check_time: datetime) -> date
         received = datetime.fromisoformat(newest["receivedDateTime"])
     except ValueError:
         return None
-    return received if received.tzinfo else None
+    # Park one second before the newest, so a same-second tie the truncation split (message 501 sharing
+    # the 500th's second-precision receivedDateTime) is re-scanned next cycle instead of lost to strict
+    # `gt`. The boundary second re-notifies (there is no id-level dedup), a bounded duplicate over a drop.
+    return received - timedelta(seconds=1) if received.tzinfo else None
 
 
 class EmailAddress(TypedDict):

--- a/agent/skills/microsoft/cli/tests/test_monitor.py
+++ b/agent/skills/microsoft/cli/tests/test_monitor.py
@@ -294,7 +294,8 @@ def test_a_window_over_the_drain_limit_parks_the_watermark_at_the_last_message_r
 
     drained = mailbox[: monitor._MAX_WINDOW_MESSAGES]
     assert [call["sender"] for call in calls] == [call["from"]["emailAddress"]["name"] for call in drained]
-    assert _watermark(ctx, "mail:me@x.com") == datetime.fromisoformat(drained[-1]["receivedDateTime"])
+    # Parked one second before the last message read, so the boundary second is re-scanned next cycle.
+    assert _watermark(ctx, "mail:me@x.com") == datetime.fromisoformat(drained[-1]["receivedDateTime"]) - timedelta(seconds=1)
     assert _watermark(ctx, "mail:me@x.com") < datetime.fromisoformat(mailbox[monitor._MAX_WINDOW_MESSAGES]["receivedDateTime"])
 
 
@@ -311,10 +312,36 @@ def test_the_rest_of_an_oversized_window_is_drained_by_the_following_cycle(tmp_p
     monkeypatch.setattr(monitor.owa_rest, "list_messages_since", _mailbox(*mailbox))
     monitor.run(ctx)
 
-    assert [call["sender"] for call in calls] == [email["from"]["emailAddress"]["name"] for email in mailbox]
+    delivered = [call["sender"] for call in calls]
+    boundary = mailbox[monitor._MAX_WINDOW_MESSAGES - 1]["from"]["emailAddress"]["name"]
+    # Every message is delivered; the truncation boundary's second is re-scanned, so it repeats once.
+    assert set(delivered) == {email["from"]["emailAddress"]["name"] for email in mailbox}
+    assert delivered.count(boundary) == 2
 
 
-def test_graph_mail_pages_a_bounded_window_and_parks_at_the_last_message_read(tmp_path, monkeypatch):
+def test_a_boundary_second_tie_in_a_truncated_window_is_not_dropped(tmp_path, monkeypatch):
+    """A 501st message sharing the 500th's second is split out of the truncated window. Strict `gt` at
+    the 500th's timestamp would drop it forever; parking one second early re-scans the tie into the next
+    cycle. Discriminates against the old park-at-newest behavior, under which "Tie" never arrives."""
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    _single_owa_account(monkeypatch)
+
+    now = datetime.now(UTC)
+    limit = monitor._MAX_WINDOW_MESSAGES
+    window = _oversized_window(now, limit)  # `limit` messages, one second apart, oldest first
+    tied = _email("tie@x.com", "Tie", window[-1]["receivedDateTime"])  # shares the 500th's second
+    mailbox = [*window, tied]
+
+    ctx = _run_ctx(tmp_path, cycles=2)
+    ctx.monitor_state_file.write_text((now - timedelta(seconds=limit + 1)).isoformat())
+    monkeypatch.setattr(monitor.owa_rest, "list_messages_since", _mailbox(*mailbox))
+    monitor.run(ctx)
+
+    assert "Tie" in [call["sender"] for call in calls]
+
+
+def test_graph_mail_pages_a_bounded_window_and_parks_before_the_last_message_read(tmp_path, monkeypatch):
     calls = []
     monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
     monkeypatch.setattr(monitor.folders, "resolve_folder_id", lambda *a, **k: "inbox-id")
@@ -336,4 +363,4 @@ def test_graph_mail_pages_a_bounded_window_and_parks_at_the_last_message_read(tm
     assert asked["params"]["$orderby"] == "receivedDateTime asc"
     assert asked["limit"] == monitor._MAX_WINDOW_MESSAGES
     assert len(calls) == monitor._MAX_WINDOW_MESSAGES
-    assert read_through == datetime.fromisoformat(mailbox[-1]["receivedDateTime"])
+    assert read_through == datetime.fromisoformat(mailbox[-1]["receivedDateTime"]) - timedelta(seconds=1)

--- a/agent/skills/microsoft/cli/tests/test_monitor.py
+++ b/agent/skills/microsoft/cli/tests/test_monitor.py
@@ -329,7 +329,7 @@ def test_a_boundary_second_tie_in_a_truncated_window_is_not_dropped(tmp_path, mo
 
     now = datetime.now(UTC)
     limit = monitor._MAX_WINDOW_MESSAGES
-    window = _oversized_window(now, limit)  # `limit` messages, one second apart, oldest first
+    window = _oversized_window(now, limit)
     tied = _email("tie@x.com", "Tie", window[-1]["receivedDateTime"])  # shares the 500th's second
     mailbox = [*window, tied]
 


### PR DESCRIPTION
## Problem

Fixes #1344 (found in the code review of #1343).

When a mail fetch comes back at `_MAX_WINDOW_MESSAGES` (500), `monitor.py:_window_read_through` parks the unit's watermark at the newest message's `receivedDateTime`. Both mail paths then window the next cycle with strict `gt` against that watermark (OWA `ReceivedDateTime gt <since>`, Graph `$filter receivedDateTime gt ...`). `receivedDateTime` is second-precision, so any unread message sharing the 500th message's second (message 501 at the truncation boundary) is excluded by `gt` and dropped permanently, the same silent-drop class #1335 set out to close.

The honest fix (a half-open `ge` window carrying the boundary message ids) is a `state.txt` value-shape change coupled to #1336, deliberately deferred. This is the cheaper alternative the issue weighs, signed off by the owner.

## Change

Only when the window is truncated, park the watermark one second before the newest message's `receivedDateTime`, so the boundary second is re-scanned next cycle. The non-truncated path is untouched, so ordinary cycles never re-notify.

## Tradeoff (real, bounded)

There is **no id-level notification dedup** in this path: `notifications.write_notification` writes one file per message with a unique timestamp filename, and every cycle re-emits every message the `gt` filter returns. So the re-scan re-notifies the already-seen boundary second: a bounded duplicate (at most a handful of same-second messages at the one truncation boundary), accepted over a permanent drop, per #1311's "a duplicate notification beats losing mail". Documented in a one-line comment at the watermark park.

## Test

`test_a_boundary_second_tie_in_a_truncated_window_is_not_dropped`: a truncated window (>= `_MAX_WINDOW_MESSAGES`) with a 501st message sharing the 500th's second; asserts the tied message still arrives on the next cycle. Verified it discriminates against the old strict-`gt`-at-newest behavior (fails, "Tie" never delivered, when the park-back is reverted). The two existing oversized-window tests are updated to the new park point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)