### PR TITLE
feat(browser): report covers automatically, and name the untrusted-click failure

### DIFF
--- a/agent/skills/browser/SKILL.md
+++ b/agent/skills/browser/SKILL.md
@@ -17,7 +17,10 @@ restarts, different across profiles.
 **Never assume you got caught by anti-bot.** Because the browser is genuinely stealth, a hang or
 a blank page is almost never a block. The overwhelmingly common cause is boring: `open`/`navigate`
 waits for the page `load` event, and heavy JS/SPA sites (airlines, banks, booking flows) fire it
-late or never, so the command times out even though the page rendered fine. Rule out the boring
+late or never, so the command times out even though the page rendered fine. The same cause also
+returns **clean** with `document.body.innerText.length` at 0, and that second symptom is the one
+that fools you: the command SUCCEEDED, so "did it time out?" answers no and you walk straight past
+this paragraph. Re-navigating the same context with `"wait":"none"` renders it. Rule out the boring
 cause FIRST: (1) take a `snapshot` or `screenshot` anyway, the content is usually already there;
 (2) navigate via BiDi with a lighter wait so you return before full load:
 `browser bidi browsingContext.navigate '{"context":"<ctx>","url":"<url>","wait":"interactive"}'`
@@ -33,6 +36,13 @@ assuming you have two. Let it reach the timeout instead of killing it, since the
 exact call that stalled, while terminating early leaves you with "it hung" and sends you hunting
 a block that is not there. Once you have seen it on a box, reach for **`browser navigate <url>`**,
 which skips tab creation and returns at once.
+
+**FIRST, when a button does nothing: ask what is under the cursor.** One call, before any
+theorising: take the target's rect and pass its centre to `document.elementFromPoint`. If the answer
+is not your button, you are clicking an invisible overlay, and every retry, every coordinate
+fallback and every theory about validation is wasted. A modal can be absent from `innerText` and
+still sit over an enabled button. See
+[interaction-skills/clicking.md](interaction-skills/clicking.md).
 
 **Same rule for a stuck FORM: a submit/next button that won't advance is a validation error, not a block.** On a multi-step wizard or checkout, when "Continue"/"Submit" appears to do nothing, do NOT conclude the site is fighting automation. Read the actual state first: screenshot it, grep the DOM for a required-but-empty field (`[required]` with no value), a `.text-danger`/`[class*=error]` message, an unticked terms checkbox, or a second hidden copy of the form you filled the wrong instance of. A false wall abandoned is worse than a real wall pushed through: the overwhelmingly common blocker on a stuck submit is one missing required field.
 
@@ -188,6 +198,14 @@ Drop to **`click(x, y)` / `browser click --at X Y`** when:
 
 `input.performActions` dispatches a real pointer event at that viewport point regardless of DOM
 structure.
+
+**Both ref clicks and `--at` clicks are TRUSTED input; an `element.click()` from `browser js` is
+not**, and the difference is invisible until it matters. An untrusted click carries no user
+activation, so Firefox silently refuses anything gated on a gesture: `window.open` and
+`target="_blank"` popups, clipboard writes, fullscreen, file pickers. Nothing errors, the tab just
+stays `about:blank` or never appears. If the action NAVIGATES, OPENS, UPLOADS or writes outside the
+page, use a real click. For ordinary in-page handlers a JS click is fine. Full story in
+[interaction-skills/clicking.md](interaction-skills/clicking.md).
 
 ## When stealth isn't enough (escalation)
 

--- a/agent/skills/browser/SKILL.md
+++ b/agent/skills/browser/SKILL.md
@@ -37,11 +37,11 @@ exact call that stalled, while terminating early leaves you with "it hung" and s
 a block that is not there. Once you have seen it on a box, reach for **`browser navigate <url>`**,
 which skips tab creation and returns at once.
 
