### PR TITLE
fix(dreamer): name the dream file after its night so a re-drop is idempotent

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -462,7 +462,9 @@ def process_nightly_memory(*, state: vm.State, config: cfg.VestaConfig) -> None:
     """Drop a dream notification if today's dream hasn't completed yet. Caller (`monitor_loop`)
     rate-limits this to once an hour and we bound retries to `DREAMER_CATCHUP_HOURS` after the
     configured hour, so a silent failure to call `mark_dreamer_complete` retries a few times but
-    cannot preempt the agent for the rest of the day."""
+    cannot preempt the agent for the rest of the day. The file is named after the night it belongs
+    to, so a re-drop while that dream is still pending overwrites it instead of queueing a second
+    one; once the dream is consumed the file is gone and a retry recreates it."""
     if config.ephemeral or config.nightly_memory_hour is None:
         return
     # A brand-new agent has no history to curate; a catch-up dream firing inside the morning
@@ -479,7 +481,10 @@ def process_nightly_memory(*, state: vm.State, config: cfg.VestaConfig) -> None:
         return
     logger.dreamer("Nightly dreamer starting...")
     prompt = load_prompt("nightly_dream", config) or ""
-    drop_core_notification(type_=TYPE_NIGHTLY_DREAM, body=prompt, config=config)
+    # The night the window opened, not today's date: a late hour's post-midnight catch-up belongs
+    # to the same night and must reuse the same name.
+    night = (now - dt.timedelta(hours=hours_since_start)).date()
+    drop_core_notification(type_=TYPE_NIGHTLY_DREAM, body=prompt, config=config, name=f"{TYPE_NIGHTLY_DREAM}-{night.isoformat()}")
     logger.dreamer("Dreamer notification dropped")
 
 

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -462,9 +462,9 @@ def process_nightly_memory(*, state: vm.State, config: cfg.VestaConfig) -> None:
     """Drop a dream notification if today's dream hasn't completed yet. Caller (`monitor_loop`)
     rate-limits this to once an hour and we bound retries to `DREAMER_CATCHUP_HOURS` after the
     configured hour, so a silent failure to call `mark_dreamer_complete` retries a few times but
-    cannot preempt the agent for the rest of the day. The file is named after the night it belongs
-    to, so a re-drop while that dream is still pending overwrites it instead of queueing a second
-    one; once the dream is consumed the file is gone and a retry recreates it."""
+    cannot preempt the agent for the rest of the day. Naming the file after its night makes a re-drop
+    over a still-pending dream an overwrite rather than a second queued turn; once consumed the file
+    is gone, so a later check inside the window recreates it."""
     if config.ephemeral or config.nightly_memory_hour is None:
         return
     # A brand-new agent has no history to curate; a catch-up dream firing inside the morning
@@ -481,8 +481,7 @@ def process_nightly_memory(*, state: vm.State, config: cfg.VestaConfig) -> None:
         return
     logger.dreamer("Nightly dreamer starting...")
     prompt = load_prompt("nightly_dream", config) or ""
