### PR TITLE
fix: close five known gaps across whatsapp, mail, and dream

### DIFF
--- a/agent/skills/dream/scripts/redact_secrets.py
+++ b/agent/skills/dream/scripts/redact_secrets.py
@@ -392,13 +392,14 @@ def _run_scrub(conn: sqlite3.Connection, ids: list[int]) -> int:
 
 def _run_scrub_literal(conn: sqlite3.Connection, rest: list[str]) -> int:
     if len(rest) != 1 or not rest[0]:
-        print("usage: redact_secrets.sh --scrub-literal '<exact value>'")
+        print("usage: redact_secrets.sh --scrub-literal '<exact value>'", file=sys.stderr)
         return 1
     secret = rest[0]
     if len(secret) < MIN_LITERAL_LEN:
         print(
             f"Refusing to scrub a literal shorter than {MIN_LITERAL_LEN} chars: the rewrite is "
-            "DB-wide, and a short value would splice the placeholder through unrelated text."
+            "DB-wide, and a short value would splice the placeholder through unrelated text.",
+            file=sys.stderr,
         )
         return 1
     scrubbed, remaining = scrub_literal(conn, secret)

--- a/agent/skills/email-client/cli/src/email_client/google_health.py
+++ b/agent/skills/email-client/cli/src/email_client/google_health.py
@@ -34,6 +34,7 @@ and never touches the user's mailbox. EMAIL_DRAFT_ONLY is irrelevant here.
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import time
 import urllib.error
@@ -259,16 +260,40 @@ _FAULT_NOTICE = {
     CLIENT_AUTH_REJECTED: (
         "google_client_secret_rejected",
         (
-            "Gmail stopped working: Google is rejecting the client secret configured for the Google "
-            "sign-in client. The client itself is still registered and was not withdrawn, and your "
-            "account and password are fine, but the secret paired with that client is wrong and "
+            "Gmail stopped working: Google is rejecting the secret of the sign-in client this skill "
+            "ships. The client itself is still registered and was not withdrawn, and your account and "
+            "password are fine, but the secret that ships with the skill no longer matches it, and "
             "re-resolving it from Thunderbird's published client did not produce a working one. Gmail "
-            "send/receive is down for account '{account}' until it is corrected. To fix it: check the "
-            "client's secret in the Google Cloud console, correct it, then re-run the auth setup for this "
-            "account with 'email-client auth add --account {account} --provider gmail --reauth'."
+            "send/receive is down for account '{account}'. Nothing you can change on your side fixes "
+            "this: the secret belongs to the shared public client, not to your account, so a re-auth "
+            "would replay the same rejected secret. It takes a newly published client from upstream, so "
+            "report it and use another way to reach this mailbox until then."
         ),
     ),
 }
+
+# The rejected-secret wording when this agent runs its OWN Google OAuth client through the
+# EMAIL_CLIENT_OAUTH_CLIENT_ID / EMAIL_CLIENT_OAUTH_CLIENT_SECRET overrides: that client lives in a
+# Google Cloud project the user controls, so unlike the shipped client its secret is theirs to fix.
+_CUSTOM_CLIENT_SECRET_REJECTED = (
+    "Gmail stopped working: Google is rejecting the client secret this agent is configured with. The "
+    "client itself is still registered and was not withdrawn, and your account and password are fine, "
+    "but the secret paired with it is wrong. That client comes from EMAIL_CLIENT_OAUTH_CLIENT_ID / "
+    "EMAIL_CLIENT_OAUTH_CLIENT_SECRET, so it is yours: check the client's secret in your Google Cloud "
+    "project, set the corrected value in EMAIL_CLIENT_OAUTH_CLIENT_SECRET, then re-run the auth setup "
+    "for this account with 'email-client auth add --account {account} --provider gmail --reauth'. Gmail "
+    "send/receive is down for account '{account}' until then."
+)
+
+# The two env overrides that put a user-owned OAuth client in play (providers.apply_env_overrides).
+_CUSTOM_CLIENT_ENV_VARS = ("EMAIL_CLIENT_OAUTH_CLIENT_ID", "EMAIL_CLIENT_OAUTH_CLIENT_SECRET")
+
+
+def _custom_client_configured(env: dict | None = None) -> bool:
+    """True when an OAuth client of the user's own is overriding the shipped one."""
+    env = env if env is not None else os.environ
+    return any(env[name].strip() for name in _CUSTOM_CLIENT_ENV_VARS if name in env)
+
 
 # Fields copied from the probe result onto the notification, when the probe recorded them.
 _DETAIL_KEYS = ("http_status", "error", "error_description", "client_id", "self_heal")
@@ -279,10 +304,13 @@ def write_client_fault_notification(account: str, result: dict) -> pathlib.Path:
 
     One writer for both faults, so they share a shape and a cadence; only the wording and the type
     differ, because a dead client and a rejected secret send the user after different fixes.
+    A rejected secret has two of them, since only a user-owned client is one the user can correct.
     Nothing dedupes by marker: the daily probe is the only caller, so a standing fault raises at
     most one alert a day.
     """
     notif_type, template = _FAULT_NOTICE[result["status"]]
+    if result["status"] == CLIENT_AUTH_REJECTED and _custom_client_configured():
+        template = _CUSTOM_CLIENT_SECRET_REJECTED
     NOTIF_DIR.mkdir(parents=True, exist_ok=True)
     notif = {
         "source": "email-client",

--- a/agent/skills/email-client/cli/src/email_client/google_health.py
+++ b/agent/skills/email-client/cli/src/email_client/google_health.py
@@ -244,25 +244,31 @@ def attempt_self_heal(account: str, failed_result: dict, *, post=None, allow_fet
 # -- notification ---------------------------------------------------
 
 
-_DEAD_CLIENT_TYPE = "google_client_dead"
-_SECRET_REJECTED_TYPE = "google_client_secret_rejected"
-
-_DEAD_CLIENT_MESSAGE = (
-    "Gmail stopped working: the shared Google sign-in client was removed upstream and needs "
-    "replacing. Automatic recovery via Thunderbird's latest published client did not succeed, so "
-    "Gmail send/receive is down for account '{account}' until a new verified public client is put "
-    "in place. This is not a problem with your account or password."
-)
-
-_SECRET_REJECTED_MESSAGE = (
-    "Gmail stopped working: Google is rejecting the client secret configured for the Google "
-    "sign-in client. The client itself is still registered and was not withdrawn, and your "
-    "account and password are fine, but the secret paired with that client is wrong and "
-    "re-resolving it from Thunderbird's published client did not produce a working one. Gmail "
-    "send/receive is down for account '{account}' until it is corrected. To fix it: check the "
-    "client's secret in the Google Cloud console, correct it, then re-run the auth setup for this "
-    "account with 'email-client auth add --account {account} --provider gmail --reauth'."
-)
+# The notification type and wording each client fault gets, keyed by the probe status that
+# produced it, so a fault with no entry here raises rather than borrowing the other one's words.
+_FAULT_NOTICE = {
+    DEAD_CLIENT: (
+        "google_client_dead",
+        (
+            "Gmail stopped working: the shared Google sign-in client was removed upstream and needs "
+            "replacing. Automatic recovery via Thunderbird's latest published client did not succeed, so "
+            "Gmail send/receive is down for account '{account}' until a new verified public client is put "
+            "in place. This is not a problem with your account or password."
+        ),
+    ),
+    CLIENT_AUTH_REJECTED: (
+        "google_client_secret_rejected",
+        (
+            "Gmail stopped working: Google is rejecting the client secret configured for the Google "
+            "sign-in client. The client itself is still registered and was not withdrawn, and your "
+            "account and password are fine, but the secret paired with that client is wrong and "
+            "re-resolving it from Thunderbird's published client did not produce a working one. Gmail "
+            "send/receive is down for account '{account}' until it is corrected. To fix it: check the "
+            "client's secret in the Google Cloud console, correct it, then re-run the auth setup for this "
+            "account with 'email-client auth add --account {account} --provider gmail --reauth'."
+        ),
+    ),
+}
 
 # Fields copied from the probe result onto the notification, when the probe recorded them.
 _DETAIL_KEYS = ("http_status", "error", "error_description", "client_id", "self_heal")
@@ -276,9 +282,7 @@ def write_client_fault_notification(account: str, result: dict) -> pathlib.Path:
     Nothing dedupes by marker: the daily probe is the only caller, so a standing fault raises at
     most one alert a day.
     """
