### PR TITLE
fix(vestad): resolve the release freshly at the maintenance window

### DIFF
--- a/vestad/src/serve.rs
+++ b/vestad/src/serve.rs
@@ -2959,6 +2959,18 @@ const WINDOW_POLL: jiff::SignedDuration = jiff::SignedDuration::from_secs(15 * 6
 // maintenance decision, so a pass pending at startup targets the fleet's real windows instead of
 // resolving a still-empty cache to host-local.
 const STARTUP_SETTLE_SECS: u64 = 60;
+const STARTUP_SETTLE_ENV: &str = "VESTAD_MAINTENANCE_SETTLE_SECS";
+
+/// The boot settle before the first maintenance decision. `VESTAD_MAINTENANCE_SETTLE_SECS` shortens
+/// it for the maintenance-update test, exactly as `VESTAD_UPDATE_ANNOUNCE_GRACE_SECS` shortens the
+/// announce window; unset in every published build, so nothing branches in production.
+fn startup_settle() -> tokio::time::Duration {
+    let seconds = std::env::var(STARTUP_SETTLE_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse().ok())
+        .unwrap_or(STARTUP_SETTLE_SECS);
+    tokio::time::Duration::from_secs(seconds)
+}
 
 /// The local timezone of every alive agent, falling back to host-local for any agent that hasn't
 /// reported one (pre-upstream-sync fleet). Drives which 4-5am window maintenance targets.
@@ -2975,12 +2987,12 @@ fn running_agent_zones(state: &SharedState) -> Vec<jiff::tz::TimeZone> {
 
 /// One maintenance cycle owns all scheduled disk and restart work: it fires in the fleet's
 /// best-coverage 4-5am agent-local window, at a poll where every agent is idle (or at the
-/// window's last poll), runs the restart-free snapshot pass, and applies a pending update
-/// as an add-on to that same pass.
+/// window's last poll), and either applies a pending update or runs the restart-free snapshot
+/// pass.
 fn spawn_maintenance_task(state: SharedState) {
     tokio::spawn(async move {
         // Settle first so the timezone cache is populated before the first window decision.
-        tokio::time::sleep(tokio::time::Duration::from_secs(STARTUP_SETTLE_SECS)).await;
+        tokio::time::sleep(startup_settle()).await;
         let mut last_pass_epoch: u64 = 0;
         loop {
             let now_epoch = crate::time_utils::now_epoch_secs();
@@ -3004,32 +3016,29 @@ fn spawn_maintenance_task(state: SharedState) {
     });
 }
 
-/// One fired maintenance cycle: the snapshot pass, or a pending update (which owns the pre-update
-/// snapshot pass itself) as its add-on. The update restarts this process on success, so control
-/// usually never returns from the update branch.
+/// One fired maintenance cycle: a pending update (which owns the pre-update snapshot pass itself),
+/// or the routine snapshot pass. The update restarts this process on success, so control usually
+/// never returns from the update branch.
 async fn run_maintenance(state: &SharedState) {
-    let update_pending = state
-        .update_info
-        .lock()
-        .await
-        .as_ref()
-        .is_some_and(|info| info.update_available);
     let auto_update = state.settings.read().await.auto_update;
-
-    if update_pending && auto_update && !state.dev_mode {
-        tracing::info!("maintenance: applying pending update");
-        // The same one entry point a manual update takes. A failed apply retries next cycle; the
-        // fresh pre-update snapshot set is reused (<24h).
+    // Resolve the release freshly here rather than reading the periodic poll's cache: that poll
+    // runs every CHECK_INTERVAL_SECS and can straddle a release published the same night, leaving
+    // the cache stale for the one daily moment this window reads it. start_update runs its own
+    // fresh check and is the single owner of the pending-release decision.
+    if auto_update && !state.dev_mode {
         match update::start_update(state.clone()).await {
             Ok(update::UpdateStart::Started { .. }) => {
                 state.operation.wait_until_settled().await;
+                return;
             }
             Ok(outcome) => tracing::info!(?outcome, "maintenance: no update to apply"),
-            Err(phase) => tracing::warn!(?phase, "maintenance: an update is already running"),
+            Err(phase) => {
+                tracing::warn!(?phase, "maintenance: an update is already running");
+                return;
+            }
         }
-    } else {
-        run_snapshot_pass(state, maintenance::PassKind::Routine).await;
     }
+    run_snapshot_pass(state, maintenance::PassKind::Routine).await;
 }
 
 /// Snapshot every agent the pass selects, restart-free and concurrently (bounded). After a

--- a/vestad/tests-integration/src/release_server.rs
+++ b/vestad/tests-integration/src/release_server.rs
@@ -8,7 +8,7 @@ use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// Bytes the stalled artifact answers before it goes quiet, so curl has a live response to wait on.
 const STALL_PREFIX: &[u8] = b"\x1f\x8b";
@@ -28,6 +28,7 @@ pub struct FakeReleaseServer {
     base_url: String,
     stop: Arc<AtomicBool>,
     port: u16,
+    tag: Arc<Mutex<String>>,
 }
 
 impl FakeReleaseServer {
@@ -43,6 +44,7 @@ impl FakeReleaseServer {
         let stop = Arc::new(AtomicBool::new(false));
 
         let routes = Arc::new(Routes::new(version, mode)?);
+        let tag = routes.tag.clone();
         let stop_flag = stop.clone();
         std::thread::spawn(move || {
             for incoming in listener.incoming() {
@@ -61,12 +63,20 @@ impl FakeReleaseServer {
             base_url: format!("http://127.0.0.1:{port}"),
             stop,
             port,
+            tag,
         })
     }
 
     /// What `VESTAD_RELEASES_BASE_URL` is set to for a vestad that should update from here.
     pub fn base_url(&self) -> &str {
         &self.base_url
+    }
+
+    /// Change the release the metadata endpoints report, so a test can offer a version only after a
+    /// gateway's boot-time check has already cached an older answer. The artifact stays the binary
+    /// built at construction, so only a `version` that names that binary downloads successfully.
+    pub fn set_version(&self, version: &str) {
+        *self.tag.lock().expect("release server tag lock") = format!("v{version}");
     }
 }
 
@@ -79,7 +89,7 @@ impl Drop for FakeReleaseServer {
 }
 
 struct Routes {
-    tag: String,
+    tag: Arc<Mutex<String>>,
     artifact_path: String,
     mode: ArtifactMode,
 }
@@ -87,7 +97,7 @@ struct Routes {
 impl Routes {
     fn new(version: &str, mode: ArtifactMode) -> Result<Self, String> {
         Ok(Self {
-            tag: format!("v{version}"),
+            tag: Arc::new(Mutex::new(format!("v{version}"))),
             artifact_path: format!(
                 "/releases/download/v{version}/vestad-{}.tar.gz",
                 rust_target()?
@@ -96,17 +106,21 @@ impl Routes {
         })
     }
 
+    fn tag(&self) -> String {
+        self.tag.lock().expect("release server tag lock").clone()
+    }
+
     fn serve(&self, mut stream: TcpStream, stop: &AtomicBool) {
         let Some(path) = read_request_path(&stream) else {
             return;
         };
         if path == "/releases/latest" {
-            let body = format!(r#"{{"tag_name": "{}", "prerelease": false}}"#, self.tag);
+            let body = format!(r#"{{"tag_name": "{}", "prerelease": false}}"#, self.tag());
             let _ = write_json(&mut stream, &body);
             return;
         }
         if path.starts_with("/releases?") {
-            let body = format!(r#"[{{"tag_name": "{}", "prerelease": true}}]"#, self.tag);
+            let body = format!(r#"[{{"tag_name": "{}", "prerelease": true}}]"#, self.tag());
             let _ = write_json(&mut stream, &body);
             return;
         }

--- a/vestad/tests/server/gateway_update.rs
+++ b/vestad/tests/server/gateway_update.rs
@@ -39,6 +39,10 @@ const POLL_INTERVAL: Duration = Duration::from_millis(200);
 /// The reconnect grace window every gateway here runs with (production is 30s). Long enough that the
 /// test's socket is always connected before it expires, short enough not to pad the suite.
 const ANNOUNCE_GRACE_SECS: u64 = 10;
+/// The boot settle the maintenance-update test runs with (production is 60s). Comfortably longer
+/// than the handshake plus the one `/version` read the test does before it offers the newer release,
+/// so the window never fires while the release is still hidden.
+const MAINTENANCE_SETTLE_SECS: u64 = 12;
 
 static GATEWAY_COUNTER: AtomicU32 = AtomicU32::new(0);
 
@@ -91,6 +95,7 @@ struct Gateway {
     installed: PathBuf,
     path: String,
     systemctl_log: PathBuf,
+    settle_secs: Option<u64>,
 }
 
 impl Gateway {
@@ -132,14 +137,34 @@ impl Gateway {
             installed,
             path: format!("{}:{inherited}", bin_dir.display()),
             systemctl_log,
+            settle_secs: None,
             _tmp: tmp,
         }
+    }
+
+    /// Let the maintenance cycle apply a pending release on its own, instead of only when the test
+    /// POSTs an update. Rewrites the settings this gateway booted with.
+    fn with_auto_update(self, on: bool) -> Self {
+        let config_dir = self.home.join(".config/vesta/vestad");
+        std::fs::write(
+            config_dir.join("settings.json"),
+            format!(r#"{{"auto_update": {on}}}"#),
+        )
+        .expect("write settings");
+        self
+    }
+
+    /// Shorten the boot settle before the first maintenance decision, so the window fires seconds
+    /// after boot rather than the production minute.
+    fn with_settle_secs(mut self, secs: u64) -> Self {
+        self.settle_secs = Some(secs);
+        self
     }
 
     /// Boot this gateway against `releases_base_url`. Every start is the same installed file, so a
     /// relaunch after an update runs whatever the update put there.
     fn start(&self, releases_base_url: &str) -> TestServer {
-        TestServerBuilder::new()
+        let mut builder = TestServerBuilder::new()
             .user(&self.user)
             .home(self.home.clone())
             .vestad_bin(self.installed.clone())
@@ -149,9 +174,11 @@ impl Gateway {
                 "VESTAD_UPDATE_ANNOUNCE_GRACE_SECS",
                 &ANNOUNCE_GRACE_SECS.to_string(),
             )
-            .env("PATH", &self.path)
-            .start()
-            .expect("start the gateway under test")
+            .env("PATH", &self.path);
+        if let Some(secs) = self.settle_secs {
+            builder = builder.env("VESTAD_MAINTENANCE_SETTLE_SECS", &secs.to_string());
+        }
+        builder.start().expect("start the gateway under test")
     }
 
     fn ledger(&self) -> Option<serde_json::Value> {
@@ -555,4 +582,47 @@ async fn a_broken_release_projects_a_failure_until_it_is_dismissed() {
         .await
         .expect("the dismiss clears the projection");
     assert!(gateway_of(&cleared)["operation"].is_null());
+}
+
+/// The maintenance window applies a release the periodic detection poll had not yet cached: it
+/// resolves the release freshly at the window rather than trusting the poll's last answer, so a
+/// release published between the poll and the window is not missed for a whole day. No manual POST,
+/// and no agents, so every window is the current one.
+#[tokio::test]
+async fn maintenance_applies_a_release_the_cached_check_had_not_yet_seen() {
+    let releases =
+        FakeReleaseServer::start(NEWER_VERSION, ArtifactMode::Serve(newer_release_archive()))
+            .expect("start the fake release source");
+    // At boot the source reports only the running version, so the boot-time detection poll caches
+    // "no update": exactly the stale answer the window must not trust.
+    releases.set_version(env!("CARGO_PKG_VERSION"));
+
+    let gateway = Gateway::install("maintenance")
+        .with_auto_update(true)
+        .with_settle_secs(MAINTENANCE_SETTLE_SECS);
+    let server = gateway.start(releases.base_url());
+    let client = server.client();
+
+    let mut sock = client.open_sync().await.expect("open /sync");
+    handshake(&mut sock).await;
+
+    // Wait until the boot poll has cached "no update", so the newer release is offered only after
+    // the cache the old code trusted already says there is nothing to do.
+    wait_until("the boot poll to cache no-update", || {
+        let info = client.gateway_version().ok()?;
+        (info["update_available"].as_bool() == Some(false)).then_some(())
+    });
+    releases.set_version(NEWER_VERSION);
+
+    // The maintenance window fires on its own and its fresh check finds the release the cache still
+    // calls absent, walking the update to the restart.
+    let operations = collect_until_phase(&mut sock, "restarting")
+        .await
+        .expect("maintenance drives the update to the restart");
+    assert_phases_in_order(&operations, NEWER_VERSION);
+    wait_until("the service restart to be requested", || {
+        gateway.restart_was_requested().then_some(())
+    });
+    let ledger = gateway.ledger().expect("a restarting update leaves its ledger");
+    assert_eq!(ledger["target_version"].as_str(), Some(NEWER_VERSION));
 }


### PR DESCRIPTION
## Problem

Last night's `0.2.0` release landed on some per-user gateways but not others. Investigating `emi-vesta` (beta channel, `auto_update: true`, still on `0.1.188`):

- `0.2.0` published **00:46 UTC**.
- The maintenance window fired **03:46 UTC** and only took a routine snapshot (`kind=Routine`), never logging `applying pending update`.
- The beta detection cache only recorded `0.2.0` at **05:30 UTC**, after the window closed.

## Root cause

`run_maintenance` gated the auto-update on the **cached** `state.update_info` produced by the background detection poll, which runs every `CHECK_INTERVAL_SECS` (5 hours). When that poll straddles a release published the same night (last poll before the release, next poll after the window), the cache is stale for the one daily moment the window reads it. So maintenance sees "nothing pending", snapshots, and waits a whole day.

`start_update` already resolves the target with its own fresh check (`resolve_target` → `refresh_update_info`), so the stale gate was the only thing standing between the window and the release.

## Fix

Stop reading the stale cache in `run_maintenance`. When `auto_update && !dev_mode`, call `start_update`, which resolves the release freshly and returns `Started` / `AlreadyCurrent` / `ReleaseCheckFailed`; branch on that (an update owns its own snapshot pass; otherwise fall through to the routine snapshot pass). This also makes `start_update` the single owner of the "is a release pending" decision instead of duplicating it with a cached read. Net subtraction.

## Test

New regression test `maintenance_applies_a_release_the_cached_check_had_not_yet_seen`: the fake release source reports only the running version at boot (so the boot poll caches "no update"), then the newer release appears; the maintenance window fires on its own and its fresh check drives the update to the restart. Would fail on the old code (stale cache → snapshot only).

Supporting test-infra: a runtime-swappable version on `FakeReleaseServer` (`set_version`), and a `VESTAD_MAINTENANCE_SETTLE_SECS` seam to shorten the boot settle (mirrors the existing `VESTAD_UPDATE_ANNOUNCE_GRACE_SECS` pattern).

## Verification

- `cargo clippy -p vestad -- -D warnings`: green
- `cargo test -p vestad --bins`: 405 passed
- `cargo test -p vestad --test server --no-run`: compiles
- The new Docker-gated integration test runs in the `integration` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)