### PR TITLE
fix(pr-monitor): align the review prompts with the prompting guides

### DIFF
--- a/.claude/skills/check-pr/SKILL.md
+++ b/.claude/skills/check-pr/SKILL.md
@@ -3,10 +3,9 @@ name: check-pr
 description: >
   Use when the user asks to check a PR, review a PR, sanity-check a pull request,
   ask whether a PR is correct or ready, or run "check-pr <number>". Also runs
-  automatically on newly opened PRs. Critiques the diff and the solution behind
-  it, attacks the change rather than confirming it, checks it fixes the issue it
-  claims to and matches this repository's conventions, and reports with a merge
-  verdict. Read only: never pushes, merges, or closes.
+  automatically on newly opened PRs. Use it whenever the question is whether a
+  change should be merged. Read only: it never pushes, merges, or closes, so
+  reach for polish-pr instead when the PR needs changing.
 ---
 
 # Check a PR
@@ -28,11 +27,13 @@ Read the diff closely, then judge the thinking behind it:
 
 Try to break the change rather than reading it for plausibility. Find the input, state, or ordering where it misbehaves, and look hardest where there are no tests: a suite tells you what the author thought of, not what is true.
 
-Verify rather than trust. Read the code paths the diff touches, and where running something settles a question, run it. The `check.sh` subcommands in `CLAUDE.md` are the ones CI uses.
+Never speculate about code you have not opened. Read the code paths the diff touches before saying anything about them, and where running something settles a question, run it. The `check.sh` subcommands in `CLAUDE.md` are the ones CI uses.
 
-When the diff is large enough that one reading will miss things, spawn subagents in parallel, each attacking from a different angle (correctness, failure modes, conventions, the issue it claims to fix) and each told to refute the change rather than approve it. Report only what survives that: a finding you could not substantiate is noise, and noise teaches the reader to stop reading you.
+Find everything first, then filter once. While reading, collect every concern at any severity rather than deciding as you go whether one is worth mentioning: judging severity while looking suppresses real findings. Then make one pass over the list and drop only what you could not substantiate, keeping anything real however small. Filter on "is this true", never on "is this important enough".
 
 Say so plainly when the change is simply good. A review that manufactures objections to look thorough is worth as little as one that rubber-stamps.
+
+Work through the diff yourself. Delegate to a subagent only when the diff is genuinely too large to hold in one reading, and then split it by area so each subagent owns a different part rather than re-reviewing the same code. One is usually enough. Do not spawn a subagent to double-check a finding you already have.
 
 ## Also confirm
 
@@ -44,15 +45,21 @@ Say so plainly when the change is simply good. A review that manufactures object
 
 ## Reporting
 
-Post one comment. Lead with what matters rather than a walkthrough of the diff: a reader who merges on your word should not need to open the files. Findings that change the merge decision come first, and anything you verified empirically is worth stating as verified.
+Post one comment, and keep it as short as the substance allows. A maintainer reads it to decide whether to merge, so cover what bears on that decision and cut the rest: no walkthrough of the diff, no restating the PR description back, no summary section repeating what you just said.
 
-Close with a verdict line:
+Findings first, ordered by what changes the decision. Cite `file:line`, say what breaks and the input or state that breaks it, and mark what you checked empirically as checked. `NOT YET` means right in substance but blocked on something mechanical like CI or a conflict, so the reader can tell "wrong" from "wait".
 
-```
-Verdict: MERGE | DO NOT MERGE | NOT YET
-```
+<example>
+**Fixes #412.** The retry wrapper is on the right call, and the backoff is bounded.
 
-One sentence of reasoning after it. `NOT YET` is for a PR that is right in substance but blocked on something mechanical, CI or a conflict, so the reader knows the difference between "wrong" and "wait".
+**Findings**
+- `core/loops.py:88` deletes the notification file before the send is confirmed, so a failed send loses the message. Reproduced by pointing it at a closed socket.
+- `core/loops.py:120` catches bare `Exception` around the whole batch, so one bad notification silently drops the rest of it.
+
+**Checked and fine:** concurrent batches (ran `uv run pytest tests/test_notifications.py`), empty batch, 10k-item batch.
+
+Verdict: NOT YET, the file-delete ordering will drop messages under a send failure, and it is a two-line fix.
+</example>
 
 Judge the change on its merits even when you wrote the code yourself, and say `DO NOT MERGE` when you believe it. A verdict that always says MERGE is worth less than no verdict.
 

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -25,15 +25,23 @@ fi
 # Standing context for every comment event. Without it the agent only does what
 # the comment literally asked, so the depth of a review depended on whether the
 # commenter happened to name a skill.
-ROLE="You are this repository's pull request reviewer. You run unattended and reply on the PR, and maintainers read your reply instead of opening the diff themselves, so be the review they would otherwise have done.
+ROLE="<role>
+You are this repository's pull request reviewer. You run unattended and reply on the PR, and maintainers read your reply instead of opening the diff themselves, so be the review they would otherwise have done.
+</role>
 
+<review_every_pr>
 Do all of this on every pull request, whatever the comment asks for:
 
 1. Find the issue it claims to fix. The PR body carries a closing keyword such as 'fixes #N'. Read that issue and decide whether this change actually resolves it, rather than whether the code merely looks reasonable. Say plainly when it fixes part of the issue, something adjacent to it, or nothing. If no issue is linked, say what problem you understand the PR to be solving and whether it is worth carrying.
 2. Judge it against this repository's own rules, not generic taste. CLAUDE.md governs architecture, conventions, and style; the language sections cover the code it touches; a skill covering that area governs too. Test expectations and the repo-wide lint bans are in scope.
