### PR TITLE
feat(core): own chat bubble grouping so web and mobile share it

### DIFF
--- a/apps/core/src/chat/bubble-grouping.test.ts
+++ b/apps/core/src/chat/bubble-grouping.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+import type { ChatMessage } from "./chat-stream-model"
+import { BUBBLE_GROUP_TIME_GAP_MS, chatMessageSide, startsNewBubbleGroup } from "./bubble-grouping"
+
+function user(ts?: string): ChatMessage {
+  return { type: "user", text: "hi", ts }
+}
+
+function agent(ts?: string): ChatMessage {
+  return { type: "chat", text: "hello", ts }
+}
+
+describe("chatMessageSide", () => {
+  it("maps user to the user side and chat to the agent side", () => {
+    expect(chatMessageSide(user())).toBe("user")
+    expect(chatMessageSide(agent())).toBe("agent")
+  })
+
+  it("gives sideless rows no side", () => {
+    expect(chatMessageSide({ type: "error", text: "boom" })).toBeNull()
+    expect(
+      chatMessageSide({ type: "rate_limited", text: "slow down", window: null, resets_at: null }),
+    ).toBeNull()
+  })
+})
+
+describe("startsNewBubbleGroup", () => {
+  const base = "2026-07-15T10:00:00Z"
+  const plus = (ms: number) => new Date(new Date(base).getTime() + ms).toISOString()
+
+  it("keeps same-sender messages within the threshold tight", () => {
+    expect(startsNewBubbleGroup(agent(base), agent(plus(BUBBLE_GROUP_TIME_GAP_MS - 1)))).toBe(false)
+  })
+
+  it("starts a new group at exactly the threshold", () => {
+    expect(startsNewBubbleGroup(agent(base), agent(plus(BUBBLE_GROUP_TIME_GAP_MS)))).toBe(true)
+  })
+
+  it("starts a new group past the threshold", () => {
+    expect(startsNewBubbleGroup(agent(base), agent(plus(BUBBLE_GROUP_TIME_GAP_MS + 1)))).toBe(true)
+  })
+
+  it("starts a new group on a sender change regardless of timing", () => {
+    expect(startsNewBubbleGroup(user(base), agent(base))).toBe(true)
+  })
+
+  it("never starts a group with no previous side-carrying message", () => {
+    expect(startsNewBubbleGroup(null, agent(base))).toBe(false)
+  })
+
+  it("falls back to tight when a timestamp is absent", () => {
+    expect(startsNewBubbleGroup(user(), user())).toBe(false)
+    expect(startsNewBubbleGroup(user(base), user())).toBe(false)
+  })
+
+  it("falls back to tight when a timestamp is unparseable", () => {
+    expect(startsNewBubbleGroup(user(base), user("not-a-date"))).toBe(false)
+    expect(startsNewBubbleGroup(user("not-a-date"), user(base))).toBe(false)
+  })
+
+  it("never starts a group off a sideless row", () => {
+    expect(startsNewBubbleGroup({ type: "error", text: "boom" }, agent(base))).toBe(false)
+  })
+})

--- a/apps/core/src/chat/bubble-grouping.ts
+++ b/apps/core/src/chat/bubble-grouping.ts
@@ -1,0 +1,37 @@
+import type { ChatMessage } from "./chat-stream-model"
+
+// Two same-sender messages closer together than this render as one tight bubble group; a longer
+// same-sender pause (or a sender change) starts a fresh group. Owned here so web and mobile share
+// one grouping decision and cannot drift.
+export const BUBBLE_GROUP_TIME_GAP_MS = 5 * 60 * 1000
+
+export type ChatMessageSide = "user" | "agent"
+
+// The conversational side a chat row belongs to. Only user/chat rows carry a side; error and
+// rate_limited rows have none, so they never open or close a bubble group.
+export function chatMessageSide(message: ChatMessage): ChatMessageSide | null {
+  if (message.type === "user") return "user"
+  if (message.type === "chat") return "agent"
+  return null
+}
+
+function timestampMillis(ts: string | undefined): number | null {
+  if (!ts) return null
+  const value = new Date(ts).getTime()
+  return Number.isNaN(value) ? null : value
+}
+
+// Does `curr` begin a new visual bubble group after the previous rendered side-carrying message
+// `prev`? A sender change or a >= BUBBLE_GROUP_TIME_GAP_MS same-sender gap starts a new group;
+// same-sender rows within the threshold group tight. An absent or unparseable timestamp falls back
+// to tight (never throws), and a sideless prev/curr (error, rate_limited) never starts a group.
+export function startsNewBubbleGroup(prev: ChatMessage | null, curr: ChatMessage): boolean {
+  const currSide = chatMessageSide(curr)
+  const prevSide = prev ? chatMessageSide(prev) : null
+  if (!currSide || !prevSide) return false
+  if (currSide !== prevSide) return true
+  const prevTs = prev ? timestampMillis(prev.ts) : null
+  const currTs = timestampMillis(curr.ts)
+  if (prevTs === null || currTs === null) return false
+  return currTs - prevTs >= BUBBLE_GROUP_TIME_GAP_MS
+}

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -52,6 +52,13 @@ export {
 } from "./chat/chat-stream-model"
 export type { ChatMessage, ChatState, HistoryPage, SendState } from "./chat/chat-stream-model"
 
