### PR TITLE
ci: per-app scoping, caching, and a faster release tail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,10 +425,16 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: apps/mobile/package-lock.json
+          cache-dependency-path: |
+            apps/package-lock.json
+            apps/mobile/package-lock.json
 
+      # Mobile type-checks against @vesta/core's source (the file: dependency),
+      # which resolves its react types from the apps workspace install.
       - name: Install deps
-        run: npm --prefix apps/mobile ci
+        run: |
+          npm --prefix apps ci
+          npm --prefix apps/mobile ci
 
       - name: Run mobile checks
         run: ./check.sh app-mobile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,6 +348,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: apps/package-lock.json
 
       - name: Install deps
         run: npm --prefix apps ci
@@ -371,6 +373,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: apps/package-lock.json
 
       - name: Install deps
         run: npm --prefix apps ci
@@ -395,6 +399,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: apps/package-lock.json
 
       - name: Install deps
         run: npm --prefix apps ci
@@ -418,6 +424,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: apps/mobile/package-lock.json
 
       - name: Install deps
         run: npm --prefix apps/mobile ci
@@ -456,10 +464,38 @@ jobs:
             jq --exit-status '.data' > "$schema"
           uvx check-jsonschema==0.36.2 --schemafile "$schema" "${workflows[@]}"
 
+  # ── Warm the agent image build cache (shared by the Docker consumers) ──
+  # test-integration and check-vestad each build the agent image from their own
+  # checkout for hermeticity, and used to cold-build it twice in parallel without
+  # seeing each other's cache. Building it once here and exporting a mode=max gha
+  # cache under the agent-image-amd64 scope lets both consumers hit warm layers.
+  # This never pushes anywhere: the consumers still build from checkout, they just
+  # reuse these layers. The gate is the union of both consumers' gates so this job
+  # runs whenever either consumer does.
+  build-agent-image:
+    name: Agent image · Warm build cache
+    needs: detect-changes
+    if: github.event_name != 'pull_request' || needs.detect-changes.outputs.vestad == 'true' || needs.detect-changes.outputs.agent == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build agent image and export cache
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: vestad/Dockerfile
+          cache-from: type=gha,scope=agent-image-amd64
+          cache-to: type=gha,mode=max,scope=agent-image-amd64
+
   # ── Integration tests (real vestad + real client, Docker required) ─────
   test-integration:
     name: vestad · Run end-to-end integration tests
-    needs: [version-check, detect-changes]
+    needs: [version-check, detect-changes, build-agent-image]
     if: github.event_name != 'pull_request' || needs.detect-changes.outputs.vestad == 'true' || needs.detect-changes.outputs.agent == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -491,10 +527,17 @@ jobs:
         # Caching is best-effort: a transient cache-service outage must not fail the
         # build (it just rebuilds uncached) the way it did during the v0.1.158 release.
         continue-on-error: true
+        # There is no root Cargo.lock, so rust-cache with no workspaces caches nothing
+        # and vestad rebuilds cold every run. Point it at the vestad workspace and share
+        # check-vestad's cache key so the two Linux x64 jobs reuse each other's entries.
+        with:
+          workspaces: vestad
+          key: x86_64-unknown-linux-gnu
 
       # Hermetic: the agent image is built from THIS checkout (GHA layer cache keeps it
       # fast), so integration tests exercise the PR's agent code and Dockerfile — never
-      # the previously released ghcr.io :latest image.
+      # the previously released ghcr.io :latest image. build-agent-image warms the shared
+      # agent-image-amd64 cache first so this build hits warm layers instead of cold.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -505,8 +548,8 @@ jobs:
           file: vestad/Dockerfile
           load: true
           tags: vesta:local
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=agent-image-amd64
+          cache-to: type=gha,mode=max,scope=agent-image-amd64
 
       - name: Build vestad
         working-directory: vestad
@@ -542,7 +585,7 @@ jobs:
   # ── Check vestad (clippy, unit tests, and Docker tests) ───────────────
   check-vestad:
     name: vestad · Lint, unit, and Docker tests (Linux x64)
