### PR TITLE
fix(vestad): prevent stale service port takeovers

### DIFF
--- a/agent/core/migrations/2026-07-bindable-service-ports.md
+++ b/agent/core/migrations/2026-07-bindable-service-ports.md
@@ -1,0 +1,41 @@
+Service startup now distinguishes claiming a port from resolving an already-running
+service. Your persisted tasks restart line predates that distinction, so update it
+to request a bindable port before tasks starts. Safe to run more than once.
+
+### 1. Update the tasks restart line
+
+Inspect the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
+
+```bash
+grep -n 'register-service tasks' ~/agent/skills/restart/SKILL.md
+```
+
+If the matching line starts tasks and already includes the `--claim` flag, it is
+converged. Otherwise, add `--claim` immediately after `tasks` while preserving
+the line's existing guard, notifications directory, and other personalized
+flags. The result should resemble:
+
+```
+running tasks || { PORT=$(~/agent/skills/vestad/scripts/register-service tasks --claim) && screen -dmS tasks tasks serve --port $PORT; sleep 1; }
+```
+
+If no tasks registration exists, there is nothing to update.
+
+### 2. Update other persisted service starts
+
+Check the same Daemons section for AgentMail and File Host:
+
+```bash
+grep -nE 'register-service (agentmail|file-host)' ~/agent/skills/restart/SKILL.md
+```
+
+For each line that starts that service, add `--claim` after the service name if
+it is missing. Preserve `--public`, the existing `running <name> ||` guard, and
+all personalized arguments. Do not add `--claim` to a line that only resolves
+the port of an already-running service.
+
+If neither registration exists, this step is done.
+
+### 3. Mark this migration applied
+
+Call `mark_migration_applied` with `name="2026-07-bindable-service-ports"`.

--- a/agent/skills/agentmail/SETUP.md
+++ b/agent/skills/agentmail/SETUP.md
@@ -64,15 +64,15 @@ The webhook reaches the local FastAPI service through the public vestad
 tunnel; that's why the service must be registered with `"public": true`.
 
 ```bash
-PORT=$(~/agent/skills/vestad/scripts/register-service agentmail --public)
-
+screen -S agentmail -X quit >/dev/null 2>&1 || true
+PORT=$(~/agent/skills/vestad/scripts/register-service agentmail --public --claim)
 screen -dmS agentmail agentmail serve --port $PORT
 ```
 
 Register it for restart (see [vestad](../vestad/SKILL.md)) by adding this startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
 
 ```
-PORT=$(~/agent/skills/vestad/scripts/register-service agentmail --public) && screen -dmS agentmail agentmail serve --port $PORT
+running agentmail || { PORT=$(~/agent/skills/vestad/scripts/register-service agentmail --public --claim) && screen -dmS agentmail agentmail serve --port $PORT; sleep 1; }
 ```
 
 **Verify**: `curl http://127.0.0.1:$PORT/health` should return

--- a/agent/skills/agentmail/cli/src/agentmail_bridge/setup.py
+++ b/agent/skills/agentmail/cli/src/agentmail_bridge/setup.py
@@ -179,12 +179,8 @@ def _print_summary(inbox: dict, webhook_url: str) -> None:
     click.echo(f"  agentmail inboxes:messages send --inbox-id {inbox['inbox_id']} \\")
     click.echo("    --to recipient@example.com --subject 'hi' --text 'hello'")
     click.echo("\nnext: register and start the local webhook receiver")
-    click.echo(
-        "  PORT=$(curl -sk -X POST https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services "
-        "-H \"X-Agent-Token: $AGENT_TOKEN\" -H 'Content-Type: application/json' "
-        '-d \'{"name":"agentmail","public":true}\' | '
-        "python3 -c \"import sys,json; print(json.load(sys.stdin)['port'])\")"
-    )
+    click.echo("  screen -S agentmail -X quit >/dev/null 2>&1 || true")
+    click.echo("  PORT=$(~/agent/skills/vestad/scripts/register-service agentmail --public --claim)")
     click.echo("  screen -dmS agentmail agentmail serve --port $PORT")
 
 

--- a/agent/skills/app-chat/cli/src/app_chat_cli/daemon.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/daemon.py
@@ -45,7 +45,7 @@ USER_NOTIFICATION = pl.Path.home() / "agent" / "skills" / "vestad" / "scripts" /
 
 
 def resolve_port() -> int:
-    result = subprocess.run([str(REGISTER_SERVICE), "app-chat"], capture_output=True, text=True, timeout=35, check=False)
+    result = subprocess.run([str(REGISTER_SERVICE), "app-chat", "--claim"], capture_output=True, text=True, timeout=35, check=False)
     if result.returncode != 0 or not result.stdout.strip():
         raise RuntimeError(f"register-service failed: {result.stderr.strip()}")
     return int(result.stdout.strip())

--- a/agent/skills/browser/cli/src/vesta_browser/handover.py
+++ b/agent/skills/browser/cli/src/vesta_browser/handover.py
@@ -18,6 +18,7 @@ box (dev/tests) it falls back to a local port.
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import os
 import shutil
 import socket
@@ -37,6 +38,8 @@ WEB_PORT_START = 6080
 X11VNC_READY_TIMEOUT_S = 10.0
 X11VNC_SETTLE_S = 0.4
 X11VNC_TERMINATE_TIMEOUT_S = 5.0
+WEBSOCKIFY_READY_TIMEOUT_S = 3.0
+WEBSOCKIFY_SETTLE_S = 0.4
 DISPLAY_CLAIM_ATTEMPTS = 10
 READY_POLL_S = 0.1
 PROC = Path("/proc")
@@ -53,6 +56,7 @@ SCREEN_W, SCREEN_H = 1280, 800
 HANDOVER_SERVICE = "browser"
 REGISTER_SERVICE = Path.home() / "agent" / "skills" / "vestad" / "scripts" / "register-service"
 SERVICE_REGISTER_TIMEOUT_S = 35  # register-service polls vestad up to ~30s before giving up
+SERVICE_UNREGISTER_TIMEOUT_S = 10
 
 # The handover display shows exactly one app. Without this, openbox smart-places the window a
 # few pixels off origin and adds a titlebar, so the stream sits misaligned in the page's screen
@@ -77,8 +81,23 @@ NOVNC_DIRS = [
 ]
 
 
+class HandoverPortError(RuntimeError):
+    pass
+
+
 def _session_file(suffix: str) -> Path:
     return Path(f"/tmp/vesta-browser-{HANDOVER_SESSION}.{suffix}")
+
+
+@contextlib.contextmanager
+def _handover_lock() -> tp.Iterator[None]:
+    lock_path = _session_file("lock")
+    with lock_path.open("a+") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock, fcntl.LOCK_UN)
 
 
 def _find_novnc_dir() -> Path:
