### PR TITLE
fix(browser): recover when the browser will not create a new tab

### DIFF
--- a/agent/skills/browser/SKILL.md
+++ b/agent/skills/browser/SKILL.md
@@ -24,6 +24,16 @@ cause FIRST: (1) take a `snapshot` or `screenshot` anyway, the content is usuall
 (or `"wait":"none"`). Only after the page truly never renders across these should you even
 consider a block, and even then suspect a cookie/consent wall or a redirect before "anti-bot".
 
+**One concrete instance: a `browser open` that sits there.** `open` creates a tab (BiDi
+`browsingContext.create {"type":"tab"}`), and in some containers that one call never gets an
+answer. It waits the full **60s** response bound, then takes over a context the browser already
+has rather than failing, preferring one showing no page. So `open` still lands, just slowly, and
+what you get back is an existing context rather than a fresh tab: run `browser tabs` before
+assuming you have two. Let it reach the timeout instead of killing it, since the error names the
+exact call that stalled, while terminating early leaves you with "it hung" and sends you hunting
+a block that is not there. Once you have seen it on a box, reach for **`browser navigate <url>`**,
+which skips tab creation and returns at once.
+
 **Same rule for a stuck FORM: a submit/next button that won't advance is a validation error, not a block.** On a multi-step wizard or checkout, when "Continue"/"Submit" appears to do nothing, do NOT conclude the site is fighting automation. Read the actual state first: screenshot it, grep the DOM for a required-but-empty field (`[required]` with no value), a `.text-danger`/`[class*=error]` message, an unticked terms checkbox, or a second hidden copy of the form you filled the wrong instance of. A false wall abandoned is worse than a real wall pushed through: the overwhelmingly common blocker on a stuck submit is one missing required field.
 
 **And the harder version: a page that appears to have NO field at all is almost never a page that cannot be filled.** "There is nowhere to type it, so this needs the user's own device" is the most expensive wrong conclusion available, because it looks like diligence. Before writing that sentence, rule out five things, in this order:

--- a/agent/skills/browser/cli/src/vesta_browser/helpers.py
+++ b/agent/skills/browser/cli/src/vesta_browser/helpers.py
@@ -133,9 +133,35 @@ def forward() -> dict:
     return _go_history(1)
 
 
+def _reusable_context() -> str | None:
+    """A top-level context to take over when the browser will not create a tab.
+
+    Prefers one showing no page, so a page in use is never clobbered.
+    """
+    try:
+        contexts = bidi("browsingContext.getTree")["contexts"]
+    except RuntimeError:
+        return None
+    for node in contexts:
+        if (node["url"] if "url" in node else "").startswith(INTERNAL_URL_PREFIXES):
+            return node["context"]
+    return contexts[0]["context"] if contexts else None
+
+
 def new_tab(url: str = "about:blank") -> str:
-    """Create a new tab, switch to it, optionally navigate. Returns its context id."""
-    ctx = bidi("browsingContext.create", type="tab")["context"]
+    """Create a new tab, switch to it, optionally navigate. Returns its context id.
+
+    Some builds accept the BiDi connection and then never answer
+    browsingContext.create, which fails after the daemon's wait even though the browser
+    is healthy and its existing contexts navigate fine. Falling back to one of those
+    keeps the session usable; with none to take over, the create error stands.
+    """
+    try:
+        ctx = bidi("browsingContext.create", type="tab")["context"]
+    except RuntimeError:
+        ctx = _reusable_context()
+        if ctx is None:
+            raise
     _set_context(ctx)
     if url and url != "about:blank":
         goto(url)

--- a/agent/skills/browser/cli/tests/test_helpers.py
+++ b/agent/skills/browser/cli/tests/test_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import re
 
 import pytest
 from vesta_browser import helpers
@@ -268,3 +269,89 @@ def test_screenshot_full_page_sets_document_origin(monkeypatch, tmp_path):
 def test_screenshot_rejects_bad_format():
     with pytest.raises(ValueError, match="format must be"):
         helpers.screenshot(image_format="gif")
