### PR TITLE
fix(agent): bring daemons up after sync and migrations, not before

### DIFF
--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -163,17 +163,6 @@ def config_issues_turn(issues: list[str]) -> str | None:
     )
 
 
-# A migration/upgrade boot is a restart: the daemons are down, but the converge turns
-# (before-sync migrations, upstream sync, after-sync migrations) run before the greeting's restart turn, so nothing
-# has restored them yet. Prepend this to the first converge turn so the agent runs the restart skill
-# first, exactly as it would on a plain restart, before tunnelling into the migration or upgrade.
-BOOT_RESTORE_ORIENTATION = (
-    "Your daemons are down after this boot, just like any restart. Before the task below, read the "
-    "`restart` skill and run its Daemons block to bring your daemons back (it is idempotent, so "
-    "running it when everything is already up is a safe no-op). Then continue with the task."
-)
-
-
 def collect_boot_turns(
     *, state: vm.State, config: cfg.VestaConfig, config_issues: list[str], agent_message: str, first_start: bool
 ) -> list[str]:
@@ -187,8 +176,13 @@ def collect_boot_turns(
     proceeds to sync. When sync merges changes, its own restart naturally leaves the still-unmarked
     after-sync migrations for the next boot.
 
-    The greeting's restart turn restores daemons; converge turns run before it, so the first one
-    carries BOOT_RESTORE_ORIENTATION to restore daemons first."""
+    Daemons come up last, at the greeting's restart turn (it runs the restart skill's Daemons block),
+    so they never start against a Daemons block the sync or a migration is about to rewrite. The
+    greeting is appended every boot, before it is known whether this boot restarts: a boot that
+    settles (no-op sync, a migration batch that does not restart, a plain restart) ends on it and
+    brings daemons up, while a boot that restarts mid-converge (sync merge, before-sync barrier)
+    abandons the still-queued greeting and the next boot re-queues it. Daemons therefore stay down
+    for the whole converge, by design, and come up once on the boot that finally settles."""
     turns: list[str] = []
     before_sync_turns = before_sync_migration_turns(state=state, config=config, first_start=first_start)
     if before_sync_turns:
@@ -201,8 +195,6 @@ def collect_boot_turns(
     config_turn = config_issues_turn(config_issues)
     if config_turn is not None:
         turns.append(config_turn)
-    if turns:
-        turns[0] = f"{BOOT_RESTORE_ORIENTATION}\n\n{turns[0]}"
     greeting = greeting_turn(config=config, state=state, agent_message=agent_message, first_start=first_start)
     if greeting is not None:
         turns.append(greeting)

--- a/agent/core/prompts/restart.md
+++ b/agent/core/prompts/restart.md
@@ -1,1 +1,1 @@
-Read the `restart` skill and follow it.
+Your daemons are down after this restart. Read the `restart` skill and follow it: its Daemons block brings them back (idempotent, a safe no-op when everything is already up).

--- a/agent/tests/test_boot_turns.py
+++ b/agent/tests/test_boot_turns.py
@@ -6,7 +6,8 @@ from test_upstream_sync_turn import _record_snapshot
 
 import core.config as cfg
 import core.models as vm
-from core.main import BOOT_RESTORE_ORIENTATION, collect_boot_turns
+from core.main import collect_boot_turns
+from core.migrations import MIGRATION_BATCH_INSTRUCTIONS
 from core.provider import ProviderAuthState, ProviderStatus
 
 BEFORE_SYNC_FRONTMATTER = "---\nmigration_phase: before_sync\n---\n\n"
@@ -42,18 +43,15 @@ def test_boot_turns_ordered_sync_then_migrations_then_config_then_greeting(tmp_p
     )
 
     assert len(turns) == 4
-    # The first converge turn carries the daemon-restore orientation so a migration/upgrade boot
-    # restores daemons via the restart skill first, exactly as a plain restart would.
-    assert turns[0].startswith(BOOT_RESTORE_ORIENTATION)
-    assert "[Upstream sync]" in turns[0]
+    # No converge turn carries a daemon-restore preamble: the sync turn opens with its own marker and
+    # the migration turn with the batch instructions. Daemons come up at the greeting (last), after
+    # the sync and migrations have landed, so a migration reshaping the Daemons block runs first.
+    assert turns[0].startswith("[Upstream sync]")
+    assert turns[1].startswith(MIGRATION_BATCH_INSTRUCTIONS)
     assert "[Migration: 001-x]" in turns[1]
     assert "[Migration: 002-y]" in turns[1]
     assert "BAD=1" in turns[2]
-    assert "[System Restart]\nReason: You restarted after a routine shutdown." in turns[3]
-    # The orientation rides only the first converge turn, never the restart greeting (it already
-    # runs the restart skill) or the later converge turns.
-    assert BOOT_RESTORE_ORIENTATION not in turns[1]
-    assert BOOT_RESTORE_ORIENTATION not in turns[3]
+    assert turns[3].startswith("[System Restart]\nReason: You restarted after a routine shutdown.")
 
 
 def test_before_sync_migrations_are_a_boot_barrier(tmp_path):
@@ -70,8 +68,9 @@ def test_before_sync_migrations_are_a_boot_barrier(tmp_path):
         first_start=False,
     )
 
+    # The before-sync barrier turn opens with the batch instructions, no daemon-restore preamble.
+    assert turns[0].startswith(MIGRATION_BATCH_INSTRUCTIONS)
     assert "[Migration: 001-before]" in turns[0]
-    assert BOOT_RESTORE_ORIENTATION in turns[0]
     assert "call `restart_vesta` once" in turns[0]
     assert all("[Upstream sync]" not in turn for turn in turns)
     assert all("[Migration: 999-later]" not in turn for turn in turns)
@@ -93,13 +92,37 @@ def test_applied_before_sync_migration_allows_sync_then_after_sync_migrations(tm
         first_start=False,
     )
 
-    assert "[Upstream sync]" in turns[0]
+    assert turns[0].startswith("[Upstream sync]")
     assert "[Migration: 999-later]" in turns[1]
 
 
-def test_restart_only_boot_carries_no_daemon_orientation(tmp_path):
-    """A plain restart has no converge turns: the greeting is the restart turn itself, so it must not
-    be prefixed with the converge-turn daemon-restore orientation."""
+def test_after_sync_migration_boot_defers_daemons_to_the_greeting(tmp_path):
+    """After the merge the running version's snapshot is in Git, so no sync turn fires, but the
+    after-sync migrations were left for this boot. The migration turn opens with the batch
+    instructions, no daemon-restore preamble: daemons come up at the greeting, after the migrations."""
+    config = _boot_config(tmp_path)
+    (config.agent_dir / "core" / "migrations" / "001-x.md").write_text("do migration x")
+    (config.agent_dir / "core" / "pyproject.toml").write_text('[project]\nname = "vesta"\nversion = "9.9.9"\n')
+    _record_snapshot(config, "9.9.9")
+
+    turns = collect_boot_turns(
+        state=_authed_state(),
+        config=config,
+        config_issues=[],
+        agent_message="You restarted after an upgrade.",
+        first_start=False,
+    )
+
+    assert len(turns) == 2
+    assert turns[0].startswith(MIGRATION_BATCH_INSTRUCTIONS)
+    assert "[Migration: 001-x]" in turns[0]
+    assert turns[1].startswith("[System Restart]")  # greeting is last, the daemon-restore point
+    assert all("[Upstream sync]" not in turn for turn in turns)
+
+
+def test_restart_only_boot_is_just_the_greeting(tmp_path):
+    """A plain restart has no converge turns: the greeting is the only turn, and it is the daemon
+    restore point (it runs the restart skill), exactly as it is on every restart."""
     config = _boot_config(tmp_path)
     (config.agent_dir / "core" / "pyproject.toml").write_text('[project]\nname = "vesta"\nversion = "9.9.9"\n')
     _record_snapshot(config, "9.9.9")
@@ -115,7 +138,7 @@ def test_restart_only_boot_carries_no_daemon_orientation(tmp_path):
         )
 
     assert len(turns) == 1
