### PR TITLE
fix(browser): consolidate the open browser PRs with their review repairs

### DIFF
--- a/agent/skills/browser/SKILL.md
+++ b/agent/skills/browser/SKILL.md
@@ -26,6 +26,17 @@ consider a block, and even then suspect a cookie/consent wall or a redirect befo
 
 **Same rule for a stuck FORM: a submit/next button that won't advance is a validation error, not a block.** On a multi-step wizard or checkout, when "Continue"/"Submit" appears to do nothing, do NOT conclude the site is fighting automation. Read the actual state first: screenshot it, grep the DOM for a required-but-empty field (`[required]` with no value), a `.text-danger`/`[class*=error]` message, an unticked terms checkbox, or a second hidden copy of the form you filled the wrong instance of. A false wall abandoned is worse than a real wall pushed through: the overwhelmingly common blocker on a stuck submit is one missing required field.
 
+**And the harder version: a page that appears to have NO field at all is almost never a page that cannot be filled.** "There is nowhere to type it, so this needs the user's own device" is the most expensive wrong conclusion available, because it looks like diligence. Before writing that sentence, rule out five things, in this order:
+1. **A cross-origin iframe.** `document.body.innerText` on the parent returns almost nothing while the screenshot plainly shows a form, and the mount point (`#onfido-mount`, `#widget-root`) reads as empty. Enumerate every browsing context and query inside each, do not trust the top document. Identity, payment and document-upload widgets are nearly always third-party iframes.
+2. **A field behind a conditional render.** The input exists only after some control is clicked (a `v-if`/`x-show` toggled by a "Get a code" or "Enter it manually" link). If the visible call-to-action opens a new tab, click it with a capture-phase `preventDefault` so the framework's handler still runs and reveals the field without navigating away.
+3. **A selector that is too specific.** Framework-rendered inputs often carry no `type` attribute, so `input[type=text]` matches nothing even though `el.type === 'text'`. Query bare `input` and filter in JS, and include `[contenteditable]` and `[role=textbox]` for masked/custom widgets. A `contenteditable` rich-text editor needs [interaction-skills/prosemirror-tiptap-editors.md](interaction-skills/prosemirror-tiptap-editors.md).
+4. **A shadow root.** `querySelectorAll` never pierces one, so a web-component field is invisible to it. Walk recursively: collect matches, then recurse into every `el.shadowRoot`.
+5. **Hydration timing.** A code-split step component mounts late, so an immediate query legitimately returns 0 a moment before the field exists. Re-query after a short wait or a `wait_for_text` on the expected label before concluding anything.
+
+A genuine wall states a capability the machine lacks (a camera, a physical document, a biometric, an on-device 2FA), not merely a field you could not find.
+
+**Parallel agents must not share a browser session**: concurrent runs on one session share tabs and can navigate each other's pages or evict each other, so give each parallel run its own `BROWSER_SESSION` (isolation details in [interaction-skills/advanced-usage.md](interaction-skills/advanced-usage.md)).
+
 **Setup**: [SETUP.md](SETUP.md)
 
 ## Search first
