### PR TITLE
fix(daemons): register through the restart skill, not the SKILL.md block

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -102,7 +102,7 @@ The user's important people are [agent_name]'s important people too. Keeps track
 
 ### Notifications
 - `~/agent/notifications/` is where everything comes in: JSON files that background services drop there. If a service isn't running, its notifications simply don't exist.
-- The `restart` skill (`~/agent/skills/restart/SKILL.md`) must start every service the user has set up on every boot, via its `## Daemons` section. New integrations follow the same pattern: a daemon that writes JSON to `~/agent/notifications/`.
+- The `restart` skill (`~/agent/skills/restart/SKILL.md`) must start every service the user has set up on every boot; read it for how daemons are registered. New integrations follow the same pattern: a daemon that writes JSON to `~/agent/notifications/`.
 - The JSON field `interrupt: bool` is the producer's default (interrupt vs snooze); the user's notification rules override it (edited via the `notifications` skill).
 
 ### Self-Modification

--- a/agent/core/main.py
+++ b/agent/core/main.py
@@ -180,8 +180,8 @@ def collect_boot_turns(
     proceeds to sync. When sync merges changes, its own restart naturally leaves the still-unmarked
     after-sync migrations for the next boot.
 
-    Daemons come up last, at the greeting's restart turn (it runs the restart skill's Daemons block),
-    so they never start against a Daemons block the sync or a migration is about to rewrite. The
+    Daemons come up last, at the greeting's restart turn (it runs the restart skill),
+    so they never start against a daemon list the sync or a migration is about to rewrite. The
     greeting is appended every boot, before it is known whether this boot restarts: a boot that
     settles (no-op sync, a migration batch that does not restart, a plain restart) ends on it and
     brings daemons up, while a boot that restarts mid-converge (sync merge, before-sync barrier)

--- a/agent/core/prompts/restart.md
+++ b/agent/core/prompts/restart.md
@@ -1,1 +1,1 @@
-Your daemons are down after this restart. Read the `restart` skill and follow it: its Daemons block brings them back (idempotent, a safe no-op when everything is already up).
+Your daemons are down after this restart. Read the `restart` skill and follow it to bring them back (idempotent, a safe no-op when everything is already up).

--- a/agent/skills/agentmail/SETUP.md
+++ b/agent/skills/agentmail/SETUP.md
@@ -71,8 +71,7 @@ Start owns the public registration and waits until the service answers; stop is 
 shutdown, so it does not fire the `daemon_died` notification every other exit fires. Manage it with
 `daemon start|stop|restart|status`, never by launching `agentmail serve` yourself.
 
-Add this line yourself, inside the fenced block in the `## Daemons` section of
-`~/agent/skills/restart/SKILL.md`:
+So it survives restarts, read the `restart` skill and add this line to your restart daemons:
 
 ```
 agentmail daemon start

--- a/agent/skills/app-chat/SKILL.md
+++ b/agent/skills/app-chat/SKILL.md
@@ -18,7 +18,7 @@ uv tool install --editable ~/agent/skills/app-chat/cli
 - Status reports whether the daemon is up and on which port, read from `~/agent/data/daemons/app-chat.pid` and `app-chat.port`
 
 Manage the daemon through these commands, not by launching `app-chat serve` yourself. Startup output lands in `~/agent/logs/app-chat.log`.
-**Restart**: Add to the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
+**Restart**: So it survives restarts, read the `restart` skill and add this line to your restart daemons:
 ```
 app-chat daemon start
 ```

--- a/agent/skills/dashboard/scripts/setup.sh
+++ b/agent/skills/dashboard/scripts/setup.sh
@@ -46,6 +46,6 @@ fi
 
 echo "Dashboard setup complete."
 echo
-echo "Remaining step, yours to do: add this line inside the fenced Daemons block"
-echo "of ~/agent/skills/restart/SKILL.md, on its own line."
+echo "Remaining step, yours to do: so the dashboard survives restarts, read the"
+echo "restart skill and add this line to your restart daemons:"
 echo '  dashboard daemon start'

--- a/agent/skills/discord/SETUP.md
+++ b/agent/skills/discord/SETUP.md
@@ -17,7 +17,7 @@
    ```bash
    discord daemon start
    ```
-7. Add this line to the `## Daemons` section of `~/agent/skills/restart/SKILL.md` so the daemon survives restarts:
+7. So the daemon survives restarts, read the `restart` skill and add this line to your restart daemons:
    ```
    discord daemon start
    ```

