### PR TITLE
fix(agent): scope the dash correction to the turn's last message

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -420,8 +420,7 @@ def _contains_dashes(text: str) -> bool:
 
 async def process_message(msg: str, *, state: vm.State, config: cfg.VestaConfig) -> tuple[list[str], vm.State]:
     turn = await converse(msg, state=state, config=config, show_output=True)
-    # turn.texts accumulates every text block of the turn; the warning asks for the last message
-    # back, so only the last block can be corrected.
+    # turn.texts holds one entry per assistant message of the turn, and the warning can only ask for the last message back.
     if config.block_dashes and turn.texts and _contains_dashes(turn.texts[-1]) and not turn.preempted:
         # A preempted turn's reply was cut short at a step boundary; correcting a truncated
         # reply would re-send it after the preempting prompt's work, so skip it.

--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -414,13 +414,15 @@ _DASH_WARNING = (
 )
 
 
-def _contains_dashes(texts: list[str]) -> bool:
-    return any(_EM_DASH in t or _EN_DASH in t or " - " in t for t in texts)
+def _contains_dashes(text: str) -> bool:
+    return _EM_DASH in text or _EN_DASH in text or " - " in text
 
 
 async def process_message(msg: str, *, state: vm.State, config: cfg.VestaConfig) -> tuple[list[str], vm.State]:
     turn = await converse(msg, state=state, config=config, show_output=True)
-    if config.block_dashes and turn.texts and _contains_dashes(turn.texts) and not turn.preempted:
+    # turn.texts accumulates every text block of the turn; the warning asks for the last message
+    # back, so only the last block can be corrected.
+    if config.block_dashes and turn.texts and _contains_dashes(turn.texts[-1]) and not turn.preempted:
         # A preempted turn's reply was cut short at a step boundary; correcting a truncated
         # reply would re-send it after the preempting prompt's work, so skip it.
         logger.warning("Em/en dash detected in response, sending correction")

--- a/agent/tests/test_formatting.py
+++ b/agent/tests/test_formatting.py
@@ -103,26 +103,21 @@ def test_filter_tool_lines(input_text, expected):
 
 
 def test_contains_dashes_detects_em_dash():
-    assert _contains_dashes(["hello \u2014 world"]) is True
+    assert _contains_dashes("hello \u2014 world") is True
 
 
 def test_contains_dashes_detects_en_dash():
-    assert _contains_dashes(["hello \u2013 world"]) is True
+    assert _contains_dashes("hello \u2013 world") is True
 
 
 def test_contains_dashes_detects_space_dash_space():
-    assert _contains_dashes(["hello - world"]) is True
+    assert _contains_dashes("hello - world") is True
 
 
 def test_contains_dashes_clean_text():
-    assert _contains_dashes(["hello-world"]) is False
-    assert _contains_dashes(["just normal text"]) is False
-    assert _contains_dashes([]) is False
-
-
-def test_contains_dashes_multiple_texts():
-    assert _contains_dashes(["clean", "also clean"]) is False
-    assert _contains_dashes(["clean", "has \u2014 dash"]) is True
+    assert _contains_dashes("hello-world") is False
+    assert _contains_dashes("just normal text") is False
+    assert _contains_dashes("") is False
 
 
 # --- SDK message parsing ---

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -377,8 +377,7 @@ async def test_process_message_sends_correction_on_em_dash(tmp_path):
 
 @pytest.mark.anyio
 async def test_process_message_no_correction_when_dash_is_only_in_an_earlier_block(tmp_path):
-    """A dash in mid-turn narration leaves the clean final message alone: asking for it back would
-    only resend it verbatim, since the correction can address the last message and nothing else."""
+    """A dash in mid-turn narration leaves the clean final message alone: the correction can only ask for the last message back."""
     config = cfg.VestaConfig(agent_dir=tmp_path / "agent")
     state = vm.State()
     converse_calls: list[str] = []

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -354,9 +354,14 @@ async def test_notification_dropped_before_intentional_restart(tmp_path):
 # --- Em/en dash correction in process_message ---
 
 
