### PR TITLE
fix(browser): cache the CDP session only after every domain is enabled

### DIFF
--- a/agent/skills/browser/cli/src/vesta_browser/cdp_backend.py
+++ b/agent/skills/browser/cli/src/vesta_browser/cdp_backend.py
@@ -161,8 +161,7 @@ class CdpBackend:
                 raise BidiError("no such frame", e.message) from e
             raise
         session_id = attach["sessionId"]
-        # The session->target map feeds event routing, so populate it before the enables run:
-        # a CDP event arriving mid-enable must resolve to this target, not fall back to self._context.
+        # Set _session_targets before the enables so a mid-enable event routes here, not to the self._context fallback.
         self._session_targets[session_id] = target_id
         for domain in _DOMAINS:
             try:
@@ -172,8 +171,7 @@ class CdpBackend:
                 # Any other error (a withheld "timeout") means a wedged browser and must propagate.
                 if e.code != "cdp error":
                     raise
-        # Cache the target->session memo only after every domain is enabled, so a wedged enable
-        # is not cached: a later _session_for retries the attach+enable instead of returning it.
+        # Cache the target->session memo only after every enable succeeds, so a wedged enable is retried, not returned half-enabled.
         self._sessions[target_id] = session_id
         return session_id
 

--- a/agent/skills/browser/cli/src/vesta_browser/cdp_backend.py
+++ b/agent/skills/browser/cli/src/vesta_browser/cdp_backend.py
@@ -161,7 +161,8 @@ class CdpBackend:
                 raise BidiError("no such frame", e.message) from e
             raise
         session_id = attach["sessionId"]
-        self._sessions[target_id] = session_id
+        # The session->target map feeds event routing, so populate it before the enables run:
+        # a CDP event arriving mid-enable must resolve to this target, not fall back to self._context.
         self._session_targets[session_id] = target_id
         for domain in _DOMAINS:
             try:
@@ -171,6 +172,9 @@ class CdpBackend:
                 # Any other error (a withheld "timeout") means a wedged browser and must propagate.
                 if e.code != "cdp error":
                     raise
+        # Cache the target->session memo only after every domain is enabled, so a wedged enable
+        # is not cached: a later _session_for retries the attach+enable instead of returning it.
+        self._sessions[target_id] = session_id
         return session_id
 
     # ── BiDi -> CDP command translation ───────────────────────

