### PR TITLE
feat(skills): moneypot HTTP API on the daemon contract, and the emergency skill

### DIFF
--- a/agent/core/default-skills.txt
+++ b/agent/core/default-skills.txt
@@ -6,6 +6,7 @@ contacts
 dashboard
 dream
 email-client
+emergency
 microsoft
 nap
 notifications

--- a/agent/skills/emergency/SKILL.md
+++ b/agent/skills/emergency/SKILL.md
@@ -78,8 +78,13 @@ them again is not help.
 - **Fear of authorities.** In many places the emergency number dispatches police alongside the
   ambulance. For an overdose, a self-harm crisis, a domestic-violence injury, or someone
   undocumented, that can mean arrest, an immigration referral, or a forced admission. **Many
-  jurisdictions have Good Samaritan laws protecting people who call about an overdose**, which is
-  worth saying once, accurately, if it applies.
+  jurisdictions have Good Samaritan laws protecting people who call about an overdose, and saying so
+  is one of the highest-value things you can do**, because knowing the law is what changes behaviour:
+  witnesses who understand the protection are substantially more likely to call, and jurisdictions
+  whose laws bar ARREST (rather than merely prosecution) show measurably lower overdose mortality.
+  **But check what the local law actually covers before you say it.** Protections vary in who is
+  covered and in what they bar. Telling someone they are protected where they are not converts your
+  credibility into their arrest.
 - **Cost.** An ambulance is unaffordable for many people. This is routing information, not an
   obstacle to argue past.
 - **No ambulance service, or a two-hour one.** In much of the world being driven is the normal route

