### PR TITLE
fix(web,mobile): key notification rows on the arrival, not the pending slot

### DIFF
--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -47,7 +47,10 @@ export { PACING, typingDelay } from "./pacing/pacing"
 export { RESTART_REASONS, restartBody } from "./lifecycle/restart-reasons"
 export type { RestartBody, RestartReason } from "./lifecycle/restart-reasons"
 
-export { parseNotificationContent } from "./notification-content/notification-content"
+export {
+  notificationRowKey,
+  parseNotificationContent,
+} from "./notification-content/notification-content"
 export type {
   NotificationContent,
   NotificationView,

--- a/apps/core/src/notification-content/notification-content.test.ts
+++ b/apps/core/src/notification-content/notification-content.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { parseNotificationContent, type NotificationView } from "./notification-content"
+import {
+  notificationRowKey,
+  parseNotificationContent,
+  type NotificationView,
+} from "./notification-content"
 
 function notification(summary: string, patch: Partial<NotificationView> = {}): NotificationView {
   return {
@@ -107,5 +111,48 @@ describe("parseNotificationContent", () => {
       body: null,
       context: null,
     })
+  })
+})
+
+describe("notificationRowKey", () => {
+  const dream = (ts?: string) =>
+    notification("time to dream", { notif_id: "nightly_dream-2026-01-01", ts })
+
+  it("separates two arrivals of one notif_id at different timestamps", () => {
+    expect(notificationRowKey(dream("2026-01-01T03:00:00Z"))).not.toEqual(
+      notificationRowKey(dream("2026-01-01T05:00:00Z")),
+    )
+  })
+
+  it("gives a replayed arrival the same key", () => {
+    expect(notificationRowKey(dream("2026-01-01T03:00:00Z"))).toEqual(
+      notificationRowKey(dream("2026-01-01T03:00:00Z")),
+    )
+  })
+
+  it("separates a timestamped arrival from a timestampless one", () => {
+    expect(notificationRowKey(dream())).not.toEqual(
+      notificationRowKey(dream("2026-01-01T03:00:00Z")),
+    )
+  })
+
+  it("keys an event predating notif_id on its timestamp", () => {
+    const ts = "2026-01-01T03:00:00Z"
+    expect(notificationRowKey(notification("a", { ts }))).toEqual(
+      notificationRowKey(notification("b", { ts, source: "email" })),
+    )
+  })
+
+  it("keys an event with neither id nor timestamp on its content", () => {
+    expect(notificationRowKey(notification("a"))).not.toEqual(notificationRowKey(notification("b")))
+  })
+
+  it("never lets one rung produce another rung's key", () => {
+    const keys = [
+      notificationRowKey(notification("a", { notif_id: "x" })),
+      notificationRowKey(notification("a", { ts: "x" })),
+      notificationRowKey(notification("a")),
+    ]
+    expect(new Set(keys).size).toBe(keys.length)
   })
 })

--- a/apps/core/src/notification-content/notification-content.ts
+++ b/apps/core/src/notification-content/notification-content.ts
@@ -10,6 +10,18 @@ import type { NotificationEvent } from "../protocol/events"
 // chat stream leaves optional (ChatMessage) and notification display never reads.
 export type NotificationView = Omit<NotificationEvent, "id"> & { id?: number }
 
