### PR TITLE
feat(whatsapp): unique contact names and name-based reply target

### DIFF
--- a/agent/core/migrations/2026-08-whatsapp-unique-contact-names.md
+++ b/agent/core/migrations/2026-08-whatsapp-unique-contact-names.md
@@ -9,13 +9,15 @@ names that still collide.
 If `~/agent/skills/whatsapp` does not exist, you never installed the skill.
 Skip to the final step.
 
-### 2. List every saved contact
+### 2. List saved contacts
 
 ```bash
 whatsapp list-contacts --limit 1000
 ```
 
-Each entry has a `name` and a `phone_number`.
+Each entry has a `name` and a `phone_number`. Only an entry with `"is_manual": true` is a saved
+contact. An entry without that field is a chat the user never saved: skip it, and use only the
+saved contacts in the next step.
 
 ### 3. Rename apart any name two different people share
 

--- a/agent/core/migrations/2026-08-whatsapp-unique-contact-names.md
+++ b/agent/core/migrations/2026-08-whatsapp-unique-contact-names.md
@@ -1,0 +1,45 @@
+Every saved WhatsApp contact name must point at one person. A reply to a direct
+WhatsApp message addresses a saved contact by name, so two different people
+saved under the same name make that reply fail as ambiguous. This migration
+renames such contacts apart. It is safe to run more than once: it only renames
+names that still collide.
+
+### 1. Skip if WhatsApp is not set up
+
+If `~/agent/skills/whatsapp` does not exist, you never installed the skill.
+Skip to the final step.
+
+### 2. List every saved contact
+
+```bash
+whatsapp list-contacts --limit 1000
+```
+
+Each entry has a `name` and a `phone_number`.
+
+### 3. Rename apart any name two different people share
+
+Group the contacts by name, ignoring case and surrounding spaces. A name is a
+problem only when two or more genuinely different people hold it. One person
+saved under both a phone number and a chat id is not a collision, so leave them.
+
+For each name that two different people share, give all but one of them a
+distinct name. Address each by their exact phone number, so the rename updates
+that person and not the other:
+
+```bash
+whatsapp add-contact --name "Emmy R" --phone "+447700900123"
+```
+
+Pick a name that tells them apart from what you know about them: a surname
+initial, their relationship, or where you know them from. Do not invent a detail
+you do not know. If you cannot tell two people apart, ask the user which name
+each should have.
+
+A colliding contact with no phone number is saved by a chat id, which this list
+does not show. Rename the others instead, so the bare name points at that one
+person.
+
+### 4. Mark this migration applied
+
+Call `mark_migration_applied` with `name="2026-08-whatsapp-unique-contact-names"`.

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -65,6 +65,7 @@ same here
 MSG
 ```
 - Before texting an unknown raw number, save it first with `add-contact` (name + phone). A chat WhatsApp shows only as an id (`...@lid`) has no number to save, so save it by that id instead: `add-contact --name <name> --chat <chat_jid>`.
+- Give each contact a distinct name. `add-contact` refuses a name another number already holds, so a saved name always points at one person and a reply can address them by name. When it refuses, pick a name that tells them apart (e.g. `Emmy R`).
 
 **Error 463, `no signal session for this device yet`.** The send fails for one recipient while
 everyone else succeeds on the same number and daemon, so it looks like local state you can repair.

--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -255,23 +255,75 @@ func (wac *WhatsAppClient) resolveRecipientJID(identifier string) (types.JID, er
 		return types.NewJID(identifier, types.DefaultUserServer), nil
 	}
 
-	// Search contacts by name
-	contacts, err := wac.store.SearchContacts(identifier, 50)
-	if err == nil {
+	// Both are searched with the same name-filtered query, cheap enough to run together so a name
+	// that reaches both a contact and a group can be caught before either resolves.
+	contacts, contactsErr := wac.store.SearchContacts(identifier, 50)
+	groups, groupsErr := wac.store.SearchGroups(identifier, 50)
+
+	// A bare name that exactly matches both a saved contact and a group is ambiguous: refuse it so a
+	// message never goes silently to the wrong one. The contact is the one name the caller controls,
+	// so the remedy renames it; the contact stays reachable meanwhile by their phone number.
+	if contactsErr == nil && groupsErr == nil && hasExactName(contactNames(contacts), identifier) && hasExactName(groupNames(groups), identifier) {
+		return types.JID{}, fmt.Errorf(
+			"'%s' is both a saved contact and a group; give the contact a different name so the name reaches one recipient, or address them by their phone number",
+			identifier,
+		)
+	}
+
+	if contactsErr == nil {
 		if jid, err := wac.resolveFromContacts(contacts, identifier); err != nil || jid.User != "" {
 			return jid, err
 		}
 	}
 
-	// Search groups by name (filtered query avoids loading all groups)
-	groups, err := wac.store.SearchGroups(identifier, 50)
-	if err == nil {
+	if groupsErr == nil {
 		if jid, err := resolveFromGroups(groups, identifier); err != nil || jid.User != "" {
 			return jid, err
 		}
 	}
 
 	return types.JID{}, fmt.Errorf("no contact or group found matching '%s'. Use search_contacts or list_groups to find available recipients", identifier)
+}
+
+// nameEquals is the one owner of "these two names are the same recipient name": non-empty, equal
+// once trimmed, ignoring case. Contact and group matching both go through it so they cannot drift.
+func nameEquals(candidate, target string) bool {
+	return candidate != "" && strings.EqualFold(strings.TrimSpace(candidate), strings.TrimSpace(target))
+}
+
+func hasExactName(candidates []string, target string) bool {
+	for _, candidate := range candidates {
+		if nameEquals(candidate, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func contactNames(contacts []Contact) []string {
+	names := make([]string, len(contacts))
+	for i, c := range contacts {
+		names[i] = c.Name
+	}
+	return names
+}
+
+func groupNames(groups []Chat) []string {
+	names := make([]string, len(groups))
+	for i, g := range groups {
+		names[i] = g.Name
+	}
+	return names
+}
+
+// nameSharedWithGroup reports whether a group holds the exact name, used to keep a reply on the chat
+// JID when a saved contact's name would otherwise resolve ambiguously.
+func (wac *WhatsAppClient) nameSharedWithGroup(name string) bool {
+	groups, err := wac.store.SearchGroups(name, 50)
+	if err != nil {
+		return false
+	}
+	return hasExactName(groupNames(groups), name)
 }
 
 func (wac *WhatsAppClient) resolveFromContacts(contacts []Contact, identifier string) (types.JID, error) {
@@ -315,7 +367,7 @@ func (wac *WhatsAppClient) preferExactContactMatch(contacts []Contact, identifie
 
 	var matches []Contact
 	for _, c := range contacts {
-		if c.Name != "" && strings.EqualFold(strings.TrimSpace(c.Name), trimmed) {
+		if nameEquals(c.Name, trimmed) {
 			matches = append(matches, c)
 		}
 	}

--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -334,12 +334,11 @@ func (wac *WhatsAppClient) preferExactContactMatch(contacts []Contact, identifie
 		return types.JID{}, false, nil
 	}
 
+	// At most one row can hold a given non-empty phone number: the jid is the primary key and is
+	// derived from those digits, so a repeat save upserts the same row rather than adding a second.
 	var phoneMatch *Contact
 	for i := range contacts {
 		if digitsOnly(contacts[i].PhoneNumber) == digits {
-			if phoneMatch != nil {
-				return types.JID{}, true, fmt.Errorf("multiple contacts share that phone number. Please specify the exact contact name instead")
-			}
 			phoneMatch = &contacts[i]
 		}
 	}

--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -258,7 +258,7 @@ func (wac *WhatsAppClient) resolveRecipientJID(identifier string) (types.JID, er
 	// Search contacts by name
 	contacts, err := wac.store.SearchContacts(identifier, 50)
 	if err == nil {
-		if jid, err := resolveFromContacts(contacts, identifier); err != nil || jid.User != "" {
+		if jid, err := wac.resolveFromContacts(contacts, identifier); err != nil || jid.User != "" {
 			return jid, err
 		}
 	}
@@ -274,12 +274,12 @@ func (wac *WhatsAppClient) resolveRecipientJID(identifier string) (types.JID, er
 	return types.JID{}, fmt.Errorf("no contact or group found matching '%s'. Use search_contacts or list_groups to find available recipients", identifier)
 }
 
-func resolveFromContacts(contacts []Contact, identifier string) (types.JID, error) {
+func (wac *WhatsAppClient) resolveFromContacts(contacts []Contact, identifier string) (types.JID, error) {
 	if len(contacts) == 0 {
 		return types.JID{}, nil
 	}
 
-	if jid, handled, err := preferExactContactMatch(contacts, identifier); handled {
+	if jid, handled, err := wac.preferExactContactMatch(contacts, identifier); handled {
 		return jid, err
 	}
 
@@ -307,7 +307,7 @@ func resolveFromContacts(contacts []Contact, identifier string) (types.JID, erro
 		identifier, strings.Join(names, ", "))
 }
 
-func preferExactContactMatch(contacts []Contact, identifier string) (types.JID, bool, error) {
+func (wac *WhatsAppClient) preferExactContactMatch(contacts []Contact, identifier string) (types.JID, bool, error) {
 	trimmed := strings.TrimSpace(identifier)
 	if trimmed == "" {
 		return types.JID{}, false, nil
@@ -321,7 +321,7 @@ func preferExactContactMatch(contacts []Contact, identifier string) (types.JID, 
 	}
 
 	if len(matches) > 1 {
-		return types.JID{}, true, fmt.Errorf("multiple contacts share the exact name '%s'. Please disambiguate with the precise phone number (+1234567890)", identifier)
+		return wac.collapseSamePeerMatches(matches, identifier)
 	}
 
 	if len(matches) == 1 {
@@ -350,6 +350,31 @@ func preferExactContactMatch(contacts []Contact, identifier string) (types.JID, 
 
 	jid, err := types.ParseJID(phoneMatch.JID)
 	return jid, true, err
+}
+
+// collapseSamePeerMatches folds exact-name matches that resolve to one peer into that peer's
+// deliverable phone JID: one person holds a row under each key form (phone JID and LID), so a name
+// held under both is not ambiguous. It reuses canonicalChatJID, the one owner of peer identity, so
+// the collapse cannot disagree with the send gate about who two rows are. canonicalChatJID resolves
+// a LID to its phone JID, so the returned identity is the deliverable phone form. The name stays
+// ambiguous only when the matches are genuinely different peers.
+func (wac *WhatsAppClient) collapseSamePeerMatches(matches []Contact, identifier string) (types.JID, bool, error) {
+	var peer types.JID
+	for _, c := range matches {
+		jid, err := types.ParseJID(c.JID)
+		if err != nil {
+			return types.JID{}, true, err
+		}
+		canonical := wac.canonicalChatJID(jid)
+		if peer.IsEmpty() {
+			peer = canonical
+			continue
+		}
+		if canonical.String() != peer.String() {
+			return types.JID{}, true, fmt.Errorf("multiple contacts share the exact name '%s'. Please disambiguate with the precise phone number (+1234567890)", identifier)
+		}
+	}
+	return peer, true, nil
 }
 
 func resolveFromGroups(groups []Chat, identifier string) (types.JID, error) {

--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -10,7 +10,51 @@ import (
 )
 
 func (wac *WhatsAppClient) AddContact(name, phone string) (Contact, error) {
+	if digits, _, err := normalizePhoneInput(phone); err == nil {
+		peer := wac.canonicalChatJID(types.NewJID(digits, types.DefaultUserServer))
+		if err := wac.rejectDuplicateContactName(name, peer); err != nil {
+			return Contact{}, err
+		}
+	}
 	return wac.store.SaveManualContact(name, phone)
+}
+
+// rejectDuplicateContactName keeps every saved name pointing at one person, so `whatsapp send --to
+// '<name>'` and the reply command that emits a name are never ambiguous. The peer's own rows are
+// excluded: one person holds a row under each of their key forms (phone JID and LID), so re-saving
+// or renaming the same person is an update, never a clash. The match is case-insensitive and trimmed
+// so a near-copy cannot reintroduce the ambiguity.
+func (wac *WhatsAppClient) rejectDuplicateContactName(name string, peer types.JID) error {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return nil
+	}
+	existing, err := wac.store.ManualContactsByName(trimmed)
+	if err != nil {
+		return fmt.Errorf("failed to check for a duplicate contact name: %v", err)
+	}
+	own := make(map[string]struct{})
+	for _, key := range wac.contactKeys(peer) {
+		own[key] = struct{}{}
+	}
+	for _, contact := range existing {
+		if _, mine := own[contact.JID]; mine {
+			continue
+		}
+		return fmt.Errorf(
+			"a contact named '%s' already exists (%s); choose a distinct name like '%s R' so a reply names one person",
+			trimmed, contactLabel(contact), trimmed,
+		)
+	}
+	return nil
+}
+
+// contactLabel names the peer already holding a name, its number when known, otherwise its chat id.
+func contactLabel(contact Contact) string {
+	if contact.PhoneNumber != "" {
+		return contact.PhoneNumber
+	}
+	return contact.JID
 }
 
 // AddContactByChat saves a contact for a chat given by its own id, the form for a peer WhatsApp
