### PR TITLE
Emphasize notification reply commands

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -115,8 +115,9 @@ async def trash_notification_files(notifications: list[Notification], *, trash_d
 def format_notification_batch(notifications: list[Notification]) -> str:
     """Join the batch as newline-separated <channel> elements, matching how Claude Code delivers
     several native channel events together on one turn. No wrapper element: each <channel> is
-    self-contained. All read-time guidance (the reply command, the group-chat caveat) is the
-    producer's, carried in its `reply_hint` attribute; core injects nothing."""
+    self-contained. All read-time guidance is producer-owned: executable reply syntax is carried in
+    `reply_command`, while behavioral guidance such as the group-chat caveat stays in
+    `reply_hint`; core injects nothing."""
     return "\n".join(n.format_for_display() for n in notifications)
 
 

--- a/agent/skills/app-chat/cli/src/app_chat_cli/service.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/service.py
@@ -56,8 +56,8 @@ _STATE_KEY: web.AppKey[ServiceState] = web.AppKey("state", ServiceState)
 
 def _write_notification(state: ServiceState, text: str, intent_id: str | None) -> None:
     """Persist an inbound app message as the source=app-chat notification the monitor loop turns into a
-    model turn. Byte-identical to core's former _write_app_chat_notification: the reply_hint and the
-    intent_id extra ride along unchanged so the model side sees no difference."""
+    model turn. The structured reply command, behavioral hint, and intent ID ride along
+    unchanged so the model receives the producer-owned response guidance."""
     directory = state.notifications_dir
     directory.mkdir(parents=True, exist_ok=True)
     fields: dict[str, object] = {
@@ -66,7 +66,8 @@ def _write_notification(state: ServiceState, text: str, intent_id: str | None) -
         "type": "message",
         "message": text,
         "interrupt": True,
-        "reply_hint": "reply with `app-chat send`, and think about how you can best show your personality",
+        "reply_command": "app-chat send",
+        "reply_hint": "think about how you can best show your personality",
     }
     if intent_id is not None:
         fields["intent_id"] = intent_id

--- a/agent/skills/app-chat/cli/tests/test_service.py
+++ b/agent/skills/app-chat/cli/tests/test_service.py
@@ -77,7 +77,8 @@ def test_message_persists_emits_and_writes_notification(tmp_path):
     assert notif["type"] == "message"
     assert notif["message"] == "hello there"
     assert notif["interrupt"] is True
-    assert "reply_hint" in notif
+    assert notif["reply_command"] == "app-chat send"
+    assert notif["reply_hint"] == "think about how you can best show your personality"
     state.store.close()
 
 

--- a/agent/skills/telegram/cli/notifications.go
+++ b/agent/skills/telegram/cli/notifications.go
@@ -26,6 +26,7 @@ type messageNotif struct {
 	Timestamp      string `json:"timestamp"`
 	MessageID      int64  `json:"message_id,omitempty"`
 	ContactUnknown bool   `json:"contact_unknown,omitempty"`
+	ReplyCommand   string `json:"reply_command,omitempty"`
 	ReplyHint      string `json:"reply_hint,omitempty"`
 }
 
@@ -61,6 +62,7 @@ type editNotif struct {
 	Timestamp       string `json:"timestamp"`
 	TargetMessageID int64  `json:"target_message_id"`
 	ContactUnknown  bool   `json:"contact_unknown,omitempty"`
+	ReplyCommand    string `json:"reply_command,omitempty"`
 	ReplyHint       string `json:"reply_hint,omitempty"`
 }
 
@@ -138,7 +140,8 @@ func WriteEditNotification(
 		Timestamp:       time.Now().Format(time.RFC3339),
 		TargetMessageID: targetMessageID,
 		ContactUnknown:  !contactSaved,
-		ReplyHint:       "they changed a message you may have already answered; reply with `telegram send` only if the change asks something new",
+		ReplyCommand:    "telegram send",
+		ReplyHint:       "they changed a message you may have already answered; reply only if the change asks something new",
 	}
 	if !isDirectChat {
 		notif.ChatName = chatName
@@ -181,11 +184,12 @@ func WriteNotification(
 		Timestamp:      time.Now().Format(time.RFC3339),
 		MessageID:      messageID,
 		ContactUnknown: !contactSaved,
-		ReplyHint:      "reply with `telegram send`, and think about how you can best show your personality",
+		ReplyCommand:   "telegram send",
+		ReplyHint:      "think about how you can best show your personality",
 	}
 	if !isDirectChat {
 		notif.ChatName = chatName
-		notif.ReplyHint = "reply with `telegram send`, and think about how you can best show your personality; this is a group chat, so it may not be expecting a reply from you"
+		notif.ReplyHint = "think about how you can best show your personality; this is a group chat, so it may not be expecting a reply from you"
 		if sender != chatName {
 			notif.Sender = sender
 		}

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -28,6 +28,7 @@ type messageNotif struct {
 	Timestamp       string `json:"timestamp"`
 	MessageID       string `json:"message_id,omitempty"`
 	ContactUnknown  bool   `json:"contact_unknown,omitempty"`
+	ReplyCommand    string `json:"reply_command,omitempty"`
 	ReplyHint       string `json:"reply_hint,omitempty"`
 }
 
@@ -64,6 +65,7 @@ type editNotif struct {
 	Timestamp       string `json:"timestamp"`
 	TargetMessageID string `json:"target_message_id"`
 	ContactUnknown  bool   `json:"contact_unknown,omitempty"`
+	ReplyCommand    string `json:"reply_command,omitempty"`
 	ReplyHint       string `json:"reply_hint,omitempty"`
 }
 
@@ -140,11 +142,12 @@ func WriteNotification(
 		Timestamp:       time.Now().Format(time.RFC3339),
 		MessageID:       messageID,
 		ContactUnknown:  !ctx.ContactSaved,
-		ReplyHint:       "reply with `whatsapp send`, and think about how you can best show your personality",
+		ReplyCommand:    "whatsapp send",
+		ReplyHint:       "think about how you can best show your personality",
 	}
 	if !ctx.IsDirectChat {
 		n.ChatName = ctx.ChatName
-		n.ReplyHint = "reply with `whatsapp send`, and think about how you can best show your personality; this is a group chat, so it may not be expecting a reply from you"
+		n.ReplyHint = "think about how you can best show your personality; this is a group chat, so it may not be expecting a reply from you"
 		// Drop Sender when it's just the same JID as the chat (happens for unsaved group participants).
 		if ctx.Sender != ctx.ChatName {
 			n.Sender = ctx.Sender
@@ -202,7 +205,8 @@ func WriteEditNotification(ctx NotifContext, targetMessageID, oldText, newText s
 		Timestamp:       time.Now().Format(time.RFC3339),
 		TargetMessageID: targetMessageID,
 		ContactUnknown:  !ctx.ContactSaved,
-		ReplyHint:       "they changed a message you may have already answered; reply with `whatsapp send` only if the change asks something new",
+		ReplyCommand:    "whatsapp send",
+		ReplyHint:       "they changed a message you may have already answered; reply only if the change asks something new",
 	}
 	n.applyChatContext(ctx)
 	return writeNotificationFile(ctx.NotifDir, n, "edit")

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -275,7 +275,7 @@ def test_format_for_display_strips_timestamp_microseconds():
     assert 'timestamp="2025-01-01T12:34:56+00:00"' in display
 
 
-def test_batch_reply_guidance_appears_only_in_producer_reply_hint():
+def test_batch_keeps_reply_command_structurally_separate_from_guidance():
     notif = Notification.model_validate(
         {
             "timestamp": "2025-01-01T00:00:00",
@@ -284,12 +284,13 @@ def test_batch_reply_guidance_appears_only_in_producer_reply_hint():
             "chat_name": "Bride squad",
             "sender": "bob",
             "message": "hi",
-            "reply_hint": "reply with `whatsapp send`; this is a group chat, so it may not be expecting a reply from you",
+            "reply_command": "whatsapp send",
+            "reply_hint": "this is a group chat, so it may not be expecting a reply from you",
         }
     )
     formatted = format_notification_batch([notif])
     assert formatted.count("group chat") == 1
-    assert formatted.count("whatsapp send") == 1
+    assert 'reply_command="whatsapp send"' in formatted
     assert "[Reply using" not in formatted
     assert "chip in or stay out" not in formatted
 


### PR DESCRIPTION
## Summary
- promote executable notification reply syntax into a dedicated `reply_command` field
- keep `reply_hint` focused on behavioral guidance such as personality and group-chat context
- apply the split consistently to app-chat, WhatsApp, Telegram, and edit notifications
- leave non-reply guidance unchanged

Example: `<channel ... reply_command="whatsapp send" reply_hint="this is a group chat, ...">...`

## Validation
- `./check.sh guards`
- `uv run pytest tests/test_notifications.py -q` (48 passed)
- app-chat CLI: `uv run pytest -q` (53 passed)
- affected Python Ruff checks pass

Go toolchain is not installed on this box, so the WhatsApp and Telegram Go suites could not be run locally.