+
+
+# ── new_tab falls back when the browser will not create a tab ──
+#
+# Some builds accept browsingContext.create and never answer it, which is what
+# tests/fake_bidi.py models via `withhold`. The transport raises rather than hanging;
+# these cover the layer above, where the session stays usable by taking over a
+# context that already exists.
+
+
+def _bidi_refusing_create(contexts, calls=None):
+    def fake(method, **params):
+        if calls is not None:
+            calls.append((method, params))
+        if method == "browsingContext.create":
+            raise RuntimeError("timeout: no response to 'browsingContext.create' within 60.0s")
+        if method == "browsingContext.getTree":
+            return {"contexts": contexts}
+        return {}
+
+    return fake
+
+
+def test_new_tab_falls_back_to_an_existing_context(monkeypatch):
+    monkeypatch.setattr(helpers, "bidi", _bidi_refusing_create([{"context": "ctx-1", "url": "about:blank"}]))
+    monkeypatch.setattr(helpers, "_set_context", lambda ctx: None)
+    assert helpers.new_tab() == "ctx-1"
+
+
+def test_new_tab_fallback_prefers_a_blank_context_over_a_page_in_use(monkeypatch):
+    """Taking over the user's loaded page would lose it; the blank one is free."""
+    contexts = [
+        {"context": "ctx-live", "url": "https://example.com/checkout"},
+        {"context": "ctx-blank", "url": "about:blank"},
+    ]
+    monkeypatch.setattr(helpers, "bidi", _bidi_refusing_create(contexts))
+    monkeypatch.setattr(helpers, "_set_context", lambda ctx: None)
+    assert helpers.new_tab() == "ctx-blank"
+
+
+def test_new_tab_fallback_uses_first_context_when_none_are_blank(monkeypatch):
+    contexts = [{"context": "ctx-a", "url": "https://a.test"}, {"context": "ctx-b", "url": "https://b.test"}]
+    monkeypatch.setattr(helpers, "bidi", _bidi_refusing_create(contexts))
+    monkeypatch.setattr(helpers, "_set_context", lambda ctx: None)
+    assert helpers.new_tab() == "ctx-a"
+
+
+def test_new_tab_fallback_tolerates_a_context_with_no_url(monkeypatch):
+    """getTree need not carry a url for every node, and a missing one is not a match."""
+    contexts = [{"context": "ctx-nourl"}, {"context": "ctx-blank", "url": "about:blank"}]
+    monkeypatch.setattr(helpers, "bidi", _bidi_refusing_create(contexts))
+    monkeypatch.setattr(helpers, "_set_context", lambda ctx: None)
+    assert helpers.new_tab() == "ctx-blank"
+
+
+def test_new_tab_still_navigates_after_falling_back(monkeypatch):
+    calls: list[tuple[str, dict]] = []
+    monkeypatch.setattr(helpers, "bidi", _bidi_refusing_create([{"context": "ctx-1", "url": "about:blank"}], calls))
+    monkeypatch.setattr(helpers, "_set_context", lambda ctx: None)
+    helpers.new_tab("https://example.com")
+    assert ("browsingContext.navigate", {"url": "https://example.com", "wait": "complete"}) in calls
+
+
+def test_new_tab_switches_to_the_context_it_fell_back_to(monkeypatch):
+    """The fallback is worthless if later commands still address the context that never opened."""
+    switched: list[str] = []
+    monkeypatch.setattr(helpers, "bidi", _bidi_refusing_create([{"context": "ctx-1", "url": "about:blank"}]))
+    monkeypatch.setattr(helpers, "_set_context", switched.append)
+    helpers.new_tab()
+    assert switched == ["ctx-1"]
+
+
+def test_new_tab_reraises_when_there_is_no_context_to_reuse(monkeypatch):
+    """A genuinely dead browser must still surface the error, not be papered over."""
+    monkeypatch.setattr(helpers, "bidi", _bidi_refusing_create([]))
+    with pytest.raises(RuntimeError, match=re.escape("browsingContext.create")):
+        helpers.new_tab()
+
+
+def test_new_tab_reraises_when_the_tree_call_also_fails(monkeypatch):
+    def fake(method, **params):
+        raise RuntimeError(f"timeout: no response to '{method}' within 60.0s")
+
+    monkeypatch.setattr(helpers, "bidi", fake)
+    with pytest.raises(RuntimeError, match=re.escape("browsingContext.create")):
+        helpers.new_tab()


### PR DESCRIPTION
Consolidates the two open PRs for one root cause: **#1853** (behaviour) and **#1831** (docs). They had to land together, because #1831's advice stops being true once #1853 changes what `open` does.

## The failure

`open` calls `new_tab()` -> BiDi `browsingContext.create {"type":"tab"}`. In some containers that one call never gets an answer, so `open` died at the 60s response bound (`BIDI_RESPONSE_TIMEOUT_S`, `cli/src/vesta_browser/bidi.py:23`) even though the browser was healthy and the context it already had navigated perfectly.

## The fix

`new_tab()` falls back to a top-level context the browser already has, preferring one showing no page so a page in use is never clobbered, and re-raising when there is nothing to take over so a genuinely dead browser still reports itself rather than being papered over.

`except RuntimeError` is the right net and not too wide: `admin.send` raises `RuntimeError` for both a timeout and a daemon-reported error, while a dead daemon raises `ConnectionRefusedError`/`FileNotFoundError`, which still propagates untouched.

## Changes made while consolidating

- **The docs now describe the post-fix behaviour.** #1831 told agents to let `open` fail and reach for `browser navigate` instead. After this change `open` recovers on its own, so the paragraph says it waits the 60s and then takes over an existing context, and keeps `navigate` as the faster path rather than the workaround.
- **It says a recovered `open` is not a fresh tab.** This is the part worth having in prose: the agent gets a real context id back with no signal that it was reused, so an agent opening two URLs would believe it has two tabs. `helpers.py` never prints (all output lives in `cli.py`), so rather than widen `new_tab`'s return type for its one caller, SKILL.md tells the agent to check `browser tabs`.
- **The docstrings state the mechanism instead of narrating the bug.** #1853's read "so every `open` died at tab creation", which is a description of a previous design in a file the agent reads cold.
- **Two tests added on top of #1853's six.** Every one of its tests stubbed `_set_context` to a no-op and never asserted on it, so the fallback could have failed to switch context and the suite would still have been green; and every fixture carried a `url`, so the `"url" in node` branch was never exercised.

## Verification

- 229 tests pass in `agent/skills/browser/cli`.
- The 6 fallback tests were confirmed to discriminate: reverting `helpers.py` alone fails exactly those 6. The 2 re-raise tests correctly still pass on the reverted source, since they guard against a future over-broad fallback.
- `./check.sh guards` clean.

Closes #1831. Closes #1853.
Credit to **bazella** (#1831) and **luna** (#1853).

🤖 Generated with [Claude Code](https://claude.com/claude-code)