### PR TITLE
Hide app-chat intent IDs from the agent

### DIFF
--- a/agent/skills/app-chat/cli/src/app_chat_cli/service.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/service.py
@@ -54,10 +54,10 @@ class ServiceState:
 _STATE_KEY: web.AppKey[ServiceState] = web.AppKey("state", ServiceState)
 
 
-def _write_notification(state: ServiceState, text: str, intent_id: str | None) -> None:
+def _write_notification(state: ServiceState, text: str) -> None:
     """Persist an inbound app message as the source=app-chat notification the monitor loop turns into a
-    model turn. The structured reply command, behavioral hint, and intent ID ride along
-    unchanged so the model receives the producer-owned response guidance."""
+    model turn. The structured reply command and behavioral hint ride along so the model receives the
+    producer-owned response guidance. The client-only intent ID stays on the chat event."""
     directory = state.notifications_dir
     directory.mkdir(parents=True, exist_ok=True)
     fields: dict[str, object] = {
@@ -69,8 +69,6 @@ def _write_notification(state: ServiceState, text: str, intent_id: str | None) -
         "reply_command": "app-chat send --message -",
         "reply_hint": "think about how you can best show your personality",
     }
-    if intent_id is not None:
-        fields["intent_id"] = intent_id
     path = directory / f"{time.time_ns()}-app-chat-message.json"
     tmp = path.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(fields))
@@ -110,7 +108,7 @@ async def message_handler(request: web.Request) -> web.Response:
     # client's retry (same intent_id) re-runs the whole intake exactly once. Only a successful write
     # persists + echoes + records the intent, keeping intake at-most-once.
     try:
-        _write_notification(state, text, intent_id)
+        _write_notification(state, text)
     except OSError as exc:
         logger.error("failed to write app-chat notification: %s", exc)
         return web.json_response({"error": "intake write failed"}, status=500)

--- a/agent/skills/app-chat/cli/tests/test_service.py
+++ b/agent/skills/app-chat/cli/tests/test_service.py
@@ -101,7 +101,7 @@ def test_duplicate_intent_id_is_dropped_whole(tmp_path):
     state.store.close()
 
 
-def test_intent_id_rides_along_on_the_event_and_notification(tmp_path):
+def test_intent_id_stays_on_event_and_out_of_model_notification(tmp_path):
     state, notif_dir = _service_state(tmp_path)
     queue = _subscribe(state)
 
@@ -109,7 +109,7 @@ def test_intent_id_rides_along_on_the_event_and_notification(tmp_path):
 
     assert _drain(queue)[0]["intent_id"] == "xyz"
     notif = json.loads(next(iter(notif_dir.glob("*-app-chat-message.json"))).read_text())
-    assert notif["intent_id"] == "xyz"
+    assert "intent_id" not in notif
     state.store.close()
 
 


### PR DESCRIPTION
## Summary

- keep client-generated `intent_id` metadata on persisted chat events and socket echoes
- omit `intent_id` from the model-facing app-chat notification
- cover the transport/model boundary with a focused service test

## Testing

- `uv run pytest tests/test_service.py` (14 passed)