### PR TITLE
fix(mail): recover the outage gap in the mail daemons instead of a manual sweep

### DIFF
--- a/agent/skills/google/cli/src/google_cli/monitor.py
+++ b/agent/skills/google/cli/src/google_cli/monitor.py
@@ -1,5 +1,10 @@
+import json
 import re
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+from functools import partial
+from pathlib import Path
+from typing import TypedDict
 from zoneinfo import ZoneInfo
 
 from googleapiclient.errors import HttpError
@@ -12,10 +17,18 @@ from .gmail import _get_header
 _INVISIBLE = re.compile(r"[\u200b-\u200f\u202a-\u202e\u2060\u2066-\u2069\ufeff]")
 _WHITESPACE_RUN = re.compile(r"\s+")
 
-# Cap how far back a first-run catch-up reaches. A long offline gap (e.g. the
-# daemon restarting with a fresh token after the old one expired) otherwise
-# replays weeks of unread email and past calendar events as notifications.
+# Cap how far back a catch-up reaches. A long offline gap (e.g. the daemon
+# restarting with a fresh token after the old one expired, or a token that was
+# dead for a day) otherwise replays weeks of unread email and past calendar
+# events as notifications.
 MAX_CATCHUP_LOOKBACK = timedelta(hours=24)
+
+# A gap wider than this means the unit missed a window (process down or token
+# dead), so its recovered items are tagged `missed`.
+_CATCHUP_GAP_SECONDS = 90
+
+# A unit polled for the first time (fresh install or legacy state) resumes from here.
+_FRESH_START_LOOKBACK = timedelta(hours=1)
 
 # One-shot markers for terminal failures the user must act on: notify the agent
 # once, then stay quiet until the failure clears (success removes the marker,
@@ -26,6 +39,51 @@ CALENDAR_BROKEN_MARKER = "calendar_broken.notified"
 
 def clamp_catchup_start(last_check_dt: datetime, now: datetime) -> datetime:
     return max(last_check_dt, now - MAX_CATCHUP_LOOKBACK)
+
+
+class MonitorState(TypedDict):
+    """last_cycle seeds a unit polled for the first time; units maps "mail"/"calendar" to the end of
+    the last window that unit read successfully, so a failed poll parks its own watermark alone."""
+
+    last_cycle: str
+    units: dict[str, str]
+
+
+def _read_state(path: Path, now: datetime) -> MonitorState:
+    """A legacy bare-timestamp file reads as a last_cycle with no units, so mail and calendar each
+    resume from where the old single-watermark monitor left off."""
+    raw = path.read_text().strip() if path.exists() else ""
+    if not raw:
+        return MonitorState(last_cycle=(now - _FRESH_START_LOOKBACK).isoformat(), units={})
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return MonitorState(last_cycle=raw, units={})
+    match parsed:
+        case {"last_cycle": str(last_cycle), "units": dict(units)}:
+            return MonitorState(last_cycle=last_cycle, units={str(unit): str(watermark) for unit, watermark in units.items()})
+        case _:
+            raise ValueError(f"Malformed monitor state in {path}: {raw[:100]}")
+
+
+def _write_state(path: Path, state: MonitorState) -> None:
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state))
+    tmp.rename(path)
+
+
+def _poll_unit(ctx: GoogleContext, state: MonitorState, unit: str, new_check_time: datetime, poll: Callable[[datetime, bool], bool]) -> None:
+    """Advance the unit's watermark only when the poll read its window, so a failed poll (an outage)
+    parks the watermark and the next healthy cycle re-reads the window instead of skipping it."""
+    units = state["units"]
+    seed = units[unit] if unit in units else state["last_cycle"]
+    query_since = clamp_catchup_start(datetime.fromisoformat(seed), new_check_time)
+    gap_seconds = (new_check_time - query_since).total_seconds()
+    catching_up = gap_seconds > _CATCHUP_GAP_SECONDS
+    if catching_up:
+        ctx.monitor_logger.info("Catching up %s from %s, %.0fs behind", unit, query_since.isoformat(), gap_seconds)
+    read = poll(query_since, catching_up)
+    units[unit] = new_check_time.isoformat() if read else query_since.isoformat()
 
 
 def notify_broken_once(ctx: GoogleContext, marker_name: str, notif_type: str, error: Exception) -> None:
