### PR TITLE
fix(presence): extend the return-to-focus settle delay to 45s

### DIFF
--- a/vestad/src/sync/presence.rs
+++ b/vestad/src/sync/presence.rs
@@ -15,7 +15,7 @@ pub(crate) const PRESENCE_NOTIFY_DEBOUNCE: Duration = Duration::from_mins(10);
 
 /// After a return to focus is detected, wait this long before notifying the fleet: a return that
 /// unfocuses inside the window was only a glance, so nothing is sent.
-pub(crate) const PRESENCE_NOTIFY_DELAY: Duration = Duration::from_secs(5);
+pub(crate) const PRESENCE_NOTIFY_DELAY: Duration = Duration::from_secs(45);
 
 pub(crate) type ConnId = u64;
 


### PR DESCRIPTION
Raises `PRESENCE_NOTIFY_DELAY` (vestad/src/sync/presence.rs) from 5s to 45s. This is the settle window after a debounced return to focus: a user who unfocuses again inside it was only glancing, so no `user-presence` notification is dropped into the fleet. At 5s a quick check-in could still fire the notification; 45s requires the user to actually stick around. The 10-minute away debounce is unchanged.

One-line constant change; the handler sleep and all presence unit tests reference the constant. Ran the vestad presence unit tests (15 passed) and `cargo clippy -p vestad -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)