### PR TITLE
fix(skills): let the agent own the restart daemons block

### DIFF
--- a/agent/skills/dashboard/SETUP.md
+++ b/agent/skills/dashboard/SETUP.md
@@ -1,21 +1,24 @@
 # Dashboard setup
 
-`node` and `npm` ship in the base image. Run the one-shot setup script; it installs
-deps, builds, starts the daemon, confirms a 200, and appends the guarded startup line
-to the restart skill, all idempotent (safe to re-run):
-```bash
-~/agent/skills/dashboard/scripts/setup.sh
-```
+`node` and `npm` ship in the base image. Setup is two steps: a script, then one edit you make.
 
-It fails loudly on a real problem rather than leaving a half-set-up dashboard: check its output, don't assume success.
+1. Run the setup script; it installs deps, builds, starts the daemon, and confirms a 200, all idempotent (safe to re-run):
+   ```bash
+   ~/agent/skills/dashboard/scripts/setup.sh
+   ```
+   It fails loudly on a real problem rather than leaving a half-set-up dashboard: check its output, don't assume success.
+
+2. **Register the restart line yourself**, so the dashboard survives a container restart. Add this line inside the fenced block in the `## Daemons` section of `~/agent/skills/restart/SKILL.md`, matching the guard form already there:
+   ```
+   running dashboard || { ~/agent/skills/dashboard/scripts/daemon start; sleep 1; }
+   ```
+   Skip this and the dashboard is up now but gone after the next restart.
 
 ## Manual steps (only if setup.sh can't be used)
+
+These replace step 1 above; step 2 stays yours either way.
 
 1. **Install dependencies**: `cd ~/agent/skills/dashboard/app && npm install`
 2. **Build**: `cd ~/agent/skills/dashboard/app && npx vite build`
 3. **Start the daemon**: `~/agent/skills/dashboard/scripts/daemon start` (idempotent, never stacks a duplicate)
-4. **Register the restart line**: add this guarded startup command to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
-   ```
-   running dashboard || { ~/agent/skills/dashboard/scripts/daemon start; sleep 1; }
-   ```
-5. **Check it's alive**: `~/agent/skills/dashboard/scripts/daemon status` reports `running`, `port`, and `http_ok` in one JSON blob.
+4. **Check it's alive**: `~/agent/skills/dashboard/scripts/daemon status` reports `running`, `port`, and `http_ok` in one JSON blob.

--- a/agent/skills/dashboard/scripts/setup.sh
+++ b/agent/skills/dashboard/scripts/setup.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -eu
 
-# Idempotent one-shot dashboard setup: installs deps, builds, starts the
-# daemon, confirms it is actually serving, and appends the guarded
-# restart-skill daemon line once. Safe to re-run; every step is a no-op when
+# Idempotent dashboard setup: installs deps, builds, starts the daemon, and
+# confirms it is actually serving. Safe to re-run; every step is a no-op when
 # already done, and a real failure exits loudly instead of leaving a half
-# set-up dashboard that looks fine until the next restart.
+# set-up dashboard that looks fine until the next restart. Registering the
+# daemon in the restart skill is the agent's step, printed at the end.
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -34,11 +34,8 @@ case "$STATUS" in
     ;;
 esac
 
-RESTART_SKILL=~/agent/skills/restart/SKILL.md
-LINE='running dashboard || { ~/agent/skills/dashboard/scripts/daemon start; sleep 1; }'
-if [ -f "$RESTART_SKILL" ] && ! grep -qF "$LINE" "$RESTART_SKILL"; then
-  printf '\n```bash\n%s\n```\n' "$LINE" >> "$RESTART_SKILL"
-  echo "Appended dashboard daemon line to restart skill."
-fi
-
 echo "Dashboard setup complete."
+echo
+echo "Remaining step, yours to do: add this line inside the fenced Daemons block"
+echo "of ~/agent/skills/restart/SKILL.md, matching the guard form already there."
+echo '  running dashboard || { ~/agent/skills/dashboard/scripts/daemon start; sleep 1; }'

--- a/agent/skills/restart/SKILL.md
+++ b/agent/skills/restart/SKILL.md
@@ -11,7 +11,11 @@ Run the Daemons block below; it is safe to re-run and starts only what's missing
 
 ## Daemons
 
