### PR TITLE
fix(microsoft): poll device-authorized accounts and back off repeated auth_needed

### DIFF
--- a/agent/skills/microsoft/cli/src/microsoft_cli/config.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/config.py
@@ -1,7 +1,20 @@
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from .settings import DEFAULT_CLIENT_ID, get_settings
+
+
+def read_json_marker(path: Path) -> dict | None:
+    """Parse a per-account token marker, treating a missing or half-written one as absent. save_token
+    rewrites a marker on every refresh and does not write atomically, so a read can catch it truncated;
+    the routing that reads markers runs outside per-account containment, so a raise here would take the
+    whole poll cycle down over one torn file."""
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
 
 # Dynamic-consent scopes for the shared default public client (it has no permissions we control,
 # so ".default" would either grant nothing useful or demand admin consent for its whole catalog).

--- a/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/monitor.py
@@ -521,20 +521,52 @@ def _poll_teams_channels_account(ctx: MicrosoftContext, config: Config, account_
     return True
 
 
-def _refresh_captured_tokens(ctx: MicrosoftContext, config: Config, gave_up: set[str]) -> None:
+def _read_auth_needed(path: Path) -> set[str]:
+    """Accounts already told to re-authenticate, so a persistently gone account is not re-notified
+    every cycle. A missing or malformed file reads as none pending."""
+    raw = path.read_text() if path.exists() else ""
+    if not raw:
+        return set()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return set()
+    if isinstance(parsed, list):
+        return {str(account) for account in parsed}
+    return set()
+
+
+def _write_auth_needed(path: Path, accounts: set[str]) -> None:
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(sorted(accounts)))
+    tmp.rename(path)
+
+
+def _refresh_captured_tokens(ctx: MicrosoftContext, config: Config) -> None:
     """Silently re-mint browser-captured tokens before they expire, so the user signs in only once.
-    On a lapsed sign-in, notify once and stop retrying that account until the daemon restarts."""
+    A gone account (mailbox deleted, refresh token revoked) is due every cycle, so notify auth_needed
+    once and then stay quiet until the account refreshes again; the quiet flag is persisted, so a
+    daemon restart does not re-notify. A later successful refresh re-arms it, so the notification
+    that matters, a genuinely lapsed sign-in, still reaches the user the next time it lapses."""
     logger = ctx.monitor_logger
+    notified_path = ctx.monitor_base_dir / "auth_needed.json"
+    notified = _read_auth_needed(notified_path)
+    changed = False
     for account in capture.due_accounts(config, time.time()):
-        if account in gave_up:
-            continue
         try:
             saved = capture.refresh_and_save(config, account)
             logger.info("Refreshed Microsoft tokens for %s: %s", account, ", ".join(saved))
+            if account in notified:
+                notified.discard(account)
+                changed = True
         except capture.CaptureError as e:
             logger.warning("Token refresh failed for %s: %s", account, e)
-            gave_up.add(account)
-            notifications.write_notification(ctx.notif_dir, "auth_needed", interrupt=False, account=account, message=str(e))
+            if account not in notified:
+                notified.add(account)
+                changed = True
+                notifications.write_notification(ctx.notif_dir, "auth_needed", interrupt=False, account=account, message=str(e))
+    if changed:
+        _write_auth_needed(notified_path, notified)
 
 
 def _poll_graph_mail(ctx: MicrosoftContext, acc, new_check_time: datetime, last_dt: datetime, catching_up: bool) -> datetime | None:
@@ -607,7 +639,6 @@ def _poll_graph_calendar(ctx: MicrosoftContext, acc, new_check_time: datetime, l
 def run(ctx: MicrosoftContext):
     logger = ctx.monitor_logger
     logger.info("Monitor thread started")
-    refresh_gave_up: set[str] = set()
 
     while not ctx.monitor_stop_event.is_set():
         try:
@@ -616,7 +647,13 @@ def run(ctx: MicrosoftContext):
             config = Config(data_dir=ctx.cache_file.parent)
 
             msal_accounts = auth.list_accounts(ctx.cache_file)
+            owa_accounts = owa_rest.list_accounts(config)
+            # A device-flow owa-login leaves the account in the MSAL cache holding OWA REST scopes
+            # only: Graph cannot poll it, so it is routed to the OWA REST loop below, never Graph.
+            device_owa = {email.casefold() for email in owa_accounts if owa_rest.is_device_account(email, config)}
             for acc in msal_accounts:
+                if acc.username.casefold() in device_owa:
+                    continue
                 logger.info("Checking account: %s", acc.username)
                 _poll_unit(ctx, state, f"mail:{acc.username}", new_check_time, partial(_poll_graph_mail, ctx, acc, new_check_time))
                 _poll_unit(
@@ -627,11 +664,11 @@ def run(ctx: MicrosoftContext):
                     _whole_window(new_check_time, partial(_poll_graph_calendar, ctx, acc, new_check_time)),
                 )
 
-            # OWA REST accounts (locked tenants) are not in the MSAL cache, so poll them separately
-            # for anything Graph did not already cover.
-            msal_usernames = {acc.username.casefold() for acc in msal_accounts}
-            for account_email in owa_rest.list_accounts(config):
-                if account_email.casefold() in msal_usernames:
+            # OWA REST accounts poll for what Graph did not cover: a locked-tenant account absent from
+            # the MSAL cache, and a device account present in it but pollable only over OWA REST.
+            graph_covered = {acc.username.casefold() for acc in msal_accounts} - device_owa
+            for account_email in owa_accounts:
+                if account_email.casefold() in graph_covered:
                     continue
                 logger.info("Checking OWA REST account: %s", account_email)
                 watch_folders = notify.get_notify_folders(ctx.notify_file, account_email) if ctx.notify_file else ["inbox"]
@@ -669,7 +706,7 @@ def run(ctx: MicrosoftContext):
                 )
 
             # Keep browser-captured tokens fresh so the user's one sign-in lasts the SSO session.
-            _refresh_captured_tokens(ctx, config, refresh_gave_up)
+            _refresh_captured_tokens(ctx, config)
 
             state["last_cycle"] = new_check_time.isoformat()
             _write_state(ctx.monitor_state_file, state)

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
@@ -28,7 +28,7 @@ from typing import Any
 import httpx
 
 from . import auth
-from .config import OWA_REST_SCOPES
+from .config import OWA_REST_SCOPES, read_json_marker
 from .payloads import EventFields, EventPatch, MailDraft
 from .settings import OWA_REST_CLIENT_ID
 
@@ -95,14 +95,7 @@ def list_accounts(config) -> list[str]:
 
 
 def _read_marker(account_email: str, config) -> dict | None:
-    # save_token rewrites this file every refresh and does not write atomically, so a read can catch
-    # it truncated. An unreadable or half-written marker is treated as absent, exactly as a missing
-    # one is: the routing that reads it runs outside per-account containment, so a raise here would
-    # take the whole poll cycle down over one torn file.
-    try:
-        return json.loads(_token_path(account_email, config).read_text())
-    except (OSError, json.JSONDecodeError):
-        return None
+    return read_json_marker(_token_path(account_email, config))
 
 
 def _source(marker: dict) -> str:

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
@@ -95,9 +95,13 @@ def list_accounts(config) -> list[str]:
 
 
 def _read_marker(account_email: str, config) -> dict | None:
+    # save_token rewrites this file every refresh and does not write atomically, so a read can catch
+    # it truncated. An unreadable or half-written marker is treated as absent, exactly as a missing
+    # one is: the routing that reads it runs outside per-account containment, so a raise here would
+    # take the whole poll cycle down over one torn file.
     try:
         return json.loads(_token_path(account_email, config).read_text())
-    except FileNotFoundError:
+    except (OSError, json.JSONDecodeError):
         return None
 
 

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
@@ -117,6 +117,14 @@ def browser_token_expiry(account_email: str, config) -> float | None:
         return None
 
 
+def is_device_account(account_email: str, config) -> bool:
+    """True (network-free) when this OWA REST account authenticates by device flow: its tokens come
+    from the MSAL cache with OWA REST scopes only, so it has no Graph scopes and must be polled over
+    OWA REST rather than Graph."""
+    marker = _read_marker(account_email, config)
+    return marker is not None and _source(marker) == "device"
+
+
 def has_valid_token(account_email: str, config) -> bool:
     """Return True (network-free) if this account can produce an OWA REST token: a device-flow
     account still in the MSAL cache, or a browser-captured token that has not expired."""

--- a/agent/skills/microsoft/cli/src/microsoft_cli/teams.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/teams.py
@@ -79,9 +79,13 @@ def _token_path(account_email: str, config) -> pl.Path:
 
 
 def _read_marker(account_email: str, config) -> dict | None:
+    # save_token rewrites this file on every silent refresh and does not write atomically, so a read
+    # can catch it truncated. An unreadable or half-written marker is treated as absent, exactly as a
+    # missing one is: the refresh loop reads it every cycle outside per-account containment, so a
+    # raise here would take the whole poll cycle down over one torn file.
     try:
         return json.loads(_token_path(account_email, config).read_text())
-    except FileNotFoundError:
+    except (OSError, json.JSONDecodeError):
         return None
 
 

--- a/agent/skills/microsoft/cli/src/microsoft_cli/teams.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/teams.py
@@ -32,6 +32,7 @@ from typing import Any
 import httpx
 
 from . import auth, backend
+from .config import read_json_marker
 from .settings import DEFAULT_CLIENT_ID
 
 GRAPH_BASE = "https://graph.microsoft.com/v1.0"
@@ -79,14 +80,7 @@ def _token_path(account_email: str, config) -> pl.Path:
 
 
 def _read_marker(account_email: str, config) -> dict | None:
-    # save_token rewrites this file on every silent refresh and does not write atomically, so a read
-    # can catch it truncated. An unreadable or half-written marker is treated as absent, exactly as a
-    # missing one is: the refresh loop reads it every cycle outside per-account containment, so a
-    # raise here would take the whole poll cycle down over one torn file.
-    try:
-        return json.loads(_token_path(account_email, config).read_text())
-    except (OSError, json.JSONDecodeError):
-        return None
+    return read_json_marker(_token_path(account_email, config))
 
 
 def _source(marker: dict) -> str:

--- a/agent/skills/microsoft/cli/tests/test_monitor.py
+++ b/agent/skills/microsoft/cli/tests/test_monitor.py
@@ -55,6 +55,7 @@ def _fake_ctx(tmp_path):
     return types.SimpleNamespace(
         monitor_logger=logging.getLogger("test-monitor"),
         notif_dir=tmp_path,
+        monitor_base_dir=tmp_path,
         http_client=None,
         cache_file=tmp_path / "auth_cache.bin",
         get_calendar_notify_thresholds=lambda: [10080, 60, 15],
@@ -364,3 +365,166 @@ def test_graph_mail_pages_a_bounded_window_and_parks_before_the_last_message_rea
     assert asked["limit"] == monitor._MAX_WINDOW_MESSAGES
     assert len(calls) == monitor._MAX_WINDOW_MESSAGES
     assert read_through == datetime.fromisoformat(mailbox[-1]["receivedDateTime"]) - timedelta(seconds=1)
+
+
+# ---------------------------------------------------------------------------
+# Backend routing: a device-flow owa-login leaves the account in the MSAL cache
+# with OWA REST scopes only. It has no usable Graph scopes, so it must be polled
+# over OWA REST, not skipped as "already Graph-covered".
+# ---------------------------------------------------------------------------
+
+
+def _no_graph_no_teams_no_refresh(monkeypatch):
+    """No MSAL Graph accounts, no Teams, no due token refresh unless a test overrides them."""
+    monkeypatch.setattr(monitor.auth, "list_accounts", lambda *a, **k: [])
+    monkeypatch.setattr(monitor.teams, "list_accounts", lambda *a, **k: [])
+    monkeypatch.setattr(monitor.capture, "due_accounts", lambda *a, **k: [])
+    monkeypatch.setattr(monitor.owa_rest, "list_events", lambda *a, **k: [])
+
+
+def _spy_graph(monkeypatch):
+    """Record any Graph poll; the return values mimic reading nothing."""
+    graph_calls: list[str] = []
+    monkeypatch.setattr(monitor, "_poll_graph_mail", lambda _ctx, acc, *a, **k: graph_calls.append(acc.username))
+    monkeypatch.setattr(monitor, "_poll_graph_calendar", lambda _ctx, acc, *a, **k: bool(graph_calls.append(acc.username)))
+    return graph_calls
+
+
+def test_device_authorized_account_is_owa_polled_not_skipped(tmp_path, monkeypatch):
+    """#1866: a device owa-login account is in the MSAL cache AND has a `{"source": "device"}` OWA
+    marker. It must be OWA-polled, not skipped as an MSAL account Graph already covers."""
+    from microsoft_cli import auth, owa_rest
+    from microsoft_cli.config import Config
+
+    account = "donatella@pichinon.com"
+    config = Config(data_dir=tmp_path)
+    owa_rest.mark_device_account(account, config)  # real device marker on disk
+
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    _no_graph_no_teams_no_refresh(monkeypatch)
+    monkeypatch.setattr(monitor.auth, "list_accounts", lambda *a, **k: [auth.Account(username=account, account_id="acct-dev")])
+    _spy_graph(monkeypatch)
+
+    now = datetime.now(UTC)
+    arrived_at = now - timedelta(seconds=30)
+    monkeypatch.setattr(monitor.owa_rest, "list_messages_since", _mailbox(_email("boss@x.com", "Manager", arrived_at.isoformat())))
+
+    ctx = _run_ctx(tmp_path, cycles=1)
+    ctx.monitor_state_file.write_text((now - timedelta(seconds=60)).isoformat())
+    monitor.run(ctx)
+
+    assert [call["sender"] for call in calls] == ["Manager"]
+    assert calls[0]["account"] == account
+
+
+def test_device_authorized_account_is_not_graph_polled(tmp_path, monkeypatch):
+    """#1866: the device account has no Graph scopes, so Graph-polling it only logs errors. Routing
+    must send it to OWA REST alone."""
+    from microsoft_cli import auth, owa_rest
+    from microsoft_cli.config import Config
+
+    account = "donatella@pichinon.com"
+    owa_rest.mark_device_account(account, Config(data_dir=tmp_path))
+
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: None)
+    _no_graph_no_teams_no_refresh(monkeypatch)
+    monkeypatch.setattr(monitor.auth, "list_accounts", lambda *a, **k: [auth.Account(username=account, account_id="acct-dev")])
+    monkeypatch.setattr(monitor.owa_rest, "list_messages_since", lambda *a, **k: [])
+    graph_calls = _spy_graph(monkeypatch)
+
+    ctx = _run_ctx(tmp_path, cycles=1)
+    ctx.monitor_state_file.write_text((datetime.now(UTC) - timedelta(seconds=60)).isoformat())
+    monitor.run(ctx)
+
+    assert graph_calls == []
+
+
+def test_graph_account_with_browser_owa_marker_is_not_double_polled(tmp_path, monkeypatch):
+    """#1866 guard: an account with usable Graph scopes AND a browser OWA token (source != device)
+    stays Graph-only, so it is never polled and notified twice."""
+    from microsoft_cli import auth, owa_rest
+    from microsoft_cli.config import Config
+
+    account = "both@x.com"
+    config = Config(data_dir=tmp_path)
+    owa_rest.save_token(account, config, token="t", expires_at=datetime.now(UTC).timestamp() + 3600, source="browser")
+
+    _no_graph_no_teams_no_refresh(monkeypatch)
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: None)
+    monkeypatch.setattr(monitor.auth, "list_accounts", lambda *a, **k: [auth.Account(username=account, account_id="acct-both")])
+    owa_calls: list[str] = []
+    monkeypatch.setattr(monitor.owa_rest, "list_messages_since", lambda _c, acc, *a, **k: owa_calls.append(acc) or [])
+    graph_calls = _spy_graph(monkeypatch)
+
+    ctx = _run_ctx(tmp_path, cycles=1)
+    ctx.monitor_state_file.write_text((datetime.now(UTC) - timedelta(seconds=60)).isoformat())
+    monitor.run(ctx)
+
+    assert graph_calls == [account, account]  # mail + calendar
+    assert owa_calls == []  # OWA loop skipped it
+
+
+# ---------------------------------------------------------------------------
+# auth_needed backoff: a persistently-gone captured account must be notified
+# once, then stay quiet across daemon restarts, re-arming on recovery.
+# ---------------------------------------------------------------------------
+
+
+def _gone_captured_account(monkeypatch, account: str, refresh):
+    """Only a browser-captured account, due for refresh; `refresh(account)` decides its fate."""
+    monkeypatch.setattr(monitor.auth, "list_accounts", lambda *a, **k: [])
+    monkeypatch.setattr(monitor.teams, "list_accounts", lambda *a, **k: [])
+    monkeypatch.setattr(monitor.owa_rest, "list_accounts", lambda *a, **k: [])
+    monkeypatch.setattr(monitor.capture, "due_accounts", lambda *a, **k: [account])
+    monkeypatch.setattr(monitor.capture, "refresh_and_save", refresh)
+
+
+def test_auth_needed_notifies_once_across_daemon_restarts(tmp_path, monkeypatch):
+    """#1868: a gone account is due every cycle; a fresh `run()` (a daemon restart) must not re-notify,
+    so the quiet flag has to be persisted, not just held in memory."""
+    from microsoft_cli import capture
+
+    account = "gone@x.com"
+
+    def always_gone(_config, _account):
+        raise capture.CaptureError("No account found; mailbox is gone")
+
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    _gone_captured_account(monkeypatch, account, always_gone)
+
+    now = datetime.now(UTC)
+    for _restart in range(2):
+        ctx = _run_ctx(tmp_path, cycles=1)
+        ctx.monitor_state_file.write_text(now.isoformat())
+        monitor.run(ctx)
+
+    assert [call["account"] for call in calls] == [account]  # notified once, not once per restart
+
+
+def test_auth_needed_rearms_after_a_successful_refresh(tmp_path, monkeypatch):
+    """#1868: a recovery (successful refresh) clears the quiet flag, so a later lapse notifies again.
+    Without the re-arm, the account would stay silently quiet forever after its first failure."""
+    from microsoft_cli import capture
+
+    account = "flappy@x.com"
+    outcome = {"fail": True}
+
+    def sometimes(_config, _account):
+        if outcome["fail"]:
+            raise capture.CaptureError("mailbox gone")
+        return ["mail/calendar"]
+
+    calls = []
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: calls.append(k))
+    _gone_captured_account(monkeypatch, account, sometimes)
+
+    now = datetime.now(UTC)
+    for fail_this_cycle in (True, False, True):  # fail, recover, fail again
+        outcome["fail"] = fail_this_cycle
+        ctx = _run_ctx(tmp_path, cycles=1)
+        ctx.monitor_state_file.write_text(now.isoformat())
+        monitor.run(ctx)
+
+    assert [call["account"] for call in calls] == [account, account]  # re-armed by the recovery

--- a/agent/skills/microsoft/cli/tests/test_monitor.py
+++ b/agent/skills/microsoft/cli/tests/test_monitor.py
@@ -440,6 +440,31 @@ def test_device_authorized_account_is_not_graph_polled(tmp_path, monkeypatch):
     assert graph_calls == []
 
 
+def test_a_torn_token_marker_does_not_abort_the_whole_poll_cycle(tmp_path, monkeypatch):
+    """#1866 regression guard: the device-routing marker read runs outside per-account containment,
+    so a half-written token file must not take the whole cycle down. A torn marker reads as
+    no-device, so the account routes to Graph and still gets polled instead of the cycle dying."""
+    from microsoft_cli import auth, owa_rest
+    from microsoft_cli.config import Config
+
+    account = "donatella@pichinon.com"
+    path = owa_rest._token_path(account, Config(data_dir=tmp_path))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"source": "dev')  # save_token caught mid-write
+
+    monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: None)
+    _no_graph_no_teams_no_refresh(monkeypatch)
+    monkeypatch.setattr(monitor.auth, "list_accounts", lambda *a, **k: [auth.Account(username=account, account_id="acct-1")])
+    monkeypatch.setattr(monitor.owa_rest, "list_messages_since", lambda *a, **k: [])
+    graph_calls = _spy_graph(monkeypatch)
+
+    ctx = _run_ctx(tmp_path, cycles=1)
+    ctx.monitor_state_file.write_text((datetime.now(UTC) - timedelta(seconds=60)).isoformat())
+    monitor.run(ctx)
+
+    assert graph_calls != []  # the account was polled; the cycle survived the torn marker
+
+
 def test_graph_account_with_browser_owa_marker_is_not_double_polled(tmp_path, monkeypatch):
     """#1866 guard: an account with usable Graph scopes AND a browser OWA token (source != device)
     stays Graph-only, so it is never polled and notified twice."""

--- a/agent/skills/microsoft/cli/tests/test_monitor.py
+++ b/agent/skills/microsoft/cli/tests/test_monitor.py
@@ -396,7 +396,7 @@ def test_device_authorized_account_is_owa_polled_not_skipped(tmp_path, monkeypat
     from microsoft_cli import auth, owa_rest
     from microsoft_cli.config import Config
 
-    account = "donatella@pichinon.com"
+    account = "dana@example.com"
     config = Config(data_dir=tmp_path)
     owa_rest.mark_device_account(account, config)  # real device marker on disk
 
@@ -424,7 +424,7 @@ def test_device_authorized_account_is_not_graph_polled(tmp_path, monkeypatch):
     from microsoft_cli import auth, owa_rest
     from microsoft_cli.config import Config
 
-    account = "donatella@pichinon.com"
+    account = "dana@example.com"
     owa_rest.mark_device_account(account, Config(data_dir=tmp_path))
 
     monkeypatch.setattr(monitor.notifications, "write_notification", lambda *a, **k: None)
@@ -447,7 +447,7 @@ def test_a_torn_token_marker_does_not_abort_the_whole_poll_cycle(tmp_path, monke
     from microsoft_cli import auth, owa_rest
     from microsoft_cli.config import Config
 
-    account = "donatella@pichinon.com"
+    account = "dana@example.com"
     path = owa_rest._token_path(account, Config(data_dir=tmp_path))
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text('{"source": "dev')  # save_token caught mid-write

--- a/agent/skills/microsoft/cli/tests/test_owa_rest.py
+++ b/agent/skills/microsoft/cli/tests/test_owa_rest.py
@@ -657,6 +657,16 @@ def test_device_account_absent_from_cache_is_unavailable(tmp_path, monkeypatch):
     assert owa_rest.has_valid_token("user@example.com", cfg) is False
 
 
+def test_a_torn_token_marker_reads_as_no_device_account_not_a_crash(tmp_path):
+    from microsoft_cli.config import Config
+
+    cfg = Config(data_dir=tmp_path)
+    path = owa_rest._token_path("user@example.com", cfg)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"source": "dev')  # save_token caught mid-write, non-atomic
+    assert owa_rest.is_device_account("user@example.com", cfg) is False
+
+
 def test_load_token_device_uses_msal_silent(tmp_path, monkeypatch):
     from microsoft_cli.config import Config
 

--- a/agent/skills/microsoft/cli/tests/test_teams.py
+++ b/agent/skills/microsoft/cli/tests/test_teams.py
@@ -52,6 +52,16 @@ def test_has_token_false_when_no_file(tmp_path):
     assert teams.has_token("user@example.com", Config(data_dir=tmp_path)) is False
 
 
+def test_a_torn_teams_marker_reads_as_absent_not_a_crash(tmp_path):
+    cfg = Config(data_dir=tmp_path)
+    path = teams._token_path("user@example.com", cfg)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"source": "brow')  # save_token caught mid-write, non-atomic
+    # browser_token_expiry runs in the refresh loop outside per-account containment, so a raise here
+    # would take the whole poll cycle down over one half-written file.
+    assert teams.browser_token_expiry("user@example.com", cfg) is None
+
+
 def test_has_token_true_for_fresh_browser_token(tmp_path):
     cfg = Config(data_dir=tmp_path)
     future = time.time() + 7200


### PR DESCRIPTION
Closes #1866
Closes #1868

## In plain terms

Two independent monitor bugs in the microsoft skill, both in `monitor.py`.

1. **A mailbox connected with `owa-login --device` was silently unmonitored (#1866).** A device sign-in leaves the account in the MSAL cache but with OWA REST scopes only, no Graph scopes. The monitor Graph-polled it (which fails, "No Graph token available") and then skipped it in the OWA REST loop because it saw it in the MSAL cache and assumed Graph already covered it. Result: the account was polled by neither path, its watermark never moved, and no new-mail notification ever fired, even though `microsoft email list --backend owa-rest` read it fine.

2. **`auth_needed` fired every poll cycle forever once an account was gone (#1868).** When a captured account's sign-in lapses permanently (mailbox deleted, refresh token revoked), it is "due" for refresh every cycle, the refresh keeps failing, and an `auth_needed` notification was emitted each time. The only guard was an in-memory give-up set, reset on every daemon restart, so the user got the notification roughly hourly. That trains the agent to filter exactly the notification that matters the first time.

## What changed

**Routing (#1866).** Each account is now routed to exactly one backend using the on-disk OWA marker (`is_device_account`, network-free):
- A device account is polled over OWA REST and excluded from the Graph loop (Graph cannot poll it anyway).
- A locked-tenant browser account absent from the MSAL cache is polled over OWA REST, as before.
- A Graph account that also carries a browser OWA token stays Graph-only and is never double-polled (the reporter's open concern), so it can never notify twice.

**Backoff (#1868).** The give-up set becomes a persisted `monitor/auth_needed.json`. A gone account is told to re-authenticate once and then stays quiet across daemon restarts. A later successful refresh clears its entry, re-arming the notification so a genuinely new lapse still reaches the user. This is the issue's preferred option 2 (notify once, then quiet, re-arm on recovery), kept minimal (no scheduler). Composes with the recent #1869 unit-isolation rework: unchanged `_poll_unit` containment, no device flow initiated from the monitor.

## Verification

Reproductions written first, confirmed to fail against the current code, then made to pass, then mutation-tested (revert each fix hunk, confirm the matching test fails).

Against unmodified code (reproductions):
```
FAILED test_device_authorized_account_is_owa_polled_not_skipped   # #1866
FAILED test_device_authorized_account_is_not_graph_polled          # #1866
FAILED test_auth_needed_notifies_once_across_daemon_restarts       # #1868
2 passed  (the double-poll guard and the re-arm guard, which hold on current behavior)
```

After the fix: full microsoft CLI suite `376 passed`. `ruff check` / `ruff format --check` clean, `ty check` clean, daemon-contract microsoft rows green.

Mutation testing (each reverted hunk killed by the intended test alone):
| Mutation | Test that fails |
| --- | --- |
| Graph loop does not skip device accounts | `test_device_authorized_account_is_not_graph_polled` |
| OWA loop skips device accounts (old `msal_usernames`) | `test_device_authorized_account_is_owa_polled_not_skipped` |
| Always notify (drop the persisted quiet check) | `test_auth_needed_notifies_once_across_daemon_restarts` |
| Drop the re-arm on successful refresh | `test_auth_needed_rearms_after_a_successful_refresh` |

No real Microsoft/Graph network calls: tests write real device/browser markers to a tmp dir and monkeypatch the fetch/refresh edges, as the existing monitor tests do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review follow-up (blocking fix)

The Fable review caught a regression this PR introduced: the new device-routing reads a token marker via `_read_marker`, which caught only `FileNotFoundError`. `save_token` rewrites that file every refresh non-atomically, so a read can catch it truncated; the resulting `JSONDecodeError` propagated from `is_device_account`, which runs at the top of the poll cycle OUTSIDE `_poll_unit`'s per-account containment, taking the whole cycle down over one torn file, silently, forever, the #1708/#1710 malformed-file class and the very outage #1866 exists to fix.

Fixed at the root (`11cbcb33`): `_read_marker` now treats any unreadable or half-written marker as absent (`except (OSError, json.JSONDecodeError)`), exactly as a missing one already was, so a torn marker routes that one account to Graph rather than crashing the fleet's mailbox monitoring. Two tests added, both mutation-verified to fail when the except is narrowed back: a unit test (torn marker -> `is_device_account` returns False, no raise) and a monitor-cycle test (a torn marker leaves the cycle running and the account still polled).

Non-blocking review note left as a follow-up: a fresh `owa-login` does not clear `auth_needed.json`, so a second genuine lapse before the first post-relogin monitor refresh is suppressed once. Narrow edge; the monitor re-arms on its next successful refresh.
