### PR TITLE
fix(tasks): keep recurring reminders visible in remind list past the limit

### DIFF
--- a/agent/skills/tasks/cli/src/tasks_cli/commands.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/commands.py
@@ -37,6 +37,9 @@ class TriggerData(TypedDict, total=False):
     fuzz_minutes: int  # "cron": each fire shifts by a deterministic sample in [-fuzz, +fuzz]
 
 
+RECURRING_TRIGGER_TYPES = ("cron", "interval")  # trigger types that fire more than once; "date" is the one-shot type
+
+
 class DueSpec(BaseModel):
     """A task due date: an absolute datetime + timezone, or a relative due-in offset."""
 
@@ -697,7 +700,7 @@ def _restore_row(scheduler: BackgroundScheduler, row, now: datetime, notif_dir: 
             "id": reminder_id,
             "replace_existing": True,
         }
-        if trigger_type in ("cron", "interval"):
+        if trigger_type in RECURRING_TRIGGER_TYPES:
             add_job_kwargs["misfire_grace_time"] = 3600
             add_job_kwargs["coalesce"] = True
         scheduler.add_job(**add_job_kwargs)
@@ -863,7 +866,8 @@ def remind_list(config: Config, *, task_id: str | None = None, limit: int = 50) 
     # Recurring reminders sort ahead of one-shots so the limit only ever trims the newest
     # one-shot tail: a long-lived daily/cron reminder is typically the oldest row and would
     # otherwise silently fall off a created_at-ordered list, a false-negative view.
-    order_clause = "ORDER BY json_extract(trigger_data, '$.type') IN ('cron', 'interval') DESC, created_at DESC LIMIT ?"
+    recurring_types = ", ".join(f"'{t}'" for t in RECURRING_TRIGGER_TYPES)
+    order_clause = f"ORDER BY json_extract(trigger_data, '$.type') IN ({recurring_types}) DESC, created_at DESC LIMIT ?"
     with closing(db.get_db(config.data_dir)) as conn:
         if task_id is not None:
             cursor = conn.execute(

--- a/agent/skills/tasks/cli/src/tasks_cli/commands.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/commands.py
@@ -860,15 +860,19 @@ def remind_set(config: Config, spec: ReminderSpec) -> dict:
 
 
 def remind_list(config: Config, *, task_id: str | None = None, limit: int = 50) -> list[dict]:
+    # Recurring reminders sort ahead of one-shots so the limit only ever trims the newest
+    # one-shot tail: a long-lived daily/cron reminder is typically the oldest row and would
+    # otherwise silently fall off a created_at-ordered list, a false-negative view.
+    order_clause = "ORDER BY json_extract(trigger_data, '$.type') IN ('cron', 'interval') DESC, created_at DESC LIMIT ?"
     with closing(db.get_db(config.data_dir)) as conn:
         if task_id is not None:
             cursor = conn.execute(
-                "SELECT * FROM reminders WHERE completed = 0 AND task_id = ? ORDER BY created_at DESC LIMIT ?",
+                f"SELECT * FROM reminders WHERE completed = 0 AND task_id = ? {order_clause}",
                 (task_id, limit),
             )
         else:
             cursor = conn.execute(
-                "SELECT * FROM reminders WHERE completed = 0 ORDER BY created_at DESC LIMIT ?",
+                f"SELECT * FROM reminders WHERE completed = 0 {order_clause}",
                 (limit,),
             )
         return [

--- a/agent/skills/tasks/cli/tests/test_remind_schedule.py
+++ b/agent/skills/tasks/cli/tests/test_remind_schedule.py
@@ -292,3 +292,33 @@ def test_migration_is_idempotent(tmp_path: Path):
     first = _read_trigger(data_dir, "daily1")
     db.init_db(data_dir)  # second run must not touch already-migrated rows
     assert _read_trigger(data_dir, "daily1") == first == {"type": "cron", "expr": "0 9 * * *", "tz": "UTC"}
+
+
+# ---------------------------------------------------------------------------
+# remind list: recurring reminders stay visible past the one-shot limit
+# ---------------------------------------------------------------------------
+
+
+def _backdate(config: Config, reminder_ids: list[str]) -> None:
+    with closing(db.get_db(config.data_dir)) as conn:
+        for reminder_id in reminder_ids:
+            conn.execute("UPDATE reminders SET created_at = '2026-01-01 00:00:00' WHERE id = ?", (reminder_id,))
+        conn.commit()
+
+
+def test_remind_list_keeps_old_recurring_reminders_past_the_limit(tmp_config: Config):
+    daily = commands.remind_set(
+        tmp_config, commands.ReminderSpec(message="standup", scheduled_datetime="2026-04-26T09:00:00", tz="Europe/Rome", recurring="daily")
+    )
+    cron = commands.remind_set(tmp_config, commands.ReminderSpec(message="weekdays", cron="0 9 * * 1-5", tz="Europe/Rome"))
+    hourly = commands.remind_set(tmp_config, commands.ReminderSpec(message="ping", recurring="hourly"))
+    _backdate(tmp_config, [daily["id"], cron["id"], hourly["id"]])
+    for index in range(5):
+        commands.remind_set(tmp_config, commands.ReminderSpec(message=f"one-shot {index}", in_hours=1))
+
+    listed = {reminder["id"]: reminder for reminder in commands.remind_list(tmp_config, limit=5)}
+
+    assert len(listed) == 5
+    assert listed[daily["id"]]["schedule"] == "daily at 09:00 Europe/Rome"
+    assert listed[cron["id"]]["schedule"] == "cron: 0 9 * * 1-5 (Europe/Rome)"
+    assert listed[hourly["id"]]["schedule"] == "hourly"


### PR DESCRIPTION
Fixes #1457

## Problem

`tasks remind list` queries active reminders with `ORDER BY created_at DESC LIMIT ?` (default 50). Recurring and cron reminders are created once and live forever, so on a busy agent they are systematically the oldest rows, while one-shot and task-attached auto reminders (the due-date ladder creates several per due-dated task) keep landing at the top. As soon as more than `limit` newer one-shots are active, every recurring reminder silently falls off the list: it keeps firing on schedule but `remind list` claims it does not exist. That false negative is exactly what the issue hit, and it led to a duplicate reminder being created.

## Fix

`remind_list` now sorts recurring reminders (trigger type `cron` or `interval`, read via `json_extract` on the stored trigger data) ahead of one-shots before applying the limit, so the limit can only ever trim the newest one-shot tail and a long-lived recurring reminder can never be pushed out. Each listed reminder already carries its recurrence schedule in the `schedule` column (`daily at 09:00 Europe/Rome`, `cron: 0 9 * * 1-5 (Europe/Rome)`, `hourly`), so the list is now a complete, annotated view. One ORDER BY clause changed, shared by both the plain and `--task`-filtered queries.

## Tests

`test_remind_list_keeps_old_recurring_reminders_past_the_limit` (in `agent/skills/tasks/cli/tests/test_remind_schedule.py`) creates daily, cron, and hourly recurring reminders, backdates them so they are the oldest rows, floods the list with more one-shots than the limit, and asserts all three recurring reminders still appear with their schedule annotations. The test fails on master (the recurring rows are absent from the listing) and passes with the fix. Full skill CLI suite (174 tests) and `./check.sh agent` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
