### PR TITLE
feat(telegram): unique contact names for name-based sends

### DIFF
--- a/agent/core/migrations/2026-08-telegram-unique-contact-names.md
+++ b/agent/core/migrations/2026-08-telegram-unique-contact-names.md
@@ -1,0 +1,42 @@
+Every saved Telegram contact name must point at one person. A send to a saved
+contact by name (`telegram send --to '<name>'`) reaches the wrong person when
+two different contacts share that name. This migration renames such contacts
+apart. It is safe to run more than once: it only renames names that still
+collide.
+
+### 1. Skip if Telegram is not set up
+
+If `~/agent/skills/telegram` does not exist, you never installed the skill.
+Skip to the final step.
+
+### 2. List saved contacts
+
+```bash
+telegram list-contacts --limit 1000
+```
+
+Each entry has a `name` and a `chat_id`. Only an entry with `"is_manual": true`
+is a saved contact. An entry without that field is a chat the user never saved:
+skip it, and use only the saved contacts in the next step.
+
+### 3. Rename apart any name two different people share
+
+Group the saved contacts by name, ignoring case and surrounding spaces. A name
+is a problem only when two or more different chat ids hold it.
+
+For each name that two different people share, give all but one of them a
+distinct name. Address each by their exact `chat_id`, so the rename updates that
+person and not the other:
+
+```bash
+telegram add-contact --name "Sarah R" --chat-id 123456789
+```
+
+Pick a name that tells them apart from what you know about them: a surname
+initial, their relationship, or where you know them from. Do not invent a detail
+you do not know. If you cannot tell two people apart, ask the user which name
+each should have.
+
+### 4. Mark this migration applied
+
+Call `mark_migration_applied` with `name="2026-08-telegram-unique-contact-names"`.

