### PR TITLE
refactor(whatsapp,otp): single-source the token mint via vesta-cloud, use whoami to detect a cloud account

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,9 @@ jobs:
       - name: Run telegram checks
         run: ./check.sh telegram
 
+      - name: Run otp checks
+        run: ./check.sh otp
+
       - name: Run app-chat checks
         run: ./check.sh app-chat
 

--- a/agent/skills/otp/SKILL.md
+++ b/agent/skills/otp/SKILL.md
@@ -25,6 +25,9 @@ otp new --service coinbase --country US
 
 `--service` is required (the service you are verifying, for pool accounting).
 `--country` is an optional ISO code when the service needs a specific region.
+`--idempotency-key` is optional: if a `new` call fails transiently and you retry it,
+pass the same key both times so the retry returns the same number instead of drawing
+(and charging for) a second. Use a fresh key for each genuinely new signup.
 
 Success prints the number to type into the service and the `id` to poll with:
 
@@ -77,5 +80,5 @@ so the pool stays available. Releasing an already-released `id` is safe.
 On a Vesta Cloud box the CLI mints a short-lived server-identity token from vestad
 and calls vesta.run, so no setup and no key are needed. A self-hosted box points at
 its own Switchboard directly with `SWITCHBOARD_API_URL` plus an `SWITCHBOARD_API_KEY`
-(an `sbk_` key); set the base URL alone to have the cloud mint the key. Never print
-or log the key.
+(an `sbk_` key handed over by whoever runs that Switchboard); both are required
+together. Never print or log the key.

