### PR TITLE
docs(agent): describe the current design, never a previous one

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -63,8 +63,8 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
     """Event bus WebSocket.
 
     Send: all events from the event bus are pushed to connected clients.
-    Recv: drained only to keep the socket live and notice a close (see _recv_loop); nothing injects
-    events anymore. On connect: sends a `snapshot` seed (state + pending notifications + config)."""
+    Recv: drained only to keep the socket live and notice a close (see _recv_loop); no inbound frame
+    injects an event. On connect: sends a `snapshot` seed (state + pending notifications + config)."""
     event_bus: EventBus = request.app["event_bus"]
     config: VestaConfig = request.app["config"]
 
@@ -105,8 +105,8 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
 
 
 async def _recv_loop(ws: web.WebSocketResponse) -> None:
-    """Drain inbound frames. Nothing injects events into the bus anymore (app-chat owns chat on its own
-    service socket); this only keeps the connection live and notices a close."""
+    """Drain inbound frames. No inbound frame injects an event into the bus (app-chat owns chat on its
+    own service socket); this only keeps the connection live and notices a close."""
     async for msg in ws:
         if msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):
             break

--- a/agent/core/cc_sdk/__init__.py
+++ b/agent/core/cc_sdk/__init__.py
@@ -1,6 +1,6 @@
 """cc_sdk — a tmux-backed reimplementation of the Claude Code agent SDK surface.
 
-Vesta talks to Claude Code through this package exactly as it used to talk to the
+Vesta talks to Claude Code through this package exactly as it talks to the
 official `claude_agent_sdk`: same message/block types, same hook plumbing, same
 MCP-tool registration, same ClaudeSDKClient lifecycle. The difference is entirely
 under the hood — `client.py` runs the real `claude` CLI interactively in tmux and

