### PR TITLE
test(agent): keep the host git config out of the test fixtures

### DIFF
--- a/agent/skills/upstream-pr/cli/tests/test_auth.py
+++ b/agent/skills/upstream-pr/cli/tests/test_auth.py
@@ -1,4 +1,5 @@
 import base64
+import os
 import subprocess
 import sys
 
@@ -6,10 +7,13 @@ import pytest
 from upstream_pr_cli import cli
 
 SENTINEL = "ghs_SENTINELtoken1234567890abcdef"
+# The host's own git config must not reach these repos: a user-level commit.gpgSign would sign
+# every fixture commit, and fail wherever no key is available.
+HERMETIC_GIT = {"GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
 
 
 def _git(repo, *args):
-    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True, env=os.environ | HERMETIC_GIT)
 
 
 @pytest.fixture

--- a/agent/tests/test_boot_turns.py
+++ b/agent/tests/test_boot_turns.py
@@ -1,6 +1,6 @@
 """Tests for boot-turn assembly: boot-time control-flow delivered as ordered, non-interruptible turns."""
 
-import subprocess
+from test_upstream_sync_turn import _record_snapshot
 
 import core.config as cfg
 import core.models as vm
@@ -20,17 +20,6 @@ def _authed_state() -> vm.State:
     state = vm.State()
     state.provider_status = ProviderStatus(state=ProviderAuthState.AUTHENTICATED, kind="claude", model="opus")
     return state
-
-
-def _record_snapshot(config, version):
-    home = config.agent_dir.parent
-    subprocess.run(["git", "init", "-q", "-b", "agent"], cwd=home, check=True)
-    subprocess.run(
-        ["git", "-c", "user.name=test", "-c", "user.email=test@vesta", "commit", "-q", "--allow-empty", "-m", "stock"],
-        cwd=home,
-        check=True,
-    )
-    subprocess.run(["git", "tag", f"agent-v{version}"], cwd=home, check=True)
 
 
 def test_boot_turns_ordered_migrations_then_sync_then_config_then_greeting(tmp_path):

--- a/agent/tests/test_upstream_sync_turn.py
+++ b/agent/tests/test_upstream_sync_turn.py
@@ -1,7 +1,10 @@
 """Upgrade-driven upstream sync: Git ancestry + boot turn."""
 
 import asyncio
+import os
 import subprocess
+
+from test_upstream_sync import BASE_ENV  # hermetic-git env, as build-upstream.sh uses
 
 import core.config as cfg
 import core.models as vm
@@ -20,14 +23,26 @@ def _config(tmp_path, version: str | None = "0.1.170") -> cfg.VestaConfig:
 
 
 def _record_snapshot(config: cfg.VestaConfig, version: str) -> None:
+    """A box's checkout at `version`: history carrying the agent-v<version> tag. Runs under the same
+    hermetic env build-upstream.sh exports, so the host's own git config cannot reach it (a user-level
+    tag.gpgSign turns `git tag` into a signed annotated tag, which fails without a message)."""
     home = config.agent_dir.parent
-    subprocess.run(["git", "init", "-q", "-b", "agent"], cwd=home, check=True)
-    subprocess.run(
-        ["git", "-c", "user.name=test", "-c", "user.email=test@vesta", "commit", "-q", "--allow-empty", "-m", "stock"],
-        cwd=home,
-        check=True,
-    )
-    subprocess.run(["git", "tag", f"agent-v{version}"], cwd=home, check=True)
+    env = os.environ | BASE_ENV
+    for args in (["init", "-q", "-b", "agent"], ["commit", "-q", "--allow-empty", "-m", "stock"], ["tag", f"agent-v{version}"]):
+        subprocess.run(["git", *args], cwd=home, check=True, env=env)
+
+
+def test_snapshot_fixtures_ignore_a_hostile_host_git_config(tmp_path, monkeypatch):
+    """A developer with tag.gpgSign/commit.gpgSign set globally must still be able to run the suite:
+    signing turns `git tag` into an annotated tag and fails for want of a message."""
+    hostile = tmp_path / "hostile.gitconfig"
+    hostile.write_text("[tag]\n\tgpgsign = true\n[commit]\n\tgpgsign = true\n")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(hostile))
+
+    config = _config(tmp_path)
+    _record_snapshot(config, "0.1.170")
+
+    assert workspace_synced(config, "0.1.170")
 
 
 def test_vesta_version_reads_core_pyproject(tmp_path):


### PR DESCRIPTION
## Summary

The upstream-sync test fixtures shell out to `git` without neutralizing the host's config. A developer with `tag.gpgSign` or `commit.gpgSign` set globally cannot run the agent suite: git turns `git tag agent-vX.Y.Z` into a signed annotated tag and dies with `fatal: no tag message?`.

Four tests fail on current master on such a machine, and pass in CI, where no global git config exists:

```
tests/test_boot_turns.py::test_restart_only_boot_carries_no_daemon_orientation
tests/test_upstream_sync_turn.py::test_no_turn_when_snapshot_is_in_git_history
tests/test_upstream_sync_turn.py::test_legacy_mark_upstream_synced_verifies_git_history
tests/test_upstream_sync_turn.py::test_mark_workspace_synced_legacy_alias_still_verifies
```

Production is not affected: `vestad/scripts/build-upstream.sh`, the script these fixtures stand in for, already exports `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null` for exactly this reason. Only the fixtures were missing it.

## Changes

- `_record_snapshot` runs under the same hermetic env `build-upstream.sh` exports, reusing the existing `BASE_ENV` helper rather than adding a third definition of it
- the two verbatim copies of `_record_snapshot` collapse into one, imported the way `test_build_upstream` already imports its git helpers from a sibling module
- the `upstream-pr` CLI fixtures get the same treatment: they set a local identity but still sign every commit under a global `commit.gpgSign`, so they pass today only because a key happens to be available

## Testing

- `./check.sh agent`: 707 passed, plus every skill CLI suite, on a machine where master fails the four tests above
- `./check.sh guards`: all checks passed
- The new test pins the behavior by running `_record_snapshot` against a deliberately hostile `GIT_CONFIG_GLOBAL`. Against the previous fixture it fails with `gpg: signing failed: No secret key`; with the fix it passes.