### PR TITLE
feat(vesta-cloud): pair a self-hosted box to a Vesta Cloud account (login/logout)

### DIFF
--- a/agent/skills/otp/SETUP.md
+++ b/agent/skills/otp/SETUP.md
@@ -1,0 +1,19 @@
+# otp setup
+
+Everything the build needs (Go) ships in the agent image; install nothing,
+download nothing.
+
+Put `otp` on PATH once:
+
+```bash
+mkdir -p ~/.local/bin && ln -sf ~/agent/skills/otp/otp ~/.local/bin/otp
+otp help >/dev/null   # a compile error surfaces HERE, loudly
+```
+
+The launcher compiles `cli/` from source on every invocation (Go's build cache
+keeps an unchanged rebuild well under a second), so a source edit is picked up
+by the next run. Never `go build` a static binary onto PATH; the launcher is
+the only entry point.
+
+There is no credential to configure here: what each `--source` needs is in
+[SKILL.md](SKILL.md) ("Choosing `--source`").

--- a/agent/skills/otp/SKILL.md
+++ b/agent/skills/otp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: otp
-description: Use when you need a one-time SMS verification code on a temporary phone number to sign up for or verify a service (a phone-number signup, an SMS 2FA step, a "we texted you a code" screen). Reserves a throwaway number, waits for the texted code, then releases the number. For WhatsApp, use the `whatsapp` skill instead.
+description: Use when you need a one-time SMS verification code on a temporary phone number to sign up for or verify a service (a phone-number signup, an SMS 2FA step, a "we texted you a code" screen). For WhatsApp, use the `whatsapp` skill instead.
 ---
 
 # otp (CLI: `otp`)
@@ -8,19 +8,35 @@ description: Use when you need a one-time SMS verification code on a temporary p
 Get a one-time SMS code on a temporary number, use it to clear a service's phone
 verification, then give the number back. Three verbs run in order:
 
-1. `otp new --service <name>` reserves a number and returns its `id`.
+1. `otp new --source <s> --service <name>` reserves a number and returns its `id`.
 2. Enter that number as the phone number on the service you are verifying.
-3. `otp code --id <id>` waits for the code the service texts, and prints it.
-4. `otp release --id <id>` returns the number to the pool once you are done.
+3. `otp code --source <s> --id <id>` waits for the code the service texts, and prints it.
+4. `otp release --source <s> --id <id>` returns the number once you are done.
 
-Every command prints JSON. The number is temporary and shared back to a pool, so
+Every command prints JSON. `--source` is required on every verb: you state where
+the number comes from (see below), the CLI never guesses, and `code`/`release`
+take the same source the number was reserved with. The number is temporary, so
 release it as soon as the code is used. Do not reuse an `id` for a second service.
+
+## Choosing `--source`
+
+Two independent services can supply numbers; you decide which to use:
+
+- `--source cloud`: Vesta Cloud. Works on any box with a Vesta Cloud account
+  (run `vesta-cloud whoami` when unsure; `account: true` means it works), with
+  no setup and no key. With no account the reserve fails with a clear error;
+  the box can be connected to a Vesta Cloud account, and the `vesta-cloud`
+  skill's SKILL.md explains how.
+- `--source switchboard`: a Switchboard the owner runs. Needs
+  `SWITCHBOARD_API_URL` plus `SWITCHBOARD_API_KEY` (an `sbk_` key handed over
+  by whoever runs that Switchboard); both are required together. Never print or
+  log the key.
 
 ## new: reserve a number
 
 ```bash
-otp new --service github
-otp new --service coinbase --country US
+otp new --source cloud --service github
+otp new --source switchboard --service coinbase --country US
 ```
 
 `--service` is required (the service you are verifying, for pool accounting).
@@ -35,18 +51,25 @@ Success prints the number to type into the service and the `id` to poll with:
 { "number": "+15550001111", "id": "lease_abc123" }
 ```
 
-Two outcomes are not errors to retry blindly:
+Four outcomes are not errors to retry blindly:
 
 - `{ "error": "otp_quota_exceeded", "next": "..." }`: the account's OTP allowance
   is spent. Wait for it to reset. Do not retry in a loop.
 - `{ "error": "out_of_stock", "next": "..." }`: no number is free right now. Retry
   shortly, or pass a different `--country`.
+- An error containing `membership_inactive`: this box's Vesta Cloud account has no
+  active paid membership, so Vesta Cloud OTP numbers are closed. Tell the owner;
+  do not retry.
+- An error containing `no server identity available` (from the token mint): this
+  box has no Vesta Cloud account and no `sbk_` key. Check `vesta-cloud whoami`;
+  the box can be connected to Vesta Cloud, and the `vesta-cloud` skill explains
+  how.
 
 ## code: wait for the SMS
 
 ```bash
-otp code --id lease_abc123
-otp code --id lease_abc123 --since 2026-07-31T18:00:00Z
+otp code --source cloud --id lease_abc123
+otp code --source cloud --id lease_abc123 --since 2026-07-31T18:00:00Z
 ```
 
 `otp code` polls until the code lands or a bounded timeout, then prints:
@@ -60,7 +83,7 @@ of failing. Trigger the service to send (or re-send) the code, then run `otp cod
 again to keep waiting:
 
 ```json
-{ "status": "pending", "next": "no code yet; re-run: otp code --id lease_abc123" }
+{ "status": "pending", "next": "no code yet; re-run: otp code --source cloud --id lease_abc123" }
 ```
 
 Pass `--since <RFC3339>` (the time you asked the service to send) to ignore any
@@ -69,16 +92,8 @@ older code on the same number and wait only for the fresh one.
 ## release: return the number
 
 ```bash
-otp release --id lease_abc123
+otp release --source cloud --id lease_abc123
 ```
 
 Prints `{}`. Release every number once its code is used or you abandon the signup,
 so the pool stays available. Releasing an already-released `id` is safe.
-
-## How it authenticates
-
-On a Vesta Cloud box the CLI mints a short-lived server-identity token from vestad
-and calls vesta.run, so no setup and no key are needed. A self-hosted box points at
-its own Switchboard directly with `SWITCHBOARD_API_URL` plus an `SWITCHBOARD_API_KEY`
-(an `sbk_` key handed over by whoever runs that Switchboard); both are required
-together. Never print or log the key.

--- a/agent/skills/otp/SKILL.md
+++ b/agent/skills/otp/SKILL.md
@@ -6,7 +6,8 @@ description: Use when you need a one-time SMS verification code on a temporary p
 # otp (CLI: `otp`)
 
 Get a one-time SMS code on a temporary number, use it to clear a service's phone
-verification, then give the number back. Three verbs run in order:
+verification, then give the number back. Install the `otp` command once from
+[SETUP.md](SETUP.md). Three verbs run in order:
 
 1. `otp new --source <s> --service <name>` reserves a number and returns its `id`.
 2. Enter that number as the phone number on the service you are verifying.
@@ -22,7 +23,7 @@ release it as soon as the code is used. Do not reuse an `id` for a second servic
 
 Two independent services can supply numbers; you decide which to use:
 
-- `--source cloud`: Vesta Cloud. Works on any box with a Vesta Cloud account
+- `--source vesta-cloud`: Vesta Cloud. Works on any box with a Vesta Cloud account
   (run `vesta-cloud whoami` when unsure; `account: true` means it works), with
   no setup and no key. With no account the reserve fails with a clear error;
   the box can be connected to a Vesta Cloud account, and the `vesta-cloud`
@@ -35,7 +36,7 @@ Two independent services can supply numbers; you decide which to use:
 ## new: reserve a number
 
 ```bash
-otp new --source cloud --service github
+otp new --source vesta-cloud --service github
 otp new --source switchboard --service coinbase --country US
 ```
 
@@ -68,8 +69,8 @@ Four outcomes are not errors to retry blindly:
 ## code: wait for the SMS
 
 ```bash
-otp code --source cloud --id lease_abc123
-otp code --source cloud --id lease_abc123 --since 2026-07-31T18:00:00Z
+otp code --source vesta-cloud --id lease_abc123
+otp code --source vesta-cloud --id lease_abc123 --since 2026-07-31T18:00:00Z
 ```
 
 `otp code` polls until the code lands or a bounded timeout, then prints:
@@ -83,7 +84,7 @@ of failing. Trigger the service to send (or re-send) the code, then run `otp cod
 again to keep waiting:
 
 ```json
-{ "status": "pending", "next": "no code yet; re-run: otp code --source cloud --id lease_abc123" }
+{ "status": "pending", "next": "no code yet; re-run: otp code --source vesta-cloud --id lease_abc123" }
 ```
 
 Pass `--since <RFC3339>` (the time you asked the service to send) to ignore any
@@ -92,7 +93,7 @@ older code on the same number and wait only for the fresh one.
 ## release: return the number
 
 ```bash
-otp release --source cloud --id lease_abc123
+otp release --source vesta-cloud --id lease_abc123
 ```
 
 Prints `{}`. Release every number once its code is used or you abandon the signup,

--- a/agent/skills/otp/cli/client.go
+++ b/agent/skills/otp/cli/client.go
@@ -18,7 +18,7 @@ import (
 // A one-time SMS code on a temporary number, for verifying any service (a signup or a
 // 2FA step): the agent reserves a number, uses it on the service, polls for the texted
 // code, then releases the number. Two independent services can supply the number, and
-// the agent CHOOSES with --source (the CLI never detects or falls back). `cloud` is
+// the agent CHOOSES with --source (the CLI never detects or falls back). `vesta-cloud` is
 // Vesta Cloud's OTP service: a short-lived server-identity token from
 // `vesta-cloud token` (available on any box whose Vesta Cloud account
 // `vesta-cloud whoami` reports), sent Bearer to vesta.run. `switchboard` is a
@@ -26,7 +26,7 @@ import (
 
 // The two number sources the agent chooses between with --source.
 const (
-	sourceCloud       = "cloud"
+	sourceVestaCloud  = "vesta-cloud"
 	sourceSwitchboard = "switchboard"
 )
 
@@ -90,7 +90,7 @@ func classifyReserve(err error) error {
 // config carries the credentials each --source needs:
 //   - switchboard: SWITCHBOARD_API_URL + SWITCHBOARD_API_KEY (a static sbk_ key),
 //     no vesta.run involved;
-//   - cloud: nothing from here; the credential is a server-identity token minted
+//   - vesta-cloud: nothing from here; the credential is a server-identity token minted
 //     per call via `vesta-cloud token`. Whether this box holds a Vesta Cloud
 //     account is `vesta-cloud whoami`'s answer, never an environment variable;
 //     the mint fails with a clear error on a box with no account.
@@ -124,7 +124,7 @@ func loadConfig() config {
 
 type client struct {
 	cfg     config
-	source  string // sourceCloud | sourceSwitchboard, the agent's --source choice
+	source  string // sourceVestaCloud | sourceSwitchboard, the agent's --source choice
 	control *http.Client
 }
 
@@ -142,14 +142,14 @@ func (c *client) isDirect() bool {
 	return c.cfg.directURL != "" && c.cfg.directKey != ""
 }
 
-// serverToken is the cloud-path credential: a short-lived server-identity token plus
+// serverToken is the Vesta Cloud credential: a short-lived server-identity token plus
 // the control-plane base URL it authenticates against.
 type serverToken struct {
 	token      string
 	controlURL string
 }
 
-// mintServerToken is a package var so tests stub the cloud credential without spawning
+// mintServerToken is a package var so tests stub the Vesta Cloud credential without spawning
 // a subprocess.
 var mintServerToken = vestaCloudToken
 
@@ -196,7 +196,7 @@ func parseServerToken(out []byte, runErr error, timedOut bool) (serverToken, err
 
 // authorize resolves the base URL and Authorization header for the agent's chosen
 // --source, plus which path family to use. `switchboard` uses the static sbk_ key
-// against native /leases paths; `cloud` mints one short-lived server-identity
+// against native /leases paths; `vesta-cloud` mints one short-lived server-identity
 // token and hits vesta.run's /reserve, /code, /release. There is no fallback
 // between sources: a source whose prerequisites are missing errors precisely.
 // A caller making several requests (the code poll) resolves once and reuses it.

--- a/agent/skills/otp/cli/client.go
+++ b/agent/skills/otp/cli/client.go
@@ -17,11 +17,18 @@ import (
 
 // A one-time SMS code on a temporary number, for verifying any service (a signup or a
 // 2FA step): the agent reserves a number, uses it on the service, polls for the texted
-// code, then releases the number. Two paths reach the same Switchboard pool. Cloud
-// (managed) mints a short-lived server-identity token from this box's vestad (loopback,
-// agent-token authed; no standing credential) and Bearers it to vesta.run's
-// /api/integrations/switchboard/*. Direct (self-hosted) sends an sbk_ key straight to a
-// Switchboard base URL; only the base URL, credential, and paths differ.
+// code, then releases the number. Two independent services can supply the number, and
+// the agent CHOOSES with --source (the CLI never detects or falls back). `cloud` is
+// Vesta Cloud's OTP service: a short-lived server-identity token from
+// `vesta-cloud token` (available on any box whose Vesta Cloud account
+// `vesta-cloud whoami` reports), sent Bearer to vesta.run. `switchboard` is a
+// Switchboard the owner runs: a static sbk_ key straight at its base URL.
+
+// The two number sources the agent chooses between with --source.
+const (
+	sourceCloud       = "cloud"
+	sourceSwitchboard = "switchboard"
+)
 
 const controlTimeout = 60 * time.Second
 
@@ -80,39 +87,26 @@ func classifyReserve(err error) error {
 	return nil
 }
 
-// config selects between the two ways to reach the same Switchboard pool:
-//   - direct (self-hosted): SWITCHBOARD_API_URL + SWITCHBOARD_API_KEY, an sbk_ key
-//     straight to a Switchboard base URL, no vesta.run and no vestad;
-//   - cloud (vesta.run tenant): a server-identity token minted from vestad, sent to
-//     vesta.run's /api/integrations/switchboard, which authenticates and forwards.
+// config carries the credentials each --source needs:
+//   - switchboard: SWITCHBOARD_API_URL + SWITCHBOARD_API_KEY (a static sbk_ key),
+//     no vesta.run involved;
+//   - cloud: nothing from here; the credential is a server-identity token minted
+//     per call via `vesta-cloud token`. Whether this box holds a Vesta Cloud
+//     account is `vesta-cloud whoami`'s answer, never an environment variable;
+//     the mint fails with a clear error on a box with no account.
 type config struct {
-	directURL  string // Switchboard base, e.g. https://<box> (direct mode)
-	directKey  string // sbk_ key for direct mode
-	vestadBase string // this box's vestad, https://$BOX_HOST:$VESTAD_PORT
-	agentName  string
-	agentToken string
-	// cloudManaged is the paid-tenant signal: cloud-init sets VESTA_CLOUD_CONTROL_URL
-	// only on managed VMs and vestad forwards it into the container, so its presence
-	// tells a cloud tenant from a plain self-hosted box (whose identity env is
-	// otherwise identical).
-	cloudManaged bool
-	configError  string
+	directURL   string // Switchboard base, e.g. https://<box> (direct mode)
+	directKey   string // sbk_ key for direct mode
+	configError string
 }
 
-// loadConfig reads the environment (mirrors the whatsapp skill's managed auth).
+// loadConfig reads the environment.
 func loadConfig() config {
-	base := ""
-	port := strings.TrimSpace(os.Getenv("VESTAD_PORT"))
-	host := strings.TrimSpace(os.Getenv("BOX_HOST"))
-	if port != "" && host != "" {
-		base = "https://" + host + ":" + port
-	}
 	directURL := strings.TrimSpace(os.Getenv("SWITCHBOARD_API_URL"))
 	directKey := strings.TrimSpace(os.Getenv("SWITCHBOARD_API_KEY"))
 	configError := ""
-	// Direct mode needs both halves: a self-hosted operator hands the box a one-time
-	// sbk_ key out of band. Either half alone is a misconfiguration. (The cloud never
-	// mints a key to the box; a paid tenant reserves through the forwarded API instead.)
+	// Direct mode needs both halves: an operator hands the box an sbk_ key out of
+	// band together with the base URL it opens. Either half alone is a misconfiguration.
 	switch {
 	case directKey != "" && directURL == "":
 		configError = "SWITCHBOARD_API_KEY is set without SWITCHBOARD_API_URL"
@@ -122,42 +116,30 @@ func loadConfig() config {
 		directURL = ""
 	}
 	return config{
-		directURL:    strings.TrimRight(directURL, "/"),
-		directKey:    directKey,
-		vestadBase:   base,
-		agentName:    strings.TrimSpace(os.Getenv("AGENT_NAME")),
-		agentToken:   strings.TrimSpace(os.Getenv("AGENT_TOKEN")),
-		cloudManaged: strings.TrimSpace(os.Getenv("VESTA_CLOUD_CONTROL_URL")) != "",
-		configError:  configError,
+		directURL:   strings.TrimRight(directURL, "/"),
+		directKey:   directKey,
+		configError: configError,
 	}
 }
 
 type client struct {
 	cfg     config
+	source  string // sourceCloud | sourceSwitchboard, the agent's --source choice
 	control *http.Client
 }
 
-func newClient(cfg config) *client {
+func newClient(cfg config, source string) *client {
 	return &client{
 		cfg:     cfg,
+		source:  source,
 		control: &http.Client{Timeout: controlTimeout},
 	}
 }
 
-// isDirect reports whether a self-hosted sbk_ key is configured: the box talks
-// straight to a Switchboard base URL with its own key, no vesta.run, no vestad.
+// isDirect reports whether a static sbk_ key is configured: the box talks
+// straight to a Switchboard base URL with its own key, no vesta.run involved.
 func (c *client) isDirect() bool {
 	return c.cfg.directURL != "" && c.cfg.directKey != ""
-}
-
-// isHosted reports whether this box can get OTP numbers at all: either a direct
-// sbk_ key (self-hosted), or a genuine vesta.run cloud tenant. Every agent
-// container carries VESTAD_PORT/AGENT_NAME/AGENT_TOKEN, so their presence alone
-// cannot tell a paid tenant from a plain self-hosted box; cloudManaged
-// (VESTA_CLOUD_CONTROL_URL) is the distinguishing signal.
-func (c *client) isHosted() bool {
-	return c.cfg.configError != "" || c.isDirect() ||
-		(c.cfg.cloudManaged && c.cfg.vestadBase != "" && c.cfg.agentName != "" && c.cfg.agentToken != "")
 }
 
 // serverToken is the cloud-path credential: a short-lived server-identity token plus
@@ -172,7 +154,7 @@ type serverToken struct {
 var mintServerToken = vestaCloudToken
 
 // vestaCloudTokenTimeout bounds the subprocess so a wedged `vesta-cloud token` can never
-// hang the CLI's auth path (the native mint it replaced had a 30s HTTP timeout).
+// hang the CLI's auth path.
 const vestaCloudTokenTimeout = 30 * time.Second
 
 // vestaCloudToken shells out to `vesta-cloud token`, the single source of truth for
@@ -212,16 +194,20 @@ func parseServerToken(out []byte, runErr error, timedOut bool) (serverToken, err
 	}
 }
 
-// authorize resolves the Switchboard base URL and Authorization header once, plus
-// which path family to use. Direct mode uses the static sbk_ key against native
-// /leases paths; cloud mode mints one short-lived server-identity token and hits
-// vesta.run's forwarded /reserve, /code, /release. A caller making several requests
-// (the code poll) resolves once here and reuses the result.
+// authorize resolves the base URL and Authorization header for the agent's chosen
+// --source, plus which path family to use. `switchboard` uses the static sbk_ key
+// against native /leases paths; `cloud` mints one short-lived server-identity
+// token and hits vesta.run's /reserve, /code, /release. There is no fallback
+// between sources: a source whose prerequisites are missing errors precisely.
+// A caller making several requests (the code poll) resolves once and reuses it.
 func (c *client) authorize() (base, auth string, direct bool, err error) {
-	if c.cfg.configError != "" {
-		return "", "", false, errors.New(c.cfg.configError)
-	}
-	if c.isDirect() {
+	if c.source == sourceSwitchboard {
+		if c.cfg.configError != "" {
+			return "", "", false, errors.New(c.cfg.configError)
+		}
+		if !c.isDirect() {
+			return "", "", false, errors.New("--source switchboard needs SWITCHBOARD_API_URL and SWITCHBOARD_API_KEY set together (an sbk_ key from whoever runs that Switchboard)")
+		}
 		return c.cfg.directURL, "Bearer " + c.cfg.directKey, true, nil
 	}
 	st, err := mintServerToken()

--- a/agent/skills/otp/cli/client_test.go
+++ b/agent/skills/otp/cli/client_test.go
@@ -30,7 +30,7 @@ func cloudClientFor(t *testing.T, control http.HandlerFunc) *client {
 	ctrl := httptest.NewServer(control)
 	t.Cleanup(ctrl.Close)
 	stubServerToken(t, ctrl.URL)
-	return newClient(config{}, sourceCloud)
+	return newClient(config{}, sourceVestaCloud)
 }
 
 // TestParseServerToken pins how a `vesta-cloud token` run maps to a credential or a

--- a/agent/skills/otp/cli/client_test.go
+++ b/agent/skills/otp/cli/client_test.go
@@ -30,7 +30,7 @@ func cloudClientFor(t *testing.T, control http.HandlerFunc) *client {
 	ctrl := httptest.NewServer(control)
 	t.Cleanup(ctrl.Close)
 	stubServerToken(t, ctrl.URL)
-	return newClient(config{vestadBase: "https://vestad.test", agentName: "alice", agentToken: "atok"})
+	return newClient(config{}, sourceCloud)
 }
 
 // TestParseServerToken pins how a `vesta-cloud token` run maps to a credential or a
@@ -198,9 +198,9 @@ func TestRelease_cloudPostsID(t *testing.T) {
 	}
 }
 
-// A direct (self-hosted) box uses its own sbk_ key straight to the Switchboard base
+// A box configured with its own sbk_ key goes straight to the Switchboard base
 // URL's native paths (/leases, /leases/{id}/otp, /leases/{id}/release), with no
-// vestad token and no vesta.run in the loop.
+// server-identity token and no vesta.run in the loop.
 func TestDirect_sbkKeyHitsNativeLeasePaths(t *testing.T) {
 	var reservePath, otpPath, releasePath, gotAuth string
 	box := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -220,10 +220,10 @@ func TestDirect_sbkKeyHitsNativeLeasePaths(t *testing.T) {
 		}
 	}))
 	t.Cleanup(box.Close)
-	c := newClient(config{directURL: box.URL, directKey: "sbk_test"})
+	c := newClient(config{directURL: box.URL, directKey: "sbk_test"}, sourceSwitchboard)
 
-	if !c.isDirect() || !c.isHosted() {
-		t.Fatal("a box with an sbk_ key is direct + hosted")
+	if !c.isDirect() {
+		t.Fatal("a box with an sbk_ key is direct")
 	}
 	l, err := c.reserve("discord", "", "")
 	if err != nil {
@@ -247,9 +247,9 @@ func TestDirect_sbkKeyHitsNativeLeasePaths(t *testing.T) {
 	}
 }
 
-// A Switchboard base URL with no key is a misconfiguration, not a delegated mode: the
-// cloud never mints a key to the box. loadConfig rejects it and reserve refuses rather
-// than reaching for a control-plane endpoint that no longer exists.
+// A Switchboard base URL with no key is a misconfiguration: direct mode always
+// needs both halves. loadConfig rejects it and reserve refuses with the exact
+// missing-var message instead of silently taking the cloud path.
 func TestLoadConfig_urlWithoutKeyIsRejected(t *testing.T) {
 	t.Setenv("SWITCHBOARD_API_URL", "https://sb.example")
 	t.Setenv("SWITCHBOARD_API_KEY", "")
@@ -257,19 +257,19 @@ func TestLoadConfig_urlWithoutKeyIsRejected(t *testing.T) {
 	if cfg.configError == "" || cfg.directURL != "" {
 		t.Fatalf("a base with no key must be rejected: %+v", cfg)
 	}
-	if _, err := newClient(cfg).reserve("x", "", ""); err == nil || !strings.Contains(err.Error(), "without SWITCHBOARD_API_KEY") {
+	if _, err := newClient(cfg, sourceSwitchboard).reserve("x", "", ""); err == nil || !strings.Contains(err.Error(), "without SWITCHBOARD_API_KEY") {
 		t.Fatalf("reserve with base-only config error = %v", err)
 	}
 }
 
-func TestAuthorize_cloudManagedUsesForwardedPath(t *testing.T) {
+func TestAuthorize_noDirectKeyUsesForwardedCloudPath(t *testing.T) {
 	c := cloudClientFor(t, func(_ http.ResponseWriter, _ *http.Request) {})
 	base, auth, direct, err := c.authorize()
 	if err != nil {
 		t.Fatalf("authorize: %v", err)
 	}
 	if direct {
-		t.Fatal("a pure cloud tenant must use the forwarded path, not direct")
+		t.Fatal("with no sbk_ key the CLI must use the forwarded cloud path, not direct")
 	}
 	if !strings.HasSuffix(base, "/integrations/switchboard") || auth != "Bearer sit_minted" {
 		t.Fatalf("cloud authorize base=%q auth=%q", base, auth)
@@ -283,7 +283,7 @@ func TestLoadConfig_keyWithoutURLIsRejected(t *testing.T) {
 	if cfg.configError == "" || cfg.directKey != "" {
 		t.Fatalf("a key with no base must be rejected: %+v", cfg)
 	}
-	if _, err := newClient(cfg).reserve("x", "", ""); err == nil || !strings.Contains(err.Error(), "without SWITCHBOARD_API_URL") {
+	if _, err := newClient(cfg, sourceSwitchboard).reserve("x", "", ""); err == nil || !strings.Contains(err.Error(), "without SWITCHBOARD_API_URL") {
 		t.Fatalf("reserve with orphan key error = %v", err)
 	}
 }

--- a/agent/skills/otp/cli/main.go
+++ b/agent/skills/otp/cli/main.go
@@ -35,12 +35,12 @@ func main() {
 }
 
 func printUsage(w io.Writer) {
-	fmt.Fprintln(w, "Usage: otp <command> --source <cloud|switchboard> [flags]")
+	fmt.Fprintln(w, "Usage: otp <command> --source <vesta-cloud|switchboard> [flags]")
 	fmt.Fprintln(w, "  new --source <s> --service <name> [--country US] [--idempotency-key <k>]   reserve a temporary number for a service; prints {number, id}")
 	fmt.Fprintln(w, "  code --source <s> --id <id> [--since <RFC3339>]    wait for the SMS code on that number; prints {code}")
 	fmt.Fprintln(w, "  release --source <s> --id <id>                     give the number back when done; prints {}")
 	fmt.Fprintln(w, "  --source states where the number comes from; you decide, the CLI never guesses:")
-	fmt.Fprintln(w, "    cloud        Vesta Cloud (needs this box's Vesta Cloud account)")
+	fmt.Fprintln(w, "    vesta-cloud  Vesta Cloud (needs this box's Vesta Cloud account)")
 	fmt.Fprintln(w, "    switchboard  a Switchboard the owner runs (needs SWITCHBOARD_API_URL + SWITCHBOARD_API_KEY)")
 }
 
@@ -48,19 +48,19 @@ func printUsage(w io.Writer) {
 // source explicitly; there is no detection and no fallback.
 func parseSource(raw string) string {
 	switch raw {
-	case sourceCloud, sourceSwitchboard:
+	case sourceVestaCloud, sourceSwitchboard:
 		return raw
 	case "":
-		failJSON("--source is required: cloud (Vesta Cloud) or switchboard (a Switchboard the owner runs)")
+		failJSON("--source is required: vesta-cloud (Vesta Cloud) or switchboard (a Switchboard the owner runs)")
 	default:
-		failJSON("unknown --source %q (use: cloud | switchboard)", raw)
+		failJSON("unknown --source %q (use: vesta-cloud | switchboard)", raw)
 	}
 	return "" // unreachable
 }
 
 func runNew(args []string) {
 	fs := flag.NewFlagSet("new", flag.ContinueOnError)
-	source := fs.String("source", "", "where the number comes from: cloud | switchboard (required)")
+	source := fs.String("source", "", "where the number comes from: vesta-cloud | switchboard (required)")
 	service := fs.String("service", "", "the service the code is for (required)")
 	country := fs.String("country", "", "optional ISO country code, e.g. US")
 	idempotencyKey := fs.String("idempotency-key", "", "optional stable key: reuse it when retrying a reserve for the same flow so it returns the same number instead of drawing another")

--- a/agent/skills/otp/cli/main.go
+++ b/agent/skills/otp/cli/main.go
@@ -35,14 +35,32 @@ func main() {
 }
 
 func printUsage(w io.Writer) {
-	fmt.Fprintln(w, "Usage: otp <command> [flags]")
-	fmt.Fprintln(w, "  new --service <name> [--country US] [--idempotency-key <k>]   reserve a temporary number for a service; prints {number, id}")
-	fmt.Fprintln(w, "  code --id <id> [--since <RFC3339>]    wait for the SMS code on that number; prints {code}")
-	fmt.Fprintln(w, "  release --id <id>                     give the number back when done; prints {}")
+	fmt.Fprintln(w, "Usage: otp <command> --source <cloud|switchboard> [flags]")
+	fmt.Fprintln(w, "  new --source <s> --service <name> [--country US] [--idempotency-key <k>]   reserve a temporary number for a service; prints {number, id}")
+	fmt.Fprintln(w, "  code --source <s> --id <id> [--since <RFC3339>]    wait for the SMS code on that number; prints {code}")
+	fmt.Fprintln(w, "  release --source <s> --id <id>                     give the number back when done; prints {}")
+	fmt.Fprintln(w, "  --source states where the number comes from; you decide, the CLI never guesses:")
+	fmt.Fprintln(w, "    cloud        Vesta Cloud (needs this box's Vesta Cloud account)")
+	fmt.Fprintln(w, "    switchboard  a Switchboard the owner runs (needs SWITCHBOARD_API_URL + SWITCHBOARD_API_KEY)")
+}
+
+// parseSource validates the required --source value. The agent states the
+// source explicitly; there is no detection and no fallback.
+func parseSource(raw string) string {
+	switch raw {
+	case sourceCloud, sourceSwitchboard:
+		return raw
+	case "":
+		failJSON("--source is required: cloud (Vesta Cloud) or switchboard (a Switchboard the owner runs)")
+	default:
+		failJSON("unknown --source %q (use: cloud | switchboard)", raw)
+	}
+	return "" // unreachable
 }
 
 func runNew(args []string) {
 	fs := flag.NewFlagSet("new", flag.ContinueOnError)
+	source := fs.String("source", "", "where the number comes from: cloud | switchboard (required)")
 	service := fs.String("service", "", "the service the code is for (required)")
 	country := fs.String("country", "", "optional ISO country code, e.g. US")
 	idempotencyKey := fs.String("idempotency-key", "", "optional stable key: reuse it when retrying a reserve for the same flow so it returns the same number instead of drawing another")
@@ -52,7 +70,7 @@ func runNew(args []string) {
 	if *service == "" {
 		failJSON("--service is required")
 	}
-	l, err := newClient(loadConfig()).reserve(*service, *country, *idempotencyKey)
+	l, err := newClient(loadConfig(), parseSource(*source)).reserve(*service, *country, *idempotencyKey)
 	if err != nil {
 		failReserve(err)
 	}
@@ -61,6 +79,7 @@ func runNew(args []string) {
 
 func runCode(args []string) {
 	fs := flag.NewFlagSet("code", flag.ContinueOnError)
+	source := fs.String("source", "", "the same --source the number was reserved with (required)")
 	id := fs.String("id", "", "the reservation id from `otp new` (required)")
 	since := fs.String("since", "", "optional RFC3339 timestamp: only codes texted after it")
 	if err := fs.Parse(args); err != nil {
@@ -69,12 +88,13 @@ func runCode(args []string) {
 	if *id == "" {
 		failJSON("--id is required")
 	}
-	code, err := newClient(loadConfig()).pollCode(*id, *since)
+	src := parseSource(*source)
+	code, err := newClient(loadConfig(), src).pollCode(*id, *since)
 	if errors.Is(err, errStillPending) {
 		// Not a failure: the SMS has not arrived yet. Re-run to keep waiting.
 		printJSON(map[string]string{
 			"status": "pending",
-			"next":   fmt.Sprintf("no code yet; re-run: otp code --id %s", *id),
+			"next":   fmt.Sprintf("no code yet; re-run: otp code --source %s --id %s", src, *id),
 		})
 		return
 	}
@@ -86,6 +106,7 @@ func runCode(args []string) {
 
 func runRelease(args []string) {
 	fs := flag.NewFlagSet("release", flag.ContinueOnError)
+	source := fs.String("source", "", "the same --source the number was reserved with (required)")
 	id := fs.String("id", "", "the reservation id to release (required)")
 	if err := fs.Parse(args); err != nil {
 		failJSON("%v", err)
@@ -93,7 +114,7 @@ func runRelease(args []string) {
 	if *id == "" {
 		failJSON("--id is required")
 	}
-	if err := newClient(loadConfig()).release(*id); err != nil {
+	if err := newClient(loadConfig(), parseSource(*source)).release(*id); err != nil {
 		failJSON("%v", err)
 	}
 	printJSON(map[string]string{})

--- a/agent/skills/otp/otp
+++ b/agent/skills/otp/otp
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Launcher for the otp CLI. Compiles cli/ from source on every invocation so no
+# stale binary can drift (Go's build cache keeps an unchanged rebuild well under
+# a second). Installed as a symlink at ~/.local/bin/otp; never `go build` a
+# static binary onto PATH.
+set -euo pipefail
+
+CLI_DIR="$(dirname "$(readlink -f "$0")")/cli"
+
+# Go lives at /usr/local/go; not every environment links it onto PATH.
+if ! command -v go >/dev/null; then export PATH="/usr/local/go/bin:$PATH"; fi
+
+# Build to a temp path then rename, so concurrent invocations never execute a
+# half-written binary.
+BIN_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/otp"
+mkdir -p "$BIN_DIR"
+BIN="$BIN_DIR/otp"
+TMP="$BIN.$$"
+(cd "$CLI_DIR" && go build -o "$TMP" .)
+mv -f "$TMP" "$BIN"
+exec "$BIN" "$@"

--- a/agent/skills/vesta-cloud/SETUP.md
+++ b/agent/skills/vesta-cloud/SETUP.md
@@ -7,5 +7,7 @@ uv tool install --editable ~/agent/skills/vesta-cloud/cli
 ```
 
 That puts the `vesta-cloud` command on `PATH`. If it is ever missing or stale, re-run
