### PR TITLE
feat(tasks): notify the agent when a task is completed in the app

### DIFF
--- a/agent/skills/tasks/cli/src/tasks_cli/cli.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/cli.py
@@ -468,7 +468,7 @@ def _run_serve(config: Config, notif_dir: Path, *, port: int):
     signal.signal(signal.SIGINT, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)
 
-    http_server = start_server(config, port)
+    http_server = start_server(config, port, notif_dir)
 
     scheduler = create_scheduler()
     scheduler.start()

--- a/agent/skills/tasks/cli/src/tasks_cli/server.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/server.py
@@ -1,5 +1,6 @@
 import logging
 import threading
+from pathlib import Path
 from typing import Literal
 
 import uvicorn
@@ -8,6 +9,7 @@ from pydantic import BaseModel
 
 from . import commands
 from .config import Config
+from .scheduler import write_notification
 
 logger = logging.getLogger(__name__)
 
@@ -50,10 +52,38 @@ class SnoozeReminderBody(BaseModel):
     tz: str | None = None
 
 
+# --- Task update (app path) ---
+
+
+def _apply_task_update(config: Config, notif_dir: Path, task_id: str, body: UpdateTaskBody) -> dict:
+    """Apply a task update coming from the app. A pending->done transition here is the one completion
+    the agent does not already know about (its own CLI edits are self-evident), so it notifies,
+    snoozed (interrupt=False), which the CLI path never does."""
+    already_done = body.status == "done" and commands.get_task(config, task_id=task_id)["status"] == "done"
+    result = commands.update_task(
+        config,
+        task_id=task_id,
+        status=body.status,
+        title=body.title,
+        priority=body.priority,
+        due=commands.DueSpec(
+            due_datetime=body.due_datetime,
+            timezone=body.timezone,
+            due_in_minutes=body.due_in_minutes,
+            due_in_hours=body.due_in_hours,
+            due_in_days=body.due_in_days,
+            clear=body.clear_due,
+        ),
+    )
+    if body.status == "done" and not already_done:
+        write_notification(notif_dir, "task_completed", interrupt=False, task_id=task_id, message=f"Task completed: {result['title']}")
+    return result
+
+
 # --- App factory ---
 
 
-def _create_app(config: Config) -> FastAPI:
+def _create_app(config: Config, notif_dir: Path) -> FastAPI:
     app = FastAPI()
 
     @app.exception_handler(ValueError)
@@ -92,21 +122,7 @@ def _create_app(config: Config) -> FastAPI:
 
     @app.patch("/tasks/{task_id}")
     def update_task(task_id: str, body: UpdateTaskBody):
-        return commands.update_task(
-            config,
-            task_id=task_id,
-            status=body.status,
-            title=body.title,
-            priority=body.priority,
-            due=commands.DueSpec(
-                due_datetime=body.due_datetime,
-                timezone=body.timezone,
-                due_in_minutes=body.due_in_minutes,
-                due_in_hours=body.due_in_hours,
-                due_in_days=body.due_in_days,
-                clear=body.clear_due,
-            ),
-        )
+        return _apply_task_update(config, notif_dir, task_id, body)
 
     @app.delete("/tasks/{task_id}")
     def delete_task(task_id: str):
@@ -145,8 +161,8 @@ def _create_app(config: Config) -> FastAPI:
     return app
 
 
-def start_server(config: Config, port: int) -> uvicorn.Server:
-    app = _create_app(config)
+def start_server(config: Config, port: int, notif_dir: Path) -> uvicorn.Server:
+    app = _create_app(config, notif_dir)
     uv_config = uvicorn.Config(app, host="0.0.0.0", port=port, log_level="info")
     server = uvicorn.Server(uv_config)
     thread = threading.Thread(target=server.run, daemon=True)