--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -474,8 +474,8 @@ class VestaConfig(pyd_settings.BaseSettings):
     """Vesta agent configuration: one central config.json (nested), per-agent.
 
     The active provider (model + context + credential) is a discriminated union under `provider`; the
-    rest are provider-independent prefs. Defaults are this model's field defaults (the manifest is the
-    generated projection of them). The store wins over env; see settings_customise_sources.
+    rest are provider-independent prefs. This model's field defaults are read from the hand-authored
+    manifest (MANIFEST_PATH). The store wins over env; see settings_customise_sources.
 
     Key env overrides (operational scalars only; provider fields live in the nested store, not env):
         LOG_LEVEL                - DEBUG | INFO | WARNING | ERROR (default: "INFO")

--- a/agent/core/events.py
+++ b/agent/core/events.py
@@ -78,8 +78,8 @@ class NotificationEvent(_BaseEvent):
     # Structured facets for the notifications history view + rule-editor suggestions. `sender` is ""
     # when the source attached no identity field. `decided` is what actually happened given the rules
     # at arrival. `notif_id` is the notification file's stem, used to tell whether it's still pending
-    # (file on disk) or cleared. NotRequired because events predating the enrichment (and any
-    # non-monitor emitter) lack them; readers already tolerate their absence. The production emit in
+    # (file on disk) or cleared. NotRequired because older stored events (and any non-monitor
+    # emitter) lack them; readers already tolerate their absence. The production emit in
     # monitor_loop always supplies them.
     notif_type: tp.NotRequired[str]
     sender: tp.NotRequired[str]

--- a/agent/core/notification_interrupt_policy.py
+++ b/agent/core/notification_interrupt_policy.py
@@ -103,8 +103,8 @@ class NotificationInterruptRule(pyd.BaseModel):
     @classmethod
     def _coerce_legacy_pool_action(cls, data: object) -> object:
         # LEGACY(remove-when: no stored rule still carries action="pool" — every agent rewrites its
-        # rules in canonical shape on its next rule edit): the snooze action was previously named
-        # "pool"; coerce stored rules on read so fleet rulesets keep validating.
+        # rules in canonical shape on its next rule edit): a stored rule may spell the snooze action
+        # "pool"; coerce it on read so fleet rulesets keep validating.
         if not isinstance(data, dict) or "action" not in data:
             return data
         data = dict(data)

--- a/agent/core/skills/upstream-sync/SKILL.md
+++ b/agent/core/skills/upstream-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: upstream-sync
-description: Sync your workspace after a Vesta upgrade by merging the new stock snapshot into your own history. Use during the upgrade boot turn, or when the user asks you to get up to date or get the latest changes.
+description: Sync your workspace after a Vesta upgrade. Use during the upgrade boot turn, or when the user asks you to get up to date or get the latest changes.
 ---
 
 # Upstream Sync
@@ -37,7 +37,7 @@ git -C ~ rev-parse -q --verify HEAD >/dev/null 2>&1 || \
 
 Then fetch the stock snapshots from Vesta's read-only local repository. A normal current
 container has the mount and uses plain `git fetch`; the fallback exists only for a fleet box
-whose container rebuild was deferred before this mount shipped:
+whose container is still awaiting the rebuild that adds the mount:
 
 ```bash
 cd ~

--- a/agent/core/skills/workspace-sync/SETUP.md
+++ b/agent/core/skills/workspace-sync/SETUP.md
@@ -1,6 +1,6 @@
-# Workspace Sync - Setup (renamed to upstream-sync)
+# Workspace Sync - Setup (pointer to upstream-sync)
 
-LEGACY(remove-when: no agent predating the release that ships this rename remains and
-the 2026-07 workspace migrations are fleet-applied): pre-rename birth instructions
-reference this path verbatim. Read `~/agent/core/skills/upstream-sync/SETUP.md` and
-follow it; everything there applies unchanged.
+LEGACY(remove-when: no agent predating the release that ships upstream-sync remains and
+the 2026-07 workspace migrations are fleet-applied): some birth instructions reference
+this path verbatim. Read `~/agent/core/skills/upstream-sync/SETUP.md` and follow it;
+everything there applies here.

--- a/agent/core/skills/workspace-sync/SKILL.md
+++ b/agent/core/skills/workspace-sync/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: workspace-sync
-description: Renamed to upstream-sync. Read ~/agent/core/skills/upstream-sync/SKILL.md instead.
+description: A pointer to upstream-sync. Read ~/agent/core/skills/upstream-sync/SKILL.md and follow that instead.
 ---
 
-# Workspace Sync (renamed to upstream-sync)
+# Workspace Sync (pointer to upstream-sync)
 
-LEGACY(remove-when: no agent predating the release that ships this rename remains and
+LEGACY(remove-when: no agent predating the release that ships upstream-sync remains and
 the 2026-07 workspace migrations are fleet-applied): released migration prompts and
-old boxes' synced scripts reference these paths verbatim. Everything this skill
-documented, including the Sync section the 2026-07 migrations point at, now lives in
+old boxes' synced scripts reference these paths verbatim. Everything under this name,
+including the Sync section the 2026-07 migrations point at, lives in
 `~/agent/core/skills/upstream-sync/SKILL.md`; read that file and follow it as written.
-Some released migration text parenthetically summarizes the old procedure as a rebase.
-That summary is historical: the current upstream-sync Sync section is authoritative and
-uses a merge. The migration may still call `set-cone.sh` and `mark_workspace_synced`
-afterward; those compatibility steps are safe no-ops that verify the result. The remaining
-scripts under `scripts/` forward to their renamed bootstrap/compatibility counterparts.
+Where a migration parenthetically summarizes the sync as a rebase, ignore that summary:
+the upstream-sync Sync section is authoritative and uses a merge. The migration may also
+call `set-cone.sh` and `mark_workspace_synced` afterward; those compatibility steps are
+safe no-ops that verify the result. The remaining scripts under `scripts/` forward to
+their upstream-sync counterparts.

--- a/agent/skills/app-chat/cli/src/app_chat_cli/cli.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/cli.py
@@ -23,11 +23,11 @@ def _build_parser() -> argparse.ArgumentParser:
 
     serve_p = sub.add_parser("serve", help="Run the app-chat daemon in the foreground")
     # LEGACY(remove-when: no running agent's restart-skill `## Daemons` line still passes
-    # --notifications-dir): accepted and ignored. Intake moved to the HTTP service; kept so
+    # --notifications-dir): accepted and ignored. Intake is owned by the HTTP service; kept so
     # existing launch lines don't break argparse.
     serve_p.add_argument("--notifications-dir", default=None, help=argparse.SUPPRESS)
     # LEGACY(remove-when: no running agent's restart-skill `## Daemons` line still passes --ws-url):
-    # accepted and ignored. The daemon no longer connects to core's /ws; the live echo fans out
+    # accepted and ignored. The daemon does not connect to core's /ws; the live echo fans out
     # in-process to the service's /ws subscribers. Kept so an existing launch line doesn't break argparse.
     serve_p.add_argument("--ws-url", default=None, help=argparse.SUPPRESS)
     serve_p.add_argument("--data-dir", default=None, help="Data directory (default: ~/.app-chat)")

--- a/agent/skills/birth/SKILL.md
+++ b/agent/skills/birth/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: birth
-description: Vesta's first-wake setup and onboarding, run once on a brand-new agent's very first boot. Come online, meet the user, move to their preferred channel, connect their email, and set up the highest-leverage skills. Invoked by the first-wake boot turn; not for later boots or restarts.
+description: Vesta's first-wake setup and onboarding, run once on a brand-new agent's very first boot. Invoked by the first-wake boot turn; not for later boots or restarts.
 ---
 
 # Birth

--- a/agent/skills/browser/cli/src/vesta_browser/bidi.py
+++ b/agent/skills/browser/cli/src/vesta_browser/bidi.py
@@ -8,8 +8,8 @@ BiDi is the W3C bidirectional protocol Camoufox's Firefox exposes on
                      {"id": N, "type": "error", "error": "...", "message": "..."}
                      {"type": "event", "method": "browsingContext.load", "params": {...}}
 
-The request/id correlation and event fan-out mirror the CDP client this replaces,
-so the daemon's loop is reused. Camoufox does not speak CDP (removed in FF141+),
+The request/id correlation and event fan-out match the CDP backend's, so the daemon's
+loop drives either one. Camoufox does not speak CDP (removed in FF141+),
 and there is no `Runtime.enable`-style leak to guard against here.
 """
 

