### PR TITLE
fix(skills): bubble lint rejects text after a full stop, exempts list markers

### DIFF
--- a/agent/skills/app-chat/SKILL.md
+++ b/agent/skills/app-chat/SKILL.md
@@ -43,6 +43,7 @@ app-chat history --limit 20
 ## Notes
 - Always reply to app messages using `app-chat send`, not through any other channel
 - `send` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass
+- A numbered or bulleted list is fine to send as one message (each item is one short thought); a line-leading marker like `1.` or `2)` is not a full stop, so a list does not need `--longform`
 - Send multiple short messages instead of one long one (like texting)
 - Lowercase, no bullets, keep messages tight, texting feel, not document feel
 - Messages render as markdown: use fenced ``` blocks for code/commands, `[label](url)` for links. Newlines work

--- a/agent/skills/app-chat/SKILL.md
+++ b/agent/skills/app-chat/SKILL.md
@@ -42,6 +42,7 @@ app-chat history --limit 20
 
 ## Notes
 - Always reply to app messages using `app-chat send`, not through any other channel
+- `send` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass
 - Send multiple short messages instead of one long one (like texting)
 - Lowercase, no bullets, keep messages tight, texting feel, not document feel
 - Messages render as markdown: use fenced ``` blocks for code/commands, `[label](url)` for links. Newlines work

--- a/agent/skills/app-chat/cli/src/app_chat_cli/bubblelint.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/bubblelint.py
@@ -15,59 +15,65 @@ import re
 
 # A bubble is "a few words to one line, rarely two" (personality SKILL.md).
 BUBBLE_MAX_CHARS = 220  # a genuinely long single bubble
-BUBBLE_MAX_SENTENCES = 1  # 2+ sentence-enders in one send = a paragraph, split it
 
 _URL_RE = re.compile(r"https?://\S+")  # urls
 _DECIMAL_RE = re.compile(r"\b\d+[.,]\d+\b")  # decimals: 8.6, 86,5
 _INITIALISM_RE = re.compile(r"\b(?:[A-Za-z]\.){2,}")  # initialisms: W.A.S.T.E., U.K.
+# Abbreviations, an allowlist, so an unlisted one reads as a full stop. Every entry is a word
+# that is always followed by more, never one that can end a thought: protecting "etc." or "min."
+# would blank the stop in "eggs, milk, etc. also bread" and let the wall through. Dotted forms
+# (e.g., a.m., U.K.) are absent because _INITIALISM_RE already covers them.
 _ABBR_RE = re.compile(
-    r"\b(?:mr|mrs|ms|dr|prof|st|vs|etc|e\.g|i\.e|a\.m|p\.m|u\.k|u\.s|approx|no|fig)\.",
+    r"\b(?:mr|mrs|ms|dr|prof|jr|sr|st|vs|approx|fig"
+    r"|jan|feb|mar|apr|jun|jul|aug|sept|sep|oct|nov|dec"
+    r"|inc|ltd|co|corp|ave|rd|blvd|vol|ch|pp)\.",
     re.IGNORECASE,
 )
+_ELLIPSIS_RE = re.compile(r"\.{3,}")  # ellipsis: a texting beat, not a full stop
 _ENDER_RE = re.compile(r"[.!?]+")
+
+_SPACE = " \t\r\n\v\f"
 
 
 def _strip_protected(text: str) -> str:
     """Blank out spans whose '.', '?' or '!' are not sentence boundaries."""
-    for rx in (_URL_RE, _DECIMAL_RE, _INITIALISM_RE, _ABBR_RE):
+    for rx in (_URL_RE, _DECIMAL_RE, _INITIALISM_RE, _ABBR_RE, _ELLIPSIS_RE):
         text = rx.sub(" ", text)
     return text
 
 
-def count_sentences(text: str) -> int:
-    """Count sentence-ending runs: terminal punctuation followed by whitespace
-    then an ASCII alphanumeric, or sitting at the end of the text."""
+def text_after_full_stop(text: str) -> bool:
+    """True when a '.', '!' or '?' has anything after it: the tell of a second
+    thought crammed into the same bubble.
+
+    A mark only reads as a full stop when whitespace follows it, so "main.py"
+    and "example.com" stay single thoughts.
+    """
     cleaned = _strip_protected(text).strip()
-    count = 0
     for match in _ENDER_RE.finditer(cleaned):
         rest = cleaned[match.end() :]
