### PR TITLE
feat(pr-monitor): check every new PR automatically

### DIFF
--- a/.claude/skills/check-pr/SKILL.md
+++ b/.claude/skills/check-pr/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: check-pr
+description: >
+  Use when the user asks to check a PR, review a PR, sanity-check a pull request,
+  ask whether a PR is correct or ready, or run "check-pr <number>". Also runs
+  automatically on newly opened PRs. Reads the issue the PR claims to fix, judges
+  whether it actually fixes it, checks it against this repository's conventions,
+  and reports with a merge verdict. Read only: never pushes, merges, or closes.
+---
+
+# Check a PR
+
+Answer one question about a pull request: should this be merged? Read only. Never push a commit, never merge, never close, never edit the PR. Changing the PR is `polish-pr`'s job, and it runs only when a human asks for it.
+
+## What to check
+
+**1. Does it fix the issue it claims to fix?**
+
+Find the issue from a closing keyword in the PR body (`fixes #N`, `closes #N`, `resolves #N`). Read the issue itself, not just the PR's description of it, then decide whether this change resolves it. Distinguish clearly between fixing the issue, fixing part of it, fixing something adjacent, and not addressing it at all.
+
+When no issue is linked, say what problem the PR appears to solve and whether it is worth carrying. A change with no traceable motivation is worth flagging on its own.
+
+**2. Is it right for this repository?**
+
+Judge against this repo's rules rather than generic taste. `CLAUDE.md` governs architecture principles, code conventions, brand voice, and the PR rules; the language section for whatever it touches applies; a skill covering that area applies too. Watch specifically for the repo-wide bans that CI does not always catch on a PR: inline lint escapes, comment blocks over 8 lines, banned Python accessors, `.unwrap()` on fallible Rust paths, `any` in TypeScript.
+
+**3. Is it actually correct?**
+
+Read the code paths the change touches. Do not trust the description, the comments, or the tests' names. Where running something settles a question, run it: the check subcommands in `CLAUDE.md` are the same ones CI uses. Look for the cases the author did not write a test for.
+
+**4. Is it in a mergeable state?**
+
+CI green, no conflicts, not draft, and scoped to one concern.
+
+## Reporting
+
+Post one comment. Lead with what matters rather than a walkthrough of the diff: a reader who merges on your word should not need to open the files. Findings that change the merge decision come first, and anything you verified empirically is worth stating as verified.
+
+Close with a verdict line:
+
+```
+Verdict: MERGE | DO NOT MERGE | NOT YET
+```
+
+One sentence of reasoning after it. `NOT YET` is for a PR that is right in substance but blocked on something mechanical, CI or a conflict, so the reader knows the difference between "wrong" and "wait".
+
+Judge the change on its merits even when you wrote the code yourself, and say `DO NOT MERGE` when you believe it. A verdict that always says MERGE is worth less than no verdict.
+
+When the PR would benefit from the simplify and tidy pass that `polish-pr` does, say so in one line and name the skill, so a maintainer can ask for it. Do not run it yourself: it pushes commits, and that is the maintainer's call.

--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -17,6 +17,7 @@ A background loop that watches open PRs and prints one line per new event. Pair 
 
 ```
 HIT     <repo> <kind> <id> <pr> <url>    a developer comment addressing the bot
+NEWPR   <repo> <pr> <url>                a newly seen open PR, for its first check
 DEPPR   <repo> <pr> <url>                a newly seen open dependabot PR
 ```
 
@@ -52,6 +53,16 @@ The loop keeps running until the session stops. Nothing survives the session: re
 Do not reach for `claude --from-pr` here. It resumes a session already linked to a PR, but a print-mode run does not create that link, so in a service it quietly starts a fresh session every time.
 
 Events are handled one at a time, so a burst of comments cannot start overlapping runs against the same session.
+
+**Every new PR is checked automatically.** A non-draft PR that has never been seen surfaces as `NEWPR` without anyone asking, and dispatch runs the `check-pr` skill on it: does it fix the issue it claims to fix, does it match this repository's conventions, does it actually work. That pass is read only. It never pushes, merges, or closes, so a PR opening cannot cause a write. Where the change would benefit from the simplify and tidy pass, the reply names `polish-pr` and stops there, leaving the maintainer to ask for it.
+
+**Seed before switching this on.** "Never seen" means "carries no 👀", so the first cycle treats every open PR as new and checks all of them at once. On a repo with a dozen open PRs that is a dozen agent runs back to back. Mark the existing ones first:
+
+```bash
+for n in $(gh pr list --repo owner/name --state open --json number -q '.[].number'); do
+  gh api -X POST "/repos/owner/name/issues/$n/reactions" -f content=eyes >/dev/null
+done
+```
 
 **The agent knows it is a reviewer.** Each comment event carries standing context ahead of the request itself: read the issue the PR claims to fix and judge whether it actually resolves it, check the change against this repository's own rules rather than generic taste (CLAUDE.md, the language conventions, any skill covering the area), and verify claims by reading the code and running things rather than trusting the description. That review happens whether or not the comment asked for one, so a bare mention still gets a real review instead of an ad-hoc answer.
 

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -128,6 +128,13 @@ Read that comment and the pull request, do what it asks, then reply on the PR co
 Only maintainers reach you here, so an explicit instruction outranks the repository's usual conventions: if the comment asks for something a skill or CLAUDE.md normally discourages, such as a force push or a rebase, do it and note it in your reply.
 End every reply with a line starting 'Verdict:' giving your own call on merging: MERGE, DO NOT MERGE, or NOT YET, then one sentence of reasoning. Judge the change on its merits, not on whether you were the one who touched it, and say DO NOT MERGE when you believe that even if the commenter clearly wants it in. Never merge or close the PR yourself: the verdict is advice and the decision stays with the maintainer."
       ;;
