### PR TITLE
feat(voice,whatsapp): provider-agnostic STT with whisper fallback

### DIFF
--- a/agent/skills/voice/cli/src/voice/config.py
+++ b/agent/skills/voice/cli/src/voice/config.py
@@ -60,6 +60,27 @@ def mutate(data_dir: pl.Path, updater: tp.Callable[[VoiceConfig], VoiceConfig]) 
     return new
 
 
+def provider_name(entry: Domain | None) -> str | None:
+    """The domain's configured provider name, or None when unset."""
+    if not entry or "provider" not in entry:
+        return None
+    name = entry["provider"]
+    return name if isinstance(name, str) and name else None
+
+
+def provider_creds(entry: Domain, provider: str) -> dict[str, str]:
+    """The credentials stored for one provider under a domain, or an empty dict."""
+    creds = entry["credentials"] if "credentials" in entry else None
+    if not isinstance(creds, dict) or provider not in creds:
+        return {}
+    value = creds[provider]
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def is_enabled(entry: Domain | None) -> bool:
+    return bool(entry and "enabled" in entry and entry["enabled"])
+
+
 def _credentials(entry: Domain) -> dict[str, dict[str, str]]:
     creds = entry["credentials"] if "credentials" in entry else {}
     return dict(creds) if isinstance(creds, dict) else {}

--- a/agent/skills/voice/cli/src/voice/config.py
+++ b/agent/skills/voice/cli/src/voice/config.py
@@ -70,10 +70,8 @@ def provider_name(entry: Domain | None) -> str | None:
 
 def provider_creds(entry: Domain, provider: str) -> dict[str, str]:
     """The credentials stored for one provider under a domain, or an empty dict."""
-    creds = entry["credentials"] if "credentials" in entry else None
-    if not isinstance(creds, dict) or provider not in creds:
-        return {}
-    value = creds[provider]
+    creds = _credentials(entry)
+    value = creds[provider] if provider in creds else {}
     return dict(value) if isinstance(value, dict) else {}
 
 

--- a/agent/skills/voice/cli/src/voice/handlers.py
+++ b/agent/skills/voice/cli/src/voice/handlers.py
@@ -62,21 +62,6 @@ def _spawn_invalidation(scope: str) -> None:
     task.add_done_callback(_INVALIDATION_TASKS.discard)
 
 
-def _provider_name(entry: voice_config.Domain | None) -> str | None:
-    """The domain's configured provider name, or None when unset."""
-    if not entry or "provider" not in entry:
-        return None
-    name = entry["provider"]
-    return name if isinstance(name, str) and name else None
-
-
-def _provider_creds(entry: voice_config.Domain, provider_name: str) -> dict[str, str]:
-    creds = entry["credentials"] if "credentials" in entry else None
-    if not isinstance(creds, dict) or provider_name not in creds:
-        return {}
-    return creds[provider_name]
-
-
 def _resolve_domain(
     domain: tp.Literal["stt", "tts"],
 ) -> tuple[dict, str, tp.Any, dict[str, str]] | web.Response:
