### PR TITLE
ci(live): retry only the failed live tests, not the whole suite

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -135,18 +135,16 @@ jobs:
         working-directory: vestad
         run: cargo build
 
+      # On a failure, retry only the tests that failed, not the whole suite: the live suite shares
+      # one in-process 2-agent pool, so the retry stays at the suite level (see the script). The
+      # job-level timeout-minutes bounds the run.
       - name: Run live end-to-end tests
         if: steps.credentials.outputs.available == 'true'
-        uses: nick-fields/retry@v4
+        shell: bash
         env:
           # Inputs are passed through the environment instead of interpolated
           # into the command, preventing workflow-dispatch shell injection.
-          TEST_FILTER: ${{ inputs.test_filter }}
+          LIVE_TEST_FILTER: ${{ inputs.test_filter }}
           VESTA_UPGRADE_FROM: ${{ inputs.upgrade_from }}
           VESTA_UPGRADE_TO: ${{ inputs.upgrade_to }}
-        with:
-          timeout_minutes: 40
-          max_attempts: 2
-          retry_wait_seconds: 30
-          shell: bash
-          command: VESTAD_AGENT_IMAGE=vesta:local LIVE_TEST_FILTER="$TEST_FILTER" ./check.sh live
+        run: scripts/run-live-retry.sh

--- a/check.sh
+++ b/check.sh
@@ -296,7 +296,9 @@ check_live() {
     # this suite, so the release gate covers it alongside the other live tests.
     local test_args=()
     if [ -n "${LIVE_TEST_FILTER:-}" ]; then
-      test_args+=("$LIVE_TEST_FILTER")
+      # Space-separated so a retry can re-run several failed tests in one filtered run.
+      read -ra live_filters <<< "$LIVE_TEST_FILTER"
+      test_args+=("${live_filters[@]}")
     fi
     cargo test -p vestad --test live "${test_args[@]}" -- --test-threads=8
   )

--- a/scripts/run-live-retry.sh
+++ b/scripts/run-live-retry.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Run the live release-gate suite; on failure, retry ONLY the tests that failed, not the whole
+# suite. The live suite shares one in-process 2-agent pool (tests/live/common.rs), so retries must
+# stay at the suite/process level: cargo-nextest runs each test in its own process and would break
+# that shared pool. Attempt 2 is a fresh cargo-test run filtered to the names that failed.
+set -uo pipefail
+
+run_live() { VESTAD_AGENT_IMAGE=vesta:local ./check.sh live; }
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+echo "live tests: attempt 1"
+if run_live 2>&1 | tee "$log"; then
+  exit 0
+fi
+
+# libtest ends a failed run with an indented list of failed test paths under a "failures:" header.
+mapfile -t failed < <(
+  sed -n '/^failures:$/,/^test result:/p' "$log" \
+    | grep -E '^    [A-Za-z0-9_]+(::[A-Za-z0-9_]+)+$' \
+    | tr -d ' ' | sort -u
+)
+
+if [ "${#failed[@]}" -eq 0 ]; then
+  echo "live tests: could not identify the failed tests; retrying the full suite"
+  retried="the full suite"
+else
+  echo "live tests: attempt 2 reruns only: ${failed[*]}"
+  retried="${failed[*]}"
+  export LIVE_TEST_FILTER="${failed[*]}"
+fi
+
+# Flakiness must stay visible, not be silently absorbed by the retry (mirrors ci.yml).
+echo "::warning title=Flaky live tests::Live suite failed on attempt 1 and retried: ${retried}"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## ⚠️ Live test flakiness"
+    echo ""
+    echo "The live suite failed on attempt 1 and retried: **${retried}**."
+    echo "Check attempt 1's logs above for a masked real failure."
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+run_live


### PR DESCRIPTION
## Problem

The live release gate wraps `./check.sh live` in `nick-fields/retry` with `max_attempts: 2`. When one live test flakes, attempt 2 re-runs **all eight** live tests instead of the one that failed, wasting ~11 minutes of real-Claude runtime (and pushing against the 45‑minute job timeout).

## Fix

Replace the blanket action retry with a small wrapper, `scripts/run-live-retry.sh`:

1. Run the suite once.
2. On failure, parse libtest's trailing `failures:` list and re-run `cargo test` filtered to just those test names.

`check.sh` now splits `LIVE_TEST_FILTER` on whitespace so the retry can pass several failed names in one filtered run. If no failed names can be parsed, it falls back to re-running the full suite (never worse than today). The flaky-retry warning + job-summary parity from `ci.yml` is preserved.

### Why not cargo-nextest

nextest's native `--retries` retries only failed tests, but it runs each test in its own **process**. The live suite shares one in-process 2-agent pool (`tests/live/common.rs`) coordinated by a process-global mutex, so per-test process isolation would break the pool. The retry has to stay at the suite/process level; attempt 2 is a fresh, filtered `cargo test` run.

## Verification

- `shellcheck -S warning` clean on the new script and `check.sh`.
- `scripts/check-conventions.py` passes.
- Workflow YAML validated.
- Failed-test extraction unit-checked against a realistic two-block libtest tail (correctly picks the one failed test, ignores `::`-bearing panic output).

The live gate itself only runs in the release pipeline (real Claude creds), so end-to-end retry behavior can't run on a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)