### PR TITLE
fix(whatsapp): consolidated whisper, LID, and mention fixes

### DIFF
--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -103,7 +103,9 @@ account/device store.
 Voice notes transcribe in-process: the CLI downloads the audio, `ffmpeg` converts
 it to 16kHz mono WAV, and the built-in whisper.cpp bindings replace the `[audio]`
 placeholder with the text. Override the model path with the `WHISPER_MODEL` env
-var (default `/usr/local/share/ggml-small.bin`, downloaded by `setup.sh`).
+var (default `/usr/local/share/ggml-small.bin`, downloaded by `setup.sh`). Set
+`WHISPER_LANGUAGE` to a whisper.cpp language code (default: auto-detect) when the
+user's voice notes are one known language, since auto-detection can misread short clips.
 
 ## Contact cards
 

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -112,9 +112,8 @@ Hold a live call in your own voice (the `voice` skill's TTS) and hear the other 
 
 - **Send one WhatsApp call at a time.** Never batch sends (or `say` lines) in a parallel tool-call
   block: if one fails you can't tell which landed, and a retry sends a duplicate; parallel `say` lines race.
-- **Run `whatsapp send` bare and check its exit status.** Never pipe it through `grep`, `head`, or
-  `jq`: a failed send exits non-zero and prints a JSON error object saying what to fix, and a filter
-  swallows that error text while replacing the exit status with the filter's own.
+- Success JSON prints on stdout; any failure exits non-zero and prints its error on stderr, so it
+  survives piping stdout through `grep`, `head`, or `jq`.
 - **Never re-link without the user's explicit go-ahead** (the linking rule). Pairing is rate-limited to
   about two attempts per hour because repeated attempts get accounts flagged and banned; if linking
   fails, report it and wait, never retry-loop.

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -112,6 +112,9 @@ Hold a live call in your own voice (the `voice` skill's TTS) and hear the other 
 
 - **Send one WhatsApp call at a time.** Never batch sends (or `say` lines) in a parallel tool-call
   block: if one fails you can't tell which landed, and a retry sends a duplicate; parallel `say` lines race.
+- **Run `whatsapp send` bare and check its exit status.** Never pipe it through `grep`, `head`, or
+  `jq`: a failed send exits non-zero and prints a JSON error object saying what to fix, and a filter
+  swallows that error text while replacing the exit status with the filter's own.
 - **Never re-link without the user's explicit go-ahead** (the linking rule). Pairing is rate-limited to
   about two attempts per hour because repeated attempts get accounts flagged and banned; if linking
   fails, report it and wait, never retry-loop.

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -107,6 +107,24 @@ func resultFailure(result any) string {
 	return "command failed"
 }
 
+// emit is the one owner of which stream a command's answer takes: stdout
+// carries only success output, and anything paired with a non-zero exit prints
+// to stderr, so a filter piped onto stdout can never swallow a failure or its
+// explanation.
+func emit(data []byte, exitCode int) {
+	if exitCode == 0 {
+		fmt.Println(string(data))
+	} else {
+		fmt.Fprintln(os.Stderr, string(data))
+	}
+}
+
+func emitAndExit(data []byte, exitCode int) {
+	emit(data, exitCode)
+	os.Exit(exitCode)
+}
+
+// printJSON prints a success result; failures go through failJSON or failDaemon.
 func printJSON(v any) {
 	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
@@ -119,8 +137,8 @@ func printJSON(v any) {
 // failJSON prints an {"error": ...} object and exits nonzero, the single owner
 // of the print-error-then-exit pattern the daemon and link commands share.
 func failJSON(format string, args ...any) {
-	printJSON(map[string]any{"error": fmt.Sprintf(format, args...)})
-	os.Exit(1)
+	data, _ := json.MarshalIndent(map[string]any{"error": fmt.Sprintf(format, args...)}, "", "  ")
+	emitAndExit(data, 1)
 }
 
 func writeDeathNotification(notifDir string, sig string) {
@@ -346,8 +364,7 @@ func runOneShot(command string) {
 	if !connected {
 		failJSON("whatsapp daemon is not answering; run `whatsapp status`")
 	}
-	fmt.Println(string(output))
-	os.Exit(exitCode)
+	emitAndExit(output, exitCode)
 }
 
 // parseFlags parses a command's flags, returning what the FlagSet wrote about the problem: the

--- a/agent/skills/whatsapp/cli/constants.go
+++ b/agent/skills/whatsapp/cli/constants.go
@@ -50,12 +50,6 @@ const (
 	QRCodeSize                  = 256
 	MaxConcurrentTranscriptions = 3
 
-	// WhisperProcessTimeout bounds one whisper Process call, timed from when the
-	// call starts (after whisperProcessMu is acquired), so queued voice notes each
-	// get the full budget. A wedged call degrades to a failure notification
-	// instead of silently dropping the message forever.
-	WhisperProcessTimeout = 2 * time.Minute
-
 	// WhisperMaxThreads caps the compute threads a transcription may use. The Go
 	// binding defaults each context to runtime.NumCPU(), which starves the
 	// daemon's own work on a big box; whisper.cpp gains little past a handful of

--- a/agent/skills/whatsapp/cli/constants.go
+++ b/agent/skills/whatsapp/cli/constants.go
@@ -56,6 +56,13 @@ const (
 	// instead of silently dropping the message forever.
 	WhisperProcessTimeout = 2 * time.Minute
 
+	// WhisperMaxThreads caps the compute threads a transcription may use. The Go
+	// binding defaults each context to runtime.NumCPU(), which starves the
+	// daemon's own work on a big box; whisper.cpp gains little past a handful of
+	// threads anyway. 4 matches the whisper skill's own default
+	// (skills/whisper/scripts/whisper_transcribe.sh).
+	WhisperMaxThreads = 4
+
 	TypingDelayPerChar = 25 * time.Millisecond
 	TypingDelayMin     = 1500 * time.Millisecond
 	TypingDelayMax     = 6 * time.Second

--- a/agent/skills/whatsapp/cli/constants.go
+++ b/agent/skills/whatsapp/cli/constants.go
@@ -50,6 +50,12 @@ const (
 	QRCodeSize                  = 256
 	MaxConcurrentTranscriptions = 3
 
+	// WhisperProcessTimeout bounds one whisper Process call, timed from when the
+	// call starts (after whisperProcessMu is acquired), so queued voice notes each
+	// get the full budget. A wedged call degrades to a failure notification
+	// instead of silently dropping the message forever.
+	WhisperProcessTimeout = 2 * time.Minute
+
 	TypingDelayPerChar = 25 * time.Millisecond
 	TypingDelayMin     = 1500 * time.Millisecond
 	TypingDelayMax     = 6 * time.Second

--- a/agent/skills/whatsapp/cli/daemon.go
+++ b/agent/skills/whatsapp/cli/daemon.go
@@ -107,16 +107,11 @@ func stopRefusal(remaining time.Duration, force bool) string {
 		remaining.Round(time.Second))
 }
 
-// failDaemon ends a verb with its error envelope on stderr, which is where the contract puts a
-// failure: stdout carries the one status object a verb answers with and nothing else.
+// failDaemon ends a verb with its error envelope as the one compact line the
+// daemon contract pins; emitAndExit routes it to stderr.
 func failDaemon(format string, args ...any) {
-	envelope, err := json.Marshal(map[string]string{"error": fmt.Sprintf(format, args...)})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "JSON encoding error: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Fprintln(os.Stderr, string(envelope))
-	os.Exit(1)
+	envelope, _ := json.Marshal(map[string]string{"error": fmt.Sprintf(format, args...)})
+	emitAndExit(envelope, 1)
 }
 
 func runDaemon() {

--- a/agent/skills/whatsapp/cli/emit_test.go
+++ b/agent/skills/whatsapp/cli/emit_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func captureStreams(t *testing.T, fn func()) (stdout, stderr string) {
+	t.Helper()
+	origOut, origErr := os.Stdout, os.Stderr
+	outRead, outWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to open stdout pipe: %v", err)
+	}
+	errRead, errWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to open stderr pipe: %v", err)
+	}
+	os.Stdout, os.Stderr = outWrite, errWrite
+	fn()
+	os.Stdout, os.Stderr = origOut, origErr
+	outWrite.Close()
+	errWrite.Close()
+	outBytes, _ := io.ReadAll(outRead)
+	errBytes, _ := io.ReadAll(errRead)
+	return string(outBytes), string(errBytes)
+}
+
+// emit owns the stream contract: stdout carries only success output, and anything
+// paired with a non-zero exit prints to stderr, so a filter piped onto stdout can
+// never swallow a failure's envelope.
+func TestEmitRoutesByOutcome(t *testing.T) {
+	cases := []struct {
+		name       string
+		data       string
+		exitCode   int
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name:       "success prints on stdout only",
+			data:       `{"success": true}`,
+			exitCode:   0,
+			wantStdout: "{\"success\": true}\n",
+			wantStderr: "",
+		},
+		{
+			name:       "failure prints on stderr only",
+			data:       `{"error": "bubble lint refused the text"}`,
+			exitCode:   1,
+			wantStdout: "",
+			wantStderr: "{\"error\": \"bubble lint refused the text\"}\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr := captureStreams(t, func() { emit([]byte(tc.data), tc.exitCode) })
+			if stdout != tc.wantStdout {
+				t.Errorf("stdout = %q, want %q", stdout, tc.wantStdout)
+			}
+			if stderr != tc.wantStderr {
+				t.Errorf("stderr = %q, want %q", stderr, tc.wantStderr)
+			}
+		})
+	}
+}

--- a/agent/skills/whatsapp/cli/link.go
+++ b/agent/skills/whatsapp/cli/link.go
@@ -322,7 +322,7 @@ func runLink() {
 		if registered && !terminal.connected && currentQRLink().port == 0 {
 			_ = unregisterVestadService(linkServiceName(), port)
 		}
-		fmt.Println(string(terminal.output))
+		emit(terminal.output, terminal.exitCode)
 		if terminal.exitCode == 0 {
 			return
 		}
@@ -352,6 +352,5 @@ func runLinkPhone(phone string) {
 	if !connected {
 		failJSON("daemon not running. Start with: whatsapp daemon start")
 	}
-	fmt.Println(string(output))
-	os.Exit(exitCode)
+	emitAndExit(output, exitCode)
 }

--- a/agent/skills/whatsapp/cli/media.go
+++ b/agent/skills/whatsapp/cli/media.go
@@ -122,30 +122,41 @@ func (wac *WhatsAppClient) DownloadMedia(messageID, chatIdentifier, downloadPath
 	return savePath, nil
 }
 
+// reactionSenderJID picks the "original sender" half of a reaction's message key. In a direct chat
+// the sender is the chat itself, which holds for a LID chat exactly as it does for a phone-number
+// one: isDirectChatJID is the same test send, calls, and contact lookup already use, so a chat you
+// can message is a chat you can react in. Groups need the stored per-message sender. Returns an
+// empty failure string on success.
+func (wac *WhatsAppClient) reactionSenderJID(jid types.JID, messageID string) (types.JID, string) {
+	if isDirectChatJID(jid) {
+		return jid, ""
+	}
+	if jid.Server != types.GroupServer {
+		return types.JID{}, fmt.Sprintf("Unsupported chat type: %s", jid.Server)
+	}
+
+	wac.sendersMutex.RLock()
+	storedSender := wac.messageSenders[messageID]
+	wac.sendersMutex.RUnlock()
+	if storedSender == "" {
+		return types.JID{}, "Message sender not found for group reaction"
+	}
+	senderJID, err := types.ParseJID(storedSender)
+	if err != nil {
+		return types.JID{}, fmt.Sprintf("Could not resolve the original sender for this message: %v", err)
+	}
+	return senderJID, ""
+}
+
 func (wac *WhatsAppClient) SendReaction(messageID, emoji, chatIdentifier string) (bool, string) {
 	jid, err := wac.ResolveRecipient(chatIdentifier)
 	if err != nil {
 		return false, fmt.Sprintf("Failed to resolve chat: %v", err)
 	}
 
-	var senderJID types.JID
-	if jid.Server == types.DefaultUserServer {
-		senderJID = jid
-	} else if jid.Server == types.GroupServer {
-		wac.sendersMutex.RLock()
-		storedSender := wac.messageSenders[messageID]
-		wac.sendersMutex.RUnlock()
-
-		if storedSender != "" {
-			senderJID, err = types.ParseJID(storedSender)
-			if err != nil {
-				return false, fmt.Sprintf("Could not resolve the original sender for this message: %v", err)
-			}
-		} else {
-			return false, "Message sender not found for group reaction"
-		}
-	} else {
-		return false, fmt.Sprintf("Unsupported chat type: %s", jid.Server)
+	senderJID, failure := wac.reactionSenderJID(jid, messageID)
+	if failure != "" {
+		return false, failure
 	}
 
 	reactionMsg := wac.client.BuildReaction(jid, senderJID, messageID, emoji)

--- a/agent/skills/whatsapp/cli/messaging.go
+++ b/agent/skills/whatsapp/cli/messaging.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"go.mau.fi/whatsmeow"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
@@ -18,6 +20,10 @@ import (
 
 // mentionPattern matches @word patterns in message text.
 var mentionPattern = regexp.MustCompile(`@(\+?\w+)`)
+
+// emailAtextSpecials are the printable specials RFC 5322 allows in an email
+// local part; an "@" preceded by one belongs to an address, not a mention.
+const emailAtextSpecials = "!#$%&'*+-/=?^_`{|}~."
 
 // WhatsApp spam filters silently drop messages containing user@IP patterns.
 var userAtIPPattern = regexp.MustCompile(`\w+@\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
@@ -442,6 +448,17 @@ func (wac *WhatsAppClient) parseMentions(text string) (string, []string) {
 		fullStart, fullEnd := matches[i][0], matches[i][1]
 		captureStart, captureEnd := matches[i][2], matches[i][3]
 		identifier := text[captureStart:captureEnd]
+
+		// A real mention starts the text or follows whitespace or plain
+		// punctuation. A preceding letter, digit, or atext rune means the "@"
+		// sits inside a larger token (an email local part such as
+		// S3044936@ed.ac.uk), and rewriting it would corrupt the address.
+		if fullStart > 0 {
+			prev, _ := utf8.DecodeLastRuneInString(text[:fullStart])
+			if unicode.IsLetter(prev) || unicode.IsDigit(prev) || strings.ContainsRune(emailAtextSpecials, prev) {
+				continue
+			}
+		}
 
 		jid, err := wac.ResolveRecipient(identifier)
 		if err != nil {

--- a/agent/skills/whatsapp/cli/messaging.go
+++ b/agent/skills/whatsapp/cli/messaging.go
@@ -502,11 +502,15 @@ func (wac *WhatsAppClient) recordOutgoingMessage(jid types.JID, p StoreMessagePa
 		p.ID = fmt.Sprintf("local-%d", time.Now().UnixNano())
 	}
 
-	p.ChatJID = jid.String()
+	// File under the canonical chat key: keyed by the raw JID, a send to a peer's
+	// LID and their phone-JID replies would split one conversation into two chats.
+	chatKey := wac.canonicalChatKey(jid)
+
+	p.ChatJID = chatKey
 	p.Timestamp = time.Now()
 	p.IsFromMe = true
 
-	if err := wac.store.StoreChat(jid.String(), wac.getChatName(jid), p.Timestamp); err != nil {
+	if err := wac.store.StoreChat(chatKey, wac.getChatName(jid), p.Timestamp); err != nil {
 		wac.logger.Warnf("Failed to store outgoing chat metadata: %v", err)
 	}
 

--- a/agent/skills/whatsapp/cli/outgoing_chatkey_test.go
+++ b/agent/skills/whatsapp/cli/outgoing_chatkey_test.go
@@ -1,44 +1,79 @@
 package main
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/store/sqlstore"
 	"go.mau.fi/whatsmeow/types"
 	waLog "go.mau.fi/whatsmeow/util/log"
 )
 
-// newOutgoingTestClient builds a store-backed client with no whatsmeow connection.
-// canonicalChatKey degrades to the raw JID when client is nil, so these tests pin the routing
-// contract (outgoing storage goes through canonicalChatKey) rather than the LID lookup itself,
-// which needs a live whatsmeow store.
+// One peer addressed two ways: sends target the LID, replies land under the phone JID.
+const (
+	outgoingLIDJID   = "18812345678901@lid"
+	outgoingPhoneJID = "15559876543@s.whatsapp.net"
+)
+
+// newOutgoingTestClient builds a store-backed client over a real whatsmeow device store seeded
+// with the outgoingLIDJID<->outgoingPhoneJID mapping, so canonicalChatKey resolves the LID to
+// the phone JID instead of degrading to the raw JID. That makes the canonical key DIFFER from
+// the send target, which is what these tests are about.
 func newOutgoingTestClient(t *testing.T) *WhatsAppClient {
 	t.Helper()
-	return &WhatsAppClient{store: newTestStore(t), logger: waLog.Noop}
+	ctx := context.Background()
+	container, err := sqlstore.New(ctx, "sqlite3", "file:"+filepath.Join(t.TempDir(), "whatsmeow.db")+"?_foreign_keys=on", nil)
+	if err != nil {
+		t.Fatalf("failed to open whatsmeow store: %v", err)
+	}
+	t.Cleanup(func() { container.Close() })
+
+	device := container.NewDevice()
+	device.LIDs = container.LIDMap
+	lid, err := types.ParseJID(outgoingLIDJID)
+	if err != nil {
+		t.Fatalf("failed to parse lid: %v", err)
+	}
+	phone, err := types.ParseJID(outgoingPhoneJID)
+	if err != nil {
+		t.Fatalf("failed to parse phone jid: %v", err)
+	}
+	if err := device.LIDs.PutLIDMapping(ctx, lid, phone); err != nil {
+		t.Fatalf("failed to seed LID mapping: %v", err)
+	}
+
+	return &WhatsAppClient{
+		store:  newTestStore(t),
+		logger: waLog.Noop,
+		client: whatsmeow.NewClient(device, waLog.Noop),
+	}
 }
 
-// TestOutgoingMessageStoredUnderCanonicalChatKey pins that an outgoing message is filed under
-// canonicalChatKey, the same key inbound storage uses, so one conversation stays one chat row.
+// TestOutgoingMessageStoredUnderCanonicalChatKey pins that a message sent to a peer's LID is
+// filed under their phone JID, the same key inbound storage resolves to, so one conversation
+// stays one chat row.
 func TestOutgoingMessageStoredUnderCanonicalChatKey(t *testing.T) {
 	wac := newOutgoingTestClient(t)
 
-	jid, err := types.ParseJID("15551234567@s.whatsapp.net")
+	lid, err := types.ParseJID(outgoingLIDJID)
 	if err != nil {
-		t.Fatalf("failed to parse jid: %v", err)
+		t.Fatalf("failed to parse lid: %v", err)
 	}
-	if err := wac.store.StoreChat(jid.String(), "Ana", time.Now()); err != nil {
+	if err := wac.store.StoreChat(outgoingLIDJID, "Ana", time.Now()); err != nil {
 		t.Fatalf("failed to store chat: %v", err)
 	}
 
-	wac.recordOutgoingMessage(jid, StoreMessageParams{ID: "MSG-OUT", Content: "hello"})
+	wac.recordOutgoingMessage(lid, StoreMessageParams{ID: "MSG-OUT", Content: "hello"})
 
-	want := wac.canonicalChatKey(jid)
-	msgs, err := wac.store.ListMessages(nil, nil, "", []string{want}, "", 10, 0)
+	msgs, err := wac.store.ListMessages(nil, nil, "", []string{outgoingPhoneJID}, "", 10, 0)
 	if err != nil {
 		t.Fatalf("failed to list messages: %v", err)
 	}
 	if len(msgs) != 1 {
-		t.Fatalf("expected 1 message under canonical key %q, got %d", want, len(msgs))
+		t.Fatalf("expected 1 message under canonical key %q, got %d", outgoingPhoneJID, len(msgs))
 	}
 	if !msgs[0].IsFromMe {
 		t.Errorf("stored outgoing message is not marked IsFromMe")
@@ -46,28 +81,27 @@ func TestOutgoingMessageStoredUnderCanonicalChatKey(t *testing.T) {
 }
 
 // TestOutgoingAndIncomingShareOneChatKey pins the threading guarantee: a reply from the same peer
-// lands in the same chat row as what we sent, so the conversation reads as one thread and
-// "did they answer?" can be resolved by reading that row.
+// lands in the same chat row as what we sent to their LID, so the conversation reads as one thread
+// and "did they answer?" can be resolved by reading that row.
 func TestOutgoingAndIncomingShareOneChatKey(t *testing.T) {
 	wac := newOutgoingTestClient(t)
 
-	jid, err := types.ParseJID("15551234567@s.whatsapp.net")
+	lid, err := types.ParseJID(outgoingLIDJID)
 	if err != nil {
-		t.Fatalf("failed to parse jid: %v", err)
+		t.Fatalf("failed to parse lid: %v", err)
 	}
-	key := wac.canonicalChatKey(jid)
-	if err := wac.store.StoreChat(key, "Ana", time.Now()); err != nil {
+	if err := wac.store.StoreChat(outgoingLIDJID, "Ana", time.Now()); err != nil {
 		t.Fatalf("failed to store chat: %v", err)
 	}
 
-	wac.recordOutgoingMessage(jid, StoreMessageParams{ID: "MSG-OUT", Content: "ping"})
+	wac.recordOutgoingMessage(lid, StoreMessageParams{ID: "MSG-OUT", Content: "ping"})
 	if err := wac.store.StoreMessage(StoreMessageParams{
-		ID: "MSG-IN", ChatJID: key, Sender: "Ana", Content: "pong", Timestamp: time.Now(),
+		ID: "MSG-IN", ChatJID: outgoingPhoneJID, Sender: "Ana", Content: "pong", Timestamp: time.Now(),
 	}); err != nil {
 		t.Fatalf("failed to store inbound message: %v", err)
 	}
 
-	msgs, err := wac.store.ListMessages(nil, nil, "", []string{key}, "", 10, 0)
+	msgs, err := wac.store.ListMessages(nil, nil, "", []string{outgoingPhoneJID}, "", 10, 0)
 	if err != nil {
 		t.Fatalf("failed to list messages: %v", err)
 	}
@@ -84,6 +118,6 @@ func TestOutgoingAndIncomingShareOneChatKey(t *testing.T) {
 		}
 	}
 	if !sawOutgoing || !sawIncoming {
-		t.Errorf("chat %q is one-sided: outgoing=%v incoming=%v", key, sawOutgoing, sawIncoming)
+		t.Errorf("chat %q is one-sided: outgoing=%v incoming=%v", outgoingPhoneJID, sawOutgoing, sawIncoming)
 	}
 }

--- a/agent/skills/whatsapp/cli/outgoing_chatkey_test.go
+++ b/agent/skills/whatsapp/cli/outgoing_chatkey_test.go
@@ -8,25 +8,13 @@ import (
 	waLog "go.mau.fi/whatsmeow/util/log"
 )
 
-// newOutgoingTestClient builds a store-backed client with no whatsmeow connection, matching the
-// pattern in edits_test.go. canonicalChatKey degrades to the raw JID when client is nil, so these
-// tests pin the routing contract (outgoing storage goes through canonicalChatKey) rather than the
-// LID lookup itself, which needs a live whatsmeow store.
+// newOutgoingTestClient builds a store-backed client with no whatsmeow connection.
+// canonicalChatKey degrades to the raw JID when client is nil, so these tests pin the routing
+// contract (outgoing storage goes through canonicalChatKey) rather than the LID lookup itself,
+// which needs a live whatsmeow store.
 func newOutgoingTestClient(t *testing.T) *WhatsAppClient {
 	t.Helper()
-	store, err := NewMessageStore(t.TempDir())
-	if err != nil {
-		t.Fatalf("failed to open store: %v", err)
-	}
-	t.Cleanup(func() { store.Close() })
-	return &WhatsAppClient{
-		store:          store,
-		logger:         waLog.Noop,
-		instance:       "personal",
-		readOnly:       true,
-		skipSenders:    map[string]bool{},
-		messageSenders: map[string]string{},
-	}
+	return &WhatsAppClient{store: newTestStore(t), logger: waLog.Noop}
 }
 
 // TestOutgoingMessageStoredUnderCanonicalChatKey pins that an outgoing message is filed under

--- a/agent/skills/whatsapp/cli/outgoing_chatkey_test.go
+++ b/agent/skills/whatsapp/cli/outgoing_chatkey_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow/types"
+	waLog "go.mau.fi/whatsmeow/util/log"
+)
+
+// newOutgoingTestClient builds a store-backed client with no whatsmeow connection, matching the
+// pattern in edits_test.go. canonicalChatKey degrades to the raw JID when client is nil, so these
+// tests pin the routing contract (outgoing storage goes through canonicalChatKey) rather than the
+// LID lookup itself, which needs a live whatsmeow store.
+func newOutgoingTestClient(t *testing.T) *WhatsAppClient {
+	t.Helper()
+	store, err := NewMessageStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return &WhatsAppClient{
+		store:          store,
+		logger:         waLog.Noop,
+		instance:       "personal",
+		readOnly:       true,
+		skipSenders:    map[string]bool{},
+		messageSenders: map[string]string{},
+	}
+}
+
+// TestOutgoingMessageStoredUnderCanonicalChatKey pins that an outgoing message is filed under
+// canonicalChatKey, the same key inbound storage uses, so one conversation stays one chat row.
+func TestOutgoingMessageStoredUnderCanonicalChatKey(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+
+	jid, err := types.ParseJID("15551234567@s.whatsapp.net")
+	if err != nil {
+		t.Fatalf("failed to parse jid: %v", err)
+	}
+	if err := wac.store.StoreChat(jid.String(), "Ana", time.Now()); err != nil {
+		t.Fatalf("failed to store chat: %v", err)
+	}
+
+	wac.recordOutgoingMessage(jid, StoreMessageParams{ID: "MSG-OUT", Content: "hello"})
+
+	want := wac.canonicalChatKey(jid)
+	msgs, err := wac.store.ListMessages(nil, nil, "", []string{want}, "", 10, 0)
+	if err != nil {
+		t.Fatalf("failed to list messages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message under canonical key %q, got %d", want, len(msgs))
+	}
+	if !msgs[0].IsFromMe {
+		t.Errorf("stored outgoing message is not marked IsFromMe")
+	}
+}
+
+// TestOutgoingAndIncomingShareOneChatKey pins the threading guarantee: a reply from the same peer
+// lands in the same chat row as what we sent, so the conversation reads as one thread and
+// "did they answer?" can be resolved by reading that row.
+func TestOutgoingAndIncomingShareOneChatKey(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+
+	jid, err := types.ParseJID("15551234567@s.whatsapp.net")
+	if err != nil {
+		t.Fatalf("failed to parse jid: %v", err)
+	}
+	key := wac.canonicalChatKey(jid)
+	if err := wac.store.StoreChat(key, "Ana", time.Now()); err != nil {
+		t.Fatalf("failed to store chat: %v", err)
+	}
+
+	wac.recordOutgoingMessage(jid, StoreMessageParams{ID: "MSG-OUT", Content: "ping"})
+	if err := wac.store.StoreMessage(StoreMessageParams{
+		ID: "MSG-IN", ChatJID: key, Sender: "Ana", Content: "pong", Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("failed to store inbound message: %v", err)
+	}
+
+	msgs, err := wac.store.ListMessages(nil, nil, "", []string{key}, "", 10, 0)
+	if err != nil {
+		t.Fatalf("failed to list messages: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected both directions under one chat key, got %d", len(msgs))
+	}
+
+	var sawOutgoing, sawIncoming bool
+	for _, m := range msgs {
+		if m.IsFromMe {
+			sawOutgoing = true
+		} else {
+			sawIncoming = true
+		}
+	}
+	if !sawOutgoing || !sawIncoming {
+		t.Errorf("chat %q is one-sided: outgoing=%v incoming=%v", key, sawOutgoing, sawIncoming)
+	}
+}

--- a/agent/skills/whatsapp/cli/parse_mentions_test.go
+++ b/agent/skills/whatsapp/cli/parse_mentions_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+// newMentionTestClient builds a store-backed client (the contacts_test.go pattern) with saved
+// contacts whose names collide with email domain segments, so a resolvable "@ed"/"@Emi" is
+// rewritten only when the guard classifies it as a real mention.
+func newMentionTestClient(t *testing.T) *WhatsAppClient {
+	t.Helper()
+	store := newTestStore(t)
+	if _, err := store.SaveManualContact("Emi", "+15551000001"); err != nil {
+		t.Fatalf("failed to save contact: %v", err)
+	}
+	if _, err := store.SaveManualContact("Ed", "+15551000002"); err != nil {
+		t.Fatalf("failed to save contact: %v", err)
+	}
+	return &WhatsAppClient{store: store}
+}
+
+func TestParseMentions(t *testing.T) {
+	wac := newMentionTestClient(t)
+
+	emiJID := "15551000001@s.whatsapp.net"
+	cases := []struct {
+		name     string
+		text     string
+		wantText string
+		wantJIDs []string
+	}{
+		{
+			name:     "mention at start of text",
+			text:     "@Emi hello",
+			wantText: "@15551000001 hello",
+			wantJIDs: []string{emiJID},
+		},
+		{
+			name:     "mention after a space",
+			text:     "hello @Emi",
+			wantText: "hello @15551000001",
+			wantJIDs: []string{emiJID},
+		},
+		{
+			name:     "mention after an open paren",
+			text:     "(@Emi)",
+			wantText: "(@15551000001)",
+			wantJIDs: []string{emiJID},
+		},
+		{
+			name:     "mention after a comma",
+			text:     "ok,@Emi",
+			wantText: "ok,@15551000001",
+			wantJIDs: []string{emiJID},
+		},
+		{
+			name:     "email local part with digits stays untouched",
+			text:     "write to S3044936@ed.ac.uk please",
+			wantText: "write to S3044936@ed.ac.uk please",
+			wantJIDs: nil,
+		},
+		{
+			name:     "email local part ending in a multibyte letter stays untouched",
+			text:     "rené@ed.ac.uk",
+			wantText: "rené@ed.ac.uk",
+			wantJIDs: nil,
+		},
+		{
+			name:     "email local part ending in atext punctuation stays untouched",
+			text:     "foo!@ed.ac.uk",
+			wantText: "foo!@ed.ac.uk",
+			wantJIDs: nil,
+		},
+		{
+			// A dot is atext, so a dot-glued "@" reads as part of an address token.
+			name:     "dot-glued mention stays untouched",
+			text:     "done.@Emi",
+			wantText: "done.@Emi",
+			wantJIDs: nil,
+		},
+		{
+			name:     "digits around an @ produce no mention",
+			text:     "5@10",
+			wantText: "5@10",
+			wantJIDs: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotText, gotJIDs := wac.parseMentions(tc.text)
+			if gotText != tc.wantText {
+				t.Errorf("text = %q, want %q", gotText, tc.wantText)
+			}
+			if !slices.Equal(gotJIDs, tc.wantJIDs) {
+				t.Errorf("jids = %v, want %v", gotJIDs, tc.wantJIDs)
+			}
+		})
+	}
+}

--- a/agent/skills/whatsapp/cli/provision.go
+++ b/agent/skills/whatsapp/cli/provision.go
@@ -1,10 +1,5 @@
 package main
 
-import (
-	"fmt"
-	"os"
-)
-
 // runProvision is the managed-WhatsApp arm of `whatsapp connect` for a hosted
 // (vesta.run) box (runConnect dispatches here when the box can reach a pool). It
 // mirrors runLink: cold-start the daemon (ensureDaemon waits for the socket
@@ -31,6 +26,5 @@ func runProvision(source, opener string) {
 	if !connected {
 		failJSON("daemon not answering after start; check 'whatsapp daemon status'")
 	}
-	fmt.Println(string(output))
-	os.Exit(exitCode)
+	emitAndExit(output, exitCode)
 }

--- a/agent/skills/whatsapp/cli/reaction_test.go
+++ b/agent/skills/whatsapp/cli/reaction_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+// A LID chat is a direct chat: `send` accepts one, so `react` must too. These tests pin that the
+// sender half of a direct reaction's message key is the chat itself for every direct-chat server,
+// phone-number and LID alike.
+func TestReactionSenderJIDAcceptsDirectChats(t *testing.T) {
+	wac := &WhatsAppClient{}
+	for _, server := range []string{types.DefaultUserServer, types.HiddenUserServer, types.HostedLIDServer} {
+		chat := types.JID{User: "123456", Server: server}
+		sender, failure := wac.reactionSenderJID(chat, "MSGID")
+		if failure != "" {
+			t.Fatalf("server %q: unexpected failure %q", server, failure)
+		}
+		if sender != chat {
+			t.Fatalf("server %q: sender = %v, want the chat itself %v", server, sender, chat)
+		}
+	}
+}
+
+func TestReactionSenderJIDUsesStoredSenderForGroups(t *testing.T) {
+	wac := &WhatsAppClient{messageSenders: map[string]string{"MSGID": "49999@s.whatsapp.net"}}
+	chat := types.JID{User: "120363", Server: types.GroupServer}
+
+	sender, failure := wac.reactionSenderJID(chat, "MSGID")
+	if failure != "" {
+		t.Fatalf("unexpected failure %q", failure)
+	}
+	if sender.User != "49999" {
+		t.Fatalf("sender = %v, want the stored per-message sender", sender)
+	}
+
+	if _, failure = wac.reactionSenderJID(chat, "UNKNOWN"); failure != "Message sender not found for group reaction" {
+		t.Fatalf("missing stored sender: got %q", failure)
+	}
+}
+
+func TestReactionSenderJIDRejectsUnsupportedChatTypes(t *testing.T) {
+	wac := &WhatsAppClient{}
+	chat := types.JID{User: "status", Server: types.BroadcastServer}
+	if _, failure := wac.reactionSenderJID(chat, "MSGID"); failure != "Unsupported chat type: broadcast" {
+		t.Fatalf("got %q, want the unsupported-chat-type failure", failure)
+	}
+}

--- a/agent/skills/whatsapp/cli/transcribe.go
+++ b/agent/skills/whatsapp/cli/transcribe.go
@@ -26,6 +26,15 @@ var (
 	whisperProcessMu sync.Mutex
 )
 
+// getLanguage returns WHISPER_LANGUAGE when set (a fixed whisper.cpp language
+// code, since auto-detection can misread short clips), defaulting to "auto".
+func getLanguage() string {
+	if l := os.Getenv("WHISPER_LANGUAGE"); l != "" {
+		return l
+	}
+	return "auto"
+}
+
 func getModelPath() string {
 	if p := os.Getenv("WHISPER_MODEL"); p != "" {
 		return p
@@ -94,9 +103,9 @@ func transcribeAudioBuiltIn(audioPath string) (string, error) {
 		return "", fmt.Errorf("failed to create whisper context: %w", err)
 	}
 
-	// Auto-detect language (supports Italian, English, etc.)
-	if err := ctx.SetLanguage("auto"); err != nil {
-		return "", fmt.Errorf("failed to set language to auto: %w", err)
+	lang := getLanguage()
+	if err := ctx.SetLanguage(lang); err != nil {
+		return "", fmt.Errorf("failed to set language to %q: %w", lang, err)
 	}
 
 	// Cap compute threads: the binding otherwise gives the context

--- a/agent/skills/whatsapp/cli/transcribe.go
+++ b/agent/skills/whatsapp/cli/transcribe.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper"
 	wav "github.com/go-audio/wav"
@@ -17,6 +18,11 @@ var (
 	whisperModel     whisper.Model
 	whisperModelOnce sync.Once
 	whisperModelErr  error
+
+	// whisperProcessMu serializes all use of the whisper C context: model.NewContext
+	// hands out a fresh wrapper per call, but every wrapper shares the one underlying
+	// C model context, which whisper.cpp does not support calling concurrently.
+	whisperProcessMu sync.Mutex
 )
 
 func getModelPath() string {
@@ -86,11 +92,37 @@ func transcribeAudioBuiltIn(audioPath string) (string, error) {
 		return "", fmt.Errorf("failed to set language to auto: %w", err)
 	}
 
+	// The timeout clock starts only once the mutex is held, so each queued voice
+	// note gets the full budget. On timeout the goroutine keeps the mutex until
+	// Process returns, so a wedged call delays later transcriptions instead of
+	// racing them on the shared C context.
+	whisperProcessMu.Lock()
+	resCh := make(chan whisperResult, 1)
+	go func() {
+		defer whisperProcessMu.Unlock()
+		resCh <- processAndCollect(ctx, samples)
+	}()
+
+	select {
+	case res := <-resCh:
+		return res.text, res.err
+	case <-time.After(WhisperProcessTimeout):
+		return "", fmt.Errorf("whisper processing timed out after %v", WhisperProcessTimeout)
+	}
+}
+
+type whisperResult struct {
+	text string
+	err  error
+}
+
+// processAndCollect runs whisper_full and reads back the segments. Both touch the
+// shared C model context, so callers must hold whisperProcessMu throughout.
+func processAndCollect(ctx whisper.Context, samples []float32) whisperResult {
 	if err := ctx.Process(samples, nil, nil, nil); err != nil {
-		return "", fmt.Errorf("whisper processing failed: %w", err)
+		return whisperResult{err: fmt.Errorf("whisper processing failed: %w", err)}
 	}
 
-	// Collect segments
 	var parts []string
 	for {
 		segment, err := ctx.NextSegment()
@@ -98,12 +130,12 @@ func transcribeAudioBuiltIn(audioPath string) (string, error) {
 			break
 		}
 		if err != nil {
-			return "", fmt.Errorf("failed to get segment: %w", err)
+			return whisperResult{err: fmt.Errorf("failed to get segment: %w", err)}
 		}
 		parts = append(parts, segment.Text)
 	}
 
-	return strings.TrimSpace(strings.Join(parts, "")), nil
+	return whisperResult{text: strings.TrimSpace(strings.Join(parts, ""))}
 }
 
 func readWAVSamples(path string) ([]float32, error) {

--- a/agent/skills/whatsapp/cli/transcribe.go
+++ b/agent/skills/whatsapp/cli/transcribe.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -57,6 +58,12 @@ func loadWhisperModel() (whisper.Model, error) {
 	return whisperModel, whisperModelErr
 }
 
+// whisperThreads is the per-transcription thread budget: all of a small box's
+// cores, capped at WhisperMaxThreads on a big one.
+func whisperThreads(numCPU int) uint {
+	return uint(min(numCPU, WhisperMaxThreads))
+}
+
 // transcribeAudioBuiltIn transcribes audio using the built-in whisper.cpp bindings.
 func transcribeAudioBuiltIn(audioPath string) (string, error) {
 	model, err := loadWhisperModel()
@@ -91,6 +98,11 @@ func transcribeAudioBuiltIn(audioPath string) (string, error) {
 	if err := ctx.SetLanguage("auto"); err != nil {
 		return "", fmt.Errorf("failed to set language to auto: %w", err)
 	}
+
+	// Cap compute threads: the binding otherwise gives the context
+	// runtime.NumCPU(). Thread count only partitions the matmuls, it is not a
+	// decoding parameter, so the transcript is unaffected.
+	ctx.SetThreads(whisperThreads(runtime.NumCPU()))
 
 	// The timeout clock starts only once the mutex is held, so each queued voice
 	// note gets the full budget. On timeout the goroutine keeps the mutex until

--- a/agent/skills/whatsapp/cli/transcribe.go
+++ b/agent/skills/whatsapp/cli/transcribe.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper"
 	wav "github.com/go-audio/wav"
@@ -113,35 +112,13 @@ func transcribeAudioBuiltIn(audioPath string) (string, error) {
 	// decoding parameter, so the transcript is unaffected.
 	ctx.SetThreads(whisperThreads(runtime.NumCPU()))
 
-	// The timeout clock starts only once the mutex is held, so each queued voice
-	// note gets the full budget. On timeout the goroutine keeps the mutex until
-	// Process returns, so a wedged call delays later transcriptions instead of
-	// racing them on the shared C context.
+	// Process and segment reads both touch the C model context shared by every
+	// context wrapper (see whisperProcessMu).
 	whisperProcessMu.Lock()
-	resCh := make(chan whisperResult, 1)
-	go func() {
-		defer whisperProcessMu.Unlock()
-		resCh <- processAndCollect(ctx, samples)
-	}()
+	defer whisperProcessMu.Unlock()
 
-	select {
-	case res := <-resCh:
-		return res.text, res.err
-	case <-time.After(WhisperProcessTimeout):
-		return "", fmt.Errorf("whisper processing timed out after %v", WhisperProcessTimeout)
-	}
-}
-
-type whisperResult struct {
-	text string
-	err  error
-}
-
-// processAndCollect runs whisper_full and reads back the segments. Both touch the
-// shared C model context, so callers must hold whisperProcessMu throughout.
-func processAndCollect(ctx whisper.Context, samples []float32) whisperResult {
 	if err := ctx.Process(samples, nil, nil, nil); err != nil {
-		return whisperResult{err: fmt.Errorf("whisper processing failed: %w", err)}
+		return "", fmt.Errorf("whisper processing failed: %w", err)
 	}
 
 	var parts []string
@@ -151,12 +128,12 @@ func processAndCollect(ctx whisper.Context, samples []float32) whisperResult {
 			break
 		}
 		if err != nil {
-			return whisperResult{err: fmt.Errorf("failed to get segment: %w", err)}
+			return "", fmt.Errorf("failed to get segment: %w", err)
 		}
 		parts = append(parts, segment.Text)
 	}
 
-	return whisperResult{text: strings.TrimSpace(strings.Join(parts, ""))}
+	return strings.TrimSpace(strings.Join(parts, "")), nil
 }
 
 func readWAVSamples(path string) ([]float32, error) {

--- a/agent/skills/whatsapp/cli/transcribe_test.go
+++ b/agent/skills/whatsapp/cli/transcribe_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+// The thread budget uses every core on a small box and stays at
+// WhisperMaxThreads on a big one, so one transcription never pins a large
+// host while a single-core box still gets a worker.
+func TestWhisperThreadsClampsToMaxOnBigBoxes(t *testing.T) {
+	cases := []struct {
+		numCPU int
+		want   uint
+	}{
+		{numCPU: 1, want: 1},
+		{numCPU: 2, want: 2},
+		{numCPU: 4, want: 4},
+		{numCPU: 8, want: 4},
+		{numCPU: 32, want: 4},
+	}
+	for _, tc := range cases {
+		if got := whisperThreads(tc.numCPU); got != tc.want {
+			t.Errorf("whisperThreads(%d) = %d, want %d", tc.numCPU, got, tc.want)
+		}
+	}
+}

--- a/agent/skills/whisper/SETUP.md
+++ b/agent/skills/whisper/SETUP.md
@@ -9,21 +9,33 @@ git clone https://github.com/ggerganov/whisper.cpp.git /opt/whisper.cpp
 cd /opt/whisper.cpp && cmake -B build && cmake --build build --config Release -j$(nproc)
 cp build/bin/whisper-cli /usr/local/bin/
 
-# 3. Download model (small.en = ~466MB, good speed/quality balance)
-curl -L -o /usr/local/share/ggml-small.en.bin \
-  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin
+# 3. Download model (small = 488 MB, multilingual, good speed/quality balance)
+curl -L -o /usr/local/share/ggml-small.bin \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin
 ```
+
+This is the same file the whatsapp skill's `setup.sh` downloads, so if you already
+ran that, step 3 is done.
 
 ## Other Models
 
-| Model | Size | Use when |
-|-------|------|----------|
-| ggml-tiny.en.bin | 75 MB | Speed matters more than accuracy |
-| ggml-small.en.bin | 466 MB | Default, good balance |
-| ggml-medium.en.bin | 1.5 GB | Higher accuracy needed |
-| ggml-large-v3-turbo.bin | 1.6 GB | Best quality, non-English support |
+Sizes are the real `content-length` from huggingface.co, rounded to the nearest MB.
 
-`.en` models are English-only but faster. For non-English audio, use a non-`.en` model with `--language`.
+| Model | Size | Languages | Use when |
+|-------|------|-----------|----------|
+| ggml-tiny.bin | 78 MB | all | Speed matters more than accuracy |
+| ggml-small.bin | 488 MB | all | Default, good balance |
+| ggml-medium.bin | 1534 MB | all | Higher accuracy needed |
+| ggml-large-v3-turbo.bin | 1625 MB | all | Best quality |
+
+Each of these has an English-only `.en` twin (`ggml-small.en.bin` and so on) that is
+slightly faster and marginally more accurate on English. The `.en` files are **not**
+smaller: `ggml-small.en.bin` is 487,614,201 bytes against `ggml-small.bin`'s
+487,601,967, so the multilingual model is the better default at no download cost.
+
+An `.en` model cannot transcribe non-English audio. whisper.cpp rewrites `--language`
+back to `en` and turns off `--translate` when the loaded model is English-only, so the
+output is confident English nonsense rather than an error.
 
 Download any model:
 ```bash

--- a/agent/skills/whisper/SKILL.md
+++ b/agent/skills/whisper/SKILL.md
@@ -22,7 +22,7 @@ Transcribe audio/video files locally using whisper.cpp. No API calls, no data le
 ~/agent/skills/whisper/scripts/whisper_transcribe.sh audio.mp3 --translate
 ~/agent/skills/whisper/scripts/whisper_transcribe.sh audio.mp3 --srt
 ~/agent/skills/whisper/scripts/whisper_transcribe.sh audio.mp3 --json
-~/agent/skills/whisper/scripts/whisper_transcribe.sh audio.mp3 --model /usr/local/share/ggml-medium.en.bin
+~/agent/skills/whisper/scripts/whisper_transcribe.sh audio.mp3 --model /usr/local/share/ggml-medium.bin
 ~/agent/skills/whisper/scripts/whisper_transcribe.sh audio.mp3 --threads 8
 ```
 
@@ -30,7 +30,7 @@ Transcribe audio/video files locally using whisper.cpp. No API calls, no data le
 
 | Flag | Description |
 |------|-------------|
-| `--language <code>` | Language code (en, es, fr, de, etc.). Default: en |
+| `--language <code>` | Language code (en, es, fr, de, etc.). Default: auto, whisper detects it |
 | `--translate` | Translate non-English audio to English text |
 | `--srt` | Output SRT subtitle format |
 | `--json` | Output JSON with timestamps |
@@ -40,6 +40,11 @@ Transcribe audio/video files locally using whisper.cpp. No API calls, no data le
 ## Notes
 
 - Accepts any format ffmpeg can read: mp3, m4a, wav, ogg, flac, mp4, webm, etc.
-- small.en processes ~15-30x faster than real-time on ARM64
+- small processes ~15-30x faster than real-time on ARM64
 - For long recordings (1h+), expect a few minutes of processing
 - Output goes to stdout. Pipe or redirect as needed
+- Default model is the multilingual `/usr/local/share/ggml-small.bin`, falling back to
+  `ggml-small.en.bin`, `ggml-tiny.bin`, `ggml-tiny.en.bin` if that one is absent.
+  Override with `WHISPER_MODEL` or `--model`. English-only `.en` models cannot
+  transcribe other languages: whisper.cpp forces `--language en` and disables
+  `--translate` on them

--- a/agent/skills/whisper/scripts/whisper_transcribe.sh
+++ b/agent/skills/whisper/scripts/whisper_transcribe.sh
@@ -2,14 +2,33 @@
 set -euo pipefail
 
 WHISPER_BIN="${WHISPER_BIN:-/usr/local/bin/whisper-cli}"
-WHISPER_MODEL="${WHISPER_MODEL:-/usr/local/share/ggml-small.en.bin}"
+
+# Default model: multilingual ggml-small.bin. The fallback chain matches the
+# model paths the whatsapp CLI's transcribe.go probes; a box may hold only an
+# english-only or tiny model.
+DEFAULT_MODEL="/usr/local/share/ggml-small.bin"
+resolve_model() {
+    for candidate in \
+        "$DEFAULT_MODEL" \
+        /usr/local/share/ggml-small.en.bin \
+        /usr/local/share/ggml-tiny.bin \
+        /usr/local/share/ggml-tiny.en.bin
+    do
+        if [ -f "$candidate" ]; then
+            echo "$candidate"
+            return
+        fi
+    done
+    echo "$DEFAULT_MODEL"
+}
+WHISPER_MODEL="${WHISPER_MODEL:-$(resolve_model)}"
 
 usage() {
     echo "Usage: whisper_transcribe.sh <audio-file> [options]"
     echo ""
     echo "Options:"
     echo "  --model <path>     Model file (default: $WHISPER_MODEL)"
-    echo "  --language <lang>  Language code, e.g. en, es, fr (default: en)"
+    echo "  --language <lang>  Language code, e.g. en, es, fr (default: auto)"
     echo "  --translate        Translate to English"
     echo "  --srt              Output SRT subtitles instead of plain text"
     echo "  --json             Output JSON with timestamps"
@@ -29,7 +48,7 @@ if [ ! -f "$INPUT_FILE" ]; then
     exit 1
 fi
 
-LANGUAGE="en"
+LANGUAGE="auto"
 TRANSLATE=""
 OUTPUT_FORMAT=""
 THREADS="4"
@@ -54,13 +73,28 @@ fi
 
 if [ ! -f "$WHISPER_MODEL" ]; then
     echo "Error: model not found at $WHISPER_MODEL" >&2
-    echo "Download it: curl -L -o $WHISPER_MODEL https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin" >&2
+    echo "Download it: curl -L -o $WHISPER_MODEL https://huggingface.co/ggerganov/whisper.cpp/resolve/main/$(basename "$WHISPER_MODEL")" >&2
     exit 1
 fi
 
 TMP_WAV=$(mktemp /tmp/whisper_XXXX.wav)
 TMP_OUT=$(mktemp /tmp/whisper_out_XXXX)
-trap 'rm -f "$TMP_WAV" "$TMP_OUT" "${TMP_OUT}.srt" "${TMP_OUT}.json"' EXIT
+TMP_ERR=$(mktemp /tmp/whisper_err_XXXX)
+trap 'rm -f "$TMP_WAV" "$TMP_OUT" "${TMP_OUT}.srt" "${TMP_OUT}.json" "$TMP_ERR"' EXIT
+
+# whisper.cpp writes its progress banner to stderr, but also real diagnostics,
+# e.g. "model is not multilingual, ignoring language and translation options"
+# when an .en model silently drops --language/--translate. Keep the banner
+# quiet, forward warnings and errors, and dump all of stderr on a failed run.
+run_whisper() {
+    local status=0
+    "$WHISPER_BIN" "$@" 2>"$TMP_ERR" || status=$?
+    if [ "$status" -ne 0 ]; then
+        cat "$TMP_ERR" >&2
+        exit "$status"
+    fi
+    grep -iE 'warning|^error:|failed' "$TMP_ERR" >&2 || true
+}
 
 ffmpeg -i "$INPUT_FILE" -ar 16000 -ac 1 -c:a pcm_s16le "$TMP_WAV" -y 2>/dev/null
 
@@ -74,9 +108,9 @@ if [ -n "$OUTPUT_FORMAT" ]; then
         srt)  ARGS+=(-osrt -of "$TMP_OUT") ;;
         json) ARGS+=(-oj -of "$TMP_OUT") ;;
     esac
-    "$WHISPER_BIN" "${ARGS[@]}" >/dev/null 2>/dev/null
+    run_whisper "${ARGS[@]}" >/dev/null
     cat "${TMP_OUT}.${OUTPUT_FORMAT}"
 else
     ARGS+=(--no-timestamps)
-    "$WHISPER_BIN" "${ARGS[@]}" 2>/dev/null
+    run_whisper "${ARGS[@]}"
 fi


### PR DESCRIPTION
Consolidates eight open whatsapp/whisper PRs into one branch, applying each with the repairs its adversarial review demanded.

## Carried PRs

- **#1610 (whisper serialization)**: carried only the root-cause fix, the mutex serializing whisper `Process` calls plus segment collection (the Go bindings share one C model context across every context wrapper, which whisper.cpp does not support calling concurrently). The timeout is deliberately not carried: the mutex removes the race that caused hangs, a 2-minute budget sat under the measured worst case (~25 minutes for a 75s note on a loaded host, #1769) so slow successes would have been discarded, and queued notes would have blocked in an untimed `Lock()` behind a wedged call anyway. No events.go change.
- **#1770 (whisper thread cap)**: carried `SetThreads` with `WhisperMaxThreads = 4`. Simplified the formula to `min(NumCPU, WhisperMaxThreads)` since transcription is now serialized (no divide by `MaxConcurrentTranscriptions`), fixed the helper placement that orphaned `transcribeAudioBuiltIn`'s doc comment, and rewrote the test as concrete in/out pairs over a pure `whisperThreads(numCPU)`.
- **#1685 (whisper skill multilingual default)**: applied essentially as-is with three repairs: the fallback-chain comment states the mechanism instead of narrating the change, `run_whisper` dumps the full captured stderr on a nonzero exit, and the default model path has one owner (`DEFAULT_MODEL`).
- **#1686 (WHISPER_LANGUAGE override)**: carried the env override, collapsed the incident-narrating comments to one short mechanism line, and documented `WHISPER_LANGUAGE` in the whatsapp SETUP.md Transcription section next to `WHISPER_MODEL`.
- **#1768 (LID reactions)**: applied as-is, with the history-narrating comment in reaction_test.go replaced by a statement of what the tests pin.
- **#1666 (canonical outgoing chat key)**: carried the `canonicalChatKey` routing in `recordOutgoingMessage`. Repaired the test file to compile against master's `ListMessages(..., []string{...}, ...)` signature (#1722 changed the chat filter to a slice), stripped "before this fix" narration, and made the tests load-bearing: the fixture seeds a real whatsmeow device store with a LID-to-phone mapping so the canonical key differs from the raw send JID, and both tests fail when the storage line is reverted to `jid.String()` (verified).
- **#1738 (email-as-mention guard)**: carried the boundary guard but replaced the byte-wise check with `utf8.DecodeLastRuneInString`: a mention is real only when it starts the text or follows whitespace or plain punctuation, and a preceding letter, digit, or RFC 5322 atext rune skips it, which covers multibyte letters (`rené@ed.ac.uk`) and atext punctuation (`foo!@ed.ac.uk`) the single-byte check let through. Added a table-driven parseMentions test including `S3044936@ed.ac.uk`, `rené@ed.ac.uk`, `foo!@ed.ac.uk`, `done.@Emi` (pinned untouched: dot is atext), and `5@10`.
- **#1775 (send piping rule)**: diff not taken; superseded by a CLI contract change (maintainer-approved) that makes filtering safe instead of documenting it as dangerous. One routing owner (`emit` in cli.go) decides the stream by outcome: stdout carries only success output, and anything paired with a non-zero exit (the `{"error": ...}` envelope, and a failed command's `{"success": false}` result) prints to stderr, so `whatsapp send ... | grep/jq/head` can never hide an error. `failJSON`, `failDaemon`, and every socket-result printer route through it; daemon verbs keep their compact one-line envelope, so the daemon contract suite stays green unchanged. The SKILL.md pipe rule shrinks to one line stating the contract.

**#1732 (DoubleTick connect/recovery) is deliberately untouched**: none of its files or concerns (cli.go provision paths, client.go proxy, linker.go, notifications.go recovery fields) are modified here, so it rebases cleanly.

Verified locally with the exact `check.sh whatsapp` steps (gofmt, `go vet -tags fts5`, `go build -tags fts5`, `go test -tags fts5 ./...`, all green), shellcheck on the whisper script, `scripts/check-conventions.py`, and the whatsapp row of the daemon contract suite (`pytest tests/test_daemon_contract.py -k whatsapp`, 7 passed, 5 skipped as on master).

Fixes #1767
Fixes #1665
Fixes #1682
Fixes #1609

Also addresses the thread-cap half of #1769; the rest of that issue is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

