### PR TITLE
feat(vestad): stage 4, the /sync aggregator

### DIFF
--- a/apps/core/fixtures/sync-protocol.json
+++ b/apps/core/fixtures/sync-protocol.json
@@ -1,0 +1,122 @@
+{
+  "deltas": {
+    "agent": {
+      "info": {
+        "activityState": "thinking",
+        "buildPhase": null,
+        "services": {
+          "dashboard": {
+            "port": 8080,
+            "rev": 3
+          }
+        },
+        "startedAt": "2026-01-01T00:00:00Z",
+        "status": "alive"
+      },
+      "name": "sample-agent",
+      "type": "agent"
+    },
+    "agent_removed": {
+      "name": "stopped-agent",
+      "type": "agent_removed"
+    },
+    "append": {
+      "agent": "sample-agent",
+      "events": [
+        {
+          "id": 5,
+          "text": "hello",
+          "type": "chat"
+        }
+      ],
+      "type": "append"
+    },
+    "notifications": {
+      "agent": "sample-agent",
+      "pending": [
+        {
+          "id": 7,
+          "notif_id": "whatsapp-123",
+          "source": "whatsapp",
+          "summary": "new message",
+          "type": "notification"
+        }
+      ],
+      "type": "notifications"
+    },
+    "resync": {
+      "agent": "sample-agent",
+      "type": "resync"
+    },
+    "state": {
+      "scope": "gateway",
+      "type": "state",
+      "value": {
+        "autoUpdate": true,
+        "channel": "stable",
+        "lan": {
+          "exposed": false,
+          "url": null
+        },
+        "latestVersion": "0.1.1",
+        "managed": false,
+        "port": 4111,
+        "tunnelUrl": "https://sample.vesta.run",
+        "updateAvailable": true,
+        "version": "0.1.0"
+      }
+    }
+  },
+  "hello": {
+    "floor": 1,
+    "protocol": 1,
+    "type": "hello",
+    "version": "0.1.0"
+  },
+  "snapshot": {
+    "tree": {
+      "agents": {
+        "sample-agent": {
+          "info": {
+            "activityState": "thinking",
+            "buildPhase": null,
+            "services": {
+              "dashboard": {
+                "port": 8080,
+                "rev": 3
+              }
+            },
+            "startedAt": "2026-01-01T00:00:00Z",
+            "status": "alive"
+          },
+          "notifications": {
+            "pending": [
+              {
+                "id": 7,
+                "notif_id": "whatsapp-123",
+                "source": "whatsapp",
+                "summary": "new message",
+                "type": "notification"
+              }
+            ]
+          }
+        }
+      },
+      "gateway": {
+        "autoUpdate": true,
+        "channel": "stable",
+        "lan": {
+          "exposed": false,
+          "url": null
+        },
+        "latestVersion": "0.1.1",
+        "managed": false,
+        "port": 4111,
+        "tunnelUrl": "https://sample.vesta.run",
+        "updateAvailable": true,
+        "version": "0.1.0"
+      }
+    },
+    "type": "snapshot"
+  }
+}

--- a/apps/core/src/protocol/sync-contract.test.ts
+++ b/apps/core/src/protocol/sync-contract.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import fixtures from "../../fixtures/sync-protocol.json"
+import { parseServerFrame } from "./parse"
+
+// The fixtures are produced by vestad's real serde path (vestad/src/sync/protocol.rs,
+// REGEN_API_FIXTURES=1). Parsing every one with the canonical types proves the Rust->TS seam.
+describe("sync protocol contract (vestad fixtures)", () => {
+  it("parses the hello frame vestad emits", () => {
+    const parsed = parseServerFrame(JSON.stringify(fixtures.hello))
+    expect(parsed.kind).toBe("hello")
+    if (parsed.kind === "hello") {
+      expect(parsed.frame.protocol).toBe(1)
+      expect(parsed.frame.floor).toBe(1)
+    }
+  })
+
+  it("parses the snapshot frame and preserves the tree", () => {
+    const parsed = parseServerFrame(JSON.stringify(fixtures.snapshot))
+    expect(parsed.kind).toBe("snapshot")
+    if (parsed.kind === "snapshot") {
+      expect(parsed.frame.tree.gateway.autoUpdate).toBe(true)
+      expect(parsed.frame.tree.agents["sample-agent"]?.info.activityState).toBe("thinking")
+    }
+  })
+
+  it("classifies every delta vestad emits", () => {
+    for (const [type, frame] of Object.entries(fixtures.deltas)) {
+      const parsed = parseServerFrame(JSON.stringify(frame))
+      expect(parsed.kind).toBe("delta")
+      if (parsed.kind === "delta") expect(parsed.delta.type).toBe(type)
+    }
+  })
+
+  it("carries event ids through the append delta for by-id dedup", () => {
+    const parsed = parseServerFrame(JSON.stringify(fixtures.deltas.append))
+    expect(parsed.kind).toBe("delta")
+    if (parsed.kind === "delta" && parsed.delta.type === "append") {
+      expect(parsed.delta.events[0]?.id).toBe(5)
+    }
+  })
+})

--- a/apps/core/tsconfig.json
+++ b/apps/core/tsconfig.json
@@ -9,7 +9,8 @@
     "noEmit": true,
     "skipLibCheck": true,
     "isolatedModules": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }

--- a/vestad/src/agent_status.rs
+++ b/vestad/src/agent_status.rs
@@ -247,18 +247,33 @@ impl AgentStatusCache {
     }
 }
 
+/// The collaborators the agent-status poll task owns for its lifetime: the shared cache, a docker
+/// handle and HTTP client for polling, and the roster/rebuild/mobile/sync collaborators it
+/// reconciles each tick.
+pub struct AgentStatusTaskDeps {
+    pub cache: Arc<AgentStatusCache>,
+    pub docker: Docker,
+    pub http_client: reqwest::Client,
+    pub agents_dir: PathBuf,
+    pub on_agents_changed: OnAgentsChanged,
+    pub rebuilding: docker::RebuildTracker,
+    pub mobile_app: MobileApp,
+    pub sync_hub: Arc<SyncHub>,
+}
+
 /// Spawns the background polling loop that keeps the cache fresh and manages
 /// internal WebSocket connections to observe live events from alive agents.
