### PR TITLE
fix(whatsapp): report a bulk chat sweep that swept nothing as a failure

### DIFF
--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -1372,6 +1372,12 @@ func cmdArchiveChat(args []string, wac *WhatsAppClient) (any, error) {
 	return cmdChatTarget("archive-chat", "Chat to archive (contact name, phone, group, or JID)", args, wac.ArchiveChat)
 }
 
+// sweptSuccessfully is the verdict of a bulk chat command: a sweep with nothing to do succeeds,
+// partial progress succeeds, and only a sweep that had work and completed none of it failed.
+func sweptSuccessfully(succeeded, failed int) bool {
+	return succeeded > 0 || failed == 0
+}
+
 func cmdArchiveAllChats(args []string, wac *WhatsAppClient) (any, error) {
 	if err := parseNoFlags("archive-all-chats", args); err != nil {
 		return nil, err
@@ -1380,7 +1386,7 @@ func cmdArchiveAllChats(args []string, wac *WhatsAppClient) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	result := map[string]any{"archived": archived}
+	result := map[string]any{"archived": archived, "success": sweptSuccessfully(archived, len(errs))}
 	if len(errs) > 0 {
 		result["errors"] = errs
 	}
@@ -1411,6 +1417,7 @@ func cmdClearAllChats(args []string, wac *WhatsAppClient) (any, error) {
 		}
 	}
 	result := map[string]any{
+		"success": sweptSuccessfully(deleted, failed),
 		"deleted": deleted,
 		"failed":  failed,
 		"total":   len(jids),

--- a/agent/skills/whatsapp/cli/server_test.go
+++ b/agent/skills/whatsapp/cli/server_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	waLog "go.mau.fi/whatsmeow/util/log"
 )
@@ -106,6 +107,57 @@ func TestSucceededWriteExitsZero(t *testing.T) {
 	body, exitCode := runTestCommand(t, startTestSocket(t, store), "remove-contact", "--identifier", "Alice")
 	if exitCode != 0 {
 		t.Errorf("a write reporting success:true must exit 0, got %d with body %v", exitCode, body)
+	}
+}
+
+// A wipe that cleared nothing must not look like a clean sweep at the shell. The chats are seeded
+// under identifiers that no longer resolve, which is what fails every delete in the loop.
+func TestBulkSweepThatClearedNothingExitsNonZero(t *testing.T) {
+	store := newTestStore(t)
+	for _, jid := range []string{"vanished chat one", "vanished chat two"} {
+		if err := store.StoreChat(jid, "Gone", time.Now()); err != nil {
+			t.Fatalf("failed to seed a chat: %v", err)
+		}
+	}
+	body, exitCode := runTestCommand(t, startTestSocket(t, store), "clear-all-chats")
+	if exitCode == 0 {
+		t.Errorf("a sweep that cleared none of two chats must exit nonzero, got exit 0 with body %v", body)
+	}
+	if body["deleted"] != float64(0) || body["failed"] != float64(2) || body["total"] != float64(2) {
+		t.Errorf("the failing sweep must keep reporting its counts, got %v", body)
+	}
+	if errs, ok := body["errors"].([]any); !ok || len(errs) != 2 {
+		t.Errorf("the failing sweep must keep one error per chat, got %v", body)
+	}
+}
+
+func TestBulkSweepWithNothingToClearExitsZero(t *testing.T) {
+	body, exitCode := runTestCommand(t, startTestSocket(t, newTestStore(t)), "clear-all-chats")
+	if exitCode != 0 {
+		t.Errorf("a sweep with no chats to clear must exit 0, got %d with body %v", exitCode, body)
+	}
+	if body["total"] != float64(0) {
+		t.Errorf("an empty sweep must report that it had nothing to do, got %v", body)
+	}
+}
+
+// The verdict the exit code above is wired to. archive-all-chats reports the same way, from
+// counts it can only produce over a live WhatsApp connection.
+func TestABulkSweepFailsOnlyWhenItCompletedNothing(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		succeeded int
+		failed    int
+		want      bool
+	}{
+		{"nothing to sweep", 0, 0, true},
+		{"every item failed", 0, 3, false},
+		{"one of three failed", 2, 1, true},
+		{"every item succeeded", 3, 0, true},
+	} {
+		if got := sweptSuccessfully(tc.succeeded, tc.failed); got != tc.want {
+			t.Errorf("%s: sweptSuccessfully(%d, %d) = %v, want %v", tc.name, tc.succeeded, tc.failed, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #1538

Builds on #1531 (merged), which made `resultFailure` and `SocketResponse.render()` the single owner of turning a `success: false` result into exit 1.

## The problem

`cmdArchiveAllChats` and `cmdClearAllChats` return count-shaped results with no `success` key, so `resultFailure` finds no verdict and both exit 0 unconditionally. Wipe 37 chats, fail all 37, and the shell sees exit 0 with `{"deleted":0,"failed":37,...}`, indistinguishable from a clean sweep.

## The change

Both results now carry a `success` key, so the verdict flows through `resultFailure`, the single owner of the exit-code decision. Purely additive: `deleted`, `failed`, `total`, `archived`, and `errors` all keep their names, types, and meanings, because the agent and shell callers parse them. No second exit-code rule, no special case in `render()` or `trySocketCommand`.

## The policy

`success: false` only when there was work to do and none of it succeeded. Partial success is success, and a sweep with nothing to do succeeds.

One helper owns it for both commands:

```go
func sweptSuccessfully(succeeded, failed int) bool {
	return succeeded > 0 || failed == 0
}
```

For `clear-all-chats` that is `sweptSuccessfully(deleted, failed)`: false exactly when `total > 0 && deleted == 0`, since `failed == total - deleted`.

For `archive-all-chats` the shape differs, so the equivalent is derived from what `ArchiveAllChats` actually returns. It walks `ListAllChatJIDs()` and, per chat, either increments `archived` or appends one string to `errs`, never both and never neither. So `archived + len(errs) == len(jids)` exactly: `len(errs)` is the failure count and `archived + len(errs)` is the total the command never reports. "There was work to do" is therefore `len(errs) > 0 || archived > 0`, and "nothing succeeded" is `archived == 0`, giving `sweptSuccessfully(archived, len(errs))`: false exactly when `archived == 0 && len(errs) > 0`. `errs` cannot be non-empty on a fully successful run, which is what makes the two shapes equivalent rather than merely similar.

Rationale: these are bulk sweeps where partial failure is routine (a chat that vanished mid-run, a locked row), the nuance already lives in `failed`/`errors` for anything that wants it, and the failure worth catching at the shell is total failure masquerading as total success. Exiting 1 on any single failure would make a 36-of-37 sweep report as broken and train callers to ignore the exit code.

`DeleteChat` was checked against the same framing: it returns false only on a resolve failure, a connection failure, or a failed local clear, all genuine failures, so a false verdict never means "nothing to do".

## Tests

Driven through the real socket path (`trySocketCommand`), as the existing exit-code tests are:

- a sweep that cleared none of two chats exits nonzero and still carries `deleted`/`failed`/`total`/`errors` unchanged
- a sweep with no chats to clear exits 0

Plus a table test on the verdict itself covering nothing-to-sweep, every-item-failed, partial, and every-item-succeeded.

The verdict table is not redundant with the socket tests: `ArchiveAllChats` calls `EnsureConnected()` before it can report any counts, and `DeleteChat` does the same per chat, so `archive-all-chats` end to end and any partial-success case need a live WhatsApp connection that a unit test cannot stand up (`WhatsAppClient.client` is a concrete `*whatsmeow.Client` whose connected state is unreachable from outside the package). The socket tests prove the verdict is wired to the exit code; the table proves the policy `archive-all-chats` shares.

The all-failed test was proved to discriminate: dropping the `success` key from `cmdClearAllChats` makes it fail with `got exit 0`, restoring it makes it pass. #1531's coverage still discriminates too: mutating `if !ok || success` to `if !ok` in `resultFailure` still fails `TestSucceededWriteExitsZero`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
