### PR TITLE
fix(vestad): fold scheduled backups into the agent's compaction restart

### DIFF
--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -251,13 +251,12 @@ function GatewaySetupFields({ setup }: { setup: GatewaySetup }) {
         <FieldContent>
           <FieldLabel className="text-sm">backups</FieldLabel>
           <FieldDescription>
-            automatic nightly snapshots of your agents
+            automatic nightly snapshots, taken during each agent&apos;s own
+            restart so none interrupts it
           </FieldDescription>
         </FieldContent>
         <span className="shrink-0 text-sm text-muted-foreground">
-          {setup.settings.auto_backup.enabled
-            ? `daily at ${String(setup.settings.auto_backup.hour).padStart(2, "0")}:00 server time`
-            : "disabled"}
+          {setup.settings.auto_backup.enabled ? "nightly" : "disabled"}
         </span>
       </Field>
     </div>

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -17,6 +17,58 @@ const MIN_DISK_SPACE_BYTES: u64 = 1_000_000_000; // 1 GB
 const DISK_SPACE_MARGIN_BYTES: u64 = 500_000_000; // 500 MB margin above container size
 pub const BACKUP_STOP_TIMEOUT_SECS: i32 = 30;
 pub const MIN_AGE_FOR_BACKUP_SECS: u64 = 6 * 3600;
+/// How stale the newest daily may get before the scheduler stops an agent to back it up. Above the
+/// ~30h two nightly dream-restarts can legitimately be apart (the dreamer's own catch-up window),
+/// so an agent that dreams keeps riding its restarts and is never stopped by the scheduler.
+pub const FORCED_BACKUP_STALENESS_SECS: u64 = 36 * 3600;
+
+/// The scheduled backup types `backups` does not yet cover: one daily per local day, one weekly per
+/// 7 days, one monthly per 30 days. Taking these is free while the container is already stopped;
+/// `forced_backup_is_overdue` is the separate, stricter bar for causing a stop.
+pub fn due_scheduled_types(backups: &[BackupInfo], now_epoch: u64) -> Vec<BackupType> {
+    let today_local = crate::time_utils::local_date_of_epoch(now_epoch);
+    let seven_days_ago = crate::time_utils::now_timestamp_from_epoch(now_epoch - 7 * 86400);
+    let thirty_days_ago = crate::time_utils::now_timestamp_from_epoch(now_epoch - 30 * 86400);
+
+    let mut due = Vec::new();
+    let has_daily_today = backups.iter().any(|b| {
+        b.backup_type == BackupType::Daily
+            && crate::time_utils::parse_compact_utc_epoch(&b.created_at)
+                .map(crate::time_utils::local_date_of_epoch)
+                .as_deref()
+                == Some(today_local.as_str())
+    });
+    if !has_daily_today {
+        due.push(BackupType::Daily);
+    }
+    let has_recent_weekly = backups
+        .iter()
+        .any(|b| b.backup_type == BackupType::Weekly && b.created_at >= seven_days_ago);
+    if !has_recent_weekly {
+        due.push(BackupType::Weekly);
+    }
+    let has_recent_monthly = backups
+        .iter()
+        .any(|b| b.backup_type == BackupType::Monthly && b.created_at >= thirty_days_ago);
+    if !has_recent_monthly {
+        due.push(BackupType::Monthly);
+    }
+    due
+}
+
+/// Whether the newest daily is stale enough to justify stopping the agent for a backup. An agent
+/// that dreams nightly rides the backup into its own compaction restart and never gets here.
+pub fn forced_backup_is_overdue(backups: &[BackupInfo], now_epoch: u64) -> bool {
+    let newest_daily = backups
+        .iter()
+        .filter(|b| b.backup_type == BackupType::Daily)
+        .filter_map(|b| crate::time_utils::parse_compact_utc_epoch(&b.created_at))
+        .max();
+    match newest_daily {
+        Some(created) => now_epoch.saturating_sub(created) >= FORCED_BACKUP_STALENESS_SECS,
+        None => true,
+    }
+}
 
 /// Acquire an exclusive file lock for the given agent. The lock is held for the
 /// lifetime of the returned Flock. Used to coordinate between the vestad API and
@@ -180,12 +232,15 @@ pub async fn create_backup(
     result
 }
 
-/// Create multiple backup types in one stop/start cycle (separate restic
-/// snapshots, deduplicated). Returns a result per type; failures don't block others.
+/// Create multiple backup types in one stop/start cycle (separate restic snapshots, deduplicated).
+/// Returns a result per type; failures don't block others. `resume_reason` is the transition the
+/// agent reads on the way back up: the scheduler's own pause, or the restart this batch folded
+/// itself into, which the agent must still see as the reason it restarted.
 pub async fn create_backups_batch(
     docker: &Docker,
     name: &str,
     types: Vec<BackupType>,
+    resume_reason: &crate::lifecycle::LifecycleReason,
 ) -> Vec<(BackupType, Result<BackupInfo, DockerError>)> {
     let fail_all = |types: Vec<BackupType>,
                     e: DockerError|
@@ -203,8 +258,7 @@ pub async fn create_backups_batch(
     };
     let types_for_stop_failure = types.clone();
 
-    // Batch backups are only ever the auto-backup's scheduled set, so one scheduled reason fits.
-    let paused_result = with_container_paused(docker, name, cs, &crate::lifecycle::SCHEDULED_BACKUP, || async {
+    let paused_result = with_container_paused(docker, name, cs, resume_reason, || async {
         let mut results = Vec::new();
         for bt in types {
             let result = crate::restic::snapshot(name, &bt).await;
@@ -443,6 +497,104 @@ mod tests {
             !restore_body.contains("remove_container_force"),
             "restore_backup must use ensure_container_removed (confirms gone), not the best-effort remove_container_force"
         );
+    }
+
+    // ── Scheduled-backup scheduling tests ─────────────────────────
+
+    // Fixed so the local-date arithmetic is deterministic in any host timezone: every expectation
+    // below derives its timestamps from this same epoch.
+    const NOW: u64 = 1_780_000_000;
+
+    fn backup_at(bt: BackupType, secs_ago: u64) -> BackupInfo {
+        make_backup(
+            "a",
+            bt,
+            &crate::time_utils::now_timestamp_from_epoch(NOW - secs_ago),
+        )
+    }
+
+    #[test]
+    fn every_type_is_due_when_the_agent_has_never_been_backed_up() {
+        assert_eq!(
+            due_scheduled_types(&[], NOW),
+            vec![BackupType::Daily, BackupType::Weekly, BackupType::Monthly]
+        );
+    }
+
+    #[test]
+    fn nothing_is_due_while_each_type_is_inside_its_window() {
+        let backups = vec![
+            backup_at(BackupType::Daily, 0),
+            backup_at(BackupType::Weekly, 2 * 86400),
+            backup_at(BackupType::Monthly, 10 * 86400),
+        ];
+        assert!(due_scheduled_types(&backups, NOW).is_empty());
+    }
+
+    #[test]
+    fn a_daily_from_a_previous_day_comes_due_again() {
+        let backups = vec![
+            backup_at(BackupType::Daily, 86400),
+            backup_at(BackupType::Weekly, 2 * 86400),
+            backup_at(BackupType::Monthly, 10 * 86400),
+        ];
+        assert_eq!(due_scheduled_types(&backups, NOW), vec![BackupType::Daily]);
+    }
+
+    #[test]
+    fn a_lapsed_weekly_and_monthly_ride_along_with_the_daily() {
+        let backups = vec![
+            backup_at(BackupType::Daily, 86400),
+            backup_at(BackupType::Weekly, 8 * 86400),
+            backup_at(BackupType::Monthly, 31 * 86400),
+        ];
+        assert_eq!(
+            due_scheduled_types(&backups, NOW),
+            vec![BackupType::Daily, BackupType::Weekly, BackupType::Monthly]
+        );
+    }
+
+    #[test]
+    fn a_never_backed_up_agent_is_overdue_enough_to_stop() {
+        assert!(forced_backup_is_overdue(&[], NOW));
+    }
+
+    #[test]
+    fn a_daily_inside_the_staleness_window_does_not_justify_a_stop() {
+        let backups = vec![backup_at(
+            BackupType::Daily,
+            FORCED_BACKUP_STALENESS_SECS - 1,
+        )];
+        assert!(!forced_backup_is_overdue(&backups, NOW));
+    }
+
+    #[test]
+    fn a_daily_past_the_staleness_window_justifies_a_stop() {
+        let backups = vec![backup_at(BackupType::Daily, FORCED_BACKUP_STALENESS_SECS)];
+        assert!(forced_backup_is_overdue(&backups, NOW));
+    }
+
+    #[test]
+    fn only_the_newest_daily_decides_staleness() {
+        let backups = vec![
+            backup_at(BackupType::Daily, 30 * 86400),
+            backup_at(BackupType::Daily, 3600),
+        ];
+        assert!(!forced_backup_is_overdue(&backups, NOW));
+    }
+
+    #[test]
+    fn an_agent_backed_up_by_its_nightly_restart_is_never_stopped_by_the_scheduler() {
+        // The dream restart takes the daily and the next one lands up to 30h later (the dreamer's
+        // catch-up window). The type is due again, but never stale enough to be worth a stop.
+        for secs_ago in [24 * 3600, 30 * 3600] {
+            let backups = vec![backup_at(BackupType::Daily, secs_ago)];
+            assert_eq!(
+                due_scheduled_types(&backups, NOW),
+                vec![BackupType::Daily, BackupType::Weekly, BackupType::Monthly]
+            );
+            assert!(!forced_backup_is_overdue(&backups, NOW));
+        }
     }
 
     // ── Retention policy tests ────────────────────────────────────

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -2216,6 +2216,20 @@ fn restart_reason_for_mount_change(
         .unwrap_or_else(|| crate::lifecycle::DEFAULT_RESTART.clone())
 }
 
+/// Whether a restart of `name` must recreate the container to apply changed host-folder grants,
+/// rather than the plain stop/start a backup can fold itself into. An inspect failure answers
+/// false, matching the plain-restart fallback `restart_agent` takes on the same failure.
+pub async fn restart_needs_recreate(
+    docker: &Docker,
+    name: &str,
+    user_mounts: &[crate::mounts::HostMount],
+) -> bool {
+    match docker.inspect_container(&container_name(name), None).await {
+        Ok(raw) => user_mounts_drifted(&actual_user_mounts(&raw), user_mounts),
+        Err(_) => false,
+    }
+}
+
 pub async fn restart_agent(
     docker: &Docker,
     name: &str,

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -688,6 +688,10 @@ async fn restart_agent_handler(
             let settings = state.settings.read().await;
             settings.agent_mounts(&name)
         };
+        if take_scheduled_backups_during_restart(&state, &name, &user_mounts, reason.as_ref()).await
+        {
+            return Ok(ok_json());
+        }
         docker::restart_agent(
             &state.docker,
             &name,
@@ -701,6 +705,81 @@ async fn restart_agent_handler(
         Ok(ok_json())
     })
     .await
+}
+
+/// The category the agent's post-compaction restart carries (`lifecycle.py`'s `COMPACTION_RESTART`).
+/// The nightly dream ends in one, which is what makes it the moment a scheduled backup is free.
+const COMPACTION_RESTART_CATEGORY: &str = "compaction:";
+
+/// Fold the agent's due scheduled backups into a restart it asked for itself, returning whether the
+/// restart is now done. A backup is a stop, a snapshot, and a start; a restart is a stop and a
+/// start. Snapshotting inside a stop already happening is what keeps the scheduler from ever having
+/// to stop a working agent, and loses nothing the restart was not about to lose anyway. Declined,
+/// leaving the caller to restart normally, when the agent did not initiate the restart (a user
+/// should not wait on a snapshot), backups are off, nothing is due, grants drifted so the container
+/// needs the recreate a plain stop/start cannot do, or every snapshot failed, since a batch that
+/// fails preflight never cycles the container at all.
+async fn take_scheduled_backups_during_restart(
+    state: &SharedState,
+    name: &str,
+    user_mounts: &[crate::mounts::HostMount],
+    reason: Option<&crate::lifecycle::LifecycleReason>,
+) -> bool {
+    let Some(reason) =
+        reason.filter(|reason| reason.log_reason.starts_with(COMPACTION_RESTART_CATEGORY))
+    else {
+        return false;
+    };
+    let (enabled, retention) = {
+        let settings = state.settings.read().await;
+        settings.backup.effective_for(name)
+    };
+    if !enabled {
+        return false;
+    }
+    let mut backups = match backup::list_backups(&state.env_config.agents_dir, name).await {
+        Ok(backups) => backups,
+        Err(e) => {
+            tracing::warn!(agent = %name, error = %e, "restart-backup: failed to list backups");
+            return false;
+        }
+    };
+    let due = backup::due_scheduled_types(&backups, crate::time_utils::now_epoch_secs());
+    if due.is_empty() || docker::restart_needs_recreate(&state.docker, name, user_mounts).await {
+        return false;
+    }
+    // A backup only starts a container it stopped itself, so it cannot double as the restart of one
+    // that is already down; that agent still has to come up.
+    if docker::container_status(&state.docker, &docker::container_name(name)).await
+        != docker::ContainerStatus::Running
+    {
+        return false;
+    }
+    let Ok(_file_lock) = backup::agent_file_lock(name) else {
+        tracing::warn!(agent = %name, "restart-backup: failed to acquire lock");
+        return false;
+    };
+    tracing::info!(agent = %name, types = ?due, "restart-backup: agent restarting, taking due backups");
+    let mut created_any = false;
+    for (backup_type, result) in
+        backup::create_backups_batch(&state.docker, name, due, reason).await
+    {
+        match result {
+            Ok(info) => {
+                tracing::info!(agent = %name, backup_type = %backup_type, backup_id = %info.id, "restart-backup: created");
+                backups.insert(0, info);
+                created_any = true;
+            }
+            Err(e) => {
+                tracing::error!(agent = %name, backup_type = %backup_type, error = %e, "restart-backup: failed");
+            }
+        }
+    }
+    if !created_any {
+        return false;
+    }
+    backup::cleanup_backups(name, &backups, &retention).await;
+    true
 }
 
 async fn destroy_agent_handler(
@@ -2506,8 +2585,9 @@ pub fn build_router(state: SharedState) -> Router {
     // token against the agent name in the path — so an agent can stop/restart only itself. This is
     // how the agent's restart_vesta/stop_vesta tools reach vestad (it then does the docker action).
     // Stop is quick (control tier); restart can trigger a full snapshot+recreate when host-folder
-    // grants drifted (docker export|import), which for a multi-GB agent exceeds the control deadline —
-    // so it rides the longrun timeout like the create route, not the control tier.
+    // grants drifted (docker export|import), and folds the agent's due scheduled backups into its
+    // stop, either of which for a multi-GB agent exceeds the control deadline — so it rides the
+    // longrun timeout like the create route, not the control tier.
     let agents_self_stop = Router::new()
         .route("/agents/{name}/stop", post(stop_agent_handler))
         .layer(control_timeout_layer())
@@ -2642,10 +2722,6 @@ fn spawn_auto_backup_task(state: SharedState) {
             tracing::info!(agent_count = agents.len(), "auto-backup: starting cycle");
 
             let now_epoch = crate::time_utils::now_epoch_secs();
-            let today_local = crate::time_utils::local_date_of_epoch(now_epoch);
-            let seven_days_ago = crate::time_utils::now_timestamp_from_epoch(now_epoch - 7 * 86400);
-            let thirty_days_ago =
-                crate::time_utils::now_timestamp_from_epoch(now_epoch - 30 * 86400);
 
             for name in &agents {
                 // Resolve per-agent settings (override or global fallback)
@@ -2674,36 +2750,12 @@ fn spawn_auto_backup_task(state: SharedState) {
                     }
                 };
 
-                let mut needed = Vec::new();
+                let needed = backup::due_scheduled_types(&backups, now_epoch);
 
-                let has_daily_today = backups.iter().any(|b| {
-                    b.backup_type == crate::types::BackupType::Daily
-                        && crate::time_utils::parse_compact_utc_epoch(&b.created_at)
-                            .map(crate::time_utils::local_date_of_epoch)
-                            .as_deref()
-                            == Some(today_local.as_str())
-                });
-                if !has_daily_today {
-                    needed.push(crate::types::BackupType::Daily);
-                }
-
-                let has_recent_weekly = backups.iter().any(|b| {
-                    b.backup_type == crate::types::BackupType::Weekly
-                        && b.created_at >= seven_days_ago
-                });
-                if !has_recent_weekly {
-                    needed.push(crate::types::BackupType::Weekly);
-                }
-
-                let has_recent_monthly = backups.iter().any(|b| {
-                    b.backup_type == crate::types::BackupType::Monthly
-                        && b.created_at >= thirty_days_ago
-                });
-                if !has_recent_monthly {
-                    needed.push(crate::types::BackupType::Monthly);
-                }
-
-                if !needed.is_empty() {
+                // The safety net, not the normal path: an agent that restarts itself nightly to
+                // compact has already had these taken during a stop it was making anyway. Stopping
+                // a working agent is only worth it once its newest daily has gone properly stale.
+                if !needed.is_empty() && backup::forced_backup_is_overdue(&backups, now_epoch) {
                     let _file_lock = match backup::agent_file_lock(name) {
                         Ok(lock) => lock,
                         Err(e) => {
@@ -2712,8 +2764,13 @@ fn spawn_auto_backup_task(state: SharedState) {
                         }
                     };
                     tracing::info!(agent = %name, types = ?needed, "auto-backup: creating backups");
-                    for (bt, result) in
-                        backup::create_backups_batch(&state.docker, name, needed).await
+                    for (bt, result) in backup::create_backups_batch(
+                        &state.docker,
+                        name,
+                        needed,
+                        &crate::lifecycle::SCHEDULED_BACKUP,
+                    )
+                    .await
                     {
                         match result {
                             Ok(info) => {

--- a/vestad/tests-integration/src/client.rs
+++ b/vestad/tests-integration/src/client.rs
@@ -256,6 +256,14 @@ impl Client {
         Ok(())
     }
 
+    /// Restart naming the transition, the way the agent itself does when it restarts after
+    /// compacting its context.
+    pub fn restart_agent_with_reason(&self, name: &str, reason: &str) -> Result<(), String> {
+        let body = serde_json::json!({"reason": reason});
+        self.post_json(&format!("/agents/{name}/restart"), &body)?;
+        Ok(())
+    }
+
     pub fn destroy_agent(&self, name: &str) -> Result<(), String> {
         self.delete(&format!("/agents/{name}"))?;
         Ok(())

--- a/vestad/tests/server/backup.rs
+++ b/vestad/tests/server/backup.rs
@@ -27,6 +27,89 @@ fn wait_for_events_db(cname: &str) {
     }
 }
 
+/// The reason the agent sends when it restarts after compacting, which the nightly dream ends with.
+const COMPACTION_RESTART_REASON: &str = "compaction: context compacted";
+
+/// The scheduler must never be the thing that stops a working agent. It doesn't have to be, because
+/// the agent already restarts itself nightly to compact: the snapshot rides that stop.
+///
+/// The restart handler runs to completion before it answers, and a folded backup is taken while the
+/// container is down, so a backup that exists once the call returns was taken during the restart.
+#[test]
+fn a_compaction_restart_takes_the_due_scheduled_backups() {
+    let c = SERVER.client();
+    let agent = TestAgent::create(&c, &unique_agent("bk-dream")).unwrap();
+    wait_for_events_db(&agent_container_name(&agent.name));
+    assert!(
+        c.list_backups(&agent.name).unwrap().is_empty(),
+        "a fresh agent starts with no backups"
+    );
+
+    c.restart_agent_with_reason(&agent.name, COMPACTION_RESTART_REASON)
+        .unwrap();
+
+    let backups = c.list_backups(&agent.name).unwrap();
+    for backup_type in [BackupType::Daily, BackupType::Weekly, BackupType::Monthly] {
+        assert!(
+            backups.iter().any(|b| b.backup_type == backup_type),
+            "the restart should have taken the due {backup_type:?} backup, got {backups:?}"
+        );
+    }
+    c.wait_until_running(&agent.name, 60)
+        .expect("agent should be up after the restart it asked for");
+
+    for b in &backups {
+        c.delete_backup(&agent.name, &b.id).ok();
+    }
+}
+
+/// A user waiting on the app must not wait on a multi-GB snapshot, so only the agent's own
+/// compaction restart carries backups.
+#[test]
+fn a_user_restart_takes_no_backup() {
+    let c = SERVER.client();
+    let agent = TestAgent::create(&c, &unique_agent("bk-userrst")).unwrap();
+    wait_for_events_db(&agent_container_name(&agent.name));
+
+    c.restart_agent(&agent.name).unwrap();
+
+    let backups = c.list_backups(&agent.name).unwrap();
+    assert!(
+        backups.is_empty(),
+        "a user-initiated restart must not snapshot, got {backups:?}"
+    );
+    c.wait_until_running(&agent.name, 60)
+        .expect("agent should be up after restart");
+}
+
+/// Nothing due means nothing to fold in, so the restart stays a plain restart.
+#[test]
+fn a_second_compaction_restart_the_same_day_takes_no_further_backup() {
+    let c = SERVER.client();
+    let agent = TestAgent::create(&c, &unique_agent("bk-dream2")).unwrap();
+    wait_for_events_db(&agent_container_name(&agent.name));
+
+    c.restart_agent_with_reason(&agent.name, COMPACTION_RESTART_REASON)
+        .unwrap();
+    let after_first = c.list_backups(&agent.name).unwrap();
+    assert!(!after_first.is_empty(), "the first restart backs up");
+
+    c.wait_until_running(&agent.name, 60).unwrap();
+    c.restart_agent_with_reason(&agent.name, COMPACTION_RESTART_REASON)
+        .unwrap();
+
+    let after_second = c.list_backups(&agent.name).unwrap();
+    assert_eq!(
+        after_second.len(),
+        after_first.len(),
+        "every type is still inside its window, so nothing more is due"
+    );
+
+    for b in &after_second {
+        c.delete_backup(&agent.name, &b.id).ok();
+    }
+}
+
 #[test]
 fn backup_create() {
     let c = SERVER.client();


### PR DESCRIPTION
Fixes #1466. Replaces #1477, which took the other approach (gate the backup on agent idleness).

## Problem

A scheduled backup stops the container, so it killed whatever the agent had in flight: the reported incident lost an authenticated browser session mid-form. Gating the backup on idleness narrows the window but keeps the stop, and the activity state it would gate on (`"idle"` | `"thinking"`) only means no turn is running, not that no work is in flight. An agent idle while waiting on a user's SMS OTP still reads as idle, and still loses its session.

## Fix

Remove the stop instead of timing it better.

A backup is a stop, a snapshot, and a start. A restart is a stop and a start. The agent already restarts itself nightly at the end of its dream (`nightly_dream.md` ends in `compact_context` with `restart` true, which reaches vestad as `POST /agents/{name}/restart` with `compaction: context compacted`). Taking the due backups inside that stop costs no additional interruption, and loses nothing the restart was not about to lose anyway.

- `take_scheduled_backups_during_restart` folds the due types into the restart, passing the caller's `LifecycleReason` through so the agent's boot inbox still reads as the compaction, not as a backup pause.
- The hourly scheduler stays as the safety net for an agent that never restarts on its own, but only forces a stop once its newest daily has gone stale (36h, above the ~30h two dream restarts can legitimately be apart through the dreamer's `DREAMER_CATCHUP_HOURS` window). Without that bar, a dream finishing after the backup hour would still be double-restarted.
- Both triggers share one pure `due_scheduled_types`, so they cannot disagree about what is owed. The per-local-day rule is unchanged; only the forced-stop path gets the staleness bar, since a single 36h threshold for both would halve the daily cadence.

Declined (falling back to a plain restart) for a restart the agent did not initiate, so a user waiting on the app never waits on a snapshot; when backups are off for the agent or nothing is due; when grants drifted and the restart needs a recreate a plain stop/start cannot do; when the container is not running, since a backup only starts one it stopped itself; and when every snapshot failed, because a batch that fails preflight never cycles the container and the agent still has to come up.

The restart route already rides the 1800s longrun timeout tier, for the analogous snapshot+recreate on grant drift, so the folded snapshot fits the existing budget.

## Net effect

An agent that dreams is now stopped **once** a night instead of twice (dream restart ~3am, backup ~4am), and the scheduler never interrupts a working agent at all.

vestad-only, no agent change, no fleet migration.

## Tests

- Nine unit tests on the two pure functions in `backup.rs` (fast `cargo test -p vestad --bins` tier), including the property that matters: an agent backed up by its nightly restart is never stale enough for the scheduler to stop it.
- Three integration tests in `tests/server/backup.rs`: a compaction restart takes the due backups and comes back up, a user restart takes none, and a second compaction restart the same day takes no further backup. The restart handler runs to completion before it answers and a folded backup is taken while the container is down, so these need no polling.
- `./check.sh vestad` and `./check.sh guards` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUwSaWmL7D6vpn3tZYBZBV