### PR TITLE
fix(enable-banking): a non-2xx API answer no longer kills the whole watcher

### DIFF
--- a/agent/skills/enable-banking/cli/src/finance_cli/cli.py
+++ b/agent/skills/enable-banking/cli/src/finance_cli/cli.py
@@ -198,7 +198,7 @@ def cmd_auth_status(_args) -> dict:
             session = eb.get_session(conf)
             result["session_status"] = session.get("status", "unknown")
             result["valid_until"] = session.get("access", {}).get("valid_until", "")
-        except SystemExit:
+        except eb.ApiError:
             result["session_status"] = "error_fetching"
 
     return result
@@ -235,7 +235,7 @@ def cmd_balances(_args) -> list:
             continue
         try:
             balances = eb.get_balances(conf, uid)
-        except SystemExit:
+        except eb.ApiError:
             balances = [{"error": "could not fetch balance"}]
         results.append(
             {
@@ -398,6 +398,6 @@ def main():
     try:
         result = args.func(args)
         print(json.dumps(result, indent=2))
-    except ValueError as e:
+    except (ValueError, eb.ApiError) as e:
         print(json.dumps({"error": str(e)}), file=sys.stderr)
         sys.exit(1)

--- a/agent/skills/enable-banking/cli/src/finance_cli/enablebanking.py
+++ b/agent/skills/enable-banking/cli/src/finance_cli/enablebanking.py
@@ -62,23 +62,26 @@ def _headers(conf: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
+class ApiError(Exception):
+    """A non-2xx answer from the Enable Banking API.
+
+    An ordinary Exception on purpose: the watcher's per-account guards catch it and keep polling,
+    where a SystemExit would sail past them and kill the whole watcher process. The CLI turns it
+    into the `{"error":...}` stderr envelope at its own boundary in `main()`.
+    """
+
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+
+
 def _raise_for_status(resp: httpx.Response, context: str) -> None:
     if resp.is_error:
         try:
             body = resp.json()
-        except Exception:
+        except ValueError:
             body = resp.text
-        print(
-            json.dumps(
-                {
-                    "error": f"Enable Banking API error ({context})",
-                    "status": resp.status_code,
-                    "body": body,
-                }
-            ),
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        raise ApiError(resp.status_code, f"Enable Banking API error ({context}): status {resp.status_code}, body {json.dumps(body)}")
 
 
 def _request(conf: dict, method: str, path: str, params: dict | None = None, body: dict | None = None) -> Any:

--- a/agent/skills/enable-banking/cli/tests/test_client.py
+++ b/agent/skills/enable-banking/cli/tests/test_client.py
@@ -132,12 +132,14 @@ def test_revoke_session_deletes_empty_body_returns_ok(http):
     assert calls[0]["url"] == "https://api.enablebanking.com/sessions/sess-9"
 
 
-def test_error_response_exits(http, capsys):
+def test_error_response_raises_a_catchable_api_error(http):
+    """The error is an ordinary Exception carrying the status: the watcher's poll loop catches
+    and classifies it, so one bad API answer can never take the whole watcher process down."""
     _, responses = http
     responses.append(FakeResponse({"detail": "bad"}, status_code=400, is_error=True))
-    with pytest.raises(SystemExit) as exc:
+    with pytest.raises(eb.ApiError) as exc:
         eb.get_session(CONF)
-    assert exc.value.code == 1
-    err = json.loads(capsys.readouterr().err)
-    assert err["status"] == 400
-    assert err["error"] == "Enable Banking API error (GET /sessions/sess-9)"
+    assert isinstance(exc.value, Exception) and not isinstance(exc.value, (SystemExit, KeyboardInterrupt))
+    assert exc.value.status == 400
+    assert "GET /sessions/sess-9" in str(exc.value)
+    assert "detail" in str(exc.value)


### PR DESCRIPTION
## In plain terms

The Enable Banking transaction watcher dies on the first API error and stays dead until someone restarts it by hand. `_raise_for_status` answered any non-2xx by printing an envelope and calling `sys.exit(1)`. A `SystemExit` is a `BaseException`, so the poll loop's `except Exception` never catches it: one 503 (or an expired session, or a rate limit) takes the whole watcher process down, and nothing brings it back. On a box this reads as "my transaction notifications just stopped", with no signal why.

This raises a typed `ApiError` (an ordinary `Exception`) instead. The poll loop's existing `except Exception` catches it and retries the next cycle, so a transient error is a logged blip rather than a death. The CLI commands that previously caught the `SystemExit` now catch `ApiError` at the same three sites, and `main()` turns it into the standard `{"error":...}` stderr envelope, so the output contract is unchanged.

This is very plausibly the unexplained watcher exit that #1681 documents ("the actual cause of the exit remains unknown").

## Scope

Carved out of the withdrawn #1901 as its own fix. The daemon-health-contract idea in #1901 was dropped: judging whether a running daemon is doing its job is Vesta's runtime duty (reading logs, noticing staleness, the proactive-check preflight), not a hardcoded per-skill classification baked into the contract. The contract's job is to say a daemon is running and where. This bugfix stands on its own regardless.

## Verification

- `test_error_response_raises_a_catchable_api_error` (rewritten from the old exit-asserting test): a 400 raises `eb.ApiError` carrying `status`, and it is provably not a `SystemExit`/`KeyboardInterrupt`, so the poll loop catches it.
- enable-banking client suite green; ruff clean.
- The three CLI catch-sites map 1:1 onto master's three `except SystemExit` sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
