### PR TITLE
ci(mobile): add per-PR visual screenshot review for iOS

### DIFF
--- a/.github/workflows/mobile-visual-comment.yml
+++ b/.github/workflows/mobile-visual-comment.yml
@@ -1,0 +1,104 @@
+# Trusted half of the mobile visual review (issue #1463): runs from the
+# default branch's workflow file with a write token, never checks out or
+# executes PR code, and interpolates nothing attacker-controlled into the
+# comment (only the head SHA, run conclusion, and run/artifact ids from the
+# workflow_run event). It keeps one sticky comment per PR pointing at the
+# newest run's screenshots artifact.
+name: Mobile Visual Review Comment
+
+on:
+  workflow_run:
+    workflows: ["Mobile Visual Review"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  comment:
+    name: Update the sticky visual review comment
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Create or update the review comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const MARKER = "<!-- mobile-visual-review -->";
+            const ARTIFACT_NAME = "mobile-visual-screenshots";
+            const run = context.payload.workflow_run;
+
+            // run.pull_requests is empty for fork PRs, so resolve the PR from
+            // the head commit instead.
+            const { data: associatedPrs } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: run.head_sha,
+              });
+            const pullRequest = associatedPrs.find(
+              (candidate) => candidate.state === "open",
+            );
+            if (!pullRequest) {
+              core.info(`no open PR found for ${run.head_sha}; skipping`);
+              return;
+            }
+
+            const { data: artifactList } =
+              await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              });
+            const artifact = artifactList.artifacts.find(
+              (candidate) => candidate.name === ARTIFACT_NAME,
+            );
+            const artifactLine = artifact
+              ? `[Download the screenshots artifact](${run.html_url}/artifacts/${artifact.id}); contact-sheet.png inside is the one-glance overview.`
+              : "No screenshots artifact was produced; open the workflow run for diagnostics.";
+            const status =
+              run.conclusion === "success"
+                ? "All catalog pages captured."
+                : `Capture finished with conclusion \`${run.conclusion}\`; the run log names the failing page.`;
+            const body = [
+              MARKER,
+              "## Mobile visual review",
+              "",
+              status,
+              "",
+              `- Commit: ${run.head_sha}`,
+              `- [Workflow run](${run.html_url})`,
+              `- ${artifactLine}`,
+              "",
+              "_Screenshots come from an unprivileged workflow that builds this PR's code on a pinned iOS simulator; this comment only links the produced artifact._",
+            ].join("\n");
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequest.number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (candidate) => candidate.body !== undefined && candidate.body.includes(MARKER),
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                body,
+              });
+            }

--- a/.github/workflows/mobile-visual.yml
+++ b/.github/workflows/mobile-visual.yml
@@ -91,18 +91,29 @@ jobs:
       - name: Install app on simulator
         run: xcrun simctl install "$SIMULATOR_UDID" apps/mobile/build/Build/Products/Release-iphonesimulator/Vesta.app
 
-      # takeScreenshot files land in --test-output-dir (never the cwd), so
-      # both output dirs point inside the uploaded visual-out tree.
+      # takeScreenshot files land in Maestro's output dirs (never the cwd),
+      # so both point inside the uploaded visual-out tree.
       - name: Run screen catalog
         run: |
-          mkdir -p visual-out/screenshots
           maestro --device "$SIMULATOR_UDID" test \
-            --test-output-dir "$GITHUB_WORKSPACE/visual-out/screenshots" \
+            --test-output-dir "$GITHUB_WORKSPACE/visual-out/maestro-output" \
             --debug-output "$GITHUB_WORKSPACE/visual-out/maestro-debug" \
             --flatten-debug-output \
             --format junit \
             --output "$GITHUB_WORKSPACE/visual-out/report.xml" \
             apps/mobile/visual/flows
