### PR TITLE
fix(tasks,notifications): honest --json limit, a title soft-cap, and sender_address matching

### DIFF
--- a/agent/core/notification_interrupt_policy.py
+++ b/agent/core/notification_interrupt_policy.py
@@ -30,7 +30,10 @@ from .notification import CORE_SOURCE, Notification
 # that exact field; an alias here expands to a set of per-source synonyms and matches if ANY of them
 # satisfies the op. This is the single place cross-source field-name knowledge lives — a new source's
 # new field is targetable by its concrete name with no code change.
-_IDENTITY_FIELDS = ("sender", "contact_name", "handle", "from", "author")
+# `sender_address` sits last: a source that splits identity (microsoft's `sender` display name +
+# `sender_address` email) must still be targetable by address, while notif_sender (first present
+# wins) keeps preferring the human-readable name.
+_IDENTITY_FIELDS = ("sender", "contact_name", "handle", "from", "author", "sender_address")
 # `subject` and `preview` belong here: email notifications carry those two and never
 # body/message/content, so a `text` alias that skipped them could never match an email, and a
 # rule that never matches looks identical to a rule whose topic never came up.

--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -23,6 +23,7 @@ tasks delete <id>                 # cascades to linked reminders
 ```
 
 - Due date: `--due-in-minutes/--due-in-hours/--due-in-days` (relative) or `--due-datetime` + `--timezone` (absolute, both required). `--priority` low/normal/high. `--initial-metadata "..."` attaches notes.
+- Keep the title under ~100 characters: it is the one field `tasks list`, the digest, and the app show, so a paragraph there is unreadable everywhere. Detail and running state go in metadata (`--initial-metadata` on add, or edit the task's `metadata_path` file). A longer title still saves, with a warning.
 - `postpone` also takes `--in-minutes/--in-hours` or `--at` + `--tz`, and works on a task with no due date (gives it one).
 - `update --clear-due` removes a due date. Every other due flag can only move a date, so without this a due date is a one-way door: auto reminders are regenerated from `due_date`, so deleting them by hand does not stick. Reach for it when a date was set by mistake or by a bulk `postpone` over a backlog, since a backburner item with a due date fires a whole reminder cascade it never earned.
 - `tasks get <id> --field status` prints just that field (repeat `--field` for several, tab-separated). Valid fields: id, title, status, priority, due_date, created_at, completed_at, metadata_path, metadata. Prefer this over reading the metadata file when you need one value.

--- a/agent/skills/tasks/cli/src/tasks_cli/cli.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/cli.py
@@ -27,6 +27,21 @@ def _require_arg(value: str | None, name: str, usage: str) -> str:
     return value
 
 
+# Soft cap only: a warning, never a rejection, because a legitimately long title exists. The title
+# is the one field every list and digest shows, so detail belongs in metadata, not appended here.
+TITLE_SOFT_CAP_CHARS = 100
+
+
+def _warn_long_title(title: str) -> None:
+    if len(title) <= TITLE_SOFT_CAP_CHARS:
+        return
+    msg = (
+        f"title is {len(title)} chars; keep the title short and scannable, and put the detail "
+        "in the task's metadata instead (the metadata_path file in this result, or --initial-metadata on add)"
+    )
+    print(json.dumps({"warning": msg}), file=sys.stderr)
+
+
 def _require_daemon():
     if daemon.live_pid() is None:
         msg = "daemon not running, start it with: tasks daemon start"
@@ -199,13 +214,25 @@ def main():
         sys.exit(1)
 
 
+REMIND_LIST_PAGE_SIZE = 50
+
+
 def _remind_list_cmd(config: Config, argv: list[str]) -> None:
     p = argparse.ArgumentParser(prog="tasks remind list", add_help=False)
     p.add_argument("--task", default=None, dest="task_id")
-    p.add_argument("--limit", type=int, default=50)
+    p.add_argument("--limit", type=int, default=None)
     _add_format_flags(p)
     args = p.parse_args(argv)
-    _print_list(args, commands.remind_list(config, task_id=args.task_id, limit=args.limit), fmt.format_reminder_list)
+    # JSON is consumed by scripts asking absence questions ("is anything scheduled for X?"), so a
+    # silent page size would make a truncated list read as "no". Only an explicit --limit caps
+    # JSON output; the human table keeps its page size.
+    if args.limit is not None:
+        limit = args.limit
+    elif args.json or args.json_pretty:
+        limit = None
+    else:
+        limit = REMIND_LIST_PAGE_SIZE
+    _print_list(args, commands.remind_list(config, task_id=args.task_id, limit=limit), fmt.format_reminder_list)
 
 
 def _remind_delete_cmd(config: Config, argv: list[str]) -> dict:
@@ -353,7 +380,7 @@ options:
   --fuzz-minutes N      Recurring/cron only: each fire lands within +/-N minutes of the nominal time
 
 subcommands:
-  list                  List active reminders
+  list                  List active reminders (table shows the first 50; --json/--json-pretty list all unless --limit is given)
   snooze                Push a one-shot reminder back (works on fired ones too)
   delete                Delete a reminder
   update                Update a reminder message""")
@@ -362,6 +389,7 @@ subcommands:
 def _handle_task(args, config: Config):
     if args.command == "add":
         title = _require_arg(args.title_pos or args.title, "title", 'tasks add "title" or tasks add --title "title"')
+        _warn_long_title(title)
         result = commands.add_task(
             config,
             title=title,
@@ -390,6 +418,8 @@ def _handle_task(args, config: Config):
         result = commands.get_task(config, task_id=task_id)
     elif args.command == "update":
         task_id = _require_arg(args.id_pos or args.task_id, "id", "tasks update <id> or tasks update --id <id>")
+        if args.title is not None:
+            _warn_long_title(args.title)
         result = commands.update_task(
             config,
             task_id=task_id,

--- a/agent/skills/tasks/cli/src/tasks_cli/commands.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/commands.py
@@ -967,7 +967,9 @@ def _next_run_for_row(row) -> str | None:
     return row["scheduled_time"]
 
 
-def remind_list(config: Config, *, task_id: str | None = None, limit: int = 50) -> list[dict]:
+def remind_list(config: Config, *, task_id: str | None = None, limit: int | None = 50) -> list[dict]:
+    # limit=None means every row: SQLite reads LIMIT -1 as unlimited.
+    limit_param = -1 if limit is None else limit
     # Recurring reminders sort first so the LIMIT only ever trims one-shots, and the one-shot tail
     # sorts by fire time (scheduled_time ASC) so the LIMIT drops the furthest-out rows, never the
     # soonest, keeping "what fires next" visible at any limit. Recurring rows keep created_at
@@ -985,12 +987,12 @@ def remind_list(config: Config, *, task_id: str | None = None, limit: int = 50) 
         if task_id is not None:
             cursor = conn.execute(
                 f"SELECT * FROM reminders WHERE completed = 0 AND task_id = ? {order_clause}",
-                (task_id, limit),
+                (task_id, limit_param),
             )
         else:
             cursor = conn.execute(
                 f"SELECT * FROM reminders WHERE completed = 0 {order_clause}",
-                (limit,),
+                (limit_param,),
             )
         return [
             {

--- a/agent/skills/tasks/cli/tests/test_remind_list_json_limit.py
+++ b/agent/skills/tasks/cli/tests/test_remind_list_json_limit.py
@@ -1,0 +1,54 @@
+"""`tasks remind list --json` never silently truncates: JSON is consumed by scripts asking absence
+questions ("is anything scheduled for X?"), so a hidden page size would answer them wrongly. Only an
+explicit --limit caps JSON output; the human table keeps its page size."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from tasks_cli import cli, commands, db
+from tasks_cli.config import Config
+
+
+@pytest.fixture
+def tmp_config(tmp_path: Path) -> Config:
+    cfg = Config(data_dir=tmp_path / "tasks", log_dir=tmp_path / "tasks" / "logs")
+    cfg.data_dir.mkdir(parents=True, exist_ok=True)
+    db.init_db(cfg.data_dir)
+    return cfg
+
+
+REMINDER_COUNT = 60  # comfortably past the table page size of 50
+
+
+def _seed_reminders(cfg: Config, count: int) -> None:
+    for i in range(count):
+        commands.remind_set(cfg, commands.ReminderSpec(message=f"r{i}", in_minutes=10 + i))
+
+
+def _run_remind_list(monkeypatch, capsys, cfg: Config, *argv: str) -> str:
+    monkeypatch.setattr(cli, "Config", lambda: cfg)
+    monkeypatch.setattr(cli.daemon, "live_pid", lambda: 1)
+    monkeypatch.setattr(sys, "argv", ["tasks", "remind", "list", *argv])
+    cli.main()
+    return capsys.readouterr().out
+
+
+@pytest.mark.parametrize("json_flag", ["--json", "--json-pretty"])
+def test_json_returns_every_reminder(tmp_config: Config, monkeypatch, capsys, json_flag: str):
+    _seed_reminders(tmp_config, REMINDER_COUNT)
+    listed = json.loads(_run_remind_list(monkeypatch, capsys, tmp_config, json_flag))
+    assert len(listed) == REMINDER_COUNT
+
+
+def test_json_honors_an_explicit_limit(tmp_config: Config, monkeypatch, capsys):
+    _seed_reminders(tmp_config, REMINDER_COUNT)
+    listed = json.loads(_run_remind_list(monkeypatch, capsys, tmp_config, "--json", "--limit", "10"))
+    assert len(listed) == 10
+
+
+def test_table_output_keeps_its_page_size(tmp_config: Config, monkeypatch, capsys):
+    _seed_reminders(tmp_config, REMINDER_COUNT)
+    table = _run_remind_list(monkeypatch, capsys, tmp_config).strip()
+    assert len(table.splitlines()) == cli.REMIND_LIST_PAGE_SIZE

--- a/agent/skills/tasks/cli/tests/test_title_soft_cap.py
+++ b/agent/skills/tasks/cli/tests/test_title_soft_cap.py
@@ -1,0 +1,59 @@
+"""A task title past the soft cap warns on stderr and points at metadata, but the write always
+happens: the cap is advisory because a legitimately long title exists. stdout stays the command's
+JSON result either way."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from tasks_cli import cli, commands, db
+from tasks_cli.config import Config
+
+LONG_TITLE = "reclaim the expense: " + "detail " * 20  # well past the 100-char soft cap
+SHORT_TITLE = "Reclaim the expense"
+
+
+@pytest.fixture
+def tmp_config(tmp_path: Path) -> Config:
+    cfg = Config(data_dir=tmp_path / "tasks", log_dir=tmp_path / "tasks" / "logs")
+    cfg.data_dir.mkdir(parents=True, exist_ok=True)
+    db.init_db(cfg.data_dir)
+    return cfg
+
+
+def _run_tasks(monkeypatch, capsys, cfg: Config, *argv: str):
+    monkeypatch.setattr(cli, "Config", lambda: cfg)
+    monkeypatch.setattr(cli.daemon, "live_pid", lambda: 1)
+    monkeypatch.setattr(sys, "argv", ["tasks", *argv])
+    cli.main()
+    return capsys.readouterr()
+
+
+def test_add_long_title_warns_but_still_creates(tmp_config: Config, monkeypatch, capsys):
+    out = _run_tasks(monkeypatch, capsys, tmp_config, "add", LONG_TITLE)
+    warning = json.loads(out.err)["warning"]
+    assert "metadata" in warning
+    created = json.loads(out.out)
+    assert created["title"] == LONG_TITLE
+    assert commands.get_task(tmp_config, task_id=created["id"])["title"] == LONG_TITLE
+
+
+def test_add_short_title_does_not_warn(tmp_config: Config, monkeypatch, capsys):
+    out = _run_tasks(monkeypatch, capsys, tmp_config, "add", SHORT_TITLE)
+    assert out.err == ""
+    assert json.loads(out.out)["title"] == SHORT_TITLE
+
+
+def test_update_long_title_warns_but_still_applies(tmp_config: Config, monkeypatch, capsys):
+    task = commands.add_task(tmp_config, title=SHORT_TITLE)
+    out = _run_tasks(monkeypatch, capsys, tmp_config, "update", task["id"], "--title", LONG_TITLE)
+    assert "metadata" in json.loads(out.err)["warning"]
+    assert commands.get_task(tmp_config, task_id=task["id"])["title"] == LONG_TITLE
+
+
+def test_update_short_title_does_not_warn(tmp_config: Config, monkeypatch, capsys):
+    task = commands.add_task(tmp_config, title=SHORT_TITLE)
+    out = _run_tasks(monkeypatch, capsys, tmp_config, "update", task["id"], "--title", "Renamed")
+    assert out.err == ""
+    assert commands.get_task(tmp_config, task_id=task["id"])["title"] == "Renamed"

--- a/agent/tests/test_notification_rules.py
+++ b/agent/tests/test_notification_rules.py
@@ -189,6 +189,22 @@ def test_match_sender_alias_searches_identity_fields():
     assert npn.notif_disposition(notif, [rule]) == "snooze"
 
 
+def test_sender_alias_matches_a_separate_sender_address_field():
+    # microsoft splits identity into `sender` (display name) + `sender_address` (email), so a
+    # --sender rule targeting the address domain must match the address field, not just the name.
+    # trash discriminates: the no-match fallback can never produce it.
+    notif = _notif(source="microsoft", type="email", sender="Some Person", sender_address="user@example.com")
+    rule = _rule(sender="example.com", action="trash")
+    assert npn.notif_disposition(notif, [rule]) == "trash"
+
+
+def test_sender_alias_matches_the_combined_name_address_form():
+    # email-client carries "Name <address>" in one `sender` field; the same domain rule matches there.
+    notif = _notif(source="email-client", type="email", sender="Some Person <user@example.com>")
+    rule = _rule(sender="example.com", action="trash")
+    assert npn.notif_disposition(notif, [rule]) == "trash"
+
+
 def test_match_text_alias_searches_body_and_message():
     rule = _rule(match=[{"field": "text", "op": "regex", "value": "taxes"}], action="snooze")
     assert npn.notif_disposition(_wa(message="ping about taxes"), [rule]) == "snooze"
@@ -388,6 +404,22 @@ def test_notif_sender_handle_field():
 def test_notif_sender_none_when_no_identity_field():
     notif = Notification.model_validate({"timestamp": "2025-01-01T00:00:00", "source": "twitter", "type": "tweet"})
     assert npn.notif_sender(notif) is None
+
+
+def test_notif_sender_prefers_display_name_over_address():
+    # A microsoft-shaped notification carries both; the log/facet sender stays the human-readable
+    # name, which is what pins sender_address to the end of the identity tuple.
+    notif = Notification.model_validate(
+        {"timestamp": "2025-01-01T00:00:00", "source": "microsoft", "type": "email", "sender": "Some Person", "sender_address": "u@x.com"}
+    )
+    assert npn.notif_sender(notif) == "Some Person"
+
+
+def test_notif_sender_falls_back_to_address_alone():
+    notif = Notification.model_validate(
+        {"timestamp": "2025-01-01T00:00:00", "source": "microsoft", "type": "email", "sender_address": "user@example.com"}
+    )
+    assert npn.notif_sender(notif) == "user@example.com"
 
 
 # --- notif_facet_fields (discoverability) ---


### PR DESCRIPTION
Closes #1843. Closes #1855. Part 1 of #1878 (the `sender_address` alias gap); part 2, rule-firing observability, is a separate larger change and remains open.

## In plain terms

- **`tasks remind list --json` told scripts a lie.** It silently returned at most 50 reminders, so any script asking "is anything scheduled for X?" read a truncated list as "no". Now JSON output returns every reminder unless `--limit` is passed explicitly; the human table keeps its 50-row page size, so nothing changes for interactive use, and the bare-array JSON shape is unchanged.
- **Nothing stopped a task title becoming a paragraph.** `tasks add` and `tasks update` now warn on stderr when a title exceeds 100 characters, pointing the agent at the task's metadata for detail. It is a soft cap: the task is still written either way, because a legitimately long title exists. stdout stays the command's JSON result. A matching line in the tasks SKILL.md steers titles short before the warning ever fires.
- **A `--sender example.com` rule silently never fired on microsoft mail.** The `sender` alias in the notification interrupt policy spanned `sender`, `contact_name`, `handle`, `from`, and `author`, but not `sender_address`, the field microsoft puts the email address in (it splits display name and address, where email-client combines them). `sender_address` is now part of the identity fields, so the SKILL.md's documented "across identity fields" behavior is true. It sits last in the tuple so `notif_sender` (first present wins) keeps preferring the display name for logs and facets.

## Changes

- `agent/skills/tasks/cli/src/tasks_cli/cli.py`: `remind list --limit` defaults to unset; JSON without an explicit limit is unlimited, the table pages at `REMIND_LIST_PAGE_SIZE` (50). New `_warn_long_title` (stderr, JSON `{"warning": ...}`) called from `add` and `update --title`.
- `agent/skills/tasks/cli/src/tasks_cli/commands.py`: `remind_list` accepts `limit=None` (SQLite `LIMIT -1`).
- `agent/core/notification_interrupt_policy.py`: `sender_address` appended to `_IDENTITY_FIELDS`.
- `agent/skills/tasks/SKILL.md`: one line on keeping titles short and putting detail in metadata.
- The `list_reminders` HTTP endpoint's own `limit=50` default is untouched: it is a separate query-param contract with explicit callers, not the silent-truncation path.

## Verification

- Reproduced all three on master first: 60 seeded reminders -> `remind list` default returned 50; a microsoft-shaped notification with `sender_address="user@example.com"` fell through a `--sender example.com` rule (action `trash` as the discriminator) while the email-client shape matched; no title cap existed anywhere.
- New tests: `test_remind_list_json_limit.py` (JSON returns all 60, `--json --limit 10` still pages, table stays at 50), `test_title_soft_cap.py` (long title warns on add and update and is still written, short title does not warn), and four cases in `test_notification_rules.py` (microsoft split-field match, email-client combined-form regression, `notif_sender` preferring the display name, address-only fallback).
- Mutation-tested: reverting `notification_interrupt_policy.py` fails the two new policy tests; reverting `cli.py` fails all five new CLI behavior tests.
- Suites: `uv run --project skills/tasks/cli pytest skills/tasks/cli/tests/` 228 passed; `pytest tests/test_notification_rules.py tests/test_notifications.py` 113 passed; ruff check + format clean on all touched files; `ty check` shows only the two pre-existing worktree-env diagnostics (also present on untouched master); `./check.sh guards` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)