### PR TITLE
build(vestad): pin the Claude Code version in the agent image

### DIFF
--- a/agent/core/pyproject.toml
+++ b/agent/core/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.14.3",
-    "claude-agent-sdk>=0.2.128",
+    "claude-agent-sdk>=0.2.134",
     "pydantic>=2.13.4",
     "pydantic-settings>=2.14.2",
     "rich>=15.0.0",

--- a/agent/core/uv.lock
+++ b/agent/core/uv.lock
@@ -229,20 +229,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.2.128"
+version = "0.2.134"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/e8/3a9622b31f9ee22274e13a620e5e75ac38454d14538391b2fe3bc7eb76dc/claude_agent_sdk-0.2.128.tar.gz", hash = "sha256:2ac7b2b3bc56ae9037fd284c8690d3dafab9493ecd28d8974bba79a418e1b800", size = 309369, upload-time = "2026-07-25T01:48:25.884Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/4e/4aa8048367c89b9cbb64f4fac58f9f59110f77231d13e728e2844898ea32/claude_agent_sdk-0.2.134.tar.gz", hash = "sha256:acac34b8068dfeb8fceeb8e2e3b3684f146da206094e55a5d34115063f2bafba", size = 312219, upload-time = "2026-08-08T03:00:16.502Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/ff/03613a38a84285cd85f114fc26d4431f545d2b3b344eb8f69f9b0f18f3c6/claude_agent_sdk-0.2.128-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e47ee95be68cb07612fd5288a40f3307763da5a5adf66d6e03ea49dc0495c9c", size = 75183825, upload-time = "2026-07-25T01:48:30.45Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/df/2adbd3077f1a1cada39cd1508990d4008a8ac9ec74c801b24b1b302348b0/claude_agent_sdk-0.2.128-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:55e8fa28918af5620f391692efe80527ad9f2294cec14dadeea93c5161dbefc4", size = 80305667, upload-time = "2026-07-25T01:48:35.091Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/56/776a41af67a53d794b420dcd2f1075b585ed3725faa9827164f4a2e945dd/claude_agent_sdk-0.2.128-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:6c10cc1c5403b2b0b3d8deb79ad5271a8e49b9db6460193599b91f49f16b4cf7", size = 84617823, upload-time = "2026-07-25T01:48:39.297Z" },
-    { url = "https://files.pythonhosted.org/packages/17/1c/37044abbddf2141c4eeb6cc8e15a486491549a27283029d73db2c4f3c3b7/claude_agent_sdk-0.2.128-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:cc4a0f20337e227fe16f00edf7cbe109349707adb440fe51ca6c44f9f8d7d21a", size = 85663462, upload-time = "2026-07-25T01:48:43.982Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/c9/ffbd8113080f87a4cd7bbfc8b00a974ea7189e3f666b5d7a2903dec7b74f/claude_agent_sdk-0.2.128-py3-none-win_amd64.whl", hash = "sha256:37b87c8e75daa2a6dc74da6d788e0981a2e5e3a6be80cfa4c287abce2bf70e0b", size = 85566882, upload-time = "2026-07-25T01:48:48.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/75/dc52d7f3632e9a5377487158785495ba5ce009adc292b0b61ffa9ce01e3a/claude_agent_sdk-0.2.134-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5c44159a4a8640edf2634fa9653c40023ed548e24e3aaac01fc3fad85685ed0e", size = 80906236, upload-time = "2026-08-08T03:00:20.156Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/19/289b9cf3f26154084070a40d9ac54fb4f624e4a36afa76529f5bd1d112f6/claude_agent_sdk-0.2.134-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:4d4e583bdd834b05f88678948b263e57aa81f20a0817f3d25adfe9d8edb50966", size = 85996885, upload-time = "2026-08-08T03:00:24.254Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b2/cb099e7b82eb43626e9dcfbf24e09cd760d59ff3b9e498642c4dffa4fa6f/claude_agent_sdk-0.2.134-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:f259671f03823e07544b52ed37e29accd295012e7d9304f5b7c1ec6a3508c758", size = 90326570, upload-time = "2026-08-08T03:00:28.544Z" },
+    { url = "https://files.pythonhosted.org/packages/88/17/59e7a9cc6ebebc9708733a03ddd2b9c90051c7de359686e1e14b1b81d2b1/claude_agent_sdk-0.2.134-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:0cba177a0f234dcdb8dfcdd46803fbe0aadd42fbc5aebba41f65f9d00d05a420", size = 91474377, upload-time = "2026-08-08T03:00:32.869Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c6/c5dd0c41ad6822218ed5af47961ba9a70c88d82ca0f0ff1d12cb7d37a543/claude_agent_sdk-0.2.134-py3-none-win_amd64.whl", hash = "sha256:e5eb243dc62a6ea624aadb4227eb2d03d40394c9ae8a43cb5a94d8d76cd2def0", size = 90944935, upload-time = "2026-08-08T03:00:37.112Z" },
 ]
 
 [[package]]
