### PR TITLE
Route notification reply commands to their source chat

### DIFF
--- a/agent/skills/app-chat/cli/src/app_chat_cli/cli.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/cli.py
@@ -45,7 +45,12 @@ def _build_parser() -> argparse.ArgumentParser:
         daemon_action_p.add_argument("--data-dir", default=None, help="Data directory (default: ~/.app-chat)")
 
     send_p = sub.add_parser("send", help="Send a message to the app")
-    send_p.add_argument("--message", "-m", required=True, help="Message text")
+    send_p.add_argument(
+        "--message",
+        "-m",
+        required=True,
+        help="Message text, or '-' to read the body from stdin (use a <<'MSG' heredoc for anything with apostrophes, quotes or newlines)",
+    )
     send_p.add_argument("--socket", default=None, help="Unix socket path (default: ~/.app-chat/app-chat.sock)")
     send_p.add_argument(
         "--longform",

--- a/agent/skills/app-chat/cli/src/app_chat_cli/commands.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/commands.py
@@ -13,7 +13,12 @@ from app_chat_cli.store import Store, store_path
 
 
 def cmd_send(args: argparse.Namespace) -> None:
-    message = args.message
+    # `-` reads the body from stdin, so a reply with apostrophes, quotes or newlines can be passed
+    # through a quoted heredoc instead of being escaped into an inline argument.
+    message = sys.stdin.read().rstrip("\r\n") if args.message == "-" else args.message
+    if not message:
+        print(json.dumps({"error": "--message is empty (pass '-' and a <<'MSG' heredoc to read the body from stdin)"}))
+        sys.exit(1)
 
     if not getattr(args, "longform", False):
         reason = bubble_lint_reason(message)

--- a/agent/skills/app-chat/cli/src/app_chat_cli/service.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/service.py
@@ -66,7 +66,7 @@ def _write_notification(state: ServiceState, text: str, intent_id: str | None) -
         "type": "message",
         "message": text,
         "interrupt": True,
-        "reply_command": "app-chat send --message '<reply>'",
+        "reply_command": "app-chat send --message -",
         "reply_hint": "think about how you can best show your personality",
     }
     if intent_id is not None:

--- a/agent/skills/app-chat/cli/src/app_chat_cli/service.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/service.py
@@ -66,7 +66,7 @@ def _write_notification(state: ServiceState, text: str, intent_id: str | None) -
         "type": "message",
         "message": text,
         "interrupt": True,
-        "reply_command": "app-chat send",
+        "reply_command": "app-chat send --message '<reply>'",
         "reply_hint": "think about how you can best show your personality",
     }
     if intent_id is not None:

--- a/agent/skills/app-chat/cli/tests/test_service.py
+++ b/agent/skills/app-chat/cli/tests/test_service.py
@@ -77,7 +77,7 @@ def test_message_persists_emits_and_writes_notification(tmp_path):
     assert notif["type"] == "message"
     assert notif["message"] == "hello there"
     assert notif["interrupt"] is True
-    assert notif["reply_command"] == "app-chat send"
+    assert notif["reply_command"] == "app-chat send --message '<reply>'"
     assert notif["reply_hint"] == "think about how you can best show your personality"
     state.store.close()
 

--- a/agent/skills/app-chat/cli/tests/test_service.py
+++ b/agent/skills/app-chat/cli/tests/test_service.py
@@ -77,7 +77,7 @@ def test_message_persists_emits_and_writes_notification(tmp_path):
     assert notif["type"] == "message"
     assert notif["message"] == "hello there"
     assert notif["interrupt"] is True
-    assert notif["reply_command"] == "app-chat send --message '<reply>'"
+    assert notif["reply_command"] == "app-chat send --message -"
     assert notif["reply_hint"] == "think about how you can best show your personality"
     state.store.close()
 

