### PR TITLE
feat(email): add native delayed send and undo

### DIFF
--- a/agent/skills/email-client/SKILL.md
+++ b/agent/skills/email-client/SKILL.md
@@ -130,6 +130,20 @@ Repeat `--cc` / `--bcc` / `--attach` for multiple values. `--body-html` sends HT
 
 After a successful send the message is IMAP-APPENDed (with attachments) to the Sent folder so it shows in the user's mail UI. Skip with `--no-sent-sync`. The Sent folder is auto-detected from the server's RFC 6154 SPECIAL-USE attribute (`\Sent`), falling back to the provider profile's `sent_folder` then `Sent` - so it works even when a server names the folder unusually.
 
+### Delayed send and undo
+
+Send, reply, and forward operations wait 30 seconds by default. The delay is one persisted setting for the entire email client, not an option on an individual send:
+
+```bash
+email-client send-delay
+email-client send-delay --seconds 60
+email-client pending
+email-client pending --account work
+email-client undo --id <pending_id>
+```
+
+`email-client-send` returns a `pending` status with the pending id and scheduled send time. Use that id with `undo` before the deadline to cancel delivery. The poll daemon dispatches due messages, then syncs them to Sent and marks replied-to originals as answered. Keep the daemon running whenever the delay is nonzero. Set `--seconds 0` for immediate delivery. Drafts and dry runs are never queued.
+
 ### Reply
 
 ```bash

--- a/agent/skills/email-client/SKILL.md
+++ b/agent/skills/email-client/SKILL.md
@@ -142,7 +142,9 @@ email-client pending --account work
 email-client undo --id <pending_id>
 ```
 
-`email-client-send` returns a `pending` status with the pending id and scheduled send time. Use that id with `undo` before the deadline to cancel delivery. The poll daemon dispatches due messages, then syncs them to Sent and marks replied-to originals as answered. Keep the daemon running whenever the delay is nonzero. Set `--seconds 0` for immediate delivery. Drafts and dry runs are never queued.
+`email-client-send` returns a `pending` status with the pending id and scheduled send time. Use that id with `undo` to cancel delivery: it works right up until the poll daemon starts dispatching that message, which is what delivers it, syncs it to Sent, and marks a replied-to original as answered. Only that daemon dispatches, so `email-client-send` refuses to queue while it is stopped; `email-client daemon start` or `email-client send-delay --seconds 0` unblocks it. Drafts and dry runs are never queued.
+
+`pending` also lists messages whose status is `failed`, with `last_error` saying why: delivery kept erroring, or it was cut off mid-dispatch. A message cut off mid-dispatch may already have reached the server, so read the Sent folder before you `undo` it or send it again.
 
 ### Reply
 

--- a/agent/skills/email-client/imap_client.py
+++ b/agent/skills/email-client/imap_client.py
@@ -45,6 +45,7 @@ from imap_tools import AND, MailBox, MailMessageFlags
 # importable without adding a new symlink for each one.
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import daemon_lifecycle
+import pending_send
 from providers import (
     apply_env_overrides,
     detect_provider,
@@ -751,6 +752,25 @@ def cmd_notify_remove(args):
     _save_notify_folders(acc, [f for f in notify_folders(acc) if f != args.folder])
 
 
+def cmd_send_delay(args):
+    seconds = pending_send.delay_seconds(_state_dir()) if args.seconds is None else pending_send.set_delay_seconds(_state_dir(), args.seconds)
+    print(json.dumps({"send_delay_seconds": seconds}, indent=2))
+
+
+def cmd_pending(args):
+    account = resolve_account(args.account) if args.account else None
+    print(json.dumps([queued.public() for queued in pending_send.list_pending(_state_dir(), account=account)], indent=2))
+
+
+def cmd_undo(args):
+    try:
+        queued = pending_send.cancel(_state_dir(), args.pending_id)
+    except ValueError as error:
+        sys.exit(str(error))
+    pending_send.finish_cancel(_state_dir(), queued.id)
+    print(json.dumps({"id": queued.id, "status": "cancelled"}, indent=2))
+
+
 # -- daemon lifecycle (start/stop/restart/status of poll_daemon.py) -
 
 
@@ -1001,7 +1021,19 @@ def _add_mutate_parsers(sub):
     _add_account_arg(p)
 
 
+def _add_pending_parsers(sub):
+    p_delay = sub.add_parser("send-delay", help="show or set the client-wide outbound email delay")
+    p_delay.add_argument("--seconds", type=int, default=None)
+
+    p_pending = sub.add_parser("pending", help="list outbound email that can still be undone")
+    _add_account_arg(p_pending)
+
+    p_undo = sub.add_parser("undo", help="cancel a pending outbound email")
+    p_undo.add_argument("--id", required=True, dest="pending_id")
+
+
 def _add_admin_parsers(sub):
+    _add_pending_parsers(sub)
     pf = sub.add_parser("folder", help="create / rename / delete / subscribe mailboxes")
     fsub = pf.add_subparsers(dest="folder_cmd", required=True)
     pf_c = fsub.add_parser("create", help="create a new mailbox")
@@ -1144,6 +1176,12 @@ def _dispatch(args):
             "restart": cmd_daemon_restart,
             "status": cmd_daemon_status,
         }[args.daemon_cmd](args)
+    elif args.cmd == "send-delay":
+        cmd_send_delay(args)
+    elif args.cmd == "pending":
+        cmd_pending(args)
+    elif args.cmd == "undo":
+        cmd_undo(args)
     elif args.cmd == "calendar":
         _cmd_calendar(args)
     else:

--- a/agent/skills/email-client/pending_send.py
+++ b/agent/skills/email-client/pending_send.py
@@ -12,7 +12,11 @@ from pathlib import Path
 
 DEFAULT_DELAY_SECONDS = 30
 RETRY_DELAY_SECONDS = 30
+MAX_DELIVERY_ATTEMPTS = 3
+INTERRUPTED_ERROR = "dispatch was interrupted; check the Sent folder before undoing or resending"
 _DATABASE_NAME = "pending-sends.db"