-    # The night the window opened, not today's date: a late hour's post-midnight catch-up belongs
-    # to the same night and must reuse the same name.
+    # The date the window opened, not today's: a late hour catches up past midnight on the same night.
     night = (now - dt.timedelta(hours=hours_since_start)).date()
     drop_core_notification(type_=TYPE_NIGHTLY_DREAM, body=prompt, config=config, name=f"{TYPE_NIGHTLY_DREAM}-{night.isoformat()}")
     logger.dreamer("Dreamer notification dropped")

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -95,6 +95,70 @@ def test_nightly_memory_scheduling(tmp_path, dreamer_hour, last_dreamer_run, now
     assert len(list(config.notifications_dir.glob("nightly_dream-*.json"))) == expected_files
 
 
+def _drop_dream(config, state, now):
+    from core.loops import process_nightly_memory
+
+    with (
+        patch("core.loops._now", return_value=now),
+        patch("core.loops.load_prompt", return_value="dreamer prompt"),
+    ):
+        process_nightly_memory(state=state, config=config)
+
+
+def _dream_files(config):
+    return sorted(f.name for f in config.notifications_dir.glob("nightly_dream-*.json"))
+
+
+@pytest.mark.parametrize(
+    "dreamer_hour,first,second",
+    [
+        (4, dt.datetime(2025, 6, 15, 4, 0, 0), dt.datetime(2025, 6, 15, 4, 20, 0)),
+        (22, dt.datetime(2025, 6, 14, 22, 0, 0), dt.datetime(2025, 6, 15, 1, 0, 0)),
+    ],
+    ids=["same-day", "catchup-past-midnight"],
+)
+def test_redrop_over_a_pending_dream_queues_only_one(tmp_path, dreamer_hour, first, second):
+    """A restart landing between the drop and mark_dreamer_complete re-runs the check while the
+    dream is still pending. That re-drop must overwrite the pending file, not queue a second dream,
+    including when a late dreamer hour's catch-up lands after midnight."""
+    config = _setup(tmp_path, dreamer_hour=dreamer_hour)
+    state = vm.State()
+    state.persisted.first_start_done = True
+
+    _drop_dream(config, state, first)
+    _drop_dream(config, state, second)
+
+    assert len(_dream_files(config)) == 1
+
+
+def test_unconsumed_dream_from_yesterday_does_not_suppress_today(tmp_path):
+    """The name is per night, never a fixed stem: a dream left unconsumed from yesterday must not
+    swallow today's."""
+    config = _setup(tmp_path)
+    state = vm.State()
+    state.persisted.first_start_done = True
+
+    _drop_dream(config, state, dt.datetime(2025, 6, 15, 4, 0, 0))
+    _drop_dream(config, state, dt.datetime(2025, 6, 16, 4, 0, 0))
+
+    assert _dream_files(config) == ["nightly_dream-2025-06-15.json", "nightly_dream-2025-06-16.json"]
+
+
+def test_consumed_dream_is_recreated_by_the_catchup_retry(tmp_path):
+    """Retry semantics are unchanged: once the pending dream is consumed (file deleted) and the
+    agent never marked it complete, a later check inside the catch-up window drops it again."""
+    config = _setup(tmp_path)
+    state = vm.State()
+    state.persisted.first_start_done = True
+
+    _drop_dream(config, state, dt.datetime(2025, 6, 15, 4, 0, 0))
+    for dream in config.notifications_dir.glob("nightly_dream-*.json"):
+        dream.unlink()
+    _drop_dream(config, state, dt.datetime(2025, 6, 15, 7, 30, 0))
+
+    assert _dream_files(config) == ["nightly_dream-2025-06-15.json"]
+
+
 # --- mark_dreamer_complete: keep the session, then compact + restart (not a hard reset) ---
 
 

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -14,6 +14,7 @@ from wait_util import wait_for_condition
 import core.config as cfg
 import core.models as vm
 from core import lifecycle
+from core.loops import process_nightly_memory
 from core.notification import TYPE_COMPACTION_FOLLOWUP, Notification
 
 
@@ -27,8 +28,6 @@ def _setup(tmp_path, *, dreamer_hour=4):
 def test_skips_dream_before_first_start_done(tmp_path):
     """A brand-new agent (first_start_done=False) has nothing to curate, so a catch-up dream
     landing inside the morning window must not fire mid-onboarding."""
-    from core.loops import process_nightly_memory
-
     config = _setup(tmp_path)
     state = vm.State()
     assert state.persisted.first_start_done is False
@@ -42,8 +41,6 @@ def test_skips_dream_before_first_start_done(tmp_path):
 
 
 def test_drops_dream_notification(tmp_path):
-    from core.loops import process_nightly_memory
-
     config = _setup(tmp_path)
     state = vm.State()
     state.persisted.first_start_done = True
@@ -79,8 +76,6 @@ def test_drops_dream_notification(tmp_path):
     ids=["already-ran-today", "before-hour", "retry-past-hour", "catchup-past-midnight", "outside-window"],
 )
 def test_nightly_memory_scheduling(tmp_path, dreamer_hour, last_dreamer_run, now, expected_files):
