### PR TITLE
fix(onboard): disclose the inviter's first-month cut at the point of sale

### DIFF
--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -89,7 +89,9 @@ and links between them and the CLI.
    first; nothing here works without it.
 3. **Agree a name + a price.** What do they want it called / how should it feel
    (`onboard presets` for personalities + skills, and the live `plan_floor_usd`)?
-   Agree the monthly price (see **Pricing**).
+   Agree the monthly price (see **Pricing**), and disclose your cut when you quote
+   it, owning it with a wink: *"Full disclosure: the friend who let you in earns
+   half your first month. The club pays its doormen."*
 4. **Send the Stripe link.** `onboard checkout --email <e> [--price <usd>] [--code
    <code>]` → `{ url, subdomain }`. Send the `url` as a tappable link, never bare
    text: where the channel renders Markdown links, format it as `[Complete your


### PR DESCRIPTION
Fixes #1146

## What

Adds one buyer-facing disclosure line to the onboard close (`agent/skills/onboard/SKILL.md`, step 3 of Setting them up): when the price is quoted, Vesta discloses the referral cut out loud:

> "Full disclosure: the friend who let you in earns half your first month. The club pays its doormen."

## Why

The pricing playbook is public in this repo, the inviter earns half the buyer's first month, and that conflict of interest was disclosed nowhere buyer-facing. Owning it at the point of sale turns the leak into charm and keeps the pricing mechanic intact.

This implements **option (a)** of the two options in the issue, following the issue's own recommendation. The alternative, **option (b)** (publish a fixed anchor price and constrain negotiation to discounts below it), is a pricing-strategy call: if the owner prefers (b), close this PR in favor of that approach.

Pairs with elyxlz/vesta-cloud#130, which adds the matching disclosure to terms section 6.

## Checks

`./check.sh agent` and `./check.sh guards` green locally (two unrelated flaky tasks-CLI e2e failures under disk/load pressure passed on rerun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
