### PR TITLE
feat(notifications): stamp delivery disposition on channel elements

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -6,7 +6,6 @@ import datetime as dt
 import json
 import pathlib as pl
 import time
-import typing as tp
 
 import pydantic
 from watchfiles import Change, awatch
@@ -26,7 +25,16 @@ from .client import (
 from .codex_proxy import start_codex_proxy
 from .diagnostics import format_crash_detail
 from .helpers import build_restart_context, clear_notifications, load_prompt
-from .notification import CORE_SNOOZE_TYPES, CORE_SOURCE, TYPE_COMPACTION_FOLLOWUP, TYPE_NIGHTLY_DREAM, TYPE_PROACTIVE_CHECK, Notification
+from .notification import (
+    CORE_SNOOZE_TYPES,
+    CORE_SOURCE,
+    TYPE_COMPACTION_FOLLOWUP,
+    TYPE_NIGHTLY_DREAM,
+    TYPE_PROACTIVE_CHECK,
+    DeliveredDisposition,
+    Disposition,
+    Notification,
+)
 from .openrouter_cache import resolve_openrouter_max_tokens, start_cache_proxy
 from .provider import ProviderAuthState, is_unauthenticated
 
@@ -65,9 +73,7 @@ def drop_core_notification(*, type_: str, body: str, config: cfg.VestaConfig, na
     return path
 
 
-def _notif_disposition(
-    notif: Notification, rules: list[notification_interrupt_policy.NotificationInterruptRule]
-) -> tp.Literal["interrupt", "snooze", "trash"]:
+def _notif_disposition(notif: Notification, rules: list[notification_interrupt_policy.NotificationInterruptRule]) -> Disposition:
     """The notification's effective disposition: `interrupt`, `snooze`, or `trash`. Core notifications are
     exempt from the user's rules — their disposition is control-flow, derived from the type
     (CORE_SNOOZE_TYPES), and is never trashed; everything else goes through the ruleset (first match wins,
@@ -111,21 +117,29 @@ async def trash_notification_files(notifications: list[Notification], *, trash_d
     _trash_paths([n.file_path for n in notifications if n.file_path], trash_dir)
 
 
-def format_notification_batch(notifications: list[Notification]) -> str:
+def format_notification_batch(notifications: list[Notification], *, disposition: DeliveredDisposition | None = None) -> str:
     """Join the batch as newline-separated <channel> elements, matching how Claude Code delivers
     several native channel events together on one turn. No wrapper element: each <channel> is
     self-contained. All read-time guidance is producer-owned: executable reply syntax is carried in
     `reply_command`, while behavioral guidance such as the group-chat caveat stays in
-    `reply_hint`; core injects nothing."""
-    return "\n".join(n.format_for_display() for n in notifications)
+    `reply_hint`; core injects only delivery context (`disposition`, BATCH_TRIAGE_HINT)."""
+    return "\n".join(n.format_for_display(disposition=disposition) for n in notifications)
+
+
+# Prepended to a multi-notification snoozed section only; interrupt batches are delivered bare.
+# A pointer, not advice: the triage workflow itself is owned by the notifications skill.
+BATCH_TRIAGE_HINT = "[{count} snoozed notifications delivered as one batch; the notifications skill covers working through them.]"
 
 
 async def process_batch(
     notifications: list[Notification],
     *,
     queue: asyncio.Queue[vm.QueuedTurn],
+    disposition: DeliveredDisposition,
 ) -> None:
     """Render a batch as one prompt and queue it. Mixed batches render in two sections, system (`source=core`) first.
+    `disposition` is how the batch was routed, stamped on each external element; a multi-notification
+    snoozed section additionally opens with BATCH_TRIAGE_HINT.
 
     Preempt delivery is owned by the processor's queue-watcher (_run_messages_with_preempts):
     an item landing mid-turn is delivered as a priority:"now" message and consumed at delivery.
@@ -138,15 +152,17 @@ async def process_batch(
     system = [n for n in notifications if n.source == CORE_SOURCE]
     external = [n for n in notifications if n.source != CORE_SOURCE]
 
-    async def queue_section(group: list[Notification]) -> None:
-        text = format_notification_batch(group)
+    async def queue_section(group: list[Notification], *, disposition: DeliveredDisposition | None) -> None:
+        text = format_notification_batch(group, disposition=disposition)
+        if disposition == "snooze" and len(group) > 1:
+            text = f"{BATCH_TRIAGE_HINT.format(count=len(group))}\n{text}"
         paths = [n.file_path for n in group if n.file_path]
         await queue.put(vm.QueuedTurn(text, False, paths))
 
     if system:
-        await queue_section(system)
+        await queue_section(system, disposition=None)
     if external:
-        await queue_section(external)
+        await queue_section(external, disposition=disposition)
 
 
 def greeting_turn(*, config: cfg.VestaConfig, state: vm.State, agent_message: str, first_start: bool) -> str | None:
@@ -573,7 +589,7 @@ async def _scan_notifications(
     queued_paths.update(n.file_path for n, disposition in decisions if disposition != "trash" and n.file_path)
 
     if interrupt_notifs:
-        await process_batch(interrupt_notifs, queue=queue)
+        await process_batch(interrupt_notifs, queue=queue, disposition="interrupt")
     return new_snoozed
 
 
@@ -630,7 +646,7 @@ async def monitor_loop(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.State, 
                 idle_since = None
 
             if pending_snoozed and idle_since is not None and (now - idle_since).total_seconds() >= config.notif_snooze_idle_grace_seconds:
-                await process_batch(pending_snoozed, queue=queue)
+                await process_batch(pending_snoozed, queue=queue, disposition="snooze")
                 pending_snoozed = []
     finally:
         await cancel_task(watcher_task)

--- a/agent/core/notification.py
+++ b/agent/core/notification.py
@@ -1,6 +1,7 @@
 """The notification data model and the core-notification vocabulary."""
 
 import datetime as dt
+import typing as tp
 import xml.sax.saxutils as xml_utils
 
 import pydantic as pyd
@@ -18,6 +19,11 @@ TYPE_COMPACTION_FOLLOWUP = "compaction_followup"
 
 # Types listed here snooze (wait for idle); every other core type interrupts.
 CORE_SNOOZE_TYPES = frozenset({TYPE_PROACTIVE_CHECK, TYPE_COMPACTION_FOLLOWUP})
+
+# The disposition vocabulary: how the interrupt rules route a notification. `trash` never reaches
+# the agent, so a delivered notification carries only the narrower form.
+Disposition = tp.Literal["interrupt", "snooze", "trash"]
+DeliveredDisposition = tp.Literal["interrupt", "snooze"]
 
 
 # Fields promoted to the <channel> element's inner body (the message), in priority order.
@@ -39,10 +45,14 @@ class Notification(pyd.BaseModel):
     body: str | None = None
     file_path: str | None = pyd.Field(default=None, exclude=True)
 
-    def format_for_display(self) -> str:
+    def format_for_display(self, *, disposition: DeliveredDisposition | None = None) -> str:
         """Render the notification as a <channel> element: routing metadata as attributes, the
         message as the inner body. This mirrors the shape Claude Code injects for native channel
         events, so the model reads Vesta notifications in a structure it already handles well.
+
+        `disposition` is delivery-time context, not producer data: the effective disposition the
+        interrupt rules decided (interrupt preempted the agent's work, snooze waited for idle),
+        rendered as a `disposition` attribute so the agent can tell how a delivery arrived.
 
         A multi-line `body` (core/system notifications) becomes the inner text directly. Otherwise
         the first present content field (message/text/content) becomes the body and every other
@@ -53,15 +63,17 @@ class Notification(pyd.BaseModel):
         (`contact_unknown`, `is_forwarded`, `missed`). Strips microsecond precision from any
         datetime field.
         """
+        attrs = [f'source="{self.source}"', f'type="{self.type}"']
+        if disposition is not None:
+            attrs.append(f'disposition="{disposition}"')
         if self.body is not None:
-            return f'<channel source="{self.source}" type="{self.type}">\n{self.body.strip()}\n</channel>'
+            return f"<channel {' '.join(attrs)}>\n{self.body.strip()}\n</channel>"
         data = self.model_dump(exclude={"file_path", "type", "source", "body", "interrupt"})
         content = ""
         for field in _CONTENT_FIELDS:
             if field in data and isinstance(data[field], str) and data[field].strip():
                 content = xml_utils.escape(data.pop(field).strip())
                 break
-        attrs = [f'source="{self.source}"', f'type="{self.type}"']
         for key, value in data.items():
             if value is None or value == "" or value is False or value == []:
                 continue

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -416,7 +416,7 @@ async def test_notification_file_deleted_before_processing_is_lost_on_restart(tm
     # monitor_loop calls process_batch on the interrupt notification.
     # process_batch queues the message and keeps the file on disk until processing completes.
     with patch("core.loops.load_prompt", return_value=""):
-        await process_batch([notif], queue=dying_queue)
+        await process_batch([notif], queue=dying_queue, disposition="interrupt")
 
     # File is preserved on disk until after the message is fully processed (the fix).
     assert notif_file.exists(), "process_batch must not delete the file before processing completes"

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -22,7 +22,7 @@ from core.loops import (
     monitor_loop,
     process_batch,
 )
-from core.notification import Notification
+from core.notification import CORE_SOURCE, Notification
 from core.provider import ProviderAuthState, ProviderStatus
 
 
@@ -309,7 +309,7 @@ async def test_process_batch_queues_prompt(tmp_path):
     notif = Notification(timestamp=dt.datetime(2025, 1, 1), source="test", type="message", file_path=str(f))
 
     with patch("core.loops.load_prompt", return_value=""):
-        await process_batch([notif], queue=queue)
+        await process_batch([notif], queue=queue, disposition="interrupt")
 
     assert not queue.empty()
     prompt, is_user, _file_paths, _ = await queue.get()
@@ -317,11 +317,73 @@ async def test_process_batch_queues_prompt(tmp_path):
     assert is_user is False
 
 
+def _external_pair() -> list[Notification]:
+    return [
+        Notification(timestamp=dt.datetime(2025, 1, 1), source="whatsapp", type="message", body="one"),
+        Notification(timestamp=dt.datetime(2025, 1, 1, 0, 0, 1), source="email", type="message", body="two"),
+    ]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("disposition", "prefix", "hint_expected"),
+    [("snooze", "[2 snoozed notifications delivered as one batch;", True), ("interrupt", "<channel ", False)],
+)
+async def test_process_batch_multiple_stamps_disposition_and_hints_only_snoozed(disposition, prefix, hint_expected):
+    """Each external element carries the effective disposition as an attribute; only a snoozed
+    batch opens with the triage pointer (interrupts were let through as important)."""
+    queue: asyncio.Queue = asyncio.Queue()
+
+    await process_batch(_external_pair(), queue=queue, disposition=disposition)
+
+    prompt, _, _, _ = await queue.get()
+    assert prompt.startswith(prefix)
+    assert ("notifications skill" in prompt) is hint_expected
+    assert prompt.count(f'disposition="{disposition}"') == 2
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("disposition", ["snooze", "interrupt"])
+async def test_process_batch_single_external_stamps_disposition_without_hint(disposition):
+    """A single notification carries its disposition attribute but no hint line: there is no
+    batch to triage."""
+    queue: asyncio.Queue = asyncio.Queue()
+    notif = Notification(timestamp=dt.datetime(2025, 1, 1), source="whatsapp", type="message", body="hi")
+
+    await process_batch([notif], queue=queue, disposition=disposition)
+
+    prompt, _, _, _ = await queue.get()
+    assert prompt.startswith(f'<channel source="whatsapp" type="message" disposition="{disposition}">')
+    assert "notifications skill" not in prompt
+
+
+@pytest.mark.anyio
+async def test_process_batch_system_section_has_no_hint():
+    """Core notifications are control flow, not triage material: even a multi-item system section
+    is delivered bare while the external section keeps its hint."""
+    queue: asyncio.Queue = asyncio.Queue()
+    notifs = [
+        Notification(timestamp=dt.datetime(2025, 1, 1), source=CORE_SOURCE, type="proactive-check", body="a"),
+        Notification(timestamp=dt.datetime(2025, 1, 1, 0, 0, 1), source=CORE_SOURCE, type="compaction-followup", body="b"),
+        *_external_pair(),
+    ]
+
+    await process_batch(notifs, queue=queue, disposition="snooze")
+
+    system_prompt, _, _, _ = await queue.get()
+    external_prompt, _, _, _ = await queue.get()
+    assert system_prompt.startswith("<channel ")
+    assert "notifications skill" not in system_prompt
+    assert "disposition=" not in system_prompt
+    assert external_prompt.startswith("[2 snoozed notifications delivered as one batch;")
+    assert external_prompt.count('disposition="snooze"') == 2
+
+
 @pytest.mark.anyio
 async def test_process_batch_empty_is_noop():
     queue: asyncio.Queue = asyncio.Queue()
 
-    await process_batch([], queue=queue)
+    await process_batch([], queue=queue, disposition="interrupt")
     assert queue.empty()
 
 
@@ -338,7 +400,7 @@ async def test_process_batch_keeps_files_until_processing(tmp_path):
     notif = Notification(timestamp=dt.datetime(2025, 1, 1), source="t", type="m", file_path=str(f))
 
     with patch("core.loops.load_prompt", return_value=""):
-        await process_batch([notif], queue=queue)
+        await process_batch([notif], queue=queue, disposition="interrupt")
 
     assert f.exists(), "notification file must stay on disk until the queued message is processed"
     _, _, file_paths, _ = await queue.get()

--- a/agent/tests/test_preempt.py
+++ b/agent/tests/test_preempt.py
@@ -161,7 +161,7 @@ async def test_process_batch_renders_and_queues_sections_plain(config, state, tm
     batch = [_notif(tmp_path, "sys", source=CORE_SOURCE), _notif(tmp_path, "ext")]
 
     with patch("core.loops.load_prompt", return_value=""):
-        await process_batch(batch, queue=queue)
+        await process_batch(batch, queue=queue, disposition="interrupt")
 
     state.client.query.assert_not_called()
     first, second = queue.get_nowait(), queue.get_nowait()
@@ -304,7 +304,7 @@ async def test_burst_of_preempts_with_merged_results_never_wedges(tmp_path):
         await wait_for_condition(lambda: state.turn is not None, message="first turn never opened")
 
         for notif in notifs:
-            await process_batch([notif], queue=queue)
+            await process_batch([notif], queue=queue, disposition="interrupt")
         await wait_for_condition(
             lambda: all(not f.exists() for f in burst_files),
             message="delivered preempts must clear their files at delivery",


### PR DESCRIPTION
## What

The rendered `<channel>` element for every delivered external notification now carries the effective disposition the interrupt rules decided, as a `disposition="interrupt"` or `disposition="snooze"` attribute. A snoozed batch of two or more additionally opens with a one-line pointer: `[N snoozed notifications delivered as one batch; the notifications skill covers working through them.]` Interrupt batches and system (`source=core`) sections are delivered bare, and single notifications get only the attribute.

## Why

The delivered prompt previously carried no marker of how a notification arrived: the agent could not tell an interrupt that preempted its work from a snoozed item held until idle, and a snoozed batch had no cue to trigger the deliberate-triage workflow the notifications skill owns. The attribute states the arrival mode per notification in the same vocabulary as the interrupt rules (`interrupt`/`snooze`), and the batch hint is a pure pointer so the triage guidance itself stays single-owned in the skill.

## How

- `Notification.format_for_display` takes an optional `disposition` and renders it through the one shared attribute path (body and attrs branches emit the tag from the same list).
- `process_batch` takes the disposition its two producers already know (`interrupt` from the scan tick, `snooze` from the idle flush), replacing no parameter: it is a new required keyword, so no caller can silently assert a wrong arrival mode.
- `Disposition` / `DeliveredDisposition` aliases in `notification.py` own the vocabulary (`trash` never reaches the agent, hence the narrower delivered form).

## Tests

Parametrized coverage in `test_notifications.py`: multi-batch stamps attributes and hints only when snoozed, single notifications get the attribute without the hint, mixed batches deliver the system section bare. Ran `agent` pytest suites (notifications, preempt, dreamer: 103 passed), ruff, and ty against current master in this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)