-    assert BOOT_RESTORE_ORIENTATION not in turns[0]
+    assert turns[0].startswith("[System Restart]")
     startup_log.assert_called_once_with("Boot turn: restart greeting")
 
 


### PR DESCRIPTION
## The bug

On a vestad-update boot, `collect_boot_turns` prepended a daemon-restore orientation to the **first converge turn**. During an update that first turn is the upstream-sync turn, so the agent read and ran the **pre-sync** `restart` skill's Daemons block *before*:

1. the sync merged the new `restart` skill (it's git-synced at `agent/skills/restart/`), and
2. the after-sync migrations reshaped the Daemons block (e.g. `2026-08-daemon-pidfile`).

Daemons started against startup logic that was about to change underneath them, which produced the port/vestad-refused failures seen during an upgrade.

## The fix

Restore daemons **last**, at the greeting's restart turn, which runs after the sync and every migration. So a migration that rewrites the Daemons block has always landed before the daemons start.

- Drop the early-restore orientation from the converge turns entirely (net deletion). Converge turns (sync, migrations) now carry no daemon preamble.
- Carry the "your daemons are down, run the Daemons block (idempotent, safe no-op)" preamble in the restart greeting itself (`agent/core/prompts/restart.md`), where the restore now happens. This is the same mechanism a plain restart already uses.

Audit backing the ordering: no migration requires a daemon to be up. Every daemon touch is `daemon start`/`daemon restart` (works whether up or down) or a Daemons-block text edit; the lone `whatsapp status` reads link state from disk. Migrations that change how a daemon runs restart that daemon themselves.

### Tradeoff

Daemons stay down for the whole converge (which can span several boots on a full upgrade), so the agent is unreachable on daemon-backed channels (app-chat, whatsapp) until the final greeting brings them up. This is deliberate: it's the price of never starting daemons against a stale Daemons block. Prior behavior kept the agent reachable throughout at the cost of the staleness bug.

### Fleet

`restart.md` is core-only (`load_prompt` reads `core_prompts_dir`, no user override) and `collect_boot_turns` is engine code, both delivered via the read-only core mount, so this reaches the fleet on the next engine update with no migration.

## Tests

`test_boot_turns.py` now asserts no converge turn carries a daemon-restore preamble (sync turn opens with `[Upstream sync]`, migration turn with the batch instructions) and the greeting is the last turn. Renamed the post-sync case to `test_after_sync_migration_boot_defers_daemons_to_the_greeting`. Verified green locally: `test_boot_turns`, `test_processor`, `test_migrations`, `test_crash_recovery`, `test_shutdown_reason`, `test_upstream_sync_turn`, `test_interrupts`, plus ty/ruff/format/conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)