### PR TITLE
fix(restart): start daemons from a file, not a parsed prose block

### DIFF
--- a/agent/core/migrations/2026-08-restart-daemons-file.md
+++ b/agent/core/migrations/2026-08-restart-daemons-file.md
@@ -1,0 +1,37 @@
+---
+migration_phase: before_sync
+---
+
+Your restart skill lists its daemons in a fenced bash block inside `~/agent/skills/restart/SKILL.md`. The restart skill now reads them from their own file, `~/agent/skills/restart/daemons.sh`. Move the lines there. Do this now, before the workspace syncs, so the daemon lines are captured before the merge rewrites `SKILL.md`. Safe to run more than once: it checks for the new file first and no-ops once the move is done.
+
+### 1. Stop if already moved
+
+```bash
+test -f ~/agent/skills/restart/daemons.sh && echo done || echo todo
+```
+
+If it prints `done`, skip to step 4.
+
+### 2. Copy the daemon lines into daemons.sh
+
+Read `~/agent/skills/restart/SKILL.md`. Inside the fenced ```bash block under `## Daemons`, every line that is not a `#` comment and not blank is a daemon this container runs. Copy them all verbatim, keeping every flag, into `~/agent/skills/restart/daemons.sh` under this header:
+
+```bash
+#!/usr/bin/env bash
+# One <skill> daemon start per line. The restart skill runs each line.
+```
+
+If the block holds only `#` comment lines (this container runs no daemons of its own), write `daemons.sh` with just that header and no command lines.
+
+### 3. Restore the block in SKILL.md to its placeholder
+
+So the coming sync merges `SKILL.md` cleanly, replace everything between the block's ```bash fence and its closing fence with exactly these two lines, dropping the daemon lines you just copied:
+
+```
+# One line per daemon, e.g.:
+#   file-host daemon start
+```
+
+### 4. Mark this migration applied
+
+Call `mark_migration_applied` with `name="2026-08-restart-daemons-file"`.

