### PR TITLE
feat: coarse device location in the client roster

### DIFF
--- a/apps/core/fixtures/sync-protocol.json
+++ b/apps/core/fixtures/sync-protocol.json
@@ -28,6 +28,7 @@
           "id": "device-1",
           "kind": "desktop",
           "lastSeen": "2026-01-01T00:00:00Z",
+          "location": "London, United Kingdom",
           "present": true,
           "pushEnabled": false
         }
@@ -118,6 +119,7 @@
           "id": "device-1",
           "kind": "desktop",
           "lastSeen": "2026-01-01T00:00:00Z",
+          "location": "London, United Kingdom",
           "present": true,
           "pushEnabled": false
         }

--- a/apps/core/src/protocol/parse.test.ts
+++ b/apps/core/src/protocol/parse.test.ts
@@ -100,6 +100,7 @@ describe("parseServerFrame", () => {
       present: true,
       lastSeen: "2026-01-01T00:00:00Z",
       pushEnabled: false,
+      location: "London, United Kingdom",
     }
     const parsed = parseServerFrame(JSON.stringify({ type: "devices", devices: [device] }))
     expect(parsed).toEqual({ kind: "delta", delta: { type: "devices", devices: [device] } })
@@ -113,9 +114,29 @@ describe("parseServerFrame", () => {
       present: false,
       lastSeen: "2026-01-01T00:00:00Z",
       pushEnabled: true,
+      location: null,
     }
     const parsed = parseServerFrame(JSON.stringify({ type: "devices", devices: [device] }))
     expect(parsed).toEqual({ kind: "delta", delta: { type: "devices", devices: [device] } })
+  })
+
+  it("defaults an absent location to null and rejects a non-string one", () => {
+    const base = {
+      id: "dev-1",
+      kind: "web",
+      descriptor: "Chrome",
+      present: true,
+      lastSeen: "2026-01-01T00:00:00Z",
+      pushEnabled: false,
+    }
+    expect(parseServerFrame(JSON.stringify({ type: "devices", devices: [base] }))).toEqual({
+      kind: "delta",
+      delta: { type: "devices", devices: [{ ...base, location: null }] },
+    })
+    const bad = { ...base, location: 42 }
+    expect(parseServerFrame(JSON.stringify({ type: "devices", devices: [bad] }))).toEqual({
+      kind: "unknown",
+    })
   })
 
   it("treats a devices delta with a malformed entry as unknown", () => {

--- a/apps/core/src/protocol/parse.ts
+++ b/apps/core/src/protocol/parse.ts
@@ -151,5 +151,7 @@ function parseDevice(value: unknown): DeviceInfo | null {
   if (!DEVICE_KINDS.includes(kind as DeviceKind)) return null
   const descriptor = device.descriptor === null ? null : str(device.descriptor)
   if (descriptor === null && device.descriptor !== null) return null
-  return { id, kind: kind as DeviceKind, descriptor, present, lastSeen, pushEnabled }
+  const location = device.location == null ? null : str(device.location)
+  if (location === null && device.location != null) return null
+  return { id, kind: kind as DeviceKind, descriptor, present, lastSeen, pushEnabled, location }
 }

--- a/apps/core/src/protocol/tree.ts
+++ b/apps/core/src/protocol/tree.ts
@@ -67,7 +67,8 @@ export type DeviceKind = "web" | "mobile" | "desktop" | "unknown"
 
 // One device in the gateway-global registry: identity plus whether it currently holds a live /sync
 // connection, or when it last did. The push token is never on the wire; `pushEnabled` is the only
-// push signal. `descriptor` is null until a device connects and names itself.
+// push signal. `descriptor` is null until a device connects and names itself. `location` is a coarse
+// "City, Country" the gateway resolves from the connection, null until resolved.
 export interface DeviceInfo {
   id: string
   kind: DeviceKind
@@ -75,6 +76,7 @@ export interface DeviceInfo {
   present: boolean
   lastSeen: string
   pushEnabled: boolean
+  location: string | null
 }
 
 export interface Tree {

--- a/apps/core/src/replica/reducer.test.ts
+++ b/apps/core/src/replica/reducer.test.ts
@@ -56,6 +56,7 @@ describe("reduceDelta", () => {
           present: true,
           lastSeen: "2026-01-01T00:00:00Z",
           pushEnabled: true,
+          location: null,
         },
       ],
     })

--- a/apps/core/src/tree/devices.test.ts
+++ b/apps/core/src/tree/devices.test.ts
@@ -10,6 +10,7 @@ function device(overrides: Partial<DeviceInfo> = {}): DeviceInfo {
     present: true,
     lastSeen: "2026-01-01T00:00:00Z",
     pushEnabled: false,
+    location: null,
     ...overrides,
   }
 }

--- a/apps/web/src/components/Settings/DevicesCard/index.tsx
+++ b/apps/web/src/components/Settings/DevicesCard/index.tsx
@@ -29,9 +29,16 @@ function DeviceRow({ device }: { device: DeviceInfo }) {
   return (
     <div className="flex min-w-0 items-center gap-3 text-sm leading-none">
       {kindIcon(device.kind)}
-      <span className="min-w-0 flex-1 truncate font-medium text-foreground">
-        {device.descriptor ?? "Unnamed device"}
-      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="min-w-0 truncate font-medium text-foreground">
+          {device.descriptor ?? "Unnamed device"}
+        </span>
+        {device.location !== null && (
+          <span className="min-w-0 truncate text-xs text-muted-foreground">
+            {device.location}
+          </span>
+        )}
+      </div>
       {device.present ? (
         <span className="flex shrink-0 items-center gap-1.5 text-xs font-medium text-emerald-500">
           <Circle className="size-2 fill-current" />

--- a/vestad/src/device_registry.rs
+++ b/vestad/src/device_registry.rs
@@ -44,6 +44,10 @@ struct DeviceRecord {
     last_seen: u64,
     #[serde(default)]
     push: Option<PushSubscription>,
+    #[serde(default)]
+    ip: Option<String>,
+    #[serde(default)]
+    location: Option<String>,
 }
 
 impl DeviceRecord {
@@ -64,6 +68,7 @@ pub(crate) struct DeviceInfo {
     pub present: bool,
     pub last_seen: String,
     pub push_enabled: bool,
+    pub location: Option<String>,
 }
 
 /// The legacy `mobile-devices.json` element, read once to migrate into `devices.json`.
@@ -136,6 +141,37 @@ impl DeviceRegistry {
         record.last_seen = now;
         self.republish(&state);
         self.dirty.notify_one();
+    }
+
+    /// Record the client IP for this device (the IP stays off the wire) and report whether a geo
+    /// lookup is needed: the IP changed, or no location is stored yet. Non-blocking; the disk write
+    /// defers. No republish, since the IP is not projected onto the roster.
+    pub(crate) fn note_ip(&self, id: &str, ip: std::net::IpAddr) -> bool {
+        let mut state = self.state.lock().expect("device registry mutex");
+        let ip_str = ip.to_string();
+        let record = state.devices.entry(id.to_string()).or_default();
+        let needs_lookup = record.ip.as_deref() != Some(ip_str.as_str()) || record.location.is_none();
+        record.ip = Some(ip_str);
+        self.dirty.notify_one();
+        needs_lookup
+    }
+
+    /// Set the resolved location, but only if the record's IP still matches the one the lookup ran
+    /// for (a racing reconnect from another IP must win). Republishes the roster on a real change.
+    pub(crate) fn set_location(&self, id: &str, ip: std::net::IpAddr, location: String) {
+        let mut state = self.state.lock().expect("device registry mutex");
+        let ip_str = ip.to_string();
+        let updated = match state.devices.get_mut(id) {
+            Some(record) if record.ip.as_deref() == Some(ip_str.as_str()) => {
+                record.location = Some(location);
+                true
+            }
+            _ => false,
+        };
+        if updated {
+            self.republish(&state);
+            self.dirty.notify_one();
+        }
     }
 
     /// A `/sync` connection for this device closing. On the device's last connection dropping, stamp
@@ -273,6 +309,7 @@ fn project(state: &RegistryState) -> Vec<DeviceInfo> {
             present: state.live_counts.get(id).copied().unwrap_or(0) > 0,
             last_seen: epoch_to_rfc3339(record.last_seen).unwrap_or_default(),
             push_enabled: record.push.is_some(),
+            location: record.location.clone(),
         })
         .collect();
     devices.sort_by(|a, b| a.id.cmp(&b.id));
@@ -339,6 +376,8 @@ fn migrate_legacy(legacy_path: &Path) -> Option<HashMap<InstallationId, DeviceRe
                     previews: device.previews,
                     registered_at: device.registered_at,
                 }),
+                ip: None,
+                location: None,
             },
         );
     }