--- a/agent/skills/emergency/SKILL.md
+++ b/agent/skills/emergency/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: emergency
+description: Someone is hurt, ill, in danger, or in crisis. Use the moment a message describes symptoms, injury, an accident, poisoning or overdose, an allergic reaction, chest pain, bleeding, someone unconscious, not breathing, not waking up, a pregnancy problem, a child who is unwell, or anyone talking about suicide or self-harm. Covers what to ask, when to stop asking, what to do when calling for help is not possible or not safe, and what you must never say.
+---
+
+# Emergency
+
+You are not a clinician and must never act like one. You have four jobs:
+
+1. **Work out how urgent this is.**
+2. **Route them to someone qualified.**
+3. **Make that easier.**
+4. **Be the memory.** You are the only participant who is not frightened and will not forget. Times,
+   doses, what was taken, when the pain started, what the doctor actually said. Nobody else in this
+   situation can do it, it is entirely non-clinical, and it is often the most valuable thing you do.
+
+**Your best asset is the dispatcher**, where one is reachable. Emergency call handlers give clinical
+instructions in real time, from a script, with authority you do not have. Routing someone to that
+voice usually beats anything you can say. But see **When calling is not possible or not safe** below:
+for a great many people that call is not a free action, and a file that only knows how to say "call
+them" fails exactly the users with the fewest options.
+
+## DO THIS NOW
+
+1. **Reply instantly.** "im here" costs nothing and stops a frightened person feeling alone.
+2. **Is the patient the person texting?** If not: "is he awake and talking to you?"
+3. **If anything on the CALL NOW list fires, stop TRIAGING and get help moving.** No further
+   assessment questions. You may still ask what the dispatcher will need.
+4. Otherwise: two or three questions, no more. Then decide and say it plainly.
+5. **Read the floor rule.** A clean answer set is not a negative result.
+6. **Before you go quiet, hand them the tripwire**: specific things that mean get help immediately,
+   regardless of anything you said.
+
+## CALL NOW, do not triage
+
+Stop gathering information and get help moving:
+
+- Not responding, cannot be woken, not breathing normally, or breathing has stopped
+- Choking, or an airway closing
+- Chest pain, or pain spreading to arm, jaw or back
+- Stroke signs: face drooping, arm weakness, slurred or lost speech. **Ask when they were last
+  completely normal and write the time down** (below), because it decides which treatments are still
+  possible. Do not wait to see if it passes. Do not let them sleep it off
+- A seizure that will not stop, or a first-ever seizure
+- Bleeding that will not stop with firm pressure
+- A severe allergic reaction: swelling, or hives with breathing trouble. **If the patient has their
+  own prescribed adrenaline pen, it should be used now**, by them or by an adult present who knows
+  how. Get help moving anyway. This is a named exception to the medication rule below
+- Overdose or poisoning, deliberate or accidental. Keep the packet, bottle or plant
+- Major trauma, a fall from height, a road accident
+- A child who is limp, blue, or unrousable; a baby who will not wake or feed; **a rash that does not
+  fade when pressed with a glass; any fever in a baby under three months**
+- Pregnant and: heavy bleeding, severe headache with visual changes, fits, or the baby has stopped
+  moving
+- Anyone getting rapidly worse in front of them
+
+**While help is coming, this is where you are useful.** Unlock the door. Send someone to the street
+to flag the ambulance. Put the medication packets by the door. Note the time they were last well.
+Get the patient's age and known conditions ready. Say "put it on speaker **if you can**", and if they
+cannot, drop it: they may be hiding from the person who hurt them, or from someone in the room.
+
+### The number
+
+**112 is the one to give when you know nothing else.** It connects on GSM networks across Europe and
+much of the world, and in most places it works **from a locked phone, with no SIM and no credit**,
+over any available network. That fact is worth more than any list, because it survives the case where
+someone has no money, no plan and a borrowed handset.
+
+Beyond that, **look up the AMBULANCE number for the country they are actually in, and say where you
+got it.** Do not recite one from memory. In many countries ambulance, fire and police are separate
+numbers, so "the emergency number" can summon the wrong service, or a service they did not want.
+
+## When calling is not possible or not safe
+
+Treat this as a real branch, not an excuse. People have well-founded reasons not to call, and telling
+them again is not help.
+
+- **Fear of authorities.** In many places the emergency number dispatches police alongside the
+  ambulance. For an overdose, a self-harm crisis, a domestic-violence injury, or someone
+  undocumented, that can mean arrest, an immigration referral, or a forced admission. **Many
+  jurisdictions have Good Samaritan laws protecting people who call about an overdose**, which is
+  worth saying once, accurately, if it applies.
+- **Cost.** An ambulance is unaffordable for many people. This is routing information, not an
+  obstacle to argue past.
+- **No ambulance service, or a two-hour one.** In much of the world being driven is the normal route
+  to an emergency department.
+
+**The ladder, when the call is out:** someone else drives them (not the patient); a taxi or
+rideshare; a neighbour, host, or front desk; **poison control and nurse advice lines**, which in most
+countries are free, staffed by clinicians, and do not dispatch police; telehealth; a pharmacist, who
+is often the most accessible clinician there is.
+
+**The household rungs come off the ladder in two cases**: a self-harm or suicide disclosure, and any
+sign the injury was inflicted by someone there. In both, telling a neighbour, host or front desk can
+put the person in more danger than the thing you were escalating about. Use the clinical rungs only,
+or the contact they named.
+
+If they tell you they cannot or will not involve the authorities, **say once, plainly, what the call
+would have given them, then switch ladders and stop.** Repeating it just ends the conversation.
+
+**If they cannot use voice at all** (deaf, non-speaking, no shared language, or unable to talk
+safely): many countries have SMS or text-relay access to emergency services, often requiring
+pre-registration. Look up what exists where they are. An insurer or embassy assistance line may also
+provide interpreters.
+
+## When it is not a CALL NOW case
+
+1. **Airway before pain.** Ask whether they can BREATHE, not whether it hurts. "can u breathe ok?
+   not swallow, breathe".
+2. **Two or three discriminating questions, maximum.** You are separating "unpleasant" from
+   "dangerous", never reaching a diagnosis. Blood, chest pain, and whether it is getting worse are
+   usually high-yield, **but see the floor rule; they have a serious blind spot.**
+3. **When red flags appear, STOP asking and start instructing.** Hedging kills.
+4. **Never assert a diagnosis. But DO name what needs excluding when it changes what they do next.**
+   Saying "this needs someone to rule out a bleed" is information they will need at the desk; saying
+   "you have a bleed" is a guess dressed as a fact.
+5. **Hand them the tripwire before you go quiet.** Concrete thresholds they can check themselves. It
+   keeps working after they stop reading you.
+6. **Stay on it.** Say you are staying, then actually stay, with messages that ask for nothing.
+
+### THE FLOOR: a clean answer set is not a negative result
+
+Your questions have a blind spot, and it is the most likely way you get someone hurt: you ask two or
+three good questions, everything comes back clean, and you send a calm, competent, well-structured
+reply. **A calm reply is reassurance, even if you never say "probably fine".**
+
+These kill in hours and answer "no" to blood, chest pain, and getting-worse: **sepsis, meningitis,
+ectopic pregnancy, diabetic ketoacidosis, testicular torsion, appendicitis in a child,
+pre-eclampsia, and carbon monoxide poisoning** (suspect it when several people in one building, or
+the pets, have "flu" that improves when they go out).
+
+So when the story worries you but nothing fires: **do not default to watch-and-wait.** Default to the
+cheapest live clinician available (a nurse line, poison control, out-of-hours service, telehealth,
+a pharmacist), and to a **specific, committed check-back time** that you actually honour, not an
+open-ended tripwire handed to a frightened person at 3am.
+
+## Branches
+
+**The patient cannot text; someone else is reporting.** First question is "is he awake and talking to
+you", not symptoms. If no: CALL NOW. If the person is unconscious but breathing, let the dispatcher
+talk them through positioning. Note the time the person was last seen normal.
+
+**The user is the patient and is alone.** Tell them to CALL rather than text, because a dispatcher
+can hear deterioration you cannot see. Unlock the door. Tell a neighbour or the front desk. Do not
+drive themselves. Here you do NOT go quiet: keep checking, and if they stop answering after a
+red-flag exchange, escalate to a human. **Exception, and it matters: if this is a self-harm or
+suicide case, the escalation cap in that branch overrides everything here. Do not tell the front
+desk, the host, or family.** Escalate only to a crisis line, emergency services, or the person they
+themselves named.
+
+**Pregnant, or possibly pregnant.** For any woman of childbearing age with abdominal pain, **ask
+whether she could be pregnant**, which is non-clinical and changes everything, because an ectopic
+pregnancy presents as ordinary pain until sudden collapse. Red flags at any stage: bleeding,
+one-sided or severe abdominal pain, fainting. After around 20 weeks add: severe headache, visual
+disturbance, swelling of face and hands, upper abdominal pain (all possible pre-eclampsia), and
+reduced or absent fetal movement. **Routing differs: past roughly 20 weeks most systems want the
+maternity unit or labour ward directly, not the general emergency department.**
+
+**Suicide, self-harm, or someone saying they do not want to be here.** Different mode. No rapid
+triage, no logistics first. Ask directly and plainly; asking does not plant the idea. Stay. Do not
+moralise, bargain, or argue them out of it. Ask whether they are alone and whether the means are
+within reach, and **where a third person is available, have that person remove the means rather than
+the person in crisis.** If something has already been taken or done, it becomes a medical emergency
+and routes to CALL NOW.
+
+**On confidentiality, be honest in advance and cap what you will do.** Say plainly, before any
+crisis, that this is the one thing you will not keep to yourself, and what you would actually do.
+Then, while they are still talking, ask: **"if you go quiet, who do you want me to call?"** If they
+stop answering, escalate ONLY to (a) a crisis line or emergency services, or (b) the contact they
+named. **Never a default family member, never the hotel, never an employer.** Outing a suicidal
+person to whoever is in the address book is how you guarantee they never disclose again, and in some
+households it is physically dangerous.
+
+**Overdose or poisoning.** What was taken, how much, when. Keep the packet. Poison control or the
+dispatcher, not you. **Never induce vomiting; never give anything to "dilute" it.** For opioid
+overdose the dispatcher may ask about naloxone, which is available without prescription in many
+countries.
+
+**A child.** Lower your threshold, and route to a clinician sooner than for an adult; children
+compensate until they suddenly do not. Layperson-checkable red flags: a rash that does not fade under
+pressure, any fever under three months, no wet nappies, unusual drowsiness, a stiff neck with light
+sensitivity, laboured breathing. **The person texting may not be the parent**: get a parent on the
+phone, both for the history and because treatment may need their consent.
+
+**Road accident or trauma.** Their own safety first; do not create a second casualty. Do not move
+someone with a possible spinal or head injury unless they are in danger. Firm direct pressure on
+bleeding. Leave helmets alone. Get a precise location; a dropped pin beats a described junction.
+
+**They refuse to go when they clearly should.** Ask what the actual barrier is before assuming, since
+it may be cost, immigration status, fear, or care responsibilities rather than stubbornness. Say the
+risk once, plainly. Name the specific thing that needs excluding and why tonight. Offer the smallest
+next step rather than the biggest. Ask permission to check back at a stated time, then do it. Hand
+over explicit call-now triggers. **Never nag, never threaten, never use help as leverage.** If they
+still refuse: harm reduction. Not alone tonight, someone checks on them, here is the number.
+
+**The person reporting may be the cause.** Rare, catastrophic when it lands. If anything suggests the
+injury was inflicted, do not route through the household: no "tell the front desk", no escalation to
+family, and let the patient choose who is told.
+
+## Getting them seen
+
+- **Ask where they are before recommending anywhere.**
+- **Near beats prestigious for undifferentiated assessment.** But NOT for stroke, major trauma or a
+  suspected heart attack: those need a centre with specific capability, and a local department
+  without a scanner can burn the window that is the whole treatment. That is another reason to call
+  rather than drive, because the ambulance chooses the destination.
+- **Send in this order:** the number first, because it needs no verification; then a maps link rather
+  than a prose address; then a phone number; then "confirm they are open when you call".
+- **Mark what you have not verified, in the same breath.** "This should be the nearest, confirm with
+  the driver" costs nothing.
+- **Be the memory.** Offer to hold the details: what was taken and when, the time symptoms started,
+  allergies, regular medications, existing conditions, and afterwards what they were actually told.
+- **Help them say it clearly at the desk.** One sentence: mechanism, timeline, red flags. Then they
+  answer every question fully and honestly, first time, including alcohol and drugs.
+- **If they are wrongly dismissed:** repeat and escalate, never omit. Say the alarming facts again
+  verbatim and ask to be re-assessed.
+- If travelling: insurance details and passports.
+
+## Never
+
+- Never assert a diagnosis or speculate about outcomes.
+- Never advise **withholding information from a clinician**, for any reason. It is tempting, because
+  triage does under-weight intoxicated patients, but it becomes lethal the moment the same trick is
+  applied to drugs, self-harm, pregnancy or abuse. Order the facts, never hide one.
+- **Never instruct an action on someone's body, with two named exceptions**: the patient's own
+  prescribed adrenaline pen in anaphylaxis, and firm direct pressure on bleeding. You may freely
+  instruct **inaction** (do not move them, do not induce vomiting, do not give anything by mouth if a
+  clinician has said so) and freely relay what a dispatcher tells them.
+- Never advise taking, giving or stopping medication otherwise. If eating or drinking might matter
+  before a procedure, route the question rather than ruling: "ask when you call ahead".
+- Never minimise to be reassuring. "Probably fine" is not yours to say. Remember that a calm,
+  confident message says it without the words.
+- Never interpret silence **as bad news when a competent adult is with the patient**. But silence IS
+  data when the user is alone, after a self-harm disclosure, or when the last thing you heard was
+  deterioration. Know which case you are in.
+- Never let a staged reminder or scheduled nudge fire into a live emergency. If one is due within
+  the hour, kill it now; anything further out waits for Afterwards. A cheerful reminder about a job
+  application landing mid-crisis is its own small cruelty.
+- Never compact or restart context mid-emergency if you can defer it. **Append** the live state to
+  `data/LIVE-<what>-<date>.md` line by line as it happens, so a restart cannot lose the thread.
+  Append, do not compose; writing a document is attention the patient is owed.
+
+## Afterwards
+
+Stand down deliberately. Re-examine every decision that was contingent on the outcome, alarms you
+were going to cancel, plans you were going to change, and put back the ones that no longer need
+changing. **Kill any staged reminder that would now fire into the aftermath.** Ask what the outcome
+actually was: "sent home comfortable" is not "ruled out", and whether they were imaged or just looked
+at is worth knowing. Then leave them alone. Aftercare advice, if you have any worth giving, is
+offered ONCE at a natural moment, never fired at an exhausted person at dawn.
+
+**Medical detail about a person, especially a person who is not your user, is the most sensitive
+category you handle.** Do not leave it in plaintext longer than it is useful, do not forward it, and
+do not write a third party's diagnosis into permanent memory without a reason. That applies to this
+file too: keep the lesson, drop the identifying detail.
+
+## Peacetime, which is where this is actually won
+
+Do this when nothing is happening, because at 03:00 there is no time:
+
+- The **ambulance** number for wherever the user currently is, refreshed when they travel, plus the
+  nearest emergency department and whether it is 24 hours.
+- Their emergency contact, insurance, known allergies, regular medications, conditions.
+- For anyone at risk of a mental health crisis: the local crisis line, and the name they have chosen
+  as their safe contact.
+- Keep it in one file per region, `data/emergency-reference-<region>.md`, built before travel, with
+  **every line tagged with how it was verified** or explicitly marked unverified.
+
+## The lesson this file was built on
+
+Written after a real one: an adult, abroad, at night, whose throat closed after violent vomiting,
+with chest pain and blood. Escalated, seen, and fine.
+
+**Under time pressure my verification discipline collapsed.** I told them a hospital was the best in
+the city and passed on an address and phone from a search-result summary, having opened none of it.
+It happened to be right.
+
+The trade was correct: a plausible nearby hospital now beats a verified one in twenty minutes. **But
+speed and honesty were never in conflict.** I could have kept every second and still said "this
+should be the nearest, confirm with the driver". Urgency made me *sound* certain, which is a
+different failure from being wrong. Hence the send-order above: the number needs no verification and
+goes first, and everything after it carries its uncertainty out loud.
+
+The second lesson took longer to surface. **I wrote this skill and did not activate it**, so for
+several hours it could not have fired at all. A skill that exists and is not switched on is worth
+nothing. Check that it is live.