+_UNDOABLE_STATES = "('pending', 'failed')"
+_COLUMNS = "id, created_at, send_at, account, action, subject, recipients, backend, payload, state, last_error"
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS settings (
     key TEXT PRIMARY KEY,
@@ -29,7 +33,8 @@ CREATE TABLE IF NOT EXISTS sends (
     backend TEXT NOT NULL,
     payload BLOB NOT NULL,
     state TEXT NOT NULL,
-    last_error TEXT
+    last_error TEXT NOT NULL DEFAULT '',
+    attempts INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS sends_due ON sends(state, send_at);
 """
@@ -46,17 +51,22 @@ class PendingSend:
     recipients: str
     backend: str
     payload: bytes
+    state: str = "pending"
+    last_error: str = ""
 
     def public(self) -> dict[str, str]:
-        return {
+        described = {
             "id": self.id,
-            "status": "pending",
+            "status": self.state,
             "account": self.account,
             "action": self.action,
             "subject": self.subject,
             "recipients": self.recipients,
             "send_at": self.send_at.isoformat(),
         }
+        if self.last_error:
+            described["last_error"] = self.last_error
+        return described
 
 
 @contextlib.contextmanager
@@ -82,6 +92,8 @@ def _from_row(row: sqlite3.Row | tuple) -> PendingSend:
         recipients=str(row[6]),
         backend=str(row[7]),
         payload=bytes(row[8]),
+        state=str(row[9]),
+        last_error=str(row[10]),
     )
 
 
@@ -144,35 +156,21 @@ def enqueue(
     return queued
 
 
-def list_pending(data_dir: Path, *, account: str | None = None, now: datetime | None = None) -> list[PendingSend]:
-    undoable_at = now or datetime.now(UTC)
+def list_pending(data_dir: Path, *, account: str | None = None) -> list[PendingSend]:
     with _connection(data_dir) as connection:
-        if account is None:
-            rows = connection.execute(
-                "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
-                "FROM sends WHERE state = 'pending' AND send_at > ? ORDER BY send_at, id",
-                (undoable_at.isoformat(),),
-            ).fetchall()
-        else:
-            rows = connection.execute(
-                "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
-                "FROM sends WHERE state = 'pending' AND account = ? AND send_at > ? ORDER BY send_at, id",
-                (account, undoable_at.isoformat()),
-            ).fetchall()
+        rows = connection.execute(
+            f"SELECT {_COLUMNS} FROM sends WHERE state IN {_UNDOABLE_STATES} AND (? IS NULL OR account = ?) ORDER BY send_at, id",
+            (account, account),
+        ).fetchall()
     return [_from_row(row) for row in rows]
 
 
-def cancel(data_dir: Path, pending_id: str, *, now: datetime | None = None) -> PendingSend:
-    cancel_at = now or datetime.now(UTC)
+def cancel(data_dir: Path, pending_id: str) -> PendingSend:
     with _connection(data_dir) as connection:
         connection.execute("BEGIN IMMEDIATE")
-        row = connection.execute(
-            "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
-            "FROM sends WHERE id = ? AND state = 'pending' AND send_at > ?",
-            (pending_id, cancel_at.isoformat()),
-        ).fetchone()
+        row = connection.execute(f"SELECT {_COLUMNS} FROM sends WHERE id = ? AND state IN {_UNDOABLE_STATES}", (pending_id,)).fetchone()
         if row is None:
-            raise ValueError(f"pending send {pending_id!r} was not found, has expired, or has already been delivered")
+            raise ValueError(f"pending send {pending_id!r} was not found, is being delivered right now, or has already been delivered")
         connection.execute("UPDATE sends SET state = 'cancelled' WHERE id = ?", (pending_id,))
     return _from_row(row)
 
@@ -187,13 +185,12 @@ def claim_due(data_dir: Path, *, now: datetime | None = None) -> PendingSend | N
     with _connection(data_dir) as connection:
         connection.execute("BEGIN IMMEDIATE")
         row = connection.execute(
-            "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
-            "FROM sends WHERE state = 'pending' AND send_at <= ? ORDER BY send_at, id LIMIT 1",
+            f"SELECT {_COLUMNS} FROM sends WHERE state = 'pending' AND send_at <= ? ORDER BY send_at, id LIMIT 1",
             (due_at.isoformat(),),
         ).fetchone()
         if row is None:
             return None
-        connection.execute("UPDATE sends SET state = 'dispatching' WHERE id = ?", (str(row[0]),))
+        connection.execute("UPDATE sends SET state = 'dispatching', attempts = attempts + 1 WHERE id = ?", (str(row[0]),))
     return _from_row(row)
 
 
@@ -206,11 +203,14 @@ def retry(data_dir: Path, pending_id: str, error: str, *, now: datetime | None =
     retry_at = (now or datetime.now(UTC)) + timedelta(seconds=RETRY_DELAY_SECONDS)
     with _connection(data_dir) as connection:
         connection.execute(
-            "UPDATE sends SET state = 'pending', send_at = ?, last_error = ? WHERE id = ? AND state = 'dispatching'",
-            (retry_at.isoformat(), error, pending_id),
+            "UPDATE sends SET state = CASE WHEN attempts >= ? THEN 'failed' ELSE 'pending' END, send_at = ?, last_error = ? "
+            "WHERE id = ? AND state = 'dispatching'",
+            (MAX_DELIVERY_ATTEMPTS, retry_at.isoformat(), error, pending_id),
         )
 
 
 def recover_dispatching(data_dir: Path) -> None:
+    # A claimed row may have reached the server before the process died, so re-sending it
+    # would duplicate the mail. Hold it for the agent to resolve instead.
     with _connection(data_dir) as connection:
-        connection.execute("UPDATE sends SET state = 'pending' WHERE state = 'dispatching'")
+        connection.execute("UPDATE sends SET state = 'failed', last_error = ? WHERE state = 'dispatching'", (INTERRUPTED_ERROR,))

--- a/agent/skills/email-client/pending_send.py
+++ b/agent/skills/email-client/pending_send.py
@@ -1,0 +1,216 @@
+"""Durable delayed-send state owned by the email client."""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+DEFAULT_DELAY_SECONDS = 30
+RETRY_DELAY_SECONDS = 30
+_DATABASE_NAME = "pending-sends.db"
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS sends (
+    id TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL,
+    send_at TEXT NOT NULL,
+    account TEXT NOT NULL,
+    action TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    recipients TEXT NOT NULL,
+    backend TEXT NOT NULL,
+    payload BLOB NOT NULL,
+    state TEXT NOT NULL,
+    last_error TEXT
+);
+CREATE INDEX IF NOT EXISTS sends_due ON sends(state, send_at);
+"""
+
+
+@dataclass(frozen=True)
+class PendingSend:
+    id: str
+    created_at: datetime
+    send_at: datetime
+    account: str
+    action: str
+    subject: str
+    recipients: str
+    backend: str
+    payload: bytes
+
+    def public(self) -> dict[str, str]:
+        return {
+            "id": self.id,
+            "status": "pending",
+            "account": self.account,
+            "action": self.action,
+            "subject": self.subject,
+            "recipients": self.recipients,
+            "send_at": self.send_at.isoformat(),
+        }
+
+
+@contextlib.contextmanager
+def _connection(data_dir: Path) -> Iterator[sqlite3.Connection]:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(data_dir / _DATABASE_NAME)
+    try:
+        connection.executescript(_SCHEMA)
+        yield connection
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _from_row(row: sqlite3.Row | tuple) -> PendingSend:
+    return PendingSend(
+        id=str(row[0]),
+        created_at=datetime.fromisoformat(str(row[1])),
+        send_at=datetime.fromisoformat(str(row[2])),
+        account=str(row[3]),
+        action=str(row[4]),
+        subject=str(row[5]),
+        recipients=str(row[6]),
+        backend=str(row[7]),
+        payload=bytes(row[8]),
+    )
+
+
+def delay_seconds(data_dir: Path) -> int:
+    with _connection(data_dir) as connection:
+        row = connection.execute("SELECT value FROM settings WHERE key = 'send_delay_seconds'").fetchone()
+    return int(row[0]) if row is not None else DEFAULT_DELAY_SECONDS
+
+
+def set_delay_seconds(data_dir: Path, seconds: int) -> int:
+    if seconds < 0:
+        raise ValueError("send delay must be zero or greater")
+    with _connection(data_dir) as connection:
+        connection.execute(
+            "INSERT INTO settings(key, value) VALUES('send_delay_seconds', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (seconds,),
+        )
+    return seconds
+
+
+def enqueue(
+    data_dir: Path,
+    *,
+    account: str,
+    action: str,
+    subject: str,
+    recipients: str,
+    backend: str,
+    payload: bytes,
+    now: datetime | None = None,
+) -> PendingSend:
+    created_at = now or datetime.now(UTC)
+    queued = PendingSend(
+        id=uuid.uuid4().hex,
+        created_at=created_at,
+        send_at=created_at + timedelta(seconds=delay_seconds(data_dir)),
+        account=account,
+        action=action,
+        subject=subject,
+        recipients=recipients,
+        backend=backend,
+        payload=payload,
+    )
+    with _connection(data_dir) as connection:
+        connection.execute(
+            "INSERT INTO sends(id, created_at, send_at, account, action, subject, recipients, backend, payload, state) "
+            "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')",
+            (
+                queued.id,
+                queued.created_at.isoformat(),
+                queued.send_at.isoformat(),
+                queued.account,
+                queued.action,
+                queued.subject,
+                queued.recipients,
+                queued.backend,
+                queued.payload,
+            ),
+        )
+    return queued
+
+
+def list_pending(data_dir: Path, *, account: str | None = None, now: datetime | None = None) -> list[PendingSend]:
+    undoable_at = now or datetime.now(UTC)
+    with _connection(data_dir) as connection:
+        if account is None:
+            rows = connection.execute(
+                "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
+                "FROM sends WHERE state = 'pending' AND send_at > ? ORDER BY send_at, id",
+                (undoable_at.isoformat(),),
+            ).fetchall()
+        else:
+            rows = connection.execute(
+                "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
+                "FROM sends WHERE state = 'pending' AND account = ? AND send_at > ? ORDER BY send_at, id",
+                (account, undoable_at.isoformat()),
+            ).fetchall()
+    return [_from_row(row) for row in rows]
+
+
+def cancel(data_dir: Path, pending_id: str, *, now: datetime | None = None) -> PendingSend:
+    cancel_at = now or datetime.now(UTC)
+    with _connection(data_dir) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        row = connection.execute(
+            "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
+            "FROM sends WHERE id = ? AND state = 'pending' AND send_at > ?",
+            (pending_id, cancel_at.isoformat()),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"pending send {pending_id!r} was not found, has expired, or has already been delivered")
+        connection.execute("UPDATE sends SET state = 'cancelled' WHERE id = ?", (pending_id,))
+    return _from_row(row)
+
+
+def finish_cancel(data_dir: Path, pending_id: str) -> None:
+    with _connection(data_dir) as connection:
+        connection.execute("DELETE FROM sends WHERE id = ? AND state = 'cancelled'", (pending_id,))
+
+
+def claim_due(data_dir: Path, *, now: datetime | None = None) -> PendingSend | None:
+    due_at = now or datetime.now(UTC)
+    with _connection(data_dir) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        row = connection.execute(
+            "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
+            "FROM sends WHERE state = 'pending' AND send_at <= ? ORDER BY send_at, id LIMIT 1",
+            (due_at.isoformat(),),
+        ).fetchone()
+        if row is None:
+            return None
+        connection.execute("UPDATE sends SET state = 'dispatching' WHERE id = ?", (str(row[0]),))
+    return _from_row(row)
+
+
+def complete(data_dir: Path, pending_id: str) -> None:
+    with _connection(data_dir) as connection:
+        connection.execute("DELETE FROM sends WHERE id = ? AND state = 'dispatching'", (pending_id,))
+
+
+def retry(data_dir: Path, pending_id: str, error: str, *, now: datetime | None = None) -> None:
+    retry_at = (now or datetime.now(UTC)) + timedelta(seconds=RETRY_DELAY_SECONDS)
+    with _connection(data_dir) as connection:
+        connection.execute(
+            "UPDATE sends SET state = 'pending', send_at = ?, last_error = ? WHERE id = ? AND state = 'dispatching'",
+            (retry_at.isoformat(), error, pending_id),
+        )
+
+
+def recover_dispatching(data_dir: Path) -> None:
+    with _connection(data_dir) as connection:
+        connection.execute("UPDATE sends SET state = 'pending' WHERE state = 'dispatching'")

--- a/agent/skills/email-client/poll_daemon.py
+++ b/agent/skills/email-client/poll_daemon.py
@@ -41,6 +41,8 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import contextlib
 
 import daemon_lifecycle
+import pending_send
+import smtp_send
 from imap_client import (
     _env,
     _from_full,
@@ -71,6 +73,7 @@ INDEX_CHECK_SECS = 10
 # IMAP transaction trying to pull thousands of headers. Caller re-enters
 # on the next IDLE/poll cycle to pick up the remaining backlog.
 FETCH_BATCH_LIMIT = 500
+PENDING_POLL_SECONDS = 1
 
 
 def _sanitize_folder(folder: str) -> str:
@@ -276,6 +279,17 @@ def _reconcile_workers(
             log(f"[{key[0]}:{key[1]}] worker stopping")
 
 
+def pending_send_worker(state_dir: pathlib.Path, log, stop_event: threading.Event) -> None:
+    pending_send.recover_dispatching(state_dir)
+    while not stop_event.is_set():
+        try:
+            if smtp_send.dispatch_due(state_dir):
+                continue
+        except Exception as error:
+            log(f"[pending-send] dispatch failed: {error}")
+        stop_event.wait(PENDING_POLL_SECONDS)
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument(
@@ -310,11 +324,18 @@ def main():
 
     workers: dict[tuple[str, str], tuple[threading.Thread, threading.Event]] = {}
     last_desired: set[tuple[str, str]] | None = None
+    pending_thread = threading.Thread(
+        target=pending_send_worker,
+        args=(state_dir, log, shutdown_event),
+        name="pending-send",
+        daemon=True,
+    )
 
     daemon_lifecycle.write_pid(state_dir)
     daemon_lifecycle.write_daemon_info(state_dir, args.interval)
 
     try:
+        pending_thread.start()
         while not shutdown_event.is_set():
             try:
                 wanted = desired_workers()
@@ -329,8 +350,10 @@ def main():
             _reconcile_workers(workers, wanted, args.interval, log)
             shutdown_event.wait(INDEX_CHECK_SECS)
     finally:
+        shutdown_event.set()
         for _, stop_event in workers.values():
             stop_event.set()
+        pending_thread.join(timeout=WORKER_JOIN_TIMEOUT_SECS)
         for thread, _ in workers.values():
             thread.join(timeout=WORKER_JOIN_TIMEOUT_SECS)
         if daemon_lifecycle.consume_stop_requested(state_dir):

--- a/agent/skills/email-client/smtp_send.py
+++ b/agent/skills/email-client/smtp_send.py
@@ -56,6 +56,7 @@ import argparse
 import base64
 import dataclasses
 import datetime as _dt
+import json
 import mimetypes
 import os
 import pathlib
@@ -63,7 +64,10 @@ import re as _re
 import smtplib
 import sys
 import time
+from email import policy
 from email.message import EmailMessage
+from email.parser import BytesParser
+from typing import TypedDict, cast
 
 from imap_tools import AND, MailMessageFlags
 
@@ -75,9 +79,11 @@ MAX_ATTACH_TOTAL_BYTES = 25 * 1024 * 1024
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import contextlib
 
+import pending_send
 from imap_client import (
     _env,
     _from_full,
+    _state_dir,
     _to_full,
     account_profile,
     account_user,
@@ -292,6 +298,13 @@ class Outbound:
     attachments: list[dict]
 
 
+class _PendingMetadata(TypedDict):
+    user: str
+    reply_uid: str
+    reply_folder: str
+    sent_sync: bool
+
+
 def _build_message(out: Outbound) -> EmailMessage:
     """Assemble the outbound EmailMessage from parts."""
     msg = EmailMessage()
@@ -450,9 +463,13 @@ def _mark_answered(acc: str | None, folder: str, uid: str) -> None:
 
 
 def _sync_sent(acc: str | None, profile: dict, out: Outbound) -> None:
-    # Strip Bcc before APPEND (those addresses must not appear in
-    # the stored copy that the user can later read in their mail UI).
-    copy = _build_message(dataclasses.replace(out, bcc=[]))
+    _sync_sent_message(acc, profile, _build_message(dataclasses.replace(out, bcc=[])))
+
+
+def _sync_sent_message(acc: str | None, profile: dict, message: EmailMessage) -> None:
+    copy = cast(EmailMessage, BytesParser(policy=policy.default).parsebytes(message.as_bytes()))
+    if "Bcc" in copy:
+        del copy["Bcc"]
     sent_fallback = profile["sent_folder"] if "sent_folder" in profile else None
     ok, info = _append_message(
         acc,
@@ -504,6 +521,21 @@ def send(req: SendRequest) -> None:
             return
         sys.exit(f"draft save failed: {info}")
 
+    state_dir = _state_dir()
+    if pending_send.delay_seconds(state_dir) > 0:
+        action = "reply" if req.reply_to_uid else "forward" if req.forward_uid else "send"
+        queued = pending_send.enqueue(
+            state_dir,
+            account=acc,
+            action=action,
+            subject=out.subject,
+            recipients=", ".join([out.to, *out.cc, *out.bcc]),
+            backend="smtp",
+            payload=_encode_pending_payload(msg, req, user),
+        )
+        print(json.dumps(queued.public(), indent=2))
+        return
+
     _smtp_deliver(acc, profile, user, smtp_host, smtp_port, msg)
     print("OK")
 
@@ -513,7 +545,64 @@ def send(req: SendRequest) -> None:
         _sync_sent(acc, profile, out)
 
 
-def main():
+def _encode_pending_payload(message: EmailMessage, request: SendRequest, user: str) -> bytes:
+    metadata = _PendingMetadata(
+        user=user,
+        reply_uid=request.reply_to_uid or "",
+        reply_folder=request.reply_folder,
+        sent_sync=request.sent_sync,
+    )
+    return json.dumps(metadata, separators=(",", ":")).encode() + b"\n" + message.as_bytes()
+
+
+def _decode_pending_payload(payload: bytes) -> tuple[_PendingMetadata, EmailMessage]:
+    encoded_metadata, separator, encoded_message = payload.partition(b"\n")
+    if not separator:
+        raise ValueError("pending SMTP payload is malformed")
+    raw_metadata = json.loads(encoded_metadata)
+    if not isinstance(raw_metadata, dict):
+        raise ValueError("pending SMTP metadata is malformed")
+    metadata = _PendingMetadata(
+        user=str(raw_metadata["user"]),
+        reply_uid=str(raw_metadata["reply_uid"]),
+        reply_folder=str(raw_metadata["reply_folder"]),
+        sent_sync=bool(raw_metadata["sent_sync"]),
+    )
+    message = cast(EmailMessage, BytesParser(policy=policy.default).parsebytes(encoded_message))
+    return metadata, message
+
+
+def _deliver_pending(queued: pending_send.PendingSend) -> None:
+    metadata, message = _decode_pending_payload(queued.payload)
+    _, profile = account_profile(queued.account)
+    smtp_host = profile["smtp_host"] if "smtp_host" in profile else None
+    smtp_port = int(profile["smtp_port"] if "smtp_port" in profile else 587)
+    if not smtp_host:
+        raise ValueError(f"account {queued.account!r} has no SMTP host configured")
+    try:
+        _smtp_deliver(queued.account, profile, metadata["user"], smtp_host, smtp_port, message)
+    except SystemExit as error:
+        raise RuntimeError(str(error)) from error
+    if metadata["reply_uid"]:
+        _mark_answered(queued.account, metadata["reply_folder"], metadata["reply_uid"])
+    if metadata["sent_sync"]:
+        _sync_sent_message(queued.account, profile, message)
+
+
+def dispatch_due(data_dir: pathlib.Path, *, now: _dt.datetime | None = None) -> bool:
+    queued = pending_send.claim_due(data_dir, now=now)
+    if queued is None:
+        return False
+    try:
+        _deliver_pending(queued)
+    except Exception as error:
+        pending_send.retry(data_dir, queued.id, str(error), now=now)
+        raise
+    pending_send.complete(data_dir, queued.id)
+    return True
+
+
+def _build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser()
     ap.add_argument(
         "--to",
@@ -600,7 +689,11 @@ def main():
         action="store_true",
         help="save the composed message to the Drafts folder instead of sending; works with --reply-to-uid / --forward-uid to draft for review",
     )
-    args = ap.parse_args()
+    return ap
+
+
+def main():
+    args = _build_parser().parse_args()
     # Hard draft-only guard: refuse any transmitting invocation (send/reply/forward)
     # before touching SMTP. Drafting (--draft) and the no-network preview (--dry-run)
     # stay allowed. Default off: no behavior change when EMAIL_DRAFT_ONLY is unset.

--- a/agent/skills/email-client/smtp_send.py
+++ b/agent/skills/email-client/smtp_send.py
@@ -79,6 +79,7 @@ MAX_ATTACH_TOTAL_BYTES = 25 * 1024 * 1024
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import contextlib
 
+import daemon_lifecycle
 import pending_send
 from imap_client import (
     _env,
@@ -463,17 +464,17 @@ def _mark_answered(acc: str | None, folder: str, uid: str) -> None:
 
 
 def _sync_sent(acc: str | None, profile: dict, out: Outbound) -> None:
-    _sync_sent_message(acc, profile, _build_message(dataclasses.replace(out, bcc=[])))
+    _sync_sent_message(acc, profile, _build_message(out))
 
 
 def _sync_sent_message(acc: str | None, profile: dict, message: EmailMessage) -> None:
-    copy = cast(EmailMessage, BytesParser(policy=policy.default).parsebytes(message.as_bytes()))
-    if "Bcc" in copy:
-        del copy["Bcc"]
+    # Strip Bcc before APPEND (those addresses must not appear in
+    # the stored copy that the user can later read in their mail UI).
+    del message["Bcc"]
     sent_fallback = profile["sent_folder"] if "sent_folder" in profile else None
     ok, info = _append_message(
         acc,
-        copy.as_bytes(),
+        message.as_bytes(),
         role="sent",
         profile_fallback=sent_fallback,
         flags=[MailMessageFlags.SEEN],
@@ -523,6 +524,12 @@ def send(req: SendRequest) -> None:
 
     state_dir = _state_dir()
     if pending_send.delay_seconds(state_dir) > 0:
+        running, _ = daemon_lifecycle.daemon_running(state_dir)
+        if not running:
+            sys.exit(
+                "the poll daemon dispatches delayed sends and is not running, so this message would never leave; "
+                "start it with `email-client daemon start`, or send immediately with `email-client send-delay --seconds 0`"
+            )
         action = "reply" if req.reply_to_uid else "forward" if req.forward_uid else "send"
         queued = pending_send.enqueue(
             state_dir,

--- a/agent/skills/email-client/tests/test_draft_only.py
+++ b/agent/skills/email-client/tests/test_draft_only.py
@@ -40,6 +40,7 @@ def _install_stubs():
         for name in (
             "_env",
             "_from_full",
+            "_state_dir",
             "_to_full",
             "account_profile",
             "account_user",

--- a/agent/skills/email-client/tests/test_pending_send.py
+++ b/agent/skills/email-client/tests/test_pending_send.py
@@ -1,0 +1,293 @@
+import json
+from datetime import UTC, datetime, timedelta
+
+import pending_send
+import pytest
+import smtp_send
+
+
+def test_delay_defaults_to_thirty_seconds_and_persists(tmp_path):
+    assert pending_send.delay_seconds(tmp_path) == 30
+
+    pending_send.set_delay_seconds(tmp_path, 75)
+
+    assert pending_send.delay_seconds(tmp_path) == 75
+
+
+def test_pending_send_uses_the_client_delay_and_can_be_claimed_once(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="personal",
+        action="reply",
+        subject="Re: Hello",
+        recipients="bob@example.com",
+        backend="smtp",
+        payload=b"mime",
+        now=now,
+    )
+
+    assert queued.send_at == now + timedelta(seconds=30)
+    assert [item.id for item in pending_send.list_pending(tmp_path, now=now)] == [queued.id]
+    assert pending_send.claim_due(tmp_path, now=queued.send_at - timedelta(microseconds=1)) is None
+    assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
+    assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
+
+
+def test_undo_removes_a_pending_send_before_delivery(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="personal",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend="smtp",
+        payload=b"mime",
+        now=now,
+    )
+
+    cancelled = pending_send.cancel(tmp_path, queued.id, now=queued.send_at - timedelta(microseconds=1))
+
+    assert cancelled.id == queued.id
+    assert pending_send.list_pending(tmp_path) == []
+    assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
+
+
+def test_undo_rejects_a_send_after_its_recovery_window(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="personal",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend="smtp",
+        payload=b"mime",
+        now=now,
+    )
+
+    with pytest.raises(ValueError, match="expired"):
+        pending_send.cancel(tmp_path, queued.id, now=queued.send_at)
+    assert pending_send.list_pending(tmp_path, now=queued.send_at) == []
+
+
+def test_changing_delay_only_affects_new_sends(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+    first = pending_send.enqueue(
+        tmp_path,
+        account="personal",
+        action="send",
+        subject="First",
+        recipients="bob@example.com",
+        backend="smtp",
+        payload=b"first",
+        now=now,
+    )
+    pending_send.set_delay_seconds(tmp_path, 75)
+    second = pending_send.enqueue(
+        tmp_path,
+        account="personal",
+        action="send",
+        subject="Second",
+        recipients="bob@example.com",
+        backend="smtp",
+        payload=b"second",
+        now=now,
+    )
+
+    assert first.send_at == now + timedelta(seconds=30)
+    assert second.send_at == now + timedelta(seconds=75)
+
+
+def test_dispatching_send_recovers_after_daemon_restart(tmp_path):
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="personal",
+        action="forward",
+        subject="Fwd: Hello",
+        recipients="bob@example.com",
+        backend="smtp",
+        payload=b"mime",
+    )
+    assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
+
+    pending_send.recover_dispatching(tmp_path)
+
+    assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
+
+
+def _smtp_profile():
+    return "generic", {
+        "smtp_host": "smtp.example.com",
+        "smtp_port": 587,
+        "smtp_starttls": True,
+        "auth_strategy": "app-password",
+        "sent_folder": "Sent",
+    }
+
+
+def _patch_account(monkeypatch):
+    monkeypatch.setattr(smtp_send, "resolve_account", lambda _account: "personal")
+    monkeypatch.setattr(smtp_send, "account_user", lambda _account: "me@example.com")
+    monkeypatch.setattr(smtp_send, "account_profile", lambda _account: _smtp_profile())
+
+
+def _original_message():
+    return {
+        "message_id": "<original@example.com>",
+        "references": "",
+        "subject": "Hello",
+        "from": "Alice <alice@example.com>",
+        "to": "me@example.com",
+        "cc": "team@example.com",
+        "date": "Tue, 28 Jul 2026 12:00:00 +0000",
+        "body": "Original body",
+    }
+
+
+def test_smtp_send_queues_the_composed_message_and_attachments(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
+    _patch_account(monkeypatch)
+    attachment = tmp_path / "report.pdf"
+    attachment.write_bytes(b"pdf")
+    delivered = []
+    monkeypatch.setattr(smtp_send, "_smtp_deliver", lambda *_args: delivered.append(True))
+
+    smtp_send.send(
+        smtp_send.SendRequest(
+            to="bob@example.com",
+            subject="Hello",
+            body="Body",
+            account="personal",
+            attach=[str(attachment)],
+        )
+    )
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "pending"
+    assert delivered == []
+    queued = pending_send.list_pending(tmp_path)
+    assert len(queued) == 1
+    _metadata, message = smtp_send._decode_pending_payload(queued[0].payload)
+    assert message["Subject"] == "Hello"
+    assert next(message.iter_attachments()).get_filename() == "report.pdf"
+
+
+def test_smtp_all_outbound_actions_inherit_the_client_delay(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
+    _patch_account(monkeypatch)
+    monkeypatch.setattr(smtp_send, "fetch_original", lambda *_args: _original_message())
+    pending_send.set_delay_seconds(tmp_path, 45)
+    attachment = tmp_path / "report.pdf"
+    attachment.write_bytes(b"pdf")
+
+    smtp_send.send(smtp_send.SendRequest(to="bob@example.com", subject="Hello", body="Body", account="personal"))
+    smtp_send.send(
+        smtp_send.SendRequest(
+            reply_to_uid="10",
+            to=None,
+            subject=None,
+            body="Reply",
+            account="personal",
+            attach=[str(attachment)],
+        )
+    )
+    smtp_send.send(
+        smtp_send.SendRequest(
+            to="bob@example.com",
+            subject=None,
+            forward_uid="11",
+            body="Forward",
+            account="personal",
+            attach=[str(attachment)],
+        )
+    )
+    capsys.readouterr()
+
+    queued = pending_send.list_pending(tmp_path)
+    assert [item.action for item in queued] == ["send", "reply", "forward"]
+    assert all(item.send_at - item.created_at == timedelta(seconds=45) for item in queued)
+    _metadata, reply_message = smtp_send._decode_pending_payload(queued[1].payload)
+    assert reply_message["Cc"] == "team@example.com"
+    assert next(reply_message.iter_attachments()).get_filename() == "report.pdf"
+
+
+def test_smtp_zero_client_delay_sends_immediately(tmp_path, monkeypatch):
+    monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
+    _patch_account(monkeypatch)
+    pending_send.set_delay_seconds(tmp_path, 0)
+    delivered = []
+    monkeypatch.setattr(smtp_send, "_smtp_deliver", lambda *_args: delivered.append(True))
+    monkeypatch.setattr(smtp_send, "_sync_sent", lambda *_args: None)
+
+    smtp_send.send(smtp_send.SendRequest(to="bob@example.com", subject="Hello", body="Body", account="personal"))
+
+    assert delivered == [True]
+    assert pending_send.list_pending(tmp_path) == []
+
+
+def test_smtp_dispatch_delivers_once_then_runs_sent_side_effects(tmp_path, monkeypatch):
+    monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
+    _patch_account(monkeypatch)
+    smtp_send.send(smtp_send.SendRequest(to="bob@example.com", subject="Hello", body="Body", account="personal"))
+    queued = pending_send.list_pending(tmp_path)[0]
+    delivered = []
+    synced = []
+    monkeypatch.setattr(smtp_send, "_smtp_deliver", lambda *_args: delivered.append(True))
+    monkeypatch.setattr(smtp_send, "_sync_sent_message", lambda *_args: synced.append(True))
+
+    assert smtp_send.dispatch_due(tmp_path, now=queued.send_at) is True
+    assert smtp_send.dispatch_due(tmp_path, now=queued.send_at) is False
+    assert delivered == [True]
+    assert synced == [True]
+
+
+def test_smtp_reply_side_effects_wait_for_delivery(tmp_path, monkeypatch):
+    monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
+    _patch_account(monkeypatch)
+    monkeypatch.setattr(smtp_send, "fetch_original", lambda *_args: _original_message())
+    answered = []
+    monkeypatch.setattr(smtp_send, "_mark_answered", lambda *_args: answered.append(True))
+    monkeypatch.setattr(smtp_send, "_smtp_deliver", lambda *_args: None)
+    monkeypatch.setattr(smtp_send, "_sync_sent_message", lambda *_args: None)
+
+    smtp_send.send(
+        smtp_send.SendRequest(
+            to=None,
+            subject=None,
+            reply_to_uid="10",
+            body="Reply",
+            account="personal",
+        )
+    )
+    queued = pending_send.list_pending(tmp_path)[0]
+    assert answered == []
+
+    smtp_send.dispatch_due(tmp_path, now=queued.send_at)
+
+    assert answered == [True]
+
+
+def test_smtp_dispatch_retries_cli_style_delivery_failures(tmp_path, monkeypatch):
+    monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
+    _patch_account(monkeypatch)
+    smtp_send.send(smtp_send.SendRequest(to="bob@example.com", subject="Hello", body="Body", account="personal"))
+    queued = pending_send.list_pending(tmp_path)[0]
+
+    def fail_delivery(*_args):
+        raise SystemExit("smtp auth failed")
+
+    monkeypatch.setattr(smtp_send, "_smtp_deliver", fail_delivery)
+
+    with pytest.raises(RuntimeError, match="smtp auth failed"):
+        smtp_send.dispatch_due(tmp_path, now=queued.send_at)
+    assert [item.id for item in pending_send.list_pending(tmp_path)] == [queued.id]
+
+
+def test_delay_is_client_configuration_not_a_send_option(tmp_path):
+    parser = smtp_send._build_parser()
+
+    args = parser.parse_args(["--to", "bob@example.com", "--subject", "Hello", "--body", "Body"])
+
+    assert "seconds" not in vars(args)

--- a/agent/skills/email-client/tests/test_pending_send.py
+++ b/agent/skills/email-client/tests/test_pending_send.py
@@ -28,7 +28,7 @@ def test_pending_send_uses_the_client_delay_and_can_be_claimed_once(tmp_path):
     )
 
     assert queued.send_at == now + timedelta(seconds=30)
-    assert [item.id for item in pending_send.list_pending(tmp_path, now=now)] == [queued.id]
+    assert [item.id for item in pending_send.list_pending(tmp_path)] == [queued.id]
     assert pending_send.claim_due(tmp_path, now=queued.send_at - timedelta(microseconds=1)) is None
     assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
     assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
@@ -47,14 +47,19 @@ def test_undo_removes_a_pending_send_before_delivery(tmp_path):
         now=now,
     )
 
-    cancelled = pending_send.cancel(tmp_path, queued.id, now=queued.send_at - timedelta(microseconds=1))
+    cancelled = pending_send.cancel(tmp_path, queued.id)
 
     assert cancelled.id == queued.id
     assert pending_send.list_pending(tmp_path) == []
     assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
 
 
-def test_undo_rejects_a_send_after_its_recovery_window(tmp_path):
+def test_undo_rejects_an_unknown_send(tmp_path):
+    with pytest.raises(ValueError, match="was not found"):
+        pending_send.cancel(tmp_path, "nope")
+
+
+def test_an_overdue_send_stays_listed_and_undoable_until_it_is_dispatched(tmp_path):
     now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
     queued = pending_send.enqueue(
         tmp_path,
@@ -67,9 +72,27 @@ def test_undo_rejects_a_send_after_its_recovery_window(tmp_path):
         now=now,
     )
 
-    with pytest.raises(ValueError, match="expired"):
-        pending_send.cancel(tmp_path, queued.id, now=queued.send_at)
-    assert pending_send.list_pending(tmp_path, now=queued.send_at) == []
+    assert [item.id for item in pending_send.list_pending(tmp_path)] == [queued.id]
+
+    pending_send.cancel(tmp_path, queued.id)
+
+    assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
+
+
+def test_a_send_being_dispatched_can_no_longer_be_undone(tmp_path):
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="personal",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend="smtp",
+        payload=b"mime",
+    )
+    pending_send.claim_due(tmp_path, now=queued.send_at)
+
+    with pytest.raises(ValueError, match="being delivered"):
+        pending_send.cancel(tmp_path, queued.id)
 
 
 def test_changing_delay_only_affects_new_sends(tmp_path):
@@ -100,7 +123,7 @@ def test_changing_delay_only_affects_new_sends(tmp_path):
     assert second.send_at == now + timedelta(seconds=75)
 
 
-def test_dispatching_send_recovers_after_daemon_restart(tmp_path):
+def test_a_send_interrupted_mid_dispatch_is_held_instead_of_resent(tmp_path):
     queued = pending_send.enqueue(
         tmp_path,
         account="personal",
@@ -114,7 +137,31 @@ def test_dispatching_send_recovers_after_daemon_restart(tmp_path):
 
     pending_send.recover_dispatching(tmp_path)
 
-    assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
+    assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
+    held = pending_send.list_pending(tmp_path)[0]
+    assert held.public()["status"] == "failed"
+    assert held.public()["last_error"] == pending_send.INTERRUPTED_ERROR
+
+
+def test_delivery_stops_retrying_once_it_has_burned_its_attempts(tmp_path):
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="personal",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend="smtp",
+        payload=b"mime",
+    )
+    at = queued.send_at
+
+    for _ in range(pending_send.MAX_DELIVERY_ATTEMPTS):
+        at = at + timedelta(seconds=pending_send.RETRY_DELAY_SECONDS)
+        assert pending_send.claim_due(tmp_path, now=at).id == queued.id
+        pending_send.retry(tmp_path, queued.id, "smtp refused", now=at)
+
+    assert pending_send.claim_due(tmp_path, now=at + timedelta(hours=1)) is None
+    assert pending_send.list_pending(tmp_path)[0].public()["last_error"] == "smtp refused"
 
 
 def _smtp_profile():
@@ -133,6 +180,10 @@ def _patch_account(monkeypatch):
     monkeypatch.setattr(smtp_send, "account_profile", lambda _account: _smtp_profile())
 
 
+def _patch_daemon(monkeypatch, *, running):
+    monkeypatch.setattr(smtp_send.daemon_lifecycle, "daemon_running", lambda _state_dir: (running, 4242 if running else None))
+
+
 def _original_message():
     return {
         "message_id": "<original@example.com>",
@@ -149,6 +200,7 @@ def _original_message():
 def test_smtp_send_queues_the_composed_message_and_attachments(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
     _patch_account(monkeypatch)
+    _patch_daemon(monkeypatch, running=True)
     attachment = tmp_path / "report.pdf"
     attachment.write_bytes(b"pdf")
     delivered = []
@@ -177,6 +229,7 @@ def test_smtp_send_queues_the_composed_message_and_attachments(tmp_path, monkeyp
 def test_smtp_all_outbound_actions_inherit_the_client_delay(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
     _patch_account(monkeypatch)
+    _patch_daemon(monkeypatch, running=True)
     monkeypatch.setattr(smtp_send, "fetch_original", lambda *_args: _original_message())
     pending_send.set_delay_seconds(tmp_path, 45)
     attachment = tmp_path / "report.pdf"
@@ -216,6 +269,7 @@ def test_smtp_all_outbound_actions_inherit_the_client_delay(tmp_path, monkeypatc
 def test_smtp_zero_client_delay_sends_immediately(tmp_path, monkeypatch):
     monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
     _patch_account(monkeypatch)
+    _patch_daemon(monkeypatch, running=True)
     pending_send.set_delay_seconds(tmp_path, 0)
     delivered = []
     monkeypatch.setattr(smtp_send, "_smtp_deliver", lambda *_args: delivered.append(True))
@@ -230,6 +284,7 @@ def test_smtp_zero_client_delay_sends_immediately(tmp_path, monkeypatch):
 def test_smtp_dispatch_delivers_once_then_runs_sent_side_effects(tmp_path, monkeypatch):
     monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
     _patch_account(monkeypatch)
+    _patch_daemon(monkeypatch, running=True)
     smtp_send.send(smtp_send.SendRequest(to="bob@example.com", subject="Hello", body="Body", account="personal"))
     queued = pending_send.list_pending(tmp_path)[0]
     delivered = []
@@ -246,6 +301,7 @@ def test_smtp_dispatch_delivers_once_then_runs_sent_side_effects(tmp_path, monke
 def test_smtp_reply_side_effects_wait_for_delivery(tmp_path, monkeypatch):
     monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
     _patch_account(monkeypatch)
+    _patch_daemon(monkeypatch, running=True)
     monkeypatch.setattr(smtp_send, "fetch_original", lambda *_args: _original_message())
     answered = []
     monkeypatch.setattr(smtp_send, "_mark_answered", lambda *_args: answered.append(True))
@@ -272,6 +328,7 @@ def test_smtp_reply_side_effects_wait_for_delivery(tmp_path, monkeypatch):
 def test_smtp_dispatch_retries_cli_style_delivery_failures(tmp_path, monkeypatch):
     monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
     _patch_account(monkeypatch)
+    _patch_daemon(monkeypatch, running=True)
     smtp_send.send(smtp_send.SendRequest(to="bob@example.com", subject="Hello", body="Body", account="personal"))
     queued = pending_send.list_pending(tmp_path)[0]
 
@@ -291,3 +348,15 @@ def test_delay_is_client_configuration_not_a_send_option(tmp_path):
     args = parser.parse_args(["--to", "bob@example.com", "--subject", "Hello", "--body", "Body"])
 
     assert "seconds" not in vars(args)
+
+
+def test_a_delayed_send_is_refused_when_no_daemon_can_dispatch_it(tmp_path, monkeypatch):
+    monkeypatch.setenv("EMAIL_CLIENT_DIR", str(tmp_path))
+    _patch_account(monkeypatch)
+    _patch_daemon(monkeypatch, running=False)
+    monkeypatch.setattr(smtp_send, "_smtp_deliver", lambda *_args: pytest.fail("must not deliver"))
+
+    with pytest.raises(SystemExit, match="daemon start"):
+        smtp_send.send(smtp_send.SendRequest(to="bob@example.com", subject="Hello", body="Body", account="personal"))
+
+    assert pending_send.list_pending(tmp_path) == []

--- a/agent/skills/google/SKILL.md
+++ b/agent/skills/google/SKILL.md
@@ -34,7 +34,9 @@ google email pending
 google email undo --id <pending_id>
 ```
 
-The send or reply command creates a Gmail draft and returns a `pending` status with its id and scheduled send time. The background daemon sends due drafts. Use `undo` before the deadline to cancel the pending send and delete its Gmail draft. Keep `google serve` running whenever the delay is nonzero. Set `--seconds 0` for immediate delivery. Explicit drafts are never queued.
+The send or reply command creates a Gmail draft and returns a `pending` status with its id and scheduled send time. `google serve` sends due drafts, and every email command already requires it to be running. Use `undo` to cancel a pending send and delete its Gmail draft: it works right up until the daemon starts dispatching that message. Set `--seconds 0` for immediate delivery. Explicit drafts are never queued.
+
+`pending` also lists messages whose status is `failed`, with `last_error` saying why: delivery kept erroring, or it was cut off mid-dispatch. A message cut off mid-dispatch may already have been sent, so read the Sent folder before you `undo` it or send it again.
 
 ## Calendar (Google Calendar REST API v3)
 

--- a/agent/skills/google/SKILL.md
+++ b/agent/skills/google/SKILL.md
@@ -25,6 +25,17 @@ google email reply --id <message_id> --body "Thanks!"
 google email search --query "project update"
 ```
 
+Email sends and replies wait 30 seconds by default. The delay is one persisted setting for the Google client and cannot be overridden on an individual send:
+
+```bash
+google email send-delay
+google email send-delay --seconds 60
+google email pending
+google email undo --id <pending_id>
+```
+
+The send or reply command creates a Gmail draft and returns a `pending` status with its id and scheduled send time. The background daemon sends due drafts. Use `undo` before the deadline to cancel the pending send and delete its Gmail draft. Keep `google serve` running whenever the delay is nonzero. Set `--seconds 0` for immediate delivery. Explicit drafts are never queued.
+
 ## Calendar (Google Calendar REST API v3)
 
 ```bash

--- a/agent/skills/google/cli/src/google_cli/cli.py
+++ b/agent/skills/google/cli/src/google_cli/cli.py
@@ -7,9 +7,12 @@ import sys
 import threading
 from pathlib import Path
 
-from . import auth_commands, calendar, gmail, monitor, notifications
+from . import auth_commands, calendar, gmail, monitor, notifications, pending_send
 from .config import Config
 from .context import GoogleContext
+
+_PENDING_POLL_SECONDS = 1
+_PENDING_JOIN_TIMEOUT_SECONDS = 5
 
 
 def _write_pid(config):
@@ -85,6 +88,14 @@ def _add_email_commands(group):
     p_reply.add_argument("--body", required=True)
     p_reply.add_argument("--attachments", nargs="+", default=None)
     p_reply.add_argument("--reply-all", action="store_true")
+
+    p_send_delay = email_sub.add_parser("send-delay")
+    p_send_delay.add_argument("--seconds", type=int, default=None)
+
+    email_sub.add_parser("pending")
+
+    p_undo = email_sub.add_parser("undo")
+    p_undo.add_argument("--id", required=True, dest="pending_id")
 
     p_attachment = email_sub.add_parser("attachment")
     p_attachment.add_argument("--email-id", required=True)
@@ -206,6 +217,17 @@ def _draft_only_enabled():
 def _dispatch_email(args, config):
     if args.command in _TRANSMIT_EMAIL_COMMANDS and _draft_only_enabled():
         raise RuntimeError("draft-only mode (EMAIL_DRAFT_ONLY): sending is disabled. Create a draft instead (email draft ...).")
+    if args.command == "send-delay":
+        seconds = (
+            pending_send.delay_seconds(config.data_dir)
+            if args.seconds is None
+            else pending_send.set_delay_seconds(config.data_dir, args.seconds)
+        )
+        return {"send_delay_seconds": seconds}
+    if args.command == "pending":
+        return [queued.public() for queued in pending_send.list_pending(config.data_dir)]
+    if args.command == "undo":
+        return gmail.undo_pending(config, args.pending_id)
     handlers = {
         "list": lambda: gmail.list_emails(config, label=args.label, limit=args.limit),
         "get": lambda: gmail.get_email(
@@ -323,9 +345,29 @@ def _run_serve(config: Config, notif_dir: Path):
     print(json.dumps({"status": "serving"}))
     sys.stdout.flush()
 
+    pending_thread = threading.Thread(
+        target=_run_pending_dispatcher,
+        args=(config, monitor_stop_event, monitor_logger),
+        name="google-pending-send",
+        daemon=True,
+    )
     _write_pid(config)
     try:
+        pending_thread.start()
         monitor.run(ctx)
     finally:
+        monitor_stop_event.set()
+        pending_thread.join(timeout=_PENDING_JOIN_TIMEOUT_SECONDS)
         notifications.write_notification(notif_dir, "daemon_died", reason=shutdown_reason)
         _remove_pid(config)
+
+
+def _run_pending_dispatcher(config: Config, stop_event: threading.Event, logger: logging.Logger) -> None:
+    pending_send.recover_dispatching(config.data_dir)
+    while not stop_event.is_set():
+        try:
+            if gmail.dispatch_due(config):
+                continue
+        except Exception:
+            logger.exception("Error dispatching pending email")
+        stop_event.wait(_PENDING_POLL_SECONDS)

--- a/agent/skills/google/cli/src/google_cli/gmail.py
+++ b/agent/skills/google/cli/src/google_cli/gmail.py
@@ -1,6 +1,7 @@
 import base64
 import pathlib as pl
 import re
+from datetime import datetime
 from email import encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
@@ -8,7 +9,7 @@ from email.mime.text import MIMEText
 from html.parser import HTMLParser
 from typing import Any
 
-from . import api
+from . import api, pending_send
 from .config import Config
 
 EMAIL_SAVE_SUBDIR = "emails"
@@ -307,8 +308,14 @@ def send_email(
 ) -> dict[str, str]:
     service = api.gmail_service(config)
     raw = _build_mime_message(to, subject, body, cc=cc, attachments=attachments)
-    result = api.retry(lambda: service.users().messages().send(userId="me", body={"raw": raw}).execute())
-    return {"status": "sent", "id": result["id"] if "id" in result else ""}
+    return _send_or_queue(
+        config,
+        service,
+        message={"raw": raw},
+        action="send",
+        subject=subject,
+        recipients=", ".join([*to, *(cc or [])]),
+    )
 
 
 def create_draft(
@@ -374,12 +381,70 @@ def reply_to_email(
         msg["References"] = f"{references} {message_id_header}".strip() if references else message_id_header
 
     raw = base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii")
-    send_body: dict[str, Any] = {"raw": raw}
+    send_body: dict[str, str] = {"raw": raw}
     if thread_id:
         send_body["threadId"] = thread_id
 
-    result = api.retry(lambda: service.users().messages().send(userId="me", body=send_body).execute())
-    return {"status": "sent", "id": result["id"] if "id" in result else ""}
+    return _send_or_queue(
+        config,
+        service,
+        message=send_body,
+        action="reply-all" if reply_all else "reply",
+        subject=subject,
+        recipients=", ".join([*to_addrs, *(cc or [])]),
+    )
+
+
+def _send_or_queue(
+    config: Config,
+    service,
+    *,
+    message: dict[str, str],
+    action: str,
+    subject: str,
+    recipients: str,
+) -> dict[str, str]:
+    if pending_send.delay_seconds(config.data_dir) == 0:
+        result = api.retry(lambda: service.users().messages().send(userId="me", body=message).execute())
+        return {"status": "sent", "id": result["id"] if "id" in result else ""}
+
+    draft = api.retry(lambda: service.users().drafts().create(userId="me", body={"message": message}).execute())
+    draft_id = draft["id"] if "id" in draft else ""
+    if not draft_id:
+        raise ValueError("Gmail did not return an id for the pending draft")
+    queued = pending_send.enqueue(
+        config.data_dir,
+        account="google",
+        action=action,
+        subject=subject,
+        recipients=recipients,
+        backend="gmail",
+        payload=draft_id.encode(),
+    )
+    return queued.public()
+
+
+def dispatch_due(config: Config, *, now: datetime | None = None) -> bool:
+    queued = pending_send.claim_due(config.data_dir, now=now)
+    if queued is None:
+        return False
+    try:
+        service = api.gmail_service(config)
+        draft_id = queued.payload.decode()
+        api.retry(lambda: service.users().drafts().send(userId="me", body={"id": draft_id}).execute())
+    except Exception as error:
+        pending_send.retry(config.data_dir, queued.id, str(error), now=now)
+        raise
+    pending_send.complete(config.data_dir, queued.id)
+    return True
+
+
+def undo_pending(config: Config, pending_id: str) -> dict[str, str]:
+    queued = pending_send.cancel(config.data_dir, pending_id)
+    service = api.gmail_service(config)
+    api.retry(lambda: service.users().drafts().delete(userId="me", id=queued.payload.decode()).execute())
+    pending_send.finish_cancel(config.data_dir, pending_id)
+    return {"id": pending_id, "status": "cancelled"}
 
 
 def get_attachment(config: Config, *, email_id: str, attachment_id: str, save_path: str) -> dict[str, Any]:

--- a/agent/skills/google/cli/src/google_cli/pending_send.py
+++ b/agent/skills/google/cli/src/google_cli/pending_send.py
@@ -12,7 +12,11 @@ from pathlib import Path
 
 DEFAULT_DELAY_SECONDS = 30
 RETRY_DELAY_SECONDS = 30
+MAX_DELIVERY_ATTEMPTS = 3
+INTERRUPTED_ERROR = "dispatch was interrupted; check the Sent folder before undoing or resending"
 _DATABASE_NAME = "pending-sends.db"
+_UNDOABLE_STATES = "('pending', 'failed')"
+_COLUMNS = "id, created_at, send_at, account, action, subject, recipients, backend, payload, state, last_error"
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS settings (
     key TEXT PRIMARY KEY,
@@ -29,7 +33,8 @@ CREATE TABLE IF NOT EXISTS sends (
     backend TEXT NOT NULL,
     payload BLOB NOT NULL,
     state TEXT NOT NULL,
-    last_error TEXT
+    last_error TEXT NOT NULL DEFAULT '',
+    attempts INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS sends_due ON sends(state, send_at);
 """
@@ -46,17 +51,22 @@ class PendingSend:
     recipients: str
     backend: str
     payload: bytes
+    state: str = "pending"
+    last_error: str = ""
 
     def public(self) -> dict[str, str]:
-        return {
+        described = {
             "id": self.id,
-            "status": "pending",
+            "status": self.state,
             "account": self.account,
             "action": self.action,
             "subject": self.subject,
             "recipients": self.recipients,
             "send_at": self.send_at.isoformat(),
         }
+        if self.last_error:
+            described["last_error"] = self.last_error
+        return described
 
 
 @contextlib.contextmanager
@@ -82,6 +92,8 @@ def _from_row(row: sqlite3.Row | tuple) -> PendingSend:
         recipients=str(row[6]),
         backend=str(row[7]),
         payload=bytes(row[8]),
+        state=str(row[9]),
+        last_error=str(row[10]),
     )
 
 
@@ -144,35 +156,21 @@ def enqueue(
     return queued
 
 
-def list_pending(data_dir: Path, *, account: str | None = None, now: datetime | None = None) -> list[PendingSend]:
-    undoable_at = now or datetime.now(UTC)
+def list_pending(data_dir: Path, *, account: str | None = None) -> list[PendingSend]:
     with _connection(data_dir) as connection:
-        if account is None:
-            rows = connection.execute(
-                "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
-                "FROM sends WHERE state = 'pending' AND send_at > ? ORDER BY send_at, id",
-                (undoable_at.isoformat(),),
-            ).fetchall()
-        else:
-            rows = connection.execute(
-                "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
-                "FROM sends WHERE state = 'pending' AND account = ? AND send_at > ? ORDER BY send_at, id",
-                (account, undoable_at.isoformat()),
-            ).fetchall()
+        rows = connection.execute(
+            f"SELECT {_COLUMNS} FROM sends WHERE state IN {_UNDOABLE_STATES} AND (? IS NULL OR account = ?) ORDER BY send_at, id",
+            (account, account),
+        ).fetchall()
     return [_from_row(row) for row in rows]
 
 
-def cancel(data_dir: Path, pending_id: str, *, now: datetime | None = None) -> PendingSend:
-    cancel_at = now or datetime.now(UTC)
+def cancel(data_dir: Path, pending_id: str) -> PendingSend:
     with _connection(data_dir) as connection:
         connection.execute("BEGIN IMMEDIATE")
-        row = connection.execute(
-            "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
-            "FROM sends WHERE id = ? AND state = 'pending' AND send_at > ?",
-            (pending_id, cancel_at.isoformat()),
-        ).fetchone()
+        row = connection.execute(f"SELECT {_COLUMNS} FROM sends WHERE id = ? AND state IN {_UNDOABLE_STATES}", (pending_id,)).fetchone()
         if row is None:
-            raise ValueError(f"pending send {pending_id!r} was not found, has expired, or has already been delivered")
+            raise ValueError(f"pending send {pending_id!r} was not found, is being delivered right now, or has already been delivered")
         connection.execute("UPDATE sends SET state = 'cancelled' WHERE id = ?", (pending_id,))
     return _from_row(row)
 
@@ -187,13 +185,12 @@ def claim_due(data_dir: Path, *, now: datetime | None = None) -> PendingSend | N
     with _connection(data_dir) as connection:
         connection.execute("BEGIN IMMEDIATE")
         row = connection.execute(
-            "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
-            "FROM sends WHERE state = 'pending' AND send_at <= ? ORDER BY send_at, id LIMIT 1",
+            f"SELECT {_COLUMNS} FROM sends WHERE state = 'pending' AND send_at <= ? ORDER BY send_at, id LIMIT 1",
             (due_at.isoformat(),),
         ).fetchone()
         if row is None:
             return None
-        connection.execute("UPDATE sends SET state = 'dispatching' WHERE id = ?", (str(row[0]),))
+        connection.execute("UPDATE sends SET state = 'dispatching', attempts = attempts + 1 WHERE id = ?", (str(row[0]),))
     return _from_row(row)
 
 
@@ -206,11 +203,14 @@ def retry(data_dir: Path, pending_id: str, error: str, *, now: datetime | None =
     retry_at = (now or datetime.now(UTC)) + timedelta(seconds=RETRY_DELAY_SECONDS)
     with _connection(data_dir) as connection:
         connection.execute(
-            "UPDATE sends SET state = 'pending', send_at = ?, last_error = ? WHERE id = ? AND state = 'dispatching'",
-            (retry_at.isoformat(), error, pending_id),
+            "UPDATE sends SET state = CASE WHEN attempts >= ? THEN 'failed' ELSE 'pending' END, send_at = ?, last_error = ? "
+            "WHERE id = ? AND state = 'dispatching'",
+            (MAX_DELIVERY_ATTEMPTS, retry_at.isoformat(), error, pending_id),
         )
 
 
 def recover_dispatching(data_dir: Path) -> None:
+    # A claimed row may have reached the server before the process died, so re-sending it
+    # would duplicate the mail. Hold it for the agent to resolve instead.
     with _connection(data_dir) as connection:
-        connection.execute("UPDATE sends SET state = 'pending' WHERE state = 'dispatching'")
+        connection.execute("UPDATE sends SET state = 'failed', last_error = ? WHERE state = 'dispatching'", (INTERRUPTED_ERROR,))

--- a/agent/skills/google/cli/src/google_cli/pending_send.py
+++ b/agent/skills/google/cli/src/google_cli/pending_send.py
@@ -1,0 +1,216 @@
+"""Durable delayed-send state owned by the Google email client."""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+DEFAULT_DELAY_SECONDS = 30
+RETRY_DELAY_SECONDS = 30
+_DATABASE_NAME = "pending-sends.db"
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS sends (
+    id TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL,
+    send_at TEXT NOT NULL,
+    account TEXT NOT NULL,
+    action TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    recipients TEXT NOT NULL,
+    backend TEXT NOT NULL,
+    payload BLOB NOT NULL,
+    state TEXT NOT NULL,
+    last_error TEXT
+);
+CREATE INDEX IF NOT EXISTS sends_due ON sends(state, send_at);
+"""
+
+
+@dataclass(frozen=True)
+class PendingSend:
+    id: str
+    created_at: datetime
+    send_at: datetime
+    account: str
+    action: str
+    subject: str
+    recipients: str
+    backend: str
+    payload: bytes
+
+    def public(self) -> dict[str, str]:
+        return {
+            "id": self.id,
+            "status": "pending",
+            "account": self.account,
+            "action": self.action,
+            "subject": self.subject,
+            "recipients": self.recipients,
+            "send_at": self.send_at.isoformat(),
+        }
+
+
+@contextlib.contextmanager
+def _connection(data_dir: Path) -> Iterator[sqlite3.Connection]:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(data_dir / _DATABASE_NAME)
+    try:
+        connection.executescript(_SCHEMA)
+        yield connection
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _from_row(row: sqlite3.Row | tuple) -> PendingSend:
+    return PendingSend(
+        id=str(row[0]),
+        created_at=datetime.fromisoformat(str(row[1])),
+        send_at=datetime.fromisoformat(str(row[2])),
+        account=str(row[3]),
+        action=str(row[4]),
+        subject=str(row[5]),
+        recipients=str(row[6]),
+        backend=str(row[7]),
+        payload=bytes(row[8]),
+    )
+
+
+def delay_seconds(data_dir: Path) -> int:
+    with _connection(data_dir) as connection:
+        row = connection.execute("SELECT value FROM settings WHERE key = 'send_delay_seconds'").fetchone()
+    return int(row[0]) if row is not None else DEFAULT_DELAY_SECONDS
+
+
+def set_delay_seconds(data_dir: Path, seconds: int) -> int:
+    if seconds < 0:
+        raise ValueError("send delay must be zero or greater")
+    with _connection(data_dir) as connection:
+        connection.execute(
+            "INSERT INTO settings(key, value) VALUES('send_delay_seconds', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (seconds,),
+        )
+    return seconds
+
+
+def enqueue(
+    data_dir: Path,
+    *,
+    account: str,
+    action: str,
+    subject: str,
+    recipients: str,
+    backend: str,
+    payload: bytes,
+    now: datetime | None = None,
+) -> PendingSend:
+    created_at = now or datetime.now(UTC)
+    queued = PendingSend(
+        id=uuid.uuid4().hex,
+        created_at=created_at,
+        send_at=created_at + timedelta(seconds=delay_seconds(data_dir)),
+        account=account,
+        action=action,
+        subject=subject,
+        recipients=recipients,
+        backend=backend,
+        payload=payload,
+    )
+    with _connection(data_dir) as connection:
+        connection.execute(
+            "INSERT INTO sends(id, created_at, send_at, account, action, subject, recipients, backend, payload, state) "
+            "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')",
+            (
+                queued.id,
+                queued.created_at.isoformat(),
+                queued.send_at.isoformat(),
+                queued.account,
+                queued.action,
+                queued.subject,
+                queued.recipients,
+                queued.backend,
+                queued.payload,
+            ),
+        )
+    return queued
+
+
+def list_pending(data_dir: Path, *, account: str | None = None, now: datetime | None = None) -> list[PendingSend]:
+    undoable_at = now or datetime.now(UTC)
+    with _connection(data_dir) as connection:
+        if account is None:
+            rows = connection.execute(
+                "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
+                "FROM sends WHERE state = 'pending' AND send_at > ? ORDER BY send_at, id",
+                (undoable_at.isoformat(),),
+            ).fetchall()
+        else:
+            rows = connection.execute(
+                "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
+                "FROM sends WHERE state = 'pending' AND account = ? AND send_at > ? ORDER BY send_at, id",
+                (account, undoable_at.isoformat()),
+            ).fetchall()
+    return [_from_row(row) for row in rows]
+
+
+def cancel(data_dir: Path, pending_id: str, *, now: datetime | None = None) -> PendingSend:
+    cancel_at = now or datetime.now(UTC)
+    with _connection(data_dir) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        row = connection.execute(
+            "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
+            "FROM sends WHERE id = ? AND state = 'pending' AND send_at > ?",
+            (pending_id, cancel_at.isoformat()),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"pending send {pending_id!r} was not found, has expired, or has already been delivered")
+        connection.execute("UPDATE sends SET state = 'cancelled' WHERE id = ?", (pending_id,))
+    return _from_row(row)
+
+
+def finish_cancel(data_dir: Path, pending_id: str) -> None:
+    with _connection(data_dir) as connection:
+        connection.execute("DELETE FROM sends WHERE id = ? AND state = 'cancelled'", (pending_id,))
+
+
+def claim_due(data_dir: Path, *, now: datetime | None = None) -> PendingSend | None:
+    due_at = now or datetime.now(UTC)
+    with _connection(data_dir) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        row = connection.execute(
+            "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
+            "FROM sends WHERE state = 'pending' AND send_at <= ? ORDER BY send_at, id LIMIT 1",
+            (due_at.isoformat(),),
+        ).fetchone()
+        if row is None:
+            return None
+        connection.execute("UPDATE sends SET state = 'dispatching' WHERE id = ?", (str(row[0]),))
+    return _from_row(row)
+
+
+def complete(data_dir: Path, pending_id: str) -> None:
+    with _connection(data_dir) as connection:
+        connection.execute("DELETE FROM sends WHERE id = ? AND state = 'dispatching'", (pending_id,))
+
+
+def retry(data_dir: Path, pending_id: str, error: str, *, now: datetime | None = None) -> None:
+    retry_at = (now or datetime.now(UTC)) + timedelta(seconds=RETRY_DELAY_SECONDS)
+    with _connection(data_dir) as connection:
+        connection.execute(
+            "UPDATE sends SET state = 'pending', send_at = ?, last_error = ? WHERE id = ? AND state = 'dispatching'",
+            (retry_at.isoformat(), error, pending_id),
+        )
+
+
+def recover_dispatching(data_dir: Path) -> None:
+    with _connection(data_dir) as connection:
+        connection.execute("UPDATE sends SET state = 'pending' WHERE state = 'dispatching'")

--- a/agent/skills/google/cli/tests/test_pending_send.py
+++ b/agent/skills/google/cli/tests/test_pending_send.py
@@ -1,0 +1,310 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from google_cli import cli, gmail, pending_send
+from google_cli.config import Config
+
+
+def test_delay_defaults_to_thirty_seconds_and_persists(tmp_path):
+    assert pending_send.delay_seconds(tmp_path) == 30
+
+    pending_send.set_delay_seconds(tmp_path, 90)
+
+    assert pending_send.delay_seconds(tmp_path) == 90
+
+
+def test_pending_send_uses_the_client_delay_and_can_be_claimed_once(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="google",
+        action="reply-all",
+        subject="Re: Hello",
+        recipients="bob@example.com",
+        backend="gmail",
+        payload=b"draft-1",
+        now=now,
+    )
+
+    assert queued.send_at == now + timedelta(seconds=30)
+    assert [item.id for item in pending_send.list_pending(tmp_path, now=now)] == [queued.id]
+    assert pending_send.claim_due(tmp_path, now=queued.send_at - timedelta(microseconds=1)) is None
+    assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
+    assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
+
+
+def test_undo_removes_a_pending_send_before_delivery(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="google",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend="gmail",
+        payload=b"draft-1",
+        now=now,
+    )
+
+    cancelled = pending_send.cancel(tmp_path, queued.id, now=queued.send_at - timedelta(microseconds=1))
+
+    assert cancelled.id == queued.id
+    assert pending_send.list_pending(tmp_path) == []
+    assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
+
+
+def test_undo_rejects_a_send_after_its_recovery_window(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="google",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend="gmail",
+        payload=b"draft-1",
+        now=now,
+    )
+
+    with pytest.raises(ValueError, match="expired"):
+        pending_send.cancel(tmp_path, queued.id, now=queued.send_at)
+    assert pending_send.list_pending(tmp_path, now=queued.send_at) == []
+
+
+def test_changing_delay_only_affects_new_sends(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+    first = pending_send.enqueue(
+        tmp_path,
+        account="google",
+        action="send",
+        subject="First",
+        recipients="bob@example.com",
+        backend="gmail",
+        payload=b"first",
+        now=now,
+    )
+    pending_send.set_delay_seconds(tmp_path, 90)
+    second = pending_send.enqueue(
+        tmp_path,
+        account="google",
+        action="send",
+        subject="Second",
+        recipients="bob@example.com",
+        backend="gmail",
+        payload=b"second",
+        now=now,
+    )
+
+    assert first.send_at == now + timedelta(seconds=30)
+    assert second.send_at == now + timedelta(seconds=90)
+
+
+def test_dispatching_send_recovers_after_daemon_restart(tmp_path):
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="google",
+        action="reply",
+        subject="Re: Hello",
+        recipients="bob@example.com",
+        backend="gmail",
+        payload=b"draft-1",
+    )
+    assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
+
+    pending_send.recover_dispatching(tmp_path)
+
+    assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
+
+
+class _Request:
+    def __init__(self, result):
+        self.result = result
+
+    def execute(self):
+        return self.result
+
+
+class _Messages:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def send(self, **kwargs):
+        self.calls.append(("message-send", kwargs))
+        return _Request({"id": "sent-1"})
+
+    def get(self, **kwargs):
+        self.calls.append(("message-get", kwargs))
+        return _Request(
+            {
+                "threadId": "thread-1",
+                "payload": {
+                    "headers": [
+                        {"name": "Subject", "value": "Hello"},
+                        {"name": "From", "value": "alice@example.com"},
+                        {"name": "To", "value": "me@example.com"},
+                        {"name": "Message-ID", "value": "<original@example.com>"},
+                    ]
+                },
+            }
+        )
+
+
+class _Drafts:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def create(self, **kwargs):
+        self.calls.append(("draft-create", kwargs))
+        return _Request({"id": "draft-1", "message": {"id": "message-1"}})
+
+    def send(self, **kwargs):
+        self.calls.append(("draft-send", kwargs))
+        return _Request({"id": "sent-1"})
+
+    def delete(self, **kwargs):
+        self.calls.append(("draft-delete", kwargs))
+        return _Request({})
+
+
+class _Users:
+    def __init__(self, calls):
+        self.messages_api = _Messages(calls)
+        self.drafts_api = _Drafts(calls)
+
+    def messages(self):
+        return self.messages_api
+
+    def drafts(self):
+        return self.drafts_api
+
+
+class _Gmail:
+    def __init__(self):
+        self.calls = []
+        self.users_api = _Users(self.calls)
+
+    def users(self):
+        return self.users_api
+
+
+def test_send_creates_a_provider_draft_and_returns_pending(tmp_path, monkeypatch):
+    service = _Gmail()
+    config = Config(data_dir=tmp_path)
+    attachment = tmp_path / "report.pdf"
+    attachment.write_bytes(b"pdf")
+    monkeypatch.setattr(gmail.api, "gmail_service", lambda _config: service)
+
+    result = gmail.send_email(config, to=["bob@example.com"], subject="Hello", body="Body", attachments=[str(attachment)])
+
+    assert result["status"] == "pending"
+    assert [name for name, _kwargs in service.calls] == ["draft-create"]
+    queued = pending_send.list_pending(tmp_path)
+    assert len(queued) == 1
+    assert queued[0].payload == b"draft-1"
+
+
+def test_all_google_outbound_actions_inherit_the_client_delay(tmp_path, monkeypatch):
+    service = _Gmail()
+    config = Config(data_dir=tmp_path)
+    pending_send.set_delay_seconds(tmp_path, 45)
+    monkeypatch.setattr(gmail.api, "gmail_service", lambda _config: service)
+
+    gmail.send_email(config, to=["bob@example.com"], subject="Hello", body="Body")
+    gmail.reply_to_email(config, message_id="original-1", body="Reply")
+    gmail.reply_to_email(config, message_id="original-2", body="Reply all", reply_all=True)
+
+    queued = pending_send.list_pending(tmp_path)
+    assert [item.action for item in queued] == ["send", "reply", "reply-all"]
+    assert all(item.send_at - item.created_at == timedelta(seconds=45) for item in queued)
+
+
+def test_zero_client_delay_sends_immediately(tmp_path, monkeypatch):
+    service = _Gmail()
+    config = Config(data_dir=tmp_path)
+    pending_send.set_delay_seconds(tmp_path, 0)
+    monkeypatch.setattr(gmail.api, "gmail_service", lambda _config: service)
+
+    result = gmail.send_email(config, to=["bob@example.com"], subject="Hello", body="Body")
+
+    assert result == {"status": "sent", "id": "sent-1"}
+    assert [name for name, _kwargs in service.calls] == ["message-send"]
+    assert pending_send.list_pending(tmp_path) == []
+
+
+def test_reply_all_is_queued_as_a_threaded_provider_draft(tmp_path, monkeypatch):
+    service = _Gmail()
+    config = Config(data_dir=tmp_path)
+    monkeypatch.setattr(gmail.api, "gmail_service", lambda _config: service)
+
+    result = gmail.reply_to_email(config, message_id="original-1", body="Thanks", reply_all=True)
+
+    assert result["status"] == "pending"
+    assert [name for name, _kwargs in service.calls] == ["message-get", "draft-create"]
+    assert pending_send.list_pending(tmp_path)[0].action == "reply-all"
+
+
+def test_reply_attachment_is_resolved_before_the_provider_draft_is_queued(tmp_path, monkeypatch):
+    service = _Gmail()
+    config = Config(data_dir=tmp_path)
+    attachment = tmp_path / "report.pdf"
+    attachment.write_bytes(b"pdf")
+    monkeypatch.setattr(gmail.api, "gmail_service", lambda _config: service)
+
+    result = gmail.reply_to_email(
+        config,
+        message_id="original-1",
+        body="Thanks",
+        attachments=[str(attachment)],
+    )
+
+    assert result["status"] == "pending"
+    assert [name for name, _kwargs in service.calls] == ["message-get", "draft-create"]
+
+
+def test_dispatch_sends_the_provider_draft_once(tmp_path, monkeypatch):
+    service = _Gmail()
+    config = Config(data_dir=tmp_path)
+    monkeypatch.setattr(gmail.api, "gmail_service", lambda _config: service)
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="google",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend="gmail",
+        payload=b"draft-1",
+    )
+
+    assert gmail.dispatch_due(config, now=queued.send_at) is True
+    assert gmail.dispatch_due(config, now=queued.send_at) is False
+    assert [name for name, _kwargs in service.calls] == ["draft-send"]
+
+
+def test_undo_deletes_the_provider_draft(tmp_path, monkeypatch):
+    service = _Gmail()
+    config = Config(data_dir=tmp_path)
+    monkeypatch.setattr(gmail.api, "gmail_service", lambda _config: service)
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="google",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend="gmail",
+        payload=b"draft-1",
+    )
+
+    result = gmail.undo_pending(config, queued.id)
+
+    assert result == {"id": queued.id, "status": "cancelled"}
+    assert [name for name, _kwargs in service.calls] == ["draft-delete"]
+    assert pending_send.list_pending(tmp_path) == []
+
+
+def test_delay_is_client_configuration_not_a_send_option(tmp_path):
+    parser = cli._build_parser()
+    send_args = parser.parse_args(["email", "send", "--to", "bob@example.com", "--subject", "Hello", "--body", "Body"])
+    delay_args = parser.parse_args(["email", "send-delay", "--seconds", "45"])
+
+    assert "seconds" not in vars(send_args)
+    assert cli._dispatch_email(delay_args, Config(data_dir=tmp_path)) == {"send_delay_seconds": 45}

--- a/agent/skills/google/cli/tests/test_pending_send.py
+++ b/agent/skills/google/cli/tests/test_pending_send.py
@@ -27,7 +27,7 @@ def test_pending_send_uses_the_client_delay_and_can_be_claimed_once(tmp_path):
     )
 
     assert queued.send_at == now + timedelta(seconds=30)
-    assert [item.id for item in pending_send.list_pending(tmp_path, now=now)] == [queued.id]
+    assert [item.id for item in pending_send.list_pending(tmp_path)] == [queued.id]
     assert pending_send.claim_due(tmp_path, now=queued.send_at - timedelta(microseconds=1)) is None
     assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
     assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
@@ -46,14 +46,19 @@ def test_undo_removes_a_pending_send_before_delivery(tmp_path):
         now=now,
     )
 
-    cancelled = pending_send.cancel(tmp_path, queued.id, now=queued.send_at - timedelta(microseconds=1))
+    cancelled = pending_send.cancel(tmp_path, queued.id)
 
     assert cancelled.id == queued.id
     assert pending_send.list_pending(tmp_path) == []
     assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
 
 
-def test_undo_rejects_a_send_after_its_recovery_window(tmp_path):
+def test_undo_rejects_an_unknown_send(tmp_path):
+    with pytest.raises(ValueError, match="was not found"):
+        pending_send.cancel(tmp_path, "nope")
+
+
+def test_an_overdue_send_stays_listed_and_undoable_until_it_is_dispatched(tmp_path):
     now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
     queued = pending_send.enqueue(
         tmp_path,
@@ -66,9 +71,27 @@ def test_undo_rejects_a_send_after_its_recovery_window(tmp_path):
         now=now,
     )
 
-    with pytest.raises(ValueError, match="expired"):
-        pending_send.cancel(tmp_path, queued.id, now=queued.send_at)
-    assert pending_send.list_pending(tmp_path, now=queued.send_at) == []
+    assert [item.id for item in pending_send.list_pending(tmp_path)] == [queued.id]
+
+    pending_send.cancel(tmp_path, queued.id)
+
+    assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
+
+
+def test_a_send_being_dispatched_can_no_longer_be_undone(tmp_path):
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="google",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend="gmail",
+        payload=b"draft-1",
+    )
+    pending_send.claim_due(tmp_path, now=queued.send_at)
+
+    with pytest.raises(ValueError, match="being delivered"):
+        pending_send.cancel(tmp_path, queued.id)
 
 
 def test_changing_delay_only_affects_new_sends(tmp_path):
@@ -99,7 +122,7 @@ def test_changing_delay_only_affects_new_sends(tmp_path):
     assert second.send_at == now + timedelta(seconds=90)
 
 
-def test_dispatching_send_recovers_after_daemon_restart(tmp_path):
+def test_a_send_interrupted_mid_dispatch_is_held_instead_of_resent(tmp_path):
     queued = pending_send.enqueue(
         tmp_path,
         account="google",
@@ -113,7 +136,31 @@ def test_dispatching_send_recovers_after_daemon_restart(tmp_path):
 
     pending_send.recover_dispatching(tmp_path)
 
-    assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
+    assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
+    held = pending_send.list_pending(tmp_path)[0]
+    assert held.public()["status"] == "failed"
+    assert held.public()["last_error"] == pending_send.INTERRUPTED_ERROR
+
+
+def test_delivery_stops_retrying_once_it_has_burned_its_attempts(tmp_path):
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="google",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend="gmail",
+        payload=b"draft-1",
+    )
+    at = queued.send_at
+
+    for _ in range(pending_send.MAX_DELIVERY_ATTEMPTS):
+        at = at + timedelta(seconds=pending_send.RETRY_DELAY_SECONDS)
+        assert pending_send.claim_due(tmp_path, now=at).id == queued.id
+        pending_send.retry(tmp_path, queued.id, "provider refused", now=at)
+
+    assert pending_send.claim_due(tmp_path, now=at + timedelta(hours=1)) is None
+    assert pending_send.list_pending(tmp_path)[0].public()["last_error"] == "provider refused"
 
 
 class _Request:

--- a/agent/skills/microsoft/SKILL.md
+++ b/agent/skills/microsoft/SKILL.md
@@ -20,8 +20,8 @@ Each area's detail lives in its own file, read it when you work in that area:
 
 ## Shared flags
 
-- `--account <email>` is required on every email/calendar/folder/teams command (list accounts with `microsoft auth list`; sign one out with `microsoft auth remove --account <email>`).
-- `--backend {auto,graph,owa-rest}` (default `auto`) picks the path; both backends support the full surface except `block`/`unblock` (Graph-only). See [SETUP.md](SETUP.md).
+- `--account <email>` is required on mailbox/calendar/folder/teams commands. Client-wide `email send-delay`, `email pending`, and `email undo` are the exceptions; `email pending` accepts an optional account filter. List accounts with `microsoft auth list`; sign one out with `microsoft auth remove --account <email>`.
+- `--backend {auto,graph,owa-rest}` (default `auto`) picks the path for mailbox operations; both backends support the full surface except `block`/`unblock` (Graph-only). Delayed-send management does not take this flag. See [SETUP.md](SETUP.md).
 - List commands (`email list`/`search`, `calendar list`/`calendars`, `folder list`, `teams chats`/`messages`/`teams`/`channels`) default to a compact tab-separated table; pass `--json` for one-line JSON or `--json-pretty` for indented JSON. Graph `@odata.*` metadata is stripped from every result.
 - `email list`/`search` take `--since YYYY-MM-DD` / `--until YYYY-MM-DD` (both inclusive) to reach mail by date. Plain `search` uses relevance-ranked `$search`, which buries old mail; the date flags switch to a `receivedDateTime` range filter ordered newest-first. See [references/email.md](references/email.md).
 

--- a/agent/skills/microsoft/cli/src/microsoft_cli/cli.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/cli.py
@@ -10,7 +10,21 @@ from pathlib import Path
 
 import httpx
 
-from . import auth_commands, backend, block, calendar, email, folders, monitor, notifications, notify, owa_rest, owa_rest_commands, teams
+from . import (
+    auth_commands,
+    backend,
+    block,
+    calendar,
+    email,
+    folders,
+    monitor,
+    notifications,
+    notify,
+    owa_rest,
+    owa_rest_commands,
+    pending_send,
+    teams,
+)
 from . import format as fmt
 from .config import Config
 from .context import MicrosoftContext
@@ -19,7 +33,10 @@ from .payloads import EventFields, EventPatch, MailDraft
 # Commands whose effect is to actually transmit mail. In draft-only mode these are
 # refused before any Graph/OWA-REST call; drafting (`email draft`) stays allowed.
 _TRANSMIT_COMMANDS = {"send", "reply", "forward"}
+_PENDING_COMMANDS = {"send-delay", "pending", "undo"}
 _DRAFT_ONLY_MESSAGE = "draft-only mode (EMAIL_DRAFT_ONLY): sending is disabled. Create a draft instead (--draft / the draft command)."
+_PENDING_POLL_SECONDS = 1
+_PENDING_JOIN_TIMEOUT_SECONDS = 5
 
 
 def _draft_only_enabled() -> bool:
@@ -75,7 +92,9 @@ def build_parser() -> argparse.ArgumentParser:
     # graph    - force the official Graph API.
     # owa-rest - force the OWA REST path (browser-captured token; requires: microsoft auth owa-login).
     for sub in (email_sub, cal_sub, folder_sub, teams_sub):
-        for sp in sub.choices.values():
+        for command, sp in sub.choices.items():
+            if sub is email_sub and command in _PENDING_COMMANDS:
+                continue
             sp.add_argument(
                 "--backend",
                 choices=[backend.AUTO, backend.GRAPH, backend.OWA_REST],
@@ -245,6 +264,15 @@ def _add_email_compose_parsers(email_sub) -> None:
 
 
 def _add_email_manage_parsers(email_sub) -> None:
+    p_send_delay = email_sub.add_parser("send-delay")
+    p_send_delay.add_argument("--seconds", type=int, default=None)
+
+    p_pending = email_sub.add_parser("pending")
+    p_pending.add_argument("--account", default=None)
+
+    p_undo = email_sub.add_parser("undo")
+    p_undo.add_argument("--id", required=True, dest="pending_id")
+
     p_move = email_sub.add_parser("move")
     p_move.add_argument("--account", required=True)
     p_move.add_argument("--id", required=True, dest="email_id")
@@ -674,12 +702,15 @@ def _email_routes():
 
 
 def _dispatch_email(args, config, client):
-    acct = args.account
-
     # Hard draft-only guard: refuse any transmitting command before it can reach
     # EITHER backend (Graph or OWA-REST). Drafting still flows through untouched.
     if args.command in _TRANSMIT_COMMANDS and _draft_only_enabled():
         raise RuntimeError(_DRAFT_ONLY_MESSAGE)
+
+    if args.command in _PENDING_COMMANDS:
+        return _dispatch_pending_email(args, config, client)
+
+    acct = args.account
 
     if args.command == "list" and args.search is not None:
         # `list --search/--query` is an alias for `email search`: run the identical search path,
@@ -695,13 +726,22 @@ def _dispatch_email(args, config, client):
             lambda: email.search_emails(config, client, **kw),
             lambda: owa_rest_commands.search_emails(config, client, **kw),
         )
+    if args.command in ("reply-draft", "attachment", "block", "unblock"):
+        return _dispatch_special_email(args, config, client)
+    routes = _email_routes()
+    if args.command in routes:
+        graph_impl, rest_impl, kw_of = routes[args.command]
+        kw = {"account_email": acct, **kw_of(args)}
+        return _route(args, config, acct, lambda: graph_impl(config, client, **kw), lambda: rest_impl(config, client, **kw))
+    return None
+
+
+def _dispatch_special_email(args, config, client):
     if args.command == "reply-draft":
-        # Graph-only: leaving a properly-threaded unsent draft over the preserved quote
-        # has no OWA REST counterpart, so this bypasses the backend router.
         return email.reply_draft(
             config,
             client,
-            account_email=acct,
+            account_email=args.account,
             email_id=args.email_id,
             body=args.body,
             attachments=args.attachments,
@@ -710,14 +750,20 @@ def _dispatch_email(args, config, client):
         )
     if args.command == "attachment":
         return _dispatch_attachment(args, config, client)
-    if args.command in ("block", "unblock"):
-        return _dispatch_block(args, config, client)
-    routes = _email_routes()
-    if args.command in routes:
-        graph_impl, rest_impl, kw_of = routes[args.command]
-        kw = {"account_email": acct, **kw_of(args)}
-        return _route(args, config, acct, lambda: graph_impl(config, client, **kw), lambda: rest_impl(config, client, **kw))
-    return None
+    return _dispatch_block(args, config, client)
+
+
+def _dispatch_pending_email(args, config, client):
+    if args.command == "send-delay":
+        seconds = (
+            pending_send.delay_seconds(config.data_dir)
+            if args.seconds is None
+            else pending_send.set_delay_seconds(config.data_dir, args.seconds)
+        )
+        return {"send_delay_seconds": seconds}
+    if args.command == "pending":
+        return [queued.public() for queued in pending_send.list_pending(config.data_dir, account=args.account)]
+    return pending_send.undo(config, client, args.pending_id)
 
 
 def _dispatch_block(args, config, client):
@@ -987,10 +1033,31 @@ def _run_serve(config: Config, notif_dir: Path):
     print(json.dumps({"status": "serving"}))
     sys.stdout.flush()
 
+    pending_thread = threading.Thread(
+        target=_run_pending_dispatcher,
+        args=(config, monitor_stop_event, monitor_logger),
+        name="microsoft-pending-send",
+        daemon=True,
+    )
     _write_pid(config)
     try:
+        pending_thread.start()
         monitor.run(ctx)
     finally:
+        monitor_stop_event.set()
+        pending_thread.join(timeout=_PENDING_JOIN_TIMEOUT_SECONDS)
         notifications.write_notification(notif_dir, "daemon_died", reason=shutdown_reason)
         _remove_pid(config)
         http_client.close()
+
+
+def _run_pending_dispatcher(config: Config, stop_event: threading.Event, logger: logging.Logger) -> None:
+    pending_send.recover_dispatching(config.data_dir)
+    with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+        while not stop_event.is_set():
+            try:
+                if pending_send.dispatch_due(config, client):
+                    continue
+            except Exception:
+                logger.exception("Error dispatching pending email")
+            stop_event.wait(_PENDING_POLL_SECONDS)

--- a/agent/skills/microsoft/cli/src/microsoft_cli/email.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/email.py
@@ -1,6 +1,7 @@
 """Email commands for Microsoft CLI."""
 
 import base64
+import dataclasses
 import html
 import pathlib as pl
 from datetime import UTC, datetime
@@ -652,16 +653,7 @@ def forward_email(config: Config, client: httpx.Client, *, account_email: str, e
         raise ValueError("--to is required to forward")
 
     if pending_send.delay_seconds(config.data_dir) > 0:
-        pending_mail = MailDraft(
-            body=mail.body,
-            subject=mail.subject,
-            to=mail.to,
-            cc=mail.cc,
-            bcc=mail.bcc,
-            attachments=mail.attachments,
-            html=mail.html,
-            forward_id=email_id,
-        )
+        pending_mail = dataclasses.replace(mail, forward_id=email_id)
         return _queue_draft(config, client, account_email=account_email, mail=pending_mail, action="forward")
 
     to, body, cc, attachments, html = mail.to, mail.body, mail.cc, mail.attachments, mail.html

--- a/agent/skills/microsoft/cli/src/microsoft_cli/email.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/email.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import httpx
 
-from . import auth, folders, graph
+from . import auth, folders, graph, pending_send
 from .config import Config
 from .payloads import MailDraft
 
@@ -348,13 +348,13 @@ def _split_attachments(attachments: list[str] | None) -> tuple[list[dict[str, An
 
 def _draft_reply_or_forward(config: Config, client: httpx.Client, account_id: str, mail: MailDraft) -> dict[str, Any]:
     source_id = mail.reply_to_id or mail.forward_id
-    create_endpoint = "createReply" if mail.reply_to_id else "createForward"
+    create_endpoint = "createReplyAll" if mail.reply_to_id and mail.reply_all else "createReply" if mail.reply_to_id else "createForward"
     draft = graph.request_cfg(config, client, "POST", f"/me/messages/{source_id}/{create_endpoint}", account_id)
     if not draft or "id" not in draft:
         raise ValueError("Failed to create reply/forward draft")
     draft_id = draft["id"]
 
-    updates: dict[str, Any] = {"body": {"contentType": "Text", "content": mail.body}}
+    updates: dict[str, Any] = {"body": {"contentType": "HTML" if mail.html else "Text", "content": mail.body}}
     if mail.subject:
         updates["subject"] = mail.subject
     if mail.to:
@@ -386,7 +386,7 @@ def create_email_draft(config: Config, client: httpx.Client, *, account_email: s
 
     message = {
         "subject": subject,
-        "body": {"contentType": "Text", "content": mail.body},
+        "body": {"contentType": "HTML" if mail.html else "Text", "content": mail.body},
         "toRecipients": [{"emailAddress": {"address": addr}} for addr in to] if to else [],
     }
 
@@ -421,6 +421,12 @@ def create_email_draft(config: Config, client: httpx.Client, *, account_email: s
 
 
 def send_email(config: Config, client: httpx.Client, *, account_email: str, mail: MailDraft) -> dict[str, str]:
+    if pending_send.delay_seconds(config.data_dir) > 0:
+        return _queue_draft(config, client, account_email=account_email, mail=mail, action="send")
+    return _send_email_now(config, client, account_email=account_email, mail=mail)
+
+
+def _send_email_now(config: Config, client: httpx.Client, *, account_email: str, mail: MailDraft) -> dict[str, str]:
     to, cc, bcc, attachments = mail.to, mail.cc, mail.bcc, mail.attachments
     if not to and not cc and not bcc:
         raise ValueError("At least one recipient is required (--to, --cc, or --bcc)")
@@ -500,6 +506,21 @@ def reply_to_email(
     reply_all: bool = False,
     html: bool = False,
 ) -> dict[str, str]:
+    if pending_send.delay_seconds(config.data_dir) > 0:
+        return _queue_draft(
+            config,
+            client,
+            account_email=account_email,
+            mail=MailDraft(
+                body=body,
+                attachments=attachments,
+                html=html,
+                reply_to_id=email_id,
+                reply_all=reply_all,
+            ),
+            action="reply-all" if reply_all else "reply",
+        )
+
     account_id = auth.get_account_id_by_email(account_email, config.cache_file)
     create_endpoint = "createReplyAll" if reply_all else "createReply"
     reply_endpoint = "replyAll" if reply_all else "reply"
@@ -627,10 +648,23 @@ def reply_draft(
 
 
 def forward_email(config: Config, client: httpx.Client, *, account_email: str, email_id: str, mail: MailDraft) -> dict[str, str]:
-    to, body, cc, attachments, html = mail.to, mail.body, mail.cc, mail.attachments, mail.html
-    if not to:
+    if not mail.to:
         raise ValueError("--to is required to forward")
 
+    if pending_send.delay_seconds(config.data_dir) > 0:
+        pending_mail = MailDraft(
+            body=mail.body,
+            subject=mail.subject,
+            to=mail.to,
+            cc=mail.cc,
+            bcc=mail.bcc,
+            attachments=mail.attachments,
+            html=mail.html,
+            forward_id=email_id,
+        )
+        return _queue_draft(config, client, account_email=account_email, mail=pending_mail, action="forward")
+
+    to, body, cc, attachments, html = mail.to, mail.body, mail.cc, mail.attachments, mail.html
     account_id = auth.get_account_id_by_email(account_email, config.cache_file)
     to_recipients = [{"emailAddress": {"address": addr}} for addr in to]
 
@@ -658,6 +692,32 @@ def forward_email(config: Config, client: httpx.Client, *, account_email: str, e
         config, client, "POST", f"/me/messages/{email_id}/forward", account_id, json={"comment": body, "toRecipients": to_recipients}
     )
     return {"status": "sent"}
+
+
+def _queue_draft(
+    config: Config,
+    client: httpx.Client,
+    *,
+    account_email: str,
+    mail: MailDraft,
+    action: str,
+) -> dict[str, str]:
+    draft = create_email_draft(config, client, account_email=account_email, mail=mail)
+    draft_id = str(draft["id"]) if "id" in draft else ""
+    if not draft_id:
+        raise ValueError("Microsoft Graph did not return an id for the pending draft")
+    recipients = ", ".join([*(mail.to or []), *(mail.cc or []), *(mail.bcc or [])]) or "thread recipients"
+    subject = mail.subject or f"{action} to {mail.reply_to_id or mail.forward_id}"
+    queued = pending_send.enqueue(
+        config.data_dir,
+        account=account_email,
+        action=action,
+        subject=subject,
+        recipients=recipients,
+        backend=pending_send.GRAPH_BACKEND,
+        payload=draft_id.encode(),
+    )
+    return queued.public()
 
 
 def move_email(

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
@@ -392,15 +392,20 @@ def send_message(client: httpx.Client, account_email: str, config, *, mail: Mail
     return {"status": "sent"}
 
 
+def send_draft(client: httpx.Client, account_email: str, config, *, item_id: str) -> None:
+    token = load_token(account_email, config)
+    _post(client, token, f"/me/messages/{item_id}/send")
+
+
 def create_draft(client: httpx.Client, account_email: str, config, *, mail: MailDraft) -> dict:
     token = load_token(account_email, config)
 
     if mail.reply_to_id or mail.forward_id:
         source_id = mail.reply_to_id or mail.forward_id
-        endpoint = "createreply" if mail.reply_to_id else "createforward"
+        endpoint = "createreplyall" if mail.reply_to_id and mail.reply_all else "createreply" if mail.reply_to_id else "createforward"
         draft = _post(client, token, f"/me/messages/{source_id}/{endpoint}")
         draft_id = draft.get("id")
-        patch: dict[str, Any] = {"body": {"contentType": "Text", "content": mail.body}}
+        patch: dict[str, Any] = {"body": {"contentType": "HTML" if mail.html else "Text", "content": mail.body}}
         if mail.subject:
             patch["subject"] = mail.subject
         if mail.to:
@@ -413,7 +418,7 @@ def create_draft(client: httpx.Client, account_email: str, config, *, mail: Mail
         _attach_files(client, token, draft_id, mail.attachments)
         return {"status": "drafted", "id": draft_id, "source_id": source_id}
 
-    result = _post(client, token, "/me/messages", _message_body(mail.subject or "", mail.body, mail.to, mail.cc, mail.bcc, False))
+    result = _post(client, token, "/me/messages", _message_body(mail.subject or "", mail.body, mail.to, mail.cc, mail.bcc, mail.html))
     draft_id = result.get("id")
     _attach_files(client, token, draft_id, mail.attachments)
     return {"status": "drafted", "id": draft_id}

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest_commands.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest_commands.py
@@ -18,7 +18,7 @@ from zoneinfo import ZoneInfo
 
 from . import calendar as calendar_mod
 from . import email as email_mod
-from . import owa_rest
+from . import owa_rest, pending_send
 from .config import Config
 from .payloads import EventFields, EventPatch, MailDraft
 
@@ -96,6 +96,8 @@ def get_email(
 def send_email(config: Config, client, *, account_email: str, mail: MailDraft) -> dict:
     if not mail.to and not mail.cc and not mail.bcc:
         raise ValueError("at least one recipient is required (--to, --cc, or --bcc)")
+    if pending_send.delay_seconds(config.data_dir) > 0:
+        return _queue_draft(config, client, account_email=account_email, mail=mail, action="send")
     return owa_rest.send_message(client, account_email, config, mail=mail)
 
 
@@ -121,6 +123,20 @@ def reply_to_email(
     reply_all: bool = False,
     html: bool = False,
 ) -> dict:
+    if pending_send.delay_seconds(config.data_dir) > 0:
+        return _queue_draft(
+            config,
+            client,
+            account_email=account_email,
+            mail=MailDraft(
+                body=body,
+                attachments=attachments,
+                html=html,
+                reply_to_id=email_id,
+                reply_all=reply_all,
+            ),
+            action="reply-all" if reply_all else "reply",
+        )
     return owa_rest.reply_message(
         client, account_email, config, item_id=email_id, body=body, attachments=attachments, reply_all=reply_all, html=html
     )
@@ -129,7 +145,29 @@ def reply_to_email(
 def forward_email(config: Config, client, *, account_email: str, email_id: str, mail: MailDraft) -> dict:
     if not mail.to:
         raise ValueError("--to is required to forward")
+    if pending_send.delay_seconds(config.data_dir) > 0:
+        pending_mail = dataclasses.replace(mail, forward_id=email_id)
+        return _queue_draft(config, client, account_email=account_email, mail=pending_mail, action="forward")
     return owa_rest.forward_message(client, account_email, config, item_id=email_id, mail=mail)
+
+
+def _queue_draft(config: Config, client, *, account_email: str, mail: MailDraft, action: str) -> dict[str, str]:
+    draft = create_email_draft(config, client, account_email=account_email, mail=mail)
+    draft_id = str(draft["id"]) if "id" in draft else ""
+    if not draft_id:
+        raise ValueError("OWA REST did not return an id for the pending draft")
+    recipients = ", ".join([*(mail.to or []), *(mail.cc or []), *(mail.bcc or [])]) or "thread recipients"
+    subject = mail.subject or f"{action} to {mail.reply_to_id or mail.forward_id}"
+    queued = pending_send.enqueue(
+        config.data_dir,
+        account=account_email,
+        action=action,
+        subject=subject,
+        recipients=recipients,
+        backend=pending_send.OWA_REST_BACKEND,
+        payload=draft_id.encode(),
+    )
+    return queued.public()
 
 
 def move_email(config: Config, client, *, account_email: str, email_id: str, to_folder: str) -> dict:

--- a/agent/skills/microsoft/cli/src/microsoft_cli/payloads.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/payloads.py
@@ -21,6 +21,7 @@ class MailDraft:
     attachments: list[str] | None = None
     html: bool = False
     reply_to_id: str | None = None
+    reply_all: bool = False
     forward_id: str | None = None
 
 

--- a/agent/skills/microsoft/cli/src/microsoft_cli/pending_send.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/pending_send.py
@@ -17,9 +17,13 @@ from .config import Config
 
 DEFAULT_DELAY_SECONDS = 30
 RETRY_DELAY_SECONDS = 30
+MAX_DELIVERY_ATTEMPTS = 3
 GRAPH_BACKEND = "graph"
 OWA_REST_BACKEND = "owa-rest"
+INTERRUPTED_ERROR = "dispatch was interrupted; check the Sent folder before undoing or resending"
 _DATABASE_NAME = "pending-sends.db"
+_UNDOABLE_STATES = "('pending', 'failed')"
+_COLUMNS = "id, created_at, send_at, account, action, subject, recipients, backend, payload, state, last_error"
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS settings (
     key TEXT PRIMARY KEY,
@@ -36,7 +40,8 @@ CREATE TABLE IF NOT EXISTS sends (
     backend TEXT NOT NULL,
     payload BLOB NOT NULL,
     state TEXT NOT NULL,
-    last_error TEXT
+    last_error TEXT NOT NULL DEFAULT '',
+    attempts INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS sends_due ON sends(state, send_at);
 """
@@ -53,17 +58,22 @@ class PendingSend:
     recipients: str
     backend: str
     payload: bytes
+    state: str = "pending"
+    last_error: str = ""
 
     def public(self) -> dict[str, str]:
-        return {
+        described = {
             "id": self.id,
-            "status": "pending",
+            "status": self.state,
             "account": self.account,
             "action": self.action,
             "subject": self.subject,
             "recipients": self.recipients,
             "send_at": self.send_at.isoformat(),
         }
+        if self.last_error:
+            described["last_error"] = self.last_error
+        return described
 
 
 @contextlib.contextmanager
@@ -89,6 +99,8 @@ def _from_row(row: sqlite3.Row | tuple) -> PendingSend:
         recipients=str(row[6]),
         backend=str(row[7]),
         payload=bytes(row[8]),
+        state=str(row[9]),
+        last_error=str(row[10]),
     )
 
 
@@ -151,35 +163,21 @@ def enqueue(
     return queued
 
 
-def list_pending(data_dir: Path, *, account: str | None = None, now: datetime | None = None) -> list[PendingSend]:
-    undoable_at = now or datetime.now(UTC)
+def list_pending(data_dir: Path, *, account: str | None = None) -> list[PendingSend]:
     with _connection(data_dir) as connection:
-        if account is None:
-            rows = connection.execute(
-                "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
-                "FROM sends WHERE state = 'pending' AND send_at > ? ORDER BY send_at, id",
-                (undoable_at.isoformat(),),
-            ).fetchall()
-        else:
-            rows = connection.execute(
-                "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
-                "FROM sends WHERE state = 'pending' AND account = ? AND send_at > ? ORDER BY send_at, id",
-                (account, undoable_at.isoformat()),
-            ).fetchall()
+        rows = connection.execute(
+            f"SELECT {_COLUMNS} FROM sends WHERE state IN {_UNDOABLE_STATES} AND (? IS NULL OR account = ?) ORDER BY send_at, id",
+            (account, account),
+        ).fetchall()
     return [_from_row(row) for row in rows]
 
 
-def cancel(data_dir: Path, pending_id: str, *, now: datetime | None = None) -> PendingSend:
-    cancel_at = now or datetime.now(UTC)
+def cancel(data_dir: Path, pending_id: str) -> PendingSend:
     with _connection(data_dir) as connection:
         connection.execute("BEGIN IMMEDIATE")
-        row = connection.execute(
-            "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
-            "FROM sends WHERE id = ? AND state = 'pending' AND send_at > ?",
-            (pending_id, cancel_at.isoformat()),
-        ).fetchone()
+        row = connection.execute(f"SELECT {_COLUMNS} FROM sends WHERE id = ? AND state IN {_UNDOABLE_STATES}", (pending_id,)).fetchone()
         if row is None:
-            raise ValueError(f"pending send {pending_id!r} was not found, has expired, or has already been delivered")
+            raise ValueError(f"pending send {pending_id!r} was not found, is being delivered right now, or has already been delivered")
         connection.execute("UPDATE sends SET state = 'cancelled' WHERE id = ?", (pending_id,))
     return _from_row(row)
 
@@ -194,13 +192,12 @@ def claim_due(data_dir: Path, *, now: datetime | None = None) -> PendingSend | N
     with _connection(data_dir) as connection:
         connection.execute("BEGIN IMMEDIATE")
         row = connection.execute(
-            "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
-            "FROM sends WHERE state = 'pending' AND send_at <= ? ORDER BY send_at, id LIMIT 1",
+            f"SELECT {_COLUMNS} FROM sends WHERE state = 'pending' AND send_at <= ? ORDER BY send_at, id LIMIT 1",
             (due_at.isoformat(),),
         ).fetchone()
         if row is None:
             return None
-        connection.execute("UPDATE sends SET state = 'dispatching' WHERE id = ?", (str(row[0]),))
+        connection.execute("UPDATE sends SET state = 'dispatching', attempts = attempts + 1 WHERE id = ?", (str(row[0]),))
     return _from_row(row)
 
 
@@ -213,14 +210,17 @@ def retry(data_dir: Path, pending_id: str, error: str, *, now: datetime | None =
     retry_at = (now or datetime.now(UTC)) + timedelta(seconds=RETRY_DELAY_SECONDS)
     with _connection(data_dir) as connection:
         connection.execute(
-            "UPDATE sends SET state = 'pending', send_at = ?, last_error = ? WHERE id = ? AND state = 'dispatching'",
-            (retry_at.isoformat(), error, pending_id),
+            "UPDATE sends SET state = CASE WHEN attempts >= ? THEN 'failed' ELSE 'pending' END, send_at = ?, last_error = ? "
+            "WHERE id = ? AND state = 'dispatching'",
+            (MAX_DELIVERY_ATTEMPTS, retry_at.isoformat(), error, pending_id),
         )
 
 
 def recover_dispatching(data_dir: Path) -> None:
+    # A claimed row may have reached the server before the process died, so re-sending it
+    # would duplicate the mail. Hold it for the agent to resolve instead.
     with _connection(data_dir) as connection:
-        connection.execute("UPDATE sends SET state = 'pending' WHERE state = 'dispatching'")
+        connection.execute("UPDATE sends SET state = 'failed', last_error = ? WHERE state = 'dispatching'", (INTERRUPTED_ERROR,))
 
 
 def dispatch_due(config: Config, client: httpx.Client, *, now: datetime | None = None) -> bool:

--- a/agent/skills/microsoft/cli/src/microsoft_cli/pending_send.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/pending_send.py
@@ -1,0 +1,257 @@
+"""Durable delayed-send state owned by the Microsoft email client."""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import httpx
+
+from . import auth, graph, owa_rest
+from .config import Config
+
+DEFAULT_DELAY_SECONDS = 30
+RETRY_DELAY_SECONDS = 30
+GRAPH_BACKEND = "graph"
+OWA_REST_BACKEND = "owa-rest"
+_DATABASE_NAME = "pending-sends.db"
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS sends (
+    id TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL,
+    send_at TEXT NOT NULL,
+    account TEXT NOT NULL,
+    action TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    recipients TEXT NOT NULL,
+    backend TEXT NOT NULL,
+    payload BLOB NOT NULL,
+    state TEXT NOT NULL,
+    last_error TEXT
+);
+CREATE INDEX IF NOT EXISTS sends_due ON sends(state, send_at);
+"""
+
+
+@dataclass(frozen=True)
+class PendingSend:
+    id: str
+    created_at: datetime
+    send_at: datetime
+    account: str
+    action: str
+    subject: str
+    recipients: str
+    backend: str
+    payload: bytes
+
+    def public(self) -> dict[str, str]:
+        return {
+            "id": self.id,
+            "status": "pending",
+            "account": self.account,
+            "action": self.action,
+            "subject": self.subject,
+            "recipients": self.recipients,
+            "send_at": self.send_at.isoformat(),
+        }
+
+
+@contextlib.contextmanager
+def _connection(data_dir: Path) -> Iterator[sqlite3.Connection]:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(data_dir / _DATABASE_NAME)
+    try:
+        connection.executescript(_SCHEMA)
+        yield connection
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _from_row(row: sqlite3.Row | tuple) -> PendingSend:
+    return PendingSend(
+        id=str(row[0]),
+        created_at=datetime.fromisoformat(str(row[1])),
+        send_at=datetime.fromisoformat(str(row[2])),
+        account=str(row[3]),
+        action=str(row[4]),
+        subject=str(row[5]),
+        recipients=str(row[6]),
+        backend=str(row[7]),
+        payload=bytes(row[8]),
+    )
+
+
+def delay_seconds(data_dir: Path) -> int:
+    with _connection(data_dir) as connection:
+        row = connection.execute("SELECT value FROM settings WHERE key = 'send_delay_seconds'").fetchone()
+    return int(row[0]) if row is not None else DEFAULT_DELAY_SECONDS
+
+
+def set_delay_seconds(data_dir: Path, seconds: int) -> int:
+    if seconds < 0:
+        raise ValueError("send delay must be zero or greater")
+    with _connection(data_dir) as connection:
+        connection.execute(
+            "INSERT INTO settings(key, value) VALUES('send_delay_seconds', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (seconds,),
+        )
+    return seconds
+
+
+def enqueue(
+    data_dir: Path,
+    *,
+    account: str,
+    action: str,
+    subject: str,
+    recipients: str,
+    backend: str,
+    payload: bytes,
+    now: datetime | None = None,
+) -> PendingSend:
+    created_at = now or datetime.now(UTC)
+    queued = PendingSend(
+        id=uuid.uuid4().hex,
+        created_at=created_at,
+        send_at=created_at + timedelta(seconds=delay_seconds(data_dir)),
+        account=account,
+        action=action,
+        subject=subject,
+        recipients=recipients,
+        backend=backend,
+        payload=payload,
+    )
+    with _connection(data_dir) as connection:
+        connection.execute(
+            "INSERT INTO sends(id, created_at, send_at, account, action, subject, recipients, backend, payload, state) "
+            "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')",
+            (
+                queued.id,
+                queued.created_at.isoformat(),
+                queued.send_at.isoformat(),
+                queued.account,
+                queued.action,
+                queued.subject,
+                queued.recipients,
+                queued.backend,
+                queued.payload,
+            ),
+        )
+    return queued
+
+
+def list_pending(data_dir: Path, *, account: str | None = None, now: datetime | None = None) -> list[PendingSend]:
+    undoable_at = now or datetime.now(UTC)
+    with _connection(data_dir) as connection:
+        if account is None:
+            rows = connection.execute(
+                "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
+                "FROM sends WHERE state = 'pending' AND send_at > ? ORDER BY send_at, id",
+                (undoable_at.isoformat(),),
+            ).fetchall()
+        else:
+            rows = connection.execute(
+                "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
+                "FROM sends WHERE state = 'pending' AND account = ? AND send_at > ? ORDER BY send_at, id",
+                (account, undoable_at.isoformat()),
+            ).fetchall()
+    return [_from_row(row) for row in rows]
+
+
+def cancel(data_dir: Path, pending_id: str, *, now: datetime | None = None) -> PendingSend:
+    cancel_at = now or datetime.now(UTC)
+    with _connection(data_dir) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        row = connection.execute(
+            "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
+            "FROM sends WHERE id = ? AND state = 'pending' AND send_at > ?",
+            (pending_id, cancel_at.isoformat()),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"pending send {pending_id!r} was not found, has expired, or has already been delivered")
+        connection.execute("UPDATE sends SET state = 'cancelled' WHERE id = ?", (pending_id,))
+    return _from_row(row)
+
+
+def finish_cancel(data_dir: Path, pending_id: str) -> None:
+    with _connection(data_dir) as connection:
+        connection.execute("DELETE FROM sends WHERE id = ? AND state = 'cancelled'", (pending_id,))
+
+
+def claim_due(data_dir: Path, *, now: datetime | None = None) -> PendingSend | None:
+    due_at = now or datetime.now(UTC)
+    with _connection(data_dir) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        row = connection.execute(
+            "SELECT id, created_at, send_at, account, action, subject, recipients, backend, payload "
+            "FROM sends WHERE state = 'pending' AND send_at <= ? ORDER BY send_at, id LIMIT 1",
+            (due_at.isoformat(),),
+        ).fetchone()
+        if row is None:
+            return None
+        connection.execute("UPDATE sends SET state = 'dispatching' WHERE id = ?", (str(row[0]),))
+    return _from_row(row)
+
+
+def complete(data_dir: Path, pending_id: str) -> None:
+    with _connection(data_dir) as connection:
+        connection.execute("DELETE FROM sends WHERE id = ? AND state = 'dispatching'", (pending_id,))
+
+
+def retry(data_dir: Path, pending_id: str, error: str, *, now: datetime | None = None) -> None:
+    retry_at = (now or datetime.now(UTC)) + timedelta(seconds=RETRY_DELAY_SECONDS)
+    with _connection(data_dir) as connection:
+        connection.execute(
+            "UPDATE sends SET state = 'pending', send_at = ?, last_error = ? WHERE id = ? AND state = 'dispatching'",
+            (retry_at.isoformat(), error, pending_id),
+        )
+
+
+def recover_dispatching(data_dir: Path) -> None:
+    with _connection(data_dir) as connection:
+        connection.execute("UPDATE sends SET state = 'pending' WHERE state = 'dispatching'")
+
+
+def dispatch_due(config: Config, client: httpx.Client, *, now: datetime | None = None) -> bool:
+    queued = claim_due(config.data_dir, now=now)
+    if queued is None:
+        return False
+    try:
+        draft_id = queued.payload.decode()
+        if queued.backend == GRAPH_BACKEND:
+            account_id = auth.get_account_id_by_email(queued.account, config.cache_file)
+            graph.request_cfg(config, client, "POST", f"/me/messages/{draft_id}/send", account_id)
+        elif queued.backend == OWA_REST_BACKEND:
+            owa_rest.send_draft(client, queued.account, config, item_id=draft_id)
+        else:
+            raise ValueError(f"unknown pending-send backend {queued.backend!r}")
+    except Exception as error:
+        retry(config.data_dir, queued.id, str(error), now=now)
+        raise
+    complete(config.data_dir, queued.id)
+    return True
+
+
+def undo(config: Config, client: httpx.Client, pending_id: str) -> dict[str, str]:
+    queued = cancel(config.data_dir, pending_id)
+    draft_id = queued.payload.decode()
+    if queued.backend == GRAPH_BACKEND:
+        account_id = auth.get_account_id_by_email(queued.account, config.cache_file)
+        graph.request_cfg(config, client, "DELETE", f"/me/messages/{draft_id}", account_id)
+    elif queued.backend == OWA_REST_BACKEND:
+        owa_rest.delete_message(client, queued.account, config, item_id=draft_id)
+    else:
+        raise ValueError(f"unknown pending-send backend {queued.backend!r}")
+    finish_cancel(config.data_dir, pending_id)
+    return {"id": pending_id, "status": "cancelled"}

--- a/agent/skills/microsoft/cli/tests/test_message_actions.py
+++ b/agent/skills/microsoft/cli/tests/test_message_actions.py
@@ -1,7 +1,7 @@
 """Unit tests for forward / move / archive / flag message actions (mocked Graph)."""
 
 import pytest
-from microsoft_cli import email
+from microsoft_cli import email, pending_send
 from microsoft_cli.config import Config
 from microsoft_cli.payloads import MailDraft
 
@@ -34,17 +34,25 @@ def patched(monkeypatch):
     return calls
 
 
-def test_forward_plain_uses_forward_action(patched):
-    result = email.forward_email(Config(), None, account_email="me@example.com", email_id="m1", mail=MailDraft(to=["bob@x.com"], body="fyi"))
+def test_forward_plain_uses_forward_action(patched, tmp_path):
+    pending_send.set_delay_seconds(tmp_path, 0)
+    result = email.forward_email(
+        Config(data_dir=tmp_path), None, account_email="me@example.com", email_id="m1", mail=MailDraft(to=["bob@x.com"], body="fyi")
+    )
     assert result == {"status": "sent"}
     assert len(patched) == 1
     assert patched[0]["path"] == "/me/messages/m1/forward"
     assert patched[0]["json"] == {"comment": "fyi", "toRecipients": [{"emailAddress": {"address": "bob@x.com"}}]}
 
 
-def test_forward_with_cc_uses_draft_path(patched):
+def test_forward_with_cc_uses_draft_path(patched, tmp_path):
+    pending_send.set_delay_seconds(tmp_path, 0)
     result = email.forward_email(
-        Config(), None, account_email="me@example.com", email_id="m1", mail=MailDraft(to=["bob@x.com"], body="fyi", cc=["cc@x.com"])
+        Config(data_dir=tmp_path),
+        None,
+        account_email="me@example.com",
+        email_id="m1",
+        mail=MailDraft(to=["bob@x.com"], body="fyi", cc=["cc@x.com"]),
     )
     assert result == {"status": "sent"}
     paths = [c["path"] for c in patched]
@@ -54,9 +62,9 @@ def test_forward_with_cc_uses_draft_path(patched):
     assert patch["json"]["toRecipients"] == [{"emailAddress": {"address": "bob@x.com"}}]
 
 
-def test_forward_requires_to(patched):
+def test_forward_requires_to(patched, tmp_path):
     with pytest.raises(ValueError, match="--to is required"):
-        email.forward_email(Config(), None, account_email="me@example.com", email_id="m1", mail=MailDraft(to=[]))
+        email.forward_email(Config(data_dir=tmp_path), None, account_email="me@example.com", email_id="m1", mail=MailDraft(to=[]))
 
 
 def test_move_to_wellknown_folder(patched):

--- a/agent/skills/microsoft/cli/tests/test_pending_send.py
+++ b/agent/skills/microsoft/cli/tests/test_pending_send.py
@@ -28,7 +28,7 @@ def test_pending_send_uses_the_client_delay_and_can_be_claimed_once(tmp_path):
     )
 
     assert queued.send_at == now + timedelta(seconds=30)
-    assert [item.id for item in pending_send.list_pending(tmp_path, now=now)] == [queued.id]
+    assert [item.id for item in pending_send.list_pending(tmp_path)] == [queued.id]
     assert pending_send.claim_due(tmp_path, now=queued.send_at - timedelta(microseconds=1)) is None
     assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
     assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
@@ -47,14 +47,19 @@ def test_undo_removes_a_pending_send_before_delivery(tmp_path):
         now=now,
     )
 
-    cancelled = pending_send.cancel(tmp_path, queued.id, now=queued.send_at - timedelta(microseconds=1))
+    cancelled = pending_send.cancel(tmp_path, queued.id)
 
     assert cancelled.id == queued.id
     assert pending_send.list_pending(tmp_path) == []
     assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
 
 
-def test_undo_rejects_a_send_after_its_recovery_window(tmp_path):
+def test_undo_rejects_an_unknown_send(tmp_path):
+    with pytest.raises(ValueError, match="was not found"):
+        pending_send.cancel(tmp_path, "nope")
+
+
+def test_an_overdue_send_stays_listed_and_undoable_until_it_is_dispatched(tmp_path):
     now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
     queued = pending_send.enqueue(
         tmp_path,
@@ -62,14 +67,32 @@ def test_undo_rejects_a_send_after_its_recovery_window(tmp_path):
         action="send",
         subject="Hello",
         recipients="bob@example.com",
-        backend="graph",
+        backend=pending_send.GRAPH_BACKEND,
         payload=b"draft-1",
         now=now,
     )
 
-    with pytest.raises(ValueError, match="expired"):
-        pending_send.cancel(tmp_path, queued.id, now=queued.send_at)
-    assert pending_send.list_pending(tmp_path, now=queued.send_at) == []
+    assert [item.id for item in pending_send.list_pending(tmp_path)] == [queued.id]
+
+    pending_send.cancel(tmp_path, queued.id)
+
+    assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
+
+
+def test_a_send_being_dispatched_can_no_longer_be_undone(tmp_path):
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="me@example.com",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend=pending_send.GRAPH_BACKEND,
+        payload=b"draft-1",
+    )
+    pending_send.claim_due(tmp_path, now=queued.send_at)
+
+    with pytest.raises(ValueError, match="being delivered"):
+        pending_send.cancel(tmp_path, queued.id)
 
 
 def test_changing_delay_only_affects_new_sends(tmp_path):
@@ -100,21 +123,45 @@ def test_changing_delay_only_affects_new_sends(tmp_path):
     assert second.send_at == now + timedelta(seconds=120)
 
 
-def test_dispatching_send_recovers_after_daemon_restart(tmp_path):
+def test_a_send_interrupted_mid_dispatch_is_held_instead_of_resent(tmp_path):
     queued = pending_send.enqueue(
         tmp_path,
         account="me@example.com",
-        action="reply-all",
+        action="reply",
         subject="Re: Hello",
         recipients="bob@example.com",
-        backend="graph",
+        backend=pending_send.GRAPH_BACKEND,
         payload=b"draft-1",
     )
     assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
 
     pending_send.recover_dispatching(tmp_path)
 
-    assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
+    assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
+    held = pending_send.list_pending(tmp_path)[0]
+    assert held.public()["status"] == "failed"
+    assert held.public()["last_error"] == pending_send.INTERRUPTED_ERROR
+
+
+def test_delivery_stops_retrying_once_it_has_burned_its_attempts(tmp_path):
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="me@example.com",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend=pending_send.GRAPH_BACKEND,
+        payload=b"draft-1",
+    )
+    at = queued.send_at
+
+    for _ in range(pending_send.MAX_DELIVERY_ATTEMPTS):
+        at = at + timedelta(seconds=pending_send.RETRY_DELAY_SECONDS)
+        assert pending_send.claim_due(tmp_path, now=at).id == queued.id
+        pending_send.retry(tmp_path, queued.id, "provider refused", now=at)
+
+    assert pending_send.claim_due(tmp_path, now=at + timedelta(hours=1)) is None
+    assert pending_send.list_pending(tmp_path)[0].public()["last_error"] == "provider refused"
 
 
 def _patch_graph(monkeypatch, calls):

--- a/agent/skills/microsoft/cli/tests/test_pending_send.py
+++ b/agent/skills/microsoft/cli/tests/test_pending_send.py
@@ -1,0 +1,452 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from microsoft_cli import backend, cli, email, owa_rest_commands, pending_send
+from microsoft_cli.config import Config
+from microsoft_cli.payloads import MailDraft
+
+
+def test_delay_defaults_to_thirty_seconds_and_persists(tmp_path):
+    assert pending_send.delay_seconds(tmp_path) == 30
+
+    pending_send.set_delay_seconds(tmp_path, 120)
+
+    assert pending_send.delay_seconds(tmp_path) == 120
+
+
+def test_pending_send_uses_the_client_delay_and_can_be_claimed_once(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="me@example.com",
+        action="forward",
+        subject="Fwd: Hello",
+        recipients="bob@example.com",
+        backend="graph",
+        payload=b"draft-1",
+        now=now,
+    )
+
+    assert queued.send_at == now + timedelta(seconds=30)
+    assert [item.id for item in pending_send.list_pending(tmp_path, now=now)] == [queued.id]
+    assert pending_send.claim_due(tmp_path, now=queued.send_at - timedelta(microseconds=1)) is None
+    assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
+    assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
+
+
+def test_undo_removes_a_pending_send_before_delivery(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="me@example.com",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend="owa-rest",
+        payload=b"draft-1",
+        now=now,
+    )
+
+    cancelled = pending_send.cancel(tmp_path, queued.id, now=queued.send_at - timedelta(microseconds=1))
+
+    assert cancelled.id == queued.id
+    assert pending_send.list_pending(tmp_path) == []
+    assert pending_send.claim_due(tmp_path, now=queued.send_at) is None
+
+
+def test_undo_rejects_a_send_after_its_recovery_window(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="me@example.com",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend="graph",
+        payload=b"draft-1",
+        now=now,
+    )
+
+    with pytest.raises(ValueError, match="expired"):
+        pending_send.cancel(tmp_path, queued.id, now=queued.send_at)
+    assert pending_send.list_pending(tmp_path, now=queued.send_at) == []
+
+
+def test_changing_delay_only_affects_new_sends(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+    first = pending_send.enqueue(
+        tmp_path,
+        account="me@example.com",
+        action="send",
+        subject="First",
+        recipients="bob@example.com",
+        backend="graph",
+        payload=b"first",
+        now=now,
+    )
+    pending_send.set_delay_seconds(tmp_path, 120)
+    second = pending_send.enqueue(
+        tmp_path,
+        account="me@example.com",
+        action="send",
+        subject="Second",
+        recipients="bob@example.com",
+        backend="graph",
+        payload=b"second",
+        now=now,
+    )
+
+    assert first.send_at == now + timedelta(seconds=30)
+    assert second.send_at == now + timedelta(seconds=120)
+
+
+def test_dispatching_send_recovers_after_daemon_restart(tmp_path):
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="me@example.com",
+        action="reply-all",
+        subject="Re: Hello",
+        recipients="bob@example.com",
+        backend="graph",
+        payload=b"draft-1",
+    )
+    assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
+
+    pending_send.recover_dispatching(tmp_path)
+
+    assert pending_send.claim_due(tmp_path, now=queued.send_at).id == queued.id
+
+
+def _patch_graph(monkeypatch, calls):
+    monkeypatch.setattr(email.auth, "get_account_id_by_email", lambda *_args: "account-1")
+
+    def request(_config, _client, method, path, _account_id, **kwargs):
+        calls.append({"method": method, "path": path, "json": kwargs["json"] if "json" in kwargs else None})
+        if method == "POST" and path.endswith("/createReplyAll"):
+            return {"id": "reply-all-draft"}
+        if method == "POST" and path.endswith("/createReply"):
+            return {"id": "reply-draft"}
+        if method == "POST" and path.endswith("/createForward"):
+            return {"id": "forward-draft"}
+        if method == "POST" and path == "/me/messages":
+            return {"id": "compose-draft"}
+        return None
+
+    monkeypatch.setattr(email.graph, "request_cfg", request)
+
+
+def test_graph_send_creates_a_provider_draft_and_returns_pending(tmp_path, monkeypatch):
+    calls = []
+    config = Config(data_dir=tmp_path)
+    attachment = tmp_path / "report.pdf"
+    attachment.write_bytes(b"pdf")
+    _patch_graph(monkeypatch, calls)
+
+    result = email.send_email(
+        config,
+        None,
+        account_email="me@example.com",
+        mail=MailDraft(to=["bob@example.com"], subject="Hello", body="Body", attachments=[str(attachment)]),
+    )
+
+    assert result["status"] == "pending"
+    assert [call["path"] for call in calls] == ["/me/messages"]
+    assert pending_send.list_pending(tmp_path)[0].payload == b"compose-draft"
+
+
+def test_all_graph_outbound_actions_inherit_the_client_delay(tmp_path, monkeypatch):
+    calls = []
+    config = Config(data_dir=tmp_path)
+    pending_send.set_delay_seconds(tmp_path, 45)
+    attachment = tmp_path / "report.pdf"
+    attachment.write_bytes(b"pdf")
+    _patch_graph(monkeypatch, calls)
+
+    email.send_email(
+        config,
+        None,
+        account_email="me@example.com",
+        mail=MailDraft(to=["bob@example.com"], subject="Hello", body="Body"),
+    )
+    email.reply_to_email(
+        config,
+        None,
+        account_email="me@example.com",
+        email_id="original-1",
+        body="Reply",
+        attachments=[str(attachment)],
+    )
+    email.reply_to_email(
+        config,
+        None,
+        account_email="me@example.com",
+        email_id="original-2",
+        body="Reply all",
+        attachments=[str(attachment)],
+        reply_all=True,
+    )
+    email.forward_email(
+        config,
+        None,
+        account_email="me@example.com",
+        email_id="original-3",
+        mail=MailDraft(to=["bob@example.com"], body="Forward", attachments=[str(attachment)]),
+    )
+
+    queued = pending_send.list_pending(tmp_path)
+    assert [item.action for item in queued] == ["send", "reply", "reply-all", "forward"]
+    assert all(item.send_at - item.created_at == timedelta(seconds=45) for item in queued)
+
+
+def test_graph_zero_client_delay_sends_immediately(tmp_path, monkeypatch):
+    calls = []
+    config = Config(data_dir=tmp_path)
+    pending_send.set_delay_seconds(tmp_path, 0)
+    _patch_graph(monkeypatch, calls)
+
+    result = email.send_email(
+        config,
+        None,
+        account_email="me@example.com",
+        mail=MailDraft(to=["bob@example.com"], subject="Hello", body="Body"),
+    )
+
+    assert result == {"status": "sent"}
+    assert [call["path"] for call in calls] == ["/me/sendMail"]
+    assert pending_send.list_pending(tmp_path) == []
+
+
+def test_graph_reply_all_creates_a_threaded_draft(tmp_path, monkeypatch):
+    calls = []
+    config = Config(data_dir=tmp_path)
+    _patch_graph(monkeypatch, calls)
+
+    result = email.reply_to_email(
+        config,
+        None,
+        account_email="me@example.com",
+        email_id="original-1",
+        body="Thanks",
+        reply_all=True,
+    )
+
+    assert result["status"] == "pending"
+    assert [call["path"] for call in calls] == ["/me/messages/original-1/createReplyAll", "/me/messages/reply-all-draft"]
+    assert pending_send.list_pending(tmp_path)[0].action == "reply-all"
+
+
+def test_graph_large_attachment_is_uploaded_before_the_draft_is_queued(tmp_path, monkeypatch):
+    calls = []
+    uploads = []
+    config = Config(data_dir=tmp_path)
+    attachment = tmp_path / "report.pdf"
+    attachment.write_bytes(b"pdf")
+    _patch_graph(monkeypatch, calls)
+    monkeypatch.setattr(email, "LARGE_ATTACHMENT_THRESHOLD", 1)
+    monkeypatch.setattr(email.graph, "upload_mail_attachment_cfg", lambda *_args: uploads.append(_args))
+
+    result = email.send_email(
+        config,
+        None,
+        account_email="me@example.com",
+        mail=MailDraft(to=["bob@example.com"], subject="Hello", body="Body", attachments=[str(attachment)]),
+    )
+
+    assert result["status"] == "pending"
+    assert len(uploads) == 1
+    assert pending_send.list_pending(tmp_path)[0].payload == b"compose-draft"
+
+
+def test_owa_send_creates_a_provider_draft_and_returns_pending(tmp_path, monkeypatch):
+    config = Config(data_dir=tmp_path)
+    calls = []
+
+    def create_draft(_client, account_email, _config, *, mail):
+        calls.append((account_email, mail))
+        return {"id": "owa-draft"}
+
+    monkeypatch.setattr(owa_rest_commands.owa_rest, "create_draft", create_draft)
+
+    result = owa_rest_commands.send_email(
+        config,
+        None,
+        account_email="me@example.com",
+        mail=MailDraft(to=["bob@example.com"], subject="Hello", body="Body"),
+    )
+
+    assert result["status"] == "pending"
+    assert len(calls) == 1
+    queued = pending_send.list_pending(tmp_path)[0]
+    assert queued.backend == backend.OWA_REST
+    assert queued.payload == b"owa-draft"
+
+
+def test_all_owa_outbound_actions_and_attachments_use_provider_drafts(tmp_path, monkeypatch):
+    config = Config(data_dir=tmp_path)
+    pending_send.set_delay_seconds(tmp_path, 70)
+    attachment = tmp_path / "report.pdf"
+    attachment.write_bytes(b"pdf")
+    drafts = []
+
+    def create_draft(_client, account_email, _config, *, mail):
+        drafts.append((account_email, mail))
+        if mail.reply_to_id:
+            draft_id = "reply-all-draft" if mail.reply_all else "reply-draft"
+        elif mail.forward_id:
+            draft_id = "forward-draft"
+        else:
+            draft_id = "send-draft"
+        return {"id": draft_id}
+
+    monkeypatch.setattr(owa_rest_commands.owa_rest, "create_draft", create_draft)
+
+    owa_rest_commands.send_email(
+        config,
+        None,
+        account_email="me@example.com",
+        mail=MailDraft(
+            to=["bob@example.com"],
+            subject="Hello",
+            body="Body",
+            attachments=[str(attachment)],
+        ),
+    )
+    owa_rest_commands.reply_to_email(
+        config,
+        None,
+        account_email="me@example.com",
+        email_id="original-1",
+        body="Reply",
+        attachments=[str(attachment)],
+    )
+    owa_rest_commands.reply_to_email(
+        config,
+        None,
+        account_email="me@example.com",
+        email_id="original-2",
+        body="Reply all",
+        reply_all=True,
+    )
+    owa_rest_commands.forward_email(
+        config,
+        None,
+        account_email="me@example.com",
+        email_id="original-3",
+        mail=MailDraft(to=["bob@example.com"], body="Forward", attachments=[str(attachment)]),
+    )
+
+    queued = pending_send.list_pending(tmp_path)
+    assert [item.action for item in queued] == ["send", "reply", "reply-all", "forward"]
+    assert all(item.send_at - item.created_at == timedelta(seconds=70) for item in queued)
+    assert drafts[0][1].attachments == [str(attachment)]
+    assert drafts[1][1].attachments == [str(attachment)]
+    assert drafts[3][1].attachments == [str(attachment)]
+
+
+def test_dispatch_sends_the_graph_draft_once(tmp_path, monkeypatch):
+    config = Config(data_dir=tmp_path)
+    calls = []
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="me@example.com",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend=backend.GRAPH,
+        payload=b"draft-1",
+    )
+    monkeypatch.setattr(pending_send.auth, "get_account_id_by_email", lambda *_args: "account-1")
+    monkeypatch.setattr(
+        pending_send.graph,
+        "request_cfg",
+        lambda _config, _client, method, path, _account_id: calls.append((method, path)),
+    )
+
+    assert pending_send.dispatch_due(config, None, now=queued.send_at) is True
+    assert pending_send.dispatch_due(config, None, now=queued.send_at) is False
+    assert calls == [("POST", "/me/messages/draft-1/send")]
+
+
+def test_dispatch_sends_the_owa_draft_once(tmp_path, monkeypatch):
+    config = Config(data_dir=tmp_path)
+    calls = []
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="me@example.com",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend=backend.OWA_REST,
+        payload=b"draft-1",
+    )
+    monkeypatch.setattr(
+        pending_send.owa_rest,
+        "send_draft",
+        lambda _client, account, _config, *, item_id: calls.append((account, item_id)),
+    )
+
+    assert pending_send.dispatch_due(config, None, now=queued.send_at) is True
+    assert pending_send.dispatch_due(config, None, now=queued.send_at) is False
+    assert calls == [("me@example.com", "draft-1")]
+
+
+def test_undo_deletes_the_provider_draft(tmp_path, monkeypatch):
+    config = Config(data_dir=tmp_path)
+    calls = []
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="me@example.com",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend=backend.GRAPH,
+        payload=b"draft-1",
+    )
+    monkeypatch.setattr(pending_send.auth, "get_account_id_by_email", lambda *_args: "account-1")
+    monkeypatch.setattr(
+        pending_send.graph,
+        "request_cfg",
+        lambda _config, _client, method, path, _account_id: calls.append((method, path)),
+    )
+
+    result = pending_send.undo(config, None, queued.id)
+
+    assert result == {"id": queued.id, "status": "cancelled"}
+    assert calls == [("DELETE", "/me/messages/draft-1")]
+    assert pending_send.list_pending(tmp_path) == []
+
+
+def test_undo_deletes_the_owa_provider_draft(tmp_path, monkeypatch):
+    config = Config(data_dir=tmp_path)
+    calls = []
+    queued = pending_send.enqueue(
+        tmp_path,
+        account="me@example.com",
+        action="send",
+        subject="Hello",
+        recipients="bob@example.com",
+        backend=backend.OWA_REST,
+        payload=b"draft-1",
+    )
+    monkeypatch.setattr(
+        pending_send.owa_rest,
+        "delete_message",
+        lambda _client, account, _config, *, item_id: calls.append((account, item_id)),
+    )
+
+    result = pending_send.undo(config, None, queued.id)
+
+    assert result == {"id": queued.id, "status": "cancelled"}
+    assert calls == [("me@example.com", "draft-1")]
+    assert pending_send.list_pending(tmp_path) == []
+
+
+def test_delay_is_client_configuration_not_a_send_option(tmp_path):
+    parser = cli.build_parser()
+    send_args = parser.parse_args(
+        ["email", "send", "--account", "me@example.com", "--to", "bob@example.com", "--subject", "Hello", "--body", "Body"]
+    )
+    delay_args = parser.parse_args(["email", "send-delay", "--seconds", "45"])
+
+    assert "seconds" not in vars(send_args)
+    assert cli._dispatch_email(delay_args, Config(data_dir=tmp_path), None) == {"send_delay_seconds": 45}

--- a/agent/skills/microsoft/references/email.md
+++ b/agent/skills/microsoft/references/email.md
@@ -1,6 +1,6 @@
 # Email (CLI: microsoft email / folder)
 
-Every command takes `--account <email>` and `--backend {auto,graph,owa-rest}` (see [SETUP.md](../SETUP.md)).
+Mailbox commands take `--account <email>` and `--backend {auto,graph,owa-rest}` (see [SETUP.md](../SETUP.md)). Delayed-send management is client-wide as described below.
 
 ## Read and send
 
@@ -17,6 +17,20 @@ microsoft email search --account user@example.com --query "invoice" --since 2021
 ```
 
 `send`, `reply`, and `forward` accept `--attachments file1 file2` and `--html` (treats `--body` as HTML). `forward` requires `--to` and also takes `--cc`.
+
+## Delayed send and undo
+
+Send, reply, and forward operations wait 30 seconds by default across all Microsoft accounts and both email backends. The delay is one persisted setting for the Microsoft client and cannot be overridden on an individual send:
+
+```bash
+microsoft email send-delay
+microsoft email send-delay --seconds 60
+microsoft email pending
+microsoft email pending --account user@example.com
+microsoft email undo --id <pending_id>
+```
+
+Each send, reply, or forward command creates a provider draft and returns a `pending` status with its id and scheduled send time. The background daemon sends due drafts through the backend that created them. Use `undo` before the deadline to cancel the pending send and delete its provider draft. Keep `microsoft serve` running whenever the delay is nonzero. Set `--seconds 0` for immediate delivery. Explicit drafts are never queued.
 
 ## Organize messages
 

--- a/agent/skills/microsoft/references/email.md
+++ b/agent/skills/microsoft/references/email.md
@@ -30,7 +30,9 @@ microsoft email pending --account user@example.com
 microsoft email undo --id <pending_id>
 ```
 
-Each send, reply, or forward command creates a provider draft and returns a `pending` status with its id and scheduled send time. The background daemon sends due drafts through the backend that created them. Use `undo` before the deadline to cancel the pending send and delete its provider draft. Keep `microsoft serve` running whenever the delay is nonzero. Set `--seconds 0` for immediate delivery. Explicit drafts are never queued.
+Each send, reply, or forward command creates a provider draft and returns a `pending` status with its id and scheduled send time. `microsoft serve` sends due drafts through the backend that created them, and every email command already requires it to be running. Use `undo` to cancel a pending send and delete its provider draft: it works right up until the daemon starts dispatching that message. Set `--seconds 0` for immediate delivery. Explicit drafts are never queued.
+
+`pending` also lists messages whose status is `failed`, with `last_error` saying why: delivery kept erroring, or it was cut off mid-dispatch. A message cut off mid-dispatch may already have been sent, so read the Sent folder before you `undo` it or send it again.
 
 ## Organize messages
 

--- a/check.sh
+++ b/check.sh
@@ -65,6 +65,9 @@ check_agent() {
     done
     uv run --project core ty check
     uv run --project core pytest tests/ -v
+    # email-client ships plain scripts rather than a cli/ project, so the loop below
+    # cannot find its suite: name it here or it never runs.
+    uv run --project core pytest skills/email-client/tests -q
     # Each skill CLI is its own standalone uv project (own venv, own lockfile).
     # uv honors UV_PROJECT_ENVIRONMENT (exported above for core) over --project,
     # so unset it here or every suite would run in the shared core venv.


### PR DESCRIPTION
## Summary

- add persisted client-wide send delays, defaulting to 30 seconds, to email-client, Google, and Microsoft
- queue fully resolved SMTP messages and provider drafts inside the native client implementations
- add pending-send inspection, undo by stable ID, daemon dispatch, retry, and restart recovery
- cover Gmail, Graph, OWA REST, SMTP, reply-all, forward, attachments, and Graph large uploads
- document delay configuration and undo commands for each skill

## Test plan

- `./check.sh guards`
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv" uv run --project core ty check`
- email-client: 140 passed
- Google: 87 passed
- Microsoft: 257 passed
- full agent run: 724 passed; 32 unrelated macOS-only baseline failures reproduced on master (`mapfile` under Bash 3.2 and WhatsApp launcher environment expectations)

Closes #1446