### PR TITLE
feat(pr-monitor): run events on different PRs at the same time

### DIFF
--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -52,7 +52,11 @@ The loop keeps running until the session stops. Nothing survives the session: re
 
 Do not reach for `claude --from-pr` here. It resumes a session already linked to a PR, but a print-mode run does not create that link, so in a service it quietly starts a fresh session every time.
 
-Events are handled one at a time, so a burst of comments cannot start overlapping runs against the same session. That also means one run holds every later event behind it, so a run is capped at `PR_MONITOR_TIMEOUT` and stopped past it. A run whose connection dies waits on a socket that never speaks again, consuming no CPU and looking alive from outside, and without the cap it holds the queue for as long as the process lives.
+Events on different PRs run at the same time, up to `PR_MONITOR_PARALLEL`. Events on one PR do not: they resume that PR's session, and two runs resuming one conversation would interleave their writes, so a per-PR lock keeps them in single file. An event arriving while its PR is busy is left unclaimed rather than queued behind the run, so it comes back on a later cycle instead of resuming a session out from under whoever holds it.
+
+Each run can build a worktree of several hundred megabytes, so the ceiling is disk as much as cost.
+
+A run is also capped at `PR_MONITOR_TIMEOUT` and stopped past it. A run whose connection dies waits on a socket that never speaks again, consuming no CPU and looking alive from outside, and without the cap it holds its slot for as long as the process lives.
 
 **Every new PR is checked automatically.** A non-draft PR that has never been seen surfaces as `NEWPR` without anyone asking, and dispatch runs the `check-pr` skill on it: does it fix the issue it claims to fix, does it match this repository's conventions, does it actually work. That pass is read only. It never pushes, merges, or closes, so a PR opening cannot cause a write. Where the change would benefit from the simplify and tidy pass, the reply names `polish-pr` and stops there, leaving the maintainer to ask for it.
 
@@ -150,6 +154,7 @@ Two consequences worth knowing:
 | `PR_MONITOR_STATE` | `$XDG_STATE_HOME/pr-monitor` | Review-summary ledger and per-PR session ids |
 | `PR_MONITOR_MODEL` | `claude-opus-5` | Model `dispatch.sh` runs each event on |
 | `PR_MONITOR_TIMEOUT` | `1800` | Seconds a single run may take before it is stopped |
+| `PR_MONITOR_PARALLEL` | `3` | Runs allowed at once, across different PRs |
 | `PR_MONITOR_PRUNE_TRANSCRIPTS` | `0` | Delete a closed PR session transcript, not just its pointer |
 
 ## Cost

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -6,17 +6,20 @@
 # stored and resumed for every later event on that PR, so the agent remembers
 # what it already pushed and tried there. Context is not shared across PRs.
 #
-# Events are handled serially, so a burst cannot start overlapping runs against
-# the same session. The 👀 is claimed here, when the event is picked up, and a
-# failed run releases it so the event surfaces again. The monitor re-emits
-# anything still unclaimed, so the same event can arrive more than once and the
-# claim is what makes handling it exactly once.
+# Events on different PRs run concurrently, up to PARALLEL. Events on one PR do
+# not: they resume that PR's session, and two runs resuming the same session
+# would interleave writes to one conversation, so a per-PR lock keeps them in
+# single file. The 👀 is claimed here, when the event is picked up, and a failed
+# run releases it so the event surfaces again. The monitor re-emits anything
+# still unclaimed, so the same event can arrive more than once and the claim is
+# what makes handling it exactly once.
 set -uo pipefail
 
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MONITOR="$SKILL_DIR/monitor.sh"
 MODEL="${PR_MONITOR_MODEL:-claude-opus-5}"
 RUN_TIMEOUT="${PR_MONITOR_TIMEOUT:-1800}"
+PARALLEL="${PR_MONITOR_PARALLEL:-3}"
 STATE_ROOT="${PR_MONITOR_STATE:-${XDG_STATE_HOME:-$HOME/.local/state}/pr-monitor}"
 ME="$(gh api /user -q .login 2>/dev/null)"
 
