### PR TITLE
fix(dreamer): judge completion against the night, not the calendar day

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -459,7 +459,7 @@ DREAMER_CATCHUP_HOURS = 6
 
 
 def process_nightly_memory(*, state: vm.State, config: cfg.VestaConfig) -> None:
-    """Drop a dream notification if today's dream hasn't completed yet. Caller (`monitor_loop`)
+    """Drop a dream notification if this night's dream hasn't completed yet. Caller (`monitor_loop`)
     rate-limits this to once an hour and we bound retries to `DREAMER_CATCHUP_HOURS` after the
     configured hour, so a silent failure to call `mark_dreamer_complete` retries a few times but
     cannot preempt the agent for the rest of the day. Naming the file after its night makes a re-drop
@@ -476,14 +476,17 @@ def process_nightly_memory(*, state: vm.State, config: cfg.VestaConfig) -> None:
     hours_since_start = (now.hour - config.nightly_memory_hour) % 24
     if hours_since_start >= DREAMER_CATCHUP_HOURS:
         return
+    # The instant this night's window opened, and the one owner of which night this is. Checks land at
+    # an arbitrary minute, so the hour is truncated to match the hour-granular window: an unaligned
+    # boundary would read a completion earlier in the same hour as belonging to an older night.
+    night_start = now.replace(minute=0, second=0, microsecond=0) - dt.timedelta(hours=hours_since_start)
     last = state.persisted.last_dreamer_run
-    if last is not None and last.date() >= now.date():
+    if last is not None and last >= night_start:
         return
     logger.dreamer("Nightly dreamer starting...")
     prompt = load_prompt("nightly_dream", config) or ""
-    # The date the window opened, not today's: a late hour catches up past midnight on the same night.
-    night = (now - dt.timedelta(hours=hours_since_start)).date()
-    drop_core_notification(type_=TYPE_NIGHTLY_DREAM, body=prompt, config=config, name=f"{TYPE_NIGHTLY_DREAM}-{night.isoformat()}")
+    name = f"{TYPE_NIGHTLY_DREAM}-{night_start.date().isoformat()}"
+    drop_core_notification(type_=TYPE_NIGHTLY_DREAM, body=prompt, config=config, name=name)
     logger.dreamer("Dreamer notification dropped")
 
 

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -70,10 +70,27 @@ def test_drops_dream_notification(tmp_path):
         (4, dt.datetime(2025, 6, 14, 4, 0, 0), dt.datetime(2025, 6, 15, 7, 30, 0), 1),  # not done today, retry past the hour
         # Late dreamer_hour (22:00) must catch up after midnight: the window is circular (modulo-24), so
         # post-midnight hours (0-3) must not fall through and drop the dream for the day.
-        (22, dt.datetime(2025, 6, 14, 22, 0, 0), dt.datetime(2025, 6, 15, 1, 0, 0), 1),  # within 22:00 + 6h window
+        (22, dt.datetime(2025, 6, 13, 22, 30, 0), dt.datetime(2025, 6, 15, 1, 0, 0), 1),  # within 22:00 + 6h window
         (22, None, dt.datetime(2025, 6, 15, 14, 0, 0), 0),  # afternoon is outside the circular window
+        # Completion is judged against the night the window opened, not the calendar day, so a dream
+        # that finished before midnight suppresses the rest of its own night and only its own night.
+        (22, dt.datetime(2025, 6, 15, 22, 30, 0), dt.datetime(2025, 6, 16, 0, 0, 0), 0),  # same night, past midnight
+        (22, dt.datetime(2025, 6, 15, 22, 30, 0), dt.datetime(2025, 6, 16, 22, 0, 0), 1),  # the next night still fires
+        # Checks land at an arbitrary minute: a completion earlier in its hour still counts as this night's.
+        (4, dt.datetime(2025, 6, 15, 4, 10, 0), dt.datetime(2025, 6, 15, 5, 50, 0), 0),  # unaligned check
+        (4, None, dt.datetime(2025, 6, 15, 7, 30, 0), 1),  # never marked complete: retries inside the window
     ],
-    ids=["already-ran-today", "before-hour", "retry-past-hour", "catchup-past-midnight", "outside-window"],
+    ids=[
+        "already-ran-today",
+        "before-hour",
+        "retry-past-hour",
+        "catchup-past-midnight",
+        "outside-window",
+        "late-hour-done-before-midnight",
+        "late-hour-next-night",
+        "unaligned-check-same-night",
+        "never-marked-retries",
+    ],
 )
 def test_nightly_memory_scheduling(tmp_path, dreamer_hour, last_dreamer_run, now, expected_files):
     config = _setup(tmp_path, dreamer_hour=dreamer_hour)


### PR DESCRIPTION
Fixes #1540


## The bug

