### PR TITLE
fix(migrations): retire daemon zombie workarounds

### DIFF
--- a/agent/core/migrations/2026-08-runtime-docker-init-daemon-cleanup-30.md
+++ b/agent/core/migrations/2026-08-runtime-docker-init-daemon-cleanup-30.md
@@ -1,6 +1,6 @@
 Docker's tiny init now runs as PID 1 in this container and reaps orphaned skill daemons. Review
-every skill you created that implements the daemon contract and remove any zombie-specific
-liveness workaround you added to compensate for an unreaped daemon.
+every skill that implements the daemon contract and remove any zombie-specific liveness workaround
+added to compensate for an unreaped daemon.
 
 Read `~/agent/skills/vestad/SKILL.md` and `~/agent/skills/skills-registry/SKILL.md` completely
 before changing a skill. Keep the daemon contract intact.
@@ -24,5 +24,5 @@ flag and setting. If one skill cannot be cleaned up safely, leave it unchanged, 
 and continue with the others. Tell the user about anything left over and leave this migration
 unmarked so it can retry later.
 
-Commit any local skill changes so the next upstream merge preserves them. If none of the skills you
-created contains a zombie-specific workaround, there is nothing to change.
+Commit any skill changes so the next upstream merge preserves them. If no skill contains a
+zombie-specific workaround, there is nothing to change.

--- a/agent/core/migrations/2026-08-runtime-docker-init-daemon-cleanup-30.md
+++ b/agent/core/migrations/2026-08-runtime-docker-init-daemon-cleanup-30.md
@@ -1,0 +1,28 @@
+Docker's tiny init now runs as PID 1 in this container and reaps orphaned skill daemons. Review
+every skill you created that implements the daemon contract and remove any zombie-specific
+liveness workaround you added to compensate for an unreaped daemon.
+
+Read `~/agent/skills/vestad/SKILL.md` and `~/agent/skills/skills-registry/SKILL.md` completely
+before changing a skill. Keep the daemon contract intact.
+
+Remove only logic whose sole purpose is to read `/proc/<pid>/stat`, detect process state `Z`, or
+treat a zombie specially. Keep the ordinary PID existence probe (`kill -0` or `os.kill(pid, 0)`),
+pid and port records, exclusive start claim, readiness check, bounded stop, JSON responses,
+registration, logging, and notification behavior. Do not remove a check merely because it is named
+`alive`; inspect what it does.
+
+For each changed skill, run its daemon tests when it has them, then exercise:
+
+```bash
+<skill> daemon status
+<skill> daemon restart <preserved flags>
+<skill> daemon status
+```
+
+The restart must bring the daemon back and the final status must report it running. Preserve every
+flag and setting. If one skill cannot be cleaned up safely, leave it unchanged, record what remains,
+and continue with the others. Tell the user about anything left over and leave this migration
+unmarked so it can retry later.
+
+Commit any local skill changes so the next upstream merge preserves them. If none of the skills you
+created contains a zombie-specific workaround, there is nothing to change.


### PR DESCRIPTION
## Summary

- add the post-Docker-init migration that missed the #1633 merge
- audit every installed daemon skill for zombie-specific `/proc/<pid>/stat` workarounds
- remove only zombie handling while preserving ordinary PID probes and the full daemon contract
- continue across skills and leave the migration pending when any cleanup cannot be completed safely

## Test plan

- `git diff --check`
- `GIT_CONFIG_GLOBAL=/dev/null uv run --project agent/core pytest -q agent/tests/test_migrations.py` (23 passed)

Follow-up to #1633.