### PR TITLE
refactor: let vestad own every word the agent reads on restart

### DIFF
--- a/apps/core/fixtures/restart-reason-tokens.json
+++ b/apps/core/fixtures/restart-reason-tokens.json
@@ -1,0 +1,6 @@
+[
+  "provider.configured",
+  "provider.signed-out",
+  "provider.model",
+  "provider.context"
+]

--- a/apps/core/src/lifecycle/restart-reasons.test.ts
+++ b/apps/core/src/lifecycle/restart-reasons.test.ts
@@ -1,18 +1,20 @@
 import { describe, expect, it } from "vitest"
+
+import vestadTokens from "../../fixtures/restart-reason-tokens.json"
 import { RESTART_REASONS, restartBody } from "./restart-reasons"
 
-describe("restartBody", () => {
-  it("puts operational copy under the legacy wire name and agent copy beside it", () => {
-    expect(restartBody(RESTART_REASONS.model)).toEqual({
-      reason: "provider: model changed",
-      agent_message: "Your configured model changed.",
-    })
+// The fixture is produced from vestad's own token table (vestad/src/lifecycle.rs, CLIENT_TOKENS,
+// via REGEN_API_FIXTURES=1). Tokens are the whole contract now that vestad owns the copy, so a
+// token this side sends that vestad cannot resolve would silently downgrade the agent's greeting
+// to the generic manual reason. Pinning them here makes that drift a failing test instead.
+describe("restart reason tokens (vestad fixture)", () => {
+  it("sends exactly the tokens vestad resolves", () => {
+    expect([...Object.values(RESTART_REASONS)].sort()).toEqual([...vestadTokens].sort())
   })
 
-  it("gives every canonical reason a 'category: detail' log reason and a full sentence", () => {
-    for (const reason of Object.values(RESTART_REASONS)) {
-      expect(reason.logReason).toMatch(/^[a-z]+: .+/)
-      expect(reason.agentMessage).toMatch(/\.$/)
-    }
+  it("names the transition and leaves the copy to vestad", () => {
+    expect(restartBody(RESTART_REASONS.model)).toEqual({
+      reason_token: "provider.model",
+    })
   })
 })

--- a/apps/core/src/lifecycle/restart-reasons.ts
+++ b/apps/core/src/lifecycle/restart-reasons.ts
@@ -1,37 +1,23 @@
-export interface RestartReason {
-  logReason: string
-  agentMessage: string
-}
+// Names for the restarts a client asks for. vestad owns the copy each token resolves to
+// (vestad/src/lifecycle.rs), so every word the agent reads has one author; the token list itself is
+// pinned against vestad's by restart-reasons.test.ts.
+//
+// A plain manual restart sends no token at all: vestad then names it itself, and can prefer the
+// mount-grant delta it derives, which is more informative than anything the client could say.
+export const RESTART_REASONS = {
+  provider: "provider.configured",
+  signOut: "provider.signed-out",
+  model: "provider.model",
+  context: "provider.context",
+} as const
+
+export type RestartReason = (typeof RESTART_REASONS)[keyof typeof RESTART_REASONS]
 
 export interface RestartBody {
-  reason: string
-  agent_message: string
+  reason_token: RestartReason
 }
 
-// Canonical copy for the restarts a client asks for with something specific to say. A plain manual
-// restart sends no reason at all: vestad then names it itself, and can prefer the mount-grant delta
-// it derives, which is more informative than anything the client could say. `reason` remains the
-// wire name for operational copy so older vestad versions can still accept requests.
-export const RESTART_REASONS = {
-  provider: {
-    logReason: "provider: configuration changed",
-    agentMessage: "Your provider configuration changed.",
-  },
-  signOut: {
-    logReason: "provider: signed out",
-    agentMessage: "Your provider was signed out.",
-  },
-  model: {
-    logReason: "provider: model changed",
-    agentMessage: "Your configured model changed.",
-  },
-  context: {
-    logReason: "provider: context window changed",
-    agentMessage: "Your configured context window changed.",
-  },
-} as const satisfies Record<string, RestartReason>
-
-/// The POST /restart body. Owned here so web and mobile cannot drift on the wire field names.
+/// The POST /restart body. Owned here so web and mobile cannot drift on the wire field name.
 export function restartBody(reason: RestartReason): RestartBody {
-  return { reason: reason.logReason, agent_message: reason.agentMessage }
+  return { reason_token: reason }
 }

--- a/vestad/src/lifecycle.rs
+++ b/vestad/src/lifecycle.rs
@@ -102,6 +102,43 @@ pub static CONTAINER_UPDATE: LifecycleReason = LifecycleReason::borrowed(
 );
 pub static DESIRED_STOP: LifecycleReason = LifecycleReason::shutdown_only("system: desired state is stopped");
 
+// Transitions only a client can name: the restart is a separate request from the provider write
+// that preceded it, so vestad cannot infer which one happened. The client names it with a token
+// and vestad supplies the copy, keeping every word the agent reads authored in this file.
+pub static PROVIDER_CONFIGURED: LifecycleReason = LifecycleReason::borrowed(
+    "provider: configuration changed",
+    "Your provider configuration changed.",
+);
+pub static PROVIDER_SIGNED_OUT: LifecycleReason =
+    LifecycleReason::borrowed("provider: signed out", "Your provider was signed out.");
+pub static PROVIDER_MODEL: LifecycleReason = LifecycleReason::borrowed(
+    "provider: model changed",
+    "Your configured model changed.",
+);
+pub static PROVIDER_CONTEXT: LifecycleReason = LifecycleReason::borrowed(
+    "provider: context window changed",
+    "Your configured context window changed.",
+);
+
+/// Every token a client may send, with the reason it resolves to. Emitted into
+/// `apps/core/fixtures/restart-reason-tokens.json` by the API contract test, so a client cannot
+/// drift onto a token this table does not carry.
+pub static CLIENT_TOKENS: [(&str, &LifecycleReason); 4] = [
+    ("provider.configured", &PROVIDER_CONFIGURED),
+    ("provider.signed-out", &PROVIDER_SIGNED_OUT),
+    ("provider.model", &PROVIDER_MODEL),
+    ("provider.context", &PROVIDER_CONTEXT),
+];
+
+/// Resolve a client token. An unknown one yields None rather than invented copy, so a client newer
+/// than this vestad degrades to the generic manual reason instead of saying something wrong.
+pub fn from_token(token: &str) -> Option<LifecycleReason> {
+    CLIENT_TOKENS
+        .iter()
+        .find(|(name, _)| *name == token)
+        .map(|(_, reason)| (*reason).clone())
+}
+
 pub fn rename(old_name: &str, new_name: &str) -> LifecycleReason {
     LifecycleReason::owned(
         format!("rename: {old_name} -> {new_name}"),
@@ -115,8 +152,12 @@ mod tests {
 
     /// Every reason vestad can hand over. Shutdown-only ones carry no agent copy: the shutdown
     /// inbox writes the log reason alone, so a sentence there would reach nobody.
-    const BOOT_FACING: [&LifecycleReason; 14] = [
+    const BOOT_FACING: [&LifecycleReason; 18] = [
         &DEFAULT_RESTART,
+        &PROVIDER_CONFIGURED,
+        &PROVIDER_SIGNED_OUT,
+        &PROVIDER_MODEL,
+        &PROVIDER_CONTEXT,
         &MANUAL_START,
         &START_ALL,
         &SCHEDULED_BACKUP,
@@ -164,6 +205,14 @@ mod tests {
         for reason in SHUTDOWN_ONLY {
             assert!(reason.agent_message.is_empty(), "{}", reason.log_reason);
         }
+    }
+
+    #[test]
+    fn every_client_token_resolves_and_unknown_ones_do_not() {
+        for (token, reason) in CLIENT_TOKENS {
+            assert_eq!(from_token(token).as_ref(), Some(reason));
+        }
+        assert!(from_token("provider.nonexistent").is_none());
     }
 
     #[test]

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -615,10 +615,15 @@ async fn stop_agent_handler(
 
 #[derive(Deserialize, Default)]
 struct RestartBody {
-    /// Operational copy. Kept under the legacy field name so older servers/clients interoperate.
+    /// Names a transition only the client can name (`crate::lifecycle::CLIENT_TOKENS`). vestad owns
+    /// the copy it resolves to, so the agent's words have one author.
+    #[serde(default)]
+    reason_token: Option<String>,
+    /// LEGACY(remove-when: no released client predating the token still posts a restart): a client
+    /// older than the token sends the copy itself.
     #[serde(default)]
     reason: Option<String>,
-    /// Complete sentence delivered to the authenticated agent after it boots.
+    /// LEGACY(remove-when: same condition as `reason`).
     #[serde(default)]
     agent_message: Option<String>,
 }
@@ -635,9 +640,19 @@ fn parse_restart_reason(
     }
     serde_json::from_slice::<RestartBody>(body)
         .map(|restart_body| {
-            restart_body.reason.map(|reason| {
-                crate::lifecycle::LifecycleReason::from_request(reason, restart_body.agent_message)
-            })
+            let RestartBody {
+                reason_token,
+                reason,
+                agent_message,
+            } = restart_body;
+            reason_token
+                .as_deref()
+                .and_then(crate::lifecycle::from_token)
+                .or_else(|| {
+                    reason.map(|reason| {
+                        crate::lifecycle::LifecycleReason::from_request(reason, agent_message)
+                    })
+                })
         })
         .map_err(|e| format!("invalid restart body: {e}"))
 }
@@ -3615,6 +3630,17 @@ mod tests {
         let sync_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../apps/core/fixtures/sync-protocol.json");
         sync_fixture_file(&sync_path, &sync_content, regen);
+
+        // The restart tokens a client may send. vestad owns the copy each resolves to, so this list
+        // is the whole contract; @vesta/core's test asserts its token table matches it exactly.
+        let tokens: Vec<&str> = crate::lifecycle::CLIENT_TOKENS
+            .iter()
+            .map(|(token, _)| *token)
+            .collect();
+        let tokens_json = serde_json::to_string_pretty(&tokens).expect("serialize tokens");
+        let tokens_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../apps/core/fixtures/restart-reason-tokens.json");
+        sync_fixture_file(&tokens_path, &format!("{tokens_json}\n"), regen);
     }
 }
 
@@ -3720,6 +3746,31 @@ mod restart_body_tests {
         assert_eq!(structured.log_reason, "provider: model changed");
         assert_eq!(structured.agent_message, "Your configured model changed.");
         assert!(parse_restart_reason(b"not json").is_err());
+    }
+
+    #[test]
+    fn a_token_resolves_to_vestad_owned_copy() {
+        let reason = parse_restart_reason(br#"{"reason_token":"provider.model"}"#)
+            .unwrap()
+            .unwrap();
+        assert_eq!(reason, crate::lifecycle::PROVIDER_MODEL);
+    }
+
+    #[test]
+    fn an_unknown_token_falls_back_rather_than_inventing_copy() {
+        // A client newer than this vestad names a transition it has no copy for. Better a generic
+        // manual restart (the None default) than a sentence vestad made up.
+        assert_eq!(
+            parse_restart_reason(br#"{"reason_token":"provider.telepathy"}"#).unwrap(),
+            None
+        );
+        // ...and a client sending both prefers the token, so the copy has one author.
+        let both = parse_restart_reason(
+            br#"{"reason_token":"provider.model","reason":"provider: something else"}"#,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(both, crate::lifecycle::PROVIDER_MODEL);
     }
 }
 


### PR DESCRIPTION
## Summary

Follows the review of #1464. The sentence an agent reads after a restart was authored in **two** places:

| Author | Where | Covers |
|---|---|---|
| vestad | `vestad/src/lifecycle.rs` | backups, restores, renames, code/container updates, mount grants, shutdown/resume |
| the clients | `apps/core/src/lifecycle/restart-reasons.ts` | the 4 provider changes |

Two authors, in two languages, for one thing the user sees, so Vesta's voice had to be reviewed in both. This moves the copy to vestad and leaves the clients naming the transition:

```jsonc
POST /agents/luna/restart   {"reason_token": "provider.model"}
```

vestad cannot infer these on its own: the restart is a **separate request** from the `PATCH /provider` that preceded it, so its restart handler has no idea which provider write just happened. The client is the only party holding the intent at that moment, and naming it is all it needs to do.

## Keeping the token list from drifting

Tokens become the whole contract once the copy moves, so they are pinned rather than trusted. `CLIENT_TOKENS` is emitted into `apps/core/fixtures/restart-reason-tokens.json` through the existing API-contract fixture seam, and a `@vesta/core` test asserts its table matches. Both drift directions fail:

- rename on the Rust side, and the fixture goes stale (`api_contract_fixtures_up_to_date`)
- rename on the TypeScript side, and it no longer matches the fixture

Verified both by deliberately renaming a token on each side and watching the corresponding test fail.

An unknown token resolves to `None` rather than invented copy, so a client newer than its gateway degrades to the generic manual reason instead of saying something wrong.

## Compatibility

Additive on the wire. `reason` / `agent_message` stay accepted for clients predating the token and now carry `LEGACY(remove-when:)` markers, so **no `MIN_SUPPORTED_CLIENT_VERSION` bump**. A client sending both prefers the token, keeping one author for the copy.

## Testing

- `./check.sh vestad`: clippy clean, 269 passed
- `./check.sh app-core` (180), `app-web` (181), `app-mobile` (113), `guards`: all pass
- Fixture regenerated with `REGEN_API_FIXTURES=1 cargo test -p vestad api_contract` and committed