### PR TITLE
fix(web,mobile): stop log list scroll jumps

### DIFF
--- a/apps/mobile/src/agent/LogsPage.tsx
+++ b/apps/mobile/src/agent/LogsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FlatList, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { ApiClient } from "@/api/client";
@@ -6,7 +6,6 @@ import { useAgent } from "@/agent/AgentProvider";
 import { openAgentLogStream } from "@/agent/agent-log-stream";
 import { addLatestLogLine, type LogLine } from "@/agent/log-list-model";
 import { subscribeLogs } from "@/agent/log-stream-subscription";
-import { useBottomAnchoredFeed } from "@/agent/use-bottom-anchored-feed";
 import { AnsiText } from "@/components/ui/AnsiText";
 import { Text } from "@/components/ui/Typography";
 import { usePreferences } from "@/preferences/PreferencesProvider";
@@ -15,6 +14,12 @@ import { useSession } from "@/session/SessionProvider";
 import { navHeaderHeight } from "@/theme/layout";
 
 const LOG_RETRY_DELAY_MS = 1_000;
+// Visual-top chrome the pager overlays on the list (agent header + page dots).
+const PAGER_HEADER_HEIGHT = 104;
+// Lines prepend at index 0, the visual bottom of the inverted list. Holding the
+// first visible line in place keeps arrivals from shifting the view mid-read;
+// within the threshold of the newest line the list follows the tail instead.
+const FOLLOW_TAIL = { minIndexForVisible: 0, autoscrollToTopThreshold: 32 };
 
 interface LogsPageProps {
   presentation?: "pager" | "standalone";
@@ -87,54 +92,29 @@ function LogList({
 }) {
   const { colors } = usePreferences();
   const insets = useSafeAreaInsets();
-  const standalone = presentation === "standalone";
-  const displayLogs = useMemo(
-    () => (standalone ? [...logs].reverse() : logs),
-    [logs, standalone],
-  );
-  const bottomAnchor = useBottomAnchoredFeed<LogLine>(displayLogs.length);
+  const topChrome =
+    presentation === "standalone" ? navHeaderHeight : PAGER_HEADER_HEIGHT;
 
   return (
     <View style={styles.screen}>
       <FlatList
-        ref={standalone ? bottomAnchor.listRef : undefined}
-        style={[
-          styles.list,
-          standalone && !bottomAnchor.contentVisible
-            ? styles.positioningList
-            : null,
-        ]}
-        data={displayLogs}
-        inverted={!standalone}
+        style={styles.list}
+        data={logs}
+        inverted
+        maintainVisibleContentPosition={FOLLOW_TAIL}
         keyExtractor={(line) => String(line.id)}
         renderItem={({ item }) => (
           <AnsiText value={item.text} selectable style={styles.logLine} />
         )}
         automaticallyAdjustContentInsets={false}
         contentInsetAdjustmentBehavior="never"
-        contentContainerStyle={
-          standalone
-            ? [
-                styles.listContent,
-                {
-                  paddingTop: insets.top + navHeaderHeight,
-                  paddingBottom: insets.bottom,
-                },
-                displayLogs.length > 0 ? styles.bottomAligned : null,
-              ]
-            : [
-                styles.listContent,
-                {
-                  paddingTop: insets.bottom,
-                  paddingBottom: insets.top + 104,
-                },
-              ]
-        }
-        onContentSizeChange={
-          standalone ? bottomAnchor.onContentSizeChange : undefined
-        }
-        onScroll={standalone ? bottomAnchor.onScroll : undefined}
-        scrollEventThrottle={standalone ? 16 : undefined}
+        contentContainerStyle={[
+          styles.listContent,
+          {
+            paddingTop: insets.bottom,
+            paddingBottom: insets.top + topChrome,
+          },
+        ]}
         ListHeaderComponent={
           logError ? (
             <Text style={[styles.logError, { color: colors.warning }]}>
@@ -155,9 +135,7 @@ function LogList({
 const styles = StyleSheet.create({
   screen: { flex: 1 },
   list: { flex: 1 },
-  positioningList: { opacity: 0 },
   listContent: { paddingHorizontal: 12 },
-  bottomAligned: { flexGrow: 1, justifyContent: "flex-end" },
   logLine: { fontSize: 13, lineHeight: 18 },
   logError: { paddingBottom: 8, paddingHorizontal: 2, fontSize: 12 },
   empty: { textAlign: "center", padding: 40, fontSize: 14 },

--- a/apps/web/src/components/Console/index.tsx
+++ b/apps/web/src/components/Console/index.tsx
@@ -19,8 +19,6 @@ import { cn } from "@/lib/utils";
 
 const RECONNECT_BASE = 1000;
 const RECONNECT_MAX = 30000;
-// One mono line is ~19px; off-screen rows reserve this via contain-intrinsic-size.
-const ESTIMATED_LINE_HEIGHT = 20;
 // How close to the bottom still counts as pinned for follow-on-append.
 const AT_BOTTOM_THRESHOLD_PX = 80;
 // The opening `tail -n N -f` dumps the recent tail back-to-back, then `-f` idles.
@@ -90,13 +88,17 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
   const quiesceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const capTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const flushBuffer = useCallback(() => {
-    if (!fillingRef.current) return;
-    fillingRef.current = false;
+  const clearFillTimers = useCallback(() => {
     if (quiesceTimerRef.current) clearTimeout(quiesceTimerRef.current);
     if (capTimerRef.current) clearTimeout(capTimerRef.current);
     quiesceTimerRef.current = null;
     capTimerRef.current = null;
+  }, []);
+
+  const flushBuffer = useCallback(() => {
+    if (!fillingRef.current) return;
+    fillingRef.current = false;
+    clearFillTimers();
     const buffered = bufferRef.current;
     bufferRef.current = [];
     setLines(
@@ -104,7 +106,7 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
         ? buffered.slice(-LOG_SCROLLBACK_LINES)
         : buffered,
     );
-  }, []);
+  }, [clearFillTimers]);
 
   const connect = useRef<(replay: boolean) => void>(undefined);
 
@@ -116,10 +118,7 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
       // Only a fresh replay connect buffers a tail; a reconnect (tail=0) appends live.
       fillingRef.current = replay;
       bufferRef.current = [];
-      if (quiesceTimerRef.current) clearTimeout(quiesceTimerRef.current);
-      if (capTimerRef.current) clearTimeout(capTimerRef.current);
-      quiesceTimerRef.current = null;
-      capTimerRef.current = null;
+      clearFillTimers();
 
       // Resolves when the stream ends; every failure arrives as a stream event instead.
       void streamLogs(
@@ -199,11 +198,10 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
     return () => {
       activeRef.current = false;
       if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
-      if (quiesceTimerRef.current) clearTimeout(quiesceTimerRef.current);
-      if (capTimerRef.current) clearTimeout(capTimerRef.current);
+      clearFillTimers();
       if (name) void stopLogs(name);
     };
-  }, [name]);
+  }, [name, clearFillTimers]);
 
   // Resume a fresh stream only when the agent comes back up after a stop. We never
   // re-stream on the down transition (that re-dumped the same final tail), and never
@@ -234,8 +232,9 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
   const newestLineId = lines.at(-1)?.id;
 
   // Every log line stays in the DOM (no windowing) so a native text selection survives
-  // scrolling and copies the full range; off-screen rows skip layout/paint via
-  // content-visibility, so 5000 lines still scroll smoothly.
+  // scrolling and copies the full range. Rows must lay out for real, not behind a
+  // content-visibility size estimate: lines wrap to unpredictable heights, and an
+  // estimate makes scrollHeight shift mid-scroll, so scrolling jumps.
   const updatePinned = useCallback(() => {
     const el = parentRef.current;
     if (!el) return;
@@ -290,10 +289,6 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
                 <div
                   key={line.id}
                   className={cn("break-words whitespace-pre-wrap", linePad)}
-                  style={{
-                    contentVisibility: "auto",
-                    containIntrinsicSize: `auto ${String(ESTIMATED_LINE_HEIGHT)}px`,
-                  }}
                   dangerouslySetInnerHTML={{ __html: line.html }}
                 />
               ))}

--- a/apps/web/src/components/Console/index.tsx
+++ b/apps/web/src/components/Console/index.tsx
@@ -231,10 +231,6 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
   // instead so a full console continues to follow live output.
   const newestLineId = lines.at(-1)?.id;
 
-  // Every log line stays in the DOM (no windowing) so a native text selection survives
-  // scrolling and copies the full range. Rows must lay out for real, not behind a
-  // content-visibility size estimate: lines wrap to unpredictable heights, and an
-  // estimate makes scrollHeight shift mid-scroll, so scrolling jumps.
   const updatePinned = useCallback(() => {
     const el = parentRef.current;
     if (!el) return;
@@ -250,7 +246,10 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
     if (el && count > 0 && pinnedRef.current) el.scrollTop = el.scrollHeight;
   }, [count, newestLineId]);
 
-  const linePad = fullscreen ? "px-page" : "px-5";
+  const lineClass = cn(
+    "break-words whitespace-pre-wrap",
+    fullscreen ? "px-page" : "px-5",
+  );
 
   return (
     <div
@@ -285,10 +284,15 @@ export function Console({ name, status, fullscreen }: ConsoleProps) {
               ) : (
                 <div className="h-6" />
               )}
+              {/* Every log line stays in the DOM (no windowing) so a native text selection
+                  survives scrolling and copies the full range. Rows must lay out for real,
+                  not behind a content-visibility size estimate: lines wrap to unpredictable
+                  heights, and an estimate makes scrollHeight shift mid-scroll, so scrolling
+                  jumps. */}
               {lines.map((line) => (
                 <div
                   key={line.id}
-                  className={cn("break-words whitespace-pre-wrap", linePad)}
+                  className={lineClass}
                   dangerouslySetInnerHTML={{ __html: line.html }}
                 />
               ))}


### PR DESCRIPTION
## Problem

Both log lists scroll badly.

- **Mobile (pager logs page)**: scroll up, and each arriving line makes the view jam around. The inverted FlatList prepends new lines at index 0 with no `maintainVisibleContentPosition`, so the content grows on the offset-zero side while the scroll offset stays fixed, and the visible rows jump under the finger.
- **Web (Console)**: scrolling down is jumpy. Every off-screen row reserved a fixed 20px via `content-visibility` / `contain-intrinsic-size`, but rows wrap (`whitespace-pre-wrap break-words`) and are often 2 to 5 lines tall. Entering never-rendered rows re-lays them out at real height, `scrollHeight` shifts mid-scroll, and scroll anchoring fights it. Scrolling up was smoother only because `auto` remembers sizes of rows already rendered once.

## Fix

- **Mobile**: one inverted `FlatList` for both presentations, with `maintainVisibleContentPosition={{ minIndexForVisible: 0, autoscrollToTopThreshold: 32 }}`: arrivals hold the view in place mid-read, and within 32px of the newest line the list follows the tail. The standalone variant loses its array reversal, `useBottomAnchoredFeed` wiring, and the opacity positioning trick (RN 0.86 counter-inverts `ListEmptyComponent`, so the empty state stays upright). The hook itself stays: NotificationsPage still uses it.
- **Web**: rows lay out for real; the estimate and its const are gone, and the comment now states the constraint. The DOM keeps every line (no windowing) so native text selection still survives scrolling. Polish: the fill-timer teardown that appeared three times is one helper now.

## Verification

- `./check.sh app-web` (245 tests), `./check.sh app-mobile`, `./check.sh guards`: all pass.
- Scroll feel is **not visually verified**: the fix is prop/CSS-level and this machine has no simulator. Please check on device: (1) mobile pager logs, scroll up while lines stream; (2) web console, scroll down through deep scrollback; (3) web console with 5000 lines still scrolls acceptably without the paint-skip optimization.

## Notes

- ChatPage's inverted list also lacks `maintainVisibleContentPosition` and likely shows the same mid-read jump when a message arrives; left out of scope here, happy to follow up.
- GatewayLogsViewer is a third list with no line cap; also untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KNWDABuK3z8sqveBBdPr