@@ -35,6 +79,9 @@ func (wac *WhatsAppClient) AddContactByChat(name, chat string) (Contact, error) 
 		return Contact{}, fmt.Errorf("'%s' is a group, not a person; only people need a saved contact", chat)
 	}
 	peer := wac.canonicalChatJID(jid)
+	if err := wac.rejectDuplicateContactName(name, peer); err != nil {
+		return Contact{}, err
+	}
 	if peer.Server == types.DefaultUserServer {
 		return wac.store.SaveManualContact(name, "+"+peer.User)
 	}

--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -379,7 +379,7 @@ func (wac *WhatsAppClient) collapseSamePeerMatches(matches []Contact, identifier
 	}
 	if len(seen) > 1 {
 		return types.JID{}, true, fmt.Errorf(
-			"multiple contacts share the exact name '%s' (%s); address one by their exact phone number, or give one a distinct name so the name points at one person",
+			"multiple contacts share the exact name '%s' (%s); address one by their exact phone number, or give one a different name",
 			identifier, strings.Join(labels, ", "),
 		)
 	}

--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -319,6 +319,9 @@ func groupNames(groups []Chat) []string {
 // nameSharedWithGroup reports whether a group holds the exact name, used to keep a reply on the chat
 // JID when a saved contact's name would otherwise resolve ambiguously.
 func (wac *WhatsAppClient) nameSharedWithGroup(name string) bool {
+	if wac.store == nil {
+		return false
+	}
 	groups, err := wac.store.SearchGroups(name, 50)
 	if err != nil {
 		return false

--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -565,10 +565,11 @@ func (wac *WhatsAppClient) formatSenderForDisplay(jid types.JID) string {
 func (wac *WhatsAppClient) prepareNotificationInfo(info types.MessageSource) (
 	resolvedSender types.JID,
 	senderDisplay string,
-	contactName, contactPhone string,
+	contactPhone string,
 	contactSaved, isDirectChat bool,
 ) {
 	resolvedSender = wac.resolveSenderJID(info.Sender, info.SenderAlt)
+	var contactName string
 
 	// resolvedChat is the peer's number for display, read through the alt address the message
 	// itself carries, which the LID store need not hold. It never decides which rows are the

--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -360,19 +360,28 @@ func (wac *WhatsAppClient) preferExactContactMatch(contacts []Contact, identifie
 // ambiguous only when the matches are genuinely different peers.
 func (wac *WhatsAppClient) collapseSamePeerMatches(matches []Contact, identifier string) (types.JID, bool, error) {
 	var peer types.JID
+	seen := make(map[string]struct{})
+	var labels []string
 	for _, c := range matches {
 		jid, err := types.ParseJID(c.JID)
 		if err != nil {
 			return types.JID{}, true, err
 		}
 		canonical := wac.canonicalChatJID(jid)
-		if peer.IsEmpty() {
-			peer = canonical
+		if _, known := seen[canonical.String()]; known {
 			continue
 		}
-		if canonical.String() != peer.String() {
-			return types.JID{}, true, fmt.Errorf("multiple contacts share the exact name '%s'. Please disambiguate with the precise phone number (+1234567890)", identifier)
+		seen[canonical.String()] = struct{}{}
+		labels = append(labels, contactLabel(c))
+		if peer.IsEmpty() {
+			peer = canonical
 		}
+	}
+	if len(seen) > 1 {
+		return types.JID{}, true, fmt.Errorf(
+			"multiple contacts share the exact name '%s' (%s); address one by their exact phone number, or give one a distinct name so the name points at one person",
+			identifier, strings.Join(labels, ", "),
+		)
 	}
 	return peer, true, nil
 }

--- a/agent/skills/whatsapp/cli/contacts.go
+++ b/agent/skills/whatsapp/cli/contacts.go
@@ -478,7 +478,11 @@ func isNumeric(s string) bool {
 	return err == nil && len(s) > 0
 }
 
-// getChatName returns a human-readable name for a chat JID.
+// getChatName returns the name shown for a chat: a saved contact's name, a group's name, or, for a
+// person with no saved contact, their phone number. A direct chat never takes the peer's WhatsApp
+// profile name (pushname), so a name in the chats table is always a saved contact or a number. Two
+// different people cannot then share a chat name, which keeps a saved name pointing at one person
+// for name-based sends and replies.
 func (wac *WhatsAppClient) getChatName(jid types.JID) string {
 	if contact, err := wac.store.GetManualContact(jid.String()); err == nil && contact != nil && contact.Name != "" {
 		return contact.Name
@@ -491,9 +495,6 @@ func (wac *WhatsAppClient) getChatName(jid types.JID) string {
 			return groupInfo.Name
 		}
 		return fmt.Sprintf("Group %s", jid.User)
-	}
-	if contact, err := wac.client.Store.Contacts.GetContact(context.Background(), jid); err == nil && contact.FullName != "" {
-		return contact.FullName
 	}
 	if jid.Server == types.DefaultUserServer && jid.User != "" {
 		return "+" + jid.User

--- a/agent/skills/whatsapp/cli/contacts_test.go
+++ b/agent/skills/whatsapp/cli/contacts_test.go
@@ -310,15 +310,15 @@ func TestNotificationNamesAPeerSavedByChatIDAfterTheMappingIsLearned(t *testing.
 		t.Fatalf("failed to record the learned mapping: %v", err)
 	}
 
-	_, senderDisplay, contactName, contactPhone, contactSaved, _ := wac.prepareNotificationInfo(
+	_, senderDisplay, contactPhone, contactSaved, _ := wac.prepareNotificationInfo(
 		types.MessageSource{Chat: lid, Sender: lid, SenderAlt: phone},
 	)
 
 	if !contactSaved {
 		t.Errorf("a peer the gate treats as confirmed must not be reported as unknown")
 	}
-	if contactName != "Ana" || senderDisplay != "Ana" {
-		t.Errorf("expected the saved name, got contact_name %q and sender %q", contactName, senderDisplay)
+	if senderDisplay != "Ana" {
+		t.Errorf("expected the saved name, got sender %q", senderDisplay)
 	}
 	if contactPhone != "+"+phone.User {
 		t.Errorf("expected the learned number %q, got %q", "+"+phone.User, contactPhone)

--- a/agent/skills/whatsapp/cli/contacts_test.go
+++ b/agent/skills/whatsapp/cli/contacts_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.mau.fi/whatsmeow/types"
+	waLog "go.mau.fi/whatsmeow/util/log"
 )
 
 // groupIDDigits is a WhatsApp group ID rendered numerically: all digits, but
@@ -420,6 +421,62 @@ func TestResolveRecipientStillErrorsForDifferentPeersSharingAName(t *testing.T) 
 	// The error names each colliding number, so the caller can address the right one instead of guessing.
 	if !strings.Contains(err.Error(), "+15551110000") || !strings.Contains(err.Error(), "+447700900123") {
 		t.Errorf("the ambiguity error must name both colliding numbers, got %v", err)
+	}
+}
+
+// An unsaved direct chat takes the peer's phone number as its name, never their WhatsApp profile
+// name, so no unsaved chat can share a name with a saved contact and make a name-based reply
+// ambiguous.
+func TestGetChatNameUsesTheNumberForAnUnsavedDirectChat(t *testing.T) {
+	wac := &WhatsAppClient{store: newTestStore(t), logger: waLog.Noop}
+	jid, err := types.ParseJID("15551234567@s.whatsapp.net")
+	if err != nil {
+		t.Fatalf("failed to parse jid: %v", err)
+	}
+	if name := wac.getChatName(jid); name != "+15551234567" {
+		t.Errorf("an unsaved direct chat must be named by its number, got %q", name)
+	}
+}
+
+// A WhatsApp profile name stored for an unsaved direct chat by an earlier version is cleared on the
+// next open, so a saved contact that shares that name resolves to exactly one person again.
+func TestStoredProfileNameIsScrubbedSoASavedNameResolves(t *testing.T) {
+	dir := t.TempDir()
+	first, err := NewMessageStore(dir)
+	if err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	if _, err := first.SaveManualContact("Emmy", "+15551110000"); err != nil {
+		t.Fatalf("failed to save contact: %v", err)
+	}
+	if err := first.StoreChat("15559998888@s.whatsapp.net", "Emmy", time.Now()); err != nil {
+		t.Fatalf("failed to store chat: %v", err)
+	}
+	// Before the scrub the unsaved chat shares the saved name, so the name is ambiguous.
+	preScrub := &WhatsAppClient{store: first, logger: waLog.Noop}
+	if _, err := preScrub.ResolveRecipient("Emmy"); err == nil {
+		t.Fatalf("a stored profile name sharing a saved name must be ambiguous before the scrub")
+	}
+	// Model a database that predates the scrub, so reopening it runs the scrub.
+	if _, err := first.db.Exec("PRAGMA user_version = 0"); err != nil {
+		t.Fatalf("failed to reset schema version: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("failed to close store: %v", err)
+	}
+
+	second, err := NewMessageStore(dir)
+	if err != nil {
+		t.Fatalf("failed to reopen store: %v", err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+	wac := &WhatsAppClient{store: second, logger: waLog.Noop}
+	resolved, err := wac.ResolveRecipient("Emmy")
+	if err != nil {
+		t.Fatalf("after the scrub a saved name must resolve, got %v", err)
+	}
+	if resolved.String() != "15551110000@s.whatsapp.net" {
+		t.Errorf("the saved contact must resolve to its phone JID, got %q", resolved)
 	}
 }
 

--- a/agent/skills/whatsapp/cli/contacts_test.go
+++ b/agent/skills/whatsapp/cli/contacts_test.go
@@ -323,6 +323,65 @@ func TestNotificationNamesAPeerSavedByChatIDAfterTheMappingIsLearned(t *testing.
 	}
 }
 
+// A saved contact name is the word a reply command addresses, so two different people cannot share
+// one. Saving a name already held by a different number is refused with a distinct-name remedy, so
+// `whatsapp send --to '<name>'` always names exactly one person.
+func TestAddContactRejectsDuplicateNameForADifferentNumber(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	if _, err := wac.AddContact("Emmy", "+15551110000"); err != nil {
+		t.Fatalf("first save must succeed, got %v", err)
+	}
+	_, err := wac.AddContact("Emmy", "+447700900123")
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("a name already used by another number must be refused, got %v", err)
+	}
+}
+
+// A duplicate name matches after trimming and ignoring case, so a near-copy cannot slip past the
+// rule and reintroduce the ambiguity.
+func TestAddContactDuplicateNameIgnoresCaseAndSpace(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	if _, err := wac.AddContact("Emmy", "+15551110000"); err != nil {
+		t.Fatalf("first save must succeed, got %v", err)
+	}
+	_, err := wac.AddContact("  emmy ", "+447700900123")
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("a name differing only by case or spacing must still collide, got %v", err)
+	}
+}
+
+// Renaming or re-saving the same number is an update, never a collision with itself.
+func TestAddContactAllowsRenamingAndReSavingTheSameNumber(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	if _, err := wac.AddContact("Emmy", "+15551110000"); err != nil {
+		t.Fatalf("first save must succeed, got %v", err)
+	}
+	if _, err := wac.AddContact("Emmy", "+15551110000"); err != nil {
+		t.Errorf("re-saving the same name and number must succeed, got %v", err)
+	}
+	if _, err := wac.AddContact("Emmy R", "+15551110000"); err != nil {
+		t.Errorf("renaming the same number must succeed, got %v", err)
+	}
+}
+
+// One peer holds a row under each key form (phone JID and LID), and those rows may carry the same
+// name, so saving the phone row for a peer already saved by chat id is the same person, not a clash.
+func TestAddContactAllowsTheSameNameForOnePeerUnderBothKeyForms(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	lid := types.NewJID("99988877766655", types.HiddenUserServer)
+	phone := types.NewJID("15551110000", types.DefaultUserServer)
+
+	if _, err := wac.AddContactByChat("Emmy", lid.String()); err != nil {
+		t.Fatalf("saving by chat id must succeed, got %v", err)
+	}
+	if err := wac.client.Store.LIDs.PutLIDMapping(context.Background(), lid, phone); err != nil {
+		t.Fatalf("failed to record the learned mapping: %v", err)
+	}
+	if _, err := wac.AddContact("Emmy", "+"+phone.User); err != nil {
+		t.Errorf("the same peer's phone row must not collide with their own LID row, got %v", err)
+	}
+}
+
 // A token that is not a chat id at all must be named as one. Reporting a mistyped id as a group
 // is the one answer that stops the caller retrying, since a group genuinely needs no contact.
 func TestAddContactByChatRefusesAMalformedChatID(t *testing.T) {

--- a/agent/skills/whatsapp/cli/contacts_test.go
+++ b/agent/skills/whatsapp/cli/contacts_test.go
@@ -416,6 +416,10 @@ func TestResolveRecipientStillErrorsForDifferentPeersSharingAName(t *testing.T) 
 	if err == nil || !strings.Contains(err.Error(), "multiple contacts share the exact name") {
 		t.Fatalf("a name held by two different peers must stay ambiguous, got %v", err)
 	}
+	// The error names each colliding number, so the caller can address the right one instead of guessing.
+	if !strings.Contains(err.Error(), "+15551110000") || !strings.Contains(err.Error(), "+447700900123") {
+		t.Errorf("the ambiguity error must name both colliding numbers, got %v", err)
+	}
 }
 
 // A token that is not a chat id at all must be named as one. Reporting a mistyped id as a group

--- a/agent/skills/whatsapp/cli/contacts_test.go
+++ b/agent/skills/whatsapp/cli/contacts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"go.mau.fi/whatsmeow/types"
 )
@@ -457,5 +458,42 @@ func TestRequireManualContactLeavesGroupsUngated(t *testing.T) {
 
 	if err := wac.requireManualContact(types.NewJID(groupIDDigits, types.GroupServer)); err != nil {
 		t.Errorf("a group must not require a saved contact, got %v", err)
+	}
+}
+
+// A bare name held by both a saved contact and a group is ambiguous: refuse it so a message never
+// goes silently to the wrong one. The remedy renames the contact, the one name the agent controls.
+func TestResolveRecipientErrorsWhenANameIsBothAContactAndAGroup(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	if _, err := wac.store.SaveManualContact("Book Club", "+15551110000"); err != nil {
+		t.Fatalf("failed to seed contact: %v", err)
+	}
+	if err := wac.store.StoreChat("120363021234567890@g.us", "Book Club", time.Now()); err != nil {
+		t.Fatalf("failed to seed group: %v", err)
+	}
+
+	_, err := wac.ResolveRecipient("Book Club")
+	if err == nil || !strings.Contains(err.Error(), "both a saved contact and a group") {
+		t.Fatalf("a name shared by a contact and a group must be refused, got %v", err)
+	}
+}
+
+// A contact name that only appears inside a group name is not a collision: the exact contact still
+// resolves, so a near-match group never blocks addressing the person.
+func TestResolveRecipientResolvesAContactWhenAGroupOnlyPartiallyMatches(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	if _, err := wac.store.SaveManualContact("Sam", "+15551110000"); err != nil {
+		t.Fatalf("failed to seed contact: %v", err)
+	}
+	if err := wac.store.StoreChat("120363021234567890@g.us", "Sam's Book Club", time.Now()); err != nil {
+		t.Fatalf("failed to seed group: %v", err)
+	}
+
+	resolved, err := wac.ResolveRecipient("Sam")
+	if err != nil {
+		t.Fatalf("an exact contact name must resolve despite a partial group match, got %v", err)
+	}
+	if resolved.User != "15551110000" {
+		t.Errorf("must resolve to the contact, got %v", resolved)
 	}
 }

--- a/agent/skills/whatsapp/cli/contacts_test.go
+++ b/agent/skills/whatsapp/cli/contacts_test.go
@@ -382,6 +382,42 @@ func TestAddContactAllowsTheSameNameForOnePeerUnderBothKeyForms(t *testing.T) {
 	}
 }
 
+// A dual-key peer holds two rows under one name, one LID and one phone JID, so the name the reply
+// command emits matches both. Both rows are the same person, so the name must resolve to that one
+// peer's deliverable phone JID rather than fail as ambiguous (#1961).
+func TestResolveRecipientCollapsesADualKeyPeerToItsPhoneJID(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	saveContactUnderBothKeys(t, wac, "Emmy", "Emmy")
+
+	resolved, err := wac.ResolveRecipient("Emmy")
+	if err != nil {
+		t.Fatalf("a name held by one peer under both key forms must resolve, got %v", err)
+	}
+	if resolved.String() != splitContactPhone {
+		t.Errorf("name must resolve to the deliverable phone JID %q, got %q", splitContactPhone, resolved)
+	}
+	if resolved.Server != types.DefaultUserServer {
+		t.Errorf("name must resolve to a phone-server JID, got %v", resolved.Server)
+	}
+}
+
+// Two genuinely different people cannot share one name a reply command emits, so a name held by
+// two distinct peers stays ambiguous and is refused with the disambiguation remedy.
+func TestResolveRecipientStillErrorsForDifferentPeersSharingAName(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	if _, err := wac.store.SaveManualContact("Emmy", "+15551110000"); err != nil {
+		t.Fatalf("failed to seed first peer: %v", err)
+	}
+	if _, err := wac.store.SaveManualContact("Emmy", "+447700900123"); err != nil {
+		t.Fatalf("failed to seed second peer: %v", err)
+	}
+
+	_, err := wac.ResolveRecipient("Emmy")
+	if err == nil || !strings.Contains(err.Error(), "multiple contacts share the exact name") {
+		t.Fatalf("a name held by two different peers must stay ambiguous, got %v", err)
+	}
+}
+
 // A token that is not a chat id at all must be named as one. Reporting a mistyped id as a group
 // is the one answer that stops the caller retrying, since a group genuinely needs no contact.
 func TestAddContactByChatRefusesAMalformedChatID(t *testing.T) {

--- a/agent/skills/whatsapp/cli/events.go
+++ b/agent/skills/whatsapp/cli/events.go
@@ -290,7 +290,7 @@ func (wac *WhatsAppClient) dropDeadDevice() {
 // name when saved, otherwise the formatted number or JID. It rides in ContactName for every
 // chat, so a group participant is named there while ChatName names the group.
 func (wac *WhatsAppClient) buildNotifContext(chatJID, chatName, senderDisplay, contactPhone string, contactSaved, isDirectChat bool) NotifContext {
-	nameSharedWithGroup := contactSaved && isDirectChat && senderDisplay != "" && wac.nameSharedWithGroup(senderDisplay)
+	nameSharedWithGroup := contactSaved && isDirectChat && senderDisplay != "" && nameAddressesAsContact(senderDisplay) && wac.nameSharedWithGroup(senderDisplay)
 	return NotifContext{
 		NotifDir: wac.notificationsDir, ChatJID: chatJID, ChatName: chatName,
 		ContactName: senderDisplay, ContactPhone: contactPhone,
@@ -343,7 +343,7 @@ func (wac *WhatsAppClient) handleMessage(evt *events.Message) {
 		return
 	}
 
-	resolvedSender, senderDisplay, _, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(info.MessageSource)
+	resolvedSender, senderDisplay, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(info.MessageSource)
 	chatName := wac.getChatName(info.Chat)
 	// Canonical storage key: resolve the peer LID to its phone JID so this chat is keyed the same
 	// whether the message arrived under the peer's LID or a reply resolves them to their number.
@@ -518,7 +518,7 @@ func (wac *WhatsAppClient) handleReaction(evt *events.Message) {
 	chatName := wac.getChatName(evt.Info.Chat)
 
 	if wac.notificationsDir != "" {
-		_, senderDisplay, _, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
+		_, senderDisplay, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
 		ctx := wac.buildNotifContext(evt.Info.Chat.String(), chatName, senderDisplay, contactPhone, contactSaved, isDirectChat)
 		WriteReactionNotification(ctx, targetID, emoji, isRemoved)
 	}
@@ -602,7 +602,7 @@ func (wac *WhatsAppClient) notifContextFor(evt *events.Message) (NotifContext, b
 	if wac.notificationsDir == "" || wac.noNotify || evt.Info.IsFromMe {
 		return NotifContext{}, false
 	}
-	_, senderDisplay, _, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
+	_, senderDisplay, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
 	if wac.skipSenders[contactPhone] {
 		return NotifContext{}, false
 	}

--- a/agent/skills/whatsapp/cli/events.go
+++ b/agent/skills/whatsapp/cli/events.go
@@ -288,11 +288,13 @@ func (wac *WhatsAppClient) dropDeadDevice() {
 // buildNotifContext assembles the NotifContext shared by message and reaction
 // notifications.
 func (wac *WhatsAppClient) buildNotifContext(chatJID, chatName, senderDisplay, contactName, contactPhone string, contactSaved, isDirectChat bool) NotifContext {
+	nameSharedWithGroup := contactSaved && isDirectChat && contactName != "" && wac.nameSharedWithGroup(contactName)
 	return NotifContext{
 		NotifDir: wac.notificationsDir, ChatJID: chatJID, ChatName: chatName,
 		ContactName: contactName, ContactPhone: contactPhone,
 		Instance: wac.instance, ContactSaved: contactSaved,
 		IsDirectChat: isDirectChat, Sender: senderDisplay,
+		NameSharedWithGroup: nameSharedWithGroup,
 	}
 }
 

--- a/agent/skills/whatsapp/cli/events.go
+++ b/agent/skills/whatsapp/cli/events.go
@@ -286,14 +286,16 @@ func (wac *WhatsAppClient) dropDeadDevice() {
 }
 
 // buildNotifContext assembles the NotifContext shared by message and reaction
-// notifications.
-func (wac *WhatsAppClient) buildNotifContext(chatJID, chatName, senderDisplay, contactName, contactPhone string, contactSaved, isDirectChat bool) NotifContext {
-	nameSharedWithGroup := contactSaved && isDirectChat && contactName != "" && wac.nameSharedWithGroup(contactName)
+// notifications. senderDisplay is the one identity a notification names: the saved contact
+// name when saved, otherwise the formatted number or JID. It rides in ContactName for every
+// chat, so a group participant is named there while ChatName names the group.
+func (wac *WhatsAppClient) buildNotifContext(chatJID, chatName, senderDisplay, contactPhone string, contactSaved, isDirectChat bool) NotifContext {
+	nameSharedWithGroup := contactSaved && isDirectChat && senderDisplay != "" && wac.nameSharedWithGroup(senderDisplay)
 	return NotifContext{
 		NotifDir: wac.notificationsDir, ChatJID: chatJID, ChatName: chatName,
-		ContactName: contactName, ContactPhone: contactPhone,
+		ContactName: senderDisplay, ContactPhone: contactPhone,
 		Instance: wac.instance, ContactSaved: contactSaved,
-		IsDirectChat: isDirectChat, Sender: senderDisplay,
+		IsDirectChat:        isDirectChat,
 		NameSharedWithGroup: nameSharedWithGroup,
 	}
 }
@@ -341,7 +343,7 @@ func (wac *WhatsAppClient) handleMessage(evt *events.Message) {
 		return
 	}
 
-	resolvedSender, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(info.MessageSource)
+	resolvedSender, senderDisplay, _, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(info.MessageSource)
 	chatName := wac.getChatName(info.Chat)
 	// Canonical storage key: resolve the peer LID to its phone JID so this chat is keyed the same
 	// whether the message arrived under the peer's LID or a reply resolves them to their number.
@@ -391,7 +393,7 @@ func (wac *WhatsAppClient) handleMessage(evt *events.Message) {
 	shouldNotify := wac.notificationsDir != "" && !wac.noNotify && !info.IsFromMe && !wac.skipSenders[contactPhone]
 	var notifCtx NotifContext
 	if shouldNotify {
-		notifCtx = wac.buildNotifContext(info.Chat.String(), chatName, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat)
+		notifCtx = wac.buildNotifContext(info.Chat.String(), chatName, senderDisplay, contactPhone, contactSaved, isDirectChat)
 	}
 
 	// Audio messages: transcribe asynchronously, then send notification
@@ -516,8 +518,8 @@ func (wac *WhatsAppClient) handleReaction(evt *events.Message) {
 	chatName := wac.getChatName(evt.Info.Chat)
 
 	if wac.notificationsDir != "" {
-		_, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
-		ctx := wac.buildNotifContext(evt.Info.Chat.String(), chatName, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat)
+		_, senderDisplay, _, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
+		ctx := wac.buildNotifContext(evt.Info.Chat.String(), chatName, senderDisplay, contactPhone, contactSaved, isDirectChat)
 		WriteReactionNotification(ctx, targetID, emoji, isRemoved)
 	}
 }
@@ -600,11 +602,11 @@ func (wac *WhatsAppClient) notifContextFor(evt *events.Message) (NotifContext, b
 	if wac.notificationsDir == "" || wac.noNotify || evt.Info.IsFromMe {
 		return NotifContext{}, false
 	}
-	_, senderDisplay, contactName, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
+	_, senderDisplay, _, contactPhone, contactSaved, isDirectChat := wac.prepareNotificationInfo(evt.Info.MessageSource)
 	if wac.skipSenders[contactPhone] {
 		return NotifContext{}, false
 	}
-	return wac.buildNotifContext(evt.Info.Chat.String(), wac.getChatName(evt.Info.Chat), senderDisplay, contactName, contactPhone, contactSaved, isDirectChat), true
+	return wac.buildNotifContext(evt.Info.Chat.String(), wac.getChatName(evt.Info.Chat), senderDisplay, contactPhone, contactSaved, isDirectChat), true
 }
 
 func (wac *WhatsAppClient) handleHistorySync(evt *events.HistorySync) {

--- a/agent/skills/whatsapp/cli/events_test.go
+++ b/agent/skills/whatsapp/cli/events_test.go
@@ -248,3 +248,27 @@ func TestLoggedOutReason(t *testing.T) {
 		t.Fatal("a stream:error logout must carry a reason")
 	}
 }
+
+// buildNotifContext folds the sender display into the one identity field: ContactName carries the
+// saved name when saved and the formatted number otherwise, for both direct and group chats.
+func TestBuildNotifContextFoldsSenderDisplayIntoContactName(t *testing.T) {
+	wac := &WhatsAppClient{notificationsDir: "/n", instance: "personal"}
+	for _, tc := range []struct {
+		name          string
+		senderDisplay string
+		contactSaved  bool
+		isDirectChat  bool
+	}{
+		{"direct-saved", "Ana", true, true},
+		{"direct-unsaved", "+15559998888", false, true},
+		{"group-saved", "Ana", true, false},
+		{"group-unsaved", "+15559998888", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := wac.buildNotifContext("chat@jid", "Chat", tc.senderDisplay, "+15559998888", tc.contactSaved, tc.isDirectChat)
+			if ctx.ContactName != tc.senderDisplay {
+				t.Errorf("ContactName = %q, want the sender display %q as the single identity", ctx.ContactName, tc.senderDisplay)
+			}
+		})
+	}
+}

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -19,7 +19,6 @@ type messageNotif struct {
 	Instance        string `json:"instance,omitempty"`
 	ContactName     string `json:"contact_name,omitempty"`
 	Message         string `json:"message"`
-	Sender          string `json:"sender,omitempty"`
 	ChatName        string `json:"chat_name,omitempty"`
 	ContactPhone    string `json:"contact_phone,omitempty"`
 	MediaType       string `json:"media_type,omitempty"`
@@ -43,7 +42,6 @@ type reactionNotif struct {
 	Instance        string `json:"instance,omitempty"`
 	ContactName     string `json:"contact_name,omitempty"`
 	Emoji           string `json:"emoji,omitempty"`
-	Sender          string `json:"sender,omitempty"`
 	ChatName        string `json:"chat_name,omitempty"`
 	ContactPhone    string `json:"contact_phone,omitempty"`
 	IsRemoved       bool   `json:"is_removed,omitempty"`
@@ -63,7 +61,6 @@ type editNotif struct {
 	Type            string `json:"type"`
 	Instance        string `json:"instance,omitempty"`
 	ContactName     string `json:"contact_name,omitempty"`
-	Sender          string `json:"sender,omitempty"`
 	ChatName        string `json:"chat_name,omitempty"`
 	ContactPhone    string `json:"contact_phone,omitempty"`
 	OldText         string `json:"old_text,omitempty"`
@@ -195,10 +192,6 @@ func WriteNotification(
 	if !ctx.IsDirectChat {
 		n.ChatName = ctx.ChatName
 		n.ReplyHint = "think about how you can best show your personality; this is a group chat, so it may not be expecting a reply from you"
-		// Drop Sender when it's just the same JID as the chat (happens for unsaved group participants).
-		if ctx.Sender != ctx.ChatName {
-			n.Sender = ctx.Sender
-		}
 	}
 	return writeNotificationFile(ctx.NotifDir, n, "message")
 }
@@ -222,23 +215,17 @@ func WriteReactionNotification(
 	}
 	if !ctx.IsDirectChat {
 		n.ChatName = ctx.ChatName
-		if ctx.Sender != ctx.ChatName {
-			n.Sender = ctx.Sender
-		}
 	}
 	return writeNotificationFile(ctx.NotifDir, n, "reaction")
 }
 
 // applyChatContext mirrors the group-chat handling the message and reaction writers do:
-// name the chat, and name the sender unless it is just the chat's own JID.
+// name the group in chat_name. The participant identity rides in contact_name, set for every chat.
 func (n *editNotif) applyChatContext(ctx NotifContext) {
 	if ctx.IsDirectChat {
 		return
 	}
 	n.ChatName = ctx.ChatName
-	if ctx.Sender != ctx.ChatName {
-		n.Sender = ctx.Sender
-	}
 }
 
 func WriteEditNotification(ctx NotifContext, targetMessageID, oldText, newText string) error {

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -132,10 +132,17 @@ func chatType(ctx NotifContext) string {
 // delivery and read receipts. When a group holds that same name the name is ambiguous, so the reply
 // keeps the chat JID. An unsaved contact and every group keep the chat JID, which always resolves.
 func replyTarget(ctx NotifContext) string {
-	if ctx.ContactSaved && ctx.IsDirectChat && ctx.ContactName != "" && !ctx.NameSharedWithGroup {
+	if ctx.ContactSaved && ctx.IsDirectChat && ctx.ContactName != "" && !ctx.NameSharedWithGroup && nameAddressesAsContact(ctx.ContactName) {
 		return ctx.ContactName
 	}
 	return ctx.ChatJID
+}
+
+// nameAddressesAsContact reports whether resolveRecipientJID would look a name up as a saved contact
+// rather than parse it as a phone number or JID. A name that is all digits, starts with '+', or
+// holds an '@' would route to the wrong recipient, so a reply keeps the chat JID for it.
+func nameAddressesAsContact(name string) bool {
+	return !strings.Contains(name, "@") && !strings.HasPrefix(name, "+") && !isNumeric(name)
 }
 
 // Every notification carries a complete reply command. It stops at `--message -`: the notification

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -131,11 +131,11 @@ func chatType(ctx NotifContext) string {
 }
 
 // replyTarget picks who a reply addresses. A saved contact in a direct chat is named, the same word
-// the user uses; a unique saved name resolves to the peer's stored phone JID, the address that
-// carries delivery and read receipts. An unsaved contact and every group keep the chat JID, which
-// needs no saved contact and always resolves.
+// the user uses, and that name resolves to the peer's stored phone JID, the address that carries
+// delivery and read receipts. When a group holds that same name the name is ambiguous, so the reply
+// keeps the chat JID. An unsaved contact and every group keep the chat JID, which always resolves.
 func replyTarget(ctx NotifContext) string {
-	if ctx.ContactSaved && ctx.IsDirectChat && ctx.ContactName != "" {
+	if ctx.ContactSaved && ctx.IsDirectChat && ctx.ContactName != "" && !ctx.NameSharedWithGroup {
 		return ctx.ContactName
 	}
 	return ctx.ChatJID

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -130,10 +130,19 @@ func chatType(ctx NotifContext) string {
 	return "group"
 }
 
-// Every notification carries a complete reply command. The target is always the chat JID, which
-// ResolveRecipient matches first and which needs no saved contact, so there is no case where the
-// agent has to work the recipient out for itself. It stops at `--message -`: the notification is
-// rendered as an XML attribute, so a heredoc here would reach the agent as &lt;&lt; and &#10;
+// replyTarget picks who a reply addresses. A saved contact in a direct chat is named, the same word
+// the user uses; a unique saved name resolves to the peer's stored phone JID, the address that
+// carries delivery and read receipts. An unsaved contact and every group keep the chat JID, which
+// needs no saved contact and always resolves.
+func replyTarget(ctx NotifContext) string {
+	if ctx.ContactSaved && ctx.IsDirectChat && ctx.ContactName != "" {
+		return ctx.ContactName
+	}
+	return ctx.ChatJID
+}
+
+// Every notification carries a complete reply command. It stops at `--message -`: the notification
+// is rendered as an XML attribute, so a heredoc here would reach the agent as &lt;&lt; and &#10;
 // entities. `-` says the body comes from stdin and SKILL.md carries the one heredoc shape, which
 // keeps the reply body out of the shell's reach.
 func notificationReplyCommand(ctx NotifContext) string {
@@ -141,7 +150,7 @@ func notificationReplyCommand(ctx NotifContext) string {
 	if ctx.Instance != "" {
 		command += " --instance " + quoteReplyArg(ctx.Instance)
 	}
-	return command + " --to " + quoteReplyArg(ctx.ChatJID) + " --message -"
+	return command + " --to " + quoteReplyArg(replyTarget(ctx)) + " --message -"
 }
 
 func writeNotificationFile(notifDir string, data any, notifType string) error {

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -13,15 +13,15 @@ func savedCtx(dir string) NotifContext {
 	return NotifContext{
 		NotifDir: dir, Instance: "personal", ChatJID: "4477000111@s.whatsapp.net", ChatName: "Ana",
 		ContactName: "Ana", ContactPhone: "+15551234567",
-		ContactSaved: true, IsDirectChat: true, Sender: "Ana",
+		ContactSaved: true, IsDirectChat: true,
 	}
 }
 
 func unsavedCtx(dir string) NotifContext {
 	return NotifContext{
 		NotifDir: dir, Instance: "personal", ChatJID: "15559998888@s.whatsapp.net", ChatName: "+15559998888",
-		ContactName: "", ContactPhone: "+15559998888",
-		ContactSaved: false, IsDirectChat: true, Sender: "+15559998888",
+		ContactName: "+15559998888", ContactPhone: "+15559998888",
+		ContactSaved: false, IsDirectChat: true,
 	}
 }
 
@@ -76,8 +76,9 @@ func TestUnsavedContactIsIdentifiedByNumber(t *testing.T) {
 	if err := json.Unmarshal(fields["contact_phone"], &phone); err != nil || phone != "+15559998888" {
 		t.Errorf("contact_phone = %q, want the number: it is the only way to reply to someone unsaved", phone)
 	}
-	if _, present := fields["contact_name"]; present {
-		t.Errorf("contact_name is present for an unsaved contact, want it absent")
+	var name string
+	if err := json.Unmarshal(fields["contact_name"], &name); err != nil || name != "+15559998888" {
+		t.Errorf("contact_name = %q, want the number: the single identity field names an unsaved contact too", name)
 	}
 	if _, present := fields["contact_unknown"]; !present {
 		t.Errorf("contact_unknown is absent for an unsaved contact, want it flagged")
@@ -90,6 +91,67 @@ func groupCtx(dir string) NotifContext {
 	ctx.ChatJID = "120363021234567890@g.us"
 	ctx.ChatName = "Bride squad"
 	return ctx
+}
+
+// unsavedGroupCtx is a group message from someone the user has not saved: the identity is the
+// formatted number, and there is no separate group vs participant name to reconcile.
+func unsavedGroupCtx(dir string) NotifContext {
+	ctx := groupCtx(dir)
+	ctx.ContactName = "+15559998888"
+	ctx.ContactPhone = "+15559998888"
+	ctx.ContactSaved = false
+	return ctx
+}
+
+// Identity rides in contact_name alone. A group notification used to carry a second `sender`
+// field that repeated the participant, so pin that no notification, direct or group, saved or
+// unsaved, ever emits one.
+func TestNotificationsCarryNoSeparateSenderField(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ctx  func(string) NotifContext
+	}{
+		{"direct-saved", savedCtx},
+		{"direct-unsaved", unsavedCtx},
+		{"group-saved", groupCtx},
+		{"group-unsaved", unsavedGroupCtx},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := WriteNotification(tc.ctx(dir), "3EB0A1", "hi", "", false, "", ""); err != nil {
+				t.Fatalf("write failed: %v", err)
+			}
+			if _, present := soleNotifFields(t, dir)["sender"]; present {
+				t.Errorf("notification carries a separate sender field; identity must ride in contact_name alone")
+			}
+		})
+	}
+}
+
+// contact_name is the single identity field. It is set for every message, direct or group, and
+// carries the saved name when the contact is saved and the formatted number otherwise.
+func TestContactNameCarriesTheIdentityForEveryMessage(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ctx  func(string) NotifContext
+		want string
+	}{
+		{"direct-saved", savedCtx, "Ana"},
+		{"direct-unsaved", unsavedCtx, "+15559998888"},
+		{"group-saved", groupCtx, "Ana"},
+		{"group-unsaved", unsavedGroupCtx, "+15559998888"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := WriteNotification(tc.ctx(dir), "3EB0A1", "hi", "", false, "", ""); err != nil {
+				t.Fatalf("write failed: %v", err)
+			}
+			var name string
+			if err := json.Unmarshal(soleNotifFields(t, dir)["contact_name"], &name); err != nil || name != tc.want {
+				t.Errorf("contact_name = %q, want %q (the single identity field)", name, tc.want)
+			}
+		})
+	}
 }
 
 func notifChatType(t *testing.T, dir string) string {

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -103,34 +103,11 @@ func unsavedGroupCtx(dir string) NotifContext {
 	return ctx
 }
 
-// Identity rides in contact_name alone. A group notification used to carry a second `sender`
-// field that repeated the participant, so pin that no notification, direct or group, saved or
-// unsaved, ever emits one.
-func TestNotificationsCarryNoSeparateSenderField(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		ctx  func(string) NotifContext
-	}{
-		{"direct-saved", savedCtx},
-		{"direct-unsaved", unsavedCtx},
-		{"group-saved", groupCtx},
-		{"group-unsaved", unsavedGroupCtx},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			if err := WriteNotification(tc.ctx(dir), "3EB0A1", "hi", "", false, "", ""); err != nil {
-				t.Fatalf("write failed: %v", err)
-			}
-			if _, present := soleNotifFields(t, dir)["sender"]; present {
-				t.Errorf("notification carries a separate sender field; identity must ride in contact_name alone")
-			}
-		})
-	}
-}
-
-// contact_name is the single identity field. It is set for every message, direct or group, and
-// carries the saved name when the contact is saved and the formatted number otherwise.
-func TestContactNameCarriesTheIdentityForEveryMessage(t *testing.T) {
+// contact_name is the sole identity field: it is set for every message, direct or group, and
+// carries the saved name when the contact is saved and the formatted number otherwise. A group
+// notification used to carry a second `sender` field that repeated the participant, so this also
+// pins that no notification, direct or group, saved or unsaved, emits one.
+func TestContactNameIsTheSoleIdentityField(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		ctx  func(string) NotifContext
@@ -146,9 +123,13 @@ func TestContactNameCarriesTheIdentityForEveryMessage(t *testing.T) {
 			if err := WriteNotification(tc.ctx(dir), "3EB0A1", "hi", "", false, "", ""); err != nil {
 				t.Fatalf("write failed: %v", err)
 			}
+			fields := soleNotifFields(t, dir)
+			if _, present := fields["sender"]; present {
+				t.Errorf("notification carries a separate sender field; identity must ride in contact_name alone")
+			}
 			var name string
-			if err := json.Unmarshal(soleNotifFields(t, dir)["contact_name"], &name); err != nil || name != tc.want {
-				t.Errorf("contact_name = %q, want %q (the single identity field)", name, tc.want)
+			if err := json.Unmarshal(fields["contact_name"], &name); err != nil || name != tc.want {
+				t.Errorf("contact_name = %q, want %q (the sole identity field)", name, tc.want)
 			}
 		})
 	}

--- a/agent/skills/whatsapp/cli/reply_command_test.go
+++ b/agent/skills/whatsapp/cli/reply_command_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"go.mau.fi/whatsmeow/types"
 )
@@ -108,5 +109,37 @@ func TestReplyNameRoundTripsToTheDeliverablePhoneJID(t *testing.T) {
 	}
 	if resolved.Server != types.DefaultUserServer {
 		t.Errorf("name must resolve to a phone-server JID, got %v", resolved.Server)
+	}
+}
+
+// When a group shares the saved contact's name, the reply keeps the chat JID, so it can never
+// resolve to the group by that ambiguous name.
+func TestNotificationReplyCommandKeepsTheJIDWhenAGroupSharesTheName(t *testing.T) {
+	ctx := NotifContext{
+		ContactSaved: true, IsDirectChat: true, ContactName: "Book Club",
+		NameSharedWithGroup: true, ChatJID: "15551110000@s.whatsapp.net",
+	}
+	got := notificationReplyCommand(ctx)
+	if !strings.Contains(got, "--to '15551110000@s.whatsapp.net'") {
+		t.Fatalf("a name shared with a group must fall back to the chat JID, got %q", got)
+	}
+}
+
+// buildNotifContext flags a saved direct contact whose name a group also holds, and leaves a name no
+// group holds unflagged, so the reply command names the contact only when that name is unambiguous.
+func TestBuildNotifContextFlagsANameAGroupShares(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	if err := wac.store.StoreChat("120363021234567890@g.us", "Book Club", time.Now()); err != nil {
+		t.Fatalf("failed to seed group: %v", err)
+	}
+
+	shared := wac.buildNotifContext("15551110000@s.whatsapp.net", "Book Club", "Book Club", "Book Club", "+15551110000", true, true)
+	if !shared.NameSharedWithGroup {
+		t.Errorf("a saved contact name a group also holds must be flagged")
+	}
+
+	distinct := wac.buildNotifContext("15551110000@s.whatsapp.net", "Alice", "Alice", "Alice", "+15551110000", true, true)
+	if distinct.NameSharedWithGroup {
+		t.Errorf("a name no group holds must not be flagged")
 	}
 }

--- a/agent/skills/whatsapp/cli/reply_command_test.go
+++ b/agent/skills/whatsapp/cli/reply_command_test.go
@@ -133,12 +133,12 @@ func TestBuildNotifContextFlagsANameAGroupShares(t *testing.T) {
 		t.Fatalf("failed to seed group: %v", err)
 	}
 
-	shared := wac.buildNotifContext("15551110000@s.whatsapp.net", "Book Club", "Book Club", "Book Club", "+15551110000", true, true)
+	shared := wac.buildNotifContext("15551110000@s.whatsapp.net", "Book Club", "Book Club", "+15551110000", true, true)
 	if !shared.NameSharedWithGroup {
 		t.Errorf("a saved contact name a group also holds must be flagged")
 	}
 
-	distinct := wac.buildNotifContext("15551110000@s.whatsapp.net", "Alice", "Alice", "Alice", "+15551110000", true, true)
+	distinct := wac.buildNotifContext("15551110000@s.whatsapp.net", "Alice", "Alice", "+15551110000", true, true)
 	if distinct.NameSharedWithGroup {
 		t.Errorf("a name no group holds must not be flagged")
 	}

--- a/agent/skills/whatsapp/cli/reply_command_test.go
+++ b/agent/skills/whatsapp/cli/reply_command_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"go.mau.fi/whatsmeow/types"
 )
 
 func TestNotificationReplyCommandIsCompleteAndUnambiguous(t *testing.T) {
@@ -35,5 +37,76 @@ func TestNotificationReplyCommandBodyIsShellInert(t *testing.T) {
 	// rendered as an XML attribute. SKILL.md carries the heredoc shape instead.
 	if strings.ContainsAny(got, "<\n") {
 		t.Fatalf("reply command must survive XML attribute rendering unescaped: %q", got)
+	}
+}
+
+// A saved contact in a direct chat is addressed by name: the same word the user uses, and the name
+// resolves to the peer's stored phone JID, the address that carries delivery and read receipts.
+func TestNotificationReplyCommandNamesASavedDirectContact(t *testing.T) {
+	ctx := NotifContext{
+		ContactSaved: true, IsDirectChat: true,
+		ContactName: "Emmy", ChatJID: "99988877766655@lid",
+	}
+	got := notificationReplyCommand(ctx)
+	want := "whatsapp send --to 'Emmy' --message -"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// An unsaved contact has no confirmed name to resolve, so the reply keeps the chat JID.
+func TestNotificationReplyCommandKeepsTheJIDForAnUnsavedContact(t *testing.T) {
+	ctx := NotifContext{IsDirectChat: true, ChatJID: "15551234567@s.whatsapp.net"}
+	got := notificationReplyCommand(ctx)
+	if !strings.Contains(got, "--to '15551234567@s.whatsapp.net'") {
+		t.Fatalf("an unsaved contact must keep the chat JID, got %q", got)
+	}
+}
+
+// A group is addressed by the chat, never by a contact name, so its reply keeps the chat JID.
+func TestNotificationReplyCommandKeepsTheJIDForAGroup(t *testing.T) {
+	ctx := NotifContext{ContactSaved: true, IsDirectChat: false, ContactName: "Alice", ChatJID: "123@g.us"}
+	got := notificationReplyCommand(ctx)
+	if !strings.Contains(got, "--to '123@g.us'") {
+		t.Fatalf("a group must keep the chat JID, got %q", got)
+	}
+}
+
+// A contact name with an apostrophe stays one shell argument.
+func TestNotificationReplyCommandQuotesAName(t *testing.T) {
+	ctx := NotifContext{ContactSaved: true, IsDirectChat: true, ContactName: "O'Brien", ChatJID: "x@s.whatsapp.net"}
+	got := notificationReplyCommand(ctx)
+	want := `whatsapp send --to 'O'"'"'Brien' --message -`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// The name a reply names must resolve back to the peer's deliverable phone JID, so addressing by
+// name reaches the same person the chat JID would, on the receipt-bearing address (see #1961).
+func TestReplyNameRoundTripsToTheDeliverablePhoneJID(t *testing.T) {
+	wac := newOutgoingTestClient(t)
+	phone, err := types.ParseJID(outgoingPhoneJID)
+	if err != nil {
+		t.Fatalf("failed to parse phone jid: %v", err)
+	}
+	if _, err := wac.AddContact("Emmy", "+"+phone.User); err != nil {
+		t.Fatalf("failed to save contact: %v", err)
+	}
+
+	ctx := NotifContext{ContactSaved: true, IsDirectChat: true, ContactName: "Emmy", ChatJID: outgoingPhoneJID}
+	if got := notificationReplyCommand(ctx); !strings.Contains(got, "--to 'Emmy'") {
+		t.Fatalf("a saved direct contact must be addressed by name, got %q", got)
+	}
+
+	resolved, err := wac.ResolveRecipient("Emmy")
+	if err != nil {
+		t.Fatalf("the emitted name must resolve, got %v", err)
+	}
+	if resolved.String() != outgoingPhoneJID {
+		t.Errorf("name must resolve to the deliverable phone JID %q, got %q", outgoingPhoneJID, resolved)
+	}
+	if resolved.Server != types.DefaultUserServer {
+		t.Errorf("name must resolve to a phone-server JID, got %v", resolved.Server)
 	}
 }

--- a/agent/skills/whatsapp/cli/storage.go
+++ b/agent/skills/whatsapp/cli/storage.go
@@ -615,6 +615,30 @@ func (ms *MessageStore) ManualContactJIDsByName(name string) ([]string, error) {
 	return jids, rows.Err()
 }
 
+// ManualContactsByName returns every contact row whose name equals name once trimmed and lowercased,
+// so a duplicate-name check catches a near-copy that differs only by case or surrounding spaces.
+func (ms *MessageStore) ManualContactsByName(name string) ([]Contact, error) {
+	rows, err := ms.db.Query(
+		`SELECT jid, name, phone_number FROM contacts WHERE lower(trim(name)) = lower(trim(?))`,
+		name,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var contacts []Contact
+	for rows.Next() {
+		var jid, phone string
+		var rowName sql.NullString
+		if err := rows.Scan(&jid, &rowName, &phone); err != nil {
+			return nil, err
+		}
+		contacts = append(contacts, Contact{JID: jid, Name: rowName.String, PhoneNumber: phone, IsManual: true})
+	}
+	return contacts, rows.Err()
+}
+
 // DeleteManualContactsByJID removes the contact rows under the given keys, reporting whether any
 // did. Callers pass every key form of one peer, so a revoke leaves nothing behind.
 func (ms *MessageStore) DeleteManualContactsByJID(jids []string) (bool, error) {

--- a/agent/skills/whatsapp/cli/storage.go
+++ b/agent/skills/whatsapp/cli/storage.go
@@ -131,6 +131,27 @@ func NewMessageStore(dataDir string) (*MessageStore, error) {
 		db.Exec("ALTER TABLE messages ADD COLUMN delivery_timestamp TIMESTAMP")
 	}
 
+	// One-time scrub: clear the WhatsApp profile names (pushnames) that direct chats once stored, so
+	// a person with no saved contact holds no chat name that could collide with a saved contact's
+	// name. SearchContacts reads chats rows only for `@s.whatsapp.net` jids, so those are exactly the
+	// names to clear; saved names live in the contacts table and are untouched. getChatName writes a
+	// number back on the next message.
+	var schemaVersion int
+	if err := db.QueryRow("PRAGMA user_version").Scan(&schemaVersion); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to read schema version: %v", err)
+	}
+	if schemaVersion < 1 {
+		if _, err := db.Exec("UPDATE chats SET name = NULL WHERE jid LIKE '%@s.whatsapp.net' AND name IS NOT NULL"); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("failed to clear stored profile names: %v", err)
+		}
+		if _, err := db.Exec("PRAGMA user_version = 1"); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("failed to set schema version: %v", err)
+		}
+	}
+
 	ms := &MessageStore{db: db}
 	if err := ms.rebuildFTS(); err != nil {
 		db.Close()

--- a/agent/skills/whatsapp/cli/types.go
+++ b/agent/skills/whatsapp/cli/types.go
@@ -50,15 +50,17 @@ type StoreMessageParams struct {
 }
 
 type NotifContext struct {
-	NotifDir     string
-	ChatJID      string
-	ChatName     string
+	NotifDir string
+	ChatJID  string
+	ChatName string
+	// ContactName is the one identity field a notification carries: the saved contact name when the
+	// sender is saved, otherwise the best human identifier (a formatted number or JID). It is set for
+	// both direct and group chats; in a group, ChatName names the group and this names the participant.
 	ContactName  string
 	ContactPhone string
 	Instance     string
 	ContactSaved bool
 	IsDirectChat bool
-	Sender       string
 	// NameSharedWithGroup marks a saved contact whose name a group also holds, so the reply keeps
 	// the chat JID rather than an ambiguous name that could resolve to the group.
 	NameSharedWithGroup bool

--- a/agent/skills/whatsapp/cli/types.go
+++ b/agent/skills/whatsapp/cli/types.go
@@ -59,6 +59,9 @@ type NotifContext struct {
 	ContactSaved bool
 	IsDirectChat bool
 	Sender       string
+	// NameSharedWithGroup marks a saved contact whose name a group also holds, so the reply keeps
+	// the chat JID rather than an ambiguous name that could resolve to the group.
+	NameSharedWithGroup bool
 }
 
 type MediaInfo struct {


### PR DESCRIPTION
## What

Two coupled changes so the WhatsApp per-notification reply command can name the contact instead of an opaque JID, safely.

### 1. Unique contact names on save

`add-contact` now refuses a name that another number already holds. The match is case-insensitive and trimmed, and the error names the number already holding it plus a distinct-name remedy:

> a contact named 'Emmy' already exists (+447700900123); choose a distinct name like 'Emmy R' so a reply names one person

Once names are unique, `ResolveRecipient` maps an exact name to exactly one JID (via the existing `SearchContacts` -> `preferExactContactMatch` path), so `whatsapp send --to '<Name>'` is deterministic.

**Idempotent re-save is preserved.** One peer legitimately holds a row under each of their key forms (their phone JID and their LID), and those rows may carry the same name. The check excludes the peer's own key set (`contactKeys`), so renaming or re-saving the same person is an update, never a false collision. The check lives at the `WhatsAppClient` layer (`AddContact` / `AddContactByChat`) because only there is the LID<->PN mapping available to decide "same peer" vs "different peer".

**No DB-level `UNIQUE(name)` constraint, deliberately.** Because one peer can hold two rows (phone JID + LID) that may share a name, a column constraint would reject that legitimate second row. Uniqueness here is "different peer", not "different row", which only the application layer (with the mapping) can decide. Enforcement is therefore the actionable application-level check, backed by tests.

### 2. Name-based reply command

`notificationReplyCommand` now emits `whatsapp send --to '<Contact Name>' --message -` for a saved contact in a direct chat, and keeps the chat JID for unsaved contacts and for every group. The name is shell-quoted through the existing `quoteReplyArg`.

### How #1961's phone-JID deliverability is kept

#1961 established that a peer reachable under two JIDs must be sent to their canonical **phone JID**, because only it gets delivery and read receipts; a LID does not.

- A saved contact's stored JID is phone-preferred: `SaveManualContact` stores `<digits>@s.whatsapp.net`, and `AddContactByChat` stores the canonical chat JID (the phone JID once the LID<->PN mapping is known). So `ResolveRecipient('<Name>')` returns that stored **phone JID**, the receipt-bearing address.
- A round-trip test (`TestReplyNameRoundTripsToTheDeliverablePhoneJID`) proves the emitted name resolves back to the deliverable `@s.whatsapp.net` JID.
- For a peer with no known number (saved only under a LID), the stored key is the LID, identical to what the JID-form reply already used, so there is no regression: the name lands on the same address the JID form would.
- Groups keep the chat JID; #1961's phone-vs-LID logic is about direct peers, not group addressing.

## Tests (TDD)

- Unique-name rejection, including case/space-insensitivity, idempotent same-number rename/re-save, and the same name allowed for one peer under both key forms.
- Reply-command name-vs-JID selection: name for a saved direct contact, JID for unsaved and for groups, correct shell-quoting, and the name -> phone-JID round-trip.

## Verification

- `check.sh whatsapp` equivalent green: `gofmt` clean, `go vet -tags fts5` ok, `go build -tags fts5` ok, `go test -tags fts5 ./...` ok.
- `check.sh guards` green.

## Scope added since opening

This PR grew into the full "a name reaches one recipient" story, and the sibling notification refactor is folded in here (PR #1996 closed):

- **Migration** (`agent/core/migrations/2026-08-whatsapp-unique-contact-names.md`): renames apart any legacy contacts where two different people share a name, so name-based replies resolve on existing agents.
- **Unambiguous collision error**: the resolve-time "same name" error now lists the colliding numbers instead of a placeholder; the dead "multiple contacts share that phone number" branch is removed (a contact row's jid is derived from its number, so two rows cannot share one).
- **Contact vs group determinism**: a bare name that exactly matches both a saved contact and a group is refused with an actionable error (rename the contact) instead of silently reaching the contact, and the reply command keeps the chat JID when a group shares the saved contact's name.
- **One identity field (folded from #1996, authorship preserved)**: the notification `sender` field is collapsed into `contact_name`, the single identity a notification names, for both direct and group chats.

`check.sh whatsapp` (gofmt, `go vet`, `go build`, full `go test -tags fts5`) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KNWDABuK3z8sqveBBdPr