### PR TITLE
fix(pr-monitor): give the claim back when a run is signalled

### DIFF
--- a/.claude/skills/pr-monitor/SKILL.md
+++ b/.claude/skills/pr-monitor/SKILL.md
@@ -139,6 +139,8 @@ A surfaced item gets a 👀 reaction on the comment (or on the PR itself, for de
 
 The reaction is posted at emit time, not by whatever handles the event. Without that, an item would re-fire every cycle for as long as it sat unhandled. The ack is also posted *before* the line is printed: if it fails, nothing is emitted and the item is retried next cycle, so a failure can never produce an event that gets handled twice.
 
+A claim is given back on every way out of a run, being killed included: the service is signalled as a whole, so a deploy lands mid-run, and a claim left behind with nothing running reads as handled and is never emitted again. The release happens once the run itself has been signalled, since a shell defers a trapped signal while it waits on a child.
+
 The reaction is therefore a **claim, not a completion**. Under `dispatch.sh` a failed run releases the claim, removing only this account's reaction, and the event surfaces again on the next cycle. That is what makes a usage limit recoverable: the runs fail, the claims are released, and the events come back once the limit resets. A consumer that emits events some other way should release claims the same way, or a failure will drop the event silently.
 
 Two consequences worth knowing:

--- a/.claude/skills/pr-monitor/dispatch.sh
+++ b/.claude/skills/pr-monitor/dispatch.sh
@@ -204,6 +204,11 @@ handle() {
   if ! claim "$repo" "$kind" "$id"; then
     return 0
   fi
+  # Every path out of a claimed run has to give the claim back, and being killed
+  # is one of them: systemd signals the whole service, so a deploy lands here
+  # mid-run. Without this the claim survives with nothing running behind it, the
+  # monitor reads it as handled, and the event is never emitted again.
+  trap 'release "$repo" "$kind" "$id"; exit 143' TERM INT
   sf="$(session_file "$repo" "$pr")"
   local before
   before=$(gh api "/repos/$repo/issues/$pr/comments" -q 'length' 2>/dev/null)
@@ -223,6 +228,7 @@ handle() {
     echo "dispatch: claude failed rc=$rc on $repo#$pr, releasing claim" >&2
     [ -s "$sf" ] && rm -f "$sf"
     release "$repo" "$kind" "$id"
+    trap - TERM INT
     return 1
   fi
   sid=$(printf '%s' "$out" | jq -r '.session_id // empty' 2>/dev/null)
@@ -230,6 +236,7 @@ handle() {
   if [ "$(printf '%s' "$out" | jq -r '.is_error // false' 2>/dev/null)" = "true" ]; then
     echo "dispatch: claude reported an error on $repo#$pr, releasing claim" >&2
     release "$repo" "$kind" "$id"
+    trap - TERM INT
     return 1
   fi
   # A run that posts nothing looks identical to a healthy one from out here, and
@@ -238,6 +245,7 @@ handle() {
   if [ "$(gh api "/repos/$repo/issues/$pr/comments" -q 'length' 2>/dev/null)" = "$before" ]; then
     echo "dispatch: WARN $repo#$pr run finished without commenting" >&2
   fi
+  trap - TERM INT
   echo "dispatch: handled $repo#$pr ($kind $id)" >&2
   prune_sessions "$repo"
   prune_worktrees "$repo"


### PR DESCRIPTION
The claim was released when a run failed or errored, never when it was killed. Since the service is signalled as a whole, every deploy lands mid-run: the run dies, the claim survives with nothing behind it, and the monitor reads it as handled and never emits the event again.

This is the same silent-drop family as #1546 and #1551, one level down. #1546 fixed "emitted but never consumed"; this is "claimed, then killed".

### It happened

Restarting to ship #1576 killed the run on #1575:

```
t+15s   running=0   claimed=1   comments=2
t+360s  running=0   claimed=1   comments=2
```

Six minutes, nothing running, claim still held. It only moved because I deleted the reaction by hand.

### Fix

A `trap` on `TERM`/`INT` releases the in-flight claim, cleared on every normal exit so a completed run never releases what it legitimately holds.

### Verified

Isolated reproduction of the claim/kill/release path:

```
CLAIMED elyxlz/vesta issue 9001
RELEASED elyxlz/vesta issue 9001
```

Worth recording, because it took three failed harnesses to see: a shell defers a trapped signal while waiting on a foreground child, so the release only lands once the run itself has been signalled too. Signalling the dispatcher alone leaves the claim held. A whole-service signal covers the run, which is exactly what systemd sends, so the real path is the one that works.