### PR TITLE
fix(whatsapp): make DoubleTick connect and recovery deterministic

### DIFF
--- a/agent/skills/whatsapp/SETUP_DOUBLETICK.md
+++ b/agent/skills/whatsapp/SETUP_DOUBLETICK.md
@@ -18,6 +18,19 @@ output. Never ask the user to paste it into a conversation and never add it to
 `.bashrc`. If it is absent, ask the operator to set it outside chat and tell you
 when the environment is ready.
 
+For an already-running Vesta container, the operator can create a temporary
+mode-`0600` env file on the host containing the two values, then run:
+
+```bash
+docker exec --env-file /secure/path/doubletick.env <agent-container> \
+  whatsapp connect --source doubletick --opener '<text>'
+```
+
+The key enters only that CLI process, crosses the owner-only WhatsApp socket, and
+is saved in owner-only state for later daemon boots. Remove the temporary host file
+after the command. The agent should then use `whatsapp status`; do not ask for the
+file contents or repeat the connect command.
+
 Run `whatsapp status` first; stop if linked or connecting.
 
 ## Connect

--- a/agent/skills/whatsapp/SETUP_DOUBLETICK.md
+++ b/agent/skills/whatsapp/SETUP_DOUBLETICK.md
@@ -14,7 +14,9 @@ export DOUBLETICK_API_KEY='wak_account-scoped-key'
 ```
 
 Set both or neither, and keep the key out of chat, logs, commits, and command
-output.
+output. Never ask the user to paste it into a conversation and never add it to
+`.bashrc`. If it is absent, ask the operator to set it outside chat and tell you
+when the environment is ready.
 
 Run `whatsapp status` first; stop if linked or connecting.
 
@@ -29,6 +31,10 @@ whatsapp connect --source doubletick --opener 'Hi, it is me, nice to meet you he
 The CLI authenticates to Double Tick with the `wak_` key, provisions or recovers
 the account, and pairs the companion over the account's
 [residential proxy lease](HEADLESS.md#residential-proxy-lease).
+
+`connect` carries credentials to an already-running daemon over its private Unix
+socket and saves them in mode-`0600` WhatsApp state. Do not restart the daemon to
+make new credentials visible.
 
 Follow the returned `next`. Reply-first behavior is in [SKILL.md](SKILL.md);
 recovery outcomes are in [SETUP.md](SETUP.md#status-and-recovery). Use the Double

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -520,9 +520,13 @@ func cleanupRejectedPairing(cleanup func(), activePort, requestedPort int) {
 // rate-limit slot or serves a blank QR). One call is the whole flow: no start/status/stop
 // trio and no client-side poll loop.
 func cmdLink(args []string, wac *WhatsAppClient) (any, error) {
-	return linkViaQR("link", args, wac, func(port int) (linkResult, error) {
+	result, err := linkViaQR("link", args, wac, func(port int) (linkResult, error) {
 		return wac.linker.linkQR(wac, port)
 	}, map[string]any{"status": string(AuthStatusAuthenticated)})
+	if err == nil {
+		wac.state.recordAccountSource(sourceSelfManaged)
+	}
+	return result, err
 }
 
 func cmdDaemonStatus(args []string, wac *WhatsAppClient) (any, error) {
@@ -544,6 +548,7 @@ func cmdDaemonStatus(args []string, wac *WhatsAppClient) (any, error) {
 		"pair_attempts_last_7d":    len(attemptsWithin(st.PairAttempts, now, PairWeekWindow)),
 	}
 	if wac.client.Store.ID != nil {
+		wac.state.recordAccountSource(source)
 		result["number"] = "+" + wac.client.Store.ID.User
 	}
 	if linkPort, linkService := wac.activeLink(); linkPort != 0 {
@@ -1182,6 +1187,7 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 		}
 		return nil, err
 	}
+	wac.state.recordAccountSource(source)
 	// A new number (first claim or a healed replacement) gets the reply-first
 	// onboarding; re-linking the same established number is a quiet resume.
 	if priorOnboardedMSISDN == "" || priorOnboardedMSISDN != res.MSISDN {
@@ -1309,6 +1315,7 @@ func cmdPairPhone(args []string, wac *WhatsAppClient) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate pairing code: %v", err)
 	}
+	wac.state.recordAccountSource(sourceSelfManaged)
 	wac.markPhonePairingPending(time.Now())
 	return map[string]any{
 		"pairing_code": code,

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -1100,13 +1100,6 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Persist the explicit recovery intent once its shape is valid, before network
-	// or pairing work begins. This deliberately supersedes a prior source even when
-	// the attempt later fails: if pairing logs the device out, recovery must retry
-	// the source the user selected rather than silently infer another one from a
-	// mixed environment. Direct credentials themselves remain uncommitted until
-	// finish(true), so a rejected unlinked provision cannot replace working secrets.
-	wac.state.recordAccountSource(source)
 	finishedSource := false
 	finish := func(commit bool) {
 		if !finishedSource {
@@ -1119,6 +1112,7 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 		// Configuration is useful even when no pairing is needed. In particular, a
 		// warm self-managed daemon may already hold the device produced by an earlier
 		// Double Tick connect but still need its managed data path installed.
+		wac.state.recordAccountSource(source)
 		finish(true)
 		// Already linked. If a takeover parked it, an explicit connect means
 		// "reclaim the session": clear the park and reconnect (a plain send never
@@ -1158,6 +1152,13 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 		return nil, errPairingInProgress
 	}
 	defer release()
+	// Persist the explicit recovery intent inside the single-flight, before network
+	// or pairing work begins. This deliberately supersedes a prior source even when
+	// the attempt later fails: if pairing logs the device out, recovery must retry
+	// the source the user selected rather than silently infer another one from a
+	// mixed environment. Direct credentials themselves remain uncommitted until
+	// finish(true), so a rejected unlinked provision cannot replace working secrets.
+	wac.state.recordAccountSource(source)
 	// Capture the number we held BEFORE provisioning: a first-ever claim (no prior
 	// number) or a control-plane heal onto a different number is a genuinely new
 	// number that needs onboarding; re-linking the same established number is a

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -1079,10 +1079,12 @@ func cmdCheckDelivery(args []string, wac *WhatsAppClient) (any, error) {
 // cold-starts the daemon before dispatching this, so the agent runs one command
 // and never orchestrates the steps itself.
 func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
-	var opener, source string
+	var opener, source, directURL, directKey string
 	fs := flag.NewFlagSet("provision", flag.ContinueOnError)
 	fs.StringVar(&opener, "opener", "", "Agent-authored first-contact greeting prefilled in the wa.me link")
 	fs.StringVar(&source, "source", "", "Resolved account source; `cloud` pins the pairing auth to the server-identity token")
+	fs.StringVar(&directURL, "direct-url", "", "Internal Double Tick API URL handoff")
+	fs.StringVar(&directKey, "direct-key", "", "Internal Double Tick API key handoff")
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
@@ -1130,18 +1132,14 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 	// number that needs onboarding; re-linking the same established number is a
 	// resume that must not tell Vesta to stop initiating mid-relationship.
 	priorOnboardedMSISDN := wac.state.snapshot().OnboardedMSISDN
-	// Honor the agent's explicit --source over the daemon's boot-time linker: a warm
-	// daemon that booted with direct pool creds still pairs off the server-identity
-	// token when the agent says `--source vesta-cloud`. wac.managed is only read on this
-	// single-flighted pairing path, so overriding it for the call (and restoring it
-	// after) races nothing; wac.linker is left untouched (the data path reads it).
-	pairLinker := wac.linker
-	if effAuth := cloudSourceAuth(source); effAuth != nil {
-		saved := wac.managed
-		wac.managed = effAuth
-		defer func() { wac.managed = saved }()
-		pairLinker = &managedLinker{auth: effAuth, state: wac.state}
+	// Honor the agent's explicit source over the daemon's boot-time linker. This
+	// switches a pre-credential daemon into Double Tick mode, or temporarily pins
+	// Vesta Cloud token auth when both credential sources exist.
+	pairLinker, restoreAuth, err := wac.provisionLinker(source, directURL, directKey)
+	if err != nil {
+		return nil, err
 	}
+	defer restoreAuth()
 	res, err := pairLinker.provision(wac)
 	if err != nil {
 		// A still-filling pool and a banned number are normal outcomes, not

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -1100,9 +1100,12 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Persist the explicit choice once its shape is valid, before network or pairing
-	// work begins. If that work logs the device out, recovery must retry the source
-	// the user selected rather than infer another one from a mixed environment.
+	// Persist the explicit recovery intent once its shape is valid, before network
+	// or pairing work begins. This deliberately supersedes a prior source even when
+	// the attempt later fails: if pairing logs the device out, recovery must retry
+	// the source the user selected rather than silently infer another one from a
+	// mixed environment. Direct credentials themselves remain uncommitted until
+	// finish(true), so a rejected unlinked provision cannot replace working secrets.
 	wac.state.recordAccountSource(source)
 	finishedSource := false
 	finish := func(commit bool) {

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -76,8 +76,12 @@ func extractSkipSenders() map[string]bool {
 // stateDataDir is the per-instance data directory under ~/.whatsapp (the bare
 // directory for the default instance, a named subdirectory otherwise).
 func stateDataDir() string {
+	return stateDataDirFor(extractInstance())
+}
+
+func stateDataDirFor(instance string) string {
 	base := filepath.Join(os.Getenv("HOME"), ".whatsapp")
-	if instance := extractInstance(); instance != "" {
+	if instance != "" {
 		return filepath.Join(base, instance)
 	}
 	return base

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -517,7 +517,7 @@ func cleanupRejectedPairing(cleanup func(), activePort, requestedPort int) {
 // trio and no client-side poll loop.
 func cmdLink(args []string, wac *WhatsAppClient) (any, error) {
 	return linkViaQR("link", args, wac, func(port int) (linkResult, error) {
-		return wac.linker.linkQR(wac, port)
+		return wac.currentLinker().linkQR(wac, port)
 	}, map[string]any{"status": string(AuthStatusAuthenticated)})
 }
 
@@ -1088,7 +1088,23 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
+	pairLinker, finishSource, err := wac.provisionLinker(source, directURL, directKey)
+	if err != nil {
+		return nil, err
+	}
+	finishedSource := false
+	finish := func(commit bool) {
+		if !finishedSource {
+			finishSource(commit)
+			finishedSource = true
+		}
+	}
+	defer finish(false)
 	if wac.client.Store.ID != nil {
+		// Configuration is useful even when no pairing is needed. In particular, a
+		// warm self-managed daemon may already hold the device produced by an earlier
+		// Double Tick connect but still need its managed data path installed.
+		finish(true)
 		// Already linked. If a takeover parked it, an explicit connect means
 		// "reclaim the session": clear the park and reconnect (a plain send never
 		// does this, so it can't ping-pong). If the other holder is still live it
@@ -1135,11 +1151,6 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 	// Honor the agent's explicit source over the daemon's boot-time linker. This
 	// switches a pre-credential daemon into Double Tick mode, or temporarily pins
 	// Vesta Cloud token auth when both credential sources exist.
-	pairLinker, restoreAuth, err := wac.provisionLinker(source, directURL, directKey)
-	if err != nil {
-		return nil, err
-	}
-	defer restoreAuth()
 	res, err := pairLinker.provision(wac)
 	if err != nil {
 		// A still-filling pool and a banned number are normal outcomes, not
@@ -1176,6 +1187,7 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 		}
 		return nil, err
 	}
+	finish(true)
 	// A new number (first claim or a healed replacement) gets the reply-first
 	// onboarding; re-linking the same established number is a quiet resume.
 	if priorOnboardedMSISDN == "" || priorOnboardedMSISDN != res.MSISDN {
@@ -1213,8 +1225,8 @@ func managedProfileName(agentName string) string {
 func (wac *WhatsAppClient) completeFreshProfile() error {
 	if wac.state.snapshot().FreshNameSetPending {
 		agentName := ""
-		if wac.managed != nil {
-			agentName = wac.managed.cfg.agentName
+		if managed := wac.currentManaged(); managed != nil {
+			agentName = managed.cfg.agentName
 		}
 		setName := wac.SetProfileName
 		if wac.setFreshProfileName != nil {
@@ -1299,7 +1311,7 @@ func cmdPairPhone(args []string, wac *WhatsAppClient) (any, error) {
 	if err := checkPairAttempt(wac.state.snapshot().PairAttempts, time.Now(), acknowledged); err != nil {
 		return nil, err
 	}
-	code, err := wac.linker.pairCode(wac, phone)
+	code, err := wac.currentLinker().pairCode(wac, phone)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate pairing code: %v", err)
 	}

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -548,7 +548,6 @@ func cmdDaemonStatus(args []string, wac *WhatsAppClient) (any, error) {
 		"pair_attempts_last_7d":    len(attemptsWithin(st.PairAttempts, now, PairWeekWindow)),
 	}
 	if wac.client.Store.ID != nil {
-		wac.state.recordAccountSource(source)
 		result["number"] = "+" + wac.client.Store.ID.User
 	}
 	if linkPort, linkService := wac.activeLink(); linkPort != 0 {
@@ -1096,6 +1095,7 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 		return nil, err
 	}
 	if wac.client.Store.ID != nil {
+		wac.state.recordAccountSource(source)
 		// Already linked. If a takeover parked it, an explicit connect means
 		// "reclaim the session": clear the park and reconnect (a plain send never
 		// does this, so it can't ping-pong). If the other holder is still live it

--- a/agent/skills/whatsapp/cli/client.go
+++ b/agent/skills/whatsapp/cli/client.go
@@ -65,6 +65,7 @@ type WhatsAppClient struct {
 	senderOrder      []string
 	sendersMutex     sync.RWMutex
 	state            *stateStore
+	linkerMu         sync.RWMutex // guards linker + managed during a live source change
 	linker           linker
 	// managed is the pool-API client when this box links a managed number (nil on a
 	// self-hosted QR box). It leases the residential proxy the cloud companion egresses
@@ -288,17 +289,24 @@ func datacenterEgress(info egressInfo) bool {
 // Every selected path is inspected through that path. Managed and proxy paths fail
 // closed when inspection is unavailable; plain QR boxes may connect with a warning.
 func (wac *WhatsAppClient) ensureManagedProxy() error {
-	if wac.managed == nil {
-		wac.managed = newManagedAuth(loadManagedConfig())
+	return wac.ensureManagedProxyFor(wac.currentManaged())
+}
+
+// ensureManagedProxyFor selects egress with the auth chosen for this operation.
+// Provisioning can therefore validate a newly supplied source before installing it
+// as the daemon's durable data path.
+func (wac *WhatsAppClient) ensureManagedProxyFor(auth *managedAuth) error {
+	if auth == nil {
+		auth = newManagedAuth(loadManagedConfig())
 	}
 	wac.proxyMu.Lock()
 	defer wac.proxyMu.Unlock()
 
-	selected := wac.managed.cfg.proxyURL
-	if selected == "" && wac.managed.usesResidentialProxy() {
+	selected := auth.cfg.proxyURL
+	if selected == "" && auth.usesResidentialProxy() {
 		selected = wac.proxyURL
 		if selected == "" {
-			leased, err := wac.managed.leaseProxy()
+			leased, err := auth.leaseProxy()
 			if err != nil {
 				return err
 			}
@@ -311,7 +319,7 @@ func (wac *WhatsAppClient) ensureManagedProxy() error {
 	if !cached {
 		info, err = lookupEgress(selected)
 		if err != nil {
-			if selected == "" && !wac.managed.isHosted() {
+			if selected == "" && !auth.isHosted() {
 				wac.logger.Warnf("Could not inspect direct WhatsApp egress; proceeding with plain QR connection: %v", err)
 				return nil
 			}
@@ -319,10 +327,10 @@ func (wac *WhatsAppClient) ensureManagedProxy() error {
 		}
 	}
 	if selected == "" && datacenterEgress(info) {
-		if !wac.managed.isHosted() {
+		if !auth.isHosted() {
 			return fmt.Errorf("WhatsApp egress IP %s is a datacenter/hosting exit; obtain a residential proxy and set WHATSAPP_PROXY_URL", info.Query)
 		}
-		leased, err := wac.managed.leaseProxy()
+		leased, err := auth.leaseProxy()
 		if err != nil {
 			return fmt.Errorf("datacenter egress detected and doubletick could not lease a residential proxy: %w", err)
 		}

--- a/agent/skills/whatsapp/cli/connect.go
+++ b/agent/skills/whatsapp/cli/connect.go
@@ -105,6 +105,8 @@ type connectRoute struct {
 	opener    string
 	linkPhone string
 	source    string
+	directURL string
+	directKey string
 }
 
 // resolveConnect validates --source against the box environment and returns the path
@@ -125,7 +127,13 @@ func resolveConnect(opts connectOptions, cfg managedConfig) (connectRoute, error
 		if !cfg.isDirect() {
 			return connectRoute{}, fmt.Errorf("--source doubletick needs DOUBLETICK_API_URL and DOUBLETICK_API_KEY set together")
 		}
-		return connectRoute{provision: true, opener: opts.opener, source: sourceDoubletick}, nil
+		return connectRoute{
+			provision: true,
+			opener:    opts.opener,
+			source:    sourceDoubletick,
+			directURL: cfg.directURL,
+			directKey: cfg.directKey,
+		}, nil
 	default: // sourceSelfManaged, already validated above
 		// A box on the managed-pool paradigm cannot link the user's own account:
 		// its daemon builds a managed linker that rejects a QR/phone link.
@@ -194,7 +202,7 @@ func runConnect() {
 func dispatchConnectRoute(route connectRoute) {
 	switch {
 	case route.provision:
-		connectProvision(route.source, route.opener)
+		connectProvision(route.source, route.opener, route.directURL, route.directKey)
 	case route.linkPhone != "":
 		connectLinkPhone(route.linkPhone)
 	default:

--- a/agent/skills/whatsapp/cli/connect_test.go
+++ b/agent/skills/whatsapp/cli/connect_test.go
@@ -157,6 +157,9 @@ func TestResolveConnectRoutesEachSource(t *testing.T) {
 	if !dtRoute.provision || dtRoute.source != sourceDoubletick || dtRoute.opener != "yo" {
 		t.Errorf("doubletick route = %+v, want provision with doubletick source", dtRoute)
 	}
+	if dtRoute.directURL != directCfg.directURL || dtRoute.directKey != directCfg.directKey {
+		t.Errorf("doubletick route lost direct credentials: %+v", dtRoute)
+	}
 
 	qrRoute, err := resolveConnect(connectOptions{source: sourceSelfManaged}, managedConfig{})
 	if err != nil {
@@ -212,7 +215,7 @@ func TestRunConnectDispatchesToProvisionForCloud(t *testing.T) {
 	var gotSource, gotOpener string
 	provisioned := false
 	restore := connectProvision
-	connectProvision = func(source, opener string) { provisioned = true; gotSource = source; gotOpener = opener }
+	connectProvision = func(source, opener, _, _ string) { provisioned = true; gotSource = source; gotOpener = opener }
 	t.Cleanup(func() { connectProvision = restore })
 
 	oldArgs := os.Args
@@ -232,12 +235,34 @@ func TestRunConnectDispatchesToProvisionForCloud(t *testing.T) {
 	}
 }
 
+// TestRunConnectCarriesDoubletickCredentialsToProvision proves a warm daemon can
+// receive credentials resolved by the foreground connect command. The seam stops
+// before the socket, so no key leaves the test process.
+func TestRunConnectCarriesDoubletickCredentialsToProvision(t *testing.T) {
+	t.Setenv("DOUBLETICK_API_URL", "https://doubletick.example")
+	t.Setenv("DOUBLETICK_API_KEY", "wak_secret")
+
+	var gotURL, gotKey string
+	restore := connectProvision
+	connectProvision = func(_, _, directURL, directKey string) { gotURL, gotKey = directURL, directKey }
+	t.Cleanup(func() { connectProvision = restore })
+
+	oldArgs := os.Args
+	os.Args = []string{"whatsapp", "--source", "doubletick"}
+	t.Cleanup(func() { os.Args = oldArgs })
+
+	runConnect()
+	if gotURL != "https://doubletick.example" || gotKey != "wak_secret" {
+		t.Fatalf("provision credentials = %q / %q", gotURL, gotKey)
+	}
+}
+
 // TestRunConnectAliasSkipsSourceRequirement verifies the dev-only provision and link
 // aliases route straight to their path without needing --source.
 func TestRunConnectAliasSkipsSourceRequirement(t *testing.T) {
 	provisioned, linked, phoneLinked := false, false, ""
 	rp, rl, rlp := connectProvision, connectLink, connectLinkPhone
-	connectProvision = func(string, string) { provisioned = true }
+	connectProvision = func(string, string, string, string) { provisioned = true }
 	connectLink = func() { linked = true }
 	connectLinkPhone = func(phone string) { phoneLinked = phone }
 	t.Cleanup(func() { connectProvision, connectLink, connectLinkPhone = rp, rl, rlp })

--- a/agent/skills/whatsapp/cli/connect_test.go
+++ b/agent/skills/whatsapp/cli/connect_test.go
@@ -289,6 +289,14 @@ func TestRunConnectAliasSkipsSourceRequirement(t *testing.T) {
 	}
 }
 
+func TestPublicProvisionAliasRejectsInternalCredentialFlags(t *testing.T) {
+	for _, flag := range []string{"--direct-key", "--direct-url"} {
+		if _, err := parseConnectOptions("provision", []string{flag, "secret"}); err == nil {
+			t.Fatalf("public provision alias accepted internal socket flag %s", flag)
+		}
+	}
+}
+
 func TestConnectPreservesExplicitZeroPort(t *testing.T) {
 	opts, err := parseConnectOptions("connect", []string{"--port", "0"})
 	if err != nil {

--- a/agent/skills/whatsapp/cli/linker.go
+++ b/agent/skills/whatsapp/cli/linker.go
@@ -76,31 +76,52 @@ func cloudSourceAuth(source string) *managedAuth {
 	return newManagedAuth(cfg)
 }
 
+// currentLinker and currentManaged read the live source as one synchronized pair.
+func (wac *WhatsAppClient) currentLinker() linker {
+	wac.linkerMu.RLock()
+	defer wac.linkerMu.RUnlock()
+	return wac.linker
+}
+
+func (wac *WhatsAppClient) currentManaged() *managedAuth {
+	wac.linkerMu.RLock()
+	defer wac.linkerMu.RUnlock()
+	return wac.managed
+}
+
+func (wac *WhatsAppClient) installManagedLinker(auth *managedAuth, selected linker) {
+	wac.linkerMu.Lock()
+	defer wac.linkerMu.Unlock()
+	wac.managed, wac.linker = auth, selected
+}
+
 // provisionLinker makes the explicit connect source authoritative inside an
-// already-running daemon. Cloud temporarily pins server-token auth for this one
-// pairing. Double Tick installs the direct credentials carried over the private
-// Unix socket and switches the daemon's data path permanently, since it may have
-// booted before those credentials existed.
-func (wac *WhatsAppClient) provisionLinker(source, directURL, directKey string) (linker, func(), error) {
+// already-running daemon. Cloud pins server-token auth to this pairing operation.
+// Double Tick is installed as the durable data path only when finish(true) is
+// called after a successful pair, so invalid credentials cannot replace a known
+// good daemon configuration.
+func (wac *WhatsAppClient) provisionLinker(source, directURL, directKey string) (linker, func(bool), error) {
 	switch source {
 	case sourceVestaCloud:
 		auth := cloudSourceAuth(source)
-		saved := wac.managed
-		wac.managed = auth
-		return &managedLinker{auth: auth, state: wac.state}, func() { wac.managed = saved }, nil
+		return &managedLinker{auth: auth, state: wac.state}, func(bool) {}, nil
 	case sourceDoubletick:
 		if directURL == "" || directKey == "" {
-			return nil, func() {}, fmt.Errorf("doubletick provision needs the direct API URL and key from the connect command")
+			return nil, func(bool) {}, fmt.Errorf("doubletick provision needs the direct API URL and key from the connect command")
 		}
 		cfg := loadManagedConfig()
 		cfg.directURL, cfg.directKey, cfg.configError = directURL, directKey, ""
 		auth := newManagedAuth(cfg)
 		selected := &managedLinker{auth: auth, state: wac.state}
-		wac.state.update(func(s *daemonState) { s.DirectURL, s.DirectKey = directURL, directKey })
-		wac.managed, wac.linker = auth, selected
-		return selected, func() {}, nil
+		return selected, func(commit bool) {
+			if !commit {
+				return
+			}
+			wac.state.update(func(s *daemonState) { s.DirectURL, s.DirectKey = directURL, directKey })
+			wac.installManagedLinker(auth, selected)
+		}, nil
 	default:
-		return wac.linker, func() {}, nil
+		return wac.currentLinker(), func(bool) {}, nil
 	}
 }
 
@@ -157,7 +178,7 @@ func (l *managedLinker) provision(wac *WhatsAppClient) (linkResult, error) {
 
 	// Route the cloud companion through the residential proxy before the pairing WS
 	// comes up, so it never pairs from the datacenter IP. Fails closed.
-	if err := wac.ensureManagedProxy(); err != nil {
+	if err := wac.ensureManagedProxyFor(l.auth); err != nil {
 		return linkResult{}, err
 	}
 

--- a/agent/skills/whatsapp/cli/linker.go
+++ b/agent/skills/whatsapp/cli/linker.go
@@ -98,8 +98,10 @@ func (wac *WhatsAppClient) installManagedLinker(auth *managedAuth, selected link
 // provisionLinker makes the explicit connect source authoritative inside an
 // already-running daemon. Cloud pins server-token auth to this pairing operation.
 // Double Tick is installed as the durable data path only when finish(true) is
-// called after a successful pair, so invalid credentials cannot replace a known
-// good daemon configuration.
+// called. The unlinked flow calls it after successful provisioning; an already-
+// linked resume calls it immediately because the explicit connect is a live source
+// reconfiguration and does not re-pair. Shape-invalid handoffs never reach finish,
+// while remote credential validation happens only when provisioning is required.
 func (wac *WhatsAppClient) provisionLinker(source, directURL, directKey string) (linker, func(bool), error) {
 	switch source {
 	case sourceVestaCloud:

--- a/agent/skills/whatsapp/cli/linker.go
+++ b/agent/skills/whatsapp/cli/linker.go
@@ -76,6 +76,34 @@ func cloudSourceAuth(source string) *managedAuth {
 	return newManagedAuth(cfg)
 }
 
+// provisionLinker makes the explicit connect source authoritative inside an
+// already-running daemon. Cloud temporarily pins server-token auth for this one
+// pairing. Double Tick installs the direct credentials carried over the private
+// Unix socket and switches the daemon's data path permanently, since it may have
+// booted before those credentials existed.
+func (wac *WhatsAppClient) provisionLinker(source, directURL, directKey string) (linker, func(), error) {
+	switch source {
+	case sourceVestaCloud:
+		auth := cloudSourceAuth(source)
+		saved := wac.managed
+		wac.managed = auth
+		return &managedLinker{auth: auth, state: wac.state}, func() { wac.managed = saved }, nil
+	case sourceDoubletick:
+		if directURL == "" || directKey == "" {
+			return nil, func() {}, fmt.Errorf("doubletick provision needs the direct API URL and key from the connect command")
+		}
+		cfg := loadManagedConfig()
+		cfg.directURL, cfg.directKey, cfg.configError = directURL, directKey, ""
+		auth := newManagedAuth(cfg)
+		selected := &managedLinker{auth: auth, state: wac.state}
+		wac.state.update(func(s *daemonState) { s.DirectURL, s.DirectKey = directURL, directKey })
+		wac.managed, wac.linker = auth, selected
+		return selected, func() {}, nil
+	default:
+		return wac.linker, func() {}, nil
+	}
+}
+
 // qrLinker links the user's own WhatsApp account (self-hosted paradigm).
 type qrLinker struct{}
 

--- a/agent/skills/whatsapp/cli/linker_test.go
+++ b/agent/skills/whatsapp/cli/linker_test.go
@@ -91,16 +91,37 @@ func TestDoubletickProvisionSwitchesAWarmDaemon(t *testing.T) {
 		managed: newManagedAuth(managedConfig{}),
 	}
 
-	selected, restore, err := wac.provisionLinker(sourceDoubletick, "https://wa.example", "wak_secret")
+	selected, finish, err := wac.provisionLinker(sourceDoubletick, "https://wa.example", "wak_secret")
 	if err != nil {
 		t.Fatal(err)
 	}
-	restore()
+	finish(true)
 	if selected.name() != "headless" || !wac.isManaged() || !wac.managed.isDirect() {
 		t.Fatalf("warm daemon did not switch to Double Tick: linker=%q managed=%v", selected.name(), wac.isManaged())
 	}
 	if state := store.snapshot(); state.DirectURL != "https://wa.example" || state.DirectKey != "wak_secret" {
 		t.Fatalf("direct credentials were not persisted: %+v", state)
+	}
+}
+
+func TestDoubletickProvisionDoesNotInstallFailedCredentials(t *testing.T) {
+	store := newStateStore(t.TempDir())
+	wac := &WhatsAppClient{
+		state:   store,
+		linker:  qrLinker{},
+		managed: newManagedAuth(managedConfig{}),
+	}
+
+	_, finish, err := wac.provisionLinker(sourceDoubletick, "https://bad.example", "wak_bad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish(false)
+	if wac.isManaged() || wac.currentManaged().isDirect() {
+		t.Fatal("failed credentials replaced the daemon's working configuration")
+	}
+	if state := store.snapshot(); state.DirectURL != "" || state.DirectKey != "" {
+		t.Fatalf("failed credentials were persisted: %+v", state)
 	}
 }
 

--- a/agent/skills/whatsapp/cli/linker_test.go
+++ b/agent/skills/whatsapp/cli/linker_test.go
@@ -80,6 +80,37 @@ func TestChooseLinkerKeepsNumberWhenReconcilingCreds(t *testing.T) {
 	}
 }
 
+// TestDoubletickProvisionSwitchesAWarmDaemon proves the exact boot-order case:
+// setup started a self-managed daemon before the credentials existed, then an
+// explicit Double Tick connect switches both pairing and messaging to managed.
+func TestDoubletickProvisionSwitchesAWarmDaemon(t *testing.T) {
+	store := newStateStore(t.TempDir())
+	wac := &WhatsAppClient{
+		state:   store,
+		linker:  qrLinker{},
+		managed: newManagedAuth(managedConfig{}),
+	}
+
+	selected, restore, err := wac.provisionLinker(sourceDoubletick, "https://wa.example", "wak_secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	restore()
+	if selected.name() != "headless" || !wac.isManaged() || !wac.managed.isDirect() {
+		t.Fatalf("warm daemon did not switch to Double Tick: linker=%q managed=%v", selected.name(), wac.isManaged())
+	}
+	if state := store.snapshot(); state.DirectURL != "https://wa.example" || state.DirectKey != "wak_secret" {
+		t.Fatalf("direct credentials were not persisted: %+v", state)
+	}
+}
+
+func TestDoubletickProvisionRejectsIncompleteSocketHandoff(t *testing.T) {
+	wac := &WhatsAppClient{state: newStateStore(t.TempDir()), linker: qrLinker{}}
+	if _, _, err := wac.provisionLinker(sourceDoubletick, "https://wa.example", ""); err == nil {
+		t.Fatal("an incomplete Double Tick credential handoff was accepted")
+	}
+}
+
 // TestGuardedPairPhoneBlocksAtCap proves the managed path is gated by the same
 // ban-avoidance rate-limit guard as the phone path: once the cap is reached the
 // guard returns errRateLimited and PairPhone is never called (no real pairing

--- a/agent/skills/whatsapp/cli/messaging.go
+++ b/agent/skills/whatsapp/cli/messaging.go
@@ -50,7 +50,7 @@ func (wac *WhatsAppClient) classifySendError(action string, err error) string {
 // construction (chooseLinker), so ban-avoidance gating reads the constructed linker
 // instead of re-deriving the mode: the managed linker is the single source of truth.
 func (wac *WhatsAppClient) isManaged() bool {
-	_, ok := wac.linker.(*managedLinker)
+	_, ok := wac.currentLinker().(*managedLinker)
 	return ok
 }
 

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -262,12 +262,9 @@ func writeCallNotification(notifDir, instance string, n callNotif) error {
 	return writeNotificationFile(notifDir, n, n.Type)
 }
 
-// managedParadigm reports whether this box runs a managed (pooled) WhatsApp number,
-// mirroring the resolution runConnect and chooseLinker use: env creds first, filled
-// from persisted state so an env scrub still resolves the managed path. The auth
-// notifications read it because they run without a *WhatsAppClient (so without the
-// constructed linker) yet must still identify the exact recovery source. Whether
-// reconnect needs approval is derived separately from persisted link history.
+// notificationManagedConfig mirrors runConnect's persisted-credential recovery for
+// auth notifications, which run without a *WhatsAppClient. The explicit source is
+// stored separately so a mixed cloud/direct environment stays unambiguous.
 func notificationManagedConfig(instance string) managedConfig {
 	cfg := loadManagedConfig()
 	if cfg.directURL == "" || cfg.directKey == "" {
@@ -282,21 +279,46 @@ func notificationManagedConfig(instance string) managedConfig {
 	return cfg
 }
 
-func managedParadigm(instance string) bool {
-	return newManagedAuth(notificationManagedConfig(instance)).isHosted()
-}
-
 func wasPreviouslyLinked(instance string) bool {
 	st := loadStateFromDisk(stateDataDirFor(instance))
 	return st.OnboardedMSISDN != "" || !st.LinkedAt.IsZero() || st.AuthStatus == "logged_out" || st.ExitStatus != ""
 }
 
+func notificationSource(instance string) (string, string) {
+	st := loadStateFromDisk(stateDataDirFor(instance))
+	cfg := notificationManagedConfig(instance)
+	switch st.AccountSource {
+	case sourceVestaCloud:
+		if cfg.isManagedVM() {
+			return sourceVestaCloud, ""
+		}
+	case sourceDoubletick:
+		if cfg.isDirect() {
+			return sourceDoubletick, ""
+		}
+	case sourceSelfManaged:
+		if !cfg.isManagedVM() && !cfg.isDirect() && cfg.configError == "" {
+			return sourceSelfManaged, ""
+		}
+	}
+	// Migration fallback follows the setup decision order. A managed VM uses its
+	// cloud entitlement even when stale direct credentials are also present.
+	if cfg.isManagedVM() {
+		return sourceVestaCloud, ""
+	}
+	if cfg.isDirect() {
+		return sourceDoubletick, ""
+	}
+	if cfg.configError != "" {
+		return "", cfg.configError
+	}
+	return sourceSelfManaged, ""
+}
+
 func connectCommand(instance string) string {
-	source := sourceSelfManaged
-	if cfg := notificationManagedConfig(instance); cfg.isDirect() {
-		source = sourceDoubletick
-	} else if cfg.isManagedVM() {
-		source = sourceVestaCloud
+	source, _ := notificationSource(instance)
+	if source == "" {
+		return ""
 	}
 	command := "whatsapp connect --source " + source
 	if instance != "" {
@@ -311,7 +333,8 @@ func connectCommand(instance string) string {
 // under the linking rule. A self-managed first link waits for user participation.
 func WriteUnpairedNotification(notifDir, instance string) error {
 	priorLink := wasPreviouslyLinked(instance)
-	managed := managedParadigm(instance)
+	source, configError := notificationSource(instance)
+	managed := source == sourceVestaCloud || source == sourceDoubletick
 	command := connectCommand(instance)
 	recovery := "first_link"
 	message := "WhatsApp daemon started without a paired device session. Run the exact next_command when the user is ready."
@@ -321,6 +344,13 @@ func WriteUnpairedNotification(notifDir, instance string) error {
 	if priorLink {
 		recovery = "relink"
 		message = "WhatsApp lost a previously linked device session. Ask the user for explicit approval before reconnecting, then run the exact next_command once."
+	}
+	if configError != "" {
+		recovery = "configuration_error"
+		message = "WhatsApp cannot choose a safe reconnect method: " + configError + ". Fix the operator-managed configuration outside chat before connecting."
+		if priorLink {
+			message += " After it is fixed, ask the user for explicit approval before reconnecting."
+		}
 	}
 	if managed {
 		message += " The headless flow needs no phone or QR step."
@@ -346,7 +376,10 @@ func WriteLoggedOutNotification(notifDir, instance, reason string) error {
 	if reason != "" {
 		message += " (" + reason + ")"
 	}
-	if managedParadigm(instance) {
+	source, configError := notificationSource(instance)
+	if configError != "" {
+		message += ". Reconnect is blocked because " + configError + ". Fix the operator-managed configuration outside chat, then ask the user for explicit approval before reconnecting. Do not retry-loop pairing."
+	} else if source == sourceVestaCloud || source == sourceDoubletick {
 		message += ". Ask the user for explicit approval before reconnecting, then run the exact next_command once. The headless flow needs no phone or QR step. Do not retry-loop pairing."
 	} else {
 		message += ". Ask the user for explicit approval before reconnecting, then run the exact next_command once. Do not retry-loop pairing."

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -73,11 +73,14 @@ type editNotif struct {
 }
 
 type authNotif struct {
-	Source    string `json:"source"`
-	Type      string `json:"type"`
-	Instance  string `json:"instance,omitempty"`
-	Message   string `json:"message"`
-	Timestamp string `json:"timestamp"`
+	Source               string `json:"source"`
+	Type                 string `json:"type"`
+	Instance             string `json:"instance,omitempty"`
+	Message              string `json:"message"`
+	Recovery             string `json:"recovery,omitempty"`
+	NextCommand          string `json:"next_command,omitempty"`
+	RequiresUserApproval bool   `json:"requires_user_approval,omitempty"`
+	Timestamp            string `json:"timestamp"`
 }
 
 // A live voice call surfaces to the agent as whatsapp notifications, reaching the model through the
@@ -264,7 +267,7 @@ func writeCallNotification(notifDir, instance string, n callNotif) error {
 // from persisted state so an env scrub still resolves the managed path. The auth
 // notifications read it because they run without a *WhatsAppClient (so without the
 // constructed linker) yet must still tell a managed agent to reauth autonomously.
-func managedParadigm() bool {
+func notificationManagedConfig() managedConfig {
 	cfg := loadManagedConfig()
 	if cfg.directURL == "" || cfg.directKey == "" {
 		st := loadStateFromDisk(stateDataDir())
@@ -275,7 +278,30 @@ func managedParadigm() bool {
 			cfg.directKey = st.DirectKey
 		}
 	}
-	return newManagedAuth(cfg).isHosted()
+	return cfg
+}
+
+func managedParadigm() bool {
+	return newManagedAuth(notificationManagedConfig()).isHosted()
+}
+
+func wasPreviouslyLinked() bool {
+	st := loadStateFromDisk(stateDataDir())
+	return st.OnboardedMSISDN != "" || !st.LinkedAt.IsZero() || st.AuthStatus == "logged_out" || st.ExitStatus != ""
+}
+
+func connectCommand(instance string) string {
+	source := sourceSelfManaged
+	if cfg := notificationManagedConfig(); cfg.isDirect() {
+		source = sourceDoubletick
+	} else if cfg.isManagedVM() {
+		source = sourceVestaCloud
+	}
+	command := "whatsapp connect --source " + source
+	if instance != "" {
+		command += " --instance " + quoteReplyArg(instance)
+	}
+	return command
 }
 
 // WriteUnpairedNotification tells the agent the WhatsApp daemon came up without a
@@ -283,16 +309,27 @@ func managedParadigm() bool {
 // managed number reclaims itself autonomously (no user step), so only self-hosted QR
 // linking, which needs the human to scan, is gated on the user being ready.
 func WriteUnpairedNotification(notifDir, instance string) error {
-	message := "WhatsApp daemon started without a paired device session. Run `whatsapp connect` to link (when the user is ready)."
-	if managedParadigm() {
-		message = "WhatsApp daemon started without a paired device session. Run `whatsapp connect` now to re-link your headless account; it reclaims the number autonomously and needs no user step."
+	priorLink := wasPreviouslyLinked()
+	managed := managedParadigm()
+	command := connectCommand(instance)
+	recovery := "first_link"
+	message := "WhatsApp daemon started without a paired device session. Run the exact next_command when the user is ready."
+	if priorLink {
+		recovery = "relink"
+		message = "WhatsApp lost a previously linked device session. Ask the user for explicit approval before reconnecting, then run the exact next_command once."
+	}
+	if managed {
+		message += " The headless flow needs no phone or QR step."
 	}
 	n := authNotif{
-		Source:    "whatsapp",
-		Type:      "unpaired",
-		Instance:  instance,
-		Message:   message,
-		Timestamp: time.Now().Format(time.RFC3339),
+		Source:               "whatsapp",
+		Type:                 "unpaired",
+		Instance:             instance,
+		Message:              message,
+		Recovery:             recovery,
+		NextCommand:          command,
+		RequiresUserApproval: priorLink,
+		Timestamp:            time.Now().Format(time.RFC3339),
 	}
 	return writeNotificationFile(notifDir, n, "unpaired")
 }
@@ -306,16 +343,19 @@ func WriteLoggedOutNotification(notifDir, instance, reason string) error {
 		message += " (" + reason + ")"
 	}
 	if managedParadigm() {
-		message += ". This is NOT re-linked automatically, but a headless account reauthorizes autonomously: run `whatsapp connect` now to re-link the SAME number, no user step needed. Do not retry-loop pairing."
+		message += ". Ask the user for explicit approval before reconnecting, then run the exact next_command once. The headless flow needs no phone or QR step. Do not retry-loop pairing."
 	} else {
-		message += ". This is NOT re-linked automatically. When the user is ready, run `whatsapp connect` to re-link. Do not retry-loop pairing."
+		message += ". Ask the user for explicit approval before reconnecting, then run the exact next_command once. Do not retry-loop pairing."
 	}
 	n := authNotif{
-		Source:    "whatsapp",
-		Type:      "logged_out",
-		Instance:  instance,
-		Message:   message,
-		Timestamp: time.Now().Format(time.RFC3339),
+		Source:               "whatsapp",
+		Type:                 "logged_out",
+		Instance:             instance,
+		Message:              message,
+		Recovery:             "relink",
+		NextCommand:          connectCommand(instance),
+		RequiresUserApproval: true,
+		Timestamp:            time.Now().Format(time.RFC3339),
 	}
 	return writeNotificationFile(notifDir, n, "logged_out")
 }

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -266,11 +266,12 @@ func writeCallNotification(notifDir, instance string, n callNotif) error {
 // mirroring the resolution runConnect and chooseLinker use: env creds first, filled
 // from persisted state so an env scrub still resolves the managed path. The auth
 // notifications read it because they run without a *WhatsAppClient (so without the
-// constructed linker) yet must still tell a managed agent to reauth autonomously.
-func notificationManagedConfig() managedConfig {
+// constructed linker) yet must still identify the exact recovery source. Whether
+// reconnect needs approval is derived separately from persisted link history.
+func notificationManagedConfig(instance string) managedConfig {
 	cfg := loadManagedConfig()
 	if cfg.directURL == "" || cfg.directKey == "" {
-		st := loadStateFromDisk(stateDataDir())
+		st := loadStateFromDisk(stateDataDirFor(instance))
 		if cfg.directURL == "" {
 			cfg.directURL = st.DirectURL
 		}
@@ -281,18 +282,18 @@ func notificationManagedConfig() managedConfig {
 	return cfg
 }
 
-func managedParadigm() bool {
-	return newManagedAuth(notificationManagedConfig()).isHosted()
+func managedParadigm(instance string) bool {
+	return newManagedAuth(notificationManagedConfig(instance)).isHosted()
 }
 
-func wasPreviouslyLinked() bool {
-	st := loadStateFromDisk(stateDataDir())
+func wasPreviouslyLinked(instance string) bool {
+	st := loadStateFromDisk(stateDataDirFor(instance))
 	return st.OnboardedMSISDN != "" || !st.LinkedAt.IsZero() || st.AuthStatus == "logged_out" || st.ExitStatus != ""
 }
 
 func connectCommand(instance string) string {
 	source := sourceSelfManaged
-	if cfg := notificationManagedConfig(); cfg.isDirect() {
+	if cfg := notificationManagedConfig(instance); cfg.isDirect() {
 		source = sourceDoubletick
 	} else if cfg.isManagedVM() {
 		source = sourceVestaCloud
@@ -306,14 +307,17 @@ func connectCommand(instance string) string {
 
 // WriteUnpairedNotification tells the agent the WhatsApp daemon came up without a
 // device session and needs re-pairing. Called once per unpaired daemon boot. A
-// managed number reclaims itself autonomously (no user step), so only self-hosted QR
-// linking, which needs the human to scan, is gated on the user being ready.
+// managed flow needs no phone or QR step, but a prior link still requires approval
+// under the linking rule. A self-managed first link waits for user participation.
 func WriteUnpairedNotification(notifDir, instance string) error {
-	priorLink := wasPreviouslyLinked()
-	managed := managedParadigm()
+	priorLink := wasPreviouslyLinked(instance)
+	managed := managedParadigm(instance)
 	command := connectCommand(instance)
 	recovery := "first_link"
 	message := "WhatsApp daemon started without a paired device session. Run the exact next_command when the user is ready."
+	if managed {
+		message = "WhatsApp daemon started without a paired device session. Run the exact next_command now."
+	}
 	if priorLink {
 		recovery = "relink"
 		message = "WhatsApp lost a previously linked device session. Ask the user for explicit approval before reconnecting, then run the exact next_command once."
@@ -342,7 +346,7 @@ func WriteLoggedOutNotification(notifDir, instance, reason string) error {
 	if reason != "" {
 		message += " (" + reason + ")"
 	}
-	if managedParadigm() {
+	if managedParadigm(instance) {
 		message += ". Ask the user for explicit approval before reconnecting, then run the exact next_command once. The headless flow needs no phone or QR step. Do not retry-loop pairing."
 	} else {
 		message += ". Ask the user for explicit approval before reconnecting, then run the exact next_command once. Do not retry-loop pairing."

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func savedCtx(dir string) NotifContext {
@@ -121,5 +123,76 @@ func TestPrimaryAccountDoesNotLabelItsInstance(t *testing.T) {
 
 	if _, present := soleNotifFields(t, dir)["instance"]; present {
 		t.Errorf("instance is present for the unnamed primary account, want it omitted")
+	}
+}
+
+func prepareAuthNotificationTest(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DOUBLETICK_API_URL", "")
+	t.Setenv("DOUBLETICK_API_KEY", "")
+	t.Setenv("WHATSAPP_API_URL", "")
+	t.Setenv("WHATSAPP_API_KEY", "")
+	t.Setenv("VESTA_CLOUD_CONTROL_URL", "")
+	if err := os.MkdirAll(filepath.Join(home, ".whatsapp"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	return t.TempDir()
+}
+
+func TestFreshManagedUnpairedCanConnectWithoutApproval(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	t.Setenv("DOUBLETICK_API_URL", "https://doubletick.example")
+	t.Setenv("DOUBLETICK_API_KEY", "wak_secret")
+
+	if err := WriteUnpairedNotification(dir, ""); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	if _, present := fields["requires_user_approval"]; present {
+		t.Fatal("first-time setup must not be mislabeled as a recovery requiring fresh approval")
+	}
+	var recovery, command string
+	_ = json.Unmarshal(fields["recovery"], &recovery)
+	_ = json.Unmarshal(fields["next_command"], &command)
+	if recovery != "first_link" || command != "whatsapp connect --source doubletick" {
+		t.Fatalf("fresh managed notification = recovery %q command %q", recovery, command)
+	}
+}
+
+func TestPreviouslyLinkedUnpairedRequiresApproval(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	t.Setenv("DOUBLETICK_API_URL", "https://doubletick.example")
+	t.Setenv("DOUBLETICK_API_KEY", "wak_secret")
+	newStateStore(stateDataDir()).update(func(state *daemonState) { state.LinkedAt = time.Now() })
+
+	if err := WriteUnpairedNotification(dir, ""); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	var approval bool
+	var recovery, message string
+	_ = json.Unmarshal(fields["requires_user_approval"], &approval)
+	_ = json.Unmarshal(fields["recovery"], &recovery)
+	_ = json.Unmarshal(fields["message"], &message)
+	if !approval || recovery != "relink" || !strings.Contains(message, "explicit approval") {
+		t.Fatalf("lost-link notification did not preserve the approval gate: approval=%v recovery=%q message=%q", approval, recovery, message)
+	}
+}
+
+func TestLoggedOutNotificationNamesExactApprovedRecoveryCommand(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+
+	if err := WriteLoggedOutNotification(dir, "personal", "removed"); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	var approval bool
+	var command string
+	_ = json.Unmarshal(fields["requires_user_approval"], &approval)
+	_ = json.Unmarshal(fields["next_command"], &command)
+	if !approval || command != "whatsapp connect --source self-managed --instance 'personal'" {
+		t.Fatalf("logged-out recovery = approval %v command %q", approval, command)
 	}
 }

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -153,11 +153,12 @@ func TestFreshManagedUnpairedCanConnectWithoutApproval(t *testing.T) {
 	if _, present := fields["requires_user_approval"]; present {
 		t.Fatal("first-time setup must not be mislabeled as a recovery requiring fresh approval")
 	}
-	var recovery, command string
+	var recovery, command, message string
 	_ = json.Unmarshal(fields["recovery"], &recovery)
 	_ = json.Unmarshal(fields["next_command"], &command)
-	if recovery != "first_link" || command != "whatsapp connect --source doubletick" {
-		t.Fatalf("fresh managed notification = recovery %q command %q", recovery, command)
+	_ = json.Unmarshal(fields["message"], &message)
+	if recovery != "first_link" || command != "whatsapp connect --source doubletick" || !strings.Contains(message, "now") {
+		t.Fatalf("fresh managed notification = recovery %q command %q message %q", recovery, command, message)
 	}
 }
 
@@ -194,5 +195,31 @@ func TestLoggedOutNotificationNamesExactApprovedRecoveryCommand(t *testing.T) {
 	_ = json.Unmarshal(fields["next_command"], &command)
 	if !approval || command != "whatsapp connect --source self-managed --instance 'personal'" {
 		t.Fatalf("logged-out recovery = approval %v command %q", approval, command)
+	}
+}
+
+func TestNamedInstanceUsesItsOwnPersistedRecoveryState(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	instance := "personal"
+	instanceDir := stateDataDirFor(instance)
+	if err := os.MkdirAll(instanceDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	newStateStore(instanceDir).update(func(state *daemonState) {
+		state.DirectURL = "https://doubletick.example"
+		state.DirectKey = "wak_secret"
+		state.OnboardedMSISDN = "+15551230000"
+	})
+
+	if err := WriteUnpairedNotification(dir, instance); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	var approval bool
+	var command string
+	_ = json.Unmarshal(fields["requires_user_approval"], &approval)
+	_ = json.Unmarshal(fields["next_command"], &command)
+	if !approval || command != "whatsapp connect --source doubletick --instance 'personal'" {
+		t.Fatalf("named-instance recovery = approval %v command %q", approval, command)
 	}
 }

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -223,3 +223,57 @@ func TestNamedInstanceUsesItsOwnPersistedRecoveryState(t *testing.T) {
 		t.Fatalf("named-instance recovery = approval %v command %q", approval, command)
 	}
 }
+
+func TestManagedVMFallbackPrefersCloudOverDirectCredentials(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	t.Setenv("VESTA_CLOUD_CONTROL_URL", "https://api.vesta.run")
+	t.Setenv("DOUBLETICK_API_URL", "https://doubletick.example")
+	t.Setenv("DOUBLETICK_API_KEY", "wak_secret")
+
+	if err := WriteUnpairedNotification(dir, ""); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	var command string
+	_ = json.Unmarshal(fields["next_command"], &command)
+	if command != "whatsapp connect --source vesta-cloud" {
+		t.Fatalf("mixed managed environment selected %q, want vesta-cloud", command)
+	}
+}
+
+func TestPersistedExplicitSourceWinsInMixedEnvironment(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	t.Setenv("VESTA_CLOUD_CONTROL_URL", "https://api.vesta.run")
+	t.Setenv("DOUBLETICK_API_URL", "https://doubletick.example")
+	t.Setenv("DOUBLETICK_API_KEY", "wak_secret")
+	newStateStore(stateDataDir()).recordAccountSource(sourceDoubletick)
+
+	if err := WriteUnpairedNotification(dir, ""); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	var command string
+	_ = json.Unmarshal(fields["next_command"], &command)
+	if command != "whatsapp connect --source doubletick" {
+		t.Fatalf("persisted explicit source produced %q, want doubletick", command)
+	}
+}
+
+func TestIncompleteDirectConfigBlocksRecoveryCommand(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	t.Setenv("DOUBLETICK_API_URL", "https://doubletick.example")
+
+	if err := WriteUnpairedNotification(dir, ""); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	if _, present := fields["next_command"]; present {
+		t.Fatal("incomplete credentials produced a connect command that cannot succeed")
+	}
+	var recovery, message string
+	_ = json.Unmarshal(fields["recovery"], &recovery)
+	_ = json.Unmarshal(fields["message"], &message)
+	if recovery != "configuration_error" || !strings.Contains(message, "must be set together") || strings.Contains(message, "headless") {
+		t.Fatalf("incomplete configuration notification = recovery %q message %q", recovery, message)
+	}
+}

--- a/agent/skills/whatsapp/cli/profile_init_test.go
+++ b/agent/skills/whatsapp/cli/profile_init_test.go
@@ -143,6 +143,16 @@ func TestProvisionCommandRetriesPendingLinkedResult(t *testing.T) {
 	}
 }
 
+func TestProvisionCommandRecordsExplicitSourceOnResume(t *testing.T) {
+	wac := newLinkedTestClient(t)
+	if _, err := cmdProvisionManaged([]string{"--source", sourceVestaCloud}, wac); err != nil {
+		t.Fatal(err)
+	}
+	if got := wac.state.snapshot().AccountSource; got != sourceVestaCloud {
+		t.Fatalf("recorded source = %q, want %q", got, sourceVestaCloud)
+	}
+}
+
 func TestFreshPhotoWipeStateRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	store := newStateStore(dir)

--- a/agent/skills/whatsapp/cli/profile_init_test.go
+++ b/agent/skills/whatsapp/cli/profile_init_test.go
@@ -143,6 +143,27 @@ func TestProvisionCommandRetriesPendingLinkedResult(t *testing.T) {
 	}
 }
 
+func TestProvisionCommandConfiguresAlreadyLinkedWarmDaemon(t *testing.T) {
+	wac := newLinkedTestClient(t)
+	wac.linker = qrLinker{}
+	wac.managed = newManagedAuth(managedConfig{})
+
+	_, err := cmdProvisionManaged([]string{
+		"--source", sourceDoubletick,
+		"--direct-url", "https://wa.example",
+		"--direct-key", "wak_secret",
+	}, wac)
+	if err != nil {
+		t.Fatalf("configure already-linked daemon: %v", err)
+	}
+	if !wac.isManaged() || !wac.currentManaged().isDirect() {
+		t.Fatal("already-linked warm daemon did not install Double Tick mode")
+	}
+	if state := wac.state.snapshot(); state.DirectURL != "https://wa.example" || state.DirectKey != "wak_secret" {
+		t.Fatalf("already-linked daemon lost direct credentials: %+v", state)
+	}
+}
+
 func TestFreshPhotoWipeStateRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	store := newStateStore(dir)

--- a/agent/skills/whatsapp/cli/profile_init_test.go
+++ b/agent/skills/whatsapp/cli/profile_init_test.go
@@ -201,6 +201,25 @@ func TestProvisionCommandRecordsExplicitSourceBeforeNetworkFailure(t *testing.T)
 	}
 }
 
+func TestProvisionRejectedBySingleFlightKeepsRecordedSource(t *testing.T) {
+	wac := newLinkedTestClient(t)
+	wac.client.Store.ID = nil
+	wac.state.recordAccountSource(sourceDoubletick)
+	release, ok := wac.beginPairing()
+	if !ok {
+		t.Fatal("could not hold the pairing single-flight")
+	}
+	defer release()
+
+	_, err := cmdProvisionManaged([]string{"--source", sourceVestaCloud}, wac)
+	if !errors.Is(err, errPairingInProgress) {
+		t.Fatalf("expected errPairingInProgress, got %v", err)
+	}
+	if got := wac.state.snapshot().AccountSource; got != sourceDoubletick {
+		t.Fatalf("rejected provision changed AccountSource to %q", got)
+	}
+}
+
 func TestFreshPhotoWipeStateRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	store := newStateStore(dir)

--- a/agent/skills/whatsapp/cli/provision.go
+++ b/agent/skills/whatsapp/cli/provision.go
@@ -27,6 +27,7 @@ func runProvision(source, opener, directURL, directKey string) {
 	// A daemon may already be warm from boot before Double Tick credentials are
 	// configured. Carry the direct pair over its private Unix socket so this one
 	// connect call can switch the daemon to the requested source without a restart.
+	// These become fields in an in-process SocketRequest, not operating-system argv.
 	if directURL != "" && directKey != "" {
 		args = append(args, "--direct-url", directURL, "--direct-key", directKey)
 	}

--- a/agent/skills/whatsapp/cli/provision.go
+++ b/agent/skills/whatsapp/cli/provision.go
@@ -13,7 +13,7 @@ import (
 // returns a terminal {status:"linked", number, next} (or {status:"provisioning"} /
 // {status:"blocked"}). No daemon management, no readiness polling, no code
 // shuttling. Idempotent, so re-running is always safe.
-func runProvision(source, opener string) {
+func runProvision(source, opener, directURL, directKey string) {
 	if err := ensureDaemon(linkServeArgs()); err != nil {
 		failJSON("%s", err.Error())
 	}
@@ -23,6 +23,12 @@ func runProvision(source, opener string) {
 	// token even on a warm daemon that also carries direct pool creds.
 	if source != "" {
 		args = append(args, "--source", source)
+	}
+	// A daemon may already be warm from boot before Double Tick credentials are
+	// configured. Carry the direct pair over its private Unix socket so this one
+	// connect call can switch the daemon to the requested source without a restart.
+	if directURL != "" && directKey != "" {
+		args = append(args, "--direct-url", directURL, "--direct-key", directKey)
 	}
 	if opener != "" {
 		args = append(args, "--opener", opener)

--- a/agent/skills/whatsapp/cli/server.go
+++ b/agent/skills/whatsapp/cli/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 )
@@ -36,11 +37,25 @@ func (resp SocketResponse) render() ([]byte, int) {
 }
 
 func startSocketServer(sockPath string, wac *WhatsAppClient) (net.Listener, error) {
+	// Close the creation-time window too: net.Listen creates the socket before it
+	// can be chmodded, so the containing state directory must already exclude other
+	// local users.
+	if err := os.Chmod(filepath.Dir(sockPath), 0700); err != nil {
+		return nil, fmt.Errorf("secure socket directory %s: %v", filepath.Dir(sockPath), err)
+	}
 	os.Remove(sockPath)
 
 	listener, err := net.Listen("unix", sockPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen on %s: %v", sockPath, err)
+	}
+	// Socket requests can carry a direct API key during a warm-daemon connect.
+	// Restrict the endpoint before accepting anything so other local users cannot
+	// read credentials or issue WhatsApp commands through it.
+	if err := os.Chmod(sockPath, 0600); err != nil {
+		listener.Close()
+		os.Remove(sockPath)
+		return nil, fmt.Errorf("secure socket %s: %v", sockPath, err)
 	}
 
 	go func() {

--- a/agent/skills/whatsapp/cli/server_test.go
+++ b/agent/skills/whatsapp/cli/server_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -9,6 +10,33 @@ import (
 
 	waLog "go.mau.fi/whatsmeow/util/log"
 )
+
+func TestSocketIsOwnerOnly(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	sockPath := filepath.Join(dir, "whatsapp.sock")
+	listener, err := startSocketServer(sockPath, &WhatsAppClient{store: newTestStore(t), logger: waLog.Noop})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { stopSocketServer(listener, sockPath) })
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0700 {
+		t.Fatalf("WhatsApp state directory mode = %04o, want 0700", got)
+	}
+	info, err := os.Stat(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("WhatsApp socket mode = %04o, want 0600", got)
+	}
+}
 
 // startTestSocket puts a command on the real path: client -> unix socket -> executeCommand -> response.
 func startTestSocket(t *testing.T, store *MessageStore) string {

--- a/agent/skills/whatsapp/cli/state.go
+++ b/agent/skills/whatsapp/cli/state.go
@@ -24,6 +24,9 @@ type daemonState struct {
 	MSISDN    string `json:"msisdn,omitempty"`
 	DirectURL string `json:"api_url,omitempty"`
 	DirectKey string `json:"api_key,omitempty"`
+	// AccountSource records the explicit connect choice so recovery notifications
+	// never infer cloud vs. Double Tick from an ambiguous mixed environment.
+	AccountSource string `json:"account_source,omitempty"`
 	// OnboardedMSISDN marks the number whose first-link profile and result finished.
 	// PendingLinkedOpener preserves first-link output across profile-init retries.
 	OnboardedMSISDN     string `json:"onboarded_msisdn,omitempty"`
@@ -133,6 +136,13 @@ func (s *stateStore) snapshot() daemonState {
 }
 
 func (s *stateStore) persistLocked() error { return atomicWriteJSON(s.path, s.st) }
+
+func (s *stateStore) recordAccountSource(source string) {
+	switch source {
+	case sourceVestaCloud, sourceDoubletick, sourceSelfManaged:
+		s.update(func(st *daemonState) { st.AccountSource = source })
+	}
+}
 
 // tryRecordPairAttempt checks the ban-avoidance rate limit and, when allowed,
 // records an attempt, atomically. For callers where initiating the flow IS the

--- a/agent/skills/whatsapp/cli/state.go
+++ b/agent/skills/whatsapp/cli/state.go
@@ -177,7 +177,7 @@ func atomicWriteJSON(path string, v any) error {
 		os.Remove(tmp)
 		return err
 	}
-	if err := os.Chmod(tmp, 0644); err != nil {
+	if err := os.Chmod(tmp, 0600); err != nil {
 		os.Remove(tmp)
 		return err
 	}

--- a/agent/skills/whatsapp/cli/state_test.go
+++ b/agent/skills/whatsapp/cli/state_test.go
@@ -43,6 +43,18 @@ func TestStateRoundTrip(t *testing.T) {
 	}
 }
 
+func TestStateFileIsOwnerOnly(t *testing.T) {
+	dir := t.TempDir()
+	newStateStore(dir).update(func(st *daemonState) { st.DirectKey = "wak_secret" })
+	info, err := os.Stat(statePath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("state.json mode = %04o, want 0600 because it contains the Double Tick key", got)
+	}
+}
+
 // TestMigrateLegacyFiles proves the pre-consolidation files are folded into
 // state.json (import-then-remove) with no data loss.
 func TestMigrateLegacyFiles(t *testing.T) {


### PR DESCRIPTION
## Problems

The incident exposed two failures in one WhatsApp lifecycle:

1. Setup started a daemon before DoubleTick credentials existed. Later, the foreground connect command saw the credentials but the warm daemon retained its self-managed linker, so the agent had to persist secrets and restart the daemon.
2. Runtime recovery notifications contradicted the skill policy by telling a previously linked headless account to reconnect without user approval, and emitted incomplete commands that omitted the source and named instance.

## Changes

- Carry DoubleTick credentials to a warm daemon through an owner-only Unix socket and install the managed data path without a restart.
- Persist WhatsApp state with mode 0600; protect the socket directory and socket with owner-only permissions.
- Synchronize live linker/auth changes and keep invalid credentials from replacing the active data path.
- Reject direct credential flags on the public provision alias; the credential handoff exists only in the in-process socket request.
- Document an operator-only mode-0600 env-file flow for a running container. Keys must never enter chat, logs, shell history, or .bashrc.
- Persist the explicit account source per instance and distinguish first_link, relink, and configuration_error recovery.
- Require explicit user approval for every prior-link recovery and emit the exact source-aware, instance-aware next_command.
- Prefer the persisted explicit source in mixed cloud/direct environments and block incomplete DoubleTick configuration.

## Verification

- ./check.sh whatsapp
- go test -tags fts5 -race ./...

Tests cover warm-daemon credential handoff, state and socket permissions, concurrent source changes, already-linked resume, rejected credentials, named instances, mixed source environments, incomplete configuration, and first-link versus relink approval.