### PR TITLE
fix(agent): stop the dash correction firing on filtered whitespace and relayed text

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -421,7 +421,9 @@ def _contains_dashes(text: str) -> bool:
 async def process_message(msg: str, *, state: vm.State, config: cfg.VestaConfig) -> tuple[list[str], vm.State]:
     turn = await converse(msg, state=state, config=config, show_output=True)
     # turn.texts holds one entry per assistant message of the turn, and the warning can only ask for the last message back.
-    if config.block_dashes and turn.texts and _contains_dashes(turn.texts[-1]) and not turn.preempted:
+    # Check the same filtered copy _emit_parsed_content publishes: filter_tool_lines strips each line's
+    # leading whitespace, so an indented markdown bullet's " - " is not a separator in the emitted text.
+    if config.block_dashes and turn.texts and _contains_dashes(sdk_parsing.filter_tool_lines(turn.texts[-1])) and not turn.preempted:
         # A preempted turn's reply was cut short at a step boundary; correcting a truncated
         # reply would re-send it after the preempting prompt's work, so skip it.
         logger.warning("Em/en dash detected in response, sending correction")

--- a/agent/skills/personality/SKILL.md
+++ b/agent/skills/personality/SKILL.md
@@ -12,7 +12,7 @@ Voice, not spine. The shared rules below hold for every preset. Each file in `pr
 These are the voice invariants. They live here once, not in MEMORY.md and not copied into each preset.
 
 - Plain language. No corporate or technical jargon, no process narration. Casual slang is fine when the voice calls for it.
-- Write without em dashes or " - " as a separator. Use commas, periods, colons.
+- Write without em dashes or " - " as a separator. Use commas, periods, colons. This covers everything you send, including text you quote or relay (subagent reports, tool output, pasted sources): rephrase their dashes away before passing them on.
 - Never "it's not X, it's Y" or "not just X, but Y" framing. Drop the contrast, just say what it is.
 - Surface results, not process.
 - Never grovels, never fake-sorries. Admit a mistake briefly and move on.

--- a/agent/tests/test_processor.py
+++ b/agent/tests/test_processor.py
@@ -402,6 +402,32 @@ async def test_process_message_no_correction(tmp_path, response):
     assert len(converse_calls) == 1
 
 
+@pytest.mark.parametrize(
+    ("response", "expected_calls"),
+    [(["Options:\n  - alpha\n  - beta"], 1), (["  - alpha\n  - beta"], 1), (["foo - bar"], 2)],
+    ids=["indented-bullets-after-intro", "indented-bullets-only", "genuine-separator"],
+)
+@pytest.mark.anyio
+async def test_process_message_checks_the_emitted_copy(tmp_path, response, expected_calls):
+    """The dash check runs over the same filter_tool_lines copy that reaches the event bus: emit strips
+    each line's leading whitespace, so an indented markdown bullet's " - " is not a separator in what the
+    user saw (issue #1539), while a genuine mid-line " - " separator survives the filter and corrects."""
+    config = cfg.VestaConfig(agent_dir=tmp_path / "agent")
+    state = vm.State()
+    converse_calls: list[str] = []
+
+    async def mock_converse(prompt, *, state, config, show_output):
+        converse_calls.append(prompt)
+        if len(converse_calls) == 1:
+            return vm.TurnSignals(texts=response)
+        return vm.TurnSignals(texts=["corrected response"])
+
+    with patch("core.client.converse", side_effect=mock_converse):
+        await process_message("hello", state=state, config=config)
+
+    assert len(converse_calls) == expected_calls
+
+
 @pytest.mark.anyio
 async def test_process_message_no_correction_when_block_dashes_off(tmp_path):
     """With block_dashes disabled, a dashed reply is left as-is: no correction turn."""


### PR DESCRIPTION
Closes #1539, closes #1401.

## In plain terms

Vesta has a rule against em dashes and " - " separators, enforced by a correction turn: if the reply contains one, core asks Vesta to resend the message without it. Two ways that correction fired when it should not have, each costing a wasted turn:

1. **Indented markdown bullets (#1539).** The check read the raw assistant text, but the copy users actually see goes through `filter_tool_lines`, which strips each line's leading whitespace. A nested bullet `"  - alpha"` contains `" - "` raw but is emitted as `"- alpha"`, no separator. So Vesta was told to fix a dash that was never visible.
2. **Quoted/relayed text (#1401).** When Vesta relays a subagent report or quotes tool output verbatim, dashes in that source text trip the check even though Vesta composed nothing with a dash. This half is guidance, not code: the runtime check is deliberately unchanged.

## Changes

- `agent/core/client.py`: `process_message` now runs `_contains_dashes` over `sdk_parsing.filter_tool_lines(turn.texts[-1])`, the same filtered copy `_emit_parsed_content` publishes to the event bus. The check and the emitted text can no longer disagree: if the filter hides a dash, the check ignores it; a dash that survives into the emitted text is always present raw too (the filter only deletes whitespace), so no visible dash goes uncorrected. Issue #1539 floated fixing the `" - "` heuristic instead; checking the emitted copy was chosen because the rule is about what the user sees, `process_message` is the check's only caller, and it tracks the display filter by construction instead of re-deriving its whitespace behavior in a second place.
- `agent/skills/personality/SKILL.md`: the shared voice rule now states its scope: it covers everything the agent sends, quoted or relayed text included, with the positive instruction to rephrase dashes out of subagent reports and tool output before passing them on. #1539's code fix does not cover #1401 mechanically (a relayed mid-line " - " or em dash survives the filter, correctly, since it is visible), so the guidance is the whole fix for that half, per the issue.
- `agent/tests/test_processor.py`: `test_process_message_checks_the_emitted_copy`, a discriminating table through the real `filter_tool_lines`: indented bullets (with and without an intro line) must not trigger the correction, a genuine `"foo - bar"` separator still must.

Composes with #1534 (merged), which scoped the check to the turn's last message; this PR only changes which copy of that last message is checked.

## Verification

- `uv run --project core pytest tests/ -k "dash or correct or filter or message"`: 66 passed, 2 skipped
- Mutation test: with the `client.py` fix reverted, both indented-bullet cases fail (reproducing #1539 on master) and the genuine-separator case still passes; restored, all pass
- `ruff check` + `ruff format --check` on touched files, `ty check`: clean
- `./check.sh guards`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)