+@pytest.mark.parametrize(
+    "response",
+    [["something \u2014 with an em dash"], ["clean narration", "final \u2014 with an em dash"]],
+    ids=["only-message", "last-message-of-several"],
+)
 @pytest.mark.anyio
-async def test_process_message_sends_correction_on_em_dash(tmp_path):
-    """process_message should call converse a second time when an em dash is detected."""
+async def test_process_message_sends_correction_on_em_dash(tmp_path, response):
+    """process_message should call converse a second time when the turn's last message has an em dash."""
     config = cfg.VestaConfig(agent_dir=tmp_path / "agent")
     state = vm.State()
     converse_calls: list[str] = []
@@ -364,7 +369,7 @@ async def test_process_message_sends_correction_on_em_dash(tmp_path):
     async def mock_converse(prompt, *, state, config, show_output):
         converse_calls.append(prompt)
         if len(converse_calls) == 1:
-            return vm.TurnSignals(texts=["something \u2014 with an em dash"])
+            return vm.TurnSignals(texts=response)
         return vm.TurnSignals(texts=["corrected response"])
 
     with patch("core.client.converse", side_effect=mock_converse):
@@ -372,55 +377,17 @@ async def test_process_message_sends_correction_on_em_dash(tmp_path):
 
     assert len(converse_calls) == 2
     assert "em dash" in converse_calls[1].lower()
-    assert responses == ["something \u2014 with an em dash"]
-
-
-@pytest.mark.anyio
-async def test_process_message_no_correction_when_dash_is_only_in_an_earlier_block(tmp_path):
-    """A dash in mid-turn narration leaves the clean final message alone: the correction can only ask for the last message back."""
-    config = cfg.VestaConfig(agent_dir=tmp_path / "agent")
-    state = vm.State()
-    converse_calls: list[str] = []
-
-    async def mock_converse(prompt, *, state, config, show_output):
-        converse_calls.append(prompt)
-        return vm.TurnSignals(texts=["narrating \u2014 with an em dash", "clean final message"])
-
-    with patch("core.client.converse", side_effect=mock_converse):
-        responses, _ = await process_message("hello", state=state, config=config)
-
-    assert len(converse_calls) == 1
-    assert responses == ["narrating \u2014 with an em dash", "clean final message"]
-
-
-@pytest.mark.anyio
-async def test_process_message_sends_correction_when_the_final_block_has_a_dash(tmp_path):
-    """A dash in the last block of a multi-block turn is still corrected."""
-    config = cfg.VestaConfig(agent_dir=tmp_path / "agent")
-    state = vm.State()
-    converse_calls: list[str] = []
-
-    async def mock_converse(prompt, *, state, config, show_output):
-        converse_calls.append(prompt)
-        if len(converse_calls) == 1:
-            return vm.TurnSignals(texts=["clean narration", "final \u2014 with an em dash"])
-        return vm.TurnSignals(texts=["corrected response"])
-
-    with patch("core.client.converse", side_effect=mock_converse):
-        await process_message("hello", state=state, config=config)
-
-    assert len(converse_calls) == 2
-    assert "em dash" in converse_calls[1].lower()
+    assert responses == response
 
 
 @pytest.mark.parametrize(
     "response",
-    [["clean response, no dashes here"], []],
-    ids=["no-dashes", "empty-response"],
+    [["clean response, no dashes here"], [], ["narrating \u2014 with an em dash", "clean final message"]],
+    ids=["no-dashes", "empty-response", "dash-only-in-an-earlier-message"],
 )
 @pytest.mark.anyio
 async def test_process_message_no_correction(tmp_path, response):
-    """process_message should not send a correction when no dashes are present (incl. an empty response)."""
+    """process_message should not send a correction unless the turn's last message has a dash (incl. an empty response)."""
     config = cfg.VestaConfig(agent_dir=tmp_path / "agent")
     state = vm.State()
     converse_calls: list[str] = []

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -375,6 +375,45 @@ async def test_process_message_sends_correction_on_em_dash(tmp_path):
     assert responses == ["something \u2014 with an em dash"]
 
 
