### PR TITLE
perf(pr-monitor): give each repo its own poll clock

### DIFF
--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -60,6 +60,8 @@ Those worktrees are cleaned up as their work concludes, at most once every `PR_M
 
 A run is also capped at `PR_MONITOR_TIMEOUT` and stopped past it. A run whose connection dies waits on a socket that never speaks again, consuming no CPU and looking alive from outside, and without the cap it holds its slot for as long as the process lives.
 
+Each repo is polled by its own loop, on its own clock, and the interval counts from the start of a pass rather than its end. A repo with a long backlog therefore delays only itself, and the time a pass takes is never added to the gap before the next one. That matters for more than latency: two events noticed a cycle apart are handled a cycle apart no matter how many runs may go at once, so how fast events are noticed is what decides whether concurrency is ever reached.
+
 **Every new PR is checked automatically.** A non-draft PR that has never been seen surfaces as `NEWPR` without anyone asking, and dispatch runs the `check-pr` skill on it: does it fix the issue it claims to fix, does it match this repository's conventions, does it actually work. That pass is read only. It never pushes, merges, or closes, so a PR opening cannot cause a write. Where the change would benefit from the simplify and tidy pass, the reply names `polish-pr` and stops there, leaving the maintainer to ask for it.
 
 An unprompted comment closes by saying how to reach the agent: that mentioning `@vestabot` on the PR is what triggers it, what is worth asking for, and that only trusted commenters can. Nobody asked for that comment, so it carries its own instructions rather than assuming the reader knows the loop exists. Replies to an explicit mention skip it, since whoever wrote the mention already knows.
@@ -152,7 +154,7 @@ Two consequences worth knowing:
 | `PR_MONITOR_TRUSTED` | (author_association) | Logins allowed to drive the agent |
 | `PR_MONITOR_DENIED_REACTION` | `confused` | Reaction marking a refused comment |
 | `PR_MONITOR_MARKER` | `vestabot:reply` | Marker identifying the agent's own comments |
-| `PR_MONITOR_INTERVAL` | `45` | Seconds between polls |
+| `PR_MONITOR_INTERVAL` | `45` | Seconds between the starts of one repo's polls |
 | `PR_MONITOR_STATE` | `$XDG_STATE_HOME/pr-monitor` | Review-summary ledger and per-PR session ids |
 | `PR_MONITOR_MODEL` | `claude-opus-5` | Model `dispatch.sh` runs each event on |
 | `PR_MONITOR_TIMEOUT` | `1800` | Seconds a single run may take before it is stopped |

--- a/.claude/skills/pr-monitor/monitor.sh
+++ b/.claude/skills/pr-monitor/monitor.sh
@@ -122,10 +122,26 @@ emit_open_prs() {
   done
 }
 
-while true; do
-  for repo in "${repos[@]}"; do
+# One poller per repo, so a slow repo never delays another, and the interval is
+# measured from the start of a pass rather than its end, so the time a pass
+# takes is not added to the gap before the next one. Both matter because how
+# soon an event is noticed is what decides whether two of them can ever be in
+# flight together: discovery a cycle apart is handled a cycle apart, however
+# many runs the consumer is willing to start at once.
+# Each line is written whole and stays under the pipe's atomic write size, so
+# pollers writing at the same time cannot interleave a line.
+poll_repo() {
+  local repo="$1" started elapsed
+  while true; do
+    started=$(date +%s)
     emit_comments "$repo"
     emit_open_prs "$repo"
+    elapsed=$(( $(date +%s) - started ))
+    [ "$elapsed" -lt "$INTERVAL" ] && sleep "$(( INTERVAL - elapsed ))"
   done
-  sleep "$INTERVAL"
+}
+
+for repo in "${repos[@]}"; do
+  poll_repo "$repo" &
 done
+wait


### PR DESCRIPTION
Raising the concurrency limit does not make runs concurrent if events are not *noticed* close together. Two events noticed a cycle apart are handled a cycle apart no matter how many runs may go at once, so discovery latency was the real constraint.

Two couplings caused it:

- repos were polled **one after another**, so each repo waited on the others
- the interval was counted from the **end** of the pass, so fetch time landed in the gap

On the live repos that turned a 45s interval into 55s of latency, and a third repo would have added its own on top.

### After

Each repo polls in its own loop, and the interval counts from the **start** of a pass. A slow repo delays only itself, and the work is absorbed into the interval rather than added to it.

### Measured, same stubs, one slow repo (12s of work) and one fast (4s), interval 10s

```
before   org/slow  polls every 26s     one shared cycle: 12 + 4 + 10
         org/fast  polled once in 34s

after    org/fast  polls every 10s     exact interval, work absorbed
         org/slow  polls every 12s     its own work, delays nobody
```

The fast repo goes from one poll in 34 seconds to one every 10.

Lines are written whole and stay well under the pipe atomic-write size, so pollers writing at once cannot interleave a line, and each repo already writes its scratch TSV to its own directory.