### PR TITLE
fix(browser): repair Camoufox's search-config stub so search init cannot wedge launch

### DIFF
--- a/agent/skills/browser/cli/src/vesta_browser/launcher.py
+++ b/agent/skills/browser/cli/src/vesta_browser/launcher.py
@@ -125,6 +125,74 @@ def _extract_preserving_mode(zip_path: Path, dest: Path) -> None:
                 (dest / info.filename).chmod(mode)
 
 
+_OMNI_SEARCH_SELECTOR = "moz-src/toolkit/components/search/SearchEngineSelector.sys.mjs"
+# Camoufox's no-search-engines patch, verbatim from its shipped omni.ja (v150 and v152).
+_BROKEN_SEARCH_STUB = """\
+      return [
+        {
+          "appliesTo": [{
+            "default": "yes",
+            "included": {
+              "everywhere": true
+            },
+            "webExtension": {
+              "id": "none@mozilla.org"
+            }
+          }],
+        },
+      ];"""
+_REPAIRED_SEARCH_STUB = """\
+      return [
+        {
+          "recordType": "engine",
+          "identifier": "ddg",
+          "base": {
+            "classification": "general",
+            "name": "DuckDuckGo",
+            "urls": {
+              "search": {
+                "base": "https://duckduckgo.com/",
+                "searchTermParamName": "q"
+              }
+            }
+          },
+          "variants": [{ "environment": { "allRegionsAndLocales": true } }]
+        },
+        {
+          "recordType": "defaultEngines",
+          "globalDefault": "ddg",
+          "specificDefaults": []
+        },
+      ];"""
+
+
+def repair_search_stub(home: Path) -> None:
+    """Fix Camoufox's search-config stub inside omni.ja so SearchService can start.
+
+    Camoufox hardcodes SearchEngineSelector's configuration to one stub record that
+    predates search-config-v2; FF150+ hands it to the Rust selector, which requires
+    `recordType` and fails search init permanently (fatal in headless boxes: every
+    open then hangs, issue #1445). Rewriting the stub to a minimal valid config
+    heals fresh extractions and already-installed builds alike; Firefox invalidates
+    the profile startupCache on its own when omni.ja changes."""
+    omni = home / "omni.ja"
+    if not omni.is_file():
+        return
+    with zipfile.ZipFile(omni) as z:
+        if _OMNI_SEARCH_SELECTOR not in z.namelist():
+            return
+        source = z.read(_OMNI_SEARCH_SELECTOR).decode()
+    if _BROKEN_SEARCH_STUB not in source:
+        return
+    repaired = source.replace(_BROKEN_SEARCH_STUB, _REPAIRED_SEARCH_STUB)
+    tmp = omni.with_name("omni.ja.tmp")
+    with zipfile.ZipFile(omni) as zin, zipfile.ZipFile(tmp, "w") as zout:
+        for info in zin.infolist():
+            data = repaired.encode() if info.filename == _OMNI_SEARCH_SELECTOR else zin.read(info)
+            zout.writestr(info, data, compress_type=zipfile.ZIP_DEFLATED)
+    tmp.replace(omni)
+
+
 def ensure_camoufox(override: str | None = None) -> str:
     """Return a path to the Camoufox executable, fetching + extracting on first use."""
     if override:
@@ -135,6 +203,9 @@ def ensure_camoufox(override: str | None = None) -> str:
     home = camoufox_home()
     exe = home / "camoufox"
     if exe.is_file():
+        # LEGACY(remove-when: CAMOUFOX_RELEASE_TAG moves past v150.0.2-beta.25): heals installs
+        # extracted before the repair shipped; a new tag always extracts (and repairs) fresh.
+        repair_search_stub(home)
         return str(exe)
 
     asset_name, expected_sha = _asset_for_arch()
@@ -148,6 +219,7 @@ def ensure_camoufox(override: str | None = None) -> str:
         shutil.rmtree(staging)
     _extract_preserving_mode(tmp_zip, staging)
     tmp_zip.unlink(missing_ok=True)
+    repair_search_stub(staging)
 
     # Atomic publish: rename staging -> home. If a concurrent launch already
     # published it, keep theirs and drop ours.

--- a/agent/skills/browser/cli/tests/test_launcher.py
+++ b/agent/skills/browser/cli/tests/test_launcher.py
@@ -84,6 +84,67 @@ def test_extract_preserving_mode_restores_exec_bit(tmp_path):
     assert (dest / "data.txt").read_text() == "plain"
 
 
