### PR TITLE
fix(mobile): serialize privacy and gateway sheets

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -353,8 +353,8 @@ export default function RootLayout() {
           <PreferencesProvider>
             <ToastProvider>
               <PrivacyProvider>
-                <PrivacyGate>
-                  <SessionProvider>
+                <SessionProvider>
+                  <PrivacyGate>
                     <RosterHoldProvider>
                       <ChatHoldProvider>
                         <ControllerProvider>
@@ -367,8 +367,8 @@ export default function RootLayout() {
                         </ControllerProvider>
                       </ChatHoldProvider>
                     </RosterHoldProvider>
-                  </SessionProvider>
-                </PrivacyGate>
+                  </PrivacyGate>
+                </SessionProvider>
               </PrivacyProvider>
             </ToastProvider>
           </PreferencesProvider>

--- a/apps/mobile/src/controller/gateway-update-gate-model.test.ts
+++ b/apps/mobile/src/controller/gateway-update-gate-model.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  gatewayUpdateGateNavigationAction,
+  type GatewayUpdateGateNavigationAction,
+} from "./gateway-update-gate-model";
+
+interface Case {
+  name: string;
+  blocked: boolean;
+  privacyBlocked: boolean;
+  privacyRouteActive: boolean;
+  gatewayUpdateRouteActive: boolean;
+  replaceActiveRoute: boolean;
+  action: GatewayUpdateGateNavigationAction;
+}
+
+const cases: Case[] = [
+  {
+    name: "waits while privacy is blocked",
+    blocked: true,
+    privacyBlocked: true,
+    privacyRouteActive: true,
+    gatewayUpdateRouteActive: false,
+    replaceActiveRoute: false,
+    action: "none",
+  },
+  {
+    name: "waits for an unlocked privacy sheet to finish dismissing",
+    blocked: true,
+    privacyBlocked: false,
+    privacyRouteActive: true,
+    gatewayUpdateRouteActive: false,
+    replaceActiveRoute: false,
+    action: "none",
+  },
+  {
+    name: "pushes the update after the privacy sheet is gone",
+    blocked: true,
+    privacyBlocked: false,
+    privacyRouteActive: false,
+    gatewayUpdateRouteActive: false,
+    replaceActiveRoute: false,
+    action: "push-update",
+  },
+  {
+    name: "replaces another native sheet with the update",
+    blocked: true,
+    privacyBlocked: false,
+    privacyRouteActive: false,
+    gatewayUpdateRouteActive: false,
+    replaceActiveRoute: true,
+    action: "replace-update",
+  },
+  {
+    name: "dismisses the update after compatibility recovers",
+    blocked: false,
+    privacyBlocked: false,
+    privacyRouteActive: false,
+    gatewayUpdateRouteActive: true,
+    replaceActiveRoute: false,
+    action: "dismiss",
+  },
+];
+
+describe("gatewayUpdateGateNavigationAction", () => {
+  it.each(cases)("$name", ({ action, ...input }) => {
+    expect(gatewayUpdateGateNavigationAction(input)).toBe(action);
+  });
+});

--- a/apps/mobile/src/controller/gateway-update-gate-model.ts
+++ b/apps/mobile/src/controller/gateway-update-gate-model.ts
@@ -1,0 +1,30 @@
+export type GatewayUpdateGateNavigationAction =
+  | "none"
+  | "push-update"
+  | "replace-update"
+  | "dismiss";
+
+interface GatewayUpdateGateNavigationInput {
+  blocked: boolean;
+  privacyBlocked: boolean;
+  privacyRouteActive: boolean;
+  gatewayUpdateRouteActive: boolean;
+  replaceActiveRoute: boolean;
+}
+
+export function gatewayUpdateGateNavigationAction({
+  blocked,
+  privacyBlocked,
+  privacyRouteActive,
+  gatewayUpdateRouteActive,
+  replaceActiveRoute,
+}: GatewayUpdateGateNavigationInput): GatewayUpdateGateNavigationAction {
+  if (privacyBlocked || privacyRouteActive) return "none";
+
+  if (blocked) {
+    if (gatewayUpdateRouteActive) return "none";
+    return replaceActiveRoute ? "replace-update" : "push-update";
+  }
+
+  return gatewayUpdateRouteActive ? "dismiss" : "none";
+}

--- a/apps/mobile/src/controller/gateway-update-gate.tsx
+++ b/apps/mobile/src/controller/gateway-update-gate.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, type ReactNode } from "react";
 import { useRouter, useSegments, type Href } from "expo-router";
 import { BlockingSheetGateView } from "@/components/blocking-sheet-gate-view";
 import { usePrivacyBlocked } from "@/privacy/use-privacy-blocked";
