### PR TITLE
fix(skills): make dashboard-builder browser verification read-only over live stores

### DIFF
--- a/agent/skills/dashboard/SKILL.md
+++ b/agent/skills/dashboard/SKILL.md
@@ -68,4 +68,4 @@ Example, for a request like "show me my running this week":
 
 ## Verify and relay
 
-When the builder returns, confirm the dashboard is actually serving before you tell the user it is done: `~/agent/skills/dashboard/scripts/daemon status` reports `http_ok`, or reload the app. Then give the user a short, non-technical summary of what changed. Don't take "done" on faith; a failed build won't tell you.
+When the builder returns, confirm the dashboard is actually serving before you tell the user it is done: `~/agent/skills/dashboard/scripts/daemon status` reports `http_ok`, or reload the app. If the builder exercised pages backed by a live store (tasks, anything wired to a skill), also confirm that store is unchanged; a browser pass that clicked a control can silently write real user data. Then give the user a short, non-technical summary of what changed. Don't take "done" on faith; a failed build won't tell you.

--- a/agent/skills/dashboard/dashboard-builder.md
+++ b/agent/skills/dashboard/dashboard-builder.md
@@ -79,6 +79,12 @@ Subagent (general-purpose):
     build fails or a page is blank, fix the reported errors and confirm `app/dist/` exists before
     starting the preview. `UNRESOLVED_IMPORT` means deps were never installed.
 
+    Pages are backed by live user stores (the tasks page reads and writes the user's real tasks),
+    so any browser pass over the served pages is read-only: load, render, and measure, never
+    click, submit, or toggle a control that can write. If verifying genuinely requires an
+    interaction, create throwaway data yourself, interact only with that, and delete it before
+    you report.
+
     ## Before you report: self-review
 
     - Completeness: did you build everything in the spec? Any content or interaction missed?
@@ -95,6 +101,7 @@ Subagent (general-purpose):
     - Status: DONE | DONE_WITH_CONCERNS | BLOCKED
     - What you built, and which files you changed
     - The daemon status line (`running`, `port`, `http_ok`) as evidence it serves
+    - Which live-data pages you exercised in a browser, so the requester knows what to re-verify
     - Any concern, or if BLOCKED, exactly what was underspecified or what failed
 
     Never claim success without the serve evidence. If the spec was genuinely ambiguous, do not


### PR DESCRIPTION
Fixes #1450

## Problem

Dashboard pages are backed by live user stores (the tasks page reads and writes the user's real tasks), and the dashboard-builder subagent's browser verification can silently mutate that data: a pure layout pass marked a real task done, unreported, caught only by a later re-read of the task list.

## Fix (prompt-level, the issue's recommended scope)

Three edits, no code changes:

1. **`agent/skills/dashboard/dashboard-builder.md`**: the builder template now states that pages are backed by live user stores, so any browser pass over the served pages is read-only: load, render, and measure, never click, submit, or toggle a control that can write. If verifying genuinely requires an interaction, the builder creates throwaway data, interacts only with that, and deletes it before reporting.
2. **Same template, report section**: the report now includes which live-data pages were exercised in a browser, so the dispatching agent knows what to re-verify.
3. **`agent/skills/dashboard/SKILL.md`, "Verify and relay"**: after the builder returns, also confirm any live store its pages touch (tasks, anything wired to a skill) is unchanged.

The larger read-only/preview mode from the issue is intentionally not built.

Frontmatter is unchanged, so skill discovery is unaffected. `./check.sh agent` and `./check.sh guards` are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)