### PR TITLE
ci(mobile): make the expo dependency drift check advisory, not blocking

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -145,7 +145,13 @@ check_app_mobile() {
     if [ ! -e node_modules/@vesta/mobile ]; then
       npm install
     fi
-    (cd mobile && npx expo install --check)
+    # Advisory only. `expo install --check` compares our pins against Expo's live SDK
+    # expectations, which Expo bumps on its own patch cadence, so a hard failure here couples
+    # every release to that cadence for no release-time safety (the mobile-ios/mobile-android
+    # native compile jobs gate real breakage). Warn, never block; catch up deliberately with
+    # `npx expo install --fix`.
+    (cd mobile && npx expo install --check) \
+      || echo "warning: expo deps are behind Expo's expected versions (advisory; run 'npx expo install --fix' to update)"
     npm -w @vesta/mobile run lint
     npm -w @vesta/mobile run check
     npm -w @vesta/mobile run test


### PR DESCRIPTION
## Problem

The v0.2.1 release pipeline failed with **no code change on our side**. Root cause: `check.sh app-mobile` runs `npx expo install --check`, which validates our pins against Expo's **live** SDK 57 expectations. Expo published patch releases (`.10/.12/.13`) after our pins were set, so the check started reporting them outdated and hard-failed (`exit 1`). That tripped `merge-gate-ci` in the release pipeline, which **skipped the entire binary build + upload chain** — so v0.2.1 shipped with no downloadable vestad binary and agents 404'd trying to update (the failed pipeline then auto-reverted the release).

Because CI is path-filtered, the mobile job only runs when mobile files change, so this drift went unnoticed on master until the release pipeline (which runs the full suite unconditionally) hit it.

This is a treadmill: the check will keep breaking CI and blocking releases on Expo's patch cadence, independent of our code.

## Fix

Make `expo install --check` **advisory** in `check.sh app-mobile`: run it, warn on drift, never fail the suite. The `mobile-ios` / `mobile-android` native compile jobs remain the real gate for actual incompatibilities, and the pins are caught up **deliberately** with `npx expo install --fix` rather than on Expo's schedule.

One-line-ish change, zero dependency/lockfile churn.

## Why not just bump the deps

Investigated thoroughly: bumping is not surgical here. `expo-dev-client` is stuck behind an npm workspace dedup quirk (`expo-updates` depends on it as `*`, so npm hoists the old version at the root and dedupes mobile's requirement down to it). The only way to force it is a full lockfile regen, which churns ~10k lines and drifts *unrelated* apps' deps (e.g. `electron-to-chromium` in desktop). A deliberate, fully-verified dep-bump PR can be done separately; it shouldn't gate this release.

## Verification

With the **old** (drifted) versions installed, as CI has them:
```
Found outdated dependencies
warning: expo deps are behind Expo's expected versions (advisory; run 'npx expo install --fix' to update)
 Test Files  37 passed (37)
      Tests  181 passed (181)
```
The check warns, the suite passes. `shellcheck -S warning` clean; `./check.sh guards` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)