### PR TITLE
chore(deps): stop Dependabot proposing Expo-locked eslint majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,7 @@ updates:
   # versions of its managed packages (react, react-native, the expo-* and
   # @expo/* families, typescript); `expo install --check` pins them to the
   # SDK's matrix, so bumping past it only yields red PRs. Ignore that set here;
-  # community deps (zod, tanstack, vitest, eslint) still get bumped.
+  # community deps (zod, tanstack, vitest) still get bumped.
   - package-ecosystem: npm
     directory: /apps/mobile
     schedule:
@@ -58,6 +58,15 @@ updates:
       - dependency-name: "@react-native-async-storage/*"
       - dependency-name: "typescript"
       - dependency-name: "@types/react"
+      # eslint-config-expo pins the lint stack (eslint and its transitive
+      # eslint-plugin-react / typescript-eslint) to the SDK's matrix: SDK 57
+      # requires eslint ^9.7. A major of either can't resolve until Expo ships
+      # an SDK that accepts it, so majors only yield red PRs (#1380). Ignore
+      # majors only; minors, patches, and security still flow.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-config-expo"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Why

Dependabot keeps opening mobile PRs that can never pass CI (e.g. #1380, eslint 9.39.5 -> 10.7.0). Dependabot cannot pre-run CI, so it does not know a bump will fail; it only knows the version exists on the registry.

The mobile lint stack is owned by Expo SDK 57, not by us. `eslint-config-expo` (~57.0.0) requires `eslint ^9.7` and pulls `eslint-plugin-react` / `typescript-eslint` transitively. No released `eslint-plugin-react` supports ESLint 10, so an `eslint` (or `eslint-config-expo`) **major** cannot resolve until Expo ships an SDK that accepts it. Those majors are structurally unmergeable.

The existing `/apps/mobile` ignore set already covers the Expo-managed families (expo, react, react-native, typescript, ...). It missed the lint stack; the old comment even listed `eslint` as a community dep that "still gets bumped", which is exactly what produced #1380.

## The fix

A major-only ignore for the two direct SDK-locked lint deps in the `/apps/mobile` source:

```yaml
- dependency-name: "eslint"
  update-types: ["version-update:semver-major"]
- dependency-name: "eslint-config-expo"
  update-types: ["version-update:semver-major"]
```

Scoped deliberately:
- **Major-only**, so eslint 9.x minors/patches and security updates still flow. Only the SDK-locked major jump is silenced.
- Only these two names. `eslint-plugin-react` and `typescript-eslint` are transitive (not in `apps/mobile/package.json`), so Dependabot never proposes them directly; naming them would be dead config. `eslint-import-resolver-typescript` and `vitest` are genuine community deps and keep bumping.

## Stale paths

Checked the other recurring class (bumps targeting removed code, e.g. the Tauri -> Electron migration). `dependabot.yml`'s cargo sources are `/cli` and `/vestad`, both current; there is no cargo/desktop source pointing at the deleted Tauri crate, so nothing to prune. That class was self-resolving once the directory was gone.

## Optional safety net (not included)

A CI action that auto-closes any Dependabot PR whose `merge-gate-ci` fails would catch *future* unknown lock classes too. Left out on purpose: it is bespoke automation that can also mask a real regression in a legitimate bump, and the user asked for a fix "at the root", which the config `ignore` is. Happy to add it if you want the broader net.

🤖 Generated with Claude Code