-with `--force --reinstall`. There is nothing else to configure: no key and no account to
-link, the CLI authenticates to the control plane on its own.
+with `--force --reinstall`. There is no key to configure: for every call the CLI asks
+this box's vestad to mint a short-lived server-identity token. A managed VM has its
+account from provisioning; a self-hosted box links one with `vesta-cloud login` (see
+SKILL.md).

--- a/agent/skills/vesta-cloud/SKILL.md
+++ b/agent/skills/vesta-cloud/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vesta-cloud
-description: THIS box's Vesta Cloud account. Use to check whether it has one and read its environment (`whoami`, the account/plan/setup signal other skills key off), get a server-identity token to call the control plane (`token`), or answer the owner about their hosting plan, billing, renewal, upgrade/cancel/card, and referral code. Not `onboard` (buying for someone else); not `stripe-pay` (third-party invoices).
+description: THIS box's Vesta Cloud account. Use to check whether it has one and read its environment (`whoami`, the account/plan/setup signal other skills key off), get a server-identity token to call the control plane (`token`), pair a self-hosted box to an account (`login`) or detach it (`logout`), or answer the owner about their hosting plan, billing, renewal, upgrade/cancel/card, and referral code. Not `onboard` (buying for someone else); not `stripe-pay` (third-party invoices).
 ---
 
 # vesta-cloud, CLI: `vesta-cloud`
@@ -40,6 +40,37 @@ it calls the control plane as this server without minting its own. One token is 
 it authenticates any server-scoped route (`/account`, integrations, ...). Errors when the
 box has no account. This is how every skill that needs to reach the control plane as the
 server gets its credential.
+
+## `login`: pair a self-hosted box to a Vesta Cloud account
+
+```bash
+vesta-cloud login
+# first, immediately:
+# { "user_code": "WXYZ-2345", "verification_url": "https://vesta.run/pair?code=WXYZ-2345",
+#   "next": "give the owner this code and link right away; ..." }
+# then, once the owner approves (the command keeps running):
+# { "account": true, "plan": "services", "status": "active", ... }
+```
+
+Use when `whoami` says `account: false` on a self-hosted box and the owner wants to
+connect it to their Vesta Cloud account. The command prints the code and link FIRST;
+relay them to the owner immediately (they open the link signed in and approve), then
+keep waiting: the same command prints a whoami-style confirmation once linked. The code
+lives about 10 minutes; on timeout, run `login` again for a fresh one. Pairing links the
+box to the account; whether that account pays for anything is separate (`plan`). A
+managed Vesta Cloud VM refuses to pair (it already has its identity).
+
+## `logout`: unpair this box
+
+```bash
+vesta-cloud logout
+# { "status": "unpaired" }
+```
+
+Detaches the box from its Vesta Cloud account (after asking the owner, this is theirs to
+decide). Also the local cleanup step when the owner already removed the box from the
+vesta.run dashboard: run it so the box forgets its stale link, then `login` can pair
+fresh. After logout, `whoami` answers `account: false` again.
 
 ## The trust model (read this)
 

--- a/agent/skills/vesta-cloud/SKILL.md
+++ b/agent/skills/vesta-cloud/SKILL.md
@@ -60,6 +60,11 @@ lives about 10 minutes; on timeout, run `login` again for a fresh one. Pairing l
 box to the account; whether that account pays for anything is separate (`plan`). A
 managed Vesta Cloud VM refuses to pair (it already has its identity).
 
+The pairing flow itself lives on vestad (this command only triggers and relays it), so
+the owner can equally start it themselves by running `vestad vesta-cloud login` on the
+box host, or from the vesta app. Either path ends the same way; `whoami` reports the
+result regardless of who initiated.
+
 ## `logout`: unpair this box
 
 ```bash
@@ -68,11 +73,12 @@ vesta-cloud logout
 ```
 
 Detaches the box from its Vesta Cloud account (after asking the owner, this is theirs to
-decide). Also the local cleanup step when the owner already removed the box from the
-vesta.run dashboard: run it so the box forgets its stale link, then `login` can pair
-fresh. After logout, `whoami` answers `account: false` again. If logout reports that
-the control plane rejected this box's identity, the link was kept on purpose: have the
-owner remove the box from the vesta.run dashboard, then run `logout` again.
+decide; `vestad vesta-cloud logout` on the box host does the same). Also the local
+cleanup step when the owner already removed the box from the vesta.run dashboard: run it
+so the box forgets its stale link, then `login` can pair fresh. After logout, `whoami`
+answers `account: false` again. If logout reports that the control plane rejected this
+box's identity, the link was kept on purpose: have the owner remove the box from the
+vesta.run dashboard, then run `logout` again.
 
 ## The trust model (read this)
 

--- a/agent/skills/vesta-cloud/SKILL.md
+++ b/agent/skills/vesta-cloud/SKILL.md
@@ -70,7 +70,9 @@ vesta-cloud logout
 Detaches the box from its Vesta Cloud account (after asking the owner, this is theirs to
 decide). Also the local cleanup step when the owner already removed the box from the
 vesta.run dashboard: run it so the box forgets its stale link, then `login` can pair
-fresh. After logout, `whoami` answers `account: false` again.
+fresh. After logout, `whoami` answers `account: false` again. If logout reports that
+the control plane rejected this box's identity, the link was kept on purpose: have the
+owner remove the box from the vesta.run dashboard, then run `logout` again.
 
 ## The trust model (read this)
 

--- a/agent/skills/vesta-cloud/SKILL.md
+++ b/agent/skills/vesta-cloud/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vesta-cloud
-description: THIS box's Vesta Cloud account. Use to check whether it has one and read its environment (`whoami`, the account/plan/setup signal other skills key off), get a server-identity token to call the control plane (`token`), pair a self-hosted box to an account (`login`) or detach it (`logout`), or answer the owner about their hosting plan, billing, renewal, upgrade/cancel/card, and referral code. Not `onboard` (buying for someone else); not `stripe-pay` (third-party invoices).
+description: THIS box's Vesta Cloud account. Use whenever you need to know if this box has one (the account/plan/setup signal other skills key off), when another skill needs a credential for the control plane, when the owner wants to connect or disconnect this box from their Vesta Cloud account, or when the owner asks about their hosting plan, billing, renewal, upgrade/cancel/card, or referral code. Not `onboard` (buying for someone else); not `stripe-pay` (third-party invoices).
 ---
 
 # vesta-cloud, CLI: `vesta-cloud`
@@ -8,16 +8,18 @@ description: THIS box's Vesta Cloud account. Use to check whether it has one and
 The single authority for **this** box's Vesta Cloud account: whether it has one, a
 credential to act as it against the control plane, its plan, and its referral code.
 Install the `vesta-cloud` command once from [SETUP.md](SETUP.md). Output is always JSON
-on stdout. Exit codes: 0 success, 2 surfaced `{error}` (no account / no billing yet),
-3 control-plane or vestad unreachable, 1 unexpected.
+on stdout. Exit codes: 0 success (`whoami` exits 0 even with `account: false`), 2 the
+control plane refused with a structured `{error}` (no billing yet, pairing refused),
+3 no credential mintable or vestad/control plane unreachable (this includes running
+`token`/`plan`/`manage`/`referral` on a box with no account), 1 unexpected.
 
 ## `whoami`: does this box have an account?
 
 ```bash
 vesta-cloud whoami
-# { "account": true, "plan": "membership", "status": "active",
-#   "renews_at": "2026-09-01T00:00:00.000Z", "price_usd": 48.0,
-#   "managed_infra": true, "control_url": "https://vesta.run/api", "agent_name": "ada" }
+# { "account": true, "managed_infra": true, "control_url": "https://vesta.run/api",
+#   "agent_name": "ada", "plan": "membership", "status": "active",
+#   "renews_at": "2026-09-01T00:00:00.000Z", "price_usd": 48.0 }
 ```
 
 `account` is the fact to branch on: `true` means this box is paired to a Vesta Cloud
@@ -37,9 +39,9 @@ vesta-cloud token
 
 Hands another skill a short-lived server-identity token plus the control-plane URL, so
 it calls the control plane as this server without minting its own. One token is general:
-it authenticates any server-scoped route (`/account`, integrations, ...). Errors when the
-box has no account. This is how every skill that needs to reach the control plane as the
-server gets its credential.
+it authenticates any server-scoped route (`/account`, integrations, ...). On a box with
+no account it exits 3 with `{"error": "no server identity available"}`. This is how
+every skill that needs to reach the control plane as the server gets its credential.
 
 ## `login`: pair a self-hosted box to a Vesta Cloud account
 

--- a/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/cli.py
+++ b/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/cli.py
@@ -8,6 +8,8 @@ first (see `client.Client.mint_token`):
 
 - ``vesta-cloud whoami``        — account? + plan/status + managed_infra + control_url (the env probe).
 - ``vesta-cloud token``         — a short-lived server-identity token + control_url, for skills to call the control plane.
+- ``vesta-cloud login``         — pair this self-hosted box to a Vesta Cloud account (owner approves a code).
+- ``vesta-cloud logout``        — unpair this box from its Vesta Cloud account.
 - ``vesta-cloud plan``          — this box's plan, price, status, renewal (a read).
 - ``vesta-cloud manage``        — a Stripe-hosted link to upgrade / cancel / change card.
 - ``vesta-cloud referral``      — this box's referral code, credit earned, invites completed.
@@ -21,6 +23,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
+import time
 from typing import Any
 
 from . import referral_store
@@ -50,7 +54,10 @@ def _cmd_whoami(_args: argparse.Namespace, client: Client, cfg: Config) -> int:
         out["reason"] = minted.get("error") or "no server-identity token"
         _print(out)
         return 0
-    summary = client.plan(minted["token"])  # transport -> exit 3
+    if minted.get("control_url"):
+        # The identity names its control plane (e.g. a staging-paired box).
+        out["control_url"] = minted["control_url"]
+    summary = client.plan(minted["token"], minted.get("control_url"))  # transport -> exit 3
     if "error" in summary:
         # Recognized box, but no active membership (e.g. suspended / no billing).
         out["reason"] = summary["error"]
@@ -75,16 +82,70 @@ def _cmd_token(_args: argparse.Namespace, client: Client, cfg: Config) -> int:
     _print(
         {
             "token": detail["token"],
-            "control_url": cfg.control_url,
+            "control_url": detail.get("control_url") or cfg.control_url,
             "expires_in": detail.get("expires_in"),
         }
     )
     return 0
 
 
+def _cmd_login(args: argparse.Namespace, client: Client, cfg: Config) -> int:
+    """Pair this self-hosted box to a Vesta Cloud account (device authorization).
+    Two-step output: first the code + link the agent must relay to the owner NOW,
+    then (after the owner approves in their signed-in browser) a whoami-style
+    confirmation. Blocks up to the code's ~10 minute lifetime."""
+    started = client.pair_start()
+    if "error" in started:
+        _print(started)
+        return 2
+    _print(
+        {
+            "user_code": started.get("user_code"),
+            "verification_url": started.get("verification_url"),
+            "next": (
+                "give the owner this code and link right away; they approve it in their "
+                "signed-in browser. keep this command running, it returns once approved."
+            ),
+        }
+    )
+    sys.stdout.flush()
+
+    interval = started.get("interval") if isinstance(started.get("interval"), int) else 5
+    budget = started.get("expires_in") if isinstance(started.get("expires_in"), int) else 600
+    deadline = time.monotonic() + budget
+    while time.monotonic() < deadline:
+        result = client.pair_poll()
+        if result.get("status") == "linked":
+            return _cmd_whoami(args, client, cfg)
+        if "pending" in str(result.get("error") or ""):
+            time.sleep(interval)
+            continue
+        # Terminal refusal (expired / account already has a server / unknown).
+        _print(result)
+        return 2
+    _print(
+        {
+            "error": "pairing timed out",
+            "message": "the code expired before the owner approved. run `vesta-cloud login` again for a fresh code.",
+        }
+    )
+    return 2
+
+
+def _cmd_logout(_args: argparse.Namespace, client: Client, _cfg: Config) -> int:
+    """Unpair this box from its Vesta Cloud account. Also the local cleanup step when
+    the owner already removed the box from the vesta.run dashboard."""
+    result = client.unpair()
+    if result.get("status") == "unpaired":
+        _print(result)
+        return 0
+    _print(result)
+    return 2
+
+
 def _cmd_plan(_args: argparse.Namespace, client: Client, _cfg: Config) -> int:
-    token = client.mint_token()
-    summary = client.plan(token)
+    detail = client.mint_token_detail()
+    summary = client.plan(detail["token"], detail.get("control_url"))
     if "error" in summary:
         _print(summary)
         return 2
@@ -99,8 +160,8 @@ def _cmd_plan(_args: argparse.Namespace, client: Client, _cfg: Config) -> int:
 
 
 def _cmd_manage(_args: argparse.Namespace, client: Client, _cfg: Config) -> int:
-    token = client.mint_token()
-    result = client.portal(token)
+    detail = client.mint_token_detail()
+    result = client.portal(detail["token"], detail.get("control_url"))
     if "url" not in result:
         # e.g. {"error": "no_billing_account"} — never completed checkout.
         _print(result)
@@ -116,7 +177,7 @@ def _cmd_manage(_args: argparse.Namespace, client: Client, _cfg: Config) -> int:
 
 def _cmd_referral(_args: argparse.Namespace, client: Client, _cfg: Config) -> int:
     try:
-        token = client.mint_token()
+        detail = client.mint_token_detail()
     except AccountError:
         # A self-hosted box has no vesta-issued code; tell the agent what to do
         # instead of surfacing the raw mint-token error.
@@ -131,7 +192,7 @@ def _cmd_referral(_args: argparse.Namespace, client: Client, _cfg: Config) -> in
             }
         )
         return 3
-    summary = client.plan(token)
+    summary = client.plan(detail["token"], detail.get("control_url"))
     if "error" in summary:
         _print(summary)
         return 2
@@ -164,6 +225,8 @@ def _build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("whoami", help="Does this box have a Vesta Cloud account? + plan/status + managed_infra.")
     sub.add_parser("token", help="A short-lived server-identity token + control_url, for skills to call the control plane.")
+    sub.add_parser("login", help="Pair this self-hosted box to a Vesta Cloud account (the owner approves a code).")
+    sub.add_parser("logout", help="Unpair this box from its Vesta Cloud account.")
     sub.add_parser("plan", help="This box's plan, price, status, and renewal date.")
     sub.add_parser("manage", help="A secure Stripe link to upgrade / cancel / change payment.")
     sub.add_parser("referral", help="This box's referral code, credit earned, and invites completed.")
@@ -183,6 +246,8 @@ def main(argv: list[str] | None = None) -> int:
     handlers = {
         "whoami": _cmd_whoami,
         "token": _cmd_token,
+        "login": _cmd_login,
+        "logout": _cmd_logout,
         "plan": _cmd_plan,
         "manage": _cmd_manage,
         "referral": _cmd_referral,

--- a/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/cli.py
+++ b/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/cli.py
@@ -114,10 +114,19 @@ def _cmd_login(args: argparse.Namespace, client: Client, cfg: Config) -> int:
     budget = started.get("expires_in") if isinstance(started.get("expires_in"), int) else 600
     deadline = time.monotonic() + budget
     while time.monotonic() < deadline:
-        result = client.pair_poll()
+        try:
+            result = client.pair_poll()
+        except AccountError:
+            # A transient vestad/control-plane blip mid-wait. The pairing is
+            # still in flight, so keep polling until the code's own deadline;
+            # aborting here would orphan an approval the owner is completing.
+            time.sleep(interval)
+            continue
         if result.get("status") == "linked":
-            return _cmd_whoami(args, client, cfg)
-        if "pending" in str(result.get("error") or ""):
+            return _login_confirmation(args, client, cfg, result)
+        # Structured pending from current vestad; the substring check keeps an
+        # older vestad (409 prose) working across the version skew.
+        if result.get("status") == "pending" or "pending" in str(result.get("error") or ""):
             time.sleep(interval)
             continue
         # Terminal refusal (expired / account already has a server / unknown).
@@ -130,6 +139,24 @@ def _cmd_login(args: argparse.Namespace, client: Client, cfg: Config) -> int:
         }
     )
     return 2
+
+
+def _login_confirmation(args: argparse.Namespace, client: Client, cfg: Config, linked: dict[str, Any]) -> int:
+    """The pairing already SUCCEEDED; a flaky confirmation read must not turn that
+    into a nonzero exit (which reads as a failed login and invites a destructive
+    logout + retry). Fall back to reporting the link itself."""
+    try:
+        return _cmd_whoami(args, client, cfg)
+    except AccountError:
+        _print(
+            {
+                "status": "linked",
+                "server_id": linked.get("server_id"),
+                "control_url": linked.get("control_url"),
+                "note": "paired successfully. the confirmation read failed transiently; run `vesta-cloud whoami` to see the account.",
+            }
+        )
+        return 0
 
 
 def _cmd_logout(_args: argparse.Namespace, client: Client, _cfg: Config) -> int:

--- a/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/cli.py
+++ b/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/cli.py
@@ -15,8 +15,11 @@ first (see `client.Client.mint_token`):
 - ``vesta-cloud referral``      — this box's referral code, credit earned, invites completed.
 - ``vesta-cloud set-referral``  — set/clear the code `onboard` sends on a completed invite.
 
