### PR TITLE
feat(agent): stage 3, stable event ids and intent threading

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -113,7 +113,7 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
     return ws
 
 
-def _write_app_chat_notification(config: VestaConfig, text: str) -> None:
+def _write_app_chat_notification(config: VestaConfig, text: str, intent_id: str | None = None) -> None:
     """Persist an inbound app message as a `source=app-chat` notification file — the in-process
     intake the monitor loop picks up. This is what actually delivers app chat to the model.
 
@@ -125,19 +125,39 @@ def _write_app_chat_notification(config: VestaConfig, text: str) -> None:
     directory.mkdir(parents=True, exist_ok=True)
     # `message` is an extra field (Notification allows extras); it renders as the notification's
     # text, matching what the app-chat sidecar used to write. model_validate takes the dict so the
-    # extra passes the type checker.
-    notif = Notification.model_validate(
-        {
-            "timestamp": dt.datetime.now(),
-            "source": "app-chat",
-            "type": "message",
-            "message": text,
-            "interrupt": True,
-            "reply_hint": "reply with `app-chat send`, and think about how you can best show your personality",
-        }
-    )
+    # extra passes the type checker. intent_id rides along as another extra when the client sent one.
+    fields: dict[str, str | bool | dt.datetime] = {
+        "timestamp": dt.datetime.now(),
+        "source": "app-chat",
+        "type": "message",
+        "message": text,
+        "interrupt": True,
+        "reply_hint": "reply with `app-chat send`, and think about how you can best show your personality",
+    }
+    if intent_id is not None:
+        fields["intent_id"] = intent_id
+    notif = Notification.model_validate(fields)
     path = directory / f"{time.time_ns()}-app-chat-message.json"
     atomic_write_text(path, notif.model_dump_json())
+
+
+async def _handle_app_message(data: dict[str, pyd.JsonValue], text: str, event_bus: EventBus, config: VestaConfig) -> None:
+    """Emit the `user` echo event (history + broadcast, the chat's own view of the message) and write
+    the intake notification the monitor loop turns into a model turn. Intake is the file write, done
+    in-process off the loop so a dead subscriber can't drop a message the UI already echoed."""
+    event: UserEvent = {"type": "user", "text": text}
+    method = data["input_method"] if "input_method" in data else None
+    if isinstance(method, str) and method in ("voice", "typed"):
+        event["input_method"] = method
+    intent_id = data["intent_id"] if "intent_id" in data and isinstance(data["intent_id"], str) else None
+    if intent_id is not None:
+        event["intent_id"] = intent_id
+    event_bus.emit(event)
+    try:
+        await asyncio.to_thread(_write_app_chat_notification, config, text, intent_id)
+    except OSError as e:
+        # A lost intake write must surface loudly, never masquerade as delivered.
+        logger.error("failed to write app-chat notification: %s", e)
 
 
 async def _recv_loop(ws: web.WebSocketResponse, event_bus: EventBus, config: VestaConfig) -> None:
@@ -157,18 +177,7 @@ async def _recv_loop(ws: web.WebSocketResponse, event_bus: EventBus, config: Ves
                 text = data["text"].strip()
                 if text:
                     if msg_type == "message":
-                        # The `user` event is history + broadcast (the chat's own echo of the
-                        # message). Intake — turning the message into the notification the model
-                        # processes — is the file write below, done in-process off the loop.
-                        event: UserEvent = {"type": "user", "text": text}
-                        if "input_method" in data and data["input_method"] in ("voice", "typed"):
-                            event["input_method"] = data["input_method"]
-                        event_bus.emit(event)
-                        try:
-                            await asyncio.to_thread(_write_app_chat_notification, config, text)
-                        except OSError as e:
-                            # A lost intake write must surface loudly, never masquerade as delivered.
-                            logger.error("failed to write app-chat notification: %s", e)
+                        await _handle_app_message(data, text, event_bus, config)
                     else:
                         event_bus.emit(ChatEvent(type="chat", text=text))
         elif msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):

--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -61,6 +61,9 @@ class UserEvent(_BaseEvent):
     type: tp.Literal["user"]
     text: str
     input_method: tp.NotRequired[tp.Literal["voice", "typed"]]
+    # The client-generated send-message id, echoed back so the optimistic UI dedups by id (not text)
+    # and a replayed send stays idempotent. Absent when the client sent none.
+    intent_id: tp.NotRequired[str]
 
 
 class ErrorEvent(_BaseEvent):

--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -24,6 +24,7 @@ type AgentState = tp.Literal["idle", "thinking"]
 
 
 class _BaseEvent(tp.TypedDict, total=False):
+    id: int
     ts: str
 
 
@@ -278,6 +279,7 @@ class EventBus:
     def __init__(self, data_dir: pl.Path | None = None) -> None:
         self._subscribers: set[asyncio.Queue[VestaEvent]] = set()
         self._state: AgentState = "idle"
+        self._live_id: int = 0
         self._conn: sqlite3.Connection | None = None
         self._db_path: pl.Path | None = None
         if data_dir:
@@ -306,10 +308,17 @@ class EventBus:
     def unsubscribe(self, q: asyncio.Queue[VestaEvent]) -> None:
         self._subscribers.discard(q)
 
+    def _next_live_id(self) -> int:
+        """An ephemeral id for a live-only event (status, notification_cleared) or one whose history
+        write was dropped: a per-session counter running negative so it can never collide with a real
+        events.db rowid, which is always positive."""
+        self._live_id -= 1
+        return self._live_id
+
     def emit(self, event: StreamEvent) -> None:
         event["ts"] = dt.datetime.now(dt.UTC).isoformat()
         # status (activity flips) and notification_cleared (pending deltas) are live-only signals with
-        # no place in history — broadcast them but don't persist.
+        # no place in history: broadcast them but don't persist.
         if event["type"] not in ("status", "notification_cleared") and self._conn:
             # Event-logging is best-effort: a failed history write must NEVER crash the
             # agent loop. Without this guard, a transient "database is locked" (the db
@@ -317,13 +326,18 @@ class EventBus:
             # and took down the whole loop on every event, turning one stuck write into a
             # crash-restart storm. Drop the row with a warning and keep the agent alive.
             try:
-                self._conn.execute(
+                cursor = self._conn.execute(
                     "INSERT INTO events (ts, data) VALUES (?, ?)",
                     (event["ts"], json.dumps(event)),
                 )
                 self._conn.commit()
+                rowid = cursor.lastrowid
+                event["id"] = rowid if rowid is not None else self._next_live_id()
             except sqlite3.Error as e:
                 logger.warning("event-log write failed, dropping event type=%s: %s", event["type"], e)
+                event["id"] = self._next_live_id()
+        else:
+            event["id"] = self._next_live_id()
         for q in list(self._subscribers):
             self._offer(q, event)
 
@@ -383,7 +397,11 @@ class EventBus:
             return [], None
         has_older = len(rows) > limit
         rows = rows[:limit]
-        events = [json.loads(r[1]) for r in reversed(rows)]
+        events: list[StreamEvent] = []
+        for row in reversed(rows):
+            event: StreamEvent = json.loads(row[1])
+            event["id"] = row[0]
+            events.append(event)
         return events, rows[-1][0] if has_older else None
 
     def _conversation_page(self, limit: int, before_cursor: int | None) -> tuple[list[StreamEvent], int | None]:
@@ -411,12 +429,16 @@ class EventBus:
             has_older = len(conv_rows) > limit
             boundary = conv_rows[:limit][-1][0]
             rows = conn.execute(
-                f"SELECT data FROM events WHERE json_extract(data, '$.type') IN ({vis_ph}) AND id >= ? {upper}ORDER BY id ASC",
+                f"SELECT id, data FROM events WHERE json_extract(data, '$.type') IN ({vis_ph}) AND id >= ? {upper}ORDER BY id ASC",
                 (*visible, boundary, *upper_params),
             ).fetchall()
         finally:
             conn.close()
-        events = [json.loads(r[0]) for r in rows]
+        events: list[StreamEvent] = []
+        for row in rows:
+            event: StreamEvent = json.loads(row[1])
+            event["id"] = row[0]
+            events.append(event)
         return events, boundary if has_older else None
 
     def recent(self, limit: int = PAGE_SIZE, *, channel: str | None = None) -> tuple[list[StreamEvent], int | None]:
@@ -445,7 +467,7 @@ class EventBus:
         try:
             rows = conn.execute(
                 """
-                SELECT e.data,
+                SELECT e.id, e.data,
                        f.rank / (1.0 + ? * max(julianday('now') - julianday(e.ts), 0)) AS score
                 FROM events_fts f
                 JOIN events e ON e.id = f.rowid
@@ -457,7 +479,12 @@ class EventBus:
             ).fetchall()
         finally:
             conn.close()
-        return [json.loads(r[0]) for r in rows]
+        events: list[StreamEvent] = []
+        for row in rows:
+            event: StreamEvent = json.loads(row[1])
+            event["id"] = row[0]
+            events.append(event)
+        return events
 
     def close(self) -> None:
         if self._conn:

--- a/agent/tests/fixtures/event-union.json
+++ b/agent/tests/fixtures/event-union.json
@@ -1,0 +1,139 @@
+{
+  "events": [
+    {
+      "id": -1,
+      "state": "thinking",
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "status"
+    },
+    {
+      "id": 1,
+      "input_method": "typed",
+      "intent_id": "intent-abc",
+      "text": "hello",
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "user"
+    },
+    {
+      "id": 2,
+      "text": "hi",
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "assistant"
+    },
+    {
+      "id": 3,
+      "signature": "sig",
+      "text": "hmm",
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "thinking"
+    },
+    {
+      "id": 4,
+      "text": "yo",
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "chat"
+    },
+    {
+      "id": 5,
+      "input": "ls",
+      "subagent": false,
+      "tool": "Bash",
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "tool_start"
+    },
+    {
+      "id": 6,
+      "subagent": false,
+      "tool": "Bash",
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "tool_end"
+    },
+    {
+      "id": 7,
+      "text": "oops",
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "error"
+    },
+    {
+      "id": 8,
+      "resets_at": 1767225600,
+      "text": "Claude rate limit hit",
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "rate_limited",
+      "window": "five_hour"
+    },
+    {
+      "decided": "interrupt",
+      "fields": {
+        "chat_name": "Bride squad"
+      },
+      "id": 9,
+      "notif_id": "whatsapp-123",
+      "notif_type": "message",
+      "sender": "Alex",
+      "source": "whatsapp",
+      "summary": "new message",
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "notification"
+    },
+    {
+      "id": -2,
+      "notif_id": "whatsapp-123",
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "notification_cleared"
+    },
+    {
+      "agent_id": "abc",
+      "agent_type": "browser",
+      "id": 10,
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "subagent_start"
+    },
+    {
+      "agent_id": "abc",
+      "agent_type": "browser",
+      "id": 11,
+      "ts": "2026-01-01T00:00:00+00:00",
+      "type": "subagent_stop"
+    }
+  ],
+  "snapshot": {
+    "chat": {
+      "cursor": null,
+      "events": [
+        {
+          "id": 1,
+          "input_method": "typed",
+          "intent_id": "intent-abc",
+          "text": "hello",
+          "ts": "2026-01-01T00:00:00+00:00",
+          "type": "user"
+        },
+        {
+          "id": 4,
+          "text": "yo",
+          "ts": "2026-01-01T00:00:00+00:00",
+          "type": "chat"
+        },
+        {
+          "id": 5,
+          "input": "ls",
+          "subagent": false,
+          "tool": "Bash",
+          "ts": "2026-01-01T00:00:00+00:00",
+          "type": "tool_start"
+        }
+      ]
+    },
+    "config": {
+      "timezone": "America/New_York"
+    },
+    "notifications": {
+      "pending": [
+        "whatsapp-123"
+      ]
+    },
+    "state": "idle",
+    "type": "snapshot"
+  }
+}

--- a/agent/tests/test_api.py
+++ b/agent/tests/test_api.py
@@ -609,3 +609,57 @@ async def test_memory_put_rejects_non_dict_body(event_bus, tmp_path):
             assert resp.status == 400
     finally:
         await runner.cleanup()
+
+
+@pytest.mark.anyio
+async def test_ws_message_threads_intent_id_to_user_event_and_notification(event_bus, tmp_path):
+    """A send-message carrying an intent_id echoes it back on the UserEvent (so the client dedups
+    its optimistic echo by id) and stores it on the intake notification (idempotency seam)."""
+    config = cfg.VestaConfig(agent_dir=tmp_path / "agent")
+    runner, base = await _start_server_with_config(event_bus, config)
+    try:
+        async with ClientSession() as session, session.ws_connect(f"{base}/ws") as ws:
+            await asyncio.wait_for(ws.receive(), timeout=1.0)  # snapshot
+            await ws.send_json({"type": "message", "text": "hi there", "intent_id": "intent-abc"})
+            received = await _drain_until(ws, lambda got: any(e["type"] == "user" for e in got))
+            user = next(e for e in received if e["type"] == "user")
+            assert user["intent_id"] == "intent-abc"
+            await wait_for_condition(
+                lambda: len(list(config.notifications_dir.glob("*.json"))) == 1,
+                message="expected one intake notification",
+            )
+        notif = json.loads(next(iter(config.notifications_dir.glob("*-app-chat-message.json"))).read_text())
+        assert notif["intent_id"] == "intent-abc"
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.anyio
+async def test_ws_message_without_intent_id_stays_absent(event_bus, tmp_path):
+    """intent_id is tolerant: a send-message without one yields a UserEvent and a notification with
+    no intent_id key at all, not a null."""
+    config = cfg.VestaConfig(agent_dir=tmp_path / "agent")
+    runner, base = await _start_server_with_config(event_bus, config)
+    try:
+        async with ClientSession() as session, session.ws_connect(f"{base}/ws") as ws:
+            await asyncio.wait_for(ws.receive(), timeout=1.0)  # snapshot
+            await ws.send_json({"type": "message", "text": "no intent"})
+            received = await _drain_until(ws, lambda got: any(e["type"] == "user" for e in got))
+            user = next(e for e in received if e["type"] == "user")
+            assert "intent_id" not in user
+            await wait_for_condition(
+                lambda: len(list(config.notifications_dir.glob("*.json"))) == 1,
+                message="expected one intake notification",
+            )
+        notif = json.loads(next(iter(config.notifications_dir.glob("*-app-chat-message.json"))).read_text())
+        assert "intent_id" not in notif
+    finally:
+        await runner.cleanup()
+
+
+def test_write_app_chat_notification_stores_intent_id(config):
+    """The intake helper persists a provided intent_id as a notification field."""
+    _write_app_chat_notification(config, "hello", "intent-xyz")
+    files = list(config.notifications_dir.glob("*.json"))
+    assert len(files) == 1
+    assert json.loads(files[0].read_text())["intent_id"] == "intent-xyz"

--- a/agent/tests/test_event_union_fixture.py
+++ b/agent/tests/test_event_union_fixture.py
@@ -1,0 +1,137 @@
+"""Event-union fixture emitter: serialize one instance of every StreamEvent variant plus a
+SnapshotEvent through the real EventBus emit/read path into a committed JSON fixture, so Stage 4's
+vestad aggregator test can parse the exact Python-to-Rust wire shape. Mirrors the REGEN_STREAM_FIXTURES
+flow in tests/test_contract.py; regenerate with REGEN_EVENT_FIXTURES=1.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from core.events import (
+    AssistantEvent,
+    ChatEvent,
+    ErrorEvent,
+    EventBus,
+    NotificationClearedEvent,
+    NotificationEvent,
+    RateLimitedEvent,
+    SnapshotEvent,
+    StatusEvent,
+    StreamEvent,
+    SubagentStartEvent,
+    SubagentStopEvent,
+    ThinkingEvent,
+    ToolEndEvent,
+    ToolStartEvent,
+    UserEvent,
+)
+
+# ts is a wall-clock value stamped inside emit; normalize it so the committed fixture is stable. The
+# ids are the contract under test and are kept exactly as the real emit/read path produced them.
+_FIXED_TS = "2026-01-01T00:00:00+00:00"
+
+
+def _variants() -> list[StreamEvent]:
+    """One representative instance of every StreamEvent variant, in the TS union order. UserEvent
+    carries intent_id and input_method so the seam exercises the send-message identity fields."""
+    return [
+        StatusEvent(type="status", state="thinking"),
+        UserEvent(type="user", text="hello", input_method="typed", intent_id="intent-abc"),
+        AssistantEvent(type="assistant", text="hi"),
+        ThinkingEvent(type="thinking", text="hmm", signature="sig"),
+        ChatEvent(type="chat", text="yo"),
+        ToolStartEvent(type="tool_start", tool="Bash", input="ls", subagent=False),
+        ToolEndEvent(type="tool_end", tool="Bash", subagent=False),
+        ErrorEvent(type="error", text="oops"),
+        RateLimitedEvent(type="rate_limited", text="Claude rate limit hit", window="five_hour", resets_at=1767225600),
+        NotificationEvent(
+            type="notification",
+            source="whatsapp",
+            summary="new message",
+            notif_type="message",
+            sender="Alex",
+            fields={"chat_name": "Bride squad"},
+            decided="interrupt",
+            notif_id="whatsapp-123",
+        ),
+        NotificationClearedEvent(type="notification_cleared", notif_id="whatsapp-123"),
+        SubagentStartEvent(type="subagent_start", agent_id="abc", agent_type="browser"),
+        SubagentStopEvent(type="subagent_stop", agent_id="abc", agent_type="browser"),
+    ]
+
+
+def _emit_all(bus: EventBus, variants: list[StreamEvent]) -> list[StreamEvent]:
+    """Emit each variant through the real bus so id is stamped by the production path (a rowid for
+    persisted variants, the negative live counter for status/notification_cleared), then normalize
+    ts for a stable fixture."""
+    emitted: list[StreamEvent] = []
+    for event in variants:
+        bus.emit(event)
+        event["ts"] = _FIXED_TS
+        emitted.append(event)
+    return emitted
+
+
+def _snapshot(bus: EventBus) -> SnapshotEvent:
+    """Build the connect snapshot the way api.py does, reading chat.events back through the paged
+    read path so they carry their rowids, then normalizing ts. The snapshot is a frame, not an
+    event, so it has no id of its own."""
+    events, cursor = bus.recent(channel="app-chat")
+    for event in events:
+        event["ts"] = _FIXED_TS
+    return SnapshotEvent(
+        type="snapshot",
+        state="idle",
+        chat={"events": events, "cursor": cursor},
+        notifications={"pending": ["whatsapp-123"]},
+        config={"timezone": "America/New_York"},
+    )
+
+
+def _fixture_content(tmp_path: Path) -> str:
+    bus = EventBus(data_dir=tmp_path)
+    try:
+        events = _emit_all(bus, _variants())
+        snapshot = _snapshot(bus)
+    finally:
+        bus.close()
+    payload = {"events": events, "snapshot": snapshot}
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _fixture_path() -> Path:
+    return Path(__file__).resolve().parent / "fixtures" / "event-union.json"
+
+
+def test_event_union_fixture_up_to_date(tmp_path):
+    """Emit every event variant plus a snapshot through the real path and fail if the committed
+    fixture is stale. Regenerate with REGEN_EVENT_FIXTURES=1."""
+    path = _fixture_path()
+    content = _fixture_content(tmp_path)
+    if "REGEN_EVENT_FIXTURES" in os.environ:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return
+    committed = path.read_text() if path.exists() else ""
+    assert committed == content, (
+        "\n\nEvent-union fixture is stale.\nRegenerate with:\n"
+        "  cd agent && REGEN_EVENT_FIXTURES=1 uv run pytest tests/test_event_union_fixture.py\n"
+        f"then commit {path}\n"
+    )
+
+
+def test_every_variant_carries_a_stable_id(tmp_path):
+    """The union covers all 13 variants and every one carries an id: persisted variants a positive
+    rowid, the two live-only variants a negative session id."""
+    bus = EventBus(data_dir=tmp_path)
+    try:
+        emitted = _emit_all(bus, _variants())
+    finally:
+        bus.close()
+    assert len(emitted) == 13
+    assert all("id" in event for event in emitted)
+    live = [e for e in emitted if e["type"] in ("status", "notification_cleared")]
+    assert all(e["id"] < 0 for e in live)
+    persisted = [e for e in emitted if e["type"] not in ("status", "notification_cleared")]
+    assert all(e["id"] > 0 for e in persisted)

--- a/agent/tests/test_event_union_fixture.py
+++ b/agent/tests/test_event_union_fixture.py
@@ -6,6 +6,7 @@ flow in tests/test_contract.py; regenerate with REGEN_EVENT_FIXTURES=1.
 
 import json
 import os
+import typing as tp
 from pathlib import Path
 
 from core.events import (
@@ -135,3 +136,15 @@ def test_every_variant_carries_a_stable_id(tmp_path):
     assert all(e["id"] < 0 for e in live)
     persisted = [e for e in emitted if e["type"] not in ("status", "notification_cleared")]
     assert all(e["id"] > 0 for e in persisted)
+
+
+def test_variants_cover_the_stream_event_union():
+    """Bind the hardcoded _variants() list to the authoritative StreamEvent union so a new variant
+    added to core/events.py but forgotten here fails, instead of the count silently matching the
+    list's own length. Each union member is a TypedDict whose `type` field is a single-literal, so
+    the set of those literals is the exact set _variants() must produce."""
+    members = tp.get_args(StreamEvent.__value__)
+    union_types = {tp.get_args(member.__annotations__["type"])[0] for member in members}
+    variant_types = {event["type"] for event in _variants()}
+    assert len(_variants()) == len(members)
+    assert variant_types == union_types

--- a/agent/tests/test_eventbus.py
+++ b/agent/tests/test_eventbus.py
@@ -1,5 +1,6 @@
 """Tests for EventBus: emit, persist, pagination, search, lifecycle, schema migration."""
 
+import json
 import sqlite3
 import typing as tp
 
@@ -11,6 +12,7 @@ from core.events import (
     SUBSCRIBER_QUEUE_MAXSIZE,
     ChatEvent,
     EventBus,
+    NotificationClearedEvent,
     NotificationEvent,
     SubagentStartEvent,
     ToolStartEvent,
@@ -390,3 +392,79 @@ def test_transient_open_error_propagates_without_quarantine(tmp_path):
 
     assert db_path.read_bytes() == original_bytes
     assert list(tmp_path.glob("events.db.corrupt-*")) == []
+
+
+# --- Event ids ---
+
+
+def test_emit_stamps_rowid_as_id(event_bus):
+    """A persisted event carries its events.db rowid as a positive, stable id on both the live
+    broadcast and the history read-back (same id from both paths)."""
+    q = event_bus.subscribe()
+    event_bus.emit(ChatEvent(type="chat", text="first"))
+    live = q.get_nowait()
+    assert live["id"] == 1
+    stored, _ = event_bus.recent()
+    assert stored[0]["id"] == 1
+
+
+def test_ids_track_rowid_in_order(event_bus):
+    for i in range(3):
+        event_bus.emit(ChatEvent(type="chat", text=f"m{i}"))
+    stored, _ = event_bus.recent()
+    assert [e["id"] for e in stored] == [1, 2, 3]
+
+
+def test_id_is_not_stored_in_the_data_blob(event_bus):
+    """id is derived from the rowid, never persisted into the JSON blob, so legacy rows stay valid."""
+    event_bus.emit(ChatEvent(type="chat", text="hi"))
+    row = event_bus._conn.execute("SELECT data FROM events").fetchone()
+    assert "id" not in json.loads(row[0])
+
+
+def test_live_only_events_get_negative_ids(event_bus):
+    """status and notification_cleared skip persistence but still carry an id: a per-session
+    counter running negative, which can never collide with a positive rowid."""
+    q = event_bus.subscribe()
+    event_bus.set_state("thinking")
+    first = q.get_nowait()
+    assert first["type"] == "status"
+    assert first["id"] == -1
+    event_bus.emit(NotificationClearedEvent(type="notification_cleared", notif_id="x"))
+    assert q.get_nowait()["id"] == -2
+
+
+def test_legacy_row_without_id_gets_rowid_on_read(tmp_path):
+    """A pre-existing row whose blob predates ids gains an id from its rowid on read: ids are
+    derived, so no schema migration is needed."""
+    conn = sqlite3.connect(str(tmp_path / "events.db"))
+    conn.executescript(_EVENTS_SCHEMA)
+    conn.execute("INSERT INTO events (ts, data) VALUES (?, ?)", ("2026-01-01T00:00:00+00:00", '{"type": "user", "text": "legacy"}'))
+    conn.commit()
+    conn.close()
+
+    bus = EventBus(data_dir=tmp_path)
+    events, _ = bus.recent()
+    bus.close()
+    assert events[0]["id"] == 1
+    assert tp.cast(tp.Any, events[0])["text"] == "legacy"
+
+
+def test_app_chat_and_search_reads_carry_ids(event_bus):
+    event_bus.emit(UserEvent(type="user", text="weather in paris"))
+    event_bus.emit(ChatEvent(type="chat", text="sunny in paris"))
+    chat, _ = event_bus.recent(channel="app-chat")
+    assert all(e["id"] > 0 for e in chat)
+    results = event_bus.search("paris")
+    assert all(e["id"] > 0 for e in results)
+
+
+def test_emit_without_persistence_still_ids(event_bus):
+    """When a history write is dropped (closed/corrupt db), the event still broadcasts and still
+    gets a live id, never a bare event with no id."""
+    q = event_bus.subscribe()
+    event_bus._conn.close()
+    event_bus.emit(ChatEvent(type="chat", text="still delivered"))
+    delivered = q.get_nowait()
+    assert delivered["text"] == "still delivered"
+    assert delivered["id"] < 0


### PR DESCRIPTION
Stage 3 of the client-protocol epic, the agent-side Python seam: every event carries a stable id (events.db rowid on all read paths, negative session-scoped ids for live-only events; blob stays id-free so legacy rows converge with zero migration), optional intent_id threads from the app-chat WS frame through the notification file into the UserEvent echo (tolerant both ways), and a byte-stable event-union fixture (all 13 variants + snapshot, union-bound so a forgotten variant fails the suite) for Stage 4's vestad aggregator to parse. check.sh agent + guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSn1nFTKDmH5HzuK97mepr