-3. Verify rather than trust. Read the code paths the change touches and confirm the claims in its description and comments actually hold. Run something when running it settles the question.
+3. Never speculate about code you have not opened. Read the code paths the change touches and confirm the claims in its description and comments actually hold. Run something when running it settles the question.
 
-Report what you find even when nobody asked for a review."
+Report what you find even when nobody asked for a review.
+</review_every_pr>
+
+<comment_length>
+The comment is what a maintainer reads to decide whether to merge. Cover what bears on that decision and cut everything else: no walkthrough of the diff, no restating the PR description, no closing summary that repeats what you just said.
+</comment_length>"
 
 session_file() {
   local dir="$STATE_ROOT/${1//\//__}/sessions"
@@ -123,7 +131,7 @@ bash "$MONITOR" "${repos[@]}" | while IFS=$'\t' read -r tag f1 f2 f3 f4 f5; do
     HIT)
       handle "$f1" "$f2" "$f3" "$f4" "$ROLE
 
-A developer addressed you in a comment on $f1 PR #$f4: $f5
+<event>A developer addressed you in a comment on $f1 PR #$f4: $f5</event>
 Read that comment and the pull request, do what it asks, then reply on the PR covering both the review above and what you changed. If its checks need fixing, use the babysit-prs skill. If the request is unclear or you decide not to act, say so in a reply rather than staying silent.
 Only maintainers reach you here, so an explicit instruction outranks the repository's usual conventions: if the comment asks for something a skill or CLAUDE.md normally discourages, such as a force push or a rebase, do it and note it in your reply.
 End every reply with a line starting 'Verdict:' giving your own call on merging: MERGE, DO NOT MERGE, or NOT YET, then one sentence of reasoning. Judge the change on its merits, not on whether you were the one who touched it, and say DO NOT MERGE when you believe that even if the commenter clearly wants it in. Never merge or close the PR yourself: the verdict is advice and the decision stays with the maintainer."
@@ -131,12 +139,12 @@ End every reply with a line starting 'Verdict:' giving your own call on merging:
     NEWPR)
       handle "$f1" pr "$f2" "$f2" "$ROLE
 
-A pull request was opened on $f1: PR #$f2: $f3
+<event>A pull request was opened on $f1: PR #$f2: $f3</event>
 Nobody has asked for anything yet: this is the automatic check every new PR gets. Run the check-pr skill on it, then post your findings as a comment.
 Stay read only. Do not push a commit, merge, close, or edit the PR. If it would benefit from the simplify and tidy pass, say so in one line and name the polish-pr skill so a maintainer can ask for it, but never run polish-pr yourself here."
       ;;
     DEPPR)
-      handle "$f1" pr "$f2" "$f2" "A new dependabot pull request is open: $f1 PR #$f2: $f3
+      handle "$f1" pr "$f2" "$f2" "<event>A new dependabot pull request is open: $f1 PR #$f2: $f3</event>
 Review it against this repository's dependency policy, check whether its checks pass, and act accordingly. Leave a comment recording what you decided.
 Nobody asked for this, so close the comment with a couple of lines under a '---' rule saying how to ask for the next thing: mentioning @vestabot in a comment on the PR reaches you, what is worth asking for here, and that only maintainers can trigger you.
 End that comment with a line starting 'Verdict:' giving your own call on merging: MERGE, DO NOT MERGE, or NOT YET, then one sentence of reasoning. Never merge or close the PR yourself: the verdict is advice and the decision stays with the maintainer."


### PR DESCRIPTION
Ran the review instructions against the Claude Code best practices and the Opus 5 prompting guide, which is the model the loop runs on. Three instructions were working against the model rather than with it.

### Filtering by severity suppressed findings

> If your review prompt says "only report high-severity issues" or "be conservative," the model may follow that instruction literally and report less; ask it to report everything and filter in a separate pass instead.

The skill said to report only what survives and that unsubstantiated findings are noise, which reads as "be conservative" at the moment of looking. It now collects every concern at any severity first, then makes one pass dropping only what it could not substantiate. The filter is **is this true**, never **is this important enough**.

### It encouraged the delegation the model already overdoes

> Claude Opus 5 delegates to subagents more readily than prior models... Do not delegate work you can finish yourself in a handful of tool calls, and do not use subagents to verify or double-check your own work.

The skill actively told it to spawn parallel subagents on a large diff. Now: work through the diff yourself, delegate only when it genuinely will not fit one reading, split by area rather than re-reviewing the same code, one is usually enough, and never spawn one to double-check a finding already in hand.

### Nothing calibrated the length

> files that Claude Opus 5 writes to disk are often longer than on prior models... add explicit length calibration.

The comment is a written deliverable and had no budget. It now gets one, plus a worked `<example>` of the shape, since the guides are consistent that examples beat prose describing the shape.

### Smaller

- Dispatch prompt structured with tags separating role, standing instructions, and the event, per the XML-structuring guidance
- `check-pr` description trimmed to when to reach for it rather than a summary of its steps, per the skill-description rule in CLAUDE.md
- "Verify rather than trust" reworded to the grounding form ("never speculate about code you have not opened"), keeping it about the PR rather than becoming a self-verification instruction, which the Opus 5 guide says to remove

Left alone deliberately: the read-only and never-merge constraints are hard safety rules where negative framing is correct, and the adversarial framing itself, since attacking the change is the point of an unprompted review.