@@ -381,6 +420,54 @@ mod tests {
         assert_eq!(device.kind, ClientKind::Web);
         assert_eq!(device.descriptor.as_deref(), Some("Chrome on macOS"));
         assert!(!device.push_enabled);
+    }
+
+    #[test]
+    fn note_ip_stores_and_flags_lookup() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let registry = DeviceRegistry::load(dir.path());
+        registry.mark_connected("dev-a", ClientKind::Web, Some("Chrome".into()), 100);
+        let ip: std::net::IpAddr = "1.2.3.4".parse().expect("ip");
+        assert!(registry.note_ip("dev-a", ip), "new ip needs a lookup");
+        assert!(registry.note_ip("dev-a", ip), "same ip with no location still needs one until resolved");
+    }
+
+    #[test]
+    fn note_ip_reuses_location_for_unchanged_ip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let registry = DeviceRegistry::load(dir.path());
+        registry.mark_connected("dev-a", ClientKind::Web, Some("Chrome".into()), 100);
+        let ip: std::net::IpAddr = "1.2.3.4".parse().expect("ip");
+        registry.note_ip("dev-a", ip);
+        registry.set_location("dev-a", ip, "London, United Kingdom".into());
+        assert!(!registry.note_ip("dev-a", ip), "unchanged ip with a location needs no lookup");
+        assert_eq!(only(&registry, "dev-a").location.as_deref(), Some("London, United Kingdom"));
+    }
+
+    #[test]
+    fn set_location_is_a_no_op_when_the_ip_changed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let registry = DeviceRegistry::load(dir.path());
+        registry.mark_connected("dev-a", ClientKind::Web, Some("Chrome".into()), 100);
+        let first: std::net::IpAddr = "1.2.3.4".parse().expect("ip");
+        let second: std::net::IpAddr = "5.6.7.8".parse().expect("ip");
+        registry.note_ip("dev-a", first);
+        registry.note_ip("dev-a", second);
+        registry.set_location("dev-a", first, "Stale City, Nowhere".into());
+        assert_eq!(only(&registry, "dev-a").location, None, "a lookup for the old ip does not land");
+    }
+
+    #[test]
+    fn roster_never_contains_the_raw_ip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let registry = DeviceRegistry::load(dir.path());
+        registry.mark_connected("dev-a", ClientKind::Web, Some("Chrome".into()), 100);
+        let ip: std::net::IpAddr = "203.0.113.9".parse().expect("ip");
+        registry.note_ip("dev-a", ip);
+        registry.set_location("dev-a", ip, "Paris, France".into());
+        let serialized = serde_json::to_string(&registry.snapshot()).expect("serialize roster");
+        assert!(!serialized.contains("203.0.113.9"), "roster leaked the ip: {serialized}");
+        assert!(serialized.contains("Paris, France"), "roster should carry the location");
     }
 
     #[test]

