### PR TITLE
feat(pr-monitor): dispatch events to one Claude session per PR

### DIFF
--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -39,6 +39,41 @@ DEPPR   <repo> <pr> <url>                a newly seen open dependabot PR
 
 The loop keeps running until the session stops. Nothing survives the session: restarting it is safe and cheap, because dedup state lives on GitHub rather than on disk.
 
+## Running unattended
+
+`dispatch.sh` runs the loop without a supervising session: it reads the event stream and hands each event to `claude` in print mode, so it can be supervised by systemd instead of a terminal.
+
+```bash
+.claude/skills/pr-monitor/dispatch.sh elyxlz/vesta elyxlz/vesta-cloud
+```
+
+**One session per PR.** The session id from a PR's first event is stored under `PR_MONITOR_STATE` and resumed for every later event on that PR, so the agent remembers what it already pushed and tried there. Different PRs never share context. Losing that file costs continuity on the next event, never correctness.
+
+Do not reach for `claude --from-pr` here. It resumes a session already linked to a PR, but a print-mode run does not create that link, so in a service it quietly starts a fresh session every time.
+
+Events are handled one at a time, so a burst of comments cannot start overlapping runs against the same session.
+
+A systemd user unit, needing `loginctl enable-linger <user>` so it runs without a login:
+
+```ini
+[Unit]
+Description=PR monitor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/pr-monitor
+ExecStart=%h/pr-monitor/.claude/skills/pr-monitor/dispatch.sh elyxlz/vesta
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+```
+
+Point `WorkingDirectory` at a checkout kept for the service rather than a working one, so the code cannot change under a running loop.
+
 ## Only comments that address the bot
 
 A comment is surfaced only when its body mentions `@vestabot`. Everything else on the PR is ignored, so developers can talk to each other freely without waking an agent. Override the mention with `PR_MONITOR_TRIGGER`.
