### PR TITLE
fix(agent): flip graceful_shutdown even when the crash-persist fails, so a dead processor never wedges the agent

### DIFF
--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -60,7 +60,13 @@ def handle_processor_done(task: asyncio.Task[None], *, name: str, state: vm.Stat
         else:
             logger.error(f"{name} exited without error, restarting")
             state.persisted.last_restart_reason = f"crash: the {name} exited silently"
-    state_store.save_state(state.persisted, config)
+    # The flip is the wedge-proof invariant: the same failing disk that killed the task makes
+    # this persist raise, and an exception escaping this callback is swallowed by asyncio, so
+    # an unguarded persist leaves the agent up but never serving again (issue #1363).
+    try:
+        state_store.save_state(state.persisted, config)
+    except OSError as e:
+        logger.error(f"failed to persist restart reason: {e}")
     state.graceful_shutdown.set()
 
 

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -602,6 +602,93 @@ async def test_compact_session_query_send_timeout_fails_compaction():
     assert state.turn is None
 
 
+# --- In-place (restart=false) compaction through the processor ---
+
+
+def _processor_nap_harness(tmp_path):
+    """Stream harness wired for driving message_processor through an in-place nap; the follow-up
+    notification write is pointed at the test's tmp dir, never the real agent home."""
+    state, config, mock_client, _, message_queue, _ = make_stream_harness()
+    config.agent_dir = tmp_path / "agent"
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return state, config, mock_client, message_queue
+
+
+async def _drive_nap(state, mock_client, message_queue, queue):
+    """One turn that requests an in-place nap, then the compaction stream that completes it."""
+    from claude_agent_sdk import SystemMessage
+
+    await queue.put(vm.QueuedTurn("please take a nap", True, []))
+    await wait_for_condition(lambda: mock_client.query.await_count >= 1, message="nap turn never queried")
+    state.pending_compaction = vm.PendingCompaction(prompt="keep threads", followup="reflect", restart=False)
+    await message_queue.put(result_msg())
+
+    await wait_for_condition(
+        lambda: any(call.args and str(call.args[0]).startswith("/compact") for call in mock_client.query.call_args_list),
+        message="idle tick never drained the nap",
+    )
+    await message_queue.put(SystemMessage(subtype="compact_boundary", data={"compact_metadata": {"pre_tokens": 5, "trigger": "manual"}}))
+    await message_queue.put(result_msg())
+
+
+@pytest.mark.anyio
+async def test_processor_serves_turns_after_inplace_nap(tmp_path):
+    """compact_context(restart=false): after the drain completes in place, the processor must
+    return to serving turns on the same session (issue #1363's expected behavior)."""
+    from core.loops import message_processor
+
+    state, config, mock_client, message_queue = _processor_nap_harness(tmp_path)
+    queue: asyncio.Queue = asyncio.Queue()
+
+    with (
+        patch("core.client.ClaudeSDKClient", return_value=mock_client),
+        patch("core.client.build_client_options", return_value=MagicMock()),
+    ):
+        processor = asyncio.create_task(message_processor(queue, state=state, config=config))
+        await _drive_nap(state, mock_client, message_queue, queue)
+        await wait_for_condition(lambda: state.pending_compaction is None and not state.processor_busy, message="drain never completed")
+
+        before = mock_client.query.await_count
+        await queue.put(vm.QueuedTurn("hello again", True, []))
+        await wait_for_condition(lambda: mock_client.query.await_count > before, message="post-nap turn never served")
+        await message_queue.put(result_msg())
+        await wait_for_condition(lambda: not state.processor_busy, message="post-nap turn never finished")
+
+        state.shutdown_event.set()
+        await asyncio.wait_for(processor, timeout=5)
+
+
+@pytest.mark.anyio
+async def test_inplace_nap_on_failing_disk_restarts_instead_of_wedging(tmp_path):
+    """Regression (issue #1363): a failing disk during the restart=false drain tail (the follow-up
+    notification write) unwinds message_processor, and the same disk fails the restart-reason
+    persist inside handle_processor_done. That callback exception is swallowed by asyncio, so
+    graceful_shutdown was never set: the agent sat with a dead processor and a live monitor,
+    busy-skipping every tick until a manual container restart. The crash must still flip
+    graceful_shutdown so the agent restarts and returns to serving turns."""
+    from core.loops import message_processor
+    from core.main import handle_processor_done
+
+    state, config, mock_client, message_queue = _processor_nap_harness(tmp_path)
+    queue: asyncio.Queue = asyncio.Queue()
+
+    with (
+        patch("core.client.ClaudeSDKClient", return_value=mock_client),
+        patch("core.client.build_client_options", return_value=MagicMock()),
+        patch("core.config.atomic_write_text", side_effect=OSError(28, "No space left on device")),
+    ):
+        processor = asyncio.create_task(message_processor(queue, state=state, config=config))
+        processor.add_done_callback(lambda t: handle_processor_done(t, name="message processor", state=state, config=config))
+        await _drive_nap(state, mock_client, message_queue, queue)
+
+        await wait_for_condition(state.graceful_shutdown.is_set, message="processor death never flipped graceful_shutdown")
+        with pytest.raises(OSError):
+            await processor
+    assert state.persisted.last_restart_reason is not None
+    assert state.persisted.last_restart_reason.startswith("crash:")
+
+
 def test_read_compaction_summary_extracts_latest(tmp_path, monkeypatch):
     """The /compact summary is read back from the session transcript for logging: pick the latest
     isCompactSummary entry and join its text blocks."""

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -649,6 +649,33 @@ async def test_handle_processor_done_silent_exit_triggers_restart(tmp_path):
 
 
 @pytest.mark.anyio
+async def test_handle_processor_done_failing_state_write_still_triggers_restart(tmp_path):
+    """Regression (issue #1363): the disk failure that crashed the processor also fails the
+    restart-reason persist inside this done-callback; asyncio swallows callback exceptions, so
+    an unguarded persist left graceful_shutdown unset and the agent wedged silently forever.
+    The flip must happen even when the persist raises."""
+    from core.main import handle_processor_done
+
+    config = cfg.VestaConfig(agent_dir=tmp_path / "agent")
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+    state = vm.State()
+
+    async def crasher():
+        raise OSError(28, "No space left on device")
+
+    task = asyncio.create_task(crasher())
+    with contextlib.suppress(OSError):
+        await task
+
+    with patch("core.config.atomic_write_text", side_effect=OSError(28, "No space left on device")):
+        handle_processor_done(task, name="processor", state=state, config=config)
+
+    assert state.graceful_shutdown.is_set(), "a failed persist must never block the restart flip"
+    assert state.persisted.last_restart_reason is not None
+    assert state.persisted.last_restart_reason.startswith("crash:")
+
+
+@pytest.mark.anyio
 async def test_handle_processor_done_noop_during_shutdown(tmp_path):
     """If shutdown was already initiated, the callback must not override the restart_reason."""
     from core.main import handle_processor_done


### PR DESCRIPTION
Fixes #1363

## Root cause

The incident log sequence pins it: `compact_result success`, `state → idle`, `Client session closed`, all in the same second, then the agent busy-skipping every 2s with no recovery until a manual container restart. The new regression test reproduces that exact log sequence on master.

The chain, restart=false only:

1. The restart=false drain tail is the one place that writes a live follow-up notification after compacting (`drain_compaction_request` -> `drop_core_notification` -> `atomic_write_text`). On a failing disk that write raises `OSError`, and nothing between the drain tail and the processor loop catches it (the drain's catch wraps only `compact_session`), so `message_processor` unwinds, logging `Client session closed` on its way out. That matches the incident timestamps: the only code between "state → idle" and the session close is that write.
2. `handle_processor_done`, whose whole job is "the agent never wedges silently", then runs `state_store.save_state` **before** `state.graceful_shutdown.set()`. On the same failing disk that persist raises too. An exception escaping a done-callback is swallowed by asyncio's callback handler, so the flip on the next line never happens.
3. With `graceful_shutdown` never set, `run_vesta` keeps waiting, nothing restarts the agent, and `monitor_loop` stays alive queueing turns nothing will ever consume. `not queue.empty()` keeps the proactive-check busy-skip firing every tick (the 20:02 start in the incident is the 60-minute proactive interval coming due), and the agent is unresponsive forever.

`restart=true` (the nightly dreamer) never touches this: its tail hands off to vestad, which restarts the container externally regardless of agent-side state, which is why the dreamer resumes cleanly every night while the in-place path wedged.

## Fix

One layer, at the invariant's owner: `handle_processor_done` now guards the persist so `graceful_shutdown.set()` always runs. A crash whose reason cannot be persisted still restarts the agent (the reason falls back to the generic crash label on the next boot); it no longer wedges it.

The drain-tail write failure itself keeps its existing semantics: an unexpected exception unwinds the processor and the agent crash-restarts via the callback, which is the designed recovery. No second defensive layer added in the drain.

## Secondary (busy-skip log spam)

Already fixed on master by #1252: the skip line is logged once per due window (`proactive_defer_logged`), not every tick, so this PR adds nothing there.

## Tests

- `test_inplace_nap_on_failing_disk_restarts_instead_of_wedging` (test_interrupts.py): drives `message_processor` end to end through a restart=false nap on a failing disk, with the done-callback attached exactly as `main.py` wires it, and asserts the crash flips `graceful_shutdown` with a `crash:` reason instead of wedging. Fails on master (times out waiting for the flip, after reproducing the incident's log sequence verbatim).
- `test_handle_processor_done_failing_state_write_still_triggers_restart` (test_processor.py): unit regression on the callback itself. Fails on master.
- `test_processor_serves_turns_after_inplace_nap` (test_interrupts.py): pins the healthy restart=false contract, the processor returns to serving turns on the same session after an in-place drain.

`./check.sh agent` and `./check.sh guards` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)