### PR TITLE
fix(whatsapp): exit nonzero when a command reports failure

### DIFF
--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -91,6 +91,25 @@ func successResult(success bool, msg string) map[string]any {
 	return map[string]any{"success": success, "message": msg}
 }
 
+// resultFailure reports the reason a result carries a false "success", the one reading
+// of that field: a write that did not happen is a failed command, so the response layer
+// carries it as an error and the client exits nonzero. Empty for a result that succeeded
+// or carries no verdict.
+func resultFailure(result any) string {
+	fields, ok := result.(map[string]any)
+	if !ok {
+		return ""
+	}
+	success, ok := fields["success"].(bool)
+	if !ok || success {
+		return ""
+	}
+	if message, ok := fields["message"].(string); ok && message != "" {
+		return message
+	}
+	return "command failed"
+}
+
 func printJSON(v any) {
 	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -91,10 +91,7 @@ func successResult(success bool, msg string) map[string]any {
 	return map[string]any{"success": success, "message": msg}
 }
 
-// resultFailure reports the reason a result carries a false "success", the one reading
-// of that field: a write that did not happen is a failed command, so the response layer
-// carries it as an error and the client exits nonzero. Empty for a result that succeeded
-// or carries no verdict.
+// resultFailure is why a result reports success:false, empty for one that succeeded or carries no verdict.
 func resultFailure(result any) string {
 	fields, ok := result.(map[string]any)
 	if !ok {

--- a/agent/skills/whatsapp/cli/link.go
+++ b/agent/skills/whatsapp/cli/link.go
@@ -242,13 +242,8 @@ func startSocketCommand(sockPath, command string, args []string) (<-chan socketC
 			result <- socketCommandResult{connected: false}
 			return
 		}
-		if resp.Error != "" {
-			data, _ := json.MarshalIndent(map[string]any{"error": resp.Error}, "", "  ")
-			result <- socketCommandResult{output: data, exitCode: 1, connected: true}
-			return
-		}
-		data, _ := json.MarshalIndent(resp.Result, "", "  ")
-		result <- socketCommandResult{output: data, connected: true}
+		data, exitCode := resp.render()
+		result <- socketCommandResult{output: data, exitCode: exitCode, connected: true}
 	}()
 	return result, func() { conn.Close() }, true
 }

--- a/agent/skills/whatsapp/cli/server.go
+++ b/agent/skills/whatsapp/cli/server.go
@@ -106,8 +106,7 @@ func trySocketCommand(sockPath string, command string, args []string) ([]byte, i
 		return nil, 0, false
 	}
 
-	// A command that failed reports its reason in the result it produced, so that result
-	// is what prints; the {"error": ...} object carries a failure that produced none.
+	// A failure that produced a result prints that result; {"error": ...} carries one that produced none.
 	body := resp.Result
 	if body == nil && resp.Error != "" {
 		body = map[string]any{"error": resp.Error}

--- a/agent/skills/whatsapp/cli/server.go
+++ b/agent/skills/whatsapp/cli/server.go
@@ -21,6 +21,20 @@ type SocketResponse struct {
 	Error  string `json:"error,omitempty"`
 }
 
+// render is the one owner of what a response prints and exits with, for every decoder of it: a
+// failure that produced a result prints that result; {"error": ...} carries one that produced none.
+func (resp SocketResponse) render() ([]byte, int) {
+	body := resp.Result
+	if body == nil && resp.Error != "" {
+		body = map[string]any{"error": resp.Error}
+	}
+	data, _ := json.MarshalIndent(body, "", "  ")
+	if resp.Error != "" {
+		return data, 1
+	}
+	return data, 0
+}
+
 func startSocketServer(sockPath string, wac *WhatsAppClient) (net.Listener, error) {
 	os.Remove(sockPath)
 
@@ -106,14 +120,6 @@ func trySocketCommand(sockPath string, command string, args []string) ([]byte, i
 		return nil, 0, false
 	}
 
-	// A failure that produced a result prints that result; {"error": ...} carries one that produced none.
-	body := resp.Result
-	if body == nil && resp.Error != "" {
-		body = map[string]any{"error": resp.Error}
-	}
-	data, _ := json.MarshalIndent(body, "", "  ")
-	if resp.Error != "" {
-		return data, 1, true
-	}
-	return data, 0, true
+	data, exitCode := resp.render()
+	return data, exitCode, true
 }

--- a/agent/skills/whatsapp/cli/server.go
+++ b/agent/skills/whatsapp/cli/server.go
@@ -78,6 +78,7 @@ func handleSocketConn(conn net.Conn, wac *WhatsAppClient) {
 		resp.Error = err.Error()
 	} else {
 		resp.Result = result
+		resp.Error = resultFailure(result)
 	}
 
 	json.NewEncoder(conn).Encode(resp)
@@ -105,11 +106,15 @@ func trySocketCommand(sockPath string, command string, args []string) ([]byte, i
 		return nil, 0, false
 	}
 
+	// A command that failed reports its reason in the result it produced, so that result
+	// is what prints; the {"error": ...} object carries a failure that produced none.
+	body := resp.Result
+	if body == nil && resp.Error != "" {
+		body = map[string]any{"error": resp.Error}
+	}
+	data, _ := json.MarshalIndent(body, "", "  ")
 	if resp.Error != "" {
-		data, _ := json.MarshalIndent(map[string]any{"error": resp.Error}, "", "  ")
 		return data, 1, true
 	}
-
-	data, _ := json.MarshalIndent(resp.Result, "", "  ")
 	return data, 0, true
 }

--- a/agent/skills/whatsapp/cli/server_test.go
+++ b/agent/skills/whatsapp/cli/server_test.go
@@ -34,6 +34,46 @@ func runTestCommand(t *testing.T, sockPath, command string, args ...string) (map
 	return body, exitCode
 }
 
+// runAsyncTestCommand drives the second decoder of SocketResponse, the one behind the pairing
+// commands, so both decoders are held to the same body-and-exit-code rule.
+func runAsyncTestCommand(t *testing.T, sockPath, command string, args ...string) (map[string]any, int) {
+	t.Helper()
+	result, stopWaiting, connected := startSocketCommand(sockPath, command, args)
+	if !connected {
+		t.Fatalf("test socket did not answer %q", command)
+	}
+	defer stopWaiting()
+	res := <-result
+	if !res.connected {
+		t.Fatalf("test socket dropped %q before answering", command)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(res.output, &body); err != nil {
+		t.Fatalf("command %q produced unparseable output %q: %v", command, res.output, err)
+	}
+	return body, res.exitCode
+}
+
+func TestAsyncFailedWriteKeepsItsResultBody(t *testing.T) {
+	body, exitCode := runAsyncTestCommand(t, startTestSocket(t, newTestStore(t)), "archive-chat", "--to", "Nobody Saved")
+	if exitCode == 0 {
+		t.Errorf("a failed write must exit nonzero, got exit 0 with body %v", body)
+	}
+	if body["success"] != false {
+		t.Errorf("the failure body must stay the command's own result, got %v", body)
+	}
+}
+
+func TestAsyncFailureWithoutResultReportsError(t *testing.T) {
+	body, exitCode := runAsyncTestCommand(t, startTestSocket(t, newTestStore(t)), "send-message", "--to", "+15551234567")
+	if exitCode == 0 {
+		t.Errorf("a validation failure must exit nonzero, got exit 0 with body %v", body)
+	}
+	if _, ok := body["error"].(string); !ok {
+		t.Errorf("a failure that produced no result must report its reason under error, got %v", body)
+	}
+}
+
 func TestFailedWriteExitsNonZero(t *testing.T) {
 	body, exitCode := runTestCommand(t, startTestSocket(t, newTestStore(t)), "archive-chat", "--to", "Nobody Saved")
 	if exitCode == 0 {

--- a/agent/skills/whatsapp/cli/server_test.go
+++ b/agent/skills/whatsapp/cli/server_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	waLog "go.mau.fi/whatsmeow/util/log"
+)
+
+// startTestSocket serves a store-backed client on a temp socket, the same path a
+// real command takes: client -> unix socket -> executeCommand -> response.
+func startTestSocket(t *testing.T) string {
+	t.Helper()
+	wac := &WhatsAppClient{store: newTestStore(t), logger: waLog.Noop}
+	sockPath := filepath.Join(t.TempDir(), "whatsapp.sock")
+	listener, err := startSocketServer(sockPath, wac)
+	if err != nil {
+		t.Fatalf("failed to start socket server: %v", err)
+	}
+	t.Cleanup(func() { stopSocketServer(listener, sockPath) })
+	return sockPath
+}
+
+func runTestCommand(t *testing.T, sockPath, command string, args ...string) (map[string]any, int) {
+	t.Helper()
+	output, exitCode, connected := trySocketCommand(sockPath, command, args)
+	if !connected {
+		t.Fatalf("test socket did not answer %q", command)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(output, &body); err != nil {
+		t.Fatalf("command %q produced unparseable output %q: %v", command, output, err)
+	}
+	return body, exitCode
+}
+
+// TestFailedWriteExitsNonZero proves a write that did not happen fails at the shell,
+// instead of looking identical to one that did, and that its structured body still
+// carries the reason.
+func TestFailedWriteExitsNonZero(t *testing.T) {
+	body, exitCode := runTestCommand(t, startTestSocket(t), "archive-chat", "--to", "Nobody Saved")
+	if exitCode == 0 {
+		t.Errorf("a failed write must exit nonzero, got exit 0 with body %v", body)
+	}
+	if body["success"] != false {
+		t.Errorf("the failure body must keep success:false, got %v", body)
+	}
+	message, ok := body["message"].(string)
+	if !ok || !strings.Contains(message, "Nobody Saved") {
+		t.Errorf("the failure body must keep the reason, got %v", body)
+	}
+}
+
+// TestRejectedSendExitsNonZero pins the bubble lint's exit code, the behavior a failed
+// write now matches: both failures of the same command exit the same way.
+func TestRejectedSendExitsNonZero(t *testing.T) {
+	body, exitCode := runTestCommand(t, startTestSocket(t), "send-message", "--to", "+15551234567", "--message", "hey. ok")
+	if exitCode == 0 {
+		t.Errorf("a send rejected by the bubble lint must exit nonzero, got exit 0 with body %v", body)
+	}
+	if _, ok := body["error"].(string); !ok {
+		t.Errorf("a rejected command must report its reason under error, got %v", body)
+	}
+}
+
+// TestSuccessfulCommandExitsZero pins the unchanged success path: exit 0 and the
+// command's own result body.
+func TestSuccessfulCommandExitsZero(t *testing.T) {
+	body, exitCode := runTestCommand(t, startTestSocket(t), "list-contacts")
+	if exitCode != 0 {
+		t.Errorf("a successful command must exit 0, got %d with body %v", exitCode, body)
+	}
+	if _, ok := body["contacts"]; !ok {
+		t.Errorf("a successful command must return its own result body, got %v", body)
+	}
+}

--- a/agent/skills/whatsapp/cli/server_test.go
+++ b/agent/skills/whatsapp/cli/server_test.go
@@ -9,13 +9,11 @@ import (
 	waLog "go.mau.fi/whatsmeow/util/log"
 )
 
-// startTestSocket serves a store-backed client on a temp socket, the same path a
-// real command takes: client -> unix socket -> executeCommand -> response.
-func startTestSocket(t *testing.T) string {
+// startTestSocket puts a command on the real path: client -> unix socket -> executeCommand -> response.
+func startTestSocket(t *testing.T, store *MessageStore) string {
 	t.Helper()
-	wac := &WhatsAppClient{store: newTestStore(t), logger: waLog.Noop}
 	sockPath := filepath.Join(t.TempDir(), "whatsapp.sock")
-	listener, err := startSocketServer(sockPath, wac)
+	listener, err := startSocketServer(sockPath, &WhatsAppClient{store: store, logger: waLog.Noop})
 	if err != nil {
 		t.Fatalf("failed to start socket server: %v", err)
 	}
@@ -36,11 +34,8 @@ func runTestCommand(t *testing.T, sockPath, command string, args ...string) (map
 	return body, exitCode
 }
 
-// TestFailedWriteExitsNonZero proves a write that did not happen fails at the shell,
-// instead of looking identical to one that did, and that its structured body still
-// carries the reason.
 func TestFailedWriteExitsNonZero(t *testing.T) {
-	body, exitCode := runTestCommand(t, startTestSocket(t), "archive-chat", "--to", "Nobody Saved")
+	body, exitCode := runTestCommand(t, startTestSocket(t, newTestStore(t)), "archive-chat", "--to", "Nobody Saved")
 	if exitCode == 0 {
 		t.Errorf("a failed write must exit nonzero, got exit 0 with body %v", body)
 	}
@@ -49,14 +44,12 @@ func TestFailedWriteExitsNonZero(t *testing.T) {
 	}
 	message, ok := body["message"].(string)
 	if !ok || !strings.Contains(message, "Nobody Saved") {
-		t.Errorf("the failure body must keep the reason, got %v", body)
+		t.Errorf("the failure body must keep the reason under message, got %v", body)
 	}
 }
 
-// TestRejectedSendExitsNonZero pins the bubble lint's exit code, the behavior a failed
-// write now matches: both failures of the same command exit the same way.
 func TestRejectedSendExitsNonZero(t *testing.T) {
-	body, exitCode := runTestCommand(t, startTestSocket(t), "send-message", "--to", "+15551234567", "--message", "hey. ok")
+	body, exitCode := runTestCommand(t, startTestSocket(t, newTestStore(t)), "send-message", "--to", "+15551234567", "--message", "hey. ok")
 	if exitCode == 0 {
 		t.Errorf("a send rejected by the bubble lint must exit nonzero, got exit 0 with body %v", body)
 	}
@@ -65,12 +58,21 @@ func TestRejectedSendExitsNonZero(t *testing.T) {
 	}
 }
 
-// TestSuccessfulCommandExitsZero pins the unchanged success path: exit 0 and the
-// command's own result body.
-func TestSuccessfulCommandExitsZero(t *testing.T) {
-	body, exitCode := runTestCommand(t, startTestSocket(t), "list-contacts")
+func TestSucceededWriteExitsZero(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.SaveManualContact("Alice", "+15551234567"); err != nil {
+		t.Fatalf("failed to seed a contact: %v", err)
+	}
+	body, exitCode := runTestCommand(t, startTestSocket(t, store), "remove-contact", "--identifier", "Alice")
 	if exitCode != 0 {
-		t.Errorf("a successful command must exit 0, got %d with body %v", exitCode, body)
+		t.Errorf("a write reporting success:true must exit 0, got %d with body %v", exitCode, body)
+	}
+}
+
+func TestCommandWithoutVerdictExitsZero(t *testing.T) {
+	body, exitCode := runTestCommand(t, startTestSocket(t, newTestStore(t)), "list-contacts")
+	if exitCode != 0 {
+		t.Errorf("a command carrying no success field must exit 0, got %d with body %v", exitCode, body)
 	}
 	if _, ok := body["contacts"]; !ok {
 		t.Errorf("a successful command must return its own result body, got %v", body)


### PR DESCRIPTION
Fixes #1529
Fixes #1537

## What was wrong

The issue's diagnosis is correct. `SendMessageWithPresence` returns `(false, reason)` for every real send failure (empty args, `EnsureConnected`, `ResolveRecipient`, `requireSendAllowed`, the whatsmeow send itself), `cmdSendMessage` returns that as `successResult(success, msg), nil`, and `handleSocketConn` only fills `SocketResponse.Error` from a non-nil Go error. So `trySocketCommand` exited 0 on a send that never happened, while a validation failure or the bubble lint in the same command exited 1.

## Scope: fixed as a class, in one place

Rather than patch twelve call sites, the daemon now reads the `success` verdict once. `resultFailure` (next to `successResult`, which owns the body shape) reports the reason a result carries `success:false`, and `handleSocketConn` carries it in `SocketResponse.Error`. Every command that returns `successResult(success, msg), nil` is covered without being touched: `cmdSendMessage`, `cmdSendFile`, `cmdSendAudio`, `cmdSendReaction`, `cmdRevokeMessage`, `cmdLeaveGroup`, `cmdUpdateGroupParticipants`, `cmdBackfill`, `cmdRenameGroup`, `cmdSetGroupPhoto`, `cmdSetGroupDescription`, `cmdChatTarget` (archive-chat, delete-chat).

I checked each one for a query-like `success:false` that is a normal outcome rather than a failed write, and there is none: every producer behind them (`messaging.go`, `chat_ops.go`, `groups.go`) returns false only on a resolve error, a gate rejection, a connection failure, or a send error. Nothing is excluded.

Three commands outside the listed twelve build the same body by hand and are covered by the same reading: `cmdDownloadMedia`, `cmdCreateGroup`, `cmdGetGroupInviteLink`. Each returns `success:false` only when the operation failed, so failing them is correct and keeps one rule instead of two. Commands whose result carries no `success` key (`list-*`, `daemon-status`, `link`, `provision`, `check-delivery`) are untouched, so the callers that branch on `exitCode == 0` around them behave exactly as before.

A second review re-derived this over all 37 commands in the registry rather than the fifteen above, including the four call commands and `remove-contact`, and reached the same conclusion: no command uses `success:false` as an informational verdict, so nothing starts wrongly exiting 1.

## The stdout body is unchanged

`SocketResponse.render` now owns what a response prints and exits with: the structured result whenever the command produced one, falling back to `{"error": ...}` only for a failure that produced no result (an unknown command, a read-only block, a flag or lint rejection: exactly the cases that print that object today). So a failed send still prints `{"success": false, "message": "<the real reason>"}`, byte for byte what it printed before, and only the exit code changes. A successful response is untouched in both shape and exit code.

That rule has one owner because the package decodes `SocketResponse` in two places (#1537). `startSocketCommand`, behind the pairing commands, read `Error` first and discarded the result body, so any command routed through it would have lost its own output the moment it reported `success:false`. It was not reachable before this PR, since its only caller sends `link`, whose result carries no `success` key. Both decoders now call `render`, so the invariant cannot drift apart again.

Mixed-version note: the daemon is long-running while the client is compiled per invocation, so an old daemon plus a new client behaves exactly as it does today until the daemon restarts. No wire field was added or renamed.

## Tests

`server_test.go` drives the real path (client -> unix socket -> `executeCommand` -> response) against a store-backed client, through both decoders:

- `TestFailedWriteExitsNonZero`: an unresolvable `archive-chat` target exits nonzero and the body still carries `success:false` plus the reason.
- `TestRejectedSendExitsNonZero`: pins the bubble lint's exit 1, the behavior a failed write now matches, so the two stay consistent.
- `TestSucceededWriteExitsZero`: a command reporting `success:true` still exits 0.
- `TestCommandWithoutVerdictExitsZero`: a command carrying no `success` key at all still exits 0.
- `TestAsyncFailedWriteKeepsItsResultBody` and `TestAsyncFailureWithoutResultReportsError`: the same two response shapes through `startSocketCommand`, the second decoder.

Every one is mutation-checked, each against the specific defect it exists to catch:

- Dropping `resp.Error = resultFailure(result)` fails `TestFailedWriteExitsNonZero` with `got exit 0 with body map[message:Failed to resolve chat... success:false]`, exactly the reported bug.
- Treating `success:true` as a failure fails only `TestSucceededWriteExitsZero`, with `got 1 with body map[message:Contact removed success:true]`.
- Restoring the old `Error`-first decoder in `startSocketCommand` fails only `TestAsyncFailedWriteKeepsItsResultBody`, which sees `map[error:Failed to resolve chat...]` where the command's own body should be. That is #1537 reproduced.

`./check.sh whatsapp` (gofmt, `go vet`, build, `go test`) passes, as does `scripts/check-conventions.py`.

## Not in scope

#1538 tracks the remaining gap: `archive-all-chats` and `clear-all-chats` report per-item failures as counts with no `success` field, so a bulk write where every item failed still exits 0. Fixing that needs a decision about what a partial failure should report, and any answer either reshapes the body or adds a second exit-code rule.
