### PR TITLE
feat(email): undo-send hold window for email-client and microsoft send verbs

### DIFF
--- a/agent/skills/email-client/SKILL.md
+++ b/agent/skills/email-client/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: email-client
-description: Personal email over IMAP/SMTP for any provider (Gmail, Outlook, Yahoo, iCloud, Fastmail, generic IMAP). Multi-account: read an inbox, send/reply/forward, save drafts, manage messages and folders, handle attachments, and get paged on new mail. Calendar over CalDAV with the same credential (Gmail, iCloud, Fastmail, any CalDAV server): list/create/update/delete/respond to events. Requires the poll daemon for notifications.
+description: Personal email over IMAP/SMTP for any provider (Gmail, Outlook, Yahoo, iCloud, Fastmail, generic IMAP). Multi-account: read an inbox, send/reply/forward (with an optional undo-send hold window), save drafts, manage messages and folders, handle attachments, and get paged on new mail. Calendar over CalDAV with the same credential (Gmail, iCloud, Fastmail, any CalDAV server): list/create/update/delete/respond to events. Requires the poll daemon for notifications.
 ---
 
 # Email Client
@@ -46,7 +46,7 @@ One-time per account, ~2 minutes. See [SETUP.md](SETUP.md) for install, every au
 Two binaries plus a daemon:
 
 - `email-client` - read (`list-folders`, `list`, `get`, `search`, `attachments`, `status`), manage messages (`mark`, `move`, `archive`, `delete`), manage folders (`folder create/rename/delete/subscribe`), and choose notify folders (`notify list/add/remove`)
-- `email-client-send` - outbound mail (send, reply, forward, save draft)
+- `email-client-send` - outbound mail (send, reply, forward, save draft, `--hold` undo window; cancel via `email-client pending`)
 - `poll_daemon.py` - watches each account's chosen folders (INBOX by default) and writes a notification per new message
 
 Omit `--account` on any command to use the default account from `accounts.json`. All commands accept `--account` and (where relevant) `--folder` (default `INBOX`).