-**FIRST, when a button does nothing: ask what is under the cursor.** One call, before any
-theorising: take the target's rect and pass its centre to `document.elementFromPoint`. If the answer
-is not your button, you are clicking an invisible overlay, and every retry, every coordinate
-fallback and every theory about validation is wasted. A modal can be absent from `innerText` and
-still sit over an enabled button. See
+**When a button does nothing, read the click's own output first.** `browser click <ref>` reports
+what was topmost at the point it clicked when that is not your element (`# e14 is covered by
+<div.modal-wrap>, which took the click instead.`). That line means an invisible overlay ate it, and
+every retry, every coordinate fallback and every theory about validation is wasted until it is
+dismissed. A modal can be absent from `innerText` and still sit over an enabled button. See
 [interaction-skills/clicking.md](interaction-skills/clicking.md).
 
 **Same rule for a stuck FORM: a submit/next button that won't advance is a validation error, not a block.** On a multi-step wizard or checkout, when "Continue"/"Submit" appears to do nothing, do NOT conclude the site is fighting automation. Read the actual state first: screenshot it, grep the DOM for a required-but-empty field (`[required]` with no value), a `.text-danger`/`[class*=error]` message, an unticked terms checkbox, or a second hidden copy of the form you filled the wrong instance of. A false wall abandoned is worse than a real wall pushed through: the overwhelmingly common blocker on a stuck submit is one missing required field.

--- a/agent/skills/browser/cli/src/vesta_browser/cli.py
+++ b/agent/skills/browser/cli/src/vesta_browser/cli.py
@@ -271,7 +271,9 @@ def cmd_click(args: argparse.Namespace) -> int:
         if not args.ref:
             print("click needs a ref or --at X Y", file=sys.stderr)
             return 2
-        helpers.click_ref(args.ref, button="right" if args.right else "left", clicks=2 if args.double else 1)
+        occluder = helpers.click_ref(args.ref, button="right" if args.right else "left", clicks=2 if args.double else 1)
+        if occluder:
+            print(f"# {args.ref} is covered by <{occluder}>, which took the click instead. See interaction-skills/clicking.md")
     helpers.wait(0.2)
     _print_feedback()
     return 0

--- a/agent/skills/browser/cli/src/vesta_browser/helpers.py
+++ b/agent/skills/browser/cli/src/vesta_browser/helpers.py
@@ -301,10 +301,36 @@ def _resolve_center(ref: str) -> tuple[float, float]:
     return box["x"], box["y"]
 
 
-def click_ref(ref: str, button: str = "left", clicks: int = 1) -> None:
-    """Click an element by ref (e.g. 'e5') from the most recent snapshot."""
+def _occluder_at(ref: str, x: float, y: float) -> str | None:
+    """Describe what sits on top at a ref's click point, or None when the ref is clear.
+
+    An overlay taking the click is otherwise indistinguishable from a dead button:
+    the click reports success and the DOM shows nothing wrong.
+    """
+    probe = (
+        "(() => {"
+        f"const r = (globalThis.__vestaRefs || {{}})[{json.dumps(_norm_ref(ref))}];"
+        "if (!r || !r.el) return null;"
+        f"const hit = document.elementFromPoint({x}, {y});"
+        "if (!hit || hit === r.el || r.el.contains(hit)) return null;"
+        "const cls = typeof hit.className === 'string' && hit.className.trim()"
+        " ? '.' + hit.className.trim().split(/\\s+/).join('.') : '';"
+        "return hit.tagName.toLowerCase() + cls;"
+        "})()"
+    )
+    return _eval_value(f"JSON.stringify({probe})")
+
+
+def click_ref(ref: str, button: str = "left", clicks: int = 1) -> str | None:
+    """Click an element by ref (e.g. 'e5') from the most recent snapshot.
+
+    Returns what intercepted the click when something else is on top at that point,
+    so an overlay is not mistaken for a button that does nothing.
+    """
     x, y = _resolve_center(ref)
+    occluder = _occluder_at(ref, x, y)
     click(x, y, button=button, clicks=clicks)
+    return occluder
 
 
 def type_ref(ref: str, text: str, submit: bool = False, slowly: bool = False) -> None:

--- a/agent/skills/browser/cli/tests/test_helpers.py
+++ b/agent/skills/browser/cli/tests/test_helpers.py
@@ -355,3 +355,55 @@ def test_new_tab_reraises_when_the_tree_call_also_fails(monkeypatch):
     monkeypatch.setattr(helpers, "bidi", fake)
     with pytest.raises(RuntimeError, match=re.escape("browsingContext.create")):
         helpers.new_tab()