--- a/agent/skills/browser/cli/tests/test_cdp_backend.py
+++ b/agent/skills/browser/cli/tests/test_cdp_backend.py
@@ -382,3 +382,46 @@ def test_wedged_domain_enable_propagates_timeout_instead_of_being_swallowed(monk
     error = asyncio.run(_with_silent_backend(body, SilentCdpServer(answer_attach)))
     assert error.code == "timeout"
     assert ".enable" in error.message
+
+
+def test_wedged_domain_enable_does_not_cache_the_half_enabled_session(monkeypatch):
+    """A wedged enable must leave the target->session memo unset, so a later _session_for retries the
+    attach+enable instead of returning a cached session that has no domains enabled."""
+    monkeypatch.setattr(cdp_backend, "_CDP_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
+
+    async def answer_attach(ws, message):
+        if message["method"] == "Target.attachToTarget":
+            await ws.send(json.dumps({"id": message["id"], "result": {"sessionId": "S1"}}))
+
+    async def body(backend):
+        with pytest.raises(BidiError):
+            await backend._session_for("T1")
+        return dict(backend._sessions)
+
+    assert asyncio.run(_with_silent_backend(body, SilentCdpServer(answer_attach))) == {}
+
+
+def test_event_arriving_mid_enable_routes_to_its_target_not_the_context(monkeypatch):
+    """A CDP event that arrives while the domain-enables are still in flight must resolve to the attaching
+    target. _session_targets is populated before the enable loop (only the _sessions memo moved below it),
+    so routing never regresses to the self._context fallback while the memo is briefly unset."""
+    monkeypatch.setattr(cdp_backend, "_CDP_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
+
+    async def answer(ws, message):
+        method = message["method"]
+        if method == "Target.attachToTarget":
+            await ws.send(json.dumps({"id": message["id"], "result": {"sessionId": "S1"}}))
+        elif method == "Page.enable":
+            # Push a load event mid-enable: it arrives before this reply, while _sessions has no T1 entry.
+            await ws.send(json.dumps({"method": "Page.loadEventFired", "params": {}, "sessionId": "S1"}))
+            await ws.send(json.dumps({"id": message["id"], "result": {}}))
+        else:
+            await ws.send(json.dumps({"id": message["id"], "result": {}}))
+
+    async def body(backend):
+        loads = backend.on_event("browsingContext.load")
+        await backend._session_for("T1")
+        return await asyncio.wait_for(loads.get(), timeout=HANG_GUARD_S)
+
+    # backend._context is "" on a fresh backend, so a routing regression would yield {"context": ""}.
+    assert asyncio.run(_with_silent_backend(body, SilentCdpServer(answer))) == {"context": "T1"}

--- a/agent/skills/browser/cli/tests/test_cdp_backend.py
+++ b/agent/skills/browser/cli/tests/test_cdp_backend.py
@@ -402,9 +402,8 @@ def test_wedged_domain_enable_does_not_cache_the_half_enabled_session(monkeypatc
 
 
 def test_event_arriving_mid_enable_routes_to_its_target_not_the_context(monkeypatch):
-    """A CDP event that arrives while the domain-enables are still in flight must resolve to the attaching
-    target. _session_targets is populated before the enable loop (only the _sessions memo moved below it),
-    so routing never regresses to the self._context fallback while the memo is briefly unset."""
+    """A CDP event arriving while the domain-enables are still in flight must resolve to the attaching target,
+    not regress to the self._context fallback while the _sessions memo is briefly unset."""
     monkeypatch.setattr(cdp_backend, "_CDP_RESPONSE_TIMEOUT_S", TEST_TIMEOUT_S)
 
     async def answer(ws, message):


### PR DESCRIPTION
## What

Completes the deferred cache-poisoning half of #1348. Its sibling, the suppress-narrowing half, already shipped as #1386 (merged); this branch is on top of that merge.

`_session_for` in `cdp_backend.py` wrote the target->session memo before enabling the four CDP domains:

```python
session_id = attach["sessionId"]
self._sessions[target_id] = session_id        # memo written before the enables
self._session_targets[session_id] = target_id
for domain in _DOMAINS:
    ...await self._cdp.send(f"{domain}.enable", ...)   # a wedged reply raises here
```

After #1386 a withheld `{domain}.enable` reply correctly propagates as `BidiError("timeout")`, but the memo write at line 164 already happened. So even with the timeout propagating, the half-enabled session stays cached: every later `_session_for(target_id)` hits the early-return at line 154-155 and returns it, never retrying the enables. Every subsequent command then runs against a session with no domains enabled.

## Change

One line moves: write `self._sessions[target_id] = session_id` **after** the enable loop instead of before. A failed enable now raises before the memo is set, so the target is left uncached and a later `_session_for` retries the attach + enable.

I deliberately did **not** move the second write. The issue prescribed moving both `self._sessions` and `self._session_targets` below the loop, but only `_sessions` is the poisoning cache (it is the memo the early-return reads at line 154-155). `_session_targets` is a pure event-routing map, read only by `_on_cdp_event` (line 359) to resolve `session_id -> target_id`, falling back to `self._context` when the session is unknown. Moving it below the loop is what the issue flags as the real ordering risk, and it is a real regression: a CDP event arriving *during* the enables would resolve to `self._context` (empty `""` on a fresh backend, or the previously-active target) instead of the attaching target. Keeping `_session_targets` above the loop leaves event routing byte-for-byte unchanged and fixes the poisoning with the single write that causes it.

## Event-routing concern: real, and ruled out by construction

The concern the issue calls out is genuine, verified not derived:

- With **both** writes moved below the loop, the new routing test fails: a `Page.loadEventFired` pushed mid-enable resolves to `{"context": ""}` instead of `{"context": "T1"}`.
- With this PR's ordering (`_session_targets` stays above the loop), the same event resolves to `{"context": "T1"}`.

So the reorder does not drop or misroute mid-enable events, because the routing map is populated before the enables run exactly as it is today. The fix is scoped to the memo that actually poisons.

## Tests

`test_cdp_backend.py` gains two tests (a server answers `Target.attachToTarget` then withholds/answers enables):

- `test_wedged_domain_enable_does_not_cache_the_half_enabled_session`: a withheld enable leaves `backend._sessions == {}` (so a later call retries). Discriminates: with the memo written before the loop it fails with `{'T1': 'S1'} == {}`.
- `test_event_arriving_mid_enable_routes_to_its_target_not_the_context`: a load event pushed while the enables are in flight routes to `{"context": "T1"}`. Discriminates: moving `_session_targets` below the loop makes it fail with `{'context': ''}`.

## Checks

- `uv run pytest tests/` (browser skill CLI, from `agent/skills/browser/cli`): 205 passed
- `./check.sh guards`: passed

## Merge order

#1386 is already merged into master, so this branches cleanly on top of it and no rebase is expected. (If #1386 had still been open, this would want to merge after it, since both touch the same enable-loop region of `_session_for`.)

Fixes #1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)