--- a/agent/skills/dashboard/SKILL.md
+++ b/agent/skills/dashboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dashboard
-description: Use before building or modifying the user's dashboard: widgets, pages, layouts, custom UI. Understand what the user wants, design it, write a spec, then dispatch the dashboard-builder to build it.
+description: Use before building or modifying the user's dashboard: widgets, pages, layouts, custom UI.
 serve: ~/agent/skills/dashboard/scripts/daemon start
 ---
 

--- a/agent/skills/email-client/daemon_lifecycle.py
+++ b/agent/skills/email-client/daemon_lifecycle.py
@@ -153,7 +153,7 @@ def daemon_start(
     if running:
         return {"status": "already_running", "pid": pid, "session": SESSION_NAME}
     if screen_session_live():
-        # A pidfile-less daemon (launched by a raw screen line before this CLI existed)
+        # A pidfile-less daemon (launched by a raw screen line rather than this CLI)
         # is still running; `screen -dmS` would stack a second poller next to it.
         return {"error": f"a live '{SESSION_NAME}' screen session has no pidfile; quit it with `screen -S {SESSION_NAME} -X quit`, then retry"}
     stop_requested_path(state_dir).unlink(missing_ok=True)

--- a/agent/skills/email-client/imap_client.py
+++ b/agent/skills/email-client/imap_client.py
@@ -423,7 +423,7 @@ def _safe_filename(name: str | None, fallback: str) -> str:
 def _msg_summary(msg, *, include_to: bool = True) -> dict:
     """Return the JSON summary used by ``list`` / ``search`` / poll daemon.
 
-    ``list`` includes ``to``; ``search`` historically does not.
+    ``list`` includes ``to``; ``search`` does not.
     """
     out: dict = {"uid": msg.uid, "from": _from_full(msg)}
     if include_to:

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboard
-description: Use when someone who doesn't have their own vesta asks what vesta is, how to get one, or hints they want in. Vesta is invite-only: you gatekeep and build desire through scarcity, draw out what they want, then sell vesta as indispensable to their goals and set them up end-to-end in chat. Not for the owner, who already has one.
+description: Use when someone who doesn't have their own vesta asks what vesta is, how to get one, or hints they want in. Vesta is invite-only, and both the sale and the setup happen with you in chat. Not for the owner, who already has one.
 ---
 
 # onboard - CLI: `onboard`

--- a/agent/skills/onboard/cli/src/onboard_cli/client.py
+++ b/agent/skills/onboard/cli/src/onboard_cli/client.py
@@ -178,7 +178,7 @@ class Client:
     def create_agent(self, *, subdomain: str, server_token: str, name: str) -> dict[str, Any]:
         """POST <tenant>/agents — create the buyer's first (empty) agent. Personality and the
         freeform seed context are delivered later, once the agent is up, through set_provider's
-        config field (the agent owns its config store; vestad no longer accepts them at create)."""
+        config field (the agent owns its config store; vestad accepts only the name at create)."""
         url = f"{self._cfg.tenant_base(subdomain)}/agents"
         return self._json(self._raw_post(url, json={"name": name}, token=server_token, timeout=_CREATE_TIMEOUT))
 

--- a/agent/skills/onboard/cli/tests/test_cli.py
+++ b/agent/skills/onboard/cli/tests/test_cli.py
@@ -141,7 +141,7 @@ def test_verify_send_surfaces_precreate_error_without_sending(capsys, monkeypatc
 
 
 def test_verify_send_self_hosted_still_onboards(capsys, monkeypatch):
-    # No server-identity gate anymore (issue #79): a box with no VESTAD_PORT /
+    # There is no server-identity gate: a box with no VESTAD_PORT /
     # AGENT_TOKEN can still onboard through the public endpoint. create_account +
     # send_otp both run and it exits 0.
     _mock_precreate(monkeypatch)
@@ -171,8 +171,8 @@ def test_checkout_forwards_price_and_code_no_referral(capsys, monkeypatch):
     _verified()
     captured = {}
 
-    # checkout no longer takes/sends a referral (issue #79): attribution is bound
-    # at account-create, so its signature has no referral_code and no X-Vesta-Referral.
+    # checkout neither takes nor sends a referral: attribution is bound at
+    # account-create, so its signature has no referral_code and no X-Vesta-Referral.
     def fake_checkout(self, *, token, plan, price, discount_code):
         captured.update(token=token, plan=plan, price=price, discount_code=discount_code)
         return {"url": "https://checkout.stripe.com/x", "subdomain": "ada", "server_id": "srv1"}
@@ -244,7 +244,7 @@ def test_create_agent_stashes_personality_and_seed(capsys, monkeypatch):
         capsys,
     )
     assert rc == 0 and data["created"] is True and data["name"] == "ada"
-    # Create carries only the name now; vestad no longer accepts personality/seed at create time.
+    # Create carries only the name; vestad does not accept personality/seed at create time.
     assert captured == {"subdomain": "ada", "server_token": "VTOK", "name": "Ada"}
     # Personality + seed context are stashed for claude-finish to deliver via the config channel. The
     # NORMALIZED name vestad returned is stored so claude-finish addresses a path vestad accepts.

--- a/agent/skills/reduce-loc/SKILL.md
+++ b/agent/skills/reduce-loc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reduce-loc
-description: Shrink a codebase's line count without changing behavior; dead code, dedup, then architectural simplification. Use when asked to reduce LOC, simplify, or trim a repo.
+description: Shrink a codebase's line count without changing behavior. Use when asked to reduce LOC, simplify, or trim a repo.
 ---
 
 # Reduce LOC

--- a/agent/skills/trivia/SKILL.md
+++ b/agent/skills/trivia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trivia
-description: Run a trivia game with the user. Use when the user says "let's play trivia", "trivia game", "quiz", or asks for trivia questions on a topic. Generates 15 multiple-choice questions easy to hard, marks correct answers, and tallies scores across multiple players.
+description: Run a trivia game with the user, solo or scored across several players. Use when the user says "let's play trivia", "trivia game", "quiz", or asks for trivia questions on a topic.
 ---
 
 # Trivia

--- a/agent/skills/whatsapp/DEVELOPING.md
+++ b/agent/skills/whatsapp/DEVELOPING.md
@@ -32,12 +32,12 @@ goroutine can race an explicit command.
 ### One state file, one owner
 
 All daemon state lives in a single `<dataDir>/state.json` owned by `state.go`
-(`stateStore`: a pure load + atomic temp+rename save). It folds what used to be six
-separate files (managed number + pool creds, auth-status cache, last-exit reason,
-daemon-info, pairing-attempts, linked-at). The serve process is the **sole writer**;
-transient CLI commands only read it (and only when no daemon answers the socket, so
-there is no cross-process write clobber). On first start the new daemon imports any
-legacy files into `state.json` and deletes them (lossless, idempotent). `daemon.log`
+(`stateStore`: a pure load + atomic temp+rename save). It holds the managed number +
+pool creds, auth-status cache, last-exit reason, daemon-info, pairing-attempts, and
+linked-at. The serve process is the **sole writer**; transient CLI commands only read
+it (and only when no daemon answers the socket, so there is no cross-process write
+clobber). On first start the daemon imports any legacy per-key files it finds into
+`state.json` and deletes them (lossless, idempotent). `daemon.log`
 (the ~5 MB self-capping debug log), `qr-code.png`, `daemon.lock`, `whatsapp.sock`,
 and the `stop-requested` IPC marker are NOT state and stay separate.
 

--- a/agent/skills/whatsapp/cli/call_test.go
+++ b/agent/skills/whatsapp/cli/call_test.go
@@ -102,7 +102,7 @@ func TestPlaceBlocksManagedColdCall(t *testing.T) {
 	}
 
 	// After an inbound the gate passes; the call then fails on the nil meowcaller
-	// client, which proves dialing was reached (the gate no longer blocks).
+	// client, which proves dialing was reached rather than blocked at the gate.
 	storeInbound(t, wac)
 	if err := wac.requireSendAllowed(types.NewJID("15557654321", types.DefaultUserServer)); err != nil {
 		t.Errorf("managed number must be allowed to call once the peer has messaged first: %v", err)

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -507,8 +507,8 @@ func cleanupRejectedPairing(cleanup func(), activePort, requestedPort int) {
 // serve the scan page on --port (when set), then block until the user scans or the
 // window elapses, returning a terminal status. Single-flighted with every other
 // pairing op, so a link during an in-flight provision is refused (never burns a
-// rate-limit slot or serves a blank QR). Replaces the old link-start/status/stop
-// trio and the client-side poll loop.
+// rate-limit slot or serves a blank QR). One call is the whole flow: no start/status/stop
+// trio and no client-side poll loop.
 func cmdLink(args []string, wac *WhatsAppClient) (any, error) {
 	return linkViaQR("link", args, wac, func(port int) (linkResult, error) {
 		return wac.linker.linkQR(wac, port)

--- a/agent/skills/whatsapp/cli/dispatch_test.go
+++ b/agent/skills/whatsapp/cli/dispatch_test.go
@@ -2,8 +2,8 @@ package main
 
 import "testing"
 
-// TestLookupCommandAliases pins the short-alias-to-canonical resolution that the
-// command registry replaced (previously the aliases map in main.go).
+// TestLookupCommandAliases pins the short-alias-to-canonical resolution the command
+// registry performs.
 func TestLookupCommandAliases(t *testing.T) {
 	cases := []struct {
 		input string
@@ -69,8 +69,7 @@ func TestLookupCommandUnknown(t *testing.T) {
 	}
 }
 
-// TestCommandWriteFlags pins the read-only block set that the registry replaced
-// (previously the writeCommands map in cli.go).
+// TestCommandWriteFlags pins the read-only block set the registry carries.
 func TestCommandWriteFlags(t *testing.T) {
 	writeExpected := map[string]bool{
 		"send-message": true, "send-file": true, "send-reaction": true,
@@ -90,8 +89,7 @@ func TestCommandWriteFlags(t *testing.T) {
 	}
 }
 
-// TestCommandPositionals pins the positional-to-flag rewrite specs that the
-// registry replaced (previously the positionalSpecs map in main.go).
+// TestCommandPositionals pins the positional-to-flag rewrite specs the registry carries.
 func TestCommandPositionals(t *testing.T) {
 	positionalExpected := map[string][]string{
 		"send-message":          {"to", "message"},

--- a/agent/skills/whatsapp/cli/linkserver_test.go
+++ b/agent/skills/whatsapp/cli/linkserver_test.go
@@ -77,7 +77,7 @@ func TestServeLinkPage(t *testing.T) {
 
 // TestClearQRClearsCode proves a finished/abandoned link session leaves no stale
 // code for the page to serve (the QR link is single-flighted and self-contained,
-// so there is no generation machinery to reason about anymore).
+// so there is no generation machinery to reason about).
 func TestClearQRClearsCode(t *testing.T) {
 	state := newStateStore(t.TempDir())
 	state.update(func(s *daemonState) { s.AuthStatus = string(AuthStatusQRReady) })

--- a/agent/skills/whatsapp/cli/storage.go
+++ b/agent/skills/whatsapp/cli/storage.go
@@ -969,7 +969,7 @@ func (ms *MessageStore) GetLastMessageInfo(chatJID string) (time.Time, string, e
 func (ms *MessageStore) DeleteChatMessages(chatJID string) (int64, error) {
 	// Remove FTS entries for this chat before deleting messages.
 	// This is faster than letting the per-row AFTER DELETE trigger fire for each message,
-	// and avoids the old approach of wiping+rebuilding the entire FTS index.
+	// and avoids wiping and rebuilding the entire FTS index.
 	ms.db.Exec(`DELETE FROM messages_fts WHERE rowid IN (SELECT rowid FROM messages WHERE chat_jid = ?)`, chatJID)
 
 	res, err := ms.db.Exec(`DELETE FROM messages WHERE chat_jid = ?`, chatJID)

--- a/agent/tests/test_api.py
+++ b/agent/tests/test_api.py
@@ -117,7 +117,7 @@ async def test_ws_sends_empty_snapshot_when_no_events(event_bus):
 
 @pytest.mark.anyio
 async def test_ws_recv_drain_survives_garbage_and_keeps_the_socket_live(event_bus):
-    """Nothing injects events over the WS anymore: the recv loop is a pure drain. Inbound frames
+    """No inbound frame injects an event over the WS: the recv loop is a pure drain. Inbound frames
     (garbage, a stale emit frame) are ignored without killing the connection, and the socket still
     receives bus events afterwards."""
     runner, base = await _start_server(event_bus)
@@ -214,9 +214,9 @@ async def test_memory_put_writes_atomically(tmp_path):
     assert not memory_path.with_name(memory_path.name + ".tmp").exists()
 
 
-# Regression: ws_runner.cleanup() used to sit on aiohttp's 60s default shutdown_timeout
-# per open WS handler because _ws_handler had no shutdown signal. Each connected client
-# (CLI + web + mobile) added another 60s wait. Now the app's on_shutdown closes them all.
+# The app's on_shutdown closes every open WS handler, so ws_runner.cleanup() never sits on
+# aiohttp's 60s default shutdown_timeout per handler. Without that signal each connected
+# client (CLI + web + mobile) would add another 60s. This budget is the ceiling proving it.
 SHUTDOWN_BUDGET_SEC = 3.0
 
 

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -225,7 +225,7 @@ def test_stored_config_serializes_null_provider(agentdir, monkeypatch, tmp_path)
 
 @pytest.mark.parametrize("key", ["openrouter_key", "agent_provider", "agent_model", "max_context_tokens", "thinking"])
 def test_validate_config_rejects_non_pref_keys(config, key):
-    # Flat provider keys are not config fields anymore; the provider is set via /provider.
+    # Flat provider keys are not config fields; the provider is set via /provider.
     with pytest.raises(ValueError, match="not config fields"):
         validate_config_updates(config, {key: "x"})
 

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -378,8 +378,8 @@ async def test_processor_drains_turnless_compaction_on_idle_tick():
     """A compaction can be requested by a turn the processor never ran: a delivered preempt
     executing as its own CLI turn calls compact_context turnlessly while the processor is parked
     on queue.get(). The idle tick must drain it, and only once the whole session is idle (the
-    bus state tracks turnless work), never mid-stream. Regression: the drain used to fire only
-    after queue items, stranding exactly this request (v0.1.177 release, live dreamer test)."""
+    bus state tracks turnless work), never mid-stream. A drain that fires only after queue
+    items strands exactly this request."""
     from claude_agent_sdk import TextBlock
     from conftest import assistant_msg, make_stream_harness, result_msg
 

--- a/agent/tests/test_e2e_transport.py
+++ b/agent/tests/test_e2e_transport.py
@@ -183,7 +183,7 @@ async def test_sidechain_lines_are_skipped(sandbox: Sandbox) -> None:
 
 @pytest.mark.anyio
 async def test_usage_flows_to_result_and_context_usage(sandbox: Sandbox) -> None:
-    # The caller supplies the reporting window; cc_sdk no longer assumes one.
+    # The caller supplies the reporting window; cc_sdk does not assume one.
     options = ClaudeAgentOptions(cwd=str(sandbox.cwd), context_window=200_000)
     async with ClaudeSDKClient(options=options) as client:
         await client.query("hello")

--- a/agent/tests/test_event_union_fixture.py
+++ b/agent/tests/test_event_union_fixture.py
@@ -122,7 +122,7 @@ def test_every_variant_carries_a_stable_id(tmp_path):
 
 def test_variants_cover_the_tap_read_subset():
     """Pin the fixture to exactly the tap-read set (D11): a variant added or dropped here fails against