-        if rest == "":
-            count += 1
-            continue
-        trimmed = rest.lstrip(" \t\r\n\v\f")
-        if len(trimmed) == len(rest) or trimmed == "":
-            continue  # no whitespace gap, or nothing after it
-        first = trimmed[0]
-        if first.isascii() and first.isalnum():
-            count += 1
-    return count
+        trimmed = rest.lstrip(_SPACE)
+        if trimmed == "" or len(trimmed) == len(rest):
+            continue  # the mark ends the bubble, or no whitespace gap follows it
+        return True
+    return False
 
 
 def bubble_lint_reason(message: str) -> str:
     """Return a non-empty explanation when message is a wall (too many
-    characters, or too many sentences in one bubble), or "" if it passes."""
+    characters, or text carrying on past a full stop), or "" if it passes."""
     n_chars = len(message)
-    n_sent = count_sentences(message)
-    if n_chars <= BUBBLE_MAX_CHARS and n_sent <= BUBBLE_MAX_SENTENCES:
-        return ""
     why = []
     if n_chars > BUBBLE_MAX_CHARS:
         why.append(f"{n_chars} chars")
-    if n_sent > BUBBLE_MAX_SENTENCES:
-        why.append(f"{n_sent} sentences in one bubble")
+    if text_after_full_stop(message):
+        why.append("text after a full stop")
+    if not why:
+        return ""
     return (
-        "bubble lint: this send is a wall (" + ", ".join(why) + "). texting rule: short bubbles, one thought per send. split it into "
-        "several separate send calls, a beat between each, one idea each. if this "
-        "is genuine reference material (a brief, a code block, a list they asked "
-        "for), resend the same command with --longform to bypass."
+        "bubble lint: this send is a wall (" + ", ".join(why) + "). texting rule: short bubbles, one thought per send, and don't use "
+        "full stops at all. split it into several separate send calls, a beat between "
+        "each, one idea each. if this is genuine reference material (a brief, a code "
+        "block, a list they asked for), resend the same command with --longform to "
+        "bypass."
     )

--- a/agent/skills/app-chat/cli/src/app_chat_cli/bubblelint.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/bubblelint.py
@@ -30,6 +30,9 @@ _ABBR_RE = re.compile(
     re.IGNORECASE,
 )
 _ELLIPSIS_RE = re.compile(r"\.{3,}")  # ellipsis: a texting beat, not a full stop
+# A line-leading ordered-list marker ("1.", "2)") is not a full stop: each item is one
+# short thought. Only the marker is blanked, so a real wall inside an item still trips.
+_LIST_MARKER_RE = re.compile(r"^[ \t]*\d+[.)][ \t]", re.MULTILINE)
 _ENDER_RE = re.compile(r"[.!?]+")
 
 _SPACE = " \t\r\n\v\f"
@@ -37,7 +40,7 @@ _SPACE = " \t\r\n\v\f"
 
 def _strip_protected(text: str) -> str:
     """Blank out spans whose '.', '?' or '!' are not sentence boundaries."""
-    for rx in (_URL_RE, _DECIMAL_RE, _INITIALISM_RE, _ABBR_RE, _ELLIPSIS_RE):
+    for rx in (_LIST_MARKER_RE, _URL_RE, _DECIMAL_RE, _INITIALISM_RE, _ABBR_RE, _ELLIPSIS_RE):
         text = rx.sub(" ", text)
     return text
 

--- a/agent/skills/app-chat/cli/tests/test_bubblelint.py
+++ b/agent/skills/app-chat/cli/tests/test_bubblelint.py
@@ -1,30 +1,50 @@
 """Mirrors telegram/whatsapp cli/bubblelint_test.go for the app-chat Python port."""
 
-from app_chat_cli.bubblelint import bubble_lint_reason, count_sentences
+from app_chat_cli.bubblelint import bubble_lint_reason, text_after_full_stop
 
 
 def test_bubble_lint_passes():
-    # Short bubbles, one sentence, and protected spans (urls, decimals,
-    # initialisms, abbreviations) whose dots must not read as sentence breaks.
+    # Short bubbles that end at their one mark (or carry none at all), and the
+    # protected spans (urls, decimals, initialisms, abbreviations, ellipses)
+    # whose dots must not read as full stops.
     for msg in [
         "nope, nothing",
         "on it",
         "yep",
         "checked both folders, nothing from them either",
         "running late, see you at 8",
+        "done, anything else?",
+        "one thought.",
         "meet at 8.30 by the door",
         "the W.A.S.T.E. system is down",
         "see https://example.com/a.b.c for the details",
         "call Dr. Smith back today",
-        "done, anything else?",
+        "meet on Jan. 5",
+        "call Acme Inc. tomorrow",
+        "it's on Oxford Ave. somewhere",
+        "ask Jr. about it",
+        "see vol. 3 for that",
+        "wait... what",
+        "hmm... ok",
+        "it's in main.py",
+        "check example.com later",
     ]:
         assert bubble_lint_reason(msg) == "", msg
 
 
 def test_bubble_lint_blocks():
     for msg in [
+        "hey. ok",
         "done. anything else?",
         "i checked the first folder. then the second one. nothing in either.",
+        "hey! how are you?",
+        "nice! on it",
+        "wait... what. ok",
+        # An abbreviation that can end a thought would hide these walls, so none is protected.
+        "the answer is no. anyway i tried",
+        "eggs, milk, etc. also bread",
+        "one sec. i'll check",
+        "takes 20 min. i'll wait",
         (
             "so the thing about the deploy is that it kept timing out on the build step "
             "and i had to bump the worker memory and also tweak the cache config and re-run "
@@ -34,15 +54,18 @@ def test_bubble_lint_blocks():
         assert bubble_lint_reason(msg) != "", msg
 
 
-def test_count_sentences():
+def test_text_after_full_stop():
     for msg, want in [
-        ("one thought", 0),
-        ("one thought.", 1),
-        ("first. second.", 2),
-        ("first. second. third.", 3),
-        ("meet at 8.30 sharp", 0),
-        ("the U.K. office opens at 9", 0),
-        ("check https://a.com/x.y now", 0),
-        ("e.g. this should not count", 0),
+        ("one thought", False),
+        ("one thought.", False),
+        ("hey. ok", True),
+        ("first. second.", True),
+        ("first. second. third.", True),
+        ("meet at 8.30 sharp", False),
+        ("the U.K. office opens at 9", False),
+        ("check https://a.com/x.y now", False),
+        ("e.g. this should not count", False),
+        ("wait... what", False),
+        ("wait...", False),
     ]:
-        assert count_sentences(msg) == want, msg
+        assert text_after_full_stop(msg) is want, msg

--- a/agent/skills/app-chat/cli/tests/test_bubblelint.py
+++ b/agent/skills/app-chat/cli/tests/test_bubblelint.py
@@ -28,6 +28,12 @@ def test_bubble_lint_passes():
         "hmm... ok",
         "it's in main.py",
         "check example.com later",
+        # A multiline list is one send, each item a short thought: the line-leading
+        # marker ("1.", "2)") must not read as a full stop.
+        "1. eggs\n2. milk",
+        "1. eggs\n2) milk",
+        "here are steps:\n1. open\n2. run",
+        "- eggs\n- milk",
     ]:
         assert bubble_lint_reason(msg) == "", msg
 
@@ -45,6 +51,10 @@ def test_bubble_lint_blocks():
         "eggs, milk, etc. also bread",
         "one sec. i'll check",
         "takes 20 min. i'll wait",
+        # Only a line-leading marker is exempt: a single-line "1. x 2. y" has a mid-line
+        # "2." that still reads as a wall, and a real full stop inside an item still trips.
+        "1. Hello 2. Hi",
+        "1. one thought. and another",
         (
             "so the thing about the deploy is that it kept timing out on the build step "
             "and i had to bump the worker memory and also tweak the cache config and re-run "
@@ -67,5 +77,10 @@ def test_text_after_full_stop():
         ("e.g. this should not count", False),
         ("wait... what", False),
         ("wait...", False),
+        ("1. eggs\n2. milk", False),
+        ("here are steps:\n1. open\n2. run", False),
+        ("1.", False),
+        ("1. one thought. and another", True),
+        ("1. Hello 2. Hi", True),
     ]:
         assert text_after_full_stop(msg) is want, msg

--- a/agent/skills/telegram/SKILL.md
+++ b/agent/skills/telegram/SKILL.md
@@ -63,7 +63,7 @@ Notification types written for the agent: `message`, `callback_query` (button ta
 reactions via `react` works). Aliases: `send`/`edit`/`del`/`voice`/`action`/`pin`/`unpin`.
 
 ## Notes
-- `send-message` enforces short-bubble texting: a wall (over ~220 chars, or 3+ sentences in one bubble) is rejected so you re-send as several short calls, one thought each. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. `--message-file` sends are linted too, so `--longform` is the only escape hatch.
+- `send-message` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. `--message-file` sends are linted too, so `--longform` is the only escape hatch.
 - Chat IDs are numeric (e.g., `123456789` for private, `-1001234567890` for groups)
 - Users must `/start` the bot before it can message them
 - Recipients can be resolved by: contact name, @username, or numeric chat ID

--- a/agent/skills/telegram/SKILL.md
+++ b/agent/skills/telegram/SKILL.md
@@ -64,6 +64,7 @@ reactions via `react` works). Aliases: `send`/`edit`/`del`/`voice`/`action`/`pin
 
 ## Notes
 - `send-message` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. `--message-file` sends are linted too, so `--longform` is the only escape hatch.
+- A numbered or bulleted list is fine to send as one message (each item is one short thought); a line-leading marker like `1.` or `2)` is not a full stop, so a list does not need `--longform`.
 - Chat IDs are numeric (e.g., `123456789` for private, `-1001234567890` for groups)
 - Users must `/start` the bot before it can message them
 - Recipients can be resolved by: contact name, @username, or numeric chat ID

--- a/agent/skills/telegram/cli/bubblelint.go
+++ b/agent/skills/telegram/cli/bubblelint.go
@@ -34,13 +34,16 @@ var (
 		`|jan|feb|mar|apr|jun|jul|aug|sept|sep|oct|nov|dec` +
 		`|inc|ltd|co|corp|ave|rd|blvd|vol|ch|pp)\.`)
 	bubbleEllipsisRe = regexp.MustCompile(`\.{3,}`) // ellipsis: a texting beat, not a full stop
-	bubbleEnderRe    = regexp.MustCompile(`[.!?]+`)
+	// A line-leading ordered-list marker ("1.", "2)") is not a full stop: each item is one
+	// short thought. Only the marker is blanked, so a real wall inside an item still trips.
+	bubbleListMarkerRe = regexp.MustCompile(`(?m)^[ \t]*\d+[.)][ \t]`)
+	bubbleEnderRe      = regexp.MustCompile(`[.!?]+`)
 )
 
 // stripProtected blanks out spans whose '.', '?' or '!' are not full stops, so
 // they cannot trip the lint.
 func stripProtected(text string) string {
-	for _, re := range []*regexp.Regexp{bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe, bubbleEllipsisRe} {
+	for _, re := range []*regexp.Regexp{bubbleListMarkerRe, bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe, bubbleEllipsisRe} {
 		text = re.ReplaceAllString(text, " ")
 	}
 	return text

--- a/agent/skills/telegram/cli/bubblelint.go
+++ b/agent/skills/telegram/cli/bubblelint.go
@@ -13,73 +13,74 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 )
 
 // A bubble is "a few words to one line, rarely two" (personality SKILL.md).
 const (
-	bubbleMaxChars     = 220 // a genuinely long single bubble
-	bubbleMaxSentences = 1   // 2+ sentence-enders in one send = a paragraph, split it
+	bubbleMaxChars = 220           // a genuinely long single bubble
+	bubbleSpace    = " \t\r\n\v\f" // the gap that makes a mark read as a full stop
 )
 
 var (
 	bubbleURLRe        = regexp.MustCompile(`https?://\S+`)         // urls
 	bubbleDecimalRe    = regexp.MustCompile(`\b\d+[.,]\d+\b`)       // decimals: 8.6, 86,5
 	bubbleInitialismRe = regexp.MustCompile(`\b(?:[A-Za-z]\.){2,}`) // initialisms: W.A.S.T.E., U.K.
-	bubbleAbbrRe       = regexp.MustCompile(`(?i)\b(?:mr|mrs|ms|dr|prof|st|vs|etc|e\.g|i\.e|a\.m|p\.m|u\.k|u\.s|approx|no|fig)\.`)
-	bubbleEnderRe      = regexp.MustCompile(`[.!?]+`)
+	// Abbreviations, an allowlist, so an unlisted one reads as a full stop. Every entry is a word
+	// that is always followed by more, never one that can end a thought: protecting "etc." or "min."
+	// would blank the stop in "eggs, milk, etc. also bread" and let the wall through. Dotted forms
+	// (e.g., a.m., U.K.) are absent because bubbleInitialismRe already covers them.
+	bubbleAbbrRe = regexp.MustCompile(`(?i)\b(?:mr|mrs|ms|dr|prof|jr|sr|st|vs|approx|fig` +
+		`|jan|feb|mar|apr|jun|jul|aug|sept|sep|oct|nov|dec` +
+		`|inc|ltd|co|corp|ave|rd|blvd|vol|ch|pp)\.`)
+	bubbleEllipsisRe = regexp.MustCompile(`\.{3,}`) // ellipsis: a texting beat, not a full stop
+	bubbleEnderRe    = regexp.MustCompile(`[.!?]+`)
 )
 
-// stripProtected blanks out spans whose '.', '?' or '!' are not sentence
-// boundaries, so they do not inflate the sentence count.
+// stripProtected blanks out spans whose '.', '?' or '!' are not full stops, so
+// they cannot trip the lint.
 func stripProtected(text string) string {
-	for _, re := range []*regexp.Regexp{bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe} {
+	for _, re := range []*regexp.Regexp{bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe, bubbleEllipsisRe} {
 		text = re.ReplaceAllString(text, " ")
 	}
 	return text
 }
 
-// countSentences counts sentence-ending runs: terminal punctuation followed by
-// whitespace and then an ASCII alphanumeric, or sitting at the end of the text.
-func countSentences(text string) int {
+// textAfterFullStop reports whether a '.', '!' or '?' has anything after it: the
+// tell of a second thought crammed into the same bubble. A mark only reads as a
+// full stop when whitespace follows it, so "main.py" and "example.com" stay
+// single thoughts.
+func textAfterFullStop(text string) bool {
 	cleaned := strings.TrimSpace(stripProtected(text))
-	count := 0
 	for _, loc := range bubbleEnderRe.FindAllStringIndex(cleaned, -1) {
 		rest := cleaned[loc[1]:]
-		if rest == "" {
-			count++
-			continue
+		trimmed := strings.TrimLeft(rest, bubbleSpace)
+		if trimmed == "" || len(trimmed) == len(rest) {
+			continue // the mark ends the bubble, or no whitespace gap follows it
 		}
-		trimmed := strings.TrimLeft(rest, " \t\r\n\v\f")
-		if len(trimmed) == len(rest) || trimmed == "" {
-			continue // no whitespace gap, or nothing after it
-		}
-		if r := rune(trimmed[0]); r < utf8.RuneSelf && (unicode.IsLetter(r) || unicode.IsDigit(r)) {
-			count++
-		}
+		return true
 	}
-	return count
+	return false
 }
 
 // bubbleLintReason returns a non-empty explanation when message is a wall (too
-// many characters, or too many sentences crammed into one bubble), or "" if it
-// passes. The caller turns a non-empty reason into an error that blocks the send.
+// many characters, or text carrying on past a full stop), or "" if it passes.
+// The caller turns a non-empty reason into an error that blocks the send.
 func bubbleLintReason(message string) string {
 	nChars := utf8.RuneCountInString(message)
-	nSent := countSentences(message)
-	if nChars <= bubbleMaxChars && nSent <= bubbleMaxSentences {
-		return ""
-	}
 	var why []string
 	if nChars > bubbleMaxChars {
 		why = append(why, fmt.Sprintf("%d chars", nChars))
 	}
-	if nSent > bubbleMaxSentences {
-		why = append(why, fmt.Sprintf("%d sentences in one bubble", nSent))
+	if textAfterFullStop(message) {
+		why = append(why, "text after a full stop")
+	}
+	if len(why) == 0 {
+		return ""
 	}
 	return "bubble lint: this send is a wall (" + strings.Join(why, ", ") + "). " +
-		"texting rule: short bubbles, one thought per send. split it into several separate send calls, " +
-		"a beat between each, one idea each. if this is genuine reference material (a brief, a code block, " +
-		"a list they asked for), resend the same command with --longform to bypass."
+		"texting rule: short bubbles, one thought per send, and don't use full stops at all. " +
+		"split it into several separate send calls, a beat between each, one idea each. if this " +
+		"is genuine reference material (a brief, a code block, a list they asked for), resend the " +
+		"same command with --longform to bypass."
 }

--- a/agent/skills/telegram/cli/bubblelint_test.go
+++ b/agent/skills/telegram/cli/bubblelint_test.go
@@ -28,6 +28,10 @@ func TestBubbleLintPasses(t *testing.T) {
 		"hmm... ok",                                     // ellipsis is a beat, not a full stop
 		"it's in main.py",                               // no whitespace gap, so not a full stop
 		"check example.com later",                       // no whitespace gap, so not a full stop
+		"1. eggs\n2. milk",                              // multiline numbered list: line-leading markers are not full stops
+		"1. eggs\n2) milk",                              // "2)" marker style is also exempt
+		"here are steps:\n1. open\n2. run",              // list under a lead-in line
+		"- eggs\n- milk",                                // bullets carry no dot, so they always passed
 	}
 	for _, msg := range cases {
 		if reason := bubbleLintReason(msg); reason != "" {
@@ -54,6 +58,10 @@ func TestBubbleLintBlocks(t *testing.T) {
 		{"etc. is not protected", "eggs, milk, etc. also bread"},
 		{"sec. is not protected", "one sec. i'll check"},
 		{"min. is not protected", "takes 20 min. i'll wait"},
+		// Only a line-leading marker is exempt: a single-line "1. x 2. y" has a mid-line
+		// "2." that still reads as a wall, and a real full stop inside an item still trips.
+		{"mid-line marker on one line is a wall", "1. Hello 2. Hi"},
+		{"real full stop inside a list item", "1. one thought. and another"},
 		{"long single sentence", "so the thing about the deploy is that it kept timing out on the build step and i had to bump the worker memory and also tweak the cache config and re-run it twice and then clear the layer cache before it finally went green for us this afternoon"},
 	}
 	for _, c := range cases {
@@ -81,6 +89,11 @@ func TestTextAfterFullStop(t *testing.T) {
 		{"e.g. this should not count", false},
 		{"wait... what", false},
 		{"wait...", false},
+		{"1. eggs\n2. milk", false},
+		{"here are steps:\n1. open\n2. run", false},
+		{"1.", false},
+		{"1. one thought. and another", true},
+		{"1. Hello 2. Hi", true},
 	}
 	for _, c := range cases {
 		if got := textAfterFullStop(c.msg); got != c.want {

--- a/agent/skills/telegram/cli/bubblelint_test.go
+++ b/agent/skills/telegram/cli/bubblelint_test.go
@@ -3,20 +3,31 @@ package main
 import "testing"
 
 // TestBubbleLintPasses pins the sends that must reach the recipient untouched:
-// short bubbles, one sentence, and the protected spans (urls, decimals,
-// initialisms, abbreviations) whose dots must not read as sentence breaks.
+// short bubbles that end at their one mark (or carry none at all), and the
+// protected spans (urls, decimals, initialisms, abbreviations, ellipses) whose
+// dots must not read as full stops.
 func TestBubbleLintPasses(t *testing.T) {
 	cases := []string{
 		"nope, nothing",
 		"on it",
 		"yep",
 		"checked both folders, nothing from them either",
-		"running late, see you at 8",                    // a decimal-free single thought
-		"meet at 8.30 by the door",                      // decimal must not split into two sentences
+		"running late, see you at 8",
+		"done, anything else?",                          // a trailing mark ends the bubble
+		"one thought.",                                  // a trailing full stop ends the bubble
+		"meet at 8.30 by the door",                      // decimal must not read as a full stop
 		"the W.A.S.T.E. system is down",                 // initialism protected
 		"see https://example.com/a.b.c for the details", // url protected
 		"call Dr. Smith back today",                     // abbreviation protected
-		"done, anything else?",                          // single sentence is allowed
+		"meet on Jan. 5",                                // month abbreviation protected
+		"call Acme Inc. tomorrow",                       // company abbreviation protected
+		"it's on Oxford Ave. somewhere",                 // street abbreviation protected
+		"ask Jr. about it",                              // name suffix protected
+		"see vol. 3 for that",                           // reference abbreviation protected
+		"wait... what",                                  // ellipsis is a beat, not a full stop
+		"hmm... ok",                                     // ellipsis is a beat, not a full stop
+		"it's in main.py",                               // no whitespace gap, so not a full stop
+		"check example.com later",                       // no whitespace gap, so not a full stop
 	}
 	for _, msg := range cases {
 		if reason := bubbleLintReason(msg); reason != "" {
@@ -26,14 +37,23 @@ func TestBubbleLintPasses(t *testing.T) {
 }
 
 // TestBubbleLintBlocks pins the walls that must be rejected so the agent re-sends
-// as several short bubbles.
+// as several short bubbles. Anything past a full stop is a second thought.
 func TestBubbleLintBlocks(t *testing.T) {
 	cases := []struct {
 		name string
 		msg  string
 	}{
+		{"text after a full stop", "hey. ok"},
 		{"two sentences in one bubble", "done. anything else?"},
 		{"three sentences in one bubble", "i checked the first folder. then the second one. nothing in either."},
+		{"text after a question mark", "hey! how are you?"},
+		{"text after an exclamation mark", "nice! on it"},
+		{"ellipsis does not license a later full stop", "wait... what. ok"},
+		// An abbreviation that can end a thought would hide these walls, so none is protected.
+		{"no. is not protected", "the answer is no. anyway i tried"},
+		{"etc. is not protected", "eggs, milk, etc. also bread"},
+		{"sec. is not protected", "one sec. i'll check"},
+		{"min. is not protected", "takes 20 min. i'll wait"},
 		{"long single sentence", "so the thing about the deploy is that it kept timing out on the build step and i had to bump the worker memory and also tweak the cache config and re-run it twice and then clear the layer cache before it finally went green for us this afternoon"},
 	}
 	for _, c := range cases {
@@ -43,25 +63,28 @@ func TestBubbleLintBlocks(t *testing.T) {
 	}
 }
 
-// TestCountSentences pins the sentence counter directly, including the protected
-// spans that must not inflate the count.
-func TestCountSentences(t *testing.T) {
+// TestTextAfterFullStop pins the detector directly, including the protected
+// spans that must not read as full stops.
+func TestTextAfterFullStop(t *testing.T) {
 	cases := []struct {
 		msg  string
-		want int
+		want bool
 	}{
-		{"one thought", 0},
-		{"one thought.", 1},
-		{"first. second.", 2},
-		{"first. second. third.", 3},
-		{"meet at 8.30 sharp", 0},
-		{"the U.K. office opens at 9", 0},
-		{"check https://a.com/x.y now", 0},
-		{"e.g. this should not count", 0},
+		{"one thought", false},
+		{"one thought.", false},
+		{"hey. ok", true},
+		{"first. second.", true},
+		{"first. second. third.", true},
+		{"meet at 8.30 sharp", false},
+		{"the U.K. office opens at 9", false},
+		{"check https://a.com/x.y now", false},
+		{"e.g. this should not count", false},
+		{"wait... what", false},
+		{"wait...", false},
 	}
 	for _, c := range cases {
-		if got := countSentences(c.msg); got != c.want {
-			t.Errorf("countSentences(%q) = %d, want %d", c.msg, got, c.want)
+		if got := textAfterFullStop(c.msg); got != c.want {
+			t.Errorf("textAfterFullStop(%q) = %v, want %v", c.msg, got, c.want)
 		}
 	}
 }

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -16,6 +16,7 @@ description: WhatsApp messages, contacts, groups, and live voice calls (place/an
 - Names for `--to` / `--chat-id` / `--group`: contact name, phone (`+E.164`), group name, or JID - the CLI resolves them.
 - For `send-message`, prefer `--message-file <path>` (or `--message-file -` / `--message -` to read from stdin) when the body contains apostrophes, quotes, backticks, `$(...)`, or multiple lines: an inline `--message 'text'` lets the shell mangle or even evaluate it.
 - `send-message` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. This applies to `--message-file` sends too, so `--longform` is the only escape hatch.
+- A numbered or bulleted list is fine to send as one message (each item is one short thought); a line-leading marker like `1.` or `2)` is not a full stop, so a list does not need `--longform`.
 
 ## Reply / Quote
 ```bash

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -15,7 +15,7 @@ description: WhatsApp messages, contacts, groups, and live voice calls (place/an
 - Flags for a specific subcommand: `whatsapp <subcommand> --help`. The top-level `whatsapp` with no args prints the command list.
 - Names for `--to` / `--chat-id` / `--group`: contact name, phone (`+E.164`), group name, or JID - the CLI resolves them.
 - For `send-message`, prefer `--message-file <path>` (or `--message-file -` / `--message -` to read from stdin) when the body contains apostrophes, quotes, backticks, `$(...)`, or multiple lines: an inline `--message 'text'` lets the shell mangle or even evaluate it.
-- `send-message` enforces short-bubble texting: a wall (over ~220 chars, or 3+ sentences in one bubble) is rejected so you re-send as several short calls, one thought each. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. This applies to `--message-file` sends too, so `--longform` is the only escape hatch.
+- `send-message` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. This applies to `--message-file` sends too, so `--longform` is the only escape hatch.
 
 ## Reply / Quote
 ```bash

--- a/agent/skills/whatsapp/cli/bubblelint.go
+++ b/agent/skills/whatsapp/cli/bubblelint.go
@@ -34,13 +34,16 @@ var (
 		`|jan|feb|mar|apr|jun|jul|aug|sept|sep|oct|nov|dec` +
 		`|inc|ltd|co|corp|ave|rd|blvd|vol|ch|pp)\.`)
 	bubbleEllipsisRe = regexp.MustCompile(`\.{3,}`) // ellipsis: a texting beat, not a full stop
-	bubbleEnderRe    = regexp.MustCompile(`[.!?]+`)
+	// A line-leading ordered-list marker ("1.", "2)") is not a full stop: each item is one
+	// short thought. Only the marker is blanked, so a real wall inside an item still trips.
+	bubbleListMarkerRe = regexp.MustCompile(`(?m)^[ \t]*\d+[.)][ \t]`)
+	bubbleEnderRe      = regexp.MustCompile(`[.!?]+`)
 )
 
 // stripProtected blanks out spans whose '.', '?' or '!' are not full stops, so
 // they cannot trip the lint.
 func stripProtected(text string) string {
-	for _, re := range []*regexp.Regexp{bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe, bubbleEllipsisRe} {
+	for _, re := range []*regexp.Regexp{bubbleListMarkerRe, bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe, bubbleEllipsisRe} {
 		text = re.ReplaceAllString(text, " ")
 	}
 	return text

--- a/agent/skills/whatsapp/cli/bubblelint.go
+++ b/agent/skills/whatsapp/cli/bubblelint.go
@@ -13,73 +13,74 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 )
 
 // A bubble is "a few words to one line, rarely two" (personality SKILL.md).
 const (
-	bubbleMaxChars     = 220 // a genuinely long single bubble
-	bubbleMaxSentences = 1   // 2+ sentence-enders in one send = a paragraph, split it
+	bubbleMaxChars = 220           // a genuinely long single bubble
+	bubbleSpace    = " \t\r\n\v\f" // the gap that makes a mark read as a full stop
 )
 
 var (
 	bubbleURLRe        = regexp.MustCompile(`https?://\S+`)         // urls
 	bubbleDecimalRe    = regexp.MustCompile(`\b\d+[.,]\d+\b`)       // decimals: 8.6, 86,5
 	bubbleInitialismRe = regexp.MustCompile(`\b(?:[A-Za-z]\.){2,}`) // initialisms: W.A.S.T.E., U.K.
-	bubbleAbbrRe       = regexp.MustCompile(`(?i)\b(?:mr|mrs|ms|dr|prof|st|vs|etc|e\.g|i\.e|a\.m|p\.m|u\.k|u\.s|approx|no|fig)\.`)
-	bubbleEnderRe      = regexp.MustCompile(`[.!?]+`)
+	// Abbreviations, an allowlist, so an unlisted one reads as a full stop. Every entry is a word
+	// that is always followed by more, never one that can end a thought: protecting "etc." or "min."
+	// would blank the stop in "eggs, milk, etc. also bread" and let the wall through. Dotted forms
+	// (e.g., a.m., U.K.) are absent because bubbleInitialismRe already covers them.
+	bubbleAbbrRe = regexp.MustCompile(`(?i)\b(?:mr|mrs|ms|dr|prof|jr|sr|st|vs|approx|fig` +
+		`|jan|feb|mar|apr|jun|jul|aug|sept|sep|oct|nov|dec` +
+		`|inc|ltd|co|corp|ave|rd|blvd|vol|ch|pp)\.`)
+	bubbleEllipsisRe = regexp.MustCompile(`\.{3,}`) // ellipsis: a texting beat, not a full stop
+	bubbleEnderRe    = regexp.MustCompile(`[.!?]+`)
 )
 
-// stripProtected blanks out spans whose '.', '?' or '!' are not sentence
-// boundaries, so they do not inflate the sentence count.
+// stripProtected blanks out spans whose '.', '?' or '!' are not full stops, so
+// they cannot trip the lint.
 func stripProtected(text string) string {
-	for _, re := range []*regexp.Regexp{bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe} {
+	for _, re := range []*regexp.Regexp{bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe, bubbleEllipsisRe} {
 		text = re.ReplaceAllString(text, " ")
 	}
 	return text
 }
 
-// countSentences counts sentence-ending runs: terminal punctuation followed by
-// whitespace and then an ASCII alphanumeric, or sitting at the end of the text.
-func countSentences(text string) int {
+// textAfterFullStop reports whether a '.', '!' or '?' has anything after it: the
+// tell of a second thought crammed into the same bubble. A mark only reads as a
+// full stop when whitespace follows it, so "main.py" and "example.com" stay
+// single thoughts.
+func textAfterFullStop(text string) bool {
 	cleaned := strings.TrimSpace(stripProtected(text))
-	count := 0
 	for _, loc := range bubbleEnderRe.FindAllStringIndex(cleaned, -1) {
 		rest := cleaned[loc[1]:]
-		if rest == "" {
-			count++
-			continue
+		trimmed := strings.TrimLeft(rest, bubbleSpace)
+		if trimmed == "" || len(trimmed) == len(rest) {
+			continue // the mark ends the bubble, or no whitespace gap follows it
 		}
-		trimmed := strings.TrimLeft(rest, " \t\r\n\v\f")
-		if len(trimmed) == len(rest) || trimmed == "" {
-			continue // no whitespace gap, or nothing after it
-		}
-		if r := rune(trimmed[0]); r < utf8.RuneSelf && (unicode.IsLetter(r) || unicode.IsDigit(r)) {
-			count++
-		}
+		return true
 	}
-	return count
+	return false
 }
 
 // bubbleLintReason returns a non-empty explanation when message is a wall (too
-// many characters, or too many sentences crammed into one bubble), or "" if it
-// passes. The caller turns a non-empty reason into an error that blocks the send.
+// many characters, or text carrying on past a full stop), or "" if it passes.
+// The caller turns a non-empty reason into an error that blocks the send.
 func bubbleLintReason(message string) string {
 	nChars := utf8.RuneCountInString(message)
-	nSent := countSentences(message)
-	if nChars <= bubbleMaxChars && nSent <= bubbleMaxSentences {
-		return ""
-	}
 	var why []string
 	if nChars > bubbleMaxChars {
 		why = append(why, fmt.Sprintf("%d chars", nChars))
 	}
-	if nSent > bubbleMaxSentences {
-		why = append(why, fmt.Sprintf("%d sentences in one bubble", nSent))
+	if textAfterFullStop(message) {
+		why = append(why, "text after a full stop")
+	}
+	if len(why) == 0 {
+		return ""
 	}
 	return "bubble lint: this send is a wall (" + strings.Join(why, ", ") + "). " +
-		"texting rule: short bubbles, one thought per send. split it into several separate send calls, " +
-		"a beat between each, one idea each. if this is genuine reference material (a brief, a code block, " +
-		"a list they asked for), resend the same command with --longform to bypass."
+		"texting rule: short bubbles, one thought per send, and don't use full stops at all. " +
+		"split it into several separate send calls, a beat between each, one idea each. if this " +
+		"is genuine reference material (a brief, a code block, a list they asked for), resend the " +
+		"same command with --longform to bypass."
 }

--- a/agent/skills/whatsapp/cli/bubblelint_test.go
+++ b/agent/skills/whatsapp/cli/bubblelint_test.go
@@ -28,6 +28,10 @@ func TestBubbleLintPasses(t *testing.T) {
 		"hmm... ok",                                     // ellipsis is a beat, not a full stop
 		"it's in main.py",                               // no whitespace gap, so not a full stop
 		"check example.com later",                       // no whitespace gap, so not a full stop
+		"1. eggs\n2. milk",                              // multiline numbered list: line-leading markers are not full stops
+		"1. eggs\n2) milk",                              // "2)" marker style is also exempt
+		"here are steps:\n1. open\n2. run",              // list under a lead-in line
+		"- eggs\n- milk",                                // bullets carry no dot, so they always passed
 	}
 	for _, msg := range cases {
 		if reason := bubbleLintReason(msg); reason != "" {
@@ -54,6 +58,10 @@ func TestBubbleLintBlocks(t *testing.T) {
 		{"etc. is not protected", "eggs, milk, etc. also bread"},
 		{"sec. is not protected", "one sec. i'll check"},
 		{"min. is not protected", "takes 20 min. i'll wait"},
+		// Only a line-leading marker is exempt: a single-line "1. x 2. y" has a mid-line
+		// "2." that still reads as a wall, and a real full stop inside an item still trips.
+		{"mid-line marker on one line is a wall", "1. Hello 2. Hi"},
+		{"real full stop inside a list item", "1. one thought. and another"},
 		{"long single sentence", "so the thing about the deploy is that it kept timing out on the build step and i had to bump the worker memory and also tweak the cache config and re-run it twice and then clear the layer cache before it finally went green for us this afternoon"},
 	}
 	for _, c := range cases {
@@ -81,6 +89,11 @@ func TestTextAfterFullStop(t *testing.T) {
 		{"e.g. this should not count", false},
 		{"wait... what", false},
 		{"wait...", false},
+		{"1. eggs\n2. milk", false},
+		{"here are steps:\n1. open\n2. run", false},
+		{"1.", false},
+		{"1. one thought. and another", true},
+		{"1. Hello 2. Hi", true},
 	}
 	for _, c := range cases {
 		if got := textAfterFullStop(c.msg); got != c.want {

--- a/agent/skills/whatsapp/cli/bubblelint_test.go
+++ b/agent/skills/whatsapp/cli/bubblelint_test.go
@@ -3,20 +3,31 @@ package main
 import "testing"
 
 // TestBubbleLintPasses pins the sends that must reach the recipient untouched:
-// short bubbles, one sentence, and the protected spans (urls, decimals,
-// initialisms, abbreviations) whose dots must not read as sentence breaks.
+// short bubbles that end at their one mark (or carry none at all), and the
+// protected spans (urls, decimals, initialisms, abbreviations, ellipses) whose
+// dots must not read as full stops.
 func TestBubbleLintPasses(t *testing.T) {
 	cases := []string{
 		"nope, nothing",
 		"on it",
 		"yep",
 		"checked both folders, nothing from them either",
-		"running late, see you at 8",                    // a decimal-free single thought
-		"meet at 8.30 by the door",                      // decimal must not split into two sentences
+		"running late, see you at 8",
+		"done, anything else?",                          // a trailing mark ends the bubble
+		"one thought.",                                  // a trailing full stop ends the bubble
+		"meet at 8.30 by the door",                      // decimal must not read as a full stop
 		"the W.A.S.T.E. system is down",                 // initialism protected
 		"see https://example.com/a.b.c for the details", // url protected
 		"call Dr. Smith back today",                     // abbreviation protected
-		"done, anything else?",                          // single sentence is allowed
+		"meet on Jan. 5",                                // month abbreviation protected
+		"call Acme Inc. tomorrow",                       // company abbreviation protected
+		"it's on Oxford Ave. somewhere",                 // street abbreviation protected
+		"ask Jr. about it",                              // name suffix protected
+		"see vol. 3 for that",                           // reference abbreviation protected
+		"wait... what",                                  // ellipsis is a beat, not a full stop
+		"hmm... ok",                                     // ellipsis is a beat, not a full stop
+		"it's in main.py",                               // no whitespace gap, so not a full stop
+		"check example.com later",                       // no whitespace gap, so not a full stop
 	}
 	for _, msg := range cases {
 		if reason := bubbleLintReason(msg); reason != "" {
@@ -26,14 +37,23 @@ func TestBubbleLintPasses(t *testing.T) {
 }
 
 // TestBubbleLintBlocks pins the walls that must be rejected so the agent re-sends
-// as several short bubbles.
+// as several short bubbles. Anything past a full stop is a second thought.
 func TestBubbleLintBlocks(t *testing.T) {
 	cases := []struct {
 		name string
 		msg  string
 	}{
+		{"text after a full stop", "hey. ok"},
 		{"two sentences in one bubble", "done. anything else?"},
 		{"three sentences in one bubble", "i checked the first folder. then the second one. nothing in either."},
+		{"text after a question mark", "hey! how are you?"},
+		{"text after an exclamation mark", "nice! on it"},
+		{"ellipsis does not license a later full stop", "wait... what. ok"},
+		// An abbreviation that can end a thought would hide these walls, so none is protected.
+		{"no. is not protected", "the answer is no. anyway i tried"},
+		{"etc. is not protected", "eggs, milk, etc. also bread"},
+		{"sec. is not protected", "one sec. i'll check"},
+		{"min. is not protected", "takes 20 min. i'll wait"},
 		{"long single sentence", "so the thing about the deploy is that it kept timing out on the build step and i had to bump the worker memory and also tweak the cache config and re-run it twice and then clear the layer cache before it finally went green for us this afternoon"},
 	}
 	for _, c := range cases {
@@ -43,25 +63,28 @@ func TestBubbleLintBlocks(t *testing.T) {
 	}
 }
 
-// TestCountSentences pins the sentence counter directly, including the protected
-// spans that must not inflate the count.
-func TestCountSentences(t *testing.T) {
+// TestTextAfterFullStop pins the detector directly, including the protected
+// spans that must not read as full stops.
+func TestTextAfterFullStop(t *testing.T) {
 	cases := []struct {
 		msg  string
-		want int
+		want bool
 	}{
-		{"one thought", 0},
-		{"one thought.", 1},
-		{"first. second.", 2},
-		{"first. second. third.", 3},
-		{"meet at 8.30 sharp", 0},
-		{"the U.K. office opens at 9", 0},
-		{"check https://a.com/x.y now", 0},
-		{"e.g. this should not count", 0},
+		{"one thought", false},
+		{"one thought.", false},
+		{"hey. ok", true},
+		{"first. second.", true},
+		{"first. second. third.", true},
+		{"meet at 8.30 sharp", false},
+		{"the U.K. office opens at 9", false},
+		{"check https://a.com/x.y now", false},
+		{"e.g. this should not count", false},
+		{"wait... what", false},
+		{"wait...", false},
 	}
 	for _, c := range cases {
-		if got := countSentences(c.msg); got != c.want {
-			t.Errorf("countSentences(%q) = %d, want %d", c.msg, got, c.want)
+		if got := textAfterFullStop(c.msg); got != c.want {
+			t.Errorf("textAfterFullStop(%q) = %v, want %v", c.msg, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## What

Two fixes to the chat bubble lint (`app-chat`, `telegram`, `whatsapp`, all three CLIs in lockstep), closing a hole and a silent list-drop.

## 1. Reject any text after a full stop (supersedes #1353)

The lint counted sentence-enders and capped at one, which punished the *closing* full stop rather than a mid-bubble one, so `hey. ok` scored 1 and **passed** while `hey. ok.` was blocked. Two thoughts in one bubble sailed through whenever the second ended bare, exactly how the agent texts. The rule is now "a `.`/`!`/`?` may only close a bubble, never carry text after it": a mark reads as a stop only when whitespace follows, so `main.py`, `example.com`, `8.30` and URLs pass for free; ellipsis is an exempt beat; a small abbreviation allowlist (`Dr.`, `Jan.`, `a.m.`, ...) is permitted but deliberately excludes thought-enders like `etc.`/`no.`. 220-char cap unchanged. This is the safe-allowlist option from #1353, rebased onto app-chat's post-epic path (`agent/skills/app-chat/`); #1353 could not merge because app-chat moved out of core.

## 2. Exempt list markers (fixes a silent numbered-list drop)

A numbered list read as multiple full stops: `1. eggs` counts `1.` as a sentence-ending period, so the whole send was rejected and the list never reached the user, while the agent got only an error it often did not surface. Now a **line-leading** list marker (`^[ \t]*\d+[.)][ \t]`, multiline) is blanked before the full-stop check, so a real multiline numbered list passes and needs no `--longform`. Only the marker token is blanked, so a genuine mid-item stop (`1. one thought. and another`) still blocks, decimals (`1.5`) are untouched, and a single-line `1. Hello 2. Hi` still blocks (its mid-line `2.` is wall-ish). Each SKILL.md now tells the agent lists are fine to send.

## Verification

app-chat Python suite (53) and `./check.sh guards` green locally. The telegram/whatsapp Go suites were verified for parity by inspection (the two Go files are byte-identical to each other and regex-equivalent to Python token-for-token); they run for real in CI (`./check.sh whatsapp`; telegram's CLI is unit-tested via its own suite). A review pass built the cross-CLI behavior table and confirmed all three agree on every case.

Refs #1370 stays for any remaining texting-voice tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSn1nFTKDmH5HzuK97mepr