### PR TITLE
feat(core): stage 2, protocol types, replica, and transport

### DIFF
--- a/apps/core/.prettierrc.json
+++ b/apps/core/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "printWidth": 100
+}

--- a/apps/core/eslint.config.js
+++ b/apps/core/eslint.config.js
@@ -1,3 +1,4 @@
+import eslintConfigPrettier from "eslint-config-prettier"
 import tseslint from "typescript-eslint"
 
 export default tseslint.config(
@@ -11,4 +12,5 @@ export default tseslint.config(
       },
     },
   },
+  eslintConfigPrettier,
 )

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -12,10 +12,14 @@
   "scripts": {
     "lint": "eslint src",
     "check": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "format": "prettier --write src",
+    "format:check": "prettier --check src"
   },
   "devDependencies": {
     "eslint": "^9.30.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.9.5",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.35.0",
     "vitest": "^3.2.4"

--- a/apps/core/src/adapters/types.ts
+++ b/apps/core/src/adapters/types.ts
@@ -1,0 +1,17 @@
+// The platform seam: interfaces only in this stage. Web supplies localStorage
+// plus the native bridge; mobile supplies SecureStore/AsyncStorage, AppState,
+// and Expo push. Implementations land with the app migrations.
+export interface StorageAdapter {
+  get: (key: string) => Promise<string | null>
+  set: (key: string, value: string) => Promise<void>
+  remove: (key: string) => Promise<void>
+}
+
+export interface ForegroundSignal {
+  isForeground: () => boolean
+  subscribe: (listener: (foreground: boolean) => void) => () => void
+}
+
+export interface PushTokenProvider {
+  token: () => Promise<string | null>
+}

--- a/apps/core/src/index.test.ts
+++ b/apps/core/src/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ApiError,
+  createHttpClient,
+  createReplica,
+  createSendMessageIntent,
+  createSyncSocket,
+  createWatchManager,
+  encodeFrame,
+  parseServerFrame,
+  PROTOCOL_FLOOR,
+  PROTOCOL_VERSION,
+  readSse,
+  reauthFrame,
+  reduceDelta,
+  unwatchFrame,
+  watchFrame,
+} from "./index"
+import type { StorageAdapter, SyncState, Tree } from "./index"
+
+describe("@vesta/core barrel", () => {
+  it("re-exports the runtime surface later stages import", () => {
+    const runtime = [
+      createHttpClient,
+      createReplica,
+      createSendMessageIntent,
+      createSyncSocket,
+      createWatchManager,
+      encodeFrame,
+      parseServerFrame,
+      readSse,
+      reauthFrame,
+      reduceDelta,
+      unwatchFrame,
+      watchFrame,
+    ]
+    for (const value of runtime) expect(value).toBeTypeOf("function")
+    expect(ApiError).toBeTypeOf("function")
+    expect(PROTOCOL_VERSION).toBe(1)
+    expect(PROTOCOL_FLOOR).toBe(1)
+  })
+
+  it("re-exports the type surface", () => {
+    const state: SyncState = "open"
+    const storage: StorageAdapter = {
+      get: () => Promise.resolve(null),
+      set: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+    }
+    const tree: Tree | null = null
+    expect(state).toBe("open")
+    expect(tree).toBeNull()
+    expect(storage.get).toBeTypeOf("function")
+  })
+})

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -1,1 +1,65 @@
 export { PROTOCOL_FLOOR, PROTOCOL_VERSION } from "./protocol/version"
+
+export type {
+  AgentActivityState,
+  AgentInfo,
+  AgentNode,
+  AgentStatus,
+  BuildPhase,
+  GatewayInfo,
+  GatewayLan,
+  ReleaseChannel,
+  ServiceInfo,
+  Tree,
+} from "./protocol/tree"
+export type { InputMethod, NotificationEvent, VestaEvent } from "./protocol/events"
+export { encodeFrame, reauthFrame, unwatchFrame, watchFrame } from "./protocol/frames"
+export type {
+  ClientFrame,
+  HelloFrame,
+  ReauthFrame,
+  SnapshotFrame,
+  UnwatchFrame,
+  WatchFrame,
+} from "./protocol/frames"
+export type {
+  AgentDelta,
+  AgentRemovedDelta,
+  AppendDelta,
+  Delta,
+  NotificationsDelta,
+  ResyncDelta,
+  StateDelta,
+} from "./protocol/deltas"
+export { parseServerFrame } from "./protocol/parse"
+export type { ParsedFrame } from "./protocol/parse"
+
+export { reduceDelta } from "./replica/reducer"
+export { createReplica } from "./replica/store"
+export type { Replica } from "./replica/store"
+export { createWatchManager } from "./replica/watch"
+export type { WatchManager } from "./replica/watch"
+
+export { ApiError, createHttpClient } from "./transport/http"
+export type { FetchLike, HttpClient, HttpDeps } from "./transport/http"
+export { createSyncSocket } from "./transport/socket"
+export type {
+  SocketLike,
+  SyncSocket,
+  SyncSocketCallbacks,
+  SyncSocketDeps,
+  SyncState,
+} from "./transport/socket"
+export { readSse } from "./transport/sse"
+export type { SseDeps, SseHandle, StreamEvent } from "./transport/sse"
+
+export { createSendMessageIntent } from "./intents/types"
+export type {
+  IdGenerator,
+  IntentEnvelope,
+  IntentId,
+  SendMessageBody,
+  SendMessageIntent,
+} from "./intents/types"
+
+export type { ForegroundSignal, PushTokenProvider, StorageAdapter } from "./adapters/types"

--- a/apps/core/src/intents/types.test.ts
+++ b/apps/core/src/intents/types.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+
+import { createSendMessageIntent } from "./types"
+
+describe("createSendMessageIntent", () => {
+  it("stamps a generated id and carries the message body", () => {
+    const intent = createSendMessageIntent(
+      "scout",
+      { text: "ship it", input_method: "typed" },
+      () => "intent-1",
+    )
+    expect(intent).toEqual({
+      kind: "send_message",
+      id: "intent-1",
+      agent: "scout",
+      body: { text: "ship it", input_method: "typed" },
+    })
+  })
+
+  it("uses the injected generator for each intent id", () => {
+    let counter = 0
+    const newId = (): string => `intent-${String((counter += 1))}`
+    const first = createSendMessageIntent("scout", { text: "a" }, newId)
+    const second = createSendMessageIntent("scout", { text: "b" }, newId)
+    expect([first.id, second.id]).toEqual(["intent-1", "intent-2"])
+  })
+})

--- a/apps/core/src/intents/types.ts
+++ b/apps/core/src/intents/types.ts
@@ -1,0 +1,31 @@
+import type { InputMethod } from "../protocol/events"
+
+// Every intent carries a client-generated id. For send-message the id threads
+// through the app-chat notification file into the UserEvent and returns on the
+// append, making optimistic-echo dedup exact and HTTP retries idempotent. The
+// id generator is injected (crypto.randomUUID in production) for testability.
+export type IntentId = string
+
+export type IdGenerator = () => IntentId
+
+export interface IntentEnvelope<TKind extends string, TBody> {
+  kind: TKind
+  id: IntentId
+  agent: string
+  body: TBody
+}
+
+export interface SendMessageBody {
+  text: string
+  input_method?: InputMethod
+}
+
+export type SendMessageIntent = IntentEnvelope<"send_message", SendMessageBody>
+
+export function createSendMessageIntent(
+  agent: string,
+  body: SendMessageBody,
+  newId: IdGenerator,
+): SendMessageIntent {
+  return { kind: "send_message", id: newId(), agent, body }
+}

