### PR TITLE
fix(vestad): defer scheduled backups while the agent is mid-task

### DIFF
--- a/vestad/src/agent_status.rs
+++ b/vestad/src/agent_status.rs
@@ -231,6 +231,13 @@ impl AgentStatusCache {
         self.activity_rx.clone()
     }
 
+    /// Snapshot of each tapped agent's live activity state ("idle"/"thinking"). Agents that are
+    /// stopped or unreachable have no entry. The auto-backup scheduler reads it to defer a
+    /// scheduled backup while an agent is mid-task.
+    pub fn activity(&self) -> HashMap<String, String> {
+        self.activity_rx.borrow().clone()
+    }
+
     /// Snapshot of each alive agent's IANA timezone, as last reported on its connect snapshot.
     pub fn timezones(&self) -> HashMap<String, String> {
         self.timezones_rx.borrow().clone()

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -17,6 +17,42 @@ const MIN_DISK_SPACE_BYTES: u64 = 1_000_000_000; // 1 GB
 const DISK_SPACE_MARGIN_BYTES: u64 = 500_000_000; // 500 MB margin above container size
 pub const BACKUP_STOP_TIMEOUT_SECS: i32 = 30;
 pub const MIN_AGE_FOR_BACKUP_SECS: u64 = 6 * 3600;
+/// How soon the auto-backup loop re-checks a busy agent it deferred.
+pub const BUSY_RECHECK_INTERVAL_SECS: u64 = 5 * 60;
+/// Hard cap on total deferral: a permanently-busy agent is backed up anyway past this.
+pub const MAX_BUSY_DEFERRAL_SECS: u64 = 6 * 3600;
+
+/// Whether a scheduled backup should run now or wait for the agent to go idle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScheduledBackupGate {
+    /// Agent idle (or unreachable, which is not mid-task): back up now.
+    Run,
+    /// Agent still busy but the deferral cap expired: back up anyway.
+    RunDeferralExpired,
+    /// Agent mid-task: skip and re-check soon.
+    Defer,
+}
+
+/// Gate a scheduled backup on agent activity. `activity` is the live tap state ("idle"/"thinking");
+/// `None` means the agent is stopped or unreachable, so the stop/snapshot cannot kill in-flight
+/// work and the backup proceeds. `deferred_since_epoch` is when this agent's pending backup was
+/// first deferred, `None` on the first busy sighting.
+pub fn gate_scheduled_backup(
+    activity: Option<&str>,
+    deferred_since_epoch: Option<u64>,
+    now_epoch: u64,
+) -> ScheduledBackupGate {
+    let busy = activity.is_some_and(|state| state != "idle");
+    if !busy {
+        return ScheduledBackupGate::Run;
+    }
+    match deferred_since_epoch {
+        Some(since) if now_epoch.saturating_sub(since) >= MAX_BUSY_DEFERRAL_SECS => {
+            ScheduledBackupGate::RunDeferralExpired
+        }
+        _ => ScheduledBackupGate::Defer,
+    }
+}
 
 /// Acquire an exclusive file lock for the given agent. The lock is held for the
 /// lifetime of the returned Flock. Used to coordinate between the vestad API and
