### PR TITLE
fix(agent): log preempted notifications

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -151,7 +151,6 @@ async def send_preempt(prompt: str, *, state: vm.State, config: cfg.VestaConfig)
         # caller queues plain and nothing is lost.
         await asyncio.wait_for(client.query(_one()), timeout=config.interrupt_timeout)
         turn.preempted = True
-        logger.debug("Preempt sent (priority=now)")
         return True
     except Exception as e:
         # Like attempt_interrupt: best-effort, broad catch. A failed preempt must never abort

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -268,6 +268,7 @@ async def _watch_queue_during_turn(
                     user=arrived.is_user,
                     is_notification=arrived.interruptible and not arrived.is_user,
                 )
+                logger.debug("Preempt sent (priority=now)")
                 clear_notifications(state, arrived.file_paths)
             else:
                 pending.append(arrived)

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -189,6 +189,16 @@ def greeting_turn(*, config: cfg.VestaConfig, state: vm.State, reason: str) -> s
 # --- Message processing ---
 
 
+def _log_queued_turn(text: str, *, user: bool, is_notification: bool) -> None:
+    """Render a queued item once, whether it runs as a plain turn or is delivered as a preempt."""
+    if user:
+        logger.user(text)
+        return
+    preview = text[:1000] + "..." if len(text) > 1000 else text
+    log = logger.notification if is_notification else logger.system
+    log(preview)
+
+
 async def _run_one_turn(
     text: str,
     *,
@@ -199,12 +209,7 @@ async def _run_one_turn(
 ) -> None:
     """Drive one queued turn through process_message, mapping failures to a graceful restart."""
     try:
-        if user:
-            logger.user(text)
-        else:
-            preview = text[:1000] + "..." if len(text) > 1000 else text
-            log = logger.notification if is_notification else logger.system
-            log(preview)
+        _log_queued_turn(text, user=user, is_notification=is_notification)
         state.event_bus.set_state("thinking")
         await process_message(text, state=state, config=config)
     except asyncio.CancelledError:
@@ -258,6 +263,11 @@ async def _watch_queue_during_turn(
         if queue_task in done:
             arrived = queue_task.result()
             if await send_preempt(arrived.text, state=state, config=config):
+                _log_queued_turn(
+                    arrived.text,
+                    user=arrived.is_user,
+                    is_notification=arrived.interruptible and not arrived.is_user,
+                )
                 clear_notifications(state, arrived.file_paths)
             else:
                 pending.append(arrived)

--- a/agent/tests/test_preempt.py
+++ b/agent/tests/test_preempt.py
@@ -191,7 +191,7 @@ def _blocking_processor():
 @pytest.mark.anyio
 async def test_watcher_delivery_consumes_item_and_clears_files(config, state, tmp_path):
     """A mid-turn item whose pre-send succeeds is consumed at delivery: files cleared,
-    notification_cleared emitted, and no turn ever runs for it."""
+    rendered in the notification log, notification_cleared emitted, and no turn ever runs for it."""
     from core.loops import _run_messages_with_preempts
 
     queue: asyncio.Queue = asyncio.Queue()
@@ -208,7 +208,11 @@ async def test_watcher_delivery_consumes_item_and_clears_files(config, state, tm
 
     state.event_bus.emit = tracking_emit
 
-    with patch("core.loops.process_message", fake_process), patch("core.loops.send_preempt", AsyncMock(return_value=True)):
+    with (
+        patch("core.loops.process_message", fake_process),
+        patch("core.loops.send_preempt", AsyncMock(return_value=True)),
+        patch("core.loops.logger.notification") as notification_log,
+    ):
         task = asyncio.create_task(_run_messages_with_preempts(vm.QueuedTurn("first", True, []), queue=queue, state=state, config=config))
         await first_started.wait()
         await queue.put(vm.QueuedTurn("urgent", False, [str(notif_file)]))
@@ -218,6 +222,7 @@ async def test_watcher_delivery_consumes_item_and_clears_files(config, state, tm
 
     assert cleared == ["urgent"]
     assert processed == ["first"], f"a delivered item must never run as a turn: {processed}"
+    notification_log.assert_called_once_with("urgent")
 
 
 @pytest.mark.anyio

--- a/agent/tests/test_preempt.py
+++ b/agent/tests/test_preempt.py
@@ -207,11 +207,13 @@ async def test_watcher_delivery_consumes_item_and_clears_files(config, state, tm
         original_emit(event)
 
     state.event_bus.emit = tracking_emit
+    logged: list[str] = []
 
     with (
         patch("core.loops.process_message", fake_process),
         patch("core.loops.send_preempt", AsyncMock(return_value=True)),
-        patch("core.loops.logger.notification") as notification_log,
+        patch("core.loops.logger.notification", side_effect=lambda _text: logged.append("notification")) as notification_log,
+        patch("core.loops.logger.debug", side_effect=lambda _text: logged.append("preempt")) as debug_log,
     ):
         task = asyncio.create_task(_run_messages_with_preempts(vm.QueuedTurn("first", True, []), queue=queue, state=state, config=config))
         await first_started.wait()
@@ -223,6 +225,8 @@ async def test_watcher_delivery_consumes_item_and_clears_files(config, state, tm
     assert cleared == ["urgent"]
     assert processed == ["first"], f"a delivered item must never run as a turn: {processed}"
     notification_log.assert_called_once_with("urgent")
+    debug_log.assert_called_once_with("Preempt sent (priority=now)")
+    assert logged == ["notification", "preempt"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- centralize queued-turn rendering so ordinary turns and successfully delivered preempts use the same user, notification, or system logger
- preserve the existing 1,000-character preview limit for non-user messages
- log a delivered preempt exactly once, before the delivery debug record and notification-file cleanup
- remove the lower-level client debug record so delivery logging has one owner

## Behavior and risk

Only preempts that are successfully written to the live session are rendered immediately. Failed or gated preempts remain queued and are rendered later by the ordinary turn path, preventing duplicate log lines. Notification completion behavior is unchanged: successful delivery still marks the open turn preempted and clears the source files.

## Testing

- `./check.sh agent` (643 core tests plus all skill CLI suites passed)
- `./check.sh guards`
- focused preempt, processor, and logger coverage included in the full suite