### PR TITLE
feat(tasks): mirror the native task-tool surface (create, --subject, in_progress/completed)

### DIFF
--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -28,6 +28,8 @@ tasks delete <id>                 # cascades to linked reminders
 - `update --clear-due` removes a due date. Every other due flag can only move a date, so without this a due date is a one-way door: auto reminders are regenerated from `due_date`, so deleting them by hand does not stick. Reach for it when a date was set by mistake or by a bulk `postpone` over a backlog, since a backburner item with a due date fires a whole reminder cascade it never earned.
 - `tasks get <id> --field status` prints just that field (repeat `--field` for several, tab-separated). Valid fields: id, title, status, priority, due_date, created_at, completed_at, metadata_path, metadata. Prefer this over reading the metadata file when you need one value.
 - `list`/`search` print compact tables (`--show-completed` to include done); add `--json` or `--json-pretty` for JSON.
+- `create` is an alias of `add`. `--subject` is an alias of `--title` on both `add` and `update`.
+- A task's status is `pending`, `in_progress`, or `completed` (`completed` is the same as `done`). `tasks done <id>` and `tasks update <id> --status completed` both close it. `tasks update <id> --status in_progress` marks a task started: it stays open, so it still shows in `tasks list` and still fires its due-date reminders.
 
 ## Reminders
 

--- a/agent/skills/tasks/cli/src/tasks_cli/cli.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/cli.py
@@ -105,9 +105,10 @@ def _build_parser() -> argparse.ArgumentParser:
     p_daemon.add_argument("action", nargs="?", default="", metavar="start|stop|restart|status")
 
     # add
-    p_add = sub.add_parser("add", help="Add a new task")
+    p_add = sub.add_parser("add", aliases=["create"], help="Add a new task (alias: create)")
     p_add.add_argument("title_pos", nargs="?", default=None, metavar="title")
     p_add.add_argument("--title", default=None)
+    p_add.add_argument("--subject", default=None, help="Alias for --title")
     _add_due_args(p_add)
     p_add.add_argument("--priority", default="normal", help="low/normal/high or 1/2/3")
     p_add.add_argument("--initial-metadata", default=None)
@@ -131,8 +132,9 @@ def _build_parser() -> argparse.ArgumentParser:
     # update
     p_update = sub.add_parser("update", help="Update a task")
     _add_id_args(p_update)
-    p_update.add_argument("--status", default=None)
+    p_update.add_argument("--status", default=None, help="pending, in_progress, or completed (completed == done)")
     p_update.add_argument("--title", default=None)
+    p_update.add_argument("--subject", default=None, help="Alias for --title")
     p_update.add_argument("--priority", default=None)
     _add_due_args(p_update)
     p_update.add_argument("--clear-due", action="store_true", help="Remove the task's due date and its auto reminders")
@@ -387,8 +389,8 @@ subcommands:
 
 
 def _handle_task(args, config: Config):