@@ -141,7 +144,15 @@ claim() {
 
 handle() {
   local repo="$1" kind="$2" id="$3" pr="$4" prompt="$5"
-  local sf sid out rc
+  local sf sid out rc lock
+  lock="$STATE_ROOT/${repo//\//__}/locks"
+  mkdir -p "$lock"
+  exec 9>"$lock/pr-$pr.lock"
+  # Another run holds this PR. Leave the event unclaimed so it comes back rather
+  # than queueing behind that run and resuming its session underneath it.
+  if ! flock -n 9; then
+    return 0
+  fi
   if ! claim "$repo" "$kind" "$id"; then
     return 0
   fi
@@ -183,6 +194,7 @@ handle() {
 for repo in "${repos[@]}"; do prune_sessions "$repo"; done
 
 bash "$MONITOR" "${repos[@]}" | while IFS=$'\t' read -r tag f1 f2 f3 f4 f5; do
+  while [ "$(jobs -rp | wc -l)" -ge "$PARALLEL" ]; do wait -n; done
   case "$tag" in
     HIT)
       handle "$f1" "$f2" "$f3" "$f4" "$ROLE
@@ -190,20 +202,20 @@ bash "$MONITOR" "${repos[@]}" | while IFS=$'\t' read -r tag f1 f2 f3 f4 f5; do
 <event>A developer addressed you in a comment on $f1 PR #$f4: $f5</event>
 Read that comment and the pull request, do what it asks, then reply on the PR covering both the review above and what you changed. If its checks need fixing, use the babysit-prs skill. If the request is unclear or you decide not to act, say so in a reply rather than staying silent.
 Only maintainers reach you here, so an explicit instruction outranks the repository's usual conventions: if the comment asks for something a skill or CLAUDE.md normally discourages, such as a force push or a rebase, do it and note it in your reply.
-End every reply with a line starting 'Verdict:' giving your own call on merging: MERGE, DO NOT MERGE, or NOT YET, then one sentence of reasoning. Judge the change on its merits, not on whether you were the one who touched it, and say DO NOT MERGE when you believe that even if the commenter clearly wants it in. Never merge or close the PR yourself: the verdict is advice and the decision stays with the maintainer."
+End every reply with a line starting 'Verdict:' giving your own call on merging: MERGE, DO NOT MERGE, or NOT YET, then one sentence of reasoning. Judge the change on its merits, not on whether you were the one who touched it, and say DO NOT MERGE when you believe that even if the commenter clearly wants it in. Never merge or close the PR yourself: the verdict is advice and the decision stays with the maintainer." &
       ;;
     NEWPR)
       handle "$f1" pr "$f2" "$f2" "$ROLE
 
 <event>A pull request was opened on $f1: PR #$f2: $f3</event>
 Nobody has asked for anything yet: this is the automatic check every new PR gets. Run the check-pr skill on it, then post your findings as a comment.
-Stay read only. Do not push a commit, merge, close, or edit the PR. If it would benefit from the simplify and tidy pass, say so in one line and name the polish-pr skill so a maintainer can ask for it, but never run polish-pr yourself here."
+Stay read only. Do not push a commit, merge, close, or edit the PR. If it would benefit from the simplify and tidy pass, say so in one line and name the polish-pr skill so a maintainer can ask for it, but never run polish-pr yourself here." &
       ;;
     DEPPR)
       handle "$f1" pr "$f2" "$f2" "<event>A new dependabot pull request is open: $f1 PR #$f2: $f3</event>
 Review it against this repository's dependency policy, check whether its checks pass, and act accordingly. Leave a comment recording what you decided.
 Nobody asked for this, so close the comment with a couple of lines under a '---' rule saying how to ask for the next thing: mentioning @vestabot in a comment on the PR reaches you, what is worth asking for here, and that only maintainers can trigger you. The marker line goes last, after that.
-End that comment with a line starting 'Verdict:' giving your own call on merging: MERGE, DO NOT MERGE, or NOT YET, then one sentence of reasoning. Never merge or close the PR yourself: the verdict is advice and the decision stays with the maintainer."
+End that comment with a line starting 'Verdict:' giving your own call on merging: MERGE, DO NOT MERGE, or NOT YET, then one sentence of reasoning. Never merge or close the PR yourself: the verdict is advice and the decision stays with the maintainer." &
       ;;
     *) [ -n "${tag:-}" ] && echo "dispatch: ignoring line: $tag" >&2 ;;
   esac


### PR DESCRIPTION
One event at a time meant a slow review delayed every PR behind it. A `polish-pr` pass takes about ten minutes, and everything else waited for it.

Events on different PRs now run concurrently, up to `PR_MONITOR_PARALLEL` (default 3).

### Same PR still runs single file

Events on one PR resume that PR session, so two concurrent runs would interleave writes into one conversation. A per-PR `flock` prevents it.

The ordering matters: an event whose PR is busy returns **before claiming**, so it stays unclaimed and comes back on a later cycle. Queueing it behind the running one would either resume the session underneath it or, if it had already been claimed, drop it the way #1546 fixed.

### Verified

- **4 events on different PRs, 3s each, cap 3:** three started together, the fourth started as a slot freed, all four completed. Max concurrent 3, total span 6.1s against 12s serial.
- **3 events on one PR, cap 3:** exactly one run, max concurrent 1, the other two left unclaimed for a later cycle.

### Sizing

The ceiling is disk as much as cost: a run can build a worktree of several hundred megabytes, so three at once is roughly 2GB transient against the 97G free now. Raise it if that headroom holds, and remember nothing prunes those worktrees yet (#1536).