### PR TITLE
refactor(whatsapp): one identity field in notifications

### DIFF
--- a/agent/skills/whatsapp/cli/events.go
+++ b/agent/skills/whatsapp/cli/events.go
@@ -286,13 +286,15 @@ func (wac *WhatsAppClient) dropDeadDevice() {
 }
 
 // buildNotifContext assembles the NotifContext shared by message and reaction
-// notifications.
-func (wac *WhatsAppClient) buildNotifContext(chatJID, chatName, senderDisplay, contactName, contactPhone string, contactSaved, isDirectChat bool) NotifContext {
+// notifications. senderDisplay is the one identity a notification names: the saved contact
+// name when saved, otherwise the formatted number or JID. It rides in ContactName for every
+// chat, so a group participant is named there while ChatName names the group.
+func (wac *WhatsAppClient) buildNotifContext(chatJID, chatName, senderDisplay, contactPhone string, contactSaved, isDirectChat bool) NotifContext {
 	return NotifContext{
 		NotifDir: wac.notificationsDir, ChatJID: chatJID, ChatName: chatName,
-		ContactName: contactName, ContactPhone: contactPhone,
+		ContactName: senderDisplay, ContactPhone: contactPhone,
 		Instance: wac.instance, ContactSaved: contactSaved,
-		IsDirectChat: isDirectChat, Sender: senderDisplay,
+		IsDirectChat: isDirectChat,
 	}
 }
 
@@ -339,7 +341,7 @@ func (wac *WhatsAppClient) handleMessage(evt *events.Message) {
 		return
 	}
 
-	resolvedSender, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(info.MessageSource)
+	resolvedSender, senderDisplay, _, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(info.MessageSource)
 	chatName := wac.getChatName(info.Chat)
 	// Canonical storage key: resolve the peer LID to its phone JID so this chat is keyed the same
 	// whether the message arrived under the peer's LID or a reply resolves them to their number.
@@ -389,7 +391,7 @@ func (wac *WhatsAppClient) handleMessage(evt *events.Message) {
 	shouldNotify := wac.notificationsDir != "" && !wac.noNotify && !info.IsFromMe && !wac.skipSenders[contactPhone]
 	var notifCtx NotifContext
 	if shouldNotify {
-		notifCtx = wac.buildNotifContext(info.Chat.String(), chatName, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat)
+		notifCtx = wac.buildNotifContext(info.Chat.String(), chatName, senderDisplay, contactPhone, contactSaved, isDirectChat)
 	}
 
 	// Audio messages: transcribe asynchronously, then send notification
@@ -514,8 +516,8 @@ func (wac *WhatsAppClient) handleReaction(evt *events.Message) {
 	chatName := wac.getChatName(evt.Info.Chat)
 
 	if wac.notificationsDir != "" {
-		_, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
-		ctx := wac.buildNotifContext(evt.Info.Chat.String(), chatName, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat)
+		_, senderDisplay, _, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
+		ctx := wac.buildNotifContext(evt.Info.Chat.String(), chatName, senderDisplay, contactPhone, contactSaved, isDirectChat)
 		WriteReactionNotification(ctx, targetID, emoji, isRemoved)
 	}
 }
@@ -598,11 +600,11 @@ func (wac *WhatsAppClient) notifContextFor(evt *events.Message) (NotifContext, b
 	if wac.notificationsDir == "" || wac.noNotify || evt.Info.IsFromMe {
 		return NotifContext{}, false
 	}
-	_, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
+	_, senderDisplay, _, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
 	if wac.skipSenders[contactPhone] {
 		return NotifContext{}, false
 	}
-	return wac.buildNotifContext(evt.Info.Chat.String(), wac.getChatName(evt.Info.Chat), senderDisplay, contactName, contactPhone, contactSaved, isDirectChat), true
+	return wac.buildNotifContext(evt.Info.Chat.String(), wac.getChatName(evt.Info.Chat), senderDisplay, contactPhone, contactSaved, isDirectChat), true
 }
 
 func (wac *WhatsAppClient) handleHistorySync(evt *events.HistorySync) {

--- a/agent/skills/whatsapp/cli/events_test.go
+++ b/agent/skills/whatsapp/cli/events_test.go
@@ -248,3 +248,27 @@ func TestLoggedOutReason(t *testing.T) {
 		t.Fatal("a stream:error logout must carry a reason")
 	}
 }
+
+// buildNotifContext folds the sender display into the one identity field: ContactName carries the
+// saved name when saved and the formatted number otherwise, for both direct and group chats.
+func TestBuildNotifContextFoldsSenderDisplayIntoContactName(t *testing.T) {
+	wac := &WhatsAppClient{notificationsDir: "/n", instance: "personal"}
+	for _, tc := range []struct {
+		name          string
+		senderDisplay string
+		contactSaved  bool
+		isDirectChat  bool
+	}{
+		{"direct-saved", "Ana", true, true},
+		{"direct-unsaved", "+15559998888", false, true},
+		{"group-saved", "Ana", true, false},
+		{"group-unsaved", "+15559998888", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := wac.buildNotifContext("chat@jid", "Chat", tc.senderDisplay, "+15559998888", tc.contactSaved, tc.isDirectChat)
+			if ctx.ContactName != tc.senderDisplay {
+				t.Errorf("ContactName = %q, want the sender display %q as the single identity", ctx.ContactName, tc.senderDisplay)
+			}
+		})
+	}
+}

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -19,7 +19,6 @@ type messageNotif struct {
 	Instance        string `json:"instance,omitempty"`
 	ContactName     string `json:"contact_name,omitempty"`
 	Message         string `json:"message"`
-	Sender          string `json:"sender,omitempty"`
 	ChatName        string `json:"chat_name,omitempty"`
 	ContactPhone    string `json:"contact_phone,omitempty"`
 	MediaType       string `json:"media_type,omitempty"`
@@ -43,7 +42,6 @@ type reactionNotif struct {
 	Instance        string `json:"instance,omitempty"`
 	ContactName     string `json:"contact_name,omitempty"`
 	Emoji           string `json:"emoji,omitempty"`
-	Sender          string `json:"sender,omitempty"`
 	ChatName        string `json:"chat_name,omitempty"`
 	ContactPhone    string `json:"contact_phone,omitempty"`
 	IsRemoved       bool   `json:"is_removed,omitempty"`
@@ -63,7 +61,6 @@ type editNotif struct {
 	Type            string `json:"type"`
 	Instance        string `json:"instance,omitempty"`
 	ContactName     string `json:"contact_name,omitempty"`
-	Sender          string `json:"sender,omitempty"`
 	ChatName        string `json:"chat_name,omitempty"`
 	ContactPhone    string `json:"contact_phone,omitempty"`
 	OldText         string `json:"old_text,omitempty"`
@@ -186,10 +183,6 @@ func WriteNotification(
 	if !ctx.IsDirectChat {
 		n.ChatName = ctx.ChatName
 		n.ReplyHint = "think about how you can best show your personality; this is a group chat, so it may not be expecting a reply from you"
-		// Drop Sender when it's just the same JID as the chat (happens for unsaved group participants).
-		if ctx.Sender != ctx.ChatName {
-			n.Sender = ctx.Sender
-		}
 	}
 	return writeNotificationFile(ctx.NotifDir, n, "message")
 }
@@ -213,23 +206,17 @@ func WriteReactionNotification(
 	}
 	if !ctx.IsDirectChat {
 		n.ChatName = ctx.ChatName
-		if ctx.Sender != ctx.ChatName {
-			n.Sender = ctx.Sender
-		}
 	}
 	return writeNotificationFile(ctx.NotifDir, n, "reaction")
 }
 
 // applyChatContext mirrors the group-chat handling the message and reaction writers do:
-// name the chat, and name the sender unless it is just the chat's own JID.
+// name the group in chat_name. The participant identity rides in contact_name, set for every chat.
 func (n *editNotif) applyChatContext(ctx NotifContext) {
 	if ctx.IsDirectChat {
 		return
 	}
 	n.ChatName = ctx.ChatName
-	if ctx.Sender != ctx.ChatName {
-		n.Sender = ctx.Sender
-	}
 }
 
 func WriteEditNotification(ctx NotifContext, targetMessageID, oldText, newText string) error {

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -13,15 +13,15 @@ func savedCtx(dir string) NotifContext {
 	return NotifContext{
 		NotifDir: dir, Instance: "personal", ChatJID: "4477000111@s.whatsapp.net", ChatName: "Ana",
 		ContactName: "Ana", ContactPhone: "+15551234567",
-		ContactSaved: true, IsDirectChat: true, Sender: "Ana",
+		ContactSaved: true, IsDirectChat: true,
 	}
 }
 
 func unsavedCtx(dir string) NotifContext {
 	return NotifContext{
 		NotifDir: dir, Instance: "personal", ChatJID: "15559998888@s.whatsapp.net", ChatName: "+15559998888",
-		ContactName: "", ContactPhone: "+15559998888",
-		ContactSaved: false, IsDirectChat: true, Sender: "+15559998888",
+		ContactName: "+15559998888", ContactPhone: "+15559998888",
+		ContactSaved: false, IsDirectChat: true,
 	}
 }
 
@@ -76,8 +76,9 @@ func TestUnsavedContactIsIdentifiedByNumber(t *testing.T) {
 	if err := json.Unmarshal(fields["contact_phone"], &phone); err != nil || phone != "+15559998888" {
 		t.Errorf("contact_phone = %q, want the number: it is the only way to reply to someone unsaved", phone)
 	}
-	if _, present := fields["contact_name"]; present {
-		t.Errorf("contact_name is present for an unsaved contact, want it absent")
+	var name string
+	if err := json.Unmarshal(fields["contact_name"], &name); err != nil || name != "+15559998888" {
+		t.Errorf("contact_name = %q, want the number: the single identity field names an unsaved contact too", name)
 	}
 	if _, present := fields["contact_unknown"]; !present {
 		t.Errorf("contact_unknown is absent for an unsaved contact, want it flagged")
@@ -90,6 +91,67 @@ func groupCtx(dir string) NotifContext {
 	ctx.ChatJID = "120363021234567890@g.us"
 	ctx.ChatName = "Bride squad"
 	return ctx
+}
+
+// unsavedGroupCtx is a group message from someone the user has not saved: the identity is the
+// formatted number, and there is no separate group vs participant name to reconcile.
+func unsavedGroupCtx(dir string) NotifContext {
+	ctx := groupCtx(dir)
+	ctx.ContactName = "+15559998888"
+	ctx.ContactPhone = "+15559998888"
+	ctx.ContactSaved = false
+	return ctx
+}
+
+// Identity rides in contact_name alone. A group notification used to carry a second `sender`
+// field that repeated the participant, so pin that no notification, direct or group, saved or
+// unsaved, ever emits one.
+func TestNotificationsCarryNoSeparateSenderField(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ctx  func(string) NotifContext
+	}{
+		{"direct-saved", savedCtx},
+		{"direct-unsaved", unsavedCtx},
+		{"group-saved", groupCtx},
+		{"group-unsaved", unsavedGroupCtx},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := WriteNotification(tc.ctx(dir), "3EB0A1", "hi", "", false, "", ""); err != nil {
+				t.Fatalf("write failed: %v", err)
+			}
+			if _, present := soleNotifFields(t, dir)["sender"]; present {
+				t.Errorf("notification carries a separate sender field; identity must ride in contact_name alone")
+			}
+		})
+	}
+}
+
+// contact_name is the single identity field. It is set for every message, direct or group, and
+// carries the saved name when the contact is saved and the formatted number otherwise.
+func TestContactNameCarriesTheIdentityForEveryMessage(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ctx  func(string) NotifContext
+		want string
+	}{
+		{"direct-saved", savedCtx, "Ana"},
+		{"direct-unsaved", unsavedCtx, "+15559998888"},
+		{"group-saved", groupCtx, "Ana"},
+		{"group-unsaved", unsavedGroupCtx, "+15559998888"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := WriteNotification(tc.ctx(dir), "3EB0A1", "hi", "", false, "", ""); err != nil {
+				t.Fatalf("write failed: %v", err)
+			}
+			var name string
+			if err := json.Unmarshal(soleNotifFields(t, dir)["contact_name"], &name); err != nil || name != tc.want {
+				t.Errorf("contact_name = %q, want %q (the single identity field)", name, tc.want)
+			}
+		})
+	}
 }
 
 func notifChatType(t *testing.T, dir string) string {

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -103,34 +103,11 @@ func unsavedGroupCtx(dir string) NotifContext {
 	return ctx
 }
 
-// Identity rides in contact_name alone. A group notification used to carry a second `sender`
-// field that repeated the participant, so pin that no notification, direct or group, saved or
-// unsaved, ever emits one.
-func TestNotificationsCarryNoSeparateSenderField(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		ctx  func(string) NotifContext
-	}{
-		{"direct-saved", savedCtx},
-		{"direct-unsaved", unsavedCtx},
-		{"group-saved", groupCtx},
-		{"group-unsaved", unsavedGroupCtx},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			if err := WriteNotification(tc.ctx(dir), "3EB0A1", "hi", "", false, "", ""); err != nil {
-				t.Fatalf("write failed: %v", err)
-			}
-			if _, present := soleNotifFields(t, dir)["sender"]; present {
-				t.Errorf("notification carries a separate sender field; identity must ride in contact_name alone")
-			}
-		})
-	}
-}
-
-// contact_name is the single identity field. It is set for every message, direct or group, and
-// carries the saved name when the contact is saved and the formatted number otherwise.
-func TestContactNameCarriesTheIdentityForEveryMessage(t *testing.T) {
+// contact_name is the sole identity field: it is set for every message, direct or group, and
+// carries the saved name when the contact is saved and the formatted number otherwise. A group
+// notification used to carry a second `sender` field that repeated the participant, so this also
+// pins that no notification, direct or group, saved or unsaved, emits one.
+func TestContactNameIsTheSoleIdentityField(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		ctx  func(string) NotifContext
@@ -146,9 +123,13 @@ func TestContactNameCarriesTheIdentityForEveryMessage(t *testing.T) {
 			if err := WriteNotification(tc.ctx(dir), "3EB0A1", "hi", "", false, "", ""); err != nil {
 				t.Fatalf("write failed: %v", err)
 			}
+			fields := soleNotifFields(t, dir)
+			if _, present := fields["sender"]; present {
+				t.Errorf("notification carries a separate sender field; identity must ride in contact_name alone")
+			}
 			var name string
-			if err := json.Unmarshal(soleNotifFields(t, dir)["contact_name"], &name); err != nil || name != tc.want {
-				t.Errorf("contact_name = %q, want %q (the single identity field)", name, tc.want)
+			if err := json.Unmarshal(fields["contact_name"], &name); err != nil || name != tc.want {
+				t.Errorf("contact_name = %q, want %q (the sole identity field)", name, tc.want)
 			}
 		})
 	}

--- a/agent/skills/whatsapp/cli/types.go
+++ b/agent/skills/whatsapp/cli/types.go
@@ -50,15 +50,17 @@ type StoreMessageParams struct {
 }
 
 type NotifContext struct {
-	NotifDir     string
-	ChatJID      string
-	ChatName     string
+	NotifDir string
+	ChatJID  string
+	ChatName string
+	// ContactName is the one identity field a notification carries: the saved contact name when the
+	// sender is saved, otherwise the best human identifier (a formatted number or JID). It is set for
+	// both direct and group chats; in a group, ChatName names the group and this names the participant.
 	ContactName  string
 	ContactPhone string
 	Instance     string
 	ContactSaved bool
 	IsDirectChat bool
-	Sender       string
 }
 
 type MediaInfo struct {


### PR DESCRIPTION
## What

WhatsApp notifications carried two identity fields, `contact_name` and `sender`, which restated each other. For a saved contact the code set the display sender equal to the contact name, so a group-chat notification showed `contact_name="Emmy"` and `sender="Emmy"`: pure noise. There was also a `ctx.Sender != ctx.ChatName` dedup branch that dropped `sender` for unsaved group participants, one more special case.

This collapses the two into `contact_name`, the single identity a notification names:

- `contact_name` carries the saved contact name when the sender is saved, and the best available human identifier (the formatted number or JID, the same value `senderDisplay` already computed for an unsaved contact) otherwise.
- It is now populated for **both** direct and group chats. In a group, `chat_name` keeps naming the group and `contact_name` names the participant.
- The `sender` field is removed from `messageNotif`, `reactionNotif`, and `editNotif`, along with the `Sender` plumbing on `NotifContext`/`buildNotifContext` and the `ctx.Sender != ctx.ChatName` dedup logic.
- `contact_phone` behavior is unchanged (still omitted for saved contacts via `notifPhone`).

## Notification rules still match

The rule matcher's `sender` alias spans every identity field (`_IDENTITY_FIELDS = ("sender", "contact_name", "handle", ...)` in `agent/core/notification_interrupt_policy.py`), so a user rule written against `sender` or `contact_name` still matches, now on `contact_name`. The server-projected `event.sender` clients read is derived by `notif_sender` from those same identity fields, so it falls through to `contact_name` unchanged: no client edit needed.

## Schema doc

The only notification-JSON-schema doc (`agent/skills/vestad/SKILL.md`) is source-agnostic and never enumerated the WhatsApp `sender` field, so it needs no change. No SKILL.md names the removed field either; the `--sender` references in `notifications/SKILL.md` are the matcher alias and stay correct.

## Tests (TDD)

- `TestNotificationsCarryNoSeparateSenderField`: no notification (direct/group, saved/unsaved) emits a `sender` field.
- `TestContactNameCarriesTheIdentityForEveryMessage` and updated `TestUnsavedContactIsIdentifiedByNumber`: `contact_name` is set and correct for every case, including unsaved direct (now the number).
- `TestBuildNotifContextFoldsSenderDisplayIntoContactName`: the merge at the build layer.

`./check.sh whatsapp` (gofmt, `go vet`, `go build`, full `go test`) passes locally.

## Merge-order note

This overlaps `notifications.go` and touches the same skill area as a sibling PR (unique-names / reply-command). Depending on merge order it may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KNWDABuK3z8sqveBBdPr