### PR TITLE
fix(vestad): never adopt a backup temp container as a managed agent

### DIFF
--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -103,7 +103,7 @@ pub async fn create_backup(
 
     let result = if cs == ContainerStatus::Running {
         // One shared name for the throwaway image repo and export container.
-        let temp_cname = format!("{BACKUP_TEMP_CONTAINER_PREFIX}-{name}");
+        let temp_cname = format!("{BACKUP_TEMP_CONTAINER_PREFIX}{name}");
         let image = format!("{temp_cname}:{TEMP_IMAGE_TAG}");
         // A leftover temp container/image from a crashed run must not fail this one.
         remove_temp_artifacts(docker, &temp_cname, &image).await;

--- a/vestad/src/backup.rs
+++ b/vestad/src/backup.rs
@@ -6,7 +6,7 @@ use crate::docker::{
     container_created, container_name, container_size_root_fs, container_size_rw, container_status,
     create_container, ensure_container_removed, env_file_names, guard_alive, handoff_boot_reason,
     handoff_shutdown_reason, read_env_value, start_container, stop_container_with_timeout,
-    validate_name, AgentEnvConfig, ContainerStatus, DockerError,
+    validate_name, AgentEnvConfig, ContainerStatus, DockerError, BACKUP_TEMP_CONTAINER_PREFIX,
 };
 use crate::types::{BackupInfo, BackupType, RetentionPolicy};
 
@@ -79,7 +79,6 @@ fn parse_rfc3339_epoch(ts: &str) -> Option<u64> {
     u64::try_from(dt.unix_timestamp()).ok()
 }
 
-const TEMP_IMAGE_REPO_PREFIX: &str = "vesta-backup-tmp";
 const TEMP_IMAGE_TAG: &str = "latest";
 
 /// Best-effort removal of the throwaway commit container/image (leftovers included).
@@ -104,7 +103,7 @@ pub async fn create_backup(
 
     let result = if cs == ContainerStatus::Running {
         // One shared name for the throwaway image repo and export container.
-        let temp_cname = format!("{TEMP_IMAGE_REPO_PREFIX}-{name}");
+        let temp_cname = format!("{BACKUP_TEMP_CONTAINER_PREFIX}-{name}");
         let image = format!("{temp_cname}:{TEMP_IMAGE_TAG}");
         // A leftover temp container/image from a crashed run must not fail this one.
         remove_temp_artifacts(docker, &temp_cname, &image).await;

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -1256,9 +1256,34 @@ pub fn update_all_agent_env_files(
 
 // --- Container listing ---
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManagedAgent {
     pub cname: String,
     pub agent_name: String,
+}
+
+/// At most one container per agent name. A stray container can carry a real agent's
+/// labels (`docker commit` copies them into any image built from the agent), and a
+/// duplicate entry would shadow the healthy container in every name-keyed consumer.
+/// The canonical `vesta-{user}-{agent}` container always wins.
+fn dedup_by_agent_name(agents: Vec<ManagedAgent>) -> Vec<ManagedAgent> {
+    let mut kept: Vec<ManagedAgent> = Vec::new();
+    for agent in agents {
+        if let Some(existing) = kept.iter_mut().find(|k| k.agent_name == agent.agent_name) {
+            let canonical = container_name(&agent.agent_name);
+            tracing::warn!(
+                agent = %agent.agent_name,
+                canonical = %canonical,
+                "duplicate containers claim one agent name; keeping the canonical one"
+            );
+            if agent.cname == canonical {
+                *existing = agent;
+            }
+        } else {
+            kept.push(agent);
+        }
+    }
+    kept
 }
 
 /// List all managed containers owned by the current user, paired with the
@@ -1279,7 +1304,7 @@ pub async fn list_managed_agents(docker: &Docker) -> Vec<ManagedAgent> {
     };
 
     let user = crate::paths::current_user();
-    containers
+    let agents = containers
         .into_iter()
         .filter_map(|c| {
             let names = c.names?;
@@ -1302,7 +1327,8 @@ pub async fn list_managed_agents(docker: &Docker) -> Vec<ManagedAgent> {
                 .unwrap_or_else(|| name_from_cname(&cname));
             Some(ManagedAgent { cname, agent_name })
         })
-        .collect()
+        .collect();
+    dedup_by_agent_name(agents)
 }
 
 // --- GPU detection ---
@@ -4008,6 +4034,39 @@ mod tests {
             !rename_body.contains("remove_container_force"),
             "rename_agent must use ensure_container_removed (confirms gone), not the best-effort remove_container_force"
         );
+    }
+
+    #[test]
+    fn dedup_keeps_the_canonical_container_whatever_the_order() {
+        let canonical = container_name("axel");
+        let stray = "stray-copy-of-axel".to_string();
+        for order in [[&stray, &canonical], [&canonical, &stray]] {
+            let agents: Vec<ManagedAgent> = order
+                .iter()
+                .map(|cname| ManagedAgent {
+                    cname: (*cname).clone(),
+                    agent_name: "axel".to_string(),
+                })
+                .collect();
+            let deduped = dedup_by_agent_name(agents);
+            assert_eq!(deduped.len(), 1, "one entry per agent name");
+            assert_eq!(deduped[0].cname, canonical);
+        }
+    }
+
+    #[test]
+    fn dedup_leaves_distinct_agents_untouched() {
+        let agents = vec![
+            ManagedAgent {
+                cname: container_name("axel"),
+                agent_name: "axel".to_string(),
+            },
+            ManagedAgent {
+                cname: container_name("luna"),
+                agent_name: "luna".to_string(),
+            },
+        ];
+        assert_eq!(dedup_by_agent_name(agents.clone()), agents);
     }
 
     // --- Docker integration tests (require Docker daemon) ---

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -78,6 +78,8 @@ const NAME_MAX_LEN: usize = 32;
 const DOCKER_DAEMON_PING_RETRIES: usize = 10;
 const LABEL_USER: &str = "vesta.user";
 const LABEL_AGENT_NAME: &str = "vesta.agent_name";
+/// Name prefix of the throwaway image repo and container a backup exports through.
+pub const BACKUP_TEMP_CONTAINER_PREFIX: &str = "vesta-backup-tmp";
 
 // --- Expected container config (single source of truth) ---
 
@@ -1282,6 +1284,12 @@ pub async fn list_managed_agents(docker: &Docker) -> Vec<ManagedAgent> {
         .filter_map(|c| {
             let names = c.names?;
             let cname = names.first()?.strip_prefix('/')?.to_string();
+            // `docker commit` copies the agent's labels into the backup temp image, so
+            // the container a backup exports through matches the managed filter. It is
+            // never an agent: adopting it would boot-start a broken ghost copy.
+            if cname.starts_with(BACKUP_TEMP_CONTAINER_PREFIX) {
+                return None;
+            }
             let labels = c.labels.unwrap_or_default();
             let owner = labels.get(LABEL_USER).cloned().unwrap_or_default();
             if owner != user {
@@ -4223,6 +4231,50 @@ mod tests {
                 .iter()
                 .any(|h| h.starts_with("host.docker.internal:")),
             "expected a host.docker.internal mapping, got {extra_hosts:?}"
+        );
+    }
+
+    /// `docker commit` copies the agent's labels into the backup temp image, so the export
+    /// container a backup streams through matches the `vesta.managed=true` filter. An
+    /// interrupted cleanup leaves it behind, and adopting it as an agent would boot-start
+    /// a broken ghost copy on every reconcile.
+    #[tokio::test]
+    #[ignore]
+    async fn backup_temp_container_is_never_a_managed_agent() {
+        let docker = test_docker();
+        let agent = format!("ghost{}", std::process::id());
+        let real = TestContainer::for_agent(&agent);
+        let ghost = TestContainer {
+            name: format!("{BACKUP_TEMP_CONTAINER_PREFIX}-{agent}"),
+        };
+        docker_cleanup(&["rm", "-f", &ghost.name]);
+        for cname in [&real.name, &ghost.name] {
+            let status = std::process::Command::new("docker")
+                .args([
+                    "create",
+                    "--name",
+                    cname,
+                    "--label",
+                    "vesta.managed=true",
+                    "--label",
+                    &format!("{LABEL_AGENT_NAME}={agent}"),
+                    "--label",
+                    &format!("{LABEL_USER}={}", crate::paths::current_user()),
+                    &test_agent_image(),
+                ])
+                .status()
+                .expect("docker create runs");
+            assert!(status.success(), "docker create {cname} failed");
+        }
+
+        let agents = list_managed_agents(&docker).await;
+        assert!(
+            agents.iter().any(|a| a.cname == real.name),
+            "the real agent container must be listed"
+        );
+        assert!(
+            !agents.iter().any(|a| a.cname == ghost.name),
+            "a backup temp container must never be adopted as an agent"
         );
     }
 

--- a/vestad/src/docker.rs
+++ b/vestad/src/docker.rs
@@ -78,8 +78,10 @@ const NAME_MAX_LEN: usize = 32;
 const DOCKER_DAEMON_PING_RETRIES: usize = 10;
 const LABEL_USER: &str = "vesta.user";
 const LABEL_AGENT_NAME: &str = "vesta.agent_name";
-/// Name prefix of the throwaway image repo and container a backup exports through.
-pub const BACKUP_TEMP_CONTAINER_PREFIX: &str = "vesta-backup-tmp";
+/// Name prefix of the throwaway image repo and container a backup exports through
+/// (`{prefix}{agent}`). The trailing separator is part of the prefix so a canonical
+/// `vesta-{user}-{agent}` name can only collide with it for a user literally named "backup".
+pub const BACKUP_TEMP_CONTAINER_PREFIX: &str = "vesta-backup-tmp-";
 
 // --- Expected container config (single source of truth) ---
 
@@ -1270,15 +1272,14 @@ fn dedup_by_agent_name(agents: Vec<ManagedAgent>) -> Vec<ManagedAgent> {
     let mut kept: Vec<ManagedAgent> = Vec::new();
     for agent in agents {
         if let Some(existing) = kept.iter_mut().find(|k| k.agent_name == agent.agent_name) {
-            let canonical = container_name(&agent.agent_name);
-            tracing::warn!(
-                agent = %agent.agent_name,
-                canonical = %canonical,
-                "duplicate containers claim one agent name; keeping the canonical one"
-            );
-            if agent.cname == canonical {
+            if agent.cname == container_name(&agent.agent_name) {
                 *existing = agent;
             }
+            tracing::warn!(
+                agent = %existing.agent_name,
+                kept = %existing.cname,
+                "duplicate containers claim one agent name; keeping one"
+            );
         } else {
             kept.push(agent);
         }
@@ -4118,16 +4119,17 @@ mod tests {
 
     impl TestContainer {
         fn new(suffix: &str) -> Self {
-            let name = format!("{}-{}-{}", TEST_PREFIX, suffix, std::process::id());
-            // Clean up any leftover from previous runs
-            docker_cleanup(&["rm", "-f", &name]);
-            Self { name }
+            Self::named(format!("{}-{}-{}", TEST_PREFIX, suffix, std::process::id()))
         }
 
         /// A container under its real `container_name()`, for the paths that rediscover an agent by
         /// name rather than being handed one.
         fn for_agent(agent: &str) -> Self {
-            let name = container_name(agent);
+            Self::named(container_name(agent))
+        }
+
+        /// A container under an exact literal name, cleaning up any leftover from previous runs.
+        fn named(name: String) -> Self {
             docker_cleanup(&["rm", "-f", &name]);
             Self { name }
         }
@@ -4303,10 +4305,7 @@ mod tests {
         let docker = test_docker();
         let agent = format!("ghost{}", std::process::id());
         let real = TestContainer::for_agent(&agent);
-        let ghost = TestContainer {
-            name: format!("{BACKUP_TEMP_CONTAINER_PREFIX}-{agent}"),
-        };
-        docker_cleanup(&["rm", "-f", &ghost.name]);
+        let ghost = TestContainer::named(format!("{BACKUP_TEMP_CONTAINER_PREFIX}{agent}"));
         for cname in [&real.name, &ghost.name] {
             let status = std::process::Command::new("docker")
                 .args([


### PR DESCRIPTION
## The incident

A manual UpdatePill update to v0.1.189 on one gateway took the pre-update rollback snapshots, and the cleanup of the backup export containers was interrupted. The leftover `vesta-backup-tmp-{agent}` containers carry the real agent's labels (`vesta.managed=true`, `vesta.agent_name`, `vesta.user`) because `docker commit` bakes the container's labels into the committed image.

`list_managed_agents` filters by exactly those labels, so it returned four entries: the two real containers and the two leftovers, each pair claiming the same `agent_name`. Downstream, the roster keys agents by name, so the duplicate collapsed last-write-wins and the ghost entry shadowed the healthy one: the app showed two agents, both wearing the broken copy's status, while the real containers ran fine underneath. Reconcile meanwhile treated each ghost cname as that agent's container, rebuilt it with full agent config (`on-failure` restart policy included), and boot-started it; each copy dies in seconds (no `/run/vestad-env` mount), which produced the started/stopped push-notification spam.

## The fix

`list_managed_agents` excludes containers whose name starts with `vesta-backup-tmp-`, the prefix `create_backup` owns. The name is the one thing `docker commit` cannot copy from the agent, so it is the reliable discriminator. With the ghost never enumerated there is no duplicate name to collapse, so the real container always backs the roster entry. Fixing it at the enumeration converges the whole fleet at once: leftovers created by any older vestad become inert on the next gateway update, and `create_backup` already removes a leftover before the next backup of that agent, so no separate sweep is needed.

The prefix const moves from `backup.rs` to `docker.rs` (which owns container naming) so both the producer and the filter read one owner.

## Test

`backup_temp_container_is_never_a_managed_agent` (Docker-gated, with the other `#[ignore]` tests in `docker.rs`): creates a properly-labeled real-named container and a ghost-named one, asserts the real one is listed and the ghost never is, which pins both the adoption bug and the shadowing. Verified red with the filter disabled, green with it. `./check.sh vestad` passes; PR CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## The invariant (second commit)

`list_managed_agents` now also guarantees at most one entry per agent name: `dedup_by_agent_name` prefers the canonical `vesta-{user}-{agent}` container and warns on every duplicate it drops. The backup-tmp filter says "this container is categorically never an agent"; the dedup says "whatever future source produces a labeled copy, it can never shadow the real container". Both rules live in the one enumeration gate every consumer reads. Covered by fast-tier unit tests on the pure helper (both duplicate orders, and the no-duplicate identity case).
