### PR TITLE
fix(chat): preserve messages across reconnect reseeds

### DIFF
--- a/apps/core/src/chat/chat-stream-model.test.ts
+++ b/apps/core/src/chat/chat-stream-model.test.ts
@@ -156,6 +156,20 @@ describe("chat-stream-model", () => {
     expect(state.cursor).toBe(1)
   })
 
+  it("restarts paging from the reseed page when the disconnect outran a whole page", () => {
+    let state = seedTail(initialChatState(), {
+      events: [chat(1, "a"), chat(2, "b")],
+      cursor: null,
+    })
+
+    // Nothing on the reconnect page overlaps what is held, so ids 3-9 are a hole between them that
+    // no cursor reaches. Keeping 1-2 would show them under that hole; drop them and page from 10.
+    state = seedTail(state, { events: [chat(10, "j"), chat(11, "k")], cursor: 10 })
+
+    expect(state.messages.map((message) => message.id)).toEqual([10, 11])
+    expect(state.cursor).toBe(10)
+  })
+
   it("preserves a pending optimistic bubble across a resync reseed and confirms its later echo", () => {
     let state = beginSend(initialChatState(), "hi", "typed", "i-1")
 

--- a/apps/core/src/chat/chat-stream-model.test.ts
+++ b/apps/core/src/chat/chat-stream-model.test.ts
@@ -137,6 +137,25 @@ describe("chat-stream-model", () => {
     expect(replay.state.messages).toHaveLength(2)
   })
 
+  it("keeps retained older pages before the newest tail when a reconnect reseeds", () => {
+    let state = seedTail(initialChatState(), {
+      events: [chat(3, "c"), chat(4, "d")],
+      cursor: 3,
+    })
+    state = prependPage(state, [chat(1, "a"), chat(2, "b")], 1)
+
+    // The reconnect page overlaps the old tail and includes one message that arrived since it.
+    // Retained ids 1-2 are older, so they must not be appended after the newest page.
+    state = seedTail(state, {
+      events: [chat(3, "c"), chat(4, "d"), chat(5, "e")],
+      cursor: 3,
+    })
+
+    expect(state.messages.map((message) => message.id)).toEqual([1, 2, 3, 4, 5])
+    expect(state.messages.at(-1)?.id).toBe(5)
+    expect(state.cursor).toBe(1)
+  })
+
   it("preserves a pending optimistic bubble across a resync reseed and confirms its later echo", () => {
     let state = beginSend(initialChatState(), "hi", "typed", "i-1")
 

--- a/apps/core/src/chat/chat-stream-model.ts
+++ b/apps/core/src/chat/chat-stream-model.ts
@@ -45,68 +45,57 @@ function capTail(messages: ChatMessage[]): ChatMessage[] {
   return messages.length > PACING.maxMessages ? messages.slice(-PACING.maxMessages) : messages
 }
 
-// Merge the newest history page and MERGE, never replace: a live row that raced the fetch (id absent
-// from the page) and an optimistic bubble still awaiting its echo both survive, so no delivered or
-// in-flight message is dropped. An optimistic bubble whose intent already appears as a persisted user
-// echo ON the page is instead dropped and its intent cleared: that echo IS the confirmation, so it
-// must not survive as a duplicate "sending" twin (mobile background/foreground, web resync-mid-send).
-// Persisted rows are merged by their skill-assigned, monotonically increasing ids: retained rows may
-// be older pages OR newer live races, so simply putting either side first corrupts one of those
-// seams. Existing id-less optimistic rows keep their position relative to live rows. A resync also
-// retains the existing older-page cursor so already-loaded history is not fetched and prepended
-// again. shownIds is unioned with the page ids. Serves the initial load and a resync alike.
+// Merge the newest history page, never replace: a live row that raced the fetch and an optimistic
+// bubble still awaiting its echo both survive, so no delivered or in-flight message is dropped. A
+// bubble whose intent already appears as a persisted echo ON the page folds into it, since that echo
+// IS the confirmation and must not survive as a duplicate "sending" twin (mobile background, web
+// resync-mid-send). Ids are handed out in order, so every retained row is either older than the whole
+// page or newer than every row on it: older rows, then the page, then live races and bubbles. The
+// loaded older-page cursor is kept, so a resync does not refetch and prepend history already held.
+// shownIds is unioned with the page ids. Serves the initial load and a resync alike.
 export function seedTail(state: ChatState, page: HistoryPage): ChatState {
   const pageIds = new Set<number>()
-  const pageById = new Map<number, ChatMessage>()
   const echoedIntents = new Set<string>()
+  let oldestPageId: number | null = null
   for (const event of page.events) {
     if (event.id != null) {
       pageIds.add(event.id)
-      pageById.set(event.id, event)
+      if (oldestPageId == null || event.id < oldestPageId) oldestPageId = event.id
     }
     if (event.type === "user" && event.intent_id != null) echoedIntents.add(event.intent_id)
   }
-  const mergedIds = new Set<number>()
-  const messages = state.messages.flatMap((message): ChatMessage[] => {
-    const pending =
-      message.type === "user" &&
-      message.intent_id != null &&
-      state.pendingIntents.has(message.intent_id)
-    if (pending && message.intent_id != null && echoedIntents.has(message.intent_id)) return []
-    if (message.id == null) return pending ? [message] : []
-    mergedIds.add(message.id)
-    return [pageById.get(message.id) ?? message]
-  })
-  for (const event of page.events) {
-    if (event.id == null) {
-      messages.push(event)
+  const older: ChatMessage[] = []
+  const newer: ChatMessage[] = []
+  let overlaps = false
+  for (const message of state.messages) {
+    const intentId = message.type === "user" ? message.intent_id : undefined
+    const pending = intentId != null && state.pendingIntents.has(intentId)
+    if (pending && echoedIntents.has(intentId)) continue
+    if (message.id == null) {
+      if (pending) newer.push(message)
       continue
     }
-    if (mergedIds.has(event.id)) continue
-    mergedIds.add(event.id)
-
-    // Insert before the first newer persisted row. Any optimistic rows immediately before that row
-    // also happened after this history event, so insert before that run rather than splitting it.
-    let insertAt = messages.findIndex(
-      (message) => message.id != null && event.id != null && message.id > event.id,
-    )
-    if (insertAt === -1) {
-      messages.push(event)
+    if (pageIds.has(message.id)) {
+      overlaps = true
       continue
     }
-    while (insertAt > 0 && messages[insertAt - 1]?.id == null) insertAt--
-    messages.splice(insertAt, 0, event)
+    if (oldestPageId != null && message.id < oldestPageId) older.push(message)
+    else newer.push(message)
   }
+
+  // Older rows the page does not reach sit above a hole no cursor can page into (a disconnect longer
+  // than one page), so they are dropped and paging restarts from the page's own cursor.
+  const joined = older.length === 0 || overlaps
   const pendingIntents = new Set(state.pendingIntents)
   for (const intentId of echoedIntents) pendingIntents.delete(intentId)
   const shownIds = new Set(state.shownIds)
   for (const id of pageIds) shownIds.add(id)
   return {
     ...state,
-    messages: capTail(messages),
+    messages: capTail([...(joined ? older : []), ...page.events, ...newer]),
     shownIds,
     pendingIntents,
-    cursor: state.historyLoaded ? state.cursor : page.cursor,
+    cursor: joined && state.historyLoaded ? state.cursor : page.cursor,
     historyLoaded: true,
   }
 }

--- a/apps/core/src/chat/chat-stream-model.ts
+++ b/apps/core/src/chat/chat-stream-model.ts
@@ -50,32 +50,63 @@ function capTail(messages: ChatMessage[]): ChatMessage[] {
 // in-flight message is dropped. An optimistic bubble whose intent already appears as a persisted user
 // echo ON the page is instead dropped and its intent cleared: that echo IS the confirmation, so it
 // must not survive as a duplicate "sending" twin (mobile background/foreground, web resync-mid-send).
-// shownIds is unioned with the page ids. Serves the initial load and a resync alike.
+// Persisted rows are merged by their skill-assigned, monotonically increasing ids: retained rows may
+// be older pages OR newer live races, so simply putting either side first corrupts one of those
+// seams. Existing id-less optimistic rows keep their position relative to live rows. A resync also
+// retains the existing older-page cursor so already-loaded history is not fetched and prepended
+// again. shownIds is unioned with the page ids. Serves the initial load and a resync alike.
 export function seedTail(state: ChatState, page: HistoryPage): ChatState {
   const pageIds = new Set<number>()
+  const pageById = new Map<number, ChatMessage>()
   const echoedIntents = new Set<string>()
   for (const event of page.events) {
-    if (event.id != null) pageIds.add(event.id)
+    if (event.id != null) {
+      pageIds.add(event.id)
+      pageById.set(event.id, event)
+    }
     if (event.type === "user" && event.intent_id != null) echoedIntents.add(event.intent_id)
   }
-  const survivors = state.messages.filter(
-    (message) =>
-      (message.type === "user" &&
-        message.intent_id != null &&
-        state.pendingIntents.has(message.intent_id) &&
-        !echoedIntents.has(message.intent_id)) ||
-      (message.id != null && !pageIds.has(message.id)),
-  )
+  const mergedIds = new Set<number>()
+  const messages = state.messages.flatMap((message): ChatMessage[] => {
+    const pending =
+      message.type === "user" &&
+      message.intent_id != null &&
+      state.pendingIntents.has(message.intent_id)
+    if (pending && message.intent_id != null && echoedIntents.has(message.intent_id)) return []
+    if (message.id == null) return pending ? [message] : []
+    mergedIds.add(message.id)
+    return [pageById.get(message.id) ?? message]
+  })
+  for (const event of page.events) {
+    if (event.id == null) {
+      messages.push(event)
+      continue
+    }
+    if (mergedIds.has(event.id)) continue
+    mergedIds.add(event.id)
+
+    // Insert before the first newer persisted row. Any optimistic rows immediately before that row
+    // also happened after this history event, so insert before that run rather than splitting it.
+    let insertAt = messages.findIndex(
+      (message) => message.id != null && event.id != null && message.id > event.id,
+    )
+    if (insertAt === -1) {
+      messages.push(event)
+      continue
+    }
+    while (insertAt > 0 && messages[insertAt - 1]?.id == null) insertAt--
+    messages.splice(insertAt, 0, event)
+  }
   const pendingIntents = new Set(state.pendingIntents)
   for (const intentId of echoedIntents) pendingIntents.delete(intentId)
   const shownIds = new Set(state.shownIds)
   for (const id of pageIds) shownIds.add(id)
   return {
     ...state,
-    messages: capTail([...page.events, ...survivors]),
+    messages: capTail(messages),
     shownIds,
     pendingIntents,
-    cursor: page.cursor,
+    cursor: state.historyLoaded ? state.cursor : page.cursor,
     historyLoaded: true,
   }
 }

--- a/apps/web/src/providers/AgentSocketProvider/use-agent-socket.test.tsx
+++ b/apps/web/src/providers/AgentSocketProvider/use-agent-socket.test.tsx
@@ -177,6 +177,47 @@ describe("useAgentSocketState", () => {
     expect(result.current.connected).toBe(true);
   });
 
+  it("keeps loaded older rows before the newest tail after a reconnect", async () => {
+    vi.useFakeTimers();
+    fetchHistoryMock
+      .mockResolvedValueOnce({
+        events: [chat(3, "c"), chat(4, "d")],
+        cursor: 3,
+      })
+      .mockResolvedValueOnce({
+        events: [chat(1, "a"), chat(2, "b")],
+        cursor: null,
+      })
+      .mockResolvedValueOnce({
+        events: [chat(3, "c"), chat(4, "d"), chat(5, "e")],
+        cursor: 3,
+      });
+    const { controller } = makeController();
+    const { result } = render(controller);
+    await openAndFlush();
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+    expect(result.current.messages.map((message) => message.id)).toEqual([
+      1, 2, 3, 4,
+    ]);
+
+    act(() => {
+      chatSockets[0]?.onclose?.();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    await openAndFlush();
+
+    expect(result.current.messages.map((message) => message.id)).toEqual([
+      1, 2, 3, 4, 5,
+    ]);
+    expect(result.current.messages.at(-1)?.id).toBe(5);
+    expect(result.current.hasMore).toBe(false);
+  });
+
   it("sends an optimistic bubble and confirms it on the chat-socket echo", async () => {
     fetchHistoryMock.mockResolvedValue({ events: [], cursor: null });
     const { controller, json } = makeController();


### PR DESCRIPTION
## Summary

- merge reconnect history rows by their monotonically increasing event IDs
- preserve optimistic bubble placement while reconciling persisted echoes
- retain the loaded-history cursor so reconnects do not fetch and prepend duplicate pages
- add core and web-hook regression coverage for load-older followed by reconnect

## Root cause

A reconnect prepended the newest history page ahead of retained older rows. That corrupted chronological order, moved stale messages to the visible bottom of the chat, and could cause the newest rows to be removed by the tail cap. Reloading appeared to recover the messages because it loaded only the correctly ordered newest page.

## Validation

- core: 247 tests passed
- web: 190 tests passed
- core and web TypeScript checks passed
- changed files passed ESLint
- web production build passed
- desktop TypeScript check passed