-Skill setup steps add their daemon startup commands here, one fenced block per skill (a daemon that vestad proxies on a port is a service, registered via the `vestad` skill; a portless background process still goes here). Every line MUST be guarded with `running <session> ||` so re-running the block can't spawn a duplicate: crash/timeout recovery re-enters this skill repeatedly, and an unguarded line piles up duplicate daemons.
+When a skill's setup gives you a daemon startup line, add it here yourself, inside the single fenced block below, on its own line before the closing fence. A setup script never edits this file: only you can see the guard form this block actually uses. (A daemon that vestad proxies on a port is a service, registered via the `vestad` skill; a portless background process goes here too.)
+
+Keep it to one fenced block. A line in a second block cannot see the `running()` helper defined in this one, so its guard fails open and every restart stacks another daemon.
+
+Every line MUST be guarded with `running <session> ||` so re-running the block can't spawn a duplicate: crash/timeout recovery re-enters this skill repeatedly, and an unguarded line piles up duplicate daemons.
 
 ```bash
 # Wipe dead sockets a restart may have left in /run/screen, else the guard treats

--- a/agent/skills/restart/SKILL.md
+++ b/agent/skills/restart/SKILL.md
@@ -32,7 +32,7 @@ running() { test -n "$(screen -ls 2>/dev/null | grep -E "[0-9]+\.$1[[:space:]]" 
 # and `false || spawn` re-spawns on every guarded restart line, silently
 # stacking duplicate daemons.
 
-# Skills append guarded startup lines below, e.g.:
+# Add guarded startup lines below, e.g.:
 #   running foo || { screen -dmS foo foo serve --notifications-dir ~/agent/notifications; sleep 1; }
 # The trailing `sleep 1` keeps back-to-back `screen -dmS` launches from racing and dropping sessions.
 ```

--- a/agent/skills/vestad/SKILL.md
+++ b/agent/skills/vestad/SKILL.md
@@ -53,8 +53,8 @@ PORT=$(~/agent/skills/vestad/scripts/register-service tasks)
 PORT=$(~/agent/skills/vestad/scripts/register-service dashboard --public)
 ```
 
-So the service comes back after a container restart, add its startup command to the
-`## Daemons` section of `~/agent/skills/restart/SKILL.md`, one fenced block per skill. Use a
+So the service comes back after a container restart, add its startup command yourself, inside the
+single fenced block in the `## Daemons` section of `~/agent/skills/restart/SKILL.md`. Use a
 single line that re-registers and starts, e.g.:
 
 ```bash

--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -1,17 +1,25 @@
 # WhatsApp Setup
 
 Everything the build needs (Go, whisper.cpp static libs, gcc, ffmpeg) ships in
-the agent image. Setup is one idempotent script:
+the agent image. Setup is two steps: a script, then one edit you make.
 
-```bash
-~/agent/skills/whatsapp/setup.sh
-```
+1. Run the setup script:
+   ```bash
+   ~/agent/skills/whatsapp/setup.sh
+   ```
+   It links the launcher onto PATH, warms the build cache (compile errors surface
+   here), downloads the whisper voice-transcription model, and starts the daemon
+   now. Re-run it any time; it only does what's missing.
 
-It links the launcher onto PATH, warms the build cache (compile errors surface
-here), downloads the whisper voice-transcription model, registers `whatsapp start`
-in the restart skill (so the daemon comes back after a container restart, with
-notifications flowing before you send anything), and starts the daemon now.
-Re-run it any time; it only does what's missing.
+2. **Register the restart line yourself**, so the daemon comes back after a
+   container restart. Add this line inside the fenced block in the `## Daemons`
+   section of `~/agent/skills/restart/SKILL.md`, matching the guard form already
+   there. `whatsapp start` brings the daemon up and waits until it answers, so
+   inbound notifications flow before you send anything:
+   ```
+   running whatsapp || { whatsapp start; sleep 1; }
+   ```
+   Skip this and WhatsApp is live now but silent after the next restart.
 
 ## Linking an account
 

--- a/agent/skills/whatsapp/setup.sh
+++ b/agent/skills/whatsapp/setup.sh
@@ -25,18 +25,13 @@ if [ ! -f "$MODEL" ]; then
   mv "$MODEL.tmp" "$MODEL"
 fi
 
-# 4. Restart-skill daemon line so the daemon survives container restarts.
-# `whatsapp start` brings the daemon up (idempotent) and waits until it answers,
-# so inbound notifications flow before the agent sends anything. The grep also
-# matches older forms (`whatsapp daemon start`, a raw `screen -dmS whatsapp`) so a
-# re-run never appends a duplicate line; a migration converts those in place.
-RESTART_MD="$HOME/agent/skills/restart/SKILL.md"
-DAEMON_LINE='running whatsapp || { whatsapp start; sleep 1; }'
-if [ -f "$RESTART_MD" ] && ! grep -qE 'whatsapp (start|daemon start)|screen -dmS whatsapp' "$RESTART_MD"; then
-  printf '\n```bash\n# whatsapp\n%s\n```\n' "$DAEMON_LINE" >> "$RESTART_MD"
-fi
-
-# 5. Start the daemon (idempotent; defaults --notifications-dir to ~/agent/notifications).
+# 4. Start the daemon (idempotent; defaults --notifications-dir to ~/agent/notifications).
 whatsapp start
 
 echo "setup complete, link an account with: whatsapp link"
