### PR TITLE
refactor(ci): dedicated app-chat suite in a communication-channels job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       mobile: ${{ steps.filter.outputs.mobile }}
       mobile_native: ${{ steps.filter.outputs.mobile_native }}
       agent: ${{ steps.filter.outputs.agent }}
-      go: ${{ steps.filter.outputs.go }}
+      comms: ${{ steps.filter.outputs.comms }}
       mac_universal: ${{ steps.flags.outputs.mac_universal }}
       mobile_matrix: ${{ steps.flags.outputs.mobile_matrix }}
     steps:
@@ -137,9 +137,10 @@ jobs:
               - 'agent/**'
               - '.github/workflows/ci.yml'
               - 'check.sh'
-            go:
+            comms:
               - 'agent/skills/whatsapp/cli/**'
               - 'agent/skills/telegram/cli/**'
+              - 'agent/skills/app-chat/cli/**'
               - '.github/workflows/ci.yml'
               - 'check.sh'
 
@@ -311,11 +312,11 @@ jobs:
       - name: Run agent checks
         run: ./check.sh agent
 
-  # ── Go checks (whatsapp + telegram CLIs) ──────────────────────────────
-  go-checks:
-    name: WhatsApp & Telegram · Lint, build, and test
+  # ── Communication channels (whatsapp + telegram Go CLIs, app-chat Python CLI) ──
+  comms-checks:
+    name: Communication channels · Lint, build, and test
     needs: detect-changes
-    if: github.event_name != 'pull_request' || needs.detect-changes.outputs.go == 'true'
+    if: github.event_name != 'pull_request' || needs.detect-changes.outputs.comms == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -329,6 +330,9 @@ jobs:
             agent/skills/whatsapp/cli/go.sum
             agent/skills/telegram/cli/go.sum
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Cache whisper.cpp static build
         uses: actions/cache@v6
         with:
@@ -340,6 +344,9 @@ jobs:
 
       - name: Run telegram checks
         run: ./check.sh telegram
+
+      - name: Run app-chat checks
+        run: ./check.sh app-chat
 
   # ── Frontend unit tests (one job per app, gated on its dependency closure) ──
   # @vesta/core is the shared controller: web bundles it, desktop bundles web,
@@ -1067,7 +1074,7 @@ jobs:
       - workflow-lint
       - dependency-review
       - agent-tests
-      - go-checks
+      - comms-checks
       - test-app-core
       - test-app-web
       - test-app-desktop

--- a/check.sh
+++ b/check.sh
@@ -28,6 +28,7 @@ Suites:
   whatsapp       gofmt + go vet + go build + go test for the whatsapp skill CLI
                  (builds whisper.cpp static libs to ~/.cache/vesta-whisper on first run)
   telegram       gofmt + go vet + go build + go test for the telegram skill CLI
+  app-chat       pytest for the app-chat skill CLI (its own standalone uv project)
   integration    vestad integration tests (needs Docker)
   live           live agent e2e tests, incl. the upgrade gate (needs Docker + ~/.claude/.credentials.json; real Claude)
   upgrade        just the upgrade e2e: create an agent on the previous release, update in place
@@ -70,6 +71,9 @@ check_agent() {
     (
       unset UV_PROJECT_ENVIRONMENT
       for tool in skills/*/cli core/skills/*/cli; do
+        # app-chat has its own dedicated suite (check_app_chat), run in the
+        # communication-channels CI job alongside whatsapp/telegram.
+        [ "$tool" = "skills/app-chat/cli" ] && continue
         if [ -d "$tool/tests" ]; then
           uv run --project "$tool" pytest "$tool/tests" -q
         fi
@@ -244,6 +248,14 @@ check_telegram() {
   )
 }
 
+check_app_chat() {
+  (
+    cd agent/skills/app-chat/cli
+    # Standalone uv project (own venv + lockfile), like every skill CLI.
+    uv run --project . pytest tests -q
+  )
+}
+
 check_integration() {
   (
     cd vestad
@@ -315,6 +327,7 @@ for suite in "$@"; do
     guards) check_guards ;;
     whatsapp) check_whatsapp ;;
     telegram) check_telegram ;;
+    app-chat) check_app_chat ;;
     integration) check_integration ;;
     live) check_live ;;
     all) check_guards && check_agent && check_vestad && check_web ;;


### PR DESCRIPTION
## What

Gives the `app-chat` skill CLI a first-class test suite and groups the three messaging skills (whatsapp, telegram, app-chat) under a single **Communication channels** CI job.

app-chat tests already existed (`agent/skills/app-chat/cli/tests/`, 5 files) and already ran, but *anonymously* inside the generic `for tool in skills/*/cli` loop of `check.sh agent`, while whatsapp/telegram (Go CLIs) each get a first-class `check.sh` suite and their own CI job. This makes app-chat consistent with them, respecting the Python/Go toolchain split.

## Changes

**`check.sh`**
- New dedicated `check_app_chat` suite (`./check.sh app-chat`), running the standalone uv project's pytest.
- Skip app-chat in the generic agent-loop so the dedicated suite is its single owner (no double-run). whatsapp/telegram were already naturally skipped by that loop.
- Usage text updated.

**`.github/workflows/ci.yml`**
- Rename job `go-checks` → `comms-checks`, display name **"Communication channels · Lint, build, and test"**; add `uv` setup + a **Run app-chat checks** step alongside whatsapp/telegram.
- Rename the `go` path filter → `comms`, adding `agent/skills/app-chat/cli/**`; update the `detect-changes` output and the `merge-gate-ci` `needs`.

No test *content* changes — purely test-runner wiring.

## Verification

- `./check.sh app-chat` → **53 passed** (with a short `TMPDIR`; 4 daemon tests hit macOS's AF_UNIX 104-char path limit locally, a pre-existing env quirk that reproduces identically on master and passes on CI's Linux runners).
- Confirmed the agent loop now skips `app-chat` and no other skill is affected.
- `shellcheck -S warning check.sh` clean; `ci.yml` parses and both the `comms-checks` job and `outputs.comms` are present; no leftover `go-checks`/`outputs.go` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)