+
+
+# ── click_ref reports an overlay that intercepts the click ─────
+#
+# An overlay taking the click looks exactly like a button that does nothing: the
+# click reports success and the DOM shows nothing wrong. click_ref asks what is
+# actually on top and hands that back, so the caller can say so.
+
+
+def _click_probe(hit_expr_result, clicked=None):
+    """Stand in for the two evals click_ref makes: resolve the ref, then probe the point."""
+
+    def fake(expression, context=None):
+        if "__vestaResolveRef" in expression:
+            return {"found": True, "x": 10, "y": 20}
+        return hit_expr_result
+
+    return fake
+
+
+def test_click_ref_returns_none_when_the_ref_is_on_top(monkeypatch):
+    monkeypatch.setattr(helpers, "_eval_value", _click_probe(None))
+    monkeypatch.setattr(helpers, "click", lambda x, y, button="left", clicks=1: None)
+    assert helpers.click_ref("e5") is None
+
+
+def test_click_ref_names_the_element_that_took_the_click(monkeypatch):
+    monkeypatch.setattr(helpers, "_eval_value", _click_probe("div.modal-wrap"))
+    monkeypatch.setattr(helpers, "click", lambda x, y, button="left", clicks=1: None)
+    assert helpers.click_ref("e5") == "div.modal-wrap"
+
+
+def test_click_ref_still_clicks_when_something_is_on_top(monkeypatch):
+    """Reporting the overlay must not swallow the click; the caller decides what to do."""
+    landed: list[tuple[float, float]] = []
+    monkeypatch.setattr(helpers, "_eval_value", _click_probe("div.modal-wrap"))
+    monkeypatch.setattr(helpers, "click", lambda x, y, button="left", clicks=1: landed.append((x, y)))
+    helpers.click_ref("e5")
+    assert landed == [(10, 20)]
+
+
+def test_occluder_probe_asks_about_the_resolved_point(monkeypatch):
+    """The probe must test the point actually clicked, not the element's own opinion."""
+    seen: list[str] = []
+
+    def fake(expression, context=None):
+        seen.append(expression)
+
+    monkeypatch.setattr(helpers, "_eval_value", fake)
+    helpers._occluder_at("e5", 33, 44)
+    assert "elementFromPoint(33, 44)" in seen[0]
+    assert '"e5"' in seen[0]

--- a/agent/skills/browser/domain-skills/trip-com/booking.md
+++ b/agent/skills/browser/domain-skills/trip-com/booking.md
@@ -26,8 +26,8 @@ The `flights` skill treats trip.com as a primary booking path. This is the flow 
 6. **Email verification**: entering the contact address triggers a 6-digit code by email. Fetch it
    from the inbox and enter it.
 7. **Next**, at which point the **"Duplicate Bookings"** dialog fires if the passengers hold another
-   flight within 24h. It is invisible in `innerText` and eats every click on Next. `elementFromPoint`
-   finds it; "Continue booking" clears it.
+   flight within 24h. It is invisible in `innerText` and eats every click on Next, which `browser
+   click` reports as a cover; "Continue booking" clears it.
 8. **Seats**: "Skip seat selection", then "Next step".
 9. **Add-ons**: decline insurance ("I don't want to protect my trip"), then "Next step", then a
    second last-chance insurance modal wants "Not now".

