### PR TITLE
fix(guards): select shell and python scripts by shebang, not extension

### DIFF
--- a/agent/skills/torrents/plugins/torrentleech/search
+++ b/agent/skills/torrents/plugins/torrentleech/search
@@ -148,68 +148,6 @@ tl_search() {
     echo "$response"
 }
 
-format_results() {
-    local json="$1"
-    local limit="${2:-20}"
-
-    python3 << 'PYEOF'
-import json, sys
-
-try:
-    data = json.loads(r"""JSONDATA""")
-except (json.JSONDecodeError, Exception) as e:
-    # Try to detect common errors
-    raw = r"""JSONDATA"""
-    if "site-blocked" in raw.lower() or "blocked" in raw.lower():
-        print("ERROR: Connection blocked by ISP. Use a VPN/SOCKS5 proxy.", file=sys.stderr)
-    elif "login" in raw.lower() or "account" in raw.lower():
-        print("ERROR: Not authenticated. Run with --relogin flag.", file=sys.stderr)
-    elif "SSL" in raw or "ssl" in raw or "wrong version" in raw:
-        print("ERROR: SSL/TLS error - likely ISP blocking. Use a VPN/SOCKS5 proxy.", file=sys.stderr)
-        print(f"Raw: {raw[:200]}", file=sys.stderr)
-    else:
-        print(f"ERROR: Could not parse response: {e}", file=sys.stderr)
-        print(f"Raw: {raw[:300]}", file=sys.stderr)
-    sys.exit(1)
-
-torrents = data.get("torrentList", data.get("torrents", []))
-total = data.get("numFound", len(torrents))
-limit = LIMIT_VAL
-
-print(f"Found {total} results (showing {min(limit, len(torrents))}):")
-print()
-print(f"{'#':>3}  {'Seeds':>5}  {'Leech':>5}  {'Size':>10}  {'Name'}")
-print(f"{'':->3}  {'':->5}  {'':->5}  {'':->10}  {'':->60}")
-
-for i, t in enumerate(torrents[:limit]):
-    name = t.get("name", t.get("filename", "Unknown"))
-    seeds = t.get("seeders", 0)
-    leech = t.get("leechers", 0)
-    size = t.get("size", 0)
-    fid = t.get("fid", t.get("id", ""))
-    filename = t.get("filename", name)
-    cat = t.get("categoryID", "")
-
-    # Format size
-    if isinstance(size, (int, float)):
-        if size > 1073741824:
-            size_str = f"{size/1073741824:.2f} GB"
-        elif size > 1048576:
-            size_str = f"{size/1048576:.1f} MB"
-        else:
-            size_str = f"{size/1024:.0f} KB"
-    else:
-        size_str = str(size)
-
-    print(f"{i+1:3d}  {seeds:5d}  {leech:5d}  {size_str:>10}  {name[:80]}")
-
-    # Store download info for --add
-    dl_url = f"/download/{fid}/{filename}.torrent"
-    print(f"     -> fid={fid}  dl={dl_url}")
-    print()
-PYEOF
-}
-
 download_torrent() {
     local fid="$1"
     local filename="$2"

--- a/agent/skills/vestad/scripts/register-service
+++ b/agent/skills/vestad/scripts/register-service
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
 # Register a background service with vestad and print the assigned port.
 # Pass --public for services that need a public tunnel route (no token), omit
 # it for token-only services. Registration is idempotent: vestad returns the
@@ -19,6 +17,8 @@ set -euo pipefail
 # Usage: register-service <name> [--public]
 #   PORT=$(~/agent/skills/vestad/scripts/register-service tasks)
 #   PORT=$(~/agent/skills/vestad/scripts/register-service dashboard --public)
+
+set -euo pipefail
 
 NAME="${1:?Usage: register-service <name> [--public]}"
 if [ "${2:-}" = "--public" ]; then

--- a/agent/skills/vpn/vpn
+++ b/agent/skills/vpn/vpn
@@ -89,8 +89,10 @@ resolve_env() {
 }
 
 build_proxy_url() {
-    local provider="${1:-$(get_active_provider)}"
-    local ptype host port user_env pass_env username password
+    local provider ptype host port user_env pass_env username password
+    # An unreadable active_provider falls through to the unknown-provider diagnostic below rather
+    # than aborting here under `set -e` with no message.
+    provider=$(get_active_provider) || provider=""
 
     ptype=$(get_provider_field "$provider" "type") || { echo "error: unknown provider '$provider'" >&2; return 1; }
     host=$(get_provider_field "$provider" "host") || { echo "error: missing host for '$provider'" >&2; return 1; }

--- a/agent/tests/test_check_conventions.py
+++ b/agent/tests/test_check_conventions.py
@@ -66,6 +66,33 @@ def test_trailing_comment_block_at_eof_is_flagged(tmp_path, monkeypatch):
     assert len(check_conventions.check_comment_blocks([rel])) == 1
 
 
+def test_header_block_under_a_shebang_is_exempt(tmp_path, monkeypatch):
+    """A shebang joins the run below it, so a documented script keeps its header exemption.
+
+    Pins the behavior extensionless skill CLIs now depend on: their doc sits under a shebang, and
+    any code between the two ends the run and makes the doc an ordinary capped block.
+    """
+    monkeypatch.chdir(tmp_path)
+    documented = "#!/usr/bin/env bash\n" + "# usage\n" * 12 + "echo ok\n"
+    assert check_conventions.check_comment_blocks([write(tmp_path, "tool.sh", documented)]) == []
+    # Code between the shebang and the block makes it an ordinary mid-file comment again.
+    after_code = "#!/usr/bin/env bash\nset -e\n" + "# usage\n" * 12 + "echo ok\n"
+    assert len(check_conventions.check_comment_blocks([write(tmp_path, "later.sh", after_code)])) == 1
+
+
+def test_extensionless_scripts_are_checked_by_shebang(tmp_path, monkeypatch):
+    """Skill CLIs are bare command names; language comes from the shebang so they stay covered."""
+    monkeypatch.chdir(tmp_path)
+    marker = "shell" + "check disable=SC2086"  # split so the conventions guard does not flag this fixture
+    shell = write(tmp_path, "hue", f"#!/usr/bin/env bash\necho hi\n# {marker}\necho $x\n")
+    assert len(check_conventions.check_escapes([shell])) == 1
+    noqa = "no" + "qa"
+    python = write(tmp_path, "skills-search", f"#!/usr/bin/env python3\nx = 1  # {noqa}: E501\n")
+    assert len(check_conventions.check_escapes([python])) == 1
+    # An extensionless file with no shell/python shebang stays out of scope.
+    assert check_conventions.check_escapes([write(tmp_path, "LICENSE", f"# {noqa}\n")]) == []
+
+
 def test_import_cycle_is_detected(tmp_path):
     (tmp_path / "a.py").write_text("from . import b\n")
     (tmp_path / "b.py").write_text("from .a import thing\n")

--- a/check.sh
+++ b/check.sh
@@ -175,7 +175,13 @@ check_guards() {
   uv run --project agent/core python scripts/check-conventions.py || failed=1
 
   if command -v shellcheck >/dev/null; then
-    git ls-files '*.sh' | xargs shellcheck -S warning || failed=1
+    # Selected by shebang, not just extension: several skill CLIs are bare command names
+    # (hue, daemon, skills-install) that must keep those names to stay invocable. The shebang
+    # pattern matches scripts/check-conventions.py so both guards cover the same set.
+    { git ls-files '*.sh'; git ls-files | while IFS= read -r f; do
+        case "${f##*/}" in *.*) continue ;; esac
+        if head -n1 -- "$f" 2>/dev/null | grep -qE '^#!.*\b(ba|da|k|z)?sh\b'; then echo "$f"; fi
+      done; } | sort -u | xargs shellcheck -S warning || failed=1
   else
     echo "error: shellcheck is not installed (apt install shellcheck / brew install shellcheck)" >&2
     failed=1

--- a/scripts/check-conventions.py
+++ b/scripts/check-conventions.py
@@ -23,6 +23,11 @@ ESCAPE_PATTERNS: list[tuple[str, re.Pattern[str], tuple[str, ...]]] = [
     ("shellcheck disable", re.compile(r"#\s*shellcheck\s+disable"), (".sh",)),
 ]
 
+# An extensionless tracked file is still Python or shell when its shebang says so. Several skill CLIs
+# are bare command names (hue, daemon, skills-install) and must keep those names to stay invocable, so
+# language is resolved from the shebang rather than by renaming them.
+SHEBANG_SUFFIXES = ((re.compile(r"^#!.*\bpython[\d.]*\b"), ".py"), (re.compile(r"^#!.*\b(ba|da|k|z)?sh\b"), ".sh"))
+
 COMMENT_MARKERS = {
     ".py": "#",
     ".sh": "#",
@@ -44,13 +49,26 @@ def tracked_files() -> list[str]:
     return [line for line in out.stdout.splitlines() if not line.startswith(SKIP_PREFIXES)]
 
 
+def effective_suffix(path: pl.Path) -> str:
+    """The suffix deciding a file's language, read from the shebang when the name carries none."""
+    if path.suffix:
+        return path.suffix
+    with path.open(errors="replace") as handle:
+        first_line = handle.readline()
+    for pattern, suffix in SHEBANG_SUFFIXES:
+        if pattern.search(first_line):
+            return suffix
+    return ""
+
+
 def check_escapes(files: list[str]) -> list[str]:
     errors = []
     for rel in files:
         path = pl.Path(rel)
         if not path.exists():
             continue
-        patterns = [(name, rx) for name, rx, exts in ESCAPE_PATTERNS if path.suffix in exts]
+        suffix = effective_suffix(path)
+        patterns = [(name, rx) for name, rx, exts in ESCAPE_PATTERNS if suffix in exts]
         if not patterns:
             continue
         for lineno, line in enumerate(path.read_text(errors="replace").splitlines(), 1):
@@ -81,8 +99,11 @@ def check_comment_blocks(files: list[str]) -> list[str]:
     errors = []
     for rel in files:
         path = pl.Path(rel)
-        marker = COMMENT_MARKERS.get(path.suffix, "")
-        if not marker or not path.exists():
+        if not path.exists():
+            continue
+        suffix = effective_suffix(path)
+        marker = COMMENT_MARKERS[suffix] if suffix in COMMENT_MARKERS else ""
+        if not marker:
             continue
         for start, length in file_comment_blocks(path, marker):
             errors.append(f"{rel}:{start}: comment block of {length} lines (max {MAX_COMMENT_BLOCK}); simplify the code instead")


### PR DESCRIPTION
## The gap

Eighteen tracked scripts are bare command names (`hue`, `daemon`, `skills-install`) because that is how the agent and their `SKILL.md` invoke them. Both guards keyed off the filename extension:

- `check.sh` ran `git ls-files '*.sh' | xargs shellcheck`
- `check-conventions.py` scoped `# shellcheck disable` to `.sh` and `# noqa` to `.py`

So none of those scripts were shellchecked, and none were scanned for banned escape hatches. Renaming them would fix the lint by breaking the interface, so language is now resolved from the shebang instead.

## What bringing them in surfaced

Two real findings, both fixed here rather than silenced:

- **`torrents/plugins/torrentleech/search`**: `format_results` was dead *and* could never have worked. Its heredoc is quoted (`<< 'PYEOF'`), so `JSONDATA` and `LIMIT_VAL` stayed literal placeholders that would raise on any call. No callers anywhere in the repo. Deleted. Flagging explicitly as pre-existing dead code this change surfaced, in case you would rather keep it.
- **`vpn`**: `build_proxy_url` took an optional provider argument that none of its three callers pass. Dropped.

## A bug in the comment-block cap

The header exemption tested `start > 1`, which cannot hold in a file whose line 1 is a shebang — so every shebang'd script had its module doc flagged. This never mattered while only extension-matched files were checked.

The exemption is now **"the block no code precedes"**, and a shebang counts as neither prose nor code. `register-service` keeps its usage doc by moving `set -euo pipefail` below it.

My first attempt at this ("first block starting within the first 5 lines") was wrong: it exempted mid-file blocks that follow code. The existing tests caught it, which is why the rule is now structural rather than positional.

## Tests

Two added, covering both new behaviors: a header block under a shebang is exempt while the same block after a line of code is not, and extensionless scripts are escape-scanned by shebang while an extensionless file with no shell/python shebang stays out of scope.

## Verification

`./check.sh guards` passed; `test_check_conventions.py` 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUwSaWmL7D6vpn3tZYBZBV