+export {
+  BUBBLE_GROUP_TIME_GAP_MS,
+  chatMessageSide,
+  startsNewBubbleGroup,
+} from "./chat/bubble-grouping"
+export type { ChatMessageSide } from "./chat/bubble-grouping"
+
 export { createChatSocket } from "./chat/chat-socket"
 export type {
   ChatSocket,

--- a/apps/mobile/src/agent/chat-list-model.ts
+++ b/apps/mobile/src/agent/chat-list-model.ts
@@ -1,4 +1,9 @@
-import type { ChatMessage } from "@vesta/core";
+import {
+  chatMessageSide,
+  startsNewBubbleGroup,
+  type ChatMessage,
+  type ChatMessageSide,
+} from "@vesta/core";
 
 export interface EventChatRow {
   kind: "event";
@@ -21,14 +26,6 @@ export interface DateChatRow {
 }
 
 export type ChatRow = EventChatRow | TypingChatRow | DateChatRow;
-type ChatSide = "user" | "agent";
-const BUBBLE_GROUP_TIME_GAP_MS = 5 * 60 * 1000;
-
-function eventChatSide(event: ChatMessage): ChatSide | null {
-  if (event.type === "user") return "user";
-  if (event.type === "chat") return "agent";
-  return null;
-}
 
 function calendarDay(timestamp: string | undefined): string | null {
   if (!timestamp) return null;
@@ -41,12 +38,6 @@ function calendarDay(timestamp: string | undefined): string | null {
   ].join("-");
 }
 
-function timestampMillis(timestamp: string | undefined): number | null {
-  if (!timestamp) return null;
-  const value = new Date(timestamp).getTime();
-  return Number.isNaN(value) ? null : value;
-}
-
 function eventRows(events: ChatMessage[]): EventChatRow[] {
   const visible = events.filter(
     (event) =>
@@ -56,33 +47,18 @@ function eventRows(events: ChatMessage[]): EventChatRow[] {
       event.type === "rate_limited",
   );
   const seen = new Map<string, number>();
-  let previousSide: ChatSide | null = null;
-  let previousTimestamp: number | null = null;
+  let previousSided: ChatMessage | null = null;
   const rows = visible.map((event) => {
     const base = `${event.ts ?? "live"}-${event.type}`;
     const count = seen.get(base) ?? 0;
     seen.set(base, count + 1);
-    const side = eventChatSide(event);
-    const timestamp = timestampMillis(event.ts);
-    const exceedsTimeGap = Boolean(
-      side &&
-      side === previousSide &&
-      timestamp !== null &&
-      previousTimestamp !== null &&
-      timestamp - previousTimestamp >= BUBBLE_GROUP_TIME_GAP_MS,
-    );
-    const startsNewBubbleGroup = Boolean(
-      side && previousSide && (side !== previousSide || exceedsTimeGap),
-    );
-    if (side) {
-      previousSide = side;
-      previousTimestamp = timestamp;
-    }
+    const startsNew = startsNewBubbleGroup(previousSided, event);
+    if (chatMessageSide(event)) previousSided = event;
     return {
       kind: "event" as const,
       key: count === 0 ? base : `${base}#${count}`,
       event,
-      startsNewBubbleGroup,
+      startsNewBubbleGroup: startsNew,
       endsBubbleGroup: false,
     };
   });
@@ -138,11 +114,11 @@ export function createInvertedChatRows(
 ): ChatRow[] {
   const rows = addDateRows(eventRows(events));
   if (isTyping) {
-    let latestSide: ChatSide | null = null;
+    let latestSide: ChatMessageSide | null = null;
     for (let index = rows.length - 1; index >= 0; index -= 1) {
       const row = rows[index];
       if (!row || row.kind !== "event") continue;
-      const side = eventChatSide(row.event);
+      const side = chatMessageSide(row.event);
       if (side) {
         latestSide = side;
         if (row.event.type === "chat") row.endsBubbleGroup = false;

--- a/apps/web/src/components/Chat/ChatMessageArea/virtual.test.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/virtual.test.ts
@@ -41,4 +41,28 @@ describe("buildDecorated", () => {
     expect(new Set(keys).size).toBe(3);
     expect(keys[0]).toBe("2026-06-08T10:00:00Z-user");
   });
+
+  it("splits same-sender bubbles after a five-minute pause", () => {
+    const rows = buildDecorated([
+      userMsg("2026-06-08T10:00:00"),
+      userMsg("2026-06-08T10:05:00"),
+    ]);
+    expect(rows[1]?.gap).toBe("mt-5");
+  });
+
+  it("keeps same-sender bubbles tight within five minutes", () => {
+    const rows = buildDecorated([
+      userMsg("2026-06-08T10:00:00"),
+      userMsg("2026-06-08T10:04:00"),
+    ]);
+    expect(rows[1]?.gap).toBe("mt-1.5");
+  });
+
+  it("keeps same-sender bubbles tight when a timestamp is unparseable", () => {
+    const rows = buildDecorated([
+      userMsg("2026-06-08T10:00:00"),
+      userMsg("not-a-date"),
+    ]);
+    expect(rows[1]?.gap).toBe("mt-1.5");
+  });
 });

--- a/apps/web/src/components/Chat/ChatMessageArea/virtual.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/virtual.ts
@@ -1,3 +1,4 @@
+import { startsNewBubbleGroup } from "@vesta/core";
 import { calendarDayKey, formatChatDayStampLabel } from "@/lib/chat-day-stamp";
 import type { ChatMessage } from "@/lib/types";
 
@@ -22,7 +23,9 @@ function rowGap(
 ): string {
   if (showDayStamp) return "mt-2";
   if (index === 0) return "";
-  return prev?.type === msg.type ? "mt-1.5" : "mt-5";
+  if (prev?.type !== msg.type) return "mt-5";
+  // Same sender: tight, unless a >= 5-minute pause splits them into a fresh bubble group.
+  return startsNewBubbleGroup(prev, msg) ? "mt-5" : "mt-1.5";
 }
 
 export function buildDecorated(chatMessages: ChatMessage[]): DecoratedRow[] {


### PR DESCRIPTION
## What

Promotes chat bubble grouping into `@vesta/core` as one pure owner, replacing the drifted per-app copies. Web gains the 5-minute conversational-pause spacing it was missing; mobile keeps its behavior byte-identical.

## Why

The grouping decision (does a message start a new visual bubble group) was duplicated: mobile computed a `startsNewBubbleGroup` boolean with a 5-minute same-sender gap, web's `rowGap` had no time-gap logic at all. So the two apps drifted, and the pending fix for web (#1388) would have added a third isolated copy. Per the repo's promote-when-a-second-client-wants-it rule, the decision moves to core: `startsNewBubbleGroup(prev, curr)` + `chatMessageSide(msg)` + `BUBBLE_GROUP_TIME_GAP_MS`. Core stays presentation-agnostic (semantic boolean out); each app maps to its own styling (mobile a row flag, web `mt-5`/`mt-1.5`).

Supersedes #1388 (its web-only 5-minute gap is included here, shared instead of isolated).

## Verification

Core table test pins the boundary, sender change, absent/unparseable timestamps (tight fallback, never throws), and sideless rows. Web ports #1388's three cases. Mobile's test file is unchanged and green: a review pass walked the eventRows loop against master to prove byte-identical output, including the subtle case of sideless (error/rate_limited) rows between same-sender messages not resetting the grouping anchor. core 174, web tsc -b + 7, mobile check + 6 all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSn1nFTKDmH5HzuK97mepr