-    if args.command == "add":
-        title = _require_arg(args.title_pos or args.title, "title", 'tasks add "title" or tasks add --title "title"')
+    if args.command in ("add", "create"):
+        title = _require_arg(args.title_pos or args.title or args.subject, "title", 'tasks add "title" or tasks add --title "title"')
         _warn_long_title(title)
         result = commands.add_task(
             config,
@@ -418,13 +420,14 @@ def _handle_task(args, config: Config):
         result = commands.get_task(config, task_id=task_id)
     elif args.command == "update":
         task_id = _require_arg(args.id_pos or args.task_id, "id", "tasks update <id> or tasks update --id <id>")
-        if args.title is not None:
-            _warn_long_title(args.title)
+        title = args.title or args.subject
+        if title is not None:
+            _warn_long_title(title)
         result = commands.update_task(
             config,
             task_id=task_id,
             status=args.status,
-            title=args.title,
+            title=title,
             priority=args.priority,
             due=commands.DueSpec(
                 due_datetime=args.due_datetime,

--- a/agent/skills/tasks/cli/src/tasks_cli/commands.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/commands.py
@@ -70,13 +70,13 @@ class ReminderSpec(BaseModel):
     fuzz_minutes: int | None = None
 
 
-# Overdue pending tasks (past due_date) always float to the top, ordered by most overdue first.
-# datetime() normalizes the ISO 'T'/offset form to SQLite's space-separated form so the
+# Overdue open tasks (not done, past due_date) always float to the top, ordered by most overdue
+# first. datetime() normalizes the ISO 'T'/offset form to SQLite's space-separated form so the
 # comparison is chronological, not lexicographic. Non-overdue tasks keep priority/due/created order.
 _TASK_ORDER_BY = (
     " ORDER BY"
-    " CASE WHEN status = 'pending' AND due_date IS NOT NULL AND datetime(due_date) < datetime('now') THEN 0 ELSE 1 END ASC,"
-    " CASE WHEN status = 'pending' AND due_date IS NOT NULL AND datetime(due_date) < datetime('now') THEN datetime(due_date) END ASC,"
+    " CASE WHEN status != 'done' AND due_date IS NOT NULL AND datetime(due_date) < datetime('now') THEN 0 ELSE 1 END ASC,"
+    " CASE WHEN status != 'done' AND due_date IS NOT NULL AND datetime(due_date) < datetime('now') THEN datetime(due_date) END ASC,"
     " priority DESC, due_date ASC NULLS LAST, created_at DESC"
 )
 
@@ -366,9 +366,10 @@ def _rebuild_due_reminders(conn, task_id: str, row, *, title: str | None, status
     if not new_due_date:
         return
     reminder_title = title if title is not None else row["title"]
-    # Only create reminders if the task is (or will be) pending.
+    # Only create reminders if the task is (or will be) open. in_progress is open like pending;
+    # only done stops reminding.
     effective_status = status if status is not None else row["status"]
-    if effective_status == "pending":
+    if effective_status != "done":
         db.create_auto_reminders(conn, task_id, reminder_title, new_due_date)
 
 
@@ -428,8 +429,12 @@ def update_task(
     due: DueSpec | None = None,
     backburner: bool | None = None,
 ) -> dict:
-    if status and status not in ("pending", "done"):
-        raise ValueError(f"Status must be pending or done, got {status}")
+    # `completed` is accepted as an alias for the stored `done`; the store keeps one status
+    # vocabulary (pending/in_progress/done).
+    if status == "completed":
+        status = "done"
+    if status and status not in ("pending", "in_progress", "done"):
+        raise ValueError(f"Status must be pending, in_progress, or completed, got {status}")
     if priority is not None:
         priority = normalize_priority(priority)
 
@@ -445,21 +450,21 @@ def update_task(
         if status is not None:
             updates.append("status = ?")
             params.append(status)
+            was_done = result["status"] == "done"
             if status == "done":
                 updates.append("completed_at = ?")
                 params.append(_now_utc().isoformat())
                 # A finished task stops reminding entirely, so this clears owned reminders too, not
                 # just auto ones. A due-date change below rebuilds only the auto ones (delete_auto).
                 db.delete_task_reminders(conn, task_id)
-            elif status == "pending":
+            elif was_done:
+                # Reopening from done (to pending or in_progress): clear completion and, unless the
+                # due date is being changed below (that block rebuilds them), recreate the auto
+                # reminders the done transition deleted. A pending<->in_progress toggle is not a
+                # reopen, so it never touches reminders and cannot duplicate them.
                 updates.append("completed_at = NULL")
-                # Recreate auto-reminders if task has a due date and is reopened.
-                # If due date is also being updated in this call, skip here;
-                # the due-date block below handles reminder recreation with the new value.
-                if not due_date_changed:
-                    old_due = result["due_date"]
-                    if old_due:
-                        db.create_auto_reminders(conn, task_id, result["title"], old_due)
+                if not due_date_changed and result["due_date"]:
+                    db.create_auto_reminders(conn, task_id, result["title"], result["due_date"])
 
         new_backburner = _backburner_update(
             conn, result, backburner=backburner, due_date_changed=due_date_changed, new_due_date=new_due_date, updates=updates
@@ -599,7 +604,7 @@ def build_digest(config: Config, *, now: datetime | None = None) -> str | None:
     """The daily digest message, or None when nothing needs attention."""
     now = now or _now_utc()
     with closing(db.get_db(config.data_dir)) as conn:
-        pending = conn.execute("SELECT id, title, priority, due_date, created_at, backburner FROM tasks WHERE status = 'pending'").fetchall()
+        pending = conn.execute("SELECT id, title, priority, due_date, created_at, backburner FROM tasks WHERE status != 'done'").fetchall()
 
     overdue: list[tuple[dict, datetime]] = []
     stale: list[tuple[dict, datetime]] = []

--- a/agent/skills/tasks/cli/src/tasks_cli/db.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/db.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 # Head schema version. Bump this in the same commit as a new _migrate_vN_to_vN+1, and assert against
 # it in tests rather than hard-coding an integer, so adding a migration cannot break unrelated tests.
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 
 class Task(TypedDict, total=False):
@@ -293,7 +293,7 @@ def delete_auto_reminders(conn: sqlite3.Connection, task_id: str):
 
 def _create_auto_reminders_for_existing(conn: sqlite3.Connection):
     """Create auto-generated reminders for all pending tasks with due dates."""
-    tasks = conn.execute("SELECT id, title, due_date FROM tasks WHERE due_date IS NOT NULL AND status='pending'").fetchall()
+    tasks = conn.execute("SELECT id, title, due_date FROM tasks WHERE due_date IS NOT NULL AND status != 'done'").fetchall()
     created = 0
     for task in tasks:
         create_auto_reminders(conn, task["id"], task["title"], task["due_date"])
@@ -322,6 +322,31 @@ def _migrate_v4_to_v5(conn: sqlite3.Connection):
     if "backburner" not in cols:
         conn.execute("ALTER TABLE tasks ADD COLUMN backburner INTEGER NOT NULL DEFAULT 0")
     logger.info("Migrated schema v4 -> v5")
+
+
+def _migrate_v5_to_v6(conn: sqlite3.Connection):
+    """v5 -> v6: widen the status CHECK to allow 'in_progress' (the CLI also accepts 'completed' as
+    an alias for 'done'). SQLite cannot alter a CHECK in place, so rebuild the table, preserving
+    every row and column."""
+    conn.execute("""
+        CREATE TABLE tasks_v6 (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            status TEXT DEFAULT 'pending' CHECK(status IN ('pending', 'in_progress', 'done')),
+            priority INTEGER DEFAULT 2 CHECK(priority IN (1, 2, 3)),
+            due_date TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            completed_at TEXT,
+            backburner INTEGER NOT NULL DEFAULT 0
+        )
+    """)
+    conn.execute("""
+        INSERT INTO tasks_v6 (id, title, status, priority, due_date, created_at, completed_at, backburner)
+        SELECT id, title, status, priority, due_date, created_at, completed_at, backburner FROM tasks
+    """)
+    conn.execute("DROP TABLE tasks")
+    conn.execute("ALTER TABLE tasks_v6 RENAME TO tasks")
+    logger.info("Migrated schema v5 -> v6")
 
 
 def get_meta(conn: sqlite3.Connection, key: str) -> str | None:
@@ -354,7 +379,7 @@ def init_db(data_dir: Path):
             CREATE TABLE IF NOT EXISTS tasks (
                 id TEXT PRIMARY KEY,
                 title TEXT NOT NULL,
-                status TEXT DEFAULT 'pending' CHECK(status IN ('pending', 'done')),
+                status TEXT DEFAULT 'pending' CHECK(status IN ('pending', 'in_progress', 'done')),
                 priority INTEGER DEFAULT 2 CHECK(priority IN (1, 2, 3)),
                 due_date TEXT,
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP,
@@ -388,6 +413,11 @@ def init_db(data_dir: Path):
             _migrate_v4_to_v5(conn)
             conn.execute("UPDATE schema_version SET version = 5")
             version = 5
+
+        if version < 6:
+            _migrate_v5_to_v6(conn)
+            conn.execute("UPDATE schema_version SET version = 6")
+            version = 6
 
         conn.commit()
 

--- a/agent/skills/tasks/cli/src/tasks_cli/format.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/format.py
@@ -58,7 +58,7 @@ def format_task_list(tasks: list[dict[str, Any]], now: datetime | None = None) -
         return "(no tasks)"
     now = now or datetime.now(UTC)
     return "\n".join(
-        f"{_trunc(_pick(t, 'status', '-'), 8)}\t"
+        f"{_trunc(_pick(t, 'status', '-'), 11)}\t"
         f"{_prio(_pick(t, 'priority', None))}\t"
         f"{_due_col(_pick(t, 'due_date', None), now)}\t"
         f"{_pick(t, 'id')}\t"

--- a/agent/skills/tasks/cli/src/tasks_cli/server.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/server.py
@@ -29,7 +29,7 @@ class AddTaskBody(BaseModel):
 
 
 class UpdateTaskBody(BaseModel):
-    status: Literal["pending", "done"] | None = None
+    status: Literal["pending", "in_progress", "done", "completed"] | None = None
     title: str | None = None
     priority: str | int | None = None
     due_datetime: str | None = None
@@ -59,7 +59,7 @@ def _apply_task_update(config: Config, notif_dir: Path, task_id: str, body: Upda
     """Apply a task update coming from the app. A pending->done transition here is the one completion
     the agent does not already know about (its own CLI edits are self-evident), so it notifies,
     snoozed (interrupt=False), which the CLI path never does."""
-    already_done = body.status == "done" and commands.get_task(config, task_id=task_id)["status"] == "done"
+    already_done = body.status in ("done", "completed") and commands.get_task(config, task_id=task_id)["status"] == "done"
     result = commands.update_task(
         config,
         task_id=task_id,
@@ -75,7 +75,7 @@ def _apply_task_update(config: Config, notif_dir: Path, task_id: str, body: Upda
             clear=body.clear_due,
         ),
     )
-    if body.status == "done" and not already_done:
+    if body.status in ("done", "completed") and not already_done:
         write_notification(notif_dir, "task_completed", interrupt=False, task_id=task_id, message=f"Task completed: {result['title']}")
     return result
 

--- a/agent/skills/tasks/cli/tests/test_e2e.py
+++ b/agent/skills/tasks/cli/tests/test_e2e.py
@@ -1282,3 +1282,39 @@ class TestDaemonLifecycle:
     def test_a_stop_with_nothing_running_is_a_no_op(self, test_home):
         home, _ = test_home
         assert parse(daemon_cli(home, "stop")) == {"status": "already_stopped"}
+
+
+class TestNativeSurface:
+    """CLI parity with the native task tools: the `create` verb and `--subject`/status aliases."""
+
+    def test_create_is_an_alias_of_add(self, shared_env):
+        home, _, _ = shared_env
+        data = parse(tasks_cli(home, "create", "made with create"))
+        assert data["title"] == "made with create"
+        assert data["status"] == "pending"
+
+    def test_subject_sets_title_on_create(self, shared_env):
+        home, _, _ = shared_env
+        data = parse(tasks_cli(home, "create", "--subject", "subject wins"))
+        assert data["title"] == "subject wins"
+
+    def test_subject_sets_title_on_update(self, shared_env):
+        home, _, _ = shared_env
+        added = parse(tasks_cli(home, "add", "before subject"))
+        data = parse(tasks_cli(home, "update", added["id"], "--subject", "after subject"))
+        assert data["title"] == "after subject"
+
+    def test_update_status_in_progress_stays_listed(self, shared_env):
+        home, _, _ = shared_env
+        added = parse(tasks_cli(home, "add", "wip via cli"))
+        data = parse(tasks_cli(home, "update", added["id"], "--status", "in_progress"))
+        assert data["status"] == "in_progress"
+        listing = parse(tasks_cli(home, "list", "--json"))
+        assert any(t["id"] == added["id"] for t in listing)
+
+    def test_update_status_completed_is_done(self, shared_env):
+        home, _, _ = shared_env
+        added = parse(tasks_cli(home, "add", "close via completed"))
+        data = parse(tasks_cli(home, "update", added["id"], "--status", "completed"))
+        assert data["status"] == "done"
+        assert data["completed_at"] is not None

--- a/agent/skills/tasks/cli/tests/test_native_surface.py
+++ b/agent/skills/tasks/cli/tests/test_native_surface.py
@@ -1,0 +1,85 @@
+"""The native-task-tool surface: the `completed` alias, the `in_progress` open status, and that
+adding it never strands a task's reminders. CLI-level aliases (`create`, `--subject`) live in
+test_e2e.py alongside the other subprocess tests."""
+
+import sqlite3
+from contextlib import closing
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from tasks_cli import commands, db
+
+
+def _auto_reminder_count(config, task_id: str) -> int:
+    with closing(db.get_db(config.data_dir)) as conn:
+        return conn.execute("SELECT COUNT(*) FROM reminders WHERE task_id = ? AND auto_generated = 1", (task_id,)).fetchone()[0]
+
+
+def test_completed_maps_to_done(tmp_config):
+    task = commands.add_task(tmp_config, title="finish")
+    result = commands.update_task(tmp_config, task_id=task["id"], status="completed")
+    assert result["status"] == "done"
+    assert result["completed_at"] is not None
+
+
+def test_invalid_status_rejected(tmp_config):
+    task = commands.add_task(tmp_config, title="x")
+    with pytest.raises(ValueError):
+        commands.update_task(tmp_config, task_id=task["id"], status="bogus")
+
+
+def test_in_progress_stays_open_in_list_and_digest(tmp_config):
+    overdue = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+    task = commands.add_task(tmp_config, title="overdue wip", due=commands.DueSpec(due_datetime=overdue, timezone="UTC"))
+    commands.update_task(tmp_config, task_id=task["id"], status="in_progress")
+    assert any(t["id"] == task["id"] for t in commands.list_tasks(tmp_config))
+    digest = commands.build_digest(tmp_config)
+    assert digest is not None
+    assert task["id"] in digest
+
+
+def test_open_status_toggle_never_duplicates_reminders(tmp_config):
+    due = (datetime.now(UTC) + timedelta(days=3)).isoformat()
+    task = commands.add_task(tmp_config, title="wip", due=commands.DueSpec(due_datetime=due, timezone="UTC"))
+    baseline = _auto_reminder_count(tmp_config, task["id"])
+    assert baseline > 0
+    commands.update_task(tmp_config, task_id=task["id"], status="in_progress")
+    assert _auto_reminder_count(tmp_config, task["id"]) == baseline
+
+
+def test_reopen_from_done_via_in_progress_rebuilds_reminders(tmp_config):
+    due = (datetime.now(UTC) + timedelta(days=3)).isoformat()
+    task = commands.add_task(tmp_config, title="reopen", due=commands.DueSpec(due_datetime=due, timezone="UTC"))
+    commands.update_task(tmp_config, task_id=task["id"], status="done")
+    assert _auto_reminder_count(tmp_config, task["id"]) == 0
+    reopened = commands.update_task(tmp_config, task_id=task["id"], status="in_progress")
+    assert reopened["status"] == "in_progress"
+    assert reopened["completed_at"] is None
+    assert _auto_reminder_count(tmp_config, task["id"]) > 0
+
+
+def test_migration_v5_to_v6_widens_status_check(tmp_path):
+    data_dir = tmp_path / "old"
+    data_dir.mkdir()
+    conn = sqlite3.connect(data_dir / "tasks.db")
+    conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+    conn.execute("INSERT INTO schema_version (version) VALUES (5)")
+    conn.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT NOT NULL,"
+        " status TEXT DEFAULT 'pending' CHECK(status IN ('pending', 'done')),"
+        " priority INTEGER DEFAULT 2 CHECK(priority IN (1, 2, 3)), due_date TEXT,"
+        " created_at TEXT DEFAULT CURRENT_TIMESTAMP, completed_at TEXT,"
+        " backburner INTEGER NOT NULL DEFAULT 0)"
+    )
+    conn.execute("INSERT INTO tasks (id, title) VALUES ('t1', 'kept')")
+    conn.commit()
+    conn.close()
+
+    db.init_db(data_dir)
+
+    with closing(sqlite3.connect(data_dir / "tasks.db")) as conn:
+        assert conn.execute("SELECT version FROM schema_version").fetchone()[0] == db.SCHEMA_VERSION
+        assert conn.execute("SELECT title FROM tasks WHERE id = 't1'").fetchone()[0] == "kept"
+        # The old CHECK would reject this; after v6 it is allowed.
+        conn.execute("UPDATE tasks SET status = 'in_progress' WHERE id = 't1'")
+        conn.commit()


### PR DESCRIPTION
## What

Makes the durable `tasks` CLI wear the same surface the agent already knows, without changing what the store is:

- `create` is an alias of `add`.
- `--subject` is an alias of `--title` on `add` and `update`.
- Status vocabulary is `pending`, `in_progress`, `completed`, where `completed` is stored as `done`. `tasks update <id> --status in_progress` marks a task started.

Scope is the surface only. Due dates, reminders, priorities, the daemon, the digest, and backburner are unchanged. There is no ephemeral or session-scoped mode here (that is #1967).

## Why

PR #1964 turns off the harness's native task tools. This makes the CLI the agent reaches for instead feel familiar, so its muscle memory transfers, without reintroducing the competing system #1964 removed.

## `in_progress` is a real third open status

The interesting part. `in_progress` is not cosmetic: it is a task that is started but not done.

- Schema v6 widens the status CHECK from `('pending','done')` to `('pending','in_progress','done')`. SQLite cannot alter a CHECK in place, so the migration rebuilds the table, preserving every row and column. Fresh and existing DBs converge on it.
- Every "open task" query now keys on `status != 'done'` rather than `= 'pending'`: `list`, `search`, the daily digest, the overdue-float ordering, and the auto-reminder backfill. So an in-progress task still lists and still fires its due-date reminders, exactly like a pending one.
- The status transition only touches reminders when it actually opens or closes a task: closing deletes them, reopening from done rebuilds them, and a `pending <-> in_progress` toggle leaves them alone. This also removes a latent path where re-setting an already-open task's status could duplicate its auto reminders.

## Tests

- `tests/test_native_surface.py`: `completed` maps to `done`, invalid status rejected, an in-progress task stays in `list` and the digest, an open-status toggle neither drops nor duplicates reminders, reopening from done via in_progress rebuilds them, and the v5 -> v6 migration preserves rows and then accepts `in_progress`.
- `tests/test_e2e.py`: the CLI surface end to end (`create`, `--subject` on add and update, `--status in_progress` stays listed, `--status completed` closes).
- Full suite: 239 passing. Pinned ruff, ruff format, and the convention guard are green.
