### PR TITLE
fix(app-chat): mobile QA pass: draft persistence, tappable links, orb flicker, date bucketing

### DIFF
--- a/apps/core/src/chat/chat-stream-model.test.ts
+++ b/apps/core/src/chat/chat-stream-model.test.ts
@@ -137,6 +137,21 @@ describe("chat-stream-model", () => {
     expect(replay.state.messages).toHaveLength(2)
   })
 
+  it("keeps history rows older than the reseed page BEFORE it so the tail stays chronological", () => {
+    // Background/foreground reseed: the hold carries earlier loadMore pages (ids 1-2, days old)
+    // plus part of the tail; the refetched newest page (ids 10-11) must land after them, never
+    // push them below today's messages.
+    let state = seedTail(initialChatState(), { events: [chat(10, "today-a")], cursor: 10 })
+    state = prependPage(state, [chat(1, "old-a"), chat(2, "old-b")], null)
+    state = seedTail(state, { events: [chat(10, "today-a"), chat(11, "today-b")], cursor: 10 })
+    expect(state.messages.map((m) => (m.type === "chat" ? m.text : ""))).toEqual([
+      "old-a",
+      "old-b",
+      "today-a",
+      "today-b",
+    ])
+  })
+
   it("preserves a pending optimistic bubble across a resync reseed and confirms its later echo", () => {
     let state = beginSend(initialChatState(), "hi", "typed", "i-1")
 

--- a/apps/core/src/chat/chat-stream-model.ts
+++ b/apps/core/src/chat/chat-stream-model.ts
@@ -66,13 +66,28 @@ export function seedTail(state: ChatState, page: HistoryPage): ChatState {
         !echoedIntents.has(message.intent_id)) ||
       (message.id != null && !pageIds.has(message.id)),
   )
+  // The page is the newest slice of history, so survivors from before it (earlier loadMore pages
+  // held across a reseed) go BEFORE it; only rows the page cannot cover (raced live rows past its
+  // end, optimistic bubbles with no id yet) stay after. Keeps the tail chronological, so a reseed
+  // never renders days-old messages below today's.
+  const oldestPageId = page.events.reduce<number | null>(
+    (oldest, event) =>
+      event.id != null && (oldest === null || event.id < oldest) ? event.id : oldest,
+    null,
+  )
+  const olderThanPage = (message: ChatMessage): boolean =>
+    message.id != null && oldestPageId !== null && message.id < oldestPageId
   const pendingIntents = new Set(state.pendingIntents)
   for (const intentId of echoedIntents) pendingIntents.delete(intentId)
   const shownIds = new Set(state.shownIds)
   for (const id of pageIds) shownIds.add(id)
   return {
     ...state,
-    messages: capTail([...page.events, ...survivors]),
+    messages: capTail([
+      ...survivors.filter(olderThanPage),
+      ...page.events,
+      ...survivors.filter((message) => !olderThanPage(message)),
+    ]),
     shownIds,
     pendingIntents,
     cursor: page.cursor,

--- a/apps/mobile/src/agent/AgentProvider.tsx
+++ b/apps/mobile/src/agent/AgentProvider.tsx
@@ -76,7 +76,7 @@ function LiveAgent({
   active: boolean;
   children: ReactNode;
 }) {
-  const socket = useAgentSocket(name, active);
+  const socket = useAgentSocket(name, active, agent?.activityState ?? "idle");
   return (
     <AgentContent name={name} agent={agent} socket={socket}>
       {children}
@@ -103,8 +103,14 @@ export function AgentProvider({ children }: { children: ReactNode }) {
   }, [name]);
 
   if (!controller) {
+    // Serve the roster hold's last-known activity while torn down, so the orb doesn't flash
+    // through a made-up "idle" on foreground before the replica resolves the real state.
+    const socket = {
+      ...DISCONNECTED_SOCKET,
+      agentState: agent?.activityState ?? "idle",
+    };
     return (
-      <AgentContent name={name} agent={agent} socket={DISCONNECTED_SOCKET}>
+      <AgentContent name={name} agent={agent} socket={socket}>
         {children}
       </AgentContent>
     );

--- a/apps/mobile/src/agent/ChatPage.tsx
+++ b/apps/mobile/src/agent/ChatPage.tsx
@@ -30,6 +30,7 @@ import Reanimated, {
   withTiming,
 } from "react-native-reanimated";
 import Markdown, {
+  MarkdownIt,
   type ASTNode,
   type RenderRules,
 } from "react-native-markdown-display";
@@ -64,6 +65,8 @@ import {
   createInvertedChatRows,
   type ChatRow,
 } from "@/agent/chat-list-model";
+import { messageSegments } from "@/agent/message-links";
+import { readChatDraft, writeChatDraft } from "@/storage/chat-draft";
 import {
   messageActionIds,
   quotedReply,
@@ -72,6 +75,8 @@ import {
 import { useInvertedChatScroll } from "@/agent/use-inverted-chat-scroll";
 
 const USES_NATIVE_BUBBLE_SHAPE = process.env.EXPO_OS === "ios";
+// The library's default instance, plus linkify so bare URLs in agent messages become tappable links.
+const MARKDOWN_IT = MarkdownIt({ typographer: true, linkify: true });
 const COMPOSER_RESIZE_DURATION = 250;
 const COMPOSER_SURFACE_PADDING = 4;
 const CHAT_COMPOSER_GAP = 6;
@@ -530,7 +535,20 @@ const ChatEvent = memo(function ChatEvent({
       ) : null}
       {user ? (
         <Text style={[styles.userText, { color: colors.accentText }]}>
-          {event.text}
+          {messageSegments(event.text).map((segment, index) =>
+            segment.url ? (
+              <Text
+                key={index}
+                style={styles.userLink}
+                onPress={() => openMarkdownLink(segment.url ?? segment.text)}
+                accessibilityRole="link"
+              >
+                {segment.text}
+              </Text>
+            ) : (
+              <Text key={index}>{segment.text}</Text>
+            ),
+          )}
           {timestamp ? (
             <Text style={styles.timestampSpacer}>
               {"\u00A0\u00A0\u00A0\u00A0"}
@@ -540,6 +558,7 @@ const ChatEvent = memo(function ChatEvent({
         </Text>
       ) : (
         <Markdown
+          markdownit={MARKDOWN_IT}
           onLinkPress={openMarkdownLink}
           rules={markdownRules}
           style={markdownStyles}
@@ -967,10 +986,30 @@ export default function ChatPage() {
   const { colors } = preferences;
   const [input, setInputState] = useState("");
   const inputValueRef = useRef("");
-  const setInput = useCallback((value: string) => {
-    inputValueRef.current = value;
-    setInputState(value);
-  }, []);
+  // Every input change writes through to the per-agent draft (cleared on send via setInput("")),
+  // so an app switch that unmounts this view never loses in-progress compose text.
+  const setInput = useCallback(
+    (value: string) => {
+      inputValueRef.current = value;
+      setInputState(value);
+      void writeChatDraft(name, value).catch(() => undefined);
+    },
+    [name],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void readChatDraft(name)
+      .then((draft) => {
+        if (cancelled || !draft || inputValueRef.current) return;
+        inputValueRef.current = draft;
+        setInputState(draft);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [name]);
   const [replyTarget, setReplyTarget] = useState<ReplyTarget | null>(null);
   const [voiceError, setVoiceError] = useState("");
   const notifyTranscriptWords = useTranscriptWordHaptics();
@@ -1309,6 +1348,7 @@ const styles = StyleSheet.create({
   },
   typingDot: { width: 6, height: 6, borderRadius: 3 },
   userText: { fontSize: 16, lineHeight: 22 },
+  userLink: { textDecorationLine: "underline" },
   timestampSpacer: { fontSize: 12, opacity: 0 },
   bubbleTimestamp: { position: "absolute", right: 12, bottom: 10, fontSize: 12 },
   finalMarkdownParagraph: { marginBottom: 0 },

--- a/apps/mobile/src/agent/message-links.test.ts
+++ b/apps/mobile/src/agent/message-links.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { messageSegments } from "./message-links";
+
+describe("messageSegments", () => {
+  it("returns one plain segment for text without URLs", () => {
+    expect(messageSegments("hello there")).toEqual([
+      { text: "hello there", url: null },
+    ]);
+  });
+
+  it("splits a URL into a tappable segment between plain ones", () => {
+    expect(messageSegments("see https://vesta.run for more")).toEqual([
+      { text: "see ", url: null },
+      { text: "https://vesta.run", url: "https://vesta.run" },
+      { text: " for more", url: null },
+    ]);
+  });
+
+  it("keeps trailing sentence punctuation out of the URL", () => {
+    expect(messageSegments("check https://vesta.run/docs.")).toEqual([
+      { text: "check ", url: null },
+      { text: "https://vesta.run/docs", url: "https://vesta.run/docs" },
+      { text: ".", url: null },
+    ]);
+  });
+
+  it("handles multiple URLs and preserves query strings", () => {
+    expect(
+      messageSegments("https://a.example/x?q=1 and http://b.example"),
+    ).toEqual([
+      { text: "https://a.example/x?q=1", url: "https://a.example/x?q=1" },
+      { text: " and ", url: null },
+      { text: "http://b.example", url: "http://b.example" },
+    ]);
+  });
+
+  it("returns no segments for empty text", () => {
+    expect(messageSegments("")).toEqual([]);
+  });
+});

--- a/apps/mobile/src/agent/message-links.ts
+++ b/apps/mobile/src/agent/message-links.ts
@@ -1,0 +1,30 @@
+// Splits plain message text (user bubbles render raw text, not markdown) into segments so URLs
+// become tappable spans. Rendering stays plain <Text> nodes built from these segments, never
+// parsed HTML, so message content cannot inject markup.
+export interface MessageSegment {
+  text: string;
+  url: string | null;
+}
+
+const URL_RE = /https?:\/\/[^\s]+/gi;
+// Punctuation that reads as sentence trailing rather than part of the URL when it ends one.
+const TRAILING_PUNCTUATION_RE = /[.,;:!?)\]}'"]+$/;
+
+export function messageSegments(text: string): MessageSegment[] {
+  const segments: MessageSegment[] = [];
+  let cursor = 0;
+  for (const match of text.matchAll(URL_RE)) {
+    const url = match[0].replace(TRAILING_PUNCTUATION_RE, "");
+    if (!url) continue;
+    const start = match.index ?? 0;
+    if (start > cursor) {
+      segments.push({ text: text.slice(cursor, start), url: null });
+    }
+    segments.push({ text: url, url });
+    cursor = start + url.length;
+  }
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor), url: null });
+  }
+  return segments;
+}

--- a/apps/mobile/src/chat/useAgentSocket.ts
+++ b/apps/mobile/src/chat/useAgentSocket.ts
@@ -12,6 +12,7 @@ import {
   seedTail,
   sendMessage,
   typingDelay,
+  type AgentActivityState,
   type ChatMessage,
   type ChatState,
   type InputMethod,
@@ -47,7 +48,14 @@ interface HistoryPage {
 // agentState + pending come from the replica; gateway connectedness from the single sync socket.
 // Sends are POST intents confirmed by their chat-socket echo. The stale-while-reconnecting hold gives
 // an instant render across a controller epoch; backgrounding never blanks the chat.
-export function useAgentSocket(name: string, active: boolean) {
+// `heldActivityState` is the last-known activity from the roster hold, served while the replica
+// tree has not resolved yet (connecting / first snapshot in flight) so the orb never flashes
+// through a made-up "idle" before settling on the real state.
+export function useAgentSocket(
+  name: string,
+  active: boolean,
+  heldActivityState: AgentActivityState = "idle",
+) {
   const controller = useController();
   const preferences = usePreferences();
   const { connection } = useSession();
@@ -74,8 +82,10 @@ export function useAgentSocket(name: string, active: boolean) {
 
   const activitySelector = useCallback(
     (tree: Tree | null) =>
-      active && name ? (tree?.agents[name]?.info.activityState ?? "idle") : "idle",
-    [active, name],
+      active && name
+        ? (tree?.agents[name]?.info.activityState ?? heldActivityState)
+        : heldActivityState,
+    [active, name, heldActivityState],
   );
   const agentState = useReplica(controller.replica, activitySelector);
 

--- a/apps/mobile/src/storage/chat-draft.ts
+++ b/apps/mobile/src/storage/chat-draft.ts
@@ -1,0 +1,20 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+// Unsent composer drafts, keyed per agent. Backgrounding tears the controller down and unmounts
+// the chat view (component state is lost), so the draft lives in storage and survives app
+// switches and relaunches alike.
+const CHAT_DRAFT_KEY_PREFIX = "vesta.chat-draft.v1.";
+
+function draftKey(agent: string): string {
+  return `${CHAT_DRAFT_KEY_PREFIX}${agent}`;
+}
+
+export function readChatDraft(agent: string): Promise<string | null> {
+  return AsyncStorage.getItem(draftKey(agent));
+}
+
+export function writeChatDraft(agent: string, text: string): Promise<void> {
+  return text
+    ? AsyncStorage.setItem(draftKey(agent), text)
+    : AsyncStorage.removeItem(draftKey(agent));
+}


### PR DESCRIPTION
Fixes #1471

QA pass over the four app-chat bugs reported on mobile. The mobile chat is the Expo/React Native app (`apps/mobile`) over the shared `@vesta/core` controller, so three fixes land in `apps/mobile` and one in `apps/core` (where the web app inherits it too).

## 1. Draft lost on app-switch

**Root cause:** backgrounding tears the controller down, which unmounts the chat view (`AgentProvider` swaps `LiveAgent` for the disconnected branch), so `ChatPage`'s `input` state is dropped. The chat/roster holds preserve messages, but the compose draft had no home.

**Fix:** per-agent draft in AsyncStorage (`src/storage/chat-draft.ts`, `vesta.chat-draft.v1.<agent>`). Every input change writes through, send clears it via the normal `setInput("")` path, and mount restores it when the composer is still empty. Survives app switches and full relaunches.

## 2. URLs render as plain text

**Root cause:** two gaps. Agent bubbles render through `react-native-markdown-display`, whose default markdown-it instance has `linkify` off, so bare URLs never become links. User bubbles render raw `<Text>`, so nothing was tappable there at all.

**Fix:** agent bubbles get a `MarkdownIt({ typographer: true, linkify: true })` instance (taps already routed through the existing `openMarkdownLink`, which opens `expo-web-browser`). User bubbles are split by a pure `messageSegments` parser (`src/agent/message-links.ts`, unit-tested) into plain and URL spans rendered as nested `<Text onPress>` nodes. No HTML is ever parsed from message content, so nothing is injectable.

## 3. Status orb flashes green then orange on load

**Root cause:** while the controller/replica is still resolving (cold connect or foreground), the activity state was hardcoded to `"idle"` (`DISCONNECTED_SOCKET` and the `?? "idle"` fallback in `useAgentSocket`'s replica selector). The roster hold keeps `status: "alive"` (green base), so a thinking agent rendered green first and snapped to orange when the snapshot landed.

**Fix:** thread the roster hold's last-known `activityState` into `useAgentSocket` and the disconnected socket as the unresolved fallback, matching the app's stale-while-reconnecting design: the orb holds the last-known state instead of flashing through a made-up idle.

## 4. Jul 16 messages grouped under "Today"

**Root cause:** `seedTail` in `@vesta/core`'s chat-stream model merges the reseeded newest history page as `[...page.events, ...survivors]`. On every background/foreground reseed, held rows older than the page (earlier `loadMore` pages, or tail rows past the page window) survive the id-dedup and get appended **after** today's page, so days-old messages render below the "Today" header at the bottom of the list.

**Fix:** survivors older than the page (id below the page's oldest id) now go before it; only rows the page cannot cover (raced live rows, optimistic bubbles with no id yet) stay after. Regression test added (`chat-stream-model.test.ts`). The web app shares `seedTail`, so its chat gets the same correction.

## Notes

- The issue framing (and the original task) assumed the mobile app embeds `apps/web` via Tauri; that architecture is gone. The bugs live in the RN app and the shared core, which is where the fixes are.
- Tests: new `seedTail` ordering regression test in `apps/core`, new `messageSegments` suite in `apps/mobile`. `./check.sh web` (app-core, app-web, app-desktop, app-mobile) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