@@ -170,6 +170,19 @@ email-client-send --account personal --forward-uid 999 --to recipient@example.co
 ```
 
 A draft does not contact SMTP and does not flag the original `\Answered` (nothing was sent). `--dry-run` previews the draft without writing it. The Drafts folder is auto-detected (see below).
+
+### Undo window (hold a send)
+
+Pass `--hold <secs>` on any send, reply, or forward to keep an undo window: the message is fully composed and validated now (recipients, threading, attachments), then held; the command prints a cancel token, and the poll daemon sends it once the window elapses uncancelled (so the daemon must be running). Not combinable with `--draft` or `--dry-run`.
+
+```bash
+email-client-send --account personal --to recipient@example.com --subject "Hi" --body "..." --hold 60
+email-client-send --account personal --reply-to-uid 12345 --body "thanks, will do" --hold 30
+email-client pending list                # held sends: token, recipient, subject, seconds until fire
+email-client pending cancel <token>     # abort a held send before it fires
+```
+
+Use it whenever a send feels irreversible-risky (fast back-and-forth drafting, changed recipients or figures): a mis-send becomes recoverable for the length of the window. A held send that fails at dispatch is kept on disk (never retried, no double-send risk) and raises a `send_failed` notification so you can recover it.
 
 ### Draft-only mode
 

--- a/agent/skills/email-client/imap_client.py
+++ b/agent/skills/email-client/imap_client.py
@@ -45,6 +45,7 @@ from imap_tools import AND, MailBox, MailMessageFlags
 # importable without adding a new symlink for each one.
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import daemon_lifecycle
+import pending_sends
 from providers import (
     apply_env_overrides,
     detect_provider,
@@ -813,6 +814,27 @@ def cmd_daemon_status(_args):
     print(json.dumps(daemon_lifecycle.daemon_status(state_dir=state_dir, accounts=accounts), indent=2))
 
 
+# -- pending subcommands (undo-window queue of held sends) ---------
+
+
+def cmd_pending_list(_args):
+    entries = pending_sends.list_pending(pending_sends.queue_dir(_state_dir()))
+    if not entries:
+        print("no held sends")
+        return
+    now = time.time()
+    for e in entries:
+        remaining = max(0, int(e.fire_at - now))
+        print(f"{e.token}\taccount={e.account}\tto={e.to}\tsubject={e.subject}\tfires_in={remaining}s")
+
+
+def cmd_pending_cancel(args):
+    if pending_sends.cancel(pending_sends.queue_dir(_state_dir()), args.token):
+        print(f"cancelled {args.token}")
+        return
+    sys.exit(f"no held send with token {args.token!r} (already sent, cancelled, or unknown)")
+
+
 # -- auth subcommands (multi-account management) -------------------
 
 
@@ -1081,6 +1103,16 @@ def _add_admin_parsers(sub):
     pd_restart.add_argument("--interval", type=int, default=None)
     dsub.add_parser("status", help="daemon process state plus per-account auth health, in one JSON blob")
 
+    _add_pending_parsers(sub)
+
+
+def _add_pending_parsers(sub):
+    pp = sub.add_parser("pending", help="held undo-window sends (email-client-send --hold): list | cancel")
+    psub = pp.add_subparsers(dest="pending_cmd", required=True)
+    psub.add_parser("list", help="show held sends waiting out their undo window")
+    pp_cancel = psub.add_parser("cancel", help="cancel a held send before it fires")
+    pp_cancel.add_argument("token", help="cancel token printed by email-client-send --hold")
+
 
 def _build_parser():
     ap = argparse.ArgumentParser(prog="email-client")
@@ -1144,6 +1176,11 @@ def _dispatch(args):
             "restart": cmd_daemon_restart,
             "status": cmd_daemon_status,
         }[args.daemon_cmd](args)
+    elif args.cmd == "pending":
+        {
+            "list": cmd_pending_list,
+            "cancel": cmd_pending_cancel,
+        }[args.pending_cmd](args)
     elif args.cmd == "calendar":
         _cmd_calendar(args)
     else:

--- a/agent/skills/email-client/pending_sends.py
+++ b/agent/skills/email-client/pending_sends.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Undo-send queue for held outbound mail (``--hold`` on email-client-send).
+
+A held send is one JSON file at ``$EMAIL_CLIENT_DIR/pending-sends/<token>.json``
+storing the fully composed message (recipients, threading headers, attachments)
+plus a fire-at timestamp. The poll daemon dispatches entries whose fire-at has
+passed. Cancel unlinks the entry; dispatch claims one by renaming it to
+``<token>.sending`` first, so cancel and dispatch can never both win. A failed
+dispatch is renamed to ``<token>.failed`` (with the error inside) and is never
+retried: retrying a maybe-sent message risks a double send. A ``.sending`` file
+left by a crash mid-dispatch is kept for the same reason.
+
+Dependency-free (no imap_tools/msal) so it unit-tests without the on-box
+runtime, mirroring daemon_lifecycle.py.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import pathlib
+import uuid
+
+QUEUE_DIR_NAME = "pending-sends"
+
+
+@dataclasses.dataclass(frozen=True)
+class HeldAttachment:
+    """One attachment of a held send, content stored base64-encoded."""
+
+    name: str
+    maintype: str
+    subtype: str
+    data_b64: str
+
+
+@dataclasses.dataclass(frozen=True)
+class HeldSend:
+    """A fully composed outbound message waiting out its undo window."""
+
+    token: str
+    fire_at: float
+    created_at: float
+    account: str
+    user: str
+    display: str
+    to: str
+    subject: str
+    body: str
+    body_html: str | None
+    cc: list[str]
+    bcc: list[str]
+    in_reply_to: str
+    references: str
+    attachments: list[HeldAttachment]
+    sent_sync: bool
+    reply_to_uid: str | None
+    reply_folder: str
+
+
+def new_token() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def queue_dir(state_dir: pathlib.Path) -> pathlib.Path:
+    d = state_dir / QUEUE_DIR_NAME
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def entry_path(qdir: pathlib.Path, token: str) -> pathlib.Path:
+    return qdir / f"{token}.json"
+
+
+def save(qdir: pathlib.Path, entry: HeldSend) -> pathlib.Path:
+    """Atomically write the entry (tmp + rename) so a reader never sees a torn file."""
+    final = entry_path(qdir, entry.token)
+    tmp = final.with_suffix(".tmp")
+    tmp.write_text(json.dumps(dataclasses.asdict(entry), ensure_ascii=False))
+    tmp.replace(final)
+    return final
+
+
+def load(path: pathlib.Path) -> HeldSend:
+    data = json.loads(path.read_text())
+    data["attachments"] = [HeldAttachment(**a) for a in data["attachments"]]
+    return HeldSend(**data)
+
+
+def cancel(qdir: pathlib.Path, token: str) -> bool:
+    """Remove a pending entry. False when it already fired (or never existed)."""
+    try:
+        entry_path(qdir, token).unlink()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def list_pending(qdir: pathlib.Path) -> list[HeldSend]:
+    return sorted((load(p) for p in qdir.glob("*.json")), key=lambda e: e.fire_at)
+
+
+def claim_due(qdir: pathlib.Path, now: float) -> list[tuple[pathlib.Path, HeldSend]]:
+    """Claim every entry whose fire-at has passed by renaming it to ``<token>.sending``.
+
+    The rename is atomic, so a concurrent cancel either removed the entry first
+    (the rename raises and the entry is skipped) or lost and is told so.
+    """
+    claimed: list[tuple[pathlib.Path, HeldSend]] = []
+    for path in sorted(qdir.glob("*.json")):
+        entry = load(path)
+        if entry.fire_at > now:
+            continue
+        sending = path.with_suffix(".sending")
+        try:
+            path.rename(sending)
+        except FileNotFoundError:
+            continue
+        claimed.append((sending, entry))
+    return claimed
+
+
+def fail(claimed_path: pathlib.Path, error: str) -> pathlib.Path:
+    """Park a claimed entry as ``<token>.failed`` with the error recorded inside."""
+    data = json.loads(claimed_path.read_text())
+    data["error"] = error
+    failed = claimed_path.with_suffix(".failed")
+    failed.write_text(json.dumps(data, ensure_ascii=False))
+    claimed_path.unlink(missing_ok=True)
+    return failed

--- a/agent/skills/email-client/poll_daemon.py
+++ b/agent/skills/email-client/poll_daemon.py
@@ -19,6 +19,9 @@ with the latest UID so there is no backlog flood.
 Notifications carry source ``email-client`` and ``account`` + ``folder``
 fields naming the source mailbox. The filename includes both so
 simultaneous notifications never collide.
+
+The supervisor also dispatches held undo-window sends (``--hold`` on
+email-client-send, queue in ``pending_sends.py``) each tick.
 """
 
 from __future__ import annotations
@@ -41,6 +44,8 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import contextlib
 
 import daemon_lifecycle
+import pending_sends
+import smtp_send
 from imap_client import (
     _env,
     _from_full,
@@ -221,6 +226,43 @@ def write_daemon_died_notification(reason: str) -> None:
     tmp.replace(final)
 
 
+def write_send_failed_notification(entry: pending_sends.HeldSend, error: str) -> None:
+    NOTIF_DIR.mkdir(parents=True, exist_ok=True)
+    notif = {
+        "source": "email-client",
+        "type": "send_failed",
+        # Interrupts: the undo window elapsed on a send the user believes is out, so a
+        # failure must reach them promptly.
+        "interrupt": True,
+        "account": entry.account,
+        "token": entry.token,
+        "to": entry.to,
+        "subject": entry.subject,
+        "error": error,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime()),
+    }
+    fname = f"email-client-send_failed-{int(time.time() * 1000)}-{uuid.uuid4().hex[:6]}.json"
+    final = NOTIF_DIR / fname
+    tmp = NOTIF_DIR / f"{fname}.tmp"
+    tmp.write_text(json.dumps(notif, ensure_ascii=False, indent=2))
+    tmp.replace(final)
+
+
+def dispatch_held(state_dir: pathlib.Path, log) -> None:
+    """Send every held entry whose undo window has elapsed (see pending_sends.py)."""
+    for claimed, entry in pending_sends.claim_due(pending_sends.queue_dir(state_dir), time.time()):
+        # SystemExit included: smtp_send's helpers sys.exit on auth/transport errors,
+        # which must fail this one entry, not the daemon.
+        try:
+            smtp_send.send_held(entry)
+            claimed.unlink(missing_ok=True)
+            log(f"[held:{entry.token}] sent to={entry.to[:60]} subject={entry.subject[:60]}")
+        except (Exception, SystemExit) as e:
+            failed = pending_sends.fail(claimed, str(e))
+            write_send_failed_notification(entry, str(e))
+            log(f"[held:{entry.token}] send failed: {e} (kept at {failed})")
+
+
 def desired_workers() -> set[tuple[str, str]]:
     """The set of ``(account, folder)`` pairs that should be watched now."""
     wanted: set[tuple[str, str]] = set()
@@ -327,6 +369,7 @@ def main():
                 log(f"watching: {sorted(wanted)}")
             _maybe_probe(state_dir, log)
             _reconcile_workers(workers, wanted, args.interval, log)
+            dispatch_held(state_dir, log)
             shutdown_event.wait(INDEX_CHECK_SECS)
     finally:
         for _, stop_event in workers.values():

--- a/agent/skills/email-client/smtp_send.py
+++ b/agent/skills/email-client/smtp_send.py
@@ -48,6 +48,12 @@ Drafts: pass ``--draft`` to APPEND the composed message to the Drafts
 folder with the ``\\Draft`` flag instead of sending it. Works with
 ``--reply-to-uid`` / ``--forward-uid`` so a threaded reply or forward
 can be drafted for the user to review and send from any mail client.
+
+Undo window: pass ``--hold <secs>`` to compose and validate now but hold
+the send in the pending queue (``pending_sends.py``); the poll daemon
+dispatches it once the window elapses uncancelled. Cancel with
+``email-client pending cancel <token>``, list with ``email-client
+pending list``.
 """
 
 from __future__ import annotations
@@ -75,9 +81,12 @@ MAX_ATTACH_TOTAL_BYTES = 25 * 1024 * 1024
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import contextlib
 
+import daemon_lifecycle
+import pending_sends
 from imap_client import (
     _env,
     _from_full,
+    _state_dir,
     _to_full,
     account_profile,
     account_user,
@@ -273,6 +282,7 @@ class SendRequest:
     sent_sync: bool = True
     dry_run: bool = False
     draft: bool = False
+    hold: int | None = None
 
 
 @dataclasses.dataclass
@@ -467,11 +477,8 @@ def _sync_sent(acc: str | None, profile: dict, out: Outbound) -> None:
         print(f"warning: sent-sync skipped ({info})", file=sys.stderr)
 
 
-def send(req: SendRequest) -> None:
-    if req.reply_to_uid and req.forward_uid:
-        sys.exit("--reply-to-uid and --forward-uid are mutually exclusive")
-    acc = resolve_account(req.account)
-    user = account_user(acc)
+def _transport(acc: str) -> tuple[dict, str, int]:
+    """Resolve the account's SMTP profile + host + port, exiting when unconfigured."""
     name, profile = account_profile(acc)
     smtp_host = profile.get("smtp_host")
     smtp_port = int(profile.get("smtp_port", 587))
@@ -480,6 +487,95 @@ def send(req: SendRequest) -> None:
             f"provider {name} (account {acc!r}) has no SMTP host configured; "
             "set smtp_host in the per-account config.json or EMAIL_CLIENT_SMTP_HOST"
         )
+    return profile, smtp_host, smtp_port
+
+
+def _held_from_outbound(out: Outbound, req: SendRequest, acc: str, token: str, fire_at: float) -> pending_sends.HeldSend:
+    return pending_sends.HeldSend(
+        token=token,
+        fire_at=fire_at,
+        created_at=time.time(),
+        account=acc,
+        user=out.user,
+        display=out.display,
+        to=out.to,
+        subject=out.subject,
+        body=out.body,
+        body_html=out.body_html,
+        cc=out.cc,
+        bcc=out.bcc,
+        in_reply_to=out.in_reply_to,
+        references=out.references,
+        attachments=[
+            pending_sends.HeldAttachment(
+                name=att["name"],
+                maintype=att["maintype"],
+                subtype=att["subtype"],
+                data_b64=base64.b64encode(att["data"]).decode(),
+            )
+            for att in out.attachments
+        ],
+        sent_sync=req.sent_sync,
+        reply_to_uid=req.reply_to_uid,
+        reply_folder=req.reply_folder,
+    )
+
+
+def _outbound_from_held(entry: pending_sends.HeldSend) -> Outbound:
+    return Outbound(
+        user=entry.user,
+        display=entry.display,
+        to=entry.to,
+        subject=entry.subject,
+        body=entry.body,
+        body_html=entry.body_html,
+        cc=entry.cc,
+        bcc=entry.bcc,
+        in_reply_to=entry.in_reply_to,
+        references=entry.references,
+        attachments=[
+            {
+                "name": att.name,
+                "maintype": att.maintype,
+                "subtype": att.subtype,
+                "data": base64.b64decode(att.data_b64),
+            }
+            for att in entry.attachments
+        ],
+    )
+
+
+def _hold(req: SendRequest, acc: str, out: Outbound) -> None:
+    """Enqueue the composed message for the poll daemon to send once the undo window elapses."""
+    state_dir = _state_dir()
+    running, _pid = daemon_lifecycle.daemon_running(state_dir)
+    if not running:
+        sys.exit("--hold needs the poll daemon to dispatch the send later, but it is not running; start it with: email-client daemon start")
+    entry = _held_from_outbound(out, req, acc, pending_sends.new_token(), time.time() + req.hold)
+    pending_sends.save(pending_sends.queue_dir(state_dir), entry)
+    fire_iso = _dt.datetime.fromtimestamp(entry.fire_at, tz=_dt.UTC).isoformat(timespec="seconds")
+    print(f"HELD {entry.token}: fires at {fire_iso} (in {req.hold}s)")
+    print(f"cancel with: email-client pending cancel {entry.token}")
+
+
+def send_held(entry: pending_sends.HeldSend) -> None:
+    """Dispatch a claimed queue entry: deliver, then the usual post-send steps."""
+    out = _outbound_from_held(entry)
+    msg = _build_message(out)
+    profile, smtp_host, smtp_port = _transport(entry.account)
+    _smtp_deliver(entry.account, profile, entry.user, smtp_host, smtp_port, msg)
+    if entry.reply_to_uid:
+        _mark_answered(entry.account, entry.reply_folder, entry.reply_to_uid)
+    if entry.sent_sync:
+        _sync_sent(entry.account, profile, out)
+
+
+def send(req: SendRequest) -> None:
+    if req.reply_to_uid and req.forward_uid:
+        sys.exit("--reply-to-uid and --forward-uid are mutually exclusive")
+    acc = resolve_account(req.account)
+    user = account_user(acc)
+    profile, smtp_host, smtp_port = _transport(acc)
     display = req.from_name or _env("EMAIL_CLIENT_FROM_NAME", user.split("@", 1)[0])
 
     out = _compose(req, acc, user, display)
@@ -503,6 +599,10 @@ def send(req: SendRequest) -> None:
             print(f"draft saved to {info}")
             return
         sys.exit(f"draft save failed: {info}")
+
+    if req.hold is not None:
+        _hold(req, acc, out)
+        return
 
     _smtp_deliver(acc, profile, user, smtp_host, smtp_port, msg)
     print("OK")
@@ -600,7 +700,18 @@ def main():
         action="store_true",
         help="save the composed message to the Drafts folder instead of sending; works with --reply-to-uid / --forward-uid to draft for review",
     )
+    ap.add_argument(
+        "--hold",
+        type=int,
+        default=None,
+        metavar="SECS",
+        help="undo window: compose now, hold the send for SECS seconds, print a cancel token (email-client pending cancel <token>)",
+    )
     args = ap.parse_args()
+    if args.hold is not None and (args.draft or args.dry_run):
+        sys.exit("--hold is mutually exclusive with --draft and --dry-run")
+    if args.hold is not None and args.hold <= 0:
+        sys.exit("--hold expects a positive number of seconds")
     # Hard draft-only guard: refuse any transmitting invocation (send/reply/forward)
     # before touching SMTP. Drafting (--draft) and the no-network preview (--dry-run)
     # stay allowed. Default off: no behavior change when EMAIL_DRAFT_ONLY is unset.
@@ -625,6 +736,7 @@ def main():
             sent_sync=not args.no_sent_sync,
             dry_run=args.dry_run,
             draft=args.draft,
+            hold=args.hold,
         )
     )
 

--- a/agent/skills/email-client/tests/test_draft_only.py
+++ b/agent/skills/email-client/tests/test_draft_only.py
@@ -40,6 +40,7 @@ def _install_stubs():
         for name in (
             "_env",
             "_from_full",
+            "_state_dir",
             "_to_full",
             "account_profile",
             "account_user",

--- a/agent/skills/email-client/tests/test_pending_sends.py
+++ b/agent/skills/email-client/tests/test_pending_sends.py
@@ -1,0 +1,267 @@
+"""Undo-send queue (``--hold`` on email-client-send): enqueue holds, cancel
+aborts, the poll daemon dispatches after fire-at and parks failures.
+
+smtp_send/poll_daemon import imap_client (which needs imap_tools from the
+on-box runtime); minimal stubs are registered first and every account/SMTP edge
+smtp_send touches is monkeypatched, so the undo-window logic runs without the
+runtime venv. Dispatch is driven with explicit fire-at values, never sleeps.
+"""
+
+import base64
+import json
+import pathlib
+import sys
+import time
+import types
+
+import pytest
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT))
+
+
+def _install_stubs():
+    """Register minimal fake imap_tools / imap_client so smtp_send and poll_daemon import."""
+    if "imap_tools" not in sys.modules:
+        it = types.ModuleType("imap_tools")
+
+        def _and(*_a, **_k):
+            return None
+
+        class MailMessageFlags:
+            DRAFT = "\\Draft"
+            SEEN = "\\Seen"
+            ANSWERED = "\\Answered"
+
+        # The attributes mirror the imap_tools API names.
+        it.AND = _and
+        it.MailBox = object
+        it.MailMessageFlags = MailMessageFlags
+        sys.modules["imap_tools"] = it
+
+    # Another test file may have registered a leaner imap_client stub already;
+    # fill in whatever names smtp_send/poll_daemon import that it lacks (a no-op
+    # when the real module is loaded).
+    ic = sys.modules["imap_client"] if "imap_client" in sys.modules else types.ModuleType("imap_client")
+    for name in (
+        "_env",
+        "_from_full",
+        "_state_dir",
+        "_to_full",
+        "account_dir",
+        "account_profile",
+        "account_user",
+        "connect",
+        "get_access_token",
+        "get_app_password",
+        "list_accounts",
+        "notify_folders",
+        "resolve_account",
+        "resolve_special_folder",
+    ):
+        if name not in vars(ic):
+            setattr(ic, name, lambda *a, **k: None)
+    sys.modules["imap_client"] = ic
+
+
+_install_stubs()
+import pending_sends
+import poll_daemon
+import smtp_send
+
+SEND = ["--to", "bob@x.com", "--subject", "Hi", "--body", "hello"]
+
+
+def _entry(token: str, fire_at: float, **over) -> pending_sends.HeldSend:
+    base = {
+        "token": token,
+        "fire_at": fire_at,
+        "created_at": 0.0,
+        "account": "personal",
+        "user": "me@x.com",
+        "display": "Me",
+        "to": "bob@x.com",
+        "subject": "Hi",
+        "body": "hello",
+        "body_html": None,
+        "cc": [],
+        "bcc": [],
+        "in_reply_to": "",
+        "references": "",
+        "attachments": [],
+        "sent_sync": False,
+        "reply_to_uid": None,
+        "reply_folder": "INBOX",
+    }
+    base.update(over)
+    return pending_sends.HeldSend(**base)
+
+
+# -- queue mechanics ------------------------------------------------
+
+
+def test_save_and_load_round_trip_including_attachments(tmp_path):
+    qdir = pending_sends.queue_dir(tmp_path)
+    att = pending_sends.HeldAttachment(name="a.txt", maintype="text", subtype="plain", data_b64=base64.b64encode(b"payload").decode())
+    entry = _entry("t1", 10.0, attachments=[att])
+    path = pending_sends.save(qdir, entry)
+    assert pending_sends.load(path) == entry
+
+
+def test_list_pending_sorts_by_fire_at(tmp_path):
+    qdir = pending_sends.queue_dir(tmp_path)
+    pending_sends.save(qdir, _entry("later", 100.0))
+    pending_sends.save(qdir, _entry("sooner", 10.0))
+    assert [e.token for e in pending_sends.list_pending(qdir)] == ["sooner", "later"]
+
+
+def test_claim_due_takes_only_entries_past_fire_at(tmp_path):
+    qdir = pending_sends.queue_dir(tmp_path)
+    pending_sends.save(qdir, _entry("due", 10.0))
+    pending_sends.save(qdir, _entry("early", 100.0))
+
+    claimed = pending_sends.claim_due(qdir, now=50.0)
+
+    assert [(path.name, entry.token) for path, entry in claimed] == [("due.sending", "due")]
+    assert [e.token for e in pending_sends.list_pending(qdir)] == ["early"]
+
+
+def test_cancel_prevents_dispatch(tmp_path):
+    qdir = pending_sends.queue_dir(tmp_path)
+    pending_sends.save(qdir, _entry("t1", 10.0))
+
+    assert pending_sends.cancel(qdir, "t1") is True
+    assert pending_sends.claim_due(qdir, now=50.0) == []
+    assert pending_sends.cancel(qdir, "t1") is False
+
+
+def test_fail_parks_the_claimed_entry_with_the_error(tmp_path):
+    qdir = pending_sends.queue_dir(tmp_path)
+    pending_sends.save(qdir, _entry("t1", 10.0))
+    [(claimed, _entry_obj)] = pending_sends.claim_due(qdir, now=50.0)
+
+    failed = pending_sends.fail(claimed, "smtp auth failed")
+
+    assert failed.name == "t1.failed"
+    assert json.loads(failed.read_text())["error"] == "smtp auth failed"
+    assert not claimed.exists()
+    assert pending_sends.list_pending(qdir) == []
+
+
+# -- the --hold CLI path --------------------------------------------
+
+
+def _prep_hold(monkeypatch, tmp_path, *, daemon_up: bool = True):
+    """Point smtp_send at a tmp state dir with a stubbed account and an exploding SMTP edge."""
+    delivered = []
+
+    def boom(*_a, **_k):
+        delivered.append("smtp")
+        raise AssertionError("_smtp_deliver must not run while the send is held")
+
+    monkeypatch.setattr(smtp_send, "resolve_account", lambda a: "personal")
+    monkeypatch.setattr(smtp_send, "account_user", lambda a: "me@x.com")
+    monkeypatch.setattr(smtp_send, "account_profile", lambda a: ("gmail", {"smtp_host": "smtp.example", "smtp_port": 587}))
+    monkeypatch.setattr(smtp_send, "_state_dir", lambda: tmp_path)
+    monkeypatch.setattr(smtp_send, "_env", lambda name, default=None, *, required=False: default)
+    monkeypatch.setattr(smtp_send.daemon_lifecycle, "daemon_running", lambda sd: (daemon_up, 1 if daemon_up else None))
+    monkeypatch.setattr(smtp_send, "_smtp_deliver", boom)
+    monkeypatch.delenv("EMAIL_DRAFT_ONLY", raising=False)
+    return delivered
+
+
+def test_hold_enqueues_without_sending(monkeypatch, tmp_path, capsys):
+    delivered = _prep_hold(monkeypatch, tmp_path)
+    monkeypatch.setattr(sys, "argv", ["email-client-send", *SEND, "--hold", "30"])
+
+    smtp_send.main()
+
+    [entry] = pending_sends.list_pending(pending_sends.queue_dir(tmp_path))
+    assert (entry.account, entry.to, entry.subject, entry.body) == ("personal", "bob@x.com", "Hi", "hello")
+    assert time.time() < entry.fire_at <= time.time() + 30
+    out = capsys.readouterr().out
+    assert f"HELD {entry.token}" in out
+    assert f"email-client pending cancel {entry.token}" in out
+    assert delivered == []
+
+
+def test_hold_needs_the_poll_daemon_running(monkeypatch, tmp_path):
+    _prep_hold(monkeypatch, tmp_path, daemon_up=False)
+    monkeypatch.setattr(sys, "argv", ["email-client-send", *SEND, "--hold", "30"])
+
+    with pytest.raises(SystemExit, match="poll daemon"):
+        smtp_send.main()
+    assert pending_sends.list_pending(pending_sends.queue_dir(tmp_path)) == []
+
+
+@pytest.mark.parametrize("extra", [["--draft"], ["--dry-run"]], ids=["draft", "dry-run"])
+def test_hold_is_mutually_exclusive_with_draft_and_dry_run(monkeypatch, extra):
+    monkeypatch.setattr(sys, "argv", ["email-client-send", *SEND, "--hold", "30", *extra])
+    with pytest.raises(SystemExit, match="mutually exclusive"):
+        smtp_send.main()
+
+
+def test_hold_rejects_nonpositive_window(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["email-client-send", *SEND, "--hold", "0"])
+    with pytest.raises(SystemExit, match="positive"):
+        smtp_send.main()
+
+
+# -- dispatch (poll daemon side) ------------------------------------
+
+
+def test_send_held_delivers_the_stored_message(monkeypatch):
+    delivered = {}
+
+    def record(acc, profile, user, host, port, msg):
+        delivered.update({"acc": acc, "user": user, "host": host, "port": port, "msg": msg})
+
+    monkeypatch.setattr(smtp_send, "account_profile", lambda a: ("gmail", {"smtp_host": "smtp.example", "smtp_port": 587}))
+    monkeypatch.setattr(smtp_send, "_smtp_deliver", record)
+    att = pending_sends.HeldAttachment(name="a.txt", maintype="text", subtype="plain", data_b64=base64.b64encode(b"payload").decode())
+    entry = _entry("t1", 10.0, attachments=[att], cc=["cc@x.com"])
+
+    smtp_send.send_held(entry)
+
+    assert (delivered["acc"], delivered["user"], delivered["host"], delivered["port"]) == ("personal", "me@x.com", "smtp.example", 587)
+    msg = delivered["msg"]
+    assert (msg["To"], msg["Cc"], msg["Subject"]) == ("bob@x.com", "cc@x.com", "Hi")
+    [attachment] = list(msg.iter_attachments())
+    assert attachment.get_filename() == "a.txt"
+    assert attachment.get_payload(decode=True) == b"payload"
+
+
+def test_dispatch_sends_due_entries_and_clears_them(monkeypatch, tmp_path):
+    qdir = pending_sends.queue_dir(tmp_path)
+    pending_sends.save(qdir, _entry("due", 10.0))
+    pending_sends.save(qdir, _entry("early", time.time() + 1000))
+    sent = []
+    monkeypatch.setattr(smtp_send, "send_held", lambda entry: sent.append(entry.token))
+    logs = []
+
+    poll_daemon.dispatch_held(tmp_path, logs.append)
+
+    assert sent == ["due"]
+    assert [e.token for e in pending_sends.list_pending(qdir)] == ["early"]
+    assert not (qdir / "due.sending").exists()
+
+
+def test_failed_dispatch_parks_the_entry_and_notifies(monkeypatch, tmp_path):
+    qdir = pending_sends.queue_dir(tmp_path)
+    pending_sends.save(qdir, _entry("t1", 10.0))
+
+    def explode(entry):
+        sys.exit("smtp auth failed")
+
+    monkeypatch.setattr(smtp_send, "send_held", explode)
+    notif_dir = tmp_path / "notifications"
+    monkeypatch.setattr(poll_daemon, "NOTIF_DIR", notif_dir)
+    logs = []
+
+    poll_daemon.dispatch_held(tmp_path, logs.append)
+
+    assert json.loads((qdir / "t1.failed").read_text())["error"] == "smtp auth failed"
+    [notif_path] = list(notif_dir.glob("*.json"))
+    notif = json.loads(notif_path.read_text())
+    assert (notif["source"], notif["type"], notif["interrupt"]) == ("email-client", "send_failed", True)
+    assert (notif["account"], notif["token"], notif["error"]) == ("personal", "t1", "smtp auth failed")

--- a/agent/skills/microsoft/SKILL.md
+++ b/agent/skills/microsoft/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: microsoft
-description: Use for any Microsoft account, personal or work (Outlook.com, Hotmail, Live, Microsoft 365); preferred over email-client for Microsoft accounts. Graph-based mail (read/send/reply/forward, drafts, flag/categorize, move/archive, folders, attachments, block senders), calendar and meetings, Microsoft Teams (chats, channels, presence), and new-mail/Teams notifications. Requires daemon.
+description: Use for any Microsoft account, personal or work (Outlook.com, Hotmail, Live, Microsoft 365); preferred over email-client for Microsoft accounts. Graph-based mail (read/send/reply/forward with an optional undo-send hold window, drafts, flag/categorize, move/archive, folders, attachments, block senders), calendar and meetings, Microsoft Teams (chats, channels, presence), and new-mail/Teams notifications. Requires daemon.
 ---
 
 # Microsoft - CLI: microsoft
@@ -13,7 +13,7 @@ description: Use for any Microsoft account, personal or work (Outlook.com, Hotma
 
 Each area's detail lives in its own file, read it when you work in that area:
 
-- **Email**: read/send/reply/forward, search, organize (flag/categorize/move/archive), drafts, folders, block/unblock, attachments. See [references/email.md](references/email.md).
+- **Email**: read/send/reply/forward, undo-send hold window (`--hold` / `cancel` / `list-pending`), search, organize (flag/categorize/move/archive), drafts, folders, block/unblock, attachments. See [references/email.md](references/email.md).
 - **Calendar**: list/create/update/respond to events and meetings. See [references/calendar.md](references/calendar.md).
 - **Teams**: chats, channels, presence (and Teams sign-in). See [references/teams.md](references/teams.md).
 - **Notifications**: new-mail folder watching + Teams chat alerts (plus non-interrupting Teams channel alerts where the account has channel access; degrades to chats-only otherwise). See [references/notifications.md](references/notifications.md).

--- a/agent/skills/microsoft/cli/src/microsoft_cli/cli.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/cli.py
@@ -6,11 +6,26 @@ import os
 import signal
 import sys
 import threading
+import time
 from pathlib import Path
 
 import httpx
 
-from . import auth_commands, backend, block, calendar, email, folders, monitor, notifications, notify, owa_rest, owa_rest_commands, teams
+from . import (
+    auth_commands,
+    backend,
+    block,
+    calendar,
+    email,
+    folders,
+    monitor,
+    notifications,
+    notify,
+    owa_rest,
+    owa_rest_commands,
+    pending,
+    teams,
+)
 from . import format as fmt
 from .config import Config
 from .context import MicrosoftContext
@@ -177,6 +192,16 @@ def _add_email_read_parsers(email_sub) -> None:
     p_attachment.add_argument("--out-dir", default=None, help="Directory for --all downloads (default ~/.microsoft/attachments/<email-id>)")
 
 
+def _add_hold_flag(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--hold",
+        type=int,
+        default=None,
+        metavar="SECS",
+        help="Undo window: hold the send for SECS seconds and print a cancel token (email cancel --token <t>) instead of sending now.",
+    )
+
+
 def _add_email_compose_parsers(email_sub) -> None:
     p_send = email_sub.add_parser("send")
     p_send.add_argument("--account", required=True)
@@ -187,6 +212,7 @@ def _add_email_compose_parsers(email_sub) -> None:
     p_send.add_argument("--bcc", nargs="+", default=None)
     p_send.add_argument("--attachments", nargs="+", default=None)
     p_send.add_argument("--html", action="store_true", default=False)
+    _add_hold_flag(p_send)
 
     p_draft = email_sub.add_parser("draft")
     p_draft.add_argument("--account", required=True)
@@ -207,6 +233,7 @@ def _add_email_compose_parsers(email_sub) -> None:
     p_reply.add_argument("--attachments", nargs="+", default=None)
     p_reply.add_argument("--reply-all", action="store_true")
     p_reply.add_argument("--html", action="store_true")
+    _add_hold_flag(p_reply)
 
     p_reply_draft = email_sub.add_parser("reply-draft")
     p_reply_draft.add_argument("--account", required=True)
@@ -224,6 +251,12 @@ def _add_email_compose_parsers(email_sub) -> None:
     p_forward.add_argument("--cc", nargs="+", default=None)
     p_forward.add_argument("--attachments", nargs="+", default=None)
     p_forward.add_argument("--html", action="store_true")
+    _add_hold_flag(p_forward)
+
+    p_cancel = email_sub.add_parser("cancel", help="Cancel a held send before its undo window elapses.")
+    p_cancel.add_argument("--token", required=True, help="Cancel token printed by a --hold send.")
+
+    email_sub.add_parser("list-pending", help="List held sends waiting out their undo window.")
 
 
 def _add_email_manage_parsers(email_sub) -> None:
@@ -645,13 +678,99 @@ def _email_routes():
     }
 
 
+def _held_mail(args) -> tuple[MailDraft, str | None, bool]:
+    """The fully resolved (mail, email_id, reply_all) payload of a --hold command."""
+    if args.command == "send":
+        mail = MailDraft(
+            to=args.to, subject=args.subject, body=args.body, cc=args.cc, bcc=args.bcc, attachments=args.attachments, html=args.html
+        )
+        return mail, None, False
+    if args.command == "reply":
+        return MailDraft(body=args.body, attachments=args.attachments, html=args.html), args.email_id, args.reply_all
+    return MailDraft(to=args.to, body=args.body, cc=args.cc, attachments=args.attachments, html=args.html), args.email_id, False
+
+
+def _hold_send(args, config):
+    """Enqueue a transmit command for the serve daemon to dispatch after the undo window."""
+    if args.hold <= 0:
+        raise ValueError("--hold expects a positive number of seconds")
+    mail, email_id, reply_all = _held_mail(args)
+    if args.command == "send" and not (mail.to or mail.cc or mail.bcc):
+        raise ValueError("At least one recipient is required (--to, --cc, or --bcc)")
+    for attachment in mail.attachments or []:
+        if not Path(attachment).expanduser().exists():
+            raise ValueError(f"attachment not found: {attachment}")
+    # Pin the backend an auto command would start on when Graph cannot even resolve
+    # the account, so dispatch needs no account lookup of its own.
+    choice = args.backend
+    if choice == backend.AUTO and owa_rest.has_valid_token(args.account, config) and not _graph_has_account(config, args.account):
+        choice = backend.OWA_REST
+    now = time.time()
+    entry = pending.PendingSend(
+        token=pending.new_token(),
+        fire_at=now + args.hold,
+        created_at=now,
+        account=args.account,
+        backend=choice,
+        command=args.command,
+        mail=mail,
+        email_id=email_id,
+        reply_all=reply_all,
+    )
+    pending.save(config, entry)
+    return {
+        "held": pending.describe(entry, now),
+        "cancel": f"microsoft email cancel --token {entry.token}",
+    }
+
+
+def _dispatch_queue(args, config, _client):
+    """Local undo-queue commands (cancel, list-pending): no account, no backend, no daemon call."""
+    if args.command == "cancel":
+        if not pending.cancel(config, args.token):
+            raise ValueError(f"no held send with token {args.token!r} (already sent, cancelled, or unknown)")
+        return {"cancelled": args.token}
+    now = time.time()
+    return [pending.describe(entry, now) for entry in pending.list_pending(config)]
+
+
+def _dispatch_reply_draft(args, config, client):
+    """Graph-only: leaving a properly-threaded unsent draft over the preserved quote
+    has no OWA REST counterpart, so this bypasses the backend router."""
+    return email.reply_draft(
+        config,
+        client,
+        account_email=args.account,
+        email_id=args.email_id,
+        body=args.body,
+        attachments=args.attachments,
+        reply_all=args.reply_all,
+        replace_draft=args.replace_draft,
+    )
+
+
 def _dispatch_email(args, config, client):
+    # Built per dispatch so module attributes stay late-bound (matching _email_routes).
+    delegated = {
+        "cancel": _dispatch_queue,
+        "list-pending": _dispatch_queue,
+        "reply-draft": _dispatch_reply_draft,
+        "attachment": _dispatch_attachment,
+        "block": _dispatch_block,
+        "unblock": _dispatch_block,
+    }
+    if args.command in delegated:
+        return delegated[args.command](args, config, client)
+
     acct = args.account
 
     # Hard draft-only guard: refuse any transmitting command before it can reach
     # EITHER backend (Graph or OWA-REST). Drafting still flows through untouched.
     if args.command in _TRANSMIT_COMMANDS and _draft_only_enabled():
         raise RuntimeError(_DRAFT_ONLY_MESSAGE)
+
+    if args.command in _TRANSMIT_COMMANDS and args.hold is not None:
+        return _hold_send(args, config)
 
     if args.command == "list" and args.search is not None:
         # `list --search/--query` is an alias for `email search`: run the identical search path,
@@ -664,23 +783,6 @@ def _dispatch_email(args, config, client):
             lambda: email.search_emails(config, client, **kw),
             lambda: owa_rest_commands.search_emails(config, client, **kw),
         )
-    if args.command == "reply-draft":
-        # Graph-only: leaving a properly-threaded unsent draft over the preserved quote
-        # has no OWA REST counterpart, so this bypasses the backend router.
-        return email.reply_draft(
-            config,
-            client,
-            account_email=acct,
-            email_id=args.email_id,
-            body=args.body,
-            attachments=args.attachments,
-            reply_all=args.reply_all,
-            replace_draft=args.replace_draft,
-        )
-    if args.command == "attachment":
-        return _dispatch_attachment(args, config, client)
-    if args.command in ("block", "unblock"):
-        return _dispatch_block(args, config, client)
     routes = _email_routes()
     if args.command in routes:
         graph_impl, rest_impl, kw_of = routes[args.command]

--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import NotRequired, TypedDict, cast
 from zoneinfo import ZoneInfo
 
-from . import auth, capture, folders, graph, notifications, notify, owa_rest, teams
+from . import auth, capture, folders, graph, notifications, notify, owa_rest, pending, teams
 from .config import Config
 from .context import MicrosoftContext
 
@@ -595,6 +595,26 @@ def _poll_graph_calendar(ctx: MicrosoftContext, acc, new_check_time: datetime, l
     return True
 
 
+def _dispatch_held_sends(ctx: MicrosoftContext, config: Config, logger) -> None:
+    """Send every held undo-window entry (--hold) whose fire-at has passed; see pending.py."""
+    for entry, error in pending.dispatch_due(config, ctx.http_client, time.time()):
+        if error is None:
+            logger.info("Dispatched held %s for %s (token %s)", entry.command, entry.account, entry.token)
+            continue
+        logger.error("Held %s for %s failed (token %s): %s", entry.command, entry.account, entry.token, error)
+        notifications.write_notification(
+            ctx.notif_dir,
+            "send_failed",
+            interrupt=True,
+            account=entry.account,
+            token=entry.token,
+            command=entry.command,
+            to=entry.mail.to,
+            subject=entry.mail.subject,
+            error=error,
+        )
+
+
 def run(ctx: MicrosoftContext):
     logger = ctx.monitor_logger
     logger.info("Monitor thread started")
@@ -605,6 +625,8 @@ def run(ctx: MicrosoftContext):
             new_check_time = datetime.now(UTC)
             state = _read_state(ctx.monitor_state_file, new_check_time)
             config = Config(data_dir=ctx.cache_file.parent)
+
+            _dispatch_held_sends(ctx, config, logger)
 
             msal_accounts = auth.list_accounts(ctx.cache_file)
             for acc in msal_accounts:

--- a/agent/skills/microsoft/cli/src/microsoft_cli/pending.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/pending.py
@@ -1,0 +1,159 @@
+"""Undo-send queue for held outbound mail (``--hold`` on email send/reply/forward).
+
+A held send is one JSON file at ``<data_dir>/pending-sends/<token>.json`` storing
+the fully resolved payload (command, account, backend, MailDraft fields) plus a
+fire-at timestamp. The serve daemon's monitor cycle dispatches entries whose
+fire-at has passed. Cancel unlinks the entry; dispatch claims one by renaming it
+to ``<token>.sending`` first, so cancel and dispatch can never both win. A
+failed dispatch is renamed to ``<token>.failed`` (error recorded inside) and is
+never retried: retrying a maybe-sent message risks a double send.
+"""
+
+import dataclasses
+import json
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+from . import backend, email, owa_rest_commands
+from .config import Config
+from .payloads import MailDraft
+
+QUEUE_DIR_NAME = "pending-sends"
+
+
+@dataclasses.dataclass(frozen=True)
+class PendingSend:
+    """A held email send/reply/forward waiting out its undo window."""
+
+    token: str
+    fire_at: float
+    created_at: float
+    account: str
+    backend: str
+    command: str
+    mail: MailDraft
+    email_id: str | None = None
+    reply_all: bool = False
+
+
+def new_token() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def queue_dir(config: Config) -> Path:
+    d = config.data_dir / QUEUE_DIR_NAME
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def entry_path(config: Config, token: str) -> Path:
+    return queue_dir(config) / f"{token}.json"
+
+
+def save(config: Config, entry: PendingSend) -> Path:
+    """Atomically write the entry (tmp + rename) so a reader never sees a torn file."""
+    final = entry_path(config, entry.token)
+    tmp = final.with_suffix(".tmp")
+    tmp.write_text(json.dumps(dataclasses.asdict(entry)))
+    tmp.replace(final)
+    return final
+
+
+def load(path: Path) -> PendingSend:
+    data = json.loads(path.read_text())
+    data["mail"] = MailDraft(**data["mail"])
+    return PendingSend(**data)
+
+
+def cancel(config: Config, token: str) -> bool:
+    """Remove a pending entry. False when it already fired (or never existed)."""
+    try:
+        entry_path(config, token).unlink()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def list_pending(config: Config) -> list[PendingSend]:
+    return sorted((load(p) for p in queue_dir(config).glob("*.json")), key=lambda e: e.fire_at)
+
+
+def describe(entry: PendingSend, now: float) -> dict:
+    """One list-pending row: what is held and when it fires."""
+    return {
+        "token": entry.token,
+        "command": entry.command,
+        "account": entry.account,
+        "to": entry.mail.to,
+        "subject": entry.mail.subject,
+        "email_id": entry.email_id,
+        "fire_at": datetime.fromtimestamp(entry.fire_at, tz=UTC).isoformat(timespec="seconds"),
+        "fires_in_seconds": max(0, int(entry.fire_at - now)),
+    }
+
+
+def claim_due(config: Config, now: float) -> list[tuple[Path, PendingSend]]:
+    """Claim every entry whose fire-at has passed by renaming it to ``<token>.sending``.
+
+    The rename is atomic, so a concurrent cancel either removed the entry first
+    (the rename raises and the entry is skipped) or lost and is told so.
+    """
+    claimed: list[tuple[Path, PendingSend]] = []
+    for path in sorted(queue_dir(config).glob("*.json")):
+        entry = load(path)
+        if entry.fire_at > now:
+            continue
+        sending = path.with_suffix(".sending")
+        try:
+            path.rename(sending)
+        except FileNotFoundError:
+            continue
+        claimed.append((sending, entry))
+    return claimed
+
+
+def fail(claimed_path: Path, error: str) -> Path:
+    """Park a claimed entry as ``<token>.failed`` with the error recorded inside."""
+    data = json.loads(claimed_path.read_text())
+    data["error"] = error
+    failed = claimed_path.with_suffix(".failed")
+    failed.write_text(json.dumps(data))
+    claimed_path.unlink(missing_ok=True)
+    return failed
+
+
+def _send_fns(config: Config, client, entry: PendingSend):
+    """The (graph, owa-rest) implementations of the held command, mirroring cli's routes."""
+    if entry.command == "send":
+        kw = {"account_email": entry.account, "mail": entry.mail}
+        return (lambda: email.send_email(config, client, **kw), lambda: owa_rest_commands.send_email(config, client, **kw))
+    if entry.command == "reply":
+        kw = {
+            "account_email": entry.account,
+            "email_id": entry.email_id,
+            "body": entry.mail.body,
+            "attachments": entry.mail.attachments,
+            "reply_all": entry.reply_all,
+            "html": entry.mail.html,
+        }
+        return (lambda: email.reply_to_email(config, client, **kw), lambda: owa_rest_commands.reply_to_email(config, client, **kw))
+    if entry.command == "forward":
+        kw = {"account_email": entry.account, "email_id": entry.email_id, "mail": entry.mail}
+        return (lambda: email.forward_email(config, client, **kw), lambda: owa_rest_commands.forward_email(config, client, **kw))
+    raise ValueError(f"unknown held command {entry.command!r}")
+
+
+def dispatch_due(config: Config, client, now: float) -> list[tuple[PendingSend, str | None]]:
+    """Send every claimed due entry. Returns (entry, error) per attempt, error None on success."""
+    outcomes: list[tuple[PendingSend, str | None]] = []
+    for claimed, entry in claim_due(config, now):
+        graph_fn, rest_fn = _send_fns(config, client, entry)
+        try:
+            backend.run(entry.backend, graph_fn, rest_fn)
+            claimed.unlink(missing_ok=True)
+            outcomes.append((entry, None))
+        except Exception as e:
+            fail(claimed, str(e))
+            outcomes.append((entry, str(e)))
+    return outcomes

--- a/agent/skills/microsoft/cli/tests/test_draft_only.py
+++ b/agent/skills/microsoft/cli/tests/test_draft_only.py
@@ -23,6 +23,7 @@ def _send_args(**over):
         "attachments": None,
         "html": False,
         "backend": backend.GRAPH,
+        "hold": None,
     }
     base.update(over)
     return SimpleNamespace(**base)
@@ -38,6 +39,7 @@ def _reply_args(**over):
         "reply_all": False,
         "html": False,
         "backend": backend.GRAPH,
+        "hold": None,
     }
     base.update(over)
     return SimpleNamespace(**base)
@@ -54,6 +56,7 @@ def _forward_args(**over):
         "attachments": None,
         "html": False,
         "backend": backend.GRAPH,
+        "hold": None,
     }
     base.update(over)
     return SimpleNamespace(**base)

--- a/agent/skills/microsoft/cli/tests/test_pending.py
+++ b/agent/skills/microsoft/cli/tests/test_pending.py
@@ -1,0 +1,228 @@
+"""Undo-send window (--hold): enqueue holds, cancel aborts, the daemon dispatch sends after fire-at.
+
+Dispatch is driven with an explicit ``now`` derived from the stored entry's own
+fire_at, so no test waits on the wall clock.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from microsoft_cli import backend, cli, pending
+from microsoft_cli.config import Config
+from microsoft_cli.payloads import MailDraft
+
+
+def _config(tmp_path):
+    return Config(data_dir=tmp_path)
+
+
+def _send_args(**over):
+    base = {
+        "command": "send",
+        "account": "me@example.com",
+        "to": ["bob@x.com"],
+        "subject": "Hi",
+        "body": "body",
+        "cc": None,
+        "bcc": None,
+        "attachments": None,
+        "html": False,
+        "backend": backend.GRAPH,
+        "hold": 30,
+    }
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _reply_args(**over):
+    base = {
+        "command": "reply",
+        "account": "me@example.com",
+        "email_id": "orig-1",
+        "body": "thanks",
+        "attachments": None,
+        "reply_all": True,
+        "html": False,
+        "backend": backend.GRAPH,
+        "hold": 30,
+    }
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _forward_args(**over):
+    base = {
+        "command": "forward",
+        "account": "me@example.com",
+        "email_id": "orig-1",
+        "to": ["bob@x.com"],
+        "body": "fyi",
+        "cc": None,
+        "attachments": None,
+        "html": False,
+        "backend": backend.GRAPH,
+        "hold": 30,
+    }
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _guard_all_sends(monkeypatch):
+    """Make every transmit function on BOTH backends explode if it's ever reached."""
+    calls = []
+
+    def boom(name):
+        def _f(*a, **k):
+            calls.append(name)
+            raise AssertionError(f"{name} must not be called while the send is held")
+
+        return _f
+
+    for mod, prefix in ((cli.email, "graph"), (cli.owa_rest_commands, "rest")):
+        for fn in ("send_email", "reply_to_email", "forward_email"):
+            monkeypatch.setattr(mod, fn, boom(f"{prefix}.{fn}"))
+    return calls
+
+
+def test_hold_enqueues_without_sending(monkeypatch, tmp_path):
+    calls = _guard_all_sends(monkeypatch)
+    config = _config(tmp_path)
+
+    result = cli._dispatch_email(_send_args(), config, client=None)
+
+    token = result["held"]["token"]
+    assert result["cancel"] == f"microsoft email cancel --token {token}"
+    assert (tmp_path / "pending-sends" / f"{token}.json").exists()
+    assert calls == []
+
+
+def test_hold_validates_recipient_up_front(tmp_path):
+    with pytest.raises(ValueError, match="recipient"):
+        cli._dispatch_email(_send_args(to=None), _config(tmp_path), client=None)
+
+
+def test_hold_validates_attachments_up_front(tmp_path):
+    with pytest.raises(ValueError, match="attachment not found"):
+        cli._dispatch_email(_send_args(attachments=[str(tmp_path / "missing.pdf")]), _config(tmp_path), client=None)
+
+
+def test_hold_rejects_nonpositive_window(tmp_path):
+    with pytest.raises(ValueError, match="positive"):
+        cli._dispatch_email(_send_args(hold=0), _config(tmp_path), client=None)
+
+
+def test_draft_only_mode_refuses_a_held_send(monkeypatch, tmp_path):
+    monkeypatch.setenv("EMAIL_DRAFT_ONLY", "1")
+    with pytest.raises(RuntimeError, match="draft-only"):
+        cli._dispatch_email(_send_args(), _config(tmp_path), client=None)
+
+
+def test_cancel_prevents_dispatch(monkeypatch, tmp_path):
+    calls = _guard_all_sends(monkeypatch)
+    config = _config(tmp_path)
+    token = cli._dispatch_email(_send_args(), config, client=None)["held"]["token"]
+    entry = pending.list_pending(config)[0]
+
+    result = cli._dispatch_email(SimpleNamespace(command="cancel", token=token), config, client=None)
+
+    assert result == {"cancelled": token}
+    assert pending.dispatch_due(config, None, now=entry.fire_at + 1) == []
+    assert pending.list_pending(config) == []
+    assert calls == []
+
+
+def test_cancel_unknown_token_errors(tmp_path):
+    with pytest.raises(ValueError, match="no held send"):
+        cli._dispatch_email(SimpleNamespace(command="cancel", token="deadbeef"), _config(tmp_path), client=None)
+
+
+@pytest.mark.parametrize(
+    ("args", "target", "expected_kw"),
+    [
+        (
+            _send_args(),
+            "send_email",
+            {
+                "account_email": "me@example.com",
+                "mail": MailDraft(to=["bob@x.com"], subject="Hi", body="body"),
+            },
+        ),
+        (
+            _reply_args(),
+            "reply_to_email",
+            {
+                "account_email": "me@example.com",
+                "email_id": "orig-1",
+                "body": "thanks",
+                "attachments": None,
+                "reply_all": True,
+                "html": False,
+            },
+        ),
+        (
+            _forward_args(),
+            "forward_email",
+            {
+                "account_email": "me@example.com",
+                "email_id": "orig-1",
+                "mail": MailDraft(to=["bob@x.com"], body="fyi"),
+            },
+        ),
+    ],
+    ids=["send", "reply", "forward"],
+)
+def test_dispatch_after_fire_at_sends_via_the_stored_backend(monkeypatch, tmp_path, args, target, expected_kw):
+    config = _config(tmp_path)
+    cli._dispatch_email(args, config, client=None)
+    entry = pending.list_pending(config)[0]
+    seen = {}
+    monkeypatch.setattr(pending.email, target, lambda cfg, client, **kw: seen.update(kw) or {"status": "sent"})
+
+    outcomes = pending.dispatch_due(config, "fake-client", now=entry.fire_at + 1)
+
+    assert [(e.token, err) for e, err in outcomes] == [(entry.token, None)]
+    assert seen == expected_kw
+    assert pending.list_pending(config) == []
+
+
+def test_dispatch_before_fire_at_leaves_the_entry_queued(monkeypatch, tmp_path):
+    calls = _guard_all_sends(monkeypatch)
+    config = _config(tmp_path)
+    token = cli._dispatch_email(_send_args(), config, client=None)["held"]["token"]
+    entry = pending.list_pending(config)[0]
+
+    assert pending.dispatch_due(config, None, now=entry.fire_at - 1) == []
+    assert [e.token for e in pending.list_pending(config)] == [token]
+    assert calls == []
+
+
+def test_list_pending_shows_entries_in_fire_order(monkeypatch, tmp_path):
+    _guard_all_sends(monkeypatch)
+    config = _config(tmp_path)
+    later = cli._dispatch_email(_send_args(hold=120, subject="Later"), config, client=None)["held"]["token"]
+    sooner = cli._dispatch_email(_send_args(hold=30, subject="Sooner"), config, client=None)["held"]["token"]
+
+    rows = cli._dispatch_email(SimpleNamespace(command="list-pending"), config, client=None)
+
+    assert [(r["token"], r["subject"], r["command"]) for r in rows] == [(sooner, "Sooner", "send"), (later, "Later", "send")]
+    assert 0 < rows[0]["fires_in_seconds"] <= 30
+    assert 0 < rows[1]["fires_in_seconds"] <= 120
+
+
+def test_failed_dispatch_parks_the_entry_and_reports_the_error(monkeypatch, tmp_path):
+    config = _config(tmp_path)
+    cli._dispatch_email(_send_args(), config, client=None)
+    entry = pending.list_pending(config)[0]
+
+    def explode(cfg, client, **kw):
+        raise RuntimeError("graph is down")
+
+    monkeypatch.setattr(pending.email, "send_email", explode)
+
+    outcomes = pending.dispatch_due(config, "fake-client", now=entry.fire_at + 1)
+
+    assert [(e.token, err) for e, err in outcomes] == [(entry.token, "graph is down")]
+    assert pending.list_pending(config) == []
+    failed = tmp_path / "pending-sends" / f"{entry.token}.failed"
+    assert json.loads(failed.read_text())["error"] == "graph is down"

--- a/agent/skills/microsoft/references/email.md
+++ b/agent/skills/microsoft/references/email.md
@@ -16,6 +16,16 @@ microsoft email search --account user@example.com --query "project update"
 
 `send`, `reply`, and `forward` accept `--attachments file1 file2` and `--html` (treats `--body` as HTML). `forward` requires `--to` and also takes `--cc`.
 
+## Undo window (hold a send)
+
+```bash
+microsoft email send --account user@example.com --to bob@example.com --subject "Hi" --body "..." --hold 60
+microsoft email list-pending                  # held sends: token, recipient, subject, seconds until fire
+microsoft email cancel --token <token>        # abort a held send before it fires
+```
+
+`--hold <secs>` on `send`/`reply`/`forward` enqueues the fully resolved send and prints a cancel token instead of dispatching; the serve daemon sends it once the window elapses uncancelled (dispatch granularity is the daemon's 45s cycle). Use it whenever a send feels irreversible-risky (fast back-and-forth drafting, changed recipients or figures). `cancel`/`list-pending` are local queue commands, no `--account` needed. A held send that fails at dispatch is kept on disk (never retried) and raises a `send_failed` notification.
+
 ## Organize messages
 
 ```bash