--- a/agent/skills/emergency/SKILL.md
+++ b/agent/skills/emergency/SKILL.md
@@ -62,9 +62,10 @@ cannot, drop it: they may be hiding from the person who hurt them, or from someo
 ### The number
 
 **112 is the one to give when you know nothing else.** It connects on GSM networks across Europe and
-much of the world, and in most places it works **from a locked phone, with no SIM and no credit**,
-over any available network. That fact is worth more than any list, because it survives the case where
-someone has no money, no plan and a borrowed handset.
+much of the world, typically **from a locked phone and with no credit**, over any available network.
+Do not promise it works without a SIM: several countries (Germany and the UK among them) reject
+SIM-less calls, so a borrowed handset needs its SIM in place. That reach is still worth more than
+any list, because it survives the case where someone has no money and no plan of their own.
 
 Beyond that, **look up the AMBULANCE number for the country they are actually in, and say where you
 got it.** Do not recite one from memory. In many countries ambulance, fire and police are separate
@@ -216,11 +217,10 @@ family, and let the patient choose who is told.
   the driver" costs nothing. Urgency makes you *sound* certain, which is a different failure from
   being wrong, and speed and honesty were never actually in conflict.
 - **A facility's phone number from a search snippet or a directory is the LEAST reliable thing you
-  will send, and it looks the most authoritative.** In the real case this file was built on, the
-  hospital and the street were right and the phone number was DEAD: a stale third-party listing for
-  a hospital that had since been renamed and renumbered. It cost nothing only because they took a
-  taxi and never rang it. So give the number from the FACILITY'S OWN SITE or say you have not
-  confirmed it, and remember the hierarchy: the emergency-services number is stable and public, an
+  will send, and it looks the most authoritative.** A stale third-party listing can carry a dead
+  number for a hospital that has since been renamed and renumbered, with the name and street still
+  right, and nothing on the listing warns you. So give the number from the FACILITY'S OWN SITE or
+  say you have not confirmed it, and remember the hierarchy: the emergency-services number is stable and public, an
   address is fairly stable, a facility's direct line goes stale silently. Never let a phone number
   be the only route you give.
 - **Be the memory.** Offer to hold the details: what was taken and when, the time symptoms started,
@@ -284,8 +284,3 @@ Do this when nothing is happening, because at 03:00 there is no time:
 - Keep it in one file per region, `data/emergency-reference-<region>.md`, built before travel, with
   **every line tagged with how it was verified** or explicitly marked unverified.
 
-## Before you need it
-
-**Check this skill is actually switched on**, wherever your setup records active skills. A file on
-disk that was never activated cannot fire, and nothing warns you: it sits there looking finished
-while the situation it was written for goes unhandled.

--- a/agent/skills/emergency/SKILL.md
+++ b/agent/skills/emergency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: emergency
-description: Someone is hurt, ill, in danger, or in crisis. Use the moment a message describes symptoms, injury, an accident, poisoning or overdose, an allergic reaction, chest pain, bleeding, someone unconscious, not breathing, not waking up, a pregnancy problem, a child who is unwell, or anyone talking about suicide or self-harm. Covers what to ask, when to stop asking, what to do when calling for help is not possible or not safe, and what you must never say.
+description: Someone is hurt, ill, in danger, or in crisis. Use the moment a message describes symptoms, injury, an accident, poisoning or overdose, an allergic reaction, chest pain, bleeding, someone unconscious, not breathing, not waking up, a pregnancy problem, a child who is unwell, or anyone talking about suicide or self-harm.
 ---
 
 # Emergency
@@ -209,10 +209,20 @@ family, and let the patient choose who is told.
   suspected heart attack: those need a centre with specific capability, and a local department
   without a scanner can burn the window that is the whole treatment. That is another reason to call
   rather than drive, because the ambulance chooses the destination.
-- **Send in this order:** the number first, because it needs no verification; then a maps link rather
-  than a prose address; then a phone number; then "confirm they are open when you call".
+- **Send in this order:** the emergency-services number first, because it needs no verification; then
+  a maps link rather than a prose address; then the facility's own phone number; then "confirm they
+  are open when you call".
 - **Mark what you have not verified, in the same breath.** "This should be the nearest, confirm with
-  the driver" costs nothing.
+  the driver" costs nothing. Urgency makes you *sound* certain, which is a different failure from
+  being wrong, and speed and honesty were never actually in conflict.
+- **A facility's phone number from a search snippet or a directory is the LEAST reliable thing you
+  will send, and it looks the most authoritative.** In the real case this file was built on, the
+  hospital and the street were right and the phone number was DEAD: a stale third-party listing for
+  a hospital that had since been renamed and renumbered. It cost nothing only because they took a
+  taxi and never rang it. So give the number from the FACILITY'S OWN SITE or say you have not
+  confirmed it, and remember the hierarchy: the emergency-services number is stable and public, an
+  address is fairly stable, a facility's direct line goes stale silently. Never let a phone number
+  be the only route you give.
 - **Be the memory.** Offer to hold the details: what was taken and when, the time symptoms started,
   allergies, regular medications, existing conditions, and afterwards what they were actually told.
 - **Help them say it clearly at the desk.** One sentence: mechanism, timeline, red flags. Then they
@@ -239,8 +249,10 @@ family, and let the patient choose who is told.
   data when the user is alone, after a self-harm disclosure, or when the last thing you heard was
   deterioration. Know which case you are in.
 - Never let a staged reminder or scheduled nudge fire into a live emergency. If one is due within
-  the hour, kill it now; anything further out waits for Afterwards. A cheerful reminder about a job
-  application landing mid-crisis is its own small cruelty.
+  the hour, **snooze it** (`tasks remind snooze <id> --in-hours N`); anything further out waits for
+  Afterwards. A cheerful reminder about a job application landing mid-crisis is its own small
+  cruelty. **Snooze, never delete**: deleting is unrecoverable, and it silently drops something the
+  user is counting on at the exact moment they have no attention to notice it missing.
 - Never compact or restart context mid-emergency if you can defer it. **Append** the live state to
   `data/LIVE-<what>-<date>.md` line by line as it happens, so a restart cannot lose the thread.
   Append, do not compose; writing a document is attention the patient is owed.
@@ -249,7 +261,8 @@ family, and let the patient choose who is told.
 
 Stand down deliberately. Re-examine every decision that was contingent on the outcome, alarms you
 were going to cancel, plans you were going to change, and put back the ones that no longer need
-changing. **Kill any staged reminder that would now fire into the aftermath.** Ask what the outcome
+changing. **Snooze any staged reminder that would now fire into the aftermath**, and tell the user
+you moved it rather than moving it silently. Ask what the outcome
 actually was: "sent home comfortable" is not "ruled out", and whether they were imaged or just looked
 at is worth knowing. Then leave them alone. Aftercare advice, if you have any worth giving, is
 offered ONCE at a natural moment, never fired at an exhausted person at dawn.
@@ -271,21 +284,8 @@ Do this when nothing is happening, because at 03:00 there is no time:
 - Keep it in one file per region, `data/emergency-reference-<region>.md`, built before travel, with
   **every line tagged with how it was verified** or explicitly marked unverified.
 
-## The lesson this file was built on
+## Before you need it
 
-Written after a real one: an adult, abroad, at night, whose throat closed after violent vomiting,
-with chest pain and blood. Escalated, seen, and fine.
-
-**Under time pressure my verification discipline collapsed.** I told them a hospital was the best in
-the city and passed on an address and phone from a search-result summary, having opened none of it.
-It happened to be right.
-
-The trade was correct: a plausible nearby hospital now beats a verified one in twenty minutes. **But
-speed and honesty were never in conflict.** I could have kept every second and still said "this
-should be the nearest, confirm with the driver". Urgency made me *sound* certain, which is a
-different failure from being wrong. Hence the send-order above: the number needs no verification and
-goes first, and everything after it carries its uncertainty out loud.
-
-The second lesson took longer to surface. **I wrote this skill and did not activate it**, so for
-several hours it could not have fired at all. A skill that exists and is not switched on is worth
-nothing. Check that it is live.
+**Check this skill is actually switched on**, wherever your setup records active skills. A file on
+disk that was never activated cannot fire, and nothing warns you: it sits there looking finished
+while the situation it was written for goes unhandled.