--- a/agent/skills/restart/SKILL.md
+++ b/agent/skills/restart/SKILL.md
@@ -27,3 +27,33 @@ Three flags never appear on a line, because the command applies them itself: a p
 whatsapp daemon start --instance personal --read-only
 file-host daemon start
 ```
+
+## After restarting a MESSAGING daemon, go and look for what arrived while it was dead
+
+**Backfill is partial, so a restart is not the end of the recovery.** Verified case: a whatsapp
+daemon was found `"running": false` by a routine check, having died at some point earlier in the day.
+The user had sent **three voice notes** in that window. On restart the daemon produced a notification
+for **exactly one of the three**. The other two generated nothing: no notification, no error, and no
+gap in any record to show something was missing. They were found only by chance, in a
+`last_message_time` field printed by an unrelated command.
+
+A dead daemon plus inbound media is a message that disappears completely, because notifications are
+written only while the daemon lives and media never surfaces on its own afterwards. So whenever a
+messaging daemon comes back from `running: false`, query its message store directly instead of
+trusting backfill:
+
+```bash
+python3 - <<'PY'
+import sqlite3
+db = sqlite3.connect('/root/.whatsapp/messages.db')   # adjust per messaging skill
+q = """SELECT timestamp, chat_jid, is_from_me, media_type, substr(coalesce(content,''),1,120)
+       FROM messages WHERE timestamp > date('now','-1 day') ORDER BY timestamp"""
+for r in db.execute(q):
+    print(r)
+PY
+```
+
+Anything inbound you have not already acted on is a message the user believes they sent you. Media
+is the case that matters most: inbound attachments generally are not downloaded until something asks
+for them, retention windows on the provider side are measured in days rather than weeks, and a
+channel whose media was never fetched looks identical to a channel that was empty.

--- a/agent/skills/restart/SKILL.md
+++ b/agent/skills/restart/SKILL.md
@@ -1,25 +1,29 @@
 ---
 name: restart
-description: What to do after a container restart. Holds the per-skill daemon startup commands.
+description: What to do after a container restart. Starts the per-skill daemons this container runs.
 ---
 
 # Restart
 
 Read `/run/vestad-env` so the values are in your context (Read tool, not bash).
 
-Run the Daemons block below; it is safe to re-run and starts only what's missing. Then check User State in MEMORY.md and reach out on their preferred channel. Match the moment: new day → warm; mid-convo restart → brief; crash → mention it; middle of the night → wait.
+Run `~/agent/skills/restart/start-daemons.sh`. It brings up every daemon this container runs and is safe to re-run: it starts only what is down. Then check User State in MEMORY.md and reach out on their preferred channel. Match the moment: new day → warm; mid-convo restart → brief; crash → mention it; middle of the night → wait.
 
 ## Daemons
 
-When a skill's setup gives you a daemon startup line, add it here yourself, inside the fenced block below, on its own line before the closing fence. A setup script never edits this file. (A daemon that vestad proxies on a port gets that port from its own `daemon start`; a portless background process goes here too.)
+The daemons this container runs live in `~/agent/skills/restart/daemons.sh`, one line per daemon. `start-daemons.sh` reads that file and runs every line, so the file is the one source of truth. Never retype these lines from memory, and never hand-start a daemon that belongs in the file.
 
-Every line is `<skill> daemon start`, with no guard around it (a trailing comment of your own, like `# TEMP` on a service you will tear down, is fine). A start is idempotent: a daemon that is already up answers `{"status":"already_running"}` and spawns nothing, so re-running this whole block cannot stack duplicates, which is what makes it safe for crash and timeout recovery to re-enter this skill repeatedly. A start also returns only once its daemon is actually up, so the lines never race each other and need no sleep between them.
+When a skill's setup gives you a daemon startup line, add it to `daemons.sh` yourself, on its own line. Create the file if it does not exist. A setup script never edits it. (A daemon that vestad proxies on a port gets that port from its own `daemon start`; a portless background process goes in the file too.)
 
-Three flags never appear on a line, because the command applies them itself: a port, a `--notifications-dir`, and a poll interval. Every other flag a skill's setup gives you stays on the line, because it is something chosen for that daemon and the command cannot infer it. Whatsapp named instances are the case you will meet: one line per account, each keeping the `--instance <name>` and per-instance flags it was set up with, e.g. `whatsapp daemon start --instance personal --read-only`.
+Every line runs, so a line that is not a working daemon command is reported as a failure on stderr, never silently skipped. A start is idempotent: a daemon already up answers `{"status":"already_running"}` and spawns nothing, so re-running cannot stack duplicates, which is what makes it safe for crash and timeout recovery to re-enter this skill. A start also returns only once its daemon is actually up, so the lines never race and need no sleep between them.
 
-Keep every line in the one fenced block below, so a single read shows you every daemon this container runs.
+Three flags never appear on a line, because the command applies them itself: a port, a `--notifications-dir`, and a poll interval. Every other flag a skill's setup gives you stays on the line, because it is chosen for that daemon and the command cannot infer it. Whatsapp named instances are the case you will meet: one line per account, each keeping the `--instance <name>` and per-instance flags it was set up with.
+
+`daemons.sh` holds one `<skill> daemon start` per line, with `#` comment lines allowed. For example:
 
 ```bash
-# One line per daemon, e.g.:
-#   file-host daemon start
+#!/usr/bin/env bash
+# One <skill> daemon start per line. The restart skill runs each line.
+whatsapp daemon start --instance personal --read-only
+file-host daemon start
 ```