@@ -86,13 +71,13 @@ def _resolve_domain(
     """
     cfg = voice_config.load(DATA_DIR)
     entry = cfg[domain]
-    provider_name = _provider_name(entry)
+    provider_name = voice_config.provider_name(entry)
     if not entry or provider_name is None:
         return web.json_response({"error": f"{domain.upper()} not configured"}, status=503)
     provider = providers.get_stt(provider_name) if domain == "stt" else providers.get_tts(provider_name)
     if not provider:
         return web.json_response({"error": f"unknown {domain} provider: {provider_name}"}, status=500)
-    return entry, provider_name, provider, _provider_creds(entry, provider_name)
+    return entry, provider_name, provider, voice_config.provider_creds(entry, provider_name)
 
 
 async def _json_body(request: web.Request) -> dict | web.Response:
@@ -128,7 +113,7 @@ async def stt_status(_request: web.Request) -> web.Response:
     cfg = voice_config.load(DATA_DIR)
     stt_entry = cfg["stt"]
 
-    provider_name = _provider_name(stt_entry)
+    provider_name = voice_config.provider_name(stt_entry)
     if not stt_entry or provider_name is None:
         return web.json_response({"configured": False, "provider": None})
 
@@ -223,7 +208,7 @@ async def tts_status(_request: web.Request) -> web.Response:
     cfg = voice_config.load(DATA_DIR)
     tts_entry = cfg["tts"]
 
-    provider_name = _provider_name(tts_entry)
+    provider_name = voice_config.provider_name(tts_entry)
     if not tts_entry or provider_name is None:
         return web.json_response({"configured": False, "provider": None})
 

--- a/agent/skills/voice/cli/src/voice/providers/base.py
+++ b/agent/skills/voice/cli/src/voice/providers/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pathlib as pl
 import typing as tp
 
 from aiohttp import web
@@ -29,6 +30,10 @@ class SttProvider(tp.Protocol):
 
     async def relay(self, browser_ws: web.WebSocketResponse, creds: dict[str, str], stt_domain: dict) -> None:
         """Open upstream STT connection, relay audio frames <-> transcript events."""
+        ...
+
+    async def transcribe_file(self, audio_path: pl.Path, creds: dict[str, str], stt_domain: dict) -> str:
+        """One-shot transcription of an audio file. Returns the trimmed transcript, empty when none."""
         ...
 
     async def usage(self, creds: dict[str, str]) -> dict:

--- a/agent/skills/voice/cli/src/voice/providers/deepgram.py
+++ b/agent/skills/voice/cli/src/voice/providers/deepgram.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import pathlib as pl
 import typing as tp
 from urllib.parse import urlencode
 
@@ -19,6 +20,10 @@ MODEL = "flux-general-en"
 MODEL_MULTI = "nova-3"
 ENCODING = "linear16"
 SAMPLE_RATE = 16000
+
+# Prerecorded (one-shot file) transcription, used by `voice-keys transcribe`.
+PRERECORDED_MODEL = "nova-3"
+PRERECORDED_TIMEOUT_SECS = 30
 
 
 class DeepgramStt:
@@ -117,6 +122,23 @@ class DeepgramStt:
         finally:
             await session.close()
 
+    async def transcribe_file(self, audio_path: pl.Path, creds: dict[str, str], stt_domain: dict) -> str:
+        api_key = creds.get("api_key")
+        if not api_key:
+            raise ValueError("missing deepgram api_key")
+        url = f"{DEEPGRAM_API}/v1/listen?{urlencode(_prerecorded_params(stt_domain))}"
+        headers = {"Authorization": f"Token {api_key}", "Content-Type": "audio/*"}
+        audio = await asyncio.to_thread(audio_path.read_bytes)
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(url, data=audio, headers=headers, timeout=aiohttp.ClientTimeout(total=PRERECORDED_TIMEOUT_SECS)) as resp,
+        ):
+            if resp.status != 200:
+                body = await resp.text()
+                raise RuntimeError(f"deepgram returned {resp.status}: {body}")
+            data = await resp.json()
+        return _prerecorded_transcript(data)
+
     async def _cached_project_id(self, api_key: str) -> str | None:
         if (cached := self._project_id_cache.get(api_key)) is not None:
             return cached
@@ -205,6 +227,35 @@ def _listen_url(stt_domain: dict, multi_language: bool) -> str:
         params.append((keyterm_param, term))
     # Build the URL only after keyterms are appended, otherwise they are dropped.
     return f"{DEEPGRAM_WS}{listen_path}?{urlencode(params)}"
+
+
+def _prerecorded_language(stt_domain: dict) -> str | None:
+    """The prerecorded language param: "multi" for multi-language, an explicit code, or None."""
+    if stt_domain.get("multi_language"):
+        return "multi"
+    language = stt_domain.get("language")
+    if isinstance(language, str) and language and language != "auto":
+        return language
+    return None
+
+
+def _prerecorded_params(stt_domain: dict) -> list[tuple[str, str]]:
+    params = [("model", PRERECORDED_MODEL), ("smart_format", "true")]
+    language = _prerecorded_language(stt_domain)
+    if language:
+        params.append(("language", language))
+    return params
+
+
+def _prerecorded_transcript(body: dict) -> str:
+    results = body.get("results") or {}
+    channels = results.get("channels") or []
+    if not channels:
+        return ""
+    alternatives = channels[0].get("alternatives") or []
+    if not alternatives:
+        return ""
+    return (alternatives[0].get("transcript") or "").strip()
 
 
 async def _browser_to_deepgram(browser_ws: web.WebSocketResponse, dg_ws: aiohttp.ClientWebSocketResponse) -> None:

--- a/agent/skills/voice/cli/src/voice/voice_keys.py
+++ b/agent/skills/voice/cli/src/voice/voice_keys.py
@@ -3,6 +3,7 @@
 
 Commands:
   status
+  transcribe <path>
   validate --provider {deepgram|elevenlabs} --key <k>
   set-key  --domain {stt|tts} --provider <p> --key <k>
   clear    --domain {stt|tts}
@@ -61,6 +62,34 @@ def _print(config: vc.VoiceConfig) -> None:
 
 def cmd_status(_args: argparse.Namespace) -> int:
     _print(vc.load(_data_dir()))
+    return 0
+
+
+async def _transcribe(path: str) -> str:
+    """Run the configured STT provider over one audio file. Raises on any config or provider fault."""
+    entry = vc.load(_data_dir())["stt"]
+    name = vc.provider_name(entry)
+    if not entry or name is None:
+        raise RuntimeError("STT not configured")
+    if not vc.is_enabled(entry):
+        raise RuntimeError("STT disabled")
+    provider = providers.get_stt(name)
+    if provider is None:
+        raise RuntimeError(f"unknown STT provider: {name}")
+    creds = vc.provider_creds(entry, name)
+    if not creds:
+        raise RuntimeError(f"no credentials for STT provider: {name}")
+    return await provider.transcribe_file(pl.Path(path), creds, dict(entry))
+
+
+def cmd_transcribe(args: argparse.Namespace) -> int:
+    """One-shot transcription: transcript to stdout, a JSON error to stderr, so a caller can fall back."""
+    try:
+        transcript = asyncio.run(_transcribe(args.path))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        return 1
+    print(transcript)
     return 0
 
 
@@ -186,6 +215,10 @@ def _build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="cmd")
 
     sub.add_parser("status").set_defaults(func=cmd_status)
+
+    p_transcribe = sub.add_parser("transcribe", help="Transcribe one audio file with the configured STT provider")
+    p_transcribe.add_argument("path")
+    p_transcribe.set_defaults(func=cmd_transcribe)
 
     p_validate = sub.add_parser("validate")
     p_validate.add_argument("--provider", required=True)

--- a/agent/skills/voice/cli/tests/test_transcribe.py
+++ b/agent/skills/voice/cli/tests/test_transcribe.py
@@ -1,0 +1,147 @@
+"""One-shot transcription: Deepgram prerecorded parsing + the voice-keys transcribe command."""
+
+import pathlib as pl
+import typing as tp
+
+import pytest
+from voice import config as vc
+from voice import voice_keys
+from voice.providers import deepgram
+
+
+def test_prerecorded_transcript_reads_first_alternative() -> None:
+    body = {"results": {"channels": [{"alternatives": [{"transcript": "  ciao come stai  "}]}]}}
+    assert deepgram._prerecorded_transcript(body) == "ciao come stai"
+
+
+def test_prerecorded_transcript_empty_when_no_channels() -> None:
+    assert deepgram._prerecorded_transcript({"results": {"channels": []}}) == ""
+    assert deepgram._prerecorded_transcript({}) == ""
+
+
+def test_prerecorded_transcript_empty_when_no_alternatives() -> None:
+    assert deepgram._prerecorded_transcript({"results": {"channels": [{"alternatives": []}]}}) == ""
+
+
+def test_prerecorded_language_prefers_multi() -> None:
+    assert deepgram._prerecorded_language({"multi_language": True, "language": "it"}) == "multi"
+
+
+def test_prerecorded_language_reads_explicit_code() -> None:
+    assert deepgram._prerecorded_language({"language": "it"}) == "it"
+
+
+def test_prerecorded_language_none_for_auto_or_absent() -> None:
+    assert deepgram._prerecorded_language({"language": "auto"}) is None
+    assert deepgram._prerecorded_language({}) is None
+
+
+def test_prerecorded_params_always_carry_model_and_smart_format() -> None:
+    params = dict(deepgram._prerecorded_params({}))
+    assert params["model"] == deepgram.PRERECORDED_MODEL
+    assert params["smart_format"] == "true"
+    assert "language" not in params
+
+
+def test_prerecorded_params_carry_language_when_set() -> None:
+    params = dict(deepgram._prerecorded_params({"language": "it"}))
+    assert params["language"] == "it"
+
+
+class _FakeStt:
+    name = "deepgram"
+
+    def __init__(self, transcript: str | None, error: Exception | None = None) -> None:
+        self._transcript = transcript
+        self._error = error
+        self.seen: dict[str, tp.Any] = {}
+
+    async def transcribe_file(self, audio_path: pl.Path, creds: dict[str, str], stt_domain: dict) -> str:
+        self.seen = {"audio_path": audio_path, "creds": creds, "stt_domain": stt_domain}
+        if self._error is not None:
+            raise self._error
+        assert self._transcript is not None
+        return self._transcript
+
+
+def _configure_stt(tmp_path: pl.Path, *, enabled: bool = True) -> None:
+    vc.set_key(tmp_path, "stt", "deepgram", "dg-key")
+    vc.set_enabled(tmp_path, "stt", enabled)
+
+
+def test_transcribe_prints_only_transcript(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _configure_stt(tmp_path)
+    fake = _FakeStt("ciao come stai")
+    monkeypatch.setattr(voice_keys, "_data_dir", lambda: tmp_path)
+    monkeypatch.setattr(voice_keys.providers, "get_stt", lambda _name: fake)
+    audio = tmp_path / "note.ogg"
+    audio.write_bytes(b"opus")
+
+    code = voice_keys.main(["transcribe", str(audio)])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() == "ciao come stai"
+    assert captured.err == ""
+    assert fake.seen["creds"] == {"api_key": "dg-key"}
+    assert fake.seen["audio_path"] == audio
+
+
+def test_transcribe_not_configured_errors_on_stderr(
+    tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(voice_keys, "_data_dir", lambda: tmp_path)
+
+    code = voice_keys.main(["transcribe", str(tmp_path / "note.ogg")])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out == ""
+    assert "error" in captured.err
+    assert "not configured" in captured.err
+
+
+def test_transcribe_disabled_errors(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _configure_stt(tmp_path, enabled=False)
+    monkeypatch.setattr(voice_keys, "_data_dir", lambda: tmp_path)
+
+    code = voice_keys.main(["transcribe", str(tmp_path / "note.ogg")])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out == ""
+    assert "disabled" in captured.err
+
+
+def test_transcribe_provider_error_errors(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _configure_stt(tmp_path)
+    fake = _FakeStt(None, error=RuntimeError("deepgram returned 500"))
+    monkeypatch.setattr(voice_keys, "_data_dir", lambda: tmp_path)
+    monkeypatch.setattr(voice_keys.providers, "get_stt", lambda _name: fake)
+    audio = tmp_path / "note.ogg"
+    audio.write_bytes(b"opus")
+
+    code = voice_keys.main(["transcribe", str(audio)])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out == ""
+    assert "deepgram returned 500" in captured.err
+
+
+def test_transcribe_empty_transcript_is_clean_success(
+    tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _configure_stt(tmp_path)
+    fake = _FakeStt("")
+    monkeypatch.setattr(voice_keys, "_data_dir", lambda: tmp_path)
+    monkeypatch.setattr(voice_keys.providers, "get_stt", lambda _name: fake)
+    audio = tmp_path / "note.ogg"
+    audio.write_bytes(b"opus")
+
+    code = voice_keys.main(["transcribe", str(audio)])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() == ""
+    assert captured.err == ""

--- a/agent/skills/whatsapp/cli/transcribe.go
+++ b/agent/skills/whatsapp/cli/transcribe.go
@@ -178,9 +178,10 @@ func readWAVSamples(path string) ([]float32, error) {
 // a real transcription. whisper.cpp emits bracketed tags ("[Musica]",
 // "[BLANK_AUDIO]", "[Musik]", "[tk]") for near-silent or low-content clips
 // instead of returning an error, and those would otherwise reach the agent as if
-// they were the transcript. Treat empty/whitespace or any single "[...]" tag-only
-// result as silence. (arxiv 2501.11378 documents the hallucination mode.)
-var tagOnlyRe = regexp.MustCompile(`^\[[^\[\]]+\]\s*$`)
+// they were the transcript. Treat empty/whitespace or a result made only of
+// "[...]" tags (a multi-segment silent clip joins several) as silence. (arxiv
+// 2501.11378 documents the hallucination mode.)
+var tagOnlyRe = regexp.MustCompile(`^(\s*\[[^\[\]]+\]\s*)+$`)
 
 func whisperOutputJunk(text string) bool {
 	t := strings.TrimSpace(text)

--- a/agent/skills/whatsapp/cli/transcribe.go
+++ b/agent/skills/whatsapp/cli/transcribe.go
@@ -1,18 +1,28 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper"
 	wav "github.com/go-audio/wav"
 )
+
+// voiceSttTimeout bounds the `voice-keys transcribe` shellout so a hung provider
+// call never wedges the whatsapp daemon's message path.
+const voiceSttTimeout = 30 * time.Second
 
 var (
 	whisperModel     whisper.Model
@@ -164,6 +174,72 @@ func readWAVSamples(path string) ([]float32, error) {
 	return samples, nil
 }
 
+// whisperOutputJunk reports whether whisper's output is a silence tag rather than
+// a real transcription. whisper.cpp emits bracketed tags ("[Musica]",
+// "[BLANK_AUDIO]", "[Musik]", "[tk]") for near-silent or low-content clips
+// instead of returning an error, and those would otherwise reach the agent as if
+// they were the transcript. Treat empty/whitespace or any single "[...]" tag-only
+// result as silence. (arxiv 2501.11378 documents the hallucination mode.)
+var tagOnlyRe = regexp.MustCompile(`^\[[^\[\]]+\]\s*$`)
+
+func whisperOutputJunk(text string) bool {
+	t := strings.TrimSpace(text)
+	return t == "" || tagOnlyRe.MatchString(t)
+}
+
+// transcribeViaVoiceStt shells the voice skill's provider-agnostic transcriber.
+// A clean exit (STT configured+enabled and the provider answered) yields the
+// transcript; any failure (unconfigured, disabled, provider error, command
+// absent, timeout) returns an error so the caller falls back to whisper.
+func transcribeViaVoiceStt(audioPath string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), voiceSttTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "voice-keys", "transcribe", audioPath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if runErr := cmd.Run(); runErr != nil {
+		return "", parseVoiceSttError(stderr.Bytes(), runErr, ctx.Err() == context.DeadlineExceeded)
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// parseVoiceSttError turns a failed `voice-keys transcribe` run into one clear
+// error: the structured {error} the command prints on stderr, a timeout, a
+// missing command, or a bare exit failure.
+func parseVoiceSttError(stderr []byte, runErr error, timedOut bool) error {
+	if timedOut {
+		return fmt.Errorf("voice STT timed out")
+	}
+	var resp struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(bytes.TrimSpace(stderr), &resp) == nil && resp.Error != "" {
+		return fmt.Errorf("voice STT: %s", resp.Error)
+	}
+	if errors.Is(runErr, exec.ErrNotFound) {
+		return fmt.Errorf("voice-keys not on PATH")
+	}
+	return fmt.Errorf("voice STT failed: %w", runErr)
+}
+
+// transcriptDecision keeps voice STT primary and whisper the fallback. A clean
+// STT answer (voiceErr == nil) always wins, even an empty one (genuine silence).
+// Otherwise whisper is used: its error propagates, and a junk (silence-tag)
+// whisper result is dropped to empty rather than delivered as the transcript.
+func transcriptDecision(voiceText string, voiceErr error, whisperText string, whisperErr error) (string, error) {
+	if voiceErr == nil {
+		return voiceText, nil
+	}
+	if whisperErr != nil {
+		return "", whisperErr
+	}
+	if whisperOutputJunk(whisperText) {
+		return "", nil
+	}
+	return whisperText, nil
+}
+
 // Convenience wrapper used by handleMessage. Returns the transcription text and any error.
 func (wac *WhatsAppClient) transcribeAudioMessage(messageID, chatJID string) (string, error) {
 	// Download audio to temp file
@@ -176,14 +252,28 @@ func (wac *WhatsAppClient) transcribeAudioMessage(messageID, chatJID string) (st
 		return "", fmt.Errorf("failed to download audio: %w", err)
 	}
 
-	text, err := transcribeAudioBuiltIn(path)
+	// Primary: the user's configured STT provider, owned by the voice skill.
+	voiceText, voiceErr := transcribeViaVoiceStt(path)
+	if voiceErr == nil {
+		if voiceText != "" {
+			wac.logger.Infof("Transcribed audio %s via voice STT: %s", messageID, voiceText)
+		}
+		return voiceText, nil
+	}
+	wac.logger.Infof("Voice STT unavailable for %s (%v); falling back to whisper", messageID, voiceErr)
+
+	// Fallback: local whisper.cpp.
+	whisperText, whisperErr := transcribeAudioBuiltIn(path)
+	text, err := transcriptDecision(voiceText, voiceErr, whisperText, whisperErr)
 	if err != nil {
-		wac.logger.Warnf("Transcription failed: %v", err)
+		wac.logger.Warnf("Transcription failed for %s: %v", messageID, err)
 		return "", err
 	}
-
-	if text != "" {
-		wac.logger.Infof("Transcribed audio %s: %s", messageID, text)
+	switch {
+	case text != "":
+		wac.logger.Infof("Transcribed audio %s via whisper: %s", messageID, text)
+	case whisperOutputJunk(whisperText):
+		wac.logger.Infof("Whisper produced tag-only/silence %q for %s; treating as no speech", whisperText, messageID)
 	}
 	return text, nil
 }

--- a/agent/skills/whatsapp/cli/transcribe_test.go
+++ b/agent/skills/whatsapp/cli/transcribe_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+)
 
 // The thread budget uses every core on a small box and stays at
 // WhisperMaxThreads on a big one, so one transcription never pins a large
@@ -20,5 +25,103 @@ func TestWhisperThreadsClampsToMaxOnBigBoxes(t *testing.T) {
 		if got := whisperThreads(tc.numCPU); got != tc.want {
 			t.Errorf("whisperThreads(%d) = %d, want %d", tc.numCPU, got, tc.want)
 		}
+	}
+}
+
+// whisper.cpp emits bracketed silence/tags like "[Musica]", "[BLANK_AUDIO]",
+// "[Musik]", "[tk]" instead of erroring on near-silent clips; those must be
+// treated as junk (silence) so we never deliver the tag as a transcript, while
+// a real transcript that merely contains a bracketed word must NOT be dropped.
+// The regex anchors to the whole string, which is what makes the distinction.
+func TestWhisperOutputJunk(t *testing.T) {
+	junk := []string{
+		"",
+		"   ",
+		"\t\n",
+		"[Musica]",
+		"[BLANK_AUDIO]",
+		"[Musik]",
+		"[tk]",
+		"[Musica]  ", // trailing whitespace still tag-only
+	}
+	for _, in := range junk {
+		if !whisperOutputJunk(in) {
+			t.Errorf("whisperOutputJunk(%q) = false, want true", in)
+		}
+	}
+	real := []string{
+		"Ciao, come stai?",
+		"See you at [the pub] later",   // bracketed word inside a real transcript
+		"[Musica] and then he said go", // tag plus real content
+		"uh [tk] hmm actually no",
+		"x",
+	}
+	for _, in := range real {
+		if whisperOutputJunk(in) {
+			t.Errorf("whisperOutputJunk(%q) = true, want false", in)
+		}
+	}
+}
+
+// transcriptDecision keeps voice STT primary and whisper the fallback: a clean
+// STT answer (voiceErr == nil) always wins, even an empty one (genuine silence);
+// otherwise whisper is used, its error propagates, and a junk (silence-tag)
+// whisper result is dropped to empty rather than delivered.
+func TestTranscriptDecision(t *testing.T) {
+	whisperFail := errors.New("whisper boom")
+	voiceFail := errors.New("voice unavailable")
+	cases := []struct {
+		name        string
+		voiceText   string
+		voiceErr    error
+		whisperText string
+		whisperErr  error
+		wantText    string
+		wantErr     bool
+	}{
+		{name: "stt wins", voiceText: "ciao", voiceErr: nil, whisperText: "whatever", wantText: "ciao"},
+		{name: "stt empty is authoritative", voiceText: "", voiceErr: nil, whisperText: "[Musica]", wantText: ""},
+		{name: "fallback to whisper", voiceErr: voiceFail, whisperText: "hello there", wantText: "hello there"},
+		{name: "whisper junk dropped", voiceErr: voiceFail, whisperText: "[Musica]", wantText: ""},
+		{name: "both fail", voiceErr: voiceFail, whisperErr: whisperFail, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := transcriptDecision(tc.voiceText, tc.voiceErr, tc.whisperText, tc.whisperErr)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("transcriptDecision(%q) err = nil, want error", tc.name)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("transcriptDecision(%q) err = %v, want nil", tc.name, err)
+			}
+			if got != tc.wantText {
+				t.Errorf("transcriptDecision(%q) = %q, want %q", tc.name, got, tc.wantText)
+			}
+		})
+	}
+}
+
+// parseVoiceSttError turns a failed `voice-keys transcribe` run into one clear
+// error: the structured {error} from stderr, a timeout, a missing command, or a
+// bare exit failure, so the fallback log names why STT did not answer.
+func TestParseVoiceSttError(t *testing.T) {
+	exit := &exec.ExitError{}
+	notFound := &exec.Error{Name: "voice-keys", Err: exec.ErrNotFound}
+
+	if err := parseVoiceSttError([]byte(`{"error":"STT not configured"}`), exit, false); err == nil ||
+		!strings.Contains(err.Error(), "STT not configured") {
+		t.Errorf("structured error = %v, want it to carry the stderr reason", err)
+	}
+	if err := parseVoiceSttError(nil, exit, true); err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("timeout error = %v, want a timeout message", err)
+	}
+	if err := parseVoiceSttError(nil, notFound, false); err == nil || !strings.Contains(err.Error(), "PATH") {
+		t.Errorf("missing-command error = %v, want a PATH message", err)
+	}
+	if err := parseVoiceSttError([]byte("not json"), exit, false); err == nil {
+		t.Errorf("bare failure error = nil, want a non-nil error")
 	}
 }

--- a/agent/skills/whatsapp/cli/transcribe_test.go
+++ b/agent/skills/whatsapp/cli/transcribe_test.go
@@ -42,7 +42,9 @@ func TestWhisperOutputJunk(t *testing.T) {
 		"[BLANK_AUDIO]",
 		"[Musik]",
 		"[tk]",
-		"[Musica]  ", // trailing whitespace still tag-only
+		"[Musica]  ",                 // trailing whitespace still tag-only
+		"[BLANK_AUDIO][BLANK_AUDIO]", // multi-segment silence joins adjacent tags
+		"[Musica] [Musik]",           // several tags separated by whitespace
 	}
 	for _, in := range junk {
 		if !whisperOutputJunk(in) {


### PR DESCRIPTION
## What

WhatsApp voice-note transcription now uses the user's configured speech-to-text (STT) provider directly, and falls back to local whisper.cpp only when no STT provider is configured or the provider call fails. This **supersedes #1970**, which hardcoded Deepgram inside the WhatsApp Go CLI and read the voice skill's private config file directly. The voice skill owns STT; WhatsApp calls it provider-agnostically.

## Design

**The voice skill owns one-shot transcription.**
- `SttProvider` (`providers/base.py`) gains `transcribe_file(audio_path, creds, stt_domain) -> str`.
- Deepgram implements it against the prerecorded REST endpoint (`POST /v1/listen`, `Authorization: Token`, model `nova-3`, `smart_format=true`, language from the STT domain when set and not `auto`, `multi` for multi-language). It returns the trimmed transcript, empty string when none.
- A new `voice-keys transcribe <path>` command reads the configured STT provider plus credentials from the voice config, runs `transcribe_file`, and prints **only** the transcript to stdout. Any failure (unconfigured, disabled, provider error) prints a JSON `{error}` to stderr and exits non-zero, following the skill output contract, so the caller can fall back.
- Provider/creds/enabled resolution moved to `config.py` (the config-shape owner); `handlers.py` now reuses those helpers instead of its own private copies (one owner per decision).

Extending the existing `voice-keys` entrypoint (rather than adding a new `voice` console script) is deliberate: skill CLIs are editable installs, so a new subcommand ships to the existing fleet on a plain upstream git sync, with no reinstall migration required.

**WhatsApp: voice STT primary, whisper fallback.**
- `transcribeAudioMessage` shells `voice-keys transcribe` first; a clean success is authoritative (even an empty transcript, i.e. genuine silence).
- On any failure it runs local whisper. The junk-tag detector (ported from #1970, anchored whole-string regex) runs on the whisper output alone: a bracketed silence tag like `[Musica]` or `[BLANK_AUDIO]` is dropped to empty rather than delivered as a transcript, while a real transcript that merely contains a bracketed word is kept.
- Go never reads `~/.voice/voice_config.json`; it goes through the command. The shellout has a 30s timeout, captures stdout as the transcript and stderr for logging, and never crashes when voice is absent.

## Tests (TDD)

- Python: Deepgram prerecorded parsing + language selection, and the `voice-keys transcribe` command (success, empty=clean success, not-configured, disabled, provider error).
- Go: `whisperOutputJunk` junk vs real (ported from #1970), `transcriptDecision` (STT wins, empty-STT authoritative, whisper fallback, junk dropped, both-fail error), `parseVoiceSttError`.

## Verification

- `voice` CLI pytest: 36 passed (13 new).
- whatsapp Go: `gofmt` clean, `go vet` clean, `go build` OK, full suite passed.
- Guards: repo ruff check + format, `check-conventions.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KNWDABuK3z8sqveBBdPr