### PR TITLE
fix(browser): terminate a replaced backend, share one liveness predicate, deflate SKILL.md stubs

### DIFF
--- a/agent/skills/browser/SKILL.md
+++ b/agent/skills/browser/SKILL.md
@@ -27,7 +27,7 @@ consider a block, and even then suspect a cookie/consent wall or a redirect befo
 **Same rule for a stuck FORM: a submit/next button that won't advance is a validation error, not a block.** On a multi-step wizard or checkout, when "Continue"/"Submit" appears to do nothing, do NOT conclude the site is fighting automation. Read the actual state first: screenshot it, grep the DOM for a required-but-empty field (`[required]` with no value), a `.text-danger`/`[class*=error]` message, an unticked terms checkbox, or a second hidden copy of the form you filled the wrong instance of. A false wall abandoned is worse than a real wall pushed through: the overwhelmingly common blocker on a stuck submit is one missing required field.
 
 **And the harder version: a page that appears to have NO field at all is almost never a page that cannot be filled.** "There is nowhere to type it, so this needs the user's own device" is the most expensive wrong conclusion available, because it looks like diligence. Before writing that sentence, rule out five things, in this order:
-1. **A cross-origin iframe.** `document.body.innerText` on the parent returns almost nothing while the screenshot plainly shows a form, and the mount point (`#onfido-mount`, `#widget-root`) reads as empty. Enumerate every browsing context and query inside each, do not trust the top document. Identity, payment and document-upload widgets are nearly always third-party iframes.
+1. **A cross-origin iframe.** Identity, payment and document-upload widgets are nearly always third-party iframes, so the parent document reads as empty while the screenshot plainly shows a form. Enumerating contexts and working inside one: [interaction-skills/cross-origin-iframes.md](interaction-skills/cross-origin-iframes.md).
 2. **A field behind a conditional render.** The input exists only after some control is clicked (a `v-if`/`x-show` toggled by a "Get a code" or "Enter it manually" link). If the visible call-to-action opens a new tab, click it with a capture-phase `preventDefault` so the framework's handler still runs and reveals the field without navigating away.
 3. **A selector that is too specific.** Framework-rendered inputs often carry no `type` attribute, so `input[type=text]` matches nothing even though `el.type === 'text'`. Query bare `input` and filter in JS, and include `[contenteditable]` and `[role=textbox]` for masked/custom widgets. A `contenteditable` rich-text editor needs [interaction-skills/prosemirror-tiptap-editors.md](interaction-skills/prosemirror-tiptap-editors.md).
 4. **A shadow root.** `querySelectorAll` never pierces one, so a web-component field is invisible to it. Walk recursively: collect matches, then recurse into every `el.shadowRoot`.
