### PR TITLE
docs(whatsapp,onboard): cut internal plumbing the agent never acts on

### DIFF
--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -129,10 +129,7 @@ At **create-agent** (step 6), put three things in `--context`:
 1. **The user's WhatsApp number**, so the new vesta knows who to expect: "your owner
    will message you from +1..., greet them by name when they arrive."
 2. **Set up WhatsApp first**: "Before anything else, set up and authenticate your own
-   Vesta Cloud-managed WhatsApp number using the `whatsapp` skill." Vesta Cloud
-   coordinates Switchboard for the number/SMS lifecycle and Double Tick for the
-   headless WhatsApp primary; the new agent should not configure either service
-   directly.
+   Vesta Cloud-managed WhatsApp number using the `whatsapp` skill."
 3. **Leave the link where you'll fetch it**: "Then write your wa.me connect link to
    `~/.file-host/connect.txt` and serve it with the `file-host` skill." That publishes
    it at a fixed public URL you can construct yourself, no channel from them to you

--- a/agent/skills/whatsapp/HEADLESS.md
+++ b/agent/skills/whatsapp/HEADLESS.md
@@ -1,39 +1,19 @@
-# WhatsApp authentication and proxy
+# WhatsApp headless proxy and failure ownership
 
-Auth boundaries and the proxy rule for the two headless methods
-([Vesta Cloud](SETUP_VESTA_CLOUD.md), [Double Tick](SETUP_DOUBLETICK.md)). The
-[SETUP.md](SETUP.md) flow selects the method and owns recovery.
-
-Account source and API transport are independent decisions: never infer both from
-the word "managed" or from the presence of credentials.
-
-## Auth
-
-**Vesta Cloud route.** The agent holds no standing Double Tick secret. It asks
-local vestad for a short-lived server-identity token and calls Vesta Cloud's
-WhatsApp route with it; Vesta Cloud verifies tenant entitlement and provisions a
-hosted Double Tick account. Vesta Cloud carries API traffic only, never the
-WhatsApp socket.
-
-**Double Tick route.** The agent calls `DOUBLETICK_API_URL` directly with
-`Authorization: Bearer $DOUBLETICK_API_KEY` (a `wak_` account-scoped key that
-never traverses Vesta Cloud). Set `DOUBLETICK_API_URL` and `DOUBLETICK_API_KEY`
-together or not at all; complete direct credentials take precedence over cloud
-identity. A `vesta.run` hostname may front a standalone Double Tick service over a
-Cloudflare tunnel without making it a Vesta Cloud request path.
+The residential-proxy rule and failure boundaries shared by the two headless
+methods ([Vesta Cloud](SETUP_VESTA_CLOUD.md), [Double Tick](SETUP_DOUBLETICK.md)).
+The [SETUP.md](SETUP.md) flow selects the method and owns recovery.
 
 ## Residential proxy lease
 
 Both headless methods bind a residential proxy to the WhatsApp account. The
 companion must install that bound lease and use it on initial pairing and on every
-reconnect. The proxy carries WhatsApp traffic only; API requests use the Vesta
-Cloud or direct route above.
+reconnect. The proxy carries WhatsApp traffic only.
 
 Fail closed: if the lease is missing or invalid, stop and report rather than
 connecting over the datacenter IP or any other direct egress. Do not let a
 user-supplied `WHATSAPP_PROXY_URL` replace the bound lease for a headless account;
-a user-supplied proxy is meaningful only for a self-managed account, where no
-Double Tick account exists.
+a user-supplied proxy is meaningful only for a self-managed account.
 
 ## Failure ownership
 

--- a/agent/skills/whatsapp/SETUP_DOUBLETICK.md
+++ b/agent/skills/whatsapp/SETUP_DOUBLETICK.md
@@ -14,10 +14,7 @@ export DOUBLETICK_API_KEY='wak_account-scoped-key'
 ```
 
 Set both or neither, and keep the key out of chat, logs, commits, and command
-output. The CLI persists valid credentials in the instance state so a later
-environment scrub does not silently switch account methods. Auth detail (including
-that a `vesta.run` hostname may front a standalone service) is in
-[HEADLESS.md](HEADLESS.md).
+output.
 
 Run `whatsapp status` first; stop if linked or connecting.
 

--- a/agent/skills/whatsapp/SETUP_VESTA_CLOUD.md
+++ b/agent/skills/whatsapp/SETUP_VESTA_CLOUD.md
@@ -7,9 +7,8 @@ rather than a self-managed one.
 ## Prerequisites
 
 Cloud provisioning supplies `VESTA_CLOUD_CONTROL_URL`, the agent identity, and
-vestad connectivity. Do not add Double Tick credentials: the agent mints
-short-lived Vesta server-identity tokens and the control plane holds the service
-credentials (see [HEADLESS.md](HEADLESS.md)).
+vestad connectivity, so no key or manual setup is needed; the CLI authenticates
+automatically.
 
 Run `whatsapp status` first; stop if linked or connecting.
 

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -40,7 +40,7 @@ warm opener in your own voice from the user's perspective, pass it with
 first. A self-managed account uses normal messaging rules.
 
 Recovery outcomes and diagnostics live in [SETUP.md](SETUP.md#status-and-recovery);
-auth and the proxy-lease rule live in [HEADLESS.md](HEADLESS.md).
+the residential proxy-lease rule lives in [HEADLESS.md](HEADLESS.md).
 
 ## Send
 - Form: `whatsapp <subcommand> [positionals] [--flag value ...]`. **Subcommand goes first**, before any flags.


### PR DESCRIPTION
## What

Follow-up cleanup on the merged #1655 docs: cut internal plumbing the agent never acts on. Once the agent picks `whatsapp connect --source <x>`, the CLI owns the auth/token/credential mechanics, so explaining them to the agent is noise.

Each setup guide stays **self-contained** (no cross-method warnings, e.g. no "don't use Double Tick" in the Vesta Cloud guide).

## Changes

- **onboard**: drop the Switchboard/Double Tick coordination aside from the create-agent seed context. "Set up WhatsApp via the `whatsapp` skill" is all the new agent needs.
- **HEADLESS.md**: remove the whole Auth section (server-identity token mint, tenant entitlement, `wak_` transport, and the stale "never infer transport from 'managed'" rule that predates the now-required `--source`). Keep the load-bearing residential-proxy fail-closed rule and the failure-ownership map.
- **SETUP_VESTA_CLOUD**: state only that cloud auth is automatic; no Double Tick mention, no token internals.
- **SETUP_DOUBLETICK**: drop the credential-persistence internals and the auth cross-reference; keep set-both-or-neither / keep-the-key-secret.

Net -27 lines. Anchors, dash guard, and conventions checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PNxHEXx3r4BM4913oYZmd