+echo
+echo "Remaining step, yours to do: add this line inside the fenced Daemons block"
+echo "of ~/agent/skills/restart/SKILL.md, matching the guard form already there."
+echo "\`whatsapp start\` brings the daemon up and waits until it answers, so inbound"
+echo "notifications flow before you send anything."
+echo '  running whatsapp || { whatsapp start; sleep 1; }'

--- a/agent/tests/test_dashboard_daemon.py
+++ b/agent/tests/test_dashboard_daemon.py
@@ -157,7 +157,7 @@ def test_unknown_subcommand_exits_nonzero(tmp_path):
     assert result.returncode != 0
 
 
-def test_setup_starts_daemon_and_appends_restart_line_once(tmp_path):
+def test_setup_starts_daemon_and_never_edits_the_restart_skill(tmp_path):
     env = _rig(tmp_path)
     # Copy the skill scripts into tmp_path (preserving the scripts/../app layout)
     # and pre-seed the app build artifacts there, so setup.sh never shells out to
@@ -169,16 +169,15 @@ def test_setup_starts_daemon_and_appends_restart_line_once(tmp_path):
     setup = skill_dir / "scripts/setup.sh"
 
     restart_skill = pl.Path(env["HOME"]) / "agent/skills/restart/SKILL.md"
-    restart_skill.write_text("# Restart\n\n## Daemons\n")
+    original = "# Restart\n\n## Daemons\n\n```bash\nrunning() { :; }\n```\n"
+    restart_skill.write_text(original)
 
-    first = subprocess.run(["sh", str(setup)], env=env, capture_output=True, text=True, check=False)
-    assert first.returncode == 0, first.stdout + first.stderr
+    result = subprocess.run(["sh", str(setup)], env=env, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
     assert json.loads(_run(DAEMON, ["status"], env).stdout)["running"] is True
 
-    line = "running dashboard || { ~/agent/skills/dashboard/scripts/daemon start; sleep 1; }"
-    content_after_first = restart_skill.read_text()
-    assert content_after_first.count(line) == 1
+    # The agent owns this file: only it can match the guard form actually in use.
+    assert restart_skill.read_text() == original
 
-    second = subprocess.run(["sh", str(setup)], env=env, capture_output=True, text=True, check=False)
-    assert second.returncode == 0, second.stdout + second.stderr
-    assert restart_skill.read_text().count(line) == 1
+    line = "running dashboard || { ~/agent/skills/dashboard/scripts/daemon start; sleep 1; }"
+    assert line in result.stdout


### PR DESCRIPTION
Found while reading the first-boot log of a freshly created dev agent.

## The bug

`dashboard/scripts/setup.sh` and `whatsapp/setup.sh` appended their startup line as a **new fenced block** at the end of `restart/SKILL.md`:

```sh
printf '\n```bash\n%s\n```\n' "$LINE" >> "$RESTART_SKILL"
```

`running()` is defined only in the *first* block. A line in a second block breaks two ways depending on how the block is read:

- run each block separately: `running: command not found`, so the `||` branch fires every time and stacks a duplicate daemon on every restart
- run only "the Daemons block" (the skill says it singular): the line never executes and the daemon never comes back

The new agent's subagent caught it live, spent two turns reasoning about it, merged the line by hand, and flagged it as an upstream bug. It was right.

## Root cause

Both scripts were faithfully implementing the restart skill's own wording:

> Skill setup steps add their daemon startup commands here, **one fenced block per skill**

That sentence is the actual defect, so it changes along with the scripts.

## The fix

Make the agent the single writer of that file, which is what every other skill already does.

A setup script fundamentally cannot know the guard form a given agent uses. Agents personalize this file heavily. One agent in the fleet drives each daemon from its own Bash call with inline `screen -ls` guards and no `running()` helper at all, and its file explicitly warns that pasting a `running <x> ||` line verbatim would leave the guard undefined and stack duplicates. An auto-appender would do exactly that. The agent editing by hand lands inside the existing block and matches the surrounding form, which is why every manually-registered daemon in the fleet is correct today.

- `restart/SKILL.md`: one fenced block, the agent adds lines inside it, and why a second block fails
- both `setup.sh`: append logic deleted; each prints the line and where it goes
- both `SETUP.md`: the restart line is an explicit numbered step, not a promise the script keeps

## No migration

Both appenders were grepped before appending, so they only ever fired for an agent that had no such line yet, i.e. a fresh birth. I checked every running agent: none carries a stray block. This is forward-looking only.

## Verification

- `agent/tests/test_dashboard_daemon.py` now asserts setup.sh leaves the restart skill byte-identical and prints the line instead. Confirmed it fails against the pre-fix script, reproducing the stray block exactly.
- `./check.sh guards` and `./check.sh agent` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)