### PR TITLE
fix(pr-monitor): cap how long one run may hold the queue

### DIFF
--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -52,7 +52,7 @@ The loop keeps running until the session stops. Nothing survives the session: re
 
 Do not reach for `claude --from-pr` here. It resumes a session already linked to a PR, but a print-mode run does not create that link, so in a service it quietly starts a fresh session every time.
 
-Events are handled one at a time, so a burst of comments cannot start overlapping runs against the same session.
+Events are handled one at a time, so a burst of comments cannot start overlapping runs against the same session. That also means one run holds every later event behind it, so a run is capped at `PR_MONITOR_TIMEOUT` and stopped past it. A run whose connection dies waits on a socket that never speaks again, consuming no CPU and looking alive from outside, and without the cap it holds the queue for as long as the process lives.
 
 **Every new PR is checked automatically.** A non-draft PR that has never been seen surfaces as `NEWPR` without anyone asking, and dispatch runs the `check-pr` skill on it: does it fix the issue it claims to fix, does it match this repository's conventions, does it actually work. That pass is read only. It never pushes, merges, or closes, so a PR opening cannot cause a write. Where the change would benefit from the simplify and tidy pass, the reply names `polish-pr` and stops there, leaving the maintainer to ask for it.
 
@@ -149,6 +149,7 @@ Two consequences worth knowing:
 | `PR_MONITOR_INTERVAL` | `45` | Seconds between polls |
 | `PR_MONITOR_STATE` | `$XDG_STATE_HOME/pr-monitor` | Review-summary ledger and per-PR session ids |
 | `PR_MONITOR_MODEL` | `claude-opus-5` | Model `dispatch.sh` runs each event on |
+| `PR_MONITOR_TIMEOUT` | `1800` | Seconds a single run may take before it is stopped |
 | `PR_MONITOR_PRUNE_TRANSCRIPTS` | `0` | Delete a closed PR session transcript, not just its pointer |
 
 ## Cost

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MONITOR="$SKILL_DIR/monitor.sh"
 MODEL="${PR_MONITOR_MODEL:-claude-opus-5}"
+RUN_TIMEOUT="${PR_MONITOR_TIMEOUT:-1800}"
 STATE_ROOT="${PR_MONITOR_STATE:-${XDG_STATE_HOME:-$HOME/.local/state}/pr-monitor}"
 ME="$(gh api /user -q .login 2>/dev/null)"
 
@@ -149,10 +150,14 @@ handle() {
   before=$(gh api "/repos/$repo/issues/$pr/comments" -q 'length' 2>/dev/null)
   local args=(-p --model "$MODEL" --output-format json --dangerously-skip-permissions)
   [ -s "$sf" ] && args+=(--resume "$(cat "$sf")")
-  out=$(claude "${args[@]}" "$prompt" 2>/dev/null)
+  # Events are handled one at a time, so a run that hangs holds every later event
+  # behind it for as long as it lives, and a lost connection leaves one waiting on
+  # a socket that never speaks again. The cap turns that into an ordinary failure.
+  out=$(timeout "$RUN_TIMEOUT" claude "${args[@]}" "$prompt" 2>/dev/null)
   rc=$?
   # A stored id that no longer resolves would fail every retry, so forget it.
   if [ "$rc" -ne 0 ]; then
+    [ "$rc" = "124" ] && echo "dispatch: run on $repo#$pr exceeded ${RUN_TIMEOUT}s and was stopped" >&2
     echo "dispatch: claude failed rc=$rc on $repo#$pr, releasing claim" >&2
     [ -s "$sf" ] && rm -f "$sf"
     release "$repo" "$kind" "$id"


### PR DESCRIPTION
The monitor handled nothing for twelve and a half hours overnight, while reporting itself healthy.

### What happened

A run started on #1555 at 20:07:50 and was still there at 08:37 the next morning:

```
transcript last written  20:07     nothing after startup
cpu used                 9s over 12.5h
open sockets             0         the API connection is gone
blocked in               ep_poll   waiting on an fd that will never speak
```

Events are handled one at a time, so that one process held every event behind it. Nothing was dispatched after 20:07:08. `systemctl` reported `active (running)` throughout, because the parent was alive and the child was merely asleep, and no log line is emitted by a run that is doing nothing.

Killing it produced exactly the designed failure: `claude failed rc=137 ... releasing claim`. The failure path was fine; nothing ever invoked it.

### Fix

A run is capped at `PR_MONITOR_TIMEOUT` (default 1800s, generous against the ~10 minutes a `polish-pr` pass takes) and stopped past it. A stopped run is an ordinary failure, so the claim is released and the event returns next cycle: a hang now costs one delayed event instead of every later one.

Verified against a stub that hangs for 300s with the cap at 5s: stopped at 5s, logged `exceeded 5s and was stopped` plus the usual `rc=124 ... releasing claim`, and the reaction `DELETE` was issued so the event is retried.

### Still true

The cap bounds a hang, it does not report one. A run that hangs and retries forever would show up only in the journal. Related to the observability point in #1536.