### PR TITLE
feat: per-agent automatic-backups control

### DIFF
--- a/apps/mobile/src/agent/settings/BackupsSection.tsx
+++ b/apps/mobile/src/agent/settings/BackupsSection.tsx
@@ -3,15 +3,17 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   createBackup,
   deleteBackup,
+  getAgentBackupSettings,
   listBackups,
   restoreBackup,
+  setAgentBackupSettings,
 } from "@/api/endpoints";
 import type { BackupInfo } from "@/api/types";
 import { useAgent } from "@/agent/AgentProvider";
 import { useToast } from "@/components/native-toast";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
-import { FormRow, FormSection } from "@/components/ui/Form";
+import { FormRow, FormSection, SwitchRow } from "@/components/ui/Form";
 import { ErrorState, LoadingState } from "@/components/ui/States";
 import { Text } from "@/components/ui/Typography";
 import { usePreferences } from "@/preferences/PreferencesProvider";
@@ -93,6 +95,17 @@ export function BackupsSection() {
     },
     onError: (error) => showError(error, "The backup action failed"),
   });
+  const backupSettings = useQuery({
+    queryKey: ["backup-settings", name],
+    queryFn: () => getAgentBackupSettings(api, name),
+  });
+  const toggleAuto = useMutation({
+    mutationFn: (enabled: boolean) => setAgentBackupSettings(api, name, enabled),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["backup-settings", name], updated);
+    },
+    onError: (error) => showError(error, "Could not update automatic backups"),
+  });
 
   if (backups.isLoading) return <LoadingState label="Loading backups…" />;
   if (!backups.data) {
@@ -106,6 +119,17 @@ export function BackupsSection() {
 
   return (
     <>
+      <FormSection
+        title="Automatic backups"
+        footer="Snapshot this agent automatically on the schedule and before every update."
+      >
+        <SwitchRow
+          label="Enabled"
+          value={backupSettings.data?.enabled ?? false}
+          disabled={backupSettings.isLoading || toggleAuto.isPending}
+          onValueChange={(enabled) => toggleAuto.mutate(enabled)}
+        />
+      </FormSection>
       <FormSection
         title="Snapshots"
         footer="A backup captures the agent state before a risky change. Restoring replaces the current state and restarts the agent."

--- a/apps/mobile/src/agent/settings/BackupsSection.tsx
+++ b/apps/mobile/src/agent/settings/BackupsSection.tsx
@@ -143,7 +143,19 @@ export function BackupsSection() {
       <Button
         loading={action.isPending}
         icon="cloud-upload-outline"
-        onPress={() => action.mutate({ type: "create" })}
+        onPress={() =>
+          Alert.alert(
+            "Back up now?",
+            "The agent pauses briefly while the snapshot is captured.",
+            [
+              { text: "Cancel", style: "cancel" },
+              {
+                text: "Back up",
+                onPress: () => action.mutate({ type: "create" }),
+              },
+            ],
+          )
+        }
       >
         Back up now
       </Button>

--- a/apps/mobile/src/api/endpoints.test.ts
+++ b/apps/mobile/src/api/endpoints.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { RESTART_REASONS, restartBody } from "@vesta/core";
 import type { ApiClient } from "./client";
-import { restartAgent } from "./endpoints";
+import { restartAgent, setAgentBackupSettings } from "./endpoints";
 
 function apiStub() {
   const request = vi.fn().mockResolvedValue(new Response());
@@ -36,6 +36,32 @@ describe("restartAgent", () => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(restartBody(RESTART_REASONS.context)),
+    });
+  });
+});
+
+describe("setAgentBackupSettings", () => {
+  it("PUTs the enabled flag to the per-agent backup settings path", async () => {
+    const json = vi.fn().mockResolvedValue({
+      enabled: false,
+      retention: { periodic: 2, pre_update_versions: 2 },
+      has_override: true,
+    });
+    const api = {
+      json,
+      jsonInit: (method: string, body: unknown) => ({
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    } as unknown as ApiClient;
+
+    await setAgentBackupSettings(api, "luna", false);
+
+    expect(json).toHaveBeenCalledWith("/agents/luna/settings/backup", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
     });
   });
 });

--- a/apps/mobile/src/api/endpoints.ts
+++ b/apps/mobile/src/api/endpoints.ts
@@ -14,6 +14,7 @@ import {
 } from "@vesta/core";
 import type { ApiClient } from "./client";
 import type {
+  AgentBackupSettings,
   BackupInfo,
   FileReadResponse,
   FileTreeEntry,
@@ -263,6 +264,24 @@ export async function deleteBackup(
   await api.request(
     `/agents/${encodeURIComponent(name)}/backups/${encodeURIComponent(backupId)}`,
     { method: "DELETE" },
+  );
+}
+
+export async function getAgentBackupSettings(
+  api: ApiClient,
+  name: string,
+): Promise<AgentBackupSettings> {
+  return api.json(`/agents/${encodeURIComponent(name)}/settings/backup`);
+}
+
+export async function setAgentBackupSettings(
+  api: ApiClient,
+  name: string,
+  enabled: boolean,
+): Promise<AgentBackupSettings> {
+  return api.json(
+    `/agents/${encodeURIComponent(name)}/settings/backup`,
+    api.jsonInit("PUT", { enabled }),
   );
 }
 

--- a/apps/mobile/src/api/types.ts
+++ b/apps/mobile/src/api/types.ts
@@ -125,6 +125,12 @@ export interface GatewaySettings {
   };
 }
 
+export interface AgentBackupSettings {
+  enabled: boolean;
+  retention: { periodic: number; pre_update_versions: number };
+  has_override: boolean;
+}
+
 export interface HostMount {
   host_path: string;
   container_path: string;

--- a/apps/mobile/visual/harness/session-provider.tsx
+++ b/apps/mobile/visual/harness/session-provider.tsx
@@ -299,6 +299,13 @@ function createVisualApi(): ApiClient {
           ],
         } as ResponseBody;
       }