@@ -42,8 +42,8 @@ A genuine wall states a capability the machine lacks (a camera, a physical docum
 ## Search first
 
 Before inventing an approach to a site, check `domain-skills/<host>/` for saved recipes and
-`interaction-skills/` for reusable mechanics (dialogs, iframes, shadow DOM, uploads, scrolling,
-dropdowns). When you open or navigate to a URL, the CLI prepends a banner listing any matching
+`interaction-skills/` for reusable mechanics (dialogs, tabs, cross-origin iframes, screenshots,
+rich-text editors). When you open or navigate to a URL, the CLI prepends a banner listing any matching
 recipes. Read them. Also check for the site's own API first: many SPAs answer their own JSON or
 config endpoints with everything the page shows, so a job board, booking widget, or account flow
 is often one `curl` or `browser http-get` instead of a launch, a navigation, and a snapshot.
@@ -145,9 +145,8 @@ browser wait --load-state load
 
 ## Screenshots
 
-Screenshots are costly in context: prefer `--webp` (much smaller than PNG) and `--region` to
-clip to the part that matters. Use PNG only when you need lossless output (e.g. pixel-diffing UI
-state). Camoufox captures PNG and JPEG natively; `--webp` is encoded as JPEG.
+Screenshots are costly in context: prefer `--webp` and `--region` to keep them small. Format and
+clipping tradeoffs: [interaction-skills/screenshots.md](interaction-skills/screenshots.md).
 
 ## Perception: a11y tree or screenshots
 
@@ -213,7 +212,7 @@ profile and an orphan look identical to any liveness check, so intent is recorde
 Occasional topics live in their own files so this one stays lean:
 
 - [interaction-skills/advanced-usage.md](interaction-skills/advanced-usage.md) : extending helpers, multi-session, the raw BiDi escape hatch, how stealth works, contributing back
-- [interaction-skills/](interaction-skills/) : reusable mechanics (dialogs, iframes, shadow DOM, uploads, tabs)
+- [interaction-skills/](interaction-skills/) : reusable mechanics (dialogs, tabs, cross-origin iframes, screenshots, connection)
 
 ## Troubleshooting
 

--- a/agent/skills/browser/cli/src/vesta_browser/admin.py
+++ b/agent/skills/browser/cli/src/vesta_browser/admin.py
@@ -17,6 +17,7 @@ from .daemon import log_path, pid_path, socket_path
 from .launcher import EPHEMERAL_ROOT, PROFILE_ROOT, RunningCamoufox, _profile_has_live_owner, launch
 
 SESSION_FILE_PREFIX = "/tmp/vesta-browser-"
+PROC = Path("/proc")
 GRACEFUL_EXIT_POLLS = 25
 GRACEFUL_POLL_INTERVAL_S = 0.2
 # Above the daemon's largest per-command bound (the navigate wait), so its error (which names the method) wins the race.
@@ -156,7 +157,12 @@ def read_session_cdp_ws(name: str | None = None) -> str | None:
 def clear_session_endpoints(name: str | None = None) -> None:
     """Drop a session's recorded endpoints + browser pid, so no later call can pick up a
     record that no longer describes the session's backend. Every writer (launch and both
-    recorders) clears before writing, so the records always describe exactly one backend."""
+    recorders) clears before writing, so the records always describe exactly one backend,
+    and a recorded browser that is still running is terminated here so replacing a backend
+    never orphans the old one. Parallel backends belong in separate sessions."""
+    pid = read_session_browser_pid(name)
+    if pid is not None and _pid_alive(pid):
+        _terminate_pid(pid)
     for suffix in ("bidi-ws", "cdp-ws", "browser-pid"):
         _session_file(name, suffix).unlink(missing_ok=True)
 
@@ -196,11 +202,8 @@ def set_mode(mode: str, name: str | None = None) -> None:
 
 
 def stop_browser(name: str | None = None) -> None:
-    """Terminate the Camoufox process for a session, if we launched it."""
+    """Terminate the Camoufox process for a session, if we launched it, and drop its records."""
     session = _session_name(name)
-    pid = read_session_browser_pid(session)
-    if pid:
-        _terminate_pid(pid)
     clear_session_endpoints(session)
     _session_file(session, "mode").unlink(missing_ok=True)
 
@@ -291,7 +294,7 @@ def list_sessions() -> list[dict]:
     for pid_f in Path("/tmp").glob("vesta-browser-*.browser-pid"):
         name = pid_f.name.removeprefix("vesta-browser-").removesuffix(".browser-pid")
         browser_pid = _read_pid(pid_f)
-        alive = _pid_alive(browser_pid) if browser_pid else False
+        alive = _pid_alive(browser_pid)
         out.append(
             {
                 "name": name,
@@ -304,12 +307,22 @@ def list_sessions() -> list[dict]:
     return out
 
 
-def _pid_alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-        return True
-    except (ProcessLookupError, PermissionError):
+def _pid_alive(pid: int | None) -> bool:
+    """True only for a process that is actually running. A signal-0 probe cannot answer this:
+    a dead process whose pid lingers unreaped (a detached child reparented to init) answers the
+    probe like a live one. /proc's state code distinguishes the corpse; the comm field can hold
+    spaces and parens, so the state is read relative to its closing paren rather than by
+    splitting on whitespace."""
+    if pid is None:
         return False
+    try:
+        stat = (PROC / str(pid) / "stat").read_text()
+    except OSError:
+        return False
+    comm_end = stat.rfind(") ")
+    if comm_end == -1:
+        return False
+    return stat[comm_end + 2] != "Z"
 
 
 def stop_all() -> None:

--- a/agent/skills/browser/cli/src/vesta_browser/handover.py
+++ b/agent/skills/browser/cli/src/vesta_browser/handover.py
@@ -39,7 +39,6 @@ X11VNC_SETTLE_S = 0.4
 X11VNC_TERMINATE_TIMEOUT_S = 5.0
 DISPLAY_CLAIM_ATTEMPTS = 10
 READY_POLL_S = 0.1
-PROC = Path("/proc")
 # The 13" MacBook's native resolution: a real monitor size, and the one the framed machine in the
 # page actually has. `fit_to_screen` reports this verbatim as screen.width/height, so a geometry no
 # real display ships would itself be an automation tell on the account-trust sites handover exists
@@ -154,26 +153,6 @@ def _claim_own_display() -> tuple[str, int]:
         if pid is not None:
             return display, pid
     raise RuntimeError(f"could not claim a free X display after {DISPLAY_CLAIM_ATTEMPTS} attempts")
-
-
-def _alive(pid: int | None) -> bool:
-    """True only for a process that is actually running.
-
-    A signal-0 probe cannot answer this: start() exits once it has spawned these, so they reparent
-    to init and a dead one's pid lingers unreaped, answering the probe like a live process.
-    /proc's state code distinguishes the corpse; the comm field can hold spaces and parens, so the
-    state is read relative to its closing paren rather than by splitting on whitespace.
-    """
-    if pid is None:
-        return False
-    try:
-        stat = (PROC / str(pid) / "stat").read_text()
-    except (FileNotFoundError, ProcessLookupError, PermissionError, OSError):
-        return False
-    comm_end = stat.rfind(") ")
-    if comm_end == -1:
-        return False
-    return stat[comm_end + 2] != "Z"
 
 
 def _read_pid(suffix: str) -> int | None:
@@ -411,11 +390,11 @@ def status() -> dict[str, object]:
     web_port = _read_pid("web-port")
     return {
         "session": HANDOVER_SESSION,
-        "browser": _alive(admin.read_session_browser_pid(HANDOVER_SESSION)),
-        "xvfb": _alive(_read_pid("xvfb-pid")),
-        "openbox": _alive(_read_pid("openbox-pid")),
-        "x11vnc": _alive(_read_pid("x11vnc-pid")),
-        "websockify": _alive(_read_pid("websockify-pid")),
+        "browser": admin._pid_alive(admin.read_session_browser_pid(HANDOVER_SESSION)),
+        "xvfb": admin._pid_alive(_read_pid("xvfb-pid")),
+        "openbox": admin._pid_alive(_read_pid("openbox-pid")),
+        "x11vnc": admin._pid_alive(_read_pid("x11vnc-pid")),
+        "websockify": admin._pid_alive(_read_pid("websockify-pid")),
         "serving": _port_serving(web_port) if web_port else False,
         "web_port": web_port,
         "page": "handover.html" if web_port else None,

--- a/agent/skills/browser/cli/tests/test_admin.py
+++ b/agent/skills/browser/cli/tests/test_admin.py
@@ -76,6 +76,32 @@ def test_pid_alive_false_for_reserved_pid():
     assert admin._pid_alive(2**31 - 1) is False
 
 
+def test_pid_alive_false_for_none():
+    assert admin._pid_alive(None) is False
+
+
+def test_pid_alive_false_for_a_real_zombie():
+    """A dead child its parent never reaped lingers in the pid table and still answers a signal-0
+    probe; the shared predicate must read it as dead, since a zombie backend can serve nothing."""
+    proc = subprocess.Popen(["true"])
+    try:
+        deadline = time.monotonic() + HANG_GUARD_S
+        while time.monotonic() < deadline and admin._pid_alive(proc.pid):
+            time.sleep(0.02)
+        assert admin._pid_alive(proc.pid) is False, "zombie still reported alive"
+        os.kill(proc.pid, 0)  # a signal-0 probe still succeeds on the corpse
+    finally:
+        proc.wait()
+
+
+def test_pid_alive_reads_the_state_past_a_comm_holding_spaces_and_parens(tmp_path, monkeypatch):
+    # /proc/<pid>/stat's comm field is unescaped, so splitting on whitespace misreads the state.
+    (tmp_path / "42").mkdir()
+    (tmp_path / "42" / "stat").write_text("42 (odd ) name Z) R 1 1 0 0 -1 0 0 0")
+    monkeypatch.setattr(admin, "PROC", tmp_path)
+    assert admin._pid_alive(42) is True
+
+
 def test_terminate_pid_no_op_when_already_dead():
     admin._terminate_pid(2**31 - 1)
 
@@ -255,6 +281,68 @@ def test_launch_records_replace_a_connect_era_endpoint(tmp_path, monkeypatch):
     assert not (tmp_path / f"{session}.cdp-ws").exists(), "a connect-era cdp endpoint must not outlive a launch"
     assert (tmp_path / f"{session}.bidi-ws").read_text() == "ws://127.0.0.1:38125/session"
     assert (tmp_path / f"{session}.browser-pid").read_text() == "4216"
+
+
+def _spawn_orphan_sleep() -> int:
+    """A sleep with no living parent in this process tree, so init reaps it the moment it dies:
+    the shape of a browser recorded by an earlier CLI invocation."""
+    out = subprocess.run(["sh", "-c", "sleep 60 & echo $!"], capture_output=True, text=True, check=True)
+    return int(out.stdout.strip())
+
+
+def test_recording_a_new_backend_terminates_the_replaced_live_browser(tmp_path, monkeypatch):
+    """The records describe exactly one backend, so recording a connect endpoint over a launched
+    browser must terminate the old process: a cleared pid with nothing pointing at it would keep
+    a headless browser running invisibly forever."""
+    session = "replace-live"
+    monkeypatch.setattr(admin, "SESSION_FILE_PREFIX", f"{tmp_path}/")
+    pid = _spawn_orphan_sleep()
+    try:
+        (tmp_path / f"{session}.browser-pid").write_text(str(pid))
+        (tmp_path / f"{session}.bidi-ws").write_text("ws://127.0.0.1:38125/session")
+
+        admin.record_cdp_endpoint("ws://127.0.0.1:9222/devtools/browser/abc", session)
+
+        deadline = time.monotonic() + HANG_GUARD_S
+        while time.monotonic() < deadline and admin._pid_alive(pid):
+            time.sleep(0.05)
+        assert not admin._pid_alive(pid), "the replaced browser was left running"
+        assert not (tmp_path / f"{session}.browser-pid").exists()
+        assert (tmp_path / f"{session}.cdp-ws").read_text() == "ws://127.0.0.1:9222/devtools/browser/abc"
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(pid, signal.SIGKILL)
+
+
+def test_recording_over_a_dead_pid_record_stays_quiet(tmp_path, monkeypatch):
+    """A recorded pid whose process is already gone is cleared with no termination attempt."""
+    session = "replace-dead"
+    monkeypatch.setattr(admin, "SESSION_FILE_PREFIX", f"{tmp_path}/")
+    reaped = subprocess.Popen(["true"])
+    reaped.wait()
+    terminated: list[int] = []
+    monkeypatch.setattr(admin, "_terminate_pid", terminated.append)
+    (tmp_path / f"{session}.browser-pid").write_text(str(reaped.pid))
+
+    admin.record_bidi_endpoint("ws://127.0.0.1:38125/session", session)
+
+    assert terminated == []
+    assert not (tmp_path / f"{session}.browser-pid").exists()
+    assert (tmp_path / f"{session}.bidi-ws").read_text() == "ws://127.0.0.1:38125/session"
+
+
+def test_stop_browser_terminates_the_recorded_browser_and_clears_records(tmp_path, monkeypatch):
+    session = "stop-live"
+    monkeypatch.setattr(admin, "SESSION_FILE_PREFIX", f"{tmp_path}/")
+    pid = _spawn_orphan_sleep()
+    try:
+        (tmp_path / f"{session}.browser-pid").write_text(str(pid))
+        admin.stop_browser(session)
+        assert not admin._pid_alive(pid)
+        assert not (tmp_path / f"{session}.browser-pid").exists()
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(pid, signal.SIGKILL)
 
 
 def _profile_tree(root, name, *, size=32):

--- a/agent/skills/browser/cli/tests/test_handover.py
+++ b/agent/skills/browser/cli/tests/test_handover.py
@@ -6,23 +6,10 @@ websocket proxy) is exercised end-to-end in a real container, not here.
 
 from __future__ import annotations
 
-import os
 import socket
-import subprocess
-import time
 
 import pytest
 from vesta_browser import handover
-
-
-def wait_until(predicate, timeout_s=5.0):
-    """Poll `predicate` to a deadline. A process reaching zombie state is not an event we can await."""
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        if predicate():
-            return True
-        time.sleep(0.02)
-    return predicate()
 
 
 @pytest.fixture(autouse=True)
@@ -173,35 +160,6 @@ def test_stop_is_idempotent_without_an_xvfb_pid(monkeypatch):
     assert killed == []
 
 
-# ── liveness ──────────────────────────────────────────────────
-
-
-def test_alive_is_false_for_a_real_zombie():
-    # A genuine zombie, made the way handover makes them: Popen never reaps until wait(), so once
-    # `true` exits its pid lingers in the table. This is the exact state that had status() calling
-    # a dead x11vnc up while the page span on "Waking".
-    proc = subprocess.Popen(["true"])
-    try:
-        assert wait_until(lambda: not handover._alive(proc.pid)), "zombie still reported alive"
-        os.kill(proc.pid, 0)  # the old signal-0 probe still succeeds on the corpse: that was the bug
-    finally:
-        proc.wait()
-
-
-def test_alive_is_true_for_a_running_process():
-    proc = subprocess.Popen(["sleep", "30"])
-    try:
-        assert handover._alive(proc.pid) is True
-    finally:
-        proc.kill()
-        proc.wait()
-
-
-def test_alive_is_false_for_an_absent_or_unknown_pid():
-    assert handover._alive(None) is False
-    assert handover._alive(999_999_999) is False
-
-
 # ── x11vnc bring-up ───────────────────────────────────────────
 
 
@@ -310,15 +268,6 @@ def test_x11vnc_that_binds_then_dies_is_not_taken_as_ready(monkeypatch, isolated
     assert attempts == [(), ("-noshm",)]  # the death after the bind still reached the fallback
 
 
-def test_alive_reads_the_state_past_a_comm_holding_spaces_and_parens(isolated, monkeypatch):
-    # /proc/<pid>/stat's comm field is unescaped, so splitting on whitespace misreads the state.
-    proc_root = isolated / "proc"
-    (proc_root / "42").mkdir(parents=True)
-    (proc_root / "42" / "stat").write_text("42 (odd ) name Z) R 1 1 0 0 -1 0 0 0")
-    monkeypatch.setattr(handover, "PROC", proc_root)
-    assert handover._alive(42) is True
-
-
 def test_readiness_reports_missing_binaries(monkeypatch):
     monkeypatch.setattr(handover.shutil, "which", lambda _: None)
     report = handover.readiness()
@@ -354,7 +303,7 @@ def test_register_public_service_returns_port_and_public_url(monkeypatch, tmp_pa
     assert url == "https://box.vesta.run/agents/ada/browser/handover.html"
 
 
-# ── ports + liveness ──────────────────────────────────────────
+# ── ports + displays ──────────────────────────────────────────
 
 
 def test_free_port_returns_a_bindable_port():
@@ -402,12 +351,6 @@ def test_claim_own_display_gives_up_after_the_attempt_cap(monkeypatch):
     monkeypatch.setattr(handover, "DISPLAY_CLAIM_ATTEMPTS", 3)
     with pytest.raises(RuntimeError, match="could not claim a free X display"):
         handover._claim_own_display()
-
-
-def test_alive_false_for_none_and_dead_pid():
-    assert handover._alive(None) is False
-    # PID 2**31-1 is not a running process on any sane system.
-    assert handover._alive(2**31 - 1) is False
 
 
 # ── teardown ──────────────────────────────────────────────────

--- a/agent/skills/browser/interaction-skills/cookies.md
+++ b/agent/skills/browser/interaction-skills/cookies.md
@@ -1,3 +1,0 @@
-# Cookies
-
-Document how to get cookies, save cookies, and set cookies without confusing browser state with page state.

--- a/agent/skills/browser/interaction-skills/cross-origin-iframes.md
+++ b/agent/skills/browser/interaction-skills/cross-origin-iframes.md
@@ -1,3 +1,15 @@
 # Cross-Origin Iframes
 
-Focus on `iframe_target(...)`, target attachment, and when compositor-level coordinate clicks are lower-friction than cross-target DOM work.
+The symptom: `document.body.innerText` on the parent returns almost nothing while the screenshot
+plainly shows a form, and the widget's mount point (`#onfido-mount`, `#widget-root`) reads as
+empty. Identity, payment, and document-upload widgets are nearly always third-party iframes, and
+the top document cannot see into them.
+
+Enumerate every browsing context and query inside each, do not trust the top document.
+`browser bidi "browsingContext.getTree"` lists every context including iframe children. In Python
+stdin mode, `iframe_target("substring-of-iframe-url")` returns the first child context whose URL
+matches; pass it as `target_id` to `js(...)` to run JS inside that frame.
+
+When cross-target DOM work gets awkward, coordinate clicks are lower friction: `click(x, y)` and
+`browser click --at X Y` dispatch a real pointer event at that viewport point regardless of DOM
+structure, so they land inside a cross-origin iframe.

--- a/agent/skills/browser/interaction-skills/downloads.md
+++ b/agent/skills/browser/interaction-skills/downloads.md
@@ -1,3 +1,0 @@
-# Downloads
-
-Separate browser-triggered downloads from direct `http_get(...)` fetches, and document the minimal signals that prove a download actually started.

--- a/agent/skills/browser/interaction-skills/drag-and-drop.md
+++ b/agent/skills/browser/interaction-skills/drag-and-drop.md
@@ -1,3 +1,0 @@
-# Drag And Drop
-
-Focus on when drag-and-drop can be driven with low-level input events versus when the site really expects a file upload or DOM-specific drag sequence.

--- a/agent/skills/browser/interaction-skills/dropdowns.md
+++ b/agent/skills/browser/interaction-skills/dropdowns.md
@@ -1,3 +1,0 @@
-# Dropdowns
-
-Split dropdowns into native selects, custom overlays, searchable comboboxes, and virtualized menus, and always re-measure after opening because option geometry often appears late.

--- a/agent/skills/browser/interaction-skills/iframes.md
+++ b/agent/skills/browser/interaction-skills/iframes.md
@@ -1,3 +1,0 @@
-# Iframes
-
-Cover same-origin iframe traversal through `contentDocument` / `contentWindow`, and keep the frame-local versus page-coordinate warning explicit for clicks.

--- a/agent/skills/browser/interaction-skills/network-requests.md
+++ b/agent/skills/browser/interaction-skills/network-requests.md
@@ -1,3 +1,0 @@
-# Network Requests
-
-Document how to watch or infer network activity when page state is ambiguous, especially for submit flows, downloads, and SPA actions that succeed without obvious DOM changes.

--- a/agent/skills/browser/interaction-skills/print-as-pdf.md
+++ b/agent/skills/browser/interaction-skills/print-as-pdf.md
@@ -1,3 +1,0 @@
-# Print As PDF
-
-Cover both direct PDF generation via `pdf()` (BiDi `browsingContext.print`) and sites that only expose a visible "Print" button which must be clicked before handling the browser print flow.

--- a/agent/skills/browser/interaction-skills/screenshots.md
+++ b/agent/skills/browser/interaction-skills/screenshots.md
@@ -1,3 +1,12 @@
 # Screenshots
 
-Separate full-page screenshots from targeted section screenshots, and note when screenshots are only for discovery versus verification.
+Screenshots are costly in context: prefer `--webp` (much smaller than PNG) and `--region` to
+clip to the part that matters. Use PNG only when you need lossless output (e.g. pixel-diffing UI
+state). Camoufox captures PNG and JPEG natively; `--webp` is encoded as JPEG.
+
+```bash
+browser screenshot [--path PATH] [--full-page] [--webp] [--region X,Y,W,H] [--quality N]
+```
+
+In Python stdin mode: `screenshot(path, full_page=..., image_format=..., region=(x, y, w, h),
+quality=...)`.

--- a/agent/skills/browser/interaction-skills/scrolling.md
+++ b/agent/skills/browser/interaction-skills/scrolling.md
@@ -1,3 +1,0 @@
-# Scrolling
-
-Separate page scroll, nested containers, virtualized lists, and dropdown menus, and identify which element is actually consuming wheel events before scrolling.

--- a/agent/skills/browser/interaction-skills/shadow-dom.md
+++ b/agent/skills/browser/interaction-skills/shadow-dom.md
@@ -1,3 +1,0 @@
-# Shadow DOM
-
-Focus on recursive `shadowRoot` traversal, and note when coordinate clicking is simpler than piercing deeply nested component trees.

--- a/agent/skills/browser/interaction-skills/uploads.md
+++ b/agent/skills/browser/interaction-skills/uploads.md
@@ -1,1 +1,0 @@
-# Uploads

--- a/agent/skills/browser/interaction-skills/viewport.md
+++ b/agent/skills/browser/interaction-skills/viewport.md
@@ -1,3 +1,0 @@
-# Viewport
-
-Cover how viewport size changes affect layout, coordinate clicks, and any workflow that depends on stable geometry.


### PR DESCRIPTION
Follow-up to #1791: backend lifecycle semantics and the reference-file structure they live in. Stacked on `fix/browser-epic`; retarget to master after the epic merges.

## Terminate on replace

Every endpoint recorder (`launch_browser`, `record_bidi_endpoint`, `record_cdp_endpoint`) clears the session's prior records before writing, so records always describe exactly one backend. This PR gives that invariant teeth: the shared clearing helper (`clear_session_endpoints`, the one owner of the record contract) now terminates a recorded `browser-pid` that is still running before dropping the record. Replacing a backend (say, `browser connect` over a launched Camoufox) stops the old process instead of orphaning a headless browser nothing points at anymore. Parallel backends are what sessions are for.

`stop_browser` previously terminated the pid itself and then cleared; the kill now lives in the clearing helper alone, so stop keeps its semantics with no double-terminate and one fewer code path.

## One zombie-aware liveness predicate

`handover.py` had a /proc-reading `_alive` that excludes zombies; `admin.py` had a signal-0 `_pid_alive`. Signal-0 lies for exactly the processes these modules track: a detached child whose parent has exited reparents to init, and until it is reaped its corpse still answers the probe like a live process, so a dead backend read as alive. The /proc state-code implementation is now the single predicate, `admin._pid_alive`, used by the staleness guard, `list_sessions`, handover `status()`, and the new terminate-on-replace check. A zombie backend reads as dead everywhere, including the kill-on-clear path, so a corpse is never "terminated" again.

One deviation from the task spec, named honestly: the spec placed the predicate in `helpers.py`, but `helpers.py` imports `admin.send`, so admin importing helpers back would create exactly the cycle the spec ruled out. `admin.py` is the consolidation point that keeps the module graph a DAG, and handover already reaches into it for `_terminate_pid`.

## SKILL.md inlines vs stub reference files

`interaction-skills/` held one-to-three line stubs that promised mechanics without containing any. Outcome per file:

| File | Outcome |
| --- | --- |
| cross-origin-iframes.md | Filled: the body's cross-origin iframe depth (empty-parent symptom, context enumeration, `iframe_target` plus `target_id`, input-level coordinate clicks) moved here; the body's checklist item keeps the symptom and points at the file |
| screenshots.md | Filled: the body's format and clipping guidance (webp vs png, `--region`, jpeg encoding) moved here; the body keeps one lean line and the pointer |
| uploads.md, cookies.md, downloads.md, drag-and-drop.md, dropdowns.md, iframes.md, network-requests.md, print-as-pdf.md, scrolling.md, shadow-dom.md, viewport.md | Deleted: no real content in the stub and no body depth worth extracting (shadow DOM and same-origin iframes keep their short inline coverage in the body's diagnostic checklist), so search never lands on an empty promise |
| advanced-usage.md, cloudflare-403-vs-js-challenge.md, connection.md, dialogs.md, geolocation-override.md, handover.md, profile-sync.md, prosemirror-tiptap-editors.md, remote-control.md, tabs.md | Left: real reference files already |

The body's mechanics lists now name only files that exist, and SKILL.md is net shorter (234 to 232 lines). No mechanics content was invented: everything in the filled files is moved body text or documented helper signatures.

## Tests

- Recording a connect endpoint over a live launched browser terminates the old process (a real orphaned process, reaped by init); the records end up describing only the new backend.
- Recording over an already-dead pid record stays quiet: no termination attempt, records replaced.
- `stop_browser` still terminates the recorded browser and clears records.
- A real zombie (unreaped dead child that still answers signal-0) reads as dead through the shared predicate; the comm-with-parens /proc parse and the None/reserved-pid cases moved from the handover suite to the admin suite with the predicate.

`./check.sh guards` passes; the browser CLI suite is green (221 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