--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -9,7 +9,7 @@ This is your scheduled moment to think unprompted. No one asked; you're checking
 
 ## Preflight: daemon liveness (do this first, every tick)
 
-Before anything else, confirm the daemons the `restart` skill starts are actually alive: ask each line in its Daemons block with the matching `<skill> daemon status`. Treat an error, a missing command, or any answer not reporting running as down, not only an explicit `"running": false`. A daemon can die silently (container up, daemon down), and a dead messaging daemon means you cannot reach the user at all, which is why this check comes first. Bring a dead daemon back with its own start line from that block, or re-run the whole Daemons block, which is idempotent and a no-op when everything is already up.
+Before anything else, confirm the daemons the `restart` skill starts are actually alive: ask each one it starts with the matching `<skill> daemon status`. Treat an error, a missing command, or any answer not reporting running as down, not only an explicit `"running": false`. A daemon can die silently (container up, daemon down), and a dead messaging daemon means you cannot reach the user at all, which is why this check comes first. Bring a dead daemon back with its own `<skill> daemon start`, or re-run the `restart` skill, which is idempotent and a no-op when everything is already up.
 
 ## Two questions, every time
 

--- a/agent/skills/skills-registry/SKILL.md
+++ b/agent/skills/skills-registry/SKILL.md
@@ -106,8 +106,8 @@ To hand that private service to someone who holds no app credential, mint it a s
 `service-key mint <service>` prints a one-time secret, and you share the keyed link. The `vestad`
 skill covers minting, revoking, and the link forms.
 
-Then add the startup line yourself, the bare `<skill> daemon start`, to the `## Daemons` section
-of the `restart` skill, so the daemon comes back after a container restart.
+Then read the `restart` skill and add the startup line yourself, the bare `<skill> daemon start`,
+to your restart daemons, so the daemon comes back after a container restart.
 
 Skills you build are yours until you file them: the `upstream-pr` skill contributes anything
 general back so every Vesta gets it.

--- a/agent/skills/slack/SETUP.md
+++ b/agent/skills/slack/SETUP.md
@@ -45,7 +45,7 @@
    ```bash
    slack daemon start
    ```
-7. Add this line to the `## Daemons` section of `~/agent/skills/restart/SKILL.md` so the daemon survives restarts:
+7. So the daemon survives restarts, read the `restart` skill and add this line to your restart daemons:
    ```
    slack daemon start
    ```

--- a/agent/skills/tasks/SKILL.md
+++ b/agent/skills/tasks/SKILL.md
@@ -82,7 +82,7 @@ the port registration with vestad; stop is the deliberate shutdown, so it does n
 `daemon_died` notification every other exit fires. Manage the daemon through these commands, never
 by launching `tasks serve` yourself.
 
-Add this line yourself, inside the fenced block in the `## Daemons` section of `~/agent/skills/restart/SKILL.md`:
+So the daemon survives restarts, read the `restart` skill and add this line to your restart daemons:
 ```
 tasks daemon start
 ```

--- a/agent/skills/vestad/SKILL.md
+++ b/agent/skills/vestad/SKILL.md
@@ -48,7 +48,7 @@ reaches it over this container's network, so a `127.0.0.1` bind is invisible to 
 with the port registered correctly. Register one when something outside the process needs to
 reach it: a web UI, an inbound webhook, an API the app calls.
 A background process that needs no inbound port is just a daemon: it does not register here,
