### PR TITLE
fix(whatsapp): require approval consistently on relink

### DIFF
--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -520,9 +520,13 @@ func cleanupRejectedPairing(cleanup func(), activePort, requestedPort int) {
 // rate-limit slot or serves a blank QR). One call is the whole flow: no start/status/stop
 // trio and no client-side poll loop.
 func cmdLink(args []string, wac *WhatsAppClient) (any, error) {
-	return linkViaQR("link", args, wac, func(port int) (linkResult, error) {
+	result, err := linkViaQR("link", args, wac, func(port int) (linkResult, error) {
 		return wac.linker.linkQR(wac, port)
 	}, map[string]any{"status": string(AuthStatusAuthenticated)})
+	if err == nil {
+		wac.state.recordAccountSource(sourceSelfManaged)
+	}
+	return result, err
 }
 
 func cmdDaemonStatus(args []string, wac *WhatsAppClient) (any, error) {
@@ -544,6 +548,7 @@ func cmdDaemonStatus(args []string, wac *WhatsAppClient) (any, error) {
 		"pair_attempts_last_7d":    len(attemptsWithin(st.PairAttempts, now, PairWeekWindow)),
 	}
 	if wac.client.Store.ID != nil {
+		wac.state.recordAccountSource(source)
 		result["number"] = "+" + wac.client.Store.ID.User
 	}
 	if linkPort, linkService := wac.activeLink(); linkPort != 0 {
@@ -1182,6 +1187,7 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 		}
 		return nil, err
 	}
+	wac.state.recordAccountSource(source)
 	// A new number (first claim or a healed replacement) gets the reply-first
 	// onboarding; re-linking the same established number is a quiet resume.
 	if priorOnboardedMSISDN == "" || priorOnboardedMSISDN != res.MSISDN {
@@ -1309,6 +1315,7 @@ func cmdPairPhone(args []string, wac *WhatsAppClient) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate pairing code: %v", err)
 	}
+	wac.state.recordAccountSource(sourceSelfManaged)
 	wac.markPhonePairingPending(time.Now())
 	return map[string]any{
 		"pairing_code": code,

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -76,8 +76,12 @@ func extractSkipSenders() map[string]bool {
 // stateDataDir is the per-instance data directory under ~/.whatsapp (the bare
 // directory for the default instance, a named subdirectory otherwise).
 func stateDataDir() string {
+	return stateDataDirFor(extractInstance())
+}
+
+func stateDataDirFor(instance string) string {
 	base := filepath.Join(os.Getenv("HOME"), ".whatsapp")
-	if instance := extractInstance(); instance != "" {
+	if instance != "" {
 		return filepath.Join(base, instance)
 	}
 	return base

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -548,7 +548,6 @@ func cmdDaemonStatus(args []string, wac *WhatsAppClient) (any, error) {
 		"pair_attempts_last_7d":    len(attemptsWithin(st.PairAttempts, now, PairWeekWindow)),
 	}
 	if wac.client.Store.ID != nil {
-		wac.state.recordAccountSource(source)
 		result["number"] = "+" + wac.client.Store.ID.User
 	}
 	if linkPort, linkService := wac.activeLink(); linkPort != 0 {
@@ -1096,6 +1095,7 @@ func cmdProvisionManaged(args []string, wac *WhatsAppClient) (any, error) {
 		return nil, err
 	}
 	if wac.client.Store.ID != nil {
+		wac.state.recordAccountSource(source)
 		// Already linked. If a takeover parked it, an explicit connect means
 		// "reclaim the session": clear the park and reconnect (a plain send never
 		// does this, so it can't ping-pong). If the other holder is still live it

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -262,12 +262,9 @@ func writeCallNotification(notifDir, instance string, n callNotif) error {
 	return writeNotificationFile(notifDir, n, n.Type)
 }
 
-// managedParadigm reports whether this box runs a managed (pooled) WhatsApp number,
-// mirroring the resolution runConnect and chooseLinker use: env creds first, filled
-// from persisted state so an env scrub still resolves the managed path. The auth
-// notifications read it because they run without a *WhatsAppClient (so without the
-// constructed linker) yet must still identify the exact recovery source. Whether
-// reconnect needs approval is derived separately from persisted link history.
+// notificationManagedConfig mirrors runConnect's persisted-credential recovery for
+// auth notifications, which run without a *WhatsAppClient. The explicit source is
+// stored separately so a mixed cloud/direct environment stays unambiguous.
 func notificationManagedConfig(instance string) managedConfig {
 	cfg := loadManagedConfig()
 	if cfg.directURL == "" || cfg.directKey == "" {
@@ -282,21 +279,46 @@ func notificationManagedConfig(instance string) managedConfig {
 	return cfg
 }
 
-func managedParadigm(instance string) bool {
-	return newManagedAuth(notificationManagedConfig(instance)).isHosted()
-}
-
 func wasPreviouslyLinked(instance string) bool {
 	st := loadStateFromDisk(stateDataDirFor(instance))
 	return st.OnboardedMSISDN != "" || !st.LinkedAt.IsZero() || st.AuthStatus == "logged_out" || st.ExitStatus != ""
 }
 
+func notificationSource(instance string) (string, string) {
+	st := loadStateFromDisk(stateDataDirFor(instance))
+	cfg := notificationManagedConfig(instance)
+	switch st.AccountSource {
+	case sourceVestaCloud:
+		if cfg.isManagedVM() {
+			return sourceVestaCloud, ""
+		}
+	case sourceDoubletick:
+		if cfg.isDirect() {
+			return sourceDoubletick, ""
+		}
+	case sourceSelfManaged:
+		if !cfg.isManagedVM() && !cfg.isDirect() && cfg.configError == "" {
+			return sourceSelfManaged, ""
+		}
+	}
+	// Migration fallback follows the setup decision order. A managed VM uses its
+	// cloud entitlement even when stale direct credentials are also present.
+	if cfg.isManagedVM() {
+		return sourceVestaCloud, ""
+	}
+	if cfg.isDirect() {
+		return sourceDoubletick, ""
+	}
+	if cfg.configError != "" {
+		return "", cfg.configError
+	}
+	return sourceSelfManaged, ""
+}
+
 func connectCommand(instance string) string {
-	source := sourceSelfManaged
-	if cfg := notificationManagedConfig(instance); cfg.isDirect() {
-		source = sourceDoubletick
-	} else if cfg.isManagedVM() {
-		source = sourceVestaCloud
+	source, _ := notificationSource(instance)
+	if source == "" {
+		return ""
 	}
 	command := "whatsapp connect --source " + source
 	if instance != "" {
@@ -311,7 +333,8 @@ func connectCommand(instance string) string {
 // under the linking rule. A self-managed first link waits for user participation.
 func WriteUnpairedNotification(notifDir, instance string) error {
 	priorLink := wasPreviouslyLinked(instance)
-	managed := managedParadigm(instance)
+	source, configError := notificationSource(instance)
+	managed := source == sourceVestaCloud || source == sourceDoubletick
 	command := connectCommand(instance)
 	recovery := "first_link"
 	message := "WhatsApp daemon started without a paired device session. Run the exact next_command when the user is ready."
@@ -321,6 +344,13 @@ func WriteUnpairedNotification(notifDir, instance string) error {
 	if priorLink {
 		recovery = "relink"
 		message = "WhatsApp lost a previously linked device session. Ask the user for explicit approval before reconnecting, then run the exact next_command once."
+	}
+	if configError != "" {
+		recovery = "configuration_error"
+		message = "WhatsApp cannot choose a safe reconnect method: " + configError + ". Fix the operator-managed configuration outside chat before connecting."
+		if priorLink {
+			message += " After it is fixed, ask the user for explicit approval before reconnecting."
+		}
 	}
 	if managed {
 		message += " The headless flow needs no phone or QR step."
@@ -346,7 +376,10 @@ func WriteLoggedOutNotification(notifDir, instance, reason string) error {
 	if reason != "" {
 		message += " (" + reason + ")"
 	}
-	if managedParadigm(instance) {
+	source, configError := notificationSource(instance)
+	if configError != "" {
+		message += ". Reconnect is blocked because " + configError + ". Fix the operator-managed configuration outside chat, then ask the user for explicit approval before reconnecting. Do not retry-loop pairing."
+	} else if source == sourceVestaCloud || source == sourceDoubletick {
 		message += ". Ask the user for explicit approval before reconnecting, then run the exact next_command once. The headless flow needs no phone or QR step. Do not retry-loop pairing."
 	} else {
 		message += ". Ask the user for explicit approval before reconnecting, then run the exact next_command once. Do not retry-loop pairing."

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -73,11 +73,14 @@ type editNotif struct {
 }
 
 type authNotif struct {
-	Source    string `json:"source"`
-	Type      string `json:"type"`
-	Instance  string `json:"instance,omitempty"`
-	Message   string `json:"message"`
-	Timestamp string `json:"timestamp"`
+	Source               string `json:"source"`
+	Type                 string `json:"type"`
+	Instance             string `json:"instance,omitempty"`
+	Message              string `json:"message"`
+	Recovery             string `json:"recovery,omitempty"`
+	NextCommand          string `json:"next_command,omitempty"`
+	RequiresUserApproval bool   `json:"requires_user_approval,omitempty"`
+	Timestamp            string `json:"timestamp"`
 }
 
 // A live voice call surfaces to the agent as whatsapp notifications, reaching the model through the
@@ -264,7 +267,7 @@ func writeCallNotification(notifDir, instance string, n callNotif) error {
 // from persisted state so an env scrub still resolves the managed path. The auth
 // notifications read it because they run without a *WhatsAppClient (so without the
 // constructed linker) yet must still tell a managed agent to reauth autonomously.
-func managedParadigm() bool {
+func notificationManagedConfig() managedConfig {
 	cfg := loadManagedConfig()
 	if cfg.directURL == "" || cfg.directKey == "" {
 		st := loadStateFromDisk(stateDataDir())
@@ -275,7 +278,30 @@ func managedParadigm() bool {
 			cfg.directKey = st.DirectKey
 		}
 	}
-	return newManagedAuth(cfg).isHosted()
+	return cfg
+}
+
+func managedParadigm() bool {
+	return newManagedAuth(notificationManagedConfig()).isHosted()
+}
+
+func wasPreviouslyLinked() bool {
+	st := loadStateFromDisk(stateDataDir())
+	return st.OnboardedMSISDN != "" || !st.LinkedAt.IsZero() || st.AuthStatus == "logged_out" || st.ExitStatus != ""
+}
+
+func connectCommand(instance string) string {
+	source := sourceSelfManaged
+	if cfg := notificationManagedConfig(); cfg.isDirect() {
+		source = sourceDoubletick
+	} else if cfg.isManagedVM() {
+		source = sourceVestaCloud
+	}
+	command := "whatsapp connect --source " + source
+	if instance != "" {
+		command += " --instance " + quoteReplyArg(instance)
+	}
+	return command
 }
 
 // WriteUnpairedNotification tells the agent the WhatsApp daemon came up without a
@@ -283,16 +309,27 @@ func managedParadigm() bool {
 // managed number reclaims itself autonomously (no user step), so only self-hosted QR
 // linking, which needs the human to scan, is gated on the user being ready.
 func WriteUnpairedNotification(notifDir, instance string) error {
-	message := "WhatsApp daemon started without a paired device session. Run `whatsapp connect` to link (when the user is ready)."
-	if managedParadigm() {
-		message = "WhatsApp daemon started without a paired device session. Run `whatsapp connect` now to re-link your headless account; it reclaims the number autonomously and needs no user step."
+	priorLink := wasPreviouslyLinked()
+	managed := managedParadigm()
+	command := connectCommand(instance)
+	recovery := "first_link"
+	message := "WhatsApp daemon started without a paired device session. Run the exact next_command when the user is ready."
+	if priorLink {
+		recovery = "relink"
+		message = "WhatsApp lost a previously linked device session. Ask the user for explicit approval before reconnecting, then run the exact next_command once."
+	}
+	if managed {
+		message += " The headless flow needs no phone or QR step."
 	}
 	n := authNotif{
-		Source:    "whatsapp",
-		Type:      "unpaired",
-		Instance:  instance,
-		Message:   message,
-		Timestamp: time.Now().Format(time.RFC3339),
+		Source:               "whatsapp",
+		Type:                 "unpaired",
+		Instance:             instance,
+		Message:              message,
+		Recovery:             recovery,
+		NextCommand:          command,
+		RequiresUserApproval: priorLink,
+		Timestamp:            time.Now().Format(time.RFC3339),
 	}
 	return writeNotificationFile(notifDir, n, "unpaired")
 }
@@ -306,16 +343,19 @@ func WriteLoggedOutNotification(notifDir, instance, reason string) error {
 		message += " (" + reason + ")"
 	}
 	if managedParadigm() {
-		message += ". This is NOT re-linked automatically, but a headless account reauthorizes autonomously: run `whatsapp connect` now to re-link the SAME number, no user step needed. Do not retry-loop pairing."
+		message += ". Ask the user for explicit approval before reconnecting, then run the exact next_command once. The headless flow needs no phone or QR step. Do not retry-loop pairing."
 	} else {
-		message += ". This is NOT re-linked automatically. When the user is ready, run `whatsapp connect` to re-link. Do not retry-loop pairing."
+		message += ". Ask the user for explicit approval before reconnecting, then run the exact next_command once. Do not retry-loop pairing."
 	}
 	n := authNotif{
-		Source:    "whatsapp",
-		Type:      "logged_out",
-		Instance:  instance,
-		Message:   message,
-		Timestamp: time.Now().Format(time.RFC3339),
+		Source:               "whatsapp",
+		Type:                 "logged_out",
+		Instance:             instance,
+		Message:              message,
+		Recovery:             "relink",
+		NextCommand:          connectCommand(instance),
+		RequiresUserApproval: true,
+		Timestamp:            time.Now().Format(time.RFC3339),
 	}
 	return writeNotificationFile(notifDir, n, "logged_out")
 }

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -266,11 +266,12 @@ func writeCallNotification(notifDir, instance string, n callNotif) error {
 // mirroring the resolution runConnect and chooseLinker use: env creds first, filled
 // from persisted state so an env scrub still resolves the managed path. The auth
 // notifications read it because they run without a *WhatsAppClient (so without the
-// constructed linker) yet must still tell a managed agent to reauth autonomously.
-func notificationManagedConfig() managedConfig {
+// constructed linker) yet must still identify the exact recovery source. Whether
+// reconnect needs approval is derived separately from persisted link history.
+func notificationManagedConfig(instance string) managedConfig {
 	cfg := loadManagedConfig()
 	if cfg.directURL == "" || cfg.directKey == "" {
-		st := loadStateFromDisk(stateDataDir())
+		st := loadStateFromDisk(stateDataDirFor(instance))
 		if cfg.directURL == "" {
 			cfg.directURL = st.DirectURL
 		}
@@ -281,18 +282,18 @@ func notificationManagedConfig() managedConfig {
 	return cfg
 }
 
-func managedParadigm() bool {
-	return newManagedAuth(notificationManagedConfig()).isHosted()
+func managedParadigm(instance string) bool {
+	return newManagedAuth(notificationManagedConfig(instance)).isHosted()
 }
 
-func wasPreviouslyLinked() bool {
-	st := loadStateFromDisk(stateDataDir())
+func wasPreviouslyLinked(instance string) bool {
+	st := loadStateFromDisk(stateDataDirFor(instance))
 	return st.OnboardedMSISDN != "" || !st.LinkedAt.IsZero() || st.AuthStatus == "logged_out" || st.ExitStatus != ""
 }
 
 func connectCommand(instance string) string {
 	source := sourceSelfManaged
-	if cfg := notificationManagedConfig(); cfg.isDirect() {
+	if cfg := notificationManagedConfig(instance); cfg.isDirect() {
 		source = sourceDoubletick
 	} else if cfg.isManagedVM() {
 		source = sourceVestaCloud
@@ -306,14 +307,17 @@ func connectCommand(instance string) string {
 
 // WriteUnpairedNotification tells the agent the WhatsApp daemon came up without a
 // device session and needs re-pairing. Called once per unpaired daemon boot. A
-// managed number reclaims itself autonomously (no user step), so only self-hosted QR
-// linking, which needs the human to scan, is gated on the user being ready.
+// managed flow needs no phone or QR step, but a prior link still requires approval
+// under the linking rule. A self-managed first link waits for user participation.
 func WriteUnpairedNotification(notifDir, instance string) error {
-	priorLink := wasPreviouslyLinked()
-	managed := managedParadigm()
+	priorLink := wasPreviouslyLinked(instance)
+	managed := managedParadigm(instance)
 	command := connectCommand(instance)
 	recovery := "first_link"
 	message := "WhatsApp daemon started without a paired device session. Run the exact next_command when the user is ready."
+	if managed {
+		message = "WhatsApp daemon started without a paired device session. Run the exact next_command now."
+	}
 	if priorLink {
 		recovery = "relink"
 		message = "WhatsApp lost a previously linked device session. Ask the user for explicit approval before reconnecting, then run the exact next_command once."
@@ -342,7 +346,7 @@ func WriteLoggedOutNotification(notifDir, instance, reason string) error {
 	if reason != "" {
 		message += " (" + reason + ")"
 	}
-	if managedParadigm() {
+	if managedParadigm(instance) {
 		message += ". Ask the user for explicit approval before reconnecting, then run the exact next_command once. The headless flow needs no phone or QR step. Do not retry-loop pairing."
 	} else {
 		message += ". Ask the user for explicit approval before reconnecting, then run the exact next_command once. Do not retry-loop pairing."

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func savedCtx(dir string) NotifContext {
@@ -121,5 +123,76 @@ func TestPrimaryAccountDoesNotLabelItsInstance(t *testing.T) {
 
 	if _, present := soleNotifFields(t, dir)["instance"]; present {
 		t.Errorf("instance is present for the unnamed primary account, want it omitted")
+	}
+}
+
+func prepareAuthNotificationTest(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DOUBLETICK_API_URL", "")
+	t.Setenv("DOUBLETICK_API_KEY", "")
+	t.Setenv("WHATSAPP_API_URL", "")
+	t.Setenv("WHATSAPP_API_KEY", "")
+	t.Setenv("VESTA_CLOUD_CONTROL_URL", "")
+	if err := os.MkdirAll(filepath.Join(home, ".whatsapp"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	return t.TempDir()
+}
+
+func TestFreshManagedUnpairedCanConnectWithoutApproval(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	t.Setenv("DOUBLETICK_API_URL", "https://doubletick.example")
+	t.Setenv("DOUBLETICK_API_KEY", "wak_secret")
+
+	if err := WriteUnpairedNotification(dir, ""); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	if _, present := fields["requires_user_approval"]; present {
+		t.Fatal("first-time setup must not be mislabeled as a recovery requiring fresh approval")
+	}
+	var recovery, command string
+	_ = json.Unmarshal(fields["recovery"], &recovery)
+	_ = json.Unmarshal(fields["next_command"], &command)
+	if recovery != "first_link" || command != "whatsapp connect --source doubletick" {
+		t.Fatalf("fresh managed notification = recovery %q command %q", recovery, command)
+	}
+}
+
+func TestPreviouslyLinkedUnpairedRequiresApproval(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	t.Setenv("DOUBLETICK_API_URL", "https://doubletick.example")
+	t.Setenv("DOUBLETICK_API_KEY", "wak_secret")
+	newStateStore(stateDataDir()).update(func(state *daemonState) { state.LinkedAt = time.Now() })
+
+	if err := WriteUnpairedNotification(dir, ""); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	var approval bool
+	var recovery, message string
+	_ = json.Unmarshal(fields["requires_user_approval"], &approval)
+	_ = json.Unmarshal(fields["recovery"], &recovery)
+	_ = json.Unmarshal(fields["message"], &message)
+	if !approval || recovery != "relink" || !strings.Contains(message, "explicit approval") {
+		t.Fatalf("lost-link notification did not preserve the approval gate: approval=%v recovery=%q message=%q", approval, recovery, message)
+	}
+}
+
+func TestLoggedOutNotificationNamesExactApprovedRecoveryCommand(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+
+	if err := WriteLoggedOutNotification(dir, "personal", "removed"); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	var approval bool
+	var command string
+	_ = json.Unmarshal(fields["requires_user_approval"], &approval)
+	_ = json.Unmarshal(fields["next_command"], &command)
+	if !approval || command != "whatsapp connect --source self-managed --instance 'personal'" {
+		t.Fatalf("logged-out recovery = approval %v command %q", approval, command)
 	}
 }

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -153,11 +153,12 @@ func TestFreshManagedUnpairedCanConnectWithoutApproval(t *testing.T) {
 	if _, present := fields["requires_user_approval"]; present {
 		t.Fatal("first-time setup must not be mislabeled as a recovery requiring fresh approval")
 	}
-	var recovery, command string
+	var recovery, command, message string
 	_ = json.Unmarshal(fields["recovery"], &recovery)
 	_ = json.Unmarshal(fields["next_command"], &command)
-	if recovery != "first_link" || command != "whatsapp connect --source doubletick" {
-		t.Fatalf("fresh managed notification = recovery %q command %q", recovery, command)
+	_ = json.Unmarshal(fields["message"], &message)
+	if recovery != "first_link" || command != "whatsapp connect --source doubletick" || !strings.Contains(message, "now") {
+		t.Fatalf("fresh managed notification = recovery %q command %q message %q", recovery, command, message)
 	}
 }
 
@@ -194,5 +195,31 @@ func TestLoggedOutNotificationNamesExactApprovedRecoveryCommand(t *testing.T) {
 	_ = json.Unmarshal(fields["next_command"], &command)
 	if !approval || command != "whatsapp connect --source self-managed --instance 'personal'" {
 		t.Fatalf("logged-out recovery = approval %v command %q", approval, command)
+	}
+}
+
+func TestNamedInstanceUsesItsOwnPersistedRecoveryState(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	instance := "personal"
+	instanceDir := stateDataDirFor(instance)
+	if err := os.MkdirAll(instanceDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	newStateStore(instanceDir).update(func(state *daemonState) {
+		state.DirectURL = "https://doubletick.example"
+		state.DirectKey = "wak_secret"
+		state.OnboardedMSISDN = "+15551230000"
+	})
+
+	if err := WriteUnpairedNotification(dir, instance); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	var approval bool
+	var command string
+	_ = json.Unmarshal(fields["requires_user_approval"], &approval)
+	_ = json.Unmarshal(fields["next_command"], &command)
+	if !approval || command != "whatsapp connect --source doubletick --instance 'personal'" {
+		t.Fatalf("named-instance recovery = approval %v command %q", approval, command)
 	}
 }

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -223,3 +223,57 @@ func TestNamedInstanceUsesItsOwnPersistedRecoveryState(t *testing.T) {
 		t.Fatalf("named-instance recovery = approval %v command %q", approval, command)
 	}
 }
+
+func TestManagedVMFallbackPrefersCloudOverDirectCredentials(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	t.Setenv("VESTA_CLOUD_CONTROL_URL", "https://api.vesta.run")
+	t.Setenv("DOUBLETICK_API_URL", "https://doubletick.example")
+	t.Setenv("DOUBLETICK_API_KEY", "wak_secret")
+
+	if err := WriteUnpairedNotification(dir, ""); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	var command string
+	_ = json.Unmarshal(fields["next_command"], &command)
+	if command != "whatsapp connect --source vesta-cloud" {
+		t.Fatalf("mixed managed environment selected %q, want vesta-cloud", command)
+	}
+}
+
+func TestPersistedExplicitSourceWinsInMixedEnvironment(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	t.Setenv("VESTA_CLOUD_CONTROL_URL", "https://api.vesta.run")
+	t.Setenv("DOUBLETICK_API_URL", "https://doubletick.example")
+	t.Setenv("DOUBLETICK_API_KEY", "wak_secret")
+	newStateStore(stateDataDir()).recordAccountSource(sourceDoubletick)
+
+	if err := WriteUnpairedNotification(dir, ""); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	var command string
+	_ = json.Unmarshal(fields["next_command"], &command)
+	if command != "whatsapp connect --source doubletick" {
+		t.Fatalf("persisted explicit source produced %q, want doubletick", command)
+	}
+}
+
+func TestIncompleteDirectConfigBlocksRecoveryCommand(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	t.Setenv("DOUBLETICK_API_URL", "https://doubletick.example")
+
+	if err := WriteUnpairedNotification(dir, ""); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	if _, present := fields["next_command"]; present {
+		t.Fatal("incomplete credentials produced a connect command that cannot succeed")
+	}
+	var recovery, message string
+	_ = json.Unmarshal(fields["recovery"], &recovery)
+	_ = json.Unmarshal(fields["message"], &message)
+	if recovery != "configuration_error" || !strings.Contains(message, "must be set together") || strings.Contains(message, "headless") {
+		t.Fatalf("incomplete configuration notification = recovery %q message %q", recovery, message)
+	}
+}

--- a/agent/skills/whatsapp/cli/profile_init_test.go
+++ b/agent/skills/whatsapp/cli/profile_init_test.go
@@ -143,6 +143,16 @@ func TestProvisionCommandRetriesPendingLinkedResult(t *testing.T) {
 	}
 }
 
+func TestProvisionCommandRecordsExplicitSourceOnResume(t *testing.T) {
+	wac := newLinkedTestClient(t)
+	if _, err := cmdProvisionManaged([]string{"--source", sourceVestaCloud}, wac); err != nil {
+		t.Fatal(err)
+	}
+	if got := wac.state.snapshot().AccountSource; got != sourceVestaCloud {
+		t.Fatalf("recorded source = %q, want %q", got, sourceVestaCloud)
+	}
+}
+
 func TestFreshPhotoWipeStateRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	store := newStateStore(dir)

--- a/agent/skills/whatsapp/cli/state.go
+++ b/agent/skills/whatsapp/cli/state.go
@@ -24,6 +24,9 @@ type daemonState struct {
 	MSISDN    string `json:"msisdn,omitempty"`
 	DirectURL string `json:"api_url,omitempty"`
 	DirectKey string `json:"api_key,omitempty"`
+	// AccountSource records the explicit connect choice so recovery notifications
+	// never infer cloud vs. Double Tick from an ambiguous mixed environment.
+	AccountSource string `json:"account_source,omitempty"`
 	// OnboardedMSISDN marks the number whose first-link profile and result finished.
 	// PendingLinkedOpener preserves first-link output across profile-init retries.
 	OnboardedMSISDN     string `json:"onboarded_msisdn,omitempty"`
@@ -133,6 +136,13 @@ func (s *stateStore) snapshot() daemonState {
 }
 
 func (s *stateStore) persistLocked() error { return atomicWriteJSON(s.path, s.st) }
+
+func (s *stateStore) recordAccountSource(source string) {
+	switch source {
+	case sourceVestaCloud, sourceDoubletick, sourceSelfManaged:
+		s.update(func(st *daemonState) { st.AccountSource = source })
+	}
+}
 
 // tryRecordPairAttempt checks the ban-avoidance rate limit and, when allowed,
 // records an attempt, atomically. For callers where initiating the flow IS the


### PR DESCRIPTION
## Problem

The WhatsApp skill says a lost prior link requires explicit user approval before reconnecting. The runtime notifications said the opposite for headless accounts: reconnect now, with no user step.

A logout also produces a later `unpaired` notification, so even an agent that handled the first notice correctly could be told to bypass approval by the second. Both notices named `whatsapp connect`, although that command requires an explicit source and cannot run as written.

## Change

1. Distinguish `first_link` from `relink` using persisted WhatsApp state.
2. Mark recovery notifications with `requires_user_approval`, `recovery`, and an exact `next_command`.
3. Require approval consistently for every prior-link recovery, while explaining that a headless account needs no phone or QR action after approval.
4. Emit the correct `--source` and named instance in the recovery command.

## Verification

`./check.sh whatsapp` passed inside the released Vesta build environment. Tests cover fresh Double Tick setup, a previously linked unpaired account, and an exact named-instance self-managed recovery command.