+@pytest.mark.anyio
+async def test_process_message_no_correction_when_dash_is_only_in_an_earlier_block(tmp_path):
+    """A dash in mid-turn narration leaves the clean final message alone: asking for it back would
+    only resend it verbatim, since the correction can address the last message and nothing else."""
+    config = cfg.VestaConfig(agent_dir=tmp_path / "agent")
+    state = vm.State()
+    converse_calls: list[str] = []
+
+    async def mock_converse(prompt, *, state, config, show_output):
+        converse_calls.append(prompt)
+        return vm.TurnSignals(texts=["narrating \u2014 with an em dash", "clean final message"])
+
+    with patch("core.client.converse", side_effect=mock_converse):
+        responses, _ = await process_message("hello", state=state, config=config)
+
+    assert len(converse_calls) == 1
+    assert responses == ["narrating \u2014 with an em dash", "clean final message"]
+
+
+@pytest.mark.anyio
+async def test_process_message_sends_correction_when_the_final_block_has_a_dash(tmp_path):
+    """A dash in the last block of a multi-block turn is still corrected."""
+    config = cfg.VestaConfig(agent_dir=tmp_path / "agent")
+    state = vm.State()
+    converse_calls: list[str] = []
+
+    async def mock_converse(prompt, *, state, config, show_output):
+        converse_calls.append(prompt)
+        if len(converse_calls) == 1:
+            return vm.TurnSignals(texts=["clean narration", "final \u2014 with an em dash"])
+        return vm.TurnSignals(texts=["corrected response"])
+
+    with patch("core.client.converse", side_effect=mock_converse):
+        await process_message("hello", state=state, config=config)
+
+    assert len(converse_calls) == 2
+    assert "em dash" in converse_calls[1].lower()
+
+
 @pytest.mark.parametrize(
     "response",
     [["clean response, no dashes here"], []],


### PR DESCRIPTION
Fixes #1528

## The issue's diagnosis was wrong

The issue frames this as a design fork between marking superseded messages on the client wire contract and sanitizing dashes at emission. Both are rejected, and neither is implemented.

The duplicate is also not user-visible in chat. Core does not transport chat; `_emit_text` publishes to the agent's internal event bus, which surfaces in the activity/log view, not in the app's chat tail.

## The real defect

`_emit_parsed_content` appends to `turn.texts` for every assistant text block across the whole turn, so `turn.texts` is an accumulation, not the final message. The check ran `_contains_dashes(turn.texts)` over that whole accumulation at turn close, but `_DASH_WARNING` says "your last response contained an em dash ... Resend your last message without them."

So when the dash occurred in an earlier block of the turn, Vesta was told its last message had a dash when it did not. It complied literally and resent the already-clean last message byte for byte. The block that actually contained the dash was never corrected.

Verified on a live agent's `events.db`. Of the three corrections in that container's log, two fired uselessly:

* dash in event 76270; the pair 76277/76278 are both 517 chars, byte-identical, neither containing a dash
* dashes in events 76428/76433 (eight minutes earlier in the same turn); the pair 76543/76544 are both 1176 chars, byte-identical, neither containing a dash
* dash in the final block (event 76633); the resend 76635 was shorter and clean, the mechanism working as designed

## The fix

Check `turn.texts[-1]` so the check matches what the warning instructs, and narrow `_contains_dashes` to take a single text so the whole accumulation can no longer be passed to it.

## Deliberate tradeoff

A dash in mid-turn narration now goes uncorrected. That is not a regression: today's behavior corrects nothing in that case either, it only duplicates the final message.

## Unchanged

Streaming (`converse` still gets `show_output=True`, and `test_process_message_always_streams` is untouched), the `not turn.preempted` guard and its comment, the `config.block_dashes` field and default, and the client wire contract.

## Tests

Two new behavioral tests in `test_processor.py`: a turn whose dash is in an earlier block sends no correction; a multi-block turn whose final block has a dash still does. The existing `_contains_dashes` unit tests move to the single-text signature.

Mutation-checked: with the fix reverted to the accumulation scan, `test_process_message_no_correction_when_dash_is_only_in_an_earlier_block` fails with `assert 2 == 1`; restored, all pass.

`./check.sh agent` and `./check.sh guards` both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
