### PR TITLE
perf(pr-monitor): read comments repo-wide instead of once per PR

### DIFF
--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -158,8 +158,11 @@ Two consequences worth knowing:
 | `PR_MONITOR_TIMEOUT` | `1800` | Seconds a single run may take before it is stopped |
 | `PR_MONITOR_PARALLEL` | `3` | Runs allowed at once, across different PRs |
 | `PR_MONITOR_PRUNE_WORKTREES` | `3600` | Seconds between sweeps for finished agent worktrees |
+| `PR_MONITOR_WINDOW` | `7 days ago` | How far back the repo-wide comment listings reach |
 | `PR_MONITOR_PRUNE_TRANSCRIPTS` | `0` | Delete a closed PR session transcript, not just its pointer |
 
 ## Cost
 
-One `gh pr list` per repo per cycle, plus three API calls per open PR. The trigger match and the reaction count are both read out of those same list payloads inside the jq expression, so neither adds a call. Only acking an event costs an extra request. At the default interval a repo with a handful of open PRs sits far under the 5000 per hour limit; a repo with many open PRs wants a longer `PR_MONITOR_INTERVAL`.
+One `gh pr list` per repo per cycle, two repo-wide comment listings windowed by `PR_MONITOR_WINDOW`, and one call per open PR for review summaries, which have no repo-wide equivalent. Cost grows with the number of open PRs only through that last one.
+
+The window bounds those listings, so a comment older than it that has never been claimed is not seen. Claims happen within a cycle of a comment appearing, so the default leaves days of margin, but widen it on a repo where the loop is often stopped for long stretches. The trigger match and the reaction count are both read out of those same list payloads inside the jq expression, so neither adds a call. Only acking an event costs an extra request. At the default interval a repo with a handful of open PRs sits far under the 5000 per hour limit; a repo with many open PRs wants a longer `PR_MONITOR_INTERVAL`.

--- a/.claude/skills/pr-monitor/fetch_comments.sh
+++ b/.claude/skills/pr-monitor/fetch_comments.sh
@@ -4,12 +4,14 @@
 # kind is issue (PR conversation), review (inline), or reviewbody (review summary).
 # assoc is the commenter's author_association, which decides who may drive the
 # agent. eyes and denied are the 👀 and 😕 reaction counts, both dedup signals.
-# Every field comes from the list payload inside jq, so neither the trigger match
-# nor either reaction count costs an extra API call.
+# Conversation and inline comments come from one repo-wide listing each, windowed
+# by PR_MONITOR_WINDOW: a listing per open PR cost three calls per PR per cycle
+# and grew with the backlog. Review summaries have no repo-wide listing.
 set -uo pipefail
 
 REPO="${REPO:?REPO is required (owner/name)}"
 TRIGGER="${PR_MONITOR_TRIGGER:-@vestabot}"
+WINDOW="${PR_MONITOR_WINDOW:-7 days ago}"
 
 valid() { grep -E "^(issue|review|reviewbody)$(printf '\t')"; }
 
@@ -20,12 +22,26 @@ valid() { grep -E "^(issue|review|reviewbody)$(printf '\t')"; }
 MARKER="${PR_MONITOR_MARKER:-vestabot:reply}"
 G='select(.body != null) | select(.body | test("'"$TRIGGER"'"; "i")) | select(.body | contains("'"$MARKER"'") | not) | select((.body|ascii_downcase|contains("generated with")) and (.body|ascii_downcase|contains("claude code")) | not)'
 