--- a/apps/core/src/protocol/deltas.ts
+++ b/apps/core/src/protocol/deltas.ts
@@ -1,0 +1,39 @@
+import type { AgentInfo, GatewayInfo } from "./tree"
+import type { NotificationEvent, VestaEvent } from "./events"
+
+export interface StateDelta {
+  type: "state"
+  scope: "gateway"
+  value: GatewayInfo
+}
+
+export interface AgentDelta {
+  type: "agent"
+  name: string
+  info: AgentInfo
+}
+
+export interface AgentRemovedDelta {
+  type: "agent_removed"
+  name: string
+}
+
+export interface AppendDelta {
+  type: "append"
+  agent: string
+  events: VestaEvent[]
+}
+
+export interface NotificationsDelta {
+  type: "notifications"
+  agent: string
+  pending: NotificationEvent[]
+}
+
+export interface ResyncDelta {
+  type: "resync"
+  agent: string
+}
+
+export type Delta =
+  StateDelta | AgentDelta | AgentRemovedDelta | AppendDelta | NotificationsDelta | ResyncDelta

--- a/apps/core/src/protocol/events.ts
+++ b/apps/core/src/protocol/events.ts
@@ -1,0 +1,42 @@
+export type InputMethod = "voice" | "typed"
+
+// Every event carries the events.db rowid as `id`; the snapshot is a frame, not
+// an event, so it is absent from this union. Field names mirror the agent's
+// Python wire verbatim (snake_case), which vestad relays unchanged.
+interface EventBase {
+  id: number
+  ts?: string
+}
+
+interface NotificationFields {
+  type: "notification"
+  source: string
+  summary: string
+  notif_type?: string
+  sender?: string
+  fields?: Record<string, string>
+  decided?: "interrupt" | "snooze" | "trash"
+  notif_id?: string
+}
+
+export type NotificationEvent = EventBase & NotificationFields
+
+export type VestaEvent =
+  | (EventBase & { type: "status"; state: "idle" | "thinking" })
+  | (EventBase & { type: "user"; text: string; input_method?: InputMethod })
+  | (EventBase & { type: "assistant"; text: string })
+  | (EventBase & { type: "thinking"; text: string; signature: string })
+  | (EventBase & { type: "chat"; text: string })
+  | (EventBase & { type: "tool_start"; tool: string; input: string; subagent?: boolean })
+  | (EventBase & { type: "tool_end"; tool: string; subagent?: boolean })
+  | (EventBase & { type: "error"; text: string })
+  | (EventBase & {
+      type: "rate_limited"
+      text: string
+      window: string | null
+      resets_at: number | null
+    })
+  | NotificationEvent
+  | (EventBase & { type: "notification_cleared"; notif_id: string })
+  | (EventBase & { type: "subagent_start"; agent_id: string; agent_type: string })
+  | (EventBase & { type: "subagent_stop"; agent_id: string; agent_type: string })

--- a/apps/core/src/protocol/frames.test.ts
+++ b/apps/core/src/protocol/frames.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+
+import { encodeFrame, reauthFrame, unwatchFrame, watchFrame } from "./frames"
+import type { HelloFrame, SnapshotFrame } from "./frames"
+import type { NotificationEvent } from "./events"
+import type { Tree } from "./tree"
+
+describe("client frame constructors", () => {
+  it("builds watch, unwatch, and reauth frames", () => {
+    expect(watchFrame("scout")).toEqual({ type: "watch", agent: "scout" })
+    expect(unwatchFrame("scout")).toEqual({ type: "unwatch", agent: "scout" })
+    expect(reauthFrame("tok")).toEqual({ type: "reauth", token: "tok" })
+  })
+
+  it("encodes a client frame as JSON", () => {
+    expect(encodeFrame(watchFrame("scout"))).toBe('{"type":"watch","agent":"scout"}')
+  })
+})
+
+describe("server frame and tree shapes", () => {
+  it("types a hello frame with version, protocol, and floor", () => {
+    const hello: HelloFrame = { type: "hello", version: "0.2.0", protocol: 1, floor: 1 }
+    expect(hello.protocol).toBe(1)
+  })
+
+  it("types a snapshot frame carrying the state tree", () => {
+    const event: NotificationEvent = { id: 7, type: "notification", source: "sms", summary: "hi" }
+    const tree: Tree = {
+      gateway: {
+        version: "0.2.0",
+        channel: "stable",
+        autoUpdate: true,
+        port: 4111,
+        lan: { exposed: false, url: null },
+        tunnelUrl: null,
+        updateAvailable: false,
+        latestVersion: null,
+        managed: false,
+      },
+      agents: {
+        scout: {
+          info: {
+            status: "alive",
+            activityState: "idle",
+            buildPhase: null,
+            startedAt: "2026-07-18T00:00:00Z",
+            services: {},
+          },
+          notifications: { pending: [event] },
+        },
+      },
+    }
+    const snapshot: SnapshotFrame = { type: "snapshot", tree }
+    expect(snapshot.tree.agents.scout?.notifications.pending[0]?.id).toBe(7)
+  })
+})

--- a/apps/core/src/protocol/frames.ts
+++ b/apps/core/src/protocol/frames.ts
@@ -1,0 +1,46 @@
+import type { Tree } from "./tree"
+
+export interface HelloFrame {
+  type: "hello"
+  version: string
+  protocol: number
+  floor: number
+}
+
+export interface SnapshotFrame {
+  type: "snapshot"
+  tree: Tree
+}
+
+export interface WatchFrame {
+  type: "watch"
+  agent: string
+}
+
+export interface UnwatchFrame {
+  type: "unwatch"
+  agent: string
+}
+
+export interface ReauthFrame {
+  type: "reauth"
+  token: string
+}
+
+export type ClientFrame = WatchFrame | UnwatchFrame | ReauthFrame
+
+export function watchFrame(agent: string): WatchFrame {
+  return { type: "watch", agent }
+}
+
+export function unwatchFrame(agent: string): UnwatchFrame {
+  return { type: "unwatch", agent }
+}
+
+export function reauthFrame(token: string): ReauthFrame {
+  return { type: "reauth", token }
+}
+
+export function encodeFrame(frame: ClientFrame): string {
+  return JSON.stringify(frame)
+}