+# ── search-config stub repair ───────────────────────
+
+
+def _omni_with_selector(path, source):
+    with zipfile.ZipFile(path, "w") as z:
+        info = zipfile.ZipInfo(launcher._OMNI_SEARCH_SELECTOR)
+        info.external_attr = 0o644 << 16
+        z.writestr(info, source)
+        z.writestr("chrome/other.txt", "untouched")
+
+
+def _selector_source(path):
+    with zipfile.ZipFile(path) as z:
+        return z.read(launcher._OMNI_SEARCH_SELECTOR).decode()
+
+
+def test_repair_search_stub_rewrites_the_broken_record(tmp_path):
+    omni = tmp_path / "omni.ja"
+    _omni_with_selector(omni, f"prefix\n{launcher._BROKEN_SEARCH_STUB}\nsuffix")
+    launcher.repair_search_stub(tmp_path)
+    source = _selector_source(omni)
+    assert '"recordType": "engine"' in source
+    assert '"recordType": "defaultEngines"' in source
+    assert "none@mozilla.org" not in source
+    assert source.startswith("prefix\n")
+    assert source.endswith("\nsuffix")
+    with zipfile.ZipFile(omni) as z:
+        assert z.read("chrome/other.txt") == b"untouched"
+
+
+def test_repair_search_stub_is_idempotent(tmp_path):
+    omni = tmp_path / "omni.ja"
+    _omni_with_selector(omni, launcher._BROKEN_SEARCH_STUB)
+    launcher.repair_search_stub(tmp_path)
+    first = omni.read_bytes()
+    launcher.repair_search_stub(tmp_path)
+    assert omni.read_bytes() == first
+
+
+def test_repair_search_stub_ignores_unknown_layouts(tmp_path):
+    omni = tmp_path / "omni.ja"
+    with zipfile.ZipFile(omni, "w") as z:
+        z.writestr("chrome/other.txt", "no selector here")
+    before = omni.read_bytes()
+    launcher.repair_search_stub(tmp_path)
+    assert omni.read_bytes() == before
+    launcher.repair_search_stub(tmp_path / "no-such-install")  # no omni.ja at all
+
+
+def test_ensure_camoufox_heals_an_existing_install(tmp_path, monkeypatch):
+    monkeypatch.setattr(launcher, "CACHE_ROOT", tmp_path)
+    home = launcher.camoufox_home()
+    home.mkdir(parents=True)
+    exe = home / "camoufox"
+    exe.write_text("#!/bin/sh\nexit 0\n")
+    exe.chmod(0o755)
+    _omni_with_selector(home / "omni.ja", launcher._BROKEN_SEARCH_STUB)
+    assert launcher.ensure_camoufox() == str(exe)
+    assert '"recordType": "engine"' in _selector_source(home / "omni.ja")
+
+
 def _dummy_proc(returncode):
     class Proc:
         def poll(self):


### PR DESCRIPTION
Addresses #1445

## Root cause

The fatal `JSON error: missing field `recordType` at line 1 column 114` is not remote data, a corrupt profile, or the pin. Camoufox's own `no-search-engines.patch` hardcodes `SearchEngineSelector.#getConfiguration` (inside `omni.ja`) to return one stub record from the pre-v2 search-config era:

```js
if (true) {
  return [{ "appliesTo": [{ "default": "yes", "included": { "everywhere": true }, "webExtension": { "id": "none@mozilla.org" } }] }];
}
```

FF150+ feeds that JSON to the Rust search selector (`RustSearch.sys.mjs` uniffi bindings), whose serde parser requires `recordType`. `JSON.stringify({data: [stub]})` is exactly 116 chars; serde reports the missing field at column 114, matching the issue byte for byte. SearchService init then fails permanently and retries forever.

Two red herrings from the issue, checked and cleared:

- The "beta.25 installed vs alpha.26 pinned" mismatch is cosmetic: release tag `v150.0.2-beta.25` genuinely ships `camoufox-150.0.2-alpha.26-lin.x86_64.zip` (per-arch asset build numbers differ from the tag upstream). The pinned sha256 matches the live asset.
- A pin bump does not help: `v152.0.4-beta.28` (latest) carries the identical stub and fails identically (verified by launching it). The stub is unchanged on camoufox master, so no upstream build fixes this.

## Fix

`repair_search_stub` in `launcher.py` rewrites the stub inside `omni.ja` to a minimal valid search-config-v2 record set (one DuckDuckGo engine + a `defaultEngines` record). It runs on fresh extraction (before the atomic publish) and on every `ensure_camoufox` hit of an existing install, so fleet boxes that already extracted the broken build heal on their next launch with no migration. Unknown future layouts (member missing, stub gone) are a no-op, and the rewrite is atomic (`tmp` + `replace`).

## Verified in this environment (x86_64, headless, real builds)

- Unpatched v150 (pinned asset, sha-verified): reproduces the exact `recordType` error from the issue on a fresh profile.
- Unpatched v152.0.4-beta.28: identical error, confirming pin bumps are not a fix.
- Patched v150 and v152: zero `recordType` errors; the skill's real flow (launcher launch, BiDi `session.new`, adopt initial context, `browsingContext.navigate` to example.com, `captureScreenshot`) succeeds and the process stays alive.
- Full shipped path end-to-end: `ensure_camoufox()` with no override (real download of the pinned asset, sha verify, extract, repair) then launch + navigate: success.
- A profile that had already run the broken build picks up the repair (Firefox invalidates its startupCache when omni.ja changes); no cache clearing needed.
- Stock Firefox over the same BiDi flow works in this environment (control).

## Verified vs inferred

Verified: the search-component crash, its root cause, and that the repaired build launches and navigates through the skill's real code path. Not reproduced here: the reporter's hard process death ("Exiting due to channel error" killing the browser right after BiDi). In this environment the unpatched browser survives the search failure with the initial-context flow, so that death has an environmental component in the reporter's container; the search-init failure it follows is what this PR removes. Hence "Addresses", not "Fixes". One upstream deficiency noted while testing: Camoufox's BiDi `browsingContext.create` never answers (stock Firefox answers fine); the skill never calls it (it adopts the initial context), so nothing to change, recorded here for future debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