--- a/agent/skills/otp/cli/client.go
+++ b/agent/skills/otp/cli/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -175,30 +176,45 @@ type serverToken struct {
 // a subprocess.
 var mintServerToken = vestaCloudToken
 
+// vestaCloudTokenTimeout bounds the subprocess so a wedged `vesta-cloud token` can never
+// hang the CLI's auth path (the native mint it replaced had a 30s HTTP timeout).
+const vestaCloudTokenTimeout = 30 * time.Second
+
 // vestaCloudToken shells out to `vesta-cloud token`, the single source of truth for
 // minting this box's server-identity token and resolving the control-plane URL. Every
 // skill that calls the control plane as the server routes through this one command, so
-// the vestad endpoint, the agent-token header, and the control URL live in one place
-// and cannot silently diverge across skills. On failure `vesta-cloud token` prints a
-// structured {error} on stdout and exits non-zero, which surfaces here verbatim.
+// the vestad endpoint, the agent-token header, and the control URL live in one place and
+// cannot silently diverge across skills.
 func vestaCloudToken() (serverToken, error) {
-	out, runErr := exec.Command("vesta-cloud", "token").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), vestaCloudTokenTimeout)
+	defer cancel()
+	out, runErr := exec.CommandContext(ctx, "vesta-cloud", "token").Output()
+	return parseServerToken(out, runErr, ctx.Err() == context.DeadlineExceeded)
+}
+
+// parseServerToken turns a `vesta-cloud token` run into a credential or a clear error,
+// split from the exec so the failure branches are unit tested. On failure the CLI prints
+// a structured {error} on stdout (surfaced verbatim); a missing command, a timeout, and
+// empty output each get their own message.
+func parseServerToken(out []byte, runErr error, timedOut bool) (serverToken, error) {
 	var resp struct {
 		Token      string `json:"token"`
 		ControlURL string `json:"control_url"`
 		Error      string `json:"error"`
 	}
 	_ = json.Unmarshal(out, &resp)
-	if resp.Token != "" && resp.ControlURL != "" {
+	switch {
+	case resp.Token != "" && resp.ControlURL != "":
 		return serverToken{token: resp.Token, controlURL: strings.TrimRight(resp.ControlURL, "/")}, nil
-	}
-	if resp.Error != "" {
+	case resp.Error != "":
 		return serverToken{}, fmt.Errorf("mint server-identity token: %s", resp.Error)
-	}
-	if runErr != nil {
+	case timedOut:
+		return serverToken{}, fmt.Errorf("`vesta-cloud token` timed out after %s", vestaCloudTokenTimeout)
+	case runErr != nil:
 		return serverToken{}, fmt.Errorf("run `vesta-cloud token` (is the vesta-cloud skill installed?): %w", runErr)
+	default:
+		return serverToken{}, fmt.Errorf("`vesta-cloud token` returned no token")
 	}
-	return serverToken{}, fmt.Errorf("`vesta-cloud token` returned no token")
 }
 
 // authorize resolves the Switchboard base URL and Authorization header once, plus

--- a/agent/skills/otp/cli/client.go
+++ b/agent/skills/otp/cli/client.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 )
@@ -90,7 +90,6 @@ func classifyReserve(err error) error {
 type config struct {
 	directURL  string // Switchboard base, e.g. https://<box> (direct mode)
 	directKey  string // sbk_ key for direct mode
-	controlURL string // vesta.run control-plane base, e.g. https://vesta.run/api (cloud mode)
 	vestadBase string // this box's vestad, https://$BOX_HOST:$VESTAD_PORT
 	agentName  string
 	agentToken string
@@ -122,7 +121,6 @@ func loadConfig() config {
 	return config{
 		directURL:    strings.TrimRight(directURL, "/"),
 		directKey:    directKey,
-		controlURL:   strings.TrimRight(envOrDefault("VESTA_CONTROL_URL", "https://vesta.run/api"), "/"),
 		vestadBase:   base,
 		agentName:    strings.TrimSpace(os.Getenv("AGENT_NAME")),
 		agentToken:   strings.TrimSpace(os.Getenv("AGENT_TOKEN")),
@@ -141,19 +139,12 @@ func envOrDefault(name, def string) string {
 type client struct {
 	cfg     config
 	control *http.Client
-	vestad  *http.Client
 }
 
 func newClient(cfg config) *client {
 	return &client{
 		cfg:     cfg,
 		control: &http.Client{Timeout: controlTimeout},
-		// vestad serves a self-signed cert on the loopback; the agent is on the same
-		// box, so TLS verification adds nothing and would just fail.
-		vestad: &http.Client{
-			Timeout:   httpTimeout,
-			Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
-		},
 	}
 }
 
@@ -173,27 +164,41 @@ func (c *client) isHosted() bool {
 		(c.cfg.cloudManaged && c.cfg.vestadBase != "" && c.cfg.agentName != "" && c.cfg.agentToken != "")
 }
 
-// mintToken asks this box's vestad for a short-lived server-identity token
-// (agent-token authed). vestad signs it locally from the box api_key, a pure crypto
-// operation with no network call, and hands it back.
-func (c *client) mintToken() (string, error) {
-	if c.cfg.vestadBase == "" || c.cfg.agentName == "" {
-		return "", fmt.Errorf("not running inside an agent container (no VESTAD_PORT/AGENT_NAME)")
+// serverToken is the cloud-path credential: a short-lived server-identity token plus
+// the control-plane base URL it authenticates against.
+type serverToken struct {
+	token      string
+	controlURL string
+}
+
+// mintServerToken is a package var so tests stub the cloud credential without spawning
+// a subprocess.
+var mintServerToken = vestaCloudToken
+
+// vestaCloudToken shells out to `vesta-cloud token`, the single source of truth for
+// minting this box's server-identity token and resolving the control-plane URL. Every
+// skill that calls the control plane as the server routes through this one command, so
+// the vestad endpoint, the agent-token header, and the control URL live in one place
+// and cannot silently diverge across skills. On failure `vesta-cloud token` prints a
+// structured {error} on stdout and exits non-zero, which surfaces here verbatim.
+func vestaCloudToken() (serverToken, error) {
+	out, runErr := exec.Command("vesta-cloud", "token").Output()
+	var resp struct {
+		Token      string `json:"token"`
+		ControlURL string `json:"control_url"`
+		Error      string `json:"error"`
 	}
-	if c.cfg.agentToken == "" {
-		return "", fmt.Errorf("missing AGENT_TOKEN, cannot authenticate to vestad")
+	_ = json.Unmarshal(out, &resp)
+	if resp.Token != "" && resp.ControlURL != "" {
+		return serverToken{token: resp.Token, controlURL: strings.TrimRight(resp.ControlURL, "/")}, nil
 	}
-	var out struct {
-		Token string `json:"token"`
+	if resp.Error != "" {
+		return serverToken{}, fmt.Errorf("mint server-identity token: %s", resp.Error)
 	}
-	u := fmt.Sprintf("%s/agents/%s/account-token", c.cfg.vestadBase, c.cfg.agentName)
-	if _, err := c.do(c.vestad, http.MethodPost, u, map[string]string{"X-Agent-Token": c.cfg.agentToken}, map[string]string{}, &out); err != nil {
-		return "", fmt.Errorf("mint server-identity token: %w", err)
+	if runErr != nil {
+		return serverToken{}, fmt.Errorf("run `vesta-cloud token` (is the vesta-cloud skill installed?): %w", runErr)
 	}
-	if out.Token == "" {
-		return "", fmt.Errorf("vestad did not return a server-identity token")
-	}
-	return out.Token, nil
+	return serverToken{}, fmt.Errorf("`vesta-cloud token` returned no token")
 }
 
 // authorize resolves the Switchboard base URL and Authorization header once, plus
@@ -218,11 +223,11 @@ func (c *client) authorize() (base, auth string, direct bool, err error) {
 		}
 		return strings.TrimRight(creds.URL, "/"), "Bearer " + creds.Key, true, nil
 	}
-	token, err := c.mintToken()
+	st, err := mintServerToken()
 	if err != nil {
 		return "", "", false, err
 	}
-	return c.cfg.controlURL + "/integrations/switchboard", "Bearer " + token, false, nil
+	return st.controlURL + "/integrations/switchboard", "Bearer " + st.token, false, nil
 }
 
 type directToken struct {
@@ -235,13 +240,13 @@ type directToken struct {
 // that talks to Switchboard directly rather than through the forwarded API. The key
 // is a secret: it stays inside this process and is never printed.
 func (c *client) fetchDirectToken() (directToken, error) {
-	token, err := c.mintToken()
+	st, err := mintServerToken()
 	if err != nil {
 		return directToken{}, err
 	}
 	var out directToken
-	u := c.cfg.controlURL + "/integrations/switchboard/token"
-	if _, err := c.do(c.control, http.MethodGet, u, map[string]string{"Authorization": "Bearer " + token}, nil, &out); err != nil {
+	u := st.controlURL + "/integrations/switchboard/token"
+	if _, err := c.do(c.control, http.MethodGet, u, map[string]string{"Authorization": "Bearer " + st.token}, nil, &out); err != nil {
 		return directToken{}, fmt.Errorf("mint direct switchboard credentials: %w", err)
 	}
 	if out.URL == "" || out.Key == "" {

--- a/agent/skills/otp/cli/client.go
+++ b/agent/skills/otp/cli/client.go
@@ -23,10 +23,7 @@ import (
 // /api/integrations/switchboard/*. Direct (self-hosted) sends an sbk_ key straight to a
 // Switchboard base URL; only the base URL, credential, and paths differ.
 
-const (
-	httpTimeout    = 30 * time.Second
-	controlTimeout = 60 * time.Second
-)
+const controlTimeout = 60 * time.Second
 
 // Non-error terminal outcomes of reserve, surfaced to the agent as a clean status
 // rather than a raw error: the per-account OTP quota is spent (wait, do not retry),
@@ -133,13 +130,6 @@ func loadConfig() config {
 		cloudManaged: strings.TrimSpace(os.Getenv("VESTA_CLOUD_CONTROL_URL")) != "",
 		configError:  configError,
 	}
-}
-
-func envOrDefault(name, def string) string {
-	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
-		return v
-	}
-	return def
 }
 
 type client struct {

--- a/agent/skills/otp/cli/client.go
+++ b/agent/skills/otp/cli/client.go
@@ -113,11 +113,16 @@ func loadConfig() config {
 	directURL := strings.TrimSpace(os.Getenv("SWITCHBOARD_API_URL"))
 	directKey := strings.TrimSpace(os.Getenv("SWITCHBOARD_API_KEY"))
 	configError := ""
-	// A key with no base is meaningless. A base alone is allowed: it means "talk to
-	// this Switchboard directly, mint me the sbk_ key from the cloud /token endpoint".
-	if directKey != "" && directURL == "" {
+	// Direct mode needs both halves: a self-hosted operator hands the box a one-time
+	// sbk_ key out of band. Either half alone is a misconfiguration. (The cloud never
+	// mints a key to the box; a paid tenant reserves through the forwarded API instead.)
+	switch {
+	case directKey != "" && directURL == "":
 		configError = "SWITCHBOARD_API_KEY is set without SWITCHBOARD_API_URL"
 		directKey = ""
+	case directURL != "" && directKey == "":
+		configError = "SWITCHBOARD_API_URL is set without SWITCHBOARD_API_KEY"
+		directURL = ""
 	}
 	return config{
 		directURL:    strings.TrimRight(directURL, "/"),
@@ -161,7 +166,7 @@ func (c *client) isDirect() bool {
 // cannot tell a paid tenant from a plain self-hosted box; cloudManaged
 // (VESTA_CLOUD_CONTROL_URL) is the distinguishing signal.
 func (c *client) isHosted() bool {
-	return c.cfg.configError != "" || c.isDirect() || c.cfg.directURL != "" ||
+	return c.cfg.configError != "" || c.isDirect() ||
 		(c.cfg.cloudManaged && c.cfg.vestadBase != "" && c.cfg.agentName != "" && c.cfg.agentToken != "")
 }
 
@@ -229,46 +234,11 @@ func (c *client) authorize() (base, auth string, direct bool, err error) {
 	if c.isDirect() {
 		return c.cfg.directURL, "Bearer " + c.cfg.directKey, true, nil
 	}
-	// A base with no key (self-hosted, delegating the key to the cloud): ask the
-	// control plane's /token endpoint for a direct Switchboard URL + sbk_ key, then
-	// talk to that Switchboard natively.
-	if c.cfg.directURL != "" {
-		creds, err := c.fetchDirectToken()
-		if err != nil {
-			return "", "", false, err
-		}
-		return strings.TrimRight(creds.URL, "/"), "Bearer " + creds.Key, true, nil
-	}
 	st, err := mintServerToken()
 	if err != nil {
 		return "", "", false, err
 	}
 	return st.controlURL + "/integrations/switchboard", "Bearer " + st.token, false, nil
-}
-
-type directToken struct {
-	URL string `json:"url"`
-	Key string `json:"key"`
-}
-
-// fetchDirectToken asks the control plane for a direct Switchboard URL + a freshly
-// minted sbk_ key (cloud-authed with a server-identity token), for a self-hosted box
-// that talks to Switchboard directly rather than through the forwarded API. The key
-// is a secret: it stays inside this process and is never printed.
-func (c *client) fetchDirectToken() (directToken, error) {
-	st, err := mintServerToken()
-	if err != nil {
-		return directToken{}, err
-	}
-	var out directToken
-	u := st.controlURL + "/integrations/switchboard/token"
-	if _, err := c.do(c.control, http.MethodGet, u, map[string]string{"Authorization": "Bearer " + st.token}, nil, &out); err != nil {
-		return directToken{}, fmt.Errorf("mint direct switchboard credentials: %w", err)
-	}
-	if out.URL == "" || out.Key == "" {
-		return directToken{}, fmt.Errorf("/token returned no url/key")
-	}
-	return out, nil
 }
 
 type lease struct {
@@ -279,8 +249,10 @@ type lease struct {
 
 // reserve claims a temporary number for one service. Cloud mode POSTs the forwarded
 // /reserve; direct mode POSTs native /leases. A spent quota comes back errQuotaExceeded
-// and an empty pool errOutOfStock, both surfaced as a clean status.
-func (c *client) reserve(service, country string) (lease, error) {
+// and an empty pool errOutOfStock, both surfaced as a clean status. A non-empty
+// idempotencyKey is passed through so a retried reserve for the same flow returns the
+// same number instead of drawing (and paying for) a second one.
+func (c *client) reserve(service, country, idempotencyKey string) (lease, error) {
 	base, auth, direct, err := c.authorize()
 	if err != nil {
 		return lease{}, err
@@ -292,6 +264,9 @@ func (c *client) reserve(service, country string) (lease, error) {
 	body := map[string]string{"service": service}
 	if country != "" {
 		body["country"] = country
+	}
+	if idempotencyKey != "" {
+		body["idempotency_key"] = idempotencyKey
 	}
 	var out lease
 	if _, err := c.do(c.control, http.MethodPost, base+path, map[string]string{"Authorization": auth}, body, &out); err != nil {

--- a/agent/skills/otp/cli/client_test.go
+++ b/agent/skills/otp/cli/client_test.go
@@ -33,6 +33,25 @@ func cloudClientFor(t *testing.T, control http.HandlerFunc) *client {
 	return newClient(config{vestadBase: "https://vestad.test", agentName: "alice", agentToken: "atok"})
 }
 
+// TestParseServerToken pins how a `vesta-cloud token` run maps to a credential or a
+// clear error: success, a structured {error} surfaced verbatim, the command missing, a
+// timeout, and empty output.
+func TestParseServerToken(t *testing.T) {
+	if st, err := parseServerToken([]byte(`{"token":"sit","control_url":"https://ctrl/"}`), nil, false); err != nil || st.token != "sit" || st.controlURL != "https://ctrl" {
+		t.Fatalf("success = %+v err=%v", st, err)
+	}
+	if _, err := parseServerToken([]byte(`{"error":"no account linked"}`), errors.New("exit status 3"), false); err == nil || !strings.Contains(err.Error(), "no account linked") {
+		t.Fatalf("structured error = %v, want it surfaced verbatim", err)
+	}
+	notFound := errors.New(`exec: "vesta-cloud": executable file not found in $PATH`)
+	if _, err := parseServerToken(nil, notFound, false); err == nil || !strings.Contains(err.Error(), "vesta-cloud skill installed") {
+		t.Fatalf("not-installed error = %v, want the install hint", err)
+	}
+	if _, err := parseServerToken(nil, errors.New("signal: killed"), true); err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("timeout error = %v, want a timeout message", err)
+	}
+}
+
 func TestReserve_cloudMintsTokenAndReturnsNumber(t *testing.T) {
 	var gotAuth, gotPath string
 	var gotBody map[string]string

--- a/agent/skills/otp/cli/client_test.go
+++ b/agent/skills/otp/cli/client_test.go
@@ -50,6 +50,11 @@ func TestParseServerToken(t *testing.T) {
 	if _, err := parseServerToken(nil, errors.New("signal: killed"), true); err == nil || !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("timeout error = %v, want a timeout message", err)
 	}
+	// Empty output with no runErr and no timeout: the command exited 0 but printed nothing,
+	// so there is no token to use and no structured error to surface.
+	if _, err := parseServerToken(nil, nil, false); err == nil || !strings.Contains(err.Error(), "no token") {
+		t.Fatalf("empty output = %v, want a no-token message", err)
+	}
 }
 
 func TestReserve_cloudMintsTokenAndReturnsNumber(t *testing.T) {

--- a/agent/skills/otp/cli/client_test.go
+++ b/agent/skills/otp/cli/client_test.go
@@ -11,38 +11,26 @@ import (
 	"time"
 )
 
-// fakeVestad stands in for this box's vestad: it mints a server-identity token for
-// the agent-token tier, exactly like POST /agents/{name}/account-token.
-func fakeVestad(t *testing.T, wantAgentToken string) *httptest.Server {
+// stubServerToken makes authorize()'s cloud path resolve to a fixed credential pointed
+// at ctrlURL, standing in for the `vesta-cloud token` subprocess so tests drive the
+// control plane directly (no subprocess, no fake vestad).
+func stubServerToken(t *testing.T, ctrlURL string) {
 	t.Helper()
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/agents/alice/account-token" {
-			http.Error(w, "no", http.StatusNotFound)
-			return
-		}
-		if r.Header.Get("X-Agent-Token") != wantAgentToken {
-			http.Error(w, `{"error":"bad agent token"}`, http.StatusUnauthorized)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(map[string]string{"token": "sit_minted"})
-	}))
-	t.Cleanup(srv.Close)
-	return srv
+	prev := mintServerToken
+	mintServerToken = func() (serverToken, error) {
+		return serverToken{token: "sit_minted", controlURL: ctrlURL}, nil
+	}
+	t.Cleanup(func() { mintServerToken = prev })
 }
 
-// cloudClientFor wires a client against a fake vestad + a control-plane handler
-// (cloud managed mode: server-identity token, forwarded /integrations/switchboard).
+// cloudClientFor wires a client against a control-plane handler, with the cloud
+// credential stubbed to point at it (forwarded /integrations/switchboard).
 func cloudClientFor(t *testing.T, control http.HandlerFunc) *client {
 	t.Helper()
-	vestad := fakeVestad(t, "atok")
 	ctrl := httptest.NewServer(control)
 	t.Cleanup(ctrl.Close)
-	return newClient(config{
-		controlURL: ctrl.URL,
-		vestadBase: vestad.URL,
-		agentName:  "alice",
-		agentToken: "atok",
-	})
+	stubServerToken(t, ctrl.URL)
+	return newClient(config{vestadBase: "https://vestad.test", agentName: "alice", agentToken: "atok"})
 }
 
 func TestReserve_cloudMintsTokenAndReturnsNumber(t *testing.T) {
@@ -234,7 +222,6 @@ func TestDirect_sbkKeyHitsNativeLeasePaths(t *testing.T) {
 // the cloud: authorize mints it from the /token endpoint (server-identity authed),
 // then talks to that Switchboard natively. The key never appears in output.
 func TestAuthorize_directCredsFromTokenEndpoint(t *testing.T) {
-	vestad := fakeVestad(t, "atok")
 	var sawTokenAuth string
 	ctrl := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/integrations/switchboard/token" {
@@ -245,12 +232,9 @@ func TestAuthorize_directCredsFromTokenEndpoint(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]string{"url": "https://sb.example", "key": "sbk_minted"})
 	}))
 	t.Cleanup(ctrl.Close)
+	stubServerToken(t, ctrl.URL)
 	c := newClient(config{
-		controlURL: ctrl.URL,
-		directURL:  "https://sb.example", // base set, key absent
-		vestadBase: vestad.URL,
-		agentName:  "alice",
-		agentToken: "atok",
+		directURL: "https://sb.example", // base set, key absent
 	})
 	base, auth, direct, err := c.authorize()
 	if err != nil {
@@ -299,18 +283,5 @@ func TestLoadConfig_directPairFromEnv(t *testing.T) {
 	cfg := loadConfig()
 	if cfg.directURL != "https://sb.example" || cfg.directKey != "sbk_env" {
 		t.Fatalf("loadConfig = url %q key %q", cfg.directURL, cfg.directKey)
-	}
-}
-
-func TestMintToken_missingCredentials(t *testing.T) {
-	// Not in an agent container at all.
-	c := newClient(config{controlURL: "https://x"})
-	if _, err := c.mintToken(); err == nil {
-		t.Fatal("expected error without VESTAD_PORT/AGENT_NAME")
-	}
-	// In a container but missing the agent token.
-	c2 := newClient(config{controlURL: "https://x", vestadBase: "https://localhost:1", agentName: "alice"})
-	if _, err := c2.mintToken(); err == nil {
-		t.Fatal("expected error without AGENT_TOKEN")
 	}
 }

--- a/agent/skills/otp/cli/client_test.go
+++ b/agent/skills/otp/cli/client_test.go
@@ -64,7 +64,7 @@ func TestReserve_cloudMintsTokenAndReturnsNumber(t *testing.T) {
 		_ = json.NewDecoder(r.Body).Decode(&gotBody)
 		_ = json.NewEncoder(w).Encode(map[string]string{"id": "lease_1", "number": "+15550001111", "service": "github"})
 	})
-	l, err := c.reserve("github", "US")
+	l, err := c.reserve("github", "US", "flow-42")
 	if err != nil {
 		t.Fatalf("reserve: %v", err)
 	}
@@ -80,6 +80,11 @@ func TestReserve_cloudMintsTokenAndReturnsNumber(t *testing.T) {
 	if gotBody["service"] != "github" || gotBody["country"] != "US" {
 		t.Fatalf("reserve body = %+v", gotBody)
 	}
+	// A stable idempotency_key must reach the control plane so a retried reserve for the
+	// same flow returns the same number rather than drawing (and paying for) a second.
+	if gotBody["idempotency_key"] != "flow-42" {
+		t.Fatalf("reserve body idempotency_key = %q, want flow-42", gotBody["idempotency_key"])
+	}
 }
 
 func TestReserve_quota429SurfacesErrQuotaExceeded(t *testing.T) {
@@ -87,7 +92,7 @@ func TestReserve_quota429SurfacesErrQuotaExceeded(t *testing.T) {
 		w.WriteHeader(http.StatusTooManyRequests)
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": "otp_quota_exceeded"})
 	})
-	if _, err := c.reserve("github", ""); !errors.Is(err, errQuotaExceeded) {
+	if _, err := c.reserve("github", "", ""); !errors.Is(err, errQuotaExceeded) {
 		t.Fatalf("reserve on 429 = %v, want errQuotaExceeded", err)
 	}
 }
@@ -97,7 +102,7 @@ func TestReserve_outOfStock503SurfacesErrOutOfStock(t *testing.T) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": "out_of_stock"})
 	})
-	if _, err := c.reserve("github", ""); !errors.Is(err, errOutOfStock) {
+	if _, err := c.reserve("github", "", ""); !errors.Is(err, errOutOfStock) {
 		t.Fatalf("reserve on 503 = %v, want errOutOfStock", err)
 	}
 }
@@ -215,7 +220,7 @@ func TestDirect_sbkKeyHitsNativeLeasePaths(t *testing.T) {
 	if !c.isDirect() || !c.isHosted() {
 		t.Fatal("a box with an sbk_ key is direct + hosted")
 	}
-	l, err := c.reserve("discord", "")
+	l, err := c.reserve("discord", "", "")
 	if err != nil {
 		t.Fatalf("direct reserve: %v", err)
 	}
@@ -237,36 +242,18 @@ func TestDirect_sbkKeyHitsNativeLeasePaths(t *testing.T) {
 	}
 }
 
-// A self-hosted box with a Switchboard base URL but no key delegates the sbk_ key to
-// the cloud: authorize mints it from the /token endpoint (server-identity authed),
-// then talks to that Switchboard natively. The key never appears in output.
-func TestAuthorize_directCredsFromTokenEndpoint(t *testing.T) {
-	var sawTokenAuth string
-	ctrl := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/integrations/switchboard/token" {
-			http.Error(w, "no", http.StatusNotFound)
-			return
-		}
-		sawTokenAuth = r.Header.Get("Authorization")
-		_ = json.NewEncoder(w).Encode(map[string]string{"url": "https://sb.example", "key": "sbk_minted"})
-	}))
-	t.Cleanup(ctrl.Close)
-	stubServerToken(t, ctrl.URL)
-	c := newClient(config{
-		directURL: "https://sb.example", // base set, key absent
-	})
-	base, auth, direct, err := c.authorize()
-	if err != nil {
-		t.Fatalf("authorize: %v", err)
+// A Switchboard base URL with no key is a misconfiguration, not a delegated mode: the
+// cloud never mints a key to the box. loadConfig rejects it and reserve refuses rather
+// than reaching for a control-plane endpoint that no longer exists.
+func TestLoadConfig_urlWithoutKeyIsRejected(t *testing.T) {
+	t.Setenv("SWITCHBOARD_API_URL", "https://sb.example")
+	t.Setenv("SWITCHBOARD_API_KEY", "")
+	cfg := loadConfig()
+	if cfg.configError == "" || cfg.directURL != "" {
+		t.Fatalf("a base with no key must be rejected: %+v", cfg)
 	}
-	if !direct {
-		t.Fatal("a /token-minted credential must resolve to direct mode (native paths)")
-	}
-	if base != "https://sb.example" || auth != "Bearer sbk_minted" {
-		t.Fatalf("authorize base=%q auth=%q, want the /token-minted creds", base, auth)
-	}
-	if sawTokenAuth != "Bearer sit_minted" {
-		t.Fatalf("/token Authorization = %q, want the server-identity token", sawTokenAuth)
+	if _, err := newClient(cfg).reserve("x", "", ""); err == nil || !strings.Contains(err.Error(), "without SWITCHBOARD_API_KEY") {
+		t.Fatalf("reserve with base-only config error = %v", err)
 	}
 }
 
@@ -291,7 +278,7 @@ func TestLoadConfig_keyWithoutURLIsRejected(t *testing.T) {
 	if cfg.configError == "" || cfg.directKey != "" {
 		t.Fatalf("a key with no base must be rejected: %+v", cfg)
 	}
-	if _, err := newClient(cfg).reserve("x", ""); err == nil || !strings.Contains(err.Error(), "without SWITCHBOARD_API_URL") {
+	if _, err := newClient(cfg).reserve("x", "", ""); err == nil || !strings.Contains(err.Error(), "without SWITCHBOARD_API_URL") {
 		t.Fatalf("reserve with orphan key error = %v", err)
 	}
 }

--- a/agent/skills/otp/cli/main.go
+++ b/agent/skills/otp/cli/main.go
@@ -36,7 +36,7 @@ func main() {
 
 func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage: otp <command> [flags]")
-	fmt.Fprintln(w, "  new --service <name> [--country US]   reserve a temporary number for a service; prints {number, id}")
+	fmt.Fprintln(w, "  new --service <name> [--country US] [--idempotency-key <k>]   reserve a temporary number for a service; prints {number, id}")
 	fmt.Fprintln(w, "  code --id <id> [--since <RFC3339>]    wait for the SMS code on that number; prints {code}")
 	fmt.Fprintln(w, "  release --id <id>                     give the number back when done; prints {}")
 }
@@ -45,13 +45,14 @@ func runNew(args []string) {
 	fs := flag.NewFlagSet("new", flag.ContinueOnError)
 	service := fs.String("service", "", "the service the code is for (required)")
 	country := fs.String("country", "", "optional ISO country code, e.g. US")
+	idempotencyKey := fs.String("idempotency-key", "", "optional stable key: reuse it when retrying a reserve for the same flow so it returns the same number instead of drawing another")
 	if err := fs.Parse(args); err != nil {
 		failJSON("%v", err)
 	}
 	if *service == "" {
 		failJSON("--service is required")
 	}
-	l, err := newClient(loadConfig()).reserve(*service, *country)
+	l, err := newClient(loadConfig()).reserve(*service, *country, *idempotencyKey)
 	if err != nil {
 		failReserve(err)
 	}

--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -22,9 +22,9 @@ yourself. It is about where the account comes from, not where the agent runs. Yo
 pick the source and pass it explicitly as `--source`; the CLI never guesses.
 
 1. **Already linked?** `whatsapp status` returns `linked:true`. Use it and stop.
-2. **Vesta Cloud managed box?** Run
-   `whatsapp connect --source cloud --opener '<text>'` straight away, silently,
-   without asking or telling the user. It is automatic. See the
+2. **Vesta Cloud account?** Run `vesta-cloud whoami`: `account:true` means this
+   box has one. If so, run `whatsapp connect --source cloud --opener '<text>'`
+   straight away, silently, without asking or telling the user. See the
    [Vesta Cloud WhatsApp account](SETUP_VESTA_CLOUD.md) guide.
 3. **`DOUBLETICK_API_URL` and `DOUBLETICK_API_KEY` both set?** Run
    `whatsapp connect --source doubletick --opener '<text>'`. See the

--- a/agent/skills/whatsapp/cli/managed_auth.go
+++ b/agent/skills/whatsapp/cli/managed_auth.go
@@ -87,7 +87,6 @@ func classifyBlock(err error) error {
 // This file is the HTTP client + on-disk state; daemon wiring lives in MANAGED_AUTH.md.
 
 const (
-	managedHTTPTimeout = 30 * time.Second
 	// controlHTTPTimeout bounds a call to the pool API. It is generous because
 	// /pair blocks server-side while the home box holds the primary online through
 	// the just-linked companion's initial sync (a cold primary there leaves the
@@ -161,13 +160,6 @@ func loadManagedConfig() managedConfig {
 	}
 }
 
-func envOrDefault(name, def string) string {
-	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
-		return v
-	}
-	return def
-}
-
 // isDirect reports whether a direct home-box key is configured: the box talks
 // straight to the pool API with its own per-account key, no vesta.run, no vestad.
 func (c managedConfig) isDirect() bool {
@@ -239,7 +231,7 @@ func (m *managedAuth) isDirect() bool {
 // is cloudManaged (VESTA_CLOUD_CONTROL_URL), which the control plane's cloud-init
 // drop-in sets only on managed VMs and vestad forwards into the container. Without
 // it, a plain box falls back to the QR strategy instead of dead-ending on a managed
-// path whose account-token mint would 404.
+// path whose `vesta-cloud token` mint would fail (it has no cloud account).
 func (m *managedAuth) isHosted() bool {
 	return m.cfg.configError != "" || m.cfg.isDirect() || m.cfg.isCloudTenant()
 }

--- a/agent/skills/whatsapp/cli/managed_auth.go
+++ b/agent/skills/whatsapp/cli/managed_auth.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -264,30 +265,45 @@ type serverToken struct {
 // a subprocess.
 var mintServerToken = vestaCloudToken
 
+// vestaCloudTokenTimeout bounds the subprocess so a wedged `vesta-cloud token` can never
+// hang the daemon's auth path (the native mint it replaced had a 30s HTTP timeout).
+const vestaCloudTokenTimeout = 30 * time.Second
+
 // vestaCloudToken shells out to `vesta-cloud token`, the single source of truth for
 // minting this box's server-identity token and resolving the control-plane URL. Every
 // skill that calls the control plane as the server routes through this one command, so
-// the vestad endpoint, the agent-token header, and the control URL live in one place
-// and cannot silently diverge across skills. On failure `vesta-cloud token` prints a
-// structured {error} on stdout and exits non-zero, which surfaces here verbatim.
+// the vestad endpoint, the agent-token header, and the control URL live in one place and
+// cannot silently diverge across skills.
 func vestaCloudToken() (serverToken, error) {
-	out, runErr := exec.Command("vesta-cloud", "token").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), vestaCloudTokenTimeout)
+	defer cancel()
+	out, runErr := exec.CommandContext(ctx, "vesta-cloud", "token").Output()
+	return parseServerToken(out, runErr, ctx.Err() == context.DeadlineExceeded)
+}
+
+// parseServerToken turns a `vesta-cloud token` run into a credential or a clear error,
+// split from the exec so the failure branches are unit tested. On failure the CLI prints
+// a structured {error} on stdout (surfaced verbatim); a missing command, a timeout, and
+// empty output each get their own message.
+func parseServerToken(out []byte, runErr error, timedOut bool) (serverToken, error) {
 	var resp struct {
 		Token      string `json:"token"`
 		ControlURL string `json:"control_url"`
 		Error      string `json:"error"`
 	}
 	_ = json.Unmarshal(out, &resp)
-	if resp.Token != "" && resp.ControlURL != "" {
+	switch {
+	case resp.Token != "" && resp.ControlURL != "":
 		return serverToken{token: resp.Token, controlURL: strings.TrimRight(resp.ControlURL, "/")}, nil
-	}
-	if resp.Error != "" {
+	case resp.Error != "":
 		return serverToken{}, fmt.Errorf("mint server-identity token: %s", resp.Error)
-	}
-	if runErr != nil {
+	case timedOut:
+		return serverToken{}, fmt.Errorf("`vesta-cloud token` timed out after %s", vestaCloudTokenTimeout)
+	case runErr != nil:
 		return serverToken{}, fmt.Errorf("run `vesta-cloud token` (is the vesta-cloud skill installed?): %w", runErr)
+	default:
+		return serverToken{}, fmt.Errorf("`vesta-cloud token` returned no token")
 	}
-	return serverToken{}, fmt.Errorf("`vesta-cloud token` returned no token")
 }
 
 // authorize resolves the pool-API base URL and Authorization header once. Direct mode

--- a/agent/skills/whatsapp/cli/managed_auth.go
+++ b/agent/skills/whatsapp/cli/managed_auth.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 )
@@ -113,7 +113,6 @@ var provisionPollInterval = 3 * time.Second
 type managedConfig struct {
 	directURL  string // home box base, e.g. https://<tunnel> (direct mode)
 	directKey  string // per-account key (wak_...) for direct mode
-	controlURL string // vesta.run control-plane base, e.g. https://vesta.run/api (cloud mode)
 	vestadBase string // this box's vestad, https://$BOX_HOST:$VESTAD_PORT
 	agentName  string
 	agentToken string
@@ -152,7 +151,6 @@ func loadManagedConfig() managedConfig {
 	return managedConfig{
 		directURL:    strings.TrimRight(directURL, "/"),
 		directKey:    directKey,
-		controlURL:   strings.TrimRight(envOrDefault("VESTA_CONTROL_URL", "https://vesta.run/api"), "/"),
 		vestadBase:   base,
 		agentName:    strings.TrimSpace(os.Getenv("AGENT_NAME")),
 		agentToken:   strings.TrimSpace(os.Getenv("AGENT_TOKEN")),
@@ -185,7 +183,6 @@ func (c managedConfig) isCloudTenant() bool {
 type managedAuth struct {
 	cfg     managedConfig
 	control *http.Client
-	vestad  *http.Client
 }
 
 // managedState is the in-memory result of a claim/provision: the assigned number
@@ -253,54 +250,59 @@ func newManagedAuth(cfg managedConfig) *managedAuth {
 	return &managedAuth{
 		cfg:     cfg,
 		control: &http.Client{Timeout: controlHTTPTimeout},
-		// vestad serves a self-signed cert on the loopback; the agent is on the
-		// same box, so TLS verification adds nothing and would just fail.
-		vestad: &http.Client{
-			Timeout:   managedHTTPTimeout,
-			Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
-		},
 	}
 }
 
-// mintToken asks this box's vestad for a short-lived server-identity token
-// (agent-token authed). vestad signs it locally from the box api_key, a pure
-// crypto operation with no network call, and hands it back.
-func (m *managedAuth) mintToken() (string, error) {
-	if m.cfg.vestadBase == "" || m.cfg.agentName == "" {
-		return "", fmt.Errorf("not running inside an agent container (no VESTAD_PORT/AGENT_NAME)")
-	}
-	if m.cfg.agentToken == "" {
-		return "", fmt.Errorf("missing AGENT_TOKEN, cannot authenticate to vestad")
-	}
-	var out struct {
-		Token string `json:"token"`
-	}
-	u := fmt.Sprintf("%s/agents/%s/account-token", m.cfg.vestadBase, m.cfg.agentName)
-	// A non-cloud-managed box answers 404; do() carries that status + body in the
-	// returned error, so the 404 detail surfaces without a separate decode branch.
-	if err := m.do(m.vestad, http.MethodPost, u, map[string]string{"X-Agent-Token": m.cfg.agentToken}, map[string]string{}, &out); err != nil {
-		return "", fmt.Errorf("mint server-identity token: %w", err)
-	}
-	if out.Token == "" {
-		return "", fmt.Errorf("vestad did not return a server-identity token")
-	}
-	return out.Token, nil
+// serverToken is the cloud-path credential: a short-lived server-identity token plus
+// the control-plane base URL it authenticates against.
+type serverToken struct {
+	token      string
+	controlURL string
 }
 
-// authorize resolves the pool-API base URL and Authorization header once. Direct
-// mode uses the static per-account key; cloud mode mints ONE short-lived
-// server-identity token (SERVER_IDENTITY_TTL 10m, comfortably longer than any
-// single command's work), so a caller making several requests in a row (claim's
-// poll loop) resolves once here and reuses the result rather than minting per call.
+// mintServerToken is a package var so tests stub the cloud credential without spawning
+// a subprocess.
+var mintServerToken = vestaCloudToken
+
+// vestaCloudToken shells out to `vesta-cloud token`, the single source of truth for
+// minting this box's server-identity token and resolving the control-plane URL. Every
+// skill that calls the control plane as the server routes through this one command, so
+// the vestad endpoint, the agent-token header, and the control URL live in one place
+// and cannot silently diverge across skills. On failure `vesta-cloud token` prints a
+// structured {error} on stdout and exits non-zero, which surfaces here verbatim.
+func vestaCloudToken() (serverToken, error) {
+	out, runErr := exec.Command("vesta-cloud", "token").Output()
+	var resp struct {
+		Token      string `json:"token"`
+		ControlURL string `json:"control_url"`
+		Error      string `json:"error"`
+	}
+	_ = json.Unmarshal(out, &resp)
+	if resp.Token != "" && resp.ControlURL != "" {
+		return serverToken{token: resp.Token, controlURL: strings.TrimRight(resp.ControlURL, "/")}, nil
+	}
+	if resp.Error != "" {
+		return serverToken{}, fmt.Errorf("mint server-identity token: %s", resp.Error)
+	}
+	if runErr != nil {
+		return serverToken{}, fmt.Errorf("run `vesta-cloud token` (is the vesta-cloud skill installed?): %w", runErr)
+	}
+	return serverToken{}, fmt.Errorf("`vesta-cloud token` returned no token")
+}
+
+// authorize resolves the pool-API base URL and Authorization header once. Direct mode
+// uses the static per-account key; cloud mode gets ONE short-lived server-identity token
+// (10m TTL, longer than any single command's work) from the vesta-cloud skill, so a
+// caller making several requests in a row (claim's poll loop) resolves once here.
 func (m *managedAuth) authorize() (base, auth string, err error) {
 	if m.isDirect() {
 		return m.cfg.directURL, "Bearer " + m.cfg.directKey, nil
 	}
-	token, err := m.mintToken()
+	st, err := mintServerToken()
 	if err != nil {
 		return "", "", err
 	}
-	return m.cfg.controlURL + "/integrations/whatsapp", "Bearer " + token, nil
+	return st.controlURL + "/integrations/whatsapp", "Bearer " + st.token, nil
 }
 
 // usesResidentialProxy reports whether this box must egress through a leased

--- a/agent/skills/whatsapp/cli/managed_auth_test.go
+++ b/agent/skills/whatsapp/cli/managed_auth_test.go
@@ -13,38 +13,26 @@ import (
 	waLog "go.mau.fi/whatsmeow/util/log"
 )
 
-// fakeVestad is a stand-in for this box's vestad: it mints a server-identity
-// token for the agent-token tier, exactly like POST /agents/{name}/account-token.
-func fakeVestad(t *testing.T, wantAgentToken string) *httptest.Server {
+// stubServerToken makes authorize()'s cloud path resolve to a fixed credential pointed
+// at ctrlURL, standing in for the `vesta-cloud token` subprocess so tests drive the
+// control plane directly (no subprocess, no fake vestad).
+func stubServerToken(t *testing.T, ctrlURL string) {
 	t.Helper()
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/agents/alice/account-token" {
-			http.Error(w, "no", http.StatusNotFound)
-			return
-		}
-		if r.Header.Get("X-Agent-Token") != wantAgentToken {
-			http.Error(w, `{"error":"bad agent token"}`, http.StatusUnauthorized)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(map[string]string{"token": "sit_minted"})
-	}))
-	t.Cleanup(srv.Close)
-	return srv
+	prev := mintServerToken
+	mintServerToken = func() (serverToken, error) {
+		return serverToken{token: "sit_minted", controlURL: ctrlURL}, nil
+	}
+	t.Cleanup(func() { mintServerToken = prev })
 }
 
-// managedFor wires a managedAuth against a fake vestad + a control-plane handler.
+// managedFor wires a managedAuth against a control-plane handler, with the cloud
+// credential stubbed to point at it.
 func managedFor(t *testing.T, control http.HandlerFunc) *managedAuth {
 	t.Helper()
-	vestad := fakeVestad(t, "atok")
 	ctrl := httptest.NewServer(control)
 	t.Cleanup(ctrl.Close)
-	m := newManagedAuth(managedConfig{
-		controlURL: ctrl.URL,
-		vestadBase: vestad.URL,
-		agentName:  "alice",
-		agentToken: "atok",
-	})
-	return m
+	stubServerToken(t, ctrl.URL)
+	return newManagedAuth(managedConfig{vestadBase: "https://vestad.test", agentName: "alice", agentToken: "atok"})
 }
 
 func TestProvision_claimsPairsAndSaves(t *testing.T) {
@@ -383,20 +371,6 @@ func TestControlError_surfaces(t *testing.T) {
 	}
 }
 
-func TestMintToken_missingCredentials(t *testing.T) {
-	// No AGENT_TOKEN: the agent cannot authenticate to vestad, so provision fails
-	// clearly rather than emitting a transport error.
-	m := newManagedAuth(managedConfig{controlURL: "https://x", vestadBase: "https://localhost:1", agentName: "alice"})
-	if _, err := m.mintToken(); err == nil {
-		t.Fatal("expected error without AGENT_TOKEN")
-	}
-	// Not in an agent container at all.
-	m2 := newManagedAuth(managedConfig{controlURL: "https://x"})
-	if _, err := m2.mintToken(); err == nil {
-		t.Fatal("expected error without VESTAD_PORT/AGENT_NAME")
-	}
-}
-
 // leaseProxy POSTs the control-plane lease endpoint with the same server-identity
 // token the rest of managed auth mints, and returns the url from the JSON body.
 func TestLeaseProxy_returnsURL(t *testing.T) {
@@ -467,7 +441,6 @@ func TestLeaseProxy_unconfigured503(t *testing.T) {
 // it returns an error, caches nothing, and never reaches SetProxyAddress (so the
 // companion never connects to WhatsApp on the datacenter IP).
 func TestEnsureManagedProxy_failsClosedWithoutLease(t *testing.T) {
-	vestad := fakeVestad(t, "atok")
 	ctrl := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/integrations/whatsapp/proxy/lease" {
 			http.Error(w, "no", http.StatusNotFound)
@@ -477,7 +450,8 @@ func TestEnsureManagedProxy_failsClosedWithoutLease(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": "proxy_unconfigured"})
 	}))
 	t.Cleanup(ctrl.Close)
-	m := newManagedAuth(managedConfig{controlURL: ctrl.URL, vestadBase: vestad.URL, agentName: "alice", agentToken: "atok", cloudManaged: true})
+	stubServerToken(t, ctrl.URL)
+	m := newManagedAuth(managedConfig{vestadBase: "https://vestad.test", agentName: "alice", agentToken: "atok", cloudManaged: true})
 	wac := &WhatsAppClient{managed: m}
 	if err := wac.ensureManagedProxy(); err == nil || !strings.Contains(err.Error(), "not configured") {
 		t.Fatalf("cloud-managed ensureManagedProxy without a lease = %v, want a fail-closed not-configured error", err)
@@ -550,7 +524,6 @@ func TestEnsureManagedProxy_cachesGoodVerdictPerProxy(t *testing.T) {
 }
 
 func TestEnsureManagedProxy_hostedLeaseFlowCachesLeaseAndVerdict(t *testing.T) {
-	vestad := fakeVestad(t, "atok")
 	var leases atomic.Int32
 	ctrl := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/integrations/whatsapp/proxy/lease" {
@@ -568,8 +541,9 @@ func TestEnsureManagedProxy_hostedLeaseFlowCachesLeaseAndVerdict(t *testing.T) {
 		return egressInfo{Status: "success", Query: "198.51.100.8"}, nil
 	}
 	t.Cleanup(func() { lookupEgress = oldLookup })
+	stubServerToken(t, ctrl.URL)
 	wac := newLinkedTestClient(t)
-	wac.managed = newManagedAuth(managedConfig{controlURL: ctrl.URL, vestadBase: vestad.URL, agentName: "alice", agentToken: "atok", cloudManaged: true})
+	wac.managed = newManagedAuth(managedConfig{vestadBase: "https://vestad.test", agentName: "alice", agentToken: "atok", cloudManaged: true})
 	if err := wac.ensureManagedProxy(); err != nil {
 		t.Fatalf("first hosted proxy setup: %v", err)
 	}

--- a/agent/skills/whatsapp/cli/managed_auth_test.go
+++ b/agent/skills/whatsapp/cli/managed_auth_test.go
@@ -35,6 +35,25 @@ func managedFor(t *testing.T, control http.HandlerFunc) *managedAuth {
 	return newManagedAuth(managedConfig{vestadBase: "https://vestad.test", agentName: "alice", agentToken: "atok"})
 }
 
+// TestParseServerToken pins how a `vesta-cloud token` run maps to a credential or a
+// clear error: success, a structured {error} surfaced verbatim, the command missing, a
+// timeout, and empty output.
+func TestParseServerToken(t *testing.T) {
+	if st, err := parseServerToken([]byte(`{"token":"sit","control_url":"https://ctrl/"}`), nil, false); err != nil || st.token != "sit" || st.controlURL != "https://ctrl" {
+		t.Fatalf("success = %+v err=%v", st, err)
+	}
+	if _, err := parseServerToken([]byte(`{"error":"no account linked"}`), errors.New("exit status 3"), false); err == nil || !strings.Contains(err.Error(), "no account linked") {
+		t.Fatalf("structured error = %v, want it surfaced verbatim", err)
+	}
+	notFound := errors.New(`exec: "vesta-cloud": executable file not found in $PATH`)
+	if _, err := parseServerToken(nil, notFound, false); err == nil || !strings.Contains(err.Error(), "vesta-cloud skill installed") {
+		t.Fatalf("not-installed error = %v, want the install hint", err)
+	}
+	if _, err := parseServerToken(nil, errors.New("signal: killed"), true); err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("timeout error = %v, want a timeout message", err)
+	}
+}
+
 func TestProvision_claimsPairsAndSaves(t *testing.T) {
 	var gotAuth, gotCode string
 	m := managedFor(t, func(w http.ResponseWriter, r *http.Request) {

--- a/check.sh
+++ b/check.sh
@@ -28,6 +28,7 @@ Suites:
   whatsapp       gofmt + go vet + go build + go test for the whatsapp skill CLI
                  (builds whisper.cpp static libs to ~/.cache/vesta-whisper on first run)
   telegram       gofmt + go vet + go build + go test for the telegram skill CLI
+  otp            gofmt + go vet + go build + go test for the otp skill CLI
   app-chat       pytest for the app-chat skill CLI (its own standalone uv project)
   integration    vestad integration tests (needs Docker)
   live           live agent e2e tests, incl. the upgrade gate (needs Docker + ~/.claude/.credentials.json; real Claude)
@@ -254,6 +255,21 @@ check_telegram() {
   )
 }
 
+check_otp() {
+  (
+    cd agent/skills/otp/cli
+    UNFORMATTED=$(gofmt -l .)
+    if [ -n "$UNFORMATTED" ]; then
+      echo "error: unformatted Go files:" >&2
+      echo "$UNFORMATTED" >&2
+      exit 1
+    fi
+    go vet ./...
+    go build -o /tmp/otp-check-build .
+    go test ./...
+  )
+}
+
 check_app_chat() {
   (
     cd agent/skills/app-chat/cli
@@ -333,6 +349,7 @@ for suite in "$@"; do
     guards) check_guards ;;
     whatsapp) check_whatsapp ;;
     telegram) check_telegram ;;
+    otp) check_otp ;;
     app-chat) check_app_chat ;;
     integration) check_integration ;;
     live) check_live ;;


### PR DESCRIPTION
## What

Follow-up 1 of the vesta-cloud account work, in two parts:

1. **`vesta-cloud whoami` as the agent's discriminator.** whatsapp SETUP.md step 2 asked "Vesta Cloud managed box?" with no way for the agent to know; it now runs `vesta-cloud whoami` and reads `account:true`. Closes the original "how does the agent know it's a cloud box" gap.

2. **Single-source the server-identity token mint.** whatsapp and otp each duplicated the cloud-path mint natively (POST to vestad's `/account-token` + a separately-resolved control URL). Both now route through `vesta-cloud token`, which returns `{token, control_url}`, so the vestad endpoint, the agent-token header, and the control URL live in one place and cannot drift across skills.

## Why the consolidation (updated after review)

I initially left the minters native and argued the shell-out was a net negative. The reviewer's point stands: duplicated auth logic gets forgotten in refactors, and it had **already drifted** here. Both Go clients read `VESTA_CONTROL_URL` for the control plane while vesta-cloud and cloud-init use `VESTA_CLOUD_CONTROL_URL`, so on staging the whatsapp/otp clients silently fell back to the prod control URL. Routing through `vesta-cloud token` removes that class of bug and fixes the staging divergence.

## Details

- Removes each client's private `mintToken`, its vestad HTTP client, and the `controlURL` config field (and the `VESTA_CONTROL_URL` read). The missing-credential guards move to vesta-cloud, already tested there.
- Static-key direct paths (`wak_` / `sbk_`) are untouched.
- A package-var seam (`mintServerToken`) lets tests stub the credential without a subprocess.
- Runtime dependency: whatsapp/otp now shell out to the `vesta-cloud` command. It is a default skill installed at birth (and by the rename migration), so it is reliably present; if missing, the error names it ("is the vesta-cloud skill installed?").

## Residual duplication (noted)

The ~15-line `vestaCloudToken` glue (exec + parse `{token, control_url}`) is duplicated verbatim in both Go skills, because they are separate go modules that cannot share a package cheaply. The *substantive* drift-prone logic (endpoint, header, control-URL env) is now single-sourced in vesta-cloud; only the thin glue against vesta-cloud's stable CLI output remains per-skill. A shared Go module could remove even that if you want to go further.

## Verification

whatsapp full `go test` suite green; otp `go test` green; `go vet`, gofmt, and the repo conventions guard clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PNxHEXx3r4BM4913oYZmd