-    needs: [version-check, detect-changes]
+    needs: [version-check, detect-changes, build-agent-image]
     if: github.event_name != 'pull_request' || needs.detect-changes.outputs.vestad == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -565,7 +608,8 @@ jobs:
         run: TARGET=x86_64-unknown-linux-gnu ./check.sh vestad
 
       # Hermetic: the #[ignore] Docker tests run against an image built from this
-      # checkout, not the released ghcr.io :latest.
+      # checkout, not the released ghcr.io :latest. build-agent-image warms the shared
+      # agent-image-amd64 cache first so this build hits warm layers instead of cold.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -576,8 +620,8 @@ jobs:
           file: vestad/Dockerfile
           load: true
           tags: vesta:local
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=agent-image-amd64
+          cache-to: type=gha,mode=max,scope=agent-image-amd64
 
       - name: Docker integration tests (vestad, Linux only)
         run: VESTAD_AGENT_IMAGE=vesta:local ./check.sh vestad-docker
@@ -679,13 +723,54 @@ jobs:
           }
           Write-Host "✅ install.ps1 is compatible with PowerShell 5.1"
 
+  # ── Build the web bundle once for all desktop platforms ───────────────
+  # electron-builder embeds apps/web/dist as extraResources. Rather than rebuild
+  # that identical bundle on macOS, Linux, and Windows, build it once here and
+  # hand it to the three desktop jobs as an artifact. Gated on the same desktop
+  # closure (core || web || desktop) with the same always-run-on-push semantics.
+  build-web-bundle:
+    name: Desktop · Build web bundle
+    needs: detect-changes
+    if: >-
+      !failure() && !cancelled() &&
+      needs.detect-changes.result == 'success' && (
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.web == 'true' ||
+      needs.detect-changes.outputs.desktop == 'true'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/package-lock.json
+
+      - name: Install frontend deps
+        run: npm --prefix apps ci
+
+      - name: Build web app
+        working-directory: apps
+        run: npm -w @vesta/web run build
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: web-bundle
+          path: apps/web/dist
+          retention-days: 1
+
   # ── Build Electron app (macOS) ───────────────────────────────────────
   build-electron-macos:
     name: Desktop · Build (macOS)
-    # Builds the desktop bundle from source (web + electron), consuming no test
-    # outputs, so it gates on the desktop closure (core || web || desktop), not
-    # on the app test jobs.
-    needs: detect-changes
+    # Packages the electron bundle (embedding the prebuilt web bundle), consuming
+    # no test outputs, so it gates on the desktop closure (core || web || desktop),
+    # not on the app test jobs. build-web-bundle produces the web dist it embeds.
+    needs: [detect-changes, build-web-bundle]
     if: >-
       !failure() && !cancelled() &&
       needs.detect-changes.result == 'success' && (
@@ -706,14 +791,25 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: apps/package-lock.json
+
+      - name: Cache electron downloads
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+          key: electron-macos-${{ hashFiles('apps/package-lock.json') }}
 
       - name: Install frontend deps
-        working-directory: apps
-        run: npm install
+        run: npm --prefix apps ci
 
-      - name: Build web app
-        working-directory: apps
-        run: npm -w @vesta/web run build
+      - name: Download web bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: web-bundle
+          path: apps/web/dist
 
       - name: Resolve macOS build arch
         env:
@@ -781,7 +877,7 @@ jobs:
   # ── Build Electron app (Linux) ────────────────────────────────────────
   build-electron-linux:
     name: Desktop · Build (${{ matrix.label }})
-    needs: detect-changes
+    needs: [detect-changes, build-web-bundle]
     if: >-
       !failure() && !cancelled() &&
       needs.detect-changes.result == 'success' && (
@@ -809,17 +905,28 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: apps/package-lock.json
+
+      - name: Cache electron downloads
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: electron-linux-${{ matrix.arch }}-${{ hashFiles('apps/package-lock.json') }}
 
       - name: Install packaging deps
         run: sudo apt-get update && sudo apt-get install -y rpm
 
       - name: Install frontend deps
-        working-directory: apps
-        run: npm install
+        run: npm --prefix apps ci
 
-      - name: Build web app
-        working-directory: apps
-        run: npm -w @vesta/web run build
+      - name: Download web bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: web-bundle
+          path: apps/web/dist
 
       - name: Build Electron app
         working-directory: apps/desktop
@@ -843,7 +950,7 @@ jobs:
   # ── Build Electron app (Windows) ──────────────────────────────────────
   build-electron-windows:
     name: Desktop · Build (Windows x64)
-    needs: detect-changes
+    needs: [detect-changes, build-web-bundle]
     if: >-
       !failure() && !cancelled() &&
       needs.detect-changes.result == 'success' && (
@@ -861,14 +968,25 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: apps/package-lock.json
+
+      - name: Cache electron downloads
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~\AppData\Local\electron\Cache
+            ~\AppData\Local\electron-builder\Cache
+          key: electron-windows-${{ hashFiles('apps/package-lock.json') }}
 
       - name: Install frontend deps
-        working-directory: apps
-        run: npm install
+        run: npm --prefix apps ci
 
-      - name: Build web app
-        working-directory: apps
-        run: npm -w @vesta/web run build
+      - name: Download web bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: web-bundle
+          path: apps/web/dist
 
       - name: Build Electron app
         working-directory: apps/desktop
@@ -945,8 +1063,10 @@ jobs:
       - test-app-web
       - test-app-desktop
       - test-app-mobile
+      - build-agent-image
       - test-integration
       - check-vestad
+      - build-web-bundle
       - build-vestad
       - check-windows
       - build-electron-macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
     timeout-minutes: 5
     outputs:
       vestad: ${{ steps.filter.outputs.vestad }}
-      app: ${{ steps.filter.outputs.app }}
+      core: ${{ steps.filter.outputs.core }}
+      web: ${{ steps.filter.outputs.web }}
+      desktop: ${{ steps.filter.outputs.desktop }}
       mobile: ${{ steps.filter.outputs.mobile }}
       mobile_native: ${{ steps.filter.outputs.mobile_native }}
       agent: ${{ steps.filter.outputs.agent }}
@@ -92,16 +94,23 @@ jobs:
               - 'agent/ruff.toml'
               - '.github/workflows/ci.yml'
               - 'check.sh'
-            app:
-              - 'apps/**'
+            core:
+              - 'apps/core/**'
+              - '.github/workflows/ci.yml'
+              - 'check.sh'
+            web:
+              - 'apps/web/**'
               - 'design/**'
               - 'scripts/sync-design-tokens.py'
               - 'scripts/sync-dashboard.sh'
               - '.github/workflows/ci.yml'
               - 'check.sh'
+            desktop:
+              - 'apps/desktop/**'
+              - '.github/workflows/ci.yml'
+              - 'check.sh'
             mobile:
               - 'apps/mobile/**'
-              - 'apps/core/**'
               - '.github/workflows/ci.yml'
               - '.github/workflows/mobile-build.yml'
               - 'check.sh'
@@ -323,11 +332,13 @@ jobs:
       - name: Run telegram checks
         run: ./check.sh telegram
 
-  # ── Frontend unit tests ──────────────────────────────────────────────
-  test-frontend:
-    name: Apps · Lint, typecheck, and test
+  # ── Frontend unit tests (one job per app, gated on its dependency closure) ──
+  # @vesta/core is the shared controller: web bundles it, desktop bundles web,
+  # mobile consumes it via file:. So each downstream job's gate includes core.
+  test-app-core:
+    name: Apps · core
     needs: detect-changes
-    if: github.event_name != 'pull_request' || needs.detect-changes.outputs.app == 'true'
+    if: github.event_name != 'pull_request' || needs.detect-changes.outputs.core == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -339,12 +350,80 @@ jobs:
           node-version: 22
 
       - name: Install deps
-        run: |
-          npm --prefix apps ci
-          npm --prefix apps/mobile ci
+        run: npm --prefix apps ci
+
+      - name: Run core checks
+        run: ./check.sh app-core
+
+  test-app-web:
+    name: Apps · web
+    needs: detect-changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Install deps
+        run: npm --prefix apps ci
 
       - name: Run web checks
-        run: ./check.sh web
+        run: ./check.sh app-web
+
+  test-app-desktop:
+    name: Apps · desktop
+    needs: detect-changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.web == 'true' ||
+      needs.detect-changes.outputs.desktop == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Install deps
+        run: npm --prefix apps ci
+
+      - name: Run desktop checks
+        run: ./check.sh app-desktop
+
+  test-app-mobile:
+    name: Apps · mobile
+    needs: detect-changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.mobile == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Install deps
+        run: npm --prefix apps/mobile ci
+
+      - name: Run mobile checks
+        run: ./check.sh app-mobile
 
   # ── EAS workflow schema validation (mobile PRs only) ─────────────────
   # This is local schema validation only. It neither authenticates to Expo nor
@@ -507,7 +586,9 @@ jobs:
   build-vestad:
     name: vestad · Build (${{ matrix.label }})
     needs: [version-check, detect-changes]
-    if: needs.detect-changes.outputs.vestad == 'true' || needs.detect-changes.outputs.app == 'true' || github.event_name != 'pull_request'
+    # vestad's build.rs embeds only the web bundle, so its app-side trigger is the
+    # web closure (core || web), not desktop or mobile.
+    if: needs.detect-changes.outputs.vestad == 'true' || needs.detect-changes.outputs.core == 'true' || needs.detect-changes.outputs.web == 'true' || github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -601,12 +682,17 @@ jobs:
   # ── Build Electron app (macOS) ───────────────────────────────────────
   build-electron-macos:
     name: Desktop · Build (macOS)
-    needs: [test-frontend, detect-changes]
+    # Builds the desktop bundle from source (web + electron), consuming no test
+    # outputs, so it gates on the desktop closure (core || web || desktop), not
+    # on the app test jobs.
+    needs: detect-changes
     if: >-
       !failure() && !cancelled() &&
       needs.detect-changes.result == 'success' && (
       github.event_name != 'pull_request' ||
-      needs.detect-changes.outputs.app == 'true'
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.web == 'true' ||
+      needs.detect-changes.outputs.desktop == 'true'
       )
     runs-on: macos-latest
     # Release builds sign and notarize; Apple's notarytool can wait well past an
@@ -695,12 +781,14 @@ jobs:
   # ── Build Electron app (Linux) ────────────────────────────────────────
   build-electron-linux:
     name: Desktop · Build (${{ matrix.label }})
-    needs: [test-frontend, detect-changes]
+    needs: detect-changes
     if: >-
       !failure() && !cancelled() &&
       needs.detect-changes.result == 'success' && (
       github.event_name != 'pull_request' ||
-      needs.detect-changes.outputs.app == 'true'
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.web == 'true' ||
+      needs.detect-changes.outputs.desktop == 'true'
       )
     strategy:
       fail-fast: false
@@ -755,12 +843,14 @@ jobs:
   # ── Build Electron app (Windows) ──────────────────────────────────────
   build-electron-windows:
     name: Desktop · Build (Windows x64)
-    needs: [test-frontend, detect-changes]
+    needs: detect-changes
     if: >-
       !failure() && !cancelled() &&
       needs.detect-changes.result == 'success' && (
       github.event_name != 'pull_request' ||
-      needs.detect-changes.outputs.app == 'true'
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.web == 'true' ||
+      needs.detect-changes.outputs.desktop == 'true'
       )
     runs-on: windows-latest
     timeout-minutes: 60
@@ -851,7 +941,10 @@ jobs:
       - dependency-review
       - agent-tests
       - go-checks
-      - test-frontend
+      - test-app-core
+      - test-app-web
+      - test-app-desktop
+      - test-app-mobile
       - test-integration
       - check-vestad
       - build-vestad

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -106,11 +106,19 @@ jobs:
       - if: steps.credentials.outputs.available == 'true'
         uses: Swatinem/rust-cache@v2
         continue-on-error: true
+        # No root Cargo.lock, so rust-cache with no workspaces caches nothing. Point it
+        # at the vestad workspace and share check-vestad's key so entries are reused.
+        with:
+          workspaces: vestad
+          key: x86_64-unknown-linux-gnu
 
       - name: Set up Docker Buildx
         if: steps.credentials.outputs.available == 'true'
         uses: docker/setup-buildx-action@v4
 
+      # Shares the agent-image-amd64 gha cache scope with the other amd64 agent-image
+      # builds so this warms and reads the same layers, and never collides with the
+      # arm64 scope used by the release image push.
       - name: Build agent image from checkout
         if: steps.credentials.outputs.available == 'true'
         uses: docker/build-push-action@v7
@@ -119,8 +127,8 @@ jobs:
           file: vestad/Dockerfile
           load: true
           tags: vesta:local
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=agent-image-amd64
+          cache-to: type=gha,mode=max,scope=agent-image-amd64
 
       - name: Build vestad
         if: steps.credentials.outputs.available == 'true'

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -63,6 +63,9 @@ jobs:
 
   test-linux:
     name: Release binaries · Run Linux smoke test
+    # Needs the whole reusable CI call, not a standalone builder: the smoke test
+    # must validate the exact release-built vestad binary that publish-release
+    # ships, and only validate-and-build (release_artifacts: true) produces it.
     needs: [validate-and-build]
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -61,6 +61,33 @@ jobs:
     secrets:
       CLAUDE_CREDENTIALS: ${{ secrets.CLAUDE_CREDENTIALS }}
 
+  # Pre-warm the arm64 agent image cache in parallel with the gates so the
+  # post-gate arm64 push is nearly cache-only. amd64 is already warmed by
+  # validate-and-build's inner jobs (agent-image-amd64 scope); this warms the
+  # matching agent-image-arm64 scope from the same tag checkout. It never pushes.
+  # continue-on-error: a cache-warming failure must never fail the release; the
+  # arm64 push just cold-builds if this misses.
+  warm-agent-image-arm64:
+    name: Agent image · Warm arm64 build cache
+    needs: verify-release
+    continue-on-error: true
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build arm64 agent image and export cache
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: vestad/Dockerfile
+          platforms: linux/arm64
+          cache-from: type=gha,scope=agent-image-arm64
+          cache-to: type=gha,mode=max,scope=agent-image-arm64
+
   test-linux:
     name: Release binaries · Run Linux smoke test
     # Needs the whole reusable CI call, not a standalone builder: the smoke test
@@ -82,11 +109,28 @@ jobs:
           chmod +x vestad
           ./vestad --version
 
+  # Build each arch NATIVELY (no QEMU) and push by digest. Nothing publishes
+  # before the gates, so this needs both [test-linux, test-live]. cache-from only:
+  # a green run must never publish an image assembled from a poisoned cross-run
+  # cache, so these never cache-to. The pre-gate warm jobs (validate-and-build's
+  # amd64 inner builds, warm-agent-image-arm64) populate the read-only caches.
   push-image:
-    name: Agent image · Publish to GHCR
+    name: Agent image · Build and push (${{ matrix.label }})
     needs: [test-linux, test-live]
     if: ${{ !failure() && !cancelled() }}
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: linux/amd64
+            platform: linux/amd64
+            os: ubuntu-latest
+            scope: agent-image-amd64
+          - label: linux/arm64
+            platform: linux/arm64
+            os: ubuntu-24.04-arm
+            scope: agent-image-arm64
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     permissions:
       contents: read
@@ -104,20 +148,76 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and publish versioned agent image
+      - name: Build and push agent image by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
           file: vestad/Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.scope }}
+          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: agent-image-digest-${{ matrix.scope }}
+          path: /tmp/digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  # Assemble the per-arch digests into the single multi-arch versioned tag.
+  push-image-manifest:
+    name: Agent image · Publish multi-arch tag
+    needs: push-image
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: agent-image-digest-*
+          merge-multiple: true
+
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          tags=()
+          for digest in *; do
+            tags+=("ghcr.io/${GITHUB_REPOSITORY}@sha256:${digest}")
+          done
+          docker buildx imagetools create -t "ghcr.io/${GITHUB_REPOSITORY}:${TAG}" "${tags[@]}"
+
+      - name: Inspect published tag
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: docker buildx imagetools inspect "ghcr.io/${GITHUB_REPOSITORY}:${TAG}"
 
   publish-release:
     name: Release · Upload artifacts
-    needs: [validate-and-build, test-live, test-linux, push-image]
+    needs: [validate-and-build, test-live, test-linux, push-image-manifest]
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -170,9 +270,16 @@ jobs:
             gh release upload "${{ github.event.release.tag_name }}" "$asset" --clobber
           done
 
+  # Gated on the release gates (test-live + test-linux, the same pair push-image
+  # waits on), not on publish-release: this job reads only the release event's body
+  # and builds mobile from the tag checkout, so it needs no uploaded GitHub assets.
+  # Decoupling lets TestFlight delivery run in parallel with the GHCR push and asset
+  # upload. Accepted tradeoff: if publish-release later fails and revert-failed-release
+  # fires, a TestFlight build of a since-reverted release may already be delivered to
+  # the internal (beta) group. The user accepted this beta-channel risk.
   mobile-testflight:
     name: Mobile · Build and upload to TestFlight
-    needs: publish-release
+    needs: [test-live, test-linux]
     if: >-
       ${{ !failure() && !cancelled() &&
       contains(github.event.release.body, '<!-- mobile-delivery: testflight -->') }}
@@ -219,6 +326,7 @@ jobs:
         test-live,
         test-linux,
         push-image,
+        push-image-manifest,
         publish-release,
         mobile-testflight,
       ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,11 @@ CI runs these exact subcommands, so passing locally means passing CI:
 ./check.sh guards         # repo-wide ruff + format, convention guards (lint escapes, comment length, import cycles), shellcheck, skills index, uv.lock, dashboard-sync freshness
 ./check.sh vestad         # cargo clippy -p vestad -D warnings + cargo test -p vestad
 ./check.sh vestad-docker  # vestad #[ignore] Docker tests (needs Docker + agent image)
-./check.sh web            # the JS/TS suite: @vesta/core (lint + format + tsc + vitest) then web, desktop, mobile
+./check.sh web            # the whole JS/TS suite locally: chains app-core, app-web, app-desktop, app-mobile
+./check.sh app-core       # @vesta/core lint + format + tsc + vitest (CI runs this as its own job)
+./check.sh app-web        # design-token sync check + @vesta/web lint + format + tsc + vitest
+./check.sh app-desktop    # @vesta/desktop lint + tsc + vitest
+./check.sh app-mobile     # Expo dep validation + @vesta/mobile lint + tsc + vitest + clean-prebuild verify
 ./check.sh integration    # vestad integration tests (needs Docker)
 ./check.sh live           # live agent e2e (Docker + CLAUDE_CREDENTIALS; real Claude)
 ./check.sh all            # guards + agent + vestad + web
@@ -265,7 +269,7 @@ If the skill ships a CLI, put it in a `cli/` subdirectory as its **own standalon
 
 ## CI
 
-`ci.yml` runs shared validation on pushes to `master` and PRs; jobs are path-filtered on PRs. `release-pipeline.yml` is triggered only by a published prerelease, calls the same reusable CI workflow, then runs the live gate and publishing jobs. Keeping delivery separate means PRs do not show irrelevant skipped release checks. The check/test jobs call `./check.sh` subcommands, so CI and local checks are identical by construction. Checks include version sync across sources, workflow syntax, dependency review when GitHub's dependency graph is enabled, ruff, ty, cargo clippy, pytest (including cc_sdk transport tests under tmux), `uv.lock` freshness, and native iOS/Android mobile compiles when native inputs change. Mobile PRs also validate every EAS workflow against Expo's public schema without authenticating or queuing a cloud build. Electron PR packages are explicitly unsigned and never receive Apple signing credentials; signing and notarization remain release-only. The single required branch-protection check is `merge-gate-ci`.
+`ci.yml` runs shared validation on pushes to `master` and PRs; jobs are path-filtered on PRs. `release-pipeline.yml` is triggered only by a published prerelease, calls the same reusable CI workflow, then runs the live gate and publishing jobs. Keeping delivery separate means PRs do not show irrelevant skipped release checks. The check/test jobs call `./check.sh` subcommands, so CI and local checks are identical by construction. The frontend runs as four per-app jobs (`app-core`, `app-web`, `app-desktop`, `app-mobile`), each path-filtered on its dependency closure (web needs core, desktop needs core + web, mobile needs core); `./check.sh web` chains all four for a local run-everything. Checks include version sync across sources, workflow syntax, dependency review when GitHub's dependency graph is enabled, ruff, ty, cargo clippy, pytest (including cc_sdk transport tests under tmux), `uv.lock` freshness, and native iOS/Android mobile compiles when native inputs change. Mobile PRs also validate every EAS workflow against Expo's public schema without authenticating or queuing a cloud build. Electron PR packages are explicitly unsigned and never receive Apple signing credentials; signing and notarization remain release-only. The single required branch-protection check is `merge-gate-ci`.
 
 Docker-based jobs (integration tests, vestad Docker unit tests, live tests) build the agent image **from the checkout** (GHA layer cache) and run with `VESTAD_AGENT_IMAGE=vesta:local`, so PRs are validated against their own agent code and Dockerfile, never the previously released image.
 

--- a/check.sh
+++ b/check.sh
@@ -15,8 +15,11 @@ Suites:
   vestad         cargo clippy -p vestad -D warnings + cargo test -p vestad
   vestad-docker  vestad #[ignore] Docker tests (needs Docker + an agent image:
                  set VESTAD_AGENT_IMAGE or docker pull ghcr.io/elyxlz/vesta:latest)
-  web            eslint + prettier --check + tsc + vitest (web), eslint + tsc + vitest (desktop),
-                 and Expo dependency validation + eslint + tsc + vitest (mobile)
+  web            all four app slices below (core, web, desktop, mobile); CI runs them as separate jobs
+  app-core       @vesta/core: eslint + prettier --check + tsc + vitest
+  app-web        design-token sync check + @vesta/web: eslint + prettier --check + tsc + vitest
+  app-desktop    @vesta/desktop: eslint + tsc + vitest
+  app-mobile     Expo dependency validation + @vesta/mobile: eslint + tsc + vitest + clean-prebuild verify
   mobile-ios     clean Expo prebuild + unsigned iOS simulator compile
   mobile-android clean Expo prebuild + Android debug compile
   guards         repo-wide ruff check + format, convention guards (lint escapes,
@@ -92,33 +95,65 @@ check_vestad_docker() {
   )
 }
 
-check_web() {
+check_app_core() {
+  (
+    cd apps
+    if [ ! -d node_modules ]; then
+      npm install
+    fi
+    npm -w @vesta/core run lint
+    npm -w @vesta/core run format:check
+    npm -w @vesta/core run check
+    npm -w @vesta/core run test
+  )
+}
+
+check_app_web() {
   python3 scripts/sync-design-tokens.py --check
   (
     cd apps
     if [ ! -d node_modules ]; then
       npm install
     fi
-    if [ ! -d mobile/node_modules ]; then
-      npm --prefix mobile install
-    fi
-    npm -w @vesta/core run lint
-    npm -w @vesta/core run format:check
-    npm -w @vesta/core run check
-    npm -w @vesta/core run test
     npm -w @vesta/web run lint
     npm -w @vesta/web run format:check
     npm -w @vesta/web run check
     npm -w @vesta/web run test
+  )
+}
+
+check_app_desktop() {
+  (
+    cd apps
+    if [ ! -d node_modules ]; then
+      npm install
+    fi
     npm -w @vesta/desktop run lint
     npm -w @vesta/desktop run check
     npm -w @vesta/desktop run test
+  )
+}
+
+check_app_mobile() {
+  (
+    cd apps
+    if [ ! -d mobile/node_modules ]; then
+      npm --prefix mobile install
+    fi
     (cd mobile && npx expo install --check)
     npm --prefix mobile run lint
     npm --prefix mobile run check
     npm --prefix mobile run test
     bash ../scripts/check-mobile-prebuild.sh
   )
+}
+
+# Local run-everything entry: CI runs the four app-* slices as separate jobs.
+check_web() {
+  check_app_core
+  check_app_web
+  check_app_desktop
+  check_app_mobile
 }
 
 check_guards() {
@@ -277,6 +312,10 @@ for suite in "$@"; do
     vestad) check_vestad ;;
     vestad-docker) check_vestad_docker ;;
     web) check_web ;;
