### PR TITLE
fix(pr-monitor): claim an event when it is picked up, not when it is emitted

### DIFF
--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -7,8 +7,10 @@
 # what it already pushed and tried there. Context is not shared across PRs.
 #
 # Events are handled serially, so a burst cannot start overlapping runs against
-# the same session. The 👀 monitor.sh posts is a claim rather than a completion:
-# a failed run releases it, and the event surfaces again on the next cycle.
+# the same session. The 👀 is claimed here, when the event is picked up, and a
+# failed run releases it so the event surfaces again. The monitor re-emits
+# anything still unclaimed, so the same event can arrive more than once and the
+# claim is what makes handling it exactly once.
 set -uo pipefail
 
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -106,9 +108,36 @@ prune_sessions() {
   done
 }
 
+# Take the event, or report that somebody already has it. The monitor re-emits
+# whatever it has not seen claimed, so this is what keeps a repeated event from
+# being handled twice, and claiming here rather than at emit time is what keeps
+# an event that was never picked up from being lost.
+claim() {
+  local repo="$1" kind="$2" id="$3" base ledger
+  if [ "$kind" = "reviewbody" ]; then
+    ledger="$STATE_ROOT/${repo//\//__}/seen_reviewbody.txt"
+    mkdir -p "$(dirname "$ledger")"
+    touch "$ledger"
+    grep -qx "$id" "$ledger" 2>/dev/null && return 1
+    echo "$id" >> "$ledger"
+    return 0
+  fi
+  case "$kind" in
+    issue)  base="/repos/$repo/issues/comments/$id/reactions" ;;
+    review) base="/repos/$repo/pulls/comments/$id/reactions" ;;
+    pr)     base="/repos/$repo/issues/$id/reactions" ;;
+    *) return 1 ;;
+  esac
+  gh api "$base" -q '.[] | select(.content=="eyes") | .user.login' 2>/dev/null | grep -qxF "$ME" && return 1
+  gh api -X POST "$base" -f content=eyes >/dev/null 2>&1
+}
+
 handle() {
   local repo="$1" kind="$2" id="$3" pr="$4" prompt="$5"
   local sf sid out rc
+  if ! claim "$repo" "$kind" "$id"; then
+    return 0
+  fi
   sf="$(session_file "$repo" "$pr")"
   local args=(-p --model "$MODEL" --output-format json --dangerously-skip-permissions)
   [ -s "$sf" ] && args+=(--resume "$(cat "$sf")")

--- a/.claude/skills/pr-monitor/monitor.sh
+++ b/.claude/skills/pr-monitor/monitor.sh
@@ -10,10 +10,12 @@
 #   DEPPR  <repo> <pr> <url>               a newly seen open dependabot PR
 # Usage: monitor.sh [owner/repo ...]   (defaults to the current repo)
 #
-# Dedup is a 👀 reaction placed on the comment or PR itself, not a local ledger,
-# so the state lives on GitHub and survives losing the working directory. The 👀
-# is posted here at emit time rather than by whatever consumes these lines, so an
-# event cannot re-fire every cycle while it waits to be handled.
+# Dedup is a 👀 reaction on the comment or PR itself, not a local ledger, so the
+# state lives on GitHub and survives losing the working directory. The consumer
+# posts it when it picks the event up, never this loop: an event claimed here but
+# never consumed, because the consumer was busy or restarted, would be lost with
+# no way to notice. Unclaimed events are simply re-emitted next cycle, so the
+# consumer must tolerate seeing one more than once.
 set -uo pipefail
 
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -45,8 +47,6 @@ react() {
     *) return 1 ;;
   esac
 }
-
-ack() { react "$1" "$2" "$3" eyes; }
 
 # Anyone who can comment on a public repo can reach this loop, so only trusted
 # commenters may drive the agent. An explicit login list wins when set;
@@ -87,8 +87,8 @@ emit_comments() {
         printf 'HIT\t%s\t%s\t%s\t%s\t%s\n' "$repo" "$kind" "$id" "$pr" "$url"
       else
         echo "monitor: ignoring $repo#$pr review from untrusted $author" >&2
+        echo "$id" >> "$ledger"
       fi
-      echo "$id" >> "$ledger"
       continue
     fi
 
@@ -104,11 +104,7 @@ emit_comments() {
       continue
     fi
 
-    if ack "$repo" "$kind" "$id"; then
-      printf 'HIT\t%s\t%s\t%s\t%s\t%s\n' "$repo" "$kind" "$id" "$pr" "$url"
-    else
-      echo "WARN: could not ack $repo $kind $id, not emitting" >&2
-    fi
+    printf 'HIT\t%s\t%s\t%s\t%s\t%s\n' "$repo" "$kind" "$id" "$pr" "$url"
   done < "$tsv"
 }
 
@@ -122,11 +118,7 @@ emit_open_prs() {
     -q '.[] | select(.isDraft | not) | select((([.reactionGroups[]? | select(.content=="EYES") | .users.totalCount] | add) // 0) == 0) | "\(if (.headRefName|startswith("dependabot/")) then "DEPPR" else "NEWPR" end)\t\(.number)\t\(.url)"' 2>/dev/null | \
   while IFS=$'\t' read -r kind num url; do
     [ -z "${num:-}" ] && continue
-    if ack "$repo" pr "$num"; then
-      printf '%s\t%s\t%s\t%s\n' "$kind" "$repo" "$num" "$url"
-    else
-      echo "WARN: could not ack $repo#$num, not emitting" >&2
-    fi
+    printf '%s\t%s\t%s\t%s\n' "$kind" "$repo" "$num" "$url"
   done
 }
 


### PR DESCRIPTION
PR #1532 was opened, acked, and never reviewed. Then a `@vestabot review this pr pls` on it was acked and never answered. No session file was ever written for it, so the model never ran either time.

### Cause

`monitor.sh` posted the 👀 at the moment it wrote the event into the pipe `dispatch.sh` drains serially. The claim hit GitHub immediately, but the event was only a line in a pipe: if the dispatcher was mid-run or the service restarted, that line went away and the claim stayed. The event could never re-surface, and nothing logged a failure, because from the loop's point of view it had been handled.

```
12:40:42Z  PR #1532 opened
12:40:51Z  👀 posted, event queued
12:54:21Z  service stopped to ship a fix     <- queued event discarded
14:03:02Z  "@vestabot review this pr pls"
14:03:35Z  👀 posted, event queued
14:29:07Z  service restarted for a deploy    <- discarded again
```

Six restarts today shipping fixes, so this was close to guaranteed. The failure path was handled (a failed run releases the claim and retries); the never-started path was not.

### Fix

The dispatcher claims each event as it reads it. Anything emitted but not picked up stays unclaimed and comes back on the next 45s poll, so a restart costs a repeat instead of a loss.

That makes repeats routine, since the monitor keeps emitting while a long run holds the dispatcher, so the claim doubles as the exactly-once guard: an already-claimed event returns early without running. Review summaries claim through their ledger, having no reaction to take.

### Verification

Stubbed dispatcher against a monitor emitting the same event repeatedly, as it would during a long run: 5 duplicate events produced exactly 2 runs, and 2 duplicate review summaries produced 1 with the ledger written once.