### PR TITLE
refactor(tasks): use the native task vocabulary (create, --subject, completed), drop the aliases

### DIFF
--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -10,26 +10,25 @@ One CLI, one daemon, one SQLite DB. Tasks are what needs doing; reminders are nu
 ## Tasks
 
 ```bash
-tasks add "Submit report" --priority high --due-in-hours 4
-tasks add "Meeting prep" --due-datetime "2026-12-01T10:00:00" --timezone "Europe/London"
+tasks create "Submit report" --priority high --due-in-hours 4
+tasks create "Meeting prep" --due-datetime "2026-12-01T10:00:00" --timezone "Europe/London"
 tasks list                        # pending tasks, overdue first
-tasks done <id>                   # mark done
+tasks done <id>                   # mark completed
 tasks postpone <id> --in-days 2   # new due date, measured from now
 tasks search "report"
 tasks get <id>
-tasks update <id> --title "..." --priority low --status pending
+tasks update <id> --subject "..." --priority low --status pending
 tasks update <id> --clear-due     # remove the due date (and its auto reminders)
 tasks delete <id>                 # cascades to linked reminders
 ```
 
 - Due date: `--due-in-minutes/--due-in-hours/--due-in-days` (relative) or `--due-datetime` + `--timezone` (absolute, both required). `--priority` low/normal/high. `--initial-metadata "..."` attaches notes.