@@ -86,7 +144,10 @@ def _parse_event_time(event: dict) -> datetime:
     return datetime.fromisoformat(date_str).replace(tzinfo=UTC)
 
 
-def _poll_gmail(ctx: GoogleContext, gmail, query_since: datetime, catching_up: bool) -> None:
+def _poll_gmail(ctx: GoogleContext, gmail, query_since: datetime, catching_up: bool) -> bool:
+    """Notify on Gmail arriving since query_since, returning True when the window was read. A failed
+    list parks the watermark; a single message that cannot be fetched stays best-effort (the window was
+    read, so re-reading would re-notify everything else)."""
     logger = ctx.monitor_logger
     try:
         epoch_seconds = int(query_since.timestamp())
@@ -94,37 +155,38 @@ def _poll_gmail(ctx: GoogleContext, gmail, query_since: datetime, catching_up: b
         results = gmail.users().messages().list(userId="me", q=query, labelIds=["INBOX"], maxResults=50).execute()
         messages = results["messages"] if "messages" in results else []
         logger.info("Found %d new emails", len(messages))
-
-        for msg_ref in messages:
-            try:
-                msg = (
-                    gmail.users()
-                    .messages()
-                    .get(userId="me", id=msg_ref["id"], format="metadata", metadataHeaders=["Subject", "From", "Date"])
-                    .execute()
-                )
-                msg_payload = msg["payload"] if "payload" in msg else {}
-                headers = msg_payload["headers"] if "headers" in msg_payload else []
-                sender = _get_header(headers, "From")
-                subject = _get_header(headers, "Subject")
-                snippet = msg["snippet"] if "snippet" in msg else ""
-
-                notifications.write_notification(
-                    ctx.notif_dir,
-                    "email",
-                    # Email pools by default (calendar reminders keep interrupting); the user adds
-                    # interrupt rules for the senders/keywords that should reach them right away.
-                    interrupt=False,
-                    sender=sender,
-                    subject=subject,
-                    preview=clean_preview(snippet)[:200],
-                    missed=catching_up or None,
-                )
-            except HttpError as e:
-                logger.error("Error processing email %s: %s", msg_ref["id"] if "id" in msg_ref else "?", e)
-
     except HttpError as e:
         logger.error("Error fetching Gmail: %s", e)
+        return False
+
+    for msg_ref in messages:
+        try:
+            msg = (
+                gmail.users()
+                .messages()
+                .get(userId="me", id=msg_ref["id"], format="metadata", metadataHeaders=["Subject", "From", "Date"])
+                .execute()
+            )
+            msg_payload = msg["payload"] if "payload" in msg else {}
+            headers = msg_payload["headers"] if "headers" in msg_payload else []
+            sender = _get_header(headers, "From")
+            subject = _get_header(headers, "Subject")
+            snippet = msg["snippet"] if "snippet" in msg else ""
+
+            notifications.write_notification(
+                ctx.notif_dir,
+                "email",
+                # Email pools by default (calendar reminders keep interrupting); the user adds
+                # interrupt rules for the senders/keywords that should reach them right away.
+                interrupt=False,
+                sender=sender,
+                subject=subject,
+                preview=clean_preview(snippet)[:200],
+                missed=catching_up or None,
+            )
+        except HttpError as e:
+            logger.error("Error processing email %s: %s", msg_ref["id"] if "id" in msg_ref else "?", e)
+    return True
 
 
 def _notify_event_reminders(ctx: GoogleContext, event: dict, query_since: datetime, new_check_time: datetime, catching_up: bool) -> None:
@@ -161,7 +223,10 @@ def _notify_event_reminders(ctx: GoogleContext, event: dict, query_since: dateti
         )
 
 
-def _poll_calendar(ctx: GoogleContext, query_since: datetime, new_check_time: datetime, catching_up: bool) -> None:
+def _poll_calendar(ctx: GoogleContext, new_check_time: datetime, query_since: datetime, catching_up: bool) -> bool:
+    """Emit calendar reminders crossing a threshold this cycle, returning True when the calendar was
+    read. A failure parks the calendar watermark alone: mail carries its own, so a terminally broken
+    calendar never re-notifies mail."""
     config = ctx.config
     logger = ctx.monitor_logger
     try:
@@ -187,50 +252,31 @@ def _poll_calendar(ctx: GoogleContext, query_since: datetime, new_check_time: da
         # Gmail still works: tell the agent once, keep polling mail.
         logger.error("Error fetching calendar: %s", e)
         notify_broken_once(ctx, CALENDAR_BROKEN_MARKER, "calendar_auth_broken", e)
-        return
+        return False
     except Exception as e:
         # A calendar failure must not sink the whole poll cycle (Gmail still ran).
         logger.error("Error fetching calendar: %s", e)
-        return
+        return False
     clear_broken_marker(ctx, CALENDAR_BROKEN_MARKER)
+    return True
 
 
 def run(ctx: GoogleContext):
     config = ctx.config
     logger = ctx.monitor_logger
     logger.info("Monitor thread started")
-    first_run = True
 
     while not ctx.monitor_stop_event.is_set():
         try:
-            if ctx.monitor_state_file.exists():
-                last_check_str = ctx.monitor_state_file.read_text().strip()
-            else:
-                last_check_str = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
-
-            last_check_dt = datetime.fromisoformat(last_check_str)
             new_check_time = datetime.now(UTC)
-
-            catching_up = False
-            if first_run:
-                gap_seconds = (new_check_time - last_check_dt).total_seconds()
-                if gap_seconds > 90:
-                    logger.info("Detected offline period of %.0fs, catching up from %s", gap_seconds, last_check_str)
-                    catching_up = True
-            first_run = False
-
-            query_since = clamp_catchup_start(last_check_dt, new_check_time)
-            if query_since != last_check_dt:
-                logger.info("Clamping catch-up window from %s to %s", last_check_str, query_since.isoformat())
-
-            logger.info("Checking for updates since %s", query_since.isoformat())
+            state = _read_state(ctx.monitor_state_file, new_check_time)
 
             try:
                 gmail = api.gmail_service(config)
             except ValueError as e:
                 # Terminal auth failure (no token, dead refresh): every poll would
-                # fail, so tell the agent once and keep polling without advancing
-                # the state file; recovery replays the gap (clamped above).
+                # fail, so tell the agent once and leave every watermark parked; the
+                # next healthy cycle re-reads the gap (clamped to MAX_CATCHUP_LOOKBACK).
                 logger.error("Google auth is broken: %s", e)
                 notify_broken_once(ctx, AUTH_BROKEN_MARKER, "auth_broken", e)
                 if ctx.monitor_stop_event.wait(45):
@@ -238,12 +284,11 @@ def run(ctx: GoogleContext):
                 continue
             clear_broken_marker(ctx, AUTH_BROKEN_MARKER)
 
-            _poll_gmail(ctx, gmail, query_since, catching_up)
-            _poll_calendar(ctx, query_since, new_check_time, catching_up)
+            _poll_unit(ctx, state, "mail", new_check_time, partial(_poll_gmail, ctx, gmail))
+            _poll_unit(ctx, state, "calendar", new_check_time, partial(_poll_calendar, ctx, new_check_time))
 
-            tmp = ctx.monitor_state_file.with_suffix(".tmp")
-            tmp.write_text(new_check_time.isoformat())
-            tmp.rename(ctx.monitor_state_file)
+            state["last_cycle"] = new_check_time.isoformat()
+            _write_state(ctx.monitor_state_file, state)
             logger.info("Completed check cycle, sleeping for 45 seconds")
             if ctx.monitor_stop_event.wait(45):
                 break

--- a/agent/skills/google/cli/tests/test_monitor.py
+++ b/agent/skills/google/cli/tests/test_monitor.py
@@ -1,13 +1,17 @@
-"""Monitor behavior: catch-up clamping and one-shot surfacing of terminal auth failures."""
+"""Monitor behavior: catch-up clamping, one-shot surfacing of terminal auth failures, and
+per-unit watermark recovery across an outage window (a failed poll must not skip its window)."""
 
 import json
 import logging
 import threading
+import types
 from datetime import UTC, datetime, timedelta
 
+import httplib2
 from google_cli import calendar, monitor
 from google_cli.config import Config
 from google_cli.context import GoogleContext
+from googleapiclient.errors import HttpError
 
 
 def test_recent_last_check_is_left_untouched():
@@ -140,3 +144,158 @@ def test_run_surfaces_calendar_auth_error_once_while_gmail_works(tmp_path, monke
     assert "google auth login" in payload["error"]
     # Gmail auth is fine, so the auth_broken path never fired.
     assert _notif_files(ctx, "auth_broken") == []
+
+
+# -- outage-gap recovery: a failed poll parks its own watermark ---------------
+
+
+def _http_error(status: int) -> HttpError:
+    return HttpError(httplib2.Response({"status": status}), b'{"error": "outage"}')
+
+
+def _gmail_message(sender: str, subject: str, snippet: str) -> dict:
+    return {"payload": {"headers": [{"name": "From", "value": sender}, {"name": "Subject", "value": subject}]}, "snippet": snippet}
+
+
+class _DrivenGmail:
+    """Chainable gmail stub honoring the real service's contract: list() runs list_hook (which may
+    raise HttpError to simulate an outage), then returns the inbox filtered by the query's ``after:``
+    epoch, exactly as Gmail's server-side filter does; get() returns the message for the fetched id."""
+
+    def __init__(self, inbox: list[tuple[str, datetime]], list_hook, messages_by_id: dict[str, dict]) -> None:
+        self._inbox = inbox
+        self._list_hook = list_hook
+        self._messages_by_id = messages_by_id
+        self._op = ""
+        self._query = ""
+        self._get_id = ""
+
+    def users(self):
+        return self
+
+    def messages(self):
+        return self
+
+    def list(self, **kwargs):
+        self._op = "list"
+        self._query = kwargs["q"]
+        return self
+
+    def get(self, **kwargs):
+        self._op = "get"
+        self._get_id = kwargs["id"]
+        return self
+
+    def execute(self):
+        if self._op == "list":
+            self._list_hook()
+            after = int(self._query.removeprefix("after:"))
+            return {"messages": [{"id": mid} for mid, arrived in self._inbox if int(arrived.timestamp()) > after]}
+        return self._messages_by_id[self._get_id]
+
+
+def _run_ctx(tmp_path, cycles: int):
+    """A context whose stop event ends run() after ``cycles`` iterations."""
+    remaining = {"cycles": cycles}
+
+    def wait(_timeout):
+        remaining["cycles"] -= 1
+        return remaining["cycles"] <= 0
+
+    base = tmp_path / "monitor"
+    base.mkdir(parents=True, exist_ok=True)
+    logger = logging.getLogger("test.google.monitor.run")
+    logger.addHandler(logging.NullHandler())
+    return types.SimpleNamespace(
+        config=types.SimpleNamespace(get_calendar_notify_thresholds=lambda: [10080, 60, 15]),
+        notif_dir=tmp_path / "notifications",
+        monitor_base_dir=base,
+        monitor_state_file=base / "state.txt",
+        monitor_logger=logger,
+        monitor_stop_event=types.SimpleNamespace(is_set=lambda: False, wait=wait),
+    )
+
+
+def _watermark(ctx, unit: str) -> datetime:
+    return datetime.fromisoformat(json.loads(ctx.monitor_state_file.read_text())["units"][unit])
+
+
+def _email_notifs(calls: list[dict]) -> list[str]:
+    return [call["subject"] for call in calls if "subject" in call]
+
+
+def test_failed_gmail_poll_recovers_the_outage_window_next_cycle(tmp_path, monkeypatch):
+    """The issue's exact case: a poll that failed on a dead token does not advance the watermark, so
+    the next healthy cycle re-reads the window and surfaces the mail that arrived during the outage."""
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    monkeypatch.setattr(monitor.calendar, "list_events_between", lambda *a, **k: [])
+
+    now = datetime.now(UTC)
+    arrived_at = now - timedelta(seconds=30)
+    ctx = _run_ctx(tmp_path, cycles=2)
+    ctx.monitor_state_file.write_text((now - timedelta(seconds=60)).isoformat())
+
+    cycle = {"n": 0}
+
+    def list_hook():
+        cycle["n"] += 1
+        if cycle["n"] == 1:
+            raise _http_error(503)
+
+    inbox = [("m1", arrived_at)]
+    messages_by_id = {"m1": _gmail_message("Manager <boss@x.com>", "Q3 plan", "please review")}
+    monkeypatch.setattr(monitor.api, "gmail_service", lambda config: _DrivenGmail(inbox, list_hook, messages_by_id))
+
+    monitor.run(ctx)
+
+    # Notified exactly once (no skip from the failed cycle, no duplicate from the recovery).
+    assert _email_notifs(calls) == ["Q3 plan"]
+    assert _watermark(ctx, "mail") > arrived_at
+
+
+def test_broken_calendar_does_not_make_mail_renotify(tmp_path, monkeypatch):
+    """Guards the per-unit granularity: a single shared watermark parked by a terminally broken
+    calendar would re-notify mail's whole window every cycle. Separate watermarks keep them apart."""
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+
+    def broken_calendar(*_args, **_kwargs):
+        raise calendar.CalendarAuthError("Calendar API disabled for this client; run 'google auth login'")
+
+    monkeypatch.setattr(monitor.calendar, "list_events_between", broken_calendar)
+
+    now = datetime.now(UTC)
+    ctx = _run_ctx(tmp_path, cycles=2)
+    ctx.monitor_state_file.write_text((now - timedelta(seconds=60)).isoformat())
+
+    inbox = [("m1", now - timedelta(seconds=30))]
+    messages_by_id = {"m1": _gmail_message("Colleague <c@x.com>", "hello", "hi there")}
+    monkeypatch.setattr(monitor.api, "gmail_service", lambda config: _DrivenGmail(inbox, lambda: None, messages_by_id))
+
+    monitor.run(ctx)
+
+    # Mail is notified once, not once per cycle; calendar stays parked behind mail.
+    assert _email_notifs(calls) == ["hello"]
+    assert _watermark(ctx, "calendar") < _watermark(ctx, "mail")
+
+
+def test_legacy_bare_timestamp_state_is_read_as_the_starting_watermark(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    monkeypatch.setattr(monitor.calendar, "list_events_between", lambda *a, **k: [])
+
+    now = datetime.now(UTC)
+    ctx = _run_ctx(tmp_path, cycles=1)
+    ctx.monitor_state_file.write_text((now - timedelta(minutes=5)).isoformat())
+
+    inbox = [("before", now - timedelta(minutes=10)), ("after", now - timedelta(minutes=2))]
+    messages_by_id = {
+        "before": _gmail_message("Before <b@x.com>", "before", "x"),
+        "after": _gmail_message("After <a@x.com>", "after", "y"),
+    }
+    monkeypatch.setattr(monitor.api, "gmail_service", lambda config: _DrivenGmail(inbox, lambda: None, messages_by_id))
+
+    monitor.run(ctx)
+
+    assert _email_notifs(calls) == ["after"]


### PR DESCRIPTION
## The bug

PR #1399 papered over a real bug with prompt guidance: it told the agent to manually sweep for mail that arrived while a connected account was down. The proper fix is in the daemon code, so no manual sweep is ever needed.

The **google monitor** (`agent/skills/google/cli/src/google_cli/monitor.py`) wrote `new_check_time` as its state watermark at the end of **every** cycle, including cycles whose Gmail poll fetched nothing because the poll raised (a transient `HttpError`, a token that died mid-window). `_poll_gmail` swallowed that error internally, so the loop committed the watermark as if the window had been read, and the next cycle's `after:<advanced watermark>` query skipped the unread window forever. Only the terminal "cannot build the gmail service" path (`gmail_service` raising `ValueError`) was handled correctly. This is exactly the class of bug PR #1321 fixed for the microsoft monitor.

## Which daemons could skip the outage window

I audited every mail daemon under `agent/skills`:

- **google**: AFFECTED. Time-based watermark, advanced unconditionally at cycle end. Fixed here.
- **microsoft**: already correct (PR #1321, "only advance the monitor watermark across successfully polled windows").
- **email-client** (`poll_daemon.py`): NOT affected. UID-based watermark; `emit_new` only calls `set_high_uid` across messages it actually fetched, and a connection error propagates out of the worker so the watermark parks. Gap-safe and idempotent by UID.
- **agentmail**: NOT affected. It is a webhook receiver (AgentMail POSTs inbound mail to a local HTTP service), no poll and no watermark to skip.

So the code fix is scoped to the one daemon that could actually skip the gap.

## The fix

Mirror the discipline PR #1321 applied to the microsoft monitor: **a watermark advances only across a window that was actually read.**

- Mail and calendar now carry their own **per-unit watermark** (`{"last_cycle": iso, "units": {"mail": iso, "calendar": iso}}`). Each poll (`_poll_gmail`, `_poll_calendar`) returns whether it read its window; `_poll_unit` advances that unit's watermark only on success, parking it (clamped to `MAX_CATCHUP_LOOKBACK`) on failure so the next healthy cycle re-sweeps from there.
- **Per-unit, not one shared watermark**, for the same reason as #1321: `notifications.write_notification` does not dedupe by message id, so a single shared watermark parked by a terminally broken calendar (e.g. Calendar API disabled forever) would re-notify mail's whole window every cycle. Separate watermarks keep a dead unit parked without touching a healthy one. Recovery is idempotent: a re-swept window only re-notifies mail newer than the parked watermark.
- **Transparent state migration**: a legacy bare-timestamp file reads as `last_cycle` with no units, so mail and calendar both resume from exactly where the old single-watermark monitor left off. No migration, no re-notify burst on update.
- Catch-up is now derived per unit from its own gap (deleting the process-only `first_run` flag), so recovered mail is tagged `missed` whether the process was down **or** the token was dead. The terminal `gmail_service` auth failure still surfaces once and leaves every watermark parked.

## Tests

`agent/skills/google/cli/tests/test_monitor.py`, driving the real `run()` loop over a real state file with a Gmail stub that honors the server-side `after:` filter:

- a failed Gmail poll does not advance the watermark, and the next successful cycle re-reads the window and surfaces the mail that arrived during the outage, **exactly once** (no skip, no duplicate). The issue's exact case.
- a terminally broken calendar does not make mail re-notify each cycle (the per-unit granularity guard), and calendar stays parked behind mail.
- a legacy bare-timestamp state file is honored as the starting watermark.

Full google CLI suite: 72 passed. `ruff check` + `ruff format --check` (repo-wide config) pass on both changed files.

## Supersedes #1399

This replaces #1399's prompt workaround with the actual code fix, so the agent never needs to manually sweep an account after an outage. #1399's prose change is not carried here; it is closed in favor of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)