--- a/agent/skills/restart/start-daemons.sh
+++ b/agent/skills/restart/start-daemons.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Start every daemon listed in daemons.sh, read from the file on disk.
+#
+# The list is read from the file, never retyped from context: a context snapshot of this skill can
+# lag the file by a line, and a daemon on the missing line would then never start while every line
+# you can see reports green. Each line runs, so a line that is not a working daemon command exits
+# non-zero and is reported as a failure, never silently skipped. Idempotent: a daemon already up
+# answers already_running and spawns nothing, and each start returns only once its daemon is up, so
+# the lines never race.
+set -uo pipefail
+
+LIST="$(cd "$(dirname "$0")" && pwd)/daemons.sh"
+
+if [ ! -f "$LIST" ]; then
+  echo "no daemon list at $LIST, nothing to start"
+  exit 0
+fi
+
+mapfile -t lines < <(grep -vE '^[[:space:]]*(#|$)' "$LIST")
+
+if [ "${#lines[@]}" -eq 0 ]; then
+  echo "no daemons in $LIST, nothing to start"
+  exit 0
+fi
+
+fail=0
+for cmd in "${lines[@]}"; do
+  name="${cmd%% *}"
+  if out="$(sh -c "$cmd" 2>&1)"; then
+    printf '%-12s %s\n' "$name" "$(printf '%s' "$out" | tr -d '\n')"
+  else
+    printf '%-12s FAILED: %s\n' "$name" "$(printf '%s' "$out" | tr -d '\n')" >&2
+    fail=1
+  fi
+done
+
+[ "$fail" -eq 0 ] || echo "one or more daemons did not come up" >&2
+exit "$fail"

