### PR TITLE
fix(whatsapp): self-bootstrap replays recorded serve flags so read-only survives a crash

### DIFF
--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -356,8 +356,10 @@ func runOneShot(command string) {
 	sockPath := getSocketPath()
 	// Self-bootstrap the background daemon (idempotent no-op when it is already
 	// answering) so every agent command works cold, without the agent ever starting
-	// anything by hand.
-	if err := ensureDaemon(linkServeArgs()); err != nil {
+	// anything by hand. Replay the last run's recorded serve flags (the same source
+	// `daemon restart` reads), so a --read-only or --no-notifications daemon that
+	// crashed comes back with the operator's controls intact rather than write-capable.
+	if err := ensureDaemon(restartServeArgs(loadStateFromDisk(stateDataDir()))); err != nil {
 		failJSON("could not start the whatsapp daemon: %v; run `whatsapp status`", err)
 	}
 	args, err := resolveStdinArgs(stripGlobalFlags(os.Args[1:]), "message", "text")

--- a/agent/skills/whatsapp/cli/cli.go
+++ b/agent/skills/whatsapp/cli/cli.go
@@ -359,7 +359,7 @@ func runOneShot(command string) {
 	// anything by hand. Replay the last run's recorded serve flags (the same source
 	// `daemon restart` reads), so a --read-only or --no-notifications daemon that
 	// crashed comes back with the operator's controls intact rather than write-capable.
-	if err := ensureDaemon(restartServeArgs(loadStateFromDisk(stateDataDir()))); err != nil {
+	if err := ensureDaemon(); err != nil {
 		failJSON("could not start the whatsapp daemon: %v; run `whatsapp status`", err)
 	}
 	args, err := resolveStdinArgs(stripGlobalFlags(os.Args[1:]), "message", "text")

--- a/agent/skills/whatsapp/cli/daemon.go
+++ b/agent/skills/whatsapp/cli/daemon.go
@@ -259,8 +259,6 @@ func pidRecordFor(pid int) string {
 	return strconv.Itoa(pid)
 }
 
-// ensureDaemon is the self-bootstrap every agent-facing command runs: a socket that answers is
-// all those commands need, whoever brought it up.
 // daemonBringupArgs picks the flags an implicit bringup starts the daemon with: the last run's
 // recorded flags, so a crashed --read-only or --no-notifications daemon comes back with the
 // control intact rather than write-capable, falling back to the instance flag alone when no run
@@ -269,6 +267,8 @@ func daemonBringupArgs() []string {
 	return restartServeArgs(loadStateFromDisk(stateDataDir()))
 }
 
+// ensureDaemon is the self-bootstrap every agent-facing command runs: a socket that answers is
+// all those commands need, whoever brought it up.
 func ensureDaemon() error {
 	if daemonAlive(getSocketPath()) {
 		return nil

--- a/agent/skills/whatsapp/cli/daemon.go
+++ b/agent/skills/whatsapp/cli/daemon.go
@@ -261,11 +261,19 @@ func pidRecordFor(pid int) string {
 
 // ensureDaemon is the self-bootstrap every agent-facing command runs: a socket that answers is
 // all those commands need, whoever brought it up.
-func ensureDaemon(serveArgs []string) error {
+// daemonBringupArgs picks the flags an implicit bringup starts the daemon with: the last run's
+// recorded flags, so a crashed --read-only or --no-notifications daemon comes back with the
+// control intact rather than write-capable, falling back to the instance flag alone when no run
+// was ever recorded. Every implicit bringup reads it, so no command path can drop the control.
+func daemonBringupArgs() []string {
+	return restartServeArgs(loadStateFromDisk(stateDataDir()))
+}
+
+func ensureDaemon() error {
 	if daemonAlive(getSocketPath()) {
 		return nil
 	}
-	_, err := startDaemonProcess(serveArgs)
+	_, err := startDaemonProcess(daemonBringupArgs())
 	return err
 }
 

--- a/agent/skills/whatsapp/cli/daemon_test.go
+++ b/agent/skills/whatsapp/cli/daemon_test.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -624,6 +625,48 @@ func TestRestartWithoutARecordedRunFallsBackToInstanceArgs(t *testing.T) {
 			t.Errorf("the default instance has no flags to fall back to, got %v", serveArgs)
 		}
 	})
+}
+
+// TestSelfBootstrapReplaysRecordedFlagsAfterCrash pins the one-shot self-bootstrap
+// (runOneShot's restartServeArgs(loadStateFromDisk(stateDataDir()))): a plain command
+// after a --read-only daemon crashed brings the daemon back read-only from the recorded
+// flags in state.json, not write-capable, even though the command's own args carry no
+// --read-only.
+func TestSelfBootstrapReplaysRecordedFlagsAfterCrash(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// The next command targets the same instance but carries no --read-only of its own.
+	withArgs(t, "--instance", "personal")
+	dataDir := stateDataDir()
+	if err := os.MkdirAll(dataDir, daemonDirPerms); err != nil {
+		t.Fatal(err)
+	}
+	// A read-only daemon ran, recorded its flags, then crashed. state.json persists.
+	newStateStore(dataDir).update(func(s *daemonState) {
+		s.Args, s.PID, s.StartedAt = []string{"--instance", "personal", "--read-only"}, 4242, time.Now().UTC()
+	})
+
+	serveArgs := restartServeArgs(loadStateFromDisk(stateDataDir()))
+	if !slices.Contains(serveArgs, "--read-only") {
+		t.Fatalf("self-bootstrap must replay the recorded --read-only flag, got %v", serveArgs)
+	}
+	if !slices.Contains(serveArgs, "personal") {
+		t.Fatalf("self-bootstrap must keep the recorded instance, got %v", serveArgs)
+	}
+}
+
+// TestSelfBootstrapFallsBackToInstanceArgsWithoutARecording pins the first-ever
+// bootstrap: with no recorded run the self-bootstrap falls back to the instance flag
+// alone (the linkServeArgs shape), so a cold start still works and carries no stray
+// --read-only.
+func TestSelfBootstrapFallsBackToInstanceArgsWithoutARecording(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	withArgs(t, "--instance", "personal")
+	serveArgs := restartServeArgs(loadStateFromDisk(stateDataDir()))
+	if !reflect.DeepEqual(serveArgs, []string{"--instance", "personal"}) {
+		t.Fatalf("without a recording the self-bootstrap falls back to instance args only, got %v", serveArgs)
+	}
 }
 
 // TestClaimTakesOverARecordTheRivalDropped pins the narrower of the two takeover paths: a rival

--- a/agent/skills/whatsapp/cli/daemon_test.go
+++ b/agent/skills/whatsapp/cli/daemon_test.go
@@ -627,12 +627,12 @@ func TestRestartWithoutARecordedRunFallsBackToInstanceArgs(t *testing.T) {
 	})
 }
 
-// TestSelfBootstrapReplaysRecordedFlagsAfterCrash pins the one-shot self-bootstrap
-// (runOneShot's restartServeArgs(loadStateFromDisk(stateDataDir()))): a plain command
-// after a --read-only daemon crashed brings the daemon back read-only from the recorded
-// flags in state.json, not write-capable, even though the command's own args carry no
-// --read-only.
-func TestSelfBootstrapReplaysRecordedFlagsAfterCrash(t *testing.T) {
+// TestDaemonBringupReplaysRecordedFlagsAfterCrash: a plain command after a --read-only daemon
+// crashed brings the daemon back read-only from the recorded flags in state.json, not
+// write-capable, even though the command's own args carry no --read-only. Every implicit bringup
+// (whatsapp status, connect, provision, the one-shot path) reads daemonBringupArgs, so this pins
+// the flags all of them start with.
+func TestDaemonBringupReplaysRecordedFlagsAfterCrash(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	// The next command targets the same instance but carries no --read-only of its own.
@@ -646,26 +646,25 @@ func TestSelfBootstrapReplaysRecordedFlagsAfterCrash(t *testing.T) {
 		s.Args, s.PID, s.StartedAt = []string{"--instance", "personal", "--read-only"}, 4242, time.Now().UTC()
 	})
 
-	serveArgs := restartServeArgs(loadStateFromDisk(stateDataDir()))
+	serveArgs := daemonBringupArgs()
 	if !slices.Contains(serveArgs, "--read-only") {
-		t.Fatalf("self-bootstrap must replay the recorded --read-only flag, got %v", serveArgs)
+		t.Fatalf("bringup must replay the recorded --read-only flag, got %v", serveArgs)
 	}
 	if !slices.Contains(serveArgs, "personal") {
-		t.Fatalf("self-bootstrap must keep the recorded instance, got %v", serveArgs)
+		t.Fatalf("bringup must keep the recorded instance, got %v", serveArgs)
 	}
 }
 
-// TestSelfBootstrapFallsBackToInstanceArgsWithoutARecording pins the first-ever
-// bootstrap: with no recorded run the self-bootstrap falls back to the instance flag
-// alone (the linkServeArgs shape), so a cold start still works and carries no stray
-// --read-only.
-func TestSelfBootstrapFallsBackToInstanceArgsWithoutARecording(t *testing.T) {
+// TestDaemonBringupFallsBackToInstanceArgsWithoutARecording pins the first-ever bringup:
+// with no recorded run it falls back to the instance flag alone (the linkServeArgs shape),
+// so a cold start still works and carries no stray --read-only.
+func TestDaemonBringupFallsBackToInstanceArgsWithoutARecording(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	withArgs(t, "--instance", "personal")
-	serveArgs := restartServeArgs(loadStateFromDisk(stateDataDir()))
+	serveArgs := daemonBringupArgs()
 	if !reflect.DeepEqual(serveArgs, []string{"--instance", "personal"}) {
-		t.Fatalf("without a recording the self-bootstrap falls back to instance args only, got %v", serveArgs)
+		t.Fatalf("without a recording the bringup falls back to instance args only, got %v", serveArgs)
 	}
 }
 

--- a/agent/skills/whatsapp/cli/link.go
+++ b/agent/skills/whatsapp/cli/link.go
@@ -274,7 +274,7 @@ func currentQRLink() activeQRLink {
 }
 
 func runLink() {
-	if err := ensureDaemon(linkServeArgs()); err != nil {
+	if err := ensureDaemon(); err != nil {
 		failJSON("%s", err.Error())
 	}
 	lock, err := acquireConnectLock()
@@ -336,7 +336,7 @@ func runLink() {
 }
 
 func runLinkPhone(phone string) {
-	if err := ensureDaemon(linkServeArgs()); err != nil {
+	if err := ensureDaemon(); err != nil {
 		failJSON("%s", err.Error())
 	}
 	lock, err := acquireConnectLock()

--- a/agent/skills/whatsapp/cli/provision.go
+++ b/agent/skills/whatsapp/cli/provision.go
@@ -9,7 +9,7 @@ package main
 // {status:"blocked"}). No daemon management, no readiness polling, no code
 // shuttling. Idempotent, so re-running is always safe.
 func runProvision(source, opener, directURL, directKey string) {
-	if err := ensureDaemon(linkServeArgs()); err != nil {
+	if err := ensureDaemon(); err != nil {
 		failJSON("%s", err.Error())
 	}
 	args := []string{}

--- a/agent/skills/whatsapp/cli/status.go
+++ b/agent/skills/whatsapp/cli/status.go
@@ -16,7 +16,7 @@ func runStatus() {
 	if err != nil {
 		failJSON("%s", err.Error())
 	}
-	if err := ensureDaemon(linkServeArgs()); err != nil {
+	if err := ensureDaemon(); err != nil {
 		printJSON(notLinkedStatus(resolved, err.Error()))
 		return
 	}


### PR DESCRIPTION
Closes #1890.

## In plain terms

An operator can run the whatsapp daemon with `--read-only` precisely so the agent can never write to an account (no sends, no read receipts, no presence). If that daemon crashes, the next ordinary `whatsapp` command self-bootstraps it back to life. The problem: the self-bootstrap brought it back **write-capable**, silently discarding the `--read-only` control. Same gap for `--no-notifications`. This closes that bypass so a read-only daemon stays read-only across a crash.

## Root cause

`runOneShot`'s self-bootstrap cold-started the daemon with `linkServeArgs()`, which carries only the instance flag:

```go
// link.go:161
func linkServeArgs() []string {
	if instance := extractInstance(); instance != "" {
		return []string{"--instance", instance}
	}
	return nil
}
```

`daemon restart` already does the right thing, replaying the last run's recorded flags:

```go
// daemon.go:410
func daemonRestart() {
	serveArgs := restartServeArgs(loadStateFromDisk(stateDataDir()))
	...
}

// daemon.go:425
func restartServeArgs(st daemonState) []string {
	if st.StartedAt.IsZero() {
		return linkServeArgs()
	}
	return st.Args
}
```

The serve process records its own flags on every boot, and that record persists across a crash (it lives in state.json):

```go
// cli.go:272
s.Args, s.PID, s.StartedAt = os.Args[1:], os.Getpid(), time.Now().UTC()
```

## The fix

Point the self-bootstrap at the same source `restartServeArgs` reads, so it replays the recorded serve flags and falls back to `linkServeArgs()` only when no run was ever recorded (a first-ever bootstrap):

```go
// cli.go, runOneShot
if err := ensureDaemon(restartServeArgs(loadStateFromDisk(stateDataDir()))); err != nil {
```

`restartServeArgs` is the one owner of "which flags bring the daemon back"; the self-bootstrap now defers to it rather than duplicating a narrower rule.

## Verification

Two new tests in the whatsapp cli package pin the behavior through the exact expression the self-bootstrap runs:

- `TestSelfBootstrapReplaysRecordedFlagsAfterCrash`: a state.json recording `--instance personal --read-only` yields a self-bootstrap arg list containing `--read-only` (and the instance), even though the current command carries no `--read-only` of its own.
- `TestSelfBootstrapFallsBackToInstanceArgsWithoutARecording`: no recording falls back to the instance-only args, so a cold first start still works and carries no stray `--read-only`.

There is no Go toolchain on the dev host, so the Go build and these tests run in CI's `comms-checks` job (`./check.sh whatsapp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review follow-up (completed the fix)

The Fable review found the first cut was a partial fix: only `runOneShot` was routed through the recorded flags, while the same `ensureDaemon(linkServeArgs())` bypass stayed reachable through `whatsapp status`, `connect`, and `provision`. Worse, `whatsapp status` is exactly what `runOneShot`'s own error text tells the user to run, and a bringup there would then record its flag-less args, permanently erasing `--read-only` from state.json so even the fixed path replays write-capable afterward. The two added tests were also vacuous (they called `restartServeArgs` directly, never the bringup path, so they passed with the fix reverted).

Fixed properly by routing the decision through one owner instead of per-call-site args:
- `ensureDaemon()` is now zero-arg and computes its bringup flags from a single named helper `daemonBringupArgs()` (`restartServeArgs(loadStateFromDisk(stateDataDir()))`), so no call site can pass the wrong args. All five implicit-bringup sites (`cli.go`, `status.go`, `link.go` x2, `provision.go`) now call `ensureDaemon()`.
- The two tests now assert on `daemonBringupArgs()` (the helper this PR adds), so a revert that drops the helper breaks their compilation: a recorded `--read-only` is replayed after a crash; no recording falls back to instance-only args.

`linkServeArgs` stays in use as `restartServeArgs`'s no-recording fallback, so first-ever bringup is unchanged and there is no dead code. No Go toolchain on this host, so the build/fmt/test run in CI comms-checks.