--- a/apps/core/src/protocol/parse.test.ts
+++ b/apps/core/src/protocol/parse.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+
+import { parseServerFrame } from "./parse"
+
+describe("parseServerFrame", () => {
+  it("parses a hello frame", () => {
+    const parsed = parseServerFrame(
+      JSON.stringify({ type: "hello", version: "0.2.0", protocol: 1, floor: 1 }),
+    )
+    expect(parsed).toEqual({
+      kind: "hello",
+      frame: { type: "hello", version: "0.2.0", protocol: 1, floor: 1 },
+    })
+  })
+
+  it("parses a snapshot frame and preserves the tree", () => {
+    const tree = { gateway: {}, agents: {} }
+    const parsed = parseServerFrame(JSON.stringify({ type: "snapshot", tree }))
+    expect(parsed.kind).toBe("snapshot")
+    if (parsed.kind === "snapshot") expect(parsed.frame.tree).toEqual(tree)
+  })
+
+  it("classifies each delta type", () => {
+    const cases: { raw: Record<string, unknown>; type: string }[] = [
+      { raw: { type: "state", scope: "gateway", value: { version: "1" } }, type: "state" },
+      { raw: { type: "agent", name: "scout", info: { status: "alive" } }, type: "agent" },
+      { raw: { type: "agent_removed", name: "scout" }, type: "agent_removed" },
+      { raw: { type: "append", agent: "scout", events: [] }, type: "append" },
+      { raw: { type: "notifications", agent: "scout", pending: [] }, type: "notifications" },
+      { raw: { type: "resync", agent: "scout" }, type: "resync" },
+    ]
+    for (const entry of cases) {
+      const parsed = parseServerFrame(JSON.stringify(entry.raw))
+      expect(parsed.kind).toBe("delta")
+      if (parsed.kind === "delta") expect(parsed.delta.type).toBe(entry.type)
+    }
+  })
+
+  it("ignores unknown frame and delta types", () => {
+    const inputs = [
+      JSON.stringify({ type: "future_frame", data: 1 }),
+      JSON.stringify({ type: "future_delta", agent: "scout" }),
+    ]
+    for (const raw of inputs) expect(parseServerFrame(raw)).toEqual({ kind: "unknown" })
+  })
+
+  it("ignores malformed input", () => {
+    const inputs = ["not json", "null", "123", JSON.stringify({ noType: true })]
+    for (const raw of inputs) expect(parseServerFrame(raw)).toEqual({ kind: "unknown" })
+  })
+
+  it("ignores a delta missing a required field", () => {
+    const inputs = [
+      JSON.stringify({ type: "agent", name: "scout" }),
+      JSON.stringify({ type: "append", agent: "scout" }),
+      JSON.stringify({ type: "state", scope: "other", value: {} }),
+    ]
+    for (const raw of inputs) expect(parseServerFrame(raw)).toEqual({ kind: "unknown" })
+  })
+})

--- a/apps/core/src/protocol/parse.ts
+++ b/apps/core/src/protocol/parse.ts
@@ -1,0 +1,117 @@
+import type { Delta } from "./deltas"
+import type { NotificationEvent, VestaEvent } from "./events"
+import type { HelloFrame, SnapshotFrame } from "./frames"
+import type { AgentInfo, GatewayInfo, Tree } from "./tree"
+
+export type ParsedFrame =
+  | { kind: "hello"; frame: HelloFrame }
+  | { kind: "snapshot"; frame: SnapshotFrame }
+  | { kind: "delta"; delta: Delta }
+  | { kind: "unknown" }
+
+const UNKNOWN: ParsedFrame = { kind: "unknown" }
+
+// Core trusts vestad's serialization within a protocol version (additive-only,
+// contract-tested at the fixture seam), so the parser routes on `type` and the
+// fields it keys on, then asserts the trusted sub-shapes. Anything it cannot
+// classify becomes `unknown`, which the reducer skips by rule.
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null
+}
+
+function str(value: unknown): string | null {
+  return typeof value === "string" ? value : null
+}
+
+function num(value: unknown): number | null {
+  return typeof value === "number" ? value : null
+}
+
+function arr(value: unknown): unknown[] | null {
+  return Array.isArray(value) ? (value as unknown[]) : null
+}
+
+export function parseServerFrame(raw: string): ParsedFrame {
+  let json: unknown
+  try {
+    json = JSON.parse(raw)
+  } catch {
+    return UNKNOWN
+  }
+  const frame = record(json)
+  if (frame === null) return UNKNOWN
+  const type = str(frame.type)
+  if (type === null) return UNKNOWN
+  switch (type) {
+    case "hello":
+      return parseHello(frame)
+    case "snapshot":
+      return parseSnapshot(frame)
+    case "state":
+    case "agent":
+    case "agent_removed":
+    case "append":
+    case "notifications":
+    case "resync":
+      return parseDelta(type, frame)
+    default:
+      return UNKNOWN
+  }
+}
+
+function parseHello(frame: Record<string, unknown>): ParsedFrame {
+  const version = str(frame.version)
+  const protocol = num(frame.protocol)
+  const floor = num(frame.floor)
+  if (version === null || protocol === null || floor === null) return UNKNOWN
+  return { kind: "hello", frame: { type: "hello", version, protocol, floor } }
+}
+
+function parseSnapshot(frame: Record<string, unknown>): ParsedFrame {
+  if (record(frame.tree) === null) return UNKNOWN
+  return { kind: "snapshot", frame: { type: "snapshot", tree: frame.tree as Tree } }
+}
+
+function parseDelta(type: string, frame: Record<string, unknown>): ParsedFrame {
+  switch (type) {
+    case "state": {
+      if (str(frame.scope) !== "gateway" || record(frame.value) === null) return UNKNOWN
+      return {
+        kind: "delta",
+        delta: { type: "state", scope: "gateway", value: frame.value as GatewayInfo },
+      }
+    }
+    case "agent": {
+      const name = str(frame.name)
+      if (name === null || record(frame.info) === null) return UNKNOWN
+      return { kind: "delta", delta: { type: "agent", name, info: frame.info as AgentInfo } }
+    }
+    case "agent_removed": {
+      const name = str(frame.name)
+      if (name === null) return UNKNOWN
+      return { kind: "delta", delta: { type: "agent_removed", name } }
+    }
+    case "append": {
+      const agent = str(frame.agent)
+      const events = arr(frame.events)
+      if (agent === null || events === null) return UNKNOWN
+      return { kind: "delta", delta: { type: "append", agent, events: events as VestaEvent[] } }
+    }
+    case "notifications": {
+      const agent = str(frame.agent)
+      const pending = arr(frame.pending)
+      if (agent === null || pending === null) return UNKNOWN
+      return {
+        kind: "delta",
+        delta: { type: "notifications", agent, pending: pending as NotificationEvent[] },
+      }
+    }
+    case "resync": {
+      const agent = str(frame.agent)
+      if (agent === null) return UNKNOWN
+      return { kind: "delta", delta: { type: "resync", agent } }
+    }
+    default:
+      return UNKNOWN
+  }
+}

--- a/apps/core/src/protocol/tree.ts
+++ b/apps/core/src/protocol/tree.ts
@@ -1,0 +1,61 @@
+import type { NotificationEvent } from "./events"
+
+export type AgentStatus =
+  | "alive"
+  | "starting"
+  | "setting_up"
+  | "not_authenticated"
+  | "unprovisioned"
+  | "restarting"
+  | "rebuilding"
+  | "stopped"
+  | "dead"
+  | "not_found"
+
+export type AgentActivityState = "idle" | "thinking"
+
+// Coarse, ordered stages of first-time agent creation, computed server-side and
+// carried in the tree (the old build-phase polling endpoint is retired).
+export type BuildPhase = "pulling" | "building" | "preparing" | "creating" | "starting"
+
+export type ReleaseChannel = "stable" | "beta"
+
+export interface ServiceInfo {
+  port: number
+  rev: number
+}
+
+export interface AgentInfo {
+  status: AgentStatus
+  activityState: AgentActivityState
+  buildPhase: BuildPhase | null
+  startedAt: string | null
+  services: Record<string, ServiceInfo>
+}
+
+export interface GatewayLan {
+  exposed: boolean
+  url: string | null
+}
+
+export interface GatewayInfo {
+  version: string
+  channel: ReleaseChannel
+  autoUpdate: boolean
+  port: number
+  lan: GatewayLan
+  tunnelUrl: string | null
+  updateAvailable: boolean
+  latestVersion: string | null
+  managed: boolean
+}
+
+export interface AgentNode {
+  info: AgentInfo
+  notifications: { pending: NotificationEvent[] }
+}
+
+export interface Tree {
+  gateway: GatewayInfo
+  agents: Record<string, AgentNode>
+}

