### PR TITLE
fix(email): consolidate the 6 open email PRs

### DIFF
--- a/agent/skills/email-client/SETUP.md
+++ b/agent/skills/email-client/SETUP.md
@@ -61,7 +61,7 @@ The CLI prints a Google consent URL and listens on `http://127.0.0.1:<random-por
 email-client auth add --account personal --user you@gmail.com --provider gmail-app-password
 ```
 
-That needs 2FA enabled on the Google account (Google only shows the app-password option once 2FA is on) and covers mail only, no calendar: the `calendar` commands error on a missing `caldav_url` under this profile. Autodetect is unchanged, `gmail.com` still resolves to OAuth `gmail`, so the app-password profile only applies when you pass it explicitly.
+That needs 2FA enabled on the Google account (Google only shows the app-password option once 2FA is on) and covers mail only, no calendar: the `calendar` commands error on a missing `caldav_url` under this profile. Autodetect sends `gmail.com` to the OAuth `gmail` profile, so this one applies only when you pass `--provider gmail-app-password` yourself.
 
 ### Gmail / Yahoo / iCloud / Fastmail / generic - app password
 

--- a/agent/skills/email-client/SETUP.md
+++ b/agent/skills/email-client/SETUP.md
@@ -8,7 +8,7 @@ Run this once and the daemon and both binaries share the same per-account token 
 
 - **Microsoft personal** (`outlook.com`, `hotmail.com`, `live.com`): OAuth2 **device flow**.
 - **Microsoft 365 work** (custom domain on Exchange Online): OAuth2 **device flow** via `--provider microsoft-work`.
-- **Gmail**: OAuth2 **loopback flow** (`http://127.0.0.1:<port>/`).
+- **Gmail**: OAuth2 **loopback flow** (`http://127.0.0.1:<port>/`), or **app password** via `--provider gmail-app-password` when the loopback flow is unavailable. The app-password path needs 2FA on the Google account (Google only offers app passwords once 2FA is on) and is mail only, no calendar.
 - **Yahoo / iCloud / Fastmail / generic IMAP**: **app password**.
 
 Both OAuth flows reuse Mozilla Thunderbird's published public client IDs (Microsoft `9e5f94bc-e8a4-4e73-b8be-63364c29d753`, Google `406964657835-aq8lmia8j95dhl1a2bvharmfk3t1hgqj.apps.googleusercontent.com` plus its published desktop-app secret `kSmqreRr0qwBWJgbf5Y-PjSU`). These are public, not secrets, and are the canonical open-source-mail-client choice. The reason: Microsoft killed basic-auth IMAP for personal accounts in late 2024 and deprecated tenantless Azure app registrations mid-2025, so reusing a published client ID is the only OAuth path that doesn't require the user to register an Azure tenant. Google deprecated the device flow for desktop apps, so its supported equivalent is the loopback redirect, which the skill captures via a throwaway `http.server` on a random port. Providers with no public OAuth client fall back to app passwords (chmod 600).
@@ -55,12 +55,19 @@ The user opens the URL on any device, enters the code, and signs in with the rig
 
 ### Gmail - loopback OAuth
 
-The CLI prints a Google consent URL and listens on `http://127.0.0.1:<random-port>/`. The user opens the URL in any browser that can reach this host (same machine, same LAN, or via SSH tunnel: `ssh -L <port>:127.0.0.1:<port> <host>`), signs in, and approves. The CLI captures the code, exchanges it, and writes tokens to `token.json`. On a headless box where the browser can't reach the loopback port, forward the port first or run auth on a workstation and copy the token file over.
+The CLI prints a Google consent URL and listens on `http://127.0.0.1:<random-port>/`. The user opens the URL in any browser that can reach this host (same machine, same LAN, or via SSH tunnel: `ssh -L <port>:127.0.0.1:<port> <host>`), signs in, and approves. The CLI captures the code, exchanges it, and writes tokens to `token.json`. On a headless box where the browser can't reach the loopback port, forward the port first, run auth on a workstation and copy the token file over, or skip OAuth entirely with an app password:
 
-### Yahoo / iCloud / Fastmail / generic - app password
+```bash
+email-client auth add --account personal --user you@gmail.com --provider gmail-app-password
+```
+
+That needs 2FA enabled on the Google account (Google only shows the app-password option once 2FA is on) and covers mail only, no calendar: the `calendar` commands error on a missing `caldav_url` under this profile. Autodetect is unchanged, `gmail.com` still resolves to OAuth `gmail`, so the app-password profile only applies when you pass it explicitly.
+
+### Gmail / Yahoo / iCloud / Fastmail / generic - app password
 
 The CLI prompts for an app password. Generate one in the provider's security settings:
 
+- Gmail (`--provider gmail-app-password`): myaccount.google.com → Security → 2-Step Verification → App passwords. The entry only exists once 2-Step Verification is on.
 - Yahoo: Account Info → Account security → Generate app password
 - iCloud: appleid.apple.com → Sign-In and Security → App-Specific Passwords
 - Fastmail: Settings → Privacy & Security → App passwords (scope: IMAP/SMTP)