+
+      # Maestro nests each capture at <flow>/takeScreenshot/<name>.png; pull
+      # them into one flat folder for the contact sheet and summary.
+      - name: Collect screenshots
+        if: always()
+        run: |
+          mkdir -p visual-out/screenshots
+          for output_dir in visual-out/maestro-output visual-out/maestro-debug; do
+            if [ -d "$output_dir" ]; then
+              find "$output_dir" -path '*/takeScreenshot/*' -name '*.png' -exec cp {} visual-out/screenshots/ \;
+            fi
+          done
 
       - name: Generate contact sheet
         if: always()

--- a/.github/workflows/mobile-visual.yml
+++ b/.github/workflows/mobile-visual.yml
@@ -91,14 +91,17 @@ jobs:
       - name: Install app on simulator
         run: xcrun simctl install "$SIMULATOR_UDID" apps/mobile/build/Build/Products/Release-iphonesimulator/Vesta.app
 
+      # takeScreenshot files land in --test-output-dir (never the cwd), so
+      # both output dirs point inside the uploaded visual-out tree.
       - name: Run screen catalog
         run: |
           mkdir -p visual-out/screenshots
           maestro --device "$SIMULATOR_UDID" test \
-            -e SCREENSHOT_DIR="$GITHUB_WORKSPACE/visual-out/screenshots" \
-            --debug-output visual-out/maestro-debug \
+            --test-output-dir "$GITHUB_WORKSPACE/visual-out/screenshots" \
+            --debug-output "$GITHUB_WORKSPACE/visual-out/maestro-debug" \
+            --flatten-debug-output \
             --format junit \
-            --output visual-out/report.xml \
+            --output "$GITHUB_WORKSPACE/visual-out/report.xml" \
             apps/mobile/visual/flows
 
       - name: Generate contact sheet
@@ -124,8 +127,8 @@ jobs:
             echo ""
             echo "Captured pages (download the mobile-visual-screenshots artifact for the images):"
             echo ""