--- a/vestad/src/geoip.rs
+++ b/vestad/src/geoip.rs
@@ -1,0 +1,75 @@
+//! The one owner of the ipwho.is geo lookup: given a public client IP, resolve a coarse
+//! "City, Country" label for the device roster. Any failure yields None; the caller treats a missing
+//! location as simply unknown.
+
+use std::net::IpAddr;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+const IPWHO_BASE: &str = "https://ipwho.is";
+const GEO_TIMEOUT_SECS: u64 = 5;
+
+#[derive(Debug, Deserialize)]
+struct IpwhoResponse {
+    #[serde(default)]
+    success: bool,
+    #[serde(default)]
+    city: Option<String>,
+    #[serde(default)]
+    country: Option<String>,
+}
+
+fn parse_ipwho(body: &str) -> Option<String> {
+    let parsed: IpwhoResponse = serde_json::from_str(body).ok()?;
+    if !parsed.success {
+        return None;
+    }
+    let city = parsed.city.filter(|value| !value.is_empty())?;
+    let country = parsed.country.filter(|value| !value.is_empty())?;
+    Some(format!("{city}, {country}"))
+}
+
+/// Resolve a coarse "City, Country" for a public IP. None on any network or shape failure.
+pub(crate) async fn lookup(client: &reqwest::Client, ip: IpAddr) -> Option<String> {
+    let url = format!("{IPWHO_BASE}/{ip}");
+    let response = client
+        .get(&url)
+        .timeout(Duration::from_secs(GEO_TIMEOUT_SECS))
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let body = response.text().await.ok()?;
+    parse_ipwho(&body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_ipwho;
+
+    #[test]
+    fn parses_a_well_formed_body() {
+        let body = r#"{"success":true,"city":"London","country":"United Kingdom"}"#;
+        assert_eq!(parse_ipwho(body).as_deref(), Some("London, United Kingdom"));
+    }
+
+    #[test]
+    fn rejects_a_failure_body() {
+        let body = r#"{"success":false,"message":"reserved range"}"#;
+        assert_eq!(parse_ipwho(body), None);
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        assert_eq!(parse_ipwho("{ not json"), None);
+    }
+
+    #[test]
+    fn rejects_missing_or_empty_fields() {
+        assert_eq!(parse_ipwho(r#"{"success":true,"country":"France"}"#), None);
+        assert_eq!(parse_ipwho(r#"{"success":true,"city":"","country":"France"}"#), None);
+    }
+}

--- a/vestad/src/main.rs
+++ b/vestad/src/main.rs
@@ -14,6 +14,7 @@ mod backup;
 mod channel;
 mod device_registry;
 mod docker;
+mod geoip;
 mod jwt;
 mod lifecycle;
 mod maintenance;

--- a/vestad/src/sync/handler.rs
+++ b/vestad/src/sync/handler.rs
@@ -1,9 +1,10 @@
 use std::collections::{BTreeMap, HashMap};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::ops::ControlFlow;
 use std::time::Duration;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::extract::{RawQuery, State};
+use axum::extract::{ConnectInfo, RawQuery, State};
 use axum::http::HeaderMap;
 use axum::response::Response;
 use futures_util::{SinkExt, StreamExt};
@@ -30,11 +31,69 @@ pub(crate) async fn sync_ws_handler(
     State(state): State<SharedState>,
     headers: HeaderMap,
     RawQuery(raw_query): RawQuery,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
     ws: WebSocketUpgrade,
 ) -> Response {
     // auth_middleware already validated the connect token; capture it to derive the reauth deadline.
     let token = connect_token(&headers, raw_query.as_deref());
-    ws.on_upgrade(move |socket| sync_session(state, socket, token))
+    let client_ip = client_ip(&headers, Some(peer));
+    ws.on_upgrade(move |socket| sync_session(state, socket, token, client_ip))
+}
+
+const CF_CONNECTING_IP: &str = "cf-connecting-ip";
+const X_FORWARDED_FOR: &str = "x-forwarded-for";
+
+/// The best client IP for geo: the cloudflared tunnel's CF-Connecting-IP, else the first
+/// X-Forwarded-For hop, else the direct peer address.
+fn client_ip(headers: &HeaderMap, peer: Option<SocketAddr>) -> Option<IpAddr> {
+    if let Some(ip) = header_ip(headers, CF_CONNECTING_IP) {
+        return Some(ip);
+    }
+    if let Some(value) = headers.get(X_FORWARDED_FOR).and_then(|value| value.to_str().ok()) {
+        if let Some(first) = value.split(',').next() {
+            if let Ok(ip) = first.trim().parse::<IpAddr>() {
+                return Some(ip);
+            }
+        }
+    }
+    peer.map(|peer| peer.ip())
+}
+
+fn header_ip(headers: &HeaderMap, name: &str) -> Option<IpAddr> {
+    headers.get(name)?.to_str().ok()?.trim().parse().ok()
+}
+
+/// Whether an IP is a routable public address worth a geo lookup.
+fn is_routable(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            !v4.is_loopback() && !v4.is_private() && !v4.is_link_local() && !v4.is_unspecified() && !v4.is_broadcast()
+        }
+        IpAddr::V6(v6) => !v6.is_loopback() && !v6.is_unspecified() && !is_unique_local(v6) && !is_link_local(v6),
+    }
+}
+
+fn is_unique_local(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xfe00) == 0xfc00
+}
+
+fn is_link_local(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xffc0) == 0xfe80
+}
+
+/// If the IP is public and the device needs a location, spawn one background ipwho.is lookup and
+/// store the result. The connect path never blocks on the network.
+fn resolve_location(state: &SharedState, device_id: String, ip: IpAddr) {
+    if !is_routable(ip) || !state.device_registry.note_ip(&device_id, ip) {
+        return;
+    }
+    let registry = state.device_registry.clone();
+    let client = state.http_client.clone();
+    tokio::spawn(async move {
+        if let Some(location) = crate::geoip::lookup(&client, ip).await {
+            registry.set_location(&device_id, ip, location);
+        }
+    });
 }
 
 /// The connect token, from either `Authorization: Bearer` or `?token=` (browser WS connects cannot
@@ -83,7 +142,7 @@ async fn settle_and_notify(state: SharedState) {
     futures_util::future::join_all(drops).await;
 }
 
-async fn sync_session(state: SharedState, socket: WebSocket, connect_token: Option<String>) {
+async fn sync_session(state: SharedState, socket: WebSocket, connect_token: Option<String>, client_ip: Option<IpAddr>) {
     let (mut tx, mut rx) = socket.split();
 
     // Register this connection's presence and a RAII guard that clears it on every break path, then
@@ -207,7 +266,12 @@ async fn sync_session(state: SharedState, socket: WebSocket, connect_token: Opti
                 match serde_json::from_str::<ClientFrame>(text.as_str()) {
                     Ok(ClientFrame::ClientContext(ctx)) => {
                         if let Some(device_id) = ctx.device_id.clone() {
-                            device_guard.attach(&device_id, ctx.client, ctx.descriptor.clone());
+                            let newly = device_guard.attach(&device_id, ctx.client, ctx.descriptor.clone());
+                            if newly {
+                                if let Some(ip) = client_ip {
+                                    resolve_location(&state, device_id, ip);
+                                }
+                            }
                         }
                         if state.presence.record(conn, ctx, tokio::time::Instant::now()) {
                             tokio::spawn(settle_and_notify(state.clone()));
@@ -361,15 +425,16 @@ struct DeviceGuard {
 }
 
 impl DeviceGuard {
-    fn attach(&mut self, device_id: &str, kind: ClientKind, descriptor: Option<String>) {
+    fn attach(&mut self, device_id: &str, kind: ClientKind, descriptor: Option<String>) -> bool {
         if self.device.as_deref() == Some(device_id) {
-            return;
+            return false;
         }
         if let Some(previous) = self.device.take() {
             self.registry.mark_disconnected(&previous, now_epoch_secs());
         }
         self.registry.mark_connected(device_id, kind, descriptor, now_epoch_secs());
         self.device = Some(device_id.to_string());
+        true
     }
 }
 
@@ -677,6 +742,35 @@ mod tests {
         assert_eq!(connect_token(&headers, None).as_deref(), Some("abc"));
         assert_eq!(connect_token(&HeaderMap::new(), Some("x=1&token=q2&y=3")).as_deref(), Some("q2"));
         assert_eq!(connect_token(&HeaderMap::new(), None), None);
+    }
+
+    #[test]
+    fn client_ip_prefers_cf_connecting_ip() {
+        let mut headers = HeaderMap::new();
+        headers.insert("cf-connecting-ip", "203.0.113.7".parse().expect("header"));
+        headers.insert("x-forwarded-for", "198.51.100.2, 10.0.0.1".parse().expect("header"));
+        let peer: SocketAddr = "127.0.0.1:9000".parse().expect("peer");
+        assert_eq!(client_ip(&headers, Some(peer)).map(|ip| ip.to_string()).as_deref(), Some("203.0.113.7"));
+    }
+
+    #[test]
+    fn client_ip_falls_back_to_forwarded_then_peer() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "198.51.100.2, 10.0.0.1".parse().expect("header"));
+        let peer: SocketAddr = "8.8.8.8:9000".parse().expect("peer");
+        assert_eq!(client_ip(&headers, Some(peer)).map(|ip| ip.to_string()).as_deref(), Some("198.51.100.2"));
+        assert_eq!(client_ip(&HeaderMap::new(), Some(peer)).map(|ip| ip.to_string()).as_deref(), Some("8.8.8.8"));
+        assert_eq!(client_ip(&HeaderMap::new(), None), None);
+    }
+
+    #[test]
+    fn is_routable_rejects_local_and_private() {
+        for private in ["127.0.0.1", "10.0.0.5", "192.168.1.4", "169.254.0.1", "::1", "fe80::1", "fc00::1"] {
+            assert!(!is_routable(private.parse().expect("ip")), "{private} should be non-routable");
+        }
+        for public in ["203.0.113.7", "8.8.8.8", "2606:4700:4700::1111"] {
+            assert!(is_routable(public.parse().expect("ip")), "{public} should be routable");
+        }
     }
 
     #[test]

--- a/vestad/src/sync/protocol.rs
+++ b/vestad/src/sync/protocol.rs
@@ -176,6 +176,7 @@ pub(crate) fn protocol_fixtures() -> serde_json::Value {
         present: true,
         last_seen: "2026-01-01T00:00:00Z".into(),
         push_enabled: false,
+        location: Some("London, United Kingdom".into()),
     }];
     let tree = Tree { gateway: gateway.clone(), agents, devices: devices.clone() };
 


### PR DESCRIPTION
## What

Show each connected client's coarse location (`"City, Country"`) under its name in the settings device roster. Display only: the location never reaches the agent.

## How

When a client opens `/sync`, vestad reads the client IP off the upgrade request (`CF-Connecting-IP` from the cloudflared tunnel, else `X-Forwarded-For`, else the peer address), stores it on the device record, and, only when the IP is public and new, spawns one background `GET https://ipwho.is/{ip}` (new edge module `vestad/src/geoip.rs`) to resolve the location. The location is projected onto the roster; the raw IP stays on the persisted record and never crosses the wire.

The client sends nothing new: no frame field, no permission prompt, no client-side external call. A private or local IP (localhost / LAN, no tunnel) resolves nothing and simply shows no location.

## Contract

Additive on the `/sync` roster projection only. `MIN_SUPPORTED_CLIENT_VERSION` is unchanged; the ignore-unknown tests stay green. `apps/core/fixtures/sync-protocol.json` regenerated for the new field.

## Testing

- `./check.sh vestad`: clippy clean, 378 tests. New coverage: `geoip::parse_ipwho` (success + every failure shape), `client_ip` precedence, `is_routable` (v4/v6 private/loopback/link-local vs public), `note_ip`/`set_location` (store, reuse, race no-op), and "roster never contains the raw ip".
- `./check.sh app-core`: 303 tests, incl. location parse (present / null / absent / non-string).
- `./check.sh app-web`: lint + tsc + vitest.

## Not verified

The two-line roster layout (location under the device name) is not visually verified: types, lint, and tests pass, but that is not visual confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)