@@ -218,3 +229,10 @@ Occasional topics live in their own files so this one stays lean:
 
 - **Heavy-JS auth pages (Google, Zoom, Apple `idmsa`/`dev.apple`, and similar SPAs) HANG `goto`/`wait_for_load` for the full timeout**: these SPAs keep network connections open so the `load` event never fires cleanly, yet the page almost always loaded underneath. After a `goto` that times out, do NOT retry it and NEVER call `wait_for_load()` on these. Run a SEPARATE short call (`timeout 30 browser`) that reads `page_info()` and inspects the DOM directly (no navigation, no wait_for_load). Cap every browser call at `timeout 40-55` so a hang costs seconds, not minutes. Long blocking browser calls during a live exchange make the agent go unresponsive, so keep them short.
 - **Login-form fills need care**: some sign-in widgets live in an iframe (e.g. Apple's `aid-auth-widget-iFrame`, same-origin so `contentDocument` works). A JS `value`-set often does NOT satisfy the form's own validation (it re-renders back to empty after "Verifying..."), and real keystrokes (`type_text`) can DOUBLE a field that already holds a value, so CLEAR it first. These flows also commonly gate on device-2FA or a passcode that only the user's phone has, so browser automation frequently cannot finish them: prefer the official API or app path.
+
+## Check for the site's own API first
+
+Many SPAs answer their own JSON or config endpoints with everything the page shows, so a job
+board, booking widget, or account flow is often one `curl` or `browser http-get` instead of a
+launch, a navigation, and a snapshot. Before driving a browser at a site, look for that underlying
+API, and check `domain-skills/<host>/` for a saved recipe.

--- a/agent/skills/browser/SKILL.md
+++ b/agent/skills/browser/SKILL.md
@@ -44,7 +44,9 @@ A genuine wall states a capability the machine lacks (a camera, a physical docum
 Before inventing an approach to a site, check `domain-skills/<host>/` for saved recipes and
 `interaction-skills/` for reusable mechanics (dialogs, iframes, shadow DOM, uploads, scrolling,
 dropdowns). When you open or navigate to a URL, the CLI prepends a banner listing any matching
-recipes. Read them.
+recipes. Read them. Also check for the site's own API first: many SPAs answer their own JSON or
+config endpoints with everything the page shows, so a job board, booking widget, or account flow
+is often one `curl` or `browser http-get` instead of a launch, a navigation, and a snapshot.
 
 ```bash
 # List everything we know about a site
@@ -229,10 +231,3 @@ Occasional topics live in their own files so this one stays lean:
 
 - **Heavy-JS auth pages (Google, Zoom, Apple `idmsa`/`dev.apple`, and similar SPAs) HANG `goto`/`wait_for_load` for the full timeout**: these SPAs keep network connections open so the `load` event never fires cleanly, yet the page almost always loaded underneath. After a `goto` that times out, do NOT retry it and NEVER call `wait_for_load()` on these. Run a SEPARATE short call (`timeout 30 browser`) that reads `page_info()` and inspects the DOM directly (no navigation, no wait_for_load). Cap every browser call at `timeout 40-55` so a hang costs seconds, not minutes. Long blocking browser calls during a live exchange make the agent go unresponsive, so keep them short.
 - **Login-form fills need care**: some sign-in widgets live in an iframe (e.g. Apple's `aid-auth-widget-iFrame`, same-origin so `contentDocument` works). A JS `value`-set often does NOT satisfy the form's own validation (it re-renders back to empty after "Verifying..."), and real keystrokes (`type_text`) can DOUBLE a field that already holds a value, so CLEAR it first. These flows also commonly gate on device-2FA or a passcode that only the user's phone has, so browser automation frequently cannot finish them: prefer the official API or app path.
-
-## Check for the site's own API first
-
-Many SPAs answer their own JSON or config endpoints with everything the page shows, so a job
-board, booking widget, or account flow is often one `curl` or `browser http-get` instead of a
-launch, a navigation, and a snapshot. Before driving a browser at a site, look for that underlying
-API, and check `domain-skills/<host>/` for a saved recipe.

--- a/agent/skills/browser/cli/src/vesta_browser/admin.py
+++ b/agent/skills/browser/cli/src/vesta_browser/admin.py
@@ -130,6 +130,8 @@ def launch_browser(
         extra_args=extra_args,
         window_size=window_size,
     )
+    # After launch(), so a failed launch leaves the old records intact.
+    clear_session_endpoints(session)
     _session_file(session, "browser-pid").write_text(str(running.pid))
     _session_file(session, "bidi-ws").write_text(running.ws_url)
     return running
@@ -153,27 +155,20 @@ def read_session_cdp_ws(name: str | None = None) -> str | None:
 
 def clear_session_endpoints(name: str | None = None) -> None:
     """Drop a session's recorded endpoints + browser pid, so no later call can pick up a
-    record that no longer describes the session's backend."""
+    record that no longer describes the session's backend. Every writer (launch and both
+    recorders) clears before writing, so the records always describe exactly one backend."""
     for suffix in ("bidi-ws", "cdp-ws", "browser-pid"):
         _session_file(name, suffix).unlink(missing_ok=True)
 
 
 def record_bidi_endpoint(ws_url: str, name: str | None = None) -> None:
-    """Record a connected Camoufox BiDi endpoint so the daemon (and restarts) find it.
-
-    Clears prior records first: a leftover browser-pid or cdp-ws from an earlier launch or
-    connect would read as the session's backend and shadow or invalidate this endpoint.
-    """
+    """Record a connected Camoufox BiDi endpoint so the daemon (and restarts) find it."""
     clear_session_endpoints(name)
     _session_file(name, "bidi-ws").write_text(ws_url)
 
 
 def record_cdp_endpoint(ws_url: str, name: str | None = None) -> None:
-    """Record a connected Chrome CDP endpoint so the daemon (and restarts) find it.
-
-    Clears prior records first: a leftover browser-pid or bidi-ws from an earlier launch or
-    connect would read as the session's backend and shadow or invalidate this endpoint.
-    """
+    """Record a connected Chrome CDP endpoint so the daemon (and restarts) find it."""
     clear_session_endpoints(name)
     _session_file(name, "cdp-ws").write_text(ws_url)
 
@@ -223,11 +218,9 @@ def ensure_daemon(wait_s: float = 30.0, name: str | None = None) -> None:
     # recorded BiDi endpoint (launched Camoufox).
     env = {**os.environ, "BROWSER_SESSION": session}
     if "VESTA_BROWSER_CDP_WS" not in env and "VESTA_BROWSER_BIDI_WS" not in env:
-        # Endpoint records live in /tmp and survive the browser dying (container restart,
-        # OOM, manual kill). Connecting to a stale one fails deep in the daemon as an opaque
-        # "Connect call failed (127.0.0.1, <port>)", which reads like a network fault rather
-        # than "the browser is gone". Check the recorded pid first so a recorded endpoint
-        # can never silently outlive its process.
+        # Endpoint records live in /tmp and outlive the browser (container restart, OOM,
+        # manual kill); dialing a stale one fails deep in the daemon as an opaque
+        # "Connect call failed", so check the recorded pid before handing the record over.
         browser_pid = read_session_browser_pid(session)
         if browser_pid is not None and not _pid_alive(browser_pid):
             clear_session_endpoints(session)

--- a/agent/skills/browser/cli/src/vesta_browser/admin.py
+++ b/agent/skills/browser/cli/src/vesta_browser/admin.py
@@ -151,13 +151,30 @@ def read_session_cdp_ws(name: str | None = None) -> str | None:
         return None
 
 
+def clear_session_endpoints(name: str | None = None) -> None:
+    """Drop a session's recorded endpoints + browser pid, so no later call can pick up a
+    record that no longer describes the session's backend."""
+    for suffix in ("bidi-ws", "cdp-ws", "browser-pid"):
+        _session_file(name, suffix).unlink(missing_ok=True)
+
+
 def record_bidi_endpoint(ws_url: str, name: str | None = None) -> None:
-    """Record a connected Camoufox BiDi endpoint so the daemon (and restarts) find it."""
+    """Record a connected Camoufox BiDi endpoint so the daemon (and restarts) find it.
+
+    Clears prior records first: a leftover browser-pid or cdp-ws from an earlier launch or
+    connect would read as the session's backend and shadow or invalidate this endpoint.
+    """
+    clear_session_endpoints(name)
     _session_file(name, "bidi-ws").write_text(ws_url)
 
 
 def record_cdp_endpoint(ws_url: str, name: str | None = None) -> None:
-    """Record a connected Chrome CDP endpoint so the daemon (and restarts) find it."""
+    """Record a connected Chrome CDP endpoint so the daemon (and restarts) find it.
+
+    Clears prior records first: a leftover browser-pid or bidi-ws from an earlier launch or
+    connect would read as the session's backend and shadow or invalidate this endpoint.
+    """
+    clear_session_endpoints(name)
     _session_file(name, "cdp-ws").write_text(ws_url)
 
 
@@ -189,13 +206,8 @@ def stop_browser(name: str | None = None) -> None:
     pid = read_session_browser_pid(session)
     if pid:
         _terminate_pid(pid)
-    for p in (
-        _session_file(session, "browser-pid"),
-        _session_file(session, "bidi-ws"),
-        _session_file(session, "cdp-ws"),
-        _session_file(session, "mode"),
-    ):
-        p.unlink(missing_ok=True)
+    clear_session_endpoints(session)
+    _session_file(session, "mode").unlink(missing_ok=True)
 
 
 def ensure_daemon(wait_s: float = 30.0, name: str | None = None) -> None:
@@ -211,6 +223,18 @@ def ensure_daemon(wait_s: float = 30.0, name: str | None = None) -> None:
     # recorded BiDi endpoint (launched Camoufox).
     env = {**os.environ, "BROWSER_SESSION": session}
     if "VESTA_BROWSER_CDP_WS" not in env and "VESTA_BROWSER_BIDI_WS" not in env:
+        # Endpoint records live in /tmp and survive the browser dying (container restart,
+        # OOM, manual kill). Connecting to a stale one fails deep in the daemon as an opaque
+        # "Connect call failed (127.0.0.1, <port>)", which reads like a network fault rather
+        # than "the browser is gone". Check the recorded pid first so a recorded endpoint
+        # can never silently outlive its process.
+        browser_pid = read_session_browser_pid(session)
+        if browser_pid is not None and not _pid_alive(browser_pid):
+            clear_session_endpoints(session)
+            raise RuntimeError(
+                f"The browser recorded for session {session!r} is gone (pid {browser_pid} is not running), "
+                "so its saved endpoint is stale. Run `browser launch` to start a new one."
+            )
         cdp_ws = read_session_cdp_ws(session)
         bidi_ws = read_session_ws_url(session)
         if cdp_ws is not None:

--- a/agent/skills/browser/cli/tests/test_admin.py
+++ b/agent/skills/browser/cli/tests/test_admin.py
@@ -179,12 +179,16 @@ class _StopSpawnError(Exception):
     """Sentinel so a test stops at the spawn boundary without starting a real daemon."""
 
 
+def _stop_spawn(*args, **kwargs):
+    raise _StopSpawnError
+
+
 def _stale_guard_setup(tmp_path, monkeypatch, *, pid_alive):
-    monkeypatch.setattr(admin, "_session_file", lambda name, suffix: tmp_path / f"{name}.{suffix}")
+    monkeypatch.setattr(admin, "SESSION_FILE_PREFIX", f"{tmp_path}/")
     monkeypatch.setattr(admin, "daemon_healthy", lambda s: False)
     monkeypatch.setattr(admin, "daemon_alive", lambda s: False)
     monkeypatch.setattr(admin, "_pid_alive", lambda pid: pid_alive)
-    monkeypatch.setattr(admin.subprocess, "Popen", lambda *a, **k: (_ for _ in ()).throw(_StopSpawnError()))
+    monkeypatch.setattr(admin.subprocess, "Popen", _stop_spawn)
     monkeypatch.delenv("VESTA_BROWSER_CDP_WS", raising=False)
     monkeypatch.delenv("VESTA_BROWSER_BIDI_WS", raising=False)
 
@@ -198,13 +202,10 @@ def test_ensure_daemon_rejects_stale_recorded_endpoint(tmp_path, monkeypatch):
     (tmp_path / f"{session}.browser-pid").write_text("4216")
     (tmp_path / f"{session}.bidi-ws").write_text("ws://127.0.0.1:38125/session")
 
-    try:
+    with pytest.raises(RuntimeError) as excinfo:
         admin.ensure_daemon(wait_s=0.1, name=session)
-    except RuntimeError as exc:
-        message = str(exc)
-    else:
-        raise AssertionError("a stale recorded endpoint must raise")
 
+    message = str(excinfo.value)
     assert "stale" in message
     assert "browser launch" in message
     assert "4216" in message, "name the dead pid so the cause is checkable"
@@ -237,6 +238,23 @@ def test_connect_endpoint_survives_a_dead_launch_pid(tmp_path, monkeypatch):
     with contextlib.suppress(_StopSpawnError):
         admin.ensure_daemon(wait_s=0.1, name=session)
     assert (tmp_path / f"{session}.cdp-ws").exists(), "a connect endpoint must survive the stale-pid guard"
+
+
+def test_launch_records_replace_a_connect_era_endpoint(tmp_path, monkeypatch):
+    """launch_browser must clear a prior connect's cdp-ws before recording its own pid + bidi-ws:
+    a surviving cdp-ws would win endpoint precedence over the launched browser, and the recorded
+    pid would let the stale-pid guard clear that unrelated endpoint once the pid dies."""
+    session = "launch-after-connect"
+    monkeypatch.setattr(admin, "SESSION_FILE_PREFIX", f"{tmp_path}/")
+    (tmp_path / f"{session}.cdp-ws").write_text("ws://127.0.0.1:9222/devtools/browser/abc")
+    running = launcher.RunningCamoufox(pid=4216, ws_url="ws://127.0.0.1:38125/session", user_data_dir=tmp_path, exe_path="camoufox", proc=None)
+    monkeypatch.setattr(admin, "launch", lambda **kwargs: running)
+
+    assert admin.launch_browser(session) is running
+
+    assert not (tmp_path / f"{session}.cdp-ws").exists(), "a connect-era cdp endpoint must not outlive a launch"
+    assert (tmp_path / f"{session}.bidi-ws").read_text() == "ws://127.0.0.1:38125/session"
+    assert (tmp_path / f"{session}.browser-pid").read_text() == "4216"
 
 
 def _profile_tree(root, name, *, size=32):

--- a/agent/skills/browser/cli/tests/test_admin.py
+++ b/agent/skills/browser/cli/tests/test_admin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import signal
 import socket
@@ -172,6 +173,70 @@ def test_send_times_out_when_the_daemon_never_replies(tmp_path, monkeypatch):
         assert "did not respond to 'browsingContext.create' within 0.3s" in str(raised[0])
     finally:
         listener.close()
+
+
+class _StopSpawnError(Exception):
+    """Sentinel so a test stops at the spawn boundary without starting a real daemon."""
+
+
+def _stale_guard_setup(tmp_path, monkeypatch, *, pid_alive):
+    monkeypatch.setattr(admin, "_session_file", lambda name, suffix: tmp_path / f"{name}.{suffix}")
+    monkeypatch.setattr(admin, "daemon_healthy", lambda s: False)
+    monkeypatch.setattr(admin, "daemon_alive", lambda s: False)
+    monkeypatch.setattr(admin, "_pid_alive", lambda pid: pid_alive)
+    monkeypatch.setattr(admin.subprocess, "Popen", lambda *a, **k: (_ for _ in ()).throw(_StopSpawnError()))
+    monkeypatch.delenv("VESTA_BROWSER_CDP_WS", raising=False)
+    monkeypatch.delenv("VESTA_BROWSER_BIDI_WS", raising=False)
+
+
+def test_ensure_daemon_rejects_stale_recorded_endpoint(tmp_path, monkeypatch):
+    """A recorded ws url outlives the browser it points at (the files live in /tmp and survive a
+    container restart). ensure_daemon must notice the recorded pid is dead and say so, instead of
+    handing the daemon a dead port and surfacing an opaque connection error."""
+    session = "stale-endpoint"
+    _stale_guard_setup(tmp_path, monkeypatch, pid_alive=False)
+    (tmp_path / f"{session}.browser-pid").write_text("4216")
+    (tmp_path / f"{session}.bidi-ws").write_text("ws://127.0.0.1:38125/session")
+
+    try:
+        admin.ensure_daemon(wait_s=0.1, name=session)
+    except RuntimeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("a stale recorded endpoint must raise")
+
+    assert "stale" in message
+    assert "browser launch" in message
+    assert "4216" in message, "name the dead pid so the cause is checkable"
+    assert not (tmp_path / f"{session}.bidi-ws").exists(), "the stale ws url must be cleared"
+
+
+def test_ensure_daemon_keeps_endpoint_when_browser_is_alive(tmp_path, monkeypatch):
+    """The guard must only fire on a dead browser. A live one keeps its recorded endpoint."""
+    session = "live-endpoint"
+    _stale_guard_setup(tmp_path, monkeypatch, pid_alive=True)
+    (tmp_path / f"{session}.browser-pid").write_text("4216")
+    (tmp_path / f"{session}.bidi-ws").write_text("ws://127.0.0.1:38125/session")
+
+    # Reaching the spawn is the point: no stale-endpoint error was raised.
+    with contextlib.suppress(_StopSpawnError):
+        admin.ensure_daemon(wait_s=0.1, name=session)
+    assert (tmp_path / f"{session}.bidi-ws").exists(), "a live browser must keep its endpoint"
+
+
+def test_connect_endpoint_survives_a_dead_launch_pid(tmp_path, monkeypatch):
+    """Recording a connect endpoint over a dead launch's records must clear the launch's
+    browser-pid, so the stale-pid guard never reads the dead pid and clears a still-valid
+    connect endpoint or raises the stale error."""
+    session = "connect-after-dead-launch"
+    _stale_guard_setup(tmp_path, monkeypatch, pid_alive=False)
+    (tmp_path / f"{session}.browser-pid").write_text("4216")
+    admin.record_cdp_endpoint("ws://127.0.0.1:9222/devtools/browser/abc", session)
+
+    # Reaching the spawn is the point: the guard did not fire on the dead launch pid.
+    with contextlib.suppress(_StopSpawnError):
+        admin.ensure_daemon(wait_s=0.1, name=session)
+    assert (tmp_path / f"{session}.cdp-ws").exists(), "a connect endpoint must survive the stale-pid guard"
 
 
 def _profile_tree(root, name, *, size=32):

--- a/agent/skills/browser/domain-skills/covermanager/availability.md
+++ b/agent/skills/browser/domain-skills/covermanager/availability.md
@@ -1,0 +1,16 @@
+# CoverManager availability (covermanager.com)
+
+The CoverManager booking module answers plain `curl` with a normal desktop UA, so never open a
+browser to check a table. Fetch
+`https://www.covermanager.com/reservation/module_restaurant/<slug>/english` and read the widget's
+own config variables rather than inferring behaviour by clicking through:
+
+- `max_people`: the online booking ceiling.
+- `groupRequestHoldOnCard` and `groupRequestCancelPolicy`: both `0` means no card hold and no
+  cancellation charge, so a backup booking costs nothing to drop.
+
+**The trap: a wrong slug returns HTTP 200 with a plausible sentence**, e.g. "The booking module is
+temporarily disabled". That reads as "this venue is unavailable" when it is really a typo, and a
+truncated slug is easy to produce when scraping one out of a restaurant's own site. Check the
+response size: a real module is ~136KB while the bad-slug reply is ~42 bytes. A 200 with prose in
+it is not proof the request was understood.

--- a/agent/skills/browser/domain-skills/job-boards/ashby.md
+++ b/agent/skills/browser/domain-skills/job-boards/ashby.md
@@ -1,0 +1,16 @@
+# Ashby job boards (jobs.ashbyhq.com)
+
+Ashby career pages are SPAs, so `WebFetch` returns an empty shell with only the page title and a
+live posting looks like it is gone. No browser is needed: Ashby publishes the whole board as a
+public JSON API.
+
+For a posting URL `jobs.ashbyhq.com/<company>/<id>`:
+
+```bash
+curl "https://api.ashbyhq.com/posting-api/job-board/<company>?includeCompensation=true"
+```
+
+Returns every live posting with `descriptionPlain` in full, plus compensation when the company
+publishes it. Match on the posting id from the URL, or on the title. No auth. A bad company slug
+returns an error rather than a plausible-looking empty board, so a failure is distinguishable from
+a company with no openings.

--- a/agent/skills/browser/domain-skills/sevenrooms/availability.md
+++ b/agent/skills/browser/domain-skills/sevenrooms/availability.md
@@ -1,0 +1,20 @@
+# SevenRooms availability (sevenrooms.com)
+
+The SevenRooms booking widget answers plain `curl` with a normal desktop UA, so never open a
+browser to check a table. Take the venue slug from the restaurant's booking link.
+
+```bash
+curl "https://www.sevenrooms.com/api-yoa/availability/widget/range?venue=<slug>&time_slot=HH%3AMM&party_size=N&halo_size_interval=64&start_date=MM-DD-YYYY&num_days=1&channel=SEVENROOMS_WIDGET"
+```
+
+- `num_days` greater than 1 returns HTTP 400 `invalid num_days`, so query one day at a time.
+- **A bad venue slug returns HTTP 400.** So a 200 with an empty availability list is a real
+  answer, not a typo signal: the venue exists and that day has nothing bookable.
+- A **closed day returns an empty availability list** while an open day returns 40+ slots. That is
+  how to establish opening days from the venue's own system rather than from opening hours in a
+  search result, which are frequently stale.
+- **Every slot carries a `type`, and for a large party that field is the whole answer.** `book`
+  means instantly confirmable, `request` means a human must convert it. Hold the date fixed and
+  vary `party_size`: if a small party gets `['book','request']` while yours gets `['request']`
+  only, that party size cannot be confirmed online at all. A venue's "we are able to accommodate
+  you" is the wording an unconverted request produces, and it is not a held table.

--- a/agent/skills/browser/domain-skills/zincwork/background-check.md
+++ b/agent/skills/browser/domain-skills/zincwork/background-check.md
@@ -1,0 +1,102 @@
+# Zinc (zincwork.com): driving a candidate background check
+
+Zinc (`app.zincwork.com`) is a UK background-screening provider; a candidate gets a
+`request-check` link from a recruiter and fills five gated sections.
+
+## Read the state from the API before touching the UI
+
+The SPA's own backend returns the entire persisted check in one call, which is better evidence
+than any screenshot and instantly tells you what is already done:
+
+```
+GET https://api.zincwork.com/recruitment/request/<request-id>
+Authorization: Bearer <localStorage['zinc.accessToken']>
+```
+
+Returns `dateOfBirth`, `nameHistory`, `addressHistory`, `currentAddress`, per-check `status` and
+`result`, the check criteria, `applicantReady` and `status`. `GET /user` is the user-level mirror.
+
+- The token is **short-lived (~2h) and rotates**. Re-read it from localStorage immediately before
+  each call. A **703 `E_INVALID_TOKEN` means stale token**; a **404 means wrong route**. Do not
+  confuse the two.
+- A brief handed to you can be stale: a section can already be complete and server-persisted.
+  Check first, or you risk clobbering correct data by re-entering a finished KYC step.
+
+## Page structure
+
+Each check is a **separate top-level Nuxt route**, not a modal:
+
+| Section | Route |
+|---|---|
+| Confirm your details | `/request-check-confirm-details/<id>/details` |
+| Address check | `/request-address-check/<id>/proof` |
+| References (employment) | `/request-employment-verification/<id>/instant-verification-questions` |
+| Identity check | `/request-id-check/<id>/rtw-nationality-selection` |
+| Criminal record check | `/request-criminal-check/<id>/...` |
+
+Navigating to a **completed** flow's route silently redirects back to `/request-check/<id>/details`.
+That is a free, non-destructive completeness test.
+
+## Finding elements
+
+- **The section cards are `<div role="button">`, not `<button>`.** `querySelectorAll('button')`
+  returns only the Fini chat widget. Query by `[data-testid]` instead: `address-check`,
+  `confirm-your-details`, `reference-check`, `identity-check`, `criminal-check`.
+- Card state reads off the class: `stone-outline-card` = completed, `pointer-events-none opacity-60`
+  = locked, `custom-outline-card cursor-pointer` = actionable.
+- The page is SSR'd but **card content hydrates late**. Snapshot too early and you see only the
+  heading, which makes a populated page look empty. Allow a 4-6s settle.
+- Section order on the landing page is not stable between visits. Do not address cards by position.
+
+## Form quirks that break naive automation
+
+- **"Next" needs TWO clicks**: the first validates, the second advances. This is not a broken
+  button and not anti-bot.
+- **A stuck Next is a validation error.** Screenshot and grep the DOM for an empty `[required]`
+  field or an error node before concluding anything about bot detection.
+- **DOB renders as "required" in red even when visibly prefilled.** Re-enter it.
+- **DOB boxes are segmented and mishandle bulk keystrokes.** Backspace on an empty box jumps to the
+  PREVIOUS box and eats its value. Reliable method: click a box, press End, press Backspace exactly
+  `len(value)` times, then type. With all three boxes empty, typing the digits straight through
+  (`DDMMYYYY`) auto-advances correctly.
+- **The phone country selector defaults to a UK flag** regardless of the number. Pick the country
+  explicitly.
+- **Address history takes MM/YYYY only.** The current address's end date is auto-filled and
+  disabled, so no fixed end date is ever asserted and the tenancy-type questions never appear.
+- Address coverage is checked against a rolling 5 years from today. Short coverage shows as
+  "You have N years and M months from K address(es)" **with no Next button at all**, only "Add
+  another address". Read that string rather than assuming the button failed to render.
+- Zinc canonicalises addresses through a postcode lookup, so what persists may not be the string you
+  typed: a flat-and-street form can come back with the building name Royal Mail holds for that
+  postcode. Same address, so do not "fix" it.
+- **Never click "Submit checks"** on the profile panel while sections are incomplete: it submits the
+  check as-is.
+
+## What the sections actually want
+
+- **Confirm your details** persists NOTHING until the whole flow completes. Reloading mid-way loses
+  everything except DOB, which comes from the account profile. Do it in one unbroken sitting, and do
+  not start without every field in hand.
+- **References is not referee names.** It is HMRC employment verification, opening on "Do you have a
+  Government Gateway ID?" Yes/No, with an "I cannot get a Government Gateway ID" link as the manual
+  fallback. The criteria object states the months to cover and the minimum months per role, and the
+  API pre-computes detected employment gaps, which are worth reading before starting.
+- **Identity check opens on a citizenship combobox** for right to work, then a document scan and
+  selfie through Onfido. The Onfido SDK loads into the profile early.
+- **Criminal record check is gated behind identity** and its payload wants a mobile number, which is
+  why the number may be absent from the details payload.
+
+## The real automation boundary
+
+Everything up to and including form-fill, address history and account state automates cleanly. The
+durable handoff points are the two Onfido steps: **proof-of-address document upload** and
+**passport scan + selfie**. Those need a real camera and the physical document, so they belong on
+the person's phone. An address check that has already run can sit in `pending-resubmission` with
+`matches: 0` while the UI only says "Upload proof of address", so read `result` and
+`submissionAttempts` from the API to know whether it failed rather than never ran.
+
+## Session
+
+Profile `~/.browser/zinc`; the signed-in session persists in the profile, with no 2FA on return.
+`browsingContext.create` can hang to its 60s timeout on this app; drive the existing context with
+`navigate` + `wait:"interactive"` instead.

--- a/agent/skills/browser/interaction-skills/advanced-usage.md
+++ b/agent/skills/browser/interaction-skills/advanced-usage.md
@@ -19,21 +19,27 @@ PY
 
 ## Multi-session (parallel sub-agents)
 
-Each sub-agent should set a unique `BROWSER_SESSION` so they don't share a daemon / socket /
-browser. Each session also gets its own profile (and therefore its own fingerprint).
+`BROWSER_SESSION` is the isolation key: the session name selects the daemon, socket, and browser
+a command talks to. Two agents on the same session (the default, whenever the variable is unset)
+drive one browser, so they share tabs, can navigate each other's pages, and can evict each other
+(`browser stop-all` from either kills both). A distinct `--user-data-dir` alone does NOT isolate:
+it changes the profile, not the session. So each parallel sub-agent sets its own unique
+`BROWSER_SESSION`, and for a throwaway run adds `--ephemeral-profile` so a crashed run leaves
+nothing behind (`browser prune` cleans up ephemeral leftovers).
 
 ```bash
-BROWSER_SESSION=agent-1 browser launch
+BROWSER_SESSION=agent-1 browser launch --ephemeral-profile
 BROWSER_SESSION=agent-1 browser open "https://a.com"
 
-BROWSER_SESSION=agent-2 browser launch
+BROWSER_SESSION=agent-2 browser launch --ephemeral-profile
 BROWSER_SESSION=agent-2 browser open "https://b.com"
 ```
 
 Each session's state lives under `/tmp/vesta-browser-<name>.*` (socket, pid, bidi-ws, log).
-`browser stop` cleans its own; `browser stop-all` stops everything. Memory warning: each Camoufox
-uses several hundred MB, so 3+ concurrently on a small host can OOM. Prefer sequential for
-wide-scrape tasks.
+`browser stop` cleans its own; `browser stop-all` stops every session in the container, so never
+run it while sibling agents may be browsing: stop your own named session instead. Memory warning:
+each Camoufox uses several hundred MB, so 3+ concurrently on a small host can OOM. Prefer
+sequential for wide-scrape tasks.
 
 ## Raw BiDi escape hatch
 

--- a/agent/skills/browser/interaction-skills/prosemirror-tiptap-editors.md
+++ b/agent/skills/browser/interaction-skills/prosemirror-tiptap-editors.md
@@ -1,0 +1,59 @@
+# Typing into ProseMirror / TipTap rich-text editors
+
+Modern web apps (Notion-likes, Linear, many CMSs, chat composers) use **ProseMirror** (often via
+the **TipTap** wrapper). The editable node looks like
+`<div class="tiptap ProseMirror" contenteditable="true">`. These editors keep their own internal
+document model and a `beforeinput`/`input` pipeline; the visible DOM is a *projection* of that
+model. That breaks the naive ways of inserting text.
+
+## What does NOT work
+
+- **`execCommand('insertText', ...)`**: mutates the DOM text but does **not** update
+  ProseMirror's document model. The editor's own word/char counter stays at 0, and any
+  "submit" reads an empty doc. You'll see text on screen but the app acts as if the box
+  is empty. The same applies to `execCommand('selectAll')`/`execCommand('delete')` for
+  clearing: the model keeps its old content.
+- **Synthetic `ClipboardEvent('paste', {clipboardData})`**: ProseMirror's paste handler
+  ignores untrusted events (`isTrusted === false`), and Firefox won't let you populate
+  `clipboardData` on a constructed event anyway. No-op.
+- **`navigator.clipboard.writeText()` + real Ctrl+V**: blocked headless:
+  `Clipboard write was blocked due to lack of user activation`.
+
+## What works: real keystrokes, chunked
+
+Real BiDi key events go through the genuine `beforeinput` pipeline, so ProseMirror registers
+them. Clearing works the same way: a real Ctrl+A then Backspace through that pipeline, never
+`execCommand`. Three gotchas: the editor node may not be attached for the first second or two
+after navigation on these SPAs, so wait for the selector before touching it; the editor needs
+**real focus** (a coordinate click, not `.focus()`); and a **single huge `type_text` payload
+breaks the socket** (`BrokenPipeError` / channel error), so chunk it.
+
+```python
+# stdin mode (helpers pre-imported)
+txt = open("/tmp/doc.txt").read().strip()
+for _ in range(20):  # the editor mounts late; wait for the node
+    if js("document.querySelectorAll('.tiptap.ProseMirror').length"):
+        break
+    wait(0.5)
+r = js("""(function(){
+  var b=document.querySelector('.tiptap.ProseMirror').getBoundingClientRect();
+  return {x:Math.round(b.x+b.width/2), y:Math.round(b.y+30)};
+})()""")
+click(r["x"], r["y"])  # real focus
+press_key("a", ["Control"])  # clear through the same input pipeline as the typing
+press_key("Backspace")
+for i in range(0, len(txt), 120):  # ~120-char chunks; larger risks BrokenPipe
+    type_text(txt[i : i + 120])
+# verify the editor's OWN counter moved before acting on it:
+print(js("(document.body.innerText.match(/([0-9,]+)\\s*words/)||['?'])[0]"))
+```
+
+Then click the app's submit button by text and read the result from
+`document.body.innerText`. Newlines in `type_text` become paragraph breaks, which is
+usually what you want.
+
+These apps are heavy-JS SPAs, so the navigation and timeout rules in
+[SKILL.md](../SKILL.md)'s "Auth-gated / heavy-JS pages" section apply. One extra: repeated
+navigations accumulate contexts until Camoufox reports `Maximum number of active sessions`.
+Fix: `browser stop` then relaunch on the **same** `--user-data-dir` (logged-in sessions
+persist in the profile). Never pkill.


### PR DESCRIPTION
Maintainer-requested consolidation of the open browser-skill PRs with the repairs their reviews demanded, superseding #1789, #1758, #1721, #1656, #1646, #1628, and #1587.

## #1789: stale endpoint guard, repaired at the root

Carried the `clear_session_endpoints` helper and the `ensure_daemon` guard that checks the recorded browser pid and, when dead, clears the endpoint records and raises a named "stale endpoints, run `browser launch`" error. Repaired the root cause the review found: `cmd_connect` records a cdp-ws (or bidi-ws) endpoint but left a previous launch's dead `browser-pid` behind, so the guard as submitted would have read the dead pid and cleared a still-valid connect endpoint. `record_cdp_endpoint`/`record_bidi_endpoint` now clear prior session records before writing, and `stop_browser` shares the same helper instead of duplicating the unlink loop. Deliberately left alone: `launch_browser` over a stale connect-era `cdp-ws` keeps that record (a pre-existing asymmetry, out of this fix's scope).

## #1656: empty page is not a wall

Carried the false-wall paragraph and list into SKILL.md's doctrine block. Repaired: the text said "three things" while listing five (now says five), the war-story tail is deleted, the last list item is no longer glued to the closing sentence, and the contenteditable item points to the new `interaction-skills/prosemirror-tiptap-editors.md`.

## #1758: Ashby job boards

Relocated from the SKILL.md body to `domain-skills/job-boards/ashby.md`, the skill's established home for site recipes. Trimmed the run anecdote ("no rate limit encountered in practice") and the closing justification paragraph; kept the endpoint, the `descriptionPlain` semantics, and the honest bad-slug error signal.

## #1721: restaurant booking widgets

Split into `domain-skills/sevenrooms/availability.md` and `domain-skills/covermanager/availability.md`, carrying the verified endpoints and slot-type semantics minus the live-venue task narration. Applied the review's correction: on SevenRooms a bad venue slug returns HTTP 400, so a small 200 response is a genuinely empty day, not a typo signal; the check-the-response-size trap is stated only for CoverManager, where it actually applies.

## #1646: zincwork recipe

Carried `domain-skills/zincwork/background-check.md` nearly as-is (placement was already correct), scrubbed of the field-tested dates line, the dated dispatch story, and "Reproduced on every pass", with the Session section's one-box anecdotes rewritten as current-mechanism statements. Every reusable mechanic is kept: API-before-UI with the localStorage bearer, the data-testids, the segmented DOB handling, the redirect completeness test, and the Onfido boundary.

## #1628: parallel isolation

Its 23-line body block is not carried. Instead the SKILL.md body gets one warning line (parallel agents must not share a browser session) pointing at `interaction-skills/advanced-usage.md`, whose multi-session section is hardened: `BROWSER_SESSION` is named as the isolation key (the session selects the daemon, socket, and browser; a distinct `--user-data-dir` alone does not isolate, and colliding agents on the default session share tabs and can evict each other via `stop-all`), each parallel sub-agent sets a unique `BROWSER_SESSION`, and throwaway runs use `launch --ephemeral-profile` with `browser prune` for crashed leftovers. Flag and command names verified against master's cli.py.

## #1587: ProseMirror/TipTap

Carried `interaction-skills/prosemirror-tiptap-editors.md` with the review's fixes actually applied: all four spaced-hyphen separators removed; the self-contradiction fixed (the doc said execCommand does not update the editor model, then cleared with `execCommand('selectAll'/'delete')`; clearing now goes through the same real-keystroke pipeline as the typing, a focused real Ctrl+A then Backspace via `press_key`); the focus is guarded by waiting for the editor selector first per the doc's own late-mount note; the SPA caveats restatement is replaced with one pointer to SKILL.md's heavy-JS section, keeping only the contexts-accumulate mechanic that section does not cover; the "Verified Jul 2026" line is removed.

## Shared lesson

One short SKILL.md paragraph ("Check for the site's own API first") states the rule the three site recipes instantiate: many SPAs answer their own JSON/config endpoints with everything the page shows, so check for the underlying API and `domain-skills/<host>/` before driving a browser. No site specifics in the body.

## Tests

The browser CLI suite carries #1789's two stale-endpoint tests plus the connect-path regression the PR lacked: a dead `browser-pid` alongside a cdp-ws recorded the way `cmd_connect` leaves them must not trip the stale guard or lose the endpoint. Verified by mutation that this test fails when the guard is applied without the `cmd_connect` repair. `uv run --project agent/skills/browser/cli pytest agent/skills/browser/cli/tests/` passes (218 passed; `test_shutdown_is_fine_without_an_ephemeral_profile` fails on this shared dev host on clean master too, because a live agent owns `/tmp/vesta-browser-default.log`, and is unaffected by this change). `./check.sh guards` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
