### PR TITLE
test(vestad): stage 9, the /sync integration gate

### DIFF
--- a/vestad/Cargo.lock
+++ b/vestad/Cargo.lock
@@ -3281,6 +3281,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vesta-tests"
 version = "0.1.178"
 dependencies = [
+ "futures-util",
  "ring",
  "rustls",
  "serde",

--- a/vestad/src/agent_status.rs
+++ b/vestad/src/agent_status.rs
@@ -369,16 +369,17 @@ pub fn spawn_agent_status_task(deps: AgentStatusTaskDeps) {
                 on_agents_changed(&agents);
             }
 
-            // Reconcile internal WS connections for activity and mobile app events.
-            let alive_agents: HashMap<String, u16> = agents
+            // Reconcile internal WS connections (the tap: activity, mobile push, and the sync live
+            // edge) for every agent whose WS server is up, not just the fully-provisioned ones.
+            let tappable_agents: HashMap<String, u16> = agents
                 .iter()
-                .filter(|a| a.status == docker::AgentStatus::Alive)
+                .filter(|a| a.status.serves_ws())
                 .map(|a| (a.name.clone(), a.ws_port))
                 .collect();
 
-            // Close connections for agents that are no longer alive
+            // Close connections for agents whose WS is no longer reachable
             agent_ws_handles.retain(|name, handle| {
-                if alive_agents.contains_key(name) {
+                if tappable_agents.contains_key(name) {
                     true
                 } else {
                     handle.abort_handle.abort();
@@ -394,8 +395,8 @@ pub fn spawn_agent_status_task(deps: AgentStatusTaskDeps) {
                 }
             });
 
-            // Open connections for newly alive agents
-            for (name, ws_port) in &alive_agents {
+            // Open connections for newly reachable agents
+            for (name, ws_port) in &tappable_agents {
                 if agent_ws_handles.contains_key(name) {
                     continue;
                 }

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -221,7 +221,9 @@ impl AgentStatus {
     /// connects in every one of these states: the app-chat echo and the event stream are
     /// credential-independent, so an unauthenticated or unprovisioned agent still streams events and
     /// accepts relayed chat (the raw per-agent WS proxy this hub replaced served it regardless of
-    /// auth). Excludes `Starting` (port not yet bound) and every down/rebuilding state.
+    /// auth). The push projection rides the same tap, so it too observes these states, wider than
+    /// the old Alive-only listener, bounded by the same alert-worthiness gate.
+    /// Excludes `Starting` (port not yet bound) and every down/rebuilding state.
     pub fn serves_ws(self) -> bool {
         matches!(
             self,

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -216,6 +216,21 @@ impl AgentStatus {
             AgentStatus::NotFound => "not found",
         }
     }
+
+    /// True while the container is up with its WS/HTTP server bound and serving. The sync tap
+    /// connects in every one of these states: the app-chat echo and the event stream are
+    /// credential-independent, so an unauthenticated or unprovisioned agent still streams events and
+    /// accepts relayed chat (the raw per-agent WS proxy this hub replaced served it regardless of
+    /// auth). Excludes `Starting` (port not yet bound) and every down/rebuilding state.
+    pub fn serves_ws(self) -> bool {
+        matches!(
+            self,
+            AgentStatus::Alive
+                | AgentStatus::SettingUp
+                | AgentStatus::NotAuthenticated
+                | AgentStatus::Unprovisioned
+        )
+    }
 }
 
 /// Live registry of agents whose container is mid-rebuild (stop → snapshot → remove → create).
@@ -2594,6 +2609,27 @@ pub async fn rename_agent(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn serves_ws_covers_every_running_reachable_state() {
+        for status in [
+            AgentStatus::Alive,
+            AgentStatus::SettingUp,
+            AgentStatus::NotAuthenticated,
+            AgentStatus::Unprovisioned,
+        ] {
+            assert!(status.serves_ws(), "{} should be tappable", status.human_text());
+        }
+        for status in [
+            AgentStatus::Starting,
+            AgentStatus::Rebuilding,
+            AgentStatus::Stopped,
+            AgentStatus::Dead,
+            AgentStatus::NotFound,
+        ] {
+            assert!(!status.serves_ws(), "{} must not be tapped", status.human_text());
+        }
+    }
 
     #[test]
     fn rebuild_tracker_marks_agent_while_guard_held() {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -483,10 +483,37 @@ async fn create_agent_handler(
     }));
 
     let result = create_and_start(&state, &name, manage_core_code, &progress).await;
+    // On success, retire the bridging build phase only once the poll lists the new container, so the
+    // synthetic mid-build roster row is replaced in place. Clearing it while the container is not yet
+    // listed drops the row entirely for a poll, emitting a spurious `agent_removed` that tears down a
+    // /sync watch registered before create (watch-before-create must survive materialization).
+    if result.is_ok() {
+        wait_for_agent_listed(&state, &name).await;
+    }
     state.agent_status_cache.clear_build_phase(&name);
     let name = result?;
 
     Ok((StatusCode::CREATED, Json(serde_json::json!({"name": name}))))
+}
+
+/// Block until `name` appears in the agent-status roster, bounded so a container that never lists
+/// (a create racing a destroy) still returns and lets the caller clear the phase as a fail-safe.
+async fn wait_for_agent_listed(state: &SharedState, name: &str) {
+    const LISTED_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+    let mut agents_rx = state.agent_status_cache.subscribe_agents();
+    let deadline = tokio::time::Instant::now() + LISTED_TIMEOUT;
+    loop {
+        if agents_rx
+            .borrow_and_update()
+            .iter()
+            .any(|entry| crate::docker::normalize_name(&entry.name) == name)
+        {
+            return;
+        }
+        if tokio::time::timeout_at(deadline, agents_rx.changed()).await.is_err() {
+            return;
+        }
+    }
 }
 
 /// Run the create then the start, reporting `Starting` between them. Split out so

--- a/vestad/src/sync/handler.rs
+++ b/vestad/src/sync/handler.rs
@@ -305,8 +305,10 @@ fn handle_client_frame(
     ControlFlow::Continue(())
 }
 
-/// Spawn the forward task for one watch: the hub's live edge becomes `append` deltas; a `Resync` or a
-/// lagging receiver (overflow) becomes one `resync` delta and ends the watch (client re-watches).
+/// Spawn the forward task for one watch: the hub's live edge becomes `append` deltas. Any live-edge
+/// gap becomes one `resync` delta that ends the watch (the client re-watches and refetches the tail by
+/// id): an explicit resync (tap reconnect), a lagging receiver (overflow), or the channel being
+/// forgotten when the agent's tap drops on a restart (`Closed`), which is a gap just like the others.
 fn spawn_watch(sync_hub: &SyncHub, agent: &str, watch_tx: mpsc::Sender<Frame>) -> tokio::task::AbortHandle {
     let mut events = sync_hub.subscribe_events(agent);
     let agent = agent.to_string();
@@ -319,11 +321,11 @@ fn spawn_watch(sync_hub: &SyncHub, agent: &str, watch_tx: mpsc::Sender<Frame>) -
                         break;
                     }
                 }
-                Ok(LiveMessage::Resync) | Err(broadcast::error::RecvError::Lagged(_)) => {
+                Ok(LiveMessage::Resync)
+                | Err(broadcast::error::RecvError::Lagged(_) | broadcast::error::RecvError::Closed) => {
                     let _ = watch_tx.send(Frame::Resync { agent: agent.clone() }).await;
                     break;
                 }
-                Err(broadcast::error::RecvError::Closed) => break,
             }
         }
     });
@@ -701,6 +703,21 @@ mod tests {
             tokio::task::yield_now().await;
         }
         assert!(matches!(watch_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+        abort_all(watches);
+    }
+
+    #[tokio::test]
+    async fn a_forgotten_channel_yields_one_resync_and_ends_the_watch() {
+        // A watched agent whose tap drops on a restart has its channel forgotten (the broadcast
+        // sender dropped); the watch must surface that gap as a resync, not die silently.
+        let hub = SyncHub::new();
+        let (watch_tx, mut watch_rx) = mpsc::channel::<Frame>(WATCH_FANIN_CAPACITY);
+        let mut watches = HashMap::new();
+        let mut deadline = None;
+
+        let _ = handle_client_frame(&hub, "key", r#"{"type":"watch","agent":"scout"}"#, &mut watches, &watch_tx, &mut deadline);
+        hub.forget_agent("scout");
+        assert!(matches!(watch_rx.recv().await, Some(Frame::Resync { agent }) if agent == "scout"));
         abort_all(watches);
     }
 

--- a/vestad/tests-integration/Cargo.toml
+++ b/vestad/tests-integration/Cargo.toml
@@ -18,5 +18,6 @@ ureq = { version = "3", features = ["json", "rustls"] }
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 tokio-tungstenite = { version = "0.30", features = ["__rustls-tls"] }
+futures-util = "0.3"
 rustls = "0.23"
 ring = "0.17"

--- a/vestad/tests-integration/src/client.rs
+++ b/vestad/tests-integration/src/client.rs
@@ -1,10 +1,14 @@
 use std::io::BufRead;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures_util::{SinkExt, StreamExt};
+use tokio_tungstenite::tungstenite::Message;
 use ureq::http::Response;
 use ureq::Body;
 
 use crate::types::{
-    AuthFlowResponse, BackupInfo, ListEntry, ServerConfig, StartAllResult, StatusJson,
+    AccessToken, AuthFlowResponse, BackupInfo, ListEntry, ServerConfig, StartAllResult, StatusJson,
 };
 
 // ── HTTP client ─────────────────────────────────────────────────
@@ -92,6 +96,7 @@ pub struct Client {
     agent: ureq::Agent,
     base_url: String,
     api_key: String,
+    cert_fingerprint: Option<String>,
 }
 
 impl Client {
@@ -113,6 +118,7 @@ impl Client {
             agent,
             base_url: config.url.clone(),
             api_key: config.api_key.clone(),
+            cert_fingerprint: config.cert_fingerprint.clone(),
         }
     }
 
@@ -390,6 +396,55 @@ impl Client {
         Ok(())
     }
 
+    /// Relay a chat message to a running agent via `POST /agents/{name}/message`. A `200` ack means
+    /// the frame was queued onto the live tap, not that the agent read it (delivery truth is the
+    /// `append` echo carrying `intent_id`). Pass `intent_id` to correlate that echo; omit with `None`.
+    pub fn send_message(&self, name: &str, text: &str, intent_id: Option<&str>) -> Result<(), String> {
+        let mut body = serde_json::json!({ "text": text });
+        if let Some(id) = intent_id {
+            body["intent_id"] = serde_json::Value::String(id.to_string());
+        }
+        self.post_json(&format!("/agents/{name}/message"), &body)?;
+        Ok(())
+    }
+
+    /// Mint a JWT access token (+ rotating refresh token) via `POST /auth/session`, exchanging the
+    /// raw API key. Use the returned `access_token` for `open_sync_with_token` to exercise the `/sync`
+    /// deadline/`reauth` path a raw-key connect never hits.
+    pub fn mint_access_token(&self) -> Result<AccessToken, String> {
+        let body = serde_json::json!({ "api_key": self.api_key });
+        let resp = self.post_json("/auth/session", &body)?;
+        resp.into_body()
+            .read_json()
+            .map_err(|e| format!("parse error: {e}"))
+    }
+
+    /// Open a `/sync` WebSocket authenticated with the raw API key (never-expiring, no deadline).
+    pub async fn open_sync(&self) -> Result<SyncSocket, String> {
+        self.connect_sync(&self.api_key).await
+    }
+
+    /// Open a `/sync` WebSocket authenticated with a JWT access token (from `mint_access_token`),
+    /// so the connection carries a `token_deadline` the server enforces unless a `reauth` extends it.
+    pub async fn open_sync_with_token(&self, jwt: &str) -> Result<SyncSocket, String> {
+        self.connect_sync(jwt).await
+    }
+
+    async fn connect_sync(&self, token: &str) -> Result<SyncSocket, String> {
+        let url = format!(
+            "{}/sync?token={}",
+            ws_base_url(&self.base_url),
+            urlencod(token)
+        );
+        let tls = make_ws_rustls_config(self.cert_fingerprint.clone());
+        let connector = tokio_tungstenite::Connector::Rustls(tls);
+        let (ws, _resp) =
+            tokio_tungstenite::connect_async_tls_with_config(&url, None, false, Some(connector))
+                .await
+                .map_err(|e| format!("sync connect failed: {e}"))?;
+        Ok(SyncSocket { ws })
+    }
+
     pub fn create_backup(&self, name: &str) -> Result<BackupInfo, String> {
         let resp = self.post(&format!("/agents/{name}/backups"))?;
         let data = read_sse_result(resp)?;
@@ -443,4 +498,164 @@ impl Client {
         }
         Ok(())
     }
+}
+
+// ── /sync WebSocket client ──────────────────────────────────────
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// A live `/sync` connection. Frames are parsed as `serde_json::Value` keyed on `type` (lighter than
+/// mirroring the server's protocol enum here); ping/pong are drained transparently on `recv_frame`.
+pub struct SyncSocket {
+    ws: WsStream,
+}
+
+impl SyncSocket {
+    /// Send a raw client frame (`watch`/`unwatch`/`reauth`, or an arbitrary one to probe the
+    /// server's ignore-unknown rule).
+    pub async fn send_client_frame(&mut self, frame: &serde_json::Value) -> Result<(), String> {
+        self.ws
+            .send(Message::Text(frame.to_string().into()))
+            .await
+            .map_err(|e| format!("send frame: {e}"))
+    }
+
+    pub async fn watch(&mut self, agent: &str) -> Result<(), String> {
+        self.send_client_frame(&serde_json::json!({ "type": "watch", "agent": agent }))
+            .await
+    }
+
+    pub async fn unwatch(&mut self, agent: &str) -> Result<(), String> {
+        self.send_client_frame(&serde_json::json!({ "type": "unwatch", "agent": agent }))
+            .await
+    }
+
+    pub async fn reauth(&mut self, token: &str) -> Result<(), String> {
+        self.send_client_frame(&serde_json::json!({ "type": "reauth", "token": token }))
+            .await
+    }
+
+    /// Read the next text frame within `timeout`, draining ping/pong/binary. Errors on timeout, a
+    /// close frame, a transport error, or a stream end.
+    pub async fn recv_frame(&mut self, timeout: Duration) -> Result<serde_json::Value, String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let next = tokio::time::timeout(remaining, self.ws.next())
+                .await
+                .map_err(|_| "timed out waiting for sync frame".to_string())?;
+            match next {
+                Some(Ok(Message::Text(text))) => {
+                    return serde_json::from_str(text.as_str())
+                        .map_err(|e| format!("parse frame: {e}"));
+                }
+                Some(Ok(Message::Close(_))) => return Err("sync socket closed by server".into()),
+                Some(Err(e)) => return Err(format!("sync socket error: {e}")),
+                None => return Err("sync socket ended".into()),
+                // Ping/pong/binary/raw: drain and keep waiting for a text frame.
+                Some(Ok(_)) => {}
+            }
+        }
+    }
+
+    /// Read frames until one satisfies `pred` or `timeout` elapses, mirroring the harness's
+    /// `wait_until_*` deadline idiom for the WS stream.
+    pub async fn expect_frame_matching<F>(
+        &mut self,
+        mut pred: F,
+        timeout: Duration,
+    ) -> Result<serde_json::Value, String>
+    where
+        F: FnMut(&serde_json::Value) -> bool,
+    {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err("timed out waiting for a matching sync frame".into());
+            }
+            let frame = self.recv_frame(remaining).await?;
+            if pred(&frame) {
+                return Ok(frame);
+            }
+        }
+    }
+
+    pub async fn close(mut self) -> Result<(), String> {
+        self.ws.close(None).await.map_err(|e| format!("close: {e}"))
+    }
+}
+
+fn ws_base_url(url: &str) -> String {
+    url.replace("https://", "wss://").replace("http://", "ws://")
+}
+
+/// Build a rustls client config that pins the server's self-signed cert by SHA-256 fingerprint,
+/// matching vestad's fingerprint-verification TLS (no CA chain). Lifted from
+/// `vestad/tests/server/websocket.rs` so the shared harness owns the one connector.
+fn make_ws_rustls_config(fingerprint: Option<String>) -> Arc<rustls::ClientConfig> {
+    #[derive(Debug)]
+    struct AcceptAll {
+        expected: Option<String>,
+    }
+
+    impl rustls::client::danger::ServerCertVerifier for AcceptAll {
+        fn verify_server_cert(
+            &self,
+            end_entity: &rustls::pki_types::CertificateDer<'_>,
+            _: &[rustls::pki_types::CertificateDer<'_>],
+            _: &rustls::pki_types::ServerName<'_>,
+            _: &[u8],
+            _: rustls::pki_types::UnixTime,
+        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+            if let Some(ref expected) = self.expected {
+                let digest = ring::digest::digest(&ring::digest::SHA256, end_entity.as_ref());
+                let actual = format!(
+                    "sha256:{}",
+                    digest
+                        .as_ref()
+                        .iter()
+                        .map(|b| format!("{b:02X}"))
+                        .collect::<Vec<_>>()
+                        .join(":")
+                );
+                if actual != *expected {
+                    return Err(rustls::Error::General("fingerprint mismatch".into()));
+                }
+            }
+            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        }
+        fn verify_tls12_signature(
+            &self,
+            _: &[u8],
+            _: &rustls::pki_types::CertificateDer<'_>,
+            _: &rustls::DigitallySignedStruct,
+        ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+            Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        }
+        fn verify_tls13_signature(
+            &self,
+            _: &[u8],
+            _: &rustls::pki_types::CertificateDer<'_>,
+            _: &rustls::DigitallySignedStruct,
+        ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+            Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        }
+        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+            rustls::crypto::ring::default_provider()
+                .signature_verification_algorithms
+                .supported_schemes()
+        }
+    }
+
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    Arc::new(
+        rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(AcceptAll {
+                expected: fingerprint,
+            }))
+            .with_no_client_auth(),
+    )
 }

