### PR TITLE
fix(install): download the Windows app artifact by its real name

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -36,7 +36,7 @@ New-Item -ItemType Directory -Path $TmpDir -Force | Out-Null
 
 try {
     # --- Desktop app ---
-    $AppArtifact = "Vesta_${Version}_x64-setup.exe"
+    $AppArtifact = "Vesta_${Version}_x64.exe"
     $AppExe = Join-Path $TmpDir $AppArtifact
     $AppUrl = "https://github.com/$Repo/releases/download/v$Version/$AppArtifact"
 


### PR DESCRIPTION
install.ps1 requested `Vesta_${Version}_x64-setup.exe`, but electron-builder's `artifactName` template (`Vesta_${version}_${arch}.${ext}`) produces `Vesta_<version>_x64.exe`, verified against the v0.1.179 release assets. Every Windows install therefore 404ed on the app download. One line: drop the `-setup` suffix.

Surfaced during the CLI-removal review (#1434), which makes this script the sole Windows install path; landing it separately since the bug predates that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSn1nFTKDmH5HzuK97mepr