+    app-core) check_app_core ;;
+    app-web) check_app_web ;;
+    app-desktop) check_app_desktop ;;
+    app-mobile) check_app_mobile ;;
     mobile-ios) check_mobile_native ios ;;
     mobile-android) check_mobile_native android ;;
     guards) check_guards ;;


### PR DESCRIPTION
## What

Two commits making CI run only what a change actually affects, and making the release pipeline finish substantially faster.

## Per-app scoping (`ci: scope app jobs per app and parallelize the graph`)

- The monolithic `app:` paths filter splits into `core` / `web` / `desktop` / `mobile`, and the single frontend job splits into four parallel jobs, each gated on its true dependency closure: web jobs fire on `core||web`, desktop on `core||web||desktop` (desktop bundles the web app), mobile on `core||mobile`. A mobile-only PR no longer runs web tests or desktop builds; a core change still fans out to everything, because it genuinely affects everything.
- `check.sh` gains matching `app-core`/`app-web`/`app-desktop`/`app-mobile` subcommands (what CI calls); `check.sh web` remains the local run-everything entry chaining all four, so local-equals-CI holds.
- Desktop builds no longer wait for the test job (they consume no test outputs); they now wait only for a small shared `build-web-bundle` job, so the web bundle is built once instead of three times.
- `build-vestad`'s app-side trigger narrows to `core||web` (its build.rs embeds only the web bundle). `merge-gate-ci` rewired for the new job names, skipped-is-pass semantics preserved.

