### PR TITLE
feat(pr-monitor): tell readers how to trigger the agent

### DIFF
--- a/.claude/skills/check-pr/SKILL.md
+++ b/.claude/skills/check-pr/SKILL.md
@@ -47,3 +47,5 @@ One sentence of reasoning after it. `NOT YET` is for a PR that is right in subst
 Judge the change on its merits even when you wrote the code yourself, and say `DO NOT MERGE` when you believe it. A verdict that always says MERGE is worth less than no verdict.
 
 When the PR would benefit from the simplify and tidy pass that `polish-pr` does, say so in one line and name the skill, so a maintainer can ask for it. Do not run it yourself: it pushes commits, and that is the maintainer's call.
+
+Nobody asked for this check, so close the comment by saying how to ask for the next thing. Keep it to a couple of lines under a `---` rule: mentioning `@vestabot` in a comment on the PR is what reaches you, name the two or three things worth asking for here (re-checking after new commits, running `polish-pr`, fixing red CI), and say that only maintainers can trigger you so a drive-by contributor is not left waiting on a reply that will never come.

--- a/.claude/skills/check-pr/SKILL.md
+++ b/.claude/skills/check-pr/SKILL.md
@@ -3,34 +3,44 @@ name: check-pr
 description: >
   Use when the user asks to check a PR, review a PR, sanity-check a pull request,
   ask whether a PR is correct or ready, or run "check-pr <number>". Also runs
-  automatically on newly opened PRs. Reads the issue the PR claims to fix, judges
-  whether it actually fixes it, checks it against this repository's conventions,
-  and reports with a merge verdict. Read only: never pushes, merges, or closes.
+  automatically on newly opened PRs. Critiques the diff and the solution behind
+  it, attacks the change rather than confirming it, checks it fixes the issue it
+  claims to and matches this repository's conventions, and reports with a merge
+  verdict. Read only: never pushes, merges, or closes.
 ---
 
 # Check a PR
 
-Answer one question about a pull request: should this be merged? Read only. Never push a commit, never merge, never close, never edit the PR. Changing the PR is `polish-pr`'s job, and it runs only when a human asks for it.
+Critique a pull request's diff and the solution behind it, and answer one question: should this be merged? Read only. Never push a commit, never merge, never close, never edit the PR. Changing the PR is `polish-pr`'s job, and it runs only when a human asks for it.
 
-## What to check
+You are not here to confirm the change works. Assume the description is optimistic and that the author stopped looking once it passed. Your value is the objection nobody else raised.
 
-**1. Does it fix the issue it claims to fix?**
+## Critique the solution, not only the code
 
-Find the issue from a closing keyword in the PR body (`fixes #N`, `closes #N`, `resolves #N`). Read the issue itself, not just the PR's description of it, then decide whether this change resolves it. Distinguish clearly between fixing the issue, fixing part of it, fixing something adjacent, and not addressing it at all.
+Read the diff closely, then judge the thinking behind it:
 
-When no issue is linked, say what problem the PR appears to solve and whether it is worth carrying. A change with no traceable motivation is worth flagging on its own.
+- **Is it the right fix?** Trace the failure to its cause and check the change addresses that rather than the symptom that happened to be visible. A guard at the call site, when the bug is in the callee, is a patch over a symptom.
+- **Is it the smallest fix?** Name a simpler change when one exists. Abstractions for a single caller, options nobody asked for, and defensive branches for impossible states all belong in the review.
+- **What did the author not consider?** Concurrency, partial failure, restart, empty and enormous inputs, the second caller, the fleet already running the old shape.
+- **What does it cost?** New coupling, a widened interface, a dependency, or state somebody has to migrate later.
 
-**2. Is it right for this repository?**
+## Attack it before accepting it
 
-Judge against this repo's rules rather than generic taste. `CLAUDE.md` governs architecture principles, code conventions, brand voice, and the PR rules; the language section for whatever it touches applies; a skill covering that area applies too. Watch specifically for the repo-wide bans that CI does not always catch on a PR: inline lint escapes, comment blocks over 8 lines, banned Python accessors, `.unwrap()` on fallible Rust paths, `any` in TypeScript.
+Try to break the change rather than reading it for plausibility. Find the input, state, or ordering where it misbehaves, and look hardest where there are no tests: a suite tells you what the author thought of, not what is true.
 
-**3. Is it actually correct?**
+Verify rather than trust. Read the code paths the diff touches, and where running something settles a question, run it. The `check.sh` subcommands in `CLAUDE.md` are the ones CI uses.
 
