### PR TITLE
feat(pr-monitor): end every reply with a merge verdict

### DIFF
--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -53,6 +53,8 @@ Do not reach for `claude --from-pr` here. It resumes a session already linked to
 
 Events are handled one at a time, so a burst of comments cannot start overlapping runs against the same session.
 
+**Every reply ends with a verdict.** The agent closes each comment with a line reading `Verdict: MERGE`, `DO NOT MERGE`, or `NOT YET`, plus one sentence of reasoning, so a maintainer scanning the PR list gets a recommendation rather than a wall of findings. The agent never merges or closes anything: the verdict is advice and the decision stays with whoever is watching. It is told to judge the change on its merits even when it wrote the code itself, and to say `DO NOT MERGE` when it means it.
+
 **Sessions are closed out when their PR closes.** A PR's session is only ever resumed while the PR is open, so once it closes the pointer is dead weight. Dispatch prunes those pointers at startup and after each event. Session transcripts under `~/.claude/projects/` are the part that actually grows, so removing them is opt-in via `PR_MONITOR_PRUNE_TRANSCRIPTS=1` rather than silent, since they are also the only record of what the agent did. Leave it off and transcripts accumulate; watch the disk on a busy repo.
 
 A long-lived PR is the one case still unbounded: every event resumes and extends the same session, so a PR with many rounds of review grows a large transcript and a large context. Nothing caps that today.

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -110,11 +110,13 @@ bash "$MONITOR" "${repos[@]}" | while IFS=$'\t' read -r tag f1 f2 f3 f4 f5; do
     HIT)
       handle "$f1" "$f2" "$f3" "$f4" "A developer addressed you in a comment on $f1 PR #$f4: $f5
 Read that comment and the pull request, do what it asks, then reply on the PR describing what you changed. If its checks need fixing, use the babysit-prs skill. If the request is unclear or you decide not to act, say so in a reply rather than staying silent.
-Only maintainers reach you here, so an explicit instruction outranks the repository's usual conventions: if the comment asks for something a skill or CLAUDE.md normally discourages, such as a force push or a rebase, do it and note it in your reply."
+Only maintainers reach you here, so an explicit instruction outranks the repository's usual conventions: if the comment asks for something a skill or CLAUDE.md normally discourages, such as a force push or a rebase, do it and note it in your reply.
+End every reply with a line starting 'Verdict:' giving your own call on merging: MERGE, DO NOT MERGE, or NOT YET, then one sentence of reasoning. Judge the change on its merits, not on whether you were the one who touched it, and say DO NOT MERGE when you believe that even if the commenter clearly wants it in. Never merge or close the PR yourself: the verdict is advice and the decision stays with the maintainer."
       ;;
     DEPPR)
       handle "$f1" pr "$f2" "$f2" "A new dependabot pull request is open: $f1 PR #$f2: $f3
-Review it against this repository's dependency policy, check whether its checks pass, and act accordingly. Leave a comment recording what you decided."
+Review it against this repository's dependency policy, check whether its checks pass, and act accordingly. Leave a comment recording what you decided.
+End that comment with a line starting 'Verdict:' giving your own call on merging: MERGE, DO NOT MERGE, or NOT YET, then one sentence of reasoning. Never merge or close the PR yourself: the verdict is advice and the decision stays with the maintainer."
       ;;
     *) [ -n "${tag:-}" ] && echo "dispatch: ignoring line: $tag" >&2 ;;
   esac


### PR DESCRIPTION
The polish pass on #1515 produced a thorough review and then left the reader to work out whether the PR was actually good to go.

Each reply now closes with:

```
Verdict: MERGE | DO NOT MERGE | NOT YET
```

plus one sentence of reasoning, on both the comment path and the dependabot path. A maintainer scanning open PRs gets a recommendation rather than a report.

Two guardrails in the wording:

- **It judges the change on its merits even when it wrote the code**, and is told to say `DO NOT MERGE` when it means it, including when the commenter clearly wants the PR in. A rubber stamp would be worse than no verdict.
- **It never merges or closes anything.** The verdict is advice; the decision stays with the maintainer.

`shellcheck -S warning` clean, `./check.sh guards` green.