-Output is always JSON on stdout. Exit codes: 0 success, 2 surfaced {error}
-(no account / no billing yet), 3 control-plane/vestad unreachable, 1 unexpected.
+Output is always JSON on stdout. Exit codes: 0 success (`whoami` exits 0 even
+with `account: false`), 2 the control plane refused with a structured {error}
+(e.g. no billing yet, pairing refused), 3 no credential mintable or
+vestad/control plane unreachable (AccountError; includes running `token`/`plan`/
+`manage`/`referral` on a box with no account), 1 unexpected.
 """
 
 from __future__ import annotations
@@ -59,7 +62,10 @@ def _cmd_whoami(_args: argparse.Namespace, client: Client, cfg: Config) -> int:
         out["control_url"] = minted["control_url"]
     summary = client.plan(minted["token"], minted.get("control_url"))  # transport -> exit 3
     if "error" in summary:
-        # Recognized box, but no active membership (e.g. suspended / no billing).
+        # Minted locally but the control plane refused the read, e.g. 401
+        # "unauthenticated" from a stale link (the account row was removed on
+        # the dashboard). A suspended or unpaid box is NOT this branch: those
+        # read /account fine and report account:true with their status/plan.
         out["reason"] = summary["error"]
         _print(out)
         return 0
@@ -124,8 +130,8 @@ def _cmd_login(args: argparse.Namespace, client: Client, cfg: Config) -> int:
             continue
         if result.get("status") == "linked":
             return _login_confirmation(args, client, cfg, result)
-        # Structured pending from current vestad; the substring check keeps an
-        # older vestad (409 prose) working across the version skew.
+        # Two pending shapes exist on the wire: 200 {"status": "pending"}, and
+        # a 409 whose error message contains "pending". Treat both as pending.
         if result.get("status") == "pending" or "pending" in str(result.get("error") or ""):
             time.sleep(interval)
             continue

--- a/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/client.py
+++ b/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/client.py
@@ -49,13 +49,10 @@ class Client:
         identity is reported as an `{error}` body, not raised, for the same reason.
 
         The minted token is a general server-identity credential the control plane honors
-        on any server-scoped route, so one token serves /account, integrations, etc.
+        on any server-scoped route, so one token serves /account, integrations, etc. The
+        response's nullable `control_url` names the control plane the identity belongs to.
         """
-        cfg = self._cfg
-        if not cfg.vestad_base or not cfg.agent_name or not cfg.agent_token:
-            return {"error": "not running inside an agent container (no VESTAD_PORT/BOX_HOST/AGENT_NAME/AGENT_TOKEN)"}
-        url = f"{cfg.vestad_base}/agents/{cfg.agent_name}/account-token"
-        return self._json(self._send("POST", url, headers={"X-Agent-Token": cfg.agent_token}, json={}, verify=False))
+        return self._vestad_post("account-token", {})
 
     def mint_token_detail(self) -> dict[str, Any]:
         """{@link account_token} but raises AccountError when no token was minted, for the
@@ -69,15 +66,46 @@ class Client:
         """A server-identity token; see {@link mint_token_detail}."""
         return self.mint_token_detail()["token"]
 
+    # --- vestad: pair / unpair a self-hosted box -----------------------------
+
+    def pair_start(self) -> dict[str, Any]:
+        """POST <vestad>/agents/<name>/vesta-cloud/pair -> {user_code, verification_url,
+        interval, expires_in} OR {error} (already managed / already paired). vestad holds
+        the poll secret; the agent only relays the code the owner must approve."""
+        return self._vestad_post("vesta-cloud/pair", {"box_name": self._cfg.agent_name})
+
+    def pair_poll(self) -> dict[str, Any]:
+        """POST <vestad>/agents/<name>/vesta-cloud/pair/poll -> {status: "linked", ...} once
+        approved, {error: "...still pending"} while the owner hasn't approved, or a terminal
+        {error} (expired / refused)."""
+        return self._vestad_post("vesta-cloud/pair/poll", {})
+
+    def unpair(self) -> dict[str, Any]:
+        """POST <vestad>/agents/<name>/vesta-cloud/unpair -> {status: "unpaired"} OR {error}."""
+        return self._vestad_post("vesta-cloud/unpair", {})
+
+    def _vestad_post(self, tail: str, body: dict[str, Any]) -> dict[str, Any]:
+        """An agent-token-authed POST to this agent's vestad surface; see `account_token`
+        for the error contract (4xx bodies returned, transport/5xx raised)."""
+        cfg = self._cfg
+        if not cfg.vestad_base or not cfg.agent_name or not cfg.agent_token:
+            return {"error": "not running inside an agent container (no VESTAD_PORT/BOX_HOST/AGENT_NAME/AGENT_TOKEN)"}
+        url = f"{cfg.vestad_base}/agents/{cfg.agent_name}/{tail}"
+        return self._json(self._send("POST", url, headers={"X-Agent-Token": cfg.agent_token}, json=body, verify=False))
+
     # --- control plane: read plan / open portal ------------------------------
 
-    def plan(self, token: str) -> dict[str, Any]:
-        """GET /account -> {plan, status, price_cents, subscription_status, renews_at, ...}."""
-        return self._json(self._send("GET", f"{self._cfg.control_url}/account", headers=self._auth(token)))
+    def plan(self, token: str, control_url: str | None = None) -> dict[str, Any]:
+        """GET /account -> {plan, status, price_cents, subscription_status, renews_at, ...}.
+        `control_url` (from the mint response) routes a staging-paired box correctly;
+        falls back to the configured default."""
+        base = control_url or self._cfg.control_url
+        return self._json(self._send("GET", f"{base}/account", headers=self._auth(token)))
 
-    def portal(self, token: str) -> dict[str, Any]:
+    def portal(self, token: str, control_url: str | None = None) -> dict[str, Any]:
         """POST /account/portal -> {url} — a Stripe-hosted manage/upgrade/cancel link."""
-        return self._json(self._send("POST", f"{self._cfg.control_url}/account/portal", headers=self._auth(token), json={}))
+        base = control_url or self._cfg.control_url
+        return self._json(self._send("POST", f"{base}/account/portal", headers=self._auth(token), json={}))
 
     # --- low-level helpers ---------------------------------------------------
 

--- a/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/client.py
+++ b/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/client.py
@@ -67,30 +67,34 @@ class Client:
         return self.mint_token_detail()["token"]
 
     # --- vestad: pair / unpair a self-hosted box -----------------------------
+    # The pairing flow LIVES in vestad (one core shared with the apps and the
+    # host CLI `vestad vesta-cloud login`); these daemon-level routes carry no
+    # agent name, and vestad accepts any of the host's agent tokens on them.
 
     def pair_start(self) -> dict[str, Any]:
-        """POST <vestad>/agents/<name>/vesta-cloud/pair -> {user_code, verification_url,
-        interval, expires_in} OR {error} (already managed / already paired). vestad holds
-        the poll secret; the agent only relays the code the owner must approve."""
-        return self._vestad_post("vesta-cloud/pair", {"box_name": self._cfg.agent_name})
+        """POST <vestad>/vesta-cloud/pair -> {user_code, verification_url, interval,
+        expires_in} OR {error} (already managed / already paired). vestad holds the poll
+        secret and names the box; the agent only relays the code the owner approves."""
+        return self._vestad_post("vesta-cloud/pair", {}, agent_scoped=False)
 
     def pair_poll(self) -> dict[str, Any]:
-        """POST <vestad>/agents/<name>/vesta-cloud/pair/poll -> {status: "linked", ...} once
-        approved, {error: "...still pending"} while the owner hasn't approved, or a terminal
-        {error} (expired / refused)."""
-        return self._vestad_post("vesta-cloud/pair/poll", {})
+        """POST <vestad>/vesta-cloud/pair/poll -> {status: "pending"} until approved,
+        {status: "linked", ...} once approved, or a terminal {error} (expired / refused)."""
+        return self._vestad_post("vesta-cloud/pair/poll", {}, agent_scoped=False)
 
     def unpair(self) -> dict[str, Any]:
-        """POST <vestad>/agents/<name>/vesta-cloud/unpair -> {status: "unpaired"} OR {error}."""
-        return self._vestad_post("vesta-cloud/unpair", {})
+        """POST <vestad>/vesta-cloud/unpair -> {status: "unpaired"} OR {error}."""
+        return self._vestad_post("vesta-cloud/unpair", {}, agent_scoped=False)
 
-    def _vestad_post(self, tail: str, body: dict[str, Any]) -> dict[str, Any]:
-        """An agent-token-authed POST to this agent's vestad surface; see `account_token`
-        for the error contract (4xx bodies returned, transport/5xx raised)."""
+    def _vestad_post(self, tail: str, body: dict[str, Any], *, agent_scoped: bool = True) -> dict[str, Any]:
+        """An agent-token-authed POST to vestad, either on this agent's own surface or a
+        daemon-level path; see `account_token` for the error contract (4xx bodies
+        returned, transport/5xx raised)."""
         cfg = self._cfg
         if not cfg.vestad_base or not cfg.agent_name or not cfg.agent_token:
             return {"error": "not running inside an agent container (no VESTAD_PORT/BOX_HOST/AGENT_NAME/AGENT_TOKEN)"}
-        url = f"{cfg.vestad_base}/agents/{cfg.agent_name}/{tail}"
+        path = f"agents/{cfg.agent_name}/{tail}" if agent_scoped else tail
+        url = f"{cfg.vestad_base}/{path}"
         return self._json(self._send("POST", url, headers={"X-Agent-Token": cfg.agent_token}, json=body, verify=False))
 
     # --- control plane: read plan / open portal ------------------------------

--- a/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/client.py
+++ b/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/client.py
@@ -1,15 +1,17 @@
 """HTTP client for the account flow.
 
-Two hops, both authenticated WITHOUT any standing secret reaching the agent:
+Every hop is authenticated WITHOUT any standing secret reaching the agent:
 
 * **vestad** (`https://<BOX_HOST>:<VESTAD_PORT>`, agent-token authed): mint a
-  short-lived server-identity token. vestad signs it locally with the box's
-  `api_key` — a pure crypto operation, no network call — and hands it back.
+  short-lived server-identity token (vestad signs it locally with the box's
+  `api_key`, a pure crypto operation), and relay the Vesta Cloud pairing verbs
+  (`/vesta-cloud/pair`, `/vesta-cloud/pair/poll`, `/vesta-cloud/unpair`), whose
+  flow vestad owns end to end.
 