-it only goes in the restart skill's `## Daemons` section.
+it only goes in your restart daemons, which the `restart` skill explains.
 
 Skills that run a service register it with vestad to get a port, then start it. The
 `register-service` helper does the curl and prints the port (idempotent: same port per name, so
@@ -175,9 +175,9 @@ tests hold to the behavior above: shell is `~/agent/skills/file-host/file-host`,
 `~/agent/skills/whatsapp/cli/daemon.go`. Read the one in the language you are writing in
 and follow it.
 
-Then add the startup line yourself, inside the fenced block in the `## Daemons` section of
-`~/agent/skills/restart/SKILL.md`, so the daemon comes back after a container restart. It is the
-bare command, nothing around it, because start is idempotent:
+Then read the `restart` skill and add the startup line yourself to your restart daemons, so the
+daemon comes back after a container restart. It is the bare command, nothing around it, because
+start is idempotent:
 
 ```bash
 file-host daemon start
@@ -290,7 +290,7 @@ The browser sits at `$VESTAD_TUNNEL/agents/$AGENT_NAME/<svc>/...`, so the prefix
 - **WebSockets work for a registered service.** vestad upgrades the connection and bridges it, pinging the client on a keepalive interval so an idle socket survives the tunnel. Only the raw agent port refuses to upgrade, because that carries the internal event bus; use `/sync` for that. A browser `WebSocket` cannot set headers, so carry a private service's key as `?token=<key>`.
 - **Bind `0.0.0.0`, not `127.0.0.1`.** The container has its own network and vestad proxies in from outside, so a loopback-only bind answers 502.
 - **Default to private** and hand the user a minted `/k/<key>/` link, the shape the signature pad uses. `public: true` is only for a page that must load with no credential at all (the QR-link-page shape), carries nothing sensitive, and is the rare exception, never the convenient default.
-- A single stdlib `http.server` on the assigned port can serve both the HTML and the JSON API with state in memory. Give it a launcher exposing `daemon start|stop|restart|status` (copy an existing one, e.g. `skills/file-host/file-host`) plus a line in the restart skill's Daemons block, so the link survives reboots.
+- A single stdlib `http.server` on the assigned port can serve both the HTML and the JSON API with state in memory. Give it a launcher exposing `daemon start|stop|restart|status` (copy an existing one, e.g. `skills/file-host/file-host`) plus a line in your restart daemons (the `restart` skill explains how), so the link survives reboots.
 
 ## Update vestad
 

--- a/agent/skills/whatsapp/setup.sh
+++ b/agent/skills/whatsapp/setup.sh
@@ -30,8 +30,8 @@ whatsapp daemon start
 
 echo "setup complete, link an account with: whatsapp connect --source <vesta-cloud|doubletick|self-managed> (see SETUP.md)"
 echo
-echo "Remaining step, yours to do: add this line inside the fenced Daemons block"
-echo "of ~/agent/skills/restart/SKILL.md, on its own line."
+echo "Remaining step, yours to do: so whatsapp survives restarts, read the restart"
+echo "skill and add this line to your restart daemons."
 echo "\`whatsapp daemon start\` brings the daemon up and waits until it answers, so"
 echo "inbound notifications flow before you send anything."
 echo '  whatsapp daemon start'


### PR DESCRIPTION
Follow-up to #1968. Completes #1913: #1968 fixed the *runner* but not the *writers* that feed it.

## The gap

`start-daemons.sh` reads `daemons.sh` on disk. The restart `SKILL.md` fenced `## Daemons` block is no longer read by anything. But many skills still told the agent to add its daemon line to that block, so a daemon set up after #1968 landed gets written where the runner never looks: it silently never starts on restart, and `start-daemons.sh` still exits 0 green. That is the exact silent-skip failure #1968 removed, relocated from the runner to the writers.

The #1968 review flagged six writers. There were more: `whatsapp/setup.sh`, `agentmail/SETUP.md`, the generic `skills-registry` guidance, and two further spots in `vestad/SKILL.md`, plus `proactive-check` reading the block as its liveness list.

## The change

Make the restart skill the **single owner** of the registration mechanism (one-owner-per-decision). Every other skill keeps its concrete `<skill> daemon start` line but directs the agent to read the `restart` skill and add it to the restart daemons, naming no block, section, or file:

- **Writers repointed** (8): `tasks`, `app-chat`, `slack`, `discord`, `dashboard`, `vestad`, `whatsapp`, `agentmail`.
- **Authoring guides repointed**: `skills-registry/SKILL.md` (the generic "add a daemon" step) and the daemon-authoring section of `vestad/SKILL.md`.
- **Reader fixed**: `proactive-check/SKILL.md` now checks each daemon the restart skill starts and re-runs the `restart` skill, instead of enumerating "the Daemons block".
- **Stale wording**: the boot prompt (`prompts/restart.md`), the `main.py` boot-order comment, and `MEMORY.md` no longer say "Daemons block".

Shipped migrations that reshape the block are left untouched: they are append-only and describe the on-disk state at the moment they run.

## Why no migration

Pure instructional-text changes to stock skill files. Agents pick them up on the next upstream sync (git merge), and #1968 already shipped the `daemons.sh` mechanism plus its state migration. Nothing on disk moves, so there is no stranded state to converge.

## Checks

- `shellcheck -S warning` clean on the two edited scripts.
- `ruff check` + `ruff format --check` clean on `main.py`.
- `scripts/check-conventions.py` exit 0.
- No em/en dashes in changed files; no remaining block references outside shipped migrations and one test comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7kVZzxNftyb8DxQdNCSwQ