--- a/agent/tests/test_start_daemons.py
+++ b/agent/tests/test_start_daemons.py
@@ -1,0 +1,88 @@
+"""Behavioral tests for the restart skill's start-daemons.sh.
+
+The script reads the daemon list from daemons.sh on disk and runs every line.
+The property that matters most: a line that is not a working daemon command is
+reported as a failure, never silently skipped, because a silent skip is the
+exact failure this script exists to remove.
+"""
+
+import os
+import pathlib as pl
+import subprocess
+
+SCRIPT = pl.Path(__file__).parent.parent / "skills" / "restart" / "start-daemons.sh"
+
+STUBS = {
+    "started-daemon": '#!/bin/sh\necho \'{"status":"started"}\'\n',
+    "running-daemon": '#!/bin/sh\necho \'{"status":"already_running"}\'\n',
+    "failing-daemon": '#!/bin/sh\necho \'{"error":"boom"}\' >&2\nexit 1\n',
+    "echo-daemon": '#!/bin/sh\necho \'{"status":"started"}\' "$@"\n',
+}
+
+
+def _run(tmp_path: pl.Path, daemons_content: str | None) -> subprocess.CompletedProcess[str]:
+    restart_dir = tmp_path / "restart"
+    restart_dir.mkdir()
+    (restart_dir / "start-daemons.sh").write_text(SCRIPT.read_text())
+    if daemons_content is not None:
+        (restart_dir / "daemons.sh").write_text(daemons_content)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name, body in STUBS.items():
+        stub = bin_dir / name
+        stub.write_text(body)
+        stub.chmod(0o755)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    return subprocess.run(
+        ["bash", str(restart_dir / "start-daemons.sh")],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_missing_list_is_a_noop(tmp_path: pl.Path) -> None:
+    result = _run(tmp_path, None)
+    assert result.returncode == 0
+    assert "nothing to start" in result.stdout
+
+
+def test_comment_only_list_is_a_noop(tmp_path: pl.Path) -> None:
+    result = _run(tmp_path, "#!/usr/bin/env bash\n# no daemons yet\n")
+    assert result.returncode == 0
+    assert "nothing to start" in result.stdout
+
+
+def test_all_daemons_up_exits_zero(tmp_path: pl.Path) -> None:
+    result = _run(tmp_path, "started-daemon daemon start\nrunning-daemon daemon start\n")
+    assert result.returncode == 0
+    assert "started-daemon" in result.stdout
+    assert "running-daemon" in result.stdout
+    assert result.stderr == ""
+
+
+def test_failing_daemon_reported_on_stderr_and_others_still_run(tmp_path: pl.Path) -> None:
+    # Failing line first: the good line after it must still run, so a mid-list failure never
+    # aborts the rest, and the failure lands on stderr with a non-zero exit.
+    result = _run(tmp_path, "failing-daemon daemon start\nstarted-daemon daemon start\n")
+    assert result.returncode == 1
+    assert "started-daemon" in result.stdout
+    assert "failing-daemon" in result.stderr
+    assert "boom" in result.stderr
+
+
+def test_malformed_line_fails_loud_not_silent(tmp_path: pl.Path) -> None:
+    # A line that is not a real command must be reported, never silently dropped.
+    result = _run(tmp_path, "not-a-daemon-command foo bar\n")
+    assert result.returncode == 1
+    assert "not-a-daemon-command" in result.stderr
+
+
+def test_flags_passed_verbatim(tmp_path: pl.Path) -> None:
+    result = _run(tmp_path, "echo-daemon daemon start --instance personal --read-only\n")
+    assert result.returncode == 0
+    assert "--instance personal --read-only" in result.stdout


### PR DESCRIPTION
Fixes #1913. Supersedes #1914 (same bug, robust against the silent-skip hole that approach left open).

## The bug

`restart/SKILL.md` told the agent to run the Daemons fenced block. That block reaches the agent as a **context snapshot** of the file, which can lag the on-disk file by a line. A daemon added since the snapshot is never started, and nothing reports it: every line the agent can see answers `started`/`already_running`, so the restart reads fully green. The checker and the checked thing are the same stale copy.

## The change

The daemon list moves out of prose and into its own file, `agent/skills/restart/daemons.sh`, which the agent edits directly. `start-daemons.sh` reads that file **on disk** and runs **every** non-comment, non-blank line.

The key property: there is **no pattern gate**. A line that is not a working daemon command exits non-zero and is reported on stderr, never silently dropped. (An earlier block-parsing approach filtered lines by a `^[a-z0-9-]+ daemon start` regex, which silently skipped any off-format line, reintroducing the exact silent-skip failure this fixes.) The runner keeps the block's own contract otherwise: idempotent, stdout carries only daemons that came up, a mid-list failure never aborts the rest, a failure sets a non-zero exit.

## Fleet migration

Existing boxes hold their daemon lines in the SKILL.md block via local commits, and this PR rewrites that same region. A **before-sync** migration (`2026-08-restart-daemons-file.md`):

1. no-ops if `daemons.sh` already exists
2. copies every non-comment line from the block into `daemons.sh` verbatim (all flags kept; copies *every* line, so no format assumption can lose data)
3. restores the SKILL.md block to its stock placeholder, so `SKILL.md` merges cleanly on the following sync instead of conflicting
4. marks itself applied

Running before sync captures the lines before the merge can touch them, and makes the merge conflict-free rather than relying on hand-resolution. `daemons.sh` is the box's own untracked-then-committed file, so no stock `daemons.sh` ships and there is no add/add conflict. A missing `daemons.sh` is a no-op, so fresh agents (which pre-mark the migration) and daemon-less boxes just print "nothing to start".

## Tests

`agent/tests/test_start_daemons.py` runs the script against stub daemons on PATH:
- missing / comment-only list: no-op, exit 0
- all daemons up: both on stdout, exit 0
- failing line: reported on stderr, exit 1, and a later line **still runs** (no abort)
- **malformed line: fails loud, exit 1, not silently skipped** (the regression test for the hole)
- flags passed verbatim

`./check.sh guards` and the new pytest pass; `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CY6sBrPHqhRKcX7zRv1iz

---

**Folded in #1987** (docs-only): appends an "after restarting a messaging daemon, query the store" section to the same `restart/SKILL.md`. Both PRs rewrite that file's daemon region, so carrying the docs here keeps it to one merge and avoids a conflict. #1987 is closed.