--- a/agent/skills/telegram/cli/contacts_test.go
+++ b/agent/skills/telegram/cli/contacts_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func newContactTestStore(t *testing.T) *MessageStore {
+	t.Helper()
+	store, err := NewMessageStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+// A saved name must reach one person, so a name another chat already holds is refused.
+func TestAddContactRejectsDuplicateNameForADifferentChat(t *testing.T) {
+	store := newContactTestStore(t)
+	if _, err := store.SaveManualContact("Sarah", 111, ""); err != nil {
+		t.Fatalf("failed to save first contact: %v", err)
+	}
+	_, err := store.SaveManualContact("Sarah", 222, "")
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("a duplicate name for a different chat must be refused, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "111") {
+		t.Errorf("the error must name the chat already holding the name, got %v", err)
+	}
+}
+
+// Case and surrounding spaces must not slip a duplicate past the check.
+func TestAddContactRejectsDuplicateNameIgnoringCaseAndSpace(t *testing.T) {
+	store := newContactTestStore(t)
+	if _, err := store.SaveManualContact("Sarah", 111, ""); err != nil {
+		t.Fatalf("failed to save first contact: %v", err)
+	}
+	if _, err := store.SaveManualContact("  sarah ", 222, ""); err == nil {
+		t.Fatalf("a duplicate name differing only by case or space must be refused")
+	}
+}
+
+// Re-saving or renaming the same chat is an update, never a self-collision.
+func TestAddContactAllowsRenamingTheSameChat(t *testing.T) {
+	store := newContactTestStore(t)
+	if _, err := store.SaveManualContact("Sarah", 111, ""); err != nil {
+		t.Fatalf("failed to save contact: %v", err)
+	}
+	if _, err := store.SaveManualContact("Sarah R", 111, ""); err != nil {
+		t.Errorf("renaming the same chat must succeed, got %v", err)
+	}
+	if _, err := store.SaveManualContact("Sarah", 111, ""); err != nil {
+		t.Errorf("re-saving the same chat under its own name must succeed, got %v", err)
+	}
+}
+
+// A unique saved name still resolves to its chat.
+func TestResolveRecipientResolvesAUniqueSavedName(t *testing.T) {
+	store := newContactTestStore(t)
+	if _, err := store.SaveManualContact("Bob", 333, ""); err != nil {
+		t.Fatalf("failed to save contact: %v", err)
+	}
+	id, err := store.ResolveRecipient("Bob")
+	if err != nil {
+		t.Fatalf("a unique saved name must resolve, got %v", err)
+	}
+	if id != 333 {
+		t.Errorf("expected chat 333, got %d", id)
+	}
+}
+
+// Legacy data can already hold two contacts under one name. A name-based send must fail safe with
+// the candidates, never silently reach one of them.
+func TestResolveRecipientErrorsWhenTwoContactsShareAName(t *testing.T) {
+	store := newContactTestStore(t)
+	for _, id := range []int64{111, 222} {
+		if _, err := store.db.Exec(`INSERT INTO contacts (chat_id, name) VALUES (?, ?)`, id, "Sarah"); err != nil {
+			t.Fatalf("failed to seed contact %d: %v", id, err)
+		}
+	}
+	_, err := store.ResolveRecipient("Sarah")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("two contacts sharing a name must resolve to an ambiguity error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "111") || !strings.Contains(err.Error(), "222") {
+		t.Errorf("the ambiguity error must name both chat ids, got %v", err)
+	}
+}

--- a/agent/skills/telegram/cli/storage.go
+++ b/agent/skills/telegram/cli/storage.go
@@ -295,6 +295,23 @@ func (ms *MessageStore) SaveManualContact(name string, chatID int64, username st
 	if trimmedName == "" {
 		return Contact{}, fmt.Errorf("contact name cannot be empty")
 	}
+	// Keep every saved name pointing at one chat, so `telegram send --to '<name>'` reaches one
+	// person. A name another chat already holds is refused; re-saving or renaming the same chat is
+	// an update, because the check excludes this chat's own id. The match is case-insensitive and
+	// trimmed so a near-copy cannot reintroduce the ambiguity.
+	var existingID int64
+	dupErr := ms.db.QueryRow(
+		`SELECT chat_id FROM contacts WHERE LOWER(name) = LOWER(?) AND chat_id != ?`, trimmedName, chatID,
+	).Scan(&existingID)
+	if dupErr == nil {
+		return Contact{}, fmt.Errorf(
+			"a contact named %q already exists (chat %d); choose a distinct name like %q so a send names one person",
+			trimmedName, existingID, trimmedName+" R",
+		)
+	}
+	if dupErr != sql.ErrNoRows {
+		return Contact{}, fmt.Errorf("failed to check for a duplicate contact name: %v", dupErr)
+	}
 	_, err := ms.db.Exec(`
 		INSERT INTO contacts (chat_id, name, username, added_at, updated_at)
 		VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
@@ -629,10 +646,27 @@ func (ms *MessageStore) ResolveRecipient(identifier string) (int64, error) {
 		return chatID, nil
 	}
 
-	// Try as contact name (exact match first)
-	err = ms.db.QueryRow(`SELECT chat_id FROM contacts WHERE LOWER(name) = LOWER(?)`, identifier).Scan(&chatID)
-	if err == nil {
-		return chatID, nil
+	// Try as contact name (exact match). Two saved contacts sharing a name are ambiguous, so error
+	// with their chat ids instead of silently reaching one.
+	if exactRows, exactErr := ms.db.Query(`SELECT chat_id FROM contacts WHERE LOWER(name) = LOWER(?)`, identifier); exactErr == nil {
+		var exactIDs []int64
+		for exactRows.Next() {
+			var id int64
+			if exactRows.Scan(&id) == nil {
+				exactIDs = append(exactIDs, id)
+			}
+		}
+		exactRows.Close()
+		if len(exactIDs) == 1 {
+			return exactIDs[0], nil
+		}
+		if len(exactIDs) > 1 {
+			var labels []string
+			for _, id := range exactIDs {
+				labels = append(labels, fmt.Sprintf("%d", id))
+			}
+			return 0, fmt.Errorf("ambiguous recipient %q: saved for multiple chats (%s); address one by its chat id, or rename one", identifier, strings.Join(labels, ", "))
+		}
 	}
 
 	// Try as chat name


### PR DESCRIPTION
## What

The telegram analog of #1998's unique-names guarantee: a saved contact name must reach one person, so `telegram send --to '<name>'` never misroutes.

### The bug

`SaveManualContact` had no duplicate-name check (it conflicts only on `chat_id`), and `ResolveRecipient`'s exact-name step used `QueryRow` with no `ORDER BY`. So two saved contacts sharing a name (two "Sarah"s) made `send --to 'Sarah'` silently reach whichever row the database returned first. `requireManualContact` does not catch it, both are saved.

### The fix

- **`add-contact` refuses a name another chat already holds** (case-insensitive, trimmed). Re-saving or renaming the same chat is an update, since the check excludes that chat's own id. The error names the colliding chat id and suggests a distinct name.
- **`ResolveRecipient`'s exact-name match errors on ambiguity** with the colliding chat ids, instead of silently returning one. Legacy databases that already hold duplicates fail safe with the candidate list rather than misrouting.
- **Migration** (`2026-08-telegram-unique-contact-names.md`) renames apart any legacy contacts that already share a name, so name-based sends keep resolving on existing agents. It groups only saved (`is_manual: true`) rows, never an unsaved chat that `list-contacts` mixes in.

### Why no pushname/scrub half

#1998 also stopped WhatsApp from naming an unsaved chat by its provider pushname, because WhatsApp replies emit a contact **name** and resolution merged saved contacts with unsaved chats. Telegram is structurally different: the reply command addresses the numeric **chat id** (never a name), and `ResolveRecipient` matches saved contacts before it ever consults the unsaved `chats` table. So an unsaved chat's Telegram display name cannot shadow a saved contact, and there is nothing to scrub. Telegram also has no phone number for a bot-seen peer, so naming unsaved chats by a stable identifier would only degrade the `list-chats` display for no correctness gain.

## Tests

- Duplicate name for a different chat is refused, including case/space variants; re-saving or renaming the same chat succeeds.
- A unique saved name resolves; two contacts sharing a name resolve to an ambiguity error naming both chat ids.

## Verification

`./check.sh telegram` and `./check.sh guards` green. `test_migrations.py`: 28 passed, the 2 failures are the known local `tag.gpgsign` host artifact (green on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7kVZzxNftyb8DxQdNCSwQ