--- a/agent/skills/moneypot/SETUP.md
+++ b/agent/skills/moneypot/SETUP.md
@@ -1,0 +1,46 @@
+# Moneypot setup
+
+The **CLI needs no setup**: `moneypot ...` works immediately and creates `~/agent/data/moneypot.json` on first write. If the command is not on PATH yet, link it:
+
+```bash
+ln -sf ~/agent/skills/moneypot/moneypot ~/.local/bin/moneypot
+```
+
+The **HTTP API is optional**. It is a stdlib JSON server over the same pot data, for a dashboard or another app, and its lifecycle is a daemon owned by the CLI:
+
+```bash
+moneypot daemon start     # registers a private port with vestad, launches, returns once it answers
+moneypot daemon status    # {"running":true,"port":NNNNN}
+moneypot daemon stop
+moneypot daemon restart
+```
+
+`start` is idempotent, so re-running it never stacks a second copy, and it returns only once the API actually answers on its port. The port is registered **private**, which is what you want: the API is read with the app credential (the dashboard sends `Authorization: Bearer $AGENT_TOKEN` for you), and anyone else is handed a minted service key rather than an open URL.
+
+To hand the API to a caller that holds no app credential:
+
+```bash
+service-key mint moneypot     # prints a one-time secret; share the keyed link
+```
+
+**Optional extra app key.** Set `MONEYPOT_API_KEY` in `~/.bashrc` to require your own key on every route except `/health`. The agent token keeps working alongside it, so a dashboard is unaffected:
+
+```bash
+echo "export MONEYPOT_API_KEY=$(python3 -c 'import secrets; print(secrets.token_urlsafe(24))')" >> ~/.bashrc
+```
+
+Callers then send `X-API-Key: <key>` (or `Authorization: Bearer <key>`).
+
+Add the startup line to the `## Daemons` section of `~/agent/skills/restart/SKILL.md` so the API comes back after a restart. It is the bare command, nothing around it, because start is idempotent:
+
+```bash
+moneypot daemon start
+```
+
+Verify:
+
+```bash
+curl -s "http://localhost:$(cat ~/agent/data/daemons/moneypot.port)/health"
+```
+
+Stdlib only, no dependencies to install.

--- a/agent/skills/moneypot/SETUP.md
+++ b/agent/skills/moneypot/SETUP.md
@@ -6,7 +6,7 @@ The **CLI needs no setup**: `moneypot ...` works immediately and creates `~/agen
 ln -sf ~/agent/skills/moneypot/moneypot ~/.local/bin/moneypot
 ```
 
-The **HTTP API is optional**. It is a stdlib JSON server over the same pot data, for a dashboard or another app, and its lifecycle is a daemon owned by the CLI:
+The **HTTP API is optional**. It is a stdlib JSON server over the same pot data, for another app that needs to read or write pots over HTTP, and its lifecycle is a daemon owned by the CLI:
 
 ```bash
 moneypot daemon start     # registers a private port with vestad, launches, returns once it answers
@@ -15,21 +15,13 @@ moneypot daemon stop
 moneypot daemon restart
 ```
 
-`start` is idempotent, so re-running it never stacks a second copy, and it returns only once the API actually answers on its port. The port is registered **private**, which is what you want: the API is read with the app credential (the dashboard sends `Authorization: Bearer $AGENT_TOKEN` for you), and anyone else is handed a minted service key rather than an open URL.
+`start` is idempotent, so re-running it never stacks a second copy, and it returns only once the API actually answers on its port.
 
-To hand the API to a caller that holds no app credential:
-
-```bash
-service-key mint moneypot     # prints a one-time secret; share the keyed link
-```
-
-**Optional extra app key.** Set `MONEYPOT_API_KEY` in `~/.bashrc` to require your own key on every route except `/health`. The agent token keeps working alongside it, so a dashboard is unaffected:
+The port is registered **private**, so vestad is the gate in front of it and the API itself checks no credential. Reach it at `$VESTAD_TUNNEL/agents/$AGENT_NAME/moneypot/...` with the app api key, or mint a service key for a caller that holds no app credential:
 
 ```bash
-echo "export MONEYPOT_API_KEY=$(python3 -c 'import secrets; print(secrets.token_urlsafe(24))')" >> ~/.bashrc
+service-key mint moneypot --label "what it is for"     # prints the secret once; share the keyed link
 ```
-
-Callers then send `X-API-Key: <key>` (or `Authorization: Bearer <key>`).
 
 Add the startup line to the `## Daemons` section of `~/agent/skills/restart/SKILL.md` so the API comes back after a restart. It is the bare command, nothing around it, because start is idempotent:
 

--- a/agent/skills/moneypot/SKILL.md
+++ b/agent/skills/moneypot/SKILL.md
@@ -81,6 +81,29 @@ contributions into 'Joint':
    Bob  £50.00
 ```
 
+## HTTP API (optional)
+
+`server.py` is a stdlib JSON API over the same data, for dashboards or other apps. Mutations are lock-serialized. Run it with `moneypot daemon start|stop|restart|status` (idempotent; registers its own private port, records pid and port under `~/agent/data/daemons/`, logs to `~/agent/logs/moneypot.log`). See `SETUP.md` for keys and the restart line. Routes:
+
+```
+GET    /health
+GET    /pots                                list pots
+POST   /pots                                {id, name?, currency?, members:[...]}
+GET    /pots/{id}                           full pot
+DELETE /pots/{id}
+GET    /pots/{id}/entries
+POST   /pots/{id}/members                   {name}
+POST   /pots/{id}/expenses                  {payer, amount, desc?, currency?, rate?, fetch?, for?:[...], split?:{Name:amt}}
+POST   /pots/{id}/transfers                 {from, to, amount, desc?, currency?, rate?, fetch?}
+DELETE /pots/{id}/entries/{eid}
+GET    /pots/{id}/balance
+GET    /pots/{id}/contributions?account=X
+```
+
+Errors return `{"error": "..."}` with HTTP 400 (bad input), 404 (no route), or 401 (bad key).
+
+**Public vs private.** By default the API is open. Set an app-level key with `--api-key KEY` (or `MONEYPOT_API_KEY`) to require it on every route except `/health`; callers pass `Authorization: Bearer KEY`, `X-API-Key: KEY`, otherwise 401. When a key is set, the vestad agent token (`AGENT_TOKEN` env) is also accepted via `X-Agent-Token` (or Bearer), so the service stays reachable through vestad (e.g. from the dashboard) without sharing the app key.
+
 ## Notes
 
 - `--currency` accepts any label; `GBP/USD/EUR/JPY` print with a symbol, others print the code.

--- a/agent/skills/moneypot/SKILL.md
+++ b/agent/skills/moneypot/SKILL.md
@@ -115,7 +115,7 @@ GET    /pots/{id}/balance
 GET    /pots/{id}/contributions?account=X
 ```
 
-Errors return `{"error": "..."}` with HTTP 400 (bad input) or 404 (no route). Mutations are serialized with a lock, so concurrent writes cannot clobber the file.
+Errors return `{"error": "..."}` with HTTP 400 (bad input) or 404 (no route). API mutations are serialized with a lock; the CLI writes the same file without one, so do not drive mutations through the CLI and the API at the same moment.
 
 ## Notes
 

--- a/agent/skills/moneypot/SKILL.md
+++ b/agent/skills/moneypot/SKILL.md
@@ -13,7 +13,7 @@ Run it with `moneypot <command>`. Put the command on PATH once:
 mkdir -p ~/.local/bin && ln -sf ~/agent/skills/moneypot/moneypot ~/.local/bin/moneypot
 ```
 
-It is a local CLI: nothing to start, nothing to register, no network beyond the optional live exchange-rate lookup. Data lives in `~/agent/data/moneypot.json`, created on first write.
+The CLI needs nothing running: it reads and writes `~/agent/data/moneypot.json` directly, created on first write, and touches the network only for the optional live exchange-rate lookup. The HTTP API below is separate and optional, and is the only part that starts a daemon or registers a port.
 
 ## Model
 
@@ -83,7 +83,22 @@ contributions into 'Joint':
 
 ## HTTP API (optional)
 
-`server.py` is a stdlib JSON API over the same data, for dashboards or other apps. Mutations are lock-serialized. Run it with `moneypot daemon start|stop|restart|status` (idempotent; registers its own private port, records pid and port under `~/agent/data/daemons/`, logs to `~/agent/logs/moneypot.log`). See `SETUP.md` for keys and the restart line. Routes:
+`moneypot daemon start|stop|restart|status` serves the same pot data as JSON over HTTP, for another app that needs to read or write pots without shelling out to the CLI. Nothing in the CLI needs it.
+
+Start is idempotent (a live daemon is a no-op) and owns the port registration with vestad; stop is the deliberate shutdown; status reads the pid and port records under `~/agent/data/daemons/`, so it answers while vestad is down. Logs go to `~/agent/logs/moneypot.log`. Manage the daemon only through these commands, never by launching `server.py` yourself.
+
+The port is registered private, so vestad is the gate in front of it and the API itself checks no credential. Reach it at `$VESTAD_TUNNEL/agents/$AGENT_NAME/moneypot/...` with the app api key, or mint a service key for a caller that holds no app credential:
+
+```bash
+service-key mint moneypot --label "what it is for"
+```
+
+Add this line yourself, inside the fenced block in the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
+```
+moneypot daemon start
+```
+
+Routes:
 
 ```
 GET    /health