--- a/agent/skills/browser/domain-skills/trip-com/booking.md
+++ b/agent/skills/browser/domain-skills/trip-com/booking.md
@@ -1,0 +1,57 @@
+# trip.com: booking a flight end to end
+
+The `flights` skill treats trip.com as a primary booking path. This is the flow that works.
+
+## The flow
+
+1. **Search**: `https://uk.trip.com/flights/showfarefirst?dcity=<from>&acity=<to>&ddate=YYYY-MM-DD&triptype=ow&class=ys&quantity=<pax>&locale=en-GB&curr=EUR`
+   Navigate with **`"wait":"none"`**. With `wait=load`, and with plain `browser open`, the command
+   returns clean and `document.body.innerText.length` is 0. See SKILL.md's blank-page paragraph.
+2. **Select the fare**: find the card containing the departure time, take its
+   `button "Select this flight"` ref, and use a **real click** (`browser click <ref>`). A JS
+   `.click()` here opens a popup that Firefox blocks silently: the tab appears and stays
+   `about:blank` forever. See `interaction-skills/clicking.md`.
+3. **Fare panel**, then `Continue`, and the passenger page opens in a NEW TAB. Focus it by URL match
+   on `flights/passenger`.
+4. **Passengers**. Names, gender, DOB, nationality. Three traps:
+   - the DOB field expands into separate DD / MM / YYYY inputs once focused, and `browser type`
+     needs `--slowly` or the value does not stick;
+   - nationality must be picked from the dropdown list, not typed. Typed free text LOOKS accepted and
+     is silently cleared on save;
+   - each passenger needs **"Save & continue"** AND then a confirmation dialog ("Passenger
+     information has been saved... check the spelling"). Until you confirm, the section reads
+     "Not completed" and the page will not advance.
+5. **Contact details**: pre-filled if signed in. **Check the phone country code**, which defaults to
+   the site locale's rather than the one belonging to the number in the field.
+6. **Email verification**: entering the contact address triggers a 6-digit code by email. Fetch it
+   from the inbox and enter it.
+7. **Next**, at which point the **"Duplicate Bookings"** dialog fires if the passengers hold another
+   flight within 24h. It is invisible in `innerText` and eats every click on Next. `elementFromPoint`
+   finds it; "Continue booking" clears it.
+8. **Seats**: "Skip seat selection", then "Next step".
+9. **Add-ons**: decline insurance ("I don't want to protect my trip"), then "Next step", then a
+   second last-chance insurance modal wants "Not now".
+10. **Cashier** (`secure.trip.com/webapp/cashier/home`): saved cards are listed; the CVV field is not
+    matchable by selector. Click its position, verify `document.activeElement` is an INPUT, then type
+    into the focused element. **11-minute hold timer**; if it lapses the booking auto-cancels and a
+    "Booking Cancelled" email follows.
+
+## Baggage
+
+The passenger page's baggage "Add" buttons may never open for a given fare. Buy bags from the
+**airline** after ticketing instead, which is also cheaper than at the airport. Trip.com's own
+bundled fare can still beat airline-bought bags, so compare before assuming the bare fare is cheaper.
+
+## After payment
+
+Payment success is NOT ticketing. The confirmation carrying the **airline PNR** arrives separately,
+promised within 12 hours. Only the PNR lets the passenger manage the booking with the airline.
+
+**The airline record's contact email is trip.com's ticketing desk, not the passenger's.** So on the
+airline's own "manage my booking", looking up by PNR + email FAILS; use **PNR + surname**.
+
+## Prices
+
+Fares move within hours on the same search. Availability and ordering can be checked cheaply from
+search results, but the price only exists in the cart at the moment of paying, and search-page base
+fares differ from cart totals by more than the gap between two fares.

--- a/agent/skills/browser/interaction-skills/clicking.md
+++ b/agent/skills/browser/interaction-skills/clicking.md
@@ -31,7 +31,28 @@ synthetic event in its own framework handler, or want a full pointer/mouse chain
 `click`. See `domain-skills/github/repo-actions.md` and `domain-skills/framer/editor.md` for those.
 A real click fixes all three, which is why it is the right first move rather than the diagnosis.
 
-## 2. If a button does nothing, ask what is actually under the cursor
+## 2. An overlay intercepting the click
+
+`browser click <ref>` checks this for you. When something else is topmost at the point it clicks,
+it says so and names it:
+
+```
+# e14 is covered by <div.modal-wrap>, which took the click instead.
+```
+
+The click is still dispatched, because taking it is sometimes what you want; the line tells you
+where it went. When you see it, dismiss the overlay (below) and click again. Nothing else is worth
+trying first: every retry, every coordinate fallback and every theory about validation is wasted
+while something is on top.
+
+A modal can be invisible in `innerText` because it renders above the fold, and still sit over an
+enabled button that reports `disabled=false` with no validation error, no unticked checkbox and no
+missing required field. Upsell and confirmation dialogs on checkout flows do this repeatedly within
+one flow, so read the line each time rather than assuming one page has one modal.
+
+**`--at X Y` does not report this**, because there is no ref to compare against; a coordinate click
+lands on whatever is topmost exactly as a ref click does, so it is not a way around an overlay
+either. To check a point by hand, or to check a button you have not clicked yet:
 
 ```js
 (() => { const b = /* the button */; const r = b.getBoundingClientRect();
@@ -39,19 +60,9 @@ A real click fixes all three, which is why it is the right first move rather tha
          return hit === b || b.contains(hit) ? 'clear' : hit.tagName + '.' + hit.className; })()
 ```
 
-One call. If the answer is not your button, you are clicking an overlay, and every retry, every
-coordinate fallback and every theory about validation is wasted.
-
-A modal can be invisible in `innerText` because it renders above the fold, and still sit over an
-enabled button that reports `disabled=false` with no validation error, no unticked checkbox and no
-missing required field. Upsell and confirmation dialogs on checkout flows do this repeatedly within
-one session, so re-run the check each time a button stops responding rather than once per page.
-
-Run this check **before** the field-hunting checklist in SKILL.md's stuck-form paragraph. That
-checklist is good advice for a form that rejects you, and useless for a form you are not reaching.
-
-A coordinate click is not a way around an overlay: `--at X Y` lands on whatever is topmost at that
-point, exactly as a ref click does. Diagnose first, then choose the fallback.
+A button that does nothing with no such line is a different problem: go to the field-hunting
+checklist in SKILL.md's stuck-form paragraph, which is good advice for a form that rejects you and
+useless for a form you are not reaching.
 
 ### Dismissing the overlay once you have found it
 
@@ -74,6 +85,6 @@ broadly and filter on exact text; and it may sit BELOW the fold, where a click l
 
 Order that works:
 
-1. `elementFromPoint` on the target's centre. Overlay? Dismiss it (above), then click.
+1. Did `browser click <ref>` report a cover? Dismiss it (above), then click again.
 2. Does the action need a real gesture (opens, uploads, navigates)? Use `browser click`, not JS.
 3. Only then consider stale rects, shadow DOM, cross-origin iframes, or a genuine validation error.

--- a/agent/skills/browser/interaction-skills/clicking.md
+++ b/agent/skills/browser/interaction-skills/clicking.md
@@ -1,0 +1,79 @@
+# When a click does nothing
+
+Two causes account for most of it, and each is one call to diagnose. Check them before any theory
+about validation, stale refs, or anti-bot.
+
+## 1. A JS click carries no user activation, so gated actions silently do nothing
+
+`element.click()` from `browser js` dispatches an **untrusted** event: `isTrusted === false`, and it
+grants no user activation. Firefox refuses anything gated on a real gesture, and refuses it
+**silently**, with no error in the console you are reading.
+
+Gated on user activation, therefore broken by a JS click:
+
+- `window.open` and any `target="_blank"` navigation (**popup blocker**)
+- clipboard writes, fullscreen requests, file pickers, notification and media permission prompts
+
+`browser click <ref>` and `browser click --at X Y` go through `input.performActions`, which is real
+input from the browser's point of view. They work.
+
+**The tell**: a new tab appears and stays `about:blank` forever, or no tab appears at all, while the
+click "succeeds" and the DOM says nothing is wrong. Hooking `window.open`, polling tabs, injecting
+`<base target="_self">` and restarting the browser are all wasted on this, because the site is not
+fighting automation and the popup blocker is not aimed at you. The click is fake.
+
+A JS click is still fine, often preferable, for ordinary in-page handlers (dropdown options, list
+items, accept buttons). React and friends do not care about `isTrusted`. Reach for a real click when
+the action **navigates, opens, uploads, or writes outside the page**.
+
+Note that a JS click failing does not by itself mean user activation: a site may also swallow a
+synthetic event in its own framework handler, or want a full pointer/mouse chain rather than a bare
+`click`. See `domain-skills/github/repo-actions.md` and `domain-skills/framer/editor.md` for those.
+A real click fixes all three, which is why it is the right first move rather than the diagnosis.
+
+## 2. If a button does nothing, ask what is actually under the cursor
+
+```js
+(() => { const b = /* the button */; const r = b.getBoundingClientRect();
+         const hit = document.elementFromPoint(r.x + r.width/2, r.y + r.height/2);
+         return hit === b || b.contains(hit) ? 'clear' : hit.tagName + '.' + hit.className; })()
+```
+
+One call. If the answer is not your button, you are clicking an overlay, and every retry, every
+coordinate fallback and every theory about validation is wasted.
+
+A modal can be invisible in `innerText` because it renders above the fold, and still sit over an
+enabled button that reports `disabled=false` with no validation error, no unticked checkbox and no
+missing required field. Upsell and confirmation dialogs on checkout flows do this repeatedly within
+one session, so re-run the check each time a button stops responding rather than once per page.
+
+Run this check **before** the field-hunting checklist in SKILL.md's stuck-form paragraph. That
+checklist is good advice for a form that rejects you, and useless for a form you are not reaching.
+
+A coordinate click is not a way around an overlay: `--at X Y` lands on whatever is topmost at that
+point, exactly as a ref click does. Diagnose first, then choose the fallback.
+
+### Dismissing the overlay once you have found it
+
+`dialogs.md` covers NATIVE prompts (`alert`, `confirm`, `beforeunload`) via
+`browsingContext.handleUserPrompt`. It will not touch a React modal, which is just a div. What works:
+
+```js
+// find the modal's own control by its exact label, take the LAST match (modals mount late,
+// so earlier matches are usually the page underneath), then real-click its rect centre
+(() => { const m = document.querySelector('.modal-wrap') || document;
+         const els = [...m.querySelectorAll('button,div,span,a')]
+           .filter(e => e.offsetParent !== null && /^Continue$/i.test((e.innerText||'').trim()));
+         const r = els[els.length-1].getBoundingClientRect();
+         return Math.round(r.x+r.width/2) + ' ' + Math.round(r.y+r.height/2); })()
+```
+
+then `browser click --at <x> <y>`. Two traps: the control is often a `div`, not a `button`, so query
+broadly and filter on exact text; and it may sit BELOW the fold, where a click lands on nothing.
+`scrollIntoView({block:'center'})` first, then re-read the rect, because the coordinates move.
+
+Order that works:
+
+1. `elementFromPoint` on the target's centre. Overlay? Dismiss it (above), then click.
+2. Does the action need a real gesture (opens, uploads, navigates)? Use `browser click`, not JS.
+3. Only then consider stale rects, shadow DOM, cross-origin iframes, or a genuine validation error.


### PR DESCRIPTION
Reworks **#1842**, plus the automatic version of its main diagnostic.

Two undocumented failure modes, both of which make a click look like it worked while nothing happened.

## 1. An overlay intercepting the click, now reported by the CLI

An invisible modal over an enabled button is indistinguishable from a dead button: the click succeeds, the DOM shows nothing wrong, and the existing stuck-form checklist sends you hunting a missing required field that does not exist.

`click_ref` already resolves a ref to a viewport point, so it now asks what is topmost there and returns anything that is not the ref or a descendant of it:

```
# e14 is covered by <div.modal-wrap>, which took the click instead.
```

The click is still dispatched, since taking it is sometimes what the caller wants. This replaces the "run `document.elementFromPoint` by hand" advice #1842 proposed: a documented diagnostic only helps an agent who remembers to read the page, and the CLI is already holding the element and the coordinates. The manual probe stays in the docs for `--at X Y` clicks and for a button you have not clicked yet, neither of which has a ref to compare against.

No rebuild of the vendored accessibility bundle was needed; the probe is its own small eval in `helpers.py`.

## 2. A JS click carries no user activation

`element.click()` from `browser js` is untrusted, so Firefox silently refuses anything gated on a gesture: `window.open` and `target="_blank"` popups, clipboard writes, fullscreen, file pickers. Nothing errors, the tab just stays `about:blank` or never appears. `browser click` goes through `input.performActions` and works. The rule: if the action navigates, opens, uploads or writes outside the page, use a real click.

## 3. The blank-page symptom that is not a timeout

The anti-bot paragraph described only a timeout. The same cause also returns clean with `innerText.length === 0`, so an agent matching on "did it time out?" walks past it.

Adds `interaction-skills/clicking.md`, since no page existed for the skill's most-used mechanic, and a `domain-skills/trip-com/booking.md` recipe.

## Changes made while reworking #1842

- **Dropped its central historical claim, which was false.** It asserted the same root cause "was already recorded three times and never generalised", citing tiktok, github and framer. Two of the three diagnose something else in the very text it quotes: `github/repo-actions.md:35` says GitHub's React fiber handler swallows the synthetic event, and `framer/editor.md:30` says the canvas wants a full pointer+mouse chain. Neither is user activation, and neither action is gated on a gesture (starring is a POST, opening an editor is in-page). Merged as written it would have taught the agent to read three different causes as one.
- **Dropped a reference to a file that does not exist.** A whole section corrected advice attributed to `interaction-skills/authed-onboarding-forms.md`; there is no such file in the repo. The substance (a coordinate click does not get you past an overlay) is kept as a plain statement.
- **Removed the change-narration and war stories.** Dated "Burned 6 Aug 2026" framing, elapsed-time anecdotes and "this file did not exist until X" describe history in files the agent reads cold, which AGENTS.md rules out under `agent/`.
- **Dropped line-number citations into other files**, which rot silently, and the em-dash heading separator.
- **Generalised the trip.com recipe off the one real booking it was written from**, which carried a passenger's phone country code and inbox details.
- **Rewrapped the SKILL.md edits** to the file's width.

## Verification

- 233 tests pass in `agent/skills/browser/cli`.
- The occlusion tests were confirmed to discriminate: reverting `helpers.py` alone fails the two that assert the new behaviour, while the two guards (still clicks, silent when clear) correctly hold either way.
- Every file path, cross-reference and link in the new and changed files resolves.
- `./check.sh guards` clean.

Closes #1842. Credit to **vesta**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)