### PR TITLE
fix(pr-monitor): stop the agent waking itself

### DIFF
--- a/.claude/skills/check-pr/SKILL.md
+++ b/.claude/skills/check-pr/SKILL.md
@@ -65,4 +65,12 @@ Judge the change on its merits even when you wrote the code yourself, and say `D
 
 When the PR would benefit from the simplify and tidy pass that `polish-pr` does, say so in one line and name the skill, so a maintainer can ask for it. Do not run it yourself: it pushes commits, and that is the maintainer's call.
 
+End the comment with this exact line, alone on the last line, after everything else including the verdict and the footer:
+
+```
+<!-- vestabot:reply -->
+```
+
+It renders as nothing, and it is what stops the loop treating your own comment as a fresh request. The footer below names the trigger, and you post under an account that also belongs to a human, so without that line your comment wakes you again on the next poll.
+
 Nobody asked for this check, so close the comment by saying how to ask for the next thing. Keep it to a couple of lines under a `---` rule: mentioning `@vestabot` in a comment on the PR is what reaches you, name the two or three things worth asking for here (re-checking after new commits, running `polish-pr`, fixing red CI), and say that only maintainers can trigger you so a drive-by contributor is not left waiting on a reply that will never come.

--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -119,6 +119,12 @@ The trust list is the whole gate, and it carries real authority. A trusted comme
 
 Keep the list to people you would let push to the branch yourself.
 
+## The agent must not wake itself
+
+Every comment the agent posts ends with `<!-- vestabot:reply -->`, which renders as nothing, and any comment carrying it is skipped. That marker is the only thing separating the agent's writing from a human's: its comments name the trigger when telling a reader how to reach it, and it posts under an account that also belongs to a maintainer, so neither the body nor the author distinguishes them. Without the marker its own comment reads as a fresh request and it wakes itself on the next poll, once per cycle, forever.
+
+The marker is written by the agent, so it holds only while the agent follows instructions. A separate bot identity would make it structural instead: comments from `<name>[bot]` are already skipped by author, needing nothing from the model. Override the string with `PR_MONITOR_MARKER`.
+
 ## How events are deduplicated
 
 A surfaced item gets a 👀 reaction on the comment (or on the PR itself, for dependabot). The next cycle sees that reaction and skips it. That state lives on GitHub, so it survives losing the working directory, a reboot, or a move to another machine.
@@ -139,6 +145,7 @@ Two consequences worth knowing:
 | `PR_MONITOR_TRIGGER` | `@vestabot` | Mention that makes a comment an event |
 | `PR_MONITOR_TRUSTED` | (author_association) | Logins allowed to drive the agent |
 | `PR_MONITOR_DENIED_REACTION` | `confused` | Reaction marking a refused comment |
+| `PR_MONITOR_MARKER` | `vestabot:reply` | Marker identifying the agent's own comments |
 | `PR_MONITOR_INTERVAL` | `45` | Seconds between polls |
 | `PR_MONITOR_STATE` | `$XDG_STATE_HOME/pr-monitor` | Review-summary ledger and per-PR session ids |
 | `PR_MONITOR_MODEL` | `claude-opus-5` | Model `dispatch.sh` runs each event on |

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -41,7 +41,15 @@ Report what you find even when nobody asked for a review.
 
 <comment_length>
 The comment is what a maintainer reads to decide whether to merge. Cover what bears on that decision and cut everything else: no walkthrough of the diff, no restating the PR description, no closing summary that repeats what you just said.
-</comment_length>"
+</comment_length>
+
+<signing_every_comment>
+End every comment you post on a PR or issue with this exact line, alone on the last line:
+
+<!-- vestabot:reply -->
+
+It renders as nothing, and it is how the loop that woke you recognises its own writing. You post under an account that also belongs to a human maintainer, and your comments name the trigger when they tell a reader how to reach you, so without that marker your own comment reads as a fresh request and wakes you again on the next poll. Never put the marker on anything you did not write, and never omit it from anything you did.
+</signing_every_comment>"
 
 session_file() {
   local dir="$STATE_ROOT/${1//\//__}/sessions"
@@ -146,7 +154,7 @@ Stay read only. Do not push a commit, merge, close, or edit the PR. If it would 
     DEPPR)
       handle "$f1" pr "$f2" "$f2" "<event>A new dependabot pull request is open: $f1 PR #$f2: $f3</event>
 Review it against this repository's dependency policy, check whether its checks pass, and act accordingly. Leave a comment recording what you decided.
-Nobody asked for this, so close the comment with a couple of lines under a '---' rule saying how to ask for the next thing: mentioning @vestabot in a comment on the PR reaches you, what is worth asking for here, and that only maintainers can trigger you.
+Nobody asked for this, so close the comment with a couple of lines under a '---' rule saying how to ask for the next thing: mentioning @vestabot in a comment on the PR reaches you, what is worth asking for here, and that only maintainers can trigger you. The marker line goes last, after that.
 End that comment with a line starting 'Verdict:' giving your own call on merging: MERGE, DO NOT MERGE, or NOT YET, then one sentence of reasoning. Never merge or close the PR yourself: the verdict is advice and the decision stays with the maintainer."
       ;;
     *) [ -n "${tag:-}" ] && echo "dispatch: ignoring line: $tag" >&2 ;;

--- a/.claude/skills/pr-monitor/fetch_comments.sh
+++ b/.claude/skills/pr-monitor/fetch_comments.sh
@@ -13,9 +13,12 @@ TRIGGER="${PR_MONITOR_TRIGGER:-@vestabot}"
 
 valid() { grep -E "^(issue|review|reviewbody)$(printf '\t')"; }
 
-# Must address the bot, and must not be one of our own replies, which quote the
-# developer's text and would otherwise re-trigger on their own mention.
-G='select(.body != null) | select(.body | test("'"$TRIGGER"'"; "i")) | select((.body|ascii_downcase|contains("generated with")) and (.body|ascii_downcase|contains("claude code")) | not)'
+# Must address the bot, and must not be one of our own comments. Our replies name
+# the trigger when telling a reader how to reach us, and they are posted by an
+# account that is also a trusted human, so nothing about the author distinguishes
+# them: only the marker does. Every comment the agent posts carries it.
+MARKER="${PR_MONITOR_MARKER:-vestabot:reply}"
+G='select(.body != null) | select(.body | test("'"$TRIGGER"'"; "i")) | select(.body | contains("'"$MARKER"'") | not) | select((.body|ascii_downcase|contains("generated with")) and (.body|ascii_downcase|contains("claude code")) | not)'
 
 prs=$(gh pr list --repo "$REPO" --state open --json number -q '.[].number' 2>/dev/null)
 for pr in $prs; do


### PR DESCRIPTION
The automatic check went into a feedback loop on #1531. It posted a review, then treated its own review as a request and posted again, ~72s apart, until the service was stopped. Two comments landed before it was caught.

### Why every guard missed it

The footer added in #1525 tells the reader how to reach the agent, so the comment contains `@vestabot` by design. Then:

- **Bot-author filter** did not apply: the agent posts as `elyxlz`, a real person, not `[bot]`
- **Trust gate** passed: `elyxlz` is on the trusted list
- **Own-reply filter** did not match: it keys on `Generated with Claude Code`, which the agent never emits. Confirmed on the live comment: `mentions_vestabot=true has_cc_footer=false`

Neither the body nor the author distinguished the agent's comment from a human request, so it was one.

### The fix

Every comment the agent posts ends with `<!-- vestabot:reply -->`, which renders as nothing, and any comment carrying it is skipped. Mandated in the dispatch prompt and in `check-pr`, filtered in `fetch_comments.sh`, overridable with `PR_MONITOR_MARKER`.

Verified against the two real looping comments (both still trigger, they predate the marker) and against a synthetic comment written under the new rule (suppressed). The two live ones are being marked seen by hand before the service restarts.

### Worth being honest about

The marker is written by the model, so this is a weaker guarantee than the author check it stands in for: if the agent omits it once, the loop returns. The structural fix is a separate identity, where comments from `<name>[bot]` are skipped by author and nothing depends on the model complying. That path is written already (`monitor-app.sh`, from the earlier `vesta-upstream` work) and blocked only on granting the app `issues: write` plus the vesta-cloud install.