--- a/agent/skills/tasks/cli/tests/test_task_completion_notify.py
+++ b/agent/skills/tasks/cli/tests/test_task_completion_notify.py
@@ -1,0 +1,61 @@
+"""Completing a task through the app notifies the agent; the agent's own CLI completions do not.
+
+The reminder fire path never checks task status, and the agent only learns of app-side edits it did
+not make, so a pending->done transition through the HTTP handler writes a snoozed `task_completed`
+notification. A completion through `commands.update_task` (the agent's own CLI) writes nothing.
+"""
+
+import json
+from pathlib import Path
+
+from tasks_cli import commands, server
+from tasks_cli.config import Config
+
+
+def _completion_notifs(notif_dir: Path) -> list[dict]:
+    return [json.loads(p.read_text()) for p in notif_dir.glob("*-tasks-task_completed.json")]
+
+
+def test_app_completion_writes_a_snoozed_notification(tmp_config: Config, tmp_path: Path):
+    notif_dir = tmp_path / "notifications"
+    notif_dir.mkdir()
+    task = commands.add_task(tmp_config, title="call the dentist")
+
+    server._apply_task_update(tmp_config, notif_dir, task["id"], server.UpdateTaskBody(status="done"))
+
+    notifs = _completion_notifs(notif_dir)
+    assert len(notifs) == 1
+    assert notifs[0]["interrupt"] is False, "a completion is informational, so it must snooze, not interrupt"
+    assert notifs[0]["task_id"] == task["id"]
+    assert "call the dentist" in notifs[0]["message"]
+
+
+def test_app_completion_notifies_once_not_on_a_repeat(tmp_config: Config, tmp_path: Path):
+    notif_dir = tmp_path / "notifications"
+    notif_dir.mkdir()
+    task = commands.add_task(tmp_config, title="x")
+
+    server._apply_task_update(tmp_config, notif_dir, task["id"], server.UpdateTaskBody(status="done"))
+    server._apply_task_update(tmp_config, notif_dir, task["id"], server.UpdateTaskBody(status="done"))
+
+    assert len(_completion_notifs(notif_dir)) == 1, "re-sending done on an already-done task must not re-notify"
+
+
+def test_app_edit_that_is_not_a_completion_does_not_notify(tmp_config: Config, tmp_path: Path):
+    notif_dir = tmp_path / "notifications"
+    notif_dir.mkdir()
+    task = commands.add_task(tmp_config, title="x")
+
+    server._apply_task_update(tmp_config, notif_dir, task["id"], server.UpdateTaskBody(title="renamed"))
+
+    assert _completion_notifs(notif_dir) == []
+
+
+def test_cli_completion_does_not_notify(tmp_config: Config, tmp_path: Path):
+    notif_dir = tmp_path / "notifications"
+    notif_dir.mkdir()
+    task = commands.add_task(tmp_config, title="x")
+
+    commands.update_task(tmp_config, task_id=task["id"], status="done")
+
+    assert _completion_notifs(notif_dir) == [], "the agent's own CLI completion is self-evident and must stay silent"


### PR DESCRIPTION
When a task is marked complete, Vesta should hear about it. Today it doesn't: the reminder fire path never checks task status, and Vesta only ever sees task edits it did not make itself.

## Change
A task can be completed two ways:
- **Vesta itself**, via the `tasks` CLI: it already knows, since it ran the command.
- **The user, in the app**, via `PATCH /tasks/{id}`: Vesta has no idea.

So the notification is written on the HTTP path only. A pending -> done transition in `_apply_task_update` writes a `source=tasks`, `type=task_completed` notification with `interrupt=false`, so it snoozes (informational, batched when Vesta is next idle) rather than preempting current work. Re-sending `done` on an already-done task does not re-notify, and a non-completion edit (rename, reprioritise) writes nothing. `commands.update_task` (the CLI path) is untouched and stays silent.

## Scope
Purely additive: threads `notif_dir` into the server and moves the update body into a testable `_apply_task_update`. No change to `commands.py`, so this is independent of #1748 and both merge cleanly.

## Tests
New `test_task_completion_notify.py`: an app completion writes one snoozed notification carrying the task id and title; a repeat done does not re-notify; a non-completion edit does not notify; a CLI completion stays silent. Full tasks CLI suite: 191 passed. `./check.sh guards`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
