### PR TITLE
fix(pr-monitor): raise the run cap above how long real work takes

### DIFF
--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -58,7 +58,7 @@ Each run can build a worktree of several hundred megabytes, so the ceiling is di
 
 Those worktrees are cleaned up as their work concludes, at most once every `PR_MONITOR_PRUNE_WORKTREES` seconds. A worktree goes only when losing it cannot lose work: its branch belongs to a closed or merged PR, or its commits are already on master by content, which is how a squash merge is recognised despite the rewritten hashes. Anything holding uncommitted changes is left alone, as is anything whose commits exist nowhere else, and a failed PR listing prunes nothing rather than reading an empty answer as "everything is closed".
 
-A run is also capped at `PR_MONITOR_TIMEOUT` and stopped past it. A run whose connection dies waits on a socket that never speaks again, consuming no CPU and looking alive from outside, and without the cap it holds its slot for as long as the process lives.
+A run is also capped at `PR_MONITOR_TIMEOUT` and stopped past it. The cap is there to end a run that has stopped progressing, not a slow one, so it sits well above how long real work takes: a polish pass dispatches a blocking subagent and can run past half an hour. Cutting a run short after it has already pushed leaves a commit on the branch with nothing explaining it, and the retry repeats the work. A run whose connection dies waits on a socket that never speaks again, consuming no CPU and looking alive from outside, and without the cap it holds its slot for as long as the process lives.
 
 Each repo is polled by its own loop, on its own clock, and the interval counts from the start of a pass rather than its end. A repo with a long backlog therefore delays only itself, and the time a pass takes is never added to the gap before the next one. That matters for more than latency: two events noticed a cycle apart are handled a cycle apart no matter how many runs may go at once, so how fast events are noticed is what decides whether concurrency is ever reached.
 
@@ -157,7 +157,7 @@ Two consequences worth knowing:
 | `PR_MONITOR_INTERVAL` | `45` | Seconds between the starts of one repo's polls |
 | `PR_MONITOR_STATE` | `$XDG_STATE_HOME/pr-monitor` | Review-summary ledger and per-PR session ids |
 | `PR_MONITOR_MODEL` | `claude-opus-5` | Model `dispatch.sh` runs each event on |
-| `PR_MONITOR_TIMEOUT` | `1800` | Seconds a single run may take before it is stopped |
+| `PR_MONITOR_TIMEOUT` | `7200` | Seconds before a run is treated as abandoned and stopped |
 | `PR_MONITOR_PARALLEL` | `3` | Runs allowed at once, across different PRs |
 | `PR_MONITOR_PRUNE_WORKTREES` | `3600` | Seconds between sweeps for finished agent worktrees |
 | `PR_MONITOR_WINDOW` | `7 days ago` | How far back the repo-wide comment listings reach |

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -18,7 +18,7 @@ set -uo pipefail
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MONITOR="$SKILL_DIR/monitor.sh"
 MODEL="${PR_MONITOR_MODEL:-claude-opus-5}"
-RUN_TIMEOUT="${PR_MONITOR_TIMEOUT:-1800}"
+RUN_TIMEOUT="${PR_MONITOR_TIMEOUT:-7200}"
 PARALLEL="${PR_MONITOR_PARALLEL:-3}"
 PRUNE_WORKTREES_EVERY="${PR_MONITOR_PRUNE_WORKTREES:-3600}"
 STATE_ROOT="${PR_MONITOR_STATE:-${XDG_STATE_HOME:-$HOME/.local/state}/pr-monitor}"
@@ -200,9 +200,12 @@ handle() {
   before=$(gh api "/repos/$repo/issues/$pr/comments" -q 'length' 2>/dev/null)
   local args=(-p --model "$MODEL" --output-format json --dangerously-skip-permissions)
   [ -s "$sf" ] && args+=(--resume "$(cat "$sf")")
-  # Events are handled one at a time, so a run that hangs holds every later event
-  # behind it for as long as it lives, and a lost connection leaves one waiting on
-  # a socket that never speaks again. The cap turns that into an ordinary failure.
+  # The cap exists to end a run that has stopped making progress, not a slow one:
+  # a lost connection leaves a run waiting on a socket that never speaks again,
+  # consuming no CPU and looking alive. It must sit well above how long real work
+  # takes, because a run killed after it has pushed leaves the commit with nothing
+  # explaining it, and the retry repeats the work. A polish pass dispatches a
+  # blocking subagent and runs past half an hour; an abandoned run sat for twelve.
   out=$(timeout "$RUN_TIMEOUT" claude "${args[@]}" "$prompt" 2>/dev/null)
   rc=$?
   # A stored id that no longer resolves would fail every retry, so forget it.


### PR DESCRIPTION
The cap added in #1565 stopped a healthy run on #1575:

```
14:38:31Z  claimed
14:50:09Z  polish subagent pushed its commit
15:08:32Z  "exceeded 1800s and was stopped"    <- the cap
           no comment posted, claim released
```

It was not stuck. 213 turns, transcript still growing, five live sockets, a blocking Opus subagent mid-work. I sized 1800s from a single observation of a roughly ten minute pass; `polish-pr` dispatches a blocking subagent and legitimately runs past half an hour.

### Why this is worse than a slow run

The kill landed **after the push**, so the commit sits on the branch with nothing explaining it. From the outside that is indistinguishable from the agent forgetting to comment, which is what it looked like. And because the claim is released, the retry repeats the work rather than resuming where it left off.

### The fix

The cap exists to end a run that has stopped progressing, not a slow one, so it has to sit well above how long real work takes:

```
real work (polish pass)      ~30 min
abandoned run (#1555)         12 hours
new cap                        2 hours
```

Two hours separates the two cases without cutting anything short. A hang still costs a slot for two hours rather than forever, which was the point of #1565.

### Known limit

Wall clock is a blunt signal: it cannot tell a working run from a wedged one, only long from short. The sharp signal is progress, since the abandoned run used 9 seconds of CPU across twelve hours and wrote nothing to its transcript after startup, while this one was writing continuously. A stall detector would be strictly better than a duration cap, and is worth doing if this ever bites from the other side.