-    the hardcoded contract, since the fixture no longer mirrors the full StreamEvent union."""
+    the hardcoded contract, since the fixture covers that subset rather than the full StreamEvent union."""
     variant_types = {event["type"] for event in _variants()}
     assert variant_types == set(_TAP_READ_TYPES)
     assert len(_variants()) == len(_TAP_READ_TYPES)

--- a/agent/tests/test_eventbus.py
+++ b/agent/tests/test_eventbus.py
@@ -124,7 +124,7 @@ def test_stalled_subscriber_is_evicted_on_overflow(event_bus):
     replaced by a single EvictedEvent telling the send loop to close (the client reconnects and
     resyncs from the connect snapshot), and further emits no longer reach it. A subscriber
     either receives every event or gets a clean disconnect; nothing is dropped silently
-    (regression: issue #1160's unbounded drop-oldest storm)."""
+    (issue #1160)."""
     q = event_bus.subscribe()
     for i in range(SUBSCRIBER_QUEUE_MAXSIZE + 1):
         event_bus.emit(AssistantEvent(type="assistant", text=f"msg {i}"))

--- a/agent/tests/test_interrupts.py
+++ b/agent/tests/test_interrupts.py
@@ -298,9 +298,9 @@ async def test_attempt_interrupt_timeout_warns_without_sigterm(tmp_path, state, 
 
 @pytest.mark.anyio
 async def test_attempt_interrupt_fires_while_tool_in_flight(tmp_path, state, event_bus):
-    """attempt_interrupt still asks the SDK to interrupt while a tool is executing. The SDK
-    services the request at its next yield point; a timeout no longer SIGTERMs (see issue #737),
-    so there is no reason to suppress the interrupt during tool work."""
+    """attempt_interrupt asks the SDK to interrupt while a tool is executing. The SDK services
+    the request at its next yield point; a timeout does not SIGTERM (see issue #737), so there
+    is no reason to suppress the interrupt during tool work."""
     from core.client import attempt_interrupt
 
     config = cfg.VestaConfig(agent_dir=tmp_path / "agent", interrupt_timeout=0.01)

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -536,8 +536,8 @@ async def test_notification_file_deleted_on_normal_processing(tmp_path):
 async def test_cancellation_triggers_restart(tmp_path):
     """If process_message raises CancelledError, restart_reason + graceful_shutdown must be set.
 
-    Regression test for a silent-death bug: CancelledError used to propagate uncaught,
-    bypassing the restart trigger and leaving the agent wedged until backup SIGTERM hours later.
+    An uncaught CancelledError bypasses the restart trigger and leaves the agent silently
+    wedged until the backup SIGTERM hours later.
     """
     from core.loops import _run_messages_with_preempts
 
@@ -594,8 +594,8 @@ async def test_cancellation_during_shutdown_is_silent(tmp_path):
 
 @pytest.mark.anyio
 async def test_handle_processor_done_silent_cancel_triggers_restart(tmp_path):
-    """Regression: a cancelled processor task used to return silently, leaving the agent wedged.
-    Now it must log + set restart_reason + set graceful_shutdown."""
+    """A cancelled processor task must log + set restart_reason + set graceful_shutdown.
+    Returning silently leaves the agent wedged."""
     from core.main import handle_processor_done
 
     config = cfg.VestaConfig(agent_dir=tmp_path / "agent")

--- a/agent/tests/test_upstream_sync.py
+++ b/agent/tests/test_upstream_sync.py
@@ -670,8 +670,8 @@ def test_forwarding_workspace_sync_scripts_behave_identically(tmp_path):
 
 def test_legacy_workspace_skill_routes_released_migration_to_the_current_merge_flow():
     text = WORKSPACE_SYNC_SKILL.read_text()
-    assert "summary is historical" in text
-    assert "current upstream-sync Sync section is authoritative" in text
+    assert "ignore that summary" in text
+    assert "upstream-sync Sync section is authoritative" in text
     assert "uses a merge" in text
 
 


### PR DESCRIPTION
Applies the prompting guide's two newest rules across everything under `agent/`: the scope is every file the agent reads, runs, or edits (including CLI code comments and docstrings), and none of it may describe a previous design.

## Why

The agent reads every instruction cold, with no knowledge that the system was ever different, so "the daemon no longer connects to core's /ws" reads as a statement about the system it is running in. Rewrites those into the mechanism and the constraint that hold now.

## What changed

- **Engine, skills, and skill CLIs**: changelog-shaped comments and docstrings restated in the present. `whatsapp/DEVELOPING.md`'s "it folds what used to be six separate files" becomes the list of what `state.json` holds; the whatsapp command-registry tests drop "(previously the aliases map in main.go)".
- **Test docstrings**: eight "Regression: X used to break" comments become the invariant they pin, so a reader learns what must be true rather than what once broke.
- **Six skill descriptions** that summarized their own workflow (`birth`, `dashboard`, `onboard`, `reduce-loc`, `trivia`, `workspace-sync`, plus `upstream-sync`). A description is discovery text; an agent that can read the steps from it follows those instead of opening the body.

Passages describing state the agent can still **encounter** are kept and reworded to describe that state directly: a stored rule spelled the old way, a box awaiting the rebuild that adds a mount, an account that must re-auth once. Migrations are untouched for the same reason.

Text-only. `test_upstream_sync.py` moves with it because it pins the workspace-sync stub's wording.

## Verification

`./check.sh agent` 720 passed; `./check.sh guards` passed. The Go files here are comment-only edits but `gofmt` is not installed locally, so that suite is unverified and left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUwSaWmL7D6vpn3tZYBZBV