+// Identity of one notification ARRIVAL, for list dedup and React keys, the single owner shared by web
+// and mobile. `notif_id` is the notification file's stem, so it names the pending slot rather than the
+// event: the same stem can legitimately arrive again once the first one has been consumed. Pairing it
+// with the arrival timestamp keeps those two rows distinct while a replayed identical event (same id
+// and same ts) still dedups. Events predating `notif_id` fall back to the timestamp, then to their
+// content; each rung carries its own prefix so no two rungs can produce the same key.
+export function notificationRowKey(event: NotificationView): string {
+  if (event.notif_id != null) return `id\u0000${event.notif_id}\u0000${event.ts ?? ""}`
+  if (event.ts != null) return `ts\u0000${event.ts}`
+  return `sig\u0000${event.source}\u0000${event.sender ?? ""}\u0000${event.summary}`
+}
+
 export interface NotificationContent {
   headline: string
   body: string | null

--- a/apps/mobile/src/agent/NotificationsPage.tsx
+++ b/apps/mobile/src/agent/NotificationsPage.tsx
@@ -8,7 +8,11 @@ import {
   getPendingNotificationIds,
   mergeLiveNotifications,
 } from "@/agent/notification-list-model";
-import { parseNotificationContent, type NotificationView } from "@vesta/core";
+import {
+  notificationRowKey,
+  parseNotificationContent,
+  type NotificationView,
+} from "@vesta/core";
 import { useBottomAnchoredFeed } from "@/agent/use-bottom-anchored-feed";
 import { Text } from "@/components/ui/Typography";
 import { usePreferences } from "@/preferences/PreferencesProvider";
@@ -168,9 +172,7 @@ export default function NotificationsPage({
         ]}
         data={displayItems}
         inverted={!standalone}
-        keyExtractor={(event, index) =>
-          `${event.notif_id ?? `${event.ts}-${event.source}`}-${index}`
-        }
+        keyExtractor={notificationRowKey}
         renderItem={({ item }) => (
           <NotificationRow
             event={item}

--- a/apps/mobile/src/agent/notification-list-model.test.ts
+++ b/apps/mobile/src/agent/notification-list-model.test.ts
@@ -29,6 +29,43 @@ describe("notification list model", () => {
     ).toEqual([second, first, existing]);
   });
 
+  it("surfaces a re-arrival of the same notif_id at a later ts", () => {
+    const first = notification("nightly_dream-2026-01-01", "2026-01-01T03:00:00Z");
+    const redrop = notification("nightly_dream-2026-01-01", "2026-01-01T05:00:00Z");
+
+    expect(mergeLiveNotifications([first], [redrop])).toEqual([redrop, first]);
+  });
+
+  it("still drops a replay of the same notif_id at the same ts", () => {
+    const arrival = notification("nightly_dream-2026-01-01", "2026-01-01T03:00:00Z");
+
+    expect(mergeLiveNotifications([arrival], [arrival])).toEqual([arrival]);
+  });
+
+  it("keeps two id-less events with the same ts collapsed, as before", () => {
+    const older: NotificationView = {
+      type: "notification",
+      source: "email",
+      summary: "a",
+      ts: "2026-01-01T00:00:00Z",
+    };
+    const other: NotificationView = {
+      type: "notification",
+      source: "twitter",
+      summary: "b",
+      ts: "2026-01-01T00:00:00Z",
+    };
+
+    expect(mergeLiveNotifications([older], [other])).toEqual([older]);
+  });
+
+  it("distinguishes id-less, ts-less events by their content", () => {
+    const one: NotificationView = { type: "notification", source: "email", summary: "a" };
+    const two: NotificationView = { type: "notification", source: "email", summary: "b" };
+
+    expect(mergeLiveNotifications([one], [two])).toEqual([two, one]);
+  });
+
   it("combines the snapshot seed with live arrivals and clears", () => {
     const events: ChatMessage[] = [
       notification("new", "2026-01-01T00:01:00Z"),

--- a/apps/mobile/src/agent/notification-list-model.ts
+++ b/apps/mobile/src/agent/notification-list-model.ts
@@ -1,23 +1,19 @@
-import type { ChatMessage, NotificationView } from "@vesta/core";
-
-function notificationKey(event: NotificationView): string {
-  return (
-    event.notif_id ??
-    event.ts ??
-    `${event.source}\u0000${event.sender ?? ""}\u0000${event.summary}`
-  );
-}
+import {
+  notificationRowKey,
+  type ChatMessage,
+  type NotificationView,
+} from "@vesta/core";
 
 export function mergeLiveNotifications(
   history: readonly NotificationView[],
   liveEvents: readonly ChatMessage[],
 ): NotificationView[] {
-  const seen = new Set(history.map(notificationKey));
+  const seen = new Set(history.map(notificationRowKey));
   const arrivals: NotificationView[] = [];
 
   for (const event of liveEvents) {
     if (event.type !== "notification") continue;
-    const key = notificationKey(event);
+    const key = notificationRowKey(event);
     if (seen.has(key)) continue;
     seen.add(key);
     arrivals.push(event);

--- a/apps/web/src/components/AgentSettings/NotificationsCard/index.test.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationsCard/index.test.tsx
@@ -7,6 +7,7 @@ import {
   type AgentSocketValue,
 } from "@/providers/AgentSocketProvider/context";
 import type { ChatMessage } from "@/lib/types";
+import type { NotificationEvent } from "@/api/agents";
 import { NotificationsCard } from "./index";
 
 // A fake AgentSocket context: `pending` is the connect-snapshot seed; `messages` carries any live
@@ -226,5 +227,56 @@ describe("NotificationsCard pending", () => {
     );
 
     await waitFor(() => expect(screen.queryByText("pending")).toBeNull());
+  });
+});
+
+describe("NotificationsCard arrival identity", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(cleanup);
+
+  const dream = (ts: string): NotificationEvent => ({
+    type: "notification",
+    source: "core",
+    summary:
+      '<channel source="core" type="nightly_dream">time to dream</channel>',
+    notif_type: "nightly_dream",
+    id: 201,
+    notif_id: "nightly_dream-2026-01-01",
+    ts,
+  });
+
+  it("renders a re-arrival of the same notif_id at a later ts as its own row", async () => {
+    vi.spyOn(api, "getNotificationHistory").mockResolvedValue({
+      notifications: [dream("2026-01-01T03:00:00Z")],
+      cursor: null,
+    });
+    render(
+      <AgentSocketContext.Provider
+        value={socketValue([dream("2026-01-01T05:00:00Z")])}
+      >
+        <NotificationsCard />
+      </AgentSocketContext.Provider>,
+    );
+
+    await waitFor(() => expect(screen.getAllByText("core")).toHaveLength(2));
+  });
+
+  it("still folds a replay of the same notif_id at the same ts into one row", async () => {
+    vi.spyOn(api, "getNotificationHistory").mockResolvedValue({
+      notifications: [dream("2026-01-01T03:00:00Z")],
+      cursor: null,
+    });
+    render(
+      <AgentSocketContext.Provider
+        value={socketValue([dream("2026-01-01T03:00:00Z")])}
+      >
+        <NotificationsCard />
+      </AgentSocketContext.Provider>,
+    );
+    await screen.findByText("core");
+
+    expect(screen.getAllByText("core")).toHaveLength(1);
   });
 });

--- a/apps/web/src/components/AgentSettings/NotificationsCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationsCard/index.tsx
@@ -17,15 +17,10 @@ import {
 } from "@/components/ui/empty";
 import { ItemGroup } from "@/components/ui/item";
 import { getNotificationHistory, type NotificationEvent } from "@/api/agents";
+import { notificationRowKey } from "@vesta/core";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { NotificationRow, NotificationRowSkeleton } from "./NotificationRow";
 import { useLiveNotifications } from "@/hooks/use-live-notifications";
-
-// Identity for dedupe: notif_id when present (stable across REST history + the live stream),
-// falling back to the timestamp for older events that predate notif_id.
-function rowKey(event: NotificationEvent): string {
-  return event.notif_id ?? event.ts ?? "";
-}
 
 // The received-notifications history. Flows at its natural height and scrolls with the settings page;
 // the rules cards beside it stay sticky. Live-updating: the row list comes from the REST history
@@ -43,7 +38,8 @@ export function NotificationsCard() {
   // The currently-selected agent, so an in-flight request drops its result if the user switches
   // agents mid-flight (this card is not unmounted on switch, only its effect re-runs).
   const currentAgent = useRef(agentName);
-  // Keys of arrivals already in `items`, so live merges don't duplicate a REST-loaded row.
+  // Keys of arrivals already in `items`, so live merges don't duplicate a REST-loaded row. The key is
+  // the arrival, not the pending slot: notif_id alone recurs across time (see notificationRowKey).
   const seenRef = useRef<Set<string>>(new Set());
 
   // Pending = on disk, not yet processed: snapshot seed ∪ live arrivals − live clears. A clear after
@@ -66,7 +62,7 @@ export function NotificationsCard() {
         if (currentAgent.current !== name) return;
         setItems(page.notifications);
         setCursor(page.cursor);
-        seenRef.current = new Set(page.notifications.map(rowKey));
+        seenRef.current = new Set(page.notifications.map(notificationRowKey));
       })
       .catch((e: unknown) => {
         if (currentAgent.current === name)
@@ -84,9 +80,11 @@ export function NotificationsCard() {
   // Runs once `items` exists, and again when it (re)loads, catching arrivals that raced the fetch.
   useEffect(() => {
     if (items === null) return;
-    const fresh = arrivals.filter((n) => !seenRef.current.has(rowKey(n)));
+    const fresh = arrivals.filter(
+      (n) => !seenRef.current.has(notificationRowKey(n)),
+    );
     if (fresh.length === 0) return;
-    fresh.forEach((n) => seenRef.current.add(rowKey(n)));
+    fresh.forEach((n) => seenRef.current.add(notificationRowKey(n)));
     setItems((prev) => (prev ? [...[...fresh].reverse(), ...prev] : prev));
   }, [arrivals, items]);
 
@@ -97,7 +95,9 @@ export function NotificationsCard() {
     try {
       const page = await getNotificationHistory(requestedAgent, cursor);
       if (currentAgent.current !== requestedAgent) return;
-      page.notifications.forEach((n) => seenRef.current.add(rowKey(n)));
+      page.notifications.forEach((n) =>
+        seenRef.current.add(notificationRowKey(n)),
+      );
       setItems((prev) => [...(prev ?? []), ...page.notifications]);
       setCursor(page.cursor);
     } catch (e) {
@@ -144,9 +144,9 @@ export function NotificationsCard() {
         ) : (
           <div className="flex flex-col gap-2.5">
             <ItemGroup>
-              {items.map((event, i) => (
+              {items.map((event) => (
                 <NotificationRow
-                  key={event.notif_id ?? event.ts ?? `row-${String(i)}`}
+                  key={notificationRowKey(event)}
                   event={event}
                   // Pending = received but not yet processed (still on disk per the live pending set).
                   isPending={!!event.notif_id && pendingIds.has(event.notif_id)}


### PR DESCRIPTION
Fixes #1541

Follows from #1532, which gives the nightly dream a stable per-night notification filename so a re-drop over a still-pending dream is an idempotent overwrite. That is correct and stays. Its consequence is that `notif_id`, which is the notification file's stem (`agent/core/loops.py`), is no longer unique across time: on the documented catch-up retry a dream is dropped, consumed (file deleted, `notification_cleared` emitted), and then legitimately dropped again under the same stem. That second arrival is a genuinely new event.

## The distinction, please do not collapse it back

`notif_id` does two different jobs in the clients, and only one of them breaks.

**Pending identity, "is a file with this name on disk?"** Add on `notification`, delete on `notification_cleared`. Still correct, unchanged by this PR. The same name really is the same pending slot, and add/clear are strictly ordered on one bus. Untouched: `getPendingNotificationIds` (mobile), the `pendingIds` memo in `NotificationsCard` (web), `use-live-notifications.ts`, `use-agent-socket.ts`.

**Arrival identity, "have I already rendered this row?"** This is what broke. Two arrivals under one stem were folded into one row, and if both landed in a single history page React saw duplicate keys. Fixed here.

## The change

One owner, `notificationRowKey` in `@vesta/core` (`notification-content/`, beside `NotificationView` and `parseNotificationContent`, the existing shared owner for how a client displays a notification), consumed by web and mobile so both apps agree.

The rung ladder is preserved, only the first rung changes from `notif_id` alone to the pair `(notif_id, ts)`:

- `notif_id` present: keyed on `notif_id` plus `ts` (empty when absent). Two arrivals of one stem at different times are distinct rows; a replayed identical event, same id and same ts, still dedups, which is the overlap guard dedup exists for.
- `notif_id` absent, `ts` present: keyed on `ts`, exactly as before, for stored events that predate `notif_id`.
- both absent: keyed on source, sender and summary, exactly as before.

Each rung carries its own prefix and NUL-separates its parts, so no rung can ever synthesize another rung's key and two absent fields cannot collapse into a key shared by unrelated events. A key is always non-empty, which lets web's React key drop its `row-${i}` index fallback and mobile's `keyExtractor` drop its `-${index}` suffix: both list keys are now derived purely from data identity, as the repo rules require.

No wire-contract change. `notif_id` and `ts` both already exist on the event; no field added, renamed or retyped, no fixture regenerated, `MIN_SUPPORTED_CLIENT_VERSION` untouched. Nothing under `agent/` or `vestad/` is touched.

## Verification

The reported shape held up against the code, with two corrections worth recording.

`apps/core` has no `notif_id` dedup of its own. The replica reducer replaces the whole `notifications.pending` array from vestad wholesale, and the chat stream model dedups on the events.db rowid (`shownIds`), never on `notif_id`. Both are unaffected. The rowid is also why the pair is the right key rather than the event id: `ChatMessage` and `NotificationView` both leave `id` optional, because the live chat stream can deliver a row without one, so the ledger id is not available at these sites.

The mobile React key was a third breaking site the issue did not list. `NotificationsPage`'s `keyExtractor` appended the array index, which hid the collision but produced index-derived keys.

Tests, all three suites, with a mutation test in both directions:

- `apps/core`: six cases pinning the ladder directly, including that no rung can produce another rung's key.
- `apps/mobile`: `notification-list-model.test.ts` gains the re-arrival case, the same-id same-ts replay case, and two cases pinning the unchanged fallback rungs.
- `apps/web`: `NotificationsCard/index.test.tsx` (the card does have a harness) gains a two-row re-arrival case and a one-row replay case, rendered through the real component.
- Mutated back to `notif_id` alone: 2 core, 1 mobile and 1 web test fail, and pass again when restored. Mutated the other way to a never-equal key: the replay-dedup tests fail in mobile and web, proving they are not vacuous.

`./check.sh app-core`, `./check.sh app-web` and `./check.sh app-mobile` all pass, plus `./check.sh guards`.