--- a/agent/skills/telegram/SKILL.md
+++ b/agent/skills/telegram/SKILL.md
@@ -10,9 +10,14 @@ description: Telegram: send/receive messages; reply to source=telegram notificat
 
 ## Quick Reference
 ```bash
-telegram send '<contact_name>' 'Hello!'
-telegram send '<contact_name>' 'long text' --message-file /tmp/body.txt   # prefer --message-file when the body has apostrophes, quotes, backticks, $(...), or multiple lines: an inline string lets the shell mangle or even evaluate it
-telegram send '<contact_name>' 'reply' --reply-to '<message_id>'          # quote a message
+# The one shape to use for any message body. Replace only the middle line.
+telegram send --to '<contact_name>' --message - <<'MSG'
+can't wait to see you
+MSG
+
+telegram send --to '<contact_name>' --message - --reply-to '<message_id>' <<'MSG'   # quote a message
+same here
+MSG
 telegram send '<contact_name>' '<a brief or list they asked for>' --longform  # bypass short-bubble lint
 telegram chats
 telegram contacts
@@ -63,7 +68,7 @@ Notification types written for the agent: `message`, `callback_query` (button ta
 reactions via `react` works). Aliases: `send`/`edit`/`del`/`voice`/`action`/`pin`/`unpin`.
 
 ## Notes
-- `send-message` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. `--message-file` sends are linted too, so `--longform` is the only escape hatch.
+- `send-message` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. Heredoc sends are linted too, so `--longform` is the only escape hatch.
 - A numbered or bulleted list is fine to send as one message (each item is one short thought); a line-leading marker like `1.` or `2)` is not a full stop, so a list does not need `--longform`.
 - Chat IDs are numeric (e.g., `123456789` for private, `-1001234567890` for groups)
 - Users must `/start` the bot before it can message them

--- a/agent/skills/telegram/cli/bubblelint.go
+++ b/agent/skills/telegram/cli/bubblelint.go
@@ -7,7 +7,7 @@ package main
 // read like an assistant, not a person. Linting the one place every send passes
 // through makes it structural: a wall is rejected with the reason, so the agent
 // re-sends as several short calls with its own break points. The single bypass
-// is `--longform` (reference material the user asked for); `--message-file` sends are linted too.
+// is `--longform` (reference material the user asked for); heredoc sends are linted too.
 
 import (
 	"fmt"

--- a/agent/skills/telegram/cli/cli.go
+++ b/agent/skills/telegram/cli/cli.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -233,9 +235,55 @@ func stripGlobalFlags(args []string) []string {
 	return filtered
 }
 
+// resolveStdinArgs replaces a `-` body value with this process's stdin, before the command is
+// forwarded to the daemon. executeCommand runs inside the daemon, whose stdin is not ours, so a `-`
+// that reached it would read EOF and the send would fail as an empty body. Handles both
+// `--flag -` and `--flag=-`; a body is read at most once.
+func resolveStdinArgs(args []string, bodyFlags ...string) ([]string, error) {
+	out := slices.Clone(args)
+	body := ""
+	read := false
+	readOnce := func() (string, error) {
+		if !read {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return "", err
+			}
+			body, read = strings.TrimRight(string(data), "\r\n"), true
+		}
+		return body, nil
+	}
+
+	for i, arg := range out {
+		name, inline, hasInline := strings.Cut(arg, "=")
+		if !strings.HasPrefix(name, "-") || !slices.Contains(bodyFlags, strings.TrimLeft(name, "-")) {
+			continue
+		}
+		if hasInline && inline == "-" {
+			text, err := readOnce()
+			if err != nil {
+				return nil, err
+			}
+			out[i] = name + "=" + text
+		} else if !hasInline && i+1 < len(out) && out[i+1] == "-" {
+			text, err := readOnce()
+			if err != nil {
+				return nil, err
+			}
+			out[i+1] = text
+		}
+	}
+	return out, nil
+}
+
 func runOneShot(command string) {
 	sockPath := getSocketPath()
-	output, exitCode, connected := trySocketCommand(sockPath, command, stripGlobalFlags(os.Args[1:]))
+	args, err := resolveStdinArgs(stripGlobalFlags(os.Args[1:]), "message")
+	if err != nil {
+		printJSON(map[string]interface{}{"error": fmt.Sprintf("could not read the body from stdin: %v", err)})
+		os.Exit(1)
+	}
+	output, exitCode, connected := trySocketCommand(sockPath, command, args)
 	if !connected {
 		printJSON(map[string]interface{}{"error": "daemon not running; start with: telegram daemon start"})
 		os.Exit(1)
@@ -380,27 +428,24 @@ func executeCommand(command string, args []string, tc *TelegramClient) (interfac
 		return map[string]interface{}{"chats": chats}, nil
 
 	case "send-message":
-		var to, message, messageFile, buttons, replyToStr string
+		var to, message, buttons, replyToStr string
 		var longform bool
 		fs := flag.NewFlagSet("send-message", flag.ContinueOnError)
 		fs.StringVar(&to, "to", "", "Recipient (name, username, or chat ID)")
-		fs.StringVar(&message, "message", "", "Message text")
-		fs.StringVar(&messageFile, "message-file", "", "Read message body from this file (avoids shell-escaping long text)")
+		fs.StringVar(&message, "message", "", "Message text, or '-' to read the body from stdin (use a <<'MSG' heredoc for anything with apostrophes, quotes, backticks or newlines)")
 		fs.StringVar(&buttons, "buttons", "", "Inline keyboard: rows by ';', buttons by ',', each 'Label=callback_data' (or 'Label=url:https://...')")
 		fs.StringVar(&replyToStr, "reply-to", "", "Quote/reply to this message ID")
 		fs.BoolVar(&longform, "longform", false, "Bypass the short-bubble lint for genuine reference material (a brief, a code block, a list they asked for).")
 		if err := fs.Parse(args); err != nil {
 			return nil, err
 		}
-		if messageFile != "" {
-			b, err := os.ReadFile(messageFile)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read --message-file: %v", err)
-			}
-			message = string(b)
+		if to == "" {
+			return nil, fmt.Errorf("--to is required")
 		}
-		if to == "" || message == "" {
-			return nil, fmt.Errorf("--to and --message (or --message-file) are required")
+		// resolveStdinArgs swapped a `-` for the real body in the client process; still seeing one
+		// here means nothing was piped in.
+		if message == "" || message == "-" {
+			return nil, fmt.Errorf("--message is required (pass '-' and a <<'MSG' heredoc to read the body from stdin)")
 		}
 		if !longform {
 			if reason := bubbleLintReason(message); reason != "" {
@@ -428,25 +473,22 @@ func executeCommand(command string, args []string, tc *TelegramClient) (interfac
 		return map[string]interface{}{"success": true, "message_id": msgID, "message": "Message sent successfully"}, nil
 
 	case "edit-message":
-		var to, messageIDStr, message, messageFile, buttons string
+		var to, messageIDStr, message, buttons string
 		fs := flag.NewFlagSet("edit-message", flag.ContinueOnError)
 		fs.StringVar(&to, "to", "", "Chat (name, username, or chat ID)")
 		fs.StringVar(&messageIDStr, "message-id", "", "ID of the message to edit")
-		fs.StringVar(&message, "message", "", "New message text")
-		fs.StringVar(&messageFile, "message-file", "", "Read new text from this file")
+		fs.StringVar(&message, "message", "", "New message text, or '-' to read it from stdin (use a <<'MSG' heredoc for anything with apostrophes, quotes, backticks or newlines)")
 		fs.StringVar(&buttons, "buttons", "", "Replacement inline keyboard (same format as send-message; omit to clear/keep none)")
 		if err := fs.Parse(args); err != nil {
 			return nil, err
 		}
-		if messageFile != "" {
-			b, err := os.ReadFile(messageFile)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read --message-file: %v", err)
-			}
-			message = string(b)
+		if to == "" || messageIDStr == "" {
+			return nil, fmt.Errorf("--to and --message-id are required")
 		}
-		if to == "" || messageIDStr == "" || message == "" {
-			return nil, fmt.Errorf("--to, --message-id, and --message (or --message-file) are required")
+		// resolveStdinArgs swapped a `-` for the real body in the client process; still seeing one
+		// here means nothing was piped in.
+		if message == "" || message == "-" {
+			return nil, fmt.Errorf("--message is required (pass '-' and a <<'MSG' heredoc to read the body from stdin)")
 		}
 		messageID, err := strconv.ParseInt(messageIDStr, 10, 64)
 		if err != nil {

--- a/agent/skills/telegram/cli/cli.go
+++ b/agent/skills/telegram/cli/cli.go
@@ -237,41 +237,36 @@ func stripGlobalFlags(args []string) []string {
 
 // resolveStdinArgs replaces a `-` body value with this process's stdin, before the command is
 // forwarded to the daemon. executeCommand runs inside the daemon, whose stdin is not ours, so a `-`
-// that reached it would read EOF and the send would fail as an empty body. Handles both
-// `--flag -` and `--flag=-`; a body is read at most once.
+// that reached it would read EOF and the send would fail as an empty body. Accepts both `--flag -`
+// and `--flag=-`, the two forms the flag package itself accepts; a command carries one body, so the
+// first match is the only one.
 func resolveStdinArgs(args []string, bodyFlags ...string) ([]string, error) {
 	out := slices.Clone(args)
-	body := ""
-	read := false
-	readOnce := func() (string, error) {
-		if !read {
-			data, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				return "", err
-			}
-			body, read = strings.TrimRight(string(data), "\r\n"), true
-		}
-		return body, nil
-	}
-
 	for i, arg := range out {
-		name, inline, hasInline := strings.Cut(arg, "=")
+		name, value, inline := strings.Cut(arg, "=")
 		if !strings.HasPrefix(name, "-") || !slices.Contains(bodyFlags, strings.TrimLeft(name, "-")) {
 			continue
 		}
-		if hasInline && inline == "-" {
-			text, err := readOnce()
-			if err != nil {
-				return nil, err
+		at := i
+		if !inline {
+			at, value = i+1, ""
+			if at < len(out) {
+				value = out[at]
 			}
-			out[i] = name + "=" + text
-		} else if !hasInline && i+1 < len(out) && out[i+1] == "-" {
-			text, err := readOnce()
-			if err != nil {
-				return nil, err
-			}
-			out[i+1] = text
 		}
+		if value != "-" {
+			continue
+		}
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, err
+		}
+		body := strings.TrimRight(string(data), "\r\n")
+		if inline {
+			body = name + "=" + body
+		}
+		out[at] = body
+		return out, nil
 	}
 	return out, nil
 }

--- a/agent/skills/telegram/cli/main.go
+++ b/agent/skills/telegram/cli/main.go
@@ -19,7 +19,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  authenticate                         save the bot token / print auth status")
 	fmt.Fprintln(w, "Commands (short aliases in parentheses):")
 	fmt.Fprintln(w, "  send-message (send) [to] [message]   send-file (file) [to] [path]")
-	fmt.Fprintln(w, "    send-message flags: --buttons 'L1=d1,L2=d2;L3=d3'  --reply-to <id>  --message-file <path>")
+	fmt.Fprintln(w, "    send-message flags: --buttons 'L1=d1,L2=d2;L3=d3'  --reply-to <id>  --message - (heredoc)")
 	fmt.Fprintln(w, "  edit-message [to] [message-id] [message] (--buttons)  delete-message (del) [to] [message-id]")
 	fmt.Fprintln(w, "  answer-callback [callback-id] (--text --alert)   send-voice [to] [file-path]")
 	fmt.Fprintln(w, "  send-chat-action [to] [action]       pin-message [to] [message-id]   unpin-message [to] [message-id]")

--- a/agent/skills/telegram/cli/notifications.go
+++ b/agent/skills/telegram/cli/notifications.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ type messageNotif struct {
 	ReplyToID      int64  `json:"reply_to_id,omitempty"`
 	Timestamp      string `json:"timestamp"`
 	MessageID      int64  `json:"message_id,omitempty"`
+	ChatID         int64  `json:"chat_id,omitempty"`
 	ContactUnknown bool   `json:"contact_unknown,omitempty"`
 	ReplyCommand   string `json:"reply_command,omitempty"`
 	ReplyHint      string `json:"reply_hint,omitempty"`
@@ -62,6 +64,7 @@ type editNotif struct {
 	Message         string `json:"message"`
 	Timestamp       string `json:"timestamp"`
 	TargetMessageID int64  `json:"target_message_id"`
+	ChatID          int64  `json:"chat_id,omitempty"`
 	ContactUnknown  bool   `json:"contact_unknown,omitempty"`
 	ReplyCommand    string `json:"reply_command,omitempty"`
 	ReplyHint       string `json:"reply_hint,omitempty"`
@@ -89,28 +92,18 @@ func quoteReplyArg(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
-// The addressed template is only offered for a target `telegram send` can actually resolve
-// (MessageStore.ResolveRecipient): a saved contact, matched on contacts.name, or a stored chat,
-// matched on chats.name. An unsaved sender has no contacts row by definition, and their @username
-// is looked up in that same table, so there is nothing to address them by; they get the bare
-// command and the agent works the recipient out from the notification's other fields.
-func notificationReplyCommand(chatName, contactName, instance string, isDirectChat, contactSaved bool) string {
-	const bare = "telegram send"
-	target := chatName
-	if isDirectChat {
-		if !contactSaved {
-			return bare
-		}
-		target = contactName
-	}
-	if target == "" {
-		return bare
-	}
-	command := bare
+// Every notification carries a complete reply command. The target is always the numeric chat ID, which
+// ResolveRecipient matches first and which needs no saved contact, so there is no case where the
+// agent has to work the recipient out for itself. It stops at `--message -`: the notification is
+// rendered as an XML attribute, so a heredoc here would reach the agent as &lt;&lt; and &#10;
+// entities. `-` says the body comes from stdin and SKILL.md carries the one heredoc shape, which
+// keeps the reply body out of the shell's reach.
+func notificationReplyCommand(chatID int64, instance string) string {
+	command := "telegram send"
 	if instance != "" {
 		command += " --instance " + quoteReplyArg(instance)
 	}
-	return command + " --to " + quoteReplyArg(target) + " --message '<reply>'"
+	return command + " --to " + quoteReplyArg(strconv.FormatInt(chatID, 10)) + " --message -"
 }
 
 func WriteCallbackNotification(
@@ -146,7 +139,7 @@ func WriteCallbackNotification(
 }
 
 func WriteEditNotification(
-	notifDir string, targetMessageID int64, chatName, contactName, username, instance string,
+	notifDir string, targetMessageID, chatID int64, chatName, contactName, username, instance string,
 	contactSaved, isDirectChat bool,
 	sender, oldText, newText string,
 ) error {
@@ -168,8 +161,9 @@ func WriteEditNotification(
 		Message:         newText,
 		Timestamp:       time.Now().Format(time.RFC3339),
 		TargetMessageID: targetMessageID,
+		ChatID:          chatID,
 		ContactUnknown:  !contactSaved,
-		ReplyCommand:    notificationReplyCommand(chatName, contactName, instance, isDirectChat, contactSaved),
+		ReplyCommand:    notificationReplyCommand(chatID, instance),
 		ReplyHint:       "they changed a message you may have already answered; reply only if the change asks something new",
 	}
 	if !isDirectChat {
@@ -188,7 +182,7 @@ func WriteEditNotification(
 }
 
 func WriteNotification(
-	notifDir string, messageID int64, chatName, contactName, username, instance string,
+	notifDir string, messageID, chatID int64, chatName, contactName, username, instance string,
 	contactSaved, isDirectChat bool,
 	sender, content, mediaType string,
 	replyToID int64,
@@ -212,8 +206,9 @@ func WriteNotification(
 		ReplyToID:      replyToID,
 		Timestamp:      time.Now().Format(time.RFC3339),
 		MessageID:      messageID,
+		ChatID:         chatID,
 		ContactUnknown: !contactSaved,
-		ReplyCommand:   notificationReplyCommand(chatName, contactName, instance, isDirectChat, contactSaved),
+		ReplyCommand:   notificationReplyCommand(chatID, instance),
 		ReplyHint:      "think about how you can best show your personality",
 	}
 	if !isDirectChat {

--- a/agent/skills/telegram/cli/notifications.go
+++ b/agent/skills/telegram/cli/notifications.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -84,6 +85,28 @@ type callbackNotif struct {
 	ContactUnknown bool   `json:"contact_unknown,omitempty"`
 }
 
+func quoteReplyArg(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func notificationReplyCommand(chatName, contactName, username, instance string, isDirectChat, contactSaved bool) string {
+	target := chatName
+	if isDirectChat {
+		if contactSaved {
+			target = contactName
+		} else if username != "" {
+			target = "@" + username
+		} else {
+			target = contactName
+		}
+	}
+	command := "telegram send"
+	if instance != "" {
+		command += " --instance " + quoteReplyArg(instance)
+	}
+	return command + " --to " + quoteReplyArg(target) + " --message '<reply>'"
+}
+
 func WriteCallbackNotification(
 	notifDir, callbackID, data string, chatID, messageID int64,
 	contactName, sender, username, instance string, contactSaved bool,
@@ -140,7 +163,7 @@ func WriteEditNotification(
 		Timestamp:       time.Now().Format(time.RFC3339),
 		TargetMessageID: targetMessageID,
 		ContactUnknown:  !contactSaved,
-		ReplyCommand:    "telegram send",
+		ReplyCommand:    notificationReplyCommand(chatName, contactName, username, instance, isDirectChat, contactSaved),
 		ReplyHint:       "they changed a message you may have already answered; reply only if the change asks something new",
 	}
 	if !isDirectChat {
@@ -184,7 +207,7 @@ func WriteNotification(
 		Timestamp:      time.Now().Format(time.RFC3339),
 		MessageID:      messageID,
 		ContactUnknown: !contactSaved,
-		ReplyCommand:   "telegram send",
+		ReplyCommand:   notificationReplyCommand(chatName, contactName, username, instance, isDirectChat, contactSaved),
 		ReplyHint:      "think about how you can best show your personality",
 	}
 	if !isDirectChat {

--- a/agent/skills/telegram/cli/notifications.go
+++ b/agent/skills/telegram/cli/notifications.go
@@ -89,18 +89,24 @@ func quoteReplyArg(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
-func notificationReplyCommand(chatName, contactName, username, instance string, isDirectChat, contactSaved bool) string {
+// The addressed template is only offered for a target `telegram send` can actually resolve
+// (MessageStore.ResolveRecipient): a saved contact, matched on contacts.name, or a stored chat,
+// matched on chats.name. An unsaved sender has no contacts row by definition, and their @username
+// is looked up in that same table, so there is nothing to address them by; they get the bare
+// command and the agent works the recipient out from the notification's other fields.
+func notificationReplyCommand(chatName, contactName, instance string, isDirectChat, contactSaved bool) string {
+	const bare = "telegram send"
 	target := chatName
 	if isDirectChat {
-		if contactSaved {
-			target = contactName
-		} else if username != "" {
-			target = "@" + username
-		} else {
-			target = contactName
+		if !contactSaved {
+			return bare
 		}
+		target = contactName
 	}
-	command := "telegram send"
+	if target == "" {
+		return bare
+	}
+	command := bare
 	if instance != "" {
 		command += " --instance " + quoteReplyArg(instance)
 	}
@@ -163,7 +169,7 @@ func WriteEditNotification(
 		Timestamp:       time.Now().Format(time.RFC3339),
 		TargetMessageID: targetMessageID,
 		ContactUnknown:  !contactSaved,
-		ReplyCommand:    notificationReplyCommand(chatName, contactName, username, instance, isDirectChat, contactSaved),
+		ReplyCommand:    notificationReplyCommand(chatName, contactName, instance, isDirectChat, contactSaved),
 		ReplyHint:       "they changed a message you may have already answered; reply only if the change asks something new",
 	}
 	if !isDirectChat {
@@ -207,7 +213,7 @@ func WriteNotification(
 		Timestamp:      time.Now().Format(time.RFC3339),
 		MessageID:      messageID,
 		ContactUnknown: !contactSaved,
-		ReplyCommand:   notificationReplyCommand(chatName, contactName, username, instance, isDirectChat, contactSaved),
+		ReplyCommand:   notificationReplyCommand(chatName, contactName, instance, isDirectChat, contactSaved),
 		ReplyHint:      "think about how you can best show your personality",
 	}
 	if !isDirectChat {

--- a/agent/skills/telegram/cli/reply_command_test.go
+++ b/agent/skills/telegram/cli/reply_command_test.go
@@ -1,0 +1,16 @@
+package main
+
+import "testing"
+
+func TestNotificationReplyCommandRoutesAndQuotes(t *testing.T) {
+	got := notificationReplyCommand("Ana", "Ana", "ana", "personal", true, true)
+	want := "telegram send --instance 'personal' --to 'Ana' --message '<reply>'"
+	if got != want {
+		t.Fatalf("saved contact: got %q, want %q", got, want)
+	}
+	got = notificationReplyCommand("Bob's Crew", "Bob", "bob", "", false, false)
+	want = "telegram send --to 'Bob'\"'\"'s Crew' --message '<reply>'"
+	if got != want {
+		t.Fatalf("group: got %q, want %q", got, want)
+	}
+}

--- a/agent/skills/telegram/cli/reply_command_test.go
+++ b/agent/skills/telegram/cli/reply_command_test.go
@@ -2,15 +2,65 @@ package main
 
 import "testing"
 
-func TestNotificationReplyCommandRoutesAndQuotes(t *testing.T) {
-	got := notificationReplyCommand("Ana", "Ana", "ana", "personal", true, true)
-	want := "telegram send --instance 'personal' --to 'Ana' --message '<reply>'"
-	if got != want {
-		t.Fatalf("saved contact: got %q, want %q", got, want)
+// chatName and contactName are deliberately different in every case: they are adjacent string
+// parameters, so identical values would let a transposition pass.
+func TestNotificationReplyCommand(t *testing.T) {
+	cases := []struct {
+		name         string
+		chatName     string
+		contactName  string
+		instance     string
+		isDirectChat bool
+		contactSaved bool
+		want         string
+	}{
+		{
+			name:         "saved contact is addressed by the name send resolves",
+			chatName:     "Ana Ruiz",
+			contactName:  "Ana",
+			instance:     "personal",
+			isDirectChat: true,
+			contactSaved: true,
+			want:         "telegram send --instance 'personal' --to 'Ana' --message '<reply>'",
+		},
+		{
+			// ResolveRecipient looks an @username up in contacts, the very table an unsaved
+			// sender is missing from, so any addressed command would fail to resolve.
+			name:         "unsaved sender falls back to the bare command",
+			chatName:     "Bob Stone",
+			contactName:  "Bob Stone",
+			instance:     "personal",
+			isDirectChat: true,
+			contactSaved: false,
+			want:         "telegram send",
+		},
+		{
+			name:        "group is addressed by chat name, shell-quoted",
+			chatName:    "Bob's Crew",
+			contactName: "Bob",
+			want:        "telegram send --to 'Bob'\"'\"'s Crew' --message '<reply>'",
+		},
+		{
+			name:        "an unnamed chat falls back to the bare command",
+			chatName:    "",
+			contactName: "Bob",
+			want:        "telegram send",
+		},
+		{
+			name:        "a single account omits the instance flag",
+			chatName:    "Team",
+			contactName: "Bob",
+			instance:    "",
+			want:        "telegram send --to 'Team' --message '<reply>'",
+		},
 	}
-	got = notificationReplyCommand("Bob's Crew", "Bob", "bob", "", false, false)
-	want = "telegram send --to 'Bob'\"'\"'s Crew' --message '<reply>'"
-	if got != want {
-		t.Fatalf("group: got %q, want %q", got, want)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := notificationReplyCommand(tc.chatName, tc.contactName, tc.instance, tc.isDirectChat, tc.contactSaved)
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/agent/skills/telegram/cli/reply_command_test.go
+++ b/agent/skills/telegram/cli/reply_command_test.go
@@ -1,66 +1,38 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-// chatName and contactName are deliberately different in every case: they are adjacent string
-// parameters, so identical values would let a transposition pass.
-func TestNotificationReplyCommand(t *testing.T) {
-	cases := []struct {
-		name         string
-		chatName     string
-		contactName  string
-		instance     string
-		isDirectChat bool
-		contactSaved bool
-		want         string
-	}{
-		{
-			name:         "saved contact is addressed by the name send resolves",
-			chatName:     "Ana Ruiz",
-			contactName:  "Ana",
-			instance:     "personal",
-			isDirectChat: true,
-			contactSaved: true,
-			want:         "telegram send --instance 'personal' --to 'Ana' --message '<reply>'",
-		},
-		{
-			// ResolveRecipient looks an @username up in contacts, the very table an unsaved
-			// sender is missing from, so any addressed command would fail to resolve.
-			name:         "unsaved sender falls back to the bare command",
-			chatName:     "Bob Stone",
-			contactName:  "Bob Stone",
-			instance:     "personal",
-			isDirectChat: true,
-			contactSaved: false,
-			want:         "telegram send",
-		},
-		{
-			name:        "group is addressed by chat name, shell-quoted",
-			chatName:    "Bob's Crew",
-			contactName: "Bob",
-			want:        "telegram send --to 'Bob'\"'\"'s Crew' --message '<reply>'",
-		},
-		{
-			name:        "an unnamed chat falls back to the bare command",
-			chatName:    "",
-			contactName: "Bob",
-			want:        "telegram send",
-		},
-		{
-			name:        "a single account omits the instance flag",
-			chatName:    "Team",
-			contactName: "Bob",
-			instance:    "",
-			want:        "telegram send --to 'Team' --message '<reply>'",
-		},
+func TestNotificationReplyCommandIsCompleteAndUnambiguous(t *testing.T) {
+	// The chat ID is what ResolveRecipient matches first and needs no saved contact, so the same
+	// command shape works for a saved contact, a stranger, and a group alike.
+	got := notificationReplyCommand(-1001234567890, "personal")
+	want := "telegram send --instance 'personal' --to '-1001234567890' --message -"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := notificationReplyCommand(tc.chatName, tc.contactName, tc.instance, tc.isDirectChat, tc.contactSaved)
-			if got != tc.want {
-				t.Fatalf("got %q, want %q", got, tc.want)
-			}
-		})
+	single := notificationReplyCommand(42, "")
+	if strings.Contains(single, "--instance") {
+		t.Fatalf("a single account should omit --instance: %q", single)
+	}
+}
+
+// The command hands the body to stdin rather than inlining it, so the reply text never reaches the
+// shell. An inline --message would break on the first apostrophe and could evaluate a $(...).
+func TestNotificationReplyCommandBodyIsShellInert(t *testing.T) {
+	got := notificationReplyCommand(42, "")
+	if !strings.HasSuffix(got, "--message -") {
+		t.Fatalf("reply command must end at --message -, leaving the body to stdin: %q", got)
+	}
+	if strings.Contains(got, "--message '") {
+		t.Fatalf("reply command must not inline the body: %q", got)
+	}
+	// A heredoc here would reach the agent as &lt;&lt; and &#10; entities: the notification is
+	// rendered as an XML attribute. SKILL.md carries the heredoc shape instead.
+	if strings.ContainsAny(got, "<\n") {
+		t.Fatalf("reply command must survive XML attribute rendering unescaped: %q", got)
 	}
 }

--- a/agent/skills/telegram/cli/stdin_args_test.go
+++ b/agent/skills/telegram/cli/stdin_args_test.go
@@ -91,7 +91,8 @@ func TestResolveStdinArgsSubstitutesBodyBeforeForwarding(t *testing.T) {
 	}
 }
 
-func TestResolveStdinArgsLeavesArgsUntouchedWhenNoDash(t *testing.T) {
+// Callers still hold the slice they passed, so the substitution must not write through it.
+func TestResolveStdinArgsDoesNotMutateItsInput(t *testing.T) {
 	args := []string{"--to", "Ana", "--message", "plain"}
 	got, err := resolveStdinArgs(args, "message")
 	if err != nil {

--- a/agent/skills/telegram/cli/stdin_args_test.go
+++ b/agent/skills/telegram/cli/stdin_args_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// withStdin runs fn with os.Stdin replaced by a pipe carrying body.
+func withStdin(t *testing.T, body string, fn func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = orig; r.Close() }()
+
+	go func() {
+		w.WriteString(body)
+		w.Close()
+	}()
+	fn()
+}
+
+// The command is executed inside the daemon, which does not share this process's stdin, so the
+// body has to be substituted before the args are forwarded. Without this, `--message -` reaches
+// the daemon verbatim and the send fails as an empty body.
+func TestResolveStdinArgsSubstitutesBodyBeforeForwarding(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		body string
+		want []string
+	}{
+		{
+			name: "separate value",
+			args: []string{"--to", "Ana", "--message", "-"},
+			body: "it's me\n",
+			want: []string{"--to", "Ana", "--message", "it's me"},
+		},
+		{
+			name: "inline value",
+			args: []string{"--to", "Ana", "--message=-"},
+			body: "it's me",
+			want: []string{"--to", "Ana", "--message=it's me"},
+		},
+		{
+			name: "single dash flag form",
+			args: []string{"-message", "-"},
+			body: "hi",
+			want: []string{"-message", "hi"},
+		},
+		{
+			name: "multi-line body survives intact",
+			args: []string{"--message", "-"},
+			body: "one\ntwo\n",
+			want: []string{"--message", "one\ntwo"},
+		},
+		{
+			name: "a literal message is left alone",
+			args: []string{"--message", "hello"},
+			body: "unused",
+			want: []string{"--message", "hello"},
+		},
+		{
+			name: "a lone dash that is not a body value is left alone",
+			args: []string{"--to", "-", "--message", "hi"},
+			body: "unused",
+			want: []string{"--to", "-", "--message", "hi"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []string
+			var err error
+			withStdin(t, tc.body, func() { got, err = resolveStdinArgs(tc.args, "message") })
+			if err != nil {
+				t.Fatalf("resolveStdinArgs: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %q, want %q", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveStdinArgsLeavesArgsUntouchedWhenNoDash(t *testing.T) {
+	args := []string{"--to", "Ana", "--message", "plain"}
+	got, err := resolveStdinArgs(args, "message")
+	if err != nil {
+		t.Fatalf("resolveStdinArgs: %v", err)
+	}
+	// The input slice must not be aliased: callers still hold it.
+	got[0] = "mutated"
+	if args[0] != "--to" {
+		t.Fatalf("resolveStdinArgs aliased its input")
+	}
+}

--- a/agent/skills/telegram/cli/telegram.go
+++ b/agent/skills/telegram/cli/telegram.go
@@ -222,7 +222,7 @@ func (tc *TelegramClient) handleEditedMessage(msg *tgbotapi.Message) {
 
 	if ctx, ok := tc.notifContextFor(msg); ok {
 		if err := WriteEditNotification(
-			tc.notificationsDir, int64(msg.MessageID), ctx.chatName, ctx.contactName,
+			tc.notificationsDir, int64(msg.MessageID), msg.Chat.ID, ctx.chatName, ctx.contactName,
 			ctx.username, tc.instance, ctx.contactSaved, ctx.isDirectChat,
 			ctx.sender, oldText, newText,
 		); err != nil {
@@ -312,6 +312,7 @@ func (tc *TelegramClient) handleMessage(msg *tgbotapi.Message) {
 		WriteNotification(
 			tc.notificationsDir,
 			int64(msg.MessageID),
+			msg.Chat.ID,
 			ctx.chatName,
 			ctx.contactName,
 			ctx.username,

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -75,17 +75,23 @@ rather than run WhatsApp over a datacenter IP. A supplied proxy is validated too
 - Most common subcommands accept leading positional args that the CLI rewrites into flags (e.g. `whatsapp send 'Alice' 'Hi'` is identical to `whatsapp send --to 'Alice' --message 'Hi'`). You can always use the flag form.
 - Flags for a specific subcommand: `whatsapp <subcommand> --help`. The top-level `whatsapp` with no args prints the command list.
 - Names for `--to` / `--chat-id` / `--group`: contact name, phone (`+E.164`), group name, or JID; the CLI resolves them.
-- For `send-message`, prefer `--message-file <path>` (or `--message-file -` / `--message -` to read from stdin) when the body contains apostrophes, quotes, backticks, `$(...)`, or multiple lines: an inline `--message 'text'` lets the shell mangle or even evaluate it.
-- `send-message` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. This applies to `--message-file` sends too, so `--longform` is the only escape hatch.
+- Send every message body through `--message -` and a quoted heredoc, as in the example below. The shell expands nothing inside `<<'MSG'`, so apostrophes, quotes, backticks, `$(...)` and newlines all pass through untouched. An inline `--message 'text'` breaks on the first apostrophe, so use it only for text you can see has none.
+- `send-message` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass. This applies to heredoc sends too, so `--longform` is the only escape hatch.
 - A numbered or bulleted list is fine to send as one message (each item is one short thought); a line-leading marker like `1.` or `2)` is not a full stop, so a list does not need `--longform`.
 
 ```bash