`process_nightly_memory` decided the catch-up window on a circular, night-based clock but decided completion on a calendar date. For any `nightly_memory_hour` in 19..23 the window crosses midnight and the two disagree. Confirmed against the code exactly as reported, with `nightly_memory_hour=22`:

- D 22:00: window opens, the dream drops, completes, `last_dreamer_run = D 22:30`.
- D 23:00: guard holds (`D >= D`).
- D+1 00:00: still inside the 22:00 to 04:00 window, but `last.date() = D < now.date() = D+1`, so a second dream drops for the same night. Each dream ends in a compaction plus restart, so the cost is a spurious extra one.
- Worse, that midnight run stamps D+1, so the next 22:00 check sees `D+1 >= D+1` and skips. The schedule settles permanently at midnight and the configured hour never fires again.

## The fix

The window's opening instant is computed once, and both the guard and #1532's per-night file stem read it, so the night has one owner in the function:

```python
night_start = now.replace(minute=0, second=0, microsecond=0) - dt.timedelta(hours=hours_since_start)
last = state.persisted.last_dreamer_run
if last is not None and last >= night_start:
    return
```

The guard reads as "a dream already completed at or after this night's window opened".

**Minutes and seconds are truncated deliberately.** The window itself is hour-granular (`now.hour` feeds the modulo) while `monitor_loop` rate-limits the check to roughly once an hour, so ticks land at arbitrary minutes. Without truncation the boundary drifts forward with the tick's minute: a dream completing at 04:10 and a check at 05:50 would compare against 04:50 and re-drop the same night. Truncating pins the boundary to the configured hour, which is what the window means. The stem is unchanged by this: subtracting whole hours preserves the minute field, so `night_start.date()` equals #1532's `(now - timedelta(hours=hours_since_start)).date()` in every case.

`last_dreamer_run` **can** be stamped outside the window: the dream is a long turn, so a drop near the end of the window can be marked complete hours after the window closed. The guard handles that correctly, because it only ever asks whether the stamp is at or after the current night's opening. A stamp from D at 10:30 (window closed at 09:00) is still older than D+1's `night_start`, so the next night fires normally, and no check inside the already-closed window exists to be confused.

No new persisted field: the fix derives everything from the existing timestamp, and `mark_dreamer_complete` is untouched.

## Fleet impact

Existing agents already carry a `last_dreamer_run` datetime, which this guard reads directly with no format change, so nothing to migrate.

An agent currently stuck dreaming at midnight converges on its own, on the first night after the update. Concretely with hour=22 and `last_dreamer_run = D 00:30` (a midnight dream): the remaining checks that night (D 01:00 to D 03:xx) belong to the night that opened D-1 22:00, and `D 00:30 >= D-1 22:00` holds, so nothing re-drops. At D 22:00 the night's window opens fresh, `D 00:30 < D 22:00`, and the dream drops at the configured hour again. No manual intervention.

## Tests

`test_nightly_memory_scheduling` gains four rows:

- `late-hour-done-before-midnight`: hour=22, completion at 22:30, checked at 00:00 the same night, must not re-drop (the reported bug).
- `late-hour-next-night`: hour=22, same completion, checked at 22:00 the next night, must drop (catches an overcorrection).
- `unaligned-check-same-night`: hour=4, completion at 04:10, checked at 05:50, must not re-drop (pins the truncation).
- `never-marked-retries`: hour=4, never marked complete, checked at 07:30, must still drop (the retry-within-window promise).

One pre-existing row changed, and it is worth flagging: `catchup-past-midnight` was `(22, last=D 22:00, now=D+1 01:00, expect 1)`, which is the buggy scenario itself, since 22:00 on D is that night's own run. Its intent, that the circular window still catches up past midnight, is preserved by moving the completion to a genuinely earlier night (`2025-06-13 22:30`); the case still asserts a drop at D+1 01:00.

Mutation results, all run locally:

- Restoring `last.date() >= now.date()`: `late-hour-done-before-midnight` fails, everything else passes.
- Over-suppressing with `last >= night_start - 24h`: `late-hour-next-night` fails (with `retry-past-hour` and `catchup-past-midnight`).
- Dropping the truncation (`night_start = now - timedelta(...)`): `unaligned-check-same-night` fails.
- #1532's mutation still discriminates on this branch: replacing the per-night stem with the default name fails its four tests (`test_redrop_over_a_pending_dream_queues_only_one[same-day]`, `[catchup-past-midnight]`, `test_unconsumed_dream_from_yesterday_does_not_suppress_today`, `test_consumed_dream_is_recreated_by_the_catchup_retry`).

`./check.sh agent` and `./check.sh guards` pass locally.

Unchanged: the circular window, `DREAMER_CATCHUP_HOURS`, the ephemeral / `nightly_memory_hour is None` / `first_start_done` guards and their order, `mark_dreamer_complete`, and `PersistedState`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