### PR DESCRIPTION
Addresses #1446 (CLI layer only; the native-client "Undo send" toast and the always-on config default are follow-up work).

## What

An opt-in Gmail-style undo-send window on the send verbs of both email skills:

- **`--hold <secs>`** on `email-client-send` (send / reply / forward) and on `microsoft email send / reply / forward`. Instead of dispatching, the send is fully resolved and validated up front (recipients, reply threading, attachments), persisted to a pending queue, and the command prints a cancel token.
- **Cancel / list**: `email-client pending list` + `email-client pending cancel <token>`, and `microsoft email list-pending` + `microsoft email cancel --token <t>`.
- **Dispatch** folds into each skill's existing daemon, no new process:
  - email-client: the poll daemon's supervisor tick (~10s) sends due entries (`poll_daemon.dispatch_held`).
  - microsoft: the serve daemon's monitor cycle (~45s) sends due entries (`monitor._dispatch_held_sends` -> `pending.dispatch_due`), replaying the stored backend choice through the existing Graph/OWA-REST router.
- Default unchanged: without `--hold` every send dispatches immediately.

## Design

- One small queue module per skill, mirroring how these skills already duplicate small shapes rather than sharing a library: `agent/skills/email-client/pending_sends.py` (dependency-free, like `daemon_lifecycle.py`) and `microsoft_cli/pending.py`.
- Queue entries are typed dataclasses persisted one JSON file per token, written atomically (tmp + rename): `$EMAIL_CLIENT_DIR/pending-sends/<token>.json` and `~/.microsoft/pending-sends/<token>.json`.
- email-client stores the fully composed message (resolved recipients, threading headers, base64 attachments), so dispatch is deliver + mark-answered + sent-sync with no re-compose; microsoft stores the resolved command payload (`MailDraft`, ids, pinned backend).
- **Race-free cancel**: dispatch claims an entry by atomically renaming it to `<token>.sending`; cancel unlinks `<token>.json`. Exactly one side can win.
- **No double-send**: a failed dispatch is parked as `<token>.failed` (error recorded inside), never retried, and raises an interrupting `send_failed` notification through the skill's existing notification writer. A `.sending` file left by a crash mid-SMTP is likewise kept, not retried.
- `EMAIL_DRAFT_ONLY` still refuses a held send at the verb (it is a transmit). `--hold` is mutually exclusive with `--draft`/`--dry-run`, and email-client refuses `--hold` when the poll daemon is not running (nothing would ever fire it).
- New skill files need no install migration: email-client modules are imported through the resolved symlink parent (existing mechanism), and the microsoft CLI ships as a package.

## Tests

- `agent/skills/microsoft/cli/tests/test_pending.py`: hold enqueues without touching either backend, up-front validation, draft-only guard, cancel prevents dispatch, dispatch after fire-at sends the exact stored payload per verb (faked send client), dispatch before fire-at leaves the entry, list-pending ordering, failed dispatch parking.
- `agent/skills/email-client/tests/test_pending_sends.py`: queue mechanics (round-trip incl. attachments, claim-due boundary, cancel-vs-claim), `--hold` CLI path (enqueue without SMTP, daemon-required, flag exclusivity), `send_held` delivery incl. attachment reconstruction, daemon dispatch success + failure notification.
- No sleeps anywhere: dispatch takes explicit `now` / entries carry explicit fire-at values.

Note: the microsoft daemon's dispatch granularity is its 45s monitor cycle, so a send can go out up to ~a cycle after the window elapses (documented in the skill reference). Skills are discovered from disk, so there is no index to regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
