### PR TITLE
fix(whatsapp): make reconnect flow agent-safe

### DIFF
--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -21,15 +21,18 @@ assistant reads and sends from their personal chats). No separate number yet?
 Read [PHONE_NUMBER.md](PHONE_NUMBER.md) and guide them through getting one.
 
 ```bash
-whatsapp link
+whatsapp connect
 ```
 
 Prints one shareable URL (public tunnel route, no token). The user opens it,
 goes to WhatsApp > Settings > Linked Devices > Link a Device, and scans. The
 page keeps the code current automatically, so there is no 20-second race. The
-command waits and reports success.
+command returns when the live page is ready. Wait for the user to scan, then run
+`whatsapp status` once. Do not run connect again while the page is active.
+If a cached public port belongs to another service, connect asks vestad for a
+bindable replacement automatically. Never choose or register a manual QR port.
 
-Fallback, pairing code (when the user can't scan): `whatsapp link --phone '+E.164'`.
+Fallback, pairing code (when the user can't scan): `whatsapp connect --phone '+E.164'`.
 Confirm the echoed number is EXACTLY the one being linked, then send the user
 the code: WhatsApp > Linked Devices > Link a Device > Link with phone number.
 
@@ -63,7 +66,7 @@ Sending is fine during the sync window; only stop/restart is locked.
 - Daemon won't start: run `whatsapp serve` in the foreground; the compile or
   serve error prints directly.
 - Auth state not linked after a restore/restart: the device session was lost;
-  re-link (with the user's go-ahead) via `whatsapp link`.
+  re-link (with the user's go-ahead) via `whatsapp connect`.
 
 ## How transcription works
 

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -13,9 +13,11 @@ world is four verbs: **connect, status, send, messages** (plus profile and calls
 
 ## The one rule
 
-**If `whatsapp status` ever shows `linked: false`, run `whatsapp connect`.**
-That is the only recovery you ever need. Never re-link, re-pair, or "restart the
-daemon" any other way; connect is idempotent and safe to re-run.
+**If `whatsapp status` shows `linked: false`, run `whatsapp connect`, except when
+it also shows `connecting: true`.** In that case a QR page is already active:
+wait for the user to scan it and do not start another connect. This is the only
+recovery you ever need. Never re-link, re-pair, or "restart the daemon" any other
+way; connect is idempotent outside an active QR session.
 
 ## Set up (one command)
 
@@ -41,7 +43,15 @@ just do what it says:
   number banned.
 - **Self-hosted (user's own WhatsApp):** it serves a QR page and returns
   `{status:"linking", url, next:...}`. Send the user the URL to scan in WhatsApp >
-  Settings > Linked Devices. See [SETUP.md](SETUP.md) / [MANAGED_AUTH.md](MANAGED_AUTH.md).
+  Settings > Linked Devices. The command returns as soon as the live page is ready.
+  Wait for the user to say they scanned it, then run `whatsapp status` once. Never
+  choose a port, register a QR service, or run a second connect while the page is
+  active. If the user cannot scan a QR, and
+  explicitly approves a pairing attempt, run `whatsapp connect --phone '+E.164'`
+  with the exact account number. Confirm the echoed number, then send the returned
+  code for WhatsApp > Linked Devices > Link a Device > Link with phone number.
+  While that code is active, wait for the user and do not run connect again. See
+  [SETUP.md](SETUP.md) / [MANAGED_AUTH.md](MANAGED_AUTH.md).
 
 ## Other ways to connect
 
@@ -68,6 +78,8 @@ rather than run WhatsApp over a datacenter IP. A supplied proxy is validated too
 
 `whatsapp status` is your one diagnostic:
 - linked: `{"linked":true,"number":"+44...","connected":true}`
+- connecting: `{"linked":false,"connecting":true,"method":"qr","next":"wait for the user to scan..."}`
+- pairing code active: `{"linked":false,"connecting":true,"method":"phone","next":"wait for the user to enter..."}`
 - not linked: `{"linked":false,"connected":false,"next":"run: whatsapp connect","reason":"<why>"}`
 
 ## Send

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -447,28 +447,55 @@ var commands = []command{
 func linkViaQR(name string, args []string, wac *WhatsAppClient, link func(port int) (linkResult, error), result map[string]any) (any, error) {
 	var port int
 	var acknowledged bool
+	var unregisterService string
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.IntVar(&port, "port", 0, "Serve the QR link page on this port (0 = no page)")
 	fs.BoolVar(&acknowledged, "acknowledge-ban-risk", false, "Override the pairing rate limit")
+	fs.StringVar(&unregisterService, "unregister-service", "", "Internal vestad service to remove when the page stops")
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
+	cleanup := func() {
+		if unregisterService != "" {
+			if err := unregisterVestadService(unregisterService, port); err != nil {
+				wac.logger.Warnf("Failed to unregister QR link service %s: %v", unregisterService, err)
+			}
+		}
+	}
 	// Gate on the linked FACT (Store.ID), not transient connection status.
 	if wac.client.Store.ID != nil {
+		cleanup()
 		return nil, fmt.Errorf("already linked; to pair a different account the user must first unlink this device from their phone (Linked Devices)")
 	}
 	release, ok := wac.beginPairing()
 	if !ok {
+		activePort, _ := wac.activeLink()
+		cleanupRejectedPairing(cleanup, activePort, port)
 		return nil, errPairingInProgress
 	}
-	defer release()
+	// Keep pairMu held through route cleanup. Releasing it first lets the next
+	// pairing reuse the same port before this pairing's conditional delete runs.
+	defer finishPairing(cleanup, release)
 	if err := wac.state.tryRecordPairAttempt(time.Now(), acknowledged); err != nil {
 		return nil, err
 	}
+	wac.setLinkService(unregisterService)
+	defer wac.clearPendingLinkService()
 	if _, err := link(port); err != nil {
 		return nil, err
 	}
 	return result, nil
+}
+
+func finishPairing(cleanup, release func()) {
+	cleanup()
+	release()
+}
+
+func cleanupRejectedPairing(cleanup func(), activePort, requestedPort int) {
+	if activePort != requestedPort {
+		cleanup()
+	}
 }
 
 // cmdLink runs the whole self-hosted QR pairing synchronously in one socket call:
@@ -513,6 +540,16 @@ func cmdDaemonStatus(args []string, wac *WhatsAppClient) (any, error) {
 	}
 	if wac.client.Store.ID != nil {
 		result["number"] = "+" + wac.client.Store.ID.User
+	}
+	if linkPort, linkService := wac.activeLink(); linkPort != 0 {
+		result["link_port"] = linkPort
+		if linkService != "" {
+			result["link_service"] = linkService
+		}
+	}
+	if seconds := wac.phonePairingSecondsLeft(now); seconds > 0 {
+		result["phone_pairing_pending"] = true
+		result["phone_pairing_seconds_left"] = seconds
 	}
 	if build, ok := debug.ReadBuildInfo(); ok {
 		for _, dep := range build.Deps {
@@ -1254,6 +1291,7 @@ func cmdPairPhone(args []string, wac *WhatsAppClient) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate pairing code: %v", err)
 	}
+	wac.markPhonePairingPending(time.Now())
 	return map[string]any{
 		"pairing_code": code,
 		"phone":        phone,

--- a/agent/skills/whatsapp/cli/client.go
+++ b/agent/skills/whatsapp/cli/client.go
@@ -69,14 +69,15 @@ type WhatsAppClient struct {
 	// managed is the pool-API client when this box links a managed number (nil on a
 	// self-hosted QR box). It leases the residential proxy the cloud companion egresses
 	// through and drives the user-owned (BYO) number flow.
-	managed       *managedAuth
-	proxyMu       sync.Mutex
-	proxyURL      string // cached residential proxy lease for the process lifetime
-	egressCache   map[string]egressInfo
-	authStatus    AuthStatus
-	authMutex     sync.RWMutex
-	qrPath        string
-	currentQRCode string // guarded by authMutex, cleared on success
+	managed        *managedAuth
+	proxyMu        sync.Mutex
+	proxyURL       string // cached residential proxy lease for the process lifetime
+	egressCache    map[string]egressInfo
+	authStatus     AuthStatus
+	authMutex      sync.RWMutex
+	qrPath         string
+	currentQRCode  string // guarded by authMutex, cleared on success
+	phonePairUntil time.Time
 	// pairMu single-flights every pairing op (provision, QR link, phone code): only
 	// one runs at a time, so a failed one leaves a clean client for the next and no
 	// two pairings ever race for the rate-limit slot or the QR channel.
@@ -86,6 +87,8 @@ type WhatsAppClient struct {
 	mode              atomic.Int32
 	linkMu            sync.Mutex // guards linkServer
 	linkServer        *http.Server
+	linkPort          int
+	linkService       string
 	presenceActive    bool
 	presenceMutex     sync.RWMutex
 	lastMessageSentAt time.Time
@@ -429,6 +432,7 @@ func (wac *WhatsAppClient) onConnected() {
 // Used only on a FRESH link (QR success, managed provision, phone-code PairSuccess),
 // never on a routine reconnect, so the window is not re-armed on every reconnect.
 func (wac *WhatsAppClient) onLinked() {
+	wac.clearPhonePairingPending()
 	wac.onConnected()
 	wac.markLinkedNow()
 	// Capture a good-device snapshot of the freshly PAIRED store immediately, bypassing
@@ -568,23 +572,84 @@ func (wac *WhatsAppClient) beginPairing() (release func(), ok bool) {
 	if !wac.pairMu.TryLock() {
 		return nil, false
 	}
+	if wac.phonePairingPending(time.Now()) {
+		wac.pairMu.Unlock()
+		return nil, false
+	}
 	wac.setConnMode(connPairing)
 	return func() {
-		wac.mode.CompareAndSwap(int32(connPairing), int32(connNormal))
+		if !wac.phonePairingPending(time.Now()) {
+			wac.mode.CompareAndSwap(int32(connPairing), int32(connNormal))
+		}
 		wac.pairMu.Unlock()
 	}, true
+}
+
+func (wac *WhatsAppClient) markPhonePairingPending(now time.Time) {
+	wac.authMutex.Lock()
+	wac.phonePairUntil = now.Add(PhonePairingWindow)
+	wac.authMutex.Unlock()
+}
+
+func (wac *WhatsAppClient) clearPhonePairingPending() {
+	wac.authMutex.Lock()
+	wac.phonePairUntil = time.Time{}
+	wac.mode.CompareAndSwap(int32(connPairing), int32(connNormal))
+	wac.authMutex.Unlock()
+}
+
+func (wac *WhatsAppClient) phonePairingPending(now time.Time) bool {
+	wac.authMutex.Lock()
+	defer wac.authMutex.Unlock()
+	if wac.phonePairUntil.IsZero() {
+		return false
+	}
+	if !now.Before(wac.phonePairUntil) {
+		wac.phonePairUntil = time.Time{}
+		wac.mode.CompareAndSwap(int32(connPairing), int32(connNormal))
+		return false
+	}
+	return true
+}
+
+func (wac *WhatsAppClient) phonePairingSecondsLeft(now time.Time) int {
+	wac.authMutex.Lock()
+	if wac.phonePairUntil.IsZero() {
+		wac.authMutex.Unlock()
+		return 0
+	}
+	if !now.Before(wac.phonePairUntil) {
+		wac.phonePairUntil = time.Time{}
+		wac.mode.CompareAndSwap(int32(connPairing), int32(connNormal))
+		wac.authMutex.Unlock()
+		return 0
+	}
+	remaining := wac.phonePairUntil.Sub(now)
+	wac.authMutex.Unlock()
+	return int((remaining + time.Second - 1) / time.Second)
 }
 
 // clearQR drops any live QR code/image so a finished or abandoned link session
 // leaves no stale artifact for the link page to serve.
 func (wac *WhatsAppClient) clearQR() {
 	wac.authMutex.Lock()
-	defer wac.authMutex.Unlock()
 	if wac.qrPath != "" {
 		os.Remove(wac.qrPath)
 		wac.qrPath = ""
 	}
 	wac.currentQRCode = ""
+	if wac.authStatus == AuthStatusQRReady {
+		wac.authStatus = AuthStatusNotAuthenticated
+	}
+	wac.authMutex.Unlock()
+	if wac.state != nil {
+		wac.state.update(func(s *daemonState) {
+			if s.AuthStatus == string(AuthStatusQRReady) {
+				s.AuthStatus = ""
+				s.AuthNote = ""
+			}
+		})
+	}
 }
 
 // runQRLink is the whole self-hosted QR pairing, run synchronously in the socket
@@ -594,7 +659,9 @@ func (wac *WhatsAppClient) clearQR() {
 // the next `whatsapp link` starts clean (never GetQRChannel-on-connected-client).
 func (wac *WhatsAppClient) runQRLink(port int) (linkResult, error) {
 	if port > 0 {
-		wac.startLinkServer(port)
+		if err := wac.startLinkServer(port); err != nil {
+			return linkResult{}, err
+		}
 		defer wac.stopLinkServer()
 	}
 	defer wac.clearQR()

--- a/agent/skills/whatsapp/cli/connect.go
+++ b/agent/skills/whatsapp/cli/connect.go
@@ -1,9 +1,115 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 )
+
+type connectOptions struct {
+	opener             string
+	phone              string
+	instance           string
+	ownNumber          bool
+	port               int
+	acknowledgeBanRisk bool
+	openerSet          bool
+	phoneSet           bool
+	portSet            bool
+	acknowledgeSet     bool
+}
+
+// parseConnectOptions owns every flag accepted by the setup wrapper. Parsing
+// happens before mode selection or daemon startup, so help, typos, and invalid
+// combinations cannot fall through into a live pairing attempt.
+func parseConnectOptions(name string, args []string) (connectOptions, error) {
+	var opts connectOptions
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.StringVar(&opts.opener, "opener", "", "Managed number greeting prefilled in the user's wa.me link")
+	fs.StringVar(&opts.phone, "phone", "", "Self-hosted pairing-code fallback for this E.164 account number")
+	fs.StringVar(&opts.instance, "instance", "", "Named WhatsApp instance")
+	fs.BoolVar(&opts.ownNumber, "own-number", false, "Hosted pool number that the user registers and owns")
+	fs.IntVar(&opts.port, "port", 0, "Self-hosted QR page port (0 = register a public service)")
+	fs.BoolVar(&opts.acknowledgeBanRisk, "acknowledge-ban-risk", false, "Override the pairing rate limit")
+	if err := parseFlags(fs, args); err != nil {
+		return connectOptions{}, err
+	}
+	if fs.NArg() != 0 {
+		return connectOptions{}, fmt.Errorf("connect takes flags only, got %q", fs.Arg(0))
+	}
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "opener":
+			opts.openerSet = true
+		case "phone":
+			opts.phoneSet = true
+		case "port":
+			opts.portSet = true
+		case "acknowledge-ban-risk":
+			opts.acknowledgeSet = true
+		}
+	})
+	if opts.phoneSet && opts.phone == "" {
+		return connectOptions{}, fmt.Errorf("--phone requires the E.164 account number")
+	}
+	if opts.phone != "" && opts.ownNumber {
+		return connectOptions{}, fmt.Errorf("--phone and --own-number select different account types")
+	}
+	if opts.phone != "" && opts.portSet {
+		return connectOptions{}, fmt.Errorf("--phone uses a pairing code and cannot be combined with the QR-only --port")
+	}
+	return opts, nil
+}
+
+func validateConnectMode(opts connectOptions, hosted bool) error {
+	if opts.ownNumber {
+		if opts.openerSet {
+			return fmt.Errorf("--opener applies only to a managed hosted number, not --own-number")
+		}
+		return nil
+	}
+	if hosted {
+		if opts.phoneSet {
+			return fmt.Errorf("--phone is for a self-hosted account; this box manages its number through `whatsapp connect`")
+		}
+		if opts.portSet {
+			return fmt.Errorf("--port applies only to a self-hosted QR page")
+		}
+		if opts.acknowledgeSet {
+			return fmt.Errorf("--acknowledge-ban-risk applies only to self-hosted pairing")
+		}
+		return nil
+	}
+	if opts.openerSet {
+		return fmt.Errorf("--opener applies only to a managed hosted number")
+	}
+	return nil
+}
+
+// canonicalConnectArgs makes the parsed options authoritative for every legacy
+// helper downstream. In particular, Go's valid -flag and --bool=true spellings
+// must not be accepted here and then silently ignored by raw os.Args scanners.
+func canonicalConnectArgs(program string, opts connectOptions) []string {
+	args := []string{program}
+	appendValue := func(name, value string) {
+		if value != "" {
+			args = append(args, "--"+name, value)
+		}
+	}
+	appendValue("opener", opts.opener)
+	appendValue("phone", opts.phone)
+	appendValue("instance", opts.instance)
+	if opts.ownNumber {
+		args = append(args, "--own-number")
+	}
+	if opts.portSet {
+		args = append(args, "--port", fmt.Sprintf("%d", opts.port))
+	}
+	if opts.acknowledgeBanRisk {
+		args = append(args, "--acknowledge-ban-risk")
+	}
+	return args
+}
 
 // runConnect is the agent's single WhatsApp setup verb. It makes the same
 // paradigm choice the daemon's chooseLinker does (a hosted box claims + links its
@@ -12,24 +118,26 @@ import (
 // Idempotent and safe to re-run until `whatsapp status` shows linked. The hidden
 // `provision` and `link` aliases route here too.
 func runConnect() {
-	if hasBareFlag("own-number") {
+	opts, err := parseConnectOptions("connect", os.Args[1:])
+	if err != nil {
+		failJSON("%s", err.Error())
+	}
+	os.Args = canonicalConnectArgs(os.Args[0], opts)
+	cfg := managedConfigFromEnvAndState()
+	hosted := newManagedAuth(cfg).isHosted()
+	if err := validateConnectMode(opts, hosted); err != nil {
+		failJSON("%s", err.Error())
+	}
+	if opts.ownNumber {
 		runConnectOwnNumber()
 		return
 	}
-	cfg := loadManagedConfig()
-	// Fill direct-mode pool creds from persisted state when the env lacks them,
-	// mirroring chooseLinker, so an env scrub still selects the managed path.
-	if cfg.directURL == "" || cfg.directKey == "" {
-		st := loadStateFromDisk(stateDataDir())
-		if cfg.directURL == "" {
-			cfg.directURL = st.DirectURL
-		}
-		if cfg.directKey == "" {
-			cfg.directKey = st.DirectKey
-		}
+	if hosted {
+		runProvision(opts.opener)
+		return
 	}
-	if newManagedAuth(cfg).isHosted() {
-		runProvision(extractFlag("opener"))
+	if opts.phone != "" {
+		runLinkPhone(opts.phone)
 		return
 	}
 	runLink()
@@ -62,6 +170,11 @@ func runConnectOwnNumber() {
 	if !auth.isHosted() {
 		failJSON("`whatsapp connect --own-number` needs a hosted (vesta.run) box to draw a pool number; a plain box links the user's own WhatsApp with `whatsapp connect`")
 	}
+	lock, err := acquireConnectLock()
+	if err != nil {
+		failJSON("%s", err.Error())
+	}
+	defer releaseConnectLock(lock)
 	number, err := auth.provisionSelf()
 	if err != nil {
 		failJSON("could not reserve a user-owned number: %v", err)

--- a/agent/skills/whatsapp/cli/connect_test.go
+++ b/agent/skills/whatsapp/cli/connect_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseConnectOptions(t *testing.T) {
+	opts, err := parseConnectOptions("connect", []string{
+		"--phone", "+393481234567",
+		"--instance", "personal",
+		"--acknowledge-ban-risk",
+	})
+	if err != nil {
+		t.Fatalf("parseConnectOptions: %v", err)
+	}
+	if opts.phone != "+393481234567" {
+		t.Errorf("phone = %q", opts.phone)
+	}
+	if opts.instance != "personal" {
+		t.Errorf("instance = %q", opts.instance)
+	}
+	if !opts.acknowledgeBanRisk {
+		t.Error("acknowledgeBanRisk = false")
+	}
+}
+
+func TestConnectRejectsUnknownFlagsInsteadOfStartingQR(t *testing.T) {
+	_, err := parseConnectOptions("connect", []string{"--phnoe", "+393481234567"})
+	if err == nil {
+		t.Fatal("unknown flag was accepted")
+	}
+	if !strings.Contains(err.Error(), "flag provided but not defined") {
+		t.Fatalf("unknown flag error = %q", err)
+	}
+}
+
+func TestConnectRejectsConflictingPairingMethods(t *testing.T) {
+	for _, args := range [][]string{
+		{"--phone", "+393481234567", "--own-number"},
+		{"--phone", "+393481234567", "--port", "61012"},
+	} {
+		if _, err := parseConnectOptions("connect", args); err == nil {
+			t.Errorf("parseConnectOptions(%q) accepted conflicting methods", args)
+		}
+	}
+}
+
+func TestConnectRejectsPositionalsAndEmptyPhone(t *testing.T) {
+	for _, args := range [][]string{
+		{"pair-now"},
+		{"--phone="},
+		{"-phone="},
+	} {
+		if _, err := parseConnectOptions("connect", args); err == nil {
+			t.Errorf("parseConnectOptions(%q) accepted invalid input", args)
+		}
+	}
+}
+
+func TestCanonicalConnectArgsPreserveEveryAcceptedFlagSpelling(t *testing.T) {
+	opts, err := parseConnectOptions("connect", []string{
+		"-instance", "personal",
+		"-port=61012",
+		"--acknowledge-ban-risk=true",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(canonicalConnectArgs("whatsapp", opts), " ")
+	for _, want := range []string{
+		"--instance personal",
+		"--port 61012",
+		"--acknowledge-ban-risk",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("canonical args = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestConnectRejectsFlagsThatDoNotApplyToTheSelectedMode(t *testing.T) {
+	cases := []struct {
+		args   []string
+		hosted bool
+	}{
+		{[]string{"--port", "61012"}, true},
+		{[]string{"--acknowledge-ban-risk"}, true},
+		{[]string{"--opener", "hello"}, false},
+		{[]string{"--own-number", "--opener", "hello"}, true},
+	}
+	for _, tc := range cases {
+		opts, err := parseConnectOptions("connect", tc.args)
+		if err != nil {
+			t.Fatalf("parseConnectOptions(%q): %v", tc.args, err)
+		}
+		if err := validateConnectMode(opts, tc.hosted); err == nil {
+			t.Errorf("validateConnectMode(%q, hosted=%v) accepted an ignored flag", tc.args, tc.hosted)
+		}
+	}
+}
+
+func TestConnectPreservesExplicitZeroPort(t *testing.T) {
+	opts, err := parseConnectOptions("connect", []string{"--port", "0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(canonicalConnectArgs("whatsapp", opts), " "); !strings.Contains(got, "--port 0") {
+		t.Fatalf("canonical args = %q, want explicit --port 0", got)
+	}
+}

--- a/agent/skills/whatsapp/cli/constants.go
+++ b/agent/skills/whatsapp/cli/constants.go
@@ -26,6 +26,10 @@ const (
 	// synchronous, so this is just the PairSuccess round-trip). Well inside
 	// SocketTimeout so a synchronous `provision` never outlives its socket call.
 	ManagedLinkTimeout = 60 * time.Second
+	// Whatsmeow documents a 160-second phone-code window before the login
+	// websocket closes. During that window status must keep agents from starting
+	// a QR pairing that invalidates the code the user is entering.
+	PhonePairingWindow = 160 * time.Second
 
 	// KeepAliveRestartThreshold is the consecutive keep-alive failure count at
 	// which the socket is treated as dead. Below it, whatsmeow is still

--- a/agent/skills/whatsapp/cli/help_test.go
+++ b/agent/skills/whatsapp/cli/help_test.go
@@ -102,6 +102,17 @@ func TestLifecycleCommandsAnswerHelpRatherThanRunning(t *testing.T) {
 	}
 }
 
+func TestSetupAliasesReportConnectFlagsWithoutPairing(t *testing.T) {
+	for _, name := range []string{"connect", "link", "provision"} {
+		usage := helpFor(t, name)
+		for _, flag := range []string{"-phone", "-own-number", "-opener"} {
+			if !strings.Contains(usage, flag) {
+				t.Errorf("%s --help does not mention %s:\n%s", name, flag, usage)
+			}
+		}
+	}
+}
+
 // An argument whose own text is `-h` is not a question. It must fail loudly: reporting usage and
 // succeeding would tell the agent a message was sent when nothing was.
 func TestAnArgumentThatLooksLikeHelpIsNotTreatedAsHelp(t *testing.T) {

--- a/agent/skills/whatsapp/cli/link.go
+++ b/agent/skills/whatsapp/cli/link.go
@@ -4,14 +4,45 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
 const vestadRequestTimeout = 10 * time.Second
+
+var (
+	linkReadyTimeout = 30 * time.Second
+	linkReadyPoll    = 200 * time.Millisecond
+)
+
+const linkNextStep = "Send the user this URL. Wait for them to scan it, then run `whatsapp status` once. Do not run connect again while this page is active."
+
+func acquireConnectLock() (*os.File, error) {
+	dir := stateDataDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("create WhatsApp state directory: %w", err)
+	}
+	file, err := os.OpenFile(filepath.Join(dir, "connect.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("open WhatsApp connect lock: %w", err)
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		file.Close()
+		return nil, fmt.Errorf("lock WhatsApp connect flow: %w", err)
+	}
+	return file, nil
+}
+
+func releaseConnectLock(file *os.File) {
+	syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	file.Close()
+}
 
 // linkServiceName is the vestad service (and tunnel path segment) for the link
 // page: the shared "wa-link" for the default instance, suffixed per named
@@ -37,7 +68,7 @@ func linkPageURL(tunnel, agentName, serviceName string, port int) string {
 // loopback (agent-token auth, self-signed TLS so verification is skipped, same
 // trust model as the vestad skill's register-service curl -k) and returns the
 // assigned port. Idempotent on vestad's side: same name, same port.
-func registerVestadService(name string) (int, error) {
+func registerVestadService(name string, requireBindable bool) (int, error) {
 	vestadPort := os.Getenv("VESTAD_PORT")
 	agentName := os.Getenv("AGENT_NAME")
 	agentToken := os.Getenv("AGENT_TOKEN")
@@ -49,7 +80,7 @@ func registerVestadService(name string) (int, error) {
 		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
 	}
 	url := fmt.Sprintf("https://localhost:%s/agents/%s/services", vestadPort, agentName)
-	body := fmt.Sprintf(`{"name":%q,"public":true}`, name)
+	body := fmt.Sprintf(`{"name":%q,"public":true,"require_bindable":%t}`, name, requireBindable)
 	req, err := http.NewRequest("POST", url, strings.NewReader(body))
 	if err != nil {
 		return 0, err
@@ -68,6 +99,40 @@ func registerVestadService(name string) (int, error) {
 		return 0, fmt.Errorf("vestad service registration returned no port (HTTP %d)", resp.StatusCode)
 	}
 	return payload.Port, nil
+}
+
+func unregisterVestadService(name string, expectedPort int) error {
+	vestadPort := os.Getenv("VESTAD_PORT")
+	agentName := os.Getenv("AGENT_NAME")
+	agentToken := os.Getenv("AGENT_TOKEN")
+	if vestadPort == "" || agentName == "" || agentToken == "" {
+		return nil
+	}
+	client := &http.Client{
+		Timeout:   vestadRequestTimeout,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	endpoint := fmt.Sprintf(
+		"https://localhost:%s/agents/%s/services/%s/registrations/%d",
+		vestadPort,
+		agentName,
+		name,
+		expectedPort,
+	)
+	req, err := http.NewRequest(http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Agent-Token", agentToken)
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("vestad service unregistration failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("vestad service unregistration returned HTTP %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // parsePortFlag parses a port flag value and returns an error if it is invalid.
@@ -102,8 +167,9 @@ func linkServeArgs() []string {
 // the one blocking socket call that serves the page and waits for the scan.
 // socketCommand is the daemon verb that runs the link (self-hosted `link` or the
 // user-owned `own-number-link`). Returns the daemon's terminal output + exit code.
-func serveAndRunQRLink(socketCommand string) ([]byte, int) {
+func resolveQRLinkPage(requireBindable bool) (int, string, bool) {
 	port := 0
+	registered := false
 	if flagPort, present := lookupFlag("port"); present {
 		var err error
 		port, err = parsePortFlag(flagPort)
@@ -112,19 +178,30 @@ func serveAndRunQRLink(socketCommand string) ([]byte, int) {
 		}
 	}
 	if port == 0 {
-		registeredPort, err := registerVestadService(linkServiceName())
+		registeredPort, err := registerVestadService(linkServiceName(), requireBindable)
 		if err != nil {
 			failJSON("%s", err.Error())
 		}
 		port = registeredPort
+		registered = true
 	}
 	pageURL := linkPageURL(os.Getenv("VESTAD_TUNNEL"), os.Getenv("AGENT_NAME"), linkServiceName(), port)
+	return port, pageURL, registered
+}
+
+// serveAndRunQRLink keeps the synchronous QR flow used by own-number setup,
+// which has more setup stages in the same invocation.
+func serveAndRunQRLink(socketCommand string) ([]byte, int) {
+	port, pageURL, registered := resolveQRLinkPage(true)
 	printJSON(map[string]any{
 		"status": "linking",
 		"url":    pageURL,
-		"next":   "Send the user this URL to scan. On their phone: WhatsApp > Settings > Linked Devices > Link a Device, then scan the code on the page. The page keeps itself current; there is no rush.",
+		"next":   linkNextStep,
 	})
 	linkArgs := []string{"--port", fmt.Sprintf("%d", port)}
+	if registered {
+		linkArgs = append(linkArgs, "--unregister-service", linkServiceName())
+	}
 	if hasBareFlag("acknowledge-ban-risk") {
 		linkArgs = append(linkArgs, "--acknowledge-ban-risk")
 	}
@@ -135,24 +212,153 @@ func serveAndRunQRLink(socketCommand string) ([]byte, int) {
 	return output, exitCode
 }
 
-func runLink() {
-	if phone, present := lookupFlag("phone"); present && phone != "" {
-		runLinkPhone(phone)
-		return
-	}
+type socketCommandResult struct {
+	output    []byte
+	exitCode  int
+	connected bool
+}
 
+// startSocketCommand begins one daemon request and lets the caller stop waiting
+// without cancelling the daemon-side command. The socket handler has already
+// decoded the request before it enters the pairing body, so closing this client
+// connection only discards the eventual response.
+func startSocketCommand(sockPath, command string, args []string) (<-chan socketCommandResult, func(), bool) {
+	conn, err := net.DialTimeout("unix", sockPath, SocketDialTimeout)
+	if err != nil {
+		return nil, func() {}, false
+	}
+	conn.SetDeadline(time.Now().Add(commandTimeout(command)))
+	if err := json.NewEncoder(conn).Encode(SocketRequest{Command: command, Args: args}); err != nil {
+		conn.Close()
+		return nil, func() {}, false
+	}
+	result := make(chan socketCommandResult, 1)
+	go func() {
+		var resp SocketResponse
+		if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+			result <- socketCommandResult{connected: false}
+			return
+		}
+		if resp.Error != "" {
+			data, _ := json.MarshalIndent(map[string]any{"error": resp.Error}, "", "  ")
+			result <- socketCommandResult{output: data, exitCode: 1, connected: true}
+			return
+		}
+		data, _ := json.MarshalIndent(resp.Result, "", "  ")
+		result <- socketCommandResult{output: data, connected: true}
+	}()
+	return result, func() { conn.Close() }, true
+}
+
+// waitForQRReady waits only for the first live code, not for the user's scan.
+// That keeps connect short enough for the agent to receive and relay the URL.
+func waitForQRReady(port int, result <-chan socketCommandResult) (socketCommandResult, bool) {
+	client := &http.Client{Timeout: time.Second}
+	deadline := time.NewTimer(linkReadyTimeout)
+	ticker := time.NewTicker(linkReadyPoll)
+	defer deadline.Stop()
+	defer ticker.Stop()
+	qrURL := fmt.Sprintf("http://127.0.0.1:%d/qr.png", port)
+	for {
+		select {
+		case terminal := <-result:
+			return terminal, false
+		case <-ticker.C:
+			resp, err := client.Get(qrURL)
+			if err == nil {
+				resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					return socketCommandResult{}, true
+				}
+			}
+		case <-deadline.C:
+			data, _ := json.MarshalIndent(map[string]any{
+				"error": "WhatsApp did not produce a QR code in time; run `whatsapp status` before retrying connect",
+			}, "", "  ")
+			return socketCommandResult{output: data, exitCode: 1, connected: true}, false
+		}
+	}
+}
+
+type activeQRLink struct {
+	port    int
+	service string
+}
+
+func currentQRLink() activeQRLink {
+	output, _, connected := trySocketCommand(getSocketPath(), "daemon-status", nil)
+	if !connected {
+		return activeQRLink{}
+	}
+	var status struct {
+		LinkPort    int    `json:"link_port"`
+		LinkService string `json:"link_service"`
+	}
+	if json.Unmarshal(output, &status) != nil {
+		return activeQRLink{}
+	}
+	return activeQRLink{port: status.LinkPort, service: status.LinkService}
+}
+
+func runLink() {
 	if err := startDaemonProcess(linkServeArgs()); err != nil {
 		failJSON("%s", err.Error())
 	}
+	lock, err := acquireConnectLock()
+	if err != nil {
+		failJSON("%s", err.Error())
+	}
+	defer releaseConnectLock(lock)
 
-	output, exitCode := serveAndRunQRLink("link")
-	if exitCode != 0 {
-		fmt.Println(string(output))
+	if active := currentQRLink(); active.port != 0 {
+		pageURL := fmt.Sprintf("http://localhost:%d/", active.port)
+		if active.service != "" {
+			pageURL = linkPageURL(
+				os.Getenv("VESTAD_TUNNEL"),
+				os.Getenv("AGENT_NAME"),
+				active.service,
+				active.port,
+			)
+		}
+		printJSON(map[string]any{
+			"status": "linking",
+			"url":    pageURL,
+			"next":   linkNextStep,
+		})
+		return
+	}
+
+	port, pageURL, registered := resolveQRLinkPage(true)
+	linkArgs := []string{"--port", fmt.Sprintf("%d", port)}
+	if registered {
+		linkArgs = append(linkArgs, "--unregister-service", linkServiceName())
+	}
+	if hasBareFlag("acknowledge-ban-risk") {
+		linkArgs = append(linkArgs, "--acknowledge-ban-risk")
+	}
+	result, stopWaiting, connected := startSocketCommand(getSocketPath(), "link", linkArgs)
+	if !connected {
+		if registered {
+			_ = unregisterVestadService(linkServiceName(), port)
+		}
+		failJSON("whatsapp daemon is not answering; run `whatsapp status`")
+	}
+	terminal, ready := waitForQRReady(port, result)
+	stopWaiting()
+	if !ready {
+		if registered && !terminal.connected && currentQRLink().port == 0 {
+			_ = unregisterVestadService(linkServiceName(), port)
+		}
+		fmt.Println(string(terminal.output))
+		if terminal.exitCode == 0 {
+			return
+		}
 		os.Exit(1)
 	}
 	printJSON(map[string]any{
-		"status": "linked",
-		"note":   fmt.Sprintf("History sync is settling: daemon stop/restart are locked for %s. Log lines like 'can't send presence' or a brief websocket EOF in this window are NORMAL. Do not restart anything.", SyncWindowDuration),
+		"status": "linking",
+		"url":    pageURL,
+		"next":   linkNextStep,
 	})
 }
 
@@ -160,6 +366,11 @@ func runLinkPhone(phone string) {
 	if err := startDaemonProcess(linkServeArgs()); err != nil {
 		failJSON("%s", err.Error())
 	}
+	lock, err := acquireConnectLock()
+	if err != nil {
+		failJSON("%s", err.Error())
+	}
+	defer releaseConnectLock(lock)
 	pairArgs := []string{"--phone", phone}
 	if hasBareFlag("acknowledge-ban-risk") {
 		pairArgs = append(pairArgs, "--acknowledge-ban-risk")

--- a/agent/skills/whatsapp/cli/link_test.go
+++ b/agent/skills/whatsapp/cli/link_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestLinkServeArgs(t *testing.T) {
@@ -68,5 +73,138 @@ func TestParsePortFlag(t *testing.T) {
 		if err == nil && got != tc.want {
 			t.Errorf("parsePortFlag(%q) = %d, want %d", tc.value, got, tc.want)
 		}
+	}
+}
+
+func TestWaitForQRReadyReturnsWhenPageIsLive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	port := server.Listener.Addr().(*net.TCPAddr).Port
+
+	savedPoll, savedTimeout := linkReadyPoll, linkReadyTimeout
+	linkReadyPoll, linkReadyTimeout = time.Millisecond, time.Second
+	defer func() {
+		linkReadyPoll, linkReadyTimeout = savedPoll, savedTimeout
+	}()
+
+	result := make(chan socketCommandResult)
+	if terminal, ready := waitForQRReady(port, result); !ready || terminal.exitCode != 0 {
+		t.Fatalf("waitForQRReady = (%+v, %v), want ready", terminal, ready)
+	}
+}
+
+func TestWaitForQRReadyReturnsImmediatePairingError(t *testing.T) {
+	result := make(chan socketCommandResult, 1)
+	result <- socketCommandResult{output: []byte(`{"error":"pairing already in progress"}`), exitCode: 1, connected: true}
+
+	terminal, ready := waitForQRReady(1, result)
+	if ready || terminal.exitCode != 1 {
+		t.Fatalf("waitForQRReady = (%+v, %v), want terminal error", terminal, ready)
+	}
+}
+
+func TestConnectLockSerializesConcurrentPairingSetup(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	first, err := acquireConnectLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var secondAcquired atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		second, lockErr := acquireConnectLock()
+		if lockErr == nil {
+			secondAcquired.Store(true)
+			releaseConnectLock(second)
+		}
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	if secondAcquired.Load() {
+		t.Fatal("a concurrent connect entered before the first released its setup lock")
+	}
+	releaseConnectLock(first)
+	select {
+	case <-done:
+		if !secondAcquired.Load() {
+			t.Fatal("the second connect never acquired the released setup lock")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("the second connect stayed blocked after the first released its lock")
+	}
+}
+
+func TestPairingCleanupRunsBeforeTheNextPairingCanReuseThePort(t *testing.T) {
+	var events []string
+	finishPairing(
+		func() { events = append(events, "cleanup-old-registration") },
+		func() { events = append(events, "release-pairing-lock") },
+	)
+	if !reflect.DeepEqual(events, []string{"cleanup-old-registration", "release-pairing-lock"}) {
+		t.Fatalf("finishPairing order = %v", events)
+	}
+}
+
+func TestRejectedPairingCleansOnlyItsOwnUnusedRegistration(t *testing.T) {
+	cleanups := 0
+	cleanup := func() { cleanups++ }
+	cleanupRejectedPairing(cleanup, 0, 61012)
+	if cleanups != 1 {
+		t.Fatalf("unused rejected registration cleanup count = %d, want 1", cleanups)
+	}
+	cleanupRejectedPairing(cleanup, 61013, 61013)
+	if cleanups != 1 {
+		t.Fatalf("active QR registration was cleaned up; count = %d", cleanups)
+	}
+}
+
+func TestPhonePairingPendingBlocksAnotherPairingUntilCleared(t *testing.T) {
+	wac := &WhatsAppClient{}
+	now := time.Now()
+	release, ok := wac.beginPairing()
+	if !ok {
+		t.Fatal("initial phone pairing could not start")
+	}
+	wac.markPhonePairingPending(now)
+	release()
+	if !wac.phonePairingPending(now.Add(time.Second)) {
+		t.Fatal("fresh phone pairing was not reported pending")
+	}
+	if release, ok := wac.beginPairing(); ok {
+		release()
+		t.Fatal("another pairing entered while the phone code was pending")
+	}
+	if !wac.connModeIs(connPairing) {
+		t.Fatal("phone pairing window did not keep connection recovery paused")
+	}
+	wac.clearPhonePairingPending()
+	if !wac.connModeIs(connNormal) {
+		t.Fatal("clearing phone pairing did not restore normal connection mode")
+	}
+	release, ok = wac.beginPairing()
+	if !ok {
+		t.Fatal("pairing stayed blocked after the phone pairing cleared")
+	}
+	release()
+}
+
+func TestPhonePairingStatusExpiresTheRecoveryPosture(t *testing.T) {
+	wac := &WhatsAppClient{}
+	wac.setConnMode(connPairing)
+	wac.authMutex.Lock()
+	wac.phonePairUntil = time.Now().Add(-time.Second)
+	wac.authMutex.Unlock()
+
+	if seconds := wac.phonePairingSecondsLeft(time.Now()); seconds != 0 {
+		t.Fatalf("expired phone pairing seconds = %d, want 0", seconds)
+	}
+	if !wac.connModeIs(connNormal) {
+		t.Fatal("expired phone pairing left connection recovery paused")
+	}
+	if wac.phonePairingPending(time.Now()) {
+		t.Fatal("expired phone pairing stayed pending")
 	}
 }

--- a/agent/skills/whatsapp/cli/linkserver.go
+++ b/agent/skills/whatsapp/cli/linkserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -61,26 +62,54 @@ func (wac *WhatsAppClient) linkHTTPHandler(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-func (wac *WhatsAppClient) startLinkServer(port int) {
+func (wac *WhatsAppClient) startLinkServer(port int) error {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return fmt.Errorf("start link page on port %d: %w", port, err)
+	}
 	server := &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", port), Handler: http.HandlerFunc(wac.linkHTTPHandler)}
 	wac.linkMu.Lock()
 	wac.linkServer = server
+	wac.linkPort = port
 	wac.linkMu.Unlock()
 	go func() {
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			wac.logger.Errorf("link page server failed: %v", err)
 		}
 	}()
+	return nil
 }
 
 func (wac *WhatsAppClient) stopLinkServer() {
 	wac.linkMu.Lock()
 	server := wac.linkServer
 	wac.linkServer = nil
+	wac.linkPort = 0
+	wac.linkService = ""
 	wac.linkMu.Unlock()
 	if server != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), linkServerShutdownTimeout)
 		defer cancel()
 		server.Shutdown(ctx)
 	}
+}
+
+func (wac *WhatsAppClient) setLinkService(service string) {
+	wac.linkMu.Lock()
+	defer wac.linkMu.Unlock()
+	wac.linkService = service
+}
+
+func (wac *WhatsAppClient) clearPendingLinkService() {
+	wac.linkMu.Lock()
+	defer wac.linkMu.Unlock()
+	if wac.linkPort == 0 {
+		wac.linkService = ""
+	}
+}
+
+func (wac *WhatsAppClient) activeLink() (int, string) {
+	wac.linkMu.Lock()
+	defer wac.linkMu.Unlock()
+	return wac.linkPort, wac.linkService
 }

--- a/agent/skills/whatsapp/cli/linkserver_test.go
+++ b/agent/skills/whatsapp/cli/linkserver_test.go
@@ -2,10 +2,24 @@ package main
 
 import (
 	"encoding/json"
+	"net"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+func TestStartLinkServerReportsOccupiedPort(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	wac := &WhatsAppClient{}
+	if err := wac.startLinkServer(listener.Addr().(*net.TCPAddr).Port); err == nil {
+		t.Fatal("startLinkServer accepted an occupied port")
+	}
+}
 
 func testClientWithQR(code string) *WhatsAppClient {
 	return &WhatsAppClient{currentQRCode: code, authStatus: AuthStatusQRReady}
@@ -65,12 +79,46 @@ func TestServeLinkPage(t *testing.T) {
 // code for the page to serve (the QR link is single-flighted and self-contained,
 // so there is no generation machinery to reason about anymore).
 func TestClearQRClearsCode(t *testing.T) {
-	wac := &WhatsAppClient{currentQRCode: "code"}
+	state := newStateStore(t.TempDir())
+	state.update(func(s *daemonState) { s.AuthStatus = string(AuthStatusQRReady) })
+	wac := &WhatsAppClient{
+		currentQRCode: "code",
+		authStatus:    AuthStatusQRReady,
+		state:         state,
+	}
 	wac.clearQR()
 	wac.authMutex.RLock()
 	code := wac.currentQRCode
+	status := wac.authStatus
 	wac.authMutex.RUnlock()
 	if code != "" {
 		t.Error("clearQR must clear the current QR code so nothing serves it")
+	}
+	if status != AuthStatusNotAuthenticated || state.snapshot().AuthStatus != "" {
+		t.Errorf("clearQR left stale QR-ready state: memory=%q disk=%q", status, state.snapshot().AuthStatus)
+	}
+}
+
+func TestLinkServerPublishesItsActivePort(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	wac := &WhatsAppClient{}
+	wac.setLinkService("wa-link")
+	if err := wac.startLinkServer(port); err != nil {
+		t.Fatal(err)
+	}
+	gotPort, gotService := wac.activeLink()
+	if gotPort != port || gotService != "wa-link" {
+		t.Fatalf("activeLink = (%d, %q), want (%d, %q)", gotPort, gotService, port, "wa-link")
+	}
+	wac.stopLinkServer()
+	gotPort, gotService = wac.activeLink()
+	if gotPort != 0 || gotService != "" {
+		t.Fatalf("activeLink after stop = (%d, %q), want empty", gotPort, gotService)
 	}
 }

--- a/agent/skills/whatsapp/cli/main.go
+++ b/agent/skills/whatsapp/cli/main.go
@@ -17,7 +17,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage: whatsapp <command> [args] [flags]")
 	// The lifecycle commands run in the client, not the daemon, so they are not in the registry.
 	fmt.Fprintln(w, "Setup / health:")
-	fmt.Fprintln(w, "  connect [--opener <text>] [--own-number] set up WhatsApp: claim + link the agent's own number, or link the user's own WhatsApp by QR. --opener: agent-authored greeting for the managed wa.me link")
+	fmt.Fprintln(w, "  connect [--opener <text>] [--phone +E.164] [--own-number] set up or recover WhatsApp; --phone uses a pairing code when the user cannot scan a QR")
 	fmt.Fprintln(w, "  status                               simple health check: linked, number, connected. If it shows linked:false, run `whatsapp connect`")
 	fmt.Fprintln(w, "  start                                bring the daemon up (idempotent); the restart skill runs this at boot")
 	fmt.Fprintln(w, "Internal (the CLI self-manages its daemon; agents never call these):")
@@ -37,6 +37,11 @@ func printUsage(w io.Writer) {
 // handler declares its FlagSet and parses before it touches the client, so passing no client
 // reports the flags without a daemon, without the socket, and without reaching any command body.
 func printCommandUsage(w io.Writer, name string) {
+	if name == "connect" || name == "link" || name == "provision" {
+		_, err := parseConnectOptions(name, []string{"--help"})
+		fmt.Fprintln(w, err)
+		return
+	}
 	cmd, ok := lookupCommand(name)
 	if !ok {
 		// A lifecycle command (serve, link, daemon, authenticate): the general usage documents it.

--- a/agent/skills/whatsapp/cli/status.go
+++ b/agent/skills/whatsapp/cli/status.go
@@ -35,6 +35,23 @@ func runStatus() {
 func simpleStatus(live map[string]any, dataDir string) map[string]any {
 	loggedIn, _ := live["logged_in"].(bool)
 	if !loggedIn {
+		if pending, _ := live["phone_pairing_pending"].(bool); pending {
+			return map[string]any{
+				"linked":     false,
+				"connecting": true,
+				"method":     "phone",
+				"next":       "wait for the user to enter the active pairing code; do not run connect again",
+			}
+		}
+		linkPort, _ := live["link_port"].(float64)
+		if live["auth_status"] == string(AuthStatusQRReady) || linkPort > 0 {
+			return map[string]any{
+				"linked":     false,
+				"connecting": true,
+				"method":     "qr",
+				"next":       "wait for the user to scan the active QR page; do not run connect again",
+			}
+		}
 		return notLinkedStatus(dataDir, "")
 	}
 	connected, _ := live["connected"].(bool)

--- a/agent/skills/whatsapp/cli/status_test.go
+++ b/agent/skills/whatsapp/cli/status_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestSimpleStatusLinked(t *testing.T) {
 	dir := t.TempDir()
@@ -33,6 +36,44 @@ func TestSimpleStatusNotLinkedSurfacesReason(t *testing.T) {
 	}
 	if got["reason"] != "unlinked from the phone (stream:error logout)" {
 		t.Errorf("reason = %v, want the recorded last-exit reason", got["reason"])
+	}
+}
+
+func TestSimpleStatusReportsActiveQRPairing(t *testing.T) {
+	got := simpleStatus(map[string]any{
+		"logged_in":   false,
+		"auth_status": string(AuthStatusQRReady),
+	}, t.TempDir())
+	if got["connecting"] != true || got["method"] != "qr" {
+		t.Fatalf("active QR status = %#v, want connecting QR", got)
+	}
+	next, _ := got["next"].(string)
+	if strings.Contains(next, "run: whatsapp connect") || !strings.Contains(next, "do not run connect again") {
+		t.Errorf("active QR next step = %q, want wait guidance without another connect", next)
+	}
+}
+
+func TestSimpleStatusReportsQRServerBeforeFirstCode(t *testing.T) {
+	got := simpleStatus(map[string]any{
+		"logged_in": false,
+		"link_port": float64(61012),
+	}, t.TempDir())
+	if got["connecting"] != true || got["method"] != "qr" {
+		t.Fatalf("pre-QR status = %#v, want connecting QR", got)
+	}
+}
+
+func TestSimpleStatusReportsPendingPhonePairing(t *testing.T) {
+	got := simpleStatus(map[string]any{
+		"logged_in":             false,
+		"phone_pairing_pending": true,
+	}, t.TempDir())
+	if got["connecting"] != true || got["method"] != "phone" {
+		t.Fatalf("phone pairing status = %#v, want connecting phone", got)
+	}
+	next, _ := got["next"].(string)
+	if strings.Contains(next, "run: whatsapp connect") || !strings.Contains(next, "do not run connect again") {
+		t.Errorf("phone pairing next step = %q, want wait guidance without another connect", next)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make whatsapp connect return as soon as the live QR page is ready, with one clear URL and next step instead of blocking through the scan window
- reject typoed, conflicting, empty, and mode-inapplicable flags before any pairing side effect; make help and skill guidance center the four intuitive agent verbs
- serialize setup, expose active QR and phone-code pairing in status, prevent duplicate connects, clear stale QR state, and clean only the route owned by the finishing attempt

## Incident coverage

This prevents the overlapping connect processes, hidden help side effects, stale QR status, phone-code conflicts, and manual port orchestration seen during the reconnect incident. Bindable public-port allocation and fail-closed conditional cleanup depend on #1488, which should deploy first.

The separate post-link send stall is already fixed on current master by bounded send recovery and offloading WhatsApp event handling, so this PR does not duplicate that work.

## Tests

- ./check.sh whatsapp guards
- repeated subagent review completed with no remaining findings