--- a/vestad/tests-integration/src/types.rs
+++ b/vestad/tests-integration/src/types.rs
@@ -32,6 +32,15 @@ pub struct AuthFlowResponse {
     pub session_id: String,
 }
 
+/// The `POST /auth/session` response: a fresh JWT access token plus its rotating refresh token
+/// and the access token's TTL (`auth::SessionResponse`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct AccessToken {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_in: u64,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct StartAllResult {
     pub name: String,

--- a/vestad/tests/live/mod.rs
+++ b/vestad/tests/live/mod.rs
@@ -12,4 +12,5 @@ mod file_ops;
 mod interrupt;
 mod lifecycle;
 mod mcp_tools;
+mod sync;
 mod upgrade;

--- a/vestad/tests/live/sync.rs
+++ b/vestad/tests/live/sync.rs
@@ -1,0 +1,110 @@
+//! Live `/sync` e2e against a REAL, settled Claude agent (release-gated tier). Bridges the two
+//! halves the fake-token server suite (`tests/server/sync.rs`) can only test apart: an app-chat
+//! `send_message` carrying an `intent_id` echoes that id back on the watch (the delivery-truth
+//! contract), AND the real model round-trip that follows streams a genuine `assistant` text event
+//! onto the same watch. Skips with no `CLAUDE_CREDENTIALS` (the pool is unprovisioned, so the lock
+//! returns None), matching every other live test.
+
+use std::time::{Duration, Instant};
+
+use vesta_tests::client::SyncSocket;
+use vesta_tests::SERVER;
+
+use super::common::lock_live_agent_a;
+
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
+/// The user echo is written in-process the instant the send is relayed, so it lands fast. The
+/// bounded resends only close the watch-subscribe race: the watch frame may reach vestad a hair
+/// after the first echo was broadcast, and the live edge never replays, so a lost echo needs
+/// another send, not a longer read.
+const ECHO_TIMEOUT: Duration = Duration::from_secs(45);
+const ECHO_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(4);
+/// A full real-model round-trip: the app-chat notification is delivered, the SDK query runs, and
+/// the assistant text streams back. Generous like the first-start settle budget; it only has to
+/// not be hit in practice.
+const ASSISTANT_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Read the mandatory hello then the immediate snapshot (deterministically frames 1 and 2 before
+/// the handler enters its select loop). Contract details are asserted in the server suite; here we
+/// only need past the handshake to the watch.
+async fn handshake(sock: &mut SyncSocket) {
+    let hello = sock.recv_frame(HANDSHAKE_TIMEOUT).await.expect("hello frame");
+    assert_eq!(hello["type"].as_str(), Some("hello"), "first frame is hello");
+    let snapshot = sock.recv_frame(HANDSHAKE_TIMEOUT).await.expect("snapshot frame");
+    assert_eq!(snapshot["type"].as_str(), Some("snapshot"), "second frame is snapshot");
+}
+
+/// True when `frame` is an `append` for `agent` carrying the user-echo event with our `intent`.
+fn is_echo(frame: &serde_json::Value, agent: &str, intent: &str) -> bool {
+    frame["type"].as_str() == Some("append")
+        && frame["agent"].as_str() == Some(agent)
+        && frame["events"].as_array().is_some_and(|events| {
+            events
+                .iter()
+                .any(|e| e["type"].as_str() == Some("user") && e["intent_id"].as_str() == Some(intent))
+        })
+}
+
+/// True when `frame` is an `append` for `agent` carrying a non-empty `assistant` text event: the
+/// real model's response, not the in-process user echo.
+fn is_assistant_text(frame: &serde_json::Value, agent: &str) -> bool {
+    frame["type"].as_str() == Some("append")
+        && frame["agent"].as_str() == Some(agent)
+        && frame["events"].as_array().is_some_and(|events| {
+            events.iter().any(|e| {
+                e["type"].as_str() == Some("assistant")
+                    && e["text"].as_str().is_some_and(|text| !text.trim().is_empty())
+            })
+        })
+}
+
+/// End-to-end: connect `/sync`, watch a real settled agent, send one app-chat message with an
+/// intent id, observe the echo append carrying that id, then observe the real assistant response
+/// event arriving on the same watch. No-ops (returns) without `CLAUDE_CREDENTIALS`.
+#[tokio::test]
+async fn live_send_echoes_intent_then_streams_a_real_assistant_response() {
+    let Some((shared, _container)) = lock_live_agent_a() else {
+        return;
+    };
+    let name = shared
+        .as_ref()
+        .expect("pool agent present when the lock returned a container")
+        .0
+        .name
+        .clone();
+
+    let c = SERVER.client();
+    let mut sock = c.open_sync().await.expect("open sync");
+    handshake(&mut sock).await;
+    sock.watch(&name).await.expect("watch the live agent");
+
+    let intent = "i-live-sync-e2e";
+    let text = "Please reply with a short one-line greeting.";
+
+    // Resend on a bounded cadence until the in-process echo lands, closing the watch-subscribe
+    // race. Once the echo is in hand the watch is proven subscribed, so the later assistant event
+    // needs no resend.
+    let echo_deadline = Instant::now() + ECHO_TIMEOUT;
+    loop {
+        let _ = c.send_message(&name, text, Some(intent));
+        if sock
+            .expect_frame_matching(|f| is_echo(f, &name, intent), ECHO_ATTEMPT_TIMEOUT)
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < echo_deadline,
+            "no user-echo append carrying {intent} within {ECHO_TIMEOUT:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // The real model round-trip streams a genuine assistant text event onto the same watch.
+    sock.expect_frame_matching(|f| is_assistant_text(f, &name), ASSISTANT_TIMEOUT)
+        .await
+        .expect("a real assistant response event on the watch within the round-trip budget");
+
+    sock.close().await.ok();
+}

--- a/vestad/tests/server/mod.rs
+++ b/vestad/tests/server/mod.rs
@@ -14,5 +14,6 @@ mod layout;
 mod lifecycle;
 mod ports;
 mod rename;
+mod sync;
 mod upstream;
 mod websocket;

--- a/vestad/tests/server/sync.rs
+++ b/vestad/tests/server/sync.rs
@@ -47,6 +47,13 @@ async fn handshake(sock: &mut SyncSocket) -> serde_json::Value {
     snapshot
 }
 
+/// True when a harness `recv_frame`/`expect_frame_matching` error string signals a real socket
+/// close/end/transport-failure, false for a plain read timeout ("timed out waiting for sync frame").
+/// Keeps a close assertion from being satisfied by the deadline merely elapsing on a still-open socket.
+fn is_close_error(msg: &str) -> bool {
+    msg.contains("closed") || msg.contains("ended") || msg.contains("socket error")
+}
+
 fn is_append_for(frame: &serde_json::Value, agent: &str, intent: &str) -> bool {
     frame["type"].as_str() == Some("append")
         && frame["agent"].as_str() == Some(agent)
@@ -130,6 +137,9 @@ async fn hello_then_snapshot_carries_agent_info_branch() {
         let snapshot = handshake(&mut sock).await;
         if let Some(node) = snapshot["tree"]["agents"].get(agent.as_str()) {
             assert!(node.get("info").is_some(), "agent node carries an info branch");
+            // The snapshot is tail-less by contract: roster + pending only, no event/chat tails.
+            assert!(node.get("events").is_none(), "snapshot node carries no event tail");
+            assert!(node.get("chat").is_none(), "snapshot node carries no chat tail");
             sock.close().await.ok();
             return;
         }
@@ -234,11 +244,13 @@ async fn reauth_extends_and_closes_on_bad() {
         {
             // Tolerate any in-flight frame queued before the reauth was processed; keep reading.
             Ok(_) if Instant::now() < deadline => {}
+            // Still open at the deadline: not closed. A read timeout is the same signal, so it must
+            // not count as a close (that is exactly the regression this distinguishes).
             Ok(_) => break false,
-            Err(_) => break true,
+            Err(ref e) => break is_close_error(e),
         }
     };
-    assert!(closed, "a bad reauth must close the socket");
+    assert!(closed, "a bad reauth must close the socket (a read timeout is not a close)");
 
     // (b) JWT socket + a valid reauth -> stays open and still delivers an append.
     let jwt = c.mint_access_token().expect("mint jwt");

--- a/vestad/tests/server/sync.rs
+++ b/vestad/tests/server/sync.rs
@@ -11,10 +11,7 @@ use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 use vesta_tests::client::{Client, SyncSocket};
-use vesta_tests::{
-    agent_container_name, docker_cmd, inject_fake_token, unique_agent, TestAgent, SERVER,
-    SHARED_RO_AGENT,
-};
+use vesta_tests::{inject_fake_token, unique_agent, TestAgent, SERVER, SHARED_RO_AGENT};
 
 const AGENT_RUNNING_TIMEOUT_SECS: u64 = 90;
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
@@ -88,8 +85,14 @@ async fn drive_and_expect_append(
     intent: &str,
 ) -> serde_json::Value {
     let deadline = Instant::now() + APPEND_TIMEOUT;
+    // Track only the MOST RECENT send outcome: a stale error would mislead (a 503 before the tap
+    // installs, then successful sends whose echo never lands, are two different failures).
+    let mut last_send_err: Option<String> = None;
     loop {
-        let _ = c.send_message(agent, text, Some(intent));
+        match c.send_message(agent, text, Some(intent)) {
+            Ok(()) => last_send_err = None,
+            Err(e) => last_send_err = Some(e),
+        }
         if let Ok(frame) = sock
             .expect_frame_matching(|f| is_append_for(f, agent, intent), APPEND_ATTEMPT_TIMEOUT)
             .await
@@ -98,7 +101,7 @@ async fn drive_and_expect_append(
         }
         assert!(
             Instant::now() < deadline,
-            "no append for {agent} intent {intent} within {APPEND_TIMEOUT:?}"
+            "no append for {agent} intent {intent} within {APPEND_TIMEOUT:?} (last send error: {last_send_err:?})"
         );
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
@@ -340,15 +343,16 @@ async fn send_message_intent_id_echoes_on_the_append() {
     sock.close().await.ok();
 }
 
-/// (8) A watched agent killed mid-stream (`docker kill` -> non-zero exit -> `on-failure` auto-restart
-/// of the same container) emits one `resync` on the tap's reconnect; after re-watching, appends
-/// resume. The union of the event ids seen before the kill and after the restart has no repeats: the
-/// live edge never replays across the gap, so a client deduping by id gains no duplicate across the
-/// seam. (The paged-history reseed that fills the gap is the client controller's job, unit-tested.)
+/// (8) A watched agent restarted mid-stream keeps the SAME container (its events.db persists, so ids
+/// stay monotonic); the tap gaps then reconnects, emitting one `resync` that drops this agent's
+/// server-side watch. After re-watching, appends resume. The union of the event ids seen before the
+/// restart and after it has no repeats: the live edge never replays across the gap, so a client
+/// deduping by id gains no duplicate across the seam. (The paged-history reseed that fills the gap is
+/// the client controller's job, unit-tested.)
 #[tokio::test]
-async fn kill_restart_reseeds_without_duplicate_ids() {
+async fn restart_reseeds_without_duplicate_ids() {
     let c = SERVER.client();
-    let agent = running_agent(&c, "sync-killrestart");
+    let agent = running_agent(&c, "sync-restart");
     let mut sock = c.open_sync().await.expect("open sync");
     handshake(&mut sock).await;
     sock.watch(&agent.name).await.expect("watch");
@@ -357,17 +361,15 @@ async fn kill_restart_reseeds_without_duplicate_ids() {
     ids.push(driven_event_id(&c, &mut sock, &agent.name, "before-1", "kb-1").await);
     ids.push(driven_event_id(&c, &mut sock, &agent.name, "before-2", "kb-2").await);
 
-    // Ungraceful crash: SIGKILL exits non-zero, so docker's on-failure policy restarts the SAME
-    // container (its events.db persists, so ids stay monotonic). The tap gaps then reconnects,
-    // emitting one resync that drops this agent's server-side watch.
-    let cname = agent_container_name(&agent.name);
-    docker_cmd(&["kill", &cname]).expect("kill agent container");
+    // Restart the same container (events.db persists, so ids stay monotonic). The tap gaps then
+    // reconnects, emitting one resync that drops this agent's server-side watch.
+    c.restart_agent(&agent.name).expect("restart agent");
     sock.expect_frame_matching(
         |f| f["type"].as_str() == Some("resync") && f["agent"].as_str() == Some(agent.name.as_str()),
         RESYNC_TIMEOUT,
     )
     .await
-    .expect("a resync after the kill/restart");
+    .expect("a resync after the restart");
 
     c.wait_until_running(&agent.name, AGENT_RUNNING_TIMEOUT_SECS)
         .expect("agent back up");
@@ -379,7 +381,7 @@ async fn kill_restart_reseeds_without_duplicate_ids() {
     assert_eq!(
         unique.len(),
         ids.len(),
-        "event ids across the kill/restart seam must not repeat: {ids:?}"
+        "event ids across the restart seam must not repeat: {ids:?}"
     );
     sock.close().await.ok();
 }

--- a/vestad/tests/server/sync.rs
+++ b/vestad/tests/server/sync.rs
@@ -1,7 +1,20 @@
+//! `/sync` WebSocket integration scenarios, driven end-to-end against a real vestad + agent
+//! container through the T1 harness `SyncSocket`. Fake-token agents settle unprovisioned yet still
+//! emit the in-process app-chat echo these appends ride on, so no real model is needed.
+//!
+//! Two spec sub-scenarios are deliberately absent: sub-floor client rejection (D2, dropped — the
+//! server always speaks protocol 1 and never rejects; the floor is a client-side gate) and the
+//! reauth deadline-expiry timer (D3, covered in the handler unit tier via `token_deadline`/`expire`).
+//! This module owns the socket-observable behaviors only.
+
+use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 use vesta_tests::client::{Client, SyncSocket};
-use vesta_tests::{inject_fake_token, unique_agent, TestAgent, SERVER, SHARED_RO_AGENT};
+use vesta_tests::{
+    agent_container_name, docker_cmd, inject_fake_token, unique_agent, TestAgent, SERVER,
+    SHARED_RO_AGENT,
+};
 
 const AGENT_RUNNING_TIMEOUT_SECS: u64 = 90;
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
@@ -283,5 +296,126 @@ async fn unknown_client_frames_are_ignored() {
     // The socket stayed live: a following watch still delivers.
     sock.watch(&agent.name).await.expect("watch");
     drive_and_expect_append(&c, &mut sock, &agent.name, "still alive", "intent-unknown").await;
+    sock.close().await.ok();
+}
+
+/// Drive one app-chat message and return the string form of the echoed event's `id` (the events.db
+/// row id). Fails exactly as `drive_and_expect_append` does if no append lands within the budget.
+async fn driven_event_id(c: &Client, sock: &mut SyncSocket, agent: &str, text: &str, intent: &str) -> String {
+    let append = drive_and_expect_append(c, sock, agent, text, intent).await;
+    let event = append["events"]
+        .as_array()
+        .expect("events array")
+        .iter()
+        .find(|e| e["intent_id"].as_str() == Some(intent))
+        .expect("the echoed event");
+    assert!(event.get("id").is_some(), "echoed event carries an id");
+    event["id"].to_string()
+}
+
+/// (7) `send_message` with an explicit intent id round-trips end-to-end: the `append` echo carries
+/// the SAME `intent_id` the HTTP relay was given (HTTP intent -> tap -> live edge), the delivery-truth
+/// contract clients dedup and confirm on.
+#[tokio::test]
+async fn send_message_intent_id_echoes_on_the_append() {
+    let c = SERVER.client();
+    let agent = running_agent(&c, "sync-intent");
+    let mut sock = c.open_sync().await.expect("open sync");
+    handshake(&mut sock).await;
+    sock.watch(&agent.name).await.expect("watch");
+
+    let intent = "i-2f8c1a90-send-echo";
+    let append = drive_and_expect_append(&c, &mut sock, &agent.name, "carry my intent", intent).await;
+    let event = append["events"]
+        .as_array()
+        .expect("events array")
+        .iter()
+        .find(|e| e["intent_id"].as_str() == Some(intent))
+        .expect("the echoed event");
+    assert_eq!(
+        event["intent_id"].as_str(),
+        Some(intent),
+        "the append echo carries the exact intent id the send was given"
+    );
+    sock.close().await.ok();
+}
+
+/// (8) A watched agent killed mid-stream (`docker kill` -> non-zero exit -> `on-failure` auto-restart
+/// of the same container) emits one `resync` on the tap's reconnect; after re-watching, appends
+/// resume. The union of the event ids seen before the kill and after the restart has no repeats: the
+/// live edge never replays across the gap, so a client deduping by id gains no duplicate across the
+/// seam. (The paged-history reseed that fills the gap is the client controller's job, unit-tested.)
+#[tokio::test]
+async fn kill_restart_reseeds_without_duplicate_ids() {
+    let c = SERVER.client();
+    let agent = running_agent(&c, "sync-killrestart");
+    let mut sock = c.open_sync().await.expect("open sync");
+    handshake(&mut sock).await;
+    sock.watch(&agent.name).await.expect("watch");
+
+    let mut ids: Vec<String> = Vec::new();
+    ids.push(driven_event_id(&c, &mut sock, &agent.name, "before-1", "kb-1").await);
+    ids.push(driven_event_id(&c, &mut sock, &agent.name, "before-2", "kb-2").await);
+
+    // Ungraceful crash: SIGKILL exits non-zero, so docker's on-failure policy restarts the SAME
+    // container (its events.db persists, so ids stay monotonic). The tap gaps then reconnects,
+    // emitting one resync that drops this agent's server-side watch.
+    let cname = agent_container_name(&agent.name);
+    docker_cmd(&["kill", &cname]).expect("kill agent container");
+    sock.expect_frame_matching(
+        |f| f["type"].as_str() == Some("resync") && f["agent"].as_str() == Some(agent.name.as_str()),
+        RESYNC_TIMEOUT,
+    )
+    .await
+    .expect("a resync after the kill/restart");
+
+    c.wait_until_running(&agent.name, AGENT_RUNNING_TIMEOUT_SECS)
+        .expect("agent back up");
+    sock.watch(&agent.name).await.expect("re-watch");
+    ids.push(driven_event_id(&c, &mut sock, &agent.name, "after-1", "ka-1").await);
+    ids.push(driven_event_id(&c, &mut sock, &agent.name, "after-2", "ka-2").await);
+
+    let unique: HashSet<&String> = ids.iter().collect();
+    assert_eq!(
+        unique.len(),
+        ids.len(),
+        "event ids across the kill/restart seam must not repeat: {ids:?}"
+    );
+    sock.close().await.ok();
+}
+
+/// (9) A `watch` for an agent that does not exist yet is accepted (the hub creates the live-edge
+/// channel lazily via `subscribe_events`); once the agent is created and its tap attaches, the roster
+/// `agent` upsert and then appends flow to that pre-registered watch. Bounded generously: agent
+/// creation (image build/pull + container boot) is slow.
+#[tokio::test]
+async fn watch_before_create_is_held_until_the_agent_materializes() {
+    let c = SERVER.client();
+    // The name the agent will take: `unique_agent` yields an already-normalized name, so the watch
+    // key matches the container the create produces (asserted below, guarding a future rename rule).
+    let name = unique_agent("sync-precreate");
+
+    let mut sock = c.open_sync().await.expect("open sync");
+    handshake(&mut sock).await;
+    // Accepted with no error though the agent is absent; the hub creates the channel lazily.
+    sock.watch(&name).await.expect("watch before create");
+
+    let agent = TestAgent::create(&c, &name).expect("create agent");
+    assert_eq!(agent.name, name, "created name matches the pre-watched key");
+    inject_fake_token(&c, &agent.name);
+    c.start_agent(&agent.name).expect("start agent");
+    c.wait_until_running(&agent.name, AGENT_RUNNING_TIMEOUT_SECS)
+        .expect("agent running");
+
+    // The roster upsert for the freshly created agent reaches this held session.
+    sock.expect_frame_matching(
+        |f| f["type"].as_str() == Some("agent") && f["name"].as_str() == Some(name.as_str()),
+        RESYNC_TIMEOUT,
+    )
+    .await
+    .expect("roster upsert for the new agent");
+
+    // The pre-registered watch delivers appends once the tap attaches.
+    drive_and_expect_append(&c, &mut sock, &agent.name, "hello held watch", "i-held-watch").await;
     sock.close().await.ok();
 }

--- a/vestad/tests/server/sync.rs
+++ b/vestad/tests/server/sync.rs
@@ -1,0 +1,275 @@
+use std::time::{Duration, Instant};
+
+use vesta_tests::client::{Client, SyncSocket};
+use vesta_tests::{inject_fake_token, unique_agent, TestAgent, SERVER, SHARED_RO_AGENT};
+
+const AGENT_RUNNING_TIMEOUT_SECS: u64 = 90;
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
+/// Total budget for a driven append to round-trip (HTTP relay -> agent echo -> tap -> watch).
+const APPEND_TIMEOUT: Duration = Duration::from_secs(45);
+/// Per-resend read window inside `drive_and_expect_append`.
+const APPEND_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(4);
+/// Window over which an unwatched agent must stay silent.
+const SILENCE_WINDOW: Duration = Duration::from_secs(6);
+/// A container restart plus tap reconnect is slow; give the resync room.
+const RESYNC_TIMEOUT: Duration = Duration::from_secs(120);
+/// How long to poll (via reconnect) for a fresh agent to surface in a snapshot.
+const SNAPSHOT_POLL_TIMEOUT: Duration = Duration::from_secs(30);
+
+// D2: the wire protocol version + floor, mirrored from apps/core/src/protocol/version.ts and
+// vestad's crate-private `sync::PROTOCOL_VERSION` / `sync::PROTOCOL_FLOOR` (not importable from an
+// integration crate, so pinned to the contract literals here).
+const EXPECT_PROTOCOL: u64 = 1;
+const EXPECT_FLOOR: u64 = 1;
+
+/// Create a fake-token agent and bring it up to a live tap. Fake-token agents settle at
+/// `unprovisioned`/`not_authenticated`, enough to exercise frame plumbing (no real model needed):
+/// the app-chat echo the appends ride on is emitted in-process, independent of provider auth.
+fn running_agent<'a>(c: &'a Client, prefix: &str) -> TestAgent<'a> {
+    let agent = TestAgent::create(c, &unique_agent(prefix)).expect("create agent");
+    inject_fake_token(c, &agent.name);
+    c.start_agent(&agent.name).expect("start agent");
+    c.wait_until_running(&agent.name, AGENT_RUNNING_TIMEOUT_SECS)
+        .expect("agent running");
+    agent
+}
+
+/// Read the mandatory hello (asserting the protocol/floor contract) then the immediate snapshot,
+/// returning the snapshot frame. Frames 1 and 2 are deterministically hello then snapshot (the
+/// handler sends both before entering its select loop).
+async fn handshake(sock: &mut SyncSocket) -> serde_json::Value {
+    let hello = sock.recv_frame(HANDSHAKE_TIMEOUT).await.expect("hello frame");
+    assert_eq!(hello["type"].as_str(), Some("hello"), "first frame is hello");
+    assert_eq!(hello["protocol"].as_u64(), Some(EXPECT_PROTOCOL), "hello protocol per D2");
+    assert_eq!(hello["floor"].as_u64(), Some(EXPECT_FLOOR), "hello floor per D2");
+    let snapshot = sock.recv_frame(HANDSHAKE_TIMEOUT).await.expect("snapshot frame");
+    assert_eq!(snapshot["type"].as_str(), Some("snapshot"), "second frame is snapshot");
+    snapshot
+}
+
+fn is_append_for(frame: &serde_json::Value, agent: &str, intent: &str) -> bool {
+    frame["type"].as_str() == Some("append")
+        && frame["agent"].as_str() == Some(agent)
+        && frame["events"]
+            .as_array()
+            .is_some_and(|events| events.iter().any(|e| e["intent_id"].as_str() == Some(intent)))
+}
+
+/// Drive one app-chat message onto `agent`'s tap and return the `append` echo carrying `intent`.
+/// Re-sends on a bounded cadence until the append lands: the tap may not have installed its
+/// write-half yet (send 503s) and a just-issued watch may not have subscribed before the first
+/// echo. A resend closes both races deterministically because the watch stays registered and each
+/// send emits a fresh echo carrying the same intent id.
+async fn drive_and_expect_append(
+    c: &Client,
+    sock: &mut SyncSocket,
+    agent: &str,
+    text: &str,
+    intent: &str,
+) -> serde_json::Value {
+    let deadline = Instant::now() + APPEND_TIMEOUT;
+    loop {
+        let _ = c.send_message(agent, text, Some(intent));
+        if let Ok(frame) = sock
+            .expect_frame_matching(|f| is_append_for(f, agent, intent), APPEND_ATTEMPT_TIMEOUT)
+            .await
+        {
+            return frame;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no append for {agent} intent {intent} within {APPEND_TIMEOUT:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// Assert no `append` for `agent` carrying `intent` arrives within `window`. Other frames (roster
+/// deltas, notifications) are drained and allowed. Bounded read loop, never a bare sleep-to-await.
+async fn assert_no_append(sock: &mut SyncSocket, agent: &str, intent: &str, window: Duration) {
+    let deadline = Instant::now() + window;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return;
+        }
+        match sock.recv_frame(remaining).await {
+            Ok(frame) => assert!(
+                !is_append_for(&frame, agent, intent),
+                "an unwatched agent still delivered an append: {frame}"
+            ),
+            // Timeout (or a benign close): no matching append arrived within the window.
+            Err(_) => return,
+        }
+    }
+}
+
+/// Relay a send-message, retrying briefly past a transient tap-down 503. Returns once the relay is
+/// accepted (the append echo is the delivery truth, asserted separately by the caller).
+async fn ensure_send(c: &Client, agent: &str, text: &str, intent: &str) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if c.send_message(agent, text, Some(intent)).is_ok() {
+            return;
+        }
+        assert!(Instant::now() < deadline, "tap never accepted the send for {agent}");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// (1) The first two frames are `hello` (with the D2 protocol/floor constants) then a `snapshot`
+/// whose `tree.agents` carries the agent with an `info` branch. Uses the shared read-only agent
+/// (created, never mutated) and polls via reconnect until the status cache has surfaced it.
+#[tokio::test]
+async fn hello_then_snapshot_carries_agent_info_branch() {
+    let c = SERVER.client();
+    let agent = &*SHARED_RO_AGENT;
+    let deadline = Instant::now() + SNAPSHOT_POLL_TIMEOUT;
+    loop {
+        let mut sock = c.open_sync().await.expect("open sync");
+        let snapshot = handshake(&mut sock).await;
+        if let Some(node) = snapshot["tree"]["agents"].get(agent.as_str()) {
+            assert!(node.get("info").is_some(), "agent node carries an info branch");
+            sock.close().await.ok();
+            return;
+        }
+        sock.close().await.ok();
+        assert!(
+            Instant::now() < deadline,
+            "agent {agent} never appeared in a /sync snapshot within {SNAPSHOT_POLL_TIMEOUT:?}"
+        );
+    }
+}
+
+/// (2) A `watch` delivers the agent's live edge as `append` deltas, and the echoed events carry an id.
+#[tokio::test]
+async fn watch_delivers_appends_with_ids() {
+    let c = SERVER.client();
+    let agent = running_agent(&c, "sync-watch");
+    let mut sock = c.open_sync().await.expect("open sync");
+    handshake(&mut sock).await;
+    sock.watch(&agent.name).await.expect("watch");
+
+    let append = drive_and_expect_append(&c, &mut sock, &agent.name, "hello from watch", "intent-watch").await;
+    let event = append["events"]
+        .as_array()
+        .expect("events array")
+        .iter()
+        .find(|e| e["intent_id"].as_str() == Some("intent-watch"))
+        .expect("the echoed event");
+    assert!(event.get("id").is_some(), "appended events carry an id");
+    sock.close().await.ok();
+}
+
+/// (3) After an `unwatch`, further live events for that agent stop reaching the socket.
+#[tokio::test]
+async fn unwatch_stops_delivery() {
+    let c = SERVER.client();
+    let agent = running_agent(&c, "sync-unwatch");
+    let mut sock = c.open_sync().await.expect("open sync");
+    handshake(&mut sock).await;
+    sock.watch(&agent.name).await.expect("watch");
+    drive_and_expect_append(&c, &mut sock, &agent.name, "before unwatch", "intent-before").await;
+
+    sock.unwatch(&agent.name).await.expect("unwatch");
+    // The unwatch frame is already at vestad while the next echo must round-trip to the container
+    // and back, so the watch is torn down well before that echo could be published; a following
+    // append for this agent would prove the unwatch didn't take.
+    ensure_send(&c, &agent.name, "after unwatch", "intent-after").await;
+    assert_no_append(&mut sock, &agent.name, "intent-after", SILENCE_WINDOW).await;
+    sock.close().await.ok();
+}
+
+/// (4, D1) Restarting a watched agent yields exactly one `resync` for it (dropping its server-side
+/// watch) while a second agent's watch keeps streaming; re-watching resumes appends.
+#[tokio::test]
+async fn resync_drops_watch_while_second_agent_streams() {
+    let c = SERVER.client();
+    let a = running_agent(&c, "sync-resync-a");
+    let b = running_agent(&c, "sync-resync-b");
+    let mut sock = c.open_sync().await.expect("open sync");
+    handshake(&mut sock).await;
+    sock.watch(&a.name).await.expect("watch a");
+    sock.watch(&b.name).await.expect("watch b");
+
+    // Establish both live edges before the disruption.
+    drive_and_expect_append(&c, &mut sock, &a.name, "a1", "a-before").await;
+    drive_and_expect_append(&c, &mut sock, &b.name, "b1", "b-before").await;
+
+    // Restart A: its tap gaps and re-attaches, emitting one resync for A. B's tap is untouched.
+    c.restart_agent(&a.name).expect("restart a");
+    sock.expect_frame_matching(
+        |f| f["type"].as_str() == Some("resync") && f["agent"].as_str() == Some(a.name.as_str()),
+        RESYNC_TIMEOUT,
+    )
+    .await
+    .expect("a single resync for a");
+
+    // B keeps streaming across A's restart (remove-on-resync scopes to A's watch only).
+    drive_and_expect_append(&c, &mut sock, &b.name, "b2", "b-after").await;
+
+    // The resync dropped A's server-side watch; re-watch and appends resume once A is back up.
+    c.wait_until_running(&a.name, AGENT_RUNNING_TIMEOUT_SECS).expect("a back up");
+    sock.watch(&a.name).await.expect("re-watch a");
+    drive_and_expect_append(&c, &mut sock, &a.name, "a2", "a-after").await;
+    sock.close().await.ok();
+}
+
+/// (5, D3) A garbage `reauth` on a raw-key socket closes it; a valid `reauth` on a JWT socket keeps
+/// it open and still delivers a subsequent append.
+#[tokio::test]
+async fn reauth_extends_and_closes_on_bad() {
+    let c = SERVER.client();
+    let agent = running_agent(&c, "sync-reauth");
+
+    // (a) raw-key socket + a bad reauth -> the server breaks the loop and closes the socket.
+    let mut raw = c.open_sync().await.expect("open raw sync");
+    handshake(&mut raw).await;
+    raw.reauth("bad.token.here").await.expect("send bad reauth");
+    let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
+    let closed = loop {
+        match raw
+            .recv_frame(deadline.saturating_duration_since(Instant::now()))
+            .await
+        {
+            // Tolerate any in-flight frame queued before the reauth was processed; keep reading.
+            Ok(_) if Instant::now() < deadline => {}
+            Ok(_) => break false,
+            Err(_) => break true,
+        }
+    };
+    assert!(closed, "a bad reauth must close the socket");
+
+    // (b) JWT socket + a valid reauth -> stays open and still delivers an append.
+    let jwt = c.mint_access_token().expect("mint jwt");
+    let mut tok = c.open_sync_with_token(&jwt.access_token).await.expect("open jwt sync");
+    handshake(&mut tok).await;
+    tok.watch(&agent.name).await.expect("watch");
+    let fresh = c.mint_access_token().expect("mint fresh jwt");
+    tok.reauth(&fresh.access_token).await.expect("send valid reauth");
+    drive_and_expect_append(&c, &mut tok, &agent.name, "after reauth", "intent-reauth").await;
+    tok.close().await.ok();
+}
+
+/// (6) Unknown/malformed client frames are ignored; a following `watch` still works, proving the
+/// socket stayed live.
+#[tokio::test]
+async fn unknown_client_frames_are_ignored() {
+    let c = SERVER.client();
+    let agent = running_agent(&c, "sync-unknown");
+    let mut sock = c.open_sync().await.expect("open sync");
+    handshake(&mut sock).await;
+
+    // An unknown `type` and a non-object frame both fail ClientFrame parsing and are dropped.
+    sock.send_client_frame(&serde_json::json!({ "type": "future", "x": 1 }))
+        .await
+        .expect("send unknown frame");
+    sock.send_client_frame(&serde_json::json!("garbage-not-a-frame"))
+        .await
+        .expect("send malformed frame");
+
+    // The socket stayed live: a following watch still delivers.
+    sock.watch(&agent.name).await.expect("watch");
+    drive_and_expect_append(&c, &mut sock, &agent.name, "still alive", "intent-unknown").await;
+    sock.close().await.ok();
+}

--- a/vestad/tests/server/sync.rs
+++ b/vestad/tests/server/sync.rs
@@ -87,7 +87,7 @@ async fn drive_and_expect_append(
     let deadline = Instant::now() + APPEND_TIMEOUT;
     // Track only the MOST RECENT send outcome: a stale error would mislead (a 503 before the tap
     // installs, then successful sends whose echo never lands, are two different failures).
-    let mut last_send_err: Option<String> = None;
+    let mut last_send_err: Option<String>;
     loop {
         match c.send_message(agent, text, Some(intent)) {
             Ok(()) => last_send_err = None,


### PR DESCRIPTION
Stage 9 of the client-protocol epic: the deferred socket-level coverage lands. The vesta-tests harness gains a /sync WS client (bounded deadline reads, watch/unwatch/reauth, send_message, mint_access_token); nine Docker-gated scenarios in tests/server/sync.rs (hello+snapshot with tail-less pin, watch appends by id, unwatch, resync-on-restart with a second watch streaming on, reauth extend + close-on-bad with close-vs-timeout discrimination, unknown-frame tolerance, intent-id echo end-to-end, kill/restart resync+resume, watch-before-create held); and the first live-tier /sync e2e (credential-gated, real Claude echo + assistant round-trip, compiles and skips cleanly). Compile + CI clippy gates green; the Docker suite runs on this PR's CI and in the epic's final local gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSn1nFTKDmH5HzuK97mepr