-            if ls visual-out/screenshots/*.png >/dev/null 2>&1; then
-              for shot in visual-out/screenshots/*.png; do
+            if find visual-out/screenshots -name '*.png' | grep -q .; then
+              find visual-out/screenshots -name '*.png' | sort | while read -r shot; do
                 echo "- $(basename "$shot" .png)"
               done
             else

--- a/.github/workflows/mobile-visual.yml
+++ b/.github/workflows/mobile-visual.yml
@@ -1,0 +1,142 @@
+# Per-PR visual screenshot review for the iOS app (issue #1463).
+#
+# This is the unprivileged half of the two-workflow model: it checks out and
+# executes PR code, so it runs with a read-only token and publishes nothing.
+# Its only output is the mobile-visual-screenshots artifact. The trusted half
+# (mobile-visual-comment.yml) links that artifact from a sticky PR comment
+# without ever executing PR code. See apps/mobile/visual/README.md for the
+# screen catalog and how to register a new page.
+name: Mobile Visual Review
+
+on:
+  pull_request:
+    paths:
+      - "apps/mobile/**"
+      - "apps/core/**"
+      - ".github/workflows/mobile-visual.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mobile-visual-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  MAESTRO_VERSION: "2.7.0"
+  PILLOW_VERSION: "12.3.0"
+  MAESTRO_CLI_NO_ANALYTICS: "1"
+  TZ: UTC
+
+jobs:
+  capture:
+    name: Mobile · Visual screenshots (iOS)
+    runs-on: macos-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            apps/package-lock.json
+            apps/mobile/package-lock.json
+
+      # Maestro's CLI runs on the JVM.
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      # Mobile bundles @vesta/core (a file: dependency resolved from the apps
+      # workspace), so both installs are needed before Metro can bundle.
+      - name: Install app dependencies
+        run: |
+          npm --prefix apps ci
+          npm --prefix apps/mobile ci
+
+      - name: Prebuild iOS project
+        working-directory: apps/mobile
+        run: CI=1 VESTA_LOCAL_IOS_NO_PUSH=1 npx expo prebuild --clean --platform ios
+
+      # Release configuration embeds the JS bundle, so the app runs standalone
+      # with no Metro server and no dev-client launcher screen.
+      - name: Build simulator app (Release)
+        working-directory: apps/mobile
+        run: |
+          xcodebuild \
+            -quiet \
+            -workspace ios/Vesta.xcworkspace \
+            -scheme Vesta \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination "generic/platform=iOS Simulator" \
+            -derivedDataPath build \
+            ARCHS="$(uname -m)" \
+            ONLY_ACTIVE_ARCH=YES \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - name: Boot pinned simulator
+        run: bash apps/mobile/visual/boot-simulator.sh
+
+      - name: Install Maestro
+        run: |
+          curl -fsSL https://get.maestro.mobile.dev | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Install app on simulator
+        run: xcrun simctl install "$SIMULATOR_UDID" apps/mobile/build/Build/Products/Release-iphonesimulator/Vesta.app
+
+      - name: Run screen catalog
+        run: |
+          mkdir -p visual-out/screenshots
+          maestro --device "$SIMULATOR_UDID" test \
+            -e SCREENSHOT_DIR="$GITHUB_WORKSPACE/visual-out/screenshots" \
+            --debug-output visual-out/maestro-debug \
+            --format junit \
+            --output visual-out/report.xml \
+            apps/mobile/visual/flows
+
+      - name: Generate contact sheet
+        if: always()
+        run: |
+          python3 -m venv "$RUNNER_TEMP/contact-sheet-venv"
+          "$RUNNER_TEMP/contact-sheet-venv/bin/pip" install --quiet "pillow==$PILLOW_VERSION"
+          "$RUNNER_TEMP/contact-sheet-venv/bin/python" apps/mobile/visual/contact-sheet.py \
+            visual-out/screenshots visual-out/contact-sheet.png
+
+      - name: Collect simulator diagnostics
+        if: always()
+        run: |
+          mkdir -p visual-out
+          xcrun simctl list runtimes > visual-out/simulator-runtimes.txt
+          xcrun simctl list devices > visual-out/simulator-devices.txt
+
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            echo "## Mobile visual review"
+            echo ""
+            echo "Captured pages (download the mobile-visual-screenshots artifact for the images):"
+            echo ""
+            if ls visual-out/screenshots/*.png >/dev/null 2>&1; then
+              for shot in visual-out/screenshots/*.png; do
+                echo "- $(basename "$shot" .png)"
+              done
+            else
+              echo "- none (capture failed before any screenshot; see the run log and maestro-debug in the artifact)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload screenshots artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mobile-visual-screenshots
+          path: visual-out
+          if-no-files-found: warn

--- a/apps/mobile/visual/README.md
+++ b/apps/mobile/visual/README.md
@@ -1,0 +1,37 @@
+# Mobile visual review
+
+Per-PR screenshot capture for the iOS app (issue #1463). The `Mobile Visual Review` workflow (`.github/workflows/mobile-visual.yml`) builds the simulator app from the PR's code, boots a pinned simulator, runs the Maestro screen catalog in `flows/`, and uploads a `mobile-visual-screenshots` artifact containing every named screenshot plus `contact-sheet.png`, a one-glance grid of all pages. A trusted follow-up workflow (`mobile-visual-comment.yml`) keeps one sticky PR comment pointing at the latest run's artifact.
+
+## Screen catalog
+
+| Screenshot | Page | How it is reached |
+| --- | --- | --- |
+| `01-connect` | Disconnected landing screen | Clean-install launch |
+| `02-connect-link` | Gateway link sheet | Tap "Self-hosting? Connect your gateway" |
+| `03-recent-gateways` | Recent gateways sheet (empty state) | Deep link `vesta://recent-gateways` |
+
+The current catalog covers the disconnected surfaces: they render deterministically on a clean install with no gateway, credentials, or user data. Connected surfaces (agent home, chat, settings, logs) need a fixture gateway feeding stable data and are tracked as follow-up work on issue #1463.
+
+## Registering a new page
+
+1. Add a flow file to `flows/` named `NN-page-name.yaml`. The numeric prefix orders the contact sheet; pick the next free number.
+2. Start from a known state: `launchApp` with `clearState: true` wipes app data so every run begins identically.
+3. Navigate deterministically: tap stable visible text or accessibility labels, or use `openLink` with the `vesta://` scheme for routes that have no tap path. Maestro selector strings are regular expressions, so escape or wildcard characters like `?`.
+4. Settle before capturing: `extendedWaitUntil` on a stable text anchor unique to the page, then `waitForAnimationToEnd`.
+5. Capture with `takeScreenshot: ${SCREENSHOT_DIR}/NN-page-name`. The workflow passes `SCREENSHOT_DIR`; the name must match the flow's prefix so the sheet stays ordered.
+
+Determinism rules for every flow: no live gateways or credentials, no dependence on wall-clock time or network responses, anchors on copy that only changes when the page itself changes. The simulator is pinned by `boot-simulator.sh` (device type, newest installed runtime, `en_US` locale, light appearance, 9:41 status bar) and the workflow pins `TZ=UTC` and the Maestro version.
+
+## Running locally
+
+```bash
+cd apps/mobile
+CI=1 VESTA_LOCAL_IOS_NO_PUSH=1 npx expo prebuild --clean --platform ios
+xcodebuild -workspace ios/Vesta.xcworkspace -scheme Vesta -configuration Release \
+  -sdk iphonesimulator -destination "generic/platform=iOS Simulator" \
+  -derivedDataPath build ARCHS="$(uname -m)" ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO build
+GITHUB_ENV=/tmp/sim-env bash visual/boot-simulator.sh && source /tmp/sim-env
+xcrun simctl install "$SIMULATOR_UDID" build/Build/Products/Release-iphonesimulator/Vesta.app
+mkdir -p /tmp/visual-shots
+maestro --device "$SIMULATOR_UDID" test -e SCREENSHOT_DIR=/tmp/visual-shots visual/flows
+```

--- a/apps/mobile/visual/README.md
+++ b/apps/mobile/visual/README.md
@@ -18,7 +18,7 @@ The current catalog covers the disconnected surfaces: they render deterministica
 2. Start from a known state: `launchApp` with `clearState: true` wipes app data so every run begins identically.
 3. Navigate deterministically: tap stable visible text or accessibility labels, or use `openLink` with the `vesta://` scheme for routes that have no tap path. Maestro selector strings are full-match regular expressions, and iOS merges child icon glyphs into a button's accessible text, so wrap anchors in `.*` when the element carries an icon and wildcard characters like `?`.
 4. Settle before capturing: `extendedWaitUntil` on a stable text anchor unique to the page, then `waitForAnimationToEnd`.
-5. Capture with `takeScreenshot: NN-page-name`, matching the flow's prefix so the contact sheet stays ordered. Screenshots land in Maestro's test output directory (the workflow points `--test-output-dir` into the artifact tree).
+5. Capture with `takeScreenshot: NN-page-name`, matching the flow's prefix so the contact sheet stays ordered. Screenshots land in Maestro's output directories (never the working directory); the workflow points them into the artifact tree and collects every `takeScreenshot` file into one flat `screenshots/` folder.
 
 Determinism rules for every flow: no live gateways or credentials, no dependence on wall-clock time or network responses, anchors on copy that only changes when the page itself changes. The simulator is pinned by `boot-simulator.sh` (device type, newest installed runtime, `en_US` locale, light appearance, 9:41 status bar) and the workflow pins `TZ=UTC` and the Maestro version.
 

--- a/apps/mobile/visual/README.md
+++ b/apps/mobile/visual/README.md
@@ -16,9 +16,9 @@ The current catalog covers the disconnected surfaces: they render deterministica
 
 1. Add a flow file to `flows/` named `NN-page-name.yaml`. The numeric prefix orders the contact sheet; pick the next free number.
 2. Start from a known state: `launchApp` with `clearState: true` wipes app data so every run begins identically.
-3. Navigate deterministically: tap stable visible text or accessibility labels, or use `openLink` with the `vesta://` scheme for routes that have no tap path. Maestro selector strings are regular expressions, so escape or wildcard characters like `?`.
+3. Navigate deterministically: tap stable visible text or accessibility labels, or use `openLink` with the `vesta://` scheme for routes that have no tap path. Maestro selector strings are full-match regular expressions, and iOS merges child icon glyphs into a button's accessible text, so wrap anchors in `.*` when the element carries an icon and wildcard characters like `?`.
 4. Settle before capturing: `extendedWaitUntil` on a stable text anchor unique to the page, then `waitForAnimationToEnd`.
-5. Capture with `takeScreenshot: ${SCREENSHOT_DIR}/NN-page-name`. The workflow passes `SCREENSHOT_DIR`; the name must match the flow's prefix so the sheet stays ordered.
+5. Capture with `takeScreenshot: NN-page-name`, matching the flow's prefix so the contact sheet stays ordered. Screenshots land in Maestro's test output directory (the workflow points `--test-output-dir` into the artifact tree).
 
 Determinism rules for every flow: no live gateways or credentials, no dependence on wall-clock time or network responses, anchors on copy that only changes when the page itself changes. The simulator is pinned by `boot-simulator.sh` (device type, newest installed runtime, `en_US` locale, light appearance, 9:41 status bar) and the workflow pins `TZ=UTC` and the Maestro version.
 
@@ -32,6 +32,5 @@ xcodebuild -workspace ios/Vesta.xcworkspace -scheme Vesta -configuration Release
   -derivedDataPath build ARCHS="$(uname -m)" ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO build
 GITHUB_ENV=/tmp/sim-env bash visual/boot-simulator.sh && source /tmp/sim-env
 xcrun simctl install "$SIMULATOR_UDID" build/Build/Products/Release-iphonesimulator/Vesta.app
-mkdir -p /tmp/visual-shots
-maestro --device "$SIMULATOR_UDID" test -e SCREENSHOT_DIR=/tmp/visual-shots visual/flows
+maestro --device "$SIMULATOR_UDID" test --test-output-dir /tmp/visual-shots visual/flows
 ```

--- a/apps/mobile/visual/boot-simulator.sh
+++ b/apps/mobile/visual/boot-simulator.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Create and boot a pinned iOS simulator for visual review captures, then
+# freeze the mutable chrome (locale, appearance, status bar) so screenshots
+# are comparable across runs. Exports SIMULATOR_UDID through GITHUB_ENV.
+set -euo pipefail
+
+DEVICE_NAME="vesta-visual-review"
+DEVICE_TYPE_CANDIDATES=(
+  "iPhone 16 Pro"
+  "iPhone 17 Pro"
+  "iPhone 16"
+  "iPhone 15 Pro"
+)
+
+udid=""
+for device_type in "${DEVICE_TYPE_CANDIDATES[@]}"; do
+  # No runtime argument: simctl picks the newest runtime for the device type.
+  if udid=$(xcrun simctl create "$DEVICE_NAME" "$device_type" 2>/dev/null); then
+    echo "created '$device_type' simulator $udid" >&2
+    break
+  fi
+  udid=""
+done
+
+if [ -z "$udid" ]; then
+  echo "error: none of the candidate device types are available on this runner" >&2
+  xcrun simctl list devicetypes >&2
+  exit 1
+fi
+
+xcrun simctl boot "$udid"
+xcrun simctl bootstatus "$udid" -b
+
+xcrun simctl spawn "$udid" defaults write "Apple Global Domain" AppleLocale -string en_US
+xcrun simctl spawn "$udid" defaults write "Apple Global Domain" AppleLanguages -array en-US
+xcrun simctl ui "$udid" appearance light
+xcrun simctl status_bar "$udid" override \
+  --time "9:41" \
+  --dataNetwork wifi --wifiMode active --wifiBars 3 \
+  --cellularMode notSupported \
+  --batteryState charged --batteryLevel 100
+
+echo "SIMULATOR_UDID=$udid" >>"${GITHUB_ENV:?GITHUB_ENV is not set}"

--- a/apps/mobile/visual/contact-sheet.py
+++ b/apps/mobile/visual/contact-sheet.py
@@ -27,7 +27,7 @@ def main() -> int:
         return 2
     screenshots_dir = Path(sys.argv[1])
     output = Path(sys.argv[2])
-    shots = sorted(screenshots_dir.glob("*.png"))
+    shots = sorted(screenshots_dir.rglob("*.png"))
     if not shots:
         print("no screenshots found; skipping contact sheet", file=sys.stderr)
         return 0

--- a/apps/mobile/visual/contact-sheet.py
+++ b/apps/mobile/visual/contact-sheet.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Assemble captured screenshots into a single contact-sheet PNG.
+
+Usage: contact-sheet.py <screenshots_dir> <output_png>
+Exits 0 with no output file when the directory holds no screenshots, so the
+CI step stays green when an earlier failure prevented any capture.
+"""
+
+import sys
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+COLUMNS = 3
+TILE_WIDTH = 360
+PADDING = 24
+LABEL_HEIGHT = 34
+LABEL_TEXT_OFFSET = 8
+LABEL_FONT_SIZE = 16
+BACKGROUND = (245, 245, 245)
+LABEL_COLOR = (60, 60, 60)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: contact-sheet.py <screenshots_dir> <output_png>", file=sys.stderr)
+        return 2
+    screenshots_dir = Path(sys.argv[1])
+    output = Path(sys.argv[2])
+    shots = sorted(screenshots_dir.glob("*.png"))
+    if not shots:
+        print("no screenshots found; skipping contact sheet", file=sys.stderr)
+        return 0
+
+    tiles: list[tuple[str, Image.Image]] = []
+    for shot in shots:
+        image = Image.open(shot)
+        height = round(image.height * TILE_WIDTH / image.width)
+        tiles.append((shot.stem, image.resize((TILE_WIDTH, height))))
+
+    tile_height = max(image.height for _, image in tiles)
+    columns = min(COLUMNS, len(tiles))
+    rows = -(-len(tiles) // columns)
+    cell_width = TILE_WIDTH + PADDING
+    cell_height = tile_height + LABEL_HEIGHT + PADDING
+    sheet = Image.new("RGB", (columns * cell_width + PADDING, rows * cell_height + PADDING), BACKGROUND)
+    draw = ImageDraw.Draw(sheet)
+    font = ImageFont.load_default(size=LABEL_FONT_SIZE)
+
+    for index, (label, image) in enumerate(tiles):
+        left = PADDING + (index % columns) * cell_width
+        top = PADDING + (index // columns) * cell_height
+        sheet.paste(image, (left, top))
+        draw.text((left, top + tile_height + LABEL_TEXT_OFFSET), label, fill=LABEL_COLOR, font=font)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    sheet.save(output)
+    print(f"contact sheet written to {output} ({len(tiles)} screenshots)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/mobile/visual/flows/01-connect.yaml
+++ b/apps/mobile/visual/flows/01-connect.yaml
@@ -1,11 +1,13 @@
 # Page: connect (the disconnected landing screen).
+# Anchors wrap in .* because iOS merges child icon glyphs into a button's
+# accessible text, and Maestro selectors are full-match regular expressions.
 appId: com.vesta.mobile
 ---
 - launchApp:
     clearState: true
 - extendedWaitUntil:
-    visible: "Connect with Vesta Cloud"
+    visible: ".*Connect with Vesta Cloud.*"
     timeout: 60000
 - waitForAnimationToEnd:
     timeout: 5000
-- takeScreenshot: ${SCREENSHOT_DIR}/01-connect
+- takeScreenshot: 01-connect

--- a/apps/mobile/visual/flows/01-connect.yaml
+++ b/apps/mobile/visual/flows/01-connect.yaml
@@ -1,0 +1,11 @@
+# Page: connect (the disconnected landing screen).
+appId: com.vesta.mobile
+---
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible: "Connect with Vesta Cloud"
+    timeout: 60000
+- waitForAnimationToEnd:
+    timeout: 5000
+- takeScreenshot: ${SCREENSHOT_DIR}/01-connect

--- a/apps/mobile/visual/flows/02-connect-link.yaml
+++ b/apps/mobile/visual/flows/02-connect-link.yaml
@@ -12,4 +12,4 @@ appId: com.vesta.mobile
     timeout: 15000
 - waitForAnimationToEnd:
     timeout: 5000
-- takeScreenshot: ${SCREENSHOT_DIR}/02-connect-link
+- takeScreenshot: 02-connect-link

--- a/apps/mobile/visual/flows/02-connect-link.yaml
+++ b/apps/mobile/visual/flows/02-connect-link.yaml
@@ -1,0 +1,15 @@
+# Page: connect-link (the self-hosted gateway link sheet).
+appId: com.vesta.mobile
+---
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible: "Self-hosting.*Connect your gateway"
+    timeout: 60000
+- tapOn: "Self-hosting.*Connect your gateway"
+- extendedWaitUntil:
+    visible: "Enter the connection link provided by your Vesta gateway."
+    timeout: 15000
+- waitForAnimationToEnd:
+    timeout: 5000
+- takeScreenshot: ${SCREENSHOT_DIR}/02-connect-link

--- a/apps/mobile/visual/flows/03-recent-gateways.yaml
+++ b/apps/mobile/visual/flows/03-recent-gateways.yaml
@@ -1,0 +1,15 @@
+# Page: recent-gateways (empty state; a clean install has no saved gateways).
+appId: com.vesta.mobile
+---
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible: "Connect with Vesta Cloud"
+    timeout: 60000
+- openLink: vesta://recent-gateways
+- extendedWaitUntil:
+    visible: "No saved gateways."
+    timeout: 15000
+- waitForAnimationToEnd:
+    timeout: 5000
+- takeScreenshot: ${SCREENSHOT_DIR}/03-recent-gateways

--- a/apps/mobile/visual/flows/03-recent-gateways.yaml
+++ b/apps/mobile/visual/flows/03-recent-gateways.yaml
@@ -4,12 +4,12 @@ appId: com.vesta.mobile
 - launchApp:
     clearState: true
 - extendedWaitUntil:
-    visible: "Connect with Vesta Cloud"
+    visible: "Self-hosting.*Connect your gateway"
     timeout: 60000
 - openLink: vesta://recent-gateways
 - extendedWaitUntil:
-    visible: "No saved gateways."
+    visible: ".*No saved gateways.*"
     timeout: 15000
 - waitForAnimationToEnd:
     timeout: 5000
-- takeScreenshot: ${SCREENSHOT_DIR}/03-recent-gateways
+- takeScreenshot: 03-recent-gateways

--- a/apps/mobile/visual/flows/03-recent-gateways.yaml
+++ b/apps/mobile/visual/flows/03-recent-gateways.yaml
@@ -7,6 +7,11 @@ appId: com.vesta.mobile
     visible: "Self-hosting.*Connect your gateway"
     timeout: 60000
 - openLink: vesta://recent-gateways
+# openLink from outside the app pops the springboard "Open in Vesta?" dialog;
+# optional so the flow survives an iOS version that skips it.
+- tapOn:
+    text: "Open"
+    optional: true
 - extendedWaitUntil:
     visible: ".*No saved gateways.*"
     timeout: 15000


### PR DESCRIPTION
Addresses #1463

Per-PR visual screenshot review for the iOS app, first increment: the unprivileged capture half done well, with the trusted comment half in its minimal safe form.

## What this delivers

**`Mobile Visual Review` (`.github/workflows/mobile-visual.yml`)**, a `pull_request` workflow path-filtered on `apps/mobile/**` and `apps/core/**` (mobile bundles `@vesta/core`; `apps/web` is not an input to the Expo app):

- Runs with `permissions: contents: read` only; per-PR concurrency cancels superseded runs, so a new commit replaces the prior review output.
- `expo prebuild` + unsigned Release-configuration simulator build (same foundation as the existing `mobile-native` job; Release embeds the JS bundle so the app runs standalone, with no Metro and no dev-client launcher).
- Boots a pinned simulator (`apps/mobile/visual/boot-simulator.sh`): fixed device-type candidate list, newest installed runtime, `en_US` locale, light appearance, frozen 9:41 status bar, `TZ=UTC`, pinned Maestro and Pillow versions.
- Runs the Maestro screen catalog in `apps/mobile/visual/flows/` with named screenshots per page, JUnit report, and Maestro debug output.
- Generates `contact-sheet.png` (labelled grid of every capture) and uploads the whole `visual-out/` tree as the `mobile-visual-screenshots` artifact, `if: always()`, so a failed capture still ships diagnostics that name the failing page.

**`Mobile Visual Review Comment` (`.github/workflows/mobile-visual-comment.yml`)**, the trusted half per the issue's security model: `workflow_run`-triggered, runs the default branch's workflow file, never checks out or executes PR code, and interpolates only event data (head SHA, conclusion, run/artifact ids) into one sticky marker comment linking the newest run's artifact. Fork PRs get the same treatment because the PR is resolved from the head commit, not `workflow_run.pull_requests`. Note: `workflow_run` workflows only activate once the file exists on the default branch, so this half can only be exercised after merge.

**Catalog scaffolding + doc** (`apps/mobile/visual/README.md`): the current catalog, determinism rules, local-run instructions, and a step-by-step "registering a new page" section (acceptance criterion).

## Initial catalog

Disconnected surfaces, which render deterministically on a clean install with no gateway, credentials, or user data:

- `01-connect`: disconnected landing screen
- `02-connect-link`: gateway link sheet (reached by tap)
- `03-recent-gateways`: recent gateways sheet, empty state (reached by deep link)

The QR scanner is excluded for now (camera permission prompt + camera-less simulator make the capture meaningless).

## Acceptance criteria: delivered vs deferred

| Criterion | Status |
| --- | --- |
| Runs automatically on mobile UI changes | Delivered (`apps/mobile/**`, `apps/core/**`) |
| Full canonical catalog with deterministic fixture data | Partial: disconnected surfaces only; connected/agent screens need a fixture gateway mode that cannot ship enabled in production, deferred |
| One persistent PR comment with contact sheet + gallery link | Partial: sticky comment links the run + artifact; durable inline thumbnails need a snapshots branch or Pages and are deferred with the comment as the safe skeleton |
| Full-resolution screenshots, logs, reports retained as artifacts | Delivered |
| Failed capture identifies the page, leaves diagnostics | Delivered (per-flow JUnit + Maestro debug output, uploaded on failure) |
| Rerun replaces prior review output | Delivered (concurrency + sticky comment update) |
| No production credentials or live user data | Delivered (clean-install app, no secrets in either workflow) |
| Fork-safe permission model documented | Delivered (read-only capture workflow; trusted half executes no PR code; documented here and in the workflow headers) |
| Doc explains registering a new page | Delivered (`apps/mobile/visual/README.md`) |

Non-goals from the issue (pixel-diff assertions, Android, dark mode, state matrices) remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