--- a/apps/core/src/replica/reducer.test.ts
+++ b/apps/core/src/replica/reducer.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+
+import { reduceDelta } from "./reducer"
+import type { Tree } from "../protocol/tree"
+
+function baseTree(): Tree {
+  return {
+    gateway: {
+      version: "0.2.0",
+      channel: "stable",
+      autoUpdate: true,
+      port: 4111,
+      lan: { exposed: false, url: null },
+      tunnelUrl: null,
+      updateAvailable: false,
+      latestVersion: null,
+      managed: false,
+    },
+    agents: {
+      scout: {
+        info: {
+          status: "alive",
+          activityState: "idle",
+          buildPhase: null,
+          startedAt: null,
+          services: {},
+        },
+        notifications: { pending: [] },
+      },
+    },
+  }
+}
+
+describe("reduceDelta", () => {
+  it("replaces the gateway branch on a state delta", () => {
+    const next = reduceDelta(baseTree(), {
+      type: "state",
+      scope: "gateway",
+      value: { ...baseTree().gateway, updateAvailable: true },
+    })
+    expect(next.gateway.updateAvailable).toBe(true)
+  })
+
+  it("upserts an agent and preserves its notifications", () => {
+    const tree = baseTree()
+    const seeded = tree.agents.scout
+    if (seeded) {
+      seeded.notifications.pending = [{ id: 1, type: "notification", source: "sms", summary: "hi" }]
+    }
+    const next = reduceDelta(tree, {
+      type: "agent",
+      name: "scout",
+      info: {
+        status: "restarting",
+        activityState: "idle",
+        buildPhase: null,
+        startedAt: null,
+        services: {},
+      },
+    })
+    expect(next.agents.scout?.info.status).toBe("restarting")
+    expect(next.agents.scout?.notifications.pending).toHaveLength(1)
+  })
+
+  it("adds a brand-new agent with an empty notification branch", () => {
+    const next = reduceDelta(baseTree(), {
+      type: "agent",
+      name: "atlas",
+      info: {
+        status: "starting",
+        activityState: "idle",
+        buildPhase: "pulling",
+        startedAt: null,
+        services: {},
+      },
+    })
+    expect(next.agents.atlas?.notifications.pending).toEqual([])
+  })
+
+  it("removes an agent", () => {
+    const next = reduceDelta(baseTree(), { type: "agent_removed", name: "scout" })
+    expect(next.agents.scout).toBeUndefined()
+  })
+
+  it("replaces the notification branch wholesale", () => {
+    const next = reduceDelta(baseTree(), {
+      type: "notifications",
+      agent: "scout",
+      pending: [{ id: 1, type: "notification", source: "sms", summary: "hi" }],
+    })
+    expect(next.agents.scout?.notifications.pending).toHaveLength(1)
+  })
+
+  it("returns the same tree for append and resync deltas", () => {
+    const tree = baseTree()
+    expect(reduceDelta(tree, { type: "append", agent: "scout", events: [] })).toBe(tree)
+    expect(reduceDelta(tree, { type: "resync", agent: "scout" })).toBe(tree)
+  })
+
+  it("returns the same tree when removing an absent agent", () => {
+    const tree = baseTree()
+    expect(reduceDelta(tree, { type: "agent_removed", name: "ghost" })).toBe(tree)
+  })
+
+  it("does not mutate the input tree", () => {
+    const tree = baseTree()
+    reduceDelta(tree, { type: "agent_removed", name: "scout" })
+    expect(tree.agents.scout).toBeDefined()
+  })
+})

--- a/apps/core/src/replica/reducer.ts
+++ b/apps/core/src/replica/reducer.ts
@@ -1,0 +1,33 @@
+import type { Delta } from "../protocol/deltas"
+import type { AgentNode, Tree } from "../protocol/tree"
+
+export function reduceDelta(tree: Tree, delta: Delta): Tree {
+  switch (delta.type) {
+    case "state":
+      return { ...tree, gateway: delta.value }
+    case "agent": {
+      const prev = tree.agents[delta.name]
+      const node: AgentNode = {
+        info: delta.info,
+        notifications: prev?.notifications ?? { pending: [] },
+      }
+      return { ...tree, agents: { ...tree.agents, [delta.name]: node } }
+    }
+    case "agent_removed": {
+      if (!(delta.name in tree.agents)) return tree
+      const agents = Object.fromEntries(
+        Object.entries(tree.agents).filter(([name]) => name !== delta.name),
+      )
+      return { ...tree, agents }
+    }
+    case "notifications": {
+      const prev = tree.agents[delta.agent]
+      if (prev === undefined) return tree
+      const node: AgentNode = { ...prev, notifications: { pending: delta.pending } }
+      return { ...tree, agents: { ...tree.agents, [delta.agent]: node } }
+    }
+    case "append":
+    case "resync":
+      return tree
+  }
+}

