### PR TITLE
feat(pr-monitor): add PR comment monitor skill

### DIFF
--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: pr-monitor
+description: >
+  Use when the user asks to watch PRs, monitor GitHub, respond to PR comments as
+  they arrive, keep an eye on review feedback, or run "pr-monitor". Starts a
+  long-running event source that surfaces developer comments addressing
+  @vestabot on open PRs, plus newly opened dependabot PRs, and keeps surfacing
+  them until the session stops. Read-only on its own: it reports events, and
+  acting on them is the session's job.
+---
+
+# PR Monitor
+
+A background loop that watches open PRs and prints one line per new event. Pair it with the `Monitor` tool so a session is woken when something needs attention, instead of polling by hand.
+
+## What it emits
+
+```
+HIT     <repo> <kind> <id> <pr> <url>    a developer comment addressing the bot
+DEPPR   <repo> <pr> <url>                a newly seen open dependabot PR
+```
+
+`kind` is `issue` (PR conversation comment), `review` (inline review comment), or `reviewbody` (review summary).
+
+## Getting running
+
+1. **Check auth.** `gh auth status` must show an account with write access to the repos being watched. The loop posts reactions, so a read-only token is not enough.
+
+2. **Start the loop under the Monitor tool**, pointing it at this skill's `monitor.sh`. With no arguments it watches the current repo; pass `owner/repo` arguments to watch several:
+
+   ```bash
+   .claude/skills/pr-monitor/monitor.sh
+   .claude/skills/pr-monitor/monitor.sh elyxlz/vesta elyxlz/vesta-cloud
+   ```
+
+   Register that command as a Monitor event source. Each printed line becomes an event delivered to the session.
+
+3. **Act on each event.** A `HIT` means a developer addressed the bot on that PR: read the comment at the URL, do what it asks, and reply on the PR. A `DEPPR` is a new dependabot PR, handled by whatever dependency policy is in force.
+
+The loop keeps running until the session stops. Nothing survives the session: restarting it is safe and cheap, because dedup state lives on GitHub rather than on disk.
+
+## Only comments that address the bot
+
+A comment is surfaced only when its body mentions `@vestabot`. Everything else on the PR is ignored, so developers can talk to each other freely without waking an agent. Override the mention with `PR_MONITOR_TRIGGER`.
+
+Dependabot PRs deliberately bypass this rule, since nobody is going to write a comment on one.
+
+## How events are deduplicated
+
+A surfaced item gets a 👀 reaction on the comment (or on the PR itself, for dependabot). The next cycle sees that reaction and skips it. That state lives on GitHub, so it survives losing the working directory, a reboot, or a move to another machine.
+
+The reaction is posted at emit time, not by whatever handles the event. Without that, an item would re-fire every cycle for as long as it sat unhandled. The ack is also posted *before* the line is printed: if it fails, nothing is emitted and the item is retried next cycle, so a failure can never produce an event that gets handled twice.
+
+Two consequences worth knowing:
+
+- **Anyone's 👀 counts.** The check reads the reaction count, not who left it. A human reacting 👀 to a comment hides it from the loop. Removing the reaction surfaces it again.
+- **Review summaries are the exception.** GitHub has no reactions endpoint for PR review summaries, so that one kind falls back to a small file under `PR_MONITOR_STATE`. Losing that file re-surfaces past review summaries.
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PR_MONITOR_TRIGGER` | `@vestabot` | Mention that makes a comment an event |
+| `PR_MONITOR_INTERVAL` | `45` | Seconds between polls |
+| `PR_MONITOR_STATE` | `$XDG_STATE_HOME/pr-monitor` | Where the review-summary ledger lives |
+
+## Cost
+
+One `gh pr list` per repo per cycle, plus three API calls per open PR. The trigger match and the reaction count are both read out of those same list payloads inside the jq expression, so neither adds a call. Only acking an event costs an extra request. At the default interval a repo with a handful of open PRs sits far under the 5000 per hour limit; a repo with many open PRs wants a longer `PR_MONITOR_INTERVAL`.

--- a/.claude/skills/pr-monitor/fetch_comments.sh
+++ b/.claude/skills/pr-monitor/fetch_comments.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Emit comments on open PRs that address the bot, as TSV:
+#   kind<TAB>id<TAB>pr<TAB>author<TAB>url<TAB>eyes
+# kind is issue (PR conversation), review (inline), or reviewbody (review summary).
+# Both filters and the reaction count are read from the list payload inside jq,
+# so neither the trigger match nor the dedup signal costs an extra API call.
+set -uo pipefail
+
+REPO="${REPO:?REPO is required (owner/name)}"
+TRIGGER="${PR_MONITOR_TRIGGER:-@vestabot}"
+
+valid() { grep -E "^(issue|review|reviewbody)$(printf '\t')"; }
+
+# Must address the bot, and must not be one of our own replies, which quote the
+# developer's text and would otherwise re-trigger on their own mention.
+G='select(.body != null) | select(.body | test("'"$TRIGGER"'"; "i")) | select((.body|ascii_downcase|contains("generated with")) and (.body|ascii_downcase|contains("claude code")) | not)'
+
+prs=$(gh pr list --repo "$REPO" --state open --json number -q '.[].number' 2>/dev/null)
+for pr in $prs; do
+  gh api "/repos/$REPO/issues/$pr/comments" --paginate \
+    -q '.[] | '"$G"' | "issue\t\(.id)\t'"$pr"'\t\(.user.login)\t\(.html_url)\t\(.reactions.eyes)"' 2>/dev/null | valid || true
+  gh api "/repos/$REPO/pulls/$pr/comments" --paginate \
+    -q '.[] | '"$G"' | "review\t\(.id)\t'"$pr"'\t\(.user.login)\t\(.html_url)\t\(.reactions.eyes)"' 2>/dev/null | valid || true
+  gh api "/repos/$REPO/pulls/$pr/reviews" --paginate \
+    -q '.[] | select(.body != "") | '"$G"' | "reviewbody\t\(.id)\t'"$pr"'\t\(.user.login)\t\(.html_url)\t0"' 2>/dev/null | valid || true
+done

--- a/.claude/skills/pr-monitor/monitor.sh
+++ b/.claude/skills/pr-monitor/monitor.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Persistent PR event source. Loops forever, printing one line per new event:
+#   HIT    <repo> <kind> <id> <pr> <url>   a developer comment addressing the bot
+#   DEPPR  <repo> <pr> <url>               a newly seen open dependabot PR
+# Usage: monitor.sh [owner/repo ...]   (defaults to the current repo)
+#
+# Dedup is a 👀 reaction placed on the comment or PR itself, not a local ledger,
+# so the state lives on GitHub and survives losing the working directory. The 👀
+# is posted here at emit time rather than by whatever consumes these lines, so an
+# event cannot re-fire every cycle while it waits to be handled.
+set -uo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FETCH="$SKILL_DIR/fetch_comments.sh"
+INTERVAL="${PR_MONITOR_INTERVAL:-45}"
+STATE_ROOT="${PR_MONITOR_STATE:-${XDG_STATE_HOME:-$HOME/.local/state}/pr-monitor}"
+
+repos=("$@")
+if [ "${#repos[@]}" -eq 0 ]; then
+  repos=("$(gh repo view --json nameWithOwner -q .nameWithOwner)")
+fi
+
+state_dir() {
+  local dir="$STATE_ROOT/${1//\//__}"
+  mkdir -p "$dir"
+  printf '%s' "$dir"
+}
+
+# Post the 👀 ack. Non-zero means it was not recorded, so callers stay silent
+# rather than emit an event they cannot mark as handled.
+ack() {
+  local repo="$1" kind="$2" id="$3"
+  case "$kind" in
+    issue)  gh api -X POST "/repos/$repo/issues/comments/$id/reactions" -f content=eyes >/dev/null 2>&1 ;;
+    review) gh api -X POST "/repos/$repo/pulls/comments/$id/reactions"  -f content=eyes >/dev/null 2>&1 ;;
+    pr)     gh api -X POST "/repos/$repo/issues/$id/reactions"          -f content=eyes >/dev/null 2>&1 ;;
+    *) return 1 ;;
+  esac
+}
+
+emit_comments() {
+  local repo="$1" dir tsv ledger
+  dir="$(state_dir "$repo")"
+  tsv="$dir/addressed.tsv"
+  ledger="$dir/seen_reviewbody.txt"
+  touch "$ledger"
+  REPO="$repo" bash "$FETCH" > "$tsv" 2>/dev/null || true
+  # An empty fetch is normal: it means nobody has addressed the bot.
+  [ -s "$tsv" ] || return 0
+  if grep -qvE "^(issue|review|reviewbody)$(printf '\t')" "$tsv" 2>/dev/null; then
+    echo "WARN: malformed fetch for $repo, skipping cycle" >&2
+    return 0
+  fi
+  local kind id pr author url eyes
+  while IFS=$'\t' read -r kind id pr author url eyes; do
+    [ -z "${id:-}" ] && continue
+    # Bots never trigger, even when they name the bot.
+    case "$author" in *'[bot]') continue ;; esac
+
+    # Review summaries have no reactions endpoint anywhere in the GitHub API,
+    # so this one kind keeps a local ledger.
+    if [ "$kind" = "reviewbody" ]; then
+      grep -qx "$id" "$ledger" 2>/dev/null && continue
+      printf 'HIT\t%s\t%s\t%s\t%s\t%s\n' "$repo" "$kind" "$id" "$pr" "$url"
+      echo "$id" >> "$ledger"
+      continue
+    fi
+
+    [ "${eyes:-0}" != "0" ] && continue
+    if ack "$repo" "$kind" "$id"; then
+      printf 'HIT\t%s\t%s\t%s\t%s\t%s\n' "$repo" "$kind" "$id" "$pr" "$url"
+    else
+      echo "WARN: could not ack $repo $kind $id, not emitting" >&2
+    fi
+  done < "$tsv"
+}
+
+# Dependabot PRs deliberately bypass the trigger and surface on sight.
+# reactionGroups rides along in the same listing, so the check costs nothing.
+emit_dependabot() {
+  local repo="$1"
+  gh pr list --repo "$repo" --state open --json number,headRefName,url,reactionGroups \
+    -q '.[] | select(.headRefName|startswith("dependabot/")) | select((([.reactionGroups[]? | select(.content=="EYES") | .users.totalCount] | add) // 0) == 0) | "\(.number)\t\(.url)"' 2>/dev/null | \
+  while IFS=$'\t' read -r num url; do
+    [ -z "${num:-}" ] && continue
+    if ack "$repo" pr "$num"; then
+      printf 'DEPPR\t%s\t%s\t%s\n' "$repo" "$num" "$url"
+    else
+      echo "WARN: could not ack dependabot PR $repo#$num, not emitting" >&2
+    fi
+  done
+}
+
+while true; do
+  for repo in "${repos[@]}"; do
+    emit_comments "$repo"
+    emit_dependabot "$repo"
+  done
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
Adds `.claude/skills/pr-monitor/`, a long-running event source that watches open PRs and prints one line per new event for a session to act on via the `Monitor` tool.

```
HIT     <repo> <kind> <id> <pr> <url>    a developer comment addressing the bot
DEPPR   <repo> <pr> <url>                a newly seen open dependabot PR
```

### Dedup lives on GitHub

A surfaced item gets a `:eyes:` reaction on the comment, or on the PR itself for dependabot. The next cycle sees it and skips. No local ledger, so the state survives losing the working directory, a reboot, or a move to another machine.

The ack is posted at emit time rather than by whatever handles the event, otherwise an item would re-fire every cycle for as long as it sat unhandled. It is also posted *before* the line is printed: a failed ack emits nothing and retries next cycle, so it cannot produce an event that gets handled twice.

Two known consequences, documented in the skill: any account's reaction counts (the check reads the count, not who left it), and review summaries fall back to a small local file because GitHub exposes no reactions endpoint for them.

### Only addressed comments

A comment is surfaced only when its body mentions the trigger, default `vestabot` with a leading at-sign, overridable with `PR_MONITOR_TRIGGER`. Developers can talk on a PR without waking an agent. Dependabot PRs bypass the rule, since nobody comments on those.

### Cost

One `gh pr list` per repo per cycle plus three calls per open PR. The trigger match and the reaction count are both read out of those same list payloads inside the jq expression, so neither adds a call. Only acking costs an extra request.

### Verification

`shellcheck -S warning` clean, `./check.sh guards` green, and both scripts exercised read-only against this repo and vesta-cloud: default-repo detection, trigger override (a match-all trigger returns the expected rows), TSV shape, and the dependabot selection query. No reactions were posted while testing.