## Caching + release parallelization (`ci: cache what recomputes and parallelize the release tail`)

- **Fixed a broken Rust cache**: the integration job's rust-cache pointed at the repo root where no lockfile exists, so vestad recompiled cold on every PR run; now scoped to the vestad workspace with a key shared with check-vestad. Same fix in live-tests.
- npm caches added where missing (four app jobs, three desktop jobs; desktop `npm install` becomes `npm ci`); Electron/electron-builder downloads cached per platform.
- The agent Docker image, previously cold-built twice in parallel per run, is warmed once by a `build-agent-image` job; both consumers keep their hermetic build-from-checkout steps and now hit a warm layer cache.
- **Release critical path**: the multi-arch image push (previously ~20 min, arm64 emulated under QEMU after the live gate) becomes a per-arch native matrix (arm64 on `ubuntu-24.04-arm`) pushing by digest with a manifest-assembly job, with the arm64 cache warmed in parallel with `test-live`. Push jobs are cache-from only; nothing reaches the registry before `test-linux` and `test-live` are green; a warm-job failure cannot red or revert a release.
- **`mobile-testflight` regates from `publish-release` to `[test-live, test-linux]`** (it reads only the release event body): its ~10 min tail now overlaps the publish chain. Accepted tradeoff, stated in a comment: TestFlight delivery can complete before the GitHub release assets finish uploading.

Expected effect: release wall clock from ~56 min toward ~30-35 min; PR CI wall dominated only by what the change actually touches.

## Verification

Both implementers' gate matrices were independently rebuilt by a review pass (scenario-by-scenario, diffed against master's behavior): no under-validation, aligned producer/consumer gates (no skipped-artifact hangs), the release DAG publishes only behind both gates. All granular `check.sh` subcommands run green locally; workflows YAML-parse; guards pass. This PR touches the workflows, so its own CI run fires every job; the per-app scoping itself is best observed on the first scoped PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSn1nFTKDmH5HzuK97mepr