-    dead = result["status"] == DEAD_CLIENT
-    notif_type = _DEAD_CLIENT_TYPE if dead else _SECRET_REJECTED_TYPE
-    template = _DEAD_CLIENT_MESSAGE if dead else _SECRET_REJECTED_MESSAGE
+    notif_type, template = _FAULT_NOTICE[result["status"]]
     NOTIF_DIR.mkdir(parents=True, exist_ok=True)
     notif = {
         "source": "email-client",

--- a/agent/skills/email-client/cli/src/email_client/google_health.py
+++ b/agent/skills/email-client/cli/src/email_client/google_health.py
@@ -23,9 +23,9 @@ already-STORED refresh token and classifies the error. The key distinction is:
 
 Both client-side faults trigger self-heal: we re-resolve Thunderbird's current
 client from comm-central (via thunderbird_client) and retry the refresh once with
-the fresh credentials. Only a genuinely dead client also writes a clear,
-plain-English notification if that retry fails, because only then has the client
-actually been removed upstream.
+the fresh credentials. Either fault that survives that retry writes a clear,
+plain-English notification, worded for the fault it actually is: a dead client was
+removed upstream, a rejected secret was not, and each points at a different fix.
 
 This is strictly Google-specific and gated to Gmail accounts. It never sends mail
 and never touches the user's mailbox. EMAIL_DRAFT_ONLY is irrelevant here.
@@ -244,37 +244,54 @@ def attempt_self_heal(account: str, failed_result: dict, *, post=None, allow_fet
 # -- notification ---------------------------------------------------
 
 
-def write_dead_client_notification(account: str, result: dict) -> pathlib.Path:
-    """Write a clear, human-readable dead-client alert (interrupt=true).
+_DEAD_CLIENT_TYPE = "google_client_dead"
+_SECRET_REJECTED_TYPE = "google_client_secret_rejected"
 
-    Reserved for DEAD_CLIENT: it states the client was removed upstream, which is
-    false (and alarming) for a client that is alive but holding a stale secret.
+_DEAD_CLIENT_MESSAGE = (
+    "Gmail stopped working: the shared Google sign-in client was removed upstream and needs "
+    "replacing. Automatic recovery via Thunderbird's latest published client did not succeed, so "
+    "Gmail send/receive is down for account '{account}' until a new verified public client is put "
+    "in place. This is not a problem with your account or password."
+)
+
+_SECRET_REJECTED_MESSAGE = (
+    "Gmail stopped working: Google is rejecting the client secret configured for the Google "
+    "sign-in client. The client itself is still registered and was not withdrawn, and your "
+    "account and password are fine, but the secret paired with that client is wrong and "
+    "re-resolving it from Thunderbird's published client did not produce a working one. Gmail "
+    "send/receive is down for account '{account}' until it is corrected. To fix it: check the "
+    "client's secret in the Google Cloud console, correct it, then re-run the auth setup for this "
+    "account with 'email-client auth add --account {account} --provider gmail --reauth'."
+)
+
+# Fields copied from the probe result onto the notification, when the probe recorded them.
+_DETAIL_KEYS = ("http_status", "error", "error_description", "client_id", "self_heal")
+
+
+def write_client_fault_notification(account: str, result: dict) -> pathlib.Path:
+    """Write a clear, human-readable alert for an unhealed client fault (interrupt=true).
+
+    One writer for both faults, so they share a shape and a cadence; only the wording and the type
+    differ, because a dead client and a rejected secret send the user after different fixes.
+    Nothing dedupes by marker: the daily probe is the only caller, so a standing fault raises at
+    most one alert a day.
     """
+    dead = result["status"] == DEAD_CLIENT
+    notif_type = _DEAD_CLIENT_TYPE if dead else _SECRET_REJECTED_TYPE
+    template = _DEAD_CLIENT_MESSAGE if dead else _SECRET_REJECTED_MESSAGE
     NOTIF_DIR.mkdir(parents=True, exist_ok=True)
     notif = {
         "source": "email-client",
-        "type": "google_client_dead",
+        "type": notif_type,
         # This is not routine mail — the whole Gmail integration is down and
-        # needs a human to swap in a new verified client, so it interrupts.
+        # needs a human before it can work again, so it interrupts.
         "interrupt": True,
         "account": account,
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime()),
-        "message": (
-            "Gmail stopped working: the shared Google sign-in client was removed "
-            "upstream and needs replacing. Automatic recovery via Thunderbird's "
-            "latest published client did not succeed, so Gmail send/receive is "
-            f"down for account '{account}' until a new verified public client is "
-            "put in place. This is not a problem with your account or password."
-        ),
-        "detail": {
-            "oauth_error": result.get("error"),
-            "oauth_error_description": result.get("error_description"),
-            "http_status": result.get("http_status"),
-            "dead_client_id": result.get("client_id"),
-            "self_heal": result.get("self_heal"),
-        },
+        "message": template.format(account=account),
+        "detail": {key: result[key] for key in _DETAIL_KEYS if key in result},
     }
-    fname = f"email-client-google_client_dead-{account}-{int(time.time() * 1000)}-{uuid.uuid4().hex[:6]}.json"
+    fname = f"email-client-{notif_type}-{account}-{int(time.time() * 1000)}-{uuid.uuid4().hex[:6]}.json"
     final = NOTIF_DIR / fname
     tmp = NOTIF_DIR / f"{fname}.tmp"
     tmp.write_text(json.dumps(notif, ensure_ascii=False, indent=2))
@@ -288,10 +305,9 @@ def write_dead_client_notification(account: str, result: dict) -> pathlib.Path:
 def run_probe(account: str, *, post=None, notify: bool = True, allow_fetch: bool = True) -> dict:
     """Probe one account; on a client fault, self-heal, then notify if unhealed.
 
-    A stale client secret self-heals exactly like a dead client (both are fixed by
-    re-resolving the shipped client), but only a dead client gets the notification:
-    telling the user their OAuth client was removed upstream would be wrong when
-    the client id is still live.
+    A stale client secret self-heals exactly like a dead client, since both are fixed by
+    re-resolving the shipped client. A fault that survives the retry has stopped Gmail for that
+    account with no other signal, so both notify; the writer words each for the fault it is.
     """
     result = probe_account(account, post=post)
     if result["status"] not in CLIENT_FAULT_STATUSES:
@@ -303,8 +319,8 @@ def run_probe(account: str, *, post=None, notify: bool = True, allow_fetch: bool
         result["status"] = HEALED
         return result
 
-    if notify and result["status"] == DEAD_CLIENT:
-        path = write_dead_client_notification(account, result)
+    if notify:
+        path = write_client_fault_notification(account, result)
         result["notification"] = str(path)
     return result
 

--- a/agent/skills/email-client/cli/tests/test_google_health.py
+++ b/agent/skills/email-client/cli/tests/test_google_health.py
@@ -7,6 +7,7 @@ network, and the imap account layer is monkeypatched per test.
 """
 
 import json
+import pathlib
 
 import pytest
 from email_client import google_health as gh
@@ -141,6 +142,9 @@ def _post_by_creds(mapping):
 @pytest.fixture(autouse=True)
 def _isolate_notifs(tmp_path, monkeypatch):
     monkeypatch.setattr(gh, "NOTIF_DIR", tmp_path / "notifications")
+    # No custom OAuth client unless a test asks for one, so the default is the shipped client.
+    monkeypatch.delenv("EMAIL_CLIENT_OAUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("EMAIL_CLIENT_OAUTH_CLIENT_SECRET", raising=False)
 
 
 def test_probe_account_skips_non_google(monkeypatch):
@@ -225,9 +229,31 @@ def test_run_probe_auth_rejected_unhealed_notifies_about_the_secret_not_a_remova
     assert notif["type"] == "google_client_secret_rejected"
     assert notif["interrupt"] is True
     assert notif["account"] == "personal"
-    assert "rejecting the client secret" in notif["message"]
+    assert "rejecting the secret of the sign-in client this skill ships" in notif["message"]
     assert "removed upstream" not in notif["message"]
-    assert "Google Cloud console" in notif["message"]
+    # The shipped client lives in Mozilla's Cloud project and its secret is hardcoded, so neither a
+    # console visit nor a re-auth can change it: naming either would send the user after nothing.
+    assert "Nothing you can change on your side fixes this" in notif["message"]
+    assert "Google Cloud" not in notif["message"]
+    assert "--reauth" not in notif["message"]
+
+
+def test_run_probe_auth_rejected_on_a_custom_client_names_the_fix_the_user_owns(monkeypatch):
+    # With EMAIL_CLIENT_OAUTH_CLIENT_* in play the client is the user's own, so the secret sits in a
+    # Google Cloud project they control and correcting it plus re-authing genuinely fixes Gmail.
+    monkeypatch.setenv("EMAIL_CLIENT_OAUTH_CLIENT_SECRET", "mine")
+    _install_fake_imap_client(monkeypatch, {"refresh_token": "RT"}, client_id=DEAD_ID)
+    monkeypatch.setattr(
+        "email_client.thunderbird_client.resolve_google_client",
+        lambda *a, **k: {"client_id": DEAD_ID, "client_secret": "sek", "source": "fetched"},
+    )
+    res = gh.run_probe("personal", post=_post_by_client({DEAD_ID: RESP_BAD_CLIENT_SECRET}))
+    assert res["status"] == gh.CLIENT_AUTH_REJECTED
+
+    notif = json.loads(pathlib.Path(res["notification"]).read_text())
+    assert notif["type"] == "google_client_secret_rejected"
+    assert "EMAIL_CLIENT_OAUTH_CLIENT_SECRET" in notif["message"]
+    assert "your Google Cloud project" in notif["message"]
     assert "email-client auth add --account personal --provider gmail --reauth" in notif["message"]
 
 

--- a/agent/skills/email-client/cli/tests/test_google_health.py
+++ b/agent/skills/email-client/cli/tests/test_google_health.py
@@ -174,9 +174,9 @@ def test_probe_account_bad_token_does_not_notify_or_heal(monkeypatch, tmp_path):
     assert not (gh.NOTIF_DIR).exists() or list(gh.NOTIF_DIR.glob("*.json")) == []
 
 
-def test_run_probe_bad_client_secret_reresolves_but_does_not_notify(monkeypatch):
-    # A stale secret on a still-live client id must keep the recovery path (the
-    # client re-resolve) and lose only the "client was removed upstream" notice.
+def test_run_probe_bad_client_secret_reresolves_before_notifying(monkeypatch):
+    # A stale secret on a still-live client id keeps the recovery path (the client
+    # re-resolve); the alert is only for what survives it.
     _install_fake_imap_client(monkeypatch, {"refresh_token": "RT"}, client_id=DEAD_ID)
     called = {"heal": 0}
 
@@ -188,8 +188,6 @@ def test_run_probe_bad_client_secret_reresolves_but_does_not_notify(monkeypatch)
     res = gh.run_probe("personal", post=_post_by_client({DEAD_ID: RESP_BAD_CLIENT_SECRET}))
     assert res["status"] == gh.CLIENT_AUTH_REJECTED
     assert called["heal"] == 1
-    assert "notification" not in res
-    assert not gh.NOTIF_DIR.exists() or list(gh.NOTIF_DIR.glob("*.json")) == []
 
 
 def test_run_probe_heals_rotated_client_secret_on_same_client_id(monkeypatch):
@@ -204,12 +202,13 @@ def test_run_probe_heals_rotated_client_secret_on_same_client_id(monkeypatch):
     res = gh.run_probe("personal", post=post)
     assert res["status"] == gh.HEALED
     assert res["self_heal"]["healed"] is True
+    assert "notification" not in res
     assert not gh.NOTIF_DIR.exists() or list(gh.NOTIF_DIR.glob("*.json")) == []
 
 
-def test_run_probe_auth_rejected_unhealed_still_does_not_notify(monkeypatch):
-    # Upstream had nothing better to give, so the retry fails too. Still no
-    # notification: the client id is alive, it was never removed upstream.
+def test_run_probe_auth_rejected_unhealed_notifies_about_the_secret_not_a_removal(monkeypatch):
+    # Upstream had nothing better to give, so the retry fails too. Gmail is now down with no other
+    # signal, so it alerts, and the wording must point at the secret rather than a removed client.
     _install_fake_imap_client(monkeypatch, {"refresh_token": "RT"}, client_id=DEAD_ID)
     monkeypatch.setattr(
         "email_client.thunderbird_client.resolve_google_client",
@@ -218,7 +217,18 @@ def test_run_probe_auth_rejected_unhealed_still_does_not_notify(monkeypatch):
     res = gh.run_probe("personal", post=_post_by_client({DEAD_ID: RESP_BAD_CLIENT_SECRET}))
     assert res["status"] == gh.CLIENT_AUTH_REJECTED
     assert res["self_heal"]["healed"] is False
-    assert not gh.NOTIF_DIR.exists() or list(gh.NOTIF_DIR.glob("*.json")) == []
+
+    files = list(gh.NOTIF_DIR.glob("*.json"))
+    assert len(files) == 1
+    assert res["notification"] == str(files[0])
+    notif = json.loads(files[0].read_text())
+    assert notif["type"] == "google_client_secret_rejected"
+    assert notif["interrupt"] is True
+    assert notif["account"] == "personal"
+    assert "rejecting the client secret" in notif["message"]
+    assert "removed upstream" not in notif["message"]
+    assert "Google Cloud console" in notif["message"]
+    assert "email-client auth add --account personal --provider gmail --reauth" in notif["message"]
 
 
 def test_self_heal_gives_up_when_nothing_fresh_was_fetched(monkeypatch):

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
@@ -571,7 +571,7 @@ def _values(resp: dict) -> list[dict]:
 def _folder_id_by_name(candidates: list[dict], key: str) -> str | None:
     for candidate in candidates:
         name = candidate["displayName"] if "displayName" in candidate else ""
-        if (name or "").casefold() == key:
+        if name and name.casefold() == key:
             return candidate["id"]
     return None
 
@@ -608,7 +608,7 @@ def list_folders(client: httpx.Client, account_email: str, config) -> list[dict]
     for folder in top:
         out.append(folder)
         kids = _get(client, token, f"/me/mailfolders/{folder['id']}/childfolders", {"$select": _FOLDER_SELECT, "$top": "100"})
-        out.extend(kids.get("value", []))
+        out.extend(_values(kids))
     return out
 
 

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
@@ -564,16 +564,40 @@ def download_attachments(client: httpx.Client, account_email: str, config, *, em
 _FOLDER_SELECT = "id,displayName,parentFolderId,totalItemCount,unreadItemCount"
 
 
+def _values(resp: dict) -> list[dict]:
+    return resp["value"] if "value" in resp else []
+
+
+def _folder_id_by_name(candidates: list[dict], key: str) -> str | None:
+    for candidate in candidates:
+        name = candidate["displayName"] if "displayName" in candidate else ""
+        if (name or "").casefold() == key:
+            return candidate["id"]
+    return None
+
+
 def resolve_folder_id(client: httpx.Client, account_email: str, config, *, folder: str) -> str:
-    """Map a well-known key, a display name, or a raw folder id to an OWA folder path segment."""
+    """Map a well-known key, a display name, or a raw folder id to an OWA folder path segment.
+
+    A well-known key costs no request. A display name is matched against the top-level listing
+    first; only on a miss does it descend one level into each top-level folder's children, which
+    is where a nested folder such as Inbox/Screened lives and is the same depth ``list_folders``
+    reports, so every folder the CLI can list is a folder it can address.
+    """
     key = folder.casefold()
     if key in _FOLDER_MAP:
         return _FOLDER_MAP[key]
     token = load_token(account_email, config)
-    resp = _get(client, token, "/me/mailfolders", {"$select": "id,displayName", "$top": "100"})
-    for candidate in resp.get("value", []):
-        if (candidate.get("displayName") or "").casefold() == key:
-            return candidate["id"]
+    params = {"$select": "id,displayName", "$top": "100"}
+    top = _values(_get(client, token, "/me/mailfolders", params))
+    match = _folder_id_by_name(top, key)
+    if match is not None:
+        return match
+    for parent in top:
+        kids = _values(_get(client, token, f"/me/mailfolders/{parent['id']}/childfolders", params))
+        match = _folder_id_by_name(kids, key)
+        if match is not None:
+            return match
     return folder
 
 

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
@@ -563,6 +563,11 @@ def download_attachments(client: httpx.Client, account_email: str, config, *, em
 
 _FOLDER_SELECT = "id,displayName,parentFolderId,totalItemCount,unreadItemCount"
 
+# What an OWA folder id is made of, and the length below which a token is read as a display name.
+# Real ids run past a hundred characters, so the floor sits well clear of any folder a user names.
+_FOLDER_ID_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=+/")
+_FOLDER_ID_MIN_LEN = 64
+
 
 def _values(resp: dict) -> list[dict]:
     return resp["value"] if "value" in resp else []
@@ -576,17 +581,29 @@ def _folder_id_by_name(candidates: list[dict], key: str) -> str | None:
     return None
 
 
+def _is_folder_id(folder: str) -> bool:
+    """True for a token that is already an OWA folder id rather than a name to look up.
+
+    A folder id is a long opaque base64 string (``AAMkAG...AAA=``); a display name is short and
+    written for a human. Nothing that long and that shape is a name any listing would match, so
+    treating it as an id keeps a caller passing an id off the network entirely.
+    """
+    return len(folder) >= _FOLDER_ID_MIN_LEN and not (set(folder) - _FOLDER_ID_CHARS)
+
+
 def resolve_folder_id(client: httpx.Client, account_email: str, config, *, folder: str) -> str:
     """Map a well-known key, a display name, or a raw folder id to an OWA folder path segment.
 
-    A well-known key costs no request. A display name is matched against the top-level listing
-    first; only on a miss does it descend one level into each top-level folder's children, which
-    is where a nested folder such as Inbox/Screened lives and is the same depth ``list_folders``
-    reports, so every folder the CLI can list is a folder it can address.
+    A well-known key and a raw folder id both cost no request. A display name is matched against
+    the top-level listing first; only on a miss does it descend one level into each top-level
+    folder's children, which is where a nested folder such as Inbox/Screened lives and is the same
+    depth ``list_folders`` reports, so every folder the CLI can list is a folder it can address.
     """
     key = folder.casefold()
     if key in _FOLDER_MAP:
         return _FOLDER_MAP[key]
+    if _is_folder_id(folder):
+        return folder
     token = load_token(account_email, config)
     params = {"$select": "id,displayName", "$top": "100"}
     top = _values(_get(client, token, "/me/mailfolders", params))

--- a/agent/skills/microsoft/cli/tests/test_folders.py
+++ b/agent/skills/microsoft/cli/tests/test_folders.py
@@ -59,6 +59,12 @@ def test_resolve_display_name_to_id(patched):
     assert any(c["path"] == "/me/mailFolders" for c in patched)
 
 
+def test_resolve_nested_display_name_to_id(patched):
+    # A folder nested under Inbox resolves too: the listing expands one level of children.
+    resolved = folders.resolve_folder_id_cfg(Config(), None, "acct-1", "Receipts")
+    assert resolved == "sub-id"
+
+
 def test_resolve_unknown_returns_token(patched):
     resolved = folders.resolve_folder_id_cfg(Config(), None, "acct-1", "already-an-id")
     assert resolved == "already-an-id"

--- a/agent/skills/microsoft/cli/tests/test_owa_rest.py
+++ b/agent/skills/microsoft/cli/tests/test_owa_rest.py
@@ -552,6 +552,17 @@ def test_resolve_folder_id_finds_a_folder_nested_under_a_top_level_one(tmp_path)
     assert mock.get.call_args.args[0].endswith("/me/mailfolders/inbox-id/childfolders")
 
 
+def test_resolve_folder_id_takes_a_raw_folder_id_off_the_network(tmp_path):
+    # A folder id is a supported input that no display name can ever match, so looking one up would
+    # spend the listing plus a request per top-level folder only to hand the id straight back.
+    cfg = _patched_token(tmp_path)
+    mock = MagicMock(spec=httpx.Client)
+    folder_id = "AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhZmY2OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQ="
+
+    assert owa_rest.resolve_folder_id(mock, "user@example.com", cfg, folder=folder_id) == folder_id
+    mock.get.assert_not_called()
+
+
 def test_resolve_folder_id_returns_the_raw_name_when_no_folder_matches(tmp_path):
     cfg = _patched_token(tmp_path)
     mock = MagicMock(spec=httpx.Client)

--- a/agent/skills/microsoft/cli/tests/test_owa_rest.py
+++ b/agent/skills/microsoft/cli/tests/test_owa_rest.py
@@ -529,6 +529,38 @@ def test_resolve_folder_id_display_name(tmp_path):
     cfg = _patched_token(tmp_path)
     client = _mock_client({"value": [{"Id": "news-id", "DisplayName": "Newsletters"}]})
     assert owa_rest.resolve_folder_id(client, "user@example.com", cfg, folder="Newsletters") == "news-id"
+    # A top-level hit costs the one listing; the child walk is only paid for on a miss.
+    assert client.get.call_count == 1
+
+
+def _folder_listing(payload: dict) -> MagicMock:
+    resp = MagicMock(status_code=200)
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = payload
+    return resp
+
+
+def test_resolve_folder_id_finds_a_folder_nested_under_a_top_level_one(tmp_path):
+    cfg = _patched_token(tmp_path)
+    mock = MagicMock(spec=httpx.Client)
+    mock.get.side_effect = [
+        _folder_listing({"value": [{"Id": "inbox-id", "DisplayName": "Inbox"}]}),
+        _folder_listing({"value": [{"Id": "screened-id", "DisplayName": "Screened"}]}),
+    ]
+
+    assert owa_rest.resolve_folder_id(mock, "user@example.com", cfg, folder="Screened") == "screened-id"
+    assert mock.get.call_args.args[0].endswith("/me/mailfolders/inbox-id/childfolders")
+
+
+def test_resolve_folder_id_returns_the_raw_name_when_no_folder_matches(tmp_path):
+    cfg = _patched_token(tmp_path)
+    mock = MagicMock(spec=httpx.Client)
+    mock.get.side_effect = [
+        _folder_listing({"value": [{"Id": "inbox-id", "DisplayName": "Inbox"}]}),
+        _folder_listing({"value": []}),
+    ]
+
+    assert owa_rest.resolve_folder_id(mock, "user@example.com", cfg, folder="Nowhere") == "Nowhere"
 
 
 def test_list_folders_flattens_children(tmp_path):

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -61,7 +61,7 @@ whatsapp send --to 'Alice' --message - --reply-to '<message_id>' <<'MSG'   # quo
 same here
 MSG
 ```
-- Before texting an unknown raw number, save it first with `add-contact` (name + phone).
+- Before texting an unknown raw number, save it first with `add-contact` (name + phone). A chat WhatsApp shows only as an id (`...@lid`) has no number to save, so save it by that id instead: `add-contact --name <name> --chat <chat_jid>`.
 
 ## Read
 

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -630,17 +630,27 @@ func cmdListContacts(args []string, wac *WhatsAppClient) (any, error) {
 }
 
 func cmdAddContact(args []string, wac *WhatsAppClient) (any, error) {
-	var name, phone string
+	var name, phone, chat string
 	fs := flag.NewFlagSet("add-contact", flag.ContinueOnError)
 	fs.StringVar(&name, "name", "", "Contact name")
 	fs.StringVar(&phone, "phone", "", "Phone number (E.164)")
+	fs.StringVar(&chat, "chat", "", "Chat id, for a chat with no phone number (e.g. 12345@lid)")
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
-	if name == "" || phone == "" {
-		return nil, fmt.Errorf("--name and --phone are required")
+	if name == "" || (phone == "" && chat == "") {
+		return nil, fmt.Errorf("--name and one of --phone or --chat are required")
 	}
-	contact, err := wac.AddContact(name, phone)
+	if phone != "" && chat != "" {
+		return nil, fmt.Errorf("pass --phone or --chat, not both")
+	}
+	var contact Contact
+	var err error
+	if chat != "" {
+		contact, err = wac.AddContactByChat(name, chat)
+	} else {
+		contact, err = wac.AddContact(name, phone)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -28,22 +28,26 @@ func errIfGroupIDDigits(digits string) error {
 	)
 }
 
+// requireManualContact is the saved-contact half of the ban gate: every person the device
+// messages must have been confirmed by the user first. It covers a direct chat addressed
+// either way, since WhatsApp addresses one peer both by phone JID and by LID, and looks the
+// contact up under the same canonical key storage files that chat under. A LID with no phone
+// mapping yet stays unconfirmed and is therefore refused. Groups carry no such requirement.
 func (wac *WhatsAppClient) requireManualContact(jid types.JID) error {
-	if jid.Server != types.DefaultUserServer {
+	if !isDirectChatJID(jid) {
 		return nil
 	}
 
-	contact, err := wac.store.GetManualContact(jid.String())
+	peer := wac.canonicalChatJID(jid)
+	contact, err := wac.store.GetManualContact(peer.String())
 	if err != nil {
 		return fmt.Errorf("failed to verify saved contacts: %v", err)
 	}
 
 	if contact == nil {
-		phone := jid.User
-		if phone != "" {
-			phone = "+" + phone
-		} else {
-			phone = "this contact"
+		phone := "this contact"
+		if peer.Server == types.DefaultUserServer && peer.User != "" {
+			phone = "+" + peer.User
 		}
 		return fmt.Errorf(
 			"No saved contact found for %s. Ask the user who this is, then run add-contact --name <name> --phone <number>.",
@@ -277,16 +281,22 @@ func (wac *WhatsAppClient) resolveSenderJID(sender, senderAlt types.JID) types.J
 	return sender
 }
 
-// canonicalChatKey returns the stable storage key for a chat. WhatsApp addresses a direct chat
+// canonicalChatJID returns the one JID that identifies a chat. WhatsApp addresses a direct chat
 // by the peer's LID (a privacy id), but a saved contact and any reply resolve to the peer's phone
-// JID; keying storage by the raw LID splits one person into two chats, which broke reply-first,
-// read-receipt targeting, and threading. Resolving the LID to its phone JID here (a group JID is
-// left unchanged) makes one person one chat key everywhere messages are stored or looked up.
-func (wac *WhatsAppClient) canonicalChatKey(chat types.JID) string {
+// JID; treating the raw LID as its own identity splits one person into two chats, which breaks
+// reply-first, read-receipt targeting, threading, and the saved-contact gate. Resolving the LID to
+// its phone JID here (a group JID is left unchanged) makes one person one identity everywhere.
+func (wac *WhatsAppClient) canonicalChatJID(chat types.JID) types.JID {
 	if wac.client == nil {
-		return chat.String()
+		return chat
 	}
-	return wac.resolveSenderJID(chat, types.JID{}).String()
+	return wac.resolveSenderJID(chat, types.JID{})
+}
+
+// canonicalChatKey is the storage-key form of canonicalChatJID, used everywhere messages and
+// chats are stored or looked up.
+func (wac *WhatsAppClient) canonicalChatKey(chat types.JID) string {
+	return wac.canonicalChatJID(chat).String()
 }
 
 // formatSenderForDisplay returns a user-friendly sender display string.

--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -13,6 +13,25 @@ func (wac *WhatsAppClient) AddContact(name, phone string) (Contact, error) {
 	return wac.store.SaveManualContact(name, phone)
 }
 
+// AddContactByChat saves a contact for a chat given by its own id, the form for a peer WhatsApp
+// addresses only by a LID: there is no phone number to save them under. The key is the same
+// canonical identity requireManualContact checks, so a LID that does map to a phone saves under
+// the phone JID and stays one contact with one number.
+func (wac *WhatsAppClient) AddContactByChat(name, chat string) (Contact, error) {
+	jid, err := types.ParseJID(strings.TrimSpace(chat))
+	if err != nil {
+		return Contact{}, fmt.Errorf("invalid chat id '%s': %v", chat, err)
+	}
+	if !isDirectChatJID(jid) {
+		return Contact{}, fmt.Errorf("'%s' is a group, not a person; only people need a saved contact", chat)
+	}
+	peer := wac.canonicalChatJID(jid)
+	if peer.Server == types.DefaultUserServer {
+		return wac.store.SaveManualContact(name, "+"+peer.User)
+	}
+	return wac.store.SaveManualContactByChatJID(name, peer.String())
+}
+
 // MaxPhoneDigits is the E.164 ceiling on phone-number length. A WhatsApp
 // group ID renders as a longer all-digit string; sending to one as a user JID
 // makes the server log the device out and destroys the pairing (#1169).
@@ -32,7 +51,8 @@ func errIfGroupIDDigits(digits string) error {
 // messages must have been confirmed by the user first. It covers a direct chat addressed
 // either way, since WhatsApp addresses one peer both by phone JID and by LID, and looks the
 // contact up under the same canonical key storage files that chat under. A LID with no phone
-// mapping yet stays unconfirmed and is therefore refused. Groups carry no such requirement.
+// mapping is a peer with no number, so the refusal asks for it to be saved by chat id, which is
+// the key it is then found under. Groups carry no such requirement.
 func (wac *WhatsAppClient) requireManualContact(jid types.JID) error {
 	if !isDirectChatJID(jid) {
 		return nil
@@ -45,13 +65,13 @@ func (wac *WhatsAppClient) requireManualContact(jid types.JID) error {
 	}
 
 	if contact == nil {
-		phone := "this contact"
+		who, target := "this chat", "--chat "+peer.String()
 		if peer.Server == types.DefaultUserServer && peer.User != "" {
-			phone = "+" + peer.User
+			who, target = "+"+peer.User, "--phone +"+peer.User
 		}
 		return fmt.Errorf(
-			"No saved contact found for %s. Ask the user who this is, then run add-contact --name <name> --phone <number>.",
-			phone,
+			"No saved contact found for %s. Ask the user who this is, then run add-contact --name <name> %s.",
+			who, target,
 		)
 	}
 

--- a/agent/skills/whatsapp/cli/contacts_test.go
+++ b/agent/skills/whatsapp/cli/contacts_test.go
@@ -94,9 +94,6 @@ func TestResolveRecipientRejectsSavedGroupIDContact(t *testing.T) {
 	}
 }
 
-// The peer whose LID the outgoing-chat-key harness maps to a phone JID, saved by that phone.
-const gatedPeerPhone = "+15559876543"
-
 // A peer addressed by their LID passes the same saved-contact gate as the same peer addressed by
 // their phone JID. Both forms are valid send targets, so gating only the phone form would let an
 // outbound reach a person the user never confirmed, which is the ban risk the gate exists for.
@@ -110,15 +107,17 @@ func TestRequireManualContactGatesALIDLikeThePhoneJID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse phone jid: %v", err)
 	}
+	// The phone the harness maps the LID to: the one number both forms must be gated by.
+	peerPhone := "+" + phone.User
 
 	for _, jid := range []types.JID{lid, phone} {
 		err := wac.requireManualContact(jid)
-		if err == nil || !strings.Contains(err.Error(), "No saved contact found for "+gatedPeerPhone) {
-			t.Errorf("unsaved peer %s must be refused naming %s, got %v", jid, gatedPeerPhone, err)
+		if err == nil || !strings.Contains(err.Error(), "No saved contact found for "+peerPhone) {
+			t.Errorf("unsaved peer %s must be refused naming %s, got %v", jid, peerPhone, err)
 		}
 	}
 
-	if _, err := wac.store.SaveManualContact("Ana", gatedPeerPhone); err != nil {
+	if _, err := wac.store.SaveManualContact("Ana", peerPhone); err != nil {
 		t.Fatalf("failed to save contact: %v", err)
 	}
 

--- a/agent/skills/whatsapp/cli/contacts_test.go
+++ b/agent/skills/whatsapp/cli/contacts_test.go
@@ -93,3 +93,62 @@ func TestResolveRecipientRejectsSavedGroupIDContact(t *testing.T) {
 		t.Errorf("a previously saved group-ID contact must not resolve to a user JID, got %v", err)
 	}
 }
+
+// The peer whose LID the outgoing-chat-key harness maps to a phone JID, saved by that phone.
+const gatedPeerPhone = "+15559876543"
+
+// A peer addressed by their LID passes the same saved-contact gate as the same peer addressed by
+// their phone JID. Both forms are valid send targets, so gating only the phone form would let an
+// outbound reach a person the user never confirmed, which is the ban risk the gate exists for.
+func TestRequireManualContactGatesALIDLikeThePhoneJID(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	lid, err := types.ParseJID(outgoingLIDJID)
+	if err != nil {
+		t.Fatalf("failed to parse lid: %v", err)
+	}
+	phone, err := types.ParseJID(outgoingPhoneJID)
+	if err != nil {
+		t.Fatalf("failed to parse phone jid: %v", err)
+	}
+
+	for _, jid := range []types.JID{lid, phone} {
+		err := wac.requireManualContact(jid)
+		if err == nil || !strings.Contains(err.Error(), "No saved contact found for "+gatedPeerPhone) {
+			t.Errorf("unsaved peer %s must be refused naming %s, got %v", jid, gatedPeerPhone, err)
+		}
+	}
+
+	if _, err := wac.store.SaveManualContact("Ana", gatedPeerPhone); err != nil {
+		t.Fatalf("failed to save contact: %v", err)
+	}
+
+	for _, jid := range []types.JID{lid, phone} {
+		if err := wac.requireManualContact(jid); err != nil {
+			t.Errorf("saved peer %s must pass the gate, got %v", jid, err)
+		}
+	}
+}
+
+// A LID with no phone mapping resolves to nobody, so it cannot have been confirmed and is refused.
+// Its user part is an internal id, never a phone, so the refusal must not render it as one.
+func TestRequireManualContactRefusesAnUnmappedLID(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	unmapped := types.NewJID("99988877766655", types.HiddenUserServer)
+
+	err := wac.requireManualContact(unmapped)
+	if err == nil || !strings.Contains(err.Error(), "No saved contact found") {
+		t.Fatalf("an unmapped LID must be refused, got %v", err)
+	}
+	if strings.Contains(err.Error(), "99988877766655") {
+		t.Errorf("refusal must not render a LID as a phone number, got %v", err)
+	}
+}
+
+// Groups carry no saved-contact requirement; only people do.
+func TestRequireManualContactLeavesGroupsUngated(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+
+	if err := wac.requireManualContact(types.NewJID(groupIDDigits, types.GroupServer)); err != nil {
+		t.Errorf("a group must not require a saved contact, got %v", err)
+	}
+}

--- a/agent/skills/whatsapp/cli/contacts_test.go
+++ b/agent/skills/whatsapp/cli/contacts_test.go
@@ -138,8 +138,66 @@ func TestRequireManualContactRefusesAnUnmappedLID(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "No saved contact found") {
 		t.Fatalf("an unmapped LID must be refused, got %v", err)
 	}
-	if strings.Contains(err.Error(), "99988877766655") {
+	if strings.Contains(err.Error(), "+99988877766655") {
 		t.Errorf("refusal must not render a LID as a phone number, got %v", err)
+	}
+}
+
+// The refusal for an unmapped LID must name a remedy that works: a peer with no phone number
+// cannot be saved by number, so the gate would otherwise refuse that chat forever and every reply
+// to it, since a reply targets the raw chat JID. This follows the printed command literally.
+func TestUnmappedLIDPassesTheGateAfterTheRefusalsOwnCommand(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	unmapped := types.NewJID("99988877766655", types.HiddenUserServer)
+
+	err := wac.requireManualContact(unmapped)
+	wanted := "run add-contact --name <name> --chat " + unmapped.String()
+	if err == nil || !strings.Contains(err.Error(), wanted) {
+		t.Fatalf("refusal must name %q, got %v", wanted, err)
+	}
+
+	if _, err := cmdAddContact([]string{"--name", "Ana", "--chat", unmapped.String()}, wac); err != nil {
+		t.Fatalf("the command the refusal names must work, got %v", err)
+	}
+
+	if err := wac.requireManualContact(unmapped); err != nil {
+		t.Errorf("a peer confirmed by chat id must pass the gate, got %v", err)
+	}
+}
+
+// Saving by chat id is confirmation of one identity, not a second one: a LID that does map to a
+// phone saves under the phone JID, so the peer stays one contact addressable either way.
+func TestAddContactByChatSavesAMappedLIDUnderItsPhoneJID(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+
+	contact, err := wac.AddContactByChat("Ana", outgoingLIDJID)
+	if err != nil {
+		t.Fatalf("failed to save contact by chat id: %v", err)
+	}
+	if contact.JID != outgoingPhoneJID {
+		t.Errorf("expected the contact keyed by %q, got %q", outgoingPhoneJID, contact.JID)
+	}
+
+	for _, raw := range []string{outgoingLIDJID, outgoingPhoneJID} {
+		jid, err := types.ParseJID(raw)
+		if err != nil {
+			t.Fatalf("failed to parse %q: %v", raw, err)
+		}
+		if err := wac.requireManualContact(jid); err != nil {
+			t.Errorf("peer addressed as %s must pass the gate, got %v", raw, err)
+		}
+	}
+}
+
+// The gate still refuses an unmapped LID nobody confirmed, and a group id is not a person to save.
+func TestAddContactByChatRefusesAGroup(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+
+	if _, err := wac.AddContactByChat("Team", types.NewJID(groupIDDigits, types.GroupServer).String()); err == nil {
+		t.Error("a group must not be saveable as a contact")
+	}
+	if err := wac.requireManualContact(types.NewJID("12312312312312", types.HiddenUserServer)); err == nil {
+		t.Error("an unconfirmed LID must stay refused")
 	}
 }
 

--- a/agent/skills/whatsapp/cli/storage.go
+++ b/agent/skills/whatsapp/cli/storage.go
@@ -528,16 +528,8 @@ func (ms *MessageStore) SaveManualContact(name, phone string) (Contact, error) {
 		return Contact{}, err
 	}
 	jid := fmt.Sprintf("%s@%s", normalizedDigits, types.DefaultUserServer)
-	_, err = ms.db.Exec(`
-		INSERT INTO contacts (jid, phone_number, name, added_at, updated_at)
-		VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-		ON CONFLICT(jid) DO UPDATE SET
-			name = excluded.name,
-			phone_number = excluded.phone_number,
-			updated_at = CURRENT_TIMESTAMP
-	`, jid, displayNumber, trimmedName)
-	if err != nil {
-		return Contact{}, fmt.Errorf("failed to save contact: %v", err)
+	if err := ms.upsertManualContact(jid, displayNumber, trimmedName); err != nil {
+		return Contact{}, err
 	}
 
 	return Contact{
@@ -546,6 +538,39 @@ func (ms *MessageStore) SaveManualContact(name, phone string) (Contact, error) {
 		PhoneNumber: displayNumber,
 		IsManual:    true,
 	}, nil
+}
+
+// SaveManualContactByChatJID saves a user-confirmed contact under a chat's own JID, for a peer
+// WhatsApp addresses only by a LID: no phone number exists to key them under, and this is the key
+// the send gate looks them up by. Callers pass the canonical chat JID.
+func (ms *MessageStore) SaveManualContactByChatJID(name, chatJID string) (Contact, error) {
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" {
+		return Contact{}, fmt.Errorf("contact name cannot be empty")
+	}
+	if strings.TrimSpace(chatJID) == "" {
+		return Contact{}, fmt.Errorf("chat id cannot be empty")
+	}
+	if err := ms.upsertManualContact(chatJID, "", trimmedName); err != nil {
+		return Contact{}, err
+	}
+
+	return Contact{JID: chatJID, Name: trimmedName, IsManual: true}, nil
+}
+
+func (ms *MessageStore) upsertManualContact(jid, phoneNumber, name string) error {
+	_, err := ms.db.Exec(`
+		INSERT INTO contacts (jid, phone_number, name, added_at, updated_at)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		ON CONFLICT(jid) DO UPDATE SET
+			name = excluded.name,
+			phone_number = excluded.phone_number,
+			updated_at = CURRENT_TIMESTAMP
+	`, jid, phoneNumber, name)
+	if err != nil {
+		return fmt.Errorf("failed to save contact: %v", err)
+	}
+	return nil
 }
 
 // getManualContact loads a manual contact by a single equality column (jid or

--- a/agent/skills/whisper/SKILL.md
+++ b/agent/skills/whisper/SKILL.md
@@ -48,3 +48,6 @@ Transcribe audio/video files locally using whisper.cpp. No API calls, no data le
   Override with `WHISPER_MODEL` or `--model`. English-only `.en` models cannot
   transcribe other languages: whisper.cpp forces `--language en` and disables
   `--translate` on them
+- Language is auto-detected per file. Set `WHISPER_LANGUAGE` to a whisper.cpp
+  language code (`en`, `es`, `fr`, ...) to pin one for every run, the same
+  variable the whatsapp CLI reads; `--language` overrides it for a single run

--- a/agent/skills/whisper/SKILL.md
+++ b/agent/skills/whisper/SKILL.md
@@ -30,7 +30,7 @@ Transcribe audio/video files locally using whisper.cpp. No API calls, no data le
 
 | Flag | Description |
 |------|-------------|
-| `--language <code>` | Language code (en, es, fr, de, etc.). Default: auto, whisper detects it |
+| `--language <code>` | Language code (en, es, fr, de, etc.). Default: `WHISPER_LANGUAGE`, or auto-detect when it is unset |
 | `--translate` | Translate non-English audio to English text |
 | `--srt` | Output SRT subtitle format |
 | `--json` | Output JSON with timestamps |

--- a/agent/skills/whisper/scripts/whisper_transcribe.sh
+++ b/agent/skills/whisper/scripts/whisper_transcribe.sh
@@ -23,12 +23,16 @@ resolve_model() {
 }
 WHISPER_MODEL="${WHISPER_MODEL:-$(resolve_model)}"
 
+# Auto-detect per file unless WHISPER_LANGUAGE pins one whisper.cpp language code;
+# --language overrides either. Same variable the whatsapp CLI reads.
+LANGUAGE="${WHISPER_LANGUAGE:-auto}"
+
 usage() {
     echo "Usage: whisper_transcribe.sh <audio-file> [options]"
     echo ""
     echo "Options:"
     echo "  --model <path>     Model file (default: $WHISPER_MODEL)"
-    echo "  --language <lang>  Language code, e.g. en, es, fr (default: auto)"
+    echo "  --language <lang>  Language code, e.g. en, es, fr (default: $LANGUAGE)"
     echo "  --translate        Translate to English"
     echo "  --srt              Output SRT subtitles instead of plain text"
     echo "  --json             Output JSON with timestamps"
@@ -48,7 +52,6 @@ if [ ! -f "$INPUT_FILE" ]; then
     exit 1
 fi
 
-LANGUAGE="auto"
 TRANSLATE=""
 OUTPUT_FORMAT=""
 THREADS="4"

--- a/agent/tests/test_redact_secrets.py
+++ b/agent/tests/test_redact_secrets.py
@@ -703,7 +703,9 @@ def test_main_scrub_literal_rejects_a_missing_value(tmp_path, event_bus, monkeyp
     monkeypatch.setattr("sys.argv", ["redact_secrets.py", "--scrub-literal"])
 
     assert redact.main() == 1
-    assert "usage:" in capsys.readouterr().out
+    captured = capsys.readouterr()
+    assert "usage:" in captured.err
+    assert captured.out == ""
 
 
 def test_main_scrub_literal_refuses_a_short_literal(tmp_path, event_bus, monkeypatch, capsys):
@@ -713,7 +715,9 @@ def test_main_scrub_literal_refuses_a_short_literal(tmp_path, event_bus, monkeyp
     monkeypatch.setattr("sys.argv", ["redact_secrets.py", "--scrub-literal", "12345"])
 
     assert redact.main() == 1
-    assert "Refusing" in capsys.readouterr().out
+    captured = capsys.readouterr()
+    assert "Refusing" in captured.err
+    assert captured.out == ""
 
 
 def test_main_scrub_explains_a_zero_event_result(tmp_path, event_bus, db_conn, monkeypatch, capsys):


### PR DESCRIPTION
Five independent gaps. Every fix ships with a test that fails without it.

## WhatsApp: a hidden-user JID walked past the ban gate

`requireManualContact` only looked at phone-server JIDs, so `whatsapp send --to '<id>@lid'` never asked whether the person had been confirmed. WhatsApp addresses the same peer both ways, so the LID form was a live send target with no gate on it, which is exactly the cold-contact pattern that gets a number banned.

The gate now covers every direct chat and resolves the target through the same canonical identity storage already uses, so a LID that maps to a saved phone passes, a LID with no mapping is refused rather than waved through, and groups stay ungated as before. A peer with no phone mapping has no number to be saved under, so the refusal points at `add-contact --name <name> --chat <chat_jid>`, a form the contacts command now takes: the confirmation is saved under that same canonical identity, the key the gate then finds it by. The user still confirms who the peer is before anything is sent, and a LID that does map to a phone saves under the phone JID, so one person stays one contact. Added Go tests for all of it, including one that follows the refusal's own command literally and then passes the gate.

## Microsoft mail: a nested folder never resolved

The OWA REST folder resolver listed `/me/mailfolders` and matched display names against the top level only. A folder living inside another one, say Inbox/Screened, matched nothing and fell through as its raw name, so every read or move naming it errored.

A miss now descends one level into each top-level folder's children, the same depth `list-folders` already reports, so every folder the CLI can list is a folder it can address. A well known key still costs no request, a top level name still costs the single listing, and a raw folder id is recognised on sight (a long opaque base64 token) and costs no request at all, where it used to spend the listing before falling through. The one input that pays more than before is a token that matches nothing at any level, such as a well known name outside the map like `outbox`: it walks each top-level folder's children before falling through as its raw name. The Graph backend already handled nesting (it expands child folders in the one call); it gained a test pinning that and no code change.

## Email client: a rejected Google client secret failed silently

When Google refuses the client secret the skill presents, the probe tries to self heal by re-resolving Thunderbird's published client. If that retry also failed, nothing was written anywhere: Gmail was simply down for the account with no signal to the user at all. Only the genuinely dead client case notified.

The unhealed rejection now writes the same shape of interrupting notification, worded for what it actually is: the secret presented with the client is being rejected, the client itself was not withdrawn, and the account and password are fine. Which fix it names depends on whose client it is. With `EMAIL_CLIENT_OAUTH_CLIENT_ID` / `EMAIL_CLIENT_OAUTH_CLIENT_SECRET` set, the client belongs to the user, so the alert names checking that client's secret in their own Google Cloud project and re-running `email-client auth add --account <name> --provider gmail --reauth`. On the shipped Thunderbird client there is no console the user owns and the secret is hardcoded, so a re-auth would replay the same rejected value: the alert says so plainly and names the only real action, reporting it so a newly published client can replace it. Both faults go through one writer, so they keep one shape and the daily probe's once a day cadence, and a healed rejection still says nothing.

## Dream: scrub-literal refusals landed on stdout

`redact_secrets.sh --scrub-literal` printed its usage line and its short-literal refusal on stdout while exiting non-zero, so anything reading stdout for the scrub report picked up a failure message instead. Both now go to stderr, the stream `--show` already used. The real report (counts, and the value's length) stays on stdout.

## Whisper: WHISPER_LANGUAGE did nothing

The transcribe script hardcoded auto-detection, so the `WHISPER_LANGUAGE` variable the whatsapp CLI already honors had no effect there and a box pinned to one language still guessed per file. The script now seeds the language from that variable, keeps auto-detection when it is unset, and still lets `--language` win for a single run. Documented next to `WHISPER_MODEL` in the whisper skill.

Nothing was skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
