### PR TITLE
fix(pr-monitor): the run is one turn, so the comment cannot be deferred

### DIFF
--- a/.claude/skills/check-pr/SKILL.md
+++ b/.claude/skills/check-pr/SKILL.md
@@ -45,6 +45,9 @@ Work through the diff yourself. Delegate to a subagent only when the diff is gen
 
 ## Reporting
 
+You get one run, and it ends when you stop. Post the comment before you finish, even with things unresolved: you cannot wait for CI or come back later. Something still pending goes in the comment as `NOT YET`, naming what to watch.
+
+
 Post one comment. Engineers read it, not markers: it is a bug list and a verdict, not an essay.
 
 The whole comment is a one-line verdict plus one bullet per finding. Nothing else. **80 words is a normal length. Past 150 you are padding.**

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -45,6 +45,12 @@ Report what you find even when nobody asked for a review.
 Engineers read your comment, not markers. It is a bug list and a verdict, not an essay: one line per finding, giving file:line, what breaks, and what triggers it. 80 words is a normal length and past 150 you are padding. Never narrate your review, never list what you checked that turned out fine, never restate the PR description.
 </comment_length>
 
+<this_run_is_your_only_turn>
+You are one run. It ends the moment you stop producing output, and nothing resumes it: there is no later in which to post, check back, or follow up. Post your comment before you finish, always, even when something is still unresolved.
+
+Never defer the comment to wait for CI, a build, a check, or anything else. Waiting is not something you can do. If something is still pending, say what is pending in the comment and give the verdict as NOT YET, so the reader knows what to look at when it settles.
+</this_run_is_your_only_turn>
+
 <signing_every_comment>
 End every comment you post on a PR or issue with this exact line, alone on the last line:
 
@@ -139,6 +145,8 @@ handle() {
     return 0
   fi
   sf="$(session_file "$repo" "$pr")"
+  local before
+  before=$(gh api "/repos/$repo/issues/$pr/comments" -q 'length' 2>/dev/null)
   local args=(-p --model "$MODEL" --output-format json --dangerously-skip-permissions)
   [ -s "$sf" ] && args+=(--resume "$(cat "$sf")")
   out=$(claude "${args[@]}" "$prompt" 2>/dev/null)
@@ -156,6 +164,12 @@ handle() {
     echo "dispatch: claude reported an error on $repo#$pr, releasing claim" >&2
     release "$repo" "$kind" "$id"
     return 1
+  fi
+  # A run that posts nothing looks identical to a healthy one from out here, and
+  # the reason is usually that the model deferred the comment to a later it does
+  # not get, so say so rather than reporting success.
+  if [ "$(gh api "/repos/$repo/issues/$pr/comments" -q 'length' 2>/dev/null)" = "$before" ]; then
+    echo "dispatch: WARN $repo#$pr run finished without commenting" >&2
   fi
   echo "dispatch: handled $repo#$pr ($kind $id)" >&2
   prune_sessions "$repo"


### PR DESCRIPTION
A polish request on #1534 pushed its commit and then said nothing on the PR. The run ended on:

> Polish landed as one commit. Waiting for CI to settle on the new head before I post the reply.

There is no waiting. The run is one `claude -p` turn that ends the moment the model stops producing output, so the commit landed on the branch and the PR was never told anything about it. Somebody reading #1534 sees an unexplained commit from an agent.

Nothing in the prompt said so. It described what the comment should contain and never that there is no later in which to write it, so deferring looked like something the agent could do.

### Changes

The prompt now states that the run is the only turn, that the comment goes out before finishing even with things unresolved, and that something still pending belongs in the comment as `NOT YET` naming what to watch, rather than being a reason to wait. Same note in `check-pr`.

Dispatch also compares the comment count across a run and logs when it did not change. A run that posts nothing was indistinguishable from a healthy one from outside, which is how this went unnoticed until a human spotted the orphan commit.

Verified both ways against a stubbed run: no comment produces `WARN ... run finished without commenting`, a comment produces only the normal handled line.