### PR TITLE
refactor: move container bootstrap into agent startup

### DIFF
--- a/agent/core/claude_runtime.py
+++ b/agent/core/claude_runtime.py
@@ -1,0 +1,87 @@
+"""Prepare Claude Code's user-scoped runtime files before the first SDK session."""
+
+import pathlib as pl
+import shutil
+import subprocess
+
+from . import config as cfg
+
+
+def _text_names(path: pl.Path) -> list[str]:
+    if not path.is_file():
+        return []
+    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+
+def _valid_skill_names(names: list[str]) -> list[str]:
+    valid: set[str] = set()
+    for name in names:
+        try:
+            valid.update(cfg.VestaConfig.model_validate({"active_skills": [name]}).active_skills)
+        except ValueError:
+            continue
+    return sorted(valid)
+
+
+def _bridge_legacy_sparse_skills(config: cfg.VestaConfig, legacy_active: pl.Path) -> None:
+    """Preserve a cone checkout's active skills on its first flat-checkout boot."""
+    # LEGACY(remove-when: the 2026-08-flat-checkout migration is fleet-applied): a cone box
+    # has only its active skills on disk, so capture that cone before creating config.json.
+    workspace_dir = config.agent_dir.parent
+    if (config.data_dir / "config.json").exists() or legacy_active.exists() or not (workspace_dir / ".git/info/sparse-checkout").is_file():
+        return
+
+    result = subprocess.run(
+        ["git", "sparse-checkout", "list"],
+        cwd=workspace_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    names = [line.removeprefix("agent/skills/") for line in result.stdout.splitlines() if line.startswith("agent/skills/")]
+    legacy_active.parent.mkdir(parents=True, exist_ok=True)
+    legacy_active.write_text("".join(f"{name}\n" for name in sorted(set(names))))
+
+
+def _replace_skill_links(link_dir: pl.Path, optional_dir: pl.Path, core_dir: pl.Path, active: list[str]) -> None:
+    if link_dir.is_symlink() or (link_dir.exists() and not link_dir.is_dir()):
+        link_dir.unlink()
+    elif link_dir.exists():
+        shutil.rmtree(link_dir)
+    link_dir.mkdir(parents=True)
+
+    def link_skill(skill_dir: pl.Path) -> None:
+        if not (skill_dir / "SKILL.md").is_file():
+            return
+        link = link_dir / skill_dir.name
+        link.unlink(missing_ok=True)
+        link.symlink_to(skill_dir, target_is_directory=True)
+
+    for name in active:
+        link_skill(optional_dir / name)
+    if core_dir.is_dir():
+        for skill_dir in sorted(core_dir.iterdir()):
+            if skill_dir.is_dir():
+                link_skill(skill_dir)
+
+
+def reconcile_claude_runtime(config: cfg.VestaConfig) -> None:
+    """Seed active skills, rebuild their symlinks, and ensure Claude has default settings."""
+    legacy_active = config.data_dir / "active-skills.txt"
+    _bridge_legacy_sparse_skills(config, legacy_active)
+
+    store = cfg.read_config_store()
+    configured = store.get("active_skills")
+    names = [name for name in configured if isinstance(name, str)] if isinstance(configured, list) else _text_names(legacy_active)
+    names.extend(_text_names(config.agent_dir / "core/default-skills.txt"))
+    active = _valid_skill_names(names)
+    cfg.update_config_store({"active_skills": active})
+    config.active_skills = active
+
+    claude_dir = pl.Path.home() / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    _replace_skill_links(claude_dir / "skills", config.agent_dir / "skills", config.agent_dir / "core/skills", active)
+
+    settings = claude_dir / "settings.json"
+    if not settings.exists():
+        settings.write_text('{"permissions":{"allow":[]}}\n')

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -599,8 +599,8 @@ def build_client_options(config: cfg.VestaConfig, state: vm.State) -> ClaudeAgen
         permission_mode="bypassPermissions",
         can_use_tool=_approve_all_tools,
         cwd=config.agent_dir,
-        # "user" enables discovery of ~/.claude/skills, where the entrypoint symlinks every
-        # installed skill (agent/skills/* + agent/core/skills/*); without it the Skill tool
+        # "user" enables discovery of ~/.claude/skills, where agent startup symlinks active
+        # optional skills plus every core skill; without it the Skill tool
         # never sees them. "project" stays for CLAUDE.md loading. skills="all" turns the
         # Skill tool on for every discovered skill (the single documented switch).
         setting_sources=["user", "project"],

--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -301,8 +301,8 @@ class VestaConfig(pyd_settings.BaseSettings):
     # When True, a reply containing an em dash, en dash, or ' - ' separator triggers a resend-without-them
     # correction turn (see client.process_message). Off lets the model use dashes freely.
     block_dashes: bool = True
-    # Optional skills linked into Claude Code at boot. The entrypoint unions shipped defaults from
-    # core/default-skills.txt into this list before core.main starts.
+    # Optional skills linked into Claude Code at boot. Agent startup unions shipped defaults from
+    # core/default-skills.txt into this list before the first SDK session starts.
     active_skills: list[str] = pyd.Field(default_factory=list)
 
     ephemeral: bool = False

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -14,6 +14,7 @@ from . import config as cfg
 from . import logger, state_store
 from . import models as vm
 from .api import start_ws_server
+from .claude_runtime import reconcile_claude_runtime
 from .diagnostics import format_crash_detail
 from .events import EventBus
 from .loops import (
@@ -225,11 +226,13 @@ async def async_main() -> bool:
     # a PUT /config timezone change applies on the next restart, never mid-request.
     os.environ["TZ"] = config.timezone
     time.tzset()
-    logger.init("Config:")
-    print_json(data=config.model_dump(mode="json"))
 
     for path in [config.agent_dir, config.notifications_dir, config.logs_dir, config.data_dir, config.dreamer_dir]:
         path.mkdir(parents=True, exist_ok=True)
+
+    reconcile_claude_runtime(config)
+    logger.init("Config:")
+    print_json(data=config.model_dump(mode="json"))
 
     # seed_context (one-shot setup notes) is delivered through the config store; materialize it to the
     # file the first-wake prompt reads. Only when absent, so a re-delivery never clobbers notes the

--- a/agent/tests/test_deployment.py
+++ b/agent/tests/test_deployment.py
@@ -57,7 +57,7 @@ def test_skill_frontmatter():
 def test_default_skills_are_real_and_include_runtime_deps():
     """Every default skill named in the version-pinned list (core/default-skills.txt) must have
     a matching directory under skills/, and the skills the core runtime points at (proactive-check,
-    personality) must ship by default. The boot entrypoint seeds/unions this list into active_skills,
+    personality) must ship by default. Agent startup seeds/unions this list into active_skills,
     so a missing entry means the runtime references a skill that can never activate."""
     skills_dir = Path(__file__).parent.parent / "skills"
     default_skills_path = Path(__file__).parent.parent / "core" / "default-skills.txt"

--- a/agent/tests/test_upstream_sync.py
+++ b/agent/tests/test_upstream_sync.py
@@ -3,9 +3,9 @@
 The box's ``~`` is a plain FULL git checkout of the agent-upstream snapshot (all skills +
 MEMORY.md; the engine ``agent/core`` is a read-only mount, gitignored, never in the tree).
 Which skills are ACTIVE is recorded in ``agent/data/config.json`` and materialized as the
-``~/.claude/skills`` symlink farm by the Docker entrypoint; every optional skill sits on disk
+``~/.claude/skills`` symlink farm by agent startup; every optional skill sits on disk
 regardless. These tests build an upstream repo with the REAL build-upstream.sh (the script
-vestad runs), then drive the REAL attach.sh / fetch-upstream.sh / sync.sh / entrypoint skill-link /
+vestad runs), then drive the REAL attach.sh / fetch-upstream.sh / sync.sh / agent startup /
 skills-activate / skills-deactivate scripts in a fake ``$HOME``, pinning the flat-checkout
 contract: clean attach, version-pinned rebase, offline activation, and the cone->flat
 migration spine.