-prs=$(gh pr list --repo "$REPO" --state open --json number -q '.[].number' 2>/dev/null)
-for pr in $prs; do
-  gh api "/repos/$REPO/issues/$pr/comments" --paginate \
-    -q '.[] | '"$G"' | "issue\t\(.id)\t'"$pr"'\t\(.user.login)\t\(.author_association)\t\(.html_url)\t\(.reactions.eyes)\t\(.reactions.confused)"' 2>/dev/null | valid || true
-  gh api "/repos/$REPO/pulls/$pr/comments" --paginate \
-    -q '.[] | '"$G"' | "review\t\(.id)\t'"$pr"'\t\(.user.login)\t\(.author_association)\t\(.html_url)\t\(.reactions.eyes)\t\(.reactions.confused)"' 2>/dev/null | valid || true
+open_prs=$(mktemp) || exit 0
+trap 'rm -f "$open_prs"' EXIT
+gh pr list --repo "$REPO" --state open --limit 200 --json number -q '.[].number' 2>/dev/null > "$open_prs"
+[ -s "$open_prs" ] || exit 0
+
+since=$(date -u -d "$WINDOW" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || exit 0
+[ -n "$since" ] || exit 0
+
+# The repo-wide listings cover every PR and issue, so drop anything whose PR is
+# not currently open: a comment on a closed PR is none of our business.
+only_open() { awk -F'\t' 'NR==FNR{o[$1];next} ($3 in o)' "$open_prs" -; }
+
+gh api "/repos/$REPO/issues/comments?since=$since&per_page=100" --paginate \
+  -q '.[] | '"$G"' | "issue\t\(.id)\t\(.issue_url|split("/")|last)\t\(.user.login)\t\(.author_association)\t\(.html_url)\t\(.reactions.eyes)\t\(.reactions.confused)"' 2>/dev/null | valid | only_open || true
+
+gh api "/repos/$REPO/pulls/comments?since=$since&per_page=100" --paginate \
+  -q '.[] | '"$G"' | "review\t\(.id)\t\(.pull_request_url|split("/")|last)\t\(.user.login)\t\(.author_association)\t\(.html_url)\t\(.reactions.eyes)\t\(.reactions.confused)"' 2>/dev/null | valid | only_open || true
+
+while read -r pr; do
+  [ -n "$pr" ] || continue
   gh api "/repos/$REPO/pulls/$pr/reviews" --paginate \
     -q '.[] | select(.body != "") | '"$G"' | "reviewbody\t\(.id)\t'"$pr"'\t\(.user.login)\t\(.author_association)\t\(.html_url)\t0\t0"' 2>/dev/null | valid || true
-done
+done < "$open_prs"


### PR DESCRIPTION
Each cycle asked every open PR for its conversation comments, inline comments, and review summaries: three calls per PR. That set how long the loop took to notice anything, and it grew with the backlog.

```
                     10 open PRs      30 open PRs
before                31 calls          91 calls
after                 13 calls          33 calls
```

Measured end to end against the live repos: **21s of fetching per cycle down to 10s** (vesta 14s to 6s, cloud 7s to 4s).

### How

Conversation and inline comments each come from one repo-wide listing (`/issues/comments`, `/pulls/comments`) windowed by `PR_MONITOR_WINDOW`, then filtered back down to currently open PRs. Review summaries have no repo-wide equivalent and are still read per PR, so that is the only part still scaling with the backlog.

A 7 day window is 78 issue comments and 14 review comments on this repo, one page each, so pagination does not bite.

### Equivalence

Both implementations run against both live repos, output sorted and diffed:

```
elyxlz/vesta         old 2 rows   new 2 rows   IDENTICAL
elyxlz/vesta-cloud   old 0 rows   new 0 rows   IDENTICAL
```

Two rows is a thin test, so repeated with a match-all trigger to exercise every comment rather than only addressed ones:

```
elyxlz/vesta         old 7 rows   new 7 rows   IDENTICAL
elyxlz/vesta-cloud   old 6 rows   new 6 rows   IDENTICAL
```

### The tradeoff

The window bounds the listings, so a comment older than it that has never been claimed is not seen. Claims happen within a cycle of a comment appearing, so the default leaves days of margin, but a repo where the loop is stopped for long stretches wants a wider one. Documented in the skill.