-whatsapp send --to 'Alice' --message 'Hi'          # positionals also work: whatsapp send Alice 'Hi'
-whatsapp send --to 'Alice' --message 'reply' --reply-to '<message_id>'   # quote a message
+# The one shape to use for any message body. Replace only the middle line.
+whatsapp send --to 'Alice' --message - <<'MSG'
+can't wait to see you
+MSG
+
+whatsapp send --to 'Alice' --message - --reply-to '<message_id>' <<'MSG'   # quote a message
+same here
+MSG
 ```
 - `--to` accepts a contact name, phone (`+E.164`), group name, or JID; the CLI resolves it.
-- Prefer `--message-file <path>` (or `--message -` / `--message-file -` for stdin) when the
-  text has apostrophes, quotes, backticks, `$(...)`, or multiple lines, so the shell can't mangle it.
+- `--message -` reads the body from stdin; pair it with a quoted heredoc so the shell cannot
+  mangle or evaluate anything in the text.
 - Short bubbles only: a wall (over ~220 chars, or 3+ sentences in one bubble) is rejected.
   Re-send as several short calls, one thought each. Pass `--longform` only for genuine
   reference material the user asked for (a brief, a code block, a list).

--- a/agent/skills/whatsapp/cli/bubblelint.go
+++ b/agent/skills/whatsapp/cli/bubblelint.go
@@ -7,7 +7,7 @@ package main
 // read like an assistant, not a person. Linting the one place every send passes
 // through makes it structural: a wall is rejected with the reason, so the agent
 // re-sends as several short calls with its own break points. The single bypass
-// is `--longform` (reference material the user asked for); `--message-file` sends are linted too.
+// is `--longform` (reference material the user asked for); heredoc sends are linted too.
 
 import (
 	"fmt"

--- a/agent/skills/whatsapp/cli/call.go
+++ b/agent/skills/whatsapp/cli/call.go
@@ -367,29 +367,16 @@ func cmdCall(args []string, wac *WhatsAppClient) (any, error) {
 }
 
 func cmdSay(args []string, wac *WhatsAppClient) (any, error) {
-	var text, textFile string
+	var text string
 	fs := flag.NewFlagSet("say", flag.ContinueOnError)
-	fs.StringVar(&text, "text", "", "What to speak into the call (use '-' to read from stdin)")
-	fs.StringVar(&textFile, "text-file", "", "Path to a file with the text to speak (use '-' for stdin). Preferred for lines with apostrophes or quotes.")
+	fs.StringVar(&text, "text", "", "What to speak into the call, or '-' to read it from stdin (use a <<'MSG' heredoc for anything with apostrophes or quotes)")
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
-	if (text == "") == (textFile == "") {
-		return nil, fmt.Errorf("exactly one of --text or --text-file is required")
-	}
-	source := text
-	if textFile != "" {
-		source = textFile
-	}
-	if source == "-" || textFile != "" {
-		body, err := readMessageSource(source)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read spoken text: %w", err)
-		}
-		text = body
-	}
-	if text == "" {
-		return nil, fmt.Errorf("spoken text is empty")
+	// resolveStdinArgs swapped a `-` for the real text in the client process; still seeing one here
+	// means nothing was piped in.
+	if text == "" || text == "-" {
+		return nil, fmt.Errorf("--text is required (pass '-' and a <<'MSG' heredoc to read it from stdin)")
 	}
 	cm, err := requireCallMgr(wac)
 	if err != nil {

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -710,41 +710,36 @@ func cmdSendMessage(args []string, wac *WhatsAppClient) (any, error) {
 
 // resolveStdinArgs replaces a `-` body value with this process's stdin, before the command is
 // forwarded to the daemon. executeCommand runs inside the daemon, whose stdin is not ours, so a `-`
-// that reached it would read EOF and the send would fail as an empty body. Handles both
-// `--flag -` and `--flag=-`; a body is read at most once.
+// that reached it would read EOF and the send would fail as an empty body. Accepts both `--flag -`
+// and `--flag=-`, the two forms the flag package itself accepts; a command carries one body, so the
+// first match is the only one.
 func resolveStdinArgs(args []string, bodyFlags ...string) ([]string, error) {
 	out := slices.Clone(args)
-	body := ""
-	read := false
-	readOnce := func() (string, error) {
-		if !read {
-			data, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				return "", err
-			}
-			body, read = strings.TrimRight(string(data), "\r\n"), true
-		}
-		return body, nil
-	}
-
 	for i, arg := range out {
-		name, inline, hasInline := strings.Cut(arg, "=")
+		name, value, inline := strings.Cut(arg, "=")
 		if !strings.HasPrefix(name, "-") || !slices.Contains(bodyFlags, strings.TrimLeft(name, "-")) {
 			continue
 		}
-		if hasInline && inline == "-" {
-			text, err := readOnce()
-			if err != nil {
-				return nil, err
+		at := i
+		if !inline {
+			at, value = i+1, ""
+			if at < len(out) {
+				value = out[at]
 			}
-			out[i] = name + "=" + text
-		} else if !hasInline && i+1 < len(out) && out[i+1] == "-" {
-			text, err := readOnce()
-			if err != nil {
-				return nil, err
-			}
-			out[i+1] = text
 		}
+		if value != "-" {
+			continue
+		}
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, err
+		}
+		body := strings.TrimRight(string(data), "\r\n")
+		if inline {
+			body = name + "=" + body
+		}
+		out[at] = body
+		return out, nil
 	}
 	return out, nil
 }

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -329,7 +330,11 @@ func runOneShot(command string) {
 	if err := startDaemonProcess(linkServeArgs()); err != nil {
 		failJSON("could not start the whatsapp daemon: %v; run `whatsapp status`", err)
 	}
-	output, exitCode, connected := trySocketCommand(sockPath, command, stripGlobalFlags(os.Args[1:]))
+	args, err := resolveStdinArgs(stripGlobalFlags(os.Args[1:]), "message", "text")
+	if err != nil {
+		failJSON("could not read the body from stdin: %v", err)
+	}
+	output, exitCode, connected := trySocketCommand(sockPath, command, args)
 	if !connected {
 		failJSON("whatsapp daemon is not answering; run `whatsapp status`")
 	}
@@ -672,12 +677,11 @@ func cmdListChats(args []string, wac *WhatsAppClient) (any, error) {
 }
 
 func cmdSendMessage(args []string, wac *WhatsAppClient) (any, error) {
-	var to, message, messageFile, replyTo string
+	var to, message, replyTo string
 	var longform bool
 	fs := flag.NewFlagSet("send-message", flag.ContinueOnError)
 	fs.StringVar(&to, "to", "", "Recipient")
-	fs.StringVar(&message, "message", "", "Message text (use '-' to read from stdin)")
-	fs.StringVar(&messageFile, "message-file", "", "Path to a file containing the message body (use '-' for stdin). Preferred for multi-line text or content with apostrophes / quotes that complicate shell escaping.")
+	fs.StringVar(&message, "message", "", "Message text, or '-' to read the body from stdin (use a <<'MSG' heredoc for anything with apostrophes, quotes, backticks or newlines)")
 	fs.StringVar(&replyTo, "reply-to", "", "Message ID to reply/quote (optional)")
 	fs.BoolVar(&longform, "longform", false, "Bypass the short-bubble lint for genuine reference material (a brief, a code block, a list they asked for).")
 	if err := parseFlags(fs, args); err != nil {
@@ -686,24 +690,10 @@ func cmdSendMessage(args []string, wac *WhatsAppClient) (any, error) {
 	if to == "" {
 		return nil, fmt.Errorf("--to is required")
 	}
-	if (message == "") == (messageFile == "") {
-		return nil, fmt.Errorf("exactly one of --message or --message-file is required")
-	}
-	if messageFile != "" {
-		body, err := readMessageSource(messageFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read --message-file: %w", err)
-		}
-		message = body
-	} else if message == "-" {
-		body, err := readMessageSource("-")
-		if err != nil {
-			return nil, fmt.Errorf("failed to read stdin: %w", err)
-		}
-		message = body
-	}
-	if message == "" {
-		return nil, fmt.Errorf("message body is empty")
+	// resolveStdinArgs swapped a `-` for the real body in the client process. Still seeing one here
+	// means nothing was piped in, so say that rather than sending a literal dash.
+	if message == "" || message == "-" {
+		return nil, fmt.Errorf("--message is required (pass '-' and a <<'MSG' heredoc to read the body from stdin)")
 	}
 	if !longform {
 		if reason := bubbleLintReason(message); reason != "" {
@@ -718,21 +708,45 @@ func cmdSendMessage(args []string, wac *WhatsAppClient) (any, error) {
 	return result, nil
 }
 
-// readMessageSource loads a message body from a file path or "-" for stdin.
-// Trailing newlines are stripped so content from `echo` or editor-saved files
-// does not produce a leading/trailing blank line in the sent message.
-func readMessageSource(src string) (string, error) {
-	var data []byte
-	var err error
-	if src == "-" {
-		data, err = io.ReadAll(os.Stdin)
-	} else {
-		data, err = os.ReadFile(src)
+// resolveStdinArgs replaces a `-` body value with this process's stdin, before the command is
+// forwarded to the daemon. executeCommand runs inside the daemon, whose stdin is not ours, so a `-`
+// that reached it would read EOF and the send would fail as an empty body. Handles both
+// `--flag -` and `--flag=-`; a body is read at most once.
+func resolveStdinArgs(args []string, bodyFlags ...string) ([]string, error) {
+	out := slices.Clone(args)
+	body := ""
+	read := false
+	readOnce := func() (string, error) {
+		if !read {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return "", err
+			}
+			body, read = strings.TrimRight(string(data), "\r\n"), true
+		}
+		return body, nil
 	}
-	if err != nil {
-		return "", err
+
+	for i, arg := range out {
+		name, inline, hasInline := strings.Cut(arg, "=")
+		if !strings.HasPrefix(name, "-") || !slices.Contains(bodyFlags, strings.TrimLeft(name, "-")) {
+			continue
+		}
+		if hasInline && inline == "-" {
+			text, err := readOnce()
+			if err != nil {
+				return nil, err
+			}
+			out[i] = name + "=" + text
+		} else if !hasInline && i+1 < len(out) && out[i+1] == "-" {
+			text, err := readOnce()
+			if err != nil {
+				return nil, err
+			}
+			out[i+1] = text
+		}
 	}
-	return strings.TrimRight(string(data), "\r\n"), nil
+	return out, nil
 }
 
 func cmdSendFile(args []string, wac *WhatsAppClient) (any, error) {

--- a/agent/skills/whatsapp/cli/events.go
+++ b/agent/skills/whatsapp/cli/events.go
@@ -287,9 +287,9 @@ func (wac *WhatsAppClient) dropDeadDevice() {
 
 // buildNotifContext assembles the NotifContext shared by message and reaction
 // notifications.
-func (wac *WhatsAppClient) buildNotifContext(chatName, senderDisplay, contactName, contactPhone string, contactSaved, isDirectChat bool) NotifContext {
+func (wac *WhatsAppClient) buildNotifContext(chatJID, chatName, senderDisplay, contactName, contactPhone string, contactSaved, isDirectChat bool) NotifContext {
 	return NotifContext{
-		NotifDir: wac.notificationsDir, ChatName: chatName,
+		NotifDir: wac.notificationsDir, ChatJID: chatJID, ChatName: chatName,
 		ContactName: contactName, ContactPhone: contactPhone,
 		Instance: wac.instance, ContactSaved: contactSaved,
 		IsDirectChat: isDirectChat, Sender: senderDisplay,
@@ -389,7 +389,7 @@ func (wac *WhatsAppClient) handleMessage(evt *events.Message) {
 	shouldNotify := wac.notificationsDir != "" && !wac.noNotify && !info.IsFromMe && !wac.skipSenders[contactPhone]
 	var notifCtx NotifContext
 	if shouldNotify {
-		notifCtx = wac.buildNotifContext(chatName, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat)
+		notifCtx = wac.buildNotifContext(info.Chat.String(), chatName, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat)
 	}
 
 	// Audio messages: transcribe asynchronously, then send notification
@@ -515,7 +515,7 @@ func (wac *WhatsAppClient) handleReaction(evt *events.Message) {
 
 	if wac.notificationsDir != "" {
 		_, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
-		ctx := wac.buildNotifContext(chatName, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat)
+		ctx := wac.buildNotifContext(evt.Info.Chat.String(), chatName, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat)
 		WriteReactionNotification(ctx, targetID, emoji, isRemoved)
 	}
 }
@@ -602,7 +602,7 @@ func (wac *WhatsAppClient) notifContextFor(evt *events.Message) (NotifContext, b
 	if wac.skipSenders[contactPhone] {
 		return NotifContext{}, false
 	}
-	return wac.buildNotifContext(wac.getChatName(evt.Info.Chat), senderDisplay, contactName, contactPhone, contactSaved, isDirectChat), true
+	return wac.buildNotifContext(evt.Info.Chat.String(), wac.getChatName(evt.Info.Chat), senderDisplay, contactName, contactPhone, contactSaved, isDirectChat), true
 }
 
 func (wac *WhatsAppClient) handleHistorySync(evt *events.HistorySync) {

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -108,6 +109,24 @@ func notifPhone(ctx NotifContext) string {
 	return ctx.ContactPhone
 }
 
+func quoteReplyArg(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func notificationReplyCommand(ctx NotifContext) string {
+	target := ctx.ContactPhone
+	if !ctx.IsDirectChat {
+		target = ctx.ChatName
+	} else if ctx.ContactSaved {
+		target = ctx.ContactName
+	}
+	command := "whatsapp send"
+	if ctx.Instance != "" {
+		command += " --instance " + quoteReplyArg(ctx.Instance)
+	}
+	return command + " --to " + quoteReplyArg(target) + " --message '<reply>'"
+}
+
 func writeNotificationFile(notifDir string, data any, notifType string) error {
 	if notifDir == "" {
 		return nil
@@ -142,7 +161,7 @@ func WriteNotification(
 		Timestamp:       time.Now().Format(time.RFC3339),
 		MessageID:       messageID,
 		ContactUnknown:  !ctx.ContactSaved,
-		ReplyCommand:    "whatsapp send",
+		ReplyCommand:    notificationReplyCommand(ctx),
 		ReplyHint:       "think about how you can best show your personality",
 	}
 	if !ctx.IsDirectChat {
@@ -205,7 +224,7 @@ func WriteEditNotification(ctx NotifContext, targetMessageID, oldText, newText s
 		Timestamp:       time.Now().Format(time.RFC3339),
 		TargetMessageID: targetMessageID,
 		ContactUnknown:  !ctx.ContactSaved,
-		ReplyCommand:    "whatsapp send",
+		ReplyCommand:    notificationReplyCommand(ctx),
 		ReplyHint:       "they changed a message you may have already answered; reply only if the change asks something new",
 	}
 	n.applyChatContext(ctx)

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -28,6 +28,7 @@ type messageNotif struct {
 	QuotedText      string `json:"quoted_text,omitempty"`
 	Timestamp       string `json:"timestamp"`
 	MessageID       string `json:"message_id,omitempty"`
+	ChatJID         string `json:"chat_jid,omitempty"`
 	ContactUnknown  bool   `json:"contact_unknown,omitempty"`
 	ReplyCommand    string `json:"reply_command,omitempty"`
 	ReplyHint       string `json:"reply_hint,omitempty"`
@@ -65,6 +66,7 @@ type editNotif struct {
 	Message         string `json:"message,omitempty"`
 	Timestamp       string `json:"timestamp"`
 	TargetMessageID string `json:"target_message_id"`
+	ChatJID         string `json:"chat_jid,omitempty"`
 	ContactUnknown  bool   `json:"contact_unknown,omitempty"`
 	ReplyCommand    string `json:"reply_command,omitempty"`
 	ReplyHint       string `json:"reply_hint,omitempty"`
@@ -113,27 +115,18 @@ func quoteReplyArg(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
-// The addressed template is only offered for a target `whatsapp send` can actually resolve
-// (WhatsAppClient.ResolveRecipient): a saved contact or group by name, or an unsaved sender by
-// phone number, which resolves on its own without a saved contact. With no name and no number
-// there is nothing to address, so the bare command goes out and the agent works the recipient out
-// from the notification's other fields.
+// Every notification carries a complete reply command. The target is always the chat JID, which
+// ResolveRecipient matches first and which needs no saved contact, so there is no case where the
+// agent has to work the recipient out for itself. It stops at `--message -`: the notification is
+// rendered as an XML attribute, so a heredoc here would reach the agent as &lt;&lt; and &#10;
+// entities. `-` says the body comes from stdin and SKILL.md carries the one heredoc shape, which
+// keeps the reply body out of the shell's reach.
 func notificationReplyCommand(ctx NotifContext) string {
-	const bare = "whatsapp send"
-	target := ctx.ContactPhone
-	if !ctx.IsDirectChat {
-		target = ctx.ChatName
-	} else if ctx.ContactSaved {
-		target = ctx.ContactName
-	}
-	if target == "" {
-		return bare
-	}
-	command := bare
+	command := "whatsapp send"
 	if ctx.Instance != "" {
 		command += " --instance " + quoteReplyArg(ctx.Instance)
 	}
-	return command + " --to " + quoteReplyArg(target) + " --message '<reply>'"
+	return command + " --to " + quoteReplyArg(ctx.ChatJID) + " --message -"
 }
 
 func writeNotificationFile(notifDir string, data any, notifType string) error {
@@ -169,6 +162,7 @@ func WriteNotification(
 		QuotedText:      quotedText,
 		Timestamp:       time.Now().Format(time.RFC3339),
 		MessageID:       messageID,
+		ChatJID:         ctx.ChatJID,
 		ContactUnknown:  !ctx.ContactSaved,
 		ReplyCommand:    notificationReplyCommand(ctx),
 		ReplyHint:       "think about how you can best show your personality",
@@ -232,6 +226,7 @@ func WriteEditNotification(ctx NotifContext, targetMessageID, oldText, newText s
 		Message:         newText,
 		Timestamp:       time.Now().Format(time.RFC3339),
 		TargetMessageID: targetMessageID,
+		ChatJID:         ctx.ChatJID,
 		ContactUnknown:  !ctx.ContactSaved,
 		ReplyCommand:    notificationReplyCommand(ctx),
 		ReplyHint:       "they changed a message you may have already answered; reply only if the change asks something new",

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -113,14 +113,23 @@ func quoteReplyArg(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
+// The addressed template is only offered for a target `whatsapp send` can actually resolve
+// (WhatsAppClient.ResolveRecipient): a saved contact or group by name, or an unsaved sender by
+// phone number, which resolves on its own without a saved contact. With no name and no number
+// there is nothing to address, so the bare command goes out and the agent works the recipient out
+// from the notification's other fields.
 func notificationReplyCommand(ctx NotifContext) string {
+	const bare = "whatsapp send"
 	target := ctx.ContactPhone
 	if !ctx.IsDirectChat {
 		target = ctx.ChatName
 	} else if ctx.ContactSaved {
 		target = ctx.ContactName
 	}
-	command := "whatsapp send"
+	if target == "" {
+		return bare
+	}
+	command := bare
 	if ctx.Instance != "" {
 		command += " --instance " + quoteReplyArg(ctx.Instance)
 	}

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -9,7 +9,7 @@ import (
 
 func savedCtx(dir string) NotifContext {
 	return NotifContext{
-		NotifDir: dir, Instance: "personal", ChatName: "Ana",
+		NotifDir: dir, Instance: "personal", ChatJID: "4477000111@s.whatsapp.net", ChatName: "Ana",
 		ContactName: "Ana", ContactPhone: "+15551234567",
 		ContactSaved: true, IsDirectChat: true, Sender: "Ana",
 	}
@@ -17,7 +17,7 @@ func savedCtx(dir string) NotifContext {
 
 func unsavedCtx(dir string) NotifContext {
 	return NotifContext{
-		NotifDir: dir, Instance: "personal", ChatName: "+15559998888",
+		NotifDir: dir, Instance: "personal", ChatJID: "15559998888@s.whatsapp.net", ChatName: "+15559998888",
 		ContactName: "", ContactPhone: "+15559998888",
 		ContactSaved: false, IsDirectChat: true, Sender: "+15559998888",
 	}

--- a/agent/skills/whatsapp/cli/reply_command_test.go
+++ b/agent/skills/whatsapp/cli/reply_command_test.go
@@ -1,0 +1,16 @@
+package main
+
+import "testing"
+
+func TestNotificationReplyCommandRoutesAndQuotes(t *testing.T) {
+	got := notificationReplyCommand(savedCtx(""))
+	want := "whatsapp send --instance 'personal' --to 'Ana' --message '<reply>'"
+	if got != want {
+		t.Fatalf("saved contact: got %q, want %q", got, want)
+	}
+	got = notificationReplyCommand(NotifContext{ChatName: "Bob's Crew"})
+	want = "whatsapp send --to 'Bob'\"'\"'s Crew' --message '<reply>'"
+	if got != want {
+		t.Fatalf("group: got %q, want %q", got, want)
+	}
+}

--- a/agent/skills/whatsapp/cli/reply_command_test.go
+++ b/agent/skills/whatsapp/cli/reply_command_test.go
@@ -2,15 +2,45 @@ package main
 
 import "testing"
 
-func TestNotificationReplyCommandRoutesAndQuotes(t *testing.T) {
-	got := notificationReplyCommand(savedCtx(""))
-	want := "whatsapp send --instance 'personal' --to 'Ana' --message '<reply>'"
-	if got != want {
-		t.Fatalf("saved contact: got %q, want %q", got, want)
+func TestNotificationReplyCommand(t *testing.T) {
+	cases := []struct {
+		name string
+		ctx  NotifContext
+		want string
+	}{
+		{
+			name: "saved contact is addressed by name",
+			ctx:  savedCtx(""),
+			want: "whatsapp send --instance 'personal' --to 'Ana' --message '<reply>'",
+		},
+		{
+			// A phone number resolves on its own, so an unsaved sender still gets addressed.
+			name: "unsaved sender is addressed by phone number",
+			ctx:  unsavedCtx(""),
+			want: "whatsapp send --instance 'personal' --to '+15559998888' --message '<reply>'",
+		},
+		{
+			name: "group is addressed by chat name, shell-quoted",
+			ctx:  NotifContext{ChatName: "Bob's Crew"},
+			want: "whatsapp send --to 'Bob'\"'\"'s Crew' --message '<reply>'",
+		},
+		{
+			name: "an unnamed group falls back to the bare command",
+			ctx:  NotifContext{ChatName: ""},
+			want: "whatsapp send",
+		},
+		{
+			name: "an unsaved sender with no number falls back to the bare command",
+			ctx:  NotifContext{IsDirectChat: true, ContactName: "Ana"},
+			want: "whatsapp send",
+		},
 	}
-	got = notificationReplyCommand(NotifContext{ChatName: "Bob's Crew"})
-	want = "whatsapp send --to 'Bob'\"'\"'s Crew' --message '<reply>'"
-	if got != want {
-		t.Fatalf("group: got %q, want %q", got, want)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := notificationReplyCommand(tc.ctx); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/agent/skills/whatsapp/cli/reply_command_test.go
+++ b/agent/skills/whatsapp/cli/reply_command_test.go
@@ -1,46 +1,39 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestNotificationReplyCommand(t *testing.T) {
-	cases := []struct {
-		name string
-		ctx  NotifContext
-		want string
-	}{
-		{
-			name: "saved contact is addressed by name",
-			ctx:  savedCtx(""),
-			want: "whatsapp send --instance 'personal' --to 'Ana' --message '<reply>'",
-		},
-		{
-			// A phone number resolves on its own, so an unsaved sender still gets addressed.
-			name: "unsaved sender is addressed by phone number",
-			ctx:  unsavedCtx(""),
-			want: "whatsapp send --instance 'personal' --to '+15559998888' --message '<reply>'",
-		},
-		{
-			name: "group is addressed by chat name, shell-quoted",
-			ctx:  NotifContext{ChatName: "Bob's Crew"},
-			want: "whatsapp send --to 'Bob'\"'\"'s Crew' --message '<reply>'",
-		},
-		{
-			name: "an unnamed group falls back to the bare command",
-			ctx:  NotifContext{ChatName: ""},
-			want: "whatsapp send",
-		},
-		{
-			name: "an unsaved sender with no number falls back to the bare command",
-			ctx:  NotifContext{IsDirectChat: true, ContactName: "Ana"},
-			want: "whatsapp send",
-		},
+func TestNotificationReplyCommandIsCompleteAndUnambiguous(t *testing.T) {
+	// The chat JID is what ResolveRecipient matches first and needs no saved contact, so the same
+	// command shape works for a saved contact, a stranger, and a group alike.
+	ctx := NotifContext{Instance: "personal", ChatJID: "4477000111@s.whatsapp.net"}
+	got := notificationReplyCommand(ctx)
+	want := "whatsapp send --instance 'personal' --to '4477000111@s.whatsapp.net' --message -"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := notificationReplyCommand(tc.ctx); got != tc.want {
-				t.Fatalf("got %q, want %q", got, tc.want)
-			}
-		})
+	single := notificationReplyCommand(NotifContext{ChatJID: "123@g.us"})
+	if strings.Contains(single, "--instance") {
+		t.Fatalf("a single account should omit --instance: %q", single)
+	}
+}
+
+// The command hands the body to stdin rather than inlining it, so the reply text never reaches the
+// shell. An inline --message would break on the first apostrophe and could evaluate a $(...).
+func TestNotificationReplyCommandBodyIsShellInert(t *testing.T) {
+	got := notificationReplyCommand(NotifContext{ChatJID: "123@g.us"})
+	if !strings.HasSuffix(got, "--message -") {
+		t.Fatalf("reply command must end at --message -, leaving the body to stdin: %q", got)
+	}
+	if strings.Contains(got, "--message '") {
+		t.Fatalf("reply command must not inline the body: %q", got)
+	}
+	// A heredoc here would reach the agent as &lt;&lt; and &#10; entities: the notification is
+	// rendered as an XML attribute. SKILL.md carries the heredoc shape instead.
+	if strings.ContainsAny(got, "<\n") {
+		t.Fatalf("reply command must survive XML attribute rendering unescaped: %q", got)
 	}
 }

--- a/agent/skills/whatsapp/cli/stdin_args_test.go
+++ b/agent/skills/whatsapp/cli/stdin_args_test.go
@@ -91,7 +91,8 @@ func TestResolveStdinArgsSubstitutesBodyBeforeForwarding(t *testing.T) {
 	}
 }
 
-func TestResolveStdinArgsLeavesArgsUntouchedWhenNoDash(t *testing.T) {
+// Callers still hold the slice they passed, so the substitution must not write through it.
+func TestResolveStdinArgsDoesNotMutateItsInput(t *testing.T) {
 	args := []string{"--to", "Ana", "--message", "plain"}
 	got, err := resolveStdinArgs(args, "message")
 	if err != nil {

--- a/agent/skills/whatsapp/cli/stdin_args_test.go
+++ b/agent/skills/whatsapp/cli/stdin_args_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// withStdin runs fn with os.Stdin replaced by a pipe carrying body.
+func withStdin(t *testing.T, body string, fn func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = orig; r.Close() }()
+
+	go func() {
+		w.WriteString(body)
+		w.Close()
+	}()
+	fn()
+}
+
+// The command is executed inside the daemon, which does not share this process's stdin, so the
+// body has to be substituted before the args are forwarded. Without this, `--message -` reaches
+// the daemon verbatim and the send fails as an empty body.
+func TestResolveStdinArgsSubstitutesBodyBeforeForwarding(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		body string
+		want []string
+	}{
+		{
+			name: "separate value",
+			args: []string{"--to", "Ana", "--message", "-"},
+			body: "it's me\n",
+			want: []string{"--to", "Ana", "--message", "it's me"},
+		},
+		{
+			name: "inline value",
+			args: []string{"--to", "Ana", "--message=-"},
+			body: "it's me",
+			want: []string{"--to", "Ana", "--message=it's me"},
+		},
+		{
+			name: "single dash flag form",
+			args: []string{"-message", "-"},
+			body: "hi",
+			want: []string{"-message", "hi"},
+		},
+		{
+			name: "multi-line body survives intact",
+			args: []string{"--message", "-"},
+			body: "one\ntwo\n",
+			want: []string{"--message", "one\ntwo"},
+		},
+		{
+			name: "a literal message is left alone",
+			args: []string{"--message", "hello"},
+			body: "unused",
+			want: []string{"--message", "hello"},
+		},
+		{
+			name: "a lone dash that is not a body value is left alone",
+			args: []string{"--to", "-", "--message", "hi"},
+			body: "unused",
+			want: []string{"--to", "-", "--message", "hi"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []string
+			var err error
+			withStdin(t, tc.body, func() { got, err = resolveStdinArgs(tc.args, "message") })
+			if err != nil {
+				t.Fatalf("resolveStdinArgs: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %q, want %q", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveStdinArgsLeavesArgsUntouchedWhenNoDash(t *testing.T) {
+	args := []string{"--to", "Ana", "--message", "plain"}
+	got, err := resolveStdinArgs(args, "message")
+	if err != nil {
+		t.Fatalf("resolveStdinArgs: %v", err)
+	}
+	// The input slice must not be aliased: callers still hold it.
+	got[0] = "mutated"
+	if args[0] != "--to" {
+		t.Fatalf("resolveStdinArgs aliased its input")
+	}
+}

--- a/agent/skills/whatsapp/cli/types.go
+++ b/agent/skills/whatsapp/cli/types.go
@@ -51,6 +51,7 @@ type StoreMessageParams struct {
 
 type NotifContext struct {
 	NotifDir     string
+	ChatJID      string
 	ChatName     string
 	ContactName  string
 	ContactPhone string


### PR DESCRIPTION
## Summary
- expand `reply_command` from a command family into a ready-to-fill command template
- bind WhatsApp and Telegram replies to the originating account and destination
- select saved contact names, unknown-contact phone/username fallbacks, and group chat names appropriately
- shell-quote generated account and destination values
- include the message placeholder explicitly: `--message '<reply>'`\n- make app-chat emit its complete `send --message` template too\n\nExamples:\n- `whatsapp send --instance 'personal' --to 'Ana' --message '<reply>'`\n- `telegram send --to '@ana' --message '<reply>'`\n- `app-chat send --message '<reply>'`\n\n## Validation\n- `./check.sh guards`\n- app-chat CLI: `uv run pytest -q` (53 passed)\n- added focused WhatsApp and Telegram Go tests for routing and shell quoting\n\nThe Go toolchain is not installed on this box, so those new Go tests could not be executed locally.