-    from core.loops import process_nightly_memory
-
     config = _setup(tmp_path, dreamer_hour=dreamer_hour)
     state = vm.State()
     state.persisted.first_start_done = True
@@ -96,8 +91,6 @@ def test_nightly_memory_scheduling(tmp_path, dreamer_hour, last_dreamer_run, now
 
 
 def _drop_dream(config, state, now):
-    from core.loops import process_nightly_memory
-
     with (
         patch("core.loops._now", return_value=now),
         patch("core.loops.load_prompt", return_value="dreamer prompt"),
@@ -118,9 +111,8 @@ def _dream_files(config):
     ids=["same-day", "catchup-past-midnight"],
 )
 def test_redrop_over_a_pending_dream_queues_only_one(tmp_path, dreamer_hour, first, second):
-    """A restart landing between the drop and mark_dreamer_complete re-runs the check while the
-    dream is still pending. That re-drop must overwrite the pending file, not queue a second dream,
-    including when a late dreamer hour's catch-up lands after midnight."""
+    """A re-drop while the dream is still pending must overwrite the pending file rather than queue a
+    second dream, including when a late dreamer hour catches up after midnight."""
     config = _setup(tmp_path, dreamer_hour=dreamer_hour)
     state = vm.State()
     state.persisted.first_start_done = True
@@ -132,8 +124,7 @@ def test_redrop_over_a_pending_dream_queues_only_one(tmp_path, dreamer_hour, fir
 
 
 def test_unconsumed_dream_from_yesterday_does_not_suppress_today(tmp_path):
-    """The name is per night, never a fixed stem: a dream left unconsumed from yesterday must not
-    swallow today's."""
+    """The stem is per night, never fixed, so yesterday's unconsumed dream cannot swallow today's."""
     config = _setup(tmp_path)
     state = vm.State()
     state.persisted.first_start_done = True
@@ -145,8 +136,7 @@ def test_unconsumed_dream_from_yesterday_does_not_suppress_today(tmp_path):
 
 
 def test_consumed_dream_is_recreated_by_the_catchup_retry(tmp_path):
-    """Retry semantics are unchanged: once the pending dream is consumed (file deleted) and the
-    agent never marked it complete, a later check inside the catch-up window drops it again."""
+    """Once the dream is consumed and never marked complete, a later check inside the window drops it again."""
     config = _setup(tmp_path)
     state = vm.State()
     state.persisted.first_start_done = True


### PR DESCRIPTION
Fixes #1527

## What was wrong

Verified the issue's diagnosis against the code; it is correct. `monitor_loop` arms `last_dreamer_check` an hour back so the dreamer check runs on the first tick after boot, and that rate limit is in-memory only. The only guard against a repeat drop is `process_nightly_memory`'s `last_dreamer_run` check, and that timestamp is stamped by `mark_dreamer_complete`, which the agent calls only once the dream has finished. For the whole span between the drop and completion, every restart inside `DREAMER_CATCHUP_HOURS` wrote a second `nightly_dream-<millis>.json`, and since the pending file's path is already in `monitor_loop`'s `queued_paths`, only the new one read as fresh and queued a second dream.

## The fix

The drop now passes a stem to `drop_core_notification`, so a re-drop over a still-pending dream is an idempotent overwrite instead of a second queued turn. That is the issue's suggestion, and it holds up: `drop_core_notification` writes atomically, the pending path stays in `queued_paths` so the overwrite never re-emits, and no consumer keys off the millisecond suffix.

The alternative, stamping `last_dreamer_run` at drop time instead of at completion, was rejected: it would collapse the drop and the completion into one signal and silently delete the documented catch-up retry, since a dream dropped and then lost to a crash would look complete for the rest of the day.

One deviation from the issue's suggested one-liner. It proposed `now.date()`; this uses the date of the configured hour that opened the current window:

```python
night = (now - dt.timedelta(hours=hours_since_start)).date()
```

The catch-up window is deliberately circular, so a late `nightly_memory_hour` (say 22:00) runs from 22:00 to 04:00 and spans midnight; that configuration is explicitly covered by the existing `catchup-past-midnight` scheduling case. With `now.date()`, a 22:00 drop and a 01:00 restart produce two different stems and the duplicate comes straight back, for the majority of that agent's window. Keying the name to the night the window opened costs the same one expression and holds for every configured hour. This is proven by the `catchup-past-midnight` parametrization of the new re-drop test: it fails with `now.date()` and passes with the night-based stem (checked by mutation).

## Preserved constraints

- **Catch-up retry.** Once the pending dream is consumed the file is deleted, so a later check inside the window recreates it exactly as before, under the same night's name. Covered by `test_consumed_dream_is_recreated_by_the_catchup_retry`.
- **Yesterday must not suppress today.** The stem is per night, not fixed, so an unconsumed dream from yesterday and today's drop are two distinct files. Covered by `test_unconsumed_dream_from_yesterday_does_not_suppress_today`.
- **`source=core` exemption.** Untouched: only the filename stem changed, and disposition is still derived from the type via `CORE_SNOOZE_TYPES`.

## Fleet impact

No migration needed, and nothing can be stranded. A live agent may right now hold a pending `nightly_dream-<millis>.json`. That file is an ordinary notification: `load_notifications` globs `*.json` and never parses the stem, so after the update it is still loaded, dispositioned by its `type`, queued, and deleted on completion exactly as before. Nothing keys off the old name.

The one residual is that an agent whose update restart lands inside its own drop-to-completion window can still see one duplicate on that boot, because the old-stem file and the new-stem file are distinct names. That is the pre-existing behavior on master, not a regression, and it is self-clearing: every later drop uses the new name. A prompt migration could not help here anyway, since migrations run as boot turns after the drop has already happened.

Two refinements from a second review sweep over every stem consumer in the repo. Neither changes the conclusion:

- The stem is not entirely unread. `_load_notification_files` sorts the dir by filename, and the stem is exported as the client-facing `notif_id`. The sort is inert here because `process_batch` splits `source=core` into its own section and the type prefix dominates the lexicographic order, so no batch reorders. On the wire the id is opaque and vestad's `PendingNotifications::apply` already treats a repeated `Added` as idempotent, which is the behavior this rename wants.
- The one genuine consequence is that `notif_id` is no longer unique across time on the catch-up retry path, which the web and mobile notification lists assume when they dedup and key rows. Cosmetic, no agent or gateway effect; filed as #1541 rather than folded in here.

The adjacent `last_dreamer_run` guard compares calendar dates while this window is night-based, which double-fires the dreamer for any `nightly_memory_hour >= 19`. Pre-existing, untouched here, filed as #1540.

## Verification

- `./check.sh agent` and `./check.sh guards` both green.
- Mutation-tested: with the fix reverted to master's unnamed drop, all four new tests fail (the same-day re-drop case is the issue's reported `2 == 1`); restored, all 31 tests in the dreamer suite pass. Separately mutated to the issue's `now.date()` stem, which fails only `catchup-past-midnight`, which is what justifies the deviation.
- The night expression was re-derived independently, then checked exhaustively: every `nightly_memory_hour` 0 through 23 over 400 consecutive dates yields exactly one stem per window and never collides across nights, with the window opening at `H:00:00` and closing at `H+6:00:00`. Replayed against real UTC time through DST transitions in both directions for New York, London, Dublin, Sao Paulo, Santiago, Tehran, Auckland, Lord Howe (30-minute shift) and Chatham (45-minute offset), including the zones that transition at midnight: no splits and no collisions. Naive subtraction is safe precisely because the input is also naive wall clock, so a repeated hour repeats the same stem and a skipped hour is absorbed by the modular offset.