+    NEWPR)
+      handle "$f1" pr "$f2" "$f2" "$ROLE
+
+A pull request was opened on $f1: PR #$f2: $f3
+Nobody has asked for anything yet: this is the automatic check every new PR gets. Run the check-pr skill on it, then post your findings as a comment.
+Stay read only. Do not push a commit, merge, close, or edit the PR. If it would benefit from the simplify and tidy pass, say so in one line and name the polish-pr skill so a maintainer can ask for it, but never run polish-pr yourself here."
+      ;;
     DEPPR)
       handle "$f1" pr "$f2" "$f2" "A new dependabot pull request is open: $f1 PR #$f2: $f3
 Review it against this repository's dependency policy, check whether its checks pass, and act accordingly. Leave a comment recording what you decided.

--- a/.claude/skills/pr-monitor/monitor.sh
+++ b/.claude/skills/pr-monitor/monitor.sh
@@ -6,6 +6,7 @@
 #
 # Loops forever, printing one line per new event:
 #   HIT    <repo> <kind> <id> <pr> <url>   a developer comment addressing the bot
+#   NEWPR  <repo> <pr> <url>               a newly seen open PR, for its first check
 #   DEPPR  <repo> <pr> <url>               a newly seen open dependabot PR
 # Usage: monitor.sh [owner/repo ...]   (defaults to the current repo)
 #
@@ -111,18 +112,20 @@ emit_comments() {
   done < "$tsv"
 }
 
-# Dependabot PRs deliberately bypass the trigger and surface on sight.
-# reactionGroups rides along in the same listing, so the check costs nothing.
-emit_dependabot() {
+# Open PRs surface once each, on sight, without needing the trigger: dependabot
+# ones as DEPPR, everything else as NEWPR. Drafts are skipped. A 👀 on the PR
+# itself is the record that it was seen, and reactionGroups rides along in the
+# same listing, so the check costs nothing extra.
+emit_open_prs() {
   local repo="$1"
-  gh pr list --repo "$repo" --state open --json number,headRefName,url,reactionGroups \
-    -q '.[] | select(.headRefName|startswith("dependabot/")) | select((([.reactionGroups[]? | select(.content=="EYES") | .users.totalCount] | add) // 0) == 0) | "\(.number)\t\(.url)"' 2>/dev/null | \
-  while IFS=$'\t' read -r num url; do
+  gh pr list --repo "$repo" --state open --limit 200 --json number,headRefName,url,isDraft,reactionGroups \
+    -q '.[] | select(.isDraft | not) | select((([.reactionGroups[]? | select(.content=="EYES") | .users.totalCount] | add) // 0) == 0) | "\(if (.headRefName|startswith("dependabot/")) then "DEPPR" else "NEWPR" end)\t\(.number)\t\(.url)"' 2>/dev/null | \
+  while IFS=$'\t' read -r kind num url; do
     [ -z "${num:-}" ] && continue
     if ack "$repo" pr "$num"; then
-      printf 'DEPPR\t%s\t%s\t%s\n' "$repo" "$num" "$url"
+      printf '%s\t%s\t%s\t%s\n' "$kind" "$repo" "$num" "$url"
     else
-      echo "WARN: could not ack dependabot PR $repo#$num, not emitting" >&2
+      echo "WARN: could not ack $repo#$num, not emitting" >&2
     fi
   done
 }
@@ -130,7 +133,7 @@ emit_dependabot() {
 while true; do
   for repo in "${repos[@]}"; do
     emit_comments "$repo"
-    emit_dependabot "$repo"
+    emit_open_prs "$repo"
   done
   sleep "$INTERVAL"
 done


### PR DESCRIPTION
A PR only got looked at when somebody remembered to mention the bot. Open PRs now surface on sight as `NEWPR` and get a first-pass review unasked, with dependabot continuing to surface as `DEPPR`.

### New skill: `check-pr`

Read only, and that is the point: it runs unattended on every PR, so it must never write. It never pushes, merges, or closes.

1. **Does it fix the issue it claims to fix?** Find the issue from the closing keyword in the PR body, read the issue itself, and distinguish fixing it from fixing part of it, something adjacent, or nothing. With no issue linked, say what problem the PR appears to solve and whether it is worth carrying.
2. **Is it right for this repo?** Judged against CLAUDE.md, the language conventions, and any skill covering the area, with attention to the repo-wide bans CI does not always catch on a PR.
3. **Is it correct?** Read the code paths, do not trust the description, run the `check.sh` subcommand when running it settles the question.
4. **Is it mergeable?** CI, conflicts, draft, one concern.

Ends with `Verdict: MERGE | DO NOT MERGE | NOT YET`. Where the PR would benefit from the simplify and tidy pass it names `polish-pr` and stops there, leaving that call to a maintainer, since polish-pr pushes commits.

An explicit `@vestabot` request still does whatever it asks, exactly as before.

### Notes

Drafts are skipped. `NEWPR` and `DEPPR` share the PR-level 👀 as their seen-marker, so the check costs no extra API call.

**Seeding matters:** "never seen" means "no 👀", so the first cycle would check every currently-open PR at once. The skill documents the one-liner to mark existing PRs first, and I am seeding this repo before enabling it.

### Verification

`shellcheck -S warning` clean, `./check.sh guards` green. Routing exercised against a stubbed event stream: NEWPR gets the check-pr prompt carrying the read-only constraint and the do-not-run-polish-pr constraint, DEPPR keeps the dependency-policy prompt, and both inherit the reviewer role and the verdict line.