-- Keep the title under ~100 characters: it is the one field `tasks list`, the digest, and the app show, so a paragraph there is unreadable everywhere. Detail and running state go in metadata (`--initial-metadata` on add, or edit the task's `metadata_path` file). A longer title still saves, with a warning.
+- Keep the subject under ~100 characters: it is the one field `tasks list`, the digest, and the app show, so a paragraph there is unreadable everywhere. Detail and running state go in metadata (`--initial-metadata` on create, or edit the task's `metadata_path` file). A longer subject still saves, with a warning.
 - `postpone` also takes `--in-minutes/--in-hours` or `--at` + `--tz`, and works on a task with no due date (gives it one).
 - `update --clear-due` removes a due date. Every other due flag can only move a date, so without this a due date is a one-way door: auto reminders are regenerated from `due_date`, so deleting them by hand does not stick. Reach for it when a date was set by mistake or by a bulk `postpone` over a backlog, since a backburner item with a due date fires a whole reminder cascade it never earned.
-- `tasks get <id> --field status` prints just that field (repeat `--field` for several, tab-separated). Valid fields: id, title, status, priority, due_date, created_at, completed_at, metadata_path, metadata. Prefer this over reading the metadata file when you need one value.
-- `list`/`search` print compact tables (`--show-completed` to include done); add `--json` or `--json-pretty` for JSON.
-- `create` is an alias of `add`. `--subject` is an alias of `--title` on both `add` and `update`.
-- A task's status is `pending`, `in_progress`, or `completed` (`completed` is the same as `done`). `tasks done <id>` and `tasks update <id> --status completed` both close it. `tasks update <id> --status in_progress` marks a task started: it stays open, so it still shows in `tasks list` and still fires its due-date reminders.
+- `tasks get <id> --field status` prints just that field (repeat `--field` for several, tab-separated). Valid fields: id, subject, status, priority, due_date, created_at, completed_at, metadata_path, metadata. Prefer this over reading the metadata file when you need one value.
+- `list`/`search` print compact tables (`--show-completed` to include completed); add `--json` or `--json-pretty` for JSON.
+- A task's status is `pending`, `in_progress`, or `completed`. `tasks done <id>` and `tasks update <id> --status completed` both close it. `tasks update <id> --status in_progress` marks a task started: it stays open, so it still shows in `tasks list` and still fires its due-date reminders.
 
 ## Reminders
 

--- a/agent/skills/tasks/cli/src/tasks_cli/cli.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/cli.py
@@ -27,17 +27,17 @@ def _require_arg(value: str | None, name: str, usage: str) -> str:
     return value
 
 
-# Soft cap only: a warning, never a rejection, because a legitimately long title exists. The title
-# is the one field every list and digest shows, so detail belongs in metadata, not appended here.
+# Soft cap only: a warning, never a rejection, because a legitimately long subject exists. The
+# subject is the one field every list and digest shows, so detail belongs in metadata, not here.
 TITLE_SOFT_CAP_CHARS = 100
 
 
-def _warn_long_title(title: str) -> None:
-    if len(title) <= TITLE_SOFT_CAP_CHARS:
+def _warn_long_subject(subject: str) -> None:
+    if len(subject) <= TITLE_SOFT_CAP_CHARS:
         return
     msg = (
-        f"title is {len(title)} chars; keep the title short and scannable, and put the detail "
-        "in the task's metadata instead (the metadata_path file in this result, or --initial-metadata on add)"
+        f"subject is {len(subject)} chars; keep the subject short and scannable, and put the detail "
+        "in the task's metadata instead (the metadata_path file in this result, or --initial-metadata on create)"
     )
     print(json.dumps({"warning": msg}), file=sys.stderr)
 
@@ -104,11 +104,10 @@ def _build_parser() -> argparse.ArgumentParser:
     p_daemon = sub.add_parser("daemon", help="Manage the background daemon: start|stop|restart|status")
     p_daemon.add_argument("action", nargs="?", default="", metavar="start|stop|restart|status")
 
-    # add
-    p_add = sub.add_parser("add", aliases=["create"], help="Add a new task (alias: create)")
-    p_add.add_argument("title_pos", nargs="?", default=None, metavar="title")
-    p_add.add_argument("--title", default=None)
-    p_add.add_argument("--subject", default=None, help="Alias for --title")
+    # create
+    p_add = sub.add_parser("create", help="Create a new task")
+    p_add.add_argument("subject_pos", nargs="?", default=None, metavar="subject")
+    p_add.add_argument("--subject", default=None)
     _add_due_args(p_add)
     p_add.add_argument("--priority", default="normal", help="low/normal/high or 1/2/3")
     p_add.add_argument("--initial-metadata", default=None)
@@ -132,9 +131,8 @@ def _build_parser() -> argparse.ArgumentParser:
     # update
     p_update = sub.add_parser("update", help="Update a task")
     _add_id_args(p_update)
-    p_update.add_argument("--status", default=None, help="pending, in_progress, or completed (completed == done)")
-    p_update.add_argument("--title", default=None)
-    p_update.add_argument("--subject", default=None, help="Alias for --title")
+    p_update.add_argument("--status", default=None, help="pending, in_progress, or completed")
+    p_update.add_argument("--subject", default=None)
     p_update.add_argument("--priority", default=None)
     _add_due_args(p_update)
     p_update.add_argument("--clear-due", action="store_true", help="Remove the task's due date and its auto reminders")
@@ -150,7 +148,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     # done
-    p_done = sub.add_parser("done", help="Mark a task done")
+    p_done = sub.add_parser("done", help="Mark a task completed")
     _add_id_args(p_done)
 
     # postpone
@@ -167,7 +165,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_id_args(p_delete)
 
     # search
-    p_search = sub.add_parser("search", help="Search tasks by title")
+    p_search = sub.add_parser("search", help="Search tasks by subject")
     p_search.add_argument("query_pos", nargs="?", default=None, metavar="query")
     p_search.add_argument("--query", default=None)
     p_search.add_argument("--show-completed", action="store_true")
@@ -389,12 +387,12 @@ subcommands:
 
 
 def _handle_task(args, config: Config):
-    if args.command in ("add", "create"):
-        title = _require_arg(args.title_pos or args.title or args.subject, "title", 'tasks add "title" or tasks add --title "title"')
-        _warn_long_title(title)
+    if args.command == "create":
+        subject = _require_arg(args.subject_pos or args.subject, "subject", 'tasks create "subject" or tasks create --subject "subject"')
+        _warn_long_subject(subject)
         result = commands.add_task(
             config,
-            title=title,
+            subject=subject,
             due=commands.DueSpec(
                 due_datetime=args.due_datetime,
                 timezone=args.timezone,
@@ -420,14 +418,14 @@ def _handle_task(args, config: Config):
         result = commands.get_task(config, task_id=task_id)
     elif args.command == "update":
         task_id = _require_arg(args.id_pos or args.task_id, "id", "tasks update <id> or tasks update --id <id>")
-        title = args.title or args.subject
-        if title is not None:
-            _warn_long_title(title)
+        subject = args.subject
+        if subject is not None:
+            _warn_long_subject(subject)
         result = commands.update_task(
             config,
             task_id=task_id,
             status=args.status,
-            title=title,
+            subject=subject,
             priority=args.priority,
             due=commands.DueSpec(
                 due_datetime=args.due_datetime,
@@ -441,7 +439,7 @@ def _handle_task(args, config: Config):
         )
     elif args.command == "done":
         task_id = _require_arg(args.id_pos or args.task_id, "id", "tasks done <id> or tasks done --id <id>")
-        result = commands.update_task(config, task_id=task_id, status="done")
+        result = commands.update_task(config, task_id=task_id, status="completed")
     elif args.command == "postpone":
         task_id = _require_arg(args.id_pos or args.task_id, "id", "tasks postpone <id> --in-days N")
         result = commands.postpone_task(

--- a/agent/skills/tasks/cli/src/tasks_cli/cli.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/cli.py
@@ -29,11 +29,11 @@ def _require_arg(value: str | None, name: str, usage: str) -> str:
 
 # Soft cap only: a warning, never a rejection, because a legitimately long subject exists. The
 # subject is the one field every list and digest shows, so detail belongs in metadata, not here.
-TITLE_SOFT_CAP_CHARS = 100
+SUBJECT_SOFT_CAP_CHARS = 100
 
 
 def _warn_long_subject(subject: str) -> None:
-    if len(subject) <= TITLE_SOFT_CAP_CHARS:
+    if len(subject) <= SUBJECT_SOFT_CAP_CHARS:
         return
     msg = (
         f"subject is {len(subject)} chars; keep the subject short and scannable, and put the detail "
@@ -105,12 +105,12 @@ def _build_parser() -> argparse.ArgumentParser:
     p_daemon.add_argument("action", nargs="?", default="", metavar="start|stop|restart|status")
 
     # create
-    p_add = sub.add_parser("create", help="Create a new task")
-    p_add.add_argument("subject_pos", nargs="?", default=None, metavar="subject")
-    p_add.add_argument("--subject", default=None)
-    _add_due_args(p_add)
-    p_add.add_argument("--priority", default="normal", help="low/normal/high or 1/2/3")
-    p_add.add_argument("--initial-metadata", default=None)
+    p_create = sub.add_parser("create", help="Create a new task")
+    p_create.add_argument("subject_pos", nargs="?", default=None, metavar="subject")
+    p_create.add_argument("--subject", default=None)
+    _add_due_args(p_create)
+    p_create.add_argument("--priority", default="normal", help="low/normal/high or 1/2/3")
+    p_create.add_argument("--initial-metadata", default=None)
 
     # list
     p_list = sub.add_parser("list", help="List tasks")

--- a/agent/skills/tasks/cli/src/tasks_cli/commands.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/commands.py
@@ -365,12 +365,12 @@ def _rebuild_due_reminders(conn, task_id: str, row, *, subject: str | None, stat
     db.delete_auto_reminders(conn, task_id)
     if not new_due_date:
         return
-    reminder_title = subject if subject is not None else row["subject"]
+    reminder_subject = subject if subject is not None else row["subject"]
     # Only create reminders if the task is (or will be) open. in_progress is open like pending;
     # only completed stops reminding.
     effective_status = status if status is not None else row["status"]
     if effective_status != "completed":
-        db.create_auto_reminders(conn, task_id, reminder_title, new_due_date)
+        db.create_auto_reminders(conn, task_id, reminder_subject, new_due_date)
 
 
 def _retitle_auto_reminder_messages(conn, task_id: str, new_title: str) -> None:

--- a/agent/skills/tasks/cli/src/tasks_cli/commands.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/commands.py
@@ -70,13 +70,13 @@ class ReminderSpec(BaseModel):
     fuzz_minutes: int | None = None
 
 
-# Overdue open tasks (not done, past due_date) always float to the top, ordered by most overdue
+# Overdue open tasks (not completed, past due_date) always float to the top, ordered by most overdue
 # first. datetime() normalizes the ISO 'T'/offset form to SQLite's space-separated form so the
 # comparison is chronological, not lexicographic. Non-overdue tasks keep priority/due/created order.
 _TASK_ORDER_BY = (
     " ORDER BY"
-    " CASE WHEN status != 'done' AND due_date IS NOT NULL AND datetime(due_date) < datetime('now') THEN 0 ELSE 1 END ASC,"
-    " CASE WHEN status != 'done' AND due_date IS NOT NULL AND datetime(due_date) < datetime('now') THEN datetime(due_date) END ASC,"
+    " CASE WHEN status != 'completed' AND due_date IS NOT NULL AND datetime(due_date) < datetime('now') THEN 0 ELSE 1 END ASC,"
+    " CASE WHEN status != 'completed' AND due_date IS NOT NULL AND datetime(due_date) < datetime('now') THEN datetime(due_date) END ASC,"
     " priority DESC, due_date ASC NULLS LAST, created_at DESC"
 )
 
@@ -317,7 +317,7 @@ def _task_with_metadata(data_dir: Path, row: dict, include_content: bool = False
 def add_task(
     config: Config,
     *,
-    title: str,
+    subject: str,
     due: DueSpec | None = None,
     priority: int | str = 2,
     initial_metadata: str | None = None,
@@ -328,11 +328,11 @@ def add_task(
 
     with closing(db.get_db(config.data_dir)) as conn:
         conn.execute(
-            "INSERT INTO tasks (id, title, priority, due_date) VALUES (?, ?, ?, ?)",
-            (task_id, title, priority, due_date),
+            "INSERT INTO tasks (id, subject, priority, due_date) VALUES (?, ?, ?, ?)",
+            (task_id, subject, priority, due_date),
         )
         if due_date:
-            db.create_auto_reminders(conn, task_id, title, due_date)
+            db.create_auto_reminders(conn, task_id, subject, due_date)
         conn.commit()
 
     if initial_metadata:
@@ -340,7 +340,7 @@ def add_task(
 
     return {
         "id": task_id,
-        "title": title,
+        "subject": subject,
         "status": "pending",
         "priority": priority,
         "due_date": due_date,
@@ -352,24 +352,24 @@ def list_tasks(config: Config, *, show_completed: bool = False) -> list[dict]:
     with closing(db.get_db(config.data_dir)) as conn:
         query = "SELECT * FROM tasks"
         if not show_completed:
-            query += " WHERE status != 'done'"
+            query += " WHERE status != 'completed'"
         query += _TASK_ORDER_BY
         cursor = conn.execute(query)
         return [_task_with_metadata(config.data_dir, dict(row), include_content=False) for row in cursor]
 
 
-def _rebuild_due_reminders(conn, task_id: str, row, *, title: str | None, status: str | None, new_due_date: str | None):
-    """Rebuild the auto reminders after a due-date or title change, preferring the values updated in
-    the same call. An auto reminder's message embeds the task title, so a title change has to
-    regenerate them for the armed reminders to carry the current title."""
+def _rebuild_due_reminders(conn, task_id: str, row, *, subject: str | None, status: str | None, new_due_date: str | None):
+    """Rebuild the auto reminders after a due-date or subject change, preferring the values updated in
+    the same call. An auto reminder's message embeds the task subject, so a subject change has to
+    regenerate them for the armed reminders to carry the current subject."""
     db.delete_auto_reminders(conn, task_id)
     if not new_due_date:
         return
-    reminder_title = title if title is not None else row["title"]
+    reminder_title = subject if subject is not None else row["subject"]
     # Only create reminders if the task is (or will be) open. in_progress is open like pending;
-    # only done stops reminding.
+    # only completed stops reminding.
     effective_status = status if status is not None else row["status"]
-    if effective_status != "done":
+    if effective_status != "completed":
         db.create_auto_reminders(conn, task_id, reminder_title, new_due_date)
 
 
@@ -424,16 +424,12 @@ def update_task(
     *,
     task_id: str,
     status: str | None = None,
-    title: str | None = None,
+    subject: str | None = None,
     priority: int | str | None = None,
     due: DueSpec | None = None,
     backburner: bool | None = None,
 ) -> dict:
-    # `completed` is accepted as an alias for the stored `done`; the store keeps one status
-    # vocabulary (pending/in_progress/done).
-    if status == "completed":
-        status = "done"
-    if status and status not in ("pending", "in_progress", "done"):
+    if status and status not in ("pending", "in_progress", "completed"):
         raise ValueError(f"Status must be pending, in_progress, or completed, got {status}")
     if priority is not None:
         priority = normalize_priority(priority)
@@ -450,26 +446,26 @@ def update_task(
         if status is not None:
             updates.append("status = ?")
             params.append(status)
-            was_done = result["status"] == "done"
-            if status == "done":
+            was_completed = result["status"] == "completed"
+            if status == "completed":
                 updates.append("completed_at = ?")
                 params.append(_now_utc().isoformat())
                 # A finished task stops reminding entirely, so this clears owned reminders too, not
                 # just auto ones. A due-date change below rebuilds only the auto ones (delete_auto).
                 db.delete_task_reminders(conn, task_id)
-            elif was_done:
-                # Reopening from done (to pending or in_progress): clear completion and, unless the
-                # due date is being changed below (that block rebuilds them), recreate the auto
-                # reminders the done transition deleted. A pending<->in_progress toggle is not a
+            elif was_completed:
+                # Reopening from completed (to pending or in_progress): clear completion and, unless
+                # the due date is being changed below (that block rebuilds them), recreate the auto
+                # reminders the completed transition deleted. A pending<->in_progress toggle is not a
                 # reopen, so it never touches reminders and cannot duplicate them.
                 updates.append("completed_at = NULL")
                 if not due_date_changed and result["due_date"]:
-                    db.create_auto_reminders(conn, task_id, result["title"], result["due_date"])
+                    db.create_auto_reminders(conn, task_id, result["subject"], result["due_date"])
 
         new_backburner = _backburner_update(
             conn, result, backburner=backburner, due_date_changed=due_date_changed, new_due_date=new_due_date, updates=updates
         )
-        for field, value in [("title", title), ("priority", priority), ("backburner", new_backburner)]:
+        for field, value in [("subject", subject), ("priority", priority), ("backburner", new_backburner)]:
             if value is not None:
                 updates.append(f"{field} = ?")
                 params.append(value)
@@ -477,11 +473,11 @@ def update_task(
         if due_date_changed:
             updates.append("due_date = ?")
             params.append(new_due_date)
-            _rebuild_due_reminders(conn, task_id, result, title=title, status=status, new_due_date=new_due_date)
-        elif title is not None and title != result["title"] and status != "done":
-            # A title change invalidates the reminder TEXT and nothing else, so rewrite the text
+            _rebuild_due_reminders(conn, task_id, result, subject=subject, status=status, new_due_date=new_due_date)
+        elif subject is not None and subject != result["subject"] and status != "completed":
+            # A subject change invalidates the reminder TEXT and nothing else, so rewrite the text
             # and leave fire times, ids, snoozes and completed history untouched.
-            _retitle_auto_reminder_messages(conn, task_id, title)
+            _retitle_auto_reminder_messages(conn, task_id, subject)
 
         if updates:
             params.append(task_id)
@@ -522,7 +518,7 @@ def get_task(config: Config, *, task_id: str) -> dict:
 
 TASK_FIELDS = (
     "id",
-    "title",
+    "subject",
     "status",
     "priority",
     "due_date",
@@ -570,9 +566,9 @@ def delete_task(config: Config, *, task_id: str) -> dict:
 
 def search_tasks(config: Config, *, query: str, show_completed: bool = False) -> list[dict]:
     with closing(db.get_db(config.data_dir)) as conn:
-        sql = "SELECT * FROM tasks WHERE title LIKE ?"
+        sql = "SELECT * FROM tasks WHERE subject LIKE ?"
         if not show_completed:
-            sql += " AND status != 'done'"
+            sql += " AND status != 'completed'"
         sql += _TASK_ORDER_BY
         cursor = conn.execute(sql, (f"%{query}%",))
         return [_task_with_metadata(config.data_dir, dict(row), include_content=False) for row in cursor]
@@ -604,7 +600,9 @@ def build_digest(config: Config, *, now: datetime | None = None) -> str | None:
     """The daily digest message, or None when nothing needs attention."""
     now = now or _now_utc()
     with closing(db.get_db(config.data_dir)) as conn:
-        pending = conn.execute("SELECT id, title, priority, due_date, created_at, backburner FROM tasks WHERE status != 'done'").fetchall()
+        pending = conn.execute(
+            "SELECT id, subject, priority, due_date, created_at, backburner FROM tasks WHERE status != 'completed'"
+        ).fetchall()
 
     overdue: list[tuple[dict, datetime]] = []
     stale: list[tuple[dict, datetime]] = []
@@ -627,12 +625,12 @@ def build_digest(config: Config, *, now: datetime | None = None) -> str | None:
     if overdue:
         overdue.sort(key=lambda pair: pair[1])
         lines.append(_OVERDUE_HEADER)
-        lines += [f'- {t["id"]} "{t["title"]}" ({PRIORITY_LABEL[t["priority"]]}, overdue {rel_delta(now - due)})' for t, due in overdue]
+        lines += [f'- {t["id"]} "{t["subject"]}" ({PRIORITY_LABEL[t["priority"]]}, overdue {rel_delta(now - due)})' for t, due in overdue]
     if stale:
         if overdue:
             lines.append("")
         lines.append(_STALE_HEADER)
-        lines += [f'- {t["id"]} "{t["title"]}" (created {rel_delta(now - created)} ago)' for t, created in stale]
+        lines += [f'- {t["id"]} "{t["subject"]}" (created {rel_delta(now - created)} ago)' for t, created in stale]
     return "\n".join(lines)
 
 

--- a/agent/skills/tasks/cli/src/tasks_cli/db.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/db.py
@@ -13,12 +13,12 @@ logger = logging.getLogger(__name__)
 
 # Head schema version. Bump this in the same commit as a new _migrate_vN_to_vN+1, and assert against
 # it in tests rather than hard-coding an integer, so adding a migration cannot break unrelated tests.
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 
 class Task(TypedDict, total=False):
     id: str
-    title: str
+    subject: str
     status: str
     priority: int
     due_date: str | None
@@ -349,6 +349,32 @@ def _migrate_v5_to_v6(conn: sqlite3.Connection):
     logger.info("Migrated schema v5 -> v6")
 
 
+def _migrate_v6_to_v7(conn: sqlite3.Connection):
+    """v6 -> v7: rename the `title` column to `subject` and the `done` status value to `completed`.
+    SQLite cannot alter a column name inside a CHECK in place, so rebuild the table, preserving
+    every row."""
+    conn.execute("""
+        CREATE TABLE tasks_v7 (
+            id TEXT PRIMARY KEY,
+            subject TEXT NOT NULL,
+            status TEXT DEFAULT 'pending' CHECK(status IN ('pending', 'in_progress', 'completed')),
+            priority INTEGER DEFAULT 2 CHECK(priority IN (1, 2, 3)),
+            due_date TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            completed_at TEXT,
+            backburner INTEGER NOT NULL DEFAULT 0
+        )
+    """)
+    conn.execute("""
+        INSERT INTO tasks_v7 (id, subject, status, priority, due_date, created_at, completed_at, backburner)
+        SELECT id, title, CASE WHEN status = 'done' THEN 'completed' ELSE status END,
+               priority, due_date, created_at, completed_at, backburner FROM tasks
+    """)
+    conn.execute("DROP TABLE tasks")
+    conn.execute("ALTER TABLE tasks_v7 RENAME TO tasks")
+    logger.info("Migrated schema v6 -> v7")
+
+
 def get_meta(conn: sqlite3.Connection, key: str) -> str | None:
     row = conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
     return row["value"] if row else None
@@ -418,6 +444,11 @@ def init_db(data_dir: Path):
             _migrate_v5_to_v6(conn)
             conn.execute("UPDATE schema_version SET version = 6")
             version = 6
+
+        if version < 7:
+            _migrate_v6_to_v7(conn)
+            conn.execute("UPDATE schema_version SET version = 7")
+            version = 7
 
         conn.commit()
 

--- a/agent/skills/tasks/cli/src/tasks_cli/format.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/format.py
@@ -53,7 +53,7 @@ def _due_col(iso: str | None, now: datetime) -> str:
 
 
 def format_task_list(tasks: list[dict[str, Any]], now: datetime | None = None) -> str:
-    """One line per task: status  prio  due  id  title (backburner tasks marked, never hidden)."""
+    """One line per task: status  prio  due  id  subject (backburner tasks marked, never hidden)."""
     if not tasks:
         return "(no tasks)"
     now = now or datetime.now(UTC)
@@ -62,7 +62,7 @@ def format_task_list(tasks: list[dict[str, Any]], now: datetime | None = None) -
         f"{_prio(_pick(t, 'priority', None))}\t"
         f"{_due_col(_pick(t, 'due_date', None), now)}\t"
         f"{_pick(t, 'id')}\t"
-        f"{'[parked] ' if _pick(t, 'backburner', False) else ''}{_trunc(_pick(t, 'title'), 80)}"
+        f"{'[parked] ' if _pick(t, 'backburner', False) else ''}{_trunc(_pick(t, 'subject'), 80)}"
         for t in tasks
     )
 

--- a/agent/skills/tasks/cli/src/tasks_cli/server.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/server.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class AddTaskBody(BaseModel):
-    title: str
+    subject: str
     due_datetime: str | None = None
     timezone: str | None = None
     due_in_minutes: int | None = None
@@ -29,8 +29,8 @@ class AddTaskBody(BaseModel):
 
 
 class UpdateTaskBody(BaseModel):
-    status: Literal["pending", "in_progress", "done", "completed"] | None = None
-    title: str | None = None
+    status: Literal["pending", "in_progress", "completed"] | None = None
+    subject: str | None = None
     priority: str | int | None = None
     due_datetime: str | None = None
     timezone: str | None = None
@@ -59,12 +59,12 @@ def _apply_task_update(config: Config, notif_dir: Path, task_id: str, body: Upda
     """Apply a task update coming from the app. A pending->done transition here is the one completion
     the agent does not already know about (its own CLI edits are self-evident), so it notifies,
     snoozed (interrupt=False), which the CLI path never does."""
-    already_done = body.status in ("done", "completed") and commands.get_task(config, task_id=task_id)["status"] == "done"
+    already_done = body.status == "completed" and commands.get_task(config, task_id=task_id)["status"] == "completed"
     result = commands.update_task(
         config,
         task_id=task_id,
         status=body.status,
-        title=body.title,
+        subject=body.subject,
         priority=body.priority,
         due=commands.DueSpec(
             due_datetime=body.due_datetime,
@@ -75,8 +75,8 @@ def _apply_task_update(config: Config, notif_dir: Path, task_id: str, body: Upda
             clear=body.clear_due,
         ),
     )
-    if body.status in ("done", "completed") and not already_done:
-        write_notification(notif_dir, "task_completed", interrupt=False, task_id=task_id, message=f"Task completed: {result['title']}")
+    if body.status == "completed" and not already_done:
+        write_notification(notif_dir, "task_completed", interrupt=False, task_id=task_id, message=f"Task completed: {result['subject']}")
     return result
 
 
@@ -104,7 +104,7 @@ def _create_app(config: Config, notif_dir: Path) -> FastAPI:
     def add_task(body: AddTaskBody):
         return commands.add_task(
             config,
-            title=body.title,
+            subject=body.subject,
             due=commands.DueSpec(
                 due_datetime=body.due_datetime,
                 timezone=body.timezone,

--- a/agent/skills/tasks/cli/src/tasks_cli/server.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/server.py
@@ -56,10 +56,10 @@ class SnoozeReminderBody(BaseModel):
 
 
 def _apply_task_update(config: Config, notif_dir: Path, task_id: str, body: UpdateTaskBody) -> dict:
-    """Apply a task update coming from the app. A pending->done transition here is the one completion
+    """Apply a task update coming from the app. A pending->completed transition here is the one completion
     the agent does not already know about (its own CLI edits are self-evident), so it notifies,
     snoozed (interrupt=False), which the CLI path never does."""
-    already_done = body.status == "completed" and commands.get_task(config, task_id=task_id)["status"] == "completed"
+    already_completed = body.status == "completed" and commands.get_task(config, task_id=task_id)["status"] == "completed"
     result = commands.update_task(
         config,
         task_id=task_id,
@@ -75,7 +75,7 @@ def _apply_task_update(config: Config, notif_dir: Path, task_id: str, body: Upda
             clear=body.clear_due,
         ),
     )
-    if body.status == "completed" and not already_done:
+    if body.status == "completed" and not already_completed:
         write_notification(notif_dir, "task_completed", interrupt=False, task_id=task_id, message=f"Task completed: {result['subject']}")
     return result
 

--- a/agent/skills/tasks/cli/tests/test_clear_due.py
+++ b/agent/skills/tasks/cli/tests/test_clear_due.py
@@ -25,7 +25,7 @@ def test_clear_due_removes_date_and_auto_reminders(tmp_config: Config):
     config = tmp_config
     task = commands.add_task(
         config,
-        title="backburner item",
+        subject="backburner item",
         due=commands.DueSpec(due_in_days=30),
     )
     task_id = task["id"]
@@ -46,7 +46,7 @@ def test_clear_due_removes_date_and_auto_reminders(tmp_config: Config):
 def test_clear_due_does_not_need_a_timezone(tmp_config: Config):
     """`due_datetime` requires a timezone; clearing must not inherit that requirement."""
     config = tmp_config
-    task = commands.add_task(config, title="item", due=commands.DueSpec(due_in_hours=5))
+    task = commands.add_task(config, subject="item", due=commands.DueSpec(due_in_hours=5))
 
     updated = commands.update_task(config, task_id=task["id"], due=commands.DueSpec(clear=True))
 
@@ -56,7 +56,7 @@ def test_clear_due_does_not_need_a_timezone(tmp_config: Config):
 def test_clear_due_rejects_a_conflicting_due_offset(tmp_config: Config):
     """`clear` and a due-setting field together are contradictory: reject, do not silently pick one."""
     config = tmp_config
-    task = commands.add_task(config, title="item", due=commands.DueSpec(due_in_days=3))
+    task = commands.add_task(config, subject="item", due=commands.DueSpec(due_in_days=3))
 
     with pytest.raises(ValueError, match="clear"):
         commands.update_task(config, task_id=task["id"], due=commands.DueSpec(clear=True, due_in_days=10))
@@ -65,10 +65,10 @@ def test_clear_due_rejects_a_conflicting_due_offset(tmp_config: Config):
 def test_update_without_due_spec_leaves_the_date_alone(tmp_config: Config):
     """A plain edit must not be read as a clear: only an explicit request touches the due date."""
     config = tmp_config
-    task = commands.add_task(config, title="item", due=commands.DueSpec(due_in_days=3))
+    task = commands.add_task(config, subject="item", due=commands.DueSpec(due_in_days=3))
     before = task["due_date"]
 
-    updated = commands.update_task(config, task_id=task["id"], title="renamed")
+    updated = commands.update_task(config, task_id=task["id"], subject="renamed")
 
     assert updated["due_date"] == before
     assert _pending_auto_reminders(config, task["id"]) > 0

--- a/agent/skills/tasks/cli/tests/test_e2e.py
+++ b/agent/skills/tasks/cli/tests/test_e2e.py
@@ -118,86 +118,86 @@ def shared_env(tmp_path_factory):
 class TestAddTask:
     def test_add_basic(self, shared_env):
         home, _, _ = shared_env
-        data = parse(tasks_cli(home, "add", "buy milk"))
-        assert data["title"] == "buy milk"
+        data = parse(tasks_cli(home, "create", "buy milk"))
+        assert data["subject"] == "buy milk"
         assert data["status"] == "pending"
         assert data["priority"] == 2
 
     def test_add_with_flag(self, shared_env):
         home, _, _ = shared_env
-        data = parse(tasks_cli(home, "add", "--title", "flag title"))
-        assert data["title"] == "flag title"
+        data = parse(tasks_cli(home, "create", "--subject", "flag title"))
+        assert data["subject"] == "flag title"
 
     def test_add_with_priority_high(self, shared_env):
         home, _, _ = shared_env
-        data = parse(tasks_cli(home, "add", "urgent", "--priority", "high"))
+        data = parse(tasks_cli(home, "create", "urgent", "--priority", "high"))
         assert data["priority"] == 3
 
     def test_add_with_priority_low(self, shared_env):
         home, _, _ = shared_env
-        data = parse(tasks_cli(home, "add", "low prio", "--priority", "low"))
+        data = parse(tasks_cli(home, "create", "low prio", "--priority", "low"))
         assert data["priority"] == 1
 
     def test_add_with_priority_numeric(self, shared_env):
         home, _, _ = shared_env
-        data = parse(tasks_cli(home, "add", "numeric", "--priority", "3"))
+        data = parse(tasks_cli(home, "create", "numeric", "--priority", "3"))
         assert data["priority"] == 3
 
     def test_add_with_due_in_hours(self, shared_env):
         home, _, _ = shared_env
-        data = parse(tasks_cli(home, "add", "due soon", "--due-in-hours", "2"))
+        data = parse(tasks_cli(home, "create", "due soon", "--due-in-hours", "2"))
         assert data["due_date"] is not None
 
     def test_add_with_due_in_days(self, shared_env):
         home, _, _ = shared_env
-        data = parse(tasks_cli(home, "add", "due later", "--due-in-days", "7"))
+        data = parse(tasks_cli(home, "create", "due later", "--due-in-days", "7"))
         assert data["due_date"] is not None
 
     def test_add_with_due_in_minutes(self, shared_env):
         home, _, _ = shared_env
-        data = parse(tasks_cli(home, "add", "due asap", "--due-in-minutes", "30"))
+        data = parse(tasks_cli(home, "create", "due asap", "--due-in-minutes", "30"))
         assert data["due_date"] is not None
 
     def test_add_with_datetime_and_tz(self, shared_env):
         home, _, _ = shared_env
         future = (datetime.now(UTC) + timedelta(hours=5)).strftime("%Y-%m-%dT%H:%M:%S")
-        data = parse(tasks_cli(home, "add", "timed", "--due-datetime", future, "--timezone", "UTC"))
+        data = parse(tasks_cli(home, "create", "timed", "--due-datetime", future, "--timezone", "UTC"))
         assert data["due_date"] is not None
 
     def test_add_no_due_date(self, shared_env):
         home, _, _ = shared_env
-        data = parse(tasks_cli(home, "add", "no deadline"))
+        data = parse(tasks_cli(home, "create", "no deadline"))
         assert data["due_date"] is None
 
     def test_add_requires_title(self, shared_env):
         home, _, _ = shared_env
-        r = tasks_cli(home, "add")
+        r = tasks_cli(home, "create")
         assert r.returncode != 0
 
     def test_add_requires_tz_with_datetime(self, shared_env):
         home, _, _ = shared_env
-        r = tasks_cli(home, "add", "test", "--due-datetime", "2025-06-15T10:00:00")
+        r = tasks_cli(home, "create", "test", "--due-datetime", "2025-06-15T10:00:00")
         assert r.returncode != 0
         assert "timezone" in parse(r)["error"].lower()
 
     def test_add_invalid_timezone(self, shared_env):
         home, _, _ = shared_env
-        r = tasks_cli(home, "add", "test", "--due-datetime", "2025-06-15T10:00:00", "--timezone", "Fake/Zone")
+        r = tasks_cli(home, "create", "test", "--due-datetime", "2025-06-15T10:00:00", "--timezone", "Fake/Zone")
         assert r.returncode != 0
 
     def test_add_rejects_negative_due(self, shared_env):
         home, _, _ = shared_env
-        r = tasks_cli(home, "add", "bad", "--due-in-hours", "-1")
+        r = tasks_cli(home, "create", "bad", "--due-in-hours", "-1")
         assert r.returncode != 0
 
     def test_add_invalid_priority(self, shared_env):
         home, _, _ = shared_env
-        r = tasks_cli(home, "add", "bad", "--priority", "5")
+        r = tasks_cli(home, "create", "bad", "--priority", "5")
         assert r.returncode != 0
 
     def test_add_with_metadata(self, shared_env):
         home, _, _ = shared_env
-        data = parse(tasks_cli(home, "add", "with meta", "--initial-metadata", "some notes here"))
+        data = parse(tasks_cli(home, "create", "with meta", "--initial-metadata", "some notes here"))
         assert data["metadata_path"]
         assert Path(data["metadata_path"]).exists()
         assert Path(data["metadata_path"]).read_text() == "some notes here"
@@ -225,16 +225,16 @@ class TestListTasks:
 class TestGetTask:
     def test_get_by_id(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "get me", "--initial-metadata", "details"))
+        added = parse(tasks_cli(home, "create", "get me", "--initial-metadata", "details"))
         data = parse(tasks_cli(home, "get", added["id"]))
-        assert data["title"] == "get me"
+        assert data["subject"] == "get me"
         assert data["metadata_content"] == "details"
 
     def test_get_via_flag(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "get flag"))
+        added = parse(tasks_cli(home, "create", "get flag"))
         data = parse(tasks_cli(home, "get", "--id", added["id"]))
-        assert data["title"] == "get flag"
+        assert data["subject"] == "get flag"
 
     def test_get_nonexistent(self, shared_env):
         home, _, _ = shared_env
@@ -250,56 +250,56 @@ class TestGetTask:
 class TestUpdateTask:
     def test_update_status_done(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "to complete"))
-        data = parse(tasks_cli(home, "update", added["id"], "--status", "done"))
-        assert data["status"] == "done"
+        added = parse(tasks_cli(home, "create", "to complete"))
+        data = parse(tasks_cli(home, "update", added["id"], "--status", "completed"))
+        assert data["status"] == "completed"
         assert data["completed_at"] is not None
 
     def test_update_status_back_to_pending(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "reopen"))
-        tasks_cli(home, "update", added["id"], "--status", "done")
+        added = parse(tasks_cli(home, "create", "reopen"))
+        tasks_cli(home, "update", added["id"], "--status", "completed")
         data = parse(tasks_cli(home, "update", added["id"], "--status", "pending"))
         assert data["status"] == "pending"
         assert data["completed_at"] is None
 
     def test_update_title(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "old title"))
-        data = parse(tasks_cli(home, "update", added["id"], "--title", "new title"))
-        assert data["title"] == "new title"
+        added = parse(tasks_cli(home, "create", "old title"))
+        data = parse(tasks_cli(home, "update", added["id"], "--subject", "new title"))
+        assert data["subject"] == "new title"
 
     def test_update_priority(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "reprioritize"))
+        added = parse(tasks_cli(home, "create", "reprioritize"))
         data = parse(tasks_cli(home, "update", added["id"], "--priority", "high"))
         assert data["priority"] == 3
 
     def test_update_via_flag(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "flag update"))
-        data = parse(tasks_cli(home, "update", "--id", added["id"], "--title", "updated"))
-        assert data["title"] == "updated"
+        added = parse(tasks_cli(home, "create", "flag update"))
+        data = parse(tasks_cli(home, "update", "--id", added["id"], "--subject", "updated"))
+        assert data["subject"] == "updated"
 
     def test_update_nonexistent(self, shared_env):
         home, _, _ = shared_env
-        r = tasks_cli(home, "update", "nope", "--title", "x")
+        r = tasks_cli(home, "update", "nope", "--subject", "x")
         assert r.returncode != 0
 
     def test_update_requires_id(self, shared_env):
         home, _, _ = shared_env
-        r = tasks_cli(home, "update", "--title", "x")
+        r = tasks_cli(home, "update", "--subject", "x")
         assert r.returncode != 0
 
     def test_update_invalid_status(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "bad status"))
+        added = parse(tasks_cli(home, "create", "bad status"))
         r = tasks_cli(home, "update", added["id"], "--status", "invalid")
         assert r.returncode != 0
 
     def test_update_due_in_hours(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "push me", "--due-in-hours", "1"))
+        added = parse(tasks_cli(home, "create", "push me", "--due-in-hours", "1"))
         assert added["due_date"] is not None
         original_due = added["due_date"]
         data = parse(tasks_cli(home, "update", added["id"], "--due-in-days", "7"))
@@ -308,7 +308,7 @@ class TestUpdateTask:
 
     def test_update_due_datetime(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "specific time"))
+        added = parse(tasks_cli(home, "create", "specific time"))
         data = parse(
             tasks_cli(
                 home,
@@ -327,20 +327,20 @@ class TestUpdateTask:
 class TestDeleteTask:
     def test_delete(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "delete me"))
+        added = parse(tasks_cli(home, "create", "delete me"))
         data = parse(tasks_cli(home, "delete", added["id"]))
         assert data["status"] == "deleted"
 
     def test_delete_removes_from_list(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "delete me 2"))
+        added = parse(tasks_cli(home, "create", "delete me 2"))
         tasks_cli(home, "delete", added["id"])
         items = parse(tasks_cli(home, "list", "--json"))
         assert not any(i["id"] == added["id"] for i in items)
 
     def test_delete_removes_metadata_file(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "with meta", "--initial-metadata", "notes"))
+        added = parse(tasks_cli(home, "create", "with meta", "--initial-metadata", "notes"))
         meta_path = Path(added["metadata_path"])
         assert meta_path.exists()
         tasks_cli(home, "delete", added["id"])
@@ -348,7 +348,7 @@ class TestDeleteTask:
 
     def test_delete_via_flag(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "flag delete"))
+        added = parse(tasks_cli(home, "create", "flag delete"))
         data = parse(tasks_cli(home, "delete", "--id", added["id"]))
         assert data["status"] == "deleted"
 
@@ -366,10 +366,10 @@ class TestDeleteTask:
 class TestSearchTasks:
     def test_search_finds_match(self, shared_env):
         home, _, _ = shared_env
-        parse(tasks_cli(home, "add", "unique_searchterm_xyz"))
+        parse(tasks_cli(home, "create", "unique_searchterm_xyz"))
         items = parse(tasks_cli(home, "search", "unique_searchterm_xyz", "--json"))
         assert len(items) >= 1
-        assert any("unique_searchterm_xyz" in i["title"] for i in items)
+        assert any("unique_searchterm_xyz" in i["subject"] for i in items)
 
     def test_search_no_match(self, shared_env):
         home, _, _ = shared_env
@@ -388,29 +388,29 @@ class TestSearchTasks:
 
     def test_search_excludes_completed(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "searchdone_abc"))
-        tasks_cli(home, "update", added["id"], "--status", "done")
+        added = parse(tasks_cli(home, "create", "searchdone_abc"))
+        tasks_cli(home, "update", added["id"], "--status", "completed")
         items = parse(tasks_cli(home, "search", "searchdone_abc", "--json"))
         assert not any(i["id"] == added["id"] for i in items)
 
     def test_search_show_completed(self, shared_env):
         home, _, _ = shared_env
         items = parse(tasks_cli(home, "search", "searchdone_abc", "--show-completed", "--json"))
-        assert any("searchdone_abc" in i["title"] for i in items)
+        assert any("searchdone_abc" in i["subject"] for i in items)
 
 
 class TestCompletedFiltering:
     def test_list_excludes_completed(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "will complete"))
-        tasks_cli(home, "update", added["id"], "--status", "done")
+        added = parse(tasks_cli(home, "create", "will complete"))
+        tasks_cli(home, "update", added["id"], "--status", "completed")
         items = parse(tasks_cli(home, "list", "--json"))
         assert not any(i["id"] == added["id"] for i in items)
 
     def test_list_show_completed(self, shared_env):
         home, _, _ = shared_env
         items = parse(tasks_cli(home, "list", "--show-completed", "--json"))
-        assert any(i["status"] == "done" for i in items)
+        assert any(i["status"] == "completed" for i in items)
 
 
 # === Reminder CRUD ===
@@ -443,7 +443,7 @@ class TestRemindSet:
 
     def test_set_linked_to_task(self, shared_env):
         home, _, _ = shared_env
-        task = parse(tasks_cli(home, "add", "linked task"))
+        task = parse(tasks_cli(home, "create", "linked task"))
         data = parse(tasks_cli(home, "remind", "check this", "--task", task["id"], "--in-hours", "1"))
         assert data["task_id"] == task["id"]
         assert data["status"] == "scheduled"
@@ -513,7 +513,7 @@ class TestRemindList:
 
     def test_list_filter_by_task(self, shared_env):
         home, _, _ = shared_env
-        task = parse(tasks_cli(home, "add", "filter task"))
+        task = parse(tasks_cli(home, "create", "filter task"))
         parse(tasks_cli(home, "remind", "linked reminder", "--task", task["id"], "--in-hours", "2"))
         parse(tasks_cli(home, "remind", "unlinked reminder", "--in-hours", "2"))
         items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
@@ -546,12 +546,12 @@ class TestRemindDelete:
 
     def test_delete_does_not_affect_task(self, shared_env):
         home, _, _ = shared_env
-        task = parse(tasks_cli(home, "add", "survives"))
+        task = parse(tasks_cli(home, "create", "survives"))
         s = parse(tasks_cli(home, "remind", "linked delete test", "--task", task["id"], "--in-hours", "1"))
         tasks_cli(home, "remind", "delete", s["id"])
         # Task should still exist
         data = parse(tasks_cli(home, "get", task["id"]))
-        assert data["title"] == "survives"
+        assert data["subject"] == "survives"
 
 
 class TestRemindUpdate:
@@ -574,7 +574,7 @@ class TestRemindUpdate:
 class TestCascadeDeletion:
     def test_delete_task_cascades_reminders(self, shared_env):
         home, _, _ = shared_env
-        task = parse(tasks_cli(home, "add", "cascade test"))
+        task = parse(tasks_cli(home, "create", "cascade test"))
         r1 = parse(tasks_cli(home, "remind", "linked 1", "--task", task["id"], "--in-hours", "1"))
         r2 = parse(tasks_cli(home, "remind", "linked 2", "--task", task["id"], "--in-hours", "2"))
 
@@ -593,7 +593,7 @@ class TestAutoReminders:
     def test_due_date_creates_auto_reminders(self, shared_env):
         home, _, _ = shared_env
         future = (datetime.now(UTC) + timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%S")
-        task = parse(tasks_cli(home, "add", "auto reminder task", "--due-datetime", future, "--timezone", "UTC"))
+        task = parse(tasks_cli(home, "create", "auto reminder task", "--due-datetime", future, "--timezone", "UTC"))
         items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         auto = [i for i in items if i["auto_generated"]]
         # Should have reminders for 1 week, 1 day, 1 hour, 15 min before
@@ -603,7 +603,7 @@ class TestAutoReminders:
         home, _, _ = shared_env
         # Due in 30 minutes: only the 15-min pre-due reminder plus the at-due decision fire remain
         future = (datetime.now(UTC) + timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%S")
-        task = parse(tasks_cli(home, "add", "soon task", "--due-datetime", future, "--timezone", "UTC"))
+        task = parse(tasks_cli(home, "create", "soon task", "--due-datetime", future, "--timezone", "UTC"))
         items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         auto = [i for i in items if i["auto_generated"]]
         assert len(auto) == 2
@@ -614,7 +614,7 @@ class TestAutoReminders:
     def test_at_due_reminder_carries_decision_menu(self, shared_env):
         home, _, _ = shared_env
         future = (datetime.now(UTC) + timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%S")
-        task = parse(tasks_cli(home, "add", "decision task", "--due-datetime", future, "--timezone", "UTC"))
+        task = parse(tasks_cli(home, "create", "decision task", "--due-datetime", future, "--timezone", "UTC"))
         items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         at_due = [i for i in items if i["schedule"] == "auto: at due"]
         assert len(at_due) == 1
@@ -626,12 +626,12 @@ class TestAutoReminders:
     def test_done_status_cleans_auto_reminders(self, shared_env):
         home, _, _ = shared_env
         future = (datetime.now(UTC) + timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%S")
-        task = parse(tasks_cli(home, "add", "done cleanup", "--due-datetime", future, "--timezone", "UTC"))
+        task = parse(tasks_cli(home, "create", "done cleanup", "--due-datetime", future, "--timezone", "UTC"))
         # Verify auto reminders exist
         items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         assert any(i["auto_generated"] for i in items)
         # Mark done
-        tasks_cli(home, "update", task["id"], "--status", "done")
+        tasks_cli(home, "update", task["id"], "--status", "completed")
         # Auto reminders should be gone
         items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         auto = [i for i in items if i["auto_generated"]]
@@ -640,7 +640,7 @@ class TestAutoReminders:
     def test_cascade_deletes_auto_reminders(self, shared_env):
         home, _, _ = shared_env
         future = (datetime.now(UTC) + timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%S")
-        task = parse(tasks_cli(home, "add", "cascade auto", "--due-datetime", future, "--timezone", "UTC"))
+        task = parse(tasks_cli(home, "create", "cascade auto", "--due-datetime", future, "--timezone", "UTC"))
         items = parse(tasks_cli(home, "remind", "list", "--task", task["id"], "--json"))
         assert len(items) >= 1
         tasks_cli(home, "delete", task["id"])
@@ -655,19 +655,19 @@ class TestAutoReminders:
 class TestVerbs:
     def test_done_marks_task_done(self, shared_env):
         home, _, _ = shared_env
-        task = parse(tasks_cli(home, "add", "verb done"))
+        task = parse(tasks_cli(home, "create", "verb done"))
         data = parse(tasks_cli(home, "done", task["id"]))
-        assert data["status"] == "done"
+        assert data["status"] == "completed"
 
     def test_postpone_sets_new_due_from_now(self, shared_env):
         home, _, _ = shared_env
-        task = parse(tasks_cli(home, "add", "verb postpone"))
+        task = parse(tasks_cli(home, "create", "verb postpone"))
         data = parse(tasks_cli(home, "postpone", task["id"], "--in-days", "2"))
         assert data["due_date"] is not None
 
     def test_postpone_without_timing_errors(self, shared_env):
         home, _, _ = shared_env
-        task = parse(tasks_cli(home, "add", "verb postpone bad"))
+        task = parse(tasks_cli(home, "create", "verb postpone bad"))
         r = tasks_cli(home, "postpone", task["id"])
         assert r.returncode != 0
 
@@ -742,7 +742,7 @@ class TestDaemonNotifications:
         home, notif_dir = test_home
         proc = start_daemon(home, notif_dir)
         try:
-            task = parse(tasks_cli(home, "add", "already late", "--due-in-minutes", "5"))
+            task = parse(tasks_cli(home, "create", "already late", "--due-in-minutes", "5"))
             past = (datetime.now(UTC) - timedelta(days=1)).isoformat()
             conn = sqlite3.connect(home / ".tasks" / "tasks.db")
             conn.execute("UPDATE tasks SET due_date = ? WHERE id = ?", (past, task["id"]))
@@ -1285,36 +1285,36 @@ class TestDaemonLifecycle:
 
 
 class TestNativeSurface:
-    """CLI parity with the native task tools: the `create` verb and `--subject`/status aliases."""
+    """CLI parity with the native task tools: the `create` verb, `--subject`, and status words."""
 
-    def test_create_is_an_alias_of_add(self, shared_env):
+    def test_create_makes_a_task(self, shared_env):
         home, _, _ = shared_env
         data = parse(tasks_cli(home, "create", "made with create"))
-        assert data["title"] == "made with create"
+        assert data["subject"] == "made with create"
         assert data["status"] == "pending"
 
-    def test_subject_sets_title_on_create(self, shared_env):
+    def test_subject_sets_the_subject_on_create(self, shared_env):
         home, _, _ = shared_env
         data = parse(tasks_cli(home, "create", "--subject", "subject wins"))
-        assert data["title"] == "subject wins"
+        assert data["subject"] == "subject wins"
 
-    def test_subject_sets_title_on_update(self, shared_env):
+    def test_subject_sets_the_subject_on_update(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "before subject"))
+        added = parse(tasks_cli(home, "create", "before subject"))
         data = parse(tasks_cli(home, "update", added["id"], "--subject", "after subject"))
-        assert data["title"] == "after subject"
+        assert data["subject"] == "after subject"
 
     def test_update_status_in_progress_stays_listed(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "wip via cli"))
+        added = parse(tasks_cli(home, "create", "wip via cli"))
         data = parse(tasks_cli(home, "update", added["id"], "--status", "in_progress"))
         assert data["status"] == "in_progress"
         listing = parse(tasks_cli(home, "list", "--json"))
         assert any(t["id"] == added["id"] for t in listing)
 
-    def test_update_status_completed_is_done(self, shared_env):
+    def test_update_status_completed_closes_a_task(self, shared_env):
         home, _, _ = shared_env
-        added = parse(tasks_cli(home, "add", "close via completed"))
+        added = parse(tasks_cli(home, "create", "close via completed"))
         data = parse(tasks_cli(home, "update", added["id"], "--status", "completed"))
-        assert data["status"] == "done"
+        assert data["status"] == "completed"
         assert data["completed_at"] is not None

--- a/agent/skills/tasks/cli/tests/test_fields.py
+++ b/agent/skills/tasks/cli/tests/test_fields.py
@@ -16,20 +16,20 @@ def tmp_config(tmp_path: Path) -> Config:
 
 
 def test_get_task_fields_returns_requested_subset(tmp_config: Config):
-    task = commands.add_task(tmp_config, title="multi", priority="low")
+    task = commands.add_task(tmp_config, subject="multi", priority="low")
     assert commands.get_task_fields(tmp_config, task_id=task["id"], fields=["status"]) == {"status": "pending"}
-    got = commands.get_task_fields(tmp_config, task_id=task["id"], fields=["title", "priority", "status"])
-    assert got == {"title": "multi", "priority": 1, "status": "pending"}
+    got = commands.get_task_fields(tmp_config, task_id=task["id"], fields=["subject", "priority", "status"])
+    assert got == {"subject": "multi", "priority": 1, "status": "pending"}
 
 
 def test_get_task_fields_reads_metadata_only_when_requested(tmp_config: Config, monkeypatch):
-    task = commands.add_task(tmp_config, title="heavy notes", initial_metadata="big notes here")
+    task = commands.add_task(tmp_config, subject="heavy notes", initial_metadata="big notes here")
 
     read_calls: list[str] = []
     original = commands._read_metadata
     monkeypatch.setattr(commands, "_read_metadata", lambda d, i: (read_calls.append(i), original(d, i))[1])
 
-    commands.get_task_fields(tmp_config, task_id=task["id"], fields=["status", "title", "metadata_path"])
+    commands.get_task_fields(tmp_config, task_id=task["id"], fields=["status", "subject", "metadata_path"])
     assert read_calls == []  # metadata_path alone does NOT trigger a file read
 
     got = commands.get_task_fields(tmp_config, task_id=task["id"], fields=["metadata"])
@@ -38,6 +38,6 @@ def test_get_task_fields_reads_metadata_only_when_requested(tmp_config: Config, 
 
 
 def test_get_task_fields_unknown_field_raises(tmp_config: Config):
-    task = commands.add_task(tmp_config, title="x")
+    task = commands.add_task(tmp_config, subject="x")
     with pytest.raises(ValueError, match="Unknown field"):
         commands.get_task_fields(tmp_config, task_id=task["id"], fields=["bogus"])

--- a/agent/skills/tasks/cli/tests/test_format.py
+++ b/agent/skills/tasks/cli/tests/test_format.py
@@ -6,20 +6,20 @@ from tasks_cli import format as fmt
 def test_format_task_list():
     assert fmt.format_task_list([]) == "(no tasks)"
     tasks = [
-        {"id": "t1", "title": "ship PR", "status": "pending", "priority": 3, "due_date": "2026-04-25T09:00:00+00:00"},
-        {"id": "t2", "title": "water plants", "status": "done", "priority": 2, "due_date": None},
+        {"id": "t1", "subject": "ship PR", "status": "pending", "priority": 3, "due_date": "2026-04-25T09:00:00+00:00"},
+        {"id": "t2", "subject": "water plants", "status": "completed", "priority": 2, "due_date": None},
     ]
     lines = fmt.format_task_list(tasks).splitlines()
     assert "pending" in lines[0] and "high" in lines[0] and "ship PR" in lines[0] and "t1" in lines[0]
-    assert "done" in lines[1] and "norm" in lines[1] and "-" in lines[1]
+    assert "completed" in lines[1] and "norm" in lines[1] and "-" in lines[1]
 
 
 def test_format_task_list_marks_parked_tasks():
     """A parked task is the one the digest stops naming, so the list is the only place left that
     says it exists. It must stay visible and it must say it is parked."""
     tasks = [
-        {"id": "t1", "title": "waiting on legal", "status": "pending", "priority": 2, "due_date": None, "backburner": 1},
-        {"id": "t2", "title": "ship PR", "status": "pending", "priority": 2, "due_date": None, "backburner": 0},
+        {"id": "t1", "subject": "waiting on legal", "status": "pending", "priority": 2, "due_date": None, "backburner": 1},
+        {"id": "t2", "subject": "ship PR", "status": "pending", "priority": 2, "due_date": None, "backburner": 0},
     ]
     lines = fmt.format_task_list(tasks).splitlines()
     assert lines[0].endswith("[parked] waiting on legal")

--- a/agent/skills/tasks/cli/tests/test_native_surface.py
+++ b/agent/skills/tasks/cli/tests/test_native_surface.py
@@ -1,5 +1,5 @@
-"""The native-task-tool surface: the `completed` alias, the `in_progress` open status, and that
-adding it never strands a task's reminders. CLI-level aliases (`create`, `--subject`) live in
+"""The native-task-tool surface: closing with `completed`, the `in_progress` open status, and that
+adding it never strands a task's reminders. CLI-level spellings (`create`, `--subject`) live in
 test_e2e.py alongside the other subprocess tests."""
 
 import sqlite3
@@ -15,22 +15,22 @@ def _auto_reminder_count(config, task_id: str) -> int:
         return conn.execute("SELECT COUNT(*) FROM reminders WHERE task_id = ? AND auto_generated = 1", (task_id,)).fetchone()[0]
 
 
-def test_completed_maps_to_done(tmp_config):
-    task = commands.add_task(tmp_config, title="finish")
+def test_completed_closes_a_task(tmp_config):
+    task = commands.add_task(tmp_config, subject="finish")
     result = commands.update_task(tmp_config, task_id=task["id"], status="completed")
-    assert result["status"] == "done"
+    assert result["status"] == "completed"
     assert result["completed_at"] is not None
 
 
 def test_invalid_status_rejected(tmp_config):
-    task = commands.add_task(tmp_config, title="x")
+    task = commands.add_task(tmp_config, subject="x")
     with pytest.raises(ValueError):
         commands.update_task(tmp_config, task_id=task["id"], status="bogus")
 
 
 def test_in_progress_stays_open_in_list_and_digest(tmp_config):
     overdue = (datetime.now(UTC) - timedelta(days=1)).isoformat()
-    task = commands.add_task(tmp_config, title="overdue wip", due=commands.DueSpec(due_datetime=overdue, timezone="UTC"))
+    task = commands.add_task(tmp_config, subject="overdue wip", due=commands.DueSpec(due_datetime=overdue, timezone="UTC"))
     commands.update_task(tmp_config, task_id=task["id"], status="in_progress")
     assert any(t["id"] == task["id"] for t in commands.list_tasks(tmp_config))
     digest = commands.build_digest(tmp_config)
@@ -40,17 +40,17 @@ def test_in_progress_stays_open_in_list_and_digest(tmp_config):
 
 def test_open_status_toggle_never_duplicates_reminders(tmp_config):
     due = (datetime.now(UTC) + timedelta(days=3)).isoformat()
-    task = commands.add_task(tmp_config, title="wip", due=commands.DueSpec(due_datetime=due, timezone="UTC"))
+    task = commands.add_task(tmp_config, subject="wip", due=commands.DueSpec(due_datetime=due, timezone="UTC"))
     baseline = _auto_reminder_count(tmp_config, task["id"])
     assert baseline > 0
     commands.update_task(tmp_config, task_id=task["id"], status="in_progress")
     assert _auto_reminder_count(tmp_config, task["id"]) == baseline
 
 
-def test_reopen_from_done_via_in_progress_rebuilds_reminders(tmp_config):
+def test_reopen_from_completed_via_in_progress_rebuilds_reminders(tmp_config):
     due = (datetime.now(UTC) + timedelta(days=3)).isoformat()
-    task = commands.add_task(tmp_config, title="reopen", due=commands.DueSpec(due_datetime=due, timezone="UTC"))
-    commands.update_task(tmp_config, task_id=task["id"], status="done")
+    task = commands.add_task(tmp_config, subject="reopen", due=commands.DueSpec(due_datetime=due, timezone="UTC"))
+    commands.update_task(tmp_config, task_id=task["id"], status="completed")
     assert _auto_reminder_count(tmp_config, task["id"]) == 0
     reopened = commands.update_task(tmp_config, task_id=task["id"], status="in_progress")
     assert reopened["status"] == "in_progress"
@@ -58,20 +58,20 @@ def test_reopen_from_done_via_in_progress_rebuilds_reminders(tmp_config):
     assert _auto_reminder_count(tmp_config, task["id"]) > 0
 
 
-def test_migration_v5_to_v6_widens_status_check(tmp_path):
+def test_migration_v6_to_v7_renames_subject_and_completed(tmp_path):
     data_dir = tmp_path / "old"
     data_dir.mkdir()
     conn = sqlite3.connect(data_dir / "tasks.db")
     conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
-    conn.execute("INSERT INTO schema_version (version) VALUES (5)")
+    conn.execute("INSERT INTO schema_version (version) VALUES (6)")
     conn.execute(
         "CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT NOT NULL,"
-        " status TEXT DEFAULT 'pending' CHECK(status IN ('pending', 'done')),"
+        " status TEXT DEFAULT 'pending' CHECK(status IN ('pending', 'in_progress', 'done')),"
         " priority INTEGER DEFAULT 2 CHECK(priority IN (1, 2, 3)), due_date TEXT,"
         " created_at TEXT DEFAULT CURRENT_TIMESTAMP, completed_at TEXT,"
         " backburner INTEGER NOT NULL DEFAULT 0)"
     )
-    conn.execute("INSERT INTO tasks (id, title) VALUES ('t1', 'kept')")
+    conn.execute("INSERT INTO tasks (id, title, status) VALUES ('t1', 'kept', 'done')")
     conn.commit()
     conn.close()
 
@@ -79,7 +79,6 @@ def test_migration_v5_to_v6_widens_status_check(tmp_path):
 
     with closing(sqlite3.connect(data_dir / "tasks.db")) as conn:
         assert conn.execute("SELECT version FROM schema_version").fetchone()[0] == db.SCHEMA_VERSION
-        assert conn.execute("SELECT title FROM tasks WHERE id = 't1'").fetchone()[0] == "kept"
-        # The old CHECK would reject this; after v6 it is allowed.
-        conn.execute("UPDATE tasks SET status = 'in_progress' WHERE id = 't1'")
-        conn.commit()
+        # The row survives with its text under the new column name and the renamed status value.
+        assert conn.execute("SELECT subject FROM tasks WHERE id = 't1'").fetchone()[0] == "kept"
+        assert conn.execute("SELECT status FROM tasks WHERE id = 't1'").fetchone()[0] == "completed"

--- a/agent/skills/tasks/cli/tests/test_overdue_loop.py
+++ b/agent/skills/tasks/cli/tests/test_overdue_loop.py
@@ -22,7 +22,7 @@ def _auto_reminders(config: Config, task_id: str) -> list[dict]:
 
 def _add_task_due_in(config: Config, title: str, delta: timedelta) -> dict:
     due = (datetime.now(UTC) + delta).strftime("%Y-%m-%dT%H:%M:%S")
-    return commands.add_task(config, title=title, due=commands.DueSpec(due_datetime=due, timezone="UTC"))
+    return commands.add_task(config, subject=title, due=commands.DueSpec(due_datetime=due, timezone="UTC"))
 
 
 def _force_due_date(config: Config, task_id: str, due: datetime):
@@ -94,7 +94,7 @@ def test_postpone_overdue_task_moves_due_forward_and_rebuilds_reminders(tmp_conf
 
 
 def test_postpone_gives_undated_task_a_due_date(tmp_config: Config):
-    task = commands.add_task(tmp_config, title="undated")
+    task = commands.add_task(tmp_config, subject="undated")
     updated = commands.postpone_task(tmp_config, task_id=task["id"], in_hours=6)
     assert updated["due_date"] is not None
     assert {r["schedule_type"] for r in _auto_reminders(tmp_config, task["id"])} == {
@@ -105,7 +105,7 @@ def test_postpone_gives_undated_task_a_due_date(tmp_config: Config):
 
 
 def test_postpone_requires_timing(tmp_config: Config):
-    task = commands.add_task(tmp_config, title="no timing")
+    task = commands.add_task(tmp_config, subject="no timing")
     with pytest.raises(ValueError, match="Say when"):
         commands.postpone_task(tmp_config, task_id=task["id"])
 
@@ -242,9 +242,9 @@ def test_just_fired_one_shot_is_not_replayed_as_missed(tmp_config: Config, tmp_p
 def test_digest_lists_overdue_and_stale_with_commands(tmp_config: Config):
     overdue = _add_task_due_in(tmp_config, "overdue task", timedelta(minutes=30))
     _force_due_date(tmp_config, overdue["id"], datetime.now(UTC) - timedelta(days=2))
-    stale = commands.add_task(tmp_config, title="stale task")
+    stale = commands.add_task(tmp_config, subject="stale task")
     _force_created_at(tmp_config, stale["id"], datetime.now(UTC) - timedelta(days=20))
-    fresh = commands.add_task(tmp_config, title="fresh task")
+    fresh = commands.add_task(tmp_config, subject="fresh task")
 
     message = commands.build_digest(tmp_config)
 
@@ -257,7 +257,7 @@ def test_digest_lists_overdue_and_stale_with_commands(tmp_config: Config):
 
 
 def test_digest_is_none_when_nothing_needs_attention(tmp_config: Config):
-    commands.add_task(tmp_config, title="fresh")
+    commands.add_task(tmp_config, subject="fresh")
     _add_task_due_in(tmp_config, "future", timedelta(days=3))
     assert commands.build_digest(tmp_config) is None
 
@@ -309,9 +309,10 @@ def test_overdue_today_floats_to_top(tmp_config: Config):
 def test_migration_v4_regenerates_auto_reminders_and_creates_meta(tmp_config: Config):
     task = _add_task_due_in(tmp_config, "legacy task", timedelta(days=5))
     with closing(db.get_db(tmp_config.data_dir)) as conn:
-        # Rewind to a v3-shaped db: no meta table, no at-due reminder.
+        # Rewind to a v3-shaped db: the `title` column, no meta table, no at-due reminder.
         conn.execute("DELETE FROM reminders WHERE schedule_type = 'auto: at due'")
         conn.execute("DROP TABLE meta")
+        conn.execute("ALTER TABLE tasks RENAME COLUMN subject TO title")
         conn.execute("UPDATE schema_version SET version = 3")
         conn.commit()
 
@@ -333,7 +334,7 @@ def test_retitle_rewrites_armed_reminder_messages(tmp_config: Config):
     """An auto reminder's message embeds the task title, so a retitle must refresh every armed
     reminder's text to carry the new title."""
     task = _add_task_due_in(tmp_config, "Chase the refund (never issued)", timedelta(days=10))
-    commands.update_task(tmp_config, task_id=task["id"], title="Refund ALREADY PAID, close this")
+    commands.update_task(tmp_config, task_id=task["id"], subject="Refund ALREADY PAID, close this")
 
     rows = _auto_reminders(tmp_config, task["id"])
     assert rows, "the ladder must survive a retitle"
@@ -355,7 +356,7 @@ def test_retitle_rewrites_armed_reminder_messages(tmp_config: Config):
 def test_retitle_keeps_the_tail_firing_at_the_same_instants(tmp_config: Config):
     task = _add_task_due_in(tmp_config, "before", timedelta(days=10))
     before = {r["schedule_type"]: r["scheduled_time"] for r in _auto_reminders(tmp_config, task["id"])}
-    commands.update_task(tmp_config, task_id=task["id"], title="after")
+    commands.update_task(tmp_config, task_id=task["id"], subject="after")
     after = {r["schedule_type"]: r["scheduled_time"] for r in _auto_reminders(tmp_config, task["id"])}
     assert before == after
 
@@ -363,8 +364,8 @@ def test_retitle_keeps_the_tail_firing_at_the_same_instants(tmp_config: Config):
 def test_retitle_does_not_duplicate_the_ladder(tmp_config: Config):
     task = _add_task_due_in(tmp_config, "one ladder", timedelta(days=10))
     count = len(_auto_reminders(tmp_config, task["id"]))
-    commands.update_task(tmp_config, task_id=task["id"], title="still one ladder")
-    commands.update_task(tmp_config, task_id=task["id"], title="and again")
+    commands.update_task(tmp_config, task_id=task["id"], subject="still one ladder")
+    commands.update_task(tmp_config, task_id=task["id"], subject="and again")
     assert len(_auto_reminders(tmp_config, task["id"])) == count
 
 
@@ -375,7 +376,7 @@ def test_retitle_does_not_duplicate_a_hand_owned_reminder(tmp_config: Config):
     owned = _auto_reminders(tmp_config, task["id"])[0]
     commands.remind_update(tmp_config, reminder_id=owned["id"], message="hand written checkpoint")
 
-    commands.update_task(tmp_config, task_id=task["id"], title="new title")
+    commands.update_task(tmp_config, task_id=task["id"], subject="new title")
 
     with closing(db.get_db(tmp_config.data_dir)) as conn:
         at_instant = [
@@ -392,15 +393,15 @@ def test_retitle_does_not_duplicate_a_hand_owned_reminder(tmp_config: Config):
 
 def test_retitling_a_done_task_does_not_resurrect_reminders(tmp_config: Config):
     task = _add_task_due_in(tmp_config, "finished", timedelta(days=10))
-    commands.update_task(tmp_config, task_id=task["id"], status="done")
-    commands.update_task(tmp_config, task_id=task["id"], title="finished, renamed")
+    commands.update_task(tmp_config, task_id=task["id"], status="completed")
+    commands.update_task(tmp_config, task_id=task["id"], subject="finished, renamed")
     assert _auto_reminders(tmp_config, task["id"]) == []
 
 
 def test_reopening_with_a_new_title_uses_the_new_title(tmp_config: Config):
     task = _add_task_due_in(tmp_config, "old claim", timedelta(days=10))
-    commands.update_task(tmp_config, task_id=task["id"], status="done")
-    commands.update_task(tmp_config, task_id=task["id"], status="pending", title="corrected claim")
+    commands.update_task(tmp_config, task_id=task["id"], status="completed")
+    commands.update_task(tmp_config, task_id=task["id"], status="pending", subject="corrected claim")
 
     messages = [r["message"] for r in _auto_reminders(tmp_config, task["id"])]
     assert messages
@@ -409,8 +410,8 @@ def test_reopening_with_a_new_title_uses_the_new_title(tmp_config: Config):
 
 
 def test_retitling_an_undated_task_is_a_no_op(tmp_config: Config):
-    task = commands.add_task(tmp_config, title="no due date")
-    commands.update_task(tmp_config, task_id=task["id"], title="still no due date")
+    task = commands.add_task(tmp_config, subject="no due date")
+    commands.update_task(tmp_config, task_id=task["id"], subject="still no due date")
     assert _auto_reminders(tmp_config, task["id"]) == []
 
 
@@ -432,7 +433,7 @@ def test_retitle_does_not_disarm_an_overdue_task(tmp_config: Config):
     assert before >= 1
     _force_due_date(tmp_config, task["id"], datetime.now(UTC) - timedelta(minutes=5))
 
-    commands.update_task(tmp_config, task_id=task["id"], title="call the clinic (they open at 9)")
+    commands.update_task(tmp_config, task_id=task["id"], subject="call the clinic (they open at 9)")
 
     after = _armed(tmp_config, task["id"])
     assert len(after) == before, "an overdue task must keep its armed reminders through a retitle"
@@ -453,7 +454,7 @@ def test_retitle_preserves_a_snoozed_reminder(tmp_config: Config):
     commands.remind_snooze(tmp_config, reminder_id=reminder_id, in_days=1)
     snoozed_to = next(r["scheduled_time"] for r in _armed(tmp_config, task["id"]) if r["id"] == reminder_id)
 
-    commands.update_task(tmp_config, task_id=task["id"], title="renew the passport (expires 12 Sep)")
+    commands.update_task(tmp_config, task_id=task["id"], subject="renew the passport (expires 12 Sep)")
 
     armed = _armed(tmp_config, task["id"])
     row = next((r for r in armed if r["id"] == reminder_id), None)
@@ -468,7 +469,7 @@ def test_retitle_keeps_reminder_ids_stable(tmp_config: Config):
     task = _add_task_due_in(tmp_config, "stable", timedelta(days=180))
     before = {r["id"] for r in _armed(tmp_config, task["id"])}
 
-    commands.update_task(tmp_config, task_id=task["id"], title="stable renamed")
+    commands.update_task(tmp_config, task_id=task["id"], subject="stable renamed")
 
     assert {r["id"] for r in _armed(tmp_config, task["id"])} == before
 
@@ -479,7 +480,7 @@ def test_retitle_keeps_completed_reminders_as_history(tmp_config: Config):
         conn.execute("UPDATE reminders SET completed = 1 WHERE task_id = ? AND schedule_type = 'auto: 1 week before due'", (task["id"],))
         conn.commit()
 
-    commands.update_task(tmp_config, task_id=task["id"], title="history renamed")
+    commands.update_task(tmp_config, task_id=task["id"], subject="history renamed")
 
     with closing(db.get_db(tmp_config.data_dir)) as conn:
         done = conn.execute("SELECT count(*) FROM reminders WHERE task_id = ? AND completed = 1", (task["id"],)).fetchone()[0]
@@ -490,7 +491,7 @@ def test_a_no_op_retitle_changes_nothing(tmp_config: Config):
     task = _add_task_due_in(tmp_config, "same", timedelta(days=10))
     before = {(r["id"], r["message"]) for r in _armed(tmp_config, task["id"])}
 
-    commands.update_task(tmp_config, task_id=task["id"], title="same")
+    commands.update_task(tmp_config, task_id=task["id"], subject="same")
 
     assert {(r["id"], r["message"]) for r in _armed(tmp_config, task["id"])} == before
 
@@ -504,8 +505,8 @@ def test_backburner_task_is_not_listed_as_stale(tmp_config: Config):
     """A task parked on purpose must stop appearing in the digest, while an ordinary undated task
     of the same age still appears. Without the second half this test would pass on a digest that
     had simply stopped reporting stale tasks at all."""
-    parked = commands.add_task(tmp_config, title="parked task")
-    ordinary = commands.add_task(tmp_config, title="ordinary undated task")
+    parked = commands.add_task(tmp_config, subject="parked task")
+    ordinary = commands.add_task(tmp_config, subject="ordinary undated task")
     for task in (parked, ordinary):
         _force_created_at(tmp_config, task["id"], datetime.now(UTC) - timedelta(days=20))
     commands.update_task(tmp_config, task_id=parked["id"], backburner=True)
@@ -520,7 +521,7 @@ def test_backburner_task_is_not_listed_as_stale(tmp_config: Config):
 def test_backburner_task_still_appears_in_task_list(tmp_config: Config):
     """Parking defers the nag, never the task. A parked task that vanished from `tasks list` would
     be a worse bug than the one this feature fixes."""
-    parked = commands.add_task(tmp_config, title="parked task")
+    parked = commands.add_task(tmp_config, subject="parked task")
     commands.update_task(tmp_config, task_id=parked["id"], backburner=True)
 
     listed = commands.list_tasks(tmp_config)
@@ -531,7 +532,7 @@ def test_backburner_task_still_appears_in_task_list(tmp_config: Config):
 
 def test_setting_a_due_date_clears_backburner(tmp_config: Config):
     """Committing to a date is the opposite state to parking, so the flag must not survive it."""
-    task = commands.add_task(tmp_config, title="parked then committed")
+    task = commands.add_task(tmp_config, subject="parked then committed")
     commands.update_task(tmp_config, task_id=task["id"], backburner=True)
 
     commands.update_task(tmp_config, task_id=task["id"], due=commands.DueSpec(due_in_days=3))
@@ -601,7 +602,7 @@ def test_setting_a_date_in_the_same_call_wins_over_parking(tmp_config: Config):
     outcome the flag exists to prevent: the digest goes quiet while the reminder ladder keeps
     firing on the same task.
     """
-    task = commands.add_task(tmp_config, title="undecided")
+    task = commands.add_task(tmp_config, subject="undecided")
     commands.update_task(tmp_config, task_id=task["id"], backburner=True)
     assert commands.get_task(tmp_config, task_id=task["id"])["backburner"] == 1
 

--- a/agent/skills/tasks/cli/tests/test_remind_ownership.py
+++ b/agent/skills/tasks/cli/tests/test_remind_ownership.py
@@ -22,7 +22,7 @@ def _reminders(config: Config, task_id: str) -> list[dict]:
 
 
 def _task_with_auto_reminders(config: Config) -> tuple[str, dict]:
-    task = commands.add_task(config, title="original title", due=commands.DueSpec(due_in_days=3))
+    task = commands.add_task(config, subject="original title", due=commands.DueSpec(due_in_days=3))
     autos = _reminders(config, task["id"])
     assert autos, "a task with a due date must start with auto reminders"
     return task["id"], autos[0]
@@ -70,7 +70,7 @@ def test_marking_a_task_done_clears_owned_reminders_too(tmp_config: Config):
     task_id, auto = _task_with_auto_reminders(tmp_config)
     commands.remind_update(tmp_config, reminder_id=auto["id"], message="hand written checkpoint")
 
-    commands.update_task(tmp_config, task_id=task_id, status="done")
+    commands.update_task(tmp_config, task_id=task_id, status="completed")
 
     assert _reminders(tmp_config, task_id) == [], "a done task must clear all its reminders, owned included"
 

--- a/agent/skills/tasks/cli/tests/test_task_completion_notify.py
+++ b/agent/skills/tasks/cli/tests/test_task_completion_notify.py
@@ -19,9 +19,9 @@ def _completion_notifs(notif_dir: Path) -> list[dict]:
 def test_app_completion_writes_a_snoozed_notification(tmp_config: Config, tmp_path: Path):
     notif_dir = tmp_path / "notifications"
     notif_dir.mkdir()
-    task = commands.add_task(tmp_config, title="call the dentist")
+    task = commands.add_task(tmp_config, subject="call the dentist")
 
-    server._apply_task_update(tmp_config, notif_dir, task["id"], server.UpdateTaskBody(status="done"))
+    server._apply_task_update(tmp_config, notif_dir, task["id"], server.UpdateTaskBody(status="completed"))
 
     notifs = _completion_notifs(notif_dir)
     assert len(notifs) == 1
@@ -33,10 +33,10 @@ def test_app_completion_writes_a_snoozed_notification(tmp_config: Config, tmp_pa
 def test_app_completion_notifies_once_not_on_a_repeat(tmp_config: Config, tmp_path: Path):
     notif_dir = tmp_path / "notifications"
     notif_dir.mkdir()
-    task = commands.add_task(tmp_config, title="x")
+    task = commands.add_task(tmp_config, subject="x")
 
-    server._apply_task_update(tmp_config, notif_dir, task["id"], server.UpdateTaskBody(status="done"))
-    server._apply_task_update(tmp_config, notif_dir, task["id"], server.UpdateTaskBody(status="done"))
+    server._apply_task_update(tmp_config, notif_dir, task["id"], server.UpdateTaskBody(status="completed"))
+    server._apply_task_update(tmp_config, notif_dir, task["id"], server.UpdateTaskBody(status="completed"))
 
     assert len(_completion_notifs(notif_dir)) == 1, "re-sending done on an already-done task must not re-notify"
 
@@ -44,9 +44,9 @@ def test_app_completion_notifies_once_not_on_a_repeat(tmp_config: Config, tmp_pa
 def test_app_edit_that_is_not_a_completion_does_not_notify(tmp_config: Config, tmp_path: Path):
     notif_dir = tmp_path / "notifications"
     notif_dir.mkdir()
-    task = commands.add_task(tmp_config, title="x")
+    task = commands.add_task(tmp_config, subject="x")
 
-    server._apply_task_update(tmp_config, notif_dir, task["id"], server.UpdateTaskBody(title="renamed"))
+    server._apply_task_update(tmp_config, notif_dir, task["id"], server.UpdateTaskBody(subject="renamed"))
 
     assert _completion_notifs(notif_dir) == []
 
@@ -54,8 +54,8 @@ def test_app_edit_that_is_not_a_completion_does_not_notify(tmp_config: Config, t
 def test_cli_completion_does_not_notify(tmp_config: Config, tmp_path: Path):
     notif_dir = tmp_path / "notifications"
     notif_dir.mkdir()
-    task = commands.add_task(tmp_config, title="x")
+    task = commands.add_task(tmp_config, subject="x")
 
-    commands.update_task(tmp_config, task_id=task["id"], status="done")
+    commands.update_task(tmp_config, task_id=task["id"], status="completed")
 
     assert _completion_notifs(notif_dir) == [], "the agent's own CLI completion is self-evident and must stay silent"

--- a/agent/skills/tasks/cli/tests/test_title_soft_cap.py
+++ b/agent/skills/tasks/cli/tests/test_title_soft_cap.py
@@ -1,5 +1,5 @@
-"""A task title past the soft cap warns on stderr and points at metadata, but the write always
-happens: the cap is advisory because a legitimately long title exists. stdout stays the command's
+"""A task subject past the soft cap warns on stderr and points at metadata, but the write always
+happens: the cap is advisory because a legitimately long subject exists. stdout stays the command's
 JSON result either way."""
 
 import json
@@ -31,29 +31,29 @@ def _run_tasks(monkeypatch, capsys, cfg: Config, *argv: str):
 
 
 def test_add_long_title_warns_but_still_creates(tmp_config: Config, monkeypatch, capsys):
-    out = _run_tasks(monkeypatch, capsys, tmp_config, "add", LONG_TITLE)
+    out = _run_tasks(monkeypatch, capsys, tmp_config, "create", LONG_TITLE)
     warning = json.loads(out.err)["warning"]
     assert "metadata" in warning
     created = json.loads(out.out)
-    assert created["title"] == LONG_TITLE
-    assert commands.get_task(tmp_config, task_id=created["id"])["title"] == LONG_TITLE
+    assert created["subject"] == LONG_TITLE
+    assert commands.get_task(tmp_config, task_id=created["id"])["subject"] == LONG_TITLE
 
 
 def test_add_short_title_does_not_warn(tmp_config: Config, monkeypatch, capsys):
-    out = _run_tasks(monkeypatch, capsys, tmp_config, "add", SHORT_TITLE)
+    out = _run_tasks(monkeypatch, capsys, tmp_config, "create", SHORT_TITLE)
     assert out.err == ""
-    assert json.loads(out.out)["title"] == SHORT_TITLE
+    assert json.loads(out.out)["subject"] == SHORT_TITLE
 
 
 def test_update_long_title_warns_but_still_applies(tmp_config: Config, monkeypatch, capsys):
-    task = commands.add_task(tmp_config, title=SHORT_TITLE)
-    out = _run_tasks(monkeypatch, capsys, tmp_config, "update", task["id"], "--title", LONG_TITLE)
+    task = commands.add_task(tmp_config, subject=SHORT_TITLE)
+    out = _run_tasks(monkeypatch, capsys, tmp_config, "update", task["id"], "--subject", LONG_TITLE)
     assert "metadata" in json.loads(out.err)["warning"]
-    assert commands.get_task(tmp_config, task_id=task["id"])["title"] == LONG_TITLE
+    assert commands.get_task(tmp_config, task_id=task["id"])["subject"] == LONG_TITLE
 
 
 def test_update_short_title_does_not_warn(tmp_config: Config, monkeypatch, capsys):
-    task = commands.add_task(tmp_config, title=SHORT_TITLE)
-    out = _run_tasks(monkeypatch, capsys, tmp_config, "update", task["id"], "--title", "Renamed")
+    task = commands.add_task(tmp_config, subject=SHORT_TITLE)
+    out = _run_tasks(monkeypatch, capsys, tmp_config, "update", task["id"], "--subject", "Renamed")
     assert out.err == ""
-    assert commands.get_task(tmp_config, task_id=task["id"])["title"] == "Renamed"
+    assert commands.get_task(tmp_config, task_id=task["id"])["subject"] == "Renamed"


### PR DESCRIPTION
## What

Follows up #1969 by dropping the dual naming: the `tasks` CLI now speaks one vocabulary, the native one, with no aliases.

- verb: `create` (the `add` verb is gone)
- title field: `--subject` (the `--title` flag is gone)
- closed status: `completed` (the `done` status value is gone)
- `in_progress` stays. The `tasks done <id>` shortcut stays and now sets `completed`.

## Why

The aliases from #1969 left two names for each thing, which read as clutter in the skill and in the CLI. One vocabulary is simpler to document and to reason about.

## Schema v7

The rename reaches the stored data, so it is a migration, not just a surface change.

- `_migrate_v6_to_v7` renames the `title` column to `subject` and rewrites status `done` to `completed`, rebuilding the table to preserve every row (SQLite cannot rename a column inside a CHECK in place).
- The historical migrations (v1 through v6), the base `CREATE TABLE`, and `_create_auto_reminders_for_existing` keep the old `title`/`done` names on purpose: they run on the pre-v7 schema, so a fresh database still builds correctly and then converges to v7.
- `SCHEMA_VERSION` is 7; tests assert against `db.SCHEMA_VERSION`, never a literal.

## Verified

- Full suite green: 239 passing. Pinned ruff, ruff format, and the convention guard are clean.
- Fresh database builds to v7 with a `subject` column and accepts a `completed` status.
- A v6 database with a `title` column and a `done` row migrates to `subject` + `completed`, rows preserved (new migration test).