-Read the code paths the change touches. Do not trust the description, the comments, or the tests' names. Where running something settles a question, run it: the check subcommands in `CLAUDE.md` are the same ones CI uses. Look for the cases the author did not write a test for.
+When the diff is large enough that one reading will miss things, spawn subagents in parallel, each attacking from a different angle (correctness, failure modes, conventions, the issue it claims to fix) and each told to refute the change rather than approve it. Report only what survives that: a finding you could not substantiate is noise, and noise teaches the reader to stop reading you.
 
-**4. Is it in a mergeable state?**
+Say so plainly when the change is simply good. A review that manufactures objections to look thorough is worth as little as one that rubber-stamps.
 
-CI green, no conflicts, not draft, and scoped to one concern.
+## Also confirm
+
+**It fixes the issue it claims to.** Find the issue from a closing keyword in the PR body (`fixes #N`, `closes #N`, `resolves #N`) and read the issue itself, not the PR's description of it. Distinguish fixing it from fixing part of it, fixing something adjacent, and not addressing it at all. With no issue linked, say what problem the PR appears to solve and whether it is worth carrying.
+
+**It is right for this repository.** Judge against this repo's rules rather than generic taste. `CLAUDE.md` governs architecture principles, code conventions, and the PR rules; the language section for whatever it touches applies; a skill covering that area applies too. Watch for the repo-wide bans CI does not always catch on a PR: inline lint escapes, comment blocks over 8 lines, banned Python accessors, `.unwrap()` on fallible Rust paths, `any` in TypeScript.
+
+**It is mergeable.** CI green, no conflicts, not draft, scoped to one concern.
 
 ## Reporting
 

--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -56,6 +56,8 @@ Events are handled one at a time, so a burst of comments cannot start overlappin
 
 **Every new PR is checked automatically.** A non-draft PR that has never been seen surfaces as `NEWPR` without anyone asking, and dispatch runs the `check-pr` skill on it: does it fix the issue it claims to fix, does it match this repository's conventions, does it actually work. That pass is read only. It never pushes, merges, or closes, so a PR opening cannot cause a write. Where the change would benefit from the simplify and tidy pass, the reply names `polish-pr` and stops there, leaving the maintainer to ask for it.
 
+An unprompted comment closes by saying how to reach the agent: that mentioning `@vestabot` on the PR is what triggers it, what is worth asking for, and that only trusted commenters can. Nobody asked for that comment, so it carries its own instructions rather than assuming the reader knows the loop exists. Replies to an explicit mention skip it, since whoever wrote the mention already knows.
+
 **Seed before switching this on.** "Never seen" means "carries no 👀", so the first cycle treats every open PR as new and checks all of them at once. On a repo with a dozen open PRs that is a dozen agent runs back to back. Mark the existing ones first:
 
 ```bash

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -138,6 +138,7 @@ Stay read only. Do not push a commit, merge, close, or edit the PR. If it would 
     DEPPR)
       handle "$f1" pr "$f2" "$f2" "A new dependabot pull request is open: $f1 PR #$f2: $f3
 Review it against this repository's dependency policy, check whether its checks pass, and act accordingly. Leave a comment recording what you decided.
+Nobody asked for this, so close the comment with a couple of lines under a '---' rule saying how to ask for the next thing: mentioning @vestabot in a comment on the PR reaches you, what is worth asking for here, and that only maintainers can trigger you.
 End that comment with a line starting 'Verdict:' giving your own call on merging: MERGE, DO NOT MERGE, or NOT YET, then one sentence of reasoning. Never merge or close the PR yourself: the verdict is advice and the decision stays with the maintainer."
       ;;
     *) [ -n "${tag:-}" ] && echo "dispatch: ignoring line: $tag" >&2 ;;


### PR DESCRIPTION
The automatic check comments on a PR nobody asked about, so the reader has no reason to know the loop exists or that they can ask it for anything.

Unprompted comments now close with a couple of lines under a rule: mentioning `@vestabot` on the PR triggers a run, what is worth asking for there (re-check after new commits, `polish-pr`, red CI), and that only trusted commenters can trigger it.

That last part is the bit that matters on a public repo. Without it a drive-by contributor reads the footer, mentions the bot, gets a 😕 and no reply, and has no idea why.

`check-pr` owns the wording for the automatic check; the dependabot prompt carries its own. Replies to an explicit mention deliberately skip it, since whoever wrote the mention already knows how to ask.

Verified against a stubbed event stream that the instruction reaches the NEWPR path via the skill and the DEPPR path via the prompt, and is absent from HIT.