+      if (path.endsWith("/settings/backup")) {
+        return {
+          enabled: true,
+          retention: { periodic: 2, pre_update_versions: 2 },
+          has_override: false,
+        } as ResponseBody;
+      }
       if (path.endsWith("/backups")) return backups as ResponseBody;
       if (path.includes("/voice/stt/status")) {
         return voiceStatuses.stt as ResponseBody;

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -242,6 +242,28 @@ export async function deleteBackup(
   );
 }
 
+export interface AgentBackupSettings {
+  enabled: boolean;
+  retention: { periodic: number; pre_update_versions: number };
+  has_override: boolean;
+}
+
+export async function fetchAgentBackupSettings(
+  name: string,
+): Promise<AgentBackupSettings> {
+  return apiJson(`/agents/${encodeURIComponent(name)}/settings/backup`);
+}
+
+export async function setAgentBackupSettings(
+  name: string,
+  enabled: boolean,
+): Promise<AgentBackupSettings> {
+  return apiJson(
+    `/agents/${encodeURIComponent(name)}/settings/backup`,
+    jsonInit("PUT", { enabled }),
+  );
+}
+
 /// Normalized, provider-agnostic plan usage (agent's GET /usage). `meters` are
 /// time-windowed quota gauges (Claude rate-limit buckets); `credits` is a spend balance
 /// (OpenRouter, or Claude extra-usage). Both already in display units (% and dollars).