@@ -195,7 +214,7 @@ def _register_public_service() -> tuple[int, str] | None:
     if not tunnel or not agent or not REGISTER_SERVICE.exists():
         return None
     result = subprocess.run(
-        [str(REGISTER_SERVICE), HANDOVER_SERVICE, "--public"],
+        [str(REGISTER_SERVICE), HANDOVER_SERVICE, "--public", "--claim"],
         capture_output=True,
         text=True,
         timeout=SERVICE_REGISTER_TIMEOUT_S,
@@ -205,6 +224,42 @@ def _register_public_service() -> tuple[int, str] | None:
         return None
     port = int(result.stdout.strip())
     return port, f"{tunnel.rstrip('/')}/agents/{agent}/{HANDOVER_SERVICE}/handover.html"
+
+
+def _unregister_public_service(expected_port: int | None = None) -> None:
+    """Remove the ephemeral public route only when this lifecycle still owns its port."""
+    if expected_port is None:
+        return
+    vestad_port = os.environ.get("VESTAD_PORT")
+    agent = os.environ.get("AGENT_NAME")
+    token = os.environ.get("AGENT_TOKEN")
+    if not vestad_port or not agent or not token:
+        return
+    endpoint = f"https://localhost:{vestad_port}/agents/{agent}/services/{HANDOVER_SERVICE}"
+    if expected_port is not None:
+        # A distinct route fails closed on older vestad versions. Putting the
+        # ownership check in a query would let an older handler ignore it and
+        # delete a newer registration unconditionally.
+        endpoint += f"/registrations/{expected_port}"
+    try:
+        result = subprocess.run(
+            [
+                "curl",
+                "-fsk",
+                "-X",
+                "DELETE",
+                endpoint,
+                "-H",
+                f"X-Agent-Token: {token}",
+            ],
+            capture_output=True,
+            timeout=SERVICE_UNREGISTER_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"could not unregister browser handover route: {exc}") from exc
+    if result.returncode != 0:
+        raise RuntimeError("vestad refused to unregister the browser handover route")
 
 
 def render_page() -> str:
@@ -232,6 +287,29 @@ def _port_serving(port: int) -> bool:
     with socket.socket() as probe:
         probe.settimeout(0.2)
         return probe.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _process_listens_on(pid: int, port: int) -> bool:
+    """Whether this exact child owns a TCP LISTEN socket on `port`."""
+    inodes: set[str] = set()
+    for table_name in ("tcp", "tcp6"):
+        try:
+            lines = (PROC / "net" / table_name).read_text().splitlines()[1:]
+        except OSError:
+            continue
+        for line in lines:
+            fields = line.split()
+            if len(fields) > 9 and fields[3] == "0A":
+                local_port = int(fields[1].rsplit(":", 1)[1], 16)
+                if local_port == port:
+                    inodes.add(fields[9])
+    if not inodes:
+        return False
+    try:
+        links = (PROC / str(pid) / "fd").iterdir()
+        return any(path.readlink().as_posix() in {f"socket:[{inode}]" for inode in inodes} for path in links)
+    except OSError:
+        return False
 
 
 def _start_x11vnc(*, display: str, vnc_port: int, log: tp.TextIO) -> subprocess.Popen[bytes]:
@@ -270,21 +348,61 @@ def _x11vnc_settles(proc: subprocess.Popen[bytes], vnc_port: int) -> bool:
     while time.monotonic() < deadline:
         if proc.poll() is not None:
             return False
-        if _port_serving(vnc_port):
+        if _process_listens_on(proc.pid, vnc_port):
             time.sleep(X11VNC_SETTLE_S)
-            return proc.poll() is None
+            return proc.poll() is None and _process_listens_on(proc.pid, vnc_port)
         time.sleep(READY_POLL_S)
     return False
 
 
-def start(*, url: str | None, port: int | None, user_data_dir: str | None) -> dict[str, object]:
+def _start_websockify(*, webroot: Path, web_port: int, vnc_port: int, log: tp.TextIO) -> subprocess.Popen[bytes]:
+    proc = subprocess.Popen(
+        ["websockify", "--web", str(webroot), str(web_port), f"localhost:{vnc_port}"],
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    deadline = time.monotonic() + WEBSOCKIFY_READY_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise HandoverPortError(f"websockify could not bind handover port {web_port}")
+        if _process_listens_on(proc.pid, web_port):
+            time.sleep(WEBSOCKIFY_SETTLE_S)
+            if proc.poll() is None and _process_listens_on(proc.pid, web_port):
+                return proc
+            raise HandoverPortError(f"websockify lost the race for handover port {web_port}")
+        time.sleep(READY_POLL_S)
+    proc.terminate()
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        proc.wait(timeout=X11VNC_TERMINATE_TIMEOUT_S)
+    raise HandoverPortError(f"websockify did not serve handover port {web_port}")
+
+
+def start(
+    *,
+    url: str | None,
+    port: int | None,
+    user_data_dir: str | None,
+    _claim_attempt: int = 0,
+    _lock_held: bool = False,
+) -> dict[str, object]:
     """Bring up headed Camoufox + a window manager + x11vnc + websockify serving the branded page.
 
     Idempotent-ish: stops any prior handover first so ports and pids don't collide. Returns a
     ready-to-send `user_url` (public tunnel link on a box, localhost off one).
     """
+    if not _lock_held:
+        with _handover_lock():
+            return start(
+                url=url,
+                port=port,
+                user_data_dir=user_data_dir,
+                _claim_attempt=_claim_attempt,
+                _lock_held=True,
+            )
+
     _require_binaries()
-    stop()
+    stop(_lock_held=True)
 
     # Resolve the port + the link to send the user. An explicit --port wins; otherwise, on a box,
     # register a public vestad service and use its port so the returned URL is the public tunnel
@@ -292,6 +410,12 @@ def start(*, url: str | None, port: int | None, user_data_dir: str | None) -> di
     service = _register_public_service() if port is None else None
     if service is not None:
         web_port, user_url = service
+        try:
+            _session_file("registration-port").write_text(str(web_port))
+        except Exception:
+            with contextlib.suppress(RuntimeError):
+                _unregister_public_service(web_port)
+            raise
     else:
         web_port = port or _free_port(WEB_PORT_START)
         user_url = f"http://localhost:{web_port}/handover.html"
@@ -304,10 +428,14 @@ def start(*, url: str | None, port: int | None, user_data_dir: str | None) -> di
     # Recorded before the launch that writes the headed prefs into it, so stop() can always find
     # the profile to strip them back out of, including when that launch is what failed.
     profile = Path(user_data_dir) if user_data_dir else launcher.PROFILE_ROOT
-    _session_file("profile").write_text(str(profile))
-    admin.stop_browser("default")
-    for lock in ("lock", ".parentlock"):
-        (profile / lock).unlink(missing_ok=True)
+    try:
+        _session_file("profile").write_text(str(profile))
+        admin.stop_browser("default")
+        for lock in ("lock", ".parentlock"):
+            (profile / lock).unlink(missing_ok=True)
+    except Exception:
+        stop(_suppress_unregister_errors=True, _lock_held=True)
+        raise
 
     # Handover owns a dedicated Xvfb display, never the ambient one: x11vnc can grab a fresh Xvfb
     # but not a live desktop seat (a real :0 fails X_GetImage BadMatch, hanging noVNC), and a
@@ -342,11 +470,11 @@ def start(*, url: str | None, port: int | None, user_data_dir: str | None) -> di
         with _session_file("handover-log").open("w") as log:
             x11vnc = _start_x11vnc(display=display, vnc_port=vnc_port, log=log)
             _session_file("x11vnc-pid").write_text(str(x11vnc.pid))
-            websockify = subprocess.Popen(
-                ["websockify", "--web", str(webroot), str(web_port), f"localhost:{vnc_port}"],
-                stdout=log,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
+            websockify = _start_websockify(
+                webroot=webroot,
+                web_port=web_port,
+                vnc_port=vnc_port,
+                log=log,
             )
             _session_file("websockify-pid").write_text(str(websockify.pid))
 
@@ -359,11 +487,18 @@ def start(*, url: str | None, port: int | None, user_data_dir: str | None) -> di
             extra_args=[url] if url else None,
             window_size=(SCREEN_W, SCREEN_H),
         )
-    except Exception:
-        stop()
+        _session_file("web-port").write_text(str(web_port))
+    except Exception as exc:
+        stop(_suppress_unregister_errors=True, _lock_held=True)
+        if isinstance(exc, HandoverPortError) and port is None and _claim_attempt == 0:
+            return start(
+                url=url,
+                port=port,
+                user_data_dir=user_data_dir,
+                _claim_attempt=1,
+                _lock_held=True,
+            )
         raise
-
-    _session_file("web-port").write_text(str(web_port))
 
     return {
         "session": HANDOVER_SESSION,
@@ -377,7 +512,7 @@ def start(*, url: str | None, port: int | None, user_data_dir: str | None) -> di
     }
 
 
-def stop() -> dict[str, object]:
+def stop(*, _suppress_unregister_errors: bool = False, _lock_held: bool = False) -> dict[str, object]:
     """Tear down the handover: websockify, x11vnc, the WM, headed Camoufox, Xvfb, and the web root. Idempotent.
 
     Xvfb goes last: the bridge and the browser are its clients, so dropping the display first would
@@ -385,6 +520,13 @@ def stop() -> dict[str, object]:
     keeps answering on its display number, so `_free_display` skips past it and the next handover
     climbs to the following one until the range runs dry.
     """
+    if not _lock_held:
+        with _handover_lock():
+            return stop(
+                _suppress_unregister_errors=_suppress_unregister_errors,
+                _lock_held=True,
+            )
+
     for suffix in ("websockify-pid", "x11vnc-pid", "openbox-pid"):
         pid = _read_pid(suffix)
         if pid is not None:
@@ -400,10 +542,20 @@ def stop() -> dict[str, object]:
     profile_file = _session_file("profile")
     if profile_file.exists():
         (Path(profile_file.read_text().strip()) / "user.js").unlink(missing_ok=True)
+    web_port = _read_pid("web-port")
+    registered_port = _read_pid("registration-port") or web_port
     for suffix in ("web-port", "vnc-port", "handover-log", "openbox-rc.xml", "profile"):
         _session_file(suffix).unlink(missing_ok=True)
     if WEBROOT.exists():
         shutil.rmtree(WEBROOT)
+    if _suppress_unregister_errors:
+        try:
+            _unregister_public_service(registered_port)
+        except RuntimeError:
+            return {"stopped": True}
+    else:
+        _unregister_public_service(registered_port)
+    _session_file("registration-port").unlink(missing_ok=True)
     return {"stopped": True}
 
 

--- a/agent/skills/browser/cli/tests/test_handover.py
+++ b/agent/skills/browser/cli/tests/test_handover.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import os
 import socket
 import subprocess
+import threading
 import time
+from types import SimpleNamespace
 
 import pytest
 from vesta_browser import handover
@@ -173,6 +175,30 @@ def test_stop_is_idempotent_without_an_xvfb_pid(monkeypatch):
     assert killed == []
 
 
+def test_stop_keeps_registration_marker_until_cleanup_can_retry(monkeypatch):
+    _record_kills(monkeypatch)
+    marker = handover._session_file("registration-port")
+    marker.write_text("7431")
+    attempts = 0
+
+    def unregister(port):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("vestad unavailable")
+        assert port == 7431
+
+    monkeypatch.setattr(handover, "_unregister_public_service", unregister)
+
+    with pytest.raises(RuntimeError, match="vestad unavailable"):
+        handover.stop()
+    assert marker.read_text() == "7431"
+
+    assert handover.stop() == {"stopped": True}
+    assert not marker.exists()
+    assert attempts == 2
+
+
 # ── liveness ──────────────────────────────────────────────────
 
 
@@ -235,7 +261,7 @@ def _stub_x11vnc(monkeypatch, *, serves_with, dies_when_refused=True):
         return FakeProc(argv)
 
     monkeypatch.setattr(handover.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(handover, "_port_serving", lambda _p: attempts[-1] == serves_with)
+    monkeypatch.setattr(handover, "_process_listens_on", lambda _pid, _port: attempts[-1] == serves_with)
     monkeypatch.setattr(handover, "X11VNC_SETTLE_S", 0)
     return attempts
 
@@ -302,7 +328,7 @@ def test_x11vnc_that_binds_then_dies_is_not_taken_as_ready(monkeypatch, isolated
         return BindsThenDies()
 
     monkeypatch.setattr(handover.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(handover, "_port_serving", lambda _p: True)
+    monkeypatch.setattr(handover, "_process_listens_on", lambda _pid, _port: True)
     monkeypatch.setattr(handover, "X11VNC_SETTLE_S", 0)
     monkeypatch.setattr(handover, "X11VNC_READY_TIMEOUT_S", 0.2)
     with (isolated / "log").open("w") as log, pytest.raises(RuntimeError, match="never served port 5900"):
@@ -346,12 +372,47 @@ def test_register_public_service_returns_port_and_public_url(monkeypatch, tmp_pa
     monkeypatch.setenv("VESTAD_TUNNEL", "https://box.vesta.run/")
     monkeypatch.setenv("AGENT_NAME", "ada")
     script = tmp_path / "register-service"
-    script.write_text("#!/bin/sh\necho 7431\n")
+    args_file = tmp_path / "register-service.args"
+    script.write_text('#!/bin/sh\nprintf \'%s\\n\' "$@" > "$0.args"\necho 7431\n')
     script.chmod(0o755)
     monkeypatch.setattr(handover, "REGISTER_SERVICE", script)
     port, url = handover._register_public_service()
     assert port == 7431
     assert url == "https://box.vesta.run/agents/ada/browser/handover.html"
+    assert args_file.read_text().splitlines() == ["browser", "--public", "--claim"]
+
+
+def test_unregister_public_service_removes_the_ephemeral_route(monkeypatch):
+    monkeypatch.setenv("VESTAD_PORT", "8443")
+    monkeypatch.setenv("AGENT_NAME", "ada")
+    monkeypatch.setenv("AGENT_TOKEN", "secret")
+    calls = []
+    monkeypatch.setattr(
+        handover.subprocess,
+        "run",
+        lambda args, **kwargs: calls.append((args, kwargs)) or subprocess.CompletedProcess(args, 0),
+    )
+
+    handover._unregister_public_service(7431)
+
+    args, kwargs = calls[0]
+    assert args[:4] == ["curl", "-fsk", "-X", "DELETE"]
+    assert args[4] == "https://localhost:8443/agents/ada/services/browser/registrations/7431"
+    assert kwargs["timeout"] == handover.SERVICE_UNREGISTER_TIMEOUT_S
+
+
+def test_unregister_public_service_surfaces_a_failed_delete(monkeypatch):
+    monkeypatch.setenv("VESTAD_PORT", "8443")
+    monkeypatch.setenv("AGENT_NAME", "ada")
+    monkeypatch.setenv("AGENT_TOKEN", "secret")
+    monkeypatch.setattr(
+        handover.subprocess,
+        "run",
+        lambda args, **kwargs: subprocess.CompletedProcess(args, 22),
+    )
+
+    with pytest.raises(RuntimeError, match="refused to unregister"):
+        handover._unregister_public_service(7431)
 
 
 # ── ports + liveness ──────────────────────────────────────────
@@ -404,6 +465,269 @@ def test_claim_own_display_gives_up_after_the_attempt_cap(monkeypatch):
         handover._claim_own_display()
 
 
+def test_start_websockify_rejects_a_foreign_listener(monkeypatch, tmp_path):
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    port = listener.getsockname()[1]
+
+    class LiveProcess:
+        pid = 123
+        terminated = False
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def wait(self, timeout=None):
+            return 0
+
+    process = LiveProcess()
+    monkeypatch.setattr(handover.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(handover, "WEBSOCKIFY_READY_TIMEOUT_S", 0.02)
+    monkeypatch.setattr(handover, "READY_POLL_S", 0.001)
+    monkeypatch.setattr(handover, "_process_listens_on", lambda _pid, _port: False)
+    try:
+        with (
+            (tmp_path / "log").open("w") as log,
+            pytest.raises(handover.HandoverPortError, match="did not serve"),
+        ):
+            handover._start_websockify(webroot=tmp_path, web_port=port, vnc_port=5900, log=log)
+    finally:
+        listener.close()
+    assert process.terminated is True
+
+
+def test_process_listens_on_matches_the_socket_owner():
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    try:
+        port = listener.getsockname()[1]
+        assert handover._process_listens_on(os.getpid(), port) is True
+        assert handover._process_listens_on(2**31 - 1, port) is False
+    finally:
+        listener.close()
+
+
+def test_start_reclaims_once_after_losing_the_registered_port(monkeypatch, isolated):
+    registrations = iter(
+        [
+            (7431, "https://box.vesta.run/agents/ada/browser/handover.html"),
+            (7432, "https://box.vesta.run/agents/ada/browser/handover.html"),
+        ]
+    )
+    websockify_ports: list[int] = []
+    stops: list[tuple[bool, int | None, int | None]] = []
+
+    monkeypatch.setattr(handover, "_require_binaries", lambda: None)
+    handover._session_file("web-port").unlink(missing_ok=True)
+    handover._session_file("registration-port").unlink(missing_ok=True)
+
+    def stop(*, _suppress_unregister_errors=False, _lock_held=False):
+        stops.append(
+            (
+                _suppress_unregister_errors,
+                handover._read_pid("registration-port"),
+                handover._read_pid("web-port"),
+            )
+        )
+        handover._session_file("web-port").unlink(missing_ok=True)
+        handover._session_file("registration-port").unlink(missing_ok=True)
+        return {"stopped": True}
+
+    monkeypatch.setattr(handover, "stop", stop)
+    monkeypatch.setattr(handover, "_register_public_service", lambda: next(registrations))
+    monkeypatch.setattr(handover, "_claim_own_display", lambda: (":99", 1001))
+    monkeypatch.setattr(handover, "_free_port", lambda _start: 5901)
+    monkeypatch.setattr(handover, "_build_webroot", lambda: isolated)
+    monkeypatch.setattr(handover.admin, "stop_browser", lambda _name: None)
+    monkeypatch.setattr(
+        handover.admin,
+        "launch_browser",
+        lambda *args, **kwargs: SimpleNamespace(ws_url="ws://browser"),
+    )
+    monkeypatch.setattr(
+        handover.subprocess,
+        "Popen",
+        lambda *args, **kwargs: SimpleNamespace(pid=1002),
+    )
+    monkeypatch.setattr(
+        handover,
+        "_start_x11vnc",
+        lambda **kwargs: SimpleNamespace(pid=1003),
+    )
+
+    def start_websockify(*, webroot, web_port, vnc_port, log):
+        websockify_ports.append(web_port)
+        if len(websockify_ports) == 1:
+            raise handover.HandoverPortError("lost the first claim")
+        return SimpleNamespace(pid=1004)
+
+    monkeypatch.setattr(handover, "_start_websockify", start_websockify)
+
+    result = handover.start(url=None, port=None, user_data_dir=str(isolated / "profile"))
+
+    assert websockify_ports == [7431, 7432]
+    assert stops == [
+        (False, None, None),
+        (True, 7431, None),
+        (False, None, None),
+    ]
+    assert result["web_port"] == 7432
+    assert result["user_url"] == "https://box.vesta.run/agents/ada/browser/handover.html"
+
+
+def test_start_cleans_registration_when_profile_setup_fails(monkeypatch, isolated):
+    cleaned: list[int] = []
+    monkeypatch.setattr(handover, "_require_binaries", lambda: None)
+    monkeypatch.setattr(
+        handover,
+        "_register_public_service",
+        lambda: (7431, "https://box.vesta.run/agents/ada/browser/handover.html"),
+    )
+    monkeypatch.setattr(
+        handover,
+        "_unregister_public_service",
+        lambda port: cleaned.append(port) if port is not None else None,
+    )
+
+    def stop_browser(name):
+        if name == "default":
+            raise RuntimeError("profile shutdown failed")
+
+    monkeypatch.setattr(handover.admin, "stop_browser", stop_browser)
+
+    with pytest.raises(RuntimeError, match="profile shutdown failed"):
+        handover.start(url=None, port=None, user_data_dir=str(isolated / "profile"))
+
+    assert cleaned == [7431]
+    assert not handover._session_file("registration-port").exists()
+
+
+def test_start_cleans_in_memory_claim_when_registration_marker_write_fails(monkeypatch):
+    original_session_file = handover._session_file
+    cleaned: list[int] = []
+
+    class FailingMarker:
+        def read_text(self):
+            raise FileNotFoundError
+
+        def write_text(self, _value):
+            raise OSError("marker disk full")
+
+        def unlink(self, *, missing_ok=False):
+            return None
+
+    monkeypatch.setattr(
+        handover,
+        "_session_file",
+        lambda suffix: FailingMarker() if suffix == "registration-port" else original_session_file(suffix),
+    )
+    monkeypatch.setattr(handover, "_require_binaries", lambda: None)
+    monkeypatch.setattr(handover.admin, "stop_browser", lambda _name: None)
+    monkeypatch.setattr(
+        handover,
+        "_register_public_service",
+        lambda: (7431, "https://box.vesta.run/agents/ada/browser/handover.html"),
+    )
+    monkeypatch.setattr(
+        handover,
+        "_unregister_public_service",
+        lambda port: cleaned.append(port) if port is not None else None,
+    )
+
+    with pytest.raises(OSError, match="marker disk full"):
+        handover.start(url=None, port=None, user_data_dir=None)
+
+    assert cleaned == [7431]
+
+
+def test_start_cleans_everything_when_final_readiness_marker_write_fails(monkeypatch, isolated):
+    original_session_file = handover._session_file
+    cleaned: list[int] = []
+    killed: list[int] = []
+
+    class FailingMarker:
+        def read_text(self):
+            raise FileNotFoundError
+
+        def write_text(self, _value):
+            raise OSError("readiness marker disk full")
+
+        def unlink(self, *, missing_ok=False):
+            return None
+
+    monkeypatch.setattr(
+        handover,
+        "_session_file",
+        lambda suffix: FailingMarker() if suffix == "web-port" else original_session_file(suffix),
+    )
+    monkeypatch.setattr(handover, "_require_binaries", lambda: None)
+    monkeypatch.setattr(
+        handover,
+        "_register_public_service",
+        lambda: (7431, "https://box.vesta.run/agents/ada/browser/handover.html"),
+    )
+    monkeypatch.setattr(handover, "_claim_own_display", lambda: (":99", 1001))
+    monkeypatch.setattr(handover, "_free_port", lambda _start: 5901)
+    monkeypatch.setattr(handover, "_build_webroot", lambda: isolated)
+    monkeypatch.setattr(handover.admin, "stop_browser", lambda _name: None)
+    monkeypatch.setattr(handover.admin, "_terminate_pid", killed.append)
+    monkeypatch.setattr(
+        handover.admin,
+        "launch_browser",
+        lambda *args, **kwargs: SimpleNamespace(ws_url="ws://browser"),
+    )
+    monkeypatch.setattr(
+        handover.subprocess,
+        "Popen",
+        lambda *args, **kwargs: SimpleNamespace(pid=1002),
+    )
+    monkeypatch.setattr(
+        handover,
+        "_start_x11vnc",
+        lambda **kwargs: SimpleNamespace(pid=1003),
+    )
+    monkeypatch.setattr(
+        handover,
+        "_start_websockify",
+        lambda **kwargs: SimpleNamespace(pid=1004),
+    )
+    monkeypatch.setattr(
+        handover,
+        "_unregister_public_service",
+        lambda port: cleaned.append(port) if port is not None else None,
+    )
+
+    with pytest.raises(OSError, match="readiness marker disk full"):
+        handover.start(url=None, port=None, user_data_dir=str(isolated / "profile"))
+
+    assert cleaned == [7431]
+    assert killed == [1004, 1003, 1002, 1001]
+    assert not handover._session_file("registration-port").exists()
+
+
+def test_handover_lock_serializes_overlapping_lifecycles():
+    attempted = threading.Event()
+    acquired = threading.Event()
+
+    def contender():
+        attempted.set()
+        with handover._handover_lock():
+            acquired.set()
+
+    with handover._handover_lock():
+        thread = threading.Thread(target=contender)
+        thread.start()
+        assert attempted.wait(timeout=1)
+        assert not acquired.wait(timeout=0.05)
+    thread.join(timeout=1)
+    assert acquired.is_set()
+
+
 def test_alive_false_for_none_and_dead_pid():
     assert handover._alive(None) is False
     # PID 2**31-1 is not a running process on any sane system.
@@ -437,6 +761,21 @@ def test_status_all_false_when_idle():
     assert st["websockify"] is False
     assert st["web_port"] is None
     assert st["page"] is None
+
+
+def test_status_does_not_report_a_claim_before_our_process_serves():
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    try:
+        handover._session_file("registration-port").write_text(str(listener.getsockname()[1]))
+        st = handover.status()
+        assert st["serving"] is False
+        assert st["web_port"] is None
+        assert st["page"] is None
+    finally:
+        listener.close()
+        handover._session_file("registration-port").unlink(missing_ok=True)
 
 
 # ── display selection: liveness, not file existence ───────────

--- a/agent/skills/dashboard/scripts/serve
+++ b/agent/skills/dashboard/scripts/serve
@@ -11,5 +11,5 @@ set -e
 cd ~/agent/skills/dashboard/app
 [ -d node_modules ] || npm install
 [ -d dist ] || npx vite build
-PORT=$(~/agent/skills/vestad/scripts/register-service dashboard --public)
+PORT=$(~/agent/skills/vestad/scripts/register-service dashboard --public --claim)
 exec npx vite preview --port "$PORT" --host 0.0.0.0

--- a/agent/skills/file-host/SKILL.md
+++ b/agent/skills/file-host/SKILL.md
@@ -15,10 +15,11 @@ The server binds to localhost, so it needs a public route.
 # 1. drop the file(s) into the served directory
 mkdir -p ~/.file-host && cp /path/to/report.pdf ~/.file-host/
 
-# 2. register a public service (idempotent: returns the same port each time)
-PORT=$(~/agent/skills/vestad/scripts/register-service file-host --public)
+# 2. stop any prior server, then claim a bindable public port
+screen -S file-host -X quit >/dev/null 2>&1 || true
+PORT=$(~/agent/skills/vestad/scripts/register-service file-host --public --claim)
 
-# 3. serve it (run in a screen so it persists)
+# 3. serve it in a screen so it persists
 screen -dmS file-host python3 ~/agent/skills/file-host/serve.py --dir ~/.file-host --port "$PORT"
 ```
 

--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -70,7 +70,7 @@ uv tool install --editable ~/agent/skills/tasks/cli
 
 One daemon handles everything: task due-date monitoring, reminder scheduling, and the daily digest. `--notifications-dir` defaults to `~/agent/notifications`; pass it only to override. Register with vestad to get a port (see [vestad](../vestad/SKILL.md)) and add this startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
 ```
-running tasks || { PORT=$(~/agent/skills/vestad/scripts/register-service tasks) && screen -dmS tasks tasks serve --port $PORT; sleep 1; }
+running tasks || { PORT=$(~/agent/skills/vestad/scripts/register-service tasks --claim) && screen -dmS tasks tasks serve --port $PORT; sleep 1; }
 ```
 
 ### Reminder Patterns

--- a/agent/skills/vestad/SKILL.md
+++ b/agent/skills/vestad/SKILL.md
@@ -40,15 +40,20 @@ A background process that needs no inbound port is just a daemon: it does not re
 it only goes in the restart skill's `## Daemons` section.
 
 Skills that run a service register it with vestad to get a port, then start it. The
-`register-service` helper does the curl and prints the port (idempotent: same port per name,
-and re-registering without `--public` keeps the service's current exposure rather than
-revoking it, so a re-register that only wants the port is safe):
+`register-service` helper does the curl and prints the port. Use `--claim` when the
+process is about to bind that port. It keeps a free cached port, but replaces one
+occupied by another host-network process. Omit `--claim` only when resolving an
+already-running service, which preserves its live port. Re-registering without
+`--public` keeps the service's current exposure rather than revoking it.
+The claim is a bindability check, not a port lease: another process can still
+win the bind after vestad replies. Verify that the process you started owns the
+listener. If its bind fails with address in use, repeat the claim and start.
 
 ```bash
 # token-only service
-PORT=$(~/agent/skills/vestad/scripts/register-service tasks)
+PORT=$(~/agent/skills/vestad/scripts/register-service tasks --claim)
 # public service
-PORT=$(~/agent/skills/vestad/scripts/register-service dashboard --public)
+PORT=$(~/agent/skills/vestad/scripts/register-service dashboard --public --claim)
 ```
 
 So the service comes back after a container restart, add its startup command to the
@@ -56,7 +61,7 @@ So the service comes back after a container restart, add its startup command to 
 single line that re-registers and starts, e.g.:
 
 ```bash
-running tasks || { PORT=$(~/agent/skills/vestad/scripts/register-service tasks) && screen -dmS tasks tasks serve --notifications-dir ~/agent/notifications --port $PORT; sleep 1; }
+running tasks || { PORT=$(~/agent/skills/vestad/scripts/register-service tasks --claim) && screen -dmS tasks tasks serve --notifications-dir ~/agent/notifications --port $PORT; sleep 1; }
 ```
 
 vestad's API may still be coming up when the daemon block runs, so `register-service` polls

--- a/agent/skills/vestad/scripts/register-service
+++ b/agent/skills/vestad/scripts/register-service
@@ -16,16 +16,32 @@ set -euo pipefail
 # seconds (default 30). On timeout, exit non-zero with a stderr message and no
 # stdout, so `PORT=$(register-service ...) && start` short-circuits cleanly.
 #
-# Usage: register-service <name> [--public]
-#   PORT=$(~/agent/skills/vestad/scripts/register-service tasks)
-#   PORT=$(~/agent/skills/vestad/scripts/register-service dashboard --public)
+# Pass --claim when the caller is about to bind the returned port. This asks
+# vestad to replace a cached port if another host-network process has claimed
+# it. Omit --claim when resolving an already-running service.
+#
+# Usage: register-service <name> [--public] [--claim]
+#   PORT=$(~/agent/skills/vestad/scripts/register-service tasks --claim)
+#   PORT=$(~/agent/skills/vestad/scripts/register-service dashboard --public --claim)
 
-NAME="${1:?Usage: register-service <name> [--public]}"
-if [ "${2:-}" = "--public" ]; then
-    REQUEST="{\"name\":\"$NAME\",\"public\":true}"
-else
-    REQUEST="{\"name\":\"$NAME\"}"
-fi
+NAME="${1:?Usage: register-service <name> [--public] [--claim]}"
+shift
+PUBLIC=false
+CLAIM=false
+for ARG in "$@"; do
+    case "$ARG" in
+        --public) PUBLIC=true ;;
+        --claim) CLAIM=true ;;
+        *)
+            echo "Usage: register-service <name> [--public] [--claim]" >&2
+            exit 2
+            ;;
+    esac
+done
+REQUEST="{\"name\":\"$NAME\""
+[ "$PUBLIC" = true ] && REQUEST="$REQUEST,\"public\":true"
+[ "$CLAIM" = true ] && REQUEST="$REQUEST,\"require_bindable\":true"
+REQUEST="$REQUEST}"
 
 WAIT_SECONDS="${REGISTER_SERVICE_WAIT:-30}"
 URL="https://localhost:$VESTAD_PORT/agents/$AGENT_NAME/services"

--- a/agent/skills/voice/cli/src/voice/daemon.py
+++ b/agent/skills/voice/cli/src/voice/daemon.py
@@ -1,9 +1,9 @@
 """Lifecycle for the voice-server screen daemon.
 
-`start` owns the register-service call (idempotent: vestad returns the same port for a
-given name on every call), so the agent runs one command instead of stitching together
-register-service + screen by hand. Liveness is a TCP connect to the registered port;
-voice-server has no admin socket of its own.
+`start` owns the register-service call, so the agent runs one command instead of
+stitching together register-service + screen by hand. A live screen session establishes
+ownership and a TCP connect establishes readiness; an unrelated listener is never
+treated as voice-server.
 """
 
 import os
@@ -64,8 +64,11 @@ def _screen_session_live(name: str) -> bool:
     return screen_output_has_live_session(result.stdout, name)
 
 
-def resolve_port() -> int:
-    result = subprocess.run([str(REGISTER_SERVICE), "voice"], capture_output=True, text=True, timeout=35, check=False)
+def resolve_port(*, claim: bool = False) -> int:
+    command = [str(REGISTER_SERVICE), "voice"]
+    if claim:
+        command.append("--claim")
+    result = subprocess.run(command, capture_output=True, text=True, timeout=35, check=False)
     if result.returncode != 0 or not result.stdout.strip():
         raise DaemonError(f"register-service failed: {result.stderr.strip()}")
     return int(result.stdout.strip())
@@ -94,9 +97,13 @@ def _auth_status() -> dict[str, AuthEntry | None]:
 
 
 def start() -> LifecycleResult:
-    port = resolve_port()
-    if port_alive(port):
-        return {"status": "already_running", "session": SESSION_NAME, "port": port}
+    if _screen_session_live(SESSION_NAME):
+        port = resolve_port()
+        if port_alive(port):
+            return {"status": "already_running", "session": SESSION_NAME, "port": port}
+        raise DaemonError(f"voice screen session is live but registered port {port} is not answering; inspect with 'screen -r {SESSION_NAME}'")
+
+    port = resolve_port(claim=True)
 
     binary = shutil.which("voice-server")
     if binary is None:
@@ -120,16 +127,16 @@ def start() -> LifecycleResult:
 
 def stop() -> LifecycleResult:
     port = resolve_port()
-    if not port_alive(port):
+    if not _screen_session_live(SESSION_NAME):
         return {"status": "already_stopped", "session": SESSION_NAME, "port": port}
 
     subprocess.run(["screen", "-S", SESSION_NAME, "-X", "quit"], check=False)
     deadline = time.monotonic() + STOP_TIMEOUT_S
     while time.monotonic() < deadline:
-        if not port_alive(port):
+        if not _screen_session_live(SESSION_NAME):
             return {"status": "stopped", "session": SESSION_NAME, "port": port}
         time.sleep(POLL_INTERVAL_S)
-    raise DaemonError(f"voice-server still answering on port {port} after screen quit; inspect with 'screen -r {SESSION_NAME}'")
+    raise DaemonError(f"voice screen session did not stop; inspect with 'screen -r {SESSION_NAME}'")
 
 
 def restart() -> LifecycleResult:
@@ -142,7 +149,7 @@ def restart() -> LifecycleResult:
 def status() -> StatusResult:
     port = resolve_port()
     return {
-        "running": port_alive(port),
+        "running": _screen_session_live(SESSION_NAME) and port_alive(port),
         "session": SESSION_NAME,
         "port": port,
         "auth": _auth_status(),

--- a/agent/skills/voice/cli/tests/test_daemon.py
+++ b/agent/skills/voice/cli/tests/test_daemon.py
@@ -41,17 +41,41 @@ def test_auth_status_reports_provider_and_enabled(tmp_path: pl.Path, monkeypatch
 
 
 def test_start_is_idempotent_when_port_already_alive(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(daemon, "resolve_port", lambda: 4242)
+    claims: list[bool] = []
+    monkeypatch.setattr(daemon, "resolve_port", lambda *, claim=False: claims.append(claim) or 4242)
+    monkeypatch.setattr(daemon, "_screen_session_live", lambda name: True)
     monkeypatch.setattr(daemon, "port_alive", lambda port: True)
 
     result = daemon.start()
 
     assert result == {"status": "already_running", "session": "voice", "port": 4242}
+    assert claims == [False]
+
+
+def test_start_claims_a_new_port_when_cached_port_has_an_unrelated_listener(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    claims: list[bool] = []
+    monkeypatch.setattr(daemon, "resolve_port", lambda *, claim=False: claims.append(claim) or 4242)
+    monkeypatch.setattr(daemon, "_screen_session_live", lambda name: False)
+    monkeypatch.setattr(daemon, "port_alive", lambda port: True)
+    monkeypatch.setattr(daemon.shutil, "which", lambda name: "/usr/bin/voice-server")
+    monkeypatch.setattr(
+        daemon.subprocess,
+        "run",
+        lambda *args, **kwargs: daemon.subprocess.CompletedProcess(args[0], 0, "", ""),
+    )
+
+    result = daemon.start()
+
+    assert result == {"status": "started", "session": "voice", "port": 4242}
+    assert claims == [True]
 
 
 def test_stop_is_idempotent_when_already_stopped(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(daemon, "resolve_port", lambda: 4242)
-    monkeypatch.setattr(daemon, "port_alive", lambda port: False)
+    monkeypatch.setattr(daemon, "resolve_port", lambda *, claim=False: 4242)
+    monkeypatch.setattr(daemon, "_screen_session_live", lambda name: False)
+    monkeypatch.setattr(daemon, "port_alive", lambda port: True)
 
     result = daemon.stop()
 
@@ -60,7 +84,8 @@ def test_stop_is_idempotent_when_already_stopped(monkeypatch: pytest.MonkeyPatch
 
 def test_status_reports_running_port_and_auth(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(daemon, "data_dir", lambda: tmp_path)
-    monkeypatch.setattr(daemon, "resolve_port", lambda: 4242)
+    monkeypatch.setattr(daemon, "resolve_port", lambda *, claim=False: 4242)
+    monkeypatch.setattr(daemon, "_screen_session_live", lambda name: True)
     monkeypatch.setattr(daemon, "port_alive", lambda port: True)
     vc.set_key(tmp_path, "stt", "deepgram", "k")
 
@@ -72,3 +97,12 @@ def test_status_reports_running_port_and_auth(tmp_path: pl.Path, monkeypatch: py
         "port": 4242,
         "auth": {"stt": {"provider": "deepgram", "enabled": True}, "tts": None},
     }
+
+
+def test_status_does_not_adopt_an_unrelated_listener(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(daemon, "data_dir", lambda: tmp_path)
+    monkeypatch.setattr(daemon, "resolve_port", lambda *, claim=False: 4242)
+    monkeypatch.setattr(daemon, "_screen_session_live", lambda name: False)
+    monkeypatch.setattr(daemon, "port_alive", lambda port: True)
+
+    assert daemon.status()["running"] is False

--- a/agent/tests/test_agentmail_setup.py
+++ b/agent/tests/test_agentmail_setup.py
@@ -1,0 +1,12 @@
+from agentmail_bridge.setup import _print_summary
+
+
+def test_setup_summary_claims_a_bindable_public_port(capsys) -> None:
+    _print_summary(
+        {"email_address": "ada@example.com", "inbox_id": "inbox_1"},
+        "https://example.test/webhook",
+    )
+
+    output = capsys.readouterr().out
+    assert "register-service agentmail --public --claim" in output
+    assert "curl -sk -X POST" not in output

--- a/agent/tests/test_register_service.py
+++ b/agent/tests/test_register_service.py
@@ -5,11 +5,13 @@ message, no Python traceback) instead of emitting an empty port that launches a
 portless daemon (issue #960)."""
 
 import http.server
+import json
 import pathlib as pl
 import socket
 import ssl
 import subprocess
 import threading
+from typing import ClassVar
 
 REPO_ROOT = pl.Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "agent/skills/vestad/scripts/register-service"
@@ -47,7 +49,7 @@ def _self_signed(tmp_path):
     return cert, key
 
 
-def _run(port, tmp_path, wait="2"):
+def _run(port, tmp_path, wait="2", *flags):
     env = {
         "PATH": "/usr/bin:/bin",
         "VESTAD_PORT": str(port),
@@ -56,15 +58,23 @@ def _run(port, tmp_path, wait="2"):
         "REGISTER_SERVICE_WAIT": wait,
         "HOME": str(tmp_path),
     }
-    return subprocess.run(["bash", str(SCRIPT), "tasks"], env=env, capture_output=True, text=True, timeout=30, check=False)
+    return subprocess.run(
+        ["bash", str(SCRIPT), "tasks", *flags],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
 
 
 class _PortHandler(http.server.BaseHTTPRequestHandler):
     port_value = 45321
+    request_body: ClassVar[dict] = {}
 
     def do_POST(self):
         length = int(self.headers["Content-Length"])
-        self.rfile.read(length)
+        type(self).request_body = json.loads(self.rfile.read(length))
         body = f'{{"port":{self.port_value}}}'.encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
@@ -96,6 +106,28 @@ def test_prints_port_when_vestad_answers(tmp_path):
         server.shutdown()
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "45321"
+
+
+def test_claim_requests_a_bindable_port(tmp_path):
+    cert, key = _self_signed(tmp_path)
+    port = _free_port()
+    server = _serve_https(port, cert, key)
+    try:
+        result = _run(port, tmp_path, "2", "--public", "--claim")
+    finally:
+        server.shutdown()
+    assert result.returncode == 0, result.stderr
+    assert _PortHandler.request_body == {
+        "name": "tasks",
+        "public": True,
+        "require_bindable": True,
+    }
+
+
+def test_rejects_unknown_flags_without_contacting_vestad(tmp_path):
+    result = _run(_free_port(), tmp_path, "1", "--pubic")
+    assert result.returncode == 2
+    assert "Usage:" in result.stderr
 
 
 def test_fails_cleanly_when_vestad_unreachable(tmp_path):

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -19,8 +19,8 @@ use crate::settings::{
 };
 use crate::state::{err_response, map_docker_err, ok_json, AppState, SharedState};
 use crate::{
-    agent_provider, agent_proxy, agent_status, auth, backup, docker, mobile_app,
-    self_update, systemd, update_check, update_window,
+    agent_provider, agent_proxy, agent_status, auth, backup, docker, mobile_app, self_update,
+    systemd, update_check, update_window,
 };
 
 const GATEWAY_RESTART_DELAY_MS: u64 = 200;
@@ -498,7 +498,10 @@ async fn wait_for_agent_listed(state: &SharedState, name: &str) {
         {
             return;
         }
-        if tokio::time::timeout_at(deadline, agents_rx.changed()).await.is_err() {
+        if tokio::time::timeout_at(deadline, agents_rx.changed())
+            .await
+            .is_err()
+        {
             return;
         }
     }
@@ -1492,6 +1495,12 @@ struct RegisterServiceBody {
     name: String,
     #[serde(default)]
     public: Option<bool>,
+    #[serde(default)]
+    require_bindable: bool,
+}
+
+fn unregister_matches(entry: Option<&ServiceEntry>, expected_port: Option<u16>) -> bool {
+    entry.is_some_and(|entry| expected_port.is_none_or(|port| entry.port == port))
 }
 
 /// Collect all ports in use across all agents in the service registry.
@@ -1536,7 +1545,7 @@ fn allocate_service_port(registry: &HashMap<String, HashMap<String, ServiceEntry
     let used = all_registered_ports(registry);
     let scan = |lo: u16| {
         (lo..=SERVICE_PORT_MAX)
-            .find(|p| !used.contains(p) && std::net::TcpListener::bind(("127.0.0.1", *p)).is_ok())
+            .find(|p| !used.contains(p) && std::net::TcpListener::bind(("0.0.0.0", *p)).is_ok())
     };
     // Preferred: above the ephemeral range, where the port can't be reused as a
     // transient outbound source port between allocation and the caller binding it.
@@ -1552,10 +1561,9 @@ fn allocate_service_port(registry: &HashMap<String, HashMap<String, ServiceEntry
 /// connect succeeds) or genuinely free (bind succeeds). Only a port that is neither,
 /// a `zombie/TIME_WAIT` corpse left by a crashed startup (#371), is dropped so the
 /// caller gets a fresh one. A bind-only probe (#436) treats every listener as a
-/// squatter, but resolvers (whatsapp's `resolveVoiceBaseURL`, voice's own
-/// status/stop/restart) POST here purely to *find* the live port, and reallocating a
-/// resident service's port leaves every later lookup on a fresh, dead port. The one
-/// caller that binds (voice `start`) guards with `port_alive` first.
+/// squatter, but resolvers POST here purely to *find* a live service. Reallocating a
+/// resident service's port leaves later lookups on a fresh, dead port. Callers that
+/// are about to bind use the explicit `require_bindable` claim instead.
 async fn is_cached_port_reusable(port: u16) -> bool {
     use std::net::Ipv4Addr;
     use std::time::Duration;
@@ -1565,10 +1573,25 @@ async fn is_cached_port_reusable(port: u16) -> bool {
     )
     .await
     .is_ok_and(|r| r.is_ok());
-    alive
-        || tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, port))
-            .await
-            .is_ok()
+    alive || is_port_bindable(port).await
+}
+
+/// A service that is about to start needs a port it can bind, while a resolver
+/// looking up an already-running service needs its live listener preserved.
+/// Keeping these intents explicit prevents an unrelated process on a cached
+/// host-network port from being mistaken for the registered service.
+async fn is_port_bindable(port: u16) -> bool {
+    tokio::net::TcpListener::bind((std::net::Ipv4Addr::UNSPECIFIED, port))
+        .await
+        .is_ok()
+}
+
+async fn can_reuse_cached_service_port(port: u16, require_bindable: bool) -> bool {
+    if require_bindable {
+        is_port_bindable(port).await
+    } else {
+        is_cached_port_reusable(port).await
+    }
 }
 
 /// `public` is intrinsic to a registration, like the port: an absent field inherits
@@ -1618,14 +1641,22 @@ async fn user_notification_handler(
     Json(body): Json<UserNotificationBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     if !valid_user_notification_kind(&body.kind) {
-        return Err(err_response(StatusCode::BAD_REQUEST, "unknown user notification kind"));
+        return Err(err_response(
+            StatusCode::BAD_REQUEST,
+            "unknown user notification kind",
+        ));
     }
     let title = truncate_chars(&body.title, USER_NOTIFICATION_TITLE_MAX_CHARS);
     let preview = truncate_chars(&body.body, USER_NOTIFICATION_BODY_MAX_CHARS);
+    state.sync_hub.publish_user_notification(
+        &name,
+        body.kind.clone(),
+        title.clone(),
+        preview.clone(),
+    );
     state
-        .sync_hub
-        .publish_user_notification(&name, body.kind.clone(), title.clone(), preview.clone());
-    state.mobile_app.push_user_notification(&name, &body.kind, &title, &preview);
+        .mobile_app
+        .push_user_notification(&name, &body.kind, &title, &preview);
     Ok(ok_json())
 }
 
@@ -1661,9 +1692,13 @@ async fn register_service_handler(
         .and_then(|services| services.get(&service_name))
         .copied();
     let port = match cached_entry.map(|entry| entry.port) {
-        Some(cached_port) if is_cached_port_reusable(cached_port).await => cached_port,
+        Some(cached_port)
+            if can_reuse_cached_service_port(cached_port, body.require_bindable).await =>
+        {
+            cached_port
+        }
         Some(stale_port) => {
-            tracing::warn!(agent = %name, service = %service_name, stale_port, "cached service port is not bindable, allocating a fresh one");
+            tracing::warn!(agent = %name, service = %service_name, stale_port, require_bindable = body.require_bindable, "cached service port cannot satisfy registration, allocating a fresh one");
             allocate_service_port(&settings.services).ok_or_else(no_free_ports_err)?
         }
         None => allocate_service_port(&settings.services).ok_or_else(no_free_ports_err)?,
@@ -1688,17 +1723,39 @@ async fn unregister_service_handler(
     State(state): State<SharedState>,
     Path((name, service_name)): Path<(String, String)>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    unregister_service_registration(state, name, service_name, None).await
+}
+
+async fn unregister_owned_service_handler(
+    State(state): State<SharedState>,
+    Path((name, service_name, expected_port)): Path<(String, String, u16)>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    unregister_service_registration(state, name, service_name, Some(expected_port)).await
+}
+
+async fn unregister_service_registration(
+    state: SharedState,
+    name: String,
+    service_name: String,
+    expected_port: Option<u16>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     let mut settings = state.settings.write().await;
+    let mut removed = false;
     if let Some(agent_services) = settings.services.get_mut(&name) {
-        agent_services.remove(&service_name);
+        let matches_expected_port =
+            unregister_matches(agent_services.get(&service_name), expected_port);
+        if matches_expected_port {
+            agent_services.remove(&service_name);
+            removed = true;
+        }
         if agent_services.is_empty() {
             settings.services.remove(&name);
         }
     }
     save_settings(&settings);
     state.agent_status_cache.update_services(&settings.services);
-    tracing::info!(agent = %name, service = %service_name, "service unregistered");
-    Ok(ok_json())
+    tracing::info!(agent = %name, service = %service_name, removed, expected_port, "service unregister requested");
+    Ok(Json(serde_json::json!({"ok": true, "removed": removed})))
 }
 
 async fn list_services_handler(
@@ -2442,11 +2499,18 @@ pub fn build_router(state: SharedState) -> Router {
             axum::routing::delete(unregister_service_handler),
         )
         .route(
+            "/agents/{name}/services/{service}/registrations/{port}",
+            axum::routing::delete(unregister_owned_service_handler),
+        )
+        .route(
             "/agents/{name}/services/{service}/invalidate",
             post(agent_status::invalidate_service_handler),
         )
         .route("/agents/{name}/account-token", post(account_token_handler))
-        .route("/agents/{name}/user-notification", post(user_notification_handler))
+        .route(
+            "/agents/{name}/user-notification",
+            post(user_notification_handler),
+        )
         .route(
             "/agents/{name}/workspace.bundle",
             get(workspace_bundle_handler),
@@ -3007,8 +3071,9 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::{
-        allocate_service_port, ensure_not_rebuilding, is_cached_port_reusable, resolve_public,
-        spawn_pipeline_sse, truncate_chars, valid_user_notification_kind, RegisterServiceBody,
+        allocate_service_port, can_reuse_cached_service_port, ensure_not_rebuilding,
+        is_cached_port_reusable, resolve_public, spawn_pipeline_sse, truncate_chars,
+        unregister_matches, valid_user_notification_kind, RegisterServiceBody,
     };
 
     #[test]
@@ -3269,6 +3334,32 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn bindable_claim_rejects_an_unrelated_live_listener() {
+        let listener = tokio::net::TcpListener::bind(("0.0.0.0", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        assert!(
+            can_reuse_cached_service_port(port, false).await,
+            "a resolver must preserve a resident service's live port",
+        );
+        assert!(
+            !can_reuse_cached_service_port(port, true).await,
+            "a service about to bind must reject a port held by another process",
+        );
+    }
+
+    #[tokio::test]
+    async fn bindable_claim_rejects_a_listener_on_another_local_address() {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.2", 0))
+            .await
+            .unwrap();
+        let port = listener.local_addr().unwrap().port();
+        assert!(
+            !can_reuse_cached_service_port(port, true).await,
+            "a wildcard-binding service cannot use a port held on one host interface",
+        );
+    }
+
     /// A port a crashed startup left *held but unserved* (#371, #433), and the corpse
     /// holding it: connect is refused, yet bind still fails. Only a raw socket bound
     /// without `SO_REUSEADDR` and never listened on models that; std/tokio listeners
@@ -3438,6 +3529,29 @@ mod tests {
         assert_eq!(parse(r#"{"name":"dashboard","public":null}"#), None);
         assert_eq!(parse(r#"{"name":"dashboard","public":false}"#), Some(false));
         assert_eq!(parse(r#"{"name":"dashboard","public":true}"#), Some(true));
+    }
+
+    #[test]
+    fn register_body_defaults_bindable_claim_off() {
+        let parse = |body: &str| {
+            serde_json::from_str::<RegisterServiceBody>(body)
+                .expect("a well-formed body should deserialize")
+                .require_bindable
+        };
+        assert!(!parse(r#"{"name":"dashboard"}"#));
+        assert!(parse(r#"{"name":"dashboard","require_bindable":true}"#));
+    }
+
+    #[test]
+    fn conditional_unregister_does_not_remove_a_newer_port() {
+        let entry = crate::settings::ServiceEntry {
+            port: 61013,
+            public: true,
+        };
+        assert!(unregister_matches(Some(&entry), None));
+        assert!(unregister_matches(Some(&entry), Some(61013)));
+        assert!(!unregister_matches(Some(&entry), Some(61012)));
+        assert!(!unregister_matches(None, Some(61013)));
     }
 
     // ── API contract fixtures ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- distinguish service startup claims from lookups, probing wildcard bindability so a cached host-network port owned by an unrelated process is replaced
- make browser handover prove its own child owns the listener, serialize the lifecycle, retry one lost bind claim, and clean routes with fail-closed ownership checks
- migrate every shipped service startup caller to request bindable ports while preserving resolver behavior for already-running services

## Root cause

Each vestad registry cached service ports independently while agents shared the host network. A successful TCP connection was treated as proof that the cached service was resident, even when an unrelated agent owned that port. That could route a browser handover URL to another app and made the WhatsApp QR server fail with address already in use.

## Tests

- ./check.sh guards agent vestad
- subagent review completed with no remaining findings