### PR TITLE
fix(auth): scope dashboard WebView auth to a short-lived agent capability

### DIFF
--- a/apps/mobile/src/agent/DashboardPage.tsx
+++ b/apps/mobile/src/agent/DashboardPage.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Linking, Platform, StyleSheet, View } from "react-native";
 import type { WebViewMessageEvent, ShouldStartLoadRequest } from "react-native-webview/lib/WebViewTypes";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAgent } from "@/agent/AgentProvider";
+import { mintDashboardToken } from "@/api/endpoints";
 import { DashboardWebView, type DashboardWebViewHandle } from "@/components/DashboardWebView";
 import { EmptyState } from "@/components/ui/States";
 import { usePreferences } from "@/preferences/PreferencesProvider";
@@ -13,18 +14,54 @@ interface DashboardMessage {
   url?: string;
 }
 
+// The WebView holds a short-lived capability scoped to this agent's service routes, never
+// the gateway token; re-mint well before expiry so an open dashboard keeps working.
+const DASHBOARD_TOKEN_REMINT_FRACTION = 0.8;
+const DASHBOARD_TOKEN_RETRY_MS = 5000;
+
 export default function DashboardPage() {
   const webView = useRef<DashboardWebViewHandle>(null);
   const insets = useSafeAreaInsets();
   const { name, agent } = useAgent();
-  const { connection } = useSession();
+  const { connection, api } = useSession();
   const { colors, dark } = usePreferences();
   const [error, setError] = useState("");
   const dashboard = agent?.services.dashboard;
+  const hasDashboard = !!dashboard;
   const dashboardUrl =
     dashboard && connection
       ? `${connection.url}/agents/${encodeURIComponent(name)}/dashboard/`
       : null;
+
+  // Derived, not reset: a token minted for another agent is simply never used.
+  const [minted, setMinted] = useState<{ agent: string; token: string } | null>(
+    null,
+  );
+  const dashboardToken = minted?.agent === name ? minted.token : null;
+  useEffect(() => {
+    if (!hasDashboard) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const mint = async () => {
+      try {
+        const { token, expires_in } = await mintDashboardToken(api, name);
+        if (cancelled) return;
+        setMinted({ agent: name, token });
+        timer = setTimeout(
+          () => void mint(),
+          expires_in * 1000 * DASHBOARD_TOKEN_REMINT_FRACTION,
+        );
+      } catch {
+        if (!cancelled)
+          timer = setTimeout(() => void mint(), DASHBOARD_TOKEN_RETRY_MS);
+      }
+    };
+    void mint();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [api, hasDashboard, name]);
 
   const bridgeMessages = useMemo<readonly Record<string, unknown>[]>(
     () =>
@@ -40,22 +77,29 @@ export default function DashboardPage() {
               isMobile: true,
               vibrancy: true,
             },
-            {
-              type: "vesta-auth",
-              token: connection.accessToken,
-              baseUrl: `${connection.url}/agents/${encodeURIComponent(name)}`,
-              agentName: name,
-            },
+            ...(dashboardToken
+              ? [
+                  {
+                    type: "vesta-auth",
+                    token: dashboardToken,
+                    baseUrl: `${connection.url}/agents/${encodeURIComponent(name)}`,
+                    agentName: name,
+                  },
+                ]
+              : []),
           ]
         : [],
-    [connection, dark, name],
+    [connection, dark, dashboardToken, name],
   );
 
   const sendContext = useCallback(() => {
-    for (const message of bridgeMessages) {
-      webView.current?.postMessage(JSON.stringify(message));
-    }
+    webView.current?.sendBridgeMessages(bridgeMessages);
   }, [bridgeMessages]);
+
+  // Deliver a freshly-minted (or re-minted) capability to an already-loaded page.
+  useEffect(() => {
+    sendContext();
+  }, [sendContext]);
 
   const onMessage = (event: WebViewMessageEvent) => {
     let message: DashboardMessage;
@@ -113,12 +157,7 @@ export default function DashboardPage() {
             ref={webView}
             bridgeMessages={bridgeMessages}
             dark={dark}
-            source={{
-              uri: dashboardUrl,
-              headers: connection
-                ? { Authorization: `Bearer ${connection.accessToken}` }
-                : undefined,
-            }}
+            source={{ uri: dashboardUrl }}
             style={styles.webView}
             containerStyle={styles.webView}
             originWhitelist={["https://*", "http://*"]}

--- a/apps/mobile/src/api/endpoints.ts
+++ b/apps/mobile/src/api/endpoints.ts
@@ -264,6 +264,22 @@ export async function fetchUsage(api: ApiClient, name: string): Promise<Usage> {
   return api.json(`/agents/${encodeURIComponent(name)}/usage`);
 }
 
+export interface DashboardToken {
+  token: string;
+  expires_in: number;
+}
+
+/// Mint a short-lived capability scoped to this agent's registered service routes: the only
+/// credential the dashboard WebView ever receives, never the gateway token (POST /dashboard-token).
+export async function mintDashboardToken(
+  api: ApiClient,
+  name: string,
+): Promise<DashboardToken> {
+  return api.json(`/agents/${encodeURIComponent(name)}/dashboard-token`, {
+    method: "POST",
+  });
+}
+
 export async function getNotificationHistory(
   api: ApiClient,
   name: string,

--- a/apps/mobile/src/components/DashboardWebView.tsx
+++ b/apps/mobile/src/components/DashboardWebView.tsx
@@ -16,6 +16,19 @@ function serializeForInjection(value: unknown): string {
     .replaceAll("\u2029", "\\u2029");
 }
 
+/// Dispatch bridge messages into the page as real MessageEvents — the shape the
+/// dashboard's parent-bridge listens for (string postMessage payloads are ignored).
+function dispatchMessagesScript(
+  bridgeMessages: readonly Record<string, unknown>[],
+): string {
+  return `
+    for (const data of ${serializeForInjection(bridgeMessages)}) {
+      window.dispatchEvent(new MessageEvent("message", { data }));
+    }
+    true;
+  `;
+}
+
 function embeddedDocumentSetup(
   dark: boolean,
   bridgeMessages: readonly Record<string, unknown>[],
@@ -62,7 +75,7 @@ function embeddedDocumentSetup(
 }
 
 export interface DashboardWebViewHandle {
-  postMessage: (message: string) => void;
+  sendBridgeMessages: (messages: readonly Record<string, unknown>[]) => void;
 }
 
 interface DashboardWebViewProps {
@@ -85,11 +98,14 @@ export const DashboardWebView = forwardRef<
   { bridgeMessages, dark, ...props },
   forwardedRef,
 ) {
-  const nativeRef = useRef<DashboardWebViewHandle>(null);
+  const nativeRef = useRef<{ injectJavaScript: (script: string) => void }>(
+    null,
+  );
   useImperativeHandle(
     forwardedRef,
     () => ({
-      postMessage: (message) => nativeRef.current?.postMessage(message),
+      sendBridgeMessages: (messages) =>
+        nativeRef.current?.injectJavaScript(dispatchMessagesScript(messages)),
     }),
     [],
   );

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -369,3 +369,18 @@ export async function getHostFolderSuggestions(): Promise<string[]> {
   const resp = await apiJson<{ folders: string[] }>("/host/folders");
   return resp.folders;
 }
+
+export interface DashboardToken {
+  token: string;
+  expires_in: number;
+}
+
+/// Mint a short-lived capability scoped to this agent's registered service routes: the only
+/// credential dashboard content ever receives, never the gateway token (POST /dashboard-token).
+export async function mintDashboardToken(
+  name: string,
+): Promise<DashboardToken> {
+  return apiJson(`/agents/${encodeURIComponent(name)}/dashboard-token`, {
+    method: "POST",
+  });
+}

--- a/apps/web/src/components/Dashboard/index.tsx
+++ b/apps/web/src/components/Dashboard/index.tsx
@@ -10,6 +10,7 @@ import { Card } from "@/components/ui/card";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { useTheme } from "@/providers/ThemeProvider";
 import { useRuntime } from "@/providers/RuntimeProvider";
+import { mintDashboardToken } from "@/api/agents";
 import { getConnection } from "@/lib/connection";
 import { openExternalUrl } from "@/lib/open-external-url";
 import {
@@ -19,6 +20,11 @@ import {
   EmptyDescription,
   EmptyMedia,
 } from "@/components/ui/empty";
+
+// The iframe holds a short-lived capability scoped to this agent's service routes, never the
+// gateway token; re-mint well before expiry so an open dashboard keeps working.
+const DASHBOARD_TOKEN_REMINT_FRACTION = 0.8;
+const DASHBOARD_TOKEN_RETRY_MS = 5000;
 
 // Pre-iframe states (no dashboard, error, loading) wear the same flat chrome as the chat card and the
 // live dashboard shell — shadow-none, just the squircle + hairline ring — so the three panels are
@@ -84,6 +90,36 @@ export function Dashboard({ fullscreen }: { fullscreen?: boolean } = {}) {
       ? `${conn.url}/agents/${encodeURIComponent(name)}/dashboard/`
       : null;
 
+  // Derived, not reset: a token minted for another agent is simply never used.
+  const [minted, setMinted] = useState<{ agent: string; token: string } | null>(
+    null,
+  );
+  const dashboardToken = minted?.agent === name ? minted.token : null;
+  useEffect(() => {
+    if (!hasDashboard) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const mint = async () => {
+      try {
+        const { token, expires_in } = await mintDashboardToken(name);
+        if (cancelled) return;
+        setMinted({ agent: name, token });
+        timer = setTimeout(
+          () => void mint(),
+          expires_in * 1000 * DASHBOARD_TOKEN_REMINT_FRACTION,
+        );
+      } catch {
+        if (!cancelled)
+          timer = setTimeout(() => void mint(), DASHBOARD_TOKEN_RETRY_MS);
+      }
+    };
+    void mint();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [hasDashboard, name]);
+
   const sendContext = useCallback(() => {
     const frame = iframeRef.current?.contentWindow;
     if (!frame) return;
@@ -103,11 +139,11 @@ export function Dashboard({ fullscreen }: { fullscreen?: boolean } = {}) {
       },
       "*",
     );
-    if (conn)
+    if (conn && dashboardToken)
       frame.postMessage(
         {
           type: "vesta-auth",
-          token: conn.accessToken,
+          token: dashboardToken,
           baseUrl: `${conn.url}/agents/${encodeURIComponent(name)}`,
           agentName: name,
         },
@@ -122,6 +158,7 @@ export function Dashboard({ fullscreen }: { fullscreen?: boolean } = {}) {
     isMobile,
     vibrancy,
     conn,
+    dashboardToken,
     name,
   ]);
 

--- a/apps/web/src/lib/api-contract.test.ts
+++ b/apps/web/src/lib/api-contract.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { AgentStatus } from "@vesta/core";
-import type { BackupInfo } from "@/api/agents";
+import type { BackupInfo, DashboardToken } from "@/api/agents";
 import type { OAuthStartResult } from "@/api/providers/claude";
 import type { FileTreeEntry } from "@/api/files";
 import { vestadApiFixtures } from "./vestad-api-fixtures";
@@ -44,5 +44,11 @@ describe("vestad API contract", () => {
   it("tree entries satisfy FileTreeEntry", () => {
     const entry = vestadApiFixtures.tree_entry satisfies FileTreeEntry;
     expect(entry.is_dir).toBe(false);
+  });
+
+  it("dashboard token mint response satisfies DashboardToken", () => {
+    const minted = vestadApiFixtures.dashboard_token satisfies DashboardToken;
+    expect(minted.expires_in).toBeGreaterThan(0);
+    expect(minted.token).toBeTruthy();
   });
 });

--- a/apps/web/src/lib/vestad-api-fixtures.ts
+++ b/apps/web/src/lib/vestad-api-fixtures.ts
@@ -73,6 +73,10 @@ export const vestadApiFixtures = {
       "size": 1234567890
     }
   ],
+  "dashboard_token": {
+    "expires_in": 600,
+    "token": "sample.dashboard.capability"
+  },
   "start_all": {
     "results": [
       {

--- a/vestad/src/agent_proxy.rs
+++ b/vestad/src/agent_proxy.rs
@@ -115,9 +115,16 @@ pub async fn agent_proxy_handler(
         None => (agent_port, format!("/{path}"), None),
     };
 
-    // Public services are fully open; everything else requires auth.
+    // Public services are fully open; the api key opens everything; the short-lived
+    // dashboard capability opens only this agent's registered services (issue #1260).
     let is_public = service.as_ref().is_some_and(|s| s.public);
-    if !is_public && !auth::has_valid_api_auth(request.headers(), request.uri(), &state.api_key) {
+    if !auth::proxy_authorized(
+        request.headers(),
+        request.uri(),
+        &state.api_key,
+        &name,
+        service.as_ref(),
+    ) {
         return Err(err_response(
             StatusCode::UNAUTHORIZED,
             "unauthorized — pass a valid Bearer token or ?token= query parameter",

--- a/vestad/src/auth.rs
+++ b/vestad/src/auth.rs
@@ -176,21 +176,59 @@ fn token_fingerprint(token: &str) -> String {
     hex::encode(&digest.as_ref()[..3])
 }
 
+/// Credentials presented on a request: the Bearer header and/or `?token=` query param.
+fn presented_tokens<'req>(
+    headers: &'req HeaderMap,
+    uri: &'req axum::http::Uri,
+) -> impl Iterator<Item = &'req str> {
+    let bearer = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "));
+    let query = uri
+        .query()
+        .and_then(|q| q.split('&').find_map(|p| p.strip_prefix("token=")));
+    bearer.into_iter().chain(query)
+}
+
 pub(crate) fn has_valid_api_auth(
     headers: &HeaderMap,
     uri: &axum::http::Uri,
     api_key: &str,
 ) -> bool {
-    let bearer_ok = headers
-        .get("authorization")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.strip_prefix("Bearer "))
-        .is_some_and(|token| verify_token(token, api_key));
-    let query_ok = uri
-        .query()
-        .and_then(|q| q.split('&').find_map(|p| p.strip_prefix("token=")))
-        .is_some_and(|token| verify_token(token, api_key));
-    bearer_ok || query_ok
+    presented_tokens(headers, uri).any(|token| verify_token(token, api_key))
+}
+
+/// True when the request presents a live dashboard capability scoped to `agent_name`
+/// (issue #1260). Deliberately NOT accepted by `has_valid_api_auth`, so the capability
+/// opens nothing behind the api-key middlewares (gateway or agent administration).
+fn has_valid_dashboard_auth(
+    headers: &HeaderMap,
+    uri: &axum::http::Uri,
+    api_key: &str,
+    agent_name: &str,
+) -> bool {
+    presented_tokens(headers, uri)
+        .any(|token| jwt::validate_dashboard_token(api_key, token, agent_name))
+}
+
+/// The agent-proxy authorization decision: public services are open to all; the api
+/// key / access token opens everything; the dashboard capability opens only this
+/// agent's REGISTERED services, never the raw agent port fallback.
+pub(crate) fn proxy_authorized(
+    headers: &HeaderMap,
+    uri: &axum::http::Uri,
+    api_key: &str,
+    agent_name: &str,
+    service: Option<&crate::settings::ServiceEntry>,
+) -> bool {
+    if service.is_some_and(|entry| entry.public) {
+        return true;
+    }
+    if has_valid_api_auth(headers, uri, api_key) {
+        return true;
+    }
+    service.is_some() && has_valid_dashboard_auth(headers, uri, api_key, agent_name)
 }
 
 fn extract_agent_name(path: &str) -> Option<String> {
@@ -352,6 +390,27 @@ pub async fn exchange_session_handler(
     Ok(Json(session_response(&state.api_key, &jti, &fam)))
 }
 
+#[derive(Serialize)]
+pub struct DashboardTokenResponse {
+    pub token: String,
+    pub expires_in: u64,
+}
+
+/// `POST /agents/{name}/dashboard-token` — behind `auth_middleware`, so only a
+/// full-token caller (the app shell, never dashboard content) can mint. Returns the
+/// short-lived agent-scoped capability the shell hands the dashboard WebView/iframe
+/// in place of the gateway token (issue #1260).
+pub async fn mint_dashboard_token_handler(
+    State(state): State<SharedState>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> Result<Json<DashboardTokenResponse>, (StatusCode, Json<serde_json::Value>)> {
+    crate::docker::validate_name(&name).map_err(crate::state::map_docker_err)?;
+    Ok(Json(DashboardTokenResponse {
+        token: jwt::create_dashboard_token(&state.api_key, &name),
+        expires_in: jwt::DASHBOARD_TOKEN_TTL,
+    }))
+}
+
 pub async fn refresh_session_handler(
     State(state): State<SharedState>,
     Json(body): Json<RefreshRequest>,
@@ -509,6 +568,79 @@ mod verify_token_tests {
     #[test]
     fn same_length_non_matching_key_does_not_verify() {
         assert!(!verify_token("the-api-kex", "the-api-key"));
+    }
+}
+
+#[cfg(test)]
+mod dashboard_auth_tests {
+    use super::{has_valid_api_auth, proxy_authorized};
+    use crate::jwt;
+    use crate::settings::ServiceEntry;
+    use axum::http::{HeaderMap, HeaderValue, Uri};
+
+    const API_KEY: &str = "the-api-key";
+    const REGISTERED: ServiceEntry = ServiceEntry { port: 8080, public: false };
+    const PUBLIC: ServiceEntry = ServiceEntry { port: 8080, public: true };
+
+    fn bearer(token: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        let value = HeaderValue::from_str(&format!("Bearer {token}")).expect("ascii header");
+        headers.insert("authorization", value);
+        headers
+    }
+
+    fn service_uri() -> Uri {
+        Uri::from_static("/agents/alpha/tasks/tasks")
+    }
+
+    #[test]
+    fn dashboard_token_opens_the_scoped_agents_registered_service() {
+        let token = jwt::create_dashboard_token(API_KEY, "alpha");
+        let via_bearer = bearer(&token);
+        assert!(proxy_authorized(&via_bearer, &service_uri(), API_KEY, "alpha", Some(&REGISTERED)));
+        // The `?token=` form (media/WS URLs) carries the same capability.
+        let query_uri: Uri = format!("/agents/alpha/tasks/tasks?token={token}")
+            .parse()
+            .expect("valid uri");
+        assert!(proxy_authorized(&HeaderMap::new(), &query_uri, API_KEY, "alpha", Some(&REGISTERED)));
+    }
+
+    #[test]
+    fn dashboard_token_is_denied_for_another_agents_service() {
+        let token = jwt::create_dashboard_token(API_KEY, "alpha");
+        assert!(!proxy_authorized(&bearer(&token), &service_uri(), API_KEY, "beta", Some(&REGISTERED)));
+    }
+
+    #[test]
+    fn dashboard_token_is_denied_on_the_raw_agent_fallback() {
+        // No registered service matched: the fallback proxies to the agent's own port
+        // (X-Agent-Token injected), which the dashboard capability must never reach.
+        let token = jwt::create_dashboard_token(API_KEY, "alpha");
+        assert!(!proxy_authorized(&bearer(&token), &service_uri(), API_KEY, "alpha", None));
+    }
+
+    #[test]
+    fn dashboard_token_is_denied_by_gateway_api_auth() {
+        // `has_valid_api_auth` backs every api-key middleware (gateway admin, agent
+        // admin, /sync, mint itself), so this single check is the gateway-level denial.
+        let token = jwt::create_dashboard_token(API_KEY, "alpha");
+        assert!(!has_valid_api_auth(&bearer(&token), &Uri::from_static("/gateway/settings"), API_KEY));
+    }
+
+    #[test]
+    fn api_key_and_access_token_still_open_non_public_services() {
+        assert!(proxy_authorized(&bearer(API_KEY), &service_uri(), API_KEY, "alpha", Some(&REGISTERED)));
+        let access = jwt::create_token(API_KEY, "access", jwt::ACCESS_TOKEN_TTL);
+        assert!(proxy_authorized(&bearer(&access), &service_uri(), API_KEY, "alpha", Some(&REGISTERED)));
+        assert!(proxy_authorized(&bearer(API_KEY), &service_uri(), API_KEY, "alpha", None));
+    }
+
+    #[test]
+    fn public_service_needs_no_credentials_and_bare_requests_are_denied_elsewhere() {
+        let no_headers = HeaderMap::new();
+        assert!(proxy_authorized(&no_headers, &service_uri(), API_KEY, "alpha", Some(&PUBLIC)));
+        assert!(!proxy_authorized(&no_headers, &service_uri(), API_KEY, "alpha", Some(&REGISTERED)));
+        assert!(!proxy_authorized(&no_headers, &service_uri(), API_KEY, "alpha", None));
     }
 }
 

--- a/vestad/src/jwt.rs
+++ b/vestad/src/jwt.rs
@@ -48,6 +48,16 @@ pub const SERVER_IDENTITY_TYP: &str = "server-identity";
 /// Server-identity token TTL — short; minted on demand, carried once.
 pub const SERVER_IDENTITY_TTL: u64 = 600; // 10 minutes
 
+/// `typ` of a dashboard capability token — the ONLY credential dashboard WebView/iframe
+/// JS ever holds (issue #1260). Scoped to one agent (`sub` = agent name) and accepted
+/// solely on that agent's registered service routes, so compromised dashboard content
+/// cannot administer the gateway or reach other agents. Its own derived subkey means
+/// it does not even verify as an `"access"` token.
+pub const DASHBOARD_TYP: &str = "dashboard";
+/// Dashboard token TTL — short; the app shell re-mints before expiry while the
+/// dashboard stays open.
+pub const DASHBOARD_TOKEN_TTL: u64 = 600; // 10 minutes
+
 #[derive(Serialize, Deserialize)]
 pub struct Claims {
     pub sub: String,
@@ -128,6 +138,31 @@ pub fn create_server_identity_token(api_key: &str, server_id: &str) -> String {
     .expect("HS256 encoding of a serializable struct is infallible")
 }
 
+/// Mint a dashboard capability: `{ sub: <agent_name>, typ: "dashboard" }` with a
+/// short expiry, signed under the dashboard subkey (see `DASHBOARD_TYP` for scope).
+pub fn create_dashboard_token(api_key: &str, agent_name: &str) -> String {
+    let now = crate::time_utils::now_epoch_secs();
+    let claims = Claims {
+        sub: agent_name.into(),
+        typ: DASHBOARD_TYP.into(),
+        iat: now,
+        exp: now + DASHBOARD_TOKEN_TTL,
+        jti: None,
+        fam: None,
+    };
+    encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(&signing_key(api_key, DASHBOARD_TYP)),
+    )
+    .expect("HS256 encoding of a serializable struct is infallible")
+}
+
+/// True when `token` is a live dashboard capability for exactly `agent_name`.
+pub fn validate_dashboard_token(api_key: &str, token: &str, agent_name: &str) -> bool {
+    validate_token(api_key, token, DASHBOARD_TYP).is_ok_and(|claims| claims.sub == agent_name)
+}
+
 pub fn validate_token(
     api_key: &str,
     token: &str,
@@ -180,9 +215,13 @@ mod tests {
         let a = signing_key("k", "access");
         let r = signing_key("k", "refresh");
         let i = signing_key("k", "server-identity");
+        let d = signing_key("k", DASHBOARD_TYP);
         assert_ne!(a, r);
         assert_ne!(a, i);
         assert_ne!(r, i);
+        assert_ne!(d, a);
+        assert_ne!(d, r);
+        assert_ne!(d, i);
     }
 
     #[test]
@@ -213,6 +252,46 @@ mod tests {
     fn wrong_key_rejected() {
         let token = create_token("secret", "access", ACCESS_TOKEN_TTL);
         assert!(validate_token("other-secret", &token, "access").is_err());
+    }
+
+    #[test]
+    fn dashboard_token_is_scoped_to_its_agent() {
+        let token = create_dashboard_token("secret", "alpha");
+        assert!(validate_dashboard_token("secret", &token, "alpha"));
+        // Another agent's name, or another host's key, is a different capability.
+        assert!(!validate_dashboard_token("secret", &token, "beta"));
+        assert!(!validate_dashboard_token("other-secret", &token, "alpha"));
+    }
+
+    #[test]
+    fn dashboard_token_cannot_be_replayed_as_another_role() {
+        let token = create_dashboard_token("secret", "alpha");
+        assert!(validate_token("secret", &token, "access").is_err());
+        assert!(validate_token("secret", &token, "refresh").is_err());
+        // And an access token is not a dashboard capability for any agent.
+        let access = create_token("secret", "access", ACCESS_TOKEN_TTL);
+        assert!(!validate_dashboard_token("secret", &access, "vesta-app"));
+    }
+
+    #[test]
+    fn expired_dashboard_token_is_rejected() {
+        // Back-dated past jsonwebtoken's default 60s exp leeway.
+        let now = crate::time_utils::now_epoch_secs();
+        let claims = Claims {
+            sub: "alpha".into(),
+            typ: DASHBOARD_TYP.into(),
+            iat: now - 300,
+            exp: now - 120,
+            jti: None,
+            fam: None,
+        };
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(&signing_key("secret", DASHBOARD_TYP)),
+        )
+        .expect("encode expired claims");
+        assert!(!validate_dashboard_token("secret", &token, "alpha"));
     }
 
     #[test]

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -39,7 +39,7 @@ const API_KEY_BYTES: usize = 32;
 
 const RESERVED_SERVICE_NAMES: &[&str] = &[
     "start", "stop", "restart", "destroy", "auth", "logs", "tree", "file", "backups", "settings",
-    "services",
+    "services", "dashboard-token",
 ];
 const DEFAULT_LOG_TAIL_LINES: u64 = 500;
 const AUTO_BACKUP_CHECK_INTERVAL_SECS: u64 = 3600;
@@ -2383,6 +2383,10 @@ pub fn build_router(state: SharedState) -> Router {
             axum::routing::delete(delete_agent_backup_settings_handler),
         )
         .route("/agents/{name}/mounts", put(set_mounts_handler))
+        .route(
+            "/agents/{name}/dashboard-token",
+            post(auth::mint_dashboard_token_handler),
+        )
         .route("/host/folders", get(host_folder_suggestions_handler))
         .route(
             "/mobile/devices",
@@ -3536,6 +3540,13 @@ mod tests {
         })
         .expect("serialize TreeEntry");
 
+        // Fixed sample token: the fixture pins the response SHAPE, not a live JWT.
+        let dashboard_token = serde_json::to_value(crate::auth::DashboardTokenResponse {
+            token: "sample.dashboard.capability".into(),
+            expires_in: crate::jwt::DASHBOARD_TOKEN_TTL,
+        })
+        .expect("serialize DashboardTokenResponse");
+
         // Mirrors version_json() above; that response is an inline json! so it cannot be
         // serialized from a struct here. Keep this in sync with version_json().
         let version = serde_json::json!({
@@ -3556,6 +3567,7 @@ mod tests {
             "auth_start": auth_start,
             "start_all": start_all,
             "tree_entry": tree_entry,
+            "dashboard_token": dashboard_token,
             "version": version,
         })
     }


### PR DESCRIPTION
Fixes #1260

## Problem

The dashboard WebView (mobile) and iframe (web/desktop) received the full gateway bearer token through the `vesta-auth` bridge, so compromised dashboard content could exercise gateway-wide privileges. The mobile WebView additionally attached the full token as an `Authorization` header on the WebView request.

## Mechanism

One owner for mint + verify: `vestad/src/jwt.rs`.

- New token role `typ: "dashboard"`, signed HS256 under its own HKDF-derived subkey (same per-purpose derivation as access/refresh/server-identity), so it cannot even *verify* as an access token: gateway and agent administration denial is cryptographic, not just a claim check. Claims: `sub` = agent name, 10 minute expiry (`DASHBOARD_TOKEN_TTL`).
- Mint endpoint `POST /agents/{name}/dashboard-token` sits behind the full-token `auth_middleware` (the app shell can call it; the capability itself cannot, so dashboard content can never mint).
- The agent proxy's authorization decision is now one function (`auth::proxy_authorized`): public services stay open, the api key/access token opens everything, and the dashboard capability opens only the scoped agent's **registered** service routes, never the raw agent port fallback (which would carry the injected `X-Agent-Token` to the agent's own API), never another agent, never a gateway route. `dashboard-token` is a reserved service name so a service cannot shadow the mint route.

## Bridges

The web bundle serves web + desktop (Electron has no dashboard code of its own); mobile has its own WebView bridge, updated too:

- `apps/web` Dashboard: mints the capability, hands only it over `vesta-auth`, re-mints at 80% of expiry, keyed to the agent so a stale token for another agent is never used.
- `apps/mobile` DashboardPage: same mint/re-mint flow; the WebView handle now injects bridge messages as real `MessageEvent`s (the old string `postMessage` path was ignored by the page bridge, so live re-mints could never land); the full-token `Authorization` header on the WebView source is removed (the dashboard service registers `--public`, so it was unnecessary).
- The dashboard app's `parent-bridge.ts` is unchanged: the token it holds is opaque to it, so already-built fleet dashboards keep working.

## Acceptance criteria

- Dashboard content never receives the full gateway token: both bridges send only the minted capability, mobile header removed.
- Capability limited to the selected agent + required service routes: `sub` binding + registered-service-only acceptance in the proxy.
- Short expiry: 10 minutes, shell re-mints while the dashboard is open.
- No gateway or other-agent administration: dashboard subkey does not verify under `has_valid_api_auth`/`verify_token` (all api-key middlewares), cross-agent `sub` mismatch denied.
- Tests: `jwt.rs` (roundtrip, cross-agent scope, role replay in both directions, expiry, distinct subkeys) and `auth.rs::dashboard_auth_tests` (proxy decision table incl. cross-agent denial, raw-agent-fallback denial, gateway-level denial, query-param form, public/no-credential cases). The mint response shape is pinned in the vestad -> web API contract fixtures with a `satisfies DashboardToken` check.

## Checks

`./check.sh vestad`, `./check.sh web` (app-core, app-web, app-desktop, app-mobile), and `./check.sh guards` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)