### PR TITLE
feat(pr-monitor): remove agent worktrees once their work concludes

### DIFF
--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -56,6 +56,8 @@ Events on different PRs run at the same time, up to `PR_MONITOR_PARALLEL`. Event
 
 Each run can build a worktree of several hundred megabytes, so the ceiling is disk as much as cost.
 
+Those worktrees are cleaned up as their work concludes, at most once every `PR_MONITOR_PRUNE_WORKTREES` seconds. A worktree goes only when losing it cannot lose work: its branch belongs to a closed or merged PR, or its commits are already on master by content, which is how a squash merge is recognised despite the rewritten hashes. Anything holding uncommitted changes is left alone, as is anything whose commits exist nowhere else, and a failed PR listing prunes nothing rather than reading an empty answer as "everything is closed".
+
 A run is also capped at `PR_MONITOR_TIMEOUT` and stopped past it. A run whose connection dies waits on a socket that never speaks again, consuming no CPU and looking alive from outside, and without the cap it holds its slot for as long as the process lives.
 
 **Every new PR is checked automatically.** A non-draft PR that has never been seen surfaces as `NEWPR` without anyone asking, and dispatch runs the `check-pr` skill on it: does it fix the issue it claims to fix, does it match this repository's conventions, does it actually work. That pass is read only. It never pushes, merges, or closes, so a PR opening cannot cause a write. Where the change would benefit from the simplify and tidy pass, the reply names `polish-pr` and stops there, leaving the maintainer to ask for it.
@@ -155,6 +157,7 @@ Two consequences worth knowing:
 | `PR_MONITOR_MODEL` | `claude-opus-5` | Model `dispatch.sh` runs each event on |
 | `PR_MONITOR_TIMEOUT` | `1800` | Seconds a single run may take before it is stopped |
 | `PR_MONITOR_PARALLEL` | `3` | Runs allowed at once, across different PRs |
+| `PR_MONITOR_PRUNE_WORKTREES` | `3600` | Seconds between sweeps for finished agent worktrees |
 | `PR_MONITOR_PRUNE_TRANSCRIPTS` | `0` | Delete a closed PR session transcript, not just its pointer |
 
 ## Cost

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -20,6 +20,7 @@ MONITOR="$SKILL_DIR/monitor.sh"
 MODEL="${PR_MONITOR_MODEL:-claude-opus-5}"
 RUN_TIMEOUT="${PR_MONITOR_TIMEOUT:-1800}"
 PARALLEL="${PR_MONITOR_PARALLEL:-3}"
+PRUNE_WORKTREES_EVERY="${PR_MONITOR_PRUNE_WORKTREES:-3600}"
 STATE_ROOT="${PR_MONITOR_STATE:-${XDG_STATE_HOME:-$HOME/.local/state}/pr-monitor}"
 ME="$(gh api /user -q .login 2>/dev/null)"
 
@@ -142,6 +143,44 @@ claim() {
   gh api -X POST "$base" -f content=eyes >/dev/null 2>&1
 }
 
+# Subagents that fan out get a worktree each, and the harness keeps any that
+# carries commits so work is never silently deleted, so they accumulate one per
+# run forever. A worktree is removed here only once its work is provably safe to
+# lose: its PR is merged or closed, or its commits are already on master by
+# content. Anything with uncommitted changes is left alone, and `git worktree
+# remove` without --force refuses a dirty tree anyway, so a race cannot delete
+# work that appeared after the check.
+prune_worktrees() {
+  local repo="$1" root marker wt branch head state
+  root="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)/.claude/worktrees"
+  [ -d "$root" ] || return 0
+  marker="$STATE_ROOT/last-worktree-prune"
+  if [ -f "$marker" ] && [ "$(( $(date +%s) - $(stat -c %Y "$marker") ))" -lt "$PRUNE_WORKTREES_EVERY" ]; then
+    return 0
+  fi
+  mkdir -p "$STATE_ROOT"; touch "$marker"
+  local closed
+  closed=$(gh pr list --repo "$repo" --state closed --limit 400 --json headRefName -q '.[].headRefName' 2>/dev/null) || return 0
+  git fetch -q origin 2>/dev/null || true
+  for wt in "$root"/*/; do
+    [ -d "$wt" ] || continue
+    [ -n "$(git -C "$wt" status --porcelain 2>/dev/null | head -1)" ] && continue
+    head=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || continue
+    state=keep
+    branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null)
+    if [ -n "$branch" ] && printf '%s\n' "$closed" | grep -qxF "$branch"; then
+      state=merged
+    elif [ -z "$(git -C "$wt" cherry origin/master "$head" 2>/dev/null | grep '^+')" ]; then
+      state=landed
+    fi
+    [ "$state" = keep ] && continue
+    if git -C "$root" worktree remove "$wt" 2>/dev/null || git -C "$wt" worktree remove "$wt" 2>/dev/null; then
+      echo "dispatch: removed worktree $(basename "$wt") ($state)" >&2
+    fi
+  done
+  git -C "$root" worktree prune 2>/dev/null || true
+}
+
 handle() {
   local repo="$1" kind="$2" id="$3" pr="$4" prompt="$5"
   local sf sid out rc lock
@@ -189,9 +228,10 @@ handle() {
   fi
   echo "dispatch: handled $repo#$pr ($kind $id)" >&2
   prune_sessions "$repo"
+  prune_worktrees "$repo"
 }
 
-for repo in "${repos[@]}"; do prune_sessions "$repo"; done
+for repo in "${repos[@]}"; do prune_sessions "$repo"; prune_worktrees "$repo"; done
 
 bash "$MONITOR" "${repos[@]}" | while IFS=$'\t' read -r tag f1 f2 f3 f4 f5; do
   while [ "$(jobs -rp | wc -l)" -ge "$PARALLEL" ]; do wait -n; done


### PR DESCRIPTION
Fan-out skills give each subagent its own worktree, and the harness keeps any that carries commits so work is never silently deleted. Nothing removed them afterwards, so they accumulate one per run: **153 worktrees, 15GB**, on a box a full disk already took down once.

### When a worktree is safe to remove

Only when losing it cannot lose work:

- its branch belongs to a **closed or merged PR**, or
- its commits are **already on master by content** (`git cherry`, which compares patch-ids, so a squash merge is recognised even though the hashes differ)

Never removed: anything with uncommitted changes, and anything whose commits exist nowhere else. Removal goes through `git worktree remove` rather than `rm`, so a tree that turned dirty between the check and the removal refuses to go rather than losing the change.

A failed `gh pr list` returns early, since an empty listing would otherwise read as every branch being closed.

Runs at most once every `PR_MONITOR_PRUNE_WORKTREES` (default 3600s), so it does not re-scan on every event.

### Verified against a real repo

Built four worktrees covering each case and ran the sweep:

```
removed worktree agent-closed  (merged)    branch on a closed PR
removed worktree agent-landed  (landed)    content already on master
survivors: agent-dirty, agent-unlanded     uncommitted / commits nowhere else
```

Plus: a second call inside the interval removed nothing (throttle), and a failing `gh` left all worktrees in place.

### Scope

This stops the accumulation from here. It will also clear existing ones as their PRs close, but the current 153 are mostly abandoned branches whose commits are genuinely nowhere else, so most will persist by design. A patch-id sample cleared only 3 of 40. Deciding those is a separate call for you and Elio, per #1536.