### PR TITLE
fix(agent): cap the events.db writer busy timeout at 1s so a held lock cannot stall the event loop

### DIFF
--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -227,10 +227,8 @@ def _migrate(conn: sqlite3.Connection) -> None:
 
 
 # The writer connection's busy timeout: emit() runs INSERT+COMMIT inline on the event loop
-# thread, so this bounds how long a held lock (a long-running VACUUM/maintenance op, an
-# external tool touching the db) can stall the whole loop per event. Kept short: on expiry
-# the guard in emit() drops the row with a warning, the accepted contention behavior, so a
-# long wait buys nothing.
+# thread, so this bounds how long a held lock can stall the whole loop per event. Kept short
+# since a long wait buys nothing; see the drop-on-expiry guard in emit() below.
 WRITER_BUSY_TIMEOUT_S = 1.0
 
 

--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -226,11 +226,16 @@ def _migrate(conn: sqlite3.Connection) -> None:
         current = version
 
 
+# The writer connection's busy timeout: emit() runs INSERT+COMMIT inline on the event loop
+# thread, so this bounds how long a held lock (a long-running VACUUM/maintenance op, an
+# external tool touching the db) can stall the whole loop per event. Kept short: on expiry
+# the guard in emit() drops the row with a warning, the accepted contention behavior, so a
+# long wait buys nothing.
+WRITER_BUSY_TIMEOUT_S = 1.0
+
+
 def _open(db_path: pl.Path) -> sqlite3.Connection:
-    # timeout sets SQLite's busy handler: a write waits up to N seconds for a held lock (e.g. a
-    # long-running VACUUM/maintenance op) instead of raising "database is locked" immediately.
-    # Pairs with the guard in emit() below.
-    conn = sqlite3.connect(str(db_path), timeout=30)
+    conn = sqlite3.connect(str(db_path), timeout=WRITER_BUSY_TIMEOUT_S)
     conn.execute("PRAGMA journal_mode=WAL")
     # Catches deep-page corruption (a hot-copied backup, bit rot) that a plain connect() would
     # let through lazily, so it surfaces here at boot rather than mid-turn during emit/recent.

--- a/agent/tests/test_eventbus.py
+++ b/agent/tests/test_eventbus.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+import time
 import typing as tp
 
 import pytest
@@ -10,6 +11,7 @@ from core.events import (
     _EVENTS_SCHEMA,
     _SCHEMA_VERSION,
     SUBSCRIBER_QUEUE_MAXSIZE,
+    WRITER_BUSY_TIMEOUT_S,
     AssistantEvent,
     EventBus,
     NotificationClearedEvent,
@@ -62,6 +64,30 @@ def test_emit_survives_history_write_failure(event_bus):
     event_bus._conn.close()
     event_bus.emit(AssistantEvent(type="assistant", text="still delivered"))
     assert q.get_nowait()["text"] == "still delivered"
+
+
+def test_emit_under_held_write_lock_returns_fast_and_drops(event_bus, caplog):
+    """A held exclusive lock on events.db (a VACUUM, an external tool) stalls emit for at most the
+    writer busy timeout, never 30s: the row is dropped with a warning, live subscribers still
+    receive the event, and the event loop thread is back within a small bound."""
+    locker = sqlite3.connect(str(event_bus._db_path))
+    locker.execute("BEGIN IMMEDIATE")
+    try:
+        q = event_bus.subscribe()
+        start = time.monotonic()
+        with caplog.at_level("WARNING", logger="vesta.events"):
+            event_bus.emit(AssistantEvent(type="assistant", text="under contention"))
+        elapsed = time.monotonic() - start
+    finally:
+        locker.rollback()
+        locker.close()
+
+    assert WRITER_BUSY_TIMEOUT_S <= 1.0
+    assert elapsed < 5.0, f"emit blocked {elapsed:.1f}s under a held write lock"
+    delivered = q.get_nowait()
+    assert delivered["text"] == "under contention"
+    assert delivered["id"] < 0
+    assert any("dropping event" in record.getMessage() for record in caplog.records)
 
 
 def test_no_data_dir():

--- a/agent/tests/test_eventbus.py
+++ b/agent/tests/test_eventbus.py
@@ -79,7 +79,6 @@ def test_emit_under_held_write_lock_returns_fast_and_drops(event_bus, caplog):
             event_bus.emit(AssistantEvent(type="assistant", text="under contention"))
         elapsed = time.monotonic() - start
     finally:
-        locker.rollback()
         locker.close()
 
     assert WRITER_BUSY_TIMEOUT_S <= 1.0


### PR DESCRIPTION
Fixes #1098

## Problem

`EventBus.emit` runs INSERT+COMMIT inline on the event loop thread, and the writer connection was created with `timeout=30`. Any exclusive lock on events.db (a VACUUM or maintenance pass, an external tool touching the db) therefore stalled the whole loop for up to 30 seconds per event: the WS server stopped answering, the monitor loop stalled, and turn processing froze. The long wait bought nothing: on expiry the guard in `emit` drops the row with a warning anyway (broadened to all `sqlite3.Error` by #1085).

## Fix

The writer connection's busy timeout is now the named constant `WRITER_BUSY_TIMEOUT_S = 1.0` in `agent/core/events.py`. A contended emit stalls the loop for at most about 1s, then falls into the already-accepted logged-drop path.

## Alternative considered

A dedicated writer thread fed by a queue (zero loop blocking, no rows dropped) was considered, per the issue, and deliberately not taken: it adds a new moving part (a thread, its shutdown, its backpressure) to a single-tenant daemon where drop-on-contention is already the accepted, logged behavior. The 1s timeout is 90% of the value at a fraction of the machinery; the writer thread remains the fork to revisit only if losing history rows under contention becomes unacceptable.

## Test

`test_emit_under_held_write_lock_returns_fast_and_drops` (agent/tests/test_eventbus.py): a second sqlite connection holds `BEGIN IMMEDIATE` on the hermetic tmpdir db, `emit` returns within a generous 5s wall bound (busy timeout pinned at or below 1s), the event still reaches live subscribers with a negative live id, and the drop warning is logged.

`./check.sh agent` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)