@@ -437,6 +473,57 @@ mod tests {
         assert!(
             !restore_body.contains("remove_container_force"),
             "restore_backup must use ensure_container_removed (confirms gone), not the best-effort remove_container_force"
+        );
+    }
+
+    // ── Scheduled-backup busy gate tests ──────────────────────────
+
+    #[test]
+    fn gate_runs_when_agent_is_idle() {
+        assert_eq!(
+            gate_scheduled_backup(Some("idle"), None, 1000),
+            ScheduledBackupGate::Run
+        );
+    }
+
+    #[test]
+    fn gate_runs_when_activity_is_unknown() {
+        // A stopped or unreachable agent has no tap entry; it is not mid-task.
+        assert_eq!(
+            gate_scheduled_backup(None, None, 1000),
+            ScheduledBackupGate::Run
+        );
+    }
+
+    #[test]
+    fn gate_defers_on_first_busy_sighting() {
+        assert_eq!(
+            gate_scheduled_backup(Some("thinking"), None, 1000),
+            ScheduledBackupGate::Defer
+        );
+    }
+
+    #[test]
+    fn gate_defers_while_under_the_cap() {
+        assert_eq!(
+            gate_scheduled_backup(Some("thinking"), Some(1000), 1000 + MAX_BUSY_DEFERRAL_SECS - 1),
+            ScheduledBackupGate::Defer
+        );
+    }
+
+    #[test]
+    fn gate_forces_the_backup_once_the_cap_expires() {
+        assert_eq!(
+            gate_scheduled_backup(Some("thinking"), Some(1000), 1000 + MAX_BUSY_DEFERRAL_SECS),
+            ScheduledBackupGate::RunDeferralExpired
+        );
+    }
+
+    #[test]
+    fn gate_runs_when_a_deferred_agent_goes_idle() {
+        assert_eq!(
+            gate_scheduled_backup(Some("idle"), Some(1000), 2000),
+            ScheduledBackupGate::Run
         );
     }
 

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2557,11 +2557,17 @@ pub fn build_router(state: SharedState) -> Router {
 
 fn spawn_auto_backup_task(state: SharedState) {
     tokio::spawn(async move {
+        // Per-agent epoch of the first busy deferral of its pending backup; cleared once it runs.
+        let mut busy_deferrals: HashMap<String, u64> = HashMap::new();
+        let mut recheck_soon = false;
         loop {
-            tokio::time::sleep(tokio::time::Duration::from_secs(
-                AUTO_BACKUP_CHECK_INTERVAL_SECS,
-            ))
-            .await;
+            let sleep_secs = if recheck_soon {
+                backup::BUSY_RECHECK_INTERVAL_SECS
+            } else {
+                AUTO_BACKUP_CHECK_INTERVAL_SECS
+            };
+            tokio::time::sleep(tokio::time::Duration::from_secs(sleep_secs)).await;
+            recheck_soon = false;
 
             let backup_settings = {
                 let settings = state.settings.read().await;
@@ -2589,6 +2595,7 @@ fn spawn_auto_backup_task(state: SharedState) {
             }
 
             let agents = backup::list_agent_names(&state.docker).await;
+            busy_deferrals.retain(|deferred_name, _| agents.contains(deferred_name));
 
             if agents.is_empty() {
                 tracing::debug!("auto-backup: no agents found, skipping cycle");
@@ -2660,6 +2667,30 @@ fn spawn_auto_backup_task(state: SharedState) {
                 }
 
                 if !needed.is_empty() {
+                    let activity = state.agent_status_cache.activity();
+                    match backup::gate_scheduled_backup(
+                        activity.get(name).map(String::as_str),
+                        busy_deferrals.get(name).copied(),
+                        now_epoch,
+                    ) {
+                        backup::ScheduledBackupGate::Defer => {
+                            let since = *busy_deferrals.entry(name.clone()).or_insert(now_epoch);
+                            tracing::info!(
+                                agent = %name,
+                                deferred_secs = now_epoch.saturating_sub(since),
+                                "auto-backup: agent busy, deferring until idle"
+                            );
+                            recheck_soon = true;
+                            continue;
+                        }
+                        backup::ScheduledBackupGate::RunDeferralExpired => {
+                            busy_deferrals.remove(name);
+                            tracing::warn!(agent = %name, "auto-backup: agent still busy after max deferral, backing up anyway");
+                        }
+                        backup::ScheduledBackupGate::Run => {
+                            busy_deferrals.remove(name);
+                        }
+                    }
                     let _file_lock = match backup::agent_file_lock(name) {
                         Ok(lock) => lock,
                         Err(e) => {


### PR DESCRIPTION
Fixes #1466

## Problem

Scheduled backups stop the container for the restic snapshot, restarting the agent even mid-task and destroying in-flight state (the reported incident: an SPID-authenticated browser session dropped mid-flow by a backup-triggered restart).

## Fix

Gate the auto-backup loop on agent idleness, using the live activity state vestad already taps from each agent's WS (`AgentStatusCache`, the same `"idle"`/`"thinking"` signal the app roster shows). No new protocol, no extra agent call: the busy-check is a read of the existing in-memory cache.

- Before taking a due scheduled backup, `backup::gate_scheduled_backup` (pure, unit-tested) decides: idle or unknown activity -> run; busy -> defer; busy past the cap -> run anyway.
- Deferral parameters: re-check every 5 minutes (`BUSY_RECHECK_INTERVAL_SECS`), hard cap of 6 hours total deferral (`MAX_BUSY_DEFERRAL_SECS`) so a permanently-busy agent still gets backed up. Deferrals and cap-expiry are logged.
- An agent with no activity entry (stopped, or its tap unreachable) is not mid-task, so the backup proceeds: the failure mode of the busy-check is designed out rather than special-cased.
- Manual and pre-restore backups are untouched and stay immediate.

## Tests

Six unit tests on the pure gate in `backup.rs` (idle, unknown activity, first busy sighting, under cap, cap expiry, busy-then-idle), in the fast `cargo test -p vestad --bins` tier. `./check.sh vestad` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)