### PR TITLE
test(upstream-sync): pin that untracked files in the core mount cannot wedge the checkpoint

### DIFF
--- a/agent/tests/test_upstream_sync.py
+++ b/agent/tests/test_upstream_sync.py
@@ -355,6 +355,29 @@ def test_direct_sync_checkpoints_dirty_work_before_merging(tmp_path):
     assert _git(["show", "-s", "--format=%s", "HEAD^1"], home, env).strip() == "checkpoint"
 
 
+def test_direct_sync_checkpoint_survives_untracked_files_in_the_core_mount(tmp_path):
+    """An upgrade can drop brand-new untracked files inside the read-only agent/core mount
+    (e.g. a fresh migration prompt). The root .gitignore scopes the mount out, so the
+    checkpoint's `git add -A` neither fails nor stages any of it and the sync completes."""
+    source = _upstream_fixture(tmp_path, versions=("0.1.170", "0.1.171"))
+    home = _fresh_box(tmp_path)
+    env = _box_env(source)
+    assert _attach(home, source).returncode == 0
+    memory = home / "agent/MEMORY.md"
+    memory.write_text(memory.read_text() + "uncommitted note\n")
+    # The upgraded mount: version moved and new files appeared that no snapshot ever tracked.
+    (home / "agent/core/pyproject.toml").write_text('[project]\nname = "vesta"\nversion = "0.1.171"\n')
+    (home / "agent/core/migrations").mkdir()
+    (home / "agent/core/migrations/2026-07-manual-upstream-review.md").write_text("review prompt\n")
+
+    r = _direct_sync(home, source)
+
+    assert r is not None and r.returncode == 0, (r.stdout + r.stderr) if r else "unexpected no-op"
+    assert _git(["show", "-s", "--format=%s", "HEAD^1"], home, env).strip() == "checkpoint"
+    assert "agent/core" not in _git(["show", "--name-only", "--format=", "HEAD^1"], home, env)
+    assert "agent/core" not in _git(["status", "--porcelain"], home, env)
+
+
 def test_direct_sync_is_idempotent_once_synced(tmp_path):
     source = _upstream_fixture(tmp_path)
     home = _fresh_box(tmp_path)


### PR DESCRIPTION
Fixes #1372

## What the issue reported

On a managed (v0.1.179, sparse-cone) box, `agent/core/skills/upstream-sync/scripts/sync.sh` ran under `set -euo pipefail`. Untracked files inside the read-only `agent/core` mount (outside the sparse cone) made `git status --porcelain` non-empty; the checkpoint then ran `git add -A`, which exits non-zero on sparse-excluded paths, killing the whole sync before the rebase.

## Why master no longer has the script to patch

The suggested `git add -A -- ':(exclude)agent/core'` targets code that no longer exists. #1455 (released in v0.1.180) removed sync.sh and the sparse cone entirely: a box is now a plain full checkout, the sync is standard Git run by the agent (fetch, checkpoint, `git merge --no-ff agent-vX.Y.Z`), and the snapshot's root `.gitignore` (written by `vestad/scripts/build-upstream.sh`) carries `/agent/core/`, so the mount never shows as untracked and `git add -A` never touches it. `attach.sh` force-adopts that ignore on conversion, and the `2026-08-flat-checkout` boot migration converts every remaining cone box (retiring its old repo, old sync.sh included) before the sync turn runs, so the wedged cohort from the issue converges on its next upgrade with no further code change. The earlier fix branches for this issue (`fix/sync-sh-core-mount` and friends) were superseded by that refactor and never merged.

## What this PR adds

The structural fix shipped, but nothing pinned the issue's exact trigger. This adds a regression test to `agent/tests/test_upstream_sync.py`: attach a box, drop a brand-new untracked file inside the core mount (a migration prompt landing with an upgrade, exactly the file from the report), bump the mount version, and run the real fetch/checkpoint/merge sequence. Asserts the sync completes, the checkpoint commit contains no `agent/core` path, and `git status` stays clean of the mount. Verified the test bites: with the pre-flat root `.gitignore` (no `/agent/core/` line), `git add -A` stages the mount file and the assertions fail.

`./check.sh agent` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)