--- a/agent/skills/email-client/SKILL.md
+++ b/agent/skills/email-client/SKILL.md
@@ -64,7 +64,7 @@ email-client search --account personal --folder INBOX --query 'SUBJECT "invoice"
 email-client search --account personal --folder INBOX --query 'SINCE 1-Jan-2026'
 ```
 
-`list` and `search` return JSON arrays of `{uid, from, to, subject, date}`. `get` returns the full message including a decoded plain-text body. `search --query` takes a raw IMAP SEARCH expression.
+`list` and `search` return JSON arrays of `{uid, from, to, subject, date}`. `get` returns the full message including a decoded plain-text body. `search --query` takes a raw IMAP SEARCH expression; a query the server rejects as malformed is retried as a plain-text phrase search, so `--query 'job alert'` works too.
 
 ## Attachments
 

--- a/agent/skills/email-client/cli/src/email_client/auth.py
+++ b/agent/skills/email-client/cli/src/email_client/auth.py
@@ -8,8 +8,9 @@ Picks a flow based on the resolved provider:
     loopback-oauth   Gmail. Spins up a localhost listener, opens (or
                      prints) the consent URL, captures the redirect,
                      exchanges the code for tokens.
-    app-password     Yahoo / iCloud / Fastmail / generic IMAP. Prompts
-                     for the app password and stores it.
+    app-password     Gmail (via gmail-app-password) / Yahoo / iCloud /
+                     Fastmail / generic IMAP. Prompts for the app
+                     password and stores it.
 
 Multi-account: every credential lives at
 ``$EMAIL_CLIENT_DIR/accounts/<name>/token.json`` so the user can have
@@ -200,8 +201,9 @@ def auth_app_password(provider: str, profile: dict, user: str) -> dict:
     print(f"Account:  {user}")
     print(
         "\nGenerate an app password in your provider's account settings "
-        "(Yahoo, iCloud, Fastmail all have this under 'app-specific "
-        "passwords' or 'security'), then paste it below.\n"
+        "(Gmail, Yahoo, iCloud, Fastmail all have this under 'app-specific "
+        "passwords' or 'security'; Gmail only offers it once 2-Step "
+        "Verification is on), then paste it below.\n"
     )
     pw = os.environ.get("EMAIL_CLIENT_APP_PASSWORD") or getpass.getpass("App password: ")
     pw = pw.strip()

--- a/agent/skills/email-client/cli/src/email_client/google_health.py
+++ b/agent/skills/email-client/cli/src/email_client/google_health.py
@@ -44,9 +44,9 @@ import uuid
 # Probe outcome classifications.
 HEALTHY = "healthy"
 DEAD_CLIENT = "dead_client"
-# The client id is alive but the credential we present with it is refused, i.e.
-# the shipped secret is out of date. Named without the word it holds so the
-# constant is not mistaken (by humans or by scanners) for the credential itself.
+# The client id is alive but the credential presented with it is refused: the
+# shipped secret is out of date. Named around the rejection rather than the
+# credential so neither a reader nor a secret scanner reads it as the secret.
 CLIENT_AUTH_REJECTED = "client_auth_rejected"
 BAD_TOKEN = "bad_token"
 UNKNOWN = "unknown"
@@ -79,12 +79,11 @@ def classify_refresh_response(_status_code: int | None, body: dict | None) -> st
     and deliberately NOT treated as a dead client, so a transient upstream blip
     never triggers a spurious client swap or notification.
 
-    One wrinkle: Google returns ``invalid_client`` for two different conditions.
-    A deleted/nonexistent client is genuinely dead, but a LIVE client presented
-    with the wrong secret answers HTTP 401 ``invalid_client`` with
-    "The provided client secret is invalid." That is a stale secret, not a dead
-    client, so it gets its own CLIENT_AUTH_REJECTED classification: it still needs
-    the client re-resolved (an upstream secret rotation is exactly how it
+    One wrinkle: ``invalid_client`` covers two conditions. A deleted client is
+    genuinely dead, but a LIVE client presented with the wrong secret answers 401
+    ``invalid_client`` with "The provided client secret is invalid." That is a
+    stale secret, so it classifies as CLIENT_AUTH_REJECTED: still worth
+    re-resolving the client (an upstream secret rotation is exactly how it
     happens), but the user must not be told their OAuth client was removed.
     """
     body = body or {}
@@ -199,14 +198,11 @@ def attempt_self_heal(account: str, failed_result: dict, *, post=None, allow_fet
     """Re-resolve Thunderbird's current client and retry the refresh once.
 
     Force-refreshes the dynamic client from comm-central, then retries the token
-    refresh with the fresh client id/secret. The retry is worth making whenever the
-    resolved client id differs from the failing one OR the force-refresh actually
-    pulled fresh credentials from upstream: upstream can rotate the shipped secret
-    while keeping the client id, so an unchanged id is not on its own a reason to
-    give up. Only when neither holds is there nothing new to try. A successful
-    retry means the freshly-fetched client is now cached, so every subsequent
-    profile build picks it up automatically: the swap is durable, not just for this
-    call.
+    refresh with the fresh client id/secret. Retrying is pointless only when the
+    resolved id equals the failing one AND nothing was fetched, since upstream can
+    rotate the shipped secret while keeping the client id. A successful retry leaves
+    the fresh client cached, so every subsequent profile build picks it up: the swap
+    is durable, not just for this call.
     """
     from . import providers
     from .thunderbird_client import resolve_google_client
@@ -219,7 +215,7 @@ def attempt_self_heal(account: str, failed_result: dict, *, post=None, allow_fet
     )
     new_id = creds["client_id"]
     new_secret = creds["client_secret"]
-    if new_id == failed_result.get("client_id") and creds.get("source") != "fetched":
+    if new_id == failed_result.get("client_id") and creds["source"] != "fetched":
         return {
             "status": UNKNOWN,
             "healed": False,

--- a/agent/skills/email-client/cli/src/email_client/google_health.py
+++ b/agent/skills/email-client/cli/src/email_client/google_health.py
@@ -13,14 +13,19 @@ already-STORED refresh token and classifies the error. The key distinction is:
     deleted_client / invalid_client / "not found"  ->  the CLIENT is dead
                                                         (swap the client id;
                                                          do NOT bother the user)
+    invalid_client + "client secret is invalid"     ->  the CLIENT SECRET we hold
+                                                        is stale (re-resolve the
+                                                         client; the client id
+                                                         itself is still alive)
     invalid_grant                                   ->  the USER TOKEN is bad
                                                         (re-auth the user; the
                                                          client is fine)
 
-Only a dead client triggers self-heal. On a dead-client detection we re-resolve
-Thunderbird's current client from comm-central (via thunderbird_client) and retry
-the refresh once with the fresh client. If that still fails we write a clear,
-plain-English notification instead of a cryptic OAuth error.
+Both client-side faults trigger self-heal: we re-resolve Thunderbird's current
+client from comm-central (via thunderbird_client) and retry the refresh once with
+the fresh credentials. Only a genuinely dead client also writes a clear,
+plain-English notification if that retry fails, because only then has the client
+actually been removed upstream.
 
 This is strictly Google-specific and gated to Gmail accounts. It never sends mail
 and never touches the user's mailbox. EMAIL_DRAFT_ONLY is irrelevant here.
@@ -39,10 +44,18 @@ import uuid
 # Probe outcome classifications.
 HEALTHY = "healthy"
 DEAD_CLIENT = "dead_client"
+# The client id is alive but the credential we present with it is refused, i.e.
+# the shipped secret is out of date. Named without the word it holds so the
+# constant is not mistaken (by humans or by scanners) for the credential itself.
+CLIENT_AUTH_REJECTED = "client_auth_rejected"
 BAD_TOKEN = "bad_token"
 UNKNOWN = "unknown"
 SKIPPED = "skipped"
 HEALED = "healed"
+
+# Outcomes that blame the SHIPPED CLIENT rather than the user's token: both are
+# recoverable by re-resolving Thunderbird's current client, so both self-heal.
+CLIENT_FAULT_STATUSES = (DEAD_CLIENT, CLIENT_AUTH_REJECTED)
 
 DEFAULT_TOKEN_URL = "https://oauth2.googleapis.com/token"
 
@@ -65,6 +78,14 @@ def classify_refresh_response(_status_code: int | None, body: dict | None) -> st
     client was "not found") is a dead client (swap it). Anything else is unknown
     and deliberately NOT treated as a dead client, so a transient upstream blip
     never triggers a spurious client swap or notification.
+
+    One wrinkle: Google returns ``invalid_client`` for two different conditions.
+    A deleted/nonexistent client is genuinely dead, but a LIVE client presented
+    with the wrong secret answers HTTP 401 ``invalid_client`` with
+    "The provided client secret is invalid." That is a stale secret, not a dead
+    client, so it gets its own CLIENT_AUTH_REJECTED classification: it still needs
+    the client re-resolved (an upstream secret rotation is exactly how it
+    happens), but the user must not be told their OAuth client was removed.
     """
     body = body or {}
     if body.get("access_token"):
@@ -74,6 +95,9 @@ def classify_refresh_response(_status_code: int | None, body: dict | None) -> st
     if err == "invalid_grant":
         return BAD_TOKEN
     if err in ("deleted_client", "invalid_client"):
+        looks_gone = "not found" in desc or "deleted" in desc
+        if err == "invalid_client" and "secret" in desc and not looks_gone:
+            return CLIENT_AUTH_REJECTED
         return DEAD_CLIENT
     # Some responses carry a generic error but say "not found" for the client in
     # the description; that is the exact ...t1glqf failure signature.
@@ -171,14 +195,18 @@ def probe_account(account: str, *, post=None) -> dict:
 # -- self-heal ------------------------------------------------------
 
 
-def attempt_self_heal(account: str, dead_result: dict, *, post=None, allow_fetch: bool = True) -> dict:
+def attempt_self_heal(account: str, failed_result: dict, *, post=None, allow_fetch: bool = True) -> dict:
     """Re-resolve Thunderbird's current client and retry the refresh once.
 
     Force-refreshes the dynamic client from comm-central, then retries the token
-    refresh with the fresh client id/secret. If the fresh id matches the dead one
-    there is nothing to swap to. A successful retry means the freshly-fetched
-    client is now cached, so every subsequent profile build picks it up
-    automatically — the swap is durable, not just for this call.
+    refresh with the fresh client id/secret. The retry is worth making whenever the
+    resolved client id differs from the failing one OR the force-refresh actually
+    pulled fresh credentials from upstream: upstream can rotate the shipped secret
+    while keeping the client id, so an unchanged id is not on its own a reason to
+    give up. Only when neither holds is there nothing new to try. A successful
+    retry means the freshly-fetched client is now cached, so every subsequent
+    profile build picks it up automatically: the swap is durable, not just for this
+    call.
     """
     from . import providers
     from .thunderbird_client import resolve_google_client
@@ -191,11 +219,11 @@ def attempt_self_heal(account: str, dead_result: dict, *, post=None, allow_fetch
     )
     new_id = creds["client_id"]
     new_secret = creds["client_secret"]
-    if new_id == dead_result.get("client_id"):
+    if new_id == failed_result.get("client_id") and creds.get("source") != "fetched":
         return {
             "status": UNKNOWN,
             "healed": False,
-            "reason": "freshly-resolved client id is identical to the dead one",
+            "reason": "no fresh client to try: same client id, and nothing was fetched from upstream",
             "source": creds["source"],
             "client_id": new_id,
         }
@@ -221,7 +249,11 @@ def attempt_self_heal(account: str, dead_result: dict, *, post=None, allow_fetch
 
 
 def write_dead_client_notification(account: str, result: dict) -> pathlib.Path:
-    """Write a clear, human-readable dead-client alert (interrupt=true)."""
+    """Write a clear, human-readable dead-client alert (interrupt=true).
+
+    Reserved for DEAD_CLIENT: it states the client was removed upstream, which is
+    false (and alarming) for a client that is alive but holding a stale secret.
+    """
     NOTIF_DIR.mkdir(parents=True, exist_ok=True)
     notif = {
         "source": "email-client",
@@ -258,9 +290,15 @@ def write_dead_client_notification(account: str, result: dict) -> pathlib.Path:
 
 
 def run_probe(account: str, *, post=None, notify: bool = True, allow_fetch: bool = True) -> dict:
-    """Probe one account; on a dead client, self-heal, then notify if unhealed."""
+    """Probe one account; on a client fault, self-heal, then notify if unhealed.
+
+    A stale client secret self-heals exactly like a dead client (both are fixed by
+    re-resolving the shipped client), but only a dead client gets the notification:
+    telling the user their OAuth client was removed upstream would be wrong when
+    the client id is still live.
+    """
     result = probe_account(account, post=post)
-    if result["status"] != DEAD_CLIENT:
+    if result["status"] not in CLIENT_FAULT_STATUSES:
         return result
 
     heal = attempt_self_heal(account, result, post=post, allow_fetch=allow_fetch)
@@ -269,7 +307,7 @@ def run_probe(account: str, *, post=None, notify: bool = True, allow_fetch: bool
         result["status"] = HEALED
         return result
 
-    if notify:
+    if notify and result["status"] == DEAD_CLIENT:
         path = write_dead_client_notification(account, result)
         result["notification"] = str(path)
     return result
@@ -325,7 +363,7 @@ def maybe_run_daily_probe(state_dir: pathlib.Path, log=None, *, now: float | Non
     results = run_probe_all()
     if log:
         for r in results:
-            if r["status"] in (DEAD_CLIENT, HEALED):
+            if r["status"] in (*CLIENT_FAULT_STATUSES, HEALED):
                 log(f"[google-health] {r['account']}: {r['status']} (self-heal={r.get('self_heal', {}).get('healed')})")
             else:
                 log(f"[google-health] {r['account']}: {r['status']}")

--- a/agent/skills/email-client/cli/src/email_client/imap.py
+++ b/agent/skills/email-client/cli/src/email_client/imap.py
@@ -30,6 +30,7 @@ Environment overrides (set in ``~/.bashrc``):
 from __future__ import annotations
 
 import argparse
+import imaplib
 import json
 import os
 import pathlib
@@ -38,7 +39,7 @@ import time
 import urllib.parse
 import urllib.request
 
-from imap_tools import AND, MailBox, MailMessageFlags
+from imap_tools import AND, MailBox, MailboxUidsError, MailMessageFlags
 
 from . import daemon, pending_send
 from .providers import (
@@ -440,7 +441,7 @@ def cmd_folders(args):
             print(f'({flags}) "{fi.delim}" {fi.name}')
 
 
-def _fetch_summaries(args, *, include_to: bool, criteria) -> None:
+def _fetch_summaries(args, *, include_to: bool, criteria, charset: str = "US-ASCII") -> None:
     with connect(getattr(args, "account", None), initial_folder=None) as mb:
         mb.folder.set(args.folder)
         # imap_tools ``limit`` keeps the FIRST N; the original CLI keeps the
@@ -450,6 +451,7 @@ def _fetch_summaries(args, *, include_to: bool, criteria) -> None:
         msgs = list(
             mb.fetch(
                 criteria,
+                charset=charset,
                 limit=args.limit or None,
                 reverse=True,
                 mark_seen=False,
@@ -469,7 +471,27 @@ def cmd_list(args):
 
 
 def cmd_search(args):
-    _fetch_summaries(args, include_to=False, criteria=args.query)
+    # The server owns the SEARCH grammar, so ask it rather than guessing here: send the query as
+    # given, and only if it is rejected as malformed treat it as a phrase. IMAP4.abort is a dropped
+    # connection, not a bad query, so it must not trigger the retry. A NO reply (imap_tools raises
+    # MailboxUidsError, which does NOT subclass IMAP4.error) is a refusal such as [BADCHARSET],
+    # not malformed criteria, so it exits with the server's answer instead of retrying.
+    charset = "US-ASCII" if args.query.isascii() else "UTF-8"
+    try:
+        _fetch_summaries(args, include_to=False, criteria=args.query, charset=charset)
+        return
+    except imaplib.IMAP4.abort:
+        raise
+    except MailboxUidsError as exc:
+        sys.exit(f"search failed for {args.query!r}: {exc}")
+    except imaplib.IMAP4.error:
+        pass
+    try:
+        _fetch_summaries(args, include_to=False, criteria=AND(text=args.query), charset=charset)
+    except imaplib.IMAP4.abort:
+        raise
+    except (MailboxUidsError, imaplib.IMAP4.error) as exc:
+        sys.exit(f"search failed for {args.query!r}: {exc}")
 
 
 def cmd_get(args):
@@ -854,7 +876,11 @@ def _add_read_parsers(sub):
 
     p = sub.add_parser("search")
     p.add_argument("--folder", default="INBOX")
-    p.add_argument("--query", required=True)
+    p.add_argument(
+        "--query",
+        required=True,
+        help="raw IMAP criteria (e.g. 'SUBJECT \"invoice\"'), or a plain phrase, searched as text",
+    )
     p.add_argument("--limit", type=int, default=20)
     _add_account_arg(p)
 

--- a/agent/skills/email-client/cli/src/email_client/imap.py
+++ b/agent/skills/email-client/cli/src/email_client/imap.py
@@ -809,8 +809,9 @@ def cmd_auth_remove(args):
 def cmd_auth_probe(args):
     """Health-probe the Google OAuth client for one or all Gmail accounts.
 
-    Exits non-zero if any account's client is found dead and could not be
-    self-healed, so it is scriptable as a monitor.
+    Exits non-zero if any account's shipped OAuth client is still at fault after
+    self-heal (dead client or stale client secret), so it is scriptable as a
+    monitor.
     """
     from . import google_health
 
@@ -824,7 +825,7 @@ def cmd_auth_probe(args):
             print(json.dumps({"status": "skipped", "reason": "no Gmail accounts registered"}, indent=2))
             return
     print(json.dumps(results if len(results) != 1 else results[0], indent=2))
-    if any(r.get("status") == google_health.DEAD_CLIENT for r in results):
+    if any(r.get("status") in google_health.CLIENT_FAULT_STATUSES for r in results):
         sys.exit(1)
 
 

--- a/agent/skills/email-client/cli/src/email_client/providers.py
+++ b/agent/skills/email-client/cli/src/email_client/providers.py
@@ -18,8 +18,9 @@ Auth strategies:
                        device-flow is restricted to TV / limited input
                        devices.
     "app-password"     Plain LOGIN with an app-specific password the
-                       user generates in their account settings (Yahoo,
-                       iCloud, Fastmail, custom IMAP servers).
+                       user generates in their account settings (Gmail
+                       with 2FA on, Yahoo, iCloud, Fastmail, custom
+                       IMAP servers).
 
 Defaults can be overridden per environment variable so any one
 profile can be reshaped without touching the dict (or use the
@@ -119,6 +120,20 @@ PROVIDERS: dict[str, dict] = {
         # CalDAV, not the Calendar REST API: Thunderbird's Cloud project has the
         # REST API disabled, while CalDAV needs only the scope above.
         "caldav_url": "https://apidata.googleusercontent.com/caldav/v2",
+    },
+    # Gmail / Google Workspace over an app password (requires 2FA on the account),
+    # the fallback when OAuth is unavailable or blocked. Mail only on purpose, no
+    # caldav_url: Google's CalDAV root is not verified against Basic auth here, so
+    # calendar stays off this profile and errors cleanly rather than guessing.
+    "gmail-app-password": {
+        "label": "Gmail / Google Workspace (app password)",
+        "auth_strategy": "app-password",
+        "imap_host": "imap.gmail.com",
+        "imap_port": 993,
+        "smtp_host": "smtp.gmail.com",
+        "smtp_port": 587,
+        "smtp_starttls": True,
+        "sent_folder": "[Gmail]/Sent Mail",
     },
     "yahoo-app-password": {
         "label": "Yahoo Mail (app password)",

--- a/agent/skills/email-client/cli/tests/test_calendar.py
+++ b/agent/skills/email-client/cli/tests/test_calendar.py
@@ -305,6 +305,20 @@ def test_builtin_profiles_carry_caldav_endpoints():
     assert "caldav_url" not in providers.PROVIDERS["generic"]
 
 
+def test_gmail_app_password_profile_is_mail_only():
+    profile = providers.PROVIDERS["gmail-app-password"]
+    assert profile["auth_strategy"] == "app-password"
+    assert profile["imap_host"] == "imap.gmail.com"
+    assert profile["smtp_host"] == "smtp.gmail.com"
+    assert profile["sent_folder"] == "[Gmail]/Sent Mail"
+    # Mail only by design: Basic auth against Google CalDAV is not verified here,
+    # so the profile must not advertise a calendar endpoint.
+    assert "caldav_url" not in profile
+    # Autodetect must keep sending Gmail domains to the OAuth profile; the
+    # app-password profile is an explicit opt-in.
+    assert providers.detect_provider("someone@gmail.com") == "gmail"
+
+
 def test_auth_header_bearer_and_basic(monkeypatch):
     monkeypatch.setattr(imap_client, "get_access_token", lambda account: "TOKEN123")
     monkeypatch.setattr(imap_client, "get_app_password", lambda account: "app-pass")

--- a/agent/skills/email-client/cli/tests/test_calendar.py
+++ b/agent/skills/email-client/cli/tests/test_calendar.py
@@ -37,10 +37,14 @@ def _install_stubs():
             ANSWERED = "\\Answered"
             FLAGGED = "\\Flagged"
 
+        class MailboxUidsError(Exception):
+            pass
+
         # The attribute mirrors the imap_tools API name.
         it.AND = _and
         it.MailBox = MailBox
         it.MailMessageFlags = MailMessageFlags
+        it.MailboxUidsError = MailboxUidsError
         sys.modules["imap_tools"] = it
 
 

--- a/agent/skills/email-client/cli/tests/test_daemon_lifecycle.py
+++ b/agent/skills/email-client/cli/tests/test_daemon_lifecycle.py
@@ -59,9 +59,13 @@ def _install_imap_tools_stub():
             ANSWERED = "\\Answered"
             FLAGGED = "\\Flagged"
 
+        class MailboxUidsError(Exception):
+            pass
+
         it.AND = _and
         it.MailBox = MailBox
         it.MailMessageFlags = MailMessageFlags
+        it.MailboxUidsError = MailboxUidsError
         sys.modules["imap_tools"] = it
 
 

--- a/agent/skills/email-client/cli/tests/test_draft_only.py
+++ b/agent/skills/email-client/cli/tests/test_draft_only.py
@@ -30,10 +30,14 @@ def _install_stubs():
             SEEN = "\\Seen"
             ANSWERED = "\\Answered"
 
+        class MailboxUidsError(Exception):
+            pass
+
         # The attribute mirrors the imap_tools API name.
         it.AND = _and
         it.MailBox = MailBox
         it.MailMessageFlags = MailMessageFlags
+        it.MailboxUidsError = MailboxUidsError
         sys.modules["imap_tools"] = it
 
 

--- a/agent/skills/email-client/cli/tests/test_generic_host_inference.py
+++ b/agent/skills/email-client/cli/tests/test_generic_host_inference.py
@@ -31,9 +31,13 @@ def _install_imap_tools_stub():
             SEEN = "\\Seen"
             ANSWERED = "\\Answered"
 
+        class MailboxUidsError(Exception):
+            pass
+
         it.AND = _and
         it.MailBox = MailBox
         it.MailMessageFlags = MailMessageFlags
+        it.MailboxUidsError = MailboxUidsError
         sys.modules["imap_tools"] = it
 
 

--- a/agent/skills/email-client/cli/tests/test_google_health.py
+++ b/agent/skills/email-client/cli/tests/test_google_health.py
@@ -18,6 +18,8 @@ NEW_ID = "fresh-999.apps.googleusercontent.com"
 RESP_DELETED_CLIENT = (401, {"error": "deleted_client", "error_description": "The OAuth client was deleted."})
 RESP_INVALID_CLIENT = (401, {"error": "invalid_client", "error_description": "The OAuth client was not found."})
 RESP_INVALID_GRANT = (400, {"error": "invalid_grant", "error_description": "Token has been expired or revoked."})
+# A LIVE client presented with the wrong secret: same error code, different meaning.
+RESP_BAD_CLIENT_SECRET = (401, {"error": "invalid_client", "error_description": "The provided client secret is invalid."})
 RESP_SUCCESS = (200, {"access_token": "ya29.new", "expires_in": 3599})
 
 
@@ -30,6 +32,32 @@ def test_classify_deleted_client_is_dead():
 
 def test_classify_invalid_client_not_found_is_dead():
     assert gh.classify_refresh_response(*RESP_INVALID_CLIENT) == gh.DEAD_CLIENT
+
+
+def test_classify_invalid_client_bad_secret_is_auth_rejected_not_dead():
+    # Google answers 401 invalid_client when a LIVE client is sent a wrong secret.
+    # Calling that client dead would notify the user their client was removed.
+    result = gh.classify_refresh_response(*RESP_BAD_CLIENT_SECRET)
+    assert result == gh.CLIENT_AUTH_REJECTED
+    assert result != gh.DEAD_CLIENT
+    # It is still a client-side fault, so it must stay on the self-heal path.
+    assert result in gh.CLIENT_FAULT_STATUSES
+
+
+def test_classify_invalid_client_bad_secret_matching_is_case_insensitive():
+    resp = (401, {"error": "INVALID_CLIENT", "error_description": "The Provided Client Secret Is Invalid."})
+    assert gh.classify_refresh_response(*resp) == gh.CLIENT_AUTH_REJECTED
+
+
+def test_classify_invalid_client_deleted_wins_over_secret_wording():
+    # If the description says the client is gone, it is dead even if it also
+    # mentions the secret.
+    resp = (401, {"error": "invalid_client", "error_description": "The OAuth client secret was not found."})
+    assert gh.classify_refresh_response(*resp) == gh.DEAD_CLIENT
+
+
+def test_classify_invalid_client_without_description_stays_dead():
+    assert gh.classify_refresh_response(401, {"error": "invalid_client"}) == gh.DEAD_CLIENT
 
 
 def test_classify_invalid_grant_is_bad_token_not_dead():
@@ -101,6 +129,15 @@ def _post_by_client(mapping):
     return post
 
 
+def _post_by_creds(mapping):
+    """Response keyed on ``(client_id, client_secret)``, for secret-rotation cases."""
+
+    def post(token_url, params):
+        return mapping[(params["client_id"], params.get("client_secret"))]
+
+    return post
+
+
 @pytest.fixture(autouse=True)
 def _isolate_notifs(tmp_path, monkeypatch):
     monkeypatch.setattr(gh, "NOTIF_DIR", tmp_path / "notifications")
@@ -135,6 +172,90 @@ def test_probe_account_bad_token_does_not_notify_or_heal(monkeypatch, tmp_path):
     assert res["status"] == gh.BAD_TOKEN
     assert called["heal"] is False
     assert not (gh.NOTIF_DIR).exists() or list(gh.NOTIF_DIR.glob("*.json")) == []
+
+
+def test_run_probe_bad_client_secret_reresolves_but_does_not_notify(monkeypatch):
+    # A stale secret on a still-live client id must keep the recovery path (the
+    # client re-resolve) and lose only the "client was removed upstream" notice.
+    _install_fake_imap_client(monkeypatch, {"refresh_token": "RT"}, client_id=DEAD_ID)
+    called = {"heal": 0}
+
+    def _fake_heal(*a, **k):
+        called["heal"] += 1
+        return {"status": gh.CLIENT_AUTH_REJECTED, "healed": False}
+
+    monkeypatch.setattr(gh, "attempt_self_heal", _fake_heal)
+    res = gh.run_probe("personal", post=_post_by_client({DEAD_ID: RESP_BAD_CLIENT_SECRET}))
+    assert res["status"] == gh.CLIENT_AUTH_REJECTED
+    assert called["heal"] == 1
+    assert "notification" not in res
+    assert not gh.NOTIF_DIR.exists() or list(gh.NOTIF_DIR.glob("*.json")) == []
+
+
+def test_run_probe_heals_rotated_client_secret_on_same_client_id(monkeypatch):
+    # Upstream rotated the shipped secret but kept the client id: the re-resolve
+    # picks up the new secret and the retry succeeds, silently.
+    _install_fake_imap_client(monkeypatch, {"refresh_token": "RT"}, client_id=DEAD_ID)
+    post = _post_by_creds({(DEAD_ID, "sek"): RESP_BAD_CLIENT_SECRET, (DEAD_ID, "rotated"): RESP_SUCCESS})
+    monkeypatch.setattr(
+        "email_client.thunderbird_client.resolve_google_client",
+        lambda *a, **k: {"client_id": DEAD_ID, "client_secret": "rotated", "source": "fetched"},
+    )
+    res = gh.run_probe("personal", post=post)
+    assert res["status"] == gh.HEALED
+    assert res["self_heal"]["healed"] is True
+    assert not gh.NOTIF_DIR.exists() or list(gh.NOTIF_DIR.glob("*.json")) == []
+
+
+def test_run_probe_auth_rejected_unhealed_still_does_not_notify(monkeypatch):
+    # Upstream had nothing better to give, so the retry fails too. Still no
+    # notification: the client id is alive, it was never removed upstream.
+    _install_fake_imap_client(monkeypatch, {"refresh_token": "RT"}, client_id=DEAD_ID)
+    monkeypatch.setattr(
+        "email_client.thunderbird_client.resolve_google_client",
+        lambda *a, **k: {"client_id": DEAD_ID, "client_secret": "sek", "source": "fetched"},
+    )
+    res = gh.run_probe("personal", post=_post_by_client({DEAD_ID: RESP_BAD_CLIENT_SECRET}))
+    assert res["status"] == gh.CLIENT_AUTH_REJECTED
+    assert res["self_heal"]["healed"] is False
+    assert not gh.NOTIF_DIR.exists() or list(gh.NOTIF_DIR.glob("*.json")) == []
+
+
+def test_self_heal_gives_up_when_nothing_fresh_was_fetched(monkeypatch):
+    # Same client id AND no upstream fetch (cache/fallback): there is nothing new
+    # to try, so do not spend a second token call on credentials known to fail.
+    _install_fake_imap_client(monkeypatch, {"refresh_token": "RT"}, client_id=DEAD_ID)
+    calls = {"n": 0}
+
+    def _post(_url, _params):
+        calls["n"] += 1
+        return RESP_DELETED_CLIENT
+
+    monkeypatch.setattr(
+        "email_client.thunderbird_client.resolve_google_client",
+        lambda *a, **k: {"client_id": DEAD_ID, "client_secret": "sek", "source": "cache-stale"},
+    )
+    heal = gh.attempt_self_heal("personal", {"client_id": DEAD_ID}, post=_post)
+    assert heal["healed"] is False
+    assert calls["n"] == 0
+
+
+def test_run_probe_deleted_client_reresolves_and_notifies(monkeypatch):
+    # The other direction: a genuinely deleted client keeps BOTH the re-resolve
+    # and the notification.
+    _install_fake_imap_client(monkeypatch, {"refresh_token": "RT"}, client_id=DEAD_ID)
+    called = {"heal": 0}
+
+    def _fake_heal(*a, **k):
+        called["heal"] += 1
+        return {"status": gh.DEAD_CLIENT, "healed": False}
+
+    monkeypatch.setattr(gh, "attempt_self_heal", _fake_heal)
+    res = gh.run_probe("personal", post=_post_by_client({DEAD_ID: RESP_DELETED_CLIENT}))
+    assert res["status"] == gh.DEAD_CLIENT
+    assert called["heal"] == 1
+    assert res["notification"]
+    assert len(list(gh.NOTIF_DIR.glob("*.json"))) == 1
 
 
 def test_run_probe_self_heals_with_fresh_client(monkeypatch):

--- a/agent/skills/email-client/cli/tests/test_pending_send.py
+++ b/agent/skills/email-client/cli/tests/test_pending_send.py
@@ -29,9 +29,13 @@ def _install_imap_tools_stub():
             ANSWERED = "\\Answered"
             FLAGGED = "\\Flagged"
 
+        class MailboxUidsError(Exception):
+            pass
+
         it.AND = _and
         it.MailBox = MailBox
         it.MailMessageFlags = MailMessageFlags
+        it.MailboxUidsError = MailboxUidsError
         sys.modules["imap_tools"] = it
 
 

--- a/agent/skills/email-client/cli/tests/test_search_criteria.py
+++ b/agent/skills/email-client/cli/tests/test_search_criteria.py
@@ -1,0 +1,118 @@
+"""`search --query` sends the query as given and falls back to a phrase search only on BAD."""
+
+import argparse
+import imaplib
+
+import pytest
+from email_client import imap
+from imap_tools import AND, MailboxUidsError
+
+
+class _Folder:
+    def __init__(self, box):
+        self._box = box
+
+    def set(self, name):
+        self._box.folder_set = name
+
+
+class _Box:
+    """Accepts criteria the fake server considers valid, raises IMAP4.error on the rest."""
+
+    def __init__(self, valid, *, abort_on_first=False, no_reply=None):
+        self._valid = valid
+        self._abort_on_first = abort_on_first
+        self._no_reply = no_reply
+        self.sent = []
+        self.charsets = []
+        self.folder = _Folder(self)
+        self.folder_set = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def fetch(self, criteria, charset="US-ASCII", **kw):
+        self.sent.append(criteria)
+        self.charsets.append(charset)
+        if self._abort_on_first and len(self.sent) == 1:
+            raise imaplib.IMAP4.abort("connection dropped")
+        if self._no_reply is not None:
+            raise MailboxUidsError(("NO", [self._no_reply]), "OK")
+        if criteria not in self._valid:
+            raise imaplib.IMAP4.error("UID command error: BAD [b'Could not parse command']")
+        return []
+
+
+def _run(monkeypatch, box, query):
+    monkeypatch.setattr(imap, "connect", lambda *a, **k: box)
+    args = argparse.Namespace(query=query, folder="INBOX", limit=5, account=None)
+    imap.cmd_search(args)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        'SUBJECT "invoice"',
+        "SUBJECT invoice",
+        "FROM billing@example.com",
+        "HEADER Message-ID abc",
+        'X-GM-RAW "has:attachment"',
+        "UNSEEN",
+        "LARGER 10000",
+        'SINCE 1-Aug-2026 SUBJECT "receipt"',
+    ],
+)
+def test_valid_criteria_are_sent_untouched_and_never_retried(monkeypatch, query):
+    box = _Box(valid={query})
+    _run(monkeypatch, box, query)
+    assert box.sent == [query]
+
+
+@pytest.mark.parametrize("query", ["job alert", "New jobs posted", "To do list", "quarterly report"])
+def test_a_rejected_query_retries_as_a_phrase(monkeypatch, query):
+    box = _Box(valid={AND(text=query)})
+    _run(monkeypatch, box, query)
+    assert box.sent == [query, AND(text=query)]
+
+
+def test_a_dropped_connection_is_not_treated_as_a_bad_query(monkeypatch):
+    """IMAP4.abort subclasses IMAP4.error, so catching only the parent would retry a network
+    failure as a phrase search and report an empty result as if it were an answer."""
+    box = _Box(valid={"UNSEEN"}, abort_on_first=True)
+    with pytest.raises(imaplib.IMAP4.abort):
+        _run(monkeypatch, box, "UNSEEN")
+    assert len(box.sent) == 1
+
+
+def test_a_server_no_reply_exits_with_the_error_instead_of_a_traceback(monkeypatch):
+    """A NO reply (e.g. [BADCHARSET]) raises imap_tools' MailboxUidsError, which does not
+    subclass IMAP4.error, so it must be caught separately and turned into a clean exit."""
+    box = _Box(valid=set(), no_reply=b"[BADCHARSET (US-ASCII)] cannot search that charset")
+    with pytest.raises(SystemExit) as excinfo:
+        _run(monkeypatch, box, "UNSEEN")
+    assert "BADCHARSET" in str(excinfo.value)
+    assert len(box.sent) == 1
+
+
+def test_a_query_the_server_rejects_twice_exits_with_a_message(monkeypatch):
+    box = _Box(valid=set())
+    with pytest.raises(SystemExit) as excinfo:
+        _run(monkeypatch, box, "hopeless")
+    assert "hopeless" in str(excinfo.value)
+
+
+def test_non_ascii_queries_request_utf8(monkeypatch):
+    """imap_tools encodes criteria with the given charset, so US-ASCII raises UnicodeEncodeError
+    before the query reaches the server."""
+    box = _Box(valid={AND(text="café")})
+    _run(monkeypatch, box, "café")
+    assert box.charsets == ["UTF-8", "UTF-8"]
+
+
+def test_ascii_queries_keep_the_default_charset(monkeypatch):
+    box = _Box(valid={"UNSEEN"})
+    _run(monkeypatch, box, "UNSEEN")
+    assert box.charsets == ["US-ASCII"]

--- a/agent/skills/google/cli/src/google_cli/cli.py
+++ b/agent/skills/google/cli/src/google_cli/cli.py
@@ -88,7 +88,7 @@ def _add_email_commands(group):
     p_undo.add_argument("--id", required=True, dest="pending_id")
 
     p_attachment = email_sub.add_parser("attachment")
-    p_attachment.add_argument("--email-id", required=True)
+    p_attachment.add_argument("--id", "--email-id", required=True, dest="email_id")
     p_attachment.add_argument("--attachment-id", required=True)
     p_attachment.add_argument("--save-path", required=True)
 

--- a/agent/skills/google/cli/tests/test_email_id_aliases.py
+++ b/agent/skills/google/cli/tests/test_email_id_aliases.py
@@ -1,0 +1,16 @@
+"""`email attachment` accepts both --id and --email-id, matching the other id-taking subcommands.
+
+Either spelling parses, so a wrong guess cannot exit 2 with a usage error. That matters because
+these commands run with stderr suppressed, where a usage error looks exactly like a command that
+ran and found nothing, turning a flag mismatch into a silent false negative.
+"""
+
+import pytest
+from google_cli import cli
+
+
+@pytest.mark.parametrize("flag", ["--id", "--email-id"])
+def test_attachment_accepts_both_id_spellings(flag):
+    argv = ["email", "attachment", flag, "MSG-ID", "--attachment-id", "ATT-ID", "--save-path", "/tmp/f.pdf"]
+    args = cli._build_parser().parse_args(argv)
+    assert args.email_id == "MSG-ID"

--- a/agent/skills/microsoft/SETUP.md
+++ b/agent/skills/microsoft/SETUP.md
@@ -119,6 +119,10 @@ microsoft auth teams-complete --flow-cache <cache>   # complete after signing in
 microsoft teams chats --account you@company.com
 ```
 
