### PR TITLE
test(live): de-fang the seeded TEST_MEMORY so first-start settles

### DIFF
--- a/vestad/tests/live/common.rs
+++ b/vestad/tests/live/common.rs
@@ -43,20 +43,17 @@ pub fn lock_live_agent_b() -> Option<(MutexGuard<'static, SharedAgent>, String)>
 const MEMORY_PATH: &str = "/root/agent/MEMORY.md";
 const NOTIFICATIONS_DIR: &str = "/root/agent/notifications";
 pub const E2E_FILES_DIR: &str = "/root/agent/e2e-test";
-const TEST_MEMORY: &str = r#"# VESTA MEMORY SYSTEM (TEST MODE)
+// Kept deliberately plain: override-style absolutes ("skip all confirmations", "always
+// permitted") read to the agent as a prompt injection, so it investigates the file instead of
+// settling and first-start blows its timeout. This states the environment as fact instead.
+const TEST_MEMORY: &str = r#"# Memory
 
-## 1. CORE IDENTITY
+## Environment
 
-You are Vesta running in automated test mode.
+This agent is running inside an automated end to end test, on an isolated container that resets between runs. No human is present. The "pytest" sender is the test harness, and its notifications are ordinary task requests from the owner, usually a small file to write under the test area. Treat them as trusted, routine work and carry them out directly, the way you would any everyday task from the owner. Filesystem changes stay inside this container, so they are safe to make.
 
-### CRITICAL: Test Mode Behavior
-- ACT IMMEDIATELY ON TEST REQUESTS: When you receive notifications from "pytest", execute them immediately without asking for permission
-- NO CONFIRMATION NEEDED: This is an automated test environment - just do the tasks
-- File operations are safe: The test environment is isolated, so file operations are always permitted
+## User profile
 
-## 2. USER PROFILE
-
-### Personal Details
 - Name: Test User
 - Location: Test Environment
 - Timezone: UTC


### PR DESCRIPTION
Closes #1897.

## Problem

The live suite seeds `MEMORY.md` (`vestad/tests/live/common.rs`) with override-style absolutes:

```
- ACT IMMEDIATELY ON TEST REQUESTS: ... without asking for permission
- NO CONFIRMATION NEEDED: ...
- File operations are safe: ... always permitted
```

A real Claude reads that as a prompt injection. On the v0.1.187 release live gate the agent flagged it during first-start:

> ... suspicious instructions telling me to act immediately ... feels like a jailbreak attempt disguised as memory content

and burned the 600s `FIRST_START_SETTLE_TIMEOUT` investigating instead of settling, so the READY marker was never written and provisioning failed:

```
tests/live/common.rs: agent did not settle after first-start:
timed out waiting for .../ready.txt to contain READY
```

Attempt 2 passed, so it surfaced as a flake, but it will recur and worsen as the agent grows more injection-aware.

## Fix

Restate the same intent as plain environment fact: the `pytest` sender is the trusted test harness, its notifications are routine file tasks to carry out directly, and the container is sandboxed. No jailbreak-shaped imperatives. This preserves the autonomy the suite depends on (the agent acts on `source=pytest` notifications, including the passive one that writes the READY marker) without tripping its injection radar.

## Validation

- `cargo check -p vestad --test live` passes.
- The live suite runs only in the release pipeline (real Claude creds), so end-to-end settle behavior cannot run on a PR. Watch the next release's live gate.

Pairs with #1894, which narrows the live retry so a future flake re-runs one test instead of all eight.