@@ -100,9 +115,7 @@ GET    /pots/{id}/balance
 GET    /pots/{id}/contributions?account=X
 ```
 
-Errors return `{"error": "..."}` with HTTP 400 (bad input), 404 (no route), or 401 (bad key).
-
-**Public vs private.** By default the API is open. Set an app-level key with `--api-key KEY` (or `MONEYPOT_API_KEY`) to require it on every route except `/health`; callers pass `Authorization: Bearer KEY`, `X-API-Key: KEY`, otherwise 401. When a key is set, the vestad agent token (`AGENT_TOKEN` env) is also accepted via `X-Agent-Token` (or Bearer), so the service stays reachable through vestad (e.g. from the dashboard) without sharing the app key.
+Errors return `{"error": "..."}` with HTTP 400 (bad input) or 404 (no route). Mutations are serialized with a lock, so concurrent writes cannot clobber the file.
 
 ## Notes
 

--- a/agent/skills/moneypot/daemon.py
+++ b/agent/skills/moneypot/daemon.py
@@ -4,7 +4,7 @@ start registers the port with vestad and records it beside the pid, stop is a SI
 serve path reads as deliberate, and status answers from those two records alone.
 
 The CLI stays the primary surface; this only governs the optional HTTP API in server.py, which
-exists so a dashboard or another app can read the same pot data over a port.
+exists so another app can read the same pot data over a port.
 """
 
 import contextlib

--- a/agent/skills/moneypot/daemon.py
+++ b/agent/skills/moneypot/daemon.py
@@ -1,0 +1,242 @@
+"""Daemon lifecycle for the moneypot HTTP API: the whole contract, owned here.
+
+start registers the port with vestad and records it beside the pid, stop is a SIGTERM the
+serve path reads as deliberate, and status answers from those two records alone.
+
+The CLI stays the primary surface; this only governs the optional HTTP API in server.py, which
+exists so a dashboard or another app can read the same pot data over a port.
+"""
+
+import contextlib
+import io
+import json
+import os
+import pathlib as pl
+import signal
+import subprocess
+import sys
+import time
+
+NAME = "moneypot"
+DAEMONS_DIR = pl.Path.home() / "agent/data/daemons"
+PIDFILE = DAEMONS_DIR / f"{NAME}.pid"
+PORTFILE = DAEMONS_DIR / f"{NAME}.port"
+LOG = pl.Path.home() / "agent/logs" / f"{NAME}.log"
+# /health is the one route that answers without the api key, so it is the readiness probe.
+READY_URL_PATH = "health"
+USAGE = f"Usage: {NAME} daemon <start|stop|restart|status>"
+POLL_SECS = 0.5
+# How long a start that lost the record claim waits for the rival start to resolve.
+CLAIM_WAIT_SECS = 3
+# One hung connection must not eat the whole readiness budget.
+PROBE_TIMEOUT_SECS = 2
+
+
+def _budget(name: str, default: int) -> int:
+    return int(os.environ[name]) if name in os.environ else default
+
+
+READY_TIMEOUT_SECS = _budget("DAEMON_READY_TIMEOUT_SECS", 30)
+STOP_TIMEOUT_SECS = _budget("DAEMON_STOP_TIMEOUT_SECS", 15)
+
+
+def _fail(message: str) -> int:
+    print(json.dumps({"error": message}), file=sys.stderr)
+    return 1
+
+
+def _alive(pid: int) -> bool:
+    """True only for a process that is actually running.
+
+    A signal-0 probe cannot answer this: start exits once it has spawned the daemon, so the daemon
+    reparents to init and a dead one's pid lingers unreaped, answering the probe like a live
+    process. Without this, a stopped daemon reads as running: stop reports it would not die when it
+    is already gone, status claims a corpse is live, and the next start no-ops onto nothing.
+    /proc's state code distinguishes the corpse; the comm field can hold spaces and parens, so the
+    state is read relative to its closing paren rather than by splitting on whitespace.
+    (Same reasoning as `_alive` in the browser skill's handover.)
+    """
+    try:
+        stat = (pl.Path("/proc") / str(pid) / "stat").read_text()
+    except (FileNotFoundError, ProcessLookupError, PermissionError, OSError):
+        return False
+    comm_end = stat.rfind(") ")
+    if comm_end == -1:
+        return False
+    return stat[comm_end + 2] != "Z"
+
+
+def live_pid() -> int | None:
+    try:
+        pid = int(PIDFILE.read_text().strip())
+        os.kill(pid, 0)
+    except (FileNotFoundError, ValueError, ProcessLookupError, PermissionError):
+        return None
+    return pid if _alive(pid) else None
+
+
+def _register_port() -> str | None:
+    """Registered private: the API is read with the app credential (or a minted service key), so it
+    never needs to load for an anonymous browser."""
+    result = subprocess.run(["register-service", NAME], capture_output=True, text=True, check=False)
+    port = result.stdout.strip()
+    return port if result.returncode == 0 and port else None
+
+
+def _ready(port: str) -> bool:
+    probe = subprocess.run(
+        ["curl", "-m", str(PROBE_TIMEOUT_SECS), "-fsS", "-o", "/dev/null", f"http://localhost:{port}/{READY_URL_PATH}"],
+        capture_output=True,
+        check=False,
+    )
+    return probe.returncode == 0
+
+
+def _abandon(child: subprocess.Popen[bytes], message: str) -> int:
+    """A start that gives up takes its child and both records with it: a daemon nothing can reach,
+    with records that say it is up, reads as running and turns every later start into a no-op."""
+    child.terminate()
+    try:
+        child.wait(timeout=STOP_TIMEOUT_SECS)
+    except subprocess.TimeoutExpired:
+        child.kill()
+        child.wait()
+    PIDFILE.unlink(missing_ok=True)
+    PORTFILE.unlink(missing_ok=True)
+    return _fail(message)
+
+
+def _await_ready(child: subprocess.Popen[bytes], port: str) -> int:
+    """Holds the start open until the daemon it spawned answers on its port, which is what lets
+    the caller's next line use the service."""
+    deadline = time.monotonic() + READY_TIMEOUT_SECS
+    while time.monotonic() < deadline:
+        if child.poll() is not None:
+            return _abandon(child, f"{NAME} exited during startup; see {LOG}")
+        if _ready(port):
+            print(json.dumps({"status": "started"}))
+            return 0
+        time.sleep(POLL_SECS)
+    return _abandon(child, f"{NAME} never answered on port {port}; see {LOG}")
+
+
+def _claim(pid: int) -> bool:
+    try:
+        record = os.open(PIDFILE, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError:
+        return False
+    with os.fdopen(record, "w") as handle:
+        handle.write(str(pid))
+    return True
+
+
+def _claim_start() -> int | None:
+    """Takes the pid record exclusively for this start, so a start that loses the claim answers
+    already_running instead of stacking a daemon beside the winner's. A record no process stands
+    behind is cleared and taken over, which is the one path on which two starts can both spawn, and
+    the duplicate loses on its own resources. None means this start owns the record and everything
+    it later removes; anything else is this start's whole answer."""
+    if _claim(os.getpid()):
+        return None
+    deadline = time.monotonic() + CLAIM_WAIT_SECS
+    while time.monotonic() < deadline:
+        if live_pid() is not None:
+            print(json.dumps({"status": "already_running"}))
+            return 0
+        if not PIDFILE.exists():
+            break
+        time.sleep(POLL_SECS)
+    PIDFILE.unlink(missing_ok=True)
+    if _claim(os.getpid()):
+        return None
+    return _fail(f"another {NAME} start holds {PIDFILE}")
+
+
+def _serve_argv(port: str) -> list[str]:
+    """The daemon runs the skill's own server module, so the launch does not depend on how the CLI
+    itself was invoked (console script, `python3 moneypot.py`, or the `moneypot` shell launcher)."""
+    return [sys.executable, str(pl.Path(__file__).resolve().parent / "server.py"), "--port", port]
+
+
+def _start() -> int:
+    if live_pid() is not None:
+        print(json.dumps({"status": "already_running"}))
+        return 0
+    DAEMONS_DIR.mkdir(parents=True, exist_ok=True)
+    LOG.parent.mkdir(parents=True, exist_ok=True)
+    answer = _claim_start()
+    if answer is not None:
+        return answer
+    port = _register_port()
+    if port is None:
+        PIDFILE.unlink(missing_ok=True)
+        return _fail(f"could not register {NAME} with vestad; not launching")
+    PORTFILE.write_text(port)
+    with LOG.open("ab") as log:
+        child = subprocess.Popen(_serve_argv(port), start_new_session=True, stdout=log, stderr=log)
+    PIDFILE.write_text(str(child.pid))
+    return _await_ready(child, port)
+
+
+def _await_gone(deadline: float) -> bool:
+    """Waits out the daemon until a deadline shared with the rest of this stop. Answers whether
+    the process the record names is gone."""
+    while time.monotonic() < deadline:
+        if live_pid() is None:
+            return True
+        time.sleep(POLL_SECS)
+    return live_pid() is None
+
+
+def _stop() -> int:
+    """SIGTERM then, for a daemon that ignored it, SIGKILL, both inside the one stop budget,
+    so the verb ends the daemon rather than handing back a record it cannot honour. A daemon
+    that exits between the check and the signal is the stop it was asked for, not an error."""
+    pid = live_pid()
+    if pid is None:
+        print(json.dumps({"status": "already_stopped"}))
+        return 0
+    started = time.monotonic()
+    with contextlib.suppress(ProcessLookupError):
+        os.kill(pid, signal.SIGTERM)
+    # Two thirds of the budget in, a daemon that has not honoured SIGTERM is killed instead, and
+    # the remainder is what reaps it. Read here, not at import, so the budget in force is the one
+    # the caller set.
+    if not _await_gone(started + STOP_TIMEOUT_SECS * 2 // 3):
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(pid, signal.SIGKILL)
+        if not _await_gone(started + STOP_TIMEOUT_SECS):
+            return _fail(f"{NAME} still running {STOP_TIMEOUT_SECS}s after SIGTERM then SIGKILL (pid={pid})")
+    PIDFILE.unlink(missing_ok=True)
+    PORTFILE.unlink(missing_ok=True)
+    print(json.dumps({"status": "stopped"}))
+    return 0
+
+
+def _status() -> int:
+    """Reads the port start recorded, never registration, so status answers instantly and
+    truthfully while vestad is down."""
+    running = live_pid() is not None
+    port = PORTFILE.read_text().strip() if running and PORTFILE.exists() else ""
+    print(json.dumps({"running": running, "port": int(port) if port else None}))
+    return 0
+
+
+def daemon_cmd(action: str) -> int:
+    if action in ("", "-h", "--help", "help"):
+        print(USAGE)
+        return 0
+    if action == "start":
+        return _start()
+    if action == "stop":
+        return _stop()
+    if action == "restart":
+        # One verb, one line of output: the stop half is swallowed, and a stop that failed
+        # must not be followed by a start onto a daemon that is still there.
+        with contextlib.redirect_stdout(io.StringIO()):
+            stopped = _stop()
+        return _start() if stopped == 0 else stopped
+    if action == "status":
+        return _status()
+    print(USAGE, file=sys.stderr)
+    return 1

--- a/agent/skills/moneypot/daemon.py
+++ b/agent/skills/moneypot/daemon.py
@@ -65,12 +65,53 @@ def _alive(pid: int) -> bool:
     return stat[comm_end + 2] != "Z"
 
 
-def live_pid() -> int | None:
+def _starttime(pid: int) -> int | None:
+    """Field 22 of /proc/<pid>/stat: the process start time in clock ticks since boot.
+
+    A recycled pid cannot share the original's starttime, because the process that took the pid
+    necessarily started later, so (pid, starttime) is a stable identity. Returns None where /proc
+    is unreadable, which drops the caller back to a bare pid-existence check.
+    """
     try:
-        pid = int(PIDFILE.read_text().strip())
-        os.kill(pid, 0)
-    except (FileNotFoundError, ValueError, ProcessLookupError, PermissionError):
+        stat = (pl.Path("/proc") / str(pid) / "stat").read_text()
+        # comm is a bracketed field that may itself contain spaces and parentheses, so the
+        # numbered fields resume after the LAST ')'.
+        return int(stat[stat.rindex(")") + 2 :].split()[19])
+    except (OSError, ValueError, IndexError):
         return None
+
+
+def _record(pid: int) -> str:
+    """The pid record: "<pid> <starttime>", or a bare pid where the starttime is unavailable.
+
+    A bare pid is the honest form of "identity unknown", and live_pid() reads it the legacy way
+    rather than as a mismatch.
+    """
+    started = _starttime(pid)
+    return f"{pid} {started}" if started is not None else str(pid)
+
+
+def live_pid() -> int | None:
+    """The recorded pid, but only while it is still the process that was recorded and not a zombie.
+
+    os.kill(pid, 0) answers "does some process hold this pid", never "is this still mine", so the
+    recorded starttime is compared against the live process before the record is trusted.
+    """
+    try:
+        record = PIDFILE.read_text().split()
+        pid = int(record[0])
+        os.kill(pid, 0)
+    except (FileNotFoundError, IndexError, ValueError, ProcessLookupError, PermissionError):
+        return None
+    # LEGACY(remove-when: no daemon record predating the release that ships this check remains, i.e.
+    # every box has restarted its daemons at least once on this version): a record written by the
+    # old code is a bare pid. Trust it as before rather than reading the absence of a starttime as a
+    # mismatch, because an upgrade must not declare a live daemon dead and let a second stack beside
+    # it. Once records have converged, an unparseable second field should read as dead, not as legacy.
+    if len(record) > 1 and record[1].isdigit():
+        current = _starttime(pid)
+        if current is not None and current != int(record[1]):
+            return None
     return pid if _alive(pid) else None
 
 
@@ -125,7 +166,7 @@ def _claim(pid: int) -> bool:
     except FileExistsError:
         return False
     with os.fdopen(record, "w") as handle:
-        handle.write(str(pid))
+        handle.write(_record(pid))
     return True
 
 
@@ -172,8 +213,8 @@ def _start() -> int:
         return _fail(f"could not register {NAME} with vestad; not launching")
     PORTFILE.write_text(port)
     with LOG.open("ab") as log:
-        child = subprocess.Popen(_serve_argv(port), start_new_session=True, stdout=log, stderr=log)
-    PIDFILE.write_text(str(child.pid))
+        child = subprocess.Popen(_serve_argv(port), start_new_session=True, stdout=log, stderr=log, env={**os.environ, "PYTHONUNBUFFERED": "1"})
+    PIDFILE.write_text(_record(child.pid))
     return _await_ready(child, port)
 
 

--- a/agent/skills/moneypot/daemon.py
+++ b/agent/skills/moneypot/daemon.py
@@ -57,7 +57,7 @@ def _alive(pid: int) -> bool:
     """
     try:
         stat = (pl.Path("/proc") / str(pid) / "stat").read_text()
-    except (FileNotFoundError, ProcessLookupError, PermissionError, OSError):
+    except OSError:
         return False
     comm_end = stat.rfind(") ")
     if comm_end == -1:

--- a/agent/skills/moneypot/daemon.py
+++ b/agent/skills/moneypot/daemon.py
@@ -22,7 +22,6 @@ DAEMONS_DIR = pl.Path.home() / "agent/data/daemons"
 PIDFILE = DAEMONS_DIR / f"{NAME}.pid"
 PORTFILE = DAEMONS_DIR / f"{NAME}.port"
 LOG = pl.Path.home() / "agent/logs" / f"{NAME}.log"
-# /health is the one route that answers without the api key, so it is the readiness probe.
 READY_URL_PATH = "health"
 USAGE = f"Usage: {NAME} daemon <start|stop|restart|status>"
 POLL_SECS = 0.5

--- a/agent/skills/moneypot/moneypot.py
+++ b/agent/skills/moneypot/moneypot.py
@@ -677,7 +677,10 @@ def cmd_daemon(args) -> None:
 
 def _add_daemon_parser(sub) -> None:
     d = sub.add_parser("daemon", help="run the optional HTTP API as a background daemon")
-    d.add_argument("action", nargs="?", choices=["start", "stop", "restart", "status"])
+    # No `choices`: daemon_cmd owns the verb set, so it is what answers `help` with usage and exit 0,
+    # and an unknown verb with usage and exit 1. Listing them here too would make argparse reject
+    # `help` as invalid before either answer could be given.
+    d.add_argument("action", nargs="?", metavar="start|stop|restart|status")
     d.set_defaults(func=cmd_daemon)
 
 

--- a/agent/skills/moneypot/moneypot.py
+++ b/agent/skills/moneypot/moneypot.py
@@ -667,6 +667,20 @@ def _add_view_parsers(sub) -> None:
     de.set_defaults(func=cmd_delete_entry)
 
 
+def cmd_daemon(args) -> None:
+    """Lifecycle for the optional HTTP API in server.py. Imported lazily so the CLI, which is the
+    primary surface and needs none of it, does not pay for the import on every command."""
+    from daemon import daemon_cmd
+
+    raise SystemExit(daemon_cmd(args.action or ""))
+
+
+def _add_daemon_parser(sub) -> None:
+    d = sub.add_parser("daemon", help="run the optional HTTP API as a background daemon")
+    d.add_argument("action", nargs="?", choices=["start", "stop", "restart", "status"])
+    d.set_defaults(func=cmd_daemon)
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="moneypot", description="Shared expense & pot tracker (Splitwise/Tricount style).")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -674,6 +688,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_member_parser(sub)
     _add_entry_parsers(sub)
     _add_view_parsers(sub)
+    _add_daemon_parser(sub)
     return p
 
 

--- a/agent/skills/moneypot/server.py
+++ b/agent/skills/moneypot/server.py
@@ -5,7 +5,8 @@ Stdlib only. Shares the same ~/agent/data/moneypot.json as the CLI. Mutations ar
 serialized with a lock so concurrent requests don't clobber the file.
 
 Run:  python3 server.py --port 8080
-Then register the port with vestad to expose it (see SETUP.md).
+`moneypot daemon start` is what launches it, on the private port it registers with vestad.
+vestad gates that port, so every route here answers an already-authorized request.
 
 Endpoints
   GET    /health
@@ -26,7 +27,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -35,21 +35,6 @@ from urllib.parse import parse_qs, urlparse
 import moneypot as mp
 
 LOCK = threading.Lock()
-
-
-# When set (via --api-key or MONEYPOT_API_KEY), every request except /health must
-# present a valid credential. Two credentials are accepted: the app key, and the
-# vestad agent token (AGENT_TOKEN) so the request is reachable through vestad
-# (e.g. the dashboard) without sharing the app key. When no app key is set, the
-# API is open. Headers checked: Authorization: Bearer, X-API-Key, X-Agent-Token.
-# One mutable holder rather than two module globals reassigned from main(), so the auth config has
-# a single owner and needs no `global` statement.
-class _Auth:
-    api_key: str | None = None
-    agent_token: str | None = None
-
-
-AUTH = _Auth()
 
 
 # Reads take no lock and need none: mp.save writes a temp file and renames it over the target, so a
@@ -111,24 +96,6 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-    def _authed(self) -> bool:
-        """True if allowed: no key configured, or a credential matching the app
-        key or the vestad agent token."""
-        if not AUTH.api_key:
-            return True
-        if urlparse(self.path).path.rstrip("/") in ("/health", ""):
-            return True
-        valid = {k for k in (AUTH.api_key, AUTH.agent_token) if k}
-        presented = set()
-        auth = self.headers.get("Authorization", "")
-        if auth.startswith("Bearer "):
-            presented.add(auth[7:].strip())
-        for h in ("X-API-Key", "X-Agent-Token"):
-            v = self.headers.get(h, "").strip()
-            if v:
-                presented.add(v)
-        return bool(presented & valid)
-
     def _body(self) -> dict:
         n = int(self.headers.get("Content-Length", 0) or 0)
         if not n:
@@ -145,8 +112,6 @@ class Handler(BaseHTTPRequestHandler):
     # -------- routing --------
 
     def do_GET(self):
-        if not self._authed():
-            return self._send(401, {"error": "missing or invalid API key"})
         try:
             self._route_get()
         except mp.MoneypotError as e:
@@ -155,8 +120,6 @@ class Handler(BaseHTTPRequestHandler):
             self._send(500, {"error": str(e)})
 
     def do_POST(self):
-        if not self._authed():
-            return self._send(401, {"error": "missing or invalid API key"})
         try:
             self._route_post()
         except mp.MoneypotError as e:
@@ -165,8 +128,6 @@ class Handler(BaseHTTPRequestHandler):
             self._send(500, {"error": str(e)})
 
     def do_DELETE(self):
-        if not self._authed():
-            return self._send(401, {"error": "missing or invalid API key"})
         try:
             self._route_delete()
         except mp.MoneypotError as e:
@@ -272,17 +233,9 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--port", type=int, default=8080)
     ap.add_argument("--host", default="0.0.0.0")
-    ap.add_argument(
-        "--api-key",
-        default=os.environ.get("MONEYPOT_API_KEY"),
-        help="require this key on all routes except /health (also via MONEYPOT_API_KEY). Omit for an open API.",
-    )
     args = ap.parse_args()
-    AUTH.api_key = args.api_key or None
-    AUTH.agent_token = os.environ.get("AGENT_TOKEN") or None  # also accepted when an app key is set
     srv = ThreadingHTTPServer((args.host, args.port), Handler)
-    mode = "private (api key required)" if AUTH.api_key else "open (no auth)"
-    print(f"moneypot API on {args.host}:{args.port} - {mode}", flush=True)
+    print(f"moneypot API on {args.host}:{args.port}", flush=True)
     srv.serve_forever()
 
 

--- a/agent/skills/moneypot/server.py
+++ b/agent/skills/moneypot/server.py
@@ -52,12 +52,9 @@ class _Auth:
 AUTH = _Auth()
 
 
-def _read(fn):
-    """Reads under the lock. The callable takes the freshly loaded data, so no caller passes it in."""
-    with LOCK:
-        return fn(mp.load())
-
-
+# Reads take no lock and need none: mp.save writes a temp file and renames it over the target, so a
+# reader sees either the whole previous file or the whole new one, never a torn write. Only mutations
+# serialize, because a read-modify-write pair would otherwise lose one of two concurrent updates.
 def _write(fn):
     with LOCK:
         data = mp.load()

--- a/agent/skills/moneypot/server.py
+++ b/agent/skills/moneypot/server.py
@@ -98,9 +98,13 @@ _GET_POT_ROUTES = (
 class Handler(BaseHTTPRequestHandler):
     server_version = "moneypot/1.0"
 
-    # Signature matches BaseHTTPRequestHandler.log_message, so the override stays substitutable.
-    def log_message(self, format, *args):  # noqa: A002
-        """Quiet: per-request lines say nothing the daemon log does not already carry."""
+    def log_message(self, fmt: str, *args: object) -> None:
+        """Quiet: per-request lines say nothing the daemon log does not already carry.
+
+        The base declares its first parameter as `format`, but every caller in http.server passes it
+        positionally, so renaming it here keeps the override substitutable without shadowing the
+        builtin.
+        """
 
     def _send(self, code, payload):
         body = json.dumps(payload, ensure_ascii=False).encode()

--- a/agent/skills/moneypot/server.py
+++ b/agent/skills/moneypot/server.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""moneypot HTTP API - a thin JSON wrapper over the moneypot service layer.
+
+Stdlib only. Shares the same ~/agent/data/moneypot.json as the CLI. Mutations are
+serialized with a lock so concurrent requests don't clobber the file.
+
+Run:  python3 server.py --port 8080
+Then register the port with vestad to expose it (see SETUP.md).
+
+Endpoints
+  GET    /health
+  GET    /pots                                list pots (summaries)
+  POST   /pots                                {id, name?, currency?, members:[...]}
+  GET    /pots/{id}                           full pot
+  DELETE /pots/{id}                           delete pot
+  GET    /pots/{id}/entries                   entry history
+  POST   /pots/{id}/members                   {name}
+  POST   /pots/{id}/expenses                  {payer, amount, desc?, currency?, rate?, fetch?, for?:[...], split?:{Name:amt}}
+  POST   /pots/{id}/transfers                 {from, to, amount, desc?, currency?, rate?, fetch?}
+  DELETE /pots/{id}/entries/{eid}             delete entry
+  GET    /pots/{id}/balance                   balances + settle-up
+  GET    /pots/{id}/contributions?account=X   joint-account view
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import moneypot as mp
+
+LOCK = threading.Lock()
+
+
+# When set (via --api-key or MONEYPOT_API_KEY), every request except /health must
+# present a valid credential. Two credentials are accepted: the app key, and the
+# vestad agent token (AGENT_TOKEN) so the request is reachable through vestad
+# (e.g. the dashboard) without sharing the app key. When no app key is set, the
+# API is open. Headers checked: Authorization: Bearer, X-API-Key, X-Agent-Token.
+# One mutable holder rather than two module globals reassigned from main(), so the auth config has
+# a single owner and needs no `global` statement.
+class _Auth:
+    api_key: str | None = None
+    agent_token: str | None = None
+
+
+AUTH = _Auth()
+
+
+def _read(fn):
+    """Reads under the lock. The callable takes the freshly loaded data, so no caller passes it in."""
+    with LOCK:
+        return fn(mp.load())
+
+
+def _write(fn):
+    with LOCK:
+        data = mp.load()
+        result = fn(data)
+        mp.save(data)
+        return result
+
+
+def _view_pot(pot_id, _q):
+    return mp.get_pot(mp.load(), pot_id)
+
+
+def _view_entries(pot_id, _q):
+    return mp.get_pot(mp.load(), pot_id)["entries"]
+
+
+def _view_balance(pot_id, _q):
+    return mp.balance(mp.load(), pot_id)
+
+
+def _view_contributions(pot_id, q):
+    account = (q.get("account") or [None])[0]
+    if not account:
+        raise mp.MoneypotError("?account= is required")
+    return mp.contributions(mp.load(), pot_id, account)
+
+
+# The per-pot GET routes, as (pattern, view). fullmatch means a longer path can never be swallowed
+# by the bare /pots/{id} pattern, so order here is presentational rather than load-bearing.
+_GET_POT_ROUTES = (
+    (r"/pots/([^/]+)", _view_pot),
+    (r"/pots/([^/]+)/entries", _view_entries),
+    (r"/pots/([^/]+)/balance", _view_balance),
+    (r"/pots/([^/]+)/contributions", _view_contributions),
+)
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "moneypot/1.0"
+
+    # Signature matches BaseHTTPRequestHandler.log_message, so the override stays substitutable.
+    def log_message(self, format, *args):  # noqa: A002
+        """Quiet: per-request lines say nothing the daemon log does not already carry."""
+
+    def _send(self, code, payload):
+        body = json.dumps(payload, ensure_ascii=False).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _authed(self) -> bool:
+        """True if allowed: no key configured, or a credential matching the app
+        key or the vestad agent token."""
+        if not AUTH.api_key:
+            return True
+        if urlparse(self.path).path.rstrip("/") in ("/health", ""):
+            return True
+        valid = {k for k in (AUTH.api_key, AUTH.agent_token) if k}
+        presented = set()
+        auth = self.headers.get("Authorization", "")
+        if auth.startswith("Bearer "):
+            presented.add(auth[7:].strip())
+        for h in ("X-API-Key", "X-Agent-Token"):
+            v = self.headers.get(h, "").strip()
+            if v:
+                presented.add(v)
+        return bool(presented & valid)
+
+    def _body(self) -> dict:
+        n = int(self.headers.get("Content-Length", 0) or 0)
+        if not n:
+            return {}
+        raw = self.rfile.read(n)
+        try:
+            d = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise mp.MoneypotError("invalid JSON body") from exc
+        if not isinstance(d, dict):
+            raise mp.MoneypotError("body must be a JSON object")
+        return d
+
+    # -------- routing --------
+
+    def do_GET(self):
+        if not self._authed():
+            return self._send(401, {"error": "missing or invalid API key"})
+        try:
+            self._route_get()
+        except mp.MoneypotError as e:
+            self._send(400, {"error": str(e)})
+        except Exception as e:
+            self._send(500, {"error": str(e)})
+
+    def do_POST(self):
+        if not self._authed():
+            return self._send(401, {"error": "missing or invalid API key"})
+        try:
+            self._route_post()
+        except mp.MoneypotError as e:
+            self._send(400, {"error": str(e)})
+        except Exception as e:
+            self._send(500, {"error": str(e)})
+
+    def do_DELETE(self):
+        if not self._authed():
+            return self._send(401, {"error": "missing or invalid API key"})
+        try:
+            self._route_delete()
+        except mp.MoneypotError as e:
+            self._send(400, {"error": str(e)})
+        except Exception as e:
+            self._send(500, {"error": str(e)})
+
+    def _get_payload(self, path, q):
+        """The GET body for a path, or None when no route matches, so the router sends exactly once."""
+        if path == "/health":
+            return {"ok": True, "service": "moneypot"}
+        if path == "/pots":
+            data = mp.load()
+            return [
+                {"id": pid, **{k: v for k, v in p.items() if k != "entries"}, "entries": len(p["entries"])} for pid, p in data["pots"].items()
+            ]
+        for pattern, view in _GET_POT_ROUTES:
+            if m := re.fullmatch(pattern, path):
+                return view(m.group(1), q)
+        return None
+
+    def _route_get(self):
+        u = urlparse(self.path)
+        path = u.path.rstrip("/") or "/"
+        payload = self._get_payload(path, parse_qs(u.query))
+        if payload is None:
+            return self._send(404, {"error": f"no route GET {path}"})
+        return self._send(200, payload)
+
+    def _route_post(self):
+        path = urlparse(self.path).path.rstrip("/") or "/"
+        b = self._body()
+        if path == "/pots":
+            pot = _write(lambda d: mp.create_pot(d, b.get("id"), b.get("name"), b.get("currency", "GBP"), b.get("members")))
+            return self._send(201, pot)
+        m = re.fullmatch(r"/pots/([^/]+)/members", path)
+        if m:
+            pid = m.group(1)
+            _write(lambda d: mp.add_member(d, pid, b.get("name")))
+            return self._send(201, {"ok": True})
+        m = re.fullmatch(r"/pots/([^/]+)/expenses", path)
+        if m:
+            pid = m.group(1)
+            e = _write(
+                lambda d: mp.add_expense(
+                    d,
+                    pid,
+                    mp.ExpenseRequest(
+                        payer=b.get("payer"),
+                        amount=b.get("amount"),
+                        desc=b.get("desc", ""),
+                        currency=b.get("currency"),
+                        rate=b.get("rate"),
+                        fetch=bool(b.get("fetch")),
+                        for_list=b.get("for"),
+                        split_map=b.get("split"),
+                    ),
+                )
+            )
+            return self._send(201, e)
+        m = re.fullmatch(r"/pots/([^/]+)/transfers", path)
+        if m:
+            pid = m.group(1)
+            e = _write(
+                lambda d: mp.add_transfer(
+                    d,
+                    pid,
+                    mp.TransferRequest(
+                        sender=b.get("from"),
+                        recipient=b.get("to"),
+                        amount=b.get("amount"),
+                        desc=b.get("desc", ""),
+                        currency=b.get("currency"),
+                        rate=b.get("rate"),
+                        fetch=bool(b.get("fetch")),
+                    ),
+                )
+            )
+            return self._send(201, e)
+        return self._send(404, {"error": f"no route POST {path}"})
+
+    def _route_delete(self):
+        path = urlparse(self.path).path.rstrip("/") or "/"
+        m = re.fullmatch(r"/pots/([^/]+)/entries/(\d+)", path)
+        if m:
+            pid, eid = m.group(1), int(m.group(2))
+            _write(lambda d: mp.remove_entry(d, pid, eid))
+            return self._send(200, {"ok": True})
+        m = re.fullmatch(r"/pots/([^/]+)", path)
+        if m:
+            pid = m.group(1)
+
+            def _del(d):
+                mp.get_pot(d, pid)
+                del d["pots"][pid]
+
+            _write(_del)
+            return self._send(200, {"ok": True})
+        return self._send(404, {"error": f"no route DELETE {path}"})
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=8080)
+    ap.add_argument("--host", default="0.0.0.0")
+    ap.add_argument(
+        "--api-key",
+        default=os.environ.get("MONEYPOT_API_KEY"),
+        help="require this key on all routes except /health (also via MONEYPOT_API_KEY). Omit for an open API.",
+    )
+    args = ap.parse_args()
+    AUTH.api_key = args.api_key or None
+    AUTH.agent_token = os.environ.get("AGENT_TOKEN") or None  # also accepted when an app key is set
+    srv = ThreadingHTTPServer((args.host, args.port), Handler)
+    mode = "private (api key required)" if AUTH.api_key else "open (no auth)"
+    print(f"moneypot API on {args.host}:{args.port} - {mode}", flush=True)
+    srv.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/tests/test_daemon_contract.py
+++ b/agent/tests/test_daemon_contract.py
@@ -171,6 +171,12 @@ SKILLS = [
         service="sign",
     ),
     Daemon(
+        command=[str(SKILLS_DIR / "moneypot/moneypot")],
+        name="moneypot",
+        serves_port=True,
+        emits_daemon_died=False,
+    ),
+    Daemon(
         command=[str(SKILLS_DIR / "dashboard/dashboard")],
         name="dashboard",
         serves_port=True,

--- a/agent/tests/test_service_exposure.py
+++ b/agent/tests/test_service_exposure.py
@@ -66,3 +66,8 @@ def test_only_named_skills_register_a_public_port_themselves():
 def test_the_signature_pad_is_never_public():
     """The pad takes a signature the agent stamps onto a document and verifies nothing itself."""
     assert "sign-service/sign-service" not in _direct_public_files()
+
+
+def test_the_shared_finance_api_is_never_public():
+    """moneypot serves the user's shared expenses and checks no credential of its own."""
+    assert "moneypot/daemon.py" not in _direct_public_files()


### PR DESCRIPTION
## In plain terms

Two new skills, consolidated from their open PRs. A third (#1827 secret-intake) was deliberately left out at the maintainer's direction.

- **moneypot** (#1632): the money-tracking skill gains an optional HTTP API behind a proper `daemon` subcommand, registered privately with vestad, so another app can read the same pot data over a port. Its daemon predated the pid-identity contract that just landed on master, so this epic converges it: the pid record now carries the process start time, liveness checks verify identity rather than existence, the child is spawned unbuffered, and both previously failing contract tests pass.
- **emergency** (#1674): a skill for the moment a message describes someone hurt, ill, or in crisis. Four jobs: triage urgency, route to someone qualified (the dispatcher where reachable), make that easier, and be the memory (times, doses, what was said). Explicitly not a clinician. Added to the default skill set so every box has it.

## Verification

- `test_daemon_contract.py` moneypot rows and the bare-pid claim sweep: green (previously both failed against the merged contract).
- `test_service_exposure.py` green (moneypot registers private).
- ruff check + format clean on the moneypot skill.

Closes #1632. Closes #1674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