--- a/apps/core/src/replica/store.test.ts
+++ b/apps/core/src/replica/store.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createReplica } from "./store"
+import type { Tree } from "../protocol/tree"
+
+function baseTree(): Tree {
+  return {
+    gateway: {
+      version: "0.2.0",
+      channel: "stable",
+      autoUpdate: true,
+      port: 4111,
+      lan: { exposed: false, url: null },
+      tunnelUrl: null,
+      updateAvailable: false,
+      latestVersion: null,
+      managed: false,
+    },
+    agents: {},
+  }
+}
+
+describe("createReplica", () => {
+  it("starts empty and adopts the first snapshot", () => {
+    const replica = createReplica()
+    expect(replica.getState()).toBeNull()
+    replica.applySnapshot(baseTree())
+    expect(replica.getState()?.gateway.port).toBe(4111)
+  })
+
+  it("notifies subscribers on snapshot and delta", () => {
+    const replica = createReplica()
+    const listener = vi.fn()
+    replica.subscribe(listener)
+    replica.applySnapshot(baseTree())
+    replica.applyDelta({
+      type: "agent",
+      name: "scout",
+      info: {
+        status: "alive",
+        activityState: "idle",
+        buildPhase: null,
+        startedAt: null,
+        services: {},
+      },
+    })
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(replica.getState()?.agents.scout?.info.status).toBe("alive")
+  })
+
+  it("ignores deltas that arrive before the first snapshot", () => {
+    const replica = createReplica()
+    const listener = vi.fn()
+    replica.subscribe(listener)
+    replica.applyDelta({ type: "resync", agent: "scout" })
+    expect(listener).not.toHaveBeenCalled()
+    expect(replica.getState()).toBeNull()
+  })
+
+  it("stops notifying after unsubscribe", () => {
+    const replica = createReplica()
+    const listener = vi.fn()
+    const off = replica.subscribe(listener)
+    off()
+    replica.applySnapshot(baseTree())
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it("does not notify when a delta leaves the tree unchanged", () => {
+    const replica = createReplica()
+    replica.applySnapshot(baseTree())
+    const listener = vi.fn()
+    replica.subscribe(listener)
+    replica.applyDelta({ type: "agent_removed", name: "ghost" })
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/apps/core/src/replica/store.ts
+++ b/apps/core/src/replica/store.ts
@@ -1,0 +1,38 @@
+import { reduceDelta } from "./reducer"
+import type { Delta } from "../protocol/deltas"
+import type { Tree } from "../protocol/tree"
+
+export interface Replica {
+  getState: () => Tree | null
+  subscribe: (listener: () => void) => () => void
+  applySnapshot: (tree: Tree) => void
+  applyDelta: (delta: Delta) => void
+}
+
+export function createReplica(): Replica {
+  let state: Tree | null = null
+  const listeners = new Set<() => void>()
+  const emit = (): void => {
+    for (const listener of listeners) listener()
+  }
+  return {
+    getState: () => state,
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+    applySnapshot: (tree) => {
+      state = tree
+      emit()
+    },
+    applyDelta: (delta) => {
+      if (state === null) return
+      const next = reduceDelta(state, delta)
+      if (next === state) return
+      state = next
+      emit()
+    },
+  }
+}

--- a/apps/core/src/replica/watch.test.ts
+++ b/apps/core/src/replica/watch.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import { createWatchManager } from "./watch"
+
+describe("createWatchManager", () => {
+  it("tracks desired agents in insertion order", () => {
+    const manager = createWatchManager()
+    manager.watch("scout")
+    manager.watch("atlas")
+    expect(manager.desired()).toEqual(["scout", "atlas"])
+  })
+
+  it("deduplicates repeated watches", () => {
+    const manager = createWatchManager()
+    manager.watch("scout")
+    manager.watch("scout")
+    expect(manager.desired()).toEqual(["scout"])
+  })
+
+  it("drops an agent on unwatch", () => {
+    const manager = createWatchManager()
+    manager.watch("scout")
+    manager.watch("atlas")
+    manager.unwatch("scout")
+    expect(manager.desired()).toEqual(["atlas"])
+  })
+
+  it("returns a fresh array each call", () => {
+    const manager = createWatchManager()
+    manager.watch("scout")
+    const first = manager.desired()
+    first.push("mutated")
+    expect(manager.desired()).toEqual(["scout"])
+  })
+})

--- a/apps/core/src/replica/watch.ts
+++ b/apps/core/src/replica/watch.ts
@@ -1,0 +1,18 @@
+export interface WatchManager {
+  watch: (agent: string) => void
+  unwatch: (agent: string) => void
+  desired: () => string[]
+}
+
+export function createWatchManager(): WatchManager {
+  const agents = new Set<string>()
+  return {
+    watch: (agent) => {
+      agents.add(agent)
+    },
+    unwatch: (agent) => {
+      agents.delete(agent)
+    },
+    desired: () => [...agents],
+  }
+}

--- a/apps/core/src/transport/http.test.ts
+++ b/apps/core/src/transport/http.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { ApiError, createHttpClient } from "./http"
+import type { FetchLike, HttpDeps } from "./http"
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+function deps(fetch: FetchLike, over: Partial<HttpDeps> = {}): HttpDeps {
+  return {
+    baseUrl: "https://vestad.test",
+    fetch,
+    token: () => "tok",
+    refresh: () => Promise.resolve(true),
+    ...over,
+  }
+}
+
+describe("createHttpClient", () => {
+  it("sends the bearer token and returns parsed JSON", async () => {
+    const fetch = vi.fn<FetchLike>().mockResolvedValue(jsonResponse(200, { ok: true }))
+    const client = createHttpClient(deps(fetch))
+    const body = await client.json<{ ok: boolean }>("/agents")
+    expect(body).toEqual({ ok: true })
+    const call = fetch.mock.calls.at(0)
+    expect(call?.[0]).toBe("https://vestad.test/agents")
+    expect(new Headers(call?.[1]?.headers).get("Authorization")).toBe("Bearer tok")
+  })
+
+  it("omits the header when no token is available", async () => {
+    const fetch = vi.fn<FetchLike>().mockResolvedValue(jsonResponse(200, {}))
+    const client = createHttpClient(deps(fetch, { token: () => null }))
+    await client.request("/agents")
+    const call = fetch.mock.calls.at(0)
+    expect(new Headers(call?.[1]?.headers).has("Authorization")).toBe(false)
+  })
+
+  it("refreshes once on 401 and retries", async () => {
+    const fetch = vi
+      .fn<FetchLike>()
+      .mockResolvedValueOnce(new Response("nope", { status: 401 }))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }))
+    const refresh = vi.fn<() => Promise<boolean>>().mockResolvedValue(true)
+    const client = createHttpClient(deps(fetch, { refresh }))
+    await client.request("/agents")
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it("throws ApiError when the refresh fails on a 401", async () => {
+    const fetch = vi.fn<FetchLike>().mockResolvedValue(new Response("nope", { status: 401 }))
+    const client = createHttpClient(deps(fetch, { refresh: () => Promise.resolve(false) }))
+    await expect(client.request("/agents")).rejects.toBeInstanceOf(ApiError)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("throws ApiError with the server error message", async () => {
+    const fetch = vi.fn<FetchLike>().mockResolvedValue(jsonResponse(409, { error: "name taken" }))
+    const client = createHttpClient(deps(fetch))
+    await expect(client.request("/agents")).rejects.toMatchObject({
+      status: 409,
+      message: "name taken",
+    })
+  })
+})

--- a/apps/core/src/transport/http.ts
+++ b/apps/core/src/transport/http.ts
@@ -1,0 +1,68 @@
+export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>
+
+export interface HttpDeps {
+  baseUrl: string
+  fetch: FetchLike
+  token: () => string | null
+  refresh: () => Promise<boolean>
+}
+
+export class ApiError extends Error {
+  readonly status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.name = "ApiError"
+    this.status = status
+  }
+}
+
+export interface HttpClient {
+  request: (path: string, init?: RequestInit) => Promise<Response>
+  json: <T>(path: string, init?: RequestInit) => Promise<T>
+}
+
+function errorMessage(body: string): string {
+  try {
+    const parsed: unknown = JSON.parse(body)
+    if (parsed !== null && typeof parsed === "object" && "error" in parsed) {
+      const value = (parsed as Record<string, unknown>).error
+      if (typeof value === "string") return value
+    }
+    return body
+  } catch {
+    return body
+  }
+}
+
+export function createHttpClient(deps: HttpDeps): HttpClient {
+  const headers = (init?: RequestInit): Headers => {
+    const result = new Headers()
+    const token = deps.token()
+    if (token !== null) result.set("Authorization", `Bearer ${token}`)
+    new Headers(init?.headers).forEach((value, key) => {
+      result.set(key, value)
+    })
+    return result
+  }
+
+  const send = (path: string, init?: RequestInit): Promise<Response> =>
+    deps.fetch(`${deps.baseUrl}${path}`, { ...init, headers: headers(init) })
+
+  const request = async (path: string, init?: RequestInit): Promise<Response> => {
+    let response = await send(path, init)
+    if (response.status === 401 && (await deps.refresh())) {
+      response = await send(path, init)
+    }
+    if (!response.ok) throw new ApiError(response.status, errorMessage(await response.text()))
+    return response
+  }
+
+  return {
+    request,
+    json: async <T>(path: string, init?: RequestInit): Promise<T> => {
+      const response = await request(path, init)
+      return (await response.json()) as T
+    },
+  }
+}

--- a/apps/core/src/transport/socket.test.ts
+++ b/apps/core/src/transport/socket.test.ts
@@ -102,6 +102,15 @@ describe("createSyncSocket", () => {
     expect(h.timers).toHaveLength(0)
   })
 
+  it("defers a watch requested before open, then replays it once", () => {
+    const h = harness()
+    const sync = start(h)
+    sync.watch("a")
+    expect(h.sockets[0]?.sent).toEqual([])
+    h.sockets[0]?.onopen?.()
+    expect(h.sockets[0]?.sent).toEqual([JSON.stringify({ type: "watch", agent: "a" })])
+  })
+
   it("replays desired watches on reconnect", () => {
     const h = harness()
     const sync = start(h)

--- a/apps/core/src/transport/socket.test.ts
+++ b/apps/core/src/transport/socket.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest"
+
+import { createSyncSocket } from "./socket"
+import type { SocketLike, SyncSocketDeps, SyncState } from "./socket"
+import type { Delta } from "../protocol/deltas"
+import type { Tree } from "../protocol/tree"
+
+class FakeSocket implements SocketLike {
+  onopen: (() => void) | null = null
+  onmessage: ((data: string) => void) | null = null
+  onclose: (() => void) | null = null
+  readonly sent: string[] = []
+  closed = false
+  send(data: string): void {
+    this.sent.push(data)
+  }
+  close(): void {
+    this.closed = true
+  }
+}
+
+interface Harness {
+  sockets: FakeSocket[]
+  timers: { fn: () => void; ms: number }[]
+  states: SyncState[]
+  snapshots: Tree[]
+  deltas: Delta[]
+  deps: SyncSocketDeps
+}
+
+function harness(): Harness {
+  const sockets: FakeSocket[] = []
+  const timers: { fn: () => void; ms: number }[] = []
+  const states: SyncState[] = []
+  const snapshots: Tree[] = []
+  const deltas: Delta[] = []
+  const deps: SyncSocketDeps = {
+    buildUrl: () => "wss://vestad.test/sync",
+    createSocket: () => {
+      const socket = new FakeSocket()
+      sockets.push(socket)
+      return socket
+    },
+    setTimer: (fn, ms) => {
+      timers.push({ fn, ms })
+      return timers.length - 1
+    },
+    clearTimer: () => undefined,
+  }
+  return { sockets, timers, states, snapshots, deltas, deps }
+}
+
+function start(h: Harness): ReturnType<typeof createSyncSocket> {
+  return createSyncSocket(h.deps, {
+    onStateChange: (state) => h.states.push(state),
+    onSnapshot: (tree) => h.snapshots.push(tree),
+    onDelta: (delta) => h.deltas.push(delta),
+  })
+}
+
+function hello(floor: number, protocol: number): string {
+  return JSON.stringify({ type: "hello", version: "0.2.0", protocol, floor })
+}
+
+describe("createSyncSocket", () => {
+  it("reports connecting then open", () => {
+    const h = harness()
+    start(h)
+    expect(h.states).toEqual(["connecting"])
+    h.sockets[0]?.onopen?.()
+    expect(h.states).toEqual(["connecting", "open"])
+  })
+
+  it("delivers snapshot and delta callbacks", () => {
+    const h = harness()
+    start(h)
+    const socket = h.sockets[0]
+    socket?.onopen?.()
+    socket?.onmessage?.(JSON.stringify({ type: "snapshot", tree: { gateway: {}, agents: {} } }))
+    socket?.onmessage?.(JSON.stringify({ type: "resync", agent: "scout" }))
+    expect(h.snapshots).toHaveLength(1)
+    expect(h.deltas).toEqual([{ type: "resync", agent: "scout" }])
+  })
+
+  it("ignores unknown frames", () => {
+    const h = harness()
+    start(h)
+    h.sockets[0]?.onmessage?.(JSON.stringify({ type: "mystery" }))
+    expect(h.snapshots).toHaveLength(0)
+    expect(h.deltas).toHaveLength(0)
+  })
+
+  it("enters the terminal incompatible state below floor", () => {
+    const h = harness()
+    start(h)
+    const socket = h.sockets[0]
+    socket?.onopen?.()
+    socket?.onmessage?.(hello(2, 2))
+    expect(h.states.at(-1)).toBe("incompatible")
+    expect(socket?.closed).toBe(true)
+    socket?.onclose?.()
+    expect(h.timers).toHaveLength(0)
+  })
+
+  it("replays desired watches on reconnect", () => {
+    const h = harness()
+    const sync = start(h)
+    h.sockets[0]?.onopen?.()
+    sync.watch("scout")
+    expect(h.sockets[0]?.sent).toEqual([JSON.stringify({ type: "watch", agent: "scout" })])
+    h.sockets[0]?.onclose?.()
+    expect(h.timers).toHaveLength(1)
+    h.timers[0]?.fn()
+    h.sockets[1]?.onopen?.()
+    expect(h.sockets[1]?.sent).toEqual([JSON.stringify({ type: "watch", agent: "scout" })])
+  })
+
+  it("drops a watch when its agent is removed", () => {
+    const h = harness()
+    const sync = start(h)
+    h.sockets[0]?.onopen?.()
+    sync.watch("scout")
+    h.sockets[0]?.onmessage?.(JSON.stringify({ type: "agent_removed", name: "scout" }))
+    h.sockets[0]?.onclose?.()
+    h.timers[0]?.fn()
+    h.sockets[1]?.onopen?.()
+    expect(h.sockets[1]?.sent).toEqual([])
+  })
+
+  it("grows the reconnect backoff from 1s toward the cap", () => {
+    const h = harness()
+    start(h)
+    h.sockets[0]?.onclose?.()
+    h.timers[0]?.fn()
+    h.sockets[1]?.onclose?.()
+    expect(h.timers.map((timer) => timer.ms)).toEqual([1000, 2000])
+  })
+
+  it("resets the backoff after a successful open", () => {
+    const h = harness()
+    start(h)
+    h.sockets[0]?.onclose?.()
+    h.timers[0]?.fn()
+    h.sockets[1]?.onopen?.()
+    h.sockets[1]?.onclose?.()
+    expect(h.timers.map((timer) => timer.ms)).toEqual([1000, 1000])
+  })
+
+  it("sends a reauth frame without reconnecting", () => {
+    const h = harness()
+    const sync = start(h)
+    h.sockets[0]?.onopen?.()
+    sync.reauth("fresh")
+    expect(h.sockets[0]?.sent).toEqual([JSON.stringify({ type: "reauth", token: "fresh" })])
+  })
+
+  it("does not reconnect after close", () => {
+    const h = harness()
+    const sync = start(h)
+    h.sockets[0]?.onopen?.()
+    sync.close()
+    expect(h.states.at(-1)).toBe("closed")
+    h.sockets[0]?.onclose?.()
+    expect(h.timers).toHaveLength(0)
+  })
+})

--- a/apps/core/src/transport/socket.ts
+++ b/apps/core/src/transport/socket.ts
@@ -53,6 +53,7 @@ export function createSyncSocket(deps: SyncSocketDeps, callbacks: SyncSocketCall
   let timer: number | null = null
   let delay = base
   let terminal = false
+  let open = false
 
   const detach = (target: SocketLike): void => {
     target.onopen = null
@@ -60,8 +61,10 @@ export function createSyncSocket(deps: SyncSocketDeps, callbacks: SyncSocketCall
     target.onclose = null
   }
 
+  // Only send on an open socket: a browser WebSocket throws before OPEN, and the
+  // onopen replay delivers the desired watches, so the connecting window sends nothing.
   const emit = (frame: ClientFrame): void => {
-    if (socket) socket.send(encodeFrame(frame))
+    if (open && socket) socket.send(encodeFrame(frame))
   }
 
   const scheduleReconnect = (): void => {
@@ -74,6 +77,7 @@ export function createSyncSocket(deps: SyncSocketDeps, callbacks: SyncSocketCall
 
   const goIncompatible = (): void => {
     terminal = true
+    open = false
     if (socket) {
       detach(socket)
       socket.close()
@@ -102,6 +106,7 @@ export function createSyncSocket(deps: SyncSocketDeps, callbacks: SyncSocketCall
 
   function connect(): void {
     if (terminal) return
+    open = false
     callbacks.onStateChange("connecting")
     let url: string
     try {
@@ -114,6 +119,7 @@ export function createSyncSocket(deps: SyncSocketDeps, callbacks: SyncSocketCall
     socket = current
     current.onopen = () => {
       if (socket !== current) return
+      open = true
       delay = base
       callbacks.onStateChange("open")
       for (const agent of watches.desired()) current.send(encodeFrame(watchFrame(agent)))
@@ -123,6 +129,7 @@ export function createSyncSocket(deps: SyncSocketDeps, callbacks: SyncSocketCall
     }
     current.onclose = () => {
       if (socket !== current) return
+      open = false
       socket = null
       if (terminal) return
       scheduleReconnect()
@@ -145,6 +152,7 @@ export function createSyncSocket(deps: SyncSocketDeps, callbacks: SyncSocketCall
     },
     close: () => {
       terminal = true
+      open = false
       if (timer !== null) {
         deps.clearTimer(timer)
         timer = null

--- a/apps/core/src/transport/socket.ts
+++ b/apps/core/src/transport/socket.ts
@@ -1,0 +1,160 @@
+import { encodeFrame, reauthFrame, unwatchFrame, watchFrame } from "../protocol/frames"
+import { parseServerFrame } from "../protocol/parse"
+import { PROTOCOL_FLOOR, PROTOCOL_VERSION } from "../protocol/version"
+import { createWatchManager } from "../replica/watch"
+import type { ClientFrame, HelloFrame } from "../protocol/frames"
+import type { Delta } from "../protocol/deltas"
+import type { Tree } from "../protocol/tree"
+
+export type SyncState = "connecting" | "open" | "reconnecting" | "incompatible" | "closed"
+
+export interface SocketLike {
+  send: (data: string) => void
+  close: () => void
+  onopen: (() => void) | null
+  onmessage: ((data: string) => void) | null
+  onclose: (() => void) | null
+}
+
+export interface SyncSocketDeps {
+  buildUrl: () => string
+  createSocket: (url: string) => SocketLike
+  setTimer: (fn: () => void, ms: number) => number
+  clearTimer: (handle: number) => void
+  baseDelayMs?: number
+  maxDelayMs?: number
+}
+
+export interface SyncSocketCallbacks {
+  onSnapshot: (tree: Tree) => void
+  onDelta: (delta: Delta) => void
+  onStateChange: (state: SyncState) => void
+}
+
+export interface SyncSocket {
+  watch: (agent: string) => void
+  unwatch: (agent: string) => void
+  reauth: (token: string) => void
+  close: () => void
+}
+
+// Compatible when the client's supported protocol range overlaps the server's:
+// the client is not below the server's floor and the server is not below the
+// client's floor. Otherwise the socket is terminally incompatible.
+function compatible(hello: HelloFrame): boolean {
+  return hello.floor <= PROTOCOL_VERSION && PROTOCOL_FLOOR <= hello.protocol
+}
+
+export function createSyncSocket(deps: SyncSocketDeps, callbacks: SyncSocketCallbacks): SyncSocket {
+  const base = deps.baseDelayMs ?? 1000
+  const max = deps.maxDelayMs ?? 30000
+  const watches = createWatchManager()
+  let socket: SocketLike | null = null
+  let timer: number | null = null
+  let delay = base
+  let terminal = false
+
+  const detach = (target: SocketLike): void => {
+    target.onopen = null
+    target.onmessage = null
+    target.onclose = null
+  }
+
+  const emit = (frame: ClientFrame): void => {
+    if (socket) socket.send(encodeFrame(frame))
+  }
+
+  const scheduleReconnect = (): void => {
+    callbacks.onStateChange("reconnecting")
+    timer = deps.setTimer(() => {
+      connect()
+    }, delay)
+    delay = Math.min(delay * 2, max)
+  }
+
+  const goIncompatible = (): void => {
+    terminal = true
+    if (socket) {
+      detach(socket)
+      socket.close()
+      socket = null
+    }
+    callbacks.onStateChange("incompatible")
+  }
+
+  const handleMessage = (data: string): void => {
+    const parsed = parseServerFrame(data)
+    switch (parsed.kind) {
+      case "hello":
+        if (!compatible(parsed.frame)) goIncompatible()
+        return
+      case "snapshot":
+        callbacks.onSnapshot(parsed.frame.tree)
+        return
+      case "delta":
+        if (parsed.delta.type === "agent_removed") watches.unwatch(parsed.delta.name)
+        callbacks.onDelta(parsed.delta)
+        return
+      case "unknown":
+        return
+    }
+  }
+
+  function connect(): void {
+    if (terminal) return
+    callbacks.onStateChange("connecting")
+    let url: string
+    try {
+      url = deps.buildUrl()
+    } catch {
+      scheduleReconnect()
+      return
+    }
+    const current = deps.createSocket(url)
+    socket = current
+    current.onopen = () => {
+      if (socket !== current) return
+      delay = base
+      callbacks.onStateChange("open")
+      for (const agent of watches.desired()) current.send(encodeFrame(watchFrame(agent)))
+    }
+    current.onmessage = (data) => {
+      if (socket === current) handleMessage(data)
+    }
+    current.onclose = () => {
+      if (socket !== current) return
+      socket = null
+      if (terminal) return
+      scheduleReconnect()
+    }
+  }
+
+  connect()
+
+  return {
+    watch: (agent) => {
+      watches.watch(agent)
+      emit(watchFrame(agent))
+    },
+    unwatch: (agent) => {
+      watches.unwatch(agent)
+      emit(unwatchFrame(agent))
+    },
+    reauth: (token) => {
+      emit(reauthFrame(token))
+    },
+    close: () => {
+      terminal = true
+      if (timer !== null) {
+        deps.clearTimer(timer)
+        timer = null
+      }
+      if (socket) {
+        detach(socket)
+        socket.close()
+        socket = null
+      }
+      callbacks.onStateChange("closed")
+    },
+  }
+}

--- a/apps/core/src/transport/sse.test.ts
+++ b/apps/core/src/transport/sse.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { readSse } from "./sse"
+import type { SseDeps, StreamEvent } from "./sse"
+import type { FetchLike } from "./http"
+
+function fetchReturning(body: string, status = 200): FetchLike {
+  return vi.fn<FetchLike>().mockResolvedValue(new Response(body, { status }))
+}
+
+async function collect(deps: SseDeps): Promise<StreamEvent[]> {
+  const events: StreamEvent[] = []
+  readSse(deps, (event) => events.push(event))
+  await vi.waitFor(() => {
+    const last = events.at(-1)
+    expect(last?.kind === "end" || last?.kind === "error").toBe(true)
+  })
+  return events
+}
+
+describe("readSse", () => {
+  it("emits line events for data blocks then end on the stopped event", async () => {
+    const events = await collect({
+      fetch: fetchReturning("data: hello\n\ndata: world\n\nevent: logs_stopped\ndata: \n\n"),
+      url: "https://vestad.test/logs",
+      stoppedEvent: "logs_stopped",
+    })
+    expect(events).toEqual([
+      { kind: "line", text: "hello" },
+      { kind: "line", text: "world" },
+      { kind: "end" },
+    ])
+  })
+
+  it("maps error-prefixed data to an error event", async () => {
+    const events = await collect({
+      fetch: fetchReturning("data: error: boom\n\nevent: logs_stopped\ndata: \n\n"),
+      url: "https://vestad.test/logs",
+      stoppedEvent: "logs_stopped",
+    })
+    expect(events).toEqual([{ kind: "error", message: "error: boom" }, { kind: "end" }])
+  })
+
+  it("reports a transport error when the response is not ok", async () => {
+    const events = await collect({
+      fetch: fetchReturning("nope", 500),
+      url: "https://vestad.test/logs",
+      stoppedEvent: "logs_stopped",
+    })
+    expect(events).toEqual([{ kind: "error", message: "log stream disconnected" }])
+  })
+
+  it("reports a transport error when fetch rejects", async () => {
+    const events = await collect({
+      fetch: vi.fn<FetchLike>().mockRejectedValue(new Error("down")),
+      url: "https://vestad.test/logs",
+      stoppedEvent: "logs_stopped",
+    })
+    expect(events).toEqual([{ kind: "error", message: "log stream disconnected" }])
+  })
+
+  it("emits end when the stream closes without a stopped event", async () => {
+    const events = await collect({
+      fetch: fetchReturning("data: only\n\n"),
+      url: "https://vestad.test/logs",
+      stoppedEvent: "logs_stopped",
+    })
+    expect(events).toEqual([{ kind: "line", text: "only" }, { kind: "end" }])
+  })
+})

--- a/apps/core/src/transport/sse.test.ts
+++ b/apps/core/src/transport/sse.test.ts
@@ -67,4 +67,44 @@ describe("readSse", () => {
     })
     expect(events).toEqual([{ kind: "line", text: "only" }, { kind: "end" }])
   })
+
+  it("buffers a data line split across chunk boundaries", async () => {
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const part of ["data: hel", "lo\n\n"]) controller.enqueue(encoder.encode(part))
+        controller.close()
+      },
+    })
+    const events = await collect({
+      fetch: vi.fn<FetchLike>().mockResolvedValue(new Response(stream)),
+      url: "https://vestad.test/logs",
+      stoppedEvent: "logs_stopped",
+    })
+    expect(events).toEqual([{ kind: "line", text: "hello" }, { kind: "end" }])
+  })
+
+  it("emits nothing further after cancel while a read is pending", async () => {
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("data: one\n\n"))
+      },
+    })
+    const events: StreamEvent[] = []
+    const handle = readSse(
+      {
+        fetch: vi.fn<FetchLike>().mockResolvedValue(new Response(stream)),
+        url: "https://vestad.test/logs",
+        stoppedEvent: "logs_stopped",
+      },
+      (event) => events.push(event),
+    )
+    await vi.waitFor(() => {
+      expect(events).toEqual([{ kind: "line", text: "one" }])
+    })
+    handle.cancel()
+    await new Promise<void>((resolve) => setTimeout(resolve, 20))
+    expect(events).toEqual([{ kind: "line", text: "one" }])
+  })
 })

--- a/apps/core/src/transport/sse.ts
+++ b/apps/core/src/transport/sse.ts
@@ -1,0 +1,97 @@
+import type { FetchLike } from "./http"
+
+export type StreamEvent =
+  { kind: "line"; text: string } | { kind: "end" } | { kind: "error"; message: string }
+
+export interface SseDeps {
+  fetch: FetchLike
+  url: string
+  stoppedEvent: string
+  token?: () => string | null
+}
+
+export interface SseHandle {
+  cancel: () => void
+}
+
+export function readSse(deps: SseDeps, onEvent: (event: StreamEvent) => void): SseHandle {
+  let cancelled = false
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null
+  const isCancelled = (): boolean => cancelled
+
+  const requestHeaders = new Headers()
+  const token = deps.token?.()
+  if (typeof token === "string") requestHeaders.set("Authorization", `Bearer ${token}`)
+
+  const fail = (message: string): void => {
+    if (cancelled) return
+    cancelled = true
+    onEvent({ kind: "error", message })
+  }
+
+  // Parse one SSE block: join its data lines, honor the caller's stopped event
+  // as end, and map an "error:"-prefixed payload to an error event.
+  const dispatch = (block: string): boolean => {
+    let name = "message"
+    const data: string[] = []
+    for (const line of block.split("\n")) {
+      if (line.startsWith("data:")) data.push(line.slice(5).replace(/^ /, ""))
+      else if (line.startsWith("event:")) name = line.slice(6).trim()
+    }
+    if (name === deps.stoppedEvent) {
+      cancelled = true
+      onEvent({ kind: "end" })
+      return true
+    }
+    const text = data.join("\n")
+    onEvent(text.startsWith("error:") ? { kind: "error", message: text } : { kind: "line", text })
+    return false
+  }
+
+  const pump = async (): Promise<void> => {
+    let response: Response
+    try {
+      response = await deps.fetch(deps.url, { headers: requestHeaders })
+    } catch {
+      fail("log stream disconnected")
+      return
+    }
+    if (isCancelled()) return
+    if (!response.ok || !response.body) {
+      fail("log stream disconnected")
+      return
+    }
+    reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ""
+    try {
+      for (;;) {
+        const chunk = await reader.read()
+        if (isCancelled()) return
+        if (chunk.done) {
+          onEvent({ kind: "end" })
+          return
+        }
+        buffer += decoder.decode(chunk.value, { stream: true })
+        let index = buffer.indexOf("\n\n")
+        while (index !== -1) {
+          const block = buffer.slice(0, index)
+          buffer = buffer.slice(index + 2)
+          if (dispatch(block)) return
+          index = buffer.indexOf("\n\n")
+        }
+      }
+    } catch {
+      fail("log stream disconnected")
+    }
+  }
+
+  void pump()
+
+  return {
+    cancel: () => {
+      cancelled = true
+      if (reader) void reader.cancel()
+    },
+  }
+}

--- a/apps/core/tsconfig.json
+++ b/apps/core/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noEmit": true,

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -16,6 +16,8 @@
       "version": "0.0.0",
       "devDependencies": {
         "eslint": "^9.30.0",
+        "eslint-config-prettier": "^9.1.0",
+        "prettier": "^3.9.5",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.35.0",
         "vitest": "^3.2.4"
@@ -9551,6 +9553,19 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-context": {

--- a/check.sh
+++ b/check.sh
@@ -112,6 +112,7 @@ check_web() {
       npm --prefix mobile install
     fi
     npm -w @vesta/core run lint
+    npm -w @vesta/core run format:check
     npm -w @vesta/core run check
     npm -w @vesta/core run test
     npm -w @vesta/web run lint


### PR DESCRIPTION
Stage 2 of the client-protocol epic: the @vesta/core controller internals. Protocol vocabulary (tree, 13-variant event union with ids, frames, exact 6-delta catalog, tolerant parser with named tolerance tests), replica (pure reducer + framework-free store + watch manager), transport (authenticated http client with 401-refresh-once, reconnecting sync socket with floor check/terminal incompatible/backoff/watch replay/open-gated sends, fetch-based SSE reader with cross-chunk buffering), intents (send_message envelope with injected id generator), adapter interfaces, and the full barrel. 56 tests, all suites green, check.sh gates including the new core format gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSn1nFTKDmH5HzuK97mepr