@@ -1287,7 +1287,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.3" },
-    { name = "claude-agent-sdk", specifier = ">=0.2.128" },
+    { name = "claude-agent-sdk", specifier = ">=0.2.134" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "rich", specifier = ">=15.0.0" },

--- a/vestad/Dockerfile
+++ b/vestad/Dockerfile
@@ -87,12 +87,15 @@ WORKDIR /root/agent
 RUN UV_PROJECT_ENVIRONMENT=/root/agent/.venv uv sync --frozen --no-install-project --project core
 ENV PATH="/root/agent/.venv/bin:${PATH}"
 
-# Install Claude Code on PATH. claude_agent_sdk would otherwise fall back to its own bundled CLI
-# (deep in site-packages), but skills shell out to `claude` directly (e.g. video-use), so it must
-# be resolvable on PATH; the SDK then reuses this same binary. cc_sdk stays in the tree (tmux is
+# Install Claude Code on PATH, pinned: the fleet runs one known CLI version, and a release built
+# from a bumped pin rebuilds every agent container onto it, so upgrades are deliberate and
+# fleet-wide. claude_agent_sdk would otherwise fall back to its own bundled CLI (deep in
+# site-packages), but skills shell out to `claude` directly (e.g. video-use), so it must be
+# resolvable on PATH; the SDK then reuses this same binary. cc_sdk stays in the tree (tmux is
 # kept) but is dormant; if ever reactivated it fetches its own pinned binary under ~/.cache/cc-sdk.
-RUN curl -fsSL https://claude.ai/install.sh | bash && \
-    claude --version && \
+ARG CLAUDE_CODE_VERSION=2.1.226
+RUN curl -fsSL https://claude.ai/install.sh | bash -s "$CLAUDE_CODE_VERSION" && \
+    claude --version | grep -F "$CLAUDE_CODE_VERSION" && \
     mkdir -p /root/.claude
 WORKDIR /root
 


### PR DESCRIPTION
## Why

The agent image installed Claude Code with `curl https://claude.ai/install.sh | bash`, taking whatever was latest at build time. The live fleet consequently spans 2.1.107 → 2.1.224 (latest is 2.1.226), and that range is not cosmetic:

- The CLI's context-window handling changed inside it: older versions honor `CLAUDE_CODE_MAX_CONTEXT_TOKENS` for first-party Claude models, 2.1.2xx sizes natively-1M models from model metadata (the bug #1933 fixes).
- 2.1.225 fixed a transient-401 bug that silently swapped the stored long-lived OAuth token for a short-lived one, breaking headless sessions until restart. Every fleet agent today is below 2.1.225.

## What

- `ARG CLAUDE_CODE_VERSION=2.1.226` (current latest), passed to `install.sh`, which accepts `[stable|latest|VERSION]`.
- The build asserts the installed CLI reports the pinned version, so a bad pin fails the image build instead of shipping.

Each release rebuilds fleet containers onto the new image, so bumping the pin ships the CLI fleet-wide with that release; without a bump, the fleet stays put. Upgrades become deliberate and answerable from the repo.

Verified: the pinned install runs green on `debian:trixie-slim` (the image base) and reports 2.1.226; `./check.sh guards` passes. CI's agent-image build job exercises the real Dockerfile path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)