@@ -14,7 +14,6 @@ migration spine.
 import json
 import os
 import pathlib as pl
-import re
 import shutil
 import subprocess
 import sys
@@ -75,18 +74,18 @@ def _run(script, home, args=(), extra_env=None):
     return subprocess.run(["bash", str(script), *args], cwd=str(home), env=_env(home, extra_env), capture_output=True, text=True, check=False)
 
 
-def _entrypoint_skill_link_script():
-    source = (REPO_ROOT / "vestad/src/docker.rs").read_text()
-    match = re.search(r"fn skill_link_entrypoint_step\(\) -> String \{\n    r#\"(.*?)\"#\n        \.into\(\)\n\}", source, re.DOTALL)
-    assert match, "skill_link_entrypoint_step raw string not found"
-    return match.group(1)
-
-
-def _run_skill_entrypoint(home, extra_env=None):
+def _run_agent_startup(home, extra_env=None):
+    env = _env(home, extra_env)
+    env["AGENT_DIR"] = str(home / "agent")
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [str(AGENT_ROOT), env.get("PYTHONPATH")]))
     return subprocess.run(
-        ["sh", "-c", _entrypoint_skill_link_script()],
+        [
+            sys.executable,
+            "-c",
+            "from core import config; from core.claude_runtime import reconcile_claude_runtime; reconcile_claude_runtime(config.VestaConfig())",
+        ],
         cwd=str(home),
-        env=_env(home, extra_env),
+        env=env,
         capture_output=True,
         text=True,
         check=False,
@@ -417,7 +416,7 @@ def test_deactivate_default_is_honest_and_keeps_it_active(tmp_path):
     home = _fresh_box(tmp_path)
     env = _box_env(source)
     assert _attach(home, source).returncode == 0
-    _run_skill_entrypoint(home, extra_env=env)  # seed active_skills with the defaults
+    _run_agent_startup(home, extra_env=env)  # seed active_skills with the defaults
     assert "tasks" in _active(home)
     r = _run(SKILLS_DEACTIVATE, home, args=("tasks",), extra_env=env)
     assert r.returncode == 0
@@ -439,7 +438,7 @@ def test_search_lists_local_catalog_and_marks_active(tmp_path):
     assert "[active]" in lines["whatsapp"]  # activation is marked from config
 
 
-# --- entrypoint skill linking: the one gate turning the active list into the symlink farm ---
+# --- agent startup: the one gate turning the active list into the symlink farm ---
 
 
 def _skill_link_box(tmp_path, defaults=DEFAULT_SKILLS, optional=("tasks", "dream", "whatsapp", "microsoft")):
@@ -457,53 +456,63 @@ def _skill_link_box(tmp_path, defaults=DEFAULT_SKILLS, optional=("tasks", "dream
     return home
 
 
-def test_entrypoint_seeds_defaults_and_always_links_core(tmp_path):
+def test_agent_startup_seeds_defaults_and_always_links_core(tmp_path):
     home = _skill_link_box(tmp_path)
-    assert _run_skill_entrypoint(home).returncode == 0
+    assert _run_agent_startup(home).returncode == 0
     assert _active(home) == sorted(DEFAULT_SKILLS)  # seeded from the shipped defaults
     # Defaults + every core skill are linked; an inactive optional (whatsapp) is not.
     assert set(_links(home)) == {*DEFAULT_SKILLS, "app-chat", "upstream-sync"}
     assert "whatsapp" not in _links(home)
+    assert json.loads((home / ".claude/settings.json").read_text()) == {"permissions": {"allow": []}}
 
 
-def test_entrypoint_unions_a_newly_shipped_default(tmp_path):
+def test_agent_startup_unions_a_newly_shipped_default(tmp_path):
     home = _skill_link_box(tmp_path)
-    assert _run_skill_entrypoint(home).returncode == 0
+    assert _run_agent_startup(home).returncode == 0
     (home / "agent/core/default-skills.txt").write_text("\n".join((*DEFAULT_SKILLS, "whatsapp")) + "\n")  # an upgrade's new default
-    assert _run_skill_entrypoint(home).returncode == 0
+    assert _run_agent_startup(home).returncode == 0
     assert "whatsapp" in _active(home) and "whatsapp" in _links(home)
 
 
-def test_entrypoint_reads_final_active_line_without_newline(tmp_path):
+def test_agent_startup_preserves_existing_claude_settings(tmp_path):
+    home = _skill_link_box(tmp_path)
+    settings = home / ".claude/settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text('{"theme":"dark"}\n')
+    assert _run_agent_startup(home).returncode == 0
+    assert json.loads(settings.read_text()) == {"theme": "dark"}
+
+
+def test_agent_startup_reads_final_active_line_without_newline(tmp_path):
     home = _skill_link_box(tmp_path)
     active = home / "agent/data/active-skills.txt"
     active.parent.mkdir(parents=True, exist_ok=True)
     active.write_text("whatsapp")
-    assert _run_skill_entrypoint(home).returncode == 0
+    assert _run_agent_startup(home).returncode == 0
     assert "whatsapp" in _links(home)
 
 
-def test_entrypoint_drops_a_deactivated_optional(tmp_path):
+def test_agent_startup_drops_a_deactivated_optional(tmp_path):
     home = _skill_link_box(tmp_path)
-    assert _run_skill_entrypoint(home).returncode == 0
+    assert _run_agent_startup(home).returncode == 0
     _write_active(home, [*DEFAULT_SKILLS, "microsoft"])  # activate a non-default
-    assert _run_skill_entrypoint(home).returncode == 0
+    assert _run_agent_startup(home).returncode == 0
     assert "microsoft" in _links(home)
     _write_active(home, DEFAULT_SKILLS)  # deactivate it again
-    assert _run_skill_entrypoint(home).returncode == 0
+    assert _run_agent_startup(home).returncode == 0
     assert "microsoft" not in _links(home)  # deactivated leaves no dangling link
     assert set(DEFAULT_SKILLS) <= set(_links(home))  # defaults still linked
 
 
-def test_entrypoint_bridges_the_cone_on_first_flat_boot(tmp_path):
-    """A cone box's first flat boot (before the migration converts it): the entrypoint seeds
+def test_agent_startup_bridges_the_cone_on_first_flat_boot(tmp_path):
+    """A cone box's first flat boot (before the migration converts it): agent startup seeds
     active_skills from the still-present cone so the user's active skills stay active,
     instead of collapsing to defaults-only."""
     source = _upstream_fixture(tmp_path)
     # whatsapp is NOT a default, so only the cone bridge (not default-seeding) can preserve it.
     home, env = _legacy_cone_box(tmp_path, source, active=("tasks", "whatsapp"))
     assert not (home / "agent/data/config.json").exists()
-    assert _run_skill_entrypoint(home, extra_env=env).returncode == 0
+    assert _run_agent_startup(home, extra_env=env).returncode == 0
     assert "whatsapp" in _active(home)  # captured from the cone, not from defaults
     assert "whatsapp" in _links(home)  # and linked (on disk in the cone)
 

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -112,117 +112,18 @@ pub(crate) const MOUNT_DESTS: &[&str] = &[
     UPSTREAM_MOUNT_DEST,
 ];
 
-fn skill_link_entrypoint_step() -> String {
-    r#"cd ~
-SKILLS_DIR="agent/skills"
-CORE_SKILLS_DIR="agent/core/skills"
-CONFIG="agent/data/config.json"
-LEGACY_ACTIVE="agent/data/active-skills.txt"
-DEFAULTS="agent/core/default-skills.txt"
-LINK_DIR="$HOME/.claude/skills"
-
-mkdir -p "$SKILLS_DIR" agent/data
-
-# LEGACY(remove-when: the 2026-08-flat-checkout migration is fleet-applied): a cone box on its
-# first flat boot has no active_skills config yet and only its coned skills on disk. Capture
-# that cone as legacy input before the config write below. A flat box has no sparse-checkout
-# file, so this never fires there.
-if [ ! -f "$CONFIG" ] && [ ! -f "$LEGACY_ACTIVE" ] && [ -f .git/info/sparse-checkout ]; then
-  git sparse-checkout list 2>/dev/null | sed -n 's#^agent/skills/##p' | sort -u > "$LEGACY_ACTIVE" || true
-fi
-
-python3 - "$CONFIG" "$LEGACY_ACTIVE" "$DEFAULTS" <<'PY'
-import json
-import pathlib
-import re
-import sys
-
-config_path = pathlib.Path(sys.argv[1])
-legacy_path = pathlib.Path(sys.argv[2])
-defaults_path = pathlib.Path(sys.argv[3])
-skill_name_re = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
-
-def text_names(path):
-    if not path.is_file():
-        return []
-    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
-
-try:
-    loaded = json.loads(config_path.read_text()) if config_path.is_file() else {}
-except json.JSONDecodeError:
-    loaded = {}
-data = loaded if isinstance(loaded, dict) else {}
-configured = data["active_skills"] if isinstance(data.get("active_skills"), list) else None
-active = [name for name in configured if isinstance(name, str)] if configured is not None else text_names(legacy_path)
-names = [*active, *text_names(defaults_path)]
-data["active_skills"] = sorted({name.strip() for name in names if skill_name_re.fullmatch(name.strip())})
-tmp = config_path.with_name(f"{config_path.name}.tmp")
-tmp.write_text(json.dumps(data, indent=2) + "\n")
-tmp.replace(config_path)
-PY
-
-# Rebuilt from scratch each boot so a deactivated skill leaves no dangling link.
-rm -rf "$LINK_DIR"
-mkdir -p "$LINK_DIR"
-
-link_skill() {
-  [ -f "$1/SKILL.md" ] || return 0
-  ln -sfn "$HOME/$1" "$LINK_DIR/$(basename "$1")"
-}
-
-# Active optional skills first, then core skills (linked last so they win any name
-# collision, as core is authoritative).
-python3 - "$CONFIG" <<'PY' | while IFS= read -r name || [ -n "$name" ]; do
-import json
-import pathlib
-import re
-import sys
-
-config_path = pathlib.Path(sys.argv[1])
-skill_name_re = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
-try:
-    data = json.loads(config_path.read_text())
-except (json.JSONDecodeError, OSError):
-    data = {}
-active = data["active_skills"] if isinstance(data, dict) and isinstance(data.get("active_skills"), list) else []
-for name in active:
-    if isinstance(name, str) and skill_name_re.fullmatch(name.strip()):
-        print(name.strip())
-PY
-  [ -n "$name" ] || continue
-  link_skill "$SKILLS_DIR/$name"
-done
-
-for d in "$CORE_SKILLS_DIR"/*/; do
-  [ -d "$d" ] && link_skill "${d%/}"
-done"#
-        .into()
-}
-
-pub(crate) fn agent_container_entrypoint_cmd() -> Vec<String> {
-    let steps: [String; 8] = [
+pub(crate) fn agent_container_cmd() -> Vec<String> {
+    let steps = [
+        "set -e",
         // The engine venv is reached via PATH, never an exported UV_PROJECT_ENVIRONMENT (nor `uv
         // run`, which exports it): exported, it retargets every uv project, so a skill's `uv run`
         // re-syncs and can delete the engine venv. The core sync gets it scoped, since uv would
         // otherwise default to core/.venv, inside the read-only mount.
-        "export PATH=\"/root/agent/.venv/bin:/root/.local/bin:/root/.claude/local/bin:$PATH\"".into(),
-        ". /run/vestad-env".into(),
-        ". ~/.bashrc || true".into(),
-        // tmux is a hard runtime dependency of cc_sdk (it drives the real claude TUI in a
-        // private tmux server). Fresh images bake it in via the Dockerfile, but `rebuild`
-        // recreates a container from a `docker export|import` snapshot and never re-runs the
-        // Dockerfile, so an agent snapshotted before tmux was added boots without it and
-        // crash-loops on FileNotFoundError deep in cc_sdk. Self-heal at boot: a no-op (no
-        // network) once tmux is on PATH, and the next snapshot captures the install so it
-        // persists across future rebuilds. `|| true` so a failed install never aborts boot.
-        "command -v tmux >/dev/null 2>&1 || (apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq tmux) || true".into(),
-        "UV_PROJECT_ENVIRONMENT=/root/agent/.venv uv sync --frozen --project /root/agent/core".into(),
-        // ~/.claude/skills is the symlink farm Claude Code discovers skills from, rebuilt
-        // every boot (before the SDK session starts) from config.active_skills:
-        // core skills always, optional skills only when active.
-        skill_link_entrypoint_step(),
-        "test -f ~/.claude/settings.json || printf '{\"permissions\":{\"allow\":[]}}\\n' > ~/.claude/settings.json".into(),
-        "cd /root/agent && exec .venv/bin/python -m core.main".into(),
+        "export PATH=\"/root/agent/.venv/bin:/root/.local/bin:/root/.claude/local/bin:$PATH\"",
+        ". /run/vestad-env",
+        ". ~/.bashrc || true",
+        "UV_PROJECT_ENVIRONMENT=/root/agent/.venv uv sync --frozen --project /root/agent/core",
+        "cd /root/agent && exec .venv/bin/python -m core.main",
     ];
     vec!["sh".into(), "-c".into(), steps.join("; \\\n")]
 }
@@ -1795,7 +1696,7 @@ pub async fn create_container(
         image: Some(image.to_string()),
         tty: Some(true),
         labels: Some(labels),
-        cmd: Some(agent_container_entrypoint_cmd()),
+        cmd: Some(agent_container_cmd()),
         working_dir: Some("/root".to_string()),
         host_config: Some(host_config),
         ..Default::default()
@@ -2395,7 +2296,7 @@ fn needs_rebuild(
     }
 
     let cmd = info.config.as_ref().and_then(|c| c.cmd.as_ref());
-    let expected_cmd = agent_container_entrypoint_cmd();
+    let expected_cmd = agent_container_cmd();
     let cmd_ok = cmd
         .is_some_and(|actual| {
             actual.len() == expected_cmd.len()
@@ -2470,7 +2371,7 @@ async fn resolve_existing_port(
     }
 }
 
-/// Recreate a container with the latest container config (entrypoint, mounts, env file)
+/// Recreate a container with the latest container config (command, mounts, env file)
 /// while preserving the filesystem. Snapshots the old container, removes it, and creates
 /// a new one from the snapshot. User mount topology is preserved from the existing
 /// container, not re-derived from settings, so the running container is the source of
@@ -2820,77 +2721,38 @@ mod tests {
     }
 
     #[test]
-    fn entrypoint_self_heals_missing_tmux() {
-        // cc_sdk hard-depends on tmux; the entrypoint must install it at boot when missing so
-        // containers rebuilt from a pre-tmux snapshot self-heal instead of crash-looping.
-        let cmd = agent_container_entrypoint_cmd();
-        let script = cmd.last().expect("entrypoint script");
-        assert!(
-            script.contains("command -v tmux"),
-            "entrypoint must guard on tmux presence: {script}"
-        );
-        assert!(
-            script.contains("apt-get install -y -qq tmux"),
-            "entrypoint must install tmux when absent: {script}"
-        );
-        // The install runs before the agent process so cc_sdk finds tmux on first launch.
-        let tmux_at = script.find("command -v tmux").expect("tmux step present");
-        let main_at = script
-            .find("python -m core.main")
-            .expect("main step present");
-        assert!(
-            tmux_at < main_at,
-            "tmux install must precede launching core.main"
-        );
-    }
-
-    #[test]
-    fn entrypoint_pins_venv_and_syncs_core() {
+    fn command_pins_venv_and_syncs_core() {
         // The venv must live outside the read-only core mount, and the sync/launch steps
         // target the core project (pyproject in core/).
-        let cmd = agent_container_entrypoint_cmd();
-        let script = cmd.last().expect("entrypoint script");
+        let cmd = agent_container_cmd();
+        let script = cmd.last().expect("container command");
         assert!(
             script.contains("UV_PROJECT_ENVIRONMENT=/root/agent/.venv uv sync --frozen --project /root/agent/core"),
-            "entrypoint must pin the core sync's venv outside core: {script}"
+            "command must pin the core sync's venv outside core: {script}"
         );
         assert!(
             script.contains("python -m core.main"),
-            "entrypoint must launch core.main: {script}"
+            "command must launch core.main: {script}"
         );
     }
 
     #[test]
-    fn entrypoint_inlines_skill_linking() {
-        let cmd = agent_container_entrypoint_cmd();
-        let script = cmd.last().expect("entrypoint script");
+    fn command_leaves_runtime_setup_to_agent_code() {
+        let cmd = agent_container_cmd();
+        let script = cmd.last().expect("container command");
         assert!(
-            script.contains("CONFIG=\"agent/data/config.json\""),
-            "entrypoint must read runtime active skills from agent config: {script}"
-        );
-        assert!(
-            script.contains("DEFAULTS=\"agent/core/default-skills.txt\""),
-            "entrypoint must read default skills from agent/core: {script}"
-        );
-        assert!(
-            script.contains("ln -sfn \"$HOME/$1\" \"$LINK_DIR/$(basename \"$1\")\""),
-            "entrypoint must rebuild the skill symlink farm inline: {script}"
-        );
-        assert!(
-            !script.contains("link-skills.sh"),
-            "entrypoint must not call the deleted link-skills.sh helper: {script}"
-        );
-        assert!(
-            !script.contains("agent/skills/active-skills.txt")
-                && !script.contains("agent/skills/default-skills.txt"),
-            "entrypoint must not use the old active/default skill paths: {script}"
+            !script.contains("active_skills")
+                && !script.contains("default-skills.txt")
+                && !script.contains("settings.json")
+                && !script.contains("ln -s"),
+            "agent-owned runtime setup must stay out of the container command: {script}"
         );
     }
 
     #[test]
-    fn entrypoint_never_exports_uv_project_environment_into_the_agent() {
-        let cmd = agent_container_entrypoint_cmd();
-        let script = cmd.last().expect("entrypoint script");
+    fn command_never_exports_uv_project_environment_into_the_agent() {
+        let cmd = agent_container_cmd();
+        let script = cmd.last().expect("container command");
         assert!(
             !script.contains("export UV_PROJECT_ENVIRONMENT"),
             "UV_PROJECT_ENVIRONMENT must never be exported: {script}"
@@ -3645,7 +3507,7 @@ mod tests {
             &docker,
             &tc,
             &[],
-            agent_container_entrypoint_cmd(),
+            agent_container_cmd(),
             NETWORK_MODE,
             RESTART_POLICY,
         )
@@ -3673,7 +3535,7 @@ mod tests {
             &docker,
             &tc,
             &[],
-            agent_container_entrypoint_cmd(),
+            agent_container_cmd(),
             NETWORK_MODE,
             RESTART_POLICY,
         )
@@ -3733,7 +3595,7 @@ mod tests {
             &docker,
             &tc,
             &mounts,
-            agent_container_entrypoint_cmd(),
+            agent_container_cmd(),
             NETWORK_MODE,
             RESTART_POLICY,
         )
@@ -3762,7 +3624,7 @@ mod tests {
             &docker,
             &tc,
             &[env_mount, core_mount],
-            agent_container_entrypoint_cmd(),
+            agent_container_cmd(),
             NETWORK_MODE,
             RESTART_POLICY,
         )
@@ -3800,7 +3662,7 @@ mod tests {
             &docker,
             &tc,
             &mounts,
-            agent_container_entrypoint_cmd(),
+            agent_container_cmd(),
             NETWORK_MODE,
             RESTART_POLICY,
         )
@@ -3853,7 +3715,7 @@ mod tests {
             &docker,
             &tc,
             &[],
-            agent_container_entrypoint_cmd(),
+            agent_container_cmd(),
             NETWORK_MODE,
             RESTART_POLICY,
         )
@@ -3882,7 +3744,7 @@ mod tests {
             &docker,
             &tc,
             &mounts,
-            agent_container_entrypoint_cmd(),
+            agent_container_cmd(),
             NETWORK_MODE,
             RESTART_POLICY,
         )
@@ -3913,7 +3775,7 @@ mod tests {
             &docker,
             &tc,
             &mounts,
-            agent_container_entrypoint_cmd(),
+            agent_container_cmd(),
             "bridge",
             RESTART_POLICY,
         )
@@ -3947,7 +3809,7 @@ mod tests {
             &docker,
             &tc,
             &mounts,
-            agent_container_entrypoint_cmd(),
+            agent_container_cmd(),
             NETWORK_MODE,
             "unless-stopped",
         )
@@ -3992,7 +3854,7 @@ mod tests {
             &docker,
             &tc,
             &mounts,
-            agent_container_entrypoint_cmd(),
+            agent_container_cmd(),
             "bridge",
             RESTART_POLICY,
         )
@@ -4013,7 +3875,7 @@ mod tests {
             &docker,
             &tc,
             &mounts,
-            agent_container_entrypoint_cmd(),
+            agent_container_cmd(),
             NETWORK_MODE,
             RESTART_POLICY,
         )
@@ -4037,7 +3899,7 @@ mod tests {
             &docker,
             &tc,
             &[env_mount],
-            agent_container_entrypoint_cmd(),
+            agent_container_cmd(),
             NETWORK_MODE,
             RESTART_POLICY,
         )

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2856,7 +2856,7 @@ pub async fn run_server(cfg: ServerConfig) {
     );
     let state = Arc::new(app_state);
     let mobile_app_handle = tokio::spawn(mobile_app_worker.run());
-    // Reconcile in the background so the API serves immediately: a rebuild (entrypoint/mount change)
+    // Reconcile in the background so the API serves immediately: a rebuild (command/mount change)
     // snapshots each container's filesystem (minutes), and awaiting it would leave vestad unreachable.
     let reconcile_docker = docker.clone();
     let reconcile_env = state.env_config.clone();

--- a/vestad/tests/live/upgrade.rs
+++ b/vestad/tests/live/upgrade.rs
@@ -364,7 +364,7 @@ fn dump_upgrade_diagnostics(home: &Path, container_name: &str) {
         Err(e) => eprintln!("container {container_name}: inspect failed ({e})"),
     }
     // `docker logs` works even when the container has exited, so it shows WHY it stopped
-    // (entrypoint `uv sync` failures, a crash on the new core, etc.).
+    // (container-command `uv sync` failures, a crash on the new core, etc.).
     match docker_cmd(&["logs", "--tail", "60", container_name]) {
         Ok(out) => eprintln!("--- container logs (tail 60) ---\n{out}"),
         Err(e) => eprintln!("container logs unavailable ({e})"),

--- a/vestad/tests/server/layout.rs
+++ b/vestad/tests/server/layout.rs
@@ -7,14 +7,14 @@ fn container_id(agent_name: &str) -> String {
         .unwrap_or_else(|| panic!("agent {agent_name} has no container id"))
 }
 
-const ENTRYPOINT_POLL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
-const ENTRYPOINT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+const STARTUP_POLL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const STARTUP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
 
 /// Poll a `test -<flag> <path>` check until it succeeds or the timeout elapses.
 /// CI runners are slow under contention — a single post-sleep check races with
-/// the entrypoint's filesystem setup.
+/// the agent command's filesystem setup.
 fn wait_for_path(cid: &str, flag: char, path: &str) {
-    let deadline = std::time::Instant::now() + ENTRYPOINT_POLL_TIMEOUT;
+    let deadline = std::time::Instant::now() + STARTUP_POLL_TIMEOUT;
     let script = format!("test -{flag} {path}");
     loop {
         if exec_in_container(cid, &script).is_ok() {
@@ -24,10 +24,10 @@ fn wait_for_path(cid: &str, flag: char, path: &str) {
             panic!(
                 "expected {} {path} to exist within {}s",
                 if flag == 'd' { "directory" } else { "file" },
-                ENTRYPOINT_POLL_TIMEOUT.as_secs()
+                STARTUP_POLL_TIMEOUT.as_secs()
             );
         }
-        std::thread::sleep(ENTRYPOINT_POLL_INTERVAL);
+        std::thread::sleep(STARTUP_POLL_INTERVAL);
     }
 }
 
@@ -36,7 +36,7 @@ fn fresh_agent_has_expected_directory_structure() {
     let name: &str = &SHARED_RO_AGENT;
     let cid = container_id(name);
 
-    // Root-level directories created by entrypoint / image COPY. Git state
+    // Root-level directories created by agent startup / image COPY. Git state
     // (/root/.git, branch, .gitignore) is not asserted here: the flat workspace
     // attaches lazily (first skills-activate or upstream sync), which fetches from
     // the mounted upstream repo (outside this test's scope).
@@ -44,7 +44,7 @@ fn fresh_agent_has_expected_directory_structure() {
         wait_for_path(&cid, 'd', dir);
     }
 
-    // .claude/skills is a directory of per-skill symlinks (built by the boot entrypoint):
+    // .claude/skills is a directory of per-skill symlinks (built by agent startup):
     // every core skill always, plus each optional skill listed in config.active_skills
     // (seeded from default-skills.txt). The image ships ALL skills on disk, but only the
     // active ones are linked; assert a default optional (tasks) and a core skill are linked.

--- a/vestad/tests/server/lifecycle.rs
+++ b/vestad/tests/server/lifecycle.rs
@@ -276,11 +276,11 @@ fn user_desired_persists_and_boot_start_respects_it() {
     let _ = client.destroy_agent(&stopped_name);
 }
 
-/// Entrypoint-UNCHANGED upgrade path: when vestad re-extracts new agent code without a container
+/// Command-UNCHANGED upgrade path: when vestad re-extracts new agent code without a container
 /// config change (so the container is NOT rebuilt), a RUNNING agent must be restarted to pick up
 /// the new core — its old code stays in memory and its core mount points at the now-replaced dir.
-/// The upgrade e2e only covers entrypoint-CHANGED upgrades (which force a rebuild), so this pins the
-/// gap that left agents serving stale code after a same-entrypoint upgrade.
+/// The upgrade e2e only covers command-CHANGED upgrades (which force a rebuild), so this pins the
+/// gap that left agents serving stale code after a same-command upgrade.
 #[test]
 fn running_agent_restarts_when_agent_code_changes() {
     let user = format!("codechange-e2e-{}", std::process::id());
@@ -315,7 +315,7 @@ fn running_agent_restarts_when_agent_code_changes() {
             "agent should be running before the simulated upgrade"
         );
 
-        // Simulate a vestad version bump WITHOUT an entrypoint change: corrupt the fingerprint so
+        // Simulate a vestad version bump WITHOUT a command change: corrupt the fingerprint so
         // the next boot re-extracts the core (agent_code_changed=true) while needs_rebuild stays
         // false. The agent stays running across the restart (TestServer SIGKILLs vestad, so its
         // stop-all-on-shutdown never runs) — exactly the case that left agents stale.


### PR DESCRIPTION
## Summary

- reduce the Docker container command to environment setup, frozen dependency sync, and launching `core.main`
- move active/default skill reconciliation, the recent cone-to-flat compatibility bridge, skill symlinks, and default Claude settings into agent startup
- remove the legacy boot-time tmux install and rename entrypoint-specific code/tests around the actual Docker `Cmd` behavior
- keep exact command comparison so command changes still trigger container rebuilds

## Tests

- `PYTHONPATH=../skills/voice/cli/src uv run pytest ../tests -q` (643 passed)
- `uv run ruff check ...`
- `uv run ty check claude_runtime.py main.py config.py client.py`
- `VESTAD_SKIP_APP_BUILD=1 cargo test command_` (3 passed)