@@ -51,6 +86,8 @@ A surfaced item gets a 👀 reaction on the comment (or on the PR itself, for de
 
 The reaction is posted at emit time, not by whatever handles the event. Without that, an item would re-fire every cycle for as long as it sat unhandled. The ack is also posted *before* the line is printed: if it fails, nothing is emitted and the item is retried next cycle, so a failure can never produce an event that gets handled twice.
 
+The reaction is therefore a **claim, not a completion**. Under `dispatch.sh` a failed run releases the claim, removing only this account's reaction, and the event surfaces again on the next cycle. That is what makes a usage limit recoverable: the runs fail, the claims are released, and the events come back once the limit resets. A consumer that emits events some other way should release claims the same way, or a failure will drop the event silently.
+
 Two consequences worth knowing:
 
 - **Anyone's 👀 counts.** The check reads the reaction count, not who left it. A human reacting 👀 to a comment hides it from the loop. Removing the reaction surfaces it again.
@@ -62,7 +99,8 @@ Two consequences worth knowing:
 | --- | --- | --- |
 | `PR_MONITOR_TRIGGER` | `@vestabot` | Mention that makes a comment an event |
 | `PR_MONITOR_INTERVAL` | `45` | Seconds between polls |
-| `PR_MONITOR_STATE` | `$XDG_STATE_HOME/pr-monitor` | Where the review-summary ledger lives |
+| `PR_MONITOR_STATE` | `$XDG_STATE_HOME/pr-monitor` | Review-summary ledger and per-PR session ids |
+| `PR_MONITOR_MODEL` | `claude-opus-5` | Model `dispatch.sh` runs each event on |
 
 ## Cost
 

--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -53,6 +53,10 @@ Do not reach for `claude --from-pr` here. It resumes a session already linked to
 
 Events are handled one at a time, so a burst of comments cannot start overlapping runs against the same session.
 
+**Sessions are closed out when their PR closes.** A PR's session is only ever resumed while the PR is open, so once it closes the pointer is dead weight. Dispatch prunes those pointers at startup and after each event. Session transcripts under `~/.claude/projects/` are the part that actually grows, so removing them is opt-in via `PR_MONITOR_PRUNE_TRANSCRIPTS=1` rather than silent, since they are also the only record of what the agent did. Leave it off and transcripts accumulate; watch the disk on a busy repo.
+
+A long-lived PR is the one case still unbounded: every event resumes and extends the same session, so a PR with many rounds of review grows a large transcript and a large context. Nothing caps that today.
+
 A systemd user unit, needing `loginctl enable-linger <user>` so it runs without a login:
 
 ```ini
@@ -101,6 +105,7 @@ Two consequences worth knowing:
 | `PR_MONITOR_INTERVAL` | `45` | Seconds between polls |
 | `PR_MONITOR_STATE` | `$XDG_STATE_HOME/pr-monitor` | Review-summary ledger and per-PR session ids |
 | `PR_MONITOR_MODEL` | `claude-opus-5` | Model `dispatch.sh` runs each event on |
+| `PR_MONITOR_PRUNE_TRANSCRIPTS` | `0` | Delete a closed PR session transcript, not just its pointer |
 
 ## Cost
 

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Drive one Claude session per PR from the monitor's event stream.
+# Usage: dispatch.sh [owner/repo ...]
+#
+# Each PR keeps a single conversation: the session id from a PR's first event is
+# stored and resumed for every later event on that PR, so the agent remembers
+# what it already pushed and tried there. Context is not shared across PRs.
+#
+# Events are handled serially, so a burst cannot start overlapping runs against
+# the same session. The 👀 monitor.sh posts is a claim rather than a completion:
+# a failed run releases it, and the event surfaces again on the next cycle.
+set -uo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MONITOR="$SKILL_DIR/monitor.sh"
+MODEL="${PR_MONITOR_MODEL:-claude-opus-5}"
+STATE_ROOT="${PR_MONITOR_STATE:-${XDG_STATE_HOME:-$HOME/.local/state}/pr-monitor}"
+ME="$(gh api /user -q .login 2>/dev/null)"
+
+session_file() {
+  local dir="$STATE_ROOT/${1//\//__}/sessions"
+  mkdir -p "$dir"
+  printf '%s/pr-%s.session' "$dir" "$2"
+}
+
+# Drop our own 👀 so a failed event is retried. Another account's reaction on the
+# same comment is left alone.
+release() {
+  local repo="$1" kind="$2" id="$3" base rid ledger
+  if [ "$kind" = "reviewbody" ]; then
+    ledger="$STATE_ROOT/${repo//\//__}/seen_reviewbody.txt"
+    if [ -f "$ledger" ]; then
+      grep -vx "$id" "$ledger" > "$ledger.tmp" || true
+      mv "$ledger.tmp" "$ledger"
+    fi
+    return 0
+  fi
+  case "$kind" in
+    issue)  base="/repos/$repo/issues/comments/$id/reactions" ;;
+    review) base="/repos/$repo/pulls/comments/$id/reactions" ;;
+    pr)     base="/repos/$repo/issues/$id/reactions" ;;
+    *) return 1 ;;
+  esac
+  rid=$(gh api "$base" -q '.[] | select(.content=="eyes") | select(.user.login=="'"$ME"'") | .id' 2>/dev/null | head -1)
+  [ -n "$rid" ] || return 0
+  gh api -X DELETE "$base/$rid" >/dev/null 2>&1
+}
+
+handle() {
+  local repo="$1" kind="$2" id="$3" pr="$4" prompt="$5"
+  local sf sid out rc
+  sf="$(session_file "$repo" "$pr")"
+  local args=(-p --model "$MODEL" --output-format json --dangerously-skip-permissions)
+  [ -s "$sf" ] && args+=(--resume "$(cat "$sf")")
+  out=$(claude "${args[@]}" "$prompt" 2>/dev/null)
+  rc=$?
+  # A stored id that no longer resolves would fail every retry, so forget it.
+  if [ "$rc" -ne 0 ]; then
+    echo "dispatch: claude failed rc=$rc on $repo#$pr, releasing claim" >&2
+    [ -s "$sf" ] && rm -f "$sf"
+    release "$repo" "$kind" "$id"
+    return 1
+  fi
+  sid=$(printf '%s' "$out" | jq -r '.session_id // empty' 2>/dev/null)
+  [ -n "$sid" ] && printf '%s' "$sid" > "$sf"
+  if [ "$(printf '%s' "$out" | jq -r '.is_error // false' 2>/dev/null)" = "true" ]; then
+    echo "dispatch: claude reported an error on $repo#$pr, releasing claim" >&2
+    release "$repo" "$kind" "$id"
+    return 1
+  fi
+  echo "dispatch: handled $repo#$pr ($kind $id)" >&2
+}
+
+bash "$MONITOR" "$@" | while IFS=$'\t' read -r tag f1 f2 f3 f4 f5; do
+  case "$tag" in
+    HIT)
+      handle "$f1" "$f2" "$f3" "$f4" "A developer addressed you in a comment on $f1 PR #$f4: $f5
+Read that comment and the pull request, do what it asks, then reply on the PR describing what you changed. If its checks need fixing, use the babysit-prs skill. If the request is unclear or you decide not to act, say so in a reply rather than staying silent."
+      ;;
+    DEPPR)
+      handle "$f1" pr "$f2" "$f2" "A new dependabot pull request is open: $f1 PR #$f2: $f3
+Review it against this repository's dependency policy, check whether its checks pass, and act accordingly. Leave a comment recording what you decided."
+      ;;
+    *) [ -n "${tag:-}" ] && echo "dispatch: ignoring line: $tag" >&2 ;;
+  esac
+done

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -17,6 +17,11 @@ MODEL="${PR_MONITOR_MODEL:-claude-opus-5}"
 STATE_ROOT="${PR_MONITOR_STATE:-${XDG_STATE_HOME:-$HOME/.local/state}/pr-monitor}"
 ME="$(gh api /user -q .login 2>/dev/null)"
 
+repos=("$@")
+if [ "${#repos[@]}" -eq 0 ]; then
+  repos=("$(gh repo view --json nameWithOwner -q .nameWithOwner)")
+fi
+
 session_file() {
   local dir="$STATE_ROOT/${1//\//__}/sessions"
   mkdir -p "$dir"
@@ -46,6 +51,32 @@ release() {
   gh api -X DELETE "$base/$rid" >/dev/null 2>&1
 }
 
+remove_transcript() {
+  [ -n "${1:-}" ] || return 0
+  find "$HOME/.claude/projects" -name "$1.jsonl" -delete 2>/dev/null || true
+}
+
+# A PR's session is resumed only while the PR is open, so once it closes the
+# pointer is dead weight and its transcript is never read again. Transcripts are
+# the part that grows without bound, so removing them is opt-in rather than
+# silent. A failed listing returns early: an empty one legitimately means every
+# PR closed, but an errored one must never be read as "prune everything".
+prune_sessions() {
+  local repo="$1" dir open file pr
+  dir="$STATE_ROOT/${repo//\//__}/sessions"
+  [ -d "$dir" ] || return 0
+  open=$(gh pr list --repo "$repo" --state open --limit 200 --json number -q '.[].number' 2>/dev/null) || return 0
+  for file in "$dir"/pr-*.session; do
+    [ -e "$file" ] || continue
+    pr="${file##*/pr-}"
+    pr="${pr%.session}"
+    printf '%s\n' "$open" | grep -qx "$pr" && continue
+    [ "${PR_MONITOR_PRUNE_TRANSCRIPTS:-0}" = "1" ] && remove_transcript "$(cat "$file")"
+    rm -f "$file"
+    echo "dispatch: pruned session for closed $repo#$pr" >&2
+  done
+}
+
 handle() {
   local repo="$1" kind="$2" id="$3" pr="$4" prompt="$5"
   local sf sid out rc
@@ -69,9 +100,12 @@ handle() {
     return 1
   fi
   echo "dispatch: handled $repo#$pr ($kind $id)" >&2
+  prune_sessions "$repo"
 }
 
-bash "$MONITOR" "$@" | while IFS=$'\t' read -r tag f1 f2 f3 f4 f5; do
+for repo in "${repos[@]}"; do prune_sessions "$repo"; done
+
+bash "$MONITOR" "${repos[@]}" | while IFS=$'\t' read -r tag f1 f2 f3 f4 f5; do
   case "$tag" in
     HIT)
       handle "$f1" "$f2" "$f3" "$f4" "A developer addressed you in a comment on $f1 PR #$f4: $f5


### PR DESCRIPTION
Follow-up to #1518. Adds `dispatch.sh` so the monitor can run under systemd instead of inside a supervising session, and fixes a correctness gap in what #1518 merged.

### One session per PR

The session id from a PR first event is stored and resumed for every later event on that PR, so the agent remembers what it already pushed and tried there. Different PRs never share context, which is the part that made the old single long-lived session accumulate a 25MB transcript.

`claude --from-pr` looks like the native answer and is deliberately not used: it resumes a session already linked to a PR, but a print-mode run does not create that link. Verified by running it twice against the same PR, the second call got a fresh session with no memory of the first, so in a service it would silently start over every event.

### The reaction is a claim, not a completion

#1518 acks at emit time, which is correct when the session that acks is the one doing the work. Once a separate process handles the event, a failed handler left the reaction in place and the event was dropped silently. A usage limit would lose work rather than defer it.

`dispatch.sh` now releases the claim on failure, deleting only this account reaction, so the event surfaces again next cycle. Once the limit resets the backlog drains on its own. A stored session id that no longer resolves is forgotten at the same time, so a bad id cannot poison every retry.

Events are handled serially, so a burst cannot start overlapping runs against one session.

### Verification

`shellcheck -S warning` clean, `./check.sh guards` green. Dispatcher exercised against a stubbed event stream with `claude` and `gh` stubbed out, covering: HIT and DEPPR routing, malformed lines ignored, per-PR session files written, the second event on a PR carrying `--resume <stored-id>`, and the failure path clearing the session file and issuing the reaction `DELETE`. Nothing real was posted to GitHub.