+import { gatewayUpdateGateNavigationAction } from "./gateway-update-gate-model";
 
 const GATEWAY_UPDATE_ROUTE = "/gateway-update" as Href;
 const ROOT_ROUTE = "/" as Href;
@@ -30,48 +31,46 @@ export function GatewayUpdateGate({
   const segments = useSegments();
   const presentationPending = useRef(false);
   const activeRoute = segments[0] as string | undefined;
+  const privacyRouteActive = activeRoute === "privacy";
   const gatewayUpdateRouteActive = activeRoute === "gateway-update";
   const privacyBlocked = usePrivacyBlocked();
   const gatewayUpdateBlocked = blocked && !privacyBlocked;
+  const action = gatewayUpdateGateNavigationAction({
+    blocked,
+    privacyBlocked,
+    privacyRouteActive,
+    gatewayUpdateRouteActive,
+    replaceActiveRoute: Boolean(
+      activeRoute && NATIVE_SHEET_ROUTES.has(activeRoute),
+    ),
+  });
 
   useEffect(() => {
-    // Privacy owns navigation while it is blocked. It replaces any active sheet and the gateway
-    // update waits until privacy clears, so simultaneous state changes cannot stack two sheets.
-    if (privacyBlocked) {
+    // Privacy owns navigation until its route is gone. Waiting through the unlocked dismissal
+    // prevents a push and back in the same commit from leaving privacy beneath this sheet.
+    if (action === "none") {
       presentationPending.current = false;
       return;
     }
 
-    if (gatewayUpdateBlocked) {
-      if (gatewayUpdateRouteActive) {
-        presentationPending.current = false;
-        return;
-      }
-      if (presentationPending.current) return;
-
-      presentationPending.current = true;
-      if (activeRoute && NATIVE_SHEET_ROUTES.has(activeRoute)) {
-        router.replace(GATEWAY_UPDATE_ROUTE);
+    if (action === "dismiss") {
+      presentationPending.current = false;
+      if (router.canGoBack()) {
+        router.back();
       } else {
-        router.push(GATEWAY_UPDATE_ROUTE);
+        router.replace(ROOT_ROUTE);
       }
       return;
     }
 
-    presentationPending.current = false;
-    if (!gatewayUpdateRouteActive) return;
-    if (router.canGoBack()) {
-      router.back();
+    if (presentationPending.current) return;
+    presentationPending.current = true;
+    if (action === "replace-update") {
+      router.replace(GATEWAY_UPDATE_ROUTE);
     } else {
-      router.replace(ROOT_ROUTE);
+      router.push(GATEWAY_UPDATE_ROUTE);
     }
-  }, [
-    activeRoute,
-    gatewayUpdateBlocked,
-    gatewayUpdateRouteActive,
-    privacyBlocked,
-    router,
-  ]);
+  }, [action, router]);
 
   return (
     <BlockingSheetGateView

--- a/apps/mobile/src/privacy/privacy-gate-model.test.ts
+++ b/apps/mobile/src/privacy/privacy-gate-model.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  privacyGateNavigationAction,
+  shouldAutomaticallyUnlock,
+  type PrivacyGateNavigationAction,
+} from "./privacy-gate-model";
+
+interface Case {
+  name: string;
+  blocked: boolean;
+  presentationReady: boolean;
+  privacyRouteActive: boolean;
+  replaceActiveRoute: boolean;
+  sessionStatus: "booting" | "disconnected" | "connected";
+  canGoBack: boolean;
+  action: PrivacyGateNavigationAction;
+}
+
+const cases: Case[] = [
+  {
+    name: "pushes privacy over ordinary content",
+    blocked: true,
+    presentationReady: true,
+    privacyRouteActive: false,
+    replaceActiveRoute: false,
+    sessionStatus: "connected",
+    canGoBack: true,
+    action: "push-privacy",
+  },
+  {
+    name: "replaces another native sheet with privacy",
+    blocked: true,
+    presentationReady: true,
+    privacyRouteActive: false,
+    replaceActiveRoute: true,
+    sessionStatus: "connected",
+    canGoBack: true,
+    action: "replace-privacy",
+  },
+  {
+    name: "leaves the active privacy sheet alone while blocked",
+    blocked: true,
+    presentationReady: true,
+    privacyRouteActive: true,
+    replaceActiveRoute: false,
+    sessionStatus: "connected",
+    canGoBack: true,
+    action: "none",
+  },
+  {
+    name: "returns to connected history after unlock",
+    blocked: false,
+    presentationReady: true,
+    privacyRouteActive: true,
+    replaceActiveRoute: false,
+    sessionStatus: "connected",
+    canGoBack: true,
+    action: "back",
+  },
+  {
+    name: "recovers a root-only connected privacy route",
+    blocked: false,
+    presentationReady: true,
+    privacyRouteActive: true,
+    replaceActiveRoute: false,
+    sessionStatus: "connected",
+    canGoBack: false,
+    action: "replace-root",
+  },
+  {
+    name: "recovers to connect when the gateway was disconnected",
+    blocked: false,
+    presentationReady: true,
+    privacyRouteActive: true,
+    replaceActiveRoute: false,
+    sessionStatus: "disconnected",
+    canGoBack: false,
+    action: "dismiss-to-connect",
+  },
+  {
+    name: "waits for session restoration before dismissing privacy",
+    blocked: false,
+    presentationReady: true,
+    privacyRouteActive: true,
+    replaceActiveRoute: false,
+    sessionStatus: "booting",
+    canGoBack: false,
+    action: "none",
+  },
+  {
+    name: "waits to present privacy until startup state is stable",
+    blocked: true,
+    presentationReady: false,
+    privacyRouteActive: false,
+    replaceActiveRoute: false,
+    sessionStatus: "booting",
+    canGoBack: false,
+    action: "none",
+  },
+];
+
+describe("privacyGateNavigationAction", () => {
+  it.each(cases)("$name", ({ action, ...input }) => {
+    expect(privacyGateNavigationAction(input)).toBe(action);
+  });
+});
+
+describe("shouldAutomaticallyUnlock", () => {
+  const ready = {
+    presentationReady: true,
+    privacyRouteActive: true,
+    hydrated: true,
+    locked: true,
+    authenticating: false,
+    initializationFailed: false,
+    attempted: false,
+  };
+
+  it("starts authentication only after the privacy route is active", () => {
+    expect(shouldAutomaticallyUnlock(ready)).toBe(true);
+    expect(
+      shouldAutomaticallyUnlock({ ...ready, privacyRouteActive: false }),
+    ).toBe(false);
+  });
+
+  it("does not automatically retry a completed authentication attempt", () => {
+    expect(shouldAutomaticallyUnlock({ ...ready, attempted: true })).toBe(
+      false,
+    );
+    expect(shouldAutomaticallyUnlock({ ...ready, authenticating: true })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/mobile/src/privacy/privacy-gate-model.ts
+++ b/apps/mobile/src/privacy/privacy-gate-model.ts
@@ -1,0 +1,67 @@
+export type PrivacyGateNavigationAction =
+  | "none"
+  | "push-privacy"
+  | "replace-privacy"
+  | "back"
+  | "dismiss-to-connect"
+  | "replace-root";
+
+interface PrivacyGateNavigationInput {
+  blocked: boolean;
+  presentationReady: boolean;
+  privacyRouteActive: boolean;
+  replaceActiveRoute: boolean;
+  sessionStatus: "booting" | "disconnected" | "connected";
+  canGoBack: boolean;
+}
+
+export function privacyGateNavigationAction({
+  blocked,
+  presentationReady,
+  privacyRouteActive,
+  replaceActiveRoute,
+  sessionStatus,
+  canGoBack,
+}: PrivacyGateNavigationInput): PrivacyGateNavigationAction {
+  if (!presentationReady) return "none";
+
+  if (blocked) {
+    if (privacyRouteActive) return "none";
+    return replaceActiveRoute ? "replace-privacy" : "push-privacy";
+  }
+
+  if (!privacyRouteActive) return "none";
+  if (sessionStatus === "booting") return "none";
+  if (sessionStatus === "disconnected") return "dismiss-to-connect";
+  return canGoBack ? "back" : "replace-root";
+}
+
+interface AutomaticUnlockInput {
+  presentationReady: boolean;
+  privacyRouteActive: boolean;
+  hydrated: boolean;
+  locked: boolean;
+  authenticating: boolean;
+  initializationFailed: boolean;
+  attempted: boolean;
+}
+
+export function shouldAutomaticallyUnlock({
+  presentationReady,
+  privacyRouteActive,
+  hydrated,
+  locked,
+  authenticating,
+  initializationFailed,
+  attempted,
+}: AutomaticUnlockInput): boolean {
+  return (
+    presentationReady &&
+    privacyRouteActive &&
+    hydrated &&
+    locked &&
+    !authenticating &&
+    !initializationFailed &&
+    !attempted
+  );
+}

--- a/apps/mobile/src/privacy/privacy-gate.tsx
+++ b/apps/mobile/src/privacy/privacy-gate.tsx
@@ -1,10 +1,18 @@
 import { useEffect, useRef, type ReactNode } from "react";
 import { useRouter, useSegments, type Href } from "expo-router";
 import { BlockingSheetGateView } from "@/components/blocking-sheet-gate-view";
+import { usePreferences } from "@/preferences/PreferencesProvider";
+import { useSession } from "@/session/SessionProvider";
+import {
+  privacyGateNavigationAction,
+  shouldAutomaticallyUnlock,
+} from "./privacy-gate-model";
+import { usePrivacy } from "./privacy-provider";
 import { usePrivacyBlocked } from "./use-privacy-blocked";
 
 const PRIVACY_ROUTE = "/privacy" as Href;
 const ROOT_ROUTE = "/" as Href;
+const CONNECT_ROUTE = "/connect" as Href;
 const ESTIMATED_PRIVACY_SHEET_HEIGHT = 181;
 const NATIVE_SHEET_ROUTES = new Set([
   "connect-actions",
@@ -21,36 +29,80 @@ const NATIVE_SHEET_ROUTES = new Set([
 export function PrivacyGate({ children }: { children: ReactNode }) {
   const router = useRouter();
   const segments = useSegments();
+  const { status } = useSession();
+  const { hydrated: preferencesHydrated } = usePreferences();
+  const privacy = usePrivacy();
   const presentationPending = useRef(false);
+  const automaticUnlockAttempted = useRef(false);
   const blocked = usePrivacyBlocked();
   const activeRoute = segments[0] as string | undefined;
   const privacyRouteActive = activeRoute === "privacy";
+  const presentationReady =
+    preferencesHydrated && privacy.hydrated && status !== "booting";
+  const action = privacyGateNavigationAction({
+    blocked,
+    presentationReady,
+    privacyRouteActive,
+    replaceActiveRoute: Boolean(
+      activeRoute && NATIVE_SHEET_ROUTES.has(activeRoute),
+    ),
+    sessionStatus: status,
+    canGoBack: router.canGoBack(),
+  });
 
   useEffect(() => {
-    if (blocked) {
-      if (privacyRouteActive) {
-        presentationPending.current = false;
-        return;
-      }
-      if (presentationPending.current) return;
-
-      presentationPending.current = true;
-      if (activeRoute && NATIVE_SHEET_ROUTES.has(activeRoute)) {
-        router.replace(PRIVACY_ROUTE);
-      } else {
-        router.push(PRIVACY_ROUTE);
-      }
+    if (action === "none") {
+      presentationPending.current = false;
       return;
     }
 
-    presentationPending.current = false;
-    if (!privacyRouteActive) return;
-    if (router.canGoBack()) {
+    if (action === "back") {
+      presentationPending.current = false;
       router.back();
-    } else {
-      router.replace(ROOT_ROUTE);
+      return;
     }
-  }, [activeRoute, blocked, privacyRouteActive, router]);
+    if (action === "dismiss-to-connect") {
+      presentationPending.current = false;
+      router.dismissTo(CONNECT_ROUTE);
+      return;
+    }
+    if (action === "replace-root") {
+      presentationPending.current = false;
+      router.replace(ROOT_ROUTE);
+      return;
+    }
+
+    if (presentationPending.current) return;
+    presentationPending.current = true;
+    if (action === "replace-privacy") {
+      router.replace(PRIVACY_ROUTE);
+    } else {
+      router.push(PRIVACY_ROUTE);
+    }
+  }, [action, router]);
+
+  useEffect(() => {
+    if (!privacy.locked) {
+      automaticUnlockAttempted.current = false;
+      return;
+    }
+    if (
+      !shouldAutomaticallyUnlock({
+        presentationReady,
+        privacyRouteActive,
+        hydrated: privacy.hydrated,
+        locked: privacy.locked,
+        authenticating: privacy.authenticating,
+        initializationFailed: privacy.initializationError !== null,
+        attempted: automaticUnlockAttempted.current,
+      })
+    ) {
+      return;
+    }
+
+    automaticUnlockAttempted.current = true;
+    void privacy.unlock();
+  }, [presentationReady, privacy, privacyRouteActive]);
 
   return (
     <BlockingSheetGateView

--- a/apps/mobile/src/privacy/privacy-provider.tsx
+++ b/apps/mobile/src/privacy/privacy-provider.tsx
@@ -310,34 +310,14 @@ export function PrivacyProvider({ children }: { children: ReactNode }) {
   );
 
   useEffect(() => {
-    if (
-      !hydrated ||
-      initializationError ||
-      !privacyReadyRef.current ||
-      !settings.appLockEnabled
-    ) {
-      return;
-    }
-    if (AppState.currentState === "active" && lockedRef.current) {
-      void unlock();
-    }
-  }, [hydrated, initializationError, settings.appLockEnabled, unlock]);
-
-  useEffect(() => {
     const subscription = AppState.addEventListener("change", (state) => {
       if (!privacyReadyRef.current) return;
       if (locksApp(state) && settingsRef.current.appLockEnabled) {
         updateLocked(true);
-      } else if (
-        state === "active" &&
-        settingsRef.current.appLockEnabled &&
-        lockedRef.current
-      ) {
-        void unlock();
       }
     });
     return () => subscription.remove();
-  }, [unlock, updateLocked]);
+  }, [updateLocked]);
 
   const value = useMemo<PrivacyValue>(
     () => ({


### PR DESCRIPTION
## Summary

- wait for session, theme, and privacy hydration before presenting the privacy form sheet
- start automatic device authentication only after the privacy route is active
- serialize the privacy and gateway update sheet handoff
- recover disconnected privacy navigation directly to the connect route

## Cause

The session route guards could change while the privacy form sheet was opening. The gateway compatibility gate could also push its sheet in the same commit that privacy dismissed. Together these transitions could strand an unlocked privacy route in the stack and leave the boot screen waiting indefinitely after disconnect.

## Testing

- `./check.sh app-mobile`
- `./check.sh guards`