### PR TITLE
Make vestad logs quieter and easier to scan

### DIFF
--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -2402,7 +2402,8 @@ fn needs_rebuild(
                 && actual.iter().zip(expected_cmd.iter()).all(|(a, e)| a == e)
         });
     if !cmd_ok {
-        tracing::info!(container = %cname, actual = ?cmd, expected = ?expected_cmd, "rebuild needed: command mismatch");
+        tracing::info!(container = %cname, "rebuild needed: command mismatch");
+        tracing::debug!(container = %cname, actual = ?cmd, expected = ?expected_cmd, "command mismatch details");
         return true;
     }
 

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -725,7 +725,7 @@ fn main() {
         }
 
         Command::Logs { n, no_follow } => {
-            systemd::exec_journal(n, !no_follow);
+            systemd::stream_journal(n, !no_follow).unwrap_or_else(|e| die(e));
         }
 
         Command::Stop => {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2522,15 +2522,9 @@ pub fn build_router(state: SharedState) -> Router {
                 .make_span_with(|request: &axum::http::Request<_>| {
                     tracing::info_span!("request", method = %request.method(), path = %request.uri().path())
                 })
-                .on_request(
-                    |request: &axum::http::Request<_>, _span: &tracing::Span| {
-                        let is_noisy = request.method() == axum::http::Method::OPTIONS
-                            || request.uri().path().ends_with("/logs");
-                        if !is_noisy {
-                            tracing::info!("request");
-                        }
-                    },
-                )
+                // Successful request starts are high-volume access-log noise. Handler
+                // events still carry this span's method/path, and failures remain ERROR.
+                .on_request(tower_http::trace::DefaultOnRequest::new().level(tracing::Level::DEBUG))
                 .on_response(tower_http::trace::DefaultOnResponse::new().level(tracing::Level::DEBUG))
                 .on_failure(tower_http::trace::DefaultOnFailure::new().level(tracing::Level::DEBUG)),
         )

--- a/vestad/src/systemd.rs
+++ b/vestad/src/systemd.rs
@@ -1,3 +1,4 @@
+use std::io::{BufRead, IsTerminal, Write};
 use std::process::{self, Command};
 
 const SERVICE_NAME: &str = "vestad";
@@ -140,13 +141,17 @@ fn journal_args(lines: usize, follow: bool) -> Vec<String> {
         "--user".into(),
         "-u".into(),
         SERVICE_NAME.into(),
+        // `-u` also includes systemd's own start/stop and resource-accounting
+        // messages. Keep the stream focused on output from the daemon itself.
+        "SYSLOG_IDENTIFIER=vestad".into(),
         "-n".into(),
         lines.to_string(),
-        "--no-hostname".into(),
-        // short-iso (not `cat`) so each line carries a timestamp — essential when
-        // debugging "when did this happen".
+        "--no-pager".into(),
+        "--quiet".into(),
+        // tracing already puts an RFC 3339 timestamp on each event. `cat` avoids
+        // wrapping it in a second journald timestamp, hostname, and process id.
         "-o".into(),
-        "short-iso".into(),
+        "cat".into(),
     ];
     if follow {
         args.push("-f".into());
@@ -154,14 +159,110 @@ fn journal_args(lines: usize, follow: bool) -> Vec<String> {
     args
 }
 
-pub fn exec_journal(lines: usize, follow: bool) -> ! {
-    use std::os::unix::process::CommandExt;
-
-    let err = Command::new("journalctl")
+pub fn stream_journal(lines: usize, follow: bool) -> Result<(), String> {
+    let mut child = Command::new("journalctl")
         .args(journal_args(lines, follow))
-        .exec();
-    eprintln!("failed to exec journalctl: {err}");
-    process::exit(1);
+        .stdout(process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("failed to run journalctl: {e}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or("failed to read journalctl output")?;
+    let color = std::io::stdout().is_terminal()
+        && std::env::var_os("NO_COLOR").is_none()
+        && std::env::var_os("TERM").is_none_or(|term| term != "dumb");
+    let mut output = std::io::stdout().lock();
+
+    for line in std::io::BufReader::new(stdout).lines() {
+        let line = line.map_err(|e| format!("failed to read journalctl output: {e}"))?;
+        if writeln!(output, "{}", format_log_line(&line, color)).is_err() {
+            // A downstream command such as `head` closed the pipe. This is a
+            // successful end to the stream, not an error worth printing.
+            child.kill().ok();
+            return Ok(());
+        }
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| format!("failed to wait for journalctl: {e}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("journalctl exited with {status}"))
+    }
+}
+
+/// Remove ANSI already embedded by an older vestad, then give tracing's stable
+/// `<timestamp> <LEVEL> <message>` shape a compact, consistent terminal view.
+fn format_log_line(line: &str, color: bool) -> String {
+    let clean = strip_ansi(line);
+    let trimmed = clean.trim_start();
+    let Some(timestamp_end) = trimmed.find(char::is_whitespace) else {
+        return clean;
+    };
+    let timestamp = &trimmed[..timestamp_end];
+    let rest = trimmed[timestamp_end..].trim_start();
+    let level_end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+    let level = &rest[..level_end];
+    let message = rest[level_end..].trim_start();
+    let level_color = match level {
+        "TRACE" => "\x1b[2;37m",
+        "DEBUG" => "\x1b[36m",
+        "INFO" => "\x1b[32m",
+        "WARN" => "\x1b[33m",
+        "ERROR" => "\x1b[1;31m",
+        _ => return clean,
+    };
+    let timestamp = compact_timestamp(timestamp);
+
+    if color {
+        format!("\x1b[2m{timestamp}\x1b[0m {level_color}{level:>5}\x1b[0m {message}")
+    } else {
+        format!("{timestamp} {level:>5} {message}")
+    }
+}
+
+fn compact_timestamp(timestamp: &str) -> String {
+    // tracing's default timer is UTC RFC 3339. Keep second precision: fractions
+    // make a live operational stream harder to scan without adding useful context.
+    if timestamp.len() >= 20
+        && timestamp.as_bytes().get(10) == Some(&b'T')
+        && timestamp
+            .as_bytes()
+            .get(19)
+            .is_some_and(|c| *c == b'.' || *c == b'Z')
+    {
+        return format!("{} {}Z", &timestamp[..10], &timestamp[11..19]);
+    }
+    timestamp.to_string()
+}
+
+fn strip_ansi(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut output = String::with_capacity(input.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == 0x1b && bytes.get(index + 1) == Some(&b'[') {
+            index += 2;
+            while index < bytes.len() {
+                let byte = bytes[index];
+                index += 1;
+                if (0x40..=0x7e).contains(&byte) {
+                    break;
+                }
+            }
+        } else {
+            let ch = input[index..]
+                .chars()
+                .next()
+                .expect("index remains on a UTF-8 boundary");
+            output.push(ch);
+            index += ch.len_utf8();
+        }
+    }
+    output
 }
 
 pub fn main_pid() -> Option<u32> {
@@ -213,7 +314,7 @@ fn run_systemctl(args: &[&str]) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{journal_args, SERVICE_NAME};
+    use super::{format_log_line, journal_args, strip_ansi, SERVICE_NAME};
 
     #[test]
     fn journal_args_scope_the_vestad_unit_and_forward_follow() {
@@ -226,6 +327,8 @@ mod tests {
             args.iter().any(|arg| arg == "-f"),
             "follow flag must be forwarded"
         );
+        assert!(args.iter().any(|arg| arg == "SYSLOG_IDENTIFIER=vestad"));
+        assert!(args.windows(2).any(|pair| pair == ["-o", "cat"]));
     }
 
     #[test]
@@ -234,6 +337,38 @@ mod tests {
         assert!(
             !args.iter().any(|arg| arg == "-f"),
             "no follow flag without follow"
+        );
+    }
+
+    #[test]
+    fn log_lines_drop_fractional_seconds_and_align_levels() {
+        let line = "2026-07-23T12:34:56.123456Z  INFO server ready port=443";
+        assert_eq!(
+            format_log_line(line, false),
+            "2026-07-23 12:34:56Z  INFO server ready port=443"
+        );
+    }
+
+    #[test]
+    fn log_lines_color_levels_only_when_requested() {
+        let line = "2026-07-23T12:34:56Z ERROR tunnel failed";
+        let colored = format_log_line(line, true);
+        assert!(colored.contains("\x1b[1;31mERROR\x1b[0m"));
+        assert_eq!(strip_ansi(&colored), format_log_line(line, false));
+    }
+
+    #[test]
+    fn old_ansi_and_non_tracing_lines_are_cleaned() {
+        assert_eq!(
+            format_log_line(
+                "\x1b[2m2026-07-23T12:34:56Z\x1b[0m \x1b[33m WARN\x1b[0m retrying",
+                false
+            ),
+            "2026-07-23 12:34:56Z  WARN retrying"
+        );
+        assert_eq!(
+            format_log_line("\x1b[1;35mvestad\x1b[0m started", false),
+            "vestad started"
         );
     }
 }

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -755,6 +755,11 @@ fn start_tunnel(
             "tunnel",
             "--protocol",
             "http2",
+            // The supervisor reports connectivity changes and recovery itself.
+            // cloudflared's info stream repeats per-connection lifecycle details
+            // and overwhelms `vestad logs`; retain only actionable diagnostics.
+            "--loglevel",
+            "warn",
             "--metrics",
             &metrics_addr,
             "--config",
@@ -770,10 +775,8 @@ fn start_tunnel(
         .spawn()
         .map_err(|e| format!("failed to start cloudflared: {e}"))?;
 
-    // cloudflared logs its connection lifecycle (registering/registered/lost connections)
-    // to stderr. Forward it into vestad's tracing so `vestad logs` shows tunnel state —
-    // otherwise a reconnecting tunnel looks like silence and a transient 502 has no trail.
-    // This also drains the piped stderr, which would otherwise fill and stall cloudflared.
+    // Forward cloudflared's remaining warnings/errors into vestad's tracing. This
+    // also drains the piped stderr, which would otherwise fill and stall it.
     if let Some(stderr) = child.stderr.take() {
         tokio::spawn(async move {
             use tokio::io::AsyncBufReadExt;
@@ -781,13 +784,52 @@ fn start_tunnel(
             while let Ok(Some(line)) = lines.next_line().await {
                 let line = line.trim();
                 if !line.is_empty() {
-                    tracing::info!(target: "tunnel", "{line}");
+                    let (message, is_error) = clean_cloudflared_log(line);
+                    if is_error {
+                        tracing::error!(target: "tunnel", "{message}");
+                    } else {
+                        tracing::warn!(target: "tunnel", "{message}");
+                    }
                 }
             }
         });
     }
 
     Ok((child, metrics_port))
+}
+
+/// cloudflared output varies between plain and JSON across builds. Keep the human
+/// message and error detail, and discard connector ids and other metadata when
+/// structured output is available.
+fn clean_cloudflared_log(line: &str) -> (String, bool) {
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(line) {
+        let level = value["level"].as_str().unwrap_or("warn");
+        let is_error = matches!(level, "error" | "fatal" | "panic");
+        let mut message = value["message"].as_str().unwrap_or(line).to_string();
+        if let Some(error) = value["error"].as_str() {
+            if !error.is_empty() && !message.contains(error) {
+                message.push_str(": ");
+                message.push_str(error);
+            }
+        }
+        return (message, is_error);
+    }
+
+    let first = line.split_whitespace().next().unwrap_or("");
+    let rest = line.strip_prefix(first).unwrap_or(line).trim_start();
+    let level = rest.split_whitespace().next().unwrap_or("");
+    let normalized_level = level.trim_matches(|c: char| !c.is_ascii_alphabetic());
+    let is_cloudflared_level = matches!(
+        normalized_level,
+        "INF" | "WRN" | "ERR" | "FTL" | "INFO" | "WARN" | "ERROR" | "FATAL"
+    );
+    let is_error = matches!(normalized_level, "ERR" | "FTL" | "ERROR" | "FATAL");
+    let message = if is_cloudflared_level {
+        rest.strip_prefix(level).unwrap_or(rest).trim_start()
+    } else {
+        line
+    };
+    (message.to_string(), is_error)
 }
 
 /// Bind-and-drop an ephemeral loopback port for cloudflared's metrics server.
@@ -1137,6 +1179,33 @@ mod tests {
         let a = animal_for_user("alice", 0);
         let b = animal_for_user("alice", 1);
         assert_ne!(a, b, "different offsets should give different animals");
+    }
+
+    #[test]
+    fn cloudflared_json_is_reduced_to_an_actionable_message() {
+        let line = r#"{"level":"error","connIndex":2,"message":"connection failed","error":"edge timeout"}"#;
+        assert_eq!(
+            clean_cloudflared_log(line),
+            ("connection failed: edge timeout".to_string(), true)
+        );
+    }
+
+    #[test]
+    fn cloudflared_plain_warnings_keep_their_text_and_severity() {
+        let line = "2026-07-23T12:34:56Z WRN reconnecting to edge";
+        assert_eq!(
+            clean_cloudflared_log(line),
+            ("reconnecting to edge".to_string(), false)
+        );
+    }
+
+    #[test]
+    fn cloudflared_plain_errors_are_cleaned_and_promoted() {
+        let line = "2026-07-23T12:34:56Z ERR failed to proxy error=\"context canceled\"";
+        assert_eq!(
+            clean_cloudflared_log(line),
+            ("failed to proxy error=\"context canceled\"".to_string(), true)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- show only vestad daemon messages, without duplicate journald metadata or systemd lifecycle noise
- add terminal-aware colors and compact, single timestamps; keep pipes and NO_COLOR plain
- suppress routine request-start access logs and move full container command diffs to debug
- limit cloudflared to warnings/errors and reduce structured connector output to actionable messages

## Testing

- ./check.sh vestad (254 passed, 15 Docker-only tests ignored)
- live smoke test: vestad logs -n 8 --no-follow against the local journal
