### PR TITLE
Prefer contact names in notification reply commands

### DIFF
--- a/agent/skills/telegram/cli/notifications.go
+++ b/agent/skills/telegram/cli/notifications.go
@@ -92,18 +92,19 @@ func quoteReplyArg(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
-// Every notification carries a complete reply command. The target is always the numeric chat ID, which
-// ResolveRecipient matches first and which needs no saved contact, so there is no case where the
-// agent has to work the recipient out for itself. It stops at `--message -`: the notification is
-// rendered as an XML attribute, so a heredoc here would reach the agent as &lt;&lt; and &#10;
-// entities. `-` says the body comes from stdin and SKILL.md carries the one heredoc shape, which
-// keeps the reply body out of the shell's reach.
-func notificationReplyCommand(chatID int64, instance string) string {
+// Every notification carries a complete reply command. Prefer a saved contact's readable name
+// when it resolves uniquely; duplicate names and all other chats retain the numeric chat ID as
+// the deterministic fallback.
+func notificationReplyCommand(chatID int64, contactName, instance string, contactSaved, contactNameUnique bool) string {
 	command := "telegram send"
 	if instance != "" {
 		command += " --instance " + quoteReplyArg(instance)
 	}
-	return command + " --to " + quoteReplyArg(strconv.FormatInt(chatID, 10)) + " --message -"
+	target := strconv.FormatInt(chatID, 10)
+	if contactSaved && contactNameUnique && contactName != "" {
+		target = contactName
+	}
+	return command + " --to " + quoteReplyArg(target) + " --message -"
 }
 
 func WriteCallbackNotification(
@@ -140,7 +141,7 @@ func WriteCallbackNotification(
 
 func WriteEditNotification(
 	notifDir string, targetMessageID, chatID int64, chatName, contactName, username, instance string,
-	contactSaved, isDirectChat bool,
+	contactSaved, contactNameUnique, isDirectChat bool,
 	sender, oldText, newText string,
 ) error {
 	if notifDir == "" {
@@ -163,7 +164,7 @@ func WriteEditNotification(
 		TargetMessageID: targetMessageID,
 		ChatID:          chatID,
 		ContactUnknown:  !contactSaved,
-		ReplyCommand:    notificationReplyCommand(chatID, instance),
+		ReplyCommand:    notificationReplyCommand(chatID, contactName, instance, contactSaved, contactNameUnique),
 		ReplyHint:       "they changed a message you may have already answered; reply only if the change asks something new",
 	}
 	if !isDirectChat {
@@ -183,7 +184,7 @@ func WriteEditNotification(
 
 func WriteNotification(
 	notifDir string, messageID, chatID int64, chatName, contactName, username, instance string,
-	contactSaved, isDirectChat bool,
+	contactSaved, contactNameUnique, isDirectChat bool,
 	sender, content, mediaType string,
 	replyToID int64,
 ) error {
@@ -208,7 +209,7 @@ func WriteNotification(
 		MessageID:      messageID,
 		ChatID:         chatID,
 		ContactUnknown: !contactSaved,
-		ReplyCommand:   notificationReplyCommand(chatID, instance),
+		ReplyCommand:   notificationReplyCommand(chatID, contactName, instance, contactSaved, contactNameUnique),
 		ReplyHint:      "think about how you can best show your personality",
 	}
 	if !isDirectChat {

--- a/agent/skills/telegram/cli/reply_command_test.go
+++ b/agent/skills/telegram/cli/reply_command_test.go
@@ -5,25 +5,50 @@ import (
 	"testing"
 )
 
-func TestNotificationReplyCommandIsCompleteAndUnambiguous(t *testing.T) {
-	// The chat ID is what ResolveRecipient matches first and needs no saved contact, so the same
-	// command shape works for a saved contact, a stranger, and a group alike.
-	got := notificationReplyCommand(-1001234567890, "personal")
-	want := "telegram send --instance 'personal' --to '-1001234567890' --message -"
+func TestNotificationReplyCommandUsesUniqueSavedContactName(t *testing.T) {
+	got := notificationReplyCommand(42, "Ana", "personal", true, true)
+	want := "telegram send --instance 'personal' --to 'Ana' --message -"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}
+}
 
-	single := notificationReplyCommand(42, "")
-	if strings.Contains(single, "--instance") {
-		t.Fatalf("a single account should omit --instance: %q", single)
+func TestNotificationReplyCommandFallsBackToChatIDForAmbiguousName(t *testing.T) {
+	got := notificationReplyCommand(42, "Ana", "", true, false)
+	want := "telegram send --to '42' --message -"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "--instance") {
+		t.Fatalf("a single account should omit --instance: %q", got)
+	}
+}
+
+func TestContactNameUniquenessDetectsDuplicateSavedNames(t *testing.T) {
+	store, err := NewMessageStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	defer store.Close()
+
+	if _, err := store.SaveManualContact("Ana", 42, "ana_one"); err != nil {
+		t.Fatalf("failed to save first contact: %v", err)
+	}
+	if !store.ContactNameUniquelyIdentifies("Ana", 42) {
+		t.Fatal("one saved contact should be uniquely identified by its name")
+	}
+	if _, err := store.SaveManualContact("Ana", 84, "ana_two"); err != nil {
+		t.Fatalf("failed to save duplicate-name contact: %v", err)
+	}
+	if store.ContactNameUniquelyIdentifies("Ana", 42) {
+		t.Fatal("duplicate saved contact names must be treated as ambiguous")
 	}
 }
 
 // The command hands the body to stdin rather than inlining it, so the reply text never reaches the
 // shell. An inline --message would break on the first apostrophe and could evaluate a $(...).
 func TestNotificationReplyCommandBodyIsShellInert(t *testing.T) {
-	got := notificationReplyCommand(42, "")
+	got := notificationReplyCommand(42, "", "", false, false)
 	if !strings.HasSuffix(got, "--message -") {
 		t.Fatalf("reply command must end at --message -, leaving the body to stdin: %q", got)
 	}

--- a/agent/skills/telegram/cli/storage.go
+++ b/agent/skills/telegram/cli/storage.go
@@ -678,6 +678,24 @@ func (ms *MessageStore) ResolveRecipient(identifier string) (int64, error) {
 	return 0, fmt.Errorf("recipient not found: %s. Add them as a contact first with: telegram add-contact <name> <chat-id>", identifier)
 }
 
+// ContactNameUniquelyIdentifies reports whether name belongs to chatID and no other saved
+// contact has the same name. Notification reply commands use this to prefer readable names
+// without ever routing a reply to an arbitrary duplicate.
+func (ms *MessageStore) ContactNameUniquelyIdentifies(name string, chatID int64) bool {
+	if strings.TrimSpace(name) == "" {
+		return false
+	}
+	var matchingChatCount, otherChatCount int
+	err := ms.db.QueryRow(`
+		SELECT
+			COUNT(CASE WHEN chat_id = ? THEN 1 END),
+			COUNT(CASE WHEN chat_id <> ? THEN 1 END)
+		FROM contacts
+		WHERE LOWER(name) = LOWER(?)
+	`, chatID, chatID, name).Scan(&matchingChatCount, &otherChatCount)
+	return err == nil && matchingChatCount == 1 && otherChatCount == 0
+}
+
 func parseInt64(s string) (int64, error) {
 	var n int64
 	for _, c := range s {

--- a/agent/skills/telegram/cli/telegram.go
+++ b/agent/skills/telegram/cli/telegram.go
@@ -143,12 +143,13 @@ func (tc *TelegramClient) Stop() {
 // notifContext is who an inbound message is from, resolved identically for a new message and
 // for an edit of one.
 type notifContext struct {
-	chatName     string
-	contactName  string
-	username     string
-	sender       string
-	contactSaved bool
-	isDirectChat bool
+	chatName          string
+	contactName       string
+	username          string
+	sender            string
+	contactSaved      bool
+	contactNameUnique bool
+	isDirectChat      bool
 }
 
 func chatNameOf(msg *tgbotapi.Message) string {
@@ -190,14 +191,18 @@ func (tc *TelegramClient) notifContextFor(msg *tgbotapi.Message) (notifContext, 
 	if contactName == "" {
 		contactName = senderName
 	}
+	isDirectChat := msg.Chat.Type == "private"
+	contactNameUnique := contactSaved && isDirectChat &&
+		tc.store.ContactNameUniquelyIdentifies(contactName, msg.Chat.ID)
 
 	return notifContext{
-		chatName:     chatNameOf(msg),
-		contactName:  contactName,
-		username:     username,
-		sender:       senderName,
-		contactSaved: contactSaved,
-		isDirectChat: msg.Chat.Type == "private",
+		chatName:          chatNameOf(msg),
+		contactName:       contactName,
+		username:          username,
+		sender:            senderName,
+		contactSaved:      contactSaved,
+		contactNameUnique: contactNameUnique,
+		isDirectChat:      isDirectChat,
 	}, true
 }
 
@@ -230,7 +235,7 @@ func (tc *TelegramClient) handleEditedMessage(msg *tgbotapi.Message) {
 	if ctx, ok := tc.notifContextFor(msg); ok {
 		if err := WriteEditNotification(
 			tc.notificationsDir, int64(msg.MessageID), msg.Chat.ID, ctx.chatName, ctx.contactName,
-			ctx.username, tc.instance, ctx.contactSaved, ctx.isDirectChat,
+			ctx.username, tc.instance, ctx.contactSaved, ctx.contactNameUnique, ctx.isDirectChat,
 			ctx.sender, oldText, newText,
 		); err != nil {
 			log.Printf("Failed to write edit notification for %d: %v", msg.MessageID, err)
@@ -325,6 +330,7 @@ func (tc *TelegramClient) handleMessage(msg *tgbotapi.Message) {
 			ctx.username,
 			tc.instance,
 			ctx.contactSaved,
+			ctx.contactNameUnique,
 			ctx.isDirectChat,
 			ctx.sender,
 			content,

--- a/agent/skills/whatsapp/cli/events.go
+++ b/agent/skills/whatsapp/cli/events.go
@@ -288,10 +288,18 @@ func (wac *WhatsAppClient) dropDeadDevice() {
 // buildNotifContext assembles the NotifContext shared by message and reaction
 // notifications.
 func (wac *WhatsAppClient) buildNotifContext(chatJID, chatName, senderDisplay, contactName, contactPhone string, contactSaved, isDirectChat bool) NotifContext {
+	contactNameUnique := false
+	if contactSaved && isDirectChat && contactName != "" {
+		// ResolveRecipient reports duplicate exact-name matches as ambiguous. Record that
+		// result now so the generated reply command can use a readable name when it is
+		// safe, while retaining the originating JID as the deterministic fallback.
+		jid, err := wac.ResolveRecipient(contactName)
+		contactNameUnique = err == nil && jid.User != ""
+	}
 	return NotifContext{
 		NotifDir: wac.notificationsDir, ChatJID: chatJID, ChatName: chatName,
 		ContactName: contactName, ContactPhone: contactPhone,
-		Instance: wac.instance, ContactSaved: contactSaved,
+		Instance: wac.instance, ContactSaved: contactSaved, ContactNameUnique: contactNameUnique,
 		IsDirectChat: isDirectChat, Sender: senderDisplay,
 	}
 }

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -115,18 +115,22 @@ func quoteReplyArg(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
-// Every notification carries a complete reply command. The target is always the chat JID, which
-// ResolveRecipient matches first and which needs no saved contact, so there is no case where the
-// agent has to work the recipient out for itself. It stops at `--message -`: the notification is
-// rendered as an XML attribute, so a heredoc here would reach the agent as &lt;&lt; and &#10;
-// entities. `-` says the body comes from stdin and SKILL.md carries the one heredoc shape, which
-// keeps the reply body out of the shell's reach.
+// Every notification carries a complete reply command. Prefer a saved contact's readable name
+// when it resolves uniquely; duplicate names and all other chats retain the originating JID as
+// the deterministic fallback. It stops at `--message -`: the notification is rendered as an XML
+// attribute, so a heredoc here would reach the agent as &lt;&lt; and &#10; entities. `-` says the
+// body comes from stdin and SKILL.md carries the one heredoc shape, which keeps the reply body out
+// of the shell's reach.
 func notificationReplyCommand(ctx NotifContext) string {
 	command := "whatsapp send"
 	if ctx.Instance != "" {
 		command += " --instance " + quoteReplyArg(ctx.Instance)
 	}
-	return command + " --to " + quoteReplyArg(ctx.ChatJID) + " --message -"
+	target := ctx.ChatJID
+	if ctx.ContactSaved && ctx.ContactNameUnique && ctx.ContactName != "" {
+		target = ctx.ContactName
+	}
+	return command + " --to " + quoteReplyArg(target) + " --message -"
 }
 
 func writeNotificationFile(notifDir string, data any, notifType string) error {

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -11,7 +11,7 @@ func savedCtx(dir string) NotifContext {
 	return NotifContext{
 		NotifDir: dir, Instance: "personal", ChatJID: "4477000111@s.whatsapp.net", ChatName: "Ana",
 		ContactName: "Ana", ContactPhone: "+15551234567",
-		ContactSaved: true, IsDirectChat: true, Sender: "Ana",
+		ContactSaved: true, ContactNameUnique: true, IsDirectChat: true, Sender: "Ana",
 	}
 }
 

--- a/agent/skills/whatsapp/cli/reply_command_test.go
+++ b/agent/skills/whatsapp/cli/reply_command_test.go
@@ -5,19 +5,30 @@ import (
 	"testing"
 )
 
-func TestNotificationReplyCommandIsCompleteAndUnambiguous(t *testing.T) {
-	// The chat JID is what ResolveRecipient matches first and needs no saved contact, so the same
-	// command shape works for a saved contact, a stranger, and a group alike.
-	ctx := NotifContext{Instance: "personal", ChatJID: "4477000111@s.whatsapp.net"}
+func TestNotificationReplyCommandUsesUniqueSavedContactName(t *testing.T) {
+	ctx := NotifContext{
+		Instance: "personal", ChatJID: "4477000111@s.whatsapp.net",
+		ContactName: "Ana", ContactSaved: true, ContactNameUnique: true,
+	}
 	got := notificationReplyCommand(ctx)
-	want := "whatsapp send --instance 'personal' --to '4477000111@s.whatsapp.net' --message -"
+	want := "whatsapp send --instance 'personal' --to 'Ana' --message -"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}
+}
 
-	single := notificationReplyCommand(NotifContext{ChatJID: "123@g.us"})
-	if strings.Contains(single, "--instance") {
-		t.Fatalf("a single account should omit --instance: %q", single)
+func TestNotificationReplyCommandFallsBackToJIDForAmbiguousContactName(t *testing.T) {
+	ctx := NotifContext{
+		ChatJID:     "4477000111@s.whatsapp.net",
+		ContactName: "Ana", ContactSaved: true, ContactNameUnique: false,
+	}
+	got := notificationReplyCommand(ctx)
+	want := "whatsapp send --to '4477000111@s.whatsapp.net' --message -"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "--instance") {
+		t.Fatalf("a single account should omit --instance: %q", got)
 	}
 }
 

--- a/agent/skills/whatsapp/cli/types.go
+++ b/agent/skills/whatsapp/cli/types.go
@@ -50,15 +50,16 @@ type StoreMessageParams struct {
 }
 
 type NotifContext struct {
-	NotifDir     string
-	ChatJID      string
-	ChatName     string
-	ContactName  string
-	ContactPhone string
-	Instance     string
-	ContactSaved bool
-	IsDirectChat bool
-	Sender       string
+	NotifDir          string
+	ChatJID           string
+	ChatName          string
+	ContactName       string
+	ContactPhone      string
+	Instance          string
+	ContactSaved      bool
+	ContactNameUnique bool
+	IsDirectChat      bool
+	Sender            string
 }
 
 type MediaInfo struct {


### PR DESCRIPTION
## Summary

- use saved contact names in WhatsApp and Telegram notification reply commands when the name resolves uniquely
- fall back to the originating JID/chat ID for ambiguous or unsaved contacts
- keep group replies routed by stable IDs
- add coverage for readable targets and duplicate-name fallback

## Testing

- `go test -tags fts5 -run "Test(NotificationReplyCommand|ContactNameUniqueness)" -count=1 ./...` (Telegram)
- `git diff --check`

The full WhatsApp suite could not run in the available container because its native whisper build dependency (`whisper.h`) is not installed.