-pub fn spawn_agent_status_task(
-    cache: Arc<AgentStatusCache>,
-    docker: Docker,
-    http_client: reqwest::Client,
-    agents_dir: PathBuf,
-    on_agents_changed: OnAgentsChanged,
-    rebuilding: docker::RebuildTracker,
-    mobile_app: MobileApp,
-    sync_hub: Arc<SyncHub>,
-) {
+pub fn spawn_agent_status_task(deps: AgentStatusTaskDeps) {
+    let AgentStatusTaskDeps {
+        cache,
+        docker,
+        http_client,
+        agents_dir,
+        on_agents_changed,
+        rebuilding,
+        mobile_app,
+        sync_hub,
+    } = deps;
     tokio::spawn(async move {
         let mut agent_ws_handles: HashMap<String, AgentWsHandle> = HashMap::new();
         let mut previous_agents: Option<Vec<ListEntry>> = None;
@@ -588,7 +603,8 @@ mod tests {
     }
 
     use crate::mobile_app::MobileApp;
-    use crate::sync::{LiveMessage, SyncHub};
+    use crate::sync::hub::LiveMessage;
+    use crate::sync::SyncHub;
     use futures_util::{SinkExt, StreamExt};
     use tokio_tungstenite::tungstenite::Message as WsMessage;
 

--- a/vestad/src/agent_status.rs
+++ b/vestad/src/agent_status.rs
@@ -9,6 +9,7 @@ use tokio::sync::watch;
 use crate::docker::{self, ListEntry};
 use crate::mobile_app::MobileApp;
 use crate::settings::ServiceEntry;
+use crate::sync::{activity_state, notification_change, SyncHub};
 
 const POLL_INTERVAL_SECS: u64 = 3;
 
@@ -256,6 +257,7 @@ pub fn spawn_agent_status_task(
     on_agents_changed: OnAgentsChanged,
     rebuilding: docker::RebuildTracker,
     mobile_app: MobileApp,
+    sync_hub: Arc<SyncHub>,
 ) {
     tokio::spawn(async move {
         let mut agent_ws_handles: HashMap<String, AgentWsHandle> = HashMap::new();
@@ -307,6 +309,7 @@ pub fn spawn_agent_status_task(
                     cache.timezones_tx.send_modify(|zones| {
                         zones.remove(name);
                     });
+                    sync_hub.forget_agent(name);
                     false
                 }
             });
@@ -321,9 +324,10 @@ pub fn spawn_agent_status_task(
                 let tx = activity_event_tx.clone();
                 let dir = agents_dir.clone();
                 let mobile_app = mobile_app.clone();
+                let hub = sync_hub.clone();
 
                 let join_handle = tokio::spawn(async move {
-                    agent_event_listener(agent_name, port, dir, tx, mobile_app).await;
+                    agent_event_listener(agent_name, port, dir, tx, mobile_app, hub).await;
                 });
 
                 agent_ws_handles.insert(
@@ -372,21 +376,25 @@ fn apply_agent_update(cache: &AgentStatusCache, name: String, update: AgentUpdat
     }
 }
 
-/// Connects to a single agent's WebSocket, relays activity and timezone changes
-/// to the cache, and hands all parsed frames to the mobile app module. Reconnects on failure.
+/// Connects to a single agent's WebSocket, relays activity/timezone to the cache, feeds the mobile
+/// push module and the sync hub's live edge, and keeps the write-half for send-message relay.
+/// Reconnects on failure; a reconnect emits a `resync` because the live edge had a gap.
 async fn agent_event_listener(
     name: String,
     ws_port: u16,
     agents_dir: PathBuf,
     tx: tokio::sync::mpsc::Sender<(String, AgentUpdate)>,
     mobile_app: MobileApp,
+    hub: Arc<SyncHub>,
 ) {
     const RECONNECT_BASE_MS: u64 = 1000;
     const RECONNECT_MAX_MS: u64 = 15000;
+    const SEND_RELAY_CAPACITY: usize = 16;
     let mut delay_ms = RECONNECT_BASE_MS;
+    let mut connected_before = false;
 
     loop {
-        // Read the agent token fresh each attempt (it may rotate)
+        // Read the agent token fresh each attempt (it may rotate).
         let agent_name = name.clone();
         let dir = agents_dir.clone();
         let token = tokio::task::spawn_blocking(move || {
@@ -405,7 +413,19 @@ async fn agent_event_listener(
         match tokio_tungstenite::connect_async(&url).await {
             Ok((ws, _)) => {
                 delay_ms = RECONNECT_BASE_MS;
-                let (_write, mut read) = ws.split();
+                let (write, mut read) = ws.split();
+
+                // Keep the write-half for the send-message relay (today's tap discarded it). A small
+                // mpsc feeds a writer task so the read loop never blocks on a slow socket.
+                let (out_tx, out_rx) = tokio::sync::mpsc::channel::<String>(SEND_RELAY_CAPACITY);
+                hub.install_writer(&name, out_tx);
+                let writer = tokio::spawn(forward_outbound(write, out_rx));
+
+                // A reconnect means the live edge had a gap; tell watchers to refetch the tail by id.
+                if connected_before {
+                    hub.publish_resync(&name);
+                }
+                connected_before = true;
 
                 while let Some(Ok(msg)) = read.next().await {
                     let text = match &msg {
@@ -417,43 +437,78 @@ async fn agent_event_listener(
                         Err(_) => continue,
                     };
                     let msg_type = parsed.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
                     // `state` is top-level on both the live `status` event and the connect `snapshot`.
                     if msg_type == "status" || msg_type == "snapshot" {
-                        if let Some(state) = parsed.get("state").and_then(|v| v.as_str()) {
-                            let _ = tx
-                                .send((name.clone(), AgentUpdate::Activity(state.to_string())))
-                                .await;
+                        if let Some(state) = activity_state(&parsed) {
+                            let _ = tx.send((name.clone(), AgentUpdate::Activity(state))).await;
                         }
                     }
-                    // The agent's IANA timezone rides the connect snapshot under `config`.
+
                     if msg_type == "snapshot" {
+                        // Timezone rides the snapshot's `config` (unchanged behavior).
                         if let Some(zone) = parsed
                             .get("config")
                             .and_then(|config| config.get("timezone"))
                             .and_then(|value| value.as_str())
                         {
-                            let _ = tx
-                                .send((name.clone(), AgentUpdate::Timezone(zone.to_string())))
-                                .await;
+                            let _ = tx.send((name.clone(), AgentUpdate::Timezone(zone.to_string()))).await;
                         }
+                        // Reseed pending notifications from the snapshot's authoritative id set. The
+                        // snapshot's chat backlog is deliberately NOT published as an append and NOT
+                        // pushed: watchers load the tail through paged HTTP history, deduped by id.
+                        hub.seed_notifications(&name, &pending_ids(&parsed));
+                        continue;
+                    }
+
+                    // A live event: feed the watch fan-out, the notifications projection, and push.
+                    hub.publish_event(&name, std::sync::Arc::new(parsed.clone()));
+                    if let Some(change) = notification_change(&parsed) {
+                        hub.apply_notification(&name, change);
                     }
                     mobile_app.observe_agent_event(&name, parsed);
                 }
 
-                // Connection lost -- reset to idle so the frontend doesn't
-                // stay stuck on the last activity state (e.g. "thinking").
-                let _ = tx
-                    .send((name.clone(), AgentUpdate::Activity("idle".into())))
-                    .await;
+                // Connection lost: tear down the write-half so a send-message now fails retryably
+                // instead of vanishing into a dead socket, and reset activity to idle so the
+                // frontend does not stay stuck on the last state.
+                hub.clear_writer(&name);
+                writer.abort();
+                let _ = tx.send((name.clone(), AgentUpdate::Activity("idle".into()))).await;
             }
             Err(err) => {
-                tracing::debug!(agent = %name, port = ws_port, error = %err, "agent activity ws connect failed");
+                tracing::debug!(agent = %name, port = ws_port, error = %err, "agent tap connect failed");
             }
         }
 
         tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
         delay_ms = (delay_ms * 2).min(RECONNECT_MAX_MS);
     }
+}
+
+/// Forward relayed send-message frames onto the tap's write-half. Ends when the socket errors or the
+/// relay channel closes (the read side tore the connection down).
+async fn forward_outbound<S>(mut write: S, mut out_rx: tokio::sync::mpsc::Receiver<String>)
+where
+    S: futures_util::Sink<tokio_tungstenite::tungstenite::Message> + Unpin,
+{
+    use futures_util::SinkExt;
+    use tokio_tungstenite::tungstenite::Message;
+    while let Some(frame) = out_rx.recv().await {
+        if write.send(Message::Text(frame.into())).await.is_err() {
+            break;
+        }
+    }
+}
+
+/// The pending notification ids on a connect snapshot (`notifications.pending`, file stems).
+fn pending_ids(snapshot: &serde_json::Value) -> Vec<String> {
+    snapshot
+        .get("notifications")
+        .and_then(|n| n.get("pending"))
+        .and_then(|p| p.as_array())
+        .map(|items| items.iter().filter_map(|v| v.as_str().map(str::to_string)).collect())
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -530,5 +585,71 @@ mod tests {
     fn empty_revs_when_nothing_invalidated() {
         let cache = AgentStatusCache::new();
         assert!(cache.service_revs().is_empty());
+    }
+
+    use crate::mobile_app::MobileApp;
+    use crate::sync::{LiveMessage, SyncHub};
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+    /// A fake agent WS server: on connect it sends a snapshot (backlog + one pending id) and one live
+    /// chat event, then records the first frame the tap relays back (the send-message). Returns its
+    /// bound port and a receiver for the relayed frame.
+    async fn fake_agent() -> (u16, tokio::sync::oneshot::Receiver<String>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let (relay_tx, relay_rx) = tokio::sync::oneshot::channel::<String>();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let ws = tokio_tungstenite::accept_async(stream).await.expect("handshake");
+            let (mut write, mut read) = ws.split();
+            let snapshot = serde_json::json!({
+                "type": "snapshot", "state": "idle",
+                "chat": {"events": [{"id": 1, "type": "chat", "text": "backlog"}], "cursor": null},
+                "notifications": {"pending": ["n1"]},
+                "config": {"timezone": "America/New_York"},
+            });
+            let chat = serde_json::json!({"id": 5, "type": "chat", "text": "live"});
+            write.send(WsMessage::Text(snapshot.to_string().into())).await.expect("send snapshot");
+            write.send(WsMessage::Text(chat.to_string().into())).await.expect("send chat");
+            if let Some(Ok(WsMessage::Text(relayed))) = read.next().await {
+                let _ = relay_tx.send(relayed.to_string());
+            }
+        });
+        (port, relay_rx)
+    }
+
+    #[tokio::test]
+    async fn tap_feeds_live_edge_excludes_backlog_and_relays_send_message() {
+        let hub = std::sync::Arc::new(SyncHub::new());
+        let mut watcher = hub.subscribe_events("fake");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (app, _worker) = MobileApp::new(dir.path().to_path_buf(), reqwest::Client::new());
+        let (port, relay_rx) = fake_agent().await;
+
+        let listener = tokio::spawn({
+            let hub = hub.clone();
+            let (tx, _rx) = tokio::sync::mpsc::channel::<(String, AgentUpdate)>(16);
+            let dir = dir.path().to_path_buf();
+            async move { agent_event_listener("fake".into(), port, dir, tx, app, hub).await }
+        });
+
+        // The first (and only) live-edge message is the live chat, never the snapshot backlog.
+        match watcher.recv().await.expect("live message") {
+            LiveMessage::Event(event) => {
+                assert_eq!(event["id"], serde_json::json!(5));
+                assert_eq!(event["text"], serde_json::json!("live"));
+            }
+            LiveMessage::Resync => panic!("first message should be the live event"),
+        }
+        // The snapshot seeded one pending notification (as a stub, since none was seen live).
+        assert_eq!(hub.pending_all()["fake"].len(), 1);
+
+        // The writer is installed by now, so a send-message relays to the fake agent.
+        hub.send_message("fake", r#"{"type":"message","text":"hey","intent_id":"i-1"}"#.into()).expect("relay");
+        let relayed = relay_rx.await.expect("relayed frame");
+        assert!(relayed.contains("\"intent_id\":\"i-1\""));
+
+        listener.abort();
     }
 }

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1776,7 +1776,7 @@ pub(crate) async fn docker_cp_content(
 /// Coarse, user-facing stage of first-time agent creation, emitted in order so the
 /// onboarding UI can show honest status instead of a decorative loop. The dominant
 /// wait is the image step (`Pulling` on a release, `Building` from a local checkout).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BuildPhase {
     Pulling,

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -27,6 +27,7 @@ mod serve;
 mod settings;
 mod state;
 mod status;
+mod sync;
 mod systemd;
 mod time_utils;
 mod tunnel;

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -3559,6 +3559,15 @@ mod tests {
         let cli_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../cli/tests/fixtures/vestad-api.json");
         sync_fixture_file(&cli_path, &cli_content, regen);
+
+        // Sync-protocol fixtures (Stage 4): the /sync frames the @vesta/core contract test parses.
+        // Additive beside the web/cli fixtures above, which retire when those clients migrate.
+        let sync_json = serde_json::to_string_pretty(&crate::sync::protocol::protocol_fixtures())
+            .expect("serialize sync fixtures");
+        let sync_content = format!("{sync_json}\n");
+        let sync_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../apps/core/fixtures/sync-protocol.json");
+        sync_fixture_file(&sync_path, &sync_content, regen);
     }
 }
 

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2364,6 +2364,7 @@ pub fn build_router(state: SharedState) -> Router {
             post(restore_backup_handler),
         )
         .route("/ws", get(control_ws::control_ws_handler))
+        .route("/sync", get(crate::sync::sync_ws_handler))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth::auth_middleware,

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2865,6 +2865,7 @@ pub async fn run_server(cfg: ServerConfig) {
         on_agents_changed,
         state.rebuilding.clone(),
         state.mobile_app.clone(),
+        state.sync_hub.clone(),
     );
     let app = build_router(state.clone());
     spawn_auto_backup_task(state.clone());

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2859,16 +2859,16 @@ pub async fn run_server(cfg: ServerConfig) {
     // Keep a docker handle for the shutdown hook: vestad stops every agent when it exits, so a
     // vestad update/restart hands off with nothing running on a stale container.
     let shutdown_docker = docker.clone();
-    agent_status::spawn_agent_status_task(
-        state.agent_status_cache.clone(),
+    agent_status::spawn_agent_status_task(agent_status::AgentStatusTaskDeps {
+        cache: state.agent_status_cache.clone(),
         docker,
-        state.http_client.clone(),
-        state.env_config.agents_dir.clone(),
+        http_client: state.http_client.clone(),
+        agents_dir: state.env_config.agents_dir.clone(),
         on_agents_changed,
-        state.rebuilding.clone(),
-        state.mobile_app.clone(),
-        state.sync_hub.clone(),
-    );
+        rebuilding: state.rebuilding.clone(),
+        mobile_app: state.mobile_app.clone(),
+        sync_hub: state.sync_hub.clone(),
+    });
     let app = build_router(state.clone());
     spawn_auto_backup_task(state.clone());
     if dev_mode {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2286,6 +2286,7 @@ pub fn build_router(state: SharedState) -> Router {
                 .patch(rename_agent_handler),
         )
         .route("/agents/{name}/build-phase", get(build_phase_handler))
+        .route("/agents/{name}/message", post(crate::sync::send_message_handler))
         .route("/agents/{name}/start", post(start_agent_handler))
         .route(
             "/agents/{name}/config",

--- a/vestad/src/state.rs
+++ b/vestad/src/state.rs
@@ -104,6 +104,10 @@ pub struct AppState {
     pub(crate) mobile_app: mobile_app::MobileApp,
     pub(crate) dev_mode: bool,
     pub(crate) agent_status_cache: Arc<agent_status::AgentStatusCache>,
+    /// The client-protocol aggregator's fan-out state: per-agent live edge, notifications
+    /// projection, and tap write-half for send-message relay. Fed by the tap in `agent_status.rs`
+    /// and read by the `/sync` handler.
+    pub(crate) sync_hub: Arc<crate::sync::SyncHub>,
     /// Agents whose container is mid-rebuild; shared with the boot reconcile and the
     /// status poll so they report `Rebuilding` and mutating handlers refuse to race it.
     pub(crate) rebuilding: docker::RebuildTracker,
@@ -167,6 +171,7 @@ impl AppState {
                 mobile_app,
                 dev_mode,
                 agent_status_cache: Arc::new(agent_status::AgentStatusCache::new()),
+                sync_hub: Arc::new(crate::sync::SyncHub::new()),
                 rebuilding: docker::RebuildTracker::default(),
                 https_port,
                 expose_lan,

--- a/vestad/src/sync/events.rs
+++ b/vestad/src/sync/events.rs
@@ -1,0 +1,180 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+/// The id + type every agent event carries (the events.db rowid on the Python seam; negative for
+/// live-only variants). The single extractor vestad uses to interpret an otherwise opaque, relayed
+/// event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EventMeta {
+    pub id: i64,
+    pub kind: String,
+}
+
+pub(crate) fn event_meta(event: &Value) -> Option<EventMeta> {
+    let id = event.get("id")?.as_i64()?;
+    let kind = event.get("type")?.as_str()?.to_string();
+    Some(EventMeta { id, kind })
+}
+
+/// The agent's live activity state, present on both a `status` event and the connect `snapshot`
+/// frame (top-level `state`). Keeps the roster's activityState fresh.
+pub(crate) fn activity_state(frame: &Value) -> Option<String> {
+    frame.get("state")?.as_str().map(str::to_string)
+}
+
+/// A change to an agent's pending-notification set derived from a live event. `notification` adds
+/// (or refreshes) a pending entry; `notification_cleared` removes one. Any other type yields None.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum NotificationChange {
+    Added { notif_id: String, event: Value },
+    Cleared { notif_id: String },
+}
+
+pub(crate) fn notification_change(event: &Value) -> Option<NotificationChange> {
+    match event.get("type")?.as_str()? {
+        "notification" => Some(NotificationChange::Added {
+            notif_id: event.get("notif_id")?.as_str()?.to_string(),
+            event: event.clone(),
+        }),
+        "notification_cleared" => Some(NotificationChange::Cleared {
+            notif_id: event.get("notif_id")?.as_str()?.to_string(),
+        }),
+        _ => None,
+    }
+}
+
+/// A per-agent pending-notification projection. Membership is authoritative from the agent's connect
+/// snapshot (a list of file-stem ids); richness (full event fields) comes from live `notification`
+/// events observed over the tap. An id present in the snapshot but never seen live is represented by
+/// a minimal stub so the tree's `pending` is always a list of notification-shaped objects, each with
+/// an id.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct PendingNotifications {
+    known: HashMap<String, Value>,
+    order: Vec<String>,
+}
+
+const STUB_NOTIFICATION_ID: i64 = 0;
+
+impl PendingNotifications {
+    /// Reconcile membership to exactly `ids` (the snapshot's authoritative pending set), preserving
+    /// known full events and stubbing ids not yet observed live. Returns whether the rendered list
+    /// changed, so the caller emits a delta only on a real change.
+    pub fn seed(&mut self, ids: &[String]) -> bool {
+        let before = self.render();
+        self.order = ids.to_vec();
+        self.known.retain(|id, _| ids.contains(id));
+        for id in ids {
+            self.known.entry(id.clone()).or_insert_with(|| stub_notification(id));
+        }
+        self.render() != before
+    }
+
+    /// Apply a live add/clear. Returns whether the rendered list changed.
+    pub fn apply(&mut self, change: NotificationChange) -> bool {
+        let before = self.render();
+        match change {
+            NotificationChange::Added { notif_id, event } => {
+                if !self.order.contains(&notif_id) {
+                    self.order.push(notif_id.clone());
+                }
+                self.known.insert(notif_id, event);
+            }
+            NotificationChange::Cleared { notif_id } => {
+                self.order.retain(|id| id != &notif_id);
+                self.known.remove(&notif_id);
+            }
+        }
+        self.render() != before
+    }
+
+    pub fn render(&self) -> Vec<Value> {
+        self.order.iter().filter_map(|id| self.known.get(id).cloned()).collect()
+    }
+}
+
+fn stub_notification(notif_id: &str) -> Value {
+    serde_json::json!({
+        "id": STUB_NOTIFICATION_ID,
+        "type": "notification",
+        "notif_id": notif_id,
+        "source": "",
+        "summary": "",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Loads Stage 3's committed union. Returns None (test no-ops) in a standalone vestad checkout
+    /// without the sibling `agent/` tree, mirroring `sync_fixture_file`'s skip-when-absent rule.
+    fn union_fixture() -> Option<Value> {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../agent/tests/fixtures/event-union.json");
+        let raw = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&raw).ok()
+    }
+
+    #[test]
+    fn every_union_event_yields_meta_with_the_right_id_sign() {
+        let Some(fixture) = union_fixture() else { return };
+        let events = fixture["events"].as_array().expect("events array");
+        assert_eq!(events.len(), 13, "the union covers all 13 stream variants");
+        for event in events {
+            let meta = event_meta(event).expect("every event carries id + type");
+            let live = meta.kind == "status" || meta.kind == "notification_cleared";
+            if live {
+                assert!(meta.id < 0, "live-only {} uses a negative id", meta.kind);
+            } else {
+                assert!(meta.id > 0, "persisted {} uses a positive rowid", meta.kind);
+            }
+        }
+    }
+
+    #[test]
+    fn classifies_notification_variants_from_the_seam() {
+        let Some(fixture) = union_fixture() else { return };
+        let events = fixture["events"].as_array().expect("events array");
+        let added = events.iter().filter_map(notification_change).filter(|c| matches!(c, NotificationChange::Added { .. })).count();
+        let cleared = events.iter().filter_map(notification_change).filter(|c| matches!(c, NotificationChange::Cleared { .. })).count();
+        assert_eq!(added, 1, "one notification variant in the union");
+        assert_eq!(cleared, 1, "one notification_cleared variant in the union");
+    }
+
+    #[test]
+    fn snapshot_activity_state_is_readable() {
+        let Some(fixture) = union_fixture() else { return };
+        assert_eq!(activity_state(&fixture["snapshot"]).as_deref(), Some("idle"));
+    }
+
+    #[test]
+    fn seed_stubs_unknown_ids_and_keeps_known_events() {
+        let mut pending = PendingNotifications::default();
+        assert!(pending.seed(&["a".into(), "b".into()]));
+        let rendered = pending.render();
+        assert_eq!(rendered.len(), 2);
+        assert_eq!(rendered[0]["notif_id"], serde_json::json!("a"));
+        // A live event enriches an already-pending id in place, keeping membership.
+        let changed = pending.apply(NotificationChange::Added {
+            notif_id: "a".into(),
+            event: serde_json::json!({"id": 7, "type": "notification", "notif_id": "a", "source": "sms", "summary": "hi"}),
+        });
+        assert!(changed);
+        assert_eq!(pending.render()[0]["source"], serde_json::json!("sms"));
+    }
+
+    #[test]
+    fn reseed_drops_ids_cleared_while_disconnected_and_a_clear_removes_membership() {
+        let mut pending = PendingNotifications::default();
+        pending.seed(&["a".into(), "b".into()]);
+        // On tap reconnect the fresh snapshot no longer lists "b": it is dropped.
+        assert!(pending.seed(&["a".into()]));
+        assert_eq!(pending.render().len(), 1);
+        // An explicit clear of "a" empties the branch.
+        assert!(pending.apply(NotificationChange::Cleared { notif_id: "a".into() }));
+        assert!(pending.render().is_empty());
+        // A no-op reseed to the same set reports no change.
+        assert!(!pending.seed(&[]));
+    }
+}

--- a/vestad/src/sync/events.rs
+++ b/vestad/src/sync/events.rs
@@ -2,21 +2,6 @@ use std::collections::HashMap;
 
 use serde_json::Value;
 
-/// The id + type every agent event carries (the events.db rowid on the Python seam; negative for
-/// live-only variants). The single extractor vestad uses to interpret an otherwise opaque, relayed
-/// event.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct EventMeta {
-    pub id: i64,
-    pub kind: String,
-}
-
-pub(crate) fn event_meta(event: &Value) -> Option<EventMeta> {
-    let id = event.get("id")?.as_i64()?;
-    let kind = event.get("type")?.as_str()?.to_string();
-    Some(EventMeta { id, kind })
-}
-
 /// The agent's live activity state, present on both a `status` event and the connect `snapshot`
 /// frame (top-level `state`). Keeps the roster's activityState fresh.
 pub(crate) fn activity_state(frame: &Value) -> Option<String> {
@@ -122,12 +107,13 @@ mod tests {
         let events = fixture["events"].as_array().expect("events array");
         assert_eq!(events.len(), 13, "the union covers all 13 stream variants");
         for event in events {
-            let meta = event_meta(event).expect("every event carries id + type");
-            let live = meta.kind == "status" || meta.kind == "notification_cleared";
+            let id = event.get("id").and_then(Value::as_i64).expect("every event carries an id");
+            let kind = event.get("type").and_then(Value::as_str).expect("every event carries a type");
+            let live = kind == "status" || kind == "notification_cleared";
             if live {
-                assert!(meta.id < 0, "live-only {} uses a negative id", meta.kind);
+                assert!(id < 0, "live-only {kind} uses a negative id");
             } else {
-                assert!(meta.id > 0, "persisted {} uses a positive rowid", meta.kind);
+                assert!(id > 0, "persisted {kind} uses a positive rowid");
             }
         }
     }

--- a/vestad/src/sync/handler.rs
+++ b/vestad/src/sync/handler.rs
@@ -419,7 +419,8 @@ pub(crate) struct SendMessageBody {
 
 /// Relay a send-message intent to the agent over the tap's write-half. Returns a typed retryable
 /// `503` when the tap is down (agent restarting/evicted) so the client keeps its composer and
-/// retries; a `200` ack means the agent's intake accepted the message.
+/// retries; a `200` ack means the frame was queued onto the live tap, not that the agent read it.
+/// Delivery truth is the `append` echo carrying the intent id; clients dedup and confirm by id.
 pub(crate) async fn send_message_handler(
     State(state): State<SharedState>,
     axum::extract::Path(name): axum::extract::Path<String>,

--- a/vestad/src/sync/handler.rs
+++ b/vestad/src/sync/handler.rs
@@ -1,0 +1,470 @@
+use std::collections::{BTreeMap, HashMap};
+use std::ops::ControlFlow;
+use std::time::Duration;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{RawQuery, State};
+use axum::http::HeaderMap;
+use axum::response::Response;
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::{broadcast, mpsc};
+
+use crate::docker::ListEntry;
+use crate::settings::ServiceEntry;
+use crate::state::{SharedState, WS_KEEPALIVE_INTERVAL_SECS};
+
+use super::hub::LiveMessage;
+use super::protocol::{
+    AgentInfo, AgentNode, ClientFrame, Frame, GatewayInfo, GatewayLan, GatewayScope,
+    NotificationsBranch, ServiceInfo, Tree,
+};
+use super::{PROTOCOL_FLOOR, PROTOCOL_VERSION};
+
+/// Per-connection buffer for the fan-in of every watch's live edge into the one socket writer.
+const WATCH_FANIN_CAPACITY: usize = 128;
+
+type Tx = futures_util::stream::SplitSink<WebSocket, Message>;
+
+pub(crate) async fn sync_ws_handler(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
+    ws: WebSocketUpgrade,
+) -> Response {
+    // auth_middleware already validated the connect token; capture it to derive the reauth deadline.
+    let token = connect_token(&headers, raw_query.as_deref());
+    ws.on_upgrade(move |socket| sync_session(state, socket, token))
+}
+
+/// The connect token, from either `Authorization: Bearer` or `?token=` (browser WS connects cannot
+/// set headers, so the query form is the one the app uses).
+fn connect_token(headers: &HeaderMap, raw_query: Option<&str>) -> Option<String> {
+    if let Some(bearer) = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+    {
+        return Some(bearer.to_string());
+    }
+    raw_query?.split('&').find_map(|p| p.strip_prefix("token=")).map(str::to_string)
+}
+
+/// The instant a connection's auth token expires, or None for the non-expiring raw API key. A JWT
+/// access token carries `exp`; `/sync` closes the socket at the deadline unless a `reauth` extends
+/// it. `auth_middleware` already gated the upgrade, so a token that does not validate here (only the
+/// raw-key path) simply yields no deadline.
+fn token_deadline(token: &str, api_key: &str) -> Option<tokio::time::Instant> {
+    if !token.contains('.') {
+        return None;
+    }
+    let claims = crate::jwt::validate_token(api_key, token, "access").ok()?;
+    let remaining = claims.exp.saturating_sub(crate::time_utils::now_epoch_secs());
+    Some(tokio::time::Instant::now() + Duration::from_secs(remaining))
+}
+
+async fn sync_session(state: SharedState, socket: WebSocket, connect_token: Option<String>) {
+    let (mut tx, mut rx) = socket.split();
+
+    // 1. hello
+    let hello = Frame::Hello {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        protocol: PROTOCOL_VERSION,
+        floor: PROTOCOL_FLOOR,
+    };
+    if send_frame(&mut tx, &hello).await.is_err() {
+        return;
+    }
+
+    // 2. immediate snapshot: gateway + agents (info + pending sets), no tails.
+    let mut last_roster = current_roster(&state);
+    let mut last_gateway = build_gateway_info(&state).await;
+    let mut last_pending = state.sync_hub.pending_all();
+    let tree = build_tree(&last_gateway, &last_roster, &last_pending);
+    if send_frame(&mut tx, &Frame::Snapshot { tree }).await.is_err() {
+        return;
+    }
+
+    let mut agents_rx = state.agent_status_cache.subscribe_agents();
+    let mut activity_rx = state.agent_status_cache.subscribe_activity();
+    let mut services_rx = state.agent_status_cache.subscribe_services();
+    let mut invalidations_rx = state.agent_status_cache.subscribe_invalidations();
+    let mut notifications_rx = state.sync_hub.subscribe_notifications();
+
+    // Each watch spawns a task forwarding the hub's live edge into this per-connection mpsc; the one
+    // socket writer drains it, so a chatty agent never blocks the others.
+    let (watch_tx, mut watch_rx) = mpsc::channel::<Frame>(WATCH_FANIN_CAPACITY);
+    let mut watches: HashMap<String, tokio::task::AbortHandle> = HashMap::new();
+
+    let mut deadline = connect_token.as_deref().and_then(|t| token_deadline(t, &state.api_key));
+
+    // The ping keeps an idle socket alive through the Cloudflare tunnel (reaps ~100s silence), same
+    // as the control WS.
+    let mut keepalive = tokio::time::interval(Duration::from_secs(WS_KEEPALIVE_INTERVAL_SECS));
+    keepalive.tick().await;
+
+    loop {
+        // Branch futures borrow only the receivers, never `tx`; the mutable send work happens after
+        // the select resolves (tokio::select! constructs every branch future up front).
+        let wake = tokio::select! {
+            r = agents_rx.changed() => { if r.is_err() { break } Wake::Roster }
+            r = activity_rx.changed() => { if r.is_err() { break } Wake::Roster }
+            r = services_rx.changed() => { if r.is_err() { break } Wake::Roster }
+            r = invalidations_rx.changed() => { if r.is_err() { break } Wake::Roster }
+            r = notifications_rx.changed() => { if r.is_err() { break } Wake::Notifications }
+            frame = watch_rx.recv() => Wake::Watch(frame),
+            client = rx.next() => Wake::Client(client),
+            _ = keepalive.tick() => Wake::Keepalive,
+            () = expire(deadline) => Wake::Expire,
+        };
+
+        match wake {
+            Wake::Keepalive => {
+                if tx.send(Message::Ping(bytes::Bytes::new())).await.is_err() {
+                    break;
+                }
+                if emit_roster_and_gateway(&state, &mut tx, &mut last_roster, &mut last_gateway, &mut watches).await.is_err() {
+                    break;
+                }
+            }
+            Wake::Roster => {
+                if emit_roster_and_gateway(&state, &mut tx, &mut last_roster, &mut last_gateway, &mut watches).await.is_err() {
+                    break;
+                }
+            }
+            Wake::Notifications => {
+                if emit_notifications(&state, &mut tx, &mut last_pending).await.is_err() {
+                    break;
+                }
+            }
+            Wake::Watch(Some(delta)) => {
+                // A resync from a watch task means that watch ended (overflow or a tap gap); drop it
+                // so the client re-watches.
+                if let Frame::Resync { agent } = &delta {
+                    watches.remove(agent);
+                }
+                if send_frame(&mut tx, &delta).await.is_err() {
+                    break;
+                }
+            }
+            Wake::Client(Some(Ok(Message::Text(text)))) => {
+                if let ControlFlow::Break(()) =
+                    handle_client_frame(&state, text.as_str(), &mut watches, &watch_tx, &mut deadline)
+                {
+                    break;
+                }
+            }
+            // End the session: the peer closed, the stream ended, a transport error, or the deadline.
+            Wake::Expire | Wake::Client(None | Some(Ok(Message::Close(_)) | Err(_))) => break,
+            // Ignore: an empty watch wake and any non-text control frame (ping/pong/binary).
+            Wake::Watch(None) | Wake::Client(Some(Ok(_))) => {}
+        }
+    }
+
+    for (_, handle) in watches {
+        handle.abort();
+    }
+}
+
+/// What woke the session loop. Kept small and owned so no branch future borrows the socket writer.
+enum Wake {
+    Roster,
+    Notifications,
+    Watch(Option<Frame>),
+    Client(Option<Result<Message, axum::Error>>),
+    Keepalive,
+    Expire,
+}
+
+/// Sleep until the token deadline, or forever when there is none (the raw API key).
+async fn expire(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(instant) => tokio::time::sleep_until(instant).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+async fn send_frame(tx: &mut Tx, frame: &Frame) -> Result<(), ()> {
+    let encoded = match frame.encode() {
+        Ok(text) => text,
+        Err(error) => {
+            tracing::error!(%error, "failed to encode sync frame; dropping it");
+            return Ok(());
+        }
+    };
+    tx.send(Message::Text(encoded.into())).await.map_err(|_| ())
+}
+
+/// Diff the roster against last-sent and emit `agent`/`agent_removed`, then the gateway `state`
+/// delta if the host branch changed. An `agent_removed` also cancels that agent's watch.
+async fn emit_roster_and_gateway(
+    state: &SharedState,
+    tx: &mut Tx,
+    last_roster: &mut BTreeMap<String, AgentInfo>,
+    last_gateway: &mut GatewayInfo,
+    watches: &mut HashMap<String, tokio::task::AbortHandle>,
+) -> Result<(), ()> {
+    let current = current_roster(state);
+    for delta in roster_deltas(last_roster, &current) {
+        if let Frame::AgentRemoved { name } = &delta {
+            if let Some(handle) = watches.remove(name) {
+                handle.abort();
+            }
+        }
+        send_frame(tx, &delta).await?;
+    }
+    *last_roster = current;
+
+    let gateway = build_gateway_info(state).await;
+    if gateway != *last_gateway {
+        send_frame(tx, &Frame::State { scope: GatewayScope::Gateway, value: gateway.clone() }).await?;
+        *last_gateway = gateway;
+    }
+    Ok(())
+}
+
+async fn emit_notifications(
+    state: &SharedState,
+    tx: &mut Tx,
+    last: &mut HashMap<String, Vec<serde_json::Value>>,
+) -> Result<(), ()> {
+    let current = state.sync_hub.pending_all();
+    for (agent, pending) in &current {
+        if last.get(agent) != Some(pending) {
+            send_frame(tx, &Frame::Notifications { agent: agent.clone(), pending: pending.clone() }).await?;
+        }
+    }
+    // Agents dropped from the map (forgotten) need no notifications delta; `agent_removed` covers it.
+    *last = current;
+    Ok(())
+}
+
+/// Handle one client frame. Unknown/malformed frames are ignored by rule. Returns Break only on a
+/// failed reauth (the loop then closes the socket).
+fn handle_client_frame(
+    state: &SharedState,
+    text: &str,
+    watches: &mut HashMap<String, tokio::task::AbortHandle>,
+    watch_tx: &mpsc::Sender<Frame>,
+    deadline: &mut Option<tokio::time::Instant>,
+) -> ControlFlow<()> {
+    let Ok(frame) = serde_json::from_str::<ClientFrame>(text) else {
+        return ControlFlow::Continue(());
+    };
+    match frame {
+        ClientFrame::Watch { agent } => {
+            if let std::collections::hash_map::Entry::Vacant(slot) = watches.entry(agent) {
+                let handle = spawn_watch(state, slot.key(), watch_tx.clone());
+                slot.insert(handle);
+            }
+        }
+        ClientFrame::Unwatch { agent } => {
+            if let Some(handle) = watches.remove(&agent) {
+                handle.abort();
+            }
+        }
+        ClientFrame::Reauth { token } => {
+            if crate::auth::verify_token(&token, &state.api_key) {
+                *deadline = token_deadline(&token, &state.api_key);
+            } else {
+                tracing::warn!("sync reauth failed; closing socket");
+                return ControlFlow::Break(());
+            }
+        }
+    }
+    ControlFlow::Continue(())
+}
+
+/// Spawn the forward task for one watch: the hub's live edge becomes `append` deltas; a `Resync` or a
+/// lagging receiver (overflow) becomes one `resync` delta and ends the watch (client re-watches).
+fn spawn_watch(state: &SharedState, agent: &str, watch_tx: mpsc::Sender<Frame>) -> tokio::task::AbortHandle {
+    let mut events = state.sync_hub.subscribe_events(agent);
+    let agent = agent.to_string();
+    let task = tokio::spawn(async move {
+        loop {
+            match events.recv().await {
+                Ok(LiveMessage::Event(event)) => {
+                    let delta = Frame::Append { agent: agent.clone(), events: vec![(*event).clone()] };
+                    if watch_tx.send(delta).await.is_err() {
+                        break;
+                    }
+                }
+                Ok(LiveMessage::Resync) | Err(broadcast::error::RecvError::Lagged(_)) => {
+                    let _ = watch_tx.send(Frame::Resync { agent: agent.clone() }).await;
+                    break;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+    task.abort_handle()
+}
+
+fn current_roster(state: &SharedState) -> BTreeMap<String, AgentInfo> {
+    let agents = state.agent_status_cache.agents();
+    let activity = state.agent_status_cache.subscribe_activity().borrow().clone();
+    let services = state.agent_status_cache.subscribe_services().borrow().clone();
+    let revs = state.agent_status_cache.service_revs();
+    agents
+        .iter()
+        .map(|entry| {
+            let build_phase = state.build_phase(&crate::docker::normalize_name(&entry.name));
+            (entry.name.clone(), agent_info(entry, &activity, &services, &revs, build_phase))
+        })
+        .collect()
+}
+
+fn agent_info(
+    entry: &ListEntry,
+    activity: &HashMap<String, String>,
+    services: &HashMap<String, HashMap<String, ServiceEntry>>,
+    revs: &HashMap<String, HashMap<String, u64>>,
+    build_phase: Option<crate::docker::BuildPhase>,
+) -> AgentInfo {
+    let activity_state = activity.get(&entry.name).cloned().unwrap_or_else(|| "idle".to_string());
+    let agent_revs = revs.get(&entry.name);
+    let services = services
+        .get(&entry.name)
+        .map(|svc| {
+            svc.iter()
+                .map(|(svc_name, e)| {
+                    let rev = agent_revs.and_then(|m| m.get(svc_name)).copied().unwrap_or(0);
+                    (svc_name.clone(), ServiceInfo { port: e.port, rev })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    AgentInfo {
+        status: entry.status,
+        activity_state,
+        build_phase,
+        started_at: entry.started_at.clone(),
+        services,
+    }
+}
+
+/// New or changed agents -> `agent` upserts; agents gone from the roster -> `agent_removed`. Ordered
+/// deterministically (`BTreeMap` iteration) so the wire stream is stable.
+fn roster_deltas(last: &BTreeMap<String, AgentInfo>, current: &BTreeMap<String, AgentInfo>) -> Vec<Frame> {
+    let mut deltas = Vec::new();
+    for (name, info) in current {
+        if last.get(name) != Some(info) {
+            deltas.push(Frame::Agent { name: name.clone(), info: info.clone() });
+        }
+    }
+    for name in last.keys() {
+        if !current.contains_key(name) {
+            deltas.push(Frame::AgentRemoved { name: name.clone() });
+        }
+    }
+    deltas
+}
+
+fn build_tree(
+    gateway: &GatewayInfo,
+    roster: &BTreeMap<String, AgentInfo>,
+    pending: &HashMap<String, Vec<serde_json::Value>>,
+) -> Tree {
+    let agents = roster
+        .iter()
+        .map(|(name, info)| {
+            let pending = pending.get(name).cloned().unwrap_or_default();
+            (name.clone(), AgentNode { info: info.clone(), notifications: NotificationsBranch { pending } })
+        })
+        .collect();
+    Tree { gateway: gateway.clone(), agents }
+}
+
+async fn build_gateway_info(state: &SharedState) -> GatewayInfo {
+    let (update_available, latest_version) = {
+        let update = state.update_info.lock().await;
+        (
+            update.as_ref().is_some_and(|i| i.update_available),
+            update.as_ref().map(|i| i.latest.clone()),
+        )
+    };
+    let (auto_update, channel) = {
+        let settings = state.settings.read().await;
+        (settings.auto_update, crate::channel::Channel::resolve(&settings.channel).as_str().to_string())
+    };
+    let tunnel_url = state.tunnel_url.lock().await.clone();
+    GatewayInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        channel,
+        auto_update,
+        port: state.https_port,
+        lan: GatewayLan { exposed: state.expose_lan, url: state.lan_url.clone() },
+        tunnel_url,
+        update_available,
+        latest_version,
+        managed: crate::is_cloud_managed(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::docker::AgentStatus;
+
+    fn entry(name: &str, status: AgentStatus) -> ListEntry {
+        ListEntry { name: name.to_string(), status, ws_port: 4200, started_at: Some("2026-01-01T00:00:00Z".into()) }
+    }
+
+    #[test]
+    fn agent_info_defaults_activity_and_carries_service_revs() {
+        let mut activity = HashMap::new();
+        activity.insert("scout".to_string(), "thinking".to_string());
+        let mut svc = HashMap::new();
+        svc.insert("scout".to_string(), HashMap::from([("dashboard".to_string(), ServiceEntry { port: 8080, public: true })]));
+        let mut revs = HashMap::new();
+        revs.insert("scout".to_string(), HashMap::from([("dashboard".to_string(), 3u64)]));
+
+        let info = agent_info(&entry("scout", AgentStatus::Alive), &activity, &svc, &revs, None);
+        assert_eq!(info.activity_state, "thinking");
+        assert_eq!(info.services["dashboard"], ServiceInfo { port: 8080, rev: 3 });
+
+        // An agent with no activity entry defaults to idle.
+        let idle = agent_info(&entry("mona", AgentStatus::Alive), &HashMap::new(), &HashMap::new(), &HashMap::new(), None);
+        assert_eq!(idle.activity_state, "idle");
+    }
+
+    fn info_of(status: AgentStatus) -> AgentInfo {
+        AgentInfo { status, activity_state: "idle".into(), build_phase: None, started_at: None, services: BTreeMap::new() }
+    }
+
+    #[test]
+    fn roster_deltas_emit_upserts_and_removals() {
+        let mut last = BTreeMap::new();
+        last.insert("scout".to_string(), info_of(AgentStatus::Alive));
+        last.insert("gone".to_string(), info_of(AgentStatus::Alive));
+
+        let mut current = BTreeMap::new();
+        current.insert("scout".to_string(), info_of(AgentStatus::Stopped)); // changed -> agent upsert
+        current.insert("new".to_string(), info_of(AgentStatus::Alive)); // added -> agent upsert
+
+        let deltas = roster_deltas(&last, &current);
+        assert!(deltas.contains(&Frame::Agent { name: "scout".into(), info: info_of(AgentStatus::Stopped) }));
+        assert!(deltas.contains(&Frame::Agent { name: "new".into(), info: info_of(AgentStatus::Alive) }));
+        assert!(deltas.contains(&Frame::AgentRemoved { name: "gone".into() }));
+        assert_eq!(deltas.len(), 3);
+
+        // No change -> no deltas.
+        assert!(roster_deltas(&current, &current).is_empty());
+    }
+
+    #[test]
+    fn connect_token_reads_bearer_then_query() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer abc".parse().expect("header"));
+        assert_eq!(connect_token(&headers, None).as_deref(), Some("abc"));
+        assert_eq!(connect_token(&HeaderMap::new(), Some("x=1&token=q2&y=3")).as_deref(), Some("q2"));
+        assert_eq!(connect_token(&HeaderMap::new(), None), None);
+    }
+
+    #[test]
+    fn token_deadline_is_set_for_jwt_and_absent_for_raw_key() {
+        let token = crate::jwt::create_token("secret", "access", crate::jwt::ACCESS_TOKEN_TTL);
+        assert!(token_deadline(&token, "secret").is_some());
+        assert!(token_deadline("secret", "secret").is_none()); // raw key never expires
+        assert!(token_deadline(&token, "other-key").is_none()); // fails validation -> no deadline
+    }
+}

--- a/vestad/src/sync/handler.rs
+++ b/vestad/src/sync/handler.rs
@@ -13,7 +13,7 @@ use crate::docker::ListEntry;
 use crate::settings::ServiceEntry;
 use crate::state::{SharedState, WS_KEEPALIVE_INTERVAL_SECS};
 
-use super::hub::LiveMessage;
+use super::hub::{LiveMessage, SyncHub};
 use super::protocol::{
     AgentInfo, AgentNode, ClientFrame, Frame, GatewayInfo, GatewayLan, GatewayScope,
     NotificationsBranch, ServiceInfo, Tree,
@@ -75,6 +75,21 @@ async fn sync_session(state: SharedState, socket: WebSocket, connect_token: Opti
         return;
     }
 
+    // Subscribe every delta source before reading the snapshot, so an update landing in the gap
+    // between the snapshot read and the subscribe still fires changed() (notifications have no
+    // keepalive re-emit to self-heal a missed one). borrow_and_update marks the current values seen,
+    // making the snapshot the baseline the deltas build on.
+    let mut agents_rx = state.agent_status_cache.subscribe_agents();
+    let mut activity_rx = state.agent_status_cache.subscribe_activity();
+    let mut services_rx = state.agent_status_cache.subscribe_services();
+    let mut invalidations_rx = state.agent_status_cache.subscribe_invalidations();
+    let mut notifications_rx = state.sync_hub.subscribe_notifications();
+    agents_rx.borrow_and_update();
+    activity_rx.borrow_and_update();
+    services_rx.borrow_and_update();
+    invalidations_rx.borrow_and_update();
+    notifications_rx.borrow_and_update();
+
     // 2. immediate snapshot: gateway + agents (info + pending sets), no tails.
     let mut last_roster = current_roster(&state);
     let mut last_gateway = build_gateway_info(&state).await;
@@ -83,12 +98,6 @@ async fn sync_session(state: SharedState, socket: WebSocket, connect_token: Opti
     if send_frame(&mut tx, &Frame::Snapshot { tree }).await.is_err() {
         return;
     }
-
-    let mut agents_rx = state.agent_status_cache.subscribe_agents();
-    let mut activity_rx = state.agent_status_cache.subscribe_activity();
-    let mut services_rx = state.agent_status_cache.subscribe_services();
-    let mut invalidations_rx = state.agent_status_cache.subscribe_invalidations();
-    let mut notifications_rx = state.sync_hub.subscribe_notifications();
 
     // Each watch spawns a task forwarding the hub's live edge into this per-connection mpsc; the one
     // socket writer drains it, so a chatty agent never blocks the others.
@@ -148,7 +157,7 @@ async fn sync_session(state: SharedState, socket: WebSocket, connect_token: Opti
             }
             Wake::Client(Some(Ok(Message::Text(text)))) => {
                 if let ControlFlow::Break(()) =
-                    handle_client_frame(&state, text.as_str(), &mut watches, &watch_tx, &mut deadline)
+                    handle_client_frame(&state.sync_hub, &state.api_key, text.as_str(), &mut watches, &watch_tx, &mut deadline)
                 {
                     break;
                 }
@@ -241,7 +250,8 @@ async fn emit_notifications(
 /// Handle one client frame. Unknown/malformed frames are ignored by rule. Returns Break only on a
 /// failed reauth (the loop then closes the socket).
 fn handle_client_frame(
-    state: &SharedState,
+    sync_hub: &SyncHub,
+    api_key: &str,
     text: &str,
     watches: &mut HashMap<String, tokio::task::AbortHandle>,
     watch_tx: &mpsc::Sender<Frame>,
@@ -253,7 +263,7 @@ fn handle_client_frame(
     match frame {
         ClientFrame::Watch { agent } => {
             if let std::collections::hash_map::Entry::Vacant(slot) = watches.entry(agent) {
-                let handle = spawn_watch(state, slot.key(), watch_tx.clone());
+                let handle = spawn_watch(sync_hub, slot.key(), watch_tx.clone());
                 slot.insert(handle);
             }
         }
@@ -263,8 +273,8 @@ fn handle_client_frame(
             }
         }
         ClientFrame::Reauth { token } => {
-            if crate::auth::verify_token(&token, &state.api_key) {
-                *deadline = token_deadline(&token, &state.api_key);
+            if crate::auth::verify_token(&token, api_key) {
+                *deadline = token_deadline(&token, api_key);
             } else {
                 tracing::warn!("sync reauth failed; closing socket");
                 return ControlFlow::Break(());
@@ -276,8 +286,8 @@ fn handle_client_frame(
 
 /// Spawn the forward task for one watch: the hub's live edge becomes `append` deltas; a `Resync` or a
 /// lagging receiver (overflow) becomes one `resync` delta and ends the watch (client re-watches).
-fn spawn_watch(state: &SharedState, agent: &str, watch_tx: mpsc::Sender<Frame>) -> tokio::task::AbortHandle {
-    let mut events = state.sync_hub.subscribe_events(agent);
+fn spawn_watch(sync_hub: &SyncHub, agent: &str, watch_tx: mpsc::Sender<Frame>) -> tokio::task::AbortHandle {
+    let mut events = sync_hub.subscribe_events(agent);
     let agent = agent.to_string();
     let task = tokio::spawn(async move {
         loop {
@@ -466,5 +476,101 @@ mod tests {
         assert!(token_deadline(&token, "secret").is_some());
         assert!(token_deadline("secret", "secret").is_none()); // raw key never expires
         assert!(token_deadline(&token, "other-key").is_none()); // fails validation -> no deadline
+    }
+
+    fn abort_all(watches: HashMap<String, tokio::task::AbortHandle>) {
+        for (_, handle) in watches {
+            handle.abort();
+        }
+    }
+
+    // The four tests below drive handle_client_frame/spawn_watch against a bare SyncHub (no
+    // SharedState), the hermetic seam the explicit-deps refactor unlocks. Current-thread runtime: a
+    // spawned forward task does not run until the test awaits, which is what makes the flood-then-lag
+    // path deterministic.
+
+    #[tokio::test]
+    async fn watch_then_publish_delivers_an_append_delta() {
+        let hub = SyncHub::new();
+        let (watch_tx, mut watch_rx) = mpsc::channel::<Frame>(WATCH_FANIN_CAPACITY);
+        let mut watches = HashMap::new();
+        let mut deadline = None;
+
+        let flow = handle_client_frame(&hub, "key", r#"{"type":"watch","agent":"scout"}"#, &mut watches, &watch_tx, &mut deadline);
+        assert!(matches!(flow, ControlFlow::Continue(())));
+        assert!(watches.contains_key("scout"));
+
+        hub.publish_event("scout", std::sync::Arc::new(serde_json::json!({"id": 1, "text": "hi"})));
+        match watch_rx.recv().await.expect("append delta") {
+            Frame::Append { agent, events } => {
+                assert_eq!(agent, "scout");
+                assert_eq!(events[0]["text"], serde_json::json!("hi"));
+            }
+            other => panic!("expected an append, got {other:?}"),
+        }
+        abort_all(watches);
+    }
+
+    #[tokio::test]
+    async fn unwatch_aborts_delivery() {
+        let hub = SyncHub::new();
+        let (watch_tx, mut watch_rx) = mpsc::channel::<Frame>(WATCH_FANIN_CAPACITY);
+        let mut watches = HashMap::new();
+        let mut deadline = None;
+
+        let _ = handle_client_frame(&hub, "key", r#"{"type":"watch","agent":"scout"}"#, &mut watches, &watch_tx, &mut deadline);
+        let _ = handle_client_frame(&hub, "key", r#"{"type":"unwatch","agent":"scout"}"#, &mut watches, &watch_tx, &mut deadline);
+        assert!(watches.is_empty());
+
+        hub.publish_event("scout", std::sync::Arc::new(serde_json::json!({"id": 1})));
+        // Let the runtime cancel the aborted forward task, then confirm it never forwarded the event.
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert!(matches!(watch_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn overflow_yields_one_resync_and_ends_the_watch() {
+        let hub = SyncHub::new();
+        let (watch_tx, mut watch_rx) = mpsc::channel::<Frame>(WATCH_FANIN_CAPACITY);
+        let mut watches = HashMap::new();
+        let mut deadline = None;
+
+        let _ = handle_client_frame(&hub, "key", r#"{"type":"watch","agent":"chatty"}"#, &mut watches, &watch_tx, &mut deadline);
+
+        // The forward task has not been polled yet, so its broadcast receiver sits at the initial
+        // version; flooding well past the buffer forces Lagged on its first recv.
+        for id in 0..2048 {
+            hub.publish_event("chatty", std::sync::Arc::new(serde_json::json!({"id": id})));
+        }
+        assert!(matches!(watch_rx.recv().await, Some(Frame::Resync { agent }) if agent == "chatty"));
+
+        // The watch ended on the resync: further live events deliver nothing.
+        hub.publish_event("chatty", std::sync::Arc::new(serde_json::json!({"id": 9999})));
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert!(matches!(watch_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+        abort_all(watches);
+    }
+
+    #[tokio::test]
+    async fn reauth_extends_on_valid_token_and_breaks_on_invalid() {
+        let hub = SyncHub::new();
+        let (watch_tx, _watch_rx) = mpsc::channel::<Frame>(WATCH_FANIN_CAPACITY);
+        let mut watches = HashMap::new();
+        let mut deadline: Option<tokio::time::Instant> = None;
+
+        let token = crate::jwt::create_token("secret", "access", crate::jwt::ACCESS_TOKEN_TTL);
+        let valid = format!(r#"{{"type":"reauth","token":"{token}"}}"#);
+        let flow = handle_client_frame(&hub, "secret", &valid, &mut watches, &watch_tx, &mut deadline);
+        assert!(matches!(flow, ControlFlow::Continue(())));
+        assert!(deadline.is_some(), "a valid reauth extends the deadline");
+
+        let before = deadline;
+        let flow = handle_client_frame(&hub, "secret", r#"{"type":"reauth","token":"bad.token.here"}"#, &mut watches, &watch_tx, &mut deadline);
+        assert!(matches!(flow, ControlFlow::Break(())), "a bad reauth breaks the loop");
+        assert_eq!(deadline, before, "a failed reauth leaves the deadline unchanged");
     }
 }

--- a/vestad/src/sync/handler.rs
+++ b/vestad/src/sync/handler.rs
@@ -410,6 +410,44 @@ async fn build_gateway_info(state: &SharedState) -> GatewayInfo {
     }
 }
 
+#[derive(serde::Deserialize)]
+pub(crate) struct SendMessageBody {
+    text: String,
+    #[serde(default)]
+    intent_id: Option<String>,
+}
+
+/// Relay a send-message intent to the agent over the tap's write-half. Returns a typed retryable
+/// `503` when the tap is down (agent restarting/evicted) so the client keeps its composer and
+/// retries; a `200` ack means the agent's intake accepted the message.
+pub(crate) async fn send_message_handler(
+    State(state): State<SharedState>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+    axum::Json(body): axum::Json<SendMessageBody>,
+) -> Result<axum::Json<serde_json::Value>, (axum::http::StatusCode, axum::Json<serde_json::Value>)> {
+    let frame = message_frame(&body).to_string();
+    match state.sync_hub.send_message(&name, frame) {
+        Ok(()) => Ok(crate::state::ok_json()),
+        Err(error) => {
+            tracing::warn!(agent = %name, %error, "send-message relay unavailable");
+            Err((
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                axum::Json(serde_json::json!({ "error": error.to_string(), "retryable": true })),
+            ))
+        }
+    }
+}
+
+/// The agent-WS `message` frame the tap relays: `{type:"message", text, intent_id?}`, matching the
+/// agent's `_recv_loop` intake (Stage 3). `intent_id` is omitted when absent, never null.
+fn message_frame(body: &SendMessageBody) -> serde_json::Value {
+    let mut frame = serde_json::json!({ "type": "message", "text": body.text });
+    if let Some(intent_id) = &body.intent_id {
+        frame["intent_id"] = serde_json::Value::String(intent_id.clone());
+    }
+    frame
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -572,5 +610,16 @@ mod tests {
         let flow = handle_client_frame(&hub, "secret", r#"{"type":"reauth","token":"bad.token.here"}"#, &mut watches, &watch_tx, &mut deadline);
         assert!(matches!(flow, ControlFlow::Break(())), "a bad reauth breaks the loop");
         assert_eq!(deadline, before, "a failed reauth leaves the deadline unchanged");
+    }
+
+    #[test]
+    fn message_frame_threads_intent_id_only_when_present() {
+        let with_id = message_frame(&SendMessageBody { text: "hi".into(), intent_id: Some("i-9".into()) });
+        assert_eq!(with_id["type"], serde_json::json!("message"));
+        assert_eq!(with_id["text"], serde_json::json!("hi"));
+        assert_eq!(with_id["intent_id"], serde_json::json!("i-9"));
+
+        let without = message_frame(&SendMessageBody { text: "hi".into(), intent_id: None });
+        assert!(without.get("intent_id").is_none(), "absent intent_id stays absent, never null");
     }
 }

--- a/vestad/src/sync/hub.rs
+++ b/vestad/src/sync/hub.rs
@@ -1,0 +1,203 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value;
+use tokio::sync::{broadcast, mpsc, watch};
+
+use super::events::{NotificationChange, PendingNotifications};
+
+/// Per-agent live-edge buffer. A watcher that falls this far behind is dropped with a `resync`
+/// delta (today's EventBus eviction contract, scoped to one subscription instead of the socket).
+const AGENT_BROADCAST_CAPACITY: usize = 256;
+
+/// One live-edge message for an agent's watchers. `Resync` tells a watcher its live edge had a gap
+/// (a tap reconnect); a lagging receiver is turned into the same resync by the handler.
+#[derive(Clone, Debug)]
+pub(crate) enum LiveMessage {
+    Event(Arc<Value>),
+    Resync,
+}
+
+struct AgentChannel {
+    events: broadcast::Sender<LiveMessage>,
+    writer: Option<mpsc::Sender<String>>,
+    pending: PendingNotifications,
+}
+
+impl AgentChannel {
+    fn new() -> Self {
+        let (events, _rx) = broadcast::channel(AGENT_BROADCAST_CAPACITY);
+        Self { events, writer: None, pending: PendingNotifications::default() }
+    }
+}
+
+/// The aggregator's shared fan-out state. The tap (in `agent_status.rs`) publishes live events,
+/// seeds notifications, and registers a write-half here; `/sync` connections subscribe for the live
+/// edge and read the notifications projection. One instance lives on `AppState`.
+pub(crate) struct SyncHub {
+    agents: Mutex<HashMap<String, AgentChannel>>,
+    notifications_tx: watch::Sender<u64>,
+    notifications_rx: watch::Receiver<u64>,
+}
+
+/// Send-message relay failed because the agent's tap is down (restarting, evicted). Retryable: the
+/// client keeps its composer state and retries; an ack means the agent's intake accepted it.
+#[derive(Debug)]
+pub(crate) struct TapUnavailable;
+
+impl std::fmt::Display for TapUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("agent tap is unavailable; retry")
+    }
+}
+
+impl std::error::Error for TapUnavailable {}
+
+impl Default for SyncHub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SyncHub {
+    pub fn new() -> Self {
+        let (notifications_tx, notifications_rx) = watch::channel(0);
+        Self { agents: Mutex::new(HashMap::new()), notifications_tx, notifications_rx }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, AgentChannel>> {
+        self.agents.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Subscribe to an agent's live edge, creating the channel if the agent has not materialized yet
+    /// (watch-before-create: the receiver simply waits until the tap publishes).
+    pub fn subscribe_events(&self, agent: &str) -> broadcast::Receiver<LiveMessage> {
+        self.lock().entry(agent.to_string()).or_insert_with(AgentChannel::new).events.subscribe()
+    }
+
+    /// Publish a live event to an agent's watchers. Backlog (the connect snapshot) is never
+    /// published; only the live edge is. A send with no receivers is a no-op.
+    pub fn publish_event(&self, agent: &str, event: Arc<Value>) {
+        let mut agents = self.lock();
+        let channel = agents.entry(agent.to_string()).or_insert_with(AgentChannel::new);
+        let _ = channel.events.send(LiveMessage::Event(event));
+    }
+
+    /// Tell an agent's watchers their live edge had a gap; each re-watches and refetches the tail by
+    /// id. Used on tap reconnect.
+    pub fn publish_resync(&self, agent: &str) {
+        if let Some(channel) = self.lock().get(agent) {
+            let _ = channel.events.send(LiveMessage::Resync);
+        }
+    }
+
+    pub fn install_writer(&self, agent: &str, writer: mpsc::Sender<String>) {
+        self.lock().entry(agent.to_string()).or_insert_with(AgentChannel::new).writer = Some(writer);
+    }
+
+    pub fn clear_writer(&self, agent: &str) {
+        if let Some(channel) = self.lock().get_mut(agent) {
+            channel.writer = None;
+        }
+    }
+
+    /// Relay a send-message frame over the agent's tap write-half. Errors (retryable) when the tap is
+    /// down or its relay queue is full.
+    pub fn send_message(&self, agent: &str, frame: String) -> Result<(), TapUnavailable> {
+        let agents = self.lock();
+        let writer = agents.get(agent).and_then(|c| c.writer.as_ref()).ok_or(TapUnavailable)?;
+        writer.try_send(frame).map_err(|_| TapUnavailable)
+    }
+
+    /// Reconcile an agent's pending notifications to the snapshot's authoritative id set; wakes
+    /// `/sync` loops only on a real change.
+    pub fn seed_notifications(&self, agent: &str, ids: &[String]) {
+        let changed = self.lock().entry(agent.to_string()).or_insert_with(AgentChannel::new).pending.seed(ids);
+        if changed {
+            self.bump_notifications();
+        }
+    }
+
+    pub fn apply_notification(&self, agent: &str, change: NotificationChange) {
+        let changed = self.lock().entry(agent.to_string()).or_insert_with(AgentChannel::new).pending.apply(change);
+        if changed {
+            self.bump_notifications();
+        }
+    }
+
+    /// Drop all fan-out state for an agent that left the alive set. Watchers' receivers close; the
+    /// `/sync` handler emits `agent_removed` from the roster diff.
+    pub fn forget_agent(&self, agent: &str) {
+        if self.lock().remove(agent).is_some() {
+            self.bump_notifications();
+        }
+    }
+
+    /// The current pending list for every agent: the connect snapshot's notification branches and
+    /// the notifications diff loop both read this.
+    pub fn pending_all(&self) -> HashMap<String, Vec<Value>> {
+        self.lock().iter().map(|(name, c)| (name.clone(), c.pending.render())).collect()
+    }
+
+    pub fn subscribe_notifications(&self) -> watch::Receiver<u64> {
+        self.notifications_rx.clone()
+    }
+
+    fn bump_notifications(&self) {
+        self.notifications_tx.send_modify(|v| *v = v.wrapping_add(1));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn send_message_without_a_writer_is_retryable() {
+        let hub = SyncHub::new();
+        let error = hub.send_message("ghost", "{}".into()).expect_err("no tap => retryable error");
+        assert_eq!(error.to_string(), "agent tap is unavailable; retry");
+    }
+
+    #[tokio::test]
+    async fn installed_writer_receives_the_relayed_frame() {
+        let hub = SyncHub::new();
+        let (tx, mut rx) = mpsc::channel::<String>(4);
+        hub.install_writer("scout", tx);
+        hub.send_message("scout", r#"{"type":"message","text":"hi"}"#.into()).expect("relay");
+        assert_eq!(rx.recv().await.expect("frame"), r#"{"type":"message","text":"hi"}"#);
+    }
+
+    #[tokio::test]
+    async fn watch_before_create_then_publish_delivers() {
+        let hub = SyncHub::new();
+        // Subscribe before the agent's tap ever created the channel.
+        let mut rx = hub.subscribe_events("late");
+        hub.publish_event("late", Arc::new(serde_json::json!({"id": 1, "type": "chat", "text": "hi"})));
+        match rx.recv().await.expect("event") {
+            LiveMessage::Event(event) => assert_eq!(event["text"], serde_json::json!("hi")),
+            LiveMessage::Resync => panic!("expected an event, got resync"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_lagging_watcher_reads_lagged() {
+        let hub = SyncHub::new();
+        let mut rx = hub.subscribe_events("chatty");
+        // Overflow the per-agent buffer without receiving; the next recv reports the drop, which the
+        // handler turns into a resync.
+        for i in 0..(AGENT_BROADCAST_CAPACITY as i64 + 1) {
+            hub.publish_event("chatty", Arc::new(serde_json::json!({"id": i, "type": "chat", "text": ""})));
+        }
+        assert!(matches!(rx.recv().await, Err(broadcast::error::RecvError::Lagged(_))));
+    }
+
+    #[test]
+    fn notifications_seed_and_apply_render_the_branch() {
+        let hub = SyncHub::new();
+        hub.seed_notifications("scout", &["a".into()]);
+        assert_eq!(hub.pending_all()["scout"].len(), 1);
+        hub.apply_notification("scout", NotificationChange::Cleared { notif_id: "a".into() });
+        assert!(hub.pending_all()["scout"].is_empty());
+    }
+}

--- a/vestad/src/sync/hub.rs
+++ b/vestad/src/sync/hub.rs
@@ -7,7 +7,7 @@ use tokio::sync::{broadcast, mpsc, watch};
 use super::events::{NotificationChange, PendingNotifications};
 
 /// Per-agent live-edge buffer. A watcher that falls this far behind is dropped with a `resync`
-/// delta (today's EventBus eviction contract, scoped to one subscription instead of the socket).
+/// delta (today's `EventBus` eviction contract, scoped to one subscription instead of the socket).
 const AGENT_BROADCAST_CAPACITY: usize = 256;
 
 /// One live-edge message for an agent's watchers. `Resync` tells a watcher its live edge had a gap

--- a/vestad/src/sync/mod.rs
+++ b/vestad/src/sync/mod.rs
@@ -1,0 +1,12 @@
+//! The client protocol's server side: the aggregator's shared fan-out state (`SyncHub`) and the
+//! `/sync` WebSocket handler. This module owns vestad's Rust side of the wire protocol, mirroring
+//! `apps/core/src/protocol` and contract-tested at the fixture seam. It is additive beside the
+//! legacy control WS in this stage; the old surface is retired later in the epic.
+
+pub(crate) mod protocol;
+
+/// The protocol version vestad speaks and the minimum it still accepts. Mirrors
+/// `apps/core/src/protocol/version.ts` (PROTOCOL_VERSION / PROTOCOL_FLOOR); the contract fixture
+/// pins them equal on both seams.
+pub(crate) const PROTOCOL_VERSION: u32 = 1;
+pub(crate) const PROTOCOL_FLOOR: u32 = 1;

--- a/vestad/src/sync/mod.rs
+++ b/vestad/src/sync/mod.rs
@@ -3,6 +3,7 @@
 //! `apps/core/src/protocol` and contract-tested at the fixture seam. It is additive beside the
 //! legacy control WS in this stage; the old surface is retired later in the epic.
 
+pub(crate) mod events;
 pub(crate) mod protocol;
 
 /// The protocol version vestad speaks and the minimum it still accepts. Mirrors
@@ -10,3 +11,5 @@ pub(crate) mod protocol;
 /// pins them equal on both seams.
 pub(crate) const PROTOCOL_VERSION: u32 = 1;
 pub(crate) const PROTOCOL_FLOOR: u32 = 1;
+
+pub(crate) use events::{NotificationChange, PendingNotifications, activity_state, notification_change};

--- a/vestad/src/sync/mod.rs
+++ b/vestad/src/sync/mod.rs
@@ -15,5 +15,5 @@ pub(crate) const PROTOCOL_VERSION: u32 = 1;
 pub(crate) const PROTOCOL_FLOOR: u32 = 1;
 
 pub(crate) use events::{NotificationChange, PendingNotifications, activity_state, notification_change};
-pub(crate) use handler::sync_ws_handler;
+pub(crate) use handler::{send_message_handler, sync_ws_handler};
 pub(crate) use hub::{LiveMessage, SyncHub, TapUnavailable};

--- a/vestad/src/sync/mod.rs
+++ b/vestad/src/sync/mod.rs
@@ -5,15 +5,15 @@
 
 pub(crate) mod events;
 mod handler;
-mod hub;
+pub(crate) mod hub;
 pub(crate) mod protocol;
 
 /// The protocol version vestad speaks and the minimum it still accepts. Mirrors
-/// `apps/core/src/protocol/version.ts` (PROTOCOL_VERSION / PROTOCOL_FLOOR); the contract fixture
+/// `apps/core/src/protocol/version.ts` (`PROTOCOL_VERSION` / `PROTOCOL_FLOOR`); the contract fixture
 /// pins them equal on both seams.
 pub(crate) const PROTOCOL_VERSION: u32 = 1;
 pub(crate) const PROTOCOL_FLOOR: u32 = 1;
 
-pub(crate) use events::{NotificationChange, PendingNotifications, activity_state, notification_change};
+pub(crate) use events::{activity_state, notification_change};
 pub(crate) use handler::{send_message_handler, sync_ws_handler};
-pub(crate) use hub::{LiveMessage, SyncHub, TapUnavailable};
+pub(crate) use hub::SyncHub;

--- a/vestad/src/sync/mod.rs
+++ b/vestad/src/sync/mod.rs
@@ -4,6 +4,7 @@
 //! legacy control WS in this stage; the old surface is retired later in the epic.
 
 pub(crate) mod events;
+mod hub;
 pub(crate) mod protocol;
 
 /// The protocol version vestad speaks and the minimum it still accepts. Mirrors
@@ -13,3 +14,4 @@ pub(crate) const PROTOCOL_VERSION: u32 = 1;
 pub(crate) const PROTOCOL_FLOOR: u32 = 1;
 
 pub(crate) use events::{NotificationChange, PendingNotifications, activity_state, notification_change};
+pub(crate) use hub::{LiveMessage, SyncHub, TapUnavailable};

--- a/vestad/src/sync/mod.rs
+++ b/vestad/src/sync/mod.rs
@@ -4,6 +4,7 @@
 //! legacy control WS in this stage; the old surface is retired later in the epic.
 
 pub(crate) mod events;
+mod handler;
 mod hub;
 pub(crate) mod protocol;
 
@@ -14,4 +15,5 @@ pub(crate) const PROTOCOL_VERSION: u32 = 1;
 pub(crate) const PROTOCOL_FLOOR: u32 = 1;
 
 pub(crate) use events::{NotificationChange, PendingNotifications, activity_state, notification_change};
+pub(crate) use handler::sync_ws_handler;
 pub(crate) use hub::{LiveMessage, SyncHub, TapUnavailable};

--- a/vestad/src/sync/protocol.rs
+++ b/vestad/src/sync/protocol.rs
@@ -1,0 +1,191 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::docker::{AgentStatus, BuildPhase};
+
+/// The gateway (host) branch of the state tree. camelCase on the wire to match
+/// `apps/core/src/protocol/tree.ts` `GatewayInfo`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GatewayInfo {
+    pub version: String,
+    pub channel: String,
+    pub auto_update: bool,
+    pub port: u16,
+    pub lan: GatewayLan,
+    pub tunnel_url: Option<String>,
+    pub update_available: bool,
+    pub latest_version: Option<String>,
+    pub managed: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub(crate) struct GatewayLan {
+    pub exposed: bool,
+    pub url: Option<String>,
+}
+
+/// One registered agent-hosted service (dashboard, voice, ...). Mirrors `ServiceInfo`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub(crate) struct ServiceInfo {
+    pub port: u16,
+    pub rev: u64,
+}
+
+/// The per-agent `info` branch. camelCase to match `AgentInfo`. `activity_state` is a plain string
+/// ("idle"/"thinking") sourced from the activity cache; the TS union narrows it.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AgentInfo {
+    pub status: AgentStatus,
+    pub activity_state: String,
+    pub build_phase: Option<BuildPhase>,
+    pub started_at: Option<String>,
+    pub services: BTreeMap<String, ServiceInfo>,
+}
+
+/// The per-agent node: info + the always-on pending-notifications branch. `pending` events are
+/// relayed verbatim from the agent's Python (opaque JSON), so they carry whatever fields the agent
+/// emitted plus their id.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub(crate) struct AgentNode {
+    pub info: AgentInfo,
+    pub notifications: NotificationsBranch,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub(crate) struct NotificationsBranch {
+    pub pending: Vec<serde_json::Value>,
+}
+
+/// The full state tree sent on the connect snapshot: roster + pending sets, no tails.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub(crate) struct Tree {
+    pub gateway: GatewayInfo,
+    pub agents: BTreeMap<String, AgentNode>,
+}
+
+/// The `state` delta's scope; always `gateway` in protocol 1 (a whole-branch replace).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum GatewayScope {
+    Gateway,
+}
+
+/// Every server -> client frame in one tagged union, matching the flat `type` routing in
+/// `apps/core/src/protocol/parse.ts`. hello/snapshot plus the six delta types share one wire
+/// discriminator space; on one ordered TCP socket there are no sequence numbers.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum Frame {
+    Hello { version: String, protocol: u32, floor: u32 },
+    Snapshot { tree: Tree },
+    State { scope: GatewayScope, value: GatewayInfo },
+    Agent { name: String, info: AgentInfo },
+    AgentRemoved { name: String },
+    Append { agent: String, events: Vec<serde_json::Value> },
+    Notifications { agent: String, pending: Vec<serde_json::Value> },
+    Resync { agent: String },
+}
+
+impl Frame {
+    /// Serialize to a wire string. Serialization of these owned DTOs does not fail in practice, but
+    /// the fallible API is honored so no `unwrap` rides the send path: a serialize error is logged
+    /// and the frame dropped by the caller.
+    pub fn encode(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+}
+
+/// Client -> server frames. Anything that fails to parse as one of these is ignored by the handler.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum ClientFrame {
+    Watch { agent: String },
+    Unwatch { agent: String },
+    Reauth { token: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_gateway() -> GatewayInfo {
+        GatewayInfo {
+            version: "0.1.0".into(),
+            channel: "stable".into(),
+            auto_update: true,
+            port: 4111,
+            lan: GatewayLan { exposed: false, url: None },
+            tunnel_url: None,
+            update_available: false,
+            latest_version: None,
+            managed: false,
+        }
+    }
+
+    #[test]
+    fn gateway_info_serializes_camelcase_like_the_ts_tree() {
+        let value = serde_json::to_value(sample_gateway()).expect("serialize");
+        // camelCase field names must match apps/core/src/protocol/tree.ts GatewayInfo.
+        assert!(value.get("autoUpdate").is_some());
+        assert!(value.get("tunnelUrl").is_some());
+        assert!(value.get("updateAvailable").is_some());
+        assert!(value.get("latestVersion").is_some());
+        assert!(value.get("auto_update").is_none());
+    }
+
+    #[test]
+    fn agent_info_serializes_camelcase() {
+        let info = AgentInfo {
+            status: crate::docker::AgentStatus::Alive,
+            activity_state: "idle".into(),
+            build_phase: None,
+            started_at: Some("2026-07-18T00:00:00Z".into()),
+            services: std::collections::BTreeMap::new(),
+        };
+        let value = serde_json::to_value(info).expect("serialize");
+        assert_eq!(value["status"], serde_json::json!("alive"));
+        assert!(value.get("activityState").is_some());
+        assert!(value.get("buildPhase").is_some());
+        assert!(value.get("startedAt").is_some());
+    }
+
+    #[test]
+    fn every_frame_variant_uses_its_wire_tag() {
+        let cases = [
+            (Frame::Hello { version: "0.1.0".into(), protocol: 1, floor: 1 }, "hello"),
+            (Frame::Snapshot { tree: Tree { gateway: sample_gateway(), agents: Default::default() } }, "snapshot"),
+            (Frame::State { scope: GatewayScope::Gateway, value: sample_gateway() }, "state"),
+            (Frame::AgentRemoved { name: "scout".into() }, "agent_removed"),
+            (Frame::Append { agent: "scout".into(), events: vec![] }, "append"),
+            (Frame::Notifications { agent: "scout".into(), pending: vec![] }, "notifications"),
+            (Frame::Resync { agent: "scout".into() }, "resync"),
+        ];
+        for (frame, tag) in cases {
+            let value = serde_json::to_value(&frame).expect("serialize frame");
+            assert_eq!(value["type"], serde_json::json!(tag));
+        }
+    }
+
+    #[test]
+    fn state_delta_scope_is_gateway() {
+        let value = serde_json::to_value(Frame::State {
+            scope: GatewayScope::Gateway,
+            value: sample_gateway(),
+        })
+        .expect("serialize");
+        assert_eq!(value["scope"], serde_json::json!("gateway"));
+    }
+
+    #[test]
+    fn client_frames_round_trip() {
+        let watch: ClientFrame = serde_json::from_str(r#"{"type":"watch","agent":"scout"}"#).expect("parse watch");
+        assert_eq!(watch, ClientFrame::Watch { agent: "scout".into() });
+        let reauth: ClientFrame = serde_json::from_str(r#"{"type":"reauth","token":"tok"}"#).expect("parse reauth");
+        assert_eq!(reauth, ClientFrame::Reauth { token: "tok".into() });
+        // An unknown client frame is a parse error the handler treats as "ignore".
+        assert!(serde_json::from_str::<ClientFrame>(r#"{"type":"future"}"#).is_err());
+    }
+}

--- a/vestad/src/sync/protocol.rs
+++ b/vestad/src/sync/protocol.rs
@@ -152,12 +152,23 @@ mod tests {
         assert!(value.get("startedAt").is_some());
     }
 
+    fn sample_agent_info() -> AgentInfo {
+        AgentInfo {
+            status: crate::docker::AgentStatus::Alive,
+            activity_state: "idle".into(),
+            build_phase: None,
+            started_at: None,
+            services: BTreeMap::new(),
+        }
+    }
+
     #[test]
     fn every_frame_variant_uses_its_wire_tag() {
         let cases = [
             (Frame::Hello { version: "0.1.0".into(), protocol: 1, floor: 1 }, "hello"),
             (Frame::Snapshot { tree: Tree { gateway: sample_gateway(), agents: Default::default() } }, "snapshot"),
             (Frame::State { scope: GatewayScope::Gateway, value: sample_gateway() }, "state"),
+            (Frame::Agent { name: "scout".into(), info: sample_agent_info() }, "agent"),
             (Frame::AgentRemoved { name: "scout".into() }, "agent_removed"),
             (Frame::Append { agent: "scout".into(), events: vec![] }, "append"),
             (Frame::Notifications { agent: "scout".into(), pending: vec![] }, "notifications"),

--- a/vestad/src/sync/protocol.rs
+++ b/vestad/src/sync/protocol.rs
@@ -107,6 +107,62 @@ pub(crate) enum ClientFrame {
     Reauth { token: String },
 }
 
+/// Build one representative of every `/sync` frame through the real serde path, for the contract
+/// fixture the `@vesta/core` test parses. Test-only.
+#[cfg(test)]
+pub(crate) fn protocol_fixtures() -> serde_json::Value {
+    use serde_json::to_value;
+
+    let gateway = GatewayInfo {
+        version: "0.1.0".into(),
+        channel: "stable".into(),
+        auto_update: true,
+        port: 4111,
+        lan: GatewayLan { exposed: false, url: None },
+        tunnel_url: Some("https://sample.vesta.run".into()),
+        update_available: true,
+        latest_version: Some("0.1.1".into()),
+        managed: false,
+    };
+    let mut services = BTreeMap::new();
+    services.insert("dashboard".to_string(), ServiceInfo { port: 8080, rev: 3 });
+    let info = AgentInfo {
+        status: AgentStatus::Alive,
+        activity_state: "thinking".into(),
+        build_phase: None,
+        started_at: Some("2026-01-01T00:00:00Z".into()),
+        services,
+    };
+    let notification = serde_json::json!({
+        "id": 7, "type": "notification", "source": "whatsapp", "summary": "new message",
+        "notif_id": "whatsapp-123",
+    });
+    let chat = serde_json::json!({ "id": 5, "type": "chat", "text": "hello" });
+    let mut agents = BTreeMap::new();
+    agents.insert(
+        "sample-agent".to_string(),
+        AgentNode { info: info.clone(), notifications: NotificationsBranch { pending: vec![notification.clone()] } },
+    );
+    let tree = Tree { gateway: gateway.clone(), agents };
+
+    serde_json::json!({
+        "hello": to_value(Frame::Hello {
+            version: "0.1.0".into(),
+            protocol: super::PROTOCOL_VERSION,
+            floor: super::PROTOCOL_FLOOR,
+        }).expect("serialize hello"),
+        "snapshot": to_value(Frame::Snapshot { tree }).expect("serialize snapshot"),
+        "deltas": {
+            "state": to_value(Frame::State { scope: GatewayScope::Gateway, value: gateway }).expect("serialize state"),
+            "agent": to_value(Frame::Agent { name: "sample-agent".into(), info }).expect("serialize agent"),
+            "agent_removed": to_value(Frame::AgentRemoved { name: "stopped-agent".into() }).expect("serialize agent_removed"),
+            "append": to_value(Frame::Append { agent: "sample-agent".into(), events: vec![chat] }).expect("serialize append"),
+            "notifications": to_value(Frame::Notifications { agent: "sample-agent".into(), pending: vec![notification] }).expect("serialize notifications"),
+            "resync": to_value(Frame::Resync { agent: "sample-agent".into() }).expect("serialize resync"),
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Stage 4 of the client-protocol epic: vestad grows the sync module, additive beside the old surface. Rust wire types mirroring @vesta/core field-for-field; the Python-to-Rust event seam verified against the committed event-union fixture; the SyncHub aggregator (per-agent broadcast fan-out, tap write-half registry, pending-notification projection); the generalized tap (push stays live-only, snapshot reseeds notifications, write-half installed for relay); the GET /sync WS handler (hello protocol=1/floor=1, tail-less snapshot, watch/unwatch, overflow-to-resync, reauth with JWT-derived deadline, subscribe-before-snapshot ordering); POST /agents/{name}/message with typed retryable 503 and omit-not-null intent_id; and dual-seam contract fixtures (Rust regen -> apps/core/fixtures/sync-protocol.json -> TS parse test). check.sh vestad green incl. clippy -D warnings (zero allows), 250 crate tests; check.sh web green (60 core tests). Six socket-level scenarios recorded for the stage-9 WS integration harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSn1nFTKDmH5HzuK97mepr