### PR TITLE
fix(web): keep full log console following tail

### DIFF
--- a/apps/web/src/components/Console/index.tsx
+++ b/apps/web/src/components/Console/index.tsx
@@ -229,6 +229,10 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
 
   const parentRef = useRef<HTMLDivElement>(null);
   const count = lines.length;
+  // `count` stops changing once the scrollback cap is full, but the tail still
+  // advances as old lines are dropped. Key follow-on-append to the newest line
+  // instead so a full console continues to follow live output.
+  const newestLineId = lines.at(-1)?.id;
 
   // Every log line stays in the DOM (no windowing) so a native text selection survives
   // scrolling and copies the full range; off-screen rows skip layout/paint via
@@ -246,7 +250,7 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
   useLayoutEffect(() => {
     const el = parentRef.current;
     if (el && count > 0 && pinnedRef.current) el.scrollTop = el.scrollHeight;
-  }, [count]);
+  }, [count, newestLineId]);
 
   const linePad = fullscreen ? "px-page" : "px-5";
 


### PR DESCRIPTION
## Summary
- trigger log auto-follow from the newest line, not only the retained line count
- keep following live output after the 5,000-line scrollback cap is reached
- preserve the existing behavior that stops following when the user scrolls up

## Validation
- `npm run check` (apps/web)
- `npm run lint -- --quiet` (apps/web)
- `git diff --check`