--- a/apps/web/src/components/AgentIslandModals/index.test.tsx
+++ b/apps/web/src/components/AgentIslandModals/index.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AgentIslandModals } from "./index";
+
+const handleBackup = vi.fn();
+
+vi.mock("@/providers/SelectedAgentProvider", () => ({
+  useSelectedAgent: () => ({ name: "bob" }),
+}));
+
+vi.mock("@/providers/ModalsProvider", () => ({
+  useModals: () => ({
+    showAuth: false,
+    handleOpenAuth: vi.fn(),
+    clearAuthState: vi.fn(),
+    deleteDialogOpen: false,
+    setDeleteDialogOpen: vi.fn(),
+    handleDelete: vi.fn(),
+    backupDialogOpen: true,
+    setBackupDialogOpen: vi.fn(),
+    handleBackup,
+  }),
+}));
+
+describe("AgentIslandModals backup confirm", () => {
+  afterEach(cleanup);
+
+  it("runs the backup only after the user confirms", async () => {
+    render(<AgentIslandModals />);
+    expect(await screen.findByText("back up bob?")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "back up" }));
+    expect(handleBackup).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/AgentIslandModals/index.tsx
+++ b/apps/web/src/components/AgentIslandModals/index.tsx
@@ -30,6 +30,9 @@ export function AgentIslandModals() {
     deleteDialogOpen,
     setDeleteDialogOpen,
     handleDelete,
+    backupDialogOpen,
+    setBackupDialogOpen,
+    handleBackup,
   } = useModals();
 
   const [submitting, setSubmitting] = useState(false);
@@ -111,6 +114,28 @@ export function AgentIslandModals() {
               }}
             >
               delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={backupDialogOpen} onOpenChange={setBackupDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>back up {name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              this captures a snapshot of {name} now. {name} pauses briefly
+              while it runs.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                handleBackup();
+              }}
+            >
+              back up
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/components/AgentMenu/index.tsx
+++ b/apps/web/src/components/AgentMenu/index.tsx
@@ -27,9 +27,9 @@ export function AgentMenu() {
   const goTo = (path: string) => {
     if (location.pathname !== path) void navigate(path);
   };
-  const { name, agent, isBusy, start, stop, restart, backup } =
-    useSelectedAgent();
-  const { setDeleteDialogOpen, handleOpenAuth } = useModals();
+  const { name, agent, isBusy, start, stop, restart } = useSelectedAgent();
+  const { setDeleteDialogOpen, setBackupDialogOpen, handleOpenAuth } =
+    useModals();
   const gateway = useGateway();
   const appMode = useAppMode((s) => s.mode);
 
@@ -57,7 +57,7 @@ export function AgentMenu() {
     },
     onAgentSettings: () => goTo(`/agent/${encodeURIComponent(name)}/settings`),
     onRestart: () => void restart(),
-    onBackup: () => backup(),
+    onBackup: () => setBackupDialogOpen(true),
     onAuthenticate: gateway.reachable ? () => handleOpenAuth() : undefined,
     isAuthenticated: !agentNeedsUser(agent.status),
     onDelete: () => setDeleteDialogOpen(true),

--- a/apps/web/src/components/AgentSettings/ActionsCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ActionsCard/index.tsx
@@ -18,9 +18,9 @@ export function ActionsCard() {
     start,
     stop,
     restart,
-    backup,
   } = useSelectedAgent();
-  const { handleOpenAuth, setDeleteDialogOpen } = useModals();
+  const { handleOpenAuth, setDeleteDialogOpen, setBackupDialogOpen } =
+    useModals();
 
   const isRunning = !agentIsDown(agent.status);
   const showAliveActions = agent.status === "alive";
@@ -60,7 +60,7 @@ export function ActionsCard() {
             else start();
           }}
           onRestart={() => void restart()}
-          onBackup={() => backup()}
+          onBackup={() => setBackupDialogOpen(true)}
           onDelete={() => setDeleteDialogOpen(true)}
         />
       </CardContent>

--- a/apps/web/src/components/AgentSettings/BackupsCard/index.test.tsx
+++ b/apps/web/src/components/AgentSettings/BackupsCard/index.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as api from "@/api/agents";
+import { BackupsCard } from "./index";
+
+vi.mock("@/providers/SelectedAgentProvider", () => ({
+  useSelectedAgent: () => ({ name: "bob" }),
+}));
+
+const settings = (enabled: boolean): api.AgentBackupSettings => ({
+  enabled,
+  retention: { periodic: 2, pre_update_versions: 2 },
+  has_override: false,
+});
+
+describe("BackupsCard", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(cleanup);
+
+  it("reflects the fetched enabled state", async () => {
+    vi.spyOn(api, "fetchAgentBackupSettings").mockResolvedValue(settings(true));
+    render(<BackupsCard />);
+    const toggle = await screen.findByRole("switch");
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("PUTs the new value on toggle", async () => {
+    vi.spyOn(api, "fetchAgentBackupSettings").mockResolvedValue(settings(true));
+    const setSpy = vi
+      .spyOn(api, "setAgentBackupSettings")
+      .mockResolvedValue(settings(false));
+    render(<BackupsCard />);
+    const toggle = await screen.findByRole("switch");
+    await userEvent.click(toggle);
+    await waitFor(() => {
+      expect(setSpy).toHaveBeenCalledWith("bob", false);
+    });
+  });
+});

--- a/apps/web/src/components/AgentSettings/BackupsCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/BackupsCard/index.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+} from "@/components/ui/field";
+import { Switch } from "@/components/ui/switch";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  fetchAgentBackupSettings,
+  setAgentBackupSettings,
+  type AgentBackupSettings,
+} from "@/api/agents";
+import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
+
+// Per-agent automatic-backups toggle. Reads the effective enabled state on mount
+// and writes an override on change; the section hides its control on load failure.
+export function BackupsCard() {
+  const { name } = useSelectedAgent();
+  const [settings, setSettings] = useState<AgentBackupSettings | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!name) return;
+    let ignore = false;
+    setSettings(null);
+    fetchAgentBackupSettings(name)
+      .then((s) => {
+        if (!ignore) setSettings(s);
+      })
+      .catch((err: unknown) => {
+        if (!ignore)
+          console.warn("[settings] failed to load automatic backups:", err);
+      });
+    return () => {
+      ignore = true;
+    };
+  }, [name]);
+
+  const onToggle = async (enabled: boolean) => {
+    setSaving(true);
+    try {
+      const updated = await setAgentBackupSettings(name, enabled);
+      setSettings(updated);
+    } catch (err) {
+      console.warn("[settings] failed to set automatic backups:", err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card size="sm">
+      <CardContent>
+        <Field
+          orientation="horizontal"
+          className="items-center justify-between"
+        >
+          <FieldContent>
+            <FieldLabel className="text-sm">automatic backups</FieldLabel>
+            <FieldDescription>
+              snapshot this agent on a schedule and before every update, without
+              interrupting it
+            </FieldDescription>
+          </FieldContent>
+          {settings ? (
+            <Switch
+              checked={settings.enabled}
+              disabled={saving}
+              onCheckedChange={(checked) => {
+                void onToggle(checked);
+              }}
+            />
+          ) : (
+            <Skeleton className="h-5 w-9" />
+          )}
+        </Field>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/AgentSettings/index.tsx
+++ b/apps/web/src/components/AgentSettings/index.tsx
@@ -1,6 +1,7 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SettingsScrollArea } from "@/components/SettingsScrollArea";
 import { ActionsCard } from "./ActionsCard";
+import { BackupsCard } from "./BackupsCard";
 import { NotificationInterruptRulesCard } from "./NotificationInterruptRulesCard";
 import { NotificationsCard } from "./NotificationsCard";
 import { FilesTab } from "./FilesTab";
@@ -29,6 +30,7 @@ export function AgentSettings() {
             </div>
             <div className="flex min-w-0 flex-col gap-4">
               <ProviderCard />
+              <BackupsCard />
               <SttCard />
               <TtsCard />
             </div>

--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -222,7 +222,7 @@ export function AppSettings() {
   );
 }
 
-// The read-only daemon setup rows (lan, tunnel, backups) of the gateway card.
+// The read-only daemon setup rows (lan, tunnel) of the gateway card.
 function GatewaySetupFields({ setup }: { setup: GatewaySetup }) {
   return (
     <div className="mt-4 flex flex-col gap-3">
@@ -248,19 +248,6 @@ function GatewaySetupFields({ setup }: { setup: GatewaySetup }) {
         </FieldContent>
         <span className="min-w-0 shrink-0 truncate text-sm text-muted-foreground">
           {setup.info.tunnel_url ?? "not set"}
-        </span>
-      </Field>
-      <Field orientation="horizontal" className="items-center justify-between">
-        <FieldContent>
-          <FieldLabel className="text-sm">backups</FieldLabel>
-          <FieldDescription>
-            automatic snapshots of your agents, without interrupting them
-          </FieldDescription>
-        </FieldContent>
-        <span className="shrink-0 text-sm text-muted-foreground">
-          {setup.settings.auto_backup.enabled
-            ? `every ${String(setup.settings.auto_backup.every_n_days)} days, and before every update`
-            : "disabled"}
         </span>
       </Field>
     </div>

--- a/apps/web/src/providers/ModalsProvider/context.ts
+++ b/apps/web/src/providers/ModalsProvider/context.ts
@@ -12,6 +12,10 @@ export interface ModalsContextValue {
   deleteDialogOpen: boolean;
   setDeleteDialogOpen: (open: boolean) => void;
   handleDelete: () => Promise<void>;
+
+  backupDialogOpen: boolean;
+  setBackupDialogOpen: (open: boolean) => void;
+  handleBackup: () => void;
 }
 
 export const ModalsContext = createContext<ModalsContextValue | null>(null);

--- a/apps/web/src/providers/ModalsProvider/index.tsx
+++ b/apps/web/src/providers/ModalsProvider/index.tsx
@@ -7,12 +7,13 @@ export { useModals } from "./context";
 
 export function ModalsProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
-  const { remove } = useSelectedAgent();
+  const { remove, backup } = useSelectedAgent();
 
   // ProviderPicker (rendered inside AgentIslandModals) owns the auth lifecycle now.
   // This provider only controls whether the dialog is open.
   const [showAuth, setShowAuth] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [backupDialogOpen, setBackupDialogOpen] = useState(false);
 
   const handleOpenAuth = () => setShowAuth(true);
   const clearAuthState = () => setShowAuth(false);
@@ -22,6 +23,8 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
     await remove();
   };
 
+  const handleBackup = () => backup();
+
   const value: ModalsContextValue = {
     showAuth,
     handleOpenAuth,
@@ -29,6 +32,9 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
     deleteDialogOpen,
     setDeleteDialogOpen,
     handleDelete,
+    backupDialogOpen,
+    setBackupDialogOpen,
+    handleBackup,
   };
 
   return (


### PR DESCRIPTION
## What

Gives the user per-agent control over backups, on web and mobile:

- **Per-agent automatic-backups toggle.** A switch on each agent decides whether the maintenance pass snapshots it. Web: a new `BackupsCard` in the agent general tab. Mobile: an "Automatic backups" switch in the per-agent backups section.
- **Removed the global backups row** from the web app settings, since backup control now lives per agent.
- **Confirm before a manual "back up now".** A snapshot briefly pauses the running container, so the action now asks first (web `AlertDialog`, mobile `Alert.alert`), matching the existing delete/restore confirm prose.

## Why

The daemon already models per-agent backup enablement (`GET/PUT /agents/{name}/settings/backup`, effective value layered over the global default, honored by `snapshot_agent`), but no client exposed it. Users could not opt a single agent out of automatic snapshots, and a manual backup fired with no confirmation.

## Notes

- No daemon change and no wire-contract change, so no `MIN_SUPPORTED_CLIENT_VERSION` bump.
- The per-agent `AgentBackupSettings` DTO and fetch helpers are duplicated per app, matching the existing backup/mount/provider helpers and the "duplicate small DTO shapes across the seam" principle; nothing moved to `@vesta/core`.
- Tests: web vitest for the toggle card and the backup-confirm dialog; mobile vitest for the new endpoint. Backend untouched, no fixture regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)