-* **Control plane** (`https://vesta.run/api`, Bearer = that token): read the
-  plan (`GET /account`) or open a billing portal (`POST /account/portal`). The
-  token proves "I am this server"; it expires in minutes and is scoped to this
-  box's account.
+* **Control plane** (`https://vesta.run/api`, Bearer = the minted token): read
+  the plan (`GET /account`) or open a billing portal (`POST /account/portal`).
+  The token proves "I am this server"; it expires in minutes and is scoped to
+  this box's account.
 """
 
 from __future__ import annotations
@@ -24,8 +26,9 @@ from .config import Config
 
 _TIMEOUT = 20
 
-# vestad serves a self-signed cert on the loopback; the agent reaches it from
-# inside the same box, so TLS verification adds nothing and would just fail.
+# vestad serves a self-signed cert on its agent-facing gateway address
+# (https://$BOX_HOST:$VESTAD_PORT, same box); TLS verification adds nothing
+# there and would just fail.
 warnings.simplefilter("ignore", InsecureRequestWarning)
 
 
@@ -40,11 +43,12 @@ class Client:
     # --- vestad: mint the server-identity token ------------------------------
 
     def account_token(self) -> dict[str, Any]:
-        """POST <vestad>/agents/<name>/account-token -> {token, expires_in} OR {error}.
+        """POST <vestad>/agents/<name>/account-token -> {token, expires_in, control_url} OR {error}.
 
         Agent-token authenticated. Returns the response body either way: a box with no
-        Vesta Cloud account answers 404 `{error}` (a REACHED vestad refusing to mint),
-        which `whoami` reads as "no account" rather than an outage. Raises AccountError
+        Vesta Cloud account answers 404 `{"error": "no server identity available"}` (a
+        REACHED vestad refusing to mint), which `whoami` reads as "no account" rather
+        than an outage. Raises AccountError
         only on a genuine transport / 5xx failure (vestad unreachable). A missing agent
         identity is reported as an `{error}` body, not raised, for the same reason.
 
@@ -138,8 +142,8 @@ class Client:
         except ValueError:
             raise AccountError(f"non-JSON response ({resp.status_code}): {resp.text[:200]}") from None
         # 4xx bodies carry a structured {error} the skill surfaces verbatim
-        # (e.g. "no_billing_account", "not a cloud-managed server"); only a 5xx is
-        # an opaque failure worth raising.
+        # (e.g. vestad's "no server identity available", the control plane's
+        # "no_billing_account"); only a 5xx is an opaque failure worth raising.
         if resp.status_code >= 500:
             raise AccountError(f"server error {resp.status_code}: {data}")
         if not isinstance(data, dict):

--- a/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/config.py
+++ b/agent/skills/vesta-cloud/cli/src/vesta_cloud_cli/config.py
@@ -9,7 +9,8 @@ Everything is read from the environment the agent container already has:
   skills use). The CLI calls vestad to mint a server-identity token; it never
   holds the box's `api_key`.
 
-There is NO on-disk state: every command mints a fresh short-lived token.
+There is NO on-disk credential: every command mints a fresh short-lived token.
+(The only file this CLI writes is the referral code, see `referral_store`.)
 
 `VESTA_CLOUD_CONTROL_URL` is only a control-plane URL knob here, NOT the "do I have
 an account" signal: cloud-init sets it on managed VMs, but a self-hosted box may hold
@@ -42,9 +43,10 @@ class Config:
         cloud_url = os.environ.get("VESTA_CLOUD_CONTROL_URL", "").strip()
         control = (cloud_url or DEFAULT_CONTROL_URL).rstrip("/")
         # vestad runs natively on the host, never in a container, so BOX_HOST
-        # (from /run/vestad-env) is how the agent reaches it, not localhost. Missing
-        # either half leaves vestad_base empty, tripping the same "not running inside
-        # an agent container" check mint_token() already does for a missing port.
+        # (from /run/vestad-env) is how the agent reaches it, not localhost.
+        # Missing either half leaves vestad_base empty, tripping Client's
+        # "not running inside an agent container" guard (which names all four
+        # required vars: VESTAD_PORT/BOX_HOST/AGENT_NAME/AGENT_TOKEN).
         port = os.environ.get("VESTAD_PORT", "").strip()
         host = os.environ.get("BOX_HOST", "").strip()
         vestad_base = f"https://{host}:{port}" if port and host else ""

--- a/agent/skills/vesta-cloud/cli/tests/test_cli.py
+++ b/agent/skills/vesta-cloud/cli/tests/test_cli.py
@@ -46,11 +46,12 @@ def test_whoami_account_true_when_minted_and_active(capsys, monkeypatch):
 
 def test_whoami_account_false_when_mint_refused(capsys, monkeypatch):
     # A reached vestad refusing to mint (no account) is a valid answer, exit 0.
-    monkeypatch.setattr(cli_mod.Client, "account_token", lambda self: {"error": "not a cloud-managed server"})
+    # "no server identity available" is vestad's actual 404 body for the miss.
+    monkeypatch.setattr(cli_mod.Client, "account_token", lambda self: {"error": "no server identity available"})
     rc, data = _run(["whoami"], capsys)
     assert rc == 0
     assert data["account"] is False
-    assert data["reason"] == "not a cloud-managed server"
+    assert data["reason"] == "no server identity available"
 
 
 def test_whoami_suspended_is_account_true_with_status(capsys, monkeypatch):
@@ -63,12 +64,15 @@ def test_whoami_suspended_is_account_true_with_status(capsys, monkeypatch):
     assert data["account"] is True and data["status"] == "suspended"
 
 
-def test_whoami_account_false_when_recognized_but_inactive(capsys, monkeypatch):
+def test_whoami_account_false_when_control_plane_refuses_the_read(capsys, monkeypatch):
+    # Minted locally but /account refused (e.g. a stale link whose row was
+    # removed on the dashboard -> 401 unauthenticated). Suspended/unpaid boxes
+    # are NOT this case: /account answers 200 for them (see the test above).
     monkeypatch.setattr(cli_mod.Client, "account_token", lambda self: {"token": "SITOK"})
-    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token, control_url=None: {"error": "membership_inactive"})
+    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token, control_url=None: {"error": "unauthenticated"})
     rc, data = _run(["whoami"], capsys)
     assert rc == 0
-    assert data["account"] is False and data["reason"] == "membership_inactive"
+    assert data["account"] is False and data["reason"] == "unauthenticated"
 
 
 def test_whoami_outage_exits_3(capsys, monkeypatch):
@@ -94,11 +98,11 @@ def test_token_returns_credential_and_control_url(capsys, monkeypatch):
 
 def test_token_no_account_exits_3(capsys, monkeypatch):
     def boom(self):
-        raise AccountError("not a cloud-managed server")
+        raise AccountError("no server identity available")
 
     monkeypatch.setattr(cli_mod.Client, "mint_token_detail", boom)
     rc, data = _run(["token"], capsys)
-    assert rc == 3 and "not a cloud-managed" in data["error"]
+    assert rc == 3 and "no server identity" in data["error"]
 
 
 # --- plan -------------------------------------------------------------------
@@ -130,9 +134,9 @@ def test_plan_summarizes_and_adds_usd(capsys, monkeypatch):
 
 def test_plan_surfaces_structured_error(capsys, monkeypatch):
     monkeypatch.setattr(cli_mod.Client, "mint_token_detail", lambda self: {"token": "SITOK"})
-    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token, control_url=None: {"error": "not a cloud-managed server"})
+    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token, control_url=None: {"error": "unauthenticated"})
     rc, data = _run(["plan"], capsys)
-    assert rc == 2 and data["error"] == "not a cloud-managed server"
+    assert rc == 2 and data["error"] == "unauthenticated"
 
 
 # --- manage -----------------------------------------------------------------
@@ -164,7 +168,7 @@ def test_manage_surfaces_no_billing_account(capsys, monkeypatch):
 
 def test_mint_failure_exits_3(capsys, monkeypatch):
     def boom(self):
-        raise AccountError("not running inside an agent container (no VESTAD_PORT/AGENT_NAME)")
+        raise AccountError("not running inside an agent container (no VESTAD_PORT/BOX_HOST/AGENT_NAME/AGENT_TOKEN)")
 
     monkeypatch.setattr(cli_mod.Client, "mint_token_detail", boom)
     rc, data = _run(["plan"], capsys)
@@ -197,14 +201,14 @@ def test_referral_reports_code_and_earnings(capsys, monkeypatch):
 
 def test_referral_surfaces_structured_error(capsys, monkeypatch):
     monkeypatch.setattr(cli_mod.Client, "mint_token_detail", lambda self: {"token": "SITOK"})
-    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token, control_url=None: {"error": "not a cloud-managed server"})
+    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token, control_url=None: {"error": "unauthenticated"})
     rc, data = _run(["referral"], capsys)
-    assert rc == 2 and data["error"] == "not a cloud-managed server"
+    assert rc == 2 and data["error"] == "unauthenticated"
 
 
 def test_referral_not_hosted_surfaces_friendly_error(capsys, monkeypatch):
     def boom(self):
-        raise AccountError("not a cloud-managed server")
+        raise AccountError("no server identity available")
 
     monkeypatch.setattr(cli_mod.Client, "mint_token_detail", boom)
     rc, data = _run(["referral"], capsys)
@@ -236,8 +240,8 @@ def test_login_relays_code_then_links(capsys, monkeypatch):
         "pair_start",
         lambda self: {"user_code": "BCDF-2345", "verification_url": "https://vesta.run/pair?code=BCDF-2345", "interval": 5, "expires_in": 600},
     )
-    # Structured pending (current vestad), legacy 409-prose pending (older
-    # vestad across the skew), then linked — both pending shapes must loop.
+    # Both pending shapes that exist on the wire (200 {"status": "pending"}
+    # and a 409 whose message contains "pending"), then linked; both must loop.
     polls = iter(
         [
             {"status": "pending"},

--- a/agent/skills/vesta-cloud/cli/tests/test_cli.py
+++ b/agent/skills/vesta-cloud/cli/tests/test_cli.py
@@ -30,7 +30,7 @@ def test_whoami_account_true_when_minted_and_active(capsys, monkeypatch):
     monkeypatch.setattr(
         cli_mod.Client,
         "plan",
-        lambda self, token: {"plan": "membership", "status": "active", "price_cents": 4800, "renews_at": "2026-07-01T00:00:00.000Z"},
+        lambda self, token, control_url=None: {"plan": "membership", "status": "active", "price_cents": 4800, "renews_at": "2026-07-01T00:00:00.000Z"},
     )
     rc, data = _run(["whoami"], capsys)
     assert rc == 0
@@ -52,7 +52,7 @@ def test_whoami_suspended_is_account_true_with_status(capsys, monkeypatch):
     # A recognized but suspended box answers /account 200 with status "suspended"
     # (not an error), so it is paired (account:true); status carries the nuance.
     monkeypatch.setattr(cli_mod.Client, "account_token", lambda self: {"token": "SITOK"})
-    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token: {"plan": "membership", "status": "suspended"})
+    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token, control_url=None: {"plan": "membership", "status": "suspended"})
     rc, data = _run(["whoami"], capsys)
     assert rc == 0
     assert data["account"] is True and data["status"] == "suspended"
@@ -60,7 +60,7 @@ def test_whoami_suspended_is_account_true_with_status(capsys, monkeypatch):
 
 def test_whoami_account_false_when_recognized_but_inactive(capsys, monkeypatch):
     monkeypatch.setattr(cli_mod.Client, "account_token", lambda self: {"token": "SITOK"})
-    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token: {"error": "membership_inactive"})
+    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token, control_url=None: {"error": "membership_inactive"})
     rc, data = _run(["whoami"], capsys)
     assert rc == 0
     assert data["account"] is False and data["reason"] == "membership_inactive"
@@ -100,11 +100,11 @@ def test_token_no_account_exits_3(capsys, monkeypatch):
 
 
 def test_plan_summarizes_and_adds_usd(capsys, monkeypatch):
-    monkeypatch.setattr(cli_mod.Client, "mint_token", lambda self: "SITOK")
+    monkeypatch.setattr(cli_mod.Client, "mint_token_detail", lambda self: {"token": "SITOK"})
     monkeypatch.setattr(
         cli_mod.Client,
         "plan",
-        lambda self, token: {
+        lambda self, token, control_url=None: {
             "plan": "membership",
             "status": "active",
             "price_cents": 4800,
@@ -124,8 +124,8 @@ def test_plan_summarizes_and_adds_usd(capsys, monkeypatch):
 
 
 def test_plan_surfaces_structured_error(capsys, monkeypatch):
-    monkeypatch.setattr(cli_mod.Client, "mint_token", lambda self: "SITOK")
-    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token: {"error": "not a cloud-managed server"})
+    monkeypatch.setattr(cli_mod.Client, "mint_token_detail", lambda self: {"token": "SITOK"})
+    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token, control_url=None: {"error": "not a cloud-managed server"})
     rc, data = _run(["plan"], capsys)
     assert rc == 2 and data["error"] == "not a cloud-managed server"
 
@@ -134,11 +134,11 @@ def test_plan_surfaces_structured_error(capsys, monkeypatch):
 
 
 def test_manage_returns_portal_link(capsys, monkeypatch):
-    monkeypatch.setattr(cli_mod.Client, "mint_token", lambda self: "SITOK")
+    monkeypatch.setattr(cli_mod.Client, "mint_token_detail", lambda self: {"token": "SITOK"})
     monkeypatch.setattr(
         cli_mod.Client,
         "portal",
-        lambda self, token: {"url": "https://billing.stripe.com/p/session/abc"},
+        lambda self, token, control_url=None: {"url": "https://billing.stripe.com/p/session/abc"},
     )
     rc, data = _run(["manage"], capsys)
     assert rc == 0
@@ -148,8 +148,8 @@ def test_manage_returns_portal_link(capsys, monkeypatch):
 
 
 def test_manage_surfaces_no_billing_account(capsys, monkeypatch):
-    monkeypatch.setattr(cli_mod.Client, "mint_token", lambda self: "SITOK")
-    monkeypatch.setattr(cli_mod.Client, "portal", lambda self, token: {"error": "no_billing_account"})
+    monkeypatch.setattr(cli_mod.Client, "mint_token_detail", lambda self: {"token": "SITOK"})
+    monkeypatch.setattr(cli_mod.Client, "portal", lambda self, token, control_url=None: {"error": "no_billing_account"})
     rc, data = _run(["manage"], capsys)
     assert rc == 2 and data["error"] == "no_billing_account"
 
@@ -161,7 +161,7 @@ def test_mint_failure_exits_3(capsys, monkeypatch):
     def boom(self):
         raise AccountError("not running inside an agent container (no VESTAD_PORT/AGENT_NAME)")
 
-    monkeypatch.setattr(cli_mod.Client, "mint_token", boom)
+    monkeypatch.setattr(cli_mod.Client, "mint_token_detail", boom)
     rc, data = _run(["plan"], capsys)
     assert rc == 3 and "not running inside an agent" in data["error"]
 
@@ -170,11 +170,11 @@ def test_mint_failure_exits_3(capsys, monkeypatch):
 
 
 def test_referral_reports_code_and_earnings(capsys, monkeypatch):
-    monkeypatch.setattr(cli_mod.Client, "mint_token", lambda self: "SITOK")
+    monkeypatch.setattr(cli_mod.Client, "mint_token_detail", lambda self: {"token": "SITOK"})
     monkeypatch.setattr(
         cli_mod.Client,
         "plan",
-        lambda self, token: {
+        lambda self, token, control_url=None: {
             "plan": "membership",
             "referral_code": "ADA123",
             "referral_credit_cents": 1200,
@@ -191,8 +191,8 @@ def test_referral_reports_code_and_earnings(capsys, monkeypatch):
 
 
 def test_referral_surfaces_structured_error(capsys, monkeypatch):
-    monkeypatch.setattr(cli_mod.Client, "mint_token", lambda self: "SITOK")
-    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token: {"error": "not a cloud-managed server"})
+    monkeypatch.setattr(cli_mod.Client, "mint_token_detail", lambda self: {"token": "SITOK"})
+    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token, control_url=None: {"error": "not a cloud-managed server"})
     rc, data = _run(["referral"], capsys)
     assert rc == 2 and data["error"] == "not a cloud-managed server"
 
@@ -201,11 +201,112 @@ def test_referral_not_hosted_surfaces_friendly_error(capsys, monkeypatch):
     def boom(self):
         raise AccountError("not a cloud-managed server")
 
-    monkeypatch.setattr(cli_mod.Client, "mint_token", boom)
+    monkeypatch.setattr(cli_mod.Client, "mint_token_detail", boom)
     rc, data = _run(["referral"], capsys)
     assert rc == 3
     assert data["error"] == "not_hosted"
     assert "set-referral --code" in data["message"]
+
+
+# --- login / logout ---------------------------------------------------------
+
+
+def _read_json_docs(out: str) -> list[dict]:
+    """`login` prints TWO json documents (the code relay, then the confirmation)."""
+    docs, decoder, i = [], json.JSONDecoder(), 0
+    while i < len(out):
+        while i < len(out) and out[i].isspace():
+            i += 1
+        if i >= len(out):
+            break
+        doc, end = decoder.raw_decode(out, i)
+        docs.append(doc)
+        i = end
+    return docs
+
+
+def test_login_relays_code_then_links(capsys, monkeypatch):
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "pair_start",
+        lambda self: {"user_code": "BCDF-2345", "verification_url": "https://vesta.run/pair?code=BCDF-2345", "interval": 5, "expires_in": 600},
+    )
+    polls = iter(
+        [
+            {"error": "authorization is still pending"},
+            {"error": "authorization is still pending"},
+            {"status": "linked", "server_id": "srv_1", "control_url": "https://vesta.run/api"},
+        ]
+    )
+    monkeypatch.setattr(cli_mod.Client, "pair_poll", lambda self: next(polls))
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _s: None)
+    # The post-link confirmation is whoami's flow.
+    monkeypatch.setattr(cli_mod.Client, "account_token", lambda self: {"token": "SITOK", "control_url": "https://vesta.run/api"})
+    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token, control_url=None: {"plan": "services", "status": "active"})
+
+    rc = cli_mod.main(["login"])
+    docs = _read_json_docs(capsys.readouterr().out)
+    assert rc == 0
+    assert docs[0]["user_code"] == "BCDF-2345"
+    assert docs[0]["verification_url"].endswith("code=BCDF-2345")
+    assert "give the owner" in docs[0]["next"]
+    assert docs[-1]["account"] is True and docs[-1]["plan"] == "services"
+
+
+def test_login_surfaces_start_error(capsys, monkeypatch):
+    monkeypatch.setattr(cli_mod.Client, "pair_start", lambda self: {"error": "already paired to a Vesta Cloud account (unpair first)"})
+    rc, data = _run(["login"], capsys)
+    assert rc == 2 and "already paired" in data["error"]
+
+
+def test_login_gives_up_on_terminal_poll_error(capsys, monkeypatch):
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "pair_start",
+        lambda self: {"user_code": "BCDF-2345", "verification_url": "https://vesta.run/pair?code=BCDF-2345", "interval": 5, "expires_in": 600},
+    )
+    calls = {"n": 0}
+
+    def poll(self):
+        calls["n"] += 1
+        return {"error": "pairing failed: already_has_server"}
+
+    monkeypatch.setattr(cli_mod.Client, "pair_poll", poll)
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _s: None)
+    rc = cli_mod.main(["login"])
+    docs = _read_json_docs(capsys.readouterr().out)
+    assert rc == 2
+    assert calls["n"] == 1  # a terminal refusal stops the loop immediately
+    assert "already_has_server" in docs[-1]["error"]
+
+
+def test_login_times_out(capsys, monkeypatch):
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "pair_start",
+        lambda self: {"user_code": "BCDF-2345", "verification_url": "https://vesta.run/pair?code=BCDF-2345", "interval": 5, "expires_in": 600},
+    )
+    monkeypatch.setattr(cli_mod.Client, "pair_poll", lambda self: {"error": "authorization is still pending"})
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _s: None)
+    # A monotonic clock that jumps past the deadline after the first poll.
+    ticks = iter([0.0, 1.0, 10_000.0])
+    monkeypatch.setattr(cli_mod.time, "monotonic", lambda: next(ticks, 10_000.0))
+    rc = cli_mod.main(["login"])
+    docs = _read_json_docs(capsys.readouterr().out)
+    assert rc == 2
+    assert docs[-1]["error"] == "pairing timed out"
+
+
+def test_logout_success(capsys, monkeypatch):
+    monkeypatch.setattr(cli_mod.Client, "unpair", lambda self: {"status": "unpaired"})
+    rc, data = _run(["logout"], capsys)
+    assert rc == 0 and data == {"status": "unpaired"}
+
+
+def test_logout_not_paired_exits_2(capsys, monkeypatch):
+    monkeypatch.setattr(cli_mod.Client, "unpair", lambda self: {"error": "not paired to a Vesta Cloud account"})
+    rc, data = _run(["logout"], capsys)
+    assert rc == 2 and "not paired" in data["error"]
 
 
 # --- set-referral ---------------------------------------------------------

--- a/agent/skills/vesta-cloud/cli/tests/test_cli.py
+++ b/agent/skills/vesta-cloud/cli/tests/test_cli.py
@@ -30,7 +30,12 @@ def test_whoami_account_true_when_minted_and_active(capsys, monkeypatch):
     monkeypatch.setattr(
         cli_mod.Client,
         "plan",
-        lambda self, token, control_url=None: {"plan": "membership", "status": "active", "price_cents": 4800, "renews_at": "2026-07-01T00:00:00.000Z"},
+        lambda self, token, control_url=None: {
+            "plan": "membership",
+            "status": "active",
+            "price_cents": 4800,
+            "renews_at": "2026-07-01T00:00:00.000Z",
+        },
     )
     rc, data = _run(["whoami"], capsys)
     assert rc == 0
@@ -231,9 +236,11 @@ def test_login_relays_code_then_links(capsys, monkeypatch):
         "pair_start",
         lambda self: {"user_code": "BCDF-2345", "verification_url": "https://vesta.run/pair?code=BCDF-2345", "interval": 5, "expires_in": 600},
     )
+    # Structured pending (current vestad), legacy 409-prose pending (older
+    # vestad across the skew), then linked — both pending shapes must loop.
     polls = iter(
         [
-            {"error": "authorization is still pending"},
+            {"status": "pending"},
             {"error": "authorization is still pending"},
             {"status": "linked", "server_id": "srv_1", "control_url": "https://vesta.run/api"},
         ]
@@ -286,7 +293,7 @@ def test_login_times_out(capsys, monkeypatch):
         "pair_start",
         lambda self: {"user_code": "BCDF-2345", "verification_url": "https://vesta.run/pair?code=BCDF-2345", "interval": 5, "expires_in": 600},
     )
-    monkeypatch.setattr(cli_mod.Client, "pair_poll", lambda self: {"error": "authorization is still pending"})
+    monkeypatch.setattr(cli_mod.Client, "pair_poll", lambda self: {"status": "pending"})
     monkeypatch.setattr(cli_mod.time, "sleep", lambda _s: None)
     # A monotonic clock that jumps past the deadline after the first poll.
     ticks = iter([0.0, 1.0, 10_000.0])
@@ -295,6 +302,60 @@ def test_login_times_out(capsys, monkeypatch):
     docs = _read_json_docs(capsys.readouterr().out)
     assert rc == 2
     assert docs[-1]["error"] == "pairing timed out"
+
+
+def test_login_survives_transient_poll_failures(capsys, monkeypatch):
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "pair_start",
+        lambda self: {"user_code": "BCDF-2345", "verification_url": "https://vesta.run/pair?code=BCDF-2345", "interval": 5, "expires_in": 600},
+    )
+    calls = {"n": 0}
+
+    def poll(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise AccountError("server error 502: control plane blip")
+        if calls["n"] == 2:
+            return {"status": "pending"}
+        return {"status": "linked", "server_id": "srv_1", "control_url": "https://vesta.run/api"}
+
+    monkeypatch.setattr(cli_mod.Client, "pair_poll", poll)
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(cli_mod.Client, "account_token", lambda self: {"token": "SITOK"})
+    monkeypatch.setattr(cli_mod.Client, "plan", lambda self, token, control_url=None: {"plan": "services", "status": "active"})
+
+    rc = cli_mod.main(["login"])
+    docs = _read_json_docs(capsys.readouterr().out)
+    assert rc == 0
+    assert calls["n"] == 3  # the 502 was retried, not fatal
+    assert docs[-1]["account"] is True
+
+
+def test_login_reports_linked_when_confirmation_read_fails(capsys, monkeypatch):
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "pair_start",
+        lambda self: {"user_code": "BCDF-2345", "verification_url": "https://vesta.run/pair?code=BCDF-2345", "interval": 5, "expires_in": 600},
+    )
+    monkeypatch.setattr(
+        cli_mod.Client,
+        "pair_poll",
+        lambda self: {"status": "linked", "server_id": "srv_1", "control_url": "https://vesta.run/api"},
+    )
+
+    def boom(self):
+        raise AccountError("could not reach vestad: timeout")
+
+    monkeypatch.setattr(cli_mod.Client, "account_token", boom)
+
+    rc = cli_mod.main(["login"])
+    docs = _read_json_docs(capsys.readouterr().out)
+    # The pairing succeeded; a flaky confirmation must NOT fail the command
+    # (a nonzero exit invites a destructive logout + retry).
+    assert rc == 0
+    assert docs[-1]["status"] == "linked" and docs[-1]["server_id"] == "srv_1"
+    assert "whoami" in docs[-1]["note"]
 
 
 def test_logout_success(capsys, monkeypatch):

--- a/agent/skills/whatsapp/HEADLESS.md
+++ b/agent/skills/whatsapp/HEADLESS.md
@@ -21,5 +21,8 @@ Keep failures with the service that owns the state:
 
 - WhatsApp restricted, banned, logged out, or pairing failed: Double Tick. Follow
   its `next` for a fresh account.
-- Tenant unauthorized: Vesta Cloud.
+- 403 `membership_inactive`: Vesta Cloud, and specifically the billing side; the
+  box's account holds no active paid membership. The fix is the membership
+  (`vesta-cloud plan` / `manage`), never a re-link or a fresh account.
+- Any other tenant-unauthorized response: Vesta Cloud.
 - Companion disconnected with a healthy account: agent/CLI.

--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -24,7 +24,7 @@ pick the source and pass it explicitly as `--source`; the CLI never guesses.
 1. **Already linked?** `whatsapp status` returns `linked:true`. Use it and stop.
 2. **Managed Vesta Cloud VM?** Run `vesta-cloud whoami`: `account:true` with
    `managed_infra:true` means this box is a vesta.run VM with a managed WhatsApp.
-   Run `whatsapp connect --source cloud --opener '<text>'` straight away,
+   Run `whatsapp connect --source vesta-cloud --opener '<text>'` straight away,
    silently, without asking or telling the user. See the
    [Vesta Cloud WhatsApp account](SETUP_VESTA_CLOUD.md) guide. (`account:true`
    without `managed_infra` is a connected self-hosted box: its managed WhatsApp

--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -22,10 +22,13 @@ yourself. It is about where the account comes from, not where the agent runs. Yo
 pick the source and pass it explicitly as `--source`; the CLI never guesses.
 
 1. **Already linked?** `whatsapp status` returns `linked:true`. Use it and stop.
-2. **Vesta Cloud account?** Run `vesta-cloud whoami`: `account:true` means this
-   box has one. If so, run `whatsapp connect --source cloud --opener '<text>'`
-   straight away, silently, without asking or telling the user. See the
-   [Vesta Cloud WhatsApp account](SETUP_VESTA_CLOUD.md) guide.
+2. **Managed Vesta Cloud VM?** Run `vesta-cloud whoami`: `account:true` with
+   `managed_infra:true` means this box is a vesta.run VM with a managed WhatsApp.
+   Run `whatsapp connect --source cloud --opener '<text>'` straight away,
+   silently, without asking or telling the user. See the
+   [Vesta Cloud WhatsApp account](SETUP_VESTA_CLOUD.md) guide. (`account:true`
+   without `managed_infra` is a connected self-hosted box: its managed WhatsApp
+   opens only with an active paid membership, so continue below.)
 3. **`DOUBLETICK_API_URL` and `DOUBLETICK_API_KEY` both set?** Run
    `whatsapp connect --source doubletick --opener '<text>'`. See the
    [Double Tick WhatsApp account](SETUP_DOUBLETICK.md) guide.

--- a/agent/skills/whatsapp/SETUP_VESTA_CLOUD.md
+++ b/agent/skills/whatsapp/SETUP_VESTA_CLOUD.md
@@ -19,7 +19,7 @@ Run `whatsapp status` first; stop if linked or connecting.
 Compose a short, natural opener from the user's perspective, then run:
 
 ```bash
-whatsapp connect --source cloud --opener 'Hi, it is me, nice to meet you here'
+whatsapp connect --source vesta-cloud --opener 'Hi, it is me, nice to meet you here'
 ```
 
 Vesta Cloud authenticates the tenant, provisions the hosted account, and pairs the

--- a/agent/skills/whatsapp/SETUP_VESTA_CLOUD.md
+++ b/agent/skills/whatsapp/SETUP_VESTA_CLOUD.md
@@ -1,14 +1,16 @@
 # Vesta Cloud WhatsApp account
 
 Vesta Cloud provisions a hosted, headless WhatsApp account and the agent links a
-companion to it. Use this for a Vesta Cloud tenant that wants a dedicated account
-rather than a self-managed one.
+companion to it. Use this on a box whose account includes managed WhatsApp: today
+that is a vesta.run managed VM (`vesta-cloud whoami` reports `account:true` with
+`managed_infra:true`).
 
 ## Prerequisites
 
-Cloud provisioning supplies `VESTA_CLOUD_CONTROL_URL`, the agent identity, and
-vestad connectivity, so no key or manual setup is needed; the CLI authenticates
-automatically.
+No key and no manual setup: the CLI authenticates with a short-lived credential
+from `vesta-cloud token` on each call. The account must hold an active paid
+membership; a 403 `membership_inactive` from the connect means it does not, and
+the fix is the membership (see `vesta-cloud plan` / `manage`), not a re-link.
 
 Run `whatsapp status` first; stop if linked or connecting.
 

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -30,7 +30,7 @@ guide before the first link.
 
 | Account source | Command | Guide |
 | --- | --- | --- |
-| Vesta Cloud WhatsApp account | `whatsapp connect --source cloud --opener '<text>'` | [SETUP_VESTA_CLOUD.md](SETUP_VESTA_CLOUD.md) |
+| Vesta Cloud WhatsApp account | `whatsapp connect --source vesta-cloud --opener '<text>'` | [SETUP_VESTA_CLOUD.md](SETUP_VESTA_CLOUD.md) |
 | Double Tick WhatsApp account | `whatsapp connect --source doubletick --opener '<text>'` | [SETUP_DOUBLETICK.md](SETUP_DOUBLETICK.md) |
 | Self-managed account | `whatsapp connect --source self-managed` (or `--phone`) | [SETUP_SELF_MANAGED.md](SETUP_SELF_MANAGED.md) |
 

--- a/agent/skills/whatsapp/cli/DEVELOPING.md
+++ b/agent/skills/whatsapp/cli/DEVELOPING.md
@@ -101,7 +101,7 @@ Recipe, a fully silent passive personal account:
 ```bash
 whatsapp serve --instance personal --read-only --no-notifications
 ```
-Link it with `whatsapp link --instance personal`; read it on demand
+Link it with `whatsapp connect --source self-managed --instance personal`; read it on demand
 (`whatsapp chats --instance personal`, `messages`, ...) with zero notifications.
 
 ## Never ship a static binary

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -1136,7 +1136,7 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 	priorOnboardedMSISDN := wac.state.snapshot().OnboardedMSISDN
 	// Honor the agent's explicit --source over the daemon's boot-time linker: a warm
 	// daemon that booted with direct pool creds still pairs off the server-identity
-	// token when the agent says `--source cloud`. wac.managed is only read on this
+	// token when the agent says `--source vesta-cloud`. wac.managed is only read on this
 	// single-flighted pairing path, so overriding it for the call (and restoring it
 	// after) races nothing; wac.linker is left untouched (the data path reads it).
 	pairLinker := wac.linker

--- a/agent/skills/whatsapp/cli/connect.go
+++ b/agent/skills/whatsapp/cli/connect.go
@@ -107,17 +107,17 @@ type connectRoute struct {
 }
 
 // resolveConnect validates --source against the box environment and returns the path
-// to run. cloud demands a genuine Vesta Cloud box (cloudManaged plus vestad identity);
-// doubletick demands the direct pool creds. self-managed always links the user's own
-// account, by phone code when --phone is given, else by QR.
+// to run. cloud runs the managed pool a Vesta-provisioned VM ships with; doubletick
+// demands the direct pool creds. self-managed always links the user's own account,
+// by phone code when --phone is given, else by QR.
 func resolveConnect(opts connectOptions, cfg managedConfig) (connectRoute, error) {
 	if err := validateConnectSource(opts); err != nil {
 		return connectRoute{}, err
 	}
 	switch opts.source {
 	case sourceCloud:
-		if !cfg.isCloudTenant() {
-			return connectRoute{}, fmt.Errorf("--source cloud needs a Vesta Cloud box: this box is not cloud-managed or is missing its vestad credentials")
+		if !cfg.isManagedVM() {
+			return connectRoute{}, fmt.Errorf("--source cloud runs the managed WhatsApp of a vesta.run managed VM (`vesta-cloud whoami` reports managed_infra true there). This box is not one; a Vesta Cloud account alone opens managed WhatsApp only with an active paid membership. Use --source self-managed for the user's own WhatsApp")
 		}
 		return connectRoute{provision: true, opener: opts.opener, source: sourceCloud}, nil
 	case sourceDoubletick:
@@ -126,11 +126,11 @@ func resolveConnect(opts connectOptions, cfg managedConfig) (connectRoute, error
 		}
 		return connectRoute{provision: true, opener: opts.opener, source: sourceDoubletick}, nil
 	default: // sourceSelfManaged, already validated above
-		// A box holding managed account credentials cannot link the user's own
-		// account: its daemon builds a managed linker that rejects a QR/phone link.
+		// A box on the managed-pool paradigm cannot link the user's own account:
+		// its daemon builds a managed linker that rejects a QR/phone link.
 		// Fail here with the fix, instead of dispatching to a link the daemon refuses.
-		if cfg.isCloudTenant() {
-			return connectRoute{}, fmt.Errorf("--source self-managed cannot run on a Vesta Cloud box: it is provisioned for a managed WhatsApp account; use --source cloud")
+		if cfg.isManagedVM() {
+			return connectRoute{}, fmt.Errorf("--source self-managed cannot run on a vesta.run managed VM: its daemon links the managed pooled number; use --source cloud")
 		}
 		if cfg.isDirect() {
 			return connectRoute{}, fmt.Errorf("--source self-managed conflicts with the DOUBLETICK_API_URL/KEY set on this box; use --source doubletick, or unset them to link the user's own account")

--- a/agent/skills/whatsapp/cli/connect.go
+++ b/agent/skills/whatsapp/cli/connect.go
@@ -6,10 +6,11 @@ import (
 	"os"
 )
 
-// The three account sources the agent chooses between with `--source`. cloud and
-// doubletick both link a headless (pooled) account; self-managed links the user's own.
+// The three account sources the agent chooses between with `--source`.
+// vesta-cloud and doubletick both link a headless (pooled) account;
+// self-managed links the user's own.
 const (
-	sourceCloud       = "cloud"
+	sourceVestaCloud  = "vesta-cloud"
 	sourceDoubletick  = "doubletick"
 	sourceSelfManaged = "self-managed"
 )
@@ -33,7 +34,7 @@ type connectOptions struct {
 func parseConnectOptions(name string, args []string) (connectOptions, error) {
 	var opts connectOptions
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
-	fs.StringVar(&opts.source, "source", "", "Account source: cloud, doubletick, or self-managed (required)")
+	fs.StringVar(&opts.source, "source", "", "Account source: vesta-cloud, doubletick, or self-managed (required)")
 	fs.StringVar(&opts.opener, "opener", "", "Opener for a headless account, prefilled in the user's wa.me link")
 	fs.StringVar(&opts.phone, "phone", "", "Self-managed pairing-code fallback for this E.164 account number")
 	fs.StringVar(&opts.instance, "instance", "", "Named WhatsApp instance")
@@ -67,16 +68,16 @@ func parseConnectOptions(name string, args []string) (connectOptions, error) {
 }
 
 // validateConnectSource enforces the required --source and the flag/mode pairings.
-// --opener belongs to the headless sources (cloud, doubletick); --phone/--port/
+// --opener belongs to the headless sources (vesta-cloud, doubletick); --phone/--port/
 // --acknowledge-ban-risk belong to self-managed pairing. An absent or unknown source
 // errors before any environment probing or daemon startup.
 func validateConnectSource(opts connectOptions) error {
 	switch opts.source {
 	case "":
-		return fmt.Errorf("connect requires --source: cloud (a Vesta Cloud box), doubletick (DOUBLETICK_API_URL/KEY set), or self-managed (the user's own account)")
-	case sourceCloud, sourceDoubletick:
+		return fmt.Errorf("connect requires --source: vesta-cloud (a vesta.run managed VM), doubletick (DOUBLETICK_API_URL/KEY set), or self-managed (the user's own account)")
+	case sourceVestaCloud, sourceDoubletick:
 		if opts.phoneSet {
-			return fmt.Errorf("--phone is for a self-managed account; a headless account is set up with `whatsapp connect --source cloud` or `--source doubletick`")
+			return fmt.Errorf("--phone is for a self-managed account; a headless account is set up with `whatsapp connect --source vesta-cloud` or `--source doubletick`")
 		}
 		if opts.portSet {
 			return fmt.Errorf("--port applies only to a self-managed QR page")
@@ -86,10 +87,10 @@ func validateConnectSource(opts connectOptions) error {
 		}
 	case sourceSelfManaged:
 		if opts.openerSet {
-			return fmt.Errorf("--opener applies only to a headless account (--source cloud or doubletick)")
+			return fmt.Errorf("--opener applies only to a headless account (--source vesta-cloud or doubletick)")
 		}
 	default:
-		return fmt.Errorf("invalid --source %q: use cloud, doubletick, or self-managed", opts.source)
+		return fmt.Errorf("invalid --source %q: use vesta-cloud, doubletick, or self-managed", opts.source)
 	}
 	return nil
 }
@@ -97,7 +98,7 @@ func validateConnectSource(opts connectOptions) error {
 // connectRoute is the validated internal path a `connect --source` resolves to: one
 // of runProvision (headless) / runLinkPhone / runLink. source is the resolved account
 // source, threaded to the daemon's provision command so the agent's explicit choice
-// (not the daemon's boot-time env) pins the pairing auth path: `cloud` makes a warm
+// (not the daemon's boot-time env) pins the pairing auth path: `vesta-cloud` makes a warm
 // daemon mint a server-identity token even when it also booted with direct creds.
 type connectRoute struct {
 	provision bool
@@ -107,7 +108,7 @@ type connectRoute struct {
 }
 
 // resolveConnect validates --source against the box environment and returns the path
-// to run. cloud runs the managed pool a Vesta-provisioned VM ships with; doubletick
+// to run. vesta-cloud runs the managed pool a Vesta-provisioned VM ships with; doubletick
 // demands the direct pool creds. self-managed always links the user's own account,
 // by phone code when --phone is given, else by QR.
 func resolveConnect(opts connectOptions, cfg managedConfig) (connectRoute, error) {
@@ -115,11 +116,11 @@ func resolveConnect(opts connectOptions, cfg managedConfig) (connectRoute, error
 		return connectRoute{}, err
 	}
 	switch opts.source {
-	case sourceCloud:
+	case sourceVestaCloud:
 		if !cfg.isManagedVM() {
-			return connectRoute{}, fmt.Errorf("--source cloud runs the managed WhatsApp of a vesta.run managed VM (`vesta-cloud whoami` reports managed_infra true there). This box is not one; a Vesta Cloud account alone opens managed WhatsApp only with an active paid membership. Use --source self-managed for the user's own WhatsApp")
+			return connectRoute{}, fmt.Errorf("--source vesta-cloud runs the managed WhatsApp of a vesta.run managed VM (`vesta-cloud whoami` reports managed_infra true there). This box is not one; a Vesta Cloud account alone opens managed WhatsApp only with an active paid membership. Use --source self-managed for the user's own WhatsApp")
 		}
-		return connectRoute{provision: true, opener: opts.opener, source: sourceCloud}, nil
+		return connectRoute{provision: true, opener: opts.opener, source: sourceVestaCloud}, nil
 	case sourceDoubletick:
 		if !cfg.isDirect() {
 			return connectRoute{}, fmt.Errorf("--source doubletick needs DOUBLETICK_API_URL and DOUBLETICK_API_KEY set together")
@@ -130,7 +131,7 @@ func resolveConnect(opts connectOptions, cfg managedConfig) (connectRoute, error
 		// its daemon builds a managed linker that rejects a QR/phone link.
 		// Fail here with the fix, instead of dispatching to a link the daemon refuses.
 		if cfg.isManagedVM() {
-			return connectRoute{}, fmt.Errorf("--source self-managed cannot run on a vesta.run managed VM: its daemon links the managed pooled number; use --source cloud")
+			return connectRoute{}, fmt.Errorf("--source self-managed cannot run on a vesta.run managed VM: its daemon links the managed pooled number; use --source vesta-cloud")
 		}
 		if cfg.isDirect() {
 			return connectRoute{}, fmt.Errorf("--source self-managed conflicts with the DOUBLETICK_API_URL/KEY set on this box; use --source doubletick, or unset them to link the user's own account")

--- a/agent/skills/whatsapp/cli/connect_test.go
+++ b/agent/skills/whatsapp/cli/connect_test.go
@@ -132,7 +132,7 @@ func TestConnectRejectsFlagsThatDoNotApplyToTheSelectedSource(t *testing.T) {
 // TestResolveConnectRoutesEachSource pins the environment gate and the internal path
 // each source resolves to, without a daemon, socket, or network.
 func TestResolveConnectRoutesEachSource(t *testing.T) {
-	cloudCfg := managedConfig{cloudManaged: true, vestadBase: "https://box:8443", agentName: "alice", agentToken: "atok"}
+	cloudCfg := managedConfig{managedInfra: true}
 	directCfg := managedConfig{directURL: "https://doubletick.example", directKey: "wak_x"}
 
 	cloudRoute, err := resolveConnect(connectOptions{source: sourceCloud, opener: "hi"}, cloudCfg)
@@ -186,7 +186,7 @@ func TestResolveConnectRejectsUnsatisfiableEnvironment(t *testing.T) {
 	}
 	// A box holding managed account credentials cannot self-manage: the daemon's
 	// managed linker would reject the QR/phone link, so resolveConnect errors up front.
-	cloudCfg := managedConfig{cloudManaged: true, vestadBase: "https://box:8443", agentName: "a", agentToken: "t"}
+	cloudCfg := managedConfig{managedInfra: true}
 	if _, err := resolveConnect(connectOptions{source: sourceSelfManaged}, cloudCfg); err == nil {
 		t.Error("--source self-managed on a Vesta Cloud box was accepted")
 	}

--- a/agent/skills/whatsapp/cli/connect_test.go
+++ b/agent/skills/whatsapp/cli/connect_test.go
@@ -88,7 +88,7 @@ func TestConnectRequiresSource(t *testing.T) {
 	if err == nil {
 		t.Fatal("a bare connect (no --source) was accepted")
 	}
-	for _, want := range []string{"--source", "cloud", "doubletick", "self-managed"} {
+	for _, want := range []string{"--source", "vesta-cloud", "doubletick", "self-managed"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("missing-source error = %q, want it to mention %q", err, want)
 		}
@@ -104,7 +104,7 @@ func TestConnectRejectsUnknownSource(t *testing.T) {
 	if err == nil {
 		t.Fatal("an unknown --source value was accepted")
 	}
-	for _, want := range []string{"cloud", "doubletick", "self-managed"} {
+	for _, want := range []string{"vesta-cloud", "doubletick", "self-managed"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("invalid-source error = %q, want it to list %q", err, want)
 		}
@@ -113,8 +113,8 @@ func TestConnectRejectsUnknownSource(t *testing.T) {
 
 func TestConnectRejectsFlagsThatDoNotApplyToTheSelectedSource(t *testing.T) {
 	cases := [][]string{
-		{"--source", "cloud", "--port", "61012"},
-		{"--source", "cloud", "--acknowledge-ban-risk"},
+		{"--source", "vesta-cloud", "--port", "61012"},
+		{"--source", "vesta-cloud", "--acknowledge-ban-risk"},
 		{"--source", "doubletick", "--phone", "+393481234567"},
 		{"--source", "self-managed", "--opener", "hello"},
 	}
@@ -135,18 +135,18 @@ func TestResolveConnectRoutesEachSource(t *testing.T) {
 	cloudCfg := managedConfig{managedInfra: true}
 	directCfg := managedConfig{directURL: "https://doubletick.example", directKey: "wak_x"}
 
-	cloudRoute, err := resolveConnect(connectOptions{source: sourceCloud, opener: "hi"}, cloudCfg)
+	cloudRoute, err := resolveConnect(connectOptions{source: sourceVestaCloud, opener: "hi"}, cloudCfg)
 	if err != nil {
 		t.Fatalf("cloud resolve: %v", err)
 	}
-	if !cloudRoute.provision || cloudRoute.source != sourceCloud || cloudRoute.opener != "hi" {
+	if !cloudRoute.provision || cloudRoute.source != sourceVestaCloud || cloudRoute.opener != "hi" {
 		t.Errorf("cloud route = %+v, want provision with cloud source and opener", cloudRoute)
 	}
 
 	// cloud even when direct creds are also set still pins the cloud auth path.
 	cloudWithDirect := cloudCfg
 	cloudWithDirect.directURL, cloudWithDirect.directKey = "https://doubletick.example", "wak_x"
-	if r, err := resolveConnect(connectOptions{source: sourceCloud}, cloudWithDirect); err != nil || r.source != sourceCloud {
+	if r, err := resolveConnect(connectOptions{source: sourceVestaCloud}, cloudWithDirect); err != nil || r.source != sourceVestaCloud {
 		t.Errorf("cloud+direct route = %+v err=%v, want cloud source", r, err)
 	}
 
@@ -178,8 +178,8 @@ func TestResolveConnectRoutesEachSource(t *testing.T) {
 // TestResolveConnectRejectsUnsatisfiableEnvironment pins the environment gates: cloud
 // without a cloud box and doubletick without direct creds must error, not fall back.
 func TestResolveConnectRejectsUnsatisfiableEnvironment(t *testing.T) {
-	if _, err := resolveConnect(connectOptions{source: sourceCloud}, managedConfig{}); err == nil {
-		t.Error("--source cloud on a non-cloud box was accepted")
+	if _, err := resolveConnect(connectOptions{source: sourceVestaCloud}, managedConfig{}); err == nil {
+		t.Error("--source vesta-cloud on a non-managed-VM box was accepted")
 	}
 	if _, err := resolveConnect(connectOptions{source: sourceDoubletick}, managedConfig{}); err == nil {
 		t.Error("--source doubletick without direct creds was accepted")
@@ -216,16 +216,16 @@ func TestRunConnectDispatchesToProvisionForCloud(t *testing.T) {
 	t.Cleanup(func() { connectProvision = restore })
 
 	oldArgs := os.Args
-	os.Args = []string{"whatsapp", "--source", "cloud", "--opener", "hello"}
+	os.Args = []string{"whatsapp", "--source", "vesta-cloud", "--opener", "hello"}
 	t.Cleanup(func() { os.Args = oldArgs })
 
 	runConnect()
 
 	if !provisioned {
-		t.Fatal("cloud connect did not route to runProvision")
+		t.Fatal("vesta-cloud connect did not route to runProvision")
 	}
-	if gotSource != sourceCloud {
-		t.Errorf("provision source = %q, want cloud", gotSource)
+	if gotSource != sourceVestaCloud {
+		t.Errorf("provision source = %q, want %q", gotSource, sourceVestaCloud)
 	}
 	if gotOpener != "hello" {
 		t.Errorf("provision opener = %q, want hello", gotOpener)

--- a/agent/skills/whatsapp/cli/linker.go
+++ b/agent/skills/whatsapp/cli/linker.go
@@ -62,13 +62,13 @@ func chooseLinker(cfg managedConfig, state *stateStore) linker {
 }
 
 // cloudSourceAuth returns a managed auth pinned to the server-identity (cloud) path
-// for an explicit `--source cloud`, dropping any direct pool creds this daemon booted
+// for an explicit `--source vesta-cloud`, dropping any direct pool creds this daemon booted
 // with so a box that carries both pairs off the minted token, not a static wak_ key,
 // even when the daemon is already warm (and so never inherited a scrubbed env). It
 // re-reads the environment rather than reusing the boot-time auth, which may still
 // prefer the direct creds. Returns nil for any other source, leaving boot-time auth.
 func cloudSourceAuth(source string) *managedAuth {
-	if source != sourceCloud {
+	if source != sourceVestaCloud {
 		return nil
 	}
 	cfg := loadManagedConfig()
@@ -104,11 +104,11 @@ type managedLinker struct {
 func (*managedLinker) name() string { return "headless" }
 
 func (*managedLinker) linkQR(*WhatsAppClient, int) (linkResult, error) {
-	return linkResult{}, fmt.Errorf("this box links its own managed pooled number; run `whatsapp connect --source cloud` (or --source doubletick with direct creds), not a QR link")
+	return linkResult{}, fmt.Errorf("this box links its own managed pooled number; run `whatsapp connect --source vesta-cloud` (or --source doubletick with direct creds), not a QR link")
 }
 
 func (*managedLinker) pairCode(*WhatsAppClient, string) (string, error) {
-	return "", fmt.Errorf("this box links its own managed pooled number; run `whatsapp connect --source cloud` (or --source doubletick with direct creds), not a phone pairing code")
+	return "", fmt.Errorf("this box links its own managed pooled number; run `whatsapp connect --source vesta-cloud` (or --source doubletick with direct creds), not a phone pairing code")
 }
 
 // provision claims (or re-links) this box's managed number and links the companion,

--- a/agent/skills/whatsapp/cli/linker.go
+++ b/agent/skills/whatsapp/cli/linker.go
@@ -82,7 +82,7 @@ type qrLinker struct{}
 func (qrLinker) name() string { return "self-managed" }
 
 func (qrLinker) provision(*WhatsAppClient) (linkResult, error) {
-	return linkResult{}, fmt.Errorf("managed WhatsApp is only available on a hosted (vesta.run) box; this box links the user's own WhatsApp: run `whatsapp connect`")
+	return linkResult{}, fmt.Errorf("this box has no managed WhatsApp pool; it links the user's own WhatsApp: run `whatsapp connect --source self-managed`")
 }
 
 func (qrLinker) linkQR(wac *WhatsAppClient, port int) (linkResult, error) {
@@ -104,11 +104,11 @@ type managedLinker struct {
 func (*managedLinker) name() string { return "headless" }
 
 func (*managedLinker) linkQR(*WhatsAppClient, int) (linkResult, error) {
-	return linkResult{}, fmt.Errorf("this managed (vesta.run) box links its own pooled number; run `whatsapp connect`")
+	return linkResult{}, fmt.Errorf("this box links its own managed pooled number; run `whatsapp connect --source cloud` (or --source doubletick with direct creds), not a QR link")
 }
 
 func (*managedLinker) pairCode(*WhatsAppClient, string) (string, error) {
-	return "", fmt.Errorf("this managed (vesta.run) box links its own pooled number; run `whatsapp connect`, not a phone pairing code")
+	return "", fmt.Errorf("this box links its own managed pooled number; run `whatsapp connect --source cloud` (or --source doubletick with direct creds), not a phone pairing code")
 }
 
 // provision claims (or re-links) this box's managed number and links the companion,

--- a/agent/skills/whatsapp/cli/linker_test.go
+++ b/agent/skills/whatsapp/cli/linker_test.go
@@ -18,8 +18,10 @@ func TestChooseLinkerParadigm(t *testing.T) {
 		want string
 	}{
 		{"direct key", managedConfig{directURL: "https://box", directKey: "wak_x"}, "headless"},
-		{"cloud tenant", managedConfig{vestadBase: "https://localhost:1", agentName: "a", agentToken: "t", cloudManaged: true}, "headless"},
-		{"self-hosted container (identity but not a tenant)", managedConfig{vestadBase: "https://localhost:1", agentName: "a", agentToken: "t"}, "self-managed"},
+		{"managed VM", managedConfig{managedInfra: true}, "headless"},
+		// A box with neither links the user's own WhatsApp, including a
+		// self-hosted box holding a Vesta Cloud account (managed WhatsApp
+		// opens for it only with an active paid membership).
 		{"plain box", managedConfig{}, "self-managed"},
 	}
 	for _, tc := range cases {

--- a/agent/skills/whatsapp/cli/managed_auth.go
+++ b/agent/skills/whatsapp/cli/managed_auth.go
@@ -79,12 +79,12 @@ func classifyBlock(err error) error {
 
 // Managed WhatsApp auth (the "token" strategy): the agent side of the hosted
 // vesta.run proxy. The agent reaches WhatsApp through the control plane, not the
-// home phone box directly, minting a short-lived server-identity token from its
-// own vestad (loopback, agent-token authed; no standing credential) and calling
-// /api/integrations/whatsapp/* with it as a Bearer. Every paid account is entitled to exactly
-// ONE number: provision claims it lazily and idempotently, reauth re-posts a
-// fresh pairing code for the same account (no new number, no OTP, no user step).
-// This file is the HTTP client + on-disk state; daemon wiring lives in MANAGED_AUTH.md.
+// home phone box directly, Bearing a short-lived server-identity token from
+// `vesta-cloud token` (no standing credential) to /api/integrations/whatsapp/*.
+// Every active paid account is entitled to exactly ONE number: provision claims
+// it lazily and idempotently, reauth re-posts a fresh pairing code for the same
+// account (no new number, no OTP, no user step). This file is the HTTP client +
+// on-disk state.
 
 const (
 	// controlHTTPTimeout bounds a call to the pool API. It is generous because
@@ -103,24 +103,27 @@ const (
 var provisionPollInterval = 3 * time.Second
 
 // managedConfig selects between two ways to reach the same pool API:
-//   - direct (self-hosted): DOUBLETICK_API_URL + DOUBLETICK_API_KEY, a per-account key
-//     straight to the home box, no vesta.run and no vestad;
-//   - cloud (vesta.run tenant): a server-identity token minted from vestad, sent to
-//     vesta.run's /api/integrations/whatsapp, which authenticates and forwards to the home box.
+//   - direct: DOUBLETICK_API_URL + DOUBLETICK_API_KEY, a per-account key straight
+//     to the home box, no vesta.run involved;
+//   - cloud: a server-identity token from `vesta-cloud token`, sent to vesta.run's
+//     /api/integrations/whatsapp, which authenticates and forwards to the home box.
 //
 // Both hit the same native paths (/provision, /pair); only the base URL
 // and the credential differ.
 type managedConfig struct {
-	directURL  string // home box base, e.g. https://<tunnel> (direct mode)
-	directKey  string // per-account key (wak_...) for direct mode
-	vestadBase string // this box's vestad, https://$BOX_HOST:$VESTAD_PORT
-	agentName  string
-	agentToken string
-	// cloudManaged is the paid-tenant signal: the control plane's cloud-init sets
-	// VESTA_CLOUD_CONTROL_URL only on managed VMs and vestad forwards it into the
-	// container, so its presence tells a cloud tenant from a plain self-hosted box
-	// (whose identity env is otherwise identical).
-	cloudManaged bool
+	directURL string // home box base, e.g. https://<tunnel> (direct mode)
+	directKey string // per-account key (wak_...) for direct mode
+	// agentName ($AGENT_NAME) names this agent in pool calls (the proxy-lease
+	// X-Vesta-Account header) and the companion's profile name. It plays no part
+	// in authentication.
+	agentName string
+	// managedInfra is the INFRA fact that this VM is Vesta-provisioned: cloud-init
+	// sets VESTA_CLOUD_CONTROL_URL on managed VMs and vestad forwards it into the
+	// container. It is NOT the account signal (`vesta-cloud whoami` owns that; a
+	// self-hosted box can hold an account too). It keys only what follows from the
+	// infra: a managed VM is sold with the managed WhatsApp pool (boot paradigm)
+	// and egresses from a datacenter IP (residential-proxy lease).
+	managedInfra bool
 	// proxyURL is a bring-your-own egress override (WHATSAPP_PROXY_URL): an explicit
 	// http(s)://user:pass@host:port or socks5:// URL the companion egresses through
 	// in every mode, taking precedence over the cloud residential lease. Empty on a
@@ -129,14 +132,8 @@ type managedConfig struct {
 	configError string
 }
 
-// loadManagedConfig reads the managed-auth environment (mirrors the account skill).
+// loadManagedConfig reads the managed-auth environment.
 func loadManagedConfig() managedConfig {
-	base := ""
-	port := strings.TrimSpace(os.Getenv("VESTAD_PORT"))
-	host := strings.TrimSpace(os.Getenv("BOX_HOST"))
-	if port != "" && host != "" {
-		base = "https://" + host + ":" + port
-	}
 	directURL := strings.TrimSpace(os.Getenv("DOUBLETICK_API_URL"))
 	directKey := strings.TrimSpace(os.Getenv("DOUBLETICK_API_KEY"))
 	configError := ""
@@ -151,26 +148,26 @@ func loadManagedConfig() managedConfig {
 	return managedConfig{
 		directURL:    strings.TrimRight(directURL, "/"),
 		directKey:    directKey,
-		vestadBase:   base,
 		agentName:    strings.TrimSpace(os.Getenv("AGENT_NAME")),
-		agentToken:   strings.TrimSpace(os.Getenv("AGENT_TOKEN")),
-		cloudManaged: strings.TrimSpace(os.Getenv("VESTA_CLOUD_CONTROL_URL")) != "",
+		managedInfra: strings.TrimSpace(os.Getenv("VESTA_CLOUD_CONTROL_URL")) != "",
 		proxyURL:     strings.TrimSpace(os.Getenv("WHATSAPP_PROXY_URL")),
 		configError:  configError,
 	}
 }
 
 // isDirect reports whether a direct home-box key is configured: the box talks
-// straight to the pool API with its own per-account key, no vesta.run, no vestad.
+// straight to the pool API with its own per-account key, no vesta.run involved.
 func (c managedConfig) isDirect() bool {
 	return c.directURL != "" && c.directKey != ""
 }
 
-// isCloudTenant reports whether this box is a genuine vesta.run cloud tenant with a
-// complete vestad identity: cloudManaged (VESTA_CLOUD_CONTROL_URL) plus the loopback
-// vestad base, agent name, and agent token needed to mint a server-identity token.
-func (c managedConfig) isCloudTenant() bool {
-	return c.cloudManaged && c.vestadBase != "" && c.agentName != "" && c.agentToken != ""
+// isManagedVM reports the infra fact that this is a Vesta-provisioned VM, which
+// ships with the managed WhatsApp pool. A paired self-hosted box is NOT this,
+// even though it can hold a Vesta Cloud account: its account gains managed
+// WhatsApp only with an active paid membership, which the control plane enforces
+// (403 membership_inactive), so the pool paradigm stays off until then.
+func (c managedConfig) isManagedVM() bool {
+	return c.managedInfra
 }
 
 type managedAuth struct {
@@ -224,16 +221,13 @@ func (m *managedAuth) isDirect() bool {
 	return m.cfg.isDirect()
 }
 
-// isHosted reports whether this box can use managed WhatsApp at all: either a direct
-// key (self-hosted managed), or a genuine vesta.run cloud tenant. Every agent
-// container carries VESTAD_PORT/AGENT_NAME/AGENT_TOKEN, so their presence alone
-// cannot tell a paid tenant from a plain self-hosted box. The distinguishing signal
-// is cloudManaged (VESTA_CLOUD_CONTROL_URL), which the control plane's cloud-init
-// drop-in sets only on managed VMs and vestad forwards into the container. Without
-// it, a plain box falls back to the QR strategy instead of dead-ending on a managed
-// path whose `vesta-cloud token` mint would fail (it has no cloud account).
+// isHosted reports whether this box runs the managed-pool paradigm: a direct
+// per-account key, or a Vesta-provisioned VM (which ships with the pool). A box
+// that is neither links the user's own WhatsApp (QR strategy) — including a
+// self-hosted box holding a Vesta Cloud account, whose managed WhatsApp opens
+// only with an active paid membership (the control plane's gate).
 func (m *managedAuth) isHosted() bool {
-	return m.cfg.configError != "" || m.cfg.isDirect() || m.cfg.isCloudTenant()
+	return m.cfg.configError != "" || m.cfg.isDirect() || m.cfg.isManagedVM()
 }
 
 // newManagedAuth builds the pool-API HTTP client. Direct-mode cred reconciliation
@@ -258,7 +252,7 @@ type serverToken struct {
 var mintServerToken = vestaCloudToken
 
 // vestaCloudTokenTimeout bounds the subprocess so a wedged `vesta-cloud token` can never
-// hang the daemon's auth path (the native mint it replaced had a 30s HTTP timeout).
+// hang the daemon's auth path.
 const vestaCloudTokenTimeout = 30 * time.Second
 
 // vestaCloudToken shells out to `vesta-cloud token`, the single source of truth for
@@ -314,11 +308,11 @@ func (m *managedAuth) authorize() (base, auth string, err error) {
 }
 
 // usesResidentialProxy reports whether this box must egress through a leased
-// residential proxy: a genuine cloud tenant whose companion would otherwise hit
-// WhatsApp from a datacenter IP (a ban signal). A direct self-hosted box already
-// egresses from the user's residential IP, so it never leases.
+// residential proxy: a Vesta-provisioned VM's companion would otherwise hit
+// WhatsApp from a datacenter IP (a ban signal). A box on the user's own
+// hardware already egresses from their residential IP, so it never leases.
 func (m *managedAuth) usesResidentialProxy() bool {
-	return m.cfg.cloudManaged && !m.isDirect()
+	return m.cfg.managedInfra && !m.isDirect()
 }
 
 // leaseProxy fetches a residential proxy from doubletick with the same authentication

--- a/agent/skills/whatsapp/cli/managed_auth_test.go
+++ b/agent/skills/whatsapp/cli/managed_auth_test.go
@@ -32,7 +32,7 @@ func managedFor(t *testing.T, control http.HandlerFunc) *managedAuth {
 	ctrl := httptest.NewServer(control)
 	t.Cleanup(ctrl.Close)
 	stubServerToken(t, ctrl.URL)
-	return newManagedAuth(managedConfig{vestadBase: "https://vestad.test", agentName: "alice", agentToken: "atok"})
+	return newManagedAuth(managedConfig{agentName: "alice"})
 }
 
 // TestParseServerToken pins how a `vesta-cloud token` run maps to a credential or a
@@ -470,7 +470,7 @@ func TestEnsureManagedProxy_failsClosedWithoutLease(t *testing.T) {
 	}))
 	t.Cleanup(ctrl.Close)
 	stubServerToken(t, ctrl.URL)
-	m := newManagedAuth(managedConfig{vestadBase: "https://vestad.test", agentName: "alice", agentToken: "atok", cloudManaged: true})
+	m := newManagedAuth(managedConfig{managedInfra: true})
 	wac := &WhatsAppClient{managed: m}
 	if err := wac.ensureManagedProxy(); err == nil || !strings.Contains(err.Error(), "not configured") {
 		t.Fatalf("cloud-managed ensureManagedProxy without a lease = %v, want a fail-closed not-configured error", err)
@@ -562,7 +562,7 @@ func TestEnsureManagedProxy_hostedLeaseFlowCachesLeaseAndVerdict(t *testing.T) {
 	t.Cleanup(func() { lookupEgress = oldLookup })
 	stubServerToken(t, ctrl.URL)
 	wac := newLinkedTestClient(t)
-	wac.managed = newManagedAuth(managedConfig{vestadBase: "https://vestad.test", agentName: "alice", agentToken: "atok", cloudManaged: true})
+	wac.managed = newManagedAuth(managedConfig{managedInfra: true})
 	if err := wac.ensureManagedProxy(); err != nil {
 		t.Fatalf("first hosted proxy setup: %v", err)
 	}

--- a/agent/skills/whatsapp/setup.sh
+++ b/agent/skills/whatsapp/setup.sh
@@ -28,7 +28,7 @@ fi
 # 4. Start the daemon (idempotent; defaults --notifications-dir to ~/agent/notifications).
 whatsapp daemon start
 
-echo "setup complete, link an account with: whatsapp connect --source <cloud|doubletick|self-managed> (see SETUP.md)"
+echo "setup complete, link an account with: whatsapp connect --source <vesta-cloud|doubletick|self-managed> (see SETUP.md)"
 echo
 echo "Remaining step, yours to do: add this line inside the fenced Daemons block"
 echo "of ~/agent/skills/restart/SKILL.md, on its own line."

--- a/agent/skills/whatsapp/setup.sh
+++ b/agent/skills/whatsapp/setup.sh
@@ -28,7 +28,7 @@ fi
 # 4. Start the daemon (idempotent; defaults --notifications-dir to ~/agent/notifications).
 whatsapp daemon start
 
-echo "setup complete, link an account with: whatsapp link"
+echo "setup complete, link an account with: whatsapp connect --source <cloud|doubletick|self-managed> (see SETUP.md)"
 echo
 echo "Remaining step, yours to do: add this line inside the fenced Daemons block"
 echo "of ~/agent/skills/restart/SKILL.md, on its own line."

--- a/vestad/src/auth.rs
+++ b/vestad/src/auth.rs
@@ -427,6 +427,29 @@ pub async fn refresh_session_handler(
 }
 
 #[cfg(test)]
+mod agent_name_extraction {
+    use super::extract_agent_name;
+
+    #[test]
+    fn nested_vesta_cloud_paths_still_self_scope_to_the_agent() {
+        for path in [
+            "/agents/alpha/vesta-cloud/pair",
+            "/agents/alpha/vesta-cloud/pair/poll",
+            "/agents/alpha/vesta-cloud/unpair",
+            "/agents/alpha/account-token",
+        ] {
+            assert_eq!(extract_agent_name(path).as_deref(), Some("alpha"));
+        }
+    }
+
+    #[test]
+    fn non_agent_paths_yield_no_name() {
+        assert_eq!(extract_agent_name("/health"), None);
+        assert_eq!(extract_agent_name("/agents"), None);
+    }
+}
+
+#[cfg(test)]
 mod refresh_rotation_tests {
     use super::*;
 

--- a/vestad/src/auth.rs
+++ b/vestad/src/auth.rs
@@ -431,19 +431,14 @@ mod agent_name_extraction {
     use super::extract_agent_name;
 
     #[test]
-    fn nested_vesta_cloud_paths_still_self_scope_to_the_agent() {
-        for path in [
-            "/agents/alpha/vesta-cloud/pair",
-            "/agents/alpha/vesta-cloud/pair/poll",
-            "/agents/alpha/vesta-cloud/unpair",
-            "/agents/alpha/account-token",
-        ] {
-            assert_eq!(extract_agent_name(path).as_deref(), Some("alpha"));
-        }
-    }
-
-    #[test]
-    fn non_agent_paths_yield_no_name() {
+    fn agent_paths_self_scope_and_daemon_paths_do_not() {
+        assert_eq!(
+            extract_agent_name("/agents/alpha/account-token").as_deref(),
+            Some("alpha")
+        );
+        // Daemon-level Vesta Cloud pairing paths carry no agent name; they ride
+        // the any-agent-token tier instead of the self-scoped one.
+        assert_eq!(extract_agent_name("/vesta-cloud/pair"), None);
         assert_eq!(extract_agent_name("/health"), None);
         assert_eq!(extract_agent_name("/agents"), None);
     }

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -92,6 +92,11 @@ enum Command {
     },
     /// Connect a Cloudflare domain so your agent gets a public URL
     Connect,
+    /// Link this box to a Vesta Cloud account (pair / unpair)
+    VestaCloud {
+        #[command(subcommand)]
+        action: VestaCloudAction,
+    },
     /// Manage the Cloudflare tunnel (advanced)
     Tunnel {
         #[command(subcommand)]
@@ -108,6 +113,14 @@ enum Command {
     Uninstall,
     /// Print version information
     Version,
+}
+
+#[derive(clap::Subcommand)]
+enum VestaCloudAction {
+    /// Pair this box to a Vesta Cloud account (shows a code the owner approves)
+    Login,
+    /// Unpair this box from its Vesta Cloud account
+    Logout,
 }
 
 #[derive(clap::Subcommand)]
@@ -925,6 +938,18 @@ fn main() {
                 paint("1", &format!("https://{}/app", tc.hostname)),
             );
             eprintln!();
+        }
+
+        Command::VestaCloud { action } => {
+            let config = config_dir();
+            match action {
+                VestaCloudAction::Login => {
+                    vesta_cloud::run_login(&config).unwrap_or_else(|e| die(e));
+                }
+                VestaCloudAction::Logout => {
+                    vesta_cloud::run_logout(&config).unwrap_or_else(|e| die(e));
+                }
+            }
         }
 
         Command::Tunnel { action } => {

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -37,6 +37,7 @@ mod update_check;
 mod update_window;
 mod upstream;
 mod vendored_bin;
+mod vesta_cloud;
 
 use status::{paint, AgentEntry, Status, TunnelStatus};
 

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -244,60 +244,15 @@ async fn account_token_handler(State(state): State<SharedState>) -> axum::respon
     .into_response()
 }
 
-const VESTA_CLOUD_HTTP_TIMEOUT_SECS: u64 = 30;
-
-#[derive(serde::Deserialize)]
-struct VestaCloudPairBody {
-    #[serde(default)]
-    box_name: Option<String>,
-}
-
-#[derive(serde::Deserialize)]
-struct VestaCloudPairStartResponse {
-    user_code: String,
-    verification_url: String,
-    device_code: String,
-    interval: u64,
-    expires_in: u64,
-}
-
-/// The in-flight pairing, from the in-memory slot or (after a restart) its
-/// persisted copy. Expired pairings are dropped from both. Caller holds the lock.
-fn loaded_vesta_cloud_pairing(
-    slot: &mut Option<crate::vesta_cloud::VestaCloudPairing>,
-    config_dir: &std::path::Path,
-    now_epoch_secs: u64,
-) -> Option<crate::vesta_cloud::VestaCloudPairing> {
-    if slot.is_none() {
-        *slot = crate::vesta_cloud::load_vesta_cloud_pairing(config_dir);
-    }
-    if let Some(pairing) = slot.as_ref() {
-        if pairing.is_expired(now_epoch_secs) {
-            clear_vesta_cloud_pairing_slot(slot, config_dir);
-        }
-    }
-    slot.clone()
-}
-
-/// Drop the in-flight pairing from the slot AND its persisted copy.
-fn clear_vesta_cloud_pairing_slot(
-    slot: &mut Option<crate::vesta_cloud::VestaCloudPairing>,
-    config_dir: &std::path::Path,
-) {
-    *slot = None;
-    crate::vesta_cloud::clear_vesta_cloud_pairing(config_dir);
-}
-
-/// `POST /agents/{name}/vesta-cloud/pair`: open (or resume) the device-authorization
-/// pairing that links this self-hosted box to a Vesta Cloud account. vestad presents
-/// the host `api_key` to the control plane and keeps the returned `device_code` out
-/// of the agent container (memory + an owner-only file that lets a restarted vestad
-/// finish the flow); the agent only sees the `user_code` + `verification_url` it
-/// must relay to the owner. A resumed pairing reports its REMAINING lifetime as
-/// `expires_in`. Managed VMs and already-paired boxes refuse with 409.
+/// `POST /vesta-cloud/pair` (daemon-level: the apps authenticate with the api
+/// key / access token, an agent with its own token): open or resume the pairing
+/// that links this self-hosted box to a Vesta Cloud account. The flow itself
+/// lives in `vesta_cloud::start_or_resume_pairing`; the caller only ever sees
+/// the `user_code` + `verification_url` to relay to the owner (never the
+/// `device_code`), with the code's REMAINING lifetime as `expires_in`.
+/// Managed VMs and already-paired boxes refuse with 409.
 async fn vesta_cloud_pair_handler(
     State(state): State<SharedState>,
-    Json(body): Json<VestaCloudPairBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     if crate::is_cloud_managed() {
         return Err(err_response(
@@ -312,89 +267,48 @@ async fn vesta_cloud_pair_handler(
         ));
     }
 
-    // An unexpired in-flight pairing is returned as-is (an agent retry must not
-    // burn a fresh code while the owner is already typing the shown one), with
-    // its REMAINING lifetime so the skill's wait matches the code's reality.
-    let now = crate::time_utils::now_epoch_secs();
-    let mut slot = state.vesta_cloud_pairing.lock().await;
-    if let Some(pairing) =
-        loaded_vesta_cloud_pairing(&mut slot, &state.env_config.config_dir, now)
-    {
-        return Ok(Json(serde_json::json!({
-            "user_code": pairing.user_code,
-            "verification_url": pairing.verification_url,
-            "interval": pairing.interval,
-            "expires_in": pairing.remaining_secs(now),
-        })));
-    }
-
-    let base = crate::vesta_cloud::control_base();
-    let box_name = body.box_name.filter(|n| !n.trim().is_empty());
-    let response = state
-        .http_client
-        .post(format!("{base}/pair/start"))
-        .timeout(std::time::Duration::from_secs(VESTA_CLOUD_HTTP_TIMEOUT_SECS))
-        .json(&serde_json::json!({
-            "api_key": state.api_key,
-            "box_name": box_name.unwrap_or_else(|| "vesta".to_string()),
-        }))
-        .send()
-        .await
-        .map_err(|e| {
-            err_response(StatusCode::BAD_GATEWAY, &format!("pairing start failed: {e}"))
-        })?;
-    let status = response.status();
-    if !status.is_success() {
-        let text = response.text().await.unwrap_or_default();
-        let mapped = if status == reqwest::StatusCode::CONFLICT {
-            StatusCode::CONFLICT
-        } else {
-            StatusCode::BAD_GATEWAY
-        };
-        return Err(err_response(
-            mapped,
-            &format!("control plane returned {status}: {text}"),
-        ));
-    }
-
-    let start: VestaCloudPairStartResponse = response.json().await.map_err(|e| {
-        err_response(
-            StatusCode::BAD_GATEWAY,
-            &format!("invalid pairing start response: {e}"),
-        )
+    let _guard = state.vesta_cloud_pairing_lock.lock().await;
+    let pairing = crate::vesta_cloud::start_or_resume_pairing(
+        &state.http_client,
+        &state.env_config.config_dir,
+        &state.api_key,
+    )
+    .await
+    .map_err(|e| match e {
+        crate::vesta_cloud::PairStartError::AlreadyPaired => err_response(
+            StatusCode::CONFLICT,
+            "the control plane already recognizes this box's key as a live server",
+        ),
+        crate::vesta_cloud::PairStartError::Control(msg)
+        | crate::vesta_cloud::PairStartError::Transport(msg) => {
+            err_response(StatusCode::BAD_GATEWAY, &msg)
+        }
     })?;
-    let pairing = crate::vesta_cloud::VestaCloudPairing {
-        device_code: start.device_code,
-        user_code: start.user_code.clone(),
-        verification_url: start.verification_url.clone(),
-        interval: start.interval,
-        expires_at_epoch_secs: crate::time_utils::now_epoch_secs() + start.expires_in,
-    };
-    crate::vesta_cloud::save_vesta_cloud_pairing(&state.env_config.config_dir, &pairing);
-    *slot = Some(pairing);
+
+    let now = crate::time_utils::now_epoch_secs();
     Ok(Json(serde_json::json!({
-        "user_code": start.user_code,
-        "verification_url": start.verification_url,
-        "interval": start.interval,
-        "expires_in": start.expires_in,
+        "user_code": pairing.user_code,
+        "verification_url": pairing.verification_url,
+        "interval": pairing.interval,
+        "expires_in": pairing.remaining_secs(now),
     })))
 }
 
-/// `POST /agents/{name}/vesta-cloud/pair/poll`: forward ONE control-plane poll for
-/// the in-flight pairing. Answers 200 `{status:"pending"}` while the owner hasn't
-/// approved (a STRUCTURED signal, so the skill never parses error prose); on
-/// `linked` the identity is persisted to `vesta-cloud-account.json` and the
-/// pairing cleared. A terminal control-plane refusal clears the pairing; a
-/// network failure keeps it (poll again).
+/// `POST /vesta-cloud/pair/poll` (daemon-level, same tiers as pair): forward
+/// ONE control-plane poll for the in-flight pairing. Answers 200
+/// `{status:"pending"}` while the owner hasn't approved (a STRUCTURED signal,
+/// callers never parse error prose); on `linked` the flow core has already
+/// persisted `vesta-cloud-account.json` and cleared the pairing. A terminal
+/// refusal clears the pairing; a network failure keeps it (poll again).
 async fn vesta_cloud_pair_poll_handler(
     State(state): State<SharedState>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     let now = crate::time_utils::now_epoch_secs();
-    let mut slot = state.vesta_cloud_pairing.lock().await;
-    let had_pairing = slot.is_some()
-        || crate::vesta_cloud::load_vesta_cloud_pairing(&state.env_config.config_dir).is_some();
+    let _guard = state.vesta_cloud_pairing_lock.lock().await;
+    let had_pairing =
+        crate::vesta_cloud::load_vesta_cloud_pairing(&state.env_config.config_dir).is_some();
     let Some(pairing) =
-        loaded_vesta_cloud_pairing(&mut slot, &state.env_config.config_dir, now)
+        crate::vesta_cloud::current_vesta_cloud_pairing(&state.env_config.config_dir, now)
     else {
         if had_pairing {
             return Err(err_response(StatusCode::GONE, "pairing expired"));
@@ -402,84 +316,44 @@ async fn vesta_cloud_pair_poll_handler(
         return Err(err_response(StatusCode::NOT_FOUND, "no pairing in progress"));
     };
 
-    let base = crate::vesta_cloud::control_base();
-    let response = state
-        .http_client
-        .post(format!("{base}/pair/poll"))
-        .timeout(std::time::Duration::from_secs(VESTA_CLOUD_HTTP_TIMEOUT_SECS))
-        .json(&serde_json::json!({ "device_code": pairing.device_code }))
-        .send()
-        .await
-        .map_err(|e| {
-            err_response(StatusCode::BAD_GATEWAY, &format!("pairing poll failed: {e}"))
-        })?;
-
-    let status = response.status();
-    let body: serde_json::Value = response.json().await.map_err(|e| {
-        err_response(
+    match crate::vesta_cloud::poll_pairing(
+        &state.http_client,
+        &state.env_config.config_dir,
+        &pairing.device_code,
+    )
+    .await
+    {
+        Err(e) => Err(err_response(
             StatusCode::BAD_GATEWAY,
-            &format!("invalid pairing poll response: {e}"),
-        )
-    })?;
-
-    if status.is_success() {
-        match body.get("status").and_then(|s| s.as_str()) {
-            Some("pending") => {
-                return Ok(Json(serde_json::json!({ "status": "pending" })));
-            }
-            Some("linked") => {
-                let (Some(server_id), Some(control_url)) = (
-                    body.get("server_id").and_then(|v| v.as_str()),
-                    body.get("control_url").and_then(|v| v.as_str()),
-                ) else {
-                    return Err(err_response(
-                        StatusCode::BAD_GATEWAY,
-                        "linked response missing server_id/control_url",
-                    ));
-                };
-                crate::vesta_cloud::save_vesta_cloud_account(
-                    &state.env_config.config_dir,
-                    &crate::vesta_cloud::VestaCloudAccount {
-                        server_id: server_id.to_string(),
-                        control_url: control_url.to_string(),
-                    },
-                );
-                clear_vesta_cloud_pairing_slot(&mut slot, &state.env_config.config_dir);
-                return Ok(Json(serde_json::json!({
-                    "status": "linked",
-                    "server_id": server_id,
-                    "control_url": control_url,
-                })));
-            }
-            _ => {
-                return Err(err_response(
-                    StatusCode::BAD_GATEWAY,
-                    "unrecognized pairing poll response",
-                ));
-            }
+            &format!("pairing poll failed: {e}"),
+        )),
+        Ok(crate::vesta_cloud::PollOutcome::Pending) => {
+            Ok(Json(serde_json::json!({ "status": "pending" })))
+        }
+        Ok(crate::vesta_cloud::PollOutcome::Linked {
+            server_id,
+            control_url,
+        }) => Ok(Json(serde_json::json!({
+            "status": "linked",
+            "server_id": server_id,
+            "control_url": control_url,
+        }))),
+        Ok(crate::vesta_cloud::PollOutcome::Refused { gone, reason }) => {
+            let mapped = if gone {
+                StatusCode::GONE
+            } else {
+                StatusCode::CONFLICT
+            };
+            Err(err_response(mapped, &format!("pairing failed: {reason}")))
         }
     }
-
-    // Terminal control-plane refusal (expired / unknown / account already has a
-    // server): the pairing is dead, clear it so a fresh /pair can start over.
-    clear_vesta_cloud_pairing_slot(&mut slot, &state.env_config.config_dir);
-    let error = body
-        .get("error")
-        .and_then(|v| v.as_str())
-        .unwrap_or("pairing refused");
-    let mapped = if status == reqwest::StatusCode::GONE {
-        StatusCode::GONE
-    } else {
-        StatusCode::CONFLICT
-    };
-    Err(err_response(mapped, &format!("pairing failed: {error}")))
 }
 
-/// `POST /agents/{name}/vesta-cloud/unpair`: detach this box from its Vesta Cloud
-/// account. vestad proves it IS the paired server (a locally-minted server-identity
-/// token) and asks the control plane to retire the registration. A 404 means the
-/// link is already gone server-side (dashboard unpair), so the local file is
-/// cleared; a 401 (identity rejected) or a network failure keeps the file.
+/// `POST /vesta-cloud/unpair` (daemon-level, same tiers as pair): detach this
+/// box from its Vesta Cloud account via `vesta_cloud::request_unpair`. A 404
+/// from the control plane means the link was already gone server-side
+/// (dashboard unpair) and the local file is cleared; an identity rejection
+/// keeps the file on purpose (409, the owner unpairs from the dashboard).
 async fn vesta_cloud_unpair_handler(
     State(state): State<SharedState>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
@@ -498,39 +372,23 @@ async fn vesta_cloud_unpair_handler(
         ));
     };
 
-    let token = crate::jwt::create_server_identity_token(&state.api_key, &account.server_id);
-    let response = state
-        .http_client
-        .post(format!("{}/pair/unpair", account.control_url))
-        .timeout(std::time::Duration::from_secs(VESTA_CLOUD_HTTP_TIMEOUT_SECS))
-        .bearer_auth(token)
-        .send()
-        .await
-        .map_err(|e| err_response(StatusCode::BAD_GATEWAY, &format!("unpair failed: {e}")))?;
-
-    let status = response.status();
-    // 404 = the control plane PROVED the link is already gone (valid signature
-    // over a destroyed row, e.g. a dashboard unpair) — clear the local file.
-    // 401 means the identity was REJECTED (the local api-key changed since
-    // pairing?): the cloud row may still be live, so the file must stay and
-    // the owner unpairs from the dashboard instead.
-    let already_gone = status == reqwest::StatusCode::NOT_FOUND;
-    if status == reqwest::StatusCode::UNAUTHORIZED {
-        return Err(err_response(
+    match crate::vesta_cloud::request_unpair(
+        &state.http_client,
+        &state.env_config.config_dir,
+        &state.api_key,
+        &account,
+    )
+    .await
+    {
+        Err(e) => Err(err_response(StatusCode::BAD_GATEWAY, &e)),
+        Ok(crate::vesta_cloud::UnpairOutcome::IdentityRejected) => Err(err_response(
             StatusCode::CONFLICT,
-            "the control plane rejected this box's identity (has the api key changed since pairing?); the link was NOT cleared. remove the box from the vesta.run dashboard, then run logout again",
-        ));
+            "the control plane rejected this box's identity (has the api key changed since pairing?); the link was NOT cleared. remove the box from the vesta.run dashboard, then unpair again",
+        )),
+        Ok(crate::vesta_cloud::UnpairOutcome::Unpaired { .. }) => {
+            Ok(Json(serde_json::json!({ "status": "unpaired" })))
+        }
     }
-    if !status.is_success() && !already_gone {
-        let text = response.text().await.unwrap_or_default();
-        return Err(err_response(
-            StatusCode::BAD_GATEWAY,
-            &format!("control plane returned {status}: {text}"),
-        ));
-    }
-
-    crate::vesta_cloud::clear_vesta_cloud_account(&state.env_config.config_dir);
-    Ok(Json(serde_json::json!({ "status": "unpaired" })))
 }
 
 /// `GET /agents/{name}/workspace.bundle` — the host's upstream snapshot as a bundle
@@ -2917,15 +2775,6 @@ pub fn build_router(state: SharedState) -> Router {
             post(agent_status::invalidate_service_handler),
         )
         .route("/agents/{name}/account-token", post(account_token_handler))
-        .route("/agents/{name}/vesta-cloud/pair", post(vesta_cloud_pair_handler))
-        .route(
-            "/agents/{name}/vesta-cloud/pair/poll",
-            post(vesta_cloud_pair_poll_handler),
-        )
-        .route(
-            "/agents/{name}/vesta-cloud/unpair",
-            post(vesta_cloud_unpair_handler),
-        )
         .route("/agents/{name}/user-notification", post(user_notification_handler))
         .route(
             "/agents/{name}/workspace.bundle",
@@ -2998,6 +2847,12 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/version", get(version))
         .route("/version/check", post(version_check))
         .route("/gateway/update", post(gateway_update_handler))
+        // Vesta Cloud pairing is host-global like the update surface: the apps
+        // drive it with the api key / access token, an agent with its own
+        // token, and `vestad vesta-cloud login` runs the same core directly.
+        .route("/vesta-cloud/pair", post(vesta_cloud_pair_handler))
+        .route("/vesta-cloud/pair/poll", post(vesta_cloud_pair_poll_handler))
+        .route("/vesta-cloud/unpair", post(vesta_cloud_unpair_handler))
         .layer(control_timeout_layer())
         .layer(middleware::from_fn_with_state(
             state.clone(),
@@ -3666,35 +3521,6 @@ mod tests {
     }
 
     // --- Legacy workspace.bundle endpoint: 404 before first build, bytes after ---
-
-    #[test]
-    fn vesta_cloud_pairing_resumes_from_disk_and_drops_when_expired() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let pairing = crate::vesta_cloud::VestaCloudPairing {
-            device_code: "d".repeat(64),
-            user_code: "BCDF-2345".to_string(),
-            verification_url: "https://vesta.run/pair?code=BCDF-2345".to_string(),
-            interval: 5,
-            expires_at_epoch_secs: 1_000,
-        };
-        crate::vesta_cloud::save_vesta_cloud_pairing(tmp.path(), &pairing);
-
-        // A fresh slot (vestad restarted mid-flow) resumes from the file, so
-        // the device_code survives to reach the control plane's replay branch.
-        let mut slot = None;
-        assert_eq!(
-            super::loaded_vesta_cloud_pairing(&mut slot, tmp.path(), 500),
-            Some(pairing)
-        );
-
-        // Once expired it is dropped from the slot AND the file.
-        let mut fresh_slot = None;
-        assert_eq!(
-            super::loaded_vesta_cloud_pairing(&mut fresh_slot, tmp.path(), 1_000),
-            None
-        );
-        assert_eq!(crate::vesta_cloud::load_vesta_cloud_pairing(tmp.path()), None);
-    }
 
     #[tokio::test]
     async fn workspace_bundle_404s_before_first_build_and_serves_bytes_after() {

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -224,25 +224,275 @@ async fn info() -> Json<serde_json::Value> {
 
 /// `POST /agents/{name}/account-token`: mint a short-lived server-identity token for
 /// the on-box agent (issue #20). Agent-token authenticated (the agent proves itself
-/// with its `X-Agent-Token`); vestad signs `{ sub: VESTA_CLOUD_SERVER_ID, typ:
-/// "server-identity" }` with its `api_key` and hands it back. The agent carries this
-/// to the control plane's `/api/account/*` to read its plan or open a billing portal.
+/// with its `X-Agent-Token`); vestad signs `{ sub: <server_id>, typ: "server-identity" }`
+/// with its `api_key` and hands it back. The server identity comes from cloud-init env
+/// on a managed VM or from `vesta-cloud-account.json` on a paired self-hosted box
+/// (`vesta_cloud::vesta_cloud_identity`); an unpaired box still 404s. The nullable
+/// `control_url` tells the skill which control plane the identity belongs to.
 /// vestad makes NO network call, it only signs locally; the `api_key` never enters
 /// the agent container, only this 10-minute token does.
 async fn account_token_handler(State(state): State<SharedState>) -> axum::response::Response {
-    if !crate::is_cloud_managed() {
-        return err_response(StatusCode::NOT_FOUND, "not a cloud-managed server").into_response();
-    }
-    let Ok(server_id) = std::env::var("VESTA_CLOUD_SERVER_ID") else {
-        // Managed but VESTA_CLOUD_SERVER_ID not seeded — nothing to mint.
+    let Some((server_id, control_url)) =
+        crate::vesta_cloud::vesta_cloud_identity(&state.env_config.config_dir)
+    else {
         return err_response(StatusCode::NOT_FOUND, "no server identity available").into_response();
     };
     let token = crate::jwt::create_server_identity_token(&state.api_key, &server_id);
     Json(serde_json::json!({
         "token": token,
         "expires_in": crate::jwt::SERVER_IDENTITY_TTL,
+        "control_url": control_url,
     }))
     .into_response()
+}
+
+const VESTA_CLOUD_HTTP_TIMEOUT_SECS: u64 = 30;
+
+#[derive(serde::Deserialize)]
+struct VestaCloudPairBody {
+    #[serde(default)]
+    box_name: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct VestaCloudPairStartResponse {
+    user_code: String,
+    verification_url: String,
+    device_code: String,
+    interval: u64,
+    expires_in: u64,
+}
+
+/// `POST /agents/{name}/vesta-cloud/pair`: open (or resume) the device-authorization
+/// pairing that links this self-hosted box to a Vesta Cloud account. vestad presents
+/// the host `api_key` to the control plane and holds the returned `device_code` in
+/// memory; the agent only ever sees the `user_code` + `verification_url` it must
+/// relay to the owner. Managed VMs (cloud-init identity) and already-paired boxes
+/// refuse with 409.
+async fn vesta_cloud_pair_handler(
+    State(state): State<SharedState>,
+    Json(body): Json<VestaCloudPairBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    if crate::is_cloud_managed() {
+        return Err(err_response(
+            StatusCode::CONFLICT,
+            "this box is already managed by Vesta Cloud",
+        ));
+    }
+    if crate::vesta_cloud::load_vesta_cloud_account(&state.env_config.config_dir).is_some() {
+        return Err(err_response(
+            StatusCode::CONFLICT,
+            "already paired to a Vesta Cloud account (unpair first)",
+        ));
+    }
+
+    // An unexpired in-flight pairing is returned as-is (an agent retry must not
+    // burn a fresh code while the owner is already typing the shown one).
+    let mut slot = state.vesta_cloud_pairing.lock().await;
+    if let Some(session) = slot.as_ref() {
+        if session.is_expired() {
+            *slot = None;
+        } else {
+            return Ok(Json(serde_json::json!({
+                "user_code": session.user_code,
+                "verification_url": session.verification_url,
+                "interval": session.interval,
+                "expires_in": session.expires_in,
+            })));
+        }
+    }
+
+    let base = crate::vesta_cloud::control_base();
+    let box_name = body.box_name.filter(|n| !n.trim().is_empty());
+    let response = state
+        .http_client
+        .post(format!("{base}/pair/start"))
+        .timeout(std::time::Duration::from_secs(VESTA_CLOUD_HTTP_TIMEOUT_SECS))
+        .json(&serde_json::json!({
+            "api_key": state.api_key,
+            "box_name": box_name.unwrap_or_else(|| "vesta".to_string()),
+        }))
+        .send()
+        .await
+        .map_err(|e| {
+            err_response(StatusCode::BAD_GATEWAY, &format!("pairing start failed: {e}"))
+        })?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        let mapped = if status == reqwest::StatusCode::CONFLICT {
+            StatusCode::CONFLICT
+        } else {
+            StatusCode::BAD_GATEWAY
+        };
+        return Err(err_response(
+            mapped,
+            &format!("control plane returned {status}: {text}"),
+        ));
+    }
+
+    let start: VestaCloudPairStartResponse = response.json().await.map_err(|e| {
+        err_response(
+            StatusCode::BAD_GATEWAY,
+            &format!("invalid pairing start response: {e}"),
+        )
+    })?;
+    *slot = Some(crate::state::VestaCloudPairingSession {
+        device_code: start.device_code,
+        user_code: start.user_code.clone(),
+        verification_url: start.verification_url.clone(),
+        interval: start.interval,
+        expires_in: start.expires_in,
+        created: std::time::Instant::now(),
+    });
+    Ok(Json(serde_json::json!({
+        "user_code": start.user_code,
+        "verification_url": start.verification_url,
+        "interval": start.interval,
+        "expires_in": start.expires_in,
+    })))
+}
+
+/// `POST /agents/{name}/vesta-cloud/pair/poll`: forward ONE control-plane poll for
+/// the in-flight pairing. 409 while the owner hasn't approved yet (the skill sleeps
+/// and retries on this, mirroring the `ChatGPT` device flow); on `linked` the
+/// identity is persisted to `vesta-cloud-account.json` and the session cleared.
+/// A terminal control-plane refusal clears the session; a network failure keeps it.
+async fn vesta_cloud_pair_poll_handler(
+    State(state): State<SharedState>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let mut slot = state.vesta_cloud_pairing.lock().await;
+    let Some(session) = slot.as_ref().cloned() else {
+        return Err(err_response(StatusCode::NOT_FOUND, "no pairing in progress"));
+    };
+    if session.is_expired() {
+        *slot = None;
+        return Err(err_response(StatusCode::GONE, "pairing expired"));
+    }
+
+    let base = crate::vesta_cloud::control_base();
+    let response = state
+        .http_client
+        .post(format!("{base}/pair/poll"))
+        .timeout(std::time::Duration::from_secs(VESTA_CLOUD_HTTP_TIMEOUT_SECS))
+        .json(&serde_json::json!({ "device_code": session.device_code }))
+        .send()
+        .await
+        .map_err(|e| {
+            err_response(StatusCode::BAD_GATEWAY, &format!("pairing poll failed: {e}"))
+        })?;
+
+    let status = response.status();
+    let body: serde_json::Value = response.json().await.map_err(|e| {
+        err_response(
+            StatusCode::BAD_GATEWAY,
+            &format!("invalid pairing poll response: {e}"),
+        )
+    })?;
+
+    if status.is_success() {
+        match body.get("status").and_then(|s| s.as_str()) {
+            Some("pending") => {
+                return Err(err_response(
+                    StatusCode::CONFLICT,
+                    "authorization is still pending",
+                ));
+            }
+            Some("linked") => {
+                let (Some(server_id), Some(control_url)) = (
+                    body.get("server_id").and_then(|v| v.as_str()),
+                    body.get("control_url").and_then(|v| v.as_str()),
+                ) else {
+                    return Err(err_response(
+                        StatusCode::BAD_GATEWAY,
+                        "linked response missing server_id/control_url",
+                    ));
+                };
+                crate::vesta_cloud::save_vesta_cloud_account(
+                    &state.env_config.config_dir,
+                    &crate::vesta_cloud::VestaCloudAccount {
+                        server_id: server_id.to_string(),
+                        control_url: control_url.to_string(),
+                    },
+                );
+                *slot = None;
+                return Ok(Json(serde_json::json!({
+                    "status": "linked",
+                    "server_id": server_id,
+                    "control_url": control_url,
+                })));
+            }
+            _ => {
+                return Err(err_response(
+                    StatusCode::BAD_GATEWAY,
+                    "unrecognized pairing poll response",
+                ));
+            }
+        }
+    }
+
+    // Terminal control-plane refusal (expired / unknown / account already has a
+    // server): the pairing is dead, clear it so a fresh /pair can start over.
+    *slot = None;
+    let error = body
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or("pairing refused");
+    let mapped = if status == reqwest::StatusCode::GONE {
+        StatusCode::GONE
+    } else {
+        StatusCode::CONFLICT
+    };
+    Err(err_response(mapped, &format!("pairing failed: {error}")))
+}
+
+/// `POST /agents/{name}/vesta-cloud/unpair`: detach this box from its Vesta Cloud
+/// account. vestad proves it IS the paired server (a locally-minted server-identity
+/// token) and asks the control plane to retire the registration; 401/404 from the
+/// control plane means the link is already gone server-side (e.g. removed from the
+/// dashboard), so the local file is cleared either way. Only a network failure
+/// keeps the file (retry later).
+async fn vesta_cloud_unpair_handler(
+    State(state): State<SharedState>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    if crate::is_cloud_managed() {
+        return Err(err_response(
+            StatusCode::CONFLICT,
+            "a managed Vesta Cloud box cannot unpair",
+        ));
+    }
+    let Some(account) =
+        crate::vesta_cloud::load_vesta_cloud_account(&state.env_config.config_dir)
+    else {
+        return Err(err_response(
+            StatusCode::NOT_FOUND,
+            "not paired to a Vesta Cloud account",
+        ));
+    };
+
+    let token = crate::jwt::create_server_identity_token(&state.api_key, &account.server_id);
+    let response = state
+        .http_client
+        .post(format!("{}/pair/unpair", account.control_url))
+        .timeout(std::time::Duration::from_secs(VESTA_CLOUD_HTTP_TIMEOUT_SECS))
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|e| err_response(StatusCode::BAD_GATEWAY, &format!("unpair failed: {e}")))?;
+
+    let status = response.status();
+    let already_gone = status == reqwest::StatusCode::UNAUTHORIZED
+        || status == reqwest::StatusCode::NOT_FOUND;
+    if !status.is_success() && !already_gone {
+        let text = response.text().await.unwrap_or_default();
+        return Err(err_response(
+            StatusCode::BAD_GATEWAY,
+            &format!("control plane returned {status}: {text}"),
+        ));
+    }
+
+    crate::vesta_cloud::clear_vesta_cloud_account(&state.env_config.config_dir);
+    Ok(Json(serde_json::json!({ "status": "unpaired" })))
 }
 
 /// `GET /agents/{name}/workspace.bundle` — the host's upstream snapshot as a bundle
@@ -2629,6 +2879,15 @@ pub fn build_router(state: SharedState) -> Router {
             post(agent_status::invalidate_service_handler),
         )
         .route("/agents/{name}/account-token", post(account_token_handler))
+        .route("/agents/{name}/vesta-cloud/pair", post(vesta_cloud_pair_handler))
+        .route(
+            "/agents/{name}/vesta-cloud/pair/poll",
+            post(vesta_cloud_pair_poll_handler),
+        )
+        .route(
+            "/agents/{name}/vesta-cloud/unpair",
+            post(vesta_cloud_unpair_handler),
+        )
         .route("/agents/{name}/user-notification", post(user_notification_handler))
         .route(
             "/agents/{name}/workspace.bundle",

--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -222,15 +222,13 @@ async fn info() -> Json<serde_json::Value> {
     Json(serde_json::json!({ "managed": crate::is_cloud_managed() }))
 }
 
-/// `POST /agents/{name}/account-token`: mint a short-lived server-identity token for
-/// the on-box agent (issue #20). Agent-token authenticated (the agent proves itself
-/// with its `X-Agent-Token`); vestad signs `{ sub: <server_id>, typ: "server-identity" }`
-/// with its `api_key` and hands it back. The server identity comes from cloud-init env
-/// on a managed VM or from `vesta-cloud-account.json` on a paired self-hosted box
-/// (`vesta_cloud::vesta_cloud_identity`); an unpaired box still 404s. The nullable
-/// `control_url` tells the skill which control plane the identity belongs to.
-/// vestad makes NO network call, it only signs locally; the `api_key` never enters
-/// the agent container, only this 10-minute token does.
+/// `POST /agents/{name}/account-token`: mint a short-lived server-identity token
+/// for the on-box agent (issue #20). Agent-token authenticated. The identity
+/// comes from cloud-init env on a managed VM or `vesta-cloud-account.json` on a
+/// paired self-hosted box (`vesta_cloud::vesta_cloud_identity`); an unpaired box
+/// 404s, and the nullable `control_url` names the identity's control plane.
+/// vestad makes NO network call, it only signs locally; the `api_key` never
+/// enters the agent container, only this 10-minute token does.
 async fn account_token_handler(State(state): State<SharedState>) -> axum::response::Response {
     let Some((server_id, control_url)) =
         crate::vesta_cloud::vesta_cloud_identity(&state.env_config.config_dir)
@@ -263,12 +261,40 @@ struct VestaCloudPairStartResponse {
     expires_in: u64,
 }
 
+/// The in-flight pairing, from the in-memory slot or (after a restart) its
+/// persisted copy. Expired pairings are dropped from both. Caller holds the lock.
+fn loaded_vesta_cloud_pairing(
+    slot: &mut Option<crate::vesta_cloud::VestaCloudPairing>,
+    config_dir: &std::path::Path,
+    now_epoch_secs: u64,
+) -> Option<crate::vesta_cloud::VestaCloudPairing> {
+    if slot.is_none() {
+        *slot = crate::vesta_cloud::load_vesta_cloud_pairing(config_dir);
+    }
+    if let Some(pairing) = slot.as_ref() {
+        if pairing.is_expired(now_epoch_secs) {
+            clear_vesta_cloud_pairing_slot(slot, config_dir);
+        }
+    }
+    slot.clone()
+}
+
+/// Drop the in-flight pairing from the slot AND its persisted copy.
+fn clear_vesta_cloud_pairing_slot(
+    slot: &mut Option<crate::vesta_cloud::VestaCloudPairing>,
+    config_dir: &std::path::Path,
+) {
+    *slot = None;
+    crate::vesta_cloud::clear_vesta_cloud_pairing(config_dir);
+}
+
 /// `POST /agents/{name}/vesta-cloud/pair`: open (or resume) the device-authorization
 /// pairing that links this self-hosted box to a Vesta Cloud account. vestad presents
-/// the host `api_key` to the control plane and holds the returned `device_code` in
-/// memory; the agent only ever sees the `user_code` + `verification_url` it must
-/// relay to the owner. Managed VMs (cloud-init identity) and already-paired boxes
-/// refuse with 409.
+/// the host `api_key` to the control plane and keeps the returned `device_code` out
+/// of the agent container (memory + an owner-only file that lets a restarted vestad
+/// finish the flow); the agent only sees the `user_code` + `verification_url` it
+/// must relay to the owner. A resumed pairing reports its REMAINING lifetime as
+/// `expires_in`. Managed VMs and already-paired boxes refuse with 409.
 async fn vesta_cloud_pair_handler(
     State(state): State<SharedState>,
     Json(body): Json<VestaCloudPairBody>,
@@ -287,19 +313,19 @@ async fn vesta_cloud_pair_handler(
     }
 
     // An unexpired in-flight pairing is returned as-is (an agent retry must not
-    // burn a fresh code while the owner is already typing the shown one).
+    // burn a fresh code while the owner is already typing the shown one), with
+    // its REMAINING lifetime so the skill's wait matches the code's reality.
+    let now = crate::time_utils::now_epoch_secs();
     let mut slot = state.vesta_cloud_pairing.lock().await;
-    if let Some(session) = slot.as_ref() {
-        if session.is_expired() {
-            *slot = None;
-        } else {
-            return Ok(Json(serde_json::json!({
-                "user_code": session.user_code,
-                "verification_url": session.verification_url,
-                "interval": session.interval,
-                "expires_in": session.expires_in,
-            })));
-        }
+    if let Some(pairing) =
+        loaded_vesta_cloud_pairing(&mut slot, &state.env_config.config_dir, now)
+    {
+        return Ok(Json(serde_json::json!({
+            "user_code": pairing.user_code,
+            "verification_url": pairing.verification_url,
+            "interval": pairing.interval,
+            "expires_in": pairing.remaining_secs(now),
+        })));
     }
 
     let base = crate::vesta_cloud::control_base();
@@ -337,14 +363,15 @@ async fn vesta_cloud_pair_handler(
             &format!("invalid pairing start response: {e}"),
         )
     })?;
-    *slot = Some(crate::state::VestaCloudPairingSession {
+    let pairing = crate::vesta_cloud::VestaCloudPairing {
         device_code: start.device_code,
         user_code: start.user_code.clone(),
         verification_url: start.verification_url.clone(),
         interval: start.interval,
-        expires_in: start.expires_in,
-        created: std::time::Instant::now(),
-    });
+        expires_at_epoch_secs: crate::time_utils::now_epoch_secs() + start.expires_in,
+    };
+    crate::vesta_cloud::save_vesta_cloud_pairing(&state.env_config.config_dir, &pairing);
+    *slot = Some(pairing);
     Ok(Json(serde_json::json!({
         "user_code": start.user_code,
         "verification_url": start.verification_url,
@@ -354,28 +381,33 @@ async fn vesta_cloud_pair_handler(
 }
 
 /// `POST /agents/{name}/vesta-cloud/pair/poll`: forward ONE control-plane poll for
-/// the in-flight pairing. 409 while the owner hasn't approved yet (the skill sleeps
-/// and retries on this, mirroring the `ChatGPT` device flow); on `linked` the
-/// identity is persisted to `vesta-cloud-account.json` and the session cleared.
-/// A terminal control-plane refusal clears the session; a network failure keeps it.
+/// the in-flight pairing. Answers 200 `{status:"pending"}` while the owner hasn't
+/// approved (a STRUCTURED signal, so the skill never parses error prose); on
+/// `linked` the identity is persisted to `vesta-cloud-account.json` and the
+/// pairing cleared. A terminal control-plane refusal clears the pairing; a
+/// network failure keeps it (poll again).
 async fn vesta_cloud_pair_poll_handler(
     State(state): State<SharedState>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let now = crate::time_utils::now_epoch_secs();
     let mut slot = state.vesta_cloud_pairing.lock().await;
-    let Some(session) = slot.as_ref().cloned() else {
+    let had_pairing = slot.is_some()
+        || crate::vesta_cloud::load_vesta_cloud_pairing(&state.env_config.config_dir).is_some();
+    let Some(pairing) =
+        loaded_vesta_cloud_pairing(&mut slot, &state.env_config.config_dir, now)
+    else {
+        if had_pairing {
+            return Err(err_response(StatusCode::GONE, "pairing expired"));
+        }
         return Err(err_response(StatusCode::NOT_FOUND, "no pairing in progress"));
     };
-    if session.is_expired() {
-        *slot = None;
-        return Err(err_response(StatusCode::GONE, "pairing expired"));
-    }
 
     let base = crate::vesta_cloud::control_base();
     let response = state
         .http_client
         .post(format!("{base}/pair/poll"))
         .timeout(std::time::Duration::from_secs(VESTA_CLOUD_HTTP_TIMEOUT_SECS))
-        .json(&serde_json::json!({ "device_code": session.device_code }))
+        .json(&serde_json::json!({ "device_code": pairing.device_code }))
         .send()
         .await
         .map_err(|e| {
@@ -393,10 +425,7 @@ async fn vesta_cloud_pair_poll_handler(
     if status.is_success() {
         match body.get("status").and_then(|s| s.as_str()) {
             Some("pending") => {
-                return Err(err_response(
-                    StatusCode::CONFLICT,
-                    "authorization is still pending",
-                ));
+                return Ok(Json(serde_json::json!({ "status": "pending" })));
             }
             Some("linked") => {
                 let (Some(server_id), Some(control_url)) = (
@@ -415,7 +444,7 @@ async fn vesta_cloud_pair_poll_handler(
                         control_url: control_url.to_string(),
                     },
                 );
-                *slot = None;
+                clear_vesta_cloud_pairing_slot(&mut slot, &state.env_config.config_dir);
                 return Ok(Json(serde_json::json!({
                     "status": "linked",
                     "server_id": server_id,
@@ -433,7 +462,7 @@ async fn vesta_cloud_pair_poll_handler(
 
     // Terminal control-plane refusal (expired / unknown / account already has a
     // server): the pairing is dead, clear it so a fresh /pair can start over.
-    *slot = None;
+    clear_vesta_cloud_pairing_slot(&mut slot, &state.env_config.config_dir);
     let error = body
         .get("error")
         .and_then(|v| v.as_str())
@@ -448,10 +477,9 @@ async fn vesta_cloud_pair_poll_handler(
 
 /// `POST /agents/{name}/vesta-cloud/unpair`: detach this box from its Vesta Cloud
 /// account. vestad proves it IS the paired server (a locally-minted server-identity
-/// token) and asks the control plane to retire the registration; 401/404 from the
-/// control plane means the link is already gone server-side (e.g. removed from the
-/// dashboard), so the local file is cleared either way. Only a network failure
-/// keeps the file (retry later).
+/// token) and asks the control plane to retire the registration. A 404 means the
+/// link is already gone server-side (dashboard unpair), so the local file is
+/// cleared; a 401 (identity rejected) or a network failure keeps the file.
 async fn vesta_cloud_unpair_handler(
     State(state): State<SharedState>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
@@ -481,8 +509,18 @@ async fn vesta_cloud_unpair_handler(
         .map_err(|e| err_response(StatusCode::BAD_GATEWAY, &format!("unpair failed: {e}")))?;
 
     let status = response.status();
-    let already_gone = status == reqwest::StatusCode::UNAUTHORIZED
-        || status == reqwest::StatusCode::NOT_FOUND;
+    // 404 = the control plane PROVED the link is already gone (valid signature
+    // over a destroyed row, e.g. a dashboard unpair) — clear the local file.
+    // 401 means the identity was REJECTED (the local api-key changed since
+    // pairing?): the cloud row may still be live, so the file must stay and
+    // the owner unpairs from the dashboard instead.
+    let already_gone = status == reqwest::StatusCode::NOT_FOUND;
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(err_response(
+            StatusCode::CONFLICT,
+            "the control plane rejected this box's identity (has the api key changed since pairing?); the link was NOT cleared. remove the box from the vesta.run dashboard, then run logout again",
+        ));
+    }
     if !status.is_success() && !already_gone {
         let text = response.text().await.unwrap_or_default();
         return Err(err_response(
@@ -3628,6 +3666,35 @@ mod tests {
     }
 
     // --- Legacy workspace.bundle endpoint: 404 before first build, bytes after ---
+
+    #[test]
+    fn vesta_cloud_pairing_resumes_from_disk_and_drops_when_expired() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let pairing = crate::vesta_cloud::VestaCloudPairing {
+            device_code: "d".repeat(64),
+            user_code: "BCDF-2345".to_string(),
+            verification_url: "https://vesta.run/pair?code=BCDF-2345".to_string(),
+            interval: 5,
+            expires_at_epoch_secs: 1_000,
+        };
+        crate::vesta_cloud::save_vesta_cloud_pairing(tmp.path(), &pairing);
+
+        // A fresh slot (vestad restarted mid-flow) resumes from the file, so
+        // the device_code survives to reach the control plane's replay branch.
+        let mut slot = None;
+        assert_eq!(
+            super::loaded_vesta_cloud_pairing(&mut slot, tmp.path(), 500),
+            Some(pairing)
+        );
+
+        // Once expired it is dropped from the slot AND the file.
+        let mut fresh_slot = None;
+        assert_eq!(
+            super::loaded_vesta_cloud_pairing(&mut fresh_slot, tmp.path(), 1_000),
+            None
+        );
+        assert_eq!(crate::vesta_cloud::load_vesta_cloud_pairing(tmp.path()), None);
+    }
 
     #[tokio::test]
     async fn workspace_bundle_404s_before_first_build_and_serves_bytes_after() {

--- a/vestad/src/state.rs
+++ b/vestad/src/state.rs
@@ -107,10 +107,11 @@ pub struct AppState {
     pub(crate) docker: bollard::Docker,
     pub(crate) auth_sessions: Mutex<HashMap<String, AuthSession>>,
     pub(crate) openai_auth_sessions: Mutex<HashMap<String, OpenAiAuthSession>>,
-    /// In-memory cache of the in-flight Vesta Cloud pairing; the durable copy
-    /// (with the poll secret) lives in `<config_dir>/vesta-cloud-pairing.json`
-    /// so a restart mid-flow can keep polling. Single slot: one box, one link.
-    pub(crate) vesta_cloud_pairing: Mutex<Option<crate::vesta_cloud::VestaCloudPairing>>,
+    /// Serializes the daemon's Vesta Cloud pairing handlers. The pairing state
+    /// itself lives ONLY in `<config_dir>/vesta-cloud-pairing.json` (single
+    /// source of truth shared with `vestad vesta-cloud login` and a restarted
+    /// vestad); this lock just keeps concurrent handlers from double-starting.
+    pub(crate) vesta_cloud_pairing_lock: Mutex<()>,
     /// Refresh-token registry: family id → {live/prev jti, exp} (rotation + reuse
     /// detection, see `auth.rs`). Loaded from / persisted to the config dir so a
     /// vestad restart/self-update does NOT invalidate outstanding refresh tokens.
@@ -183,7 +184,7 @@ impl AppState {
                 docker,
                 auth_sessions: Mutex::new(HashMap::new()),
                 openai_auth_sessions: Mutex::new(HashMap::new()),
-                vesta_cloud_pairing: Mutex::new(None),
+                vesta_cloud_pairing_lock: Mutex::new(()),
                 refresh_live: Mutex::new(refresh_live),
                 agent_locks: Mutex::new(HashMap::new()),
                 tunnel_url: Mutex::new(tunnel_url),

--- a/vestad/src/state.rs
+++ b/vestad/src/state.rs
@@ -39,6 +39,25 @@ pub(crate) struct OpenAiAuthSession {
     pub created: std::time::Instant,
 }
 
+/// The in-flight Vesta Cloud pairing, if any (see serve.rs `vesta_cloud_pair_*`).
+/// Single slot: a box pairs to at most one account. The `device_code` is the
+/// control-plane poll secret; it lives ONLY here, never in the agent container.
+#[derive(Clone)]
+pub(crate) struct VestaCloudPairingSession {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_url: String,
+    pub interval: u64,
+    pub expires_in: u64,
+    pub created: std::time::Instant,
+}
+
+impl VestaCloudPairingSession {
+    pub fn is_expired(&self) -> bool {
+        self.created.elapsed().as_secs() > self.expires_in
+    }
+}
+
 impl OpenAiAuthSession {
     pub fn is_expired(&self) -> bool {
         self.created.elapsed().as_secs() > AUTH_SESSION_TIMEOUT_SECS
@@ -106,6 +125,7 @@ pub struct AppState {
     pub(crate) docker: bollard::Docker,
     pub(crate) auth_sessions: Mutex<HashMap<String, AuthSession>>,
     pub(crate) openai_auth_sessions: Mutex<HashMap<String, OpenAiAuthSession>>,
+    pub(crate) vesta_cloud_pairing: Mutex<Option<VestaCloudPairingSession>>,
     /// Refresh-token registry: family id → {live/prev jti, exp} (rotation + reuse
     /// detection, see `auth.rs`). Loaded from / persisted to the config dir so a
     /// vestad restart/self-update does NOT invalidate outstanding refresh tokens.
@@ -178,6 +198,7 @@ impl AppState {
                 docker,
                 auth_sessions: Mutex::new(HashMap::new()),
                 openai_auth_sessions: Mutex::new(HashMap::new()),
+                vesta_cloud_pairing: Mutex::new(None),
                 refresh_live: Mutex::new(refresh_live),
                 agent_locks: Mutex::new(HashMap::new()),
                 tunnel_url: Mutex::new(tunnel_url),

--- a/vestad/src/state.rs
+++ b/vestad/src/state.rs
@@ -39,24 +39,6 @@ pub(crate) struct OpenAiAuthSession {
     pub created: std::time::Instant,
 }
 
-/// The in-flight Vesta Cloud pairing, if any (see serve.rs `vesta_cloud_pair_*`).
-/// Single slot: a box pairs to at most one account. The `device_code` is the
-/// control-plane poll secret; it lives ONLY here, never in the agent container.
-#[derive(Clone)]
-pub(crate) struct VestaCloudPairingSession {
-    pub device_code: String,
-    pub user_code: String,
-    pub verification_url: String,
-    pub interval: u64,
-    pub expires_in: u64,
-    pub created: std::time::Instant,
-}
-
-impl VestaCloudPairingSession {
-    pub fn is_expired(&self) -> bool {
-        self.created.elapsed().as_secs() > self.expires_in
-    }
-}
 
 impl OpenAiAuthSession {
     pub fn is_expired(&self) -> bool {
@@ -125,7 +107,10 @@ pub struct AppState {
     pub(crate) docker: bollard::Docker,
     pub(crate) auth_sessions: Mutex<HashMap<String, AuthSession>>,
     pub(crate) openai_auth_sessions: Mutex<HashMap<String, OpenAiAuthSession>>,
-    pub(crate) vesta_cloud_pairing: Mutex<Option<VestaCloudPairingSession>>,
+    /// In-memory cache of the in-flight Vesta Cloud pairing; the durable copy
+    /// (with the poll secret) lives in `<config_dir>/vesta-cloud-pairing.json`
+    /// so a restart mid-flow can keep polling. Single slot: one box, one link.
+    pub(crate) vesta_cloud_pairing: Mutex<Option<crate::vesta_cloud::VestaCloudPairing>>,
     /// Refresh-token registry: family id → {live/prev jti, exp} (rotation + reuse
     /// detection, see `auth.rs`). Loaded from / persisted to the config dir so a
     /// vestad restart/self-update does NOT invalidate outstanding refresh tokens.

--- a/vestad/src/tunnel.rs
+++ b/vestad/src/tunnel.rs
@@ -474,7 +474,7 @@ fn generate_subdomain(offset: usize) -> String {
     format!("{}-{}", animal, short.trim_end_matches('-'))
 }
 
-fn gethostname() -> String {
+pub(crate) fn gethostname() -> String {
     let output = std::process::Command::new("hostname")
         .output()
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())

--- a/vestad/src/vesta_cloud.rs
+++ b/vestad/src/vesta_cloud.rs
@@ -151,6 +151,313 @@ pub(crate) fn control_base() -> String {
         )
 }
 
+// ---------------------------------------------------------------------------
+// The pairing flow core — ONE implementation, three frontends: the daemon's
+// `/vesta-cloud/*` HTTP surface (apps + agents), `vestad login`/`logout` (the
+// owner at the host shell), and nothing else. Every frontend goes through the
+// functions below; none re-implements the control-plane exchange.
+// ---------------------------------------------------------------------------
+
+const HTTP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+#[derive(serde::Deserialize)]
+struct PairStartResponse {
+    user_code: String,
+    verification_url: String,
+    device_code: String,
+    interval: u64,
+    expires_in: u64,
+}
+
+pub(crate) enum PairStartError {
+    /// The control plane already recognizes this box's key as a live server.
+    AlreadyPaired,
+    /// A non-2xx the caller should surface (status + control-plane error text).
+    Control(String),
+    /// Transport failure (control plane unreachable / bad response shape).
+    Transport(String),
+}
+
+pub(crate) enum PollOutcome {
+    Pending,
+    Linked { server_id: String, control_url: String },
+    /// Terminal control-plane refusal; `gone` = the code expired (HTTP 410).
+    Refused { gone: bool, reason: String },
+}
+
+pub(crate) enum UnpairOutcome {
+    /// The registration was retired (or was already gone server-side).
+    Unpaired { already_gone: bool },
+    /// The control plane rejected the identity token; the link must be kept.
+    IdentityRejected,
+}
+
+/// The current in-flight pairing, if any: loaded from its file, with an expired
+/// one dropped (file removed). The FILE is the single source of truth so the
+/// daemon surface, the host CLI, and a restarted vestad all see the same flow.
+pub(crate) fn current_vesta_cloud_pairing(
+    config_dir: &Path,
+    now_epoch_secs: u64,
+) -> Option<VestaCloudPairing> {
+    let pairing = load_vesta_cloud_pairing(config_dir)?;
+    if pairing.is_expired(now_epoch_secs) {
+        clear_vesta_cloud_pairing(config_dir);
+        return None;
+    }
+    Some(pairing)
+}
+
+/// `vestad vesta-cloud login`: pair this box to a Vesta Cloud account. Runs ON
+/// THE HOST as the owner (the `api_key` never leaves this process), shows the
+/// code + link, and blocks until the owner approves in their signed-in browser.
+/// An in-flight pairing persists to `vesta-cloud-pairing.json`, so an
+/// interrupted login resumes its code (the control plane replays a consumed
+/// pairing's result).
+pub(crate) fn run_login(config_dir: &Path) -> Result<(), String> {
+    if crate::is_cloud_managed() {
+        return Err("this box is already managed by Vesta Cloud; it has its identity from provisioning".to_string());
+    }
+    if load_vesta_cloud_account(config_dir).is_some() {
+        return Err("already paired to a Vesta Cloud account. run `vestad vesta-cloud logout` first to unpair".to_string());
+    }
+    let api_key = crate::serve::ensure_api_key(config_dir)?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("failed to start async runtime: {e}"))?;
+    runtime.block_on(login_flow(config_dir, &api_key))
+}
+
+async fn login_flow(config_dir: &Path, api_key: &str) -> Result<(), String> {
+    let client = reqwest::Client::new();
+    let pairing = start_or_resume_pairing(&client, config_dir, api_key)
+        .await
+        .map_err(|e| match e {
+            PairStartError::AlreadyPaired => "the control plane already recognizes this box's key as a live server. if your account page shows this box, unpair it there first".to_string(),
+            PairStartError::Control(msg) | PairStartError::Transport(msg) => msg,
+        })?;
+
+    let now = crate::time_utils::now_epoch_secs();
+    let minutes_left = pairing.remaining_secs(now).div_ceil(60);
+    eprintln!();
+    eprintln!(
+        "  pairing code: {}",
+        crate::status::paint("1", &pairing.user_code)
+    );
+    eprintln!(
+        "  open {} while signed in and approve the link",
+        crate::status::paint("1", &pairing.verification_url)
+    );
+    eprintln!("  waiting for approval (this code lives about {minutes_left} more minutes)...");
+    eprintln!();
+
+    let interval = std::time::Duration::from_secs(pairing.interval.max(1));
+    loop {
+        if crate::time_utils::now_epoch_secs() >= pairing.expires_at_epoch_secs {
+            clear_vesta_cloud_pairing(config_dir);
+            return Err("the code expired before it was approved. run `vestad vesta-cloud login` again for a fresh one".to_string());
+        }
+        // A transient network error mid-wait must not abort the flow the owner
+        // is completing in the browser; keep polling until the code's deadline.
+        match poll_pairing(&client, config_dir, &pairing.device_code).await {
+            Ok(PollOutcome::Linked { .. }) => {
+                eprintln!(
+                    "  {} paired to your Vesta Cloud account",
+                    crate::status::paint("32", "✓")
+                );
+                return Ok(());
+            }
+            Ok(PollOutcome::Refused { reason, .. }) => {
+                return Err(format!("pairing refused: {reason}"));
+            }
+            Ok(PollOutcome::Pending) | Err(_) => tokio::time::sleep(interval).await,
+        }
+    }
+}
+
+/// Open a pairing with the control plane (or resume the unexpired in-flight
+/// one, so retries never burn a code the owner is already typing). On a fresh
+/// start the pairing is persisted before it is returned.
+pub(crate) async fn start_or_resume_pairing(
+    client: &reqwest::Client,
+    config_dir: &Path,
+    api_key: &str,
+) -> Result<VestaCloudPairing, PairStartError> {
+    let now = crate::time_utils::now_epoch_secs();
+    if let Some(pairing) = current_vesta_cloud_pairing(config_dir, now) {
+        return Ok(pairing);
+    }
+    let base = control_base();
+    let response = client
+        .post(format!("{base}/pair/start"))
+        .timeout(HTTP_TIMEOUT)
+        .json(&serde_json::json!({
+            "api_key": api_key,
+            "box_name": crate::tunnel::gethostname(),
+        }))
+        .send()
+        .await
+        .map_err(|e| {
+            PairStartError::Transport(format!("could not reach the Vesta Cloud control plane: {e}"))
+        })?;
+    let status = response.status();
+    let body: serde_json::Value = response.json().await.map_err(|e| {
+        PairStartError::Transport(format!("invalid pairing start response: {e}"))
+    })?;
+    if !status.is_success() {
+        let error = body.get("error").and_then(|v| v.as_str()).unwrap_or("");
+        if error == "already_paired" {
+            return Err(PairStartError::AlreadyPaired);
+        }
+        return Err(PairStartError::Control(format!(
+            "control plane returned {status}: {error}"
+        )));
+    }
+    let start: PairStartResponse = serde_json::from_value(body).map_err(|e| {
+        PairStartError::Transport(format!("invalid pairing start response: {e}"))
+    })?;
+    let pairing = VestaCloudPairing {
+        device_code: start.device_code,
+        user_code: start.user_code,
+        verification_url: start.verification_url,
+        interval: start.interval,
+        expires_at_epoch_secs: crate::time_utils::now_epoch_secs() + start.expires_in,
+    };
+    save_vesta_cloud_pairing(config_dir, &pairing);
+    Ok(pairing)
+}
+
+/// Forward ONE control-plane poll for `device_code`. `Err` is transport-level
+/// (retry later, the pairing survives); `Refused` is terminal. On `Linked` the
+/// account is persisted and the in-flight pairing cleared HERE, so every
+/// frontend that polls gets the same durable outcome.
+pub(crate) async fn poll_pairing(
+    client: &reqwest::Client,
+    config_dir: &Path,
+    device_code: &str,
+) -> Result<PollOutcome, String> {
+    let base = control_base();
+    let response = client
+        .post(format!("{base}/pair/poll"))
+        .timeout(HTTP_TIMEOUT)
+        .json(&serde_json::json!({ "device_code": device_code }))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    let status = response.status();
+    if status.is_server_error() {
+        return Err(format!("control plane returned {status}"));
+    }
+    let body: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
+    if status.is_success() {
+        return match body.get("status").and_then(|v| v.as_str()) {
+            Some("pending") => Ok(PollOutcome::Pending),
+            Some("linked") => {
+                let (Some(server_id), Some(control_url)) = (
+                    body.get("server_id").and_then(|v| v.as_str()),
+                    body.get("control_url").and_then(|v| v.as_str()),
+                ) else {
+                    return Err("linked response missing server_id/control_url".to_string());
+                };
+                save_vesta_cloud_account(
+                    config_dir,
+                    &VestaCloudAccount {
+                        server_id: server_id.to_string(),
+                        control_url: control_url.to_string(),
+                    },
+                );
+                clear_vesta_cloud_pairing(config_dir);
+                Ok(PollOutcome::Linked {
+                    server_id: server_id.to_string(),
+                    control_url: control_url.to_string(),
+                })
+            }
+            _ => Err("unrecognized pairing poll response".to_string()),
+        };
+    }
+    // A 4xx is a terminal refusal (expired / unknown / account already has a
+    // server), not a transient failure: the dead pairing is cleared.
+    clear_vesta_cloud_pairing(config_dir);
+    let error = body
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or("pairing refused");
+    Ok(PollOutcome::Refused {
+        gone: status == reqwest::StatusCode::GONE,
+        reason: error.to_string(),
+    })
+}
+
+/// Ask the control plane to retire this box's registration. `Err` is
+/// transport-level or an unexpected status; on `Unpaired` the local account
+/// link is cleared HERE (a 404 means it was already gone server-side, e.g. a
+/// dashboard unpair). `IdentityRejected` keeps the link on purpose.
+pub(crate) async fn request_unpair(
+    client: &reqwest::Client,
+    config_dir: &Path,
+    api_key: &str,
+    account: &VestaCloudAccount,
+) -> Result<UnpairOutcome, String> {
+    let token = crate::jwt::create_server_identity_token(api_key, &account.server_id);
+    let response = client
+        .post(format!("{}/pair/unpair", account.control_url))
+        .timeout(HTTP_TIMEOUT)
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|e| format!("could not reach the Vesta Cloud control plane: {e}"))?;
+
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Ok(UnpairOutcome::IdentityRejected);
+    }
+    let already_gone = status == reqwest::StatusCode::NOT_FOUND;
+    if !status.is_success() && !already_gone {
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("control plane returned {status}: {text}"));
+    }
+    clear_vesta_cloud_account(config_dir);
+    Ok(UnpairOutcome::Unpaired { already_gone })
+}
+
+// ---------------------------------------------------------------------------
+// `vestad login` / `vestad logout` — the owner-at-the-host frontend
+// ---------------------------------------------------------------------------
+
+/// `vestad vesta-cloud logout`: unpair this box from its Vesta Cloud account.
+pub(crate) fn run_logout(config_dir: &Path) -> Result<(), String> {
+    if crate::is_cloud_managed() {
+        return Err("a managed Vesta Cloud box cannot unpair".to_string());
+    }
+    let Some(account) = load_vesta_cloud_account(config_dir) else {
+        eprintln!("this box is not paired to a Vesta Cloud account");
+        return Ok(());
+    };
+    let api_key = crate::serve::ensure_api_key(config_dir)?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("failed to start async runtime: {e}"))?;
+    runtime.block_on(async {
+        let client = reqwest::Client::new();
+        match request_unpair(&client, config_dir, &api_key, &account).await? {
+            UnpairOutcome::IdentityRejected => Err(
+                "the control plane rejected this box's identity (has the api key changed since pairing?); the link was NOT cleared. remove the box from the vesta.run dashboard, then run `vestad vesta-cloud logout` again".to_string(),
+            ),
+            UnpairOutcome::Unpaired { already_gone } => {
+                if already_gone {
+                    eprintln!("the account link was already removed on vesta.run; local link cleared");
+                }
+                eprintln!(
+                    "  {} unpaired from Vesta Cloud",
+                    crate::status::paint("32", "✓")
+                );
+                Ok(())
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -288,5 +595,26 @@ mod tests {
         clear_vesta_cloud_pairing(dir.path());
         assert_eq!(load_vesta_cloud_pairing(dir.path()), None);
         clear_vesta_cloud_pairing(dir.path()); // absent: no-op
+    }
+
+    #[test]
+    fn current_pairing_resumes_from_disk_and_drops_when_expired() {
+        // The file is the single source of truth: a restarted vestad (or the
+        // host CLI) resumes the in-flight pairing, so the device_code survives
+        // to reach the control plane's consumed-pairing replay branch.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pairing = VestaCloudPairing {
+            device_code: "d".repeat(64),
+            user_code: "BCDF-2345".to_string(),
+            verification_url: "https://vesta.run/pair?code=BCDF-2345".to_string(),
+            interval: 5,
+            expires_at_epoch_secs: 1_000,
+        };
+        save_vesta_cloud_pairing(dir.path(), &pairing);
+        assert_eq!(current_vesta_cloud_pairing(dir.path(), 500), Some(pairing));
+
+        // Once expired it is dropped AND its file removed.
+        assert_eq!(current_vesta_cloud_pairing(dir.path(), 1_000), None);
+        assert_eq!(load_vesta_cloud_pairing(dir.path()), None);
     }
 }

--- a/vestad/src/vesta_cloud.rs
+++ b/vestad/src/vesta_cloud.rs
@@ -3,8 +3,9 @@
 //! A box holds a Vesta Cloud account when the control plane recognizes its
 //! `(server_id, api_key)`. A managed VM gets that identity from cloud-init env
 //! (`VESTA_CLOUD_SERVER_ID`); a self-hosted box acquires it through the pairing
-//! flow (`/agents/{name}/vesta-cloud/pair`, RFC 8628 device-authorization
-//! shape) and persists it here as `<config_dir>/vesta-cloud-account.json`.
+//! flow (RFC 8628 device-authorization shape, daemon routes `/vesta-cloud/*`
+//! or the `vestad vesta-cloud login` CLI) and persists it here as
+//! `<config_dir>/vesta-cloud-account.json`.
 //! `resolve_vesta_cloud_identity` is the single answer to "what is this box's
 //! Vesta Cloud identity": cloud-init env first, else the persisted pairing.
 

--- a/vestad/src/vesta_cloud.rs
+++ b/vestad/src/vesta_cloud.rs
@@ -55,9 +55,12 @@ pub(crate) fn clear_vesta_cloud_account(config_dir: &Path) {
 }
 
 /// The box's Vesta Cloud identity, if any: `(server_id, control_url)`.
-/// Cloud-init env wins (a managed VM with a stray pairing file stays managed);
-/// a paired self-hosted box answers from `vesta-cloud-account.json`.
-/// Pure over its inputs so tests never mutate process env.
+/// A MANAGED box answers only from cloud-init env: when the env server id is
+/// missing there it has no identity, and a stray `vesta-cloud-account.json`
+/// left over from a self-hosted past must never supply one (it would mint
+/// tokens for, and open billing of, the old account's row). Only an unmanaged
+/// box answers from the pairing file. Pure over its inputs so tests never
+/// mutate process env.
 pub(crate) fn resolve_vesta_cloud_identity(
     config_dir: &Path,
     cloud_managed: bool,
@@ -65,9 +68,7 @@ pub(crate) fn resolve_vesta_cloud_identity(
     env_control_url: Option<String>,
 ) -> Option<(String, Option<String>)> {
     if cloud_managed {
-        if let Some(server_id) = env_server_id {
-            return Some((server_id, env_control_url));
-        }
+        return env_server_id.map(|server_id| (server_id, env_control_url));
     }
     load_vesta_cloud_account(config_dir).map(|a| (a.server_id, Some(a.control_url)))
 }
@@ -80,6 +81,62 @@ pub(crate) fn vesta_cloud_identity(config_dir: &Path) -> Option<(String, Option<
         std::env::var("VESTA_CLOUD_SERVER_ID").ok(),
         std::env::var("VESTA_CLOUD_CONTROL_URL").ok(),
     )
+}
+
+/// One in-flight pairing attempt, persisted to `<config_dir>/vesta-cloud-pairing.json`
+/// so a vestad restart mid-flow can keep polling: the control plane replays a
+/// consumed pairing's result to the same `device_code`, and that secret exists
+/// nowhere else (it never enters the agent container).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct VestaCloudPairing {
+    pub(crate) device_code: String,
+    pub(crate) user_code: String,
+    pub(crate) verification_url: String,
+    pub(crate) interval: u64,
+    pub(crate) expires_at_epoch_secs: u64,
+}
+
+impl VestaCloudPairing {
+    pub(crate) fn is_expired(&self, now_epoch_secs: u64) -> bool {
+        now_epoch_secs >= self.expires_at_epoch_secs
+    }
+
+    /// Seconds of code lifetime left; what a resumed `pair` reports as
+    /// `expires_in` so the skill's poll deadline matches reality.
+    pub(crate) fn remaining_secs(&self, now_epoch_secs: u64) -> u64 {
+        self.expires_at_epoch_secs.saturating_sub(now_epoch_secs)
+    }
+}
+
+pub(crate) fn vesta_cloud_pairing_path(config_dir: &Path) -> PathBuf {
+    config_dir.join("vesta-cloud-pairing.json")
+}
+
+/// Load the persisted in-flight pairing; missing = none, corrupt = warn + none.
+pub(crate) fn load_vesta_cloud_pairing(config_dir: &Path) -> Option<VestaCloudPairing> {
+    let path = vesta_cloud_pairing_path(config_dir);
+    let data = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str(&data) {
+        Ok(pairing) => Some(pairing),
+        Err(err) => {
+            tracing::warn!(path = %path.display(), error = %err, "corrupt vesta-cloud-pairing.json, discarding");
+            None
+        }
+    }
+}
+
+/// Persist the in-flight pairing (owner-only: it holds the poll secret).
+pub(crate) fn save_vesta_cloud_pairing(config_dir: &Path, pairing: &VestaCloudPairing) {
+    crate::settings::save_json_atomic(
+        &vesta_cloud_pairing_path(config_dir),
+        pairing,
+        Some(0o600),
+    );
+}
+
+/// Remove the in-flight pairing (finished or dead). No-op when absent.
+pub(crate) fn clear_vesta_cloud_pairing(config_dir: &Path) {
+    let _ = std::fs::remove_file(vesta_cloud_pairing_path(config_dir));
 }
 
 /// The control-plane API base to PAIR against: `VESTA_CLOUD_CONTROL_URL` (so a
@@ -190,7 +247,46 @@ mod tests {
     fn identity_none_when_neither_source_exists() {
         let dir = tempfile::tempdir().expect("tempdir");
         assert_eq!(resolve_vesta_cloud_identity(dir.path(), false, None, None), None);
-        // Managed but no server id seeded: the file (absent) is still the fallback.
         assert_eq!(resolve_vesta_cloud_identity(dir.path(), true, None, None), None);
+    }
+
+    #[test]
+    fn managed_box_without_env_id_never_reads_a_stale_pairing_file() {
+        // A managed VM whose cloud-init seeding failed must answer "no
+        // identity", not adopt the identity of a self-hosted past.
+        let dir = tempfile::tempdir().expect("tempdir");
+        save_vesta_cloud_account(
+            dir.path(),
+            &VestaCloudAccount {
+                server_id: "srv_stale".to_string(),
+                control_url: "https://vesta.run/api".to_string(),
+            },
+        );
+        assert_eq!(resolve_vesta_cloud_identity(dir.path(), true, None, None), None);
+    }
+
+    #[test]
+    fn pairing_roundtrips_expires_and_clears() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(load_vesta_cloud_pairing(dir.path()), None);
+
+        let pairing = VestaCloudPairing {
+            device_code: "d".repeat(64),
+            user_code: "BCDF-2345".to_string(),
+            verification_url: "https://vesta.run/pair?code=BCDF-2345".to_string(),
+            interval: 5,
+            expires_at_epoch_secs: 1_000,
+        };
+        save_vesta_cloud_pairing(dir.path(), &pairing);
+        assert_eq!(load_vesta_cloud_pairing(dir.path()), Some(pairing.clone()));
+
+        assert!(!pairing.is_expired(999));
+        assert!(pairing.is_expired(1_000));
+        assert_eq!(pairing.remaining_secs(400), 600);
+        assert_eq!(pairing.remaining_secs(2_000), 0);
+
+        clear_vesta_cloud_pairing(dir.path());
+        assert_eq!(load_vesta_cloud_pairing(dir.path()), None);
+        clear_vesta_cloud_pairing(dir.path()); // absent: no-op
     }
 }

--- a/vestad/src/vesta_cloud.rs
+++ b/vestad/src/vesta_cloud.rs
@@ -1,0 +1,196 @@
+//! The box's Vesta Cloud account link.
+//!
+//! A box holds a Vesta Cloud account when the control plane recognizes its
+//! `(server_id, api_key)`. A managed VM gets that identity from cloud-init env
+//! (`VESTA_CLOUD_SERVER_ID`); a self-hosted box acquires it through the pairing
+//! flow (`/agents/{name}/vesta-cloud/pair`, RFC 8628 device-authorization
+//! shape) and persists it here as `<config_dir>/vesta-cloud-account.json`.
+//! `resolve_vesta_cloud_identity` is the single answer to "what is this box's
+//! Vesta Cloud identity": cloud-init env first, else the persisted pairing.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+pub(crate) const DEFAULT_CONTROL_URL: &str = "https://vesta.run/api";
+
+/// The persisted account link: which control-plane server this box IS, and the
+/// control-plane API base it was paired against (staging vs prod).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct VestaCloudAccount {
+    pub(crate) server_id: String,
+    pub(crate) control_url: String,
+}
+
+pub(crate) fn vesta_cloud_account_path(config_dir: &Path) -> PathBuf {
+    config_dir.join("vesta-cloud-account.json")
+}
+
+/// Load the persisted account link. A missing file is the normal unpaired
+/// state; a corrupt file is logged and treated as unpaired (re-pair heals it).
+pub(crate) fn load_vesta_cloud_account(config_dir: &Path) -> Option<VestaCloudAccount> {
+    let path = vesta_cloud_account_path(config_dir);
+    let data = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str(&data) {
+        Ok(account) => Some(account),
+        Err(err) => {
+            tracing::warn!(path = %path.display(), error = %err, "corrupt vesta-cloud-account.json, treating as unpaired");
+            None
+        }
+    }
+}
+
+/// Persist the account link (owner-only: it names the box's cloud identity).
+pub(crate) fn save_vesta_cloud_account(config_dir: &Path, account: &VestaCloudAccount) {
+    crate::settings::save_json_atomic(
+        &vesta_cloud_account_path(config_dir),
+        account,
+        Some(0o600),
+    );
+}
+
+/// Remove the account link (unpair). A no-op when the file is absent.
+pub(crate) fn clear_vesta_cloud_account(config_dir: &Path) {
+    let _ = std::fs::remove_file(vesta_cloud_account_path(config_dir));
+}
+
+/// The box's Vesta Cloud identity, if any: `(server_id, control_url)`.
+/// Cloud-init env wins (a managed VM with a stray pairing file stays managed);
+/// a paired self-hosted box answers from `vesta-cloud-account.json`.
+/// Pure over its inputs so tests never mutate process env.
+pub(crate) fn resolve_vesta_cloud_identity(
+    config_dir: &Path,
+    cloud_managed: bool,
+    env_server_id: Option<String>,
+    env_control_url: Option<String>,
+) -> Option<(String, Option<String>)> {
+    if cloud_managed {
+        if let Some(server_id) = env_server_id {
+            return Some((server_id, env_control_url));
+        }
+    }
+    load_vesta_cloud_account(config_dir).map(|a| (a.server_id, Some(a.control_url)))
+}
+
+/// `resolve_vesta_cloud_identity` over the live environment.
+pub(crate) fn vesta_cloud_identity(config_dir: &Path) -> Option<(String, Option<String>)> {
+    resolve_vesta_cloud_identity(
+        config_dir,
+        crate::is_cloud_managed(),
+        std::env::var("VESTA_CLOUD_SERVER_ID").ok(),
+        std::env::var("VESTA_CLOUD_CONTROL_URL").ok(),
+    )
+}
+
+/// The control-plane API base to PAIR against: `VESTA_CLOUD_CONTROL_URL` (so a
+/// box can pair to staging) or the production default.
+pub(crate) fn control_base() -> String {
+    std::env::var("VESTA_CLOUD_CONTROL_URL")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .map_or_else(
+            || DEFAULT_CONTROL_URL.to_string(),
+            |v| v.trim().trim_end_matches('/').to_string(),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn account_roundtrips_with_owner_only_mode() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let account = VestaCloudAccount {
+            server_id: "srv_123".to_string(),
+            control_url: "https://vesta.run/api".to_string(),
+        };
+        save_vesta_cloud_account(dir.path(), &account);
+        assert_eq!(load_vesta_cloud_account(dir.path()), Some(account));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(vesta_cloud_account_path(dir.path()))
+                .expect("metadata")
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+    }
+
+    #[test]
+    fn corrupt_account_file_is_unpaired() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(vesta_cloud_account_path(dir.path()), "not json").expect("write");
+        assert_eq!(load_vesta_cloud_account(dir.path()), None);
+    }
+
+    #[test]
+    fn clear_removes_the_file_and_tolerates_absence() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        clear_vesta_cloud_account(dir.path()); // absent: no-op
+        save_vesta_cloud_account(
+            dir.path(),
+            &VestaCloudAccount {
+                server_id: "srv".to_string(),
+                control_url: "u".to_string(),
+            },
+        );
+        clear_vesta_cloud_account(dir.path());
+        assert_eq!(load_vesta_cloud_account(dir.path()), None);
+    }
+
+    #[test]
+    fn identity_prefers_cloud_env_over_pairing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        save_vesta_cloud_account(
+            dir.path(),
+            &VestaCloudAccount {
+                server_id: "srv_paired".to_string(),
+                control_url: "https://staging.vesta.run/api".to_string(),
+            },
+        );
+        let identity = resolve_vesta_cloud_identity(
+            dir.path(),
+            true,
+            Some("srv_env".to_string()),
+            Some("https://vesta.run/api".to_string()),
+        );
+        assert_eq!(
+            identity,
+            Some((
+                "srv_env".to_string(),
+                Some("https://vesta.run/api".to_string())
+            ))
+        );
+    }
+
+    #[test]
+    fn identity_falls_back_to_pairing_file_when_unmanaged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        save_vesta_cloud_account(
+            dir.path(),
+            &VestaCloudAccount {
+                server_id: "srv_paired".to_string(),
+                control_url: "https://staging.vesta.run/api".to_string(),
+            },
+        );
+        let identity = resolve_vesta_cloud_identity(dir.path(), false, None, None);
+        assert_eq!(
+            identity,
+            Some((
+                "srv_paired".to_string(),
+                Some("https://staging.vesta.run/api".to_string())
+            ))
+        );
+    }
+
+    #[test]
+    fn identity_none_when_neither_source_exists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(resolve_vesta_cloud_identity(dir.path(), false, None, None), None);
+        // Managed but no server id seeded: the file (absent) is still the fallback.
+        assert_eq!(resolve_vesta_cloud_identity(dir.path(), true, None, None), None);
+    }
+}


### PR DESCRIPTION
The daemon + skill half of self-hosted pairing. Requires the control-plane endpoints in elyxlz/vesta-cloud#139 (merge/deploy that first; this code is inert until an owner runs `vesta-cloud login`). Design doc rides that PR (`docs/self-hosted-pairing.md`).

## vestad

- New module `vestad/src/vesta_cloud.rs`: the box's Vesta Cloud account link. Persists `<config_dir>/vesta-cloud-account.json` (`{server_id, control_url}`, 0600, atomic write), and resolves the box's identity with cloud-init env winning over the pairing file.
- New agent-token routes `POST /agents/{name}/vesta-cloud/pair`, `.../pair/poll`, `.../unpair`. The host `api_key` and the control-plane `device_code` never enter the agent container; the agent only relays `user_code` + `verification_url`. Poll mirrors the ChatGPT device flow (409 while pending). Unpair proves identity with a locally-minted server-identity token and clears the local file even when the control plane already forgot the link (dashboard unpair recovery). Managed VMs refuse to pair or unpair.
- `account_token_handler` drops its env-only gates for the identity resolver, so a paired self-hosted box mints exactly like a managed VM (an unpaired box still 404s, which `whoami` depends on). The response gains a nullable `control_url` so a staging-paired box routes the skill correctly.

## vesta-cloud skill

- `login`: prints the code + link first (relay to the owner immediately), then polls until linked and ends with a whoami-style confirmation. `logout`: unpair + local cleanup. SKILL.md documents both.
- `plan` / `manage` / `referral` / `token` now prefer the mint response's `control_url` over the configured default.

## Tests

- vesta_cloud.rs unit tests (roundtrip + 0600 mode, corrupt file, clear, identity precedence via the pure resolver), agent-name self-scoping pinned for the new nested paths (auth.rs), 6 new CLI tests (login relay/terminal/timeout, logout).
- `./check.sh vestad` green (clippy -D warnings, 344 tests). vesta-cloud skill pytest: 29 passed. Note: `./check.sh agent`'s core suite has 3 failures that reproduce identically on clean `origin/master` in this environment (2x test_migrations workspace-repair, 1x flaky daemon race under full-suite load); none touch this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)