### PR TITLE
fix(whatsapp): status hint and SETUP flags match what connect actually accepts

### DIFF
--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -50,7 +50,7 @@ pick the source and pass it explicitly as `--source`; the CLI never guesses.
 - `{"linked":true,"connected":false,...}`: let the daemon reconnect; use the
   returned `next` only if it cannot.
 - `{"linked":false,"connecting":true,...}`: wait for the active link attempt.
-- `{"linked":false,"connected":false,"next":"run: whatsapp connect",...}`: for
+- `{"linked":false,"connected":false,"next":"run: whatsapp connect --source ...",...}`: for
   first setup, run the selected method once; if a prior link was lost, get
   approval first (see the [linking rule](SKILL.md#the-linking-rule)).
 
@@ -85,9 +85,11 @@ whatsapp messages --instance personal --limit 10
 ```
 
 For a read-only or silent instance, pass `--read-only` (blocks sending, receipts,
-and presence) or `--no-notifications` when you first bring it up (on `whatsapp
-connect` or `whatsapp daemon start`); the daemon records them in `state.json` and
-reapplies them across its own restarts. Never point two instances at the same
+and presence) or `--no-notifications` on `whatsapp daemon start`; they are daemon
+flags, and `whatsapp connect` does not accept them. The running daemon records its
+flags in `state.json` and `whatsapp daemon restart` reapplies them, but a fresh
+start does not, so include them on that instance's `whatsapp daemon start` line
+under `## Daemons` in the restart skill. Never point two instances at the same
 account/device store.
 
 ## Operational notes

--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -84,13 +84,21 @@ whatsapp status --instance personal
 whatsapp messages --instance personal --limit 10
 ```
 
-For a read-only or silent instance, pass `--read-only` (blocks sending, receipts,
-and presence) or `--no-notifications` on `whatsapp daemon start`; they are daemon
-flags, and `whatsapp connect` does not accept them. The running daemon records its
-flags in `state.json` and `whatsapp daemon restart` reapplies them, but a fresh
-start does not, so include them on that instance's `whatsapp daemon start` line
-under `## Daemons` in the restart skill. Never point two instances at the same
-account/device store.
+For a read-only or silent instance, start its daemon with the flag BEFORE the first
+connect, so the instance is never even briefly write-capable:
+
+```bash
+whatsapp daemon start --instance personal --read-only
+whatsapp connect --source self-managed --instance personal
+```
+
+`--read-only` blocks sending, receipts, and presence; `--no-notifications` silences
+notifications. `whatsapp connect` does not accept these flags itself, and running it
+first would cold-start the daemon write-capable, after which `daemon start --read-only`
+only reports `already_running` and the instance stays write-capable. Connecting after
+the daemon is already up links through it and leaves the flag in force. Keep the flag on
+that instance's `whatsapp daemon start` line under `## Daemons` in the restart skill so
+it survives every restart. Never point two instances at the same account/device store.
 
 ## Operational notes
 

--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -93,12 +93,11 @@ whatsapp connect --source self-managed --instance personal
 ```
 
 `--read-only` blocks sending, receipts, and presence; `--no-notifications` silences
-notifications. `whatsapp connect` does not accept these flags itself, and running it
-first would cold-start the daemon write-capable, after which `daemon start --read-only`
-only reports `already_running` and the instance stays write-capable. Connecting after
-the daemon is already up links through it and leaves the flag in force. Keep the flag on
-that instance's `whatsapp daemon start` line under `## Daemons` in the restart skill so
-it survives every restart. Never point two instances at the same account/device store.
+notifications. `whatsapp connect` takes neither flag, so running it first cold-starts the
+daemon write-capable, after which `daemon start --read-only` only reports `already_running`.
+Connecting after the daemon is up links through it and leaves the flag in force. Keep the
+flag on that instance's `whatsapp daemon start` line under `## Daemons` in the restart skill
+so it survives every restart. Never point two instances at the same account/device store.
 
 ## Operational notes
 

--- a/agent/skills/whatsapp/cli/connect.go
+++ b/agent/skills/whatsapp/cli/connect.go
@@ -182,7 +182,7 @@ func canonicalConnectArgs(program string, opts connectOptions) []string {
 }
 
 // runConnect is the agent's single WhatsApp setup verb. The agent states the account
-// source with --source (cloud, doubletick, or self-managed); the CLI validates that
+// source with --source (vesta-cloud, doubletick, or self-managed); the CLI validates that
 // the box environment can satisfy it and routes to the matching path, erring clearly
 // when it cannot. There is no auto-detection: the mode is the agent's explicit choice.
 // Idempotent and safe to re-run until `whatsapp status` shows linked.

--- a/agent/skills/whatsapp/cli/main.go
+++ b/agent/skills/whatsapp/cli/main.go
@@ -17,8 +17,8 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage: whatsapp <command> [args] [flags]")
 	// The lifecycle commands run in the client, not the daemon, so they are not in the registry.
 	fmt.Fprintln(w, "Setup / health:")
-	fmt.Fprintln(w, "  connect --source <cloud|doubletick|self-managed> [--opener <text>] [--phone +E.164] set up or recover WhatsApp; --opener is for cloud/doubletick, --phone (self-managed) uses a pairing code when the user cannot scan a QR")
-	fmt.Fprintln(w, "  status                               simple health check: linked, number, connected. If it shows linked:false, run `whatsapp connect`")
+	fmt.Fprintln(w, "  connect --source <vesta-cloud|doubletick|self-managed> [--opener <text>] [--phone +E.164] set up or recover WhatsApp; --opener is for vesta-cloud/doubletick, --phone (self-managed) uses a pairing code when the user cannot scan a QR")
+	fmt.Fprintln(w, "  status                               simple health check: linked, number, connected. If it shows linked:false, run `whatsapp connect --source <vesta-cloud|doubletick|self-managed>`")
 	fmt.Fprintln(w, "  daemon <start|stop|restart|status>   manage the background daemon; the restart skill runs `whatsapp daemon start` at boot")
 	fmt.Fprintln(w, "  start                                alias for `daemon start`: bring the daemon up and wait until it answers (idempotent)")
 	fmt.Fprintln(w, "Internal:")

--- a/agent/skills/whatsapp/cli/status.go
+++ b/agent/skills/whatsapp/cli/status.go
@@ -9,7 +9,7 @@ import (
 // live connection, and prints a simple self-explanatory verdict:
 //
 //	linked:    {"linked":true,"number":"+44...","connected":true}
-//	not linked:{"linked":false,"connected":false,"next":"run: whatsapp connect --source <cloud|doubletick|self-managed>","reason":"..."}
+//	not linked:{"linked":false,"connected":false,"next":"run: whatsapp connect --source <vesta-cloud|doubletick|self-managed>","reason":"..."}
 func runStatus() {
 	dataDir := stateDataDir()
 	resolved, err := resolveDir(dataDir)
@@ -68,7 +68,7 @@ func notLinkedStatus(dataDir, startErr string) map[string]any {
 	result := map[string]any{
 		"linked":    false,
 		"connected": false,
-		"next":      "run: whatsapp connect --source <cloud|doubletick|self-managed>",
+		"next":      "run: whatsapp connect --source <vesta-cloud|doubletick|self-managed>",
 	}
 	// A live daemon-start error is the real, current failure, so it wins over the
 	// last-exit reason (which a successful connect clears anyway).

--- a/agent/skills/whatsapp/cli/status_test.go
+++ b/agent/skills/whatsapp/cli/status_test.go
@@ -31,11 +31,30 @@ func TestSimpleStatusNotLinkedSurfacesReason(t *testing.T) {
 	if got["linked"] != false {
 		t.Errorf("linked = %v, want false", got["linked"])
 	}
-	if got["next"] != "run: whatsapp connect --source <cloud|doubletick|self-managed>" {
+	if got["next"] != "run: whatsapp connect --source <vesta-cloud|doubletick|self-managed>" {
 		t.Errorf("next = %v, want the connect hint", got["next"])
 	}
 	if got["reason"] != "unlinked from the phone (stream:error logout)" {
 		t.Errorf("reason = %v, want the recorded last-exit reason", got["reason"])
+	}
+}
+
+// TestStatusHintSourcesAreAccepted runs every source named in the not-linked
+// recovery hint through validateConnectSource, so the hint can never hand the
+// agent a --source value connect rejects.
+func TestStatusHintSourcesAreAccepted(t *testing.T) {
+	next, ok := notLinkedStatus(t.TempDir(), "")["next"].(string)
+	if !ok {
+		t.Fatal("not-linked status must carry a next hint")
+	}
+	start, end := strings.Index(next, "<"), strings.Index(next, ">")
+	if start < 0 || end < start {
+		t.Fatalf("next = %q, want a <source|...> placeholder", next)
+	}
+	for _, source := range strings.Split(next[start+1:end], "|") {
+		if err := validateConnectSource(connectOptions{source: source}); err != nil {
+			t.Errorf("hinted source %q rejected by connect: %v", source, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #1715.

## In plain terms

The whatsapp CLI told the agent to run a command that the CLI itself rejects. When WhatsApp is not linked, `whatsapp status` said to run `whatsapp connect --source <cloud|...>`, but `connect` only accepts `vesta-cloud`, so copying the hint failed. Separately, SETUP.md told the agent to pass `--read-only` / `--no-notifications` on `whatsapp connect`, which does not accept those flags; the failed retry path could quietly stand up a write-capable instance the operator believed was read-only. This PR makes the emitted hint and the docs say exactly what the parser accepts.

## Changes

**Half 1: the `--source` hint (code strings and comments)**
- `agent/skills/whatsapp/cli/status.go`: the not-linked `next` hint (and its doc comment) now reads `--source <vesta-cloud|doubletick|self-managed>`.
- `agent/skills/whatsapp/cli/main.go`: top-level usage shows the same set, `--opener is for vesta-cloud/doubletick`, and the status line's recovery command now includes the required `--source`.
- `agent/skills/whatsapp/cli/connect.go`: the `runConnect` doc comment names `vesta-cloud`, matching its own validator.
- `agent/skills/whatsapp/cli/status_test.go`: the pinned hint string is updated, and a new `TestStatusHintSourcesAreAccepted` parses every source out of the emitted `<...|...>` placeholder and runs it through `validateConnectSource`, so the hint can never again name a source `connect` rejects.

**Half 2: SETUP.md read-only / no-notifications flags**
- `agent/skills/whatsapp/SETUP.md`: the named-instances section now says the flags belong on `whatsapp daemon start` (they are daemon flags; `connect` does not accept them), that the running daemon records its flags in `state.json` and `daemon restart` replays them while a fresh start does not, and to keep them on the instance's `daemon start` line in the restart skill. The abbreviated status example also shows the real `next` value (`run: whatsapp connect --source ...`).

The docs fix was chosen over teaching `connect` the flags: `parseConnectOptions` deliberately owns a closed flag set and canonicalizes args so raw `os.Args` scanners can never silently ignore a flag, and the working mechanism (`daemon start [serve flags]`, replayed by `daemon restart` via `restartServeArgs`) already exists and is what `restart/SKILL.md` uses.

## Verification (ground truth from the parser)

`validateConnectSource` in `cli/connect.go` is the authority on the accepted set:

```go
case "":
    return fmt.Errorf("connect requires --source: vesta-cloud (a vesta.run managed VM), doubletick (DOUBLETICK_API_URL/KEY set), or self-managed (the user's own account)")
case sourceVestaCloud, sourceDoubletick:
    ...
case sourceSelfManaged:
    ...
default:
    return fmt.Errorf("invalid --source %q: use vesta-cloud, doubletick, or self-managed", opts.source)
```

with `sourceVestaCloud = "vesta-cloud"`, `sourceDoubletick = "doubletick"`, `sourceSelfManaged = "self-managed"` (`connect.go:13-15`). So `cloud` is rejected and the emitted hint must say `vesta-cloud`.

`parseConnectOptions` (`connect.go:34-42`) declares the complete connect flag set: `source`, `opener`, `phone`, `instance`, `port`, `acknowledge-ban-risk`. No `--read-only`, no `--no-notifications`. Those are serve flags read by `hasBareFlag` (`cli.go:59-60`), forwarded by `daemon start [serve flags]`, recorded by the serve process (`cli.go:272`: `s.Args = os.Args[1:]`), and replayed on `daemon restart`:

```go
// restartServeArgs picks the flags a restart brings the daemon back with: the last run's
// flags recorded in state.json (which survives stops and crashes, so e.g. --read-only is
// never silently dropped), falling back to the instance flag alone when no run was ever
// recorded.
func restartServeArgs(st daemonState) []string {
```

Both halves of #1715 were re-verified as still drifted on current master before changing anything. There is no Go toolchain on this host, so the Go build and tests run in CI's `comms-checks` (`./check.sh whatsapp`); the changes are string/comment edits plus one test that only calls existing same-package functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
