### PR TITLE
fix(tasks): post-review cleanups (clear-due, done-cleanup, snooze label, store path)

### DIFF
--- a/agent/skills/tasks/cli/src/tasks_cli/commands.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/commands.py
@@ -399,7 +399,9 @@ def update_task(
             if status == "done":
                 updates.append("completed_at = ?")
                 params.append(_now_utc().isoformat())
-                db.delete_auto_reminders(conn, task_id)
+                # A finished task stops reminding entirely, so this clears owned reminders too, not
+                # just auto ones. A due-date change below rebuilds only the auto ones (delete_auto).
+                db.delete_task_reminders(conn, task_id)
             elif status == "pending":
                 updates.append("completed_at = NULL")
                 # Recreate auto-reminders if task has a due date and is reopened.
@@ -946,6 +948,7 @@ def remind_snooze(
                 raise ValueError("Say when: tasks remind snooze <id> --in-hours N (or --in-minutes/--in-days, or --at + --tz)")
             run_time = _now_utc() + offset
 
+        run_time = run_time.replace(microsecond=0)
         new_data = {"type": "date", "run_date": run_time.isoformat()}
         # schedule_type is the human-readable label `remind list` prints, so it tracks the new fire time.
         new_schedule = f"once at {run_time.isoformat()}"

--- a/agent/skills/tasks/cli/src/tasks_cli/commands.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/commands.py
@@ -43,9 +43,8 @@ RECURRING_TRIGGER_TYPES = ("cron", "interval")  # trigger types that fire more t
 class DueSpec(BaseModel):
     """A task due date: an absolute datetime + timezone, or a relative due-in offset.
 
-    `clear` removes the due date entirely. Without it, setting a due date is a one-way door:
-    every other field can only move the date, never unset it, and auto reminders are regenerated
-    from due_date, so a date set by mistake keeps its reminder cascade forever.
+    The due-setting fields only move the date. `clear` is the one that unsets it, along with the
+    auto reminders regenerated from it, and cannot be combined with a due-setting field.
     """
 
     due_datetime: str | None = None
@@ -239,21 +238,22 @@ def normalize_priority(priority: int | str) -> int:
     return priority_map[key]
 
 
+def _due_field_set(due: DueSpec) -> bool:
+    """Whether any due-setting field is populated (`clear` is not one of them)."""
+    return due.due_datetime is not None or due.due_in_minutes is not None or due.due_in_hours is not None or due.due_in_days is not None
+
+
 def _due_requested(due: DueSpec | None) -> bool:
     """Whether the spec asks for a due-date change (a timezone alone does not)."""
-    return due is not None and (
-        due.clear
-        or due.due_datetime is not None
-        or due.due_in_minutes is not None
-        or due.due_in_hours is not None
-        or due.due_in_days is not None
-    )
+    return due is not None and (due.clear or _due_field_set(due))
 
 
 def _compute_due_date(due: DueSpec | None) -> str | None:
     if due is None:
         return None
     if due.clear:
+        if _due_field_set(due):
+            raise ValueError("clear removes the due date, so it cannot be combined with a due date or offset")
         return None
     if due.due_datetime is not None:
         if due.timezone is None:

--- a/agent/skills/tasks/cli/src/tasks_cli/config.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/config.py
@@ -1,9 +1,14 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+
+
+def default_data_dir() -> Path:
+    """The production tasks store, and the single owner of this path (the db migration guard reads it too)."""
+    return Path.home() / ".tasks"
 
 
 @dataclass
 class Config:
-    data_dir: Path = Path.home() / ".tasks"
-    log_dir: Path = Path.home() / ".tasks" / "logs"
+    data_dir: Path = field(default_factory=default_data_dir)
+    log_dir: Path = field(default_factory=lambda: default_data_dir() / "logs")
     monitor_interval: int = 60

--- a/agent/skills/tasks/cli/src/tasks_cli/db.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/db.py
@@ -7,6 +7,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TypedDict
 
+from .config import default_data_dir
+
 logger = logging.getLogger(__name__)
 
 
@@ -121,12 +123,12 @@ def _migrate_v1_to_v2(conn: sqlite3.Connection, data_dir: Path):
         conn.execute("DROP TABLE tasks")
         conn.execute("ALTER TABLE tasks_v2 RENAME TO tasks")
 
-    # Import reminders from the old reminder CLI db, but ONLY into the real store. The legacy path
-    # is absolute and home-relative while the database being built is whatever the caller passed,
-    # so without this guard EVERY new database gets seeded from the developer's own reminders:
-    # a temp-directory database comes up holding 40 rows that belong to a different store entirely.
+    # LEGACY(remove-when: no fleet agent's tasks.db remains below schema v2): one-time import from the
+    # old reminder CLI db, and ONLY into the real store. The legacy path is absolute and home-relative
+    # while the database being built is whatever the caller passed, so without this guard every new
+    # database (a temp-directory test db included) gets seeded from a store that isn't its own.
     old_reminder_db = Path.home() / ".reminder" / "reminders.db"
-    if data_dir == Path.home() / ".tasks" and old_reminder_db.exists():
+    if data_dir == default_data_dir() and old_reminder_db.exists():
         try:
             old_conn = sqlite3.connect(old_reminder_db)
             old_conn.row_factory = sqlite3.Row
@@ -249,6 +251,10 @@ def create_auto_reminders(conn: sqlite3.Connection, task_id: str, title: str, du
 
     if due_dt > now:
         _insert_auto_reminder(conn, task_id, DUE_NOW_MESSAGE.format(title=title, task_id=task_id), "auto: at due", due_dt)
+
+
+def delete_task_reminders(conn: sqlite3.Connection, task_id: str):
+    conn.execute("DELETE FROM reminders WHERE task_id = ?", (task_id,))
 
 
 def delete_auto_reminders(conn: sqlite3.Connection, task_id: str):

--- a/agent/skills/tasks/cli/tests/test_clear_due.py
+++ b/agent/skills/tasks/cli/tests/test_clear_due.py
@@ -1,17 +1,19 @@
 """Clearing a due date.
 
-Before `clear`, setting a due date was a one-way door: every DueSpec field could only move the
-date, never unset it. Because auto reminders are regenerated from `due_date` (see
-`db._create_auto_reminders_for_existing`), deleting them by hand did not help either, so a date set
-by mistake, or by a bulk postpone across a backlog, kept its whole reminder cascade forever.
+`clear` unsets a task's due date and deletes the auto reminders regenerated from it (see
+`db._create_auto_reminders_for_existing`). Only an explicit clear touches the date, and it cannot
+be combined with a due-setting field.
 """
 
+from contextlib import closing
+
+import pytest
 from tasks_cli import commands, db
 from tasks_cli.config import Config
 
 
 def _pending_auto_reminders(config: Config, task_id: str) -> int:
-    with db.get_db(config.data_dir) as conn:
+    with closing(db.get_db(config.data_dir)) as conn:
         row = conn.execute(
             "SELECT COUNT(*) FROM reminders WHERE task_id = ? AND auto_generated = 1",
             (task_id,),
@@ -49,6 +51,15 @@ def test_clear_due_does_not_need_a_timezone(tmp_config: Config):
     updated = commands.update_task(config, task_id=task["id"], due=commands.DueSpec(clear=True))
 
     assert updated["due_date"] is None
+
+
+def test_clear_due_rejects_a_conflicting_due_offset(tmp_config: Config):
+    """`clear` and a due-setting field together are contradictory: reject, do not silently pick one."""
+    config = tmp_config
+    task = commands.add_task(config, title="item", due=commands.DueSpec(due_in_days=3))
+
+    with pytest.raises(ValueError, match="clear"):
+        commands.update_task(config, task_id=task["id"], due=commands.DueSpec(clear=True, due_in_days=10))
 
 
 def test_update_without_due_spec_leaves_the_date_alone(tmp_config: Config):

--- a/agent/skills/tasks/cli/tests/test_overdue_loop.py
+++ b/agent/skills/tasks/cli/tests/test_overdue_loop.py
@@ -161,6 +161,18 @@ def test_snooze_relabels_the_schedule_shown_by_remind_list(tmp_config: Config):
     assert rendered.startswith("in 8d\t")
 
 
+def test_snooze_fire_time_is_second_precision(tmp_config: Config):
+    """A relative snooze derives its fire time from now, so it must not leak the sub-second precision
+    no other schedule label carries."""
+    reminder = commands.remind_set(tmp_config, commands.ReminderSpec(message="chase it", scheduled_datetime="2026-07-19T09:00:00", tz="UTC"))
+
+    result = commands.remind_snooze(tmp_config, reminder_id=reminder["id"], in_hours=5)
+
+    assert db.parse_datetime(result["next_run"]).microsecond == 0
+    assert result["schedule"] == f"once at {result['next_run']}"
+    assert "." not in result["next_run"].split("+")[0], f"snooze fire time leaked sub-second precision: {result['next_run']}"
+
+
 def test_snooze_rejects_recurring(tmp_config: Config):
     reminder = commands.remind_set(
         tmp_config, commands.ReminderSpec(message="daily", scheduled_datetime="2026-04-26T10:30:00", tz="UTC", recurring="daily")

--- a/agent/skills/tasks/cli/tests/test_remind_ownership.py
+++ b/agent/skills/tasks/cli/tests/test_remind_ownership.py
@@ -65,6 +65,16 @@ def test_postpone_still_replaces_untouched_auto_reminders(tmp_config: Config):
     assert not (before & {r["id"] for r in after}), "untouched auto reminders should be regenerated"
 
 
+def test_marking_a_task_done_clears_owned_reminders_too(tmp_config: Config):
+    """A finished task stops reminding, so ownership must not let a rewritten reminder outlive it."""
+    task_id, auto = _task_with_auto_reminders(tmp_config)
+    commands.remind_update(tmp_config, reminder_id=auto["id"], message="hand written checkpoint")
+
+    commands.update_task(tmp_config, task_id=task_id, status="done")
+
+    assert _reminders(tmp_config, task_id) == [], "a done task must clear all its reminders, owned included"
+
+
 def test_rewriting_relabels_the_schedule(tmp_config: Config):
     """An owned reminder must not still describe itself as auto-generated. `remind list` renders
     schedule_type, so leaving it makes a hand-written row read `auto: 1 day before due` while its


### PR DESCRIPTION
Cleanups from a post-merge review of the four tasks-skill PRs (#1680, #1719, #1731, #1663). Grouped into one PR per request; every change is scoped to the tasks skill and covered by a test.

## Changes

**#1680, reject contradictory clear flags.** `tasks update <id> --clear-due --due-in-days 10` checked `clear` first and silently discarded the offset, just clearing the date. `_compute_due_date` now raises a `ValueError` (the CLI's clean error path) when `clear` is combined with any due-setting field. Extracted the duplicated "any due field set" check into `_due_field_set`. Also dropped two old-behavior descriptions (the `DueSpec` and `test_clear_due` docstrings narrated the pre-`clear` design, which the `agent/`-read-cold rule forbids) and added a missing `closing()` on a test DB handle.

**#1731, a done task clears all its reminders.** The reminder fire path (`send_reminder_job`) never checks task status, so a reminder rewritten into user ownership kept firing after its task was marked done. `update_task(status="done")` now clears every reminder for the task, not just the auto ones. This is coherent with the existing design: auto reminders are regenerable (deleted on done, recreated on reopen), and this extends "done means stop reminding" to owned ones. A due-date change still rebuilds only the auto reminders, so an unrelated edit never nukes a rewrite.

**#1663, snooze label second-precision.** A relative snooze takes its fire time from `now + offset`, so the `once at ...` label leaked microseconds (`...T08:42:01.872801+00:00`) that no other label carries. Truncated to seconds.

**#1719, one owner for the store path.** `~/.tasks` was hardcoded in both `config.py` and the `db.py` migration guard. A single `default_data_dir()` now feeds both; `config`'s field became a runtime `default_factory` so the guard stays monkeypatch-safe in tests. The legacy `~/.reminder` import now carries a `LEGACY(remove-when: no fleet agent's tasks.db remains below schema v2)` marker.

## Tests
New regression tests: contradictory clear/set flags raise; a rewritten reminder is cleared when its task is done; a snooze fire time is second-precision. Full tasks CLI suite: 190 passed. `./check.sh guards`: green (import-cycle check passes with the new `db -> config` edge, config being a leaf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