+`teams-complete` reads the granted scopes, not the requested ones. When the sign-in grants no Teams
+permission it answers `status: teams_unavailable` and leaves the account unmarked. That is the answer,
+not a retryable failure: the account cannot hold Teams permissions.
+
 Locked tenant (blocks the CLI's app registration)? Capture a token from Teams on the web, the same
 mechanism as `owa-login`:
 

--- a/agent/skills/microsoft/SETUP.md
+++ b/agent/skills/microsoft/SETUP.md
@@ -30,9 +30,10 @@ Then copy the **Application (client) ID** and set `MICROSOFT_MCP_CLIENT_ID=<your
 
 ## Authentication
 
-**Run one command: `microsoft auth setup --account <email>`.** It provisions mail, calendar, and
-Teams together and picks the right path on its own; each step returns a `next:` command telling you
-exactly what to run.
+**Run one command: `microsoft auth setup --account <email>`.** It provisions mail and calendar,
+plus Teams on a work/school account (Teams Graph permissions are work/school only, so a personal
+account gets mail and calendar), and picks the right path on its own; each step returns a `next:`
+command telling you exactly what to run.
 
 ```bash
 microsoft auth setup --account you@example.com          # start (default depends on domain, see below)
@@ -43,7 +44,7 @@ microsoft auth setup --account you@example.com --capture             # finish af
 ```
 
 How it chooses (by the account's domain, no need to ask):
-- **Personal Microsoft account** (outlook.com, hotmail.*, live.*, msn.com, etc.): defaults to **device-code** sign-in. The user visits a URL and enters a code, once. Tokens auto-refresh via MSAL indefinitely.
+- **Personal Microsoft account** (outlook.com, hotmail.*, live.*, msn.com, etc.): defaults to **device-code** sign-in. The user visits a URL and enters a code, once. Tokens auto-refresh via MSAL indefinitely. The sign-in covers mail and calendar; Teams is work/school only.
 - **Work/school account** (any custom domain, e.g. a university or company like UCL): defaults to the **browser handover** up front, because the tenant almost always blocks the default public client and would reject a device code. `auth setup` hands the user **one URL** to sign into their own webmail (SSO + MFA), then captures the token. No admin consent needed. No wasted device-code round-trip.
 - **Escape hatches**: `--browser` forces the browser route for any account; `--device` forces device code even for a work/school domain (for a permissive tenant that still allows it). If a device-code sign-in is later walled by the tenant, `auth setup --flow-cache` still **automatically pivots** to the browser handover.
 
@@ -106,9 +107,11 @@ auto-refreshes that token.
 ## Microsoft Teams
 
 Teams uses the same client and daemon as mail, but has its **own** sign-in so a mail-only account is
-never prompted for Teams scopes. The Teams scopes (`Chat.ReadWrite`, `ChannelMessage.Send`,
-`Team.ReadBasic.All`, `Channel.ReadBasic.All`, `Presence.ReadWrite`) are all user-consentable, so no
-admin approval is needed for chats, channel posting, or presence:
+never prompted for Teams scopes. **Teams needs a work or school account**: every Teams Graph
+permission (`Chat.ReadWrite`, `ChannelMessage.Send`, `Team.ReadBasic.All`, `Channel.ReadBasic.All`,
+`Presence.ReadWrite`) is work/school only, so a personal Microsoft account cannot authorize Teams by
+any route (see [references/teams.md](references/teams.md)). On a work/school tenant the scopes are
+user-consentable, so no admin approval is needed for chats, channel posting, or presence:
 
 ```bash
 microsoft auth teams-login                           # device flow: gives a URL and code

--- a/agent/skills/microsoft/cli/src/microsoft_cli/auth_commands.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/auth_commands.py
@@ -367,7 +367,9 @@ def teams_complete(config: Config, *, flow_cache: str) -> dict[str, str]:
         raise Exception("Teams authorization succeeded but no account was found")
     if not granted_teams_scope(result):
         # An answer, not a failure: the endpoint signed the account in and narrowed the grant,
-        # so this account cannot hold Teams permissions on this route.
+        # so this account cannot hold Teams permissions on this route. Dropping any stale device
+        # marker converges an account an earlier sign-in mis-marked as Teams-capable.
+        teams.unmark_device_account(username, config)
         return {
             "status": "teams_unavailable",
             "account": username,
@@ -483,10 +485,8 @@ def setup_scopes_for(account_email: str) -> list[str]:
     """Scopes to consent during `auth setup` for this account.
 
     Every Teams Graph permission (Chat.*, Team.*, Channel.*, Presence.*) is work/school only: the
-    consumer (MSA) token endpoint never grants them. Bundling them into a personal account's sign-in
-    therefore cannot help and can only hurt: at best the endpoint silently drops them and returns a
-    token with no Teams access, at worst consent fails outright and the user sees a bare sign-in
-    error. So ask a personal account for mail + calendar alone."""
+    consumer (MSA) token endpoint never grants them, so asking a personal account for them buys
+    nothing and risks a bare sign-in error. A personal account is asked for mail + calendar alone."""
     if _is_personal_ms_account(account_email):
         return list(DEFAULT_CLIENT_SCOPES)
     return list(_SETUP_SCOPES)

--- a/agent/skills/microsoft/cli/src/microsoft_cli/auth_commands.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/auth_commands.py
@@ -365,6 +365,18 @@ def teams_complete(config: Config, *, flow_cache: str) -> dict[str, str]:
     username = claims["preferred_username"] if "preferred_username" in claims else ""
     if not username:
         raise Exception("Teams authorization succeeded but no account was found")
+    if not granted_teams_scope(result):
+        # An answer, not a failure: the endpoint signed the account in and narrowed the grant,
+        # so this account cannot hold Teams permissions on this route.
+        return {
+            "status": "teams_unavailable",
+            "account": username,
+            "message": (
+                f"{username} signed in, but no Teams permission was granted: Teams Graph permissions are work/school "
+                "only, so a personal Microsoft account (outlook.com, hotmail.*, live.*) cannot authorize Teams, and a "
+                "work/school tenant that narrows the grant withholds it the same way. Mail and calendar are unaffected."
+            ),
+        }
     teams.mark_device_account(username, config)
     return {
         "status": "success",
@@ -447,8 +459,9 @@ def _teams_capture_browser(config: Config, *, account_email: str) -> dict[str, s
 # Unified onboarding: one command sets up mail, calendar, and Teams together.
 # ---------------------------------------------------------------------------
 
-# Device-code setup consents mail + calendar + Teams in one sign-in, so a personal or permissive
+# Device-code setup consents mail + calendar + Teams in one sign-in, so a permissive work/school
 # tenant is fully provisioned by a single code. Locked tenants fall through to the browser capture.
+# Personal accounts get the mail + calendar subset instead: see setup_scopes_for().
 _SETUP_SCOPES = [*DEFAULT_CLIENT_SCOPES, *teams.TEAMS_SCOPES]
 
 # Personal Microsoft consumer domains. Everything else is treated as a work/school (custom-domain)
@@ -464,6 +477,29 @@ def _is_personal_ms_account(email: str) -> bool:
     # Country variants: outlook.fr, hotmail.co.uk, live.de, etc.
     first = domain.split(".")[0]
     return first in {"outlook", "hotmail", "live"}
+
+
+def setup_scopes_for(account_email: str) -> list[str]:
+    """Scopes to consent during `auth setup` for this account.
+
+    Every Teams Graph permission (Chat.*, Team.*, Channel.*, Presence.*) is work/school only: the
+    consumer (MSA) token endpoint never grants them. Bundling them into a personal account's sign-in
+    therefore cannot help and can only hurt: at best the endpoint silently drops them and returns a
+    token with no Teams access, at worst consent fails outright and the user sees a bare sign-in
+    error. So ask a personal account for mail + calendar alone."""
+    if _is_personal_ms_account(account_email):
+        return list(DEFAULT_CLIENT_SCOPES)
+    return list(_SETUP_SCOPES)
+
+
+def granted_teams_scope(result: dict) -> bool:
+    """True if a token response actually carries a Teams permission.
+
+    The consumer endpoint answers an over-broad scope request with a *narrowed* grant rather than an
+    error, so "no error" does not mean Teams was consented. Trust the granted scope string, not the
+    request, before marking an account as Teams-capable."""
+    granted = (result["scope"] if "scope" in result else "").lower()
+    return any(scope.rsplit("/", 1)[-1].lower() in granted for scope in teams.TEAMS_SCOPES)
 
 
 def _setup_save_captured(config: Config, *, account_email: str, captured: dict) -> dict[str, str]:
@@ -514,6 +550,25 @@ def _setup_finish_device(config: Config, *, account_email: str, flow_cache: str)
     cache = app.token_cache
     if isinstance(cache, auth.msal.SerializableTokenCache) and cache.has_state_changed:
         auth._write_cache(config.cache_file, content=cache.serialize())
+    if not granted_teams_scope(result):
+        # Personal (MSA) accounts, and any tenant that narrowed the grant: mail and calendar are live,
+        # Teams over Graph is not. Say so instead of marking an account Teams-capable and letting every
+        # later Teams call fail with an opaque 403. Dropping any stale device marker converges an
+        # account that an earlier setup mis-marked as Teams-capable.
+        teams.unmark_device_account(account_email, config)
+        return {
+            "status": "success",
+            "account": account_email,
+            "provisioned": "mail/calendar",
+            "backend": "graph",
+            "message": (
+                f"{account_email} is set up over Graph (mail, calendar). Tokens auto-refresh; no re-auth needed. "
+                "Teams over Graph is not available for this account: the sign-in granted no Teams permission "
+                "(a personal Microsoft account cannot hold Teams Graph permissions, and a work/school tenant can "
+                "withhold them). For a work/school account that needs Teams, run: microsoft auth teams-capture "
+                f"--account {account_email}"
+            ),
+        }
     teams.mark_device_account(account_email, config)
     return {
         "status": "success",
@@ -537,7 +592,8 @@ def auth_setup(
 
     No flags: a work/school (custom-domain) account defaults to the browser handover, since its tenant
     usually blocks the default public client and would reject a device code; a personal Microsoft account
-    (outlook.com, hotmail.*, etc.) starts a device-code sign-in (auto-refreshes via MSAL). ``--flow-cache``:
+    (outlook.com, hotmail.*, etc.) starts a device-code sign-in (auto-refreshes via MSAL) for mail + calendar
+    only, since Teams Graph permissions are work/school only. ``--flow-cache``:
     finish a device-code sign-in; if the tenant walls it, pivot to the browser automatically. ``--browser``:
     force the browser capture (for a known locked tenant). ``--device`` (``force_device``): force device code
     even for a work/school domain (permissive tenants). ``--capture``: after signing in via the browser, lift
@@ -558,7 +614,7 @@ def auth_setup(
         return _setup_begin_browser(config, account_email=account_email)
 
     app = auth.get_app(config.cache_file, DEFAULT_CLIENT_ID)
-    flow = app.initiate_device_flow(scopes=_SETUP_SCOPES)
+    flow = app.initiate_device_flow(scopes=setup_scopes_for(account_email))
     if "user_code" not in flow:
         error_msg = flow["error_description"] if "error_description" in flow else "Unknown error"
         raise Exception(f"Failed to get device code: {error_msg}")

--- a/agent/skills/microsoft/cli/src/microsoft_cli/cli.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/cli.py
@@ -174,7 +174,7 @@ def _add_email_read_parsers(email_sub) -> None:
 
     p_get_email = email_sub.add_parser("get")
     p_get_email.add_argument("--account", required=True)
-    p_get_email.add_argument("--id", required=True, dest="email_id")
+    p_get_email.add_argument("--id", "--email-id", required=True, dest="email_id")
     p_get_email.add_argument("--no-attachments", action="store_true")
     p_get_email.add_argument("--save-to", default=None)
 
@@ -196,7 +196,7 @@ def _add_email_read_parsers(email_sub) -> None:
 
     p_attachment = email_sub.add_parser("attachment")
     p_attachment.add_argument("--account", required=True)
-    p_attachment.add_argument("--email-id", required=True)
+    p_attachment.add_argument("--id", "--email-id", required=True, dest="email_id")
     p_attachment.add_argument("--attachment-id", default=None)
     p_attachment.add_argument("--save-path", default=None)
     p_attachment.add_argument("--list", action="store_true", dest="list_only", help="List attachment metadata only")
@@ -229,7 +229,7 @@ def _add_email_compose_parsers(email_sub) -> None:
 
     p_reply = email_sub.add_parser("reply")
     p_reply.add_argument("--account", required=True)
-    p_reply.add_argument("--id", required=True, dest="email_id")
+    p_reply.add_argument("--id", "--email-id", required=True, dest="email_id")
     p_reply.add_argument("--body", required=True)
     p_reply.add_argument("--attachments", nargs="+", default=None)
     p_reply.add_argument("--reply-all", action="store_true")
@@ -237,7 +237,7 @@ def _add_email_compose_parsers(email_sub) -> None:
 
     p_reply_draft = email_sub.add_parser("reply-draft")
     p_reply_draft.add_argument("--account", required=True)
-    p_reply_draft.add_argument("--id", required=True, dest="email_id", help="Message id to reply to (latest in thread)")
+    p_reply_draft.add_argument("--id", "--email-id", required=True, dest="email_id", help="Message id to reply to (latest in thread)")
     p_reply_draft.add_argument("--body", required=True, help="Reply text placed above the quoted history; '- ' lines become bullets")
     p_reply_draft.add_argument("--attachments", nargs="+", default=None)
     p_reply_draft.add_argument("--reply-all", action="store_true")
@@ -245,7 +245,7 @@ def _add_email_compose_parsers(email_sub) -> None:
 
     p_forward = email_sub.add_parser("forward")
     p_forward.add_argument("--account", required=True)
-    p_forward.add_argument("--id", required=True, dest="email_id")
+    p_forward.add_argument("--id", "--email-id", required=True, dest="email_id")
     p_forward.add_argument("--to", nargs="+", required=True)
     p_forward.add_argument("--body", default="")
     p_forward.add_argument("--cc", nargs="+", default=None)
@@ -265,16 +265,16 @@ def _add_email_manage_parsers(email_sub) -> None:
 
     p_move = email_sub.add_parser("move")
     p_move.add_argument("--account", required=True)
-    p_move.add_argument("--id", required=True, dest="email_id")
+    p_move.add_argument("--id", "--email-id", required=True, dest="email_id")
     p_move.add_argument("--to-folder", required=True, dest="to_folder")
 
     p_archive = email_sub.add_parser("archive")
     p_archive.add_argument("--account", required=True)
-    p_archive.add_argument("--id", required=True, dest="email_id")
+    p_archive.add_argument("--id", "--email-id", required=True, dest="email_id")
 
     p_update = email_sub.add_parser("update")
     p_update.add_argument("--account", required=True)
-    p_update.add_argument("--id", required=True, dest="email_id")
+    p_update.add_argument("--id", "--email-id", required=True, dest="email_id")
     p_update.add_argument("--is-read", type=lambda x: x.lower() == "true", default=None)
     p_update.add_argument("--categories", nargs="+", default=None)
     p_update_flag = p_update.add_mutually_exclusive_group()
@@ -284,7 +284,7 @@ def _add_email_manage_parsers(email_sub) -> None:
     p_delete = email_sub.add_parser("delete")
     p_delete.add_argument("--account", required=True)
     p_delete_group = p_delete.add_mutually_exclusive_group(required=True)
-    p_delete_group.add_argument("--id", default=None, dest="email_id", help="ID of a single message to delete")
+    p_delete_group.add_argument("--id", "--email-id", default=None, dest="email_id", help="ID of a single message to delete")
     p_delete_group.add_argument("--sender", default=None, help="Delete all messages from this sender address")
     p_delete.add_argument("--permanent", action="store_true", help="Hard delete instead of moving to Deleted Items")
 

--- a/agent/skills/microsoft/cli/src/microsoft_cli/email.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/email.py
@@ -192,9 +192,16 @@ def _scrub_email_snapshot(record: dict[str, Any]) -> None:
         record.setdefault("preview", record.pop("bodyPreview"))
 
 
-def _resolve_mail_endpoint(config: Config, folder: str | None) -> str:
+def _resolve_mail_endpoint(config: Config, client: httpx.Client, account_id: str, folder: str | None) -> str:
+    """Messages endpoint for a folder given as a well-known key, a display name, or a raw id.
+
+    Resolution goes through `folders.resolve_folder_id_cfg`, the same resolver `move_email` uses.
+    Graph accepts a bare name in the URL path only for its own well-known folders, so a
+    user-created one such as `Screened` has to be looked up and addressed by id; putting the
+    display name straight in the path returns 400.
+    """
     if folder:
-        folder_path = config.folders[folder.casefold()] if folder.casefold() in config.folders else folder
+        folder_path = folders.resolve_folder_id_cfg(config, client, account_id, folder)
         return f"/me/mailFolders/{folder_path}/messages"
     return "/me/messages"
 
@@ -231,8 +238,7 @@ def list_emails(
 ) -> list[dict[str, Any]]:
     account_id = auth.get_account_id_by_email(account_email, config.cache_file)
 
-    folder_path = config.folders[folder.casefold()] if folder.casefold() in config.folders else folder
-    endpoint = f"/me/mailFolders/{folder_path}/messages"
+    endpoint = _resolve_mail_endpoint(config, client, account_id, folder)
 
     if since or until:
         # Date-range path: $filter reaches ANY date directly, unlike relevance-ranked $search.
@@ -836,7 +842,7 @@ def search_emails(
     until: str | None = None,
 ) -> list[dict[str, Any]]:
     account_id = auth.get_account_id_by_email(account_email, config.cache_file)
-    endpoint = _resolve_mail_endpoint(config, folder)
+    endpoint = _resolve_mail_endpoint(config, client, account_id, folder)
     if since or until:
         # Graph forbids $search + $filter together, so a date range wins: filter by date, match text client-side.
         return _filter_mailbox_messages(config, client, account_id, endpoint, since=since, until=until, query=query, limit=limit)

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
@@ -273,19 +273,18 @@ _MSG_SELECT = (
 _MAX_PAGE_SIZE = 100
 
 
-def _folder_id(name: str | None) -> str:
-    key = (name or "inbox").casefold()
-    return _FOLDER_MAP.get(key, key)
-
-
 # ---------------------------------------------------------------------------
 # Mail: read
 # ---------------------------------------------------------------------------
 
+# Read paths resolve folders via `resolve_folder_id`, the same resolver `move` uses: OWA REST
+# accepts a bare name in the URL path only for well-known folders, so a user-created one such
+# as `Screened` has to be looked up and addressed by id.
+
 
 def list_messages(client: httpx.Client, account_email: str, config, *, folder: str = "inbox", limit: int = 10) -> list[dict]:
     token = load_token(account_email, config)
-    fid = _folder_id(folder)
+    fid = resolve_folder_id(client, account_email, config, folder=folder)
     params = {
         "$select": _MSG_SELECT,
         "$orderby": "ReceivedDateTime desc",
@@ -297,7 +296,7 @@ def list_messages(client: httpx.Client, account_email: str, config, *, folder: s
 def list_messages_since(client: httpx.Client, account_email: str, config, *, folder: str, since_utc: str, limit: int) -> list[dict]:
     """Ascending order makes a truncated read a resumable prefix of the window, not its newest slice."""
     token = load_token(account_email, config)
-    fid = _folder_id(folder)
+    fid = resolve_folder_id(client, account_email, config, folder=folder)
     params = {
         "$select": _MSG_SELECT,
         "$filter": f"ReceivedDateTime gt {since_utc}",
@@ -312,7 +311,7 @@ def filter_messages_by_date(
 ) -> list[dict]:
     """Fetch messages in a receivedDateTime range, newest first, via server-side $filter."""
     token = load_token(account_email, config)
-    fid = _folder_id(folder or "inbox")
+    fid = resolve_folder_id(client, account_email, config, folder=folder or "inbox")
     params = {
         "$select": _MSG_SELECT,
         "$filter": date_filter,
@@ -324,7 +323,7 @@ def filter_messages_by_date(
 
 def search_messages(client: httpx.Client, account_email: str, config, *, query: str, folder: str | None = None, limit: int = 10) -> list[dict]:
     token = load_token(account_email, config)
-    fid = _folder_id(folder or "inbox")
+    fid = resolve_folder_id(client, account_email, config, folder=folder or "inbox")
     params: dict = {
         "$select": _MSG_SELECT,
         "$search": f'"{query}"',

--- a/agent/skills/microsoft/cli/src/microsoft_cli/teams.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/teams.py
@@ -36,12 +36,13 @@ from .settings import DEFAULT_CLIENT_ID
 
 GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 
-# Delegated Graph scopes for Teams. Every one is user-consentable (no admin
-# consent), so `auth teams-login` works for non-admins. Chat.ReadWrite subsumes
-# read + send + create-chat + edit; ChannelMessage.Send covers channel posts and
-# replies. Reading channel *messages* needs the admin-only ChannelMessage.Read.All,
-# deliberately left out so it never blocks the consent bundle; grant it on your own
-# app registration (MICROSOFT_MCP_CLIENT_ID) if you need channel reads.
+# Delegated Graph scopes for Teams. All are work/school only: the consumer (MSA)
+# endpoint never grants them, so Teams needs a work or school account. On such a
+# tenant every one is user-consentable, so `auth teams-login` works for non-admins.
+# Chat.ReadWrite subsumes read + send + create-chat + edit; ChannelMessage.Send
+# covers channel posts and replies. Reading channel *messages* needs the admin-only
+# ChannelMessage.Read.All, deliberately left out so it never blocks the consent
+# bundle; grant it on your own app registration (MICROSOFT_MCP_CLIENT_ID) instead.
 TEAMS_SCOPES = [
     "https://graph.microsoft.com/Chat.ReadWrite",
     "https://graph.microsoft.com/ChannelMessage.Send",

--- a/agent/skills/microsoft/cli/src/microsoft_cli/teams.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/teams.py
@@ -103,6 +103,16 @@ def mark_device_account(account_email: str, config) -> None:
     p.write_text(json.dumps({"source": "device"}))
 
 
+def unmark_device_account(account_email: str, config) -> None:
+    """Drop a device marker so `has_token` stops claiming Teams for this account.
+
+    Leaves a browser-captured token alone: that marker holds a real token this function
+    has no reason to destroy."""
+    marker = _read_marker(account_email, config)
+    if marker is not None and _source(marker) == "device":
+        _token_path(account_email, config).unlink(missing_ok=True)
+
+
 def save_token(account_email: str, config, *, token: str, expires_at: float, source: str = "browser") -> None:
     """Persist a captured token. Never log the token value."""
     p = _token_path(account_email, config)

--- a/agent/skills/microsoft/cli/tests/test_auth_setup_scopes.py
+++ b/agent/skills/microsoft/cli/tests/test_auth_setup_scopes.py
@@ -78,10 +78,14 @@ def test_setup_still_provisions_teams_when_the_grant_includes_it(monkeypatch: py
 
 
 def test_teams_complete_reports_the_real_reason_instead_of_marking_the_account(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    config = Config(data_dir=tmp_path)
+    teams.mark_device_account("a@hotmail.com", config)  # stale marker left by a sign-in that trusted the request scopes
     result = {"access_token": "t", "scope": NARROWED_GRANT, "id_token_claims": {"preferred_username": "a@hotmail.com"}}
     marked = _patch_device_flow(monkeypatch, result)
-    out = auth_commands.teams_complete(Config(data_dir=tmp_path), flow_cache="{}")
+    out = auth_commands.teams_complete(config, flow_cache="{}")
     # An answer about the account, not a command failure: the sign-in itself succeeded.
     assert out["status"] == "teams_unavailable"
     assert "work/school only" in out["message"]
     assert marked == []
+    # Same convergence as the `auth setup` path: has_token stops claiming Teams for this account.
+    assert teams.list_accounts(config) == []

--- a/agent/skills/microsoft/cli/tests/test_auth_setup_scopes.py
+++ b/agent/skills/microsoft/cli/tests/test_auth_setup_scopes.py
@@ -1,0 +1,87 @@
+"""`auth setup` scope selection for personal (MSA) vs work/school accounts.
+
+Teams Graph permissions are work/school only. The consumer token endpoint answers a request that
+includes them with a *narrowed* grant (openid profile) rather than an error, so the request scopes
+must exclude Teams for a personal account, and the granted scopes, not the requested ones, must
+decide whether an account is marked Teams-capable.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from microsoft_cli import auth_commands, teams
+from microsoft_cli.config import DEFAULT_CLIENT_SCOPES, Config
+
+TEAMS_GRANT = "https://graph.microsoft.com/Chat.ReadWrite https://graph.microsoft.com/Team.ReadBasic.All openid profile"
+MAIL_GRANT = "https://graph.microsoft.com/Mail.ReadWrite https://graph.microsoft.com/Calendars.ReadWrite openid profile"
+NARROWED_GRANT = "openid profile"
+
+
+@pytest.mark.parametrize("email", ["a@hotmail.com", "a@outlook.com", "a@live.com", "a@msn.com", "a@hotmail.co.uk", "a@outlook.fr"])
+def test_personal_account_never_requests_teams_scopes(email: str) -> None:
+    scopes = auth_commands.setup_scopes_for(email)
+    assert scopes == list(DEFAULT_CLIENT_SCOPES)
+    assert not [s for s in scopes if s in teams.TEAMS_SCOPES]
+
+
+@pytest.mark.parametrize("email", ["a@contoso.com", "a@example.org"])
+def test_work_account_still_bundles_teams_scopes(email: str) -> None:
+    scopes = auth_commands.setup_scopes_for(email)
+    for scope in teams.TEAMS_SCOPES:
+        assert scope in scopes
+    for scope in DEFAULT_CLIENT_SCOPES:
+        assert scope in scopes
+
+
+@pytest.mark.parametrize(
+    ("granted", "expected"),
+    [(TEAMS_GRANT, True), (MAIL_GRANT, False), (NARROWED_GRANT, False), ("", False)],
+)
+def test_granted_teams_scope_reads_the_grant_not_the_request(granted: str, expected: bool) -> None:
+    assert auth_commands.granted_teams_scope({"scope": granted}) is expected
+    assert auth_commands.granted_teams_scope({}) is False
+
+
+def _patch_device_flow(monkeypatch: pytest.MonkeyPatch, result: dict) -> list[str]:
+    """Wire a fake MSAL app whose device flow returns `result`; collect marked Teams accounts."""
+    app = MagicMock()
+    app.acquire_token_by_device_flow.return_value = result
+    app.token_cache = SimpleNamespace()
+    app.get_accounts.return_value = []
+    monkeypatch.setattr(auth_commands.auth, "get_app", lambda *a, **k: app)
+    marked: list[str] = []
+    monkeypatch.setattr(teams, "mark_device_account", lambda email, config: marked.append(email))
+    return marked
+
+
+def test_setup_does_not_claim_teams_when_the_grant_was_narrowed(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    config = Config(data_dir=tmp_path)
+    teams.mark_device_account("a@hotmail.com", config)  # stale marker left by a setup that trusted the request scopes
+    marked = _patch_device_flow(monkeypatch, {"access_token": "t", "scope": NARROWED_GRANT})
+    out = auth_commands._setup_finish_device(config, account_email="a@hotmail.com", flow_cache="{}")
+    assert out["status"] == "success"
+    assert out["provisioned"] == "mail/calendar"
+    assert "Teams over Graph is not available" in out["message"]
+    assert marked == []
+    # The stale device marker is gone, so has_token stops claiming Teams for this account.
+    assert teams.list_accounts(config) == []
+
+
+def test_setup_still_provisions_teams_when_the_grant_includes_it(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    marked = _patch_device_flow(monkeypatch, {"access_token": "t", "scope": TEAMS_GRANT})
+    out = auth_commands._setup_finish_device(Config(data_dir=tmp_path), account_email="a@contoso.com", flow_cache="{}")
+    assert out["provisioned"] == "mail/calendar, Teams"
+    assert marked == ["a@contoso.com"]
+
+
+def test_teams_complete_reports_the_real_reason_instead_of_marking_the_account(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    result = {"access_token": "t", "scope": NARROWED_GRANT, "id_token_claims": {"preferred_username": "a@hotmail.com"}}
+    marked = _patch_device_flow(monkeypatch, result)
+    out = auth_commands.teams_complete(Config(data_dir=tmp_path), flow_cache="{}")
+    # An answer about the account, not a command failure: the sign-in itself succeeded.
+    assert out["status"] == "teams_unavailable"
+    assert "work/school only" in out["message"]
+    assert marked == []

--- a/agent/skills/microsoft/cli/tests/test_capture.py
+++ b/agent/skills/microsoft/cli/tests/test_capture.py
@@ -110,6 +110,9 @@ def test_setup_start_personal_returns_device_code(monkeypatch, tmp_path):
     assert out["status"] == "device_code"
     assert out["code"] == "ABC123"
     assert "_flow_cache" in out
+    # A personal account is asked for mail + calendar only: Teams Graph scopes are work/school only.
+    requested = app.initiate_device_flow.call_args.kwargs["scopes"]
+    assert not [scope for scope in requested if scope in teams.TEAMS_SCOPES]
 
 
 def test_setup_start_work_domain_defaults_to_browser(monkeypatch, tmp_path):
@@ -140,7 +143,8 @@ def test_setup_browser_flag_starts_handover(monkeypatch, tmp_path):
 
 def test_setup_flow_complete_success_marks_teams(monkeypatch, tmp_path):
     cfg = Config(data_dir=tmp_path)
-    app = _fake_app(result={"access_token": "tok", "id_token_claims": {"preferred_username": "a@x.com"}})
+    granted = " ".join([*teams.TEAMS_SCOPES, "openid", "profile"])
+    app = _fake_app(result={"access_token": "tok", "scope": granted, "id_token_claims": {"preferred_username": "a@x.com"}})
     monkeypatch.setattr(auth_commands.auth, "get_app", lambda *a, **k: app)
     out = auth_commands.auth_setup(cfg, account_email="a@x.com", flow_cache=json.dumps({"device_code": "d"}))
     assert out["status"] == "success"

--- a/agent/skills/microsoft/cli/tests/test_email_id_aliases.py
+++ b/agent/skills/microsoft/cli/tests/test_email_id_aliases.py
@@ -1,0 +1,29 @@
+"""Every email subcommand that takes a message id accepts both --id and --email-id.
+
+Either spelling parses on all nine, so a wrong guess cannot exit 2 with a usage error. That
+matters because these commands run with stderr suppressed, where a usage error looks exactly
+like a command that ran and found nothing, turning a flag mismatch into a silent false negative.
+"""
+
+import pytest
+from microsoft_cli.cli import build_parser
+
+# (subcommand, extra required args beyond --account/--id)
+ID_SUBCOMMANDS = [
+    ("get", []),
+    ("attachment", []),
+    ("move", ["--to-folder", "Screened"]),
+    ("archive", []),
+    ("update", []),
+    ("delete", []),
+    ("reply", ["--body", "x"]),
+    ("reply-draft", ["--body", "x"]),
+    ("forward", ["--body", "x", "--to", "someone@example.com"]),
+]
+
+
+@pytest.mark.parametrize("command,extra", ID_SUBCOMMANDS)
+@pytest.mark.parametrize("flag", ["--id", "--email-id"])
+def test_both_id_spellings_parse(command, extra, flag):
+    args = build_parser().parse_args(["email", command, "--account", "me@example.com", flag, "MSG-ID", *extra])
+    assert args.email_id == "MSG-ID"

--- a/agent/skills/microsoft/cli/tests/test_folders.py
+++ b/agent/skills/microsoft/cli/tests/test_folders.py
@@ -95,3 +95,29 @@ def test_delete_folder(patched):
     assert result == {"status": "deleted", "id": "fid"}
     delete = next(c for c in patched if c["method"] == "DELETE")
     assert delete["path"] == "/me/mailFolders/fid"
+
+
+def test_read_paths_address_a_custom_folder_by_id(patched, monkeypatch):
+    """`email list`/`search` must resolve a user-created folder to its id, like `move` does.
+
+    Graph accepts a bare name in the URL path only for its own well-known folders, so putting a
+    display name such as `Newsletters` straight into the path returns 400. Reading and moving
+    therefore have to share one resolver.
+    """
+    from microsoft_cli import email
+
+    seen: list[str] = []
+
+    def fake_paginate(config, client, endpoint, account_id=None, **kwargs):
+        seen.append(endpoint)
+        return iter(())
+
+    monkeypatch.setattr(email.auth, "get_account_id_by_email", lambda e, c: "acct-1")
+    monkeypatch.setattr(email.graph, "paginate_cfg", fake_paginate)
+    monkeypatch.setattr(email.folders.graph, "request", lambda *a, **k: _FOLDERS_PAGE)
+
+    email.list_emails(Config(), None, account_email="me@example.com", folder="Newsletters")
+    email.search_emails(Config(), None, account_email="me@example.com", query="hi", folder="Newsletters")
+
+    assert seen == ["/me/mailFolders/news-id/messages"] * 2
+    assert all("Newsletters" not in endpoint for endpoint in seen)

--- a/agent/skills/microsoft/cli/tests/test_owa_rest.py
+++ b/agent/skills/microsoft/cli/tests/test_owa_rest.py
@@ -231,6 +231,23 @@ def test_list_messages_folder_alias_deleted(tmp_path):
     assert "deleteditems" in call_args[0][0]
 
 
+def test_read_paths_address_a_custom_folder_by_id(tmp_path):
+    """`list`/`search` must resolve a user-created folder to its id, like `move` does.
+
+    OWA REST accepts a bare name in the URL path only for well-known folders, so putting a
+    display name such as `Newsletters` straight into the path fails; reading and moving
+    therefore have to share one resolver.
+    """
+    cfg = _patched_token(tmp_path)
+    client = _mock_client({"value": [{"Id": "news-id", "DisplayName": "Newsletters"}]})
+    owa_rest.list_messages(client, "user@example.com", cfg, folder="Newsletters", limit=5)
+    owa_rest.search_messages(client, "user@example.com", cfg, query="hi", folder="Newsletters", limit=5)
+    message_urls = [call.args[0] for call in client.get.call_args_list if "/messages" in call.args[0]]
+    assert len(message_urls) == 2
+    assert all("/me/mailfolders/news-id/messages" in url for url in message_urls)
+    assert all("Newsletters" not in url for url in message_urls)
+
+
 def test_list_messages_passes_select_in_pascal_case(tmp_path):
     cfg = _patched_token(tmp_path)
     client = _mock_client({"value": []})

--- a/agent/skills/microsoft/references/email.md
+++ b/agent/skills/microsoft/references/email.md
@@ -92,14 +92,15 @@ Delete soft-deletes to Deleted Items by default (moves to `deleteditems`); `--pe
 ## Attachments
 
 ```bash
-microsoft email attachment --account user@example.com --email-id '<email_id>' --list                                   # list attachment metadata
-microsoft email attachment --account user@example.com --email-id '<email_id>' --all                                     # download all (to ~/.microsoft/attachments/<id>)
-microsoft email attachment --account user@example.com --email-id '<email_id>' --all --out-dir /tmp/x                     # download all to a dir
-microsoft email attachment --account user@example.com --email-id '<email_id>' --attachment-id '<attachment_id>' --save-path /tmp/file.pdf  # one
+microsoft email attachment --account user@example.com --id '<email_id>' --list                                   # list attachment metadata
+microsoft email attachment --account user@example.com --id '<email_id>' --all                                     # download all (to ~/.microsoft/attachments/<id>)
+microsoft email attachment --account user@example.com --id '<email_id>' --all --out-dir /tmp/x                     # download all to a dir
+microsoft email attachment --account user@example.com --id '<email_id>' --attachment-id '<attachment_id>' --save-path /tmp/file.pdf  # one
 ```
 
 ## Notes
 
+- **Message id: `--id` and `--email-id` are interchangeable** on every subcommand that takes one (`get`, `attachment`, `move`, `archive`, `update`, `delete`, `reply`, `reply-draft`, `forward`). Either spelling parses everywhere, so a wrong guess cannot exit 2 with a usage error that reads like an empty result when stderr is suppressed.
 - `--folder` on `email list`/`search` filters by folder (default "inbox"). It resolves a display name to the folder id the same way `--to-folder` does on `move`, so a user-created folder such as `Screened` works by name.
 - `--since YYYY-MM-DD` / `--until YYYY-MM-DD` on `email list`/`search` (both inclusive) reach mail by date. Plain `search` uses Graph `$search`, which ranks by relevance and buries old mail, so searching a large mailbox for old messages returns nothing useful; the date flags switch to a `$filter=receivedDateTime` range ordered newest-first, which reaches any date directly. Graph forbids combining `$search` with `$filter`, so when a `--query` and a date range are given together, the date range is applied server-side and the query is matched client-side (case-insensitive) against subject, sender, and body preview.
 - `--no-attachments` on `email get` skips attachment metadata; `--save-to` overrides the auto-save path for the body.

--- a/agent/skills/microsoft/references/email.md
+++ b/agent/skills/microsoft/references/email.md
@@ -100,7 +100,7 @@ microsoft email attachment --account user@example.com --email-id '<email_id>' --
 
 ## Notes
 
-- `--folder` on `email list`/`search` filters by folder (default "inbox").
+- `--folder` on `email list`/`search` filters by folder (default "inbox"). It resolves a display name to the folder id the same way `--to-folder` does on `move`, so a user-created folder such as `Screened` works by name.
 - `--since YYYY-MM-DD` / `--until YYYY-MM-DD` on `email list`/`search` (both inclusive) reach mail by date. Plain `search` uses Graph `$search`, which ranks by relevance and buries old mail, so searching a large mailbox for old messages returns nothing useful; the date flags switch to a `$filter=receivedDateTime` range ordered newest-first, which reaches any date directly. Graph forbids combining `$search` with `$filter`, so when a `--query` and a date range are given together, the date range is applied server-side and the query is matched client-side (case-insensitive) against subject, sender, and body preview.
 - `--no-attachments` on `email get` skips attachment metadata; `--save-to` overrides the auto-save path for the body.
 - **`email get` always saves the body to disk** under `~/.microsoft/emails/<timestamp>_<subject>_<id>.txt` and strips it from the JSON response. The JSON returns `body: {saved_to, length, size_bytes, _note}` plus the legacy `body_saved_to`, `body_saved_size`, `body_length` fields, and a short `preview`. To inspect content, read the file at `body.saved_to`. The full `body.content` field is intentionally never returned inline to keep agent context small. Bodies over 5000 chars also surface a warning telling you to grep/crop before pasting snippets.

--- a/agent/skills/microsoft/references/teams.md
+++ b/agent/skills/microsoft/references/teams.md
@@ -4,6 +4,12 @@
 not authorize it separately (see [SETUP.md](../SETUP.md)). On a locked tenant the one browser sign-in
 covers Teams too, and the daemon keeps its token fresh.
 
+**Teams needs a work or school account.** Every Teams Graph permission (`Chat.*`, `Team.*`,
+`Channel.*`, `Presence.*`) is work/school only, so a personal Microsoft account (outlook.com,
+hotmail.\*, live.\*, msn.com) cannot authorize Teams by any route. `auth setup` handles this on its
+own: it signs a personal account in for mail and calendar only, and reports `provisioned:
+mail/calendar`. Do not go looking for a Teams workaround for a personal account, there isn't one.
+
 Every command takes `--backend {auto,graph,owa-rest}` (default `auto`): `graph` uses the device-flow
 token, `owa-rest` uses the browser-captured token, `auto` tries Graph then falls back. If a command
 returns a scope error, the token was captured without that permission, re-run `auth setup --browser`.

--- a/agent/skills/microsoft/references/teams.md
+++ b/agent/skills/microsoft/references/teams.md
@@ -8,7 +8,7 @@ covers Teams too, and the daemon keeps its token fresh.
 `Channel.*`, `Presence.*`) is work/school only, so a personal Microsoft account (outlook.com,
 hotmail.\*, live.\*, msn.com) cannot authorize Teams by any route. `auth setup` handles this on its
 own: it signs a personal account in for mail and calendar only, and reports `provisioned:
-mail/calendar`. Do not go looking for a Teams workaround for a personal account, there isn't one.
+mail/calendar`. There is no workaround, so do not look for one.
 
 Every command takes `--backend {auto,graph,owa-rest}` (default `auto`): `graph` uses the device-flow
 token, `owa-rest` uses the browser-captured token, `auto` tries Graph then falls back. If a command


### PR DESCRIPTION
Consolidates the six reviewed email PRs into one branch, one commit per source PR, with the review repairs applied. All three touched skill CLI suites are green (email-client 165, microsoft 295, google 92), `ty check` passes, and `check.sh guards` passes. No source PR is closed by this one.

## From #1645: read mail from a custom folder by id (by vesta, Elio's instance)

Carried as reviewed: both Graph read paths (`email list`/`search`) resolve folders through `folders.resolve_folder_id_cfg`, the resolver `move` already uses, so a user-created folder such as `Screened` is readable again. Repaired on top: the OWA REST backend had the same bug in its own twin, `_folder_id` dropped an unknown display name into the URL path at all four read sites while OWA move resolved properly through `resolve_folder_id`. Those read paths now share that resolver, `_folder_id` is deleted, and a regression test pins the OWA side. Also documented in `references/email.md` that `--folder` on list/search resolves display names the same way `--to-folder` does.

## From #1624: accept --id and --email-id interchangeably (by vesta)

Carried as reviewed: all nine id-taking `email` subcommands in the microsoft CLI, and `attachment` in the google CLI, accept both spellings. Repaired on top: the two attachment parsers now list `--id` first so help text leads with the canonical flag.

## From #1616: gmail-app-password provider profile (by charbel)

Carried as reviewed: a named app-password profile for Gmail / Google Workspace, mail only by design, autodetect unchanged. Repaired on top: the module docstring headers in `providers.py` and `auth.py` had drifted, both now include Gmail in their app-password provider lists.

## From #1626: wrong Google client secret is not a dead OAuth client (by charbel)

Carried as reviewed, no repairs. A live client presented with a stale secret keeps the self-heal path but no longer produces the false "client was removed upstream" notification. Open follow-up, deliberately not resolved here: what a correctly worded alert should say when a stale-secret state fails to heal remains a product question.

## From #1830: search --query accepts a phrase (by gianfranco)

Carried as reviewed: the server owns the SEARCH grammar, so the query is sent as given and only a malformed-criteria rejection retries it as a text search; `IMAP4.abort` re-raises, and non-ascii queries request UTF-8. Repaired on top: a server `NO` reply (for example `[BADCHARSET]`) raises imap_tools' `MailboxUidsError`, which does not subclass `IMAP4.error`, so it used to escape as a traceback. `cmd_search` now catches it and exits with the server's answer, with a test in `test_search_criteria.py` shaped like the existing fakes.

## From #1766: no Teams consent for personal accounts (by bazella)

The only source PR that conflicted with master, rebased by hand. Carried: personal accounts are asked for mail and calendar scopes only, and both finish paths trust the granted scope string, not the request, before marking an account Teams-capable. Adjusted during the rebase: the no-account return in `teams_complete` keeps master's raise, and the narrowed-grant path returns an answer-style `status: teams_unavailable` instead of the `status: error` shape master had just eliminated, matching the file's `admin_consent_required` precedent, since a personal account that cannot hold Teams is an answer about the account, not a command failure. Added on top: the narrowed-grant setup path drops any stale `teams_tokens/{email}.json` device marker via a new `teams.unmark_device_account`, so previously mis-marked personal accounts converge on re-setup; SETUP.md no longer claims the Teams scopes are all user-consentable and set up together, aligned with `references/teams.md`; and the narrowed-grant messages cover a work tenant that withholds the grant, not only personal accounts. The carried `test_auth_setup_scopes.py` suite keeps its 15 tests, adjusted for the status change and extended with the marker-cleanup assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
