### PR TITLE
fix(agent): close failed tool events

### DIFF
--- a/agent/core/sdk_parsing.py
+++ b/agent/core/sdk_parsing.py
@@ -271,8 +271,9 @@ def make_hooks(state: vm.State) -> dict[HookEvent, list[HookMatcher]]:
     async def log_tool_failure(input_data: PostToolUseFailureHookInput, tool_use_id: str | None, _context: HookContext) -> HookJSONOutput:
         name = input_data["tool_name"] if "tool_name" in input_data else "?"
         error = input_data["error"] if "error" in input_data else "(unknown error)"
-        prefix, _ = _subagent_prefix(input_data)
+        prefix, is_sub = _subagent_prefix(input_data)
         logger.warning(f"{prefix}Tool failed: {name}: {error}")
+        state.event_bus.emit({"type": "tool_end", "tool": name, "subagent": is_sub})
         tool_id = tool_use_id or name
         state.active_tools.pop(tool_id, None)
         diagnostics.touch_activity(state, f"tool_fail:{name}")

--- a/agent/tests/test_watchdog.py
+++ b/agent/tests/test_watchdog.py
@@ -283,6 +283,7 @@ async def test_tool_failure_hook_cleans_up():
 
     state = vm.State()
     hooks = sdk_parsing.make_hooks(state)
+    sub = state.event_bus.subscribe()
 
     pre_hook = hooks["PreToolUse"][0].hooks[0]
     fail_hook = hooks["PostToolUseFailure"][0].hooks[0]
@@ -296,6 +297,11 @@ async def test_tool_failure_hook_cleans_up():
     await fail_hook(fail_input, "tool-456", ctx)
     assert "tool-456" not in state.active_tools
     assert state.last_sdk_activity_label == "tool_fail:Bash"
+    events = [sub.get_nowait() for _ in range(sub.qsize())]
+    assert [(event["type"], event.get("tool"), event.get("subagent")) for event in events] == [
+        ("tool_start", "Bash", False),
+        ("tool_end", "Bash", False),
+    ]
 
 
 # --- converse() liveness integration ---


### PR DESCRIPTION
## Summary

- emit the existing `tool_end` event when the Claude SDK’s `PostToolUseFailure` hook fires
- preserve the failed tool name and subagent classification in the terminal event
- remove the failed tool from active tracking only after publishing the balanced lifecycle event
- cover the exact failed lifecycle sequence with a `tool_start` to `tool_end` assertion

## Testing

- `uv run --project agent/core pytest agent/tests/test_watchdog.py agent/tests/test_sdk_parsing.py agent/tests/test_contract.py agent/tests/test_event_union_fixture.py -q -p no:cacheprovider` (27 passed)
- `uv run --project agent/core ruff check --no-cache agent/core/sdk_parsing.py agent/tests/test_watchdog.py`

## Behavior and compatibility

- no new event type is introduced; consumers that already handle `tool_end` now receive a balanced event for failed tools as well as successful ones
