### PR TITLE
chore: revert the burned 0.2.3 version bump

### DIFF
--- a/agent/core/pyproject.toml
+++ b/agent/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vesta"
-version = "0.2.3"
+version = "0.2.2"
 description = "AI guardian angel that works autonomously on your behalf"
 license = "MIT"
 authors = [

--- a/agent/core/uv.lock
+++ b/agent/core/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.2.3"
+version = "0.2.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vesta/desktop",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.2",
   "description": "Vesta desktop app (Electron wrapper around @vesta/web)",
   "author": "elyxlz <58893694+elyxlz@users.noreply.github.com>",
   "license": "MIT",

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -33,7 +33,7 @@ const config: ExpoConfig = {
   name: isDevelopment ? "Vesta Dev" : "Vesta",
   owner: "vesta-cloud",
   slug: "vesta",
-  version: "0.2.3",
+  version: "0.2.2",
   scheme: isDevelopment ? "vesta-dev" : "vesta",
   orientation: "portrait",
   icon: appIcon,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vesta/mobile",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.2",
   "description": "Vesta native mobile app for iOS and Android",
   "license": "MIT",
   "main": "expo-router/entry",

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -141,7 +141,7 @@
     },
     "desktop": {
       "name": "@vesta/desktop",
-      "version": "0.2.3",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9"
@@ -254,7 +254,7 @@
     },
     "mobile": {
       "name": "@vesta/mobile",
-      "version": "0.2.3",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -25709,7 +25709,7 @@
     },
     "web": {
       "name": "@vesta/web",
-      "version": "0.2.3",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-rc.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vesta/web",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.2",
   "description": "Vesta web app (served by vestad at /app)",
   "license": "MIT",
   "repository": {

--- a/vestad/Cargo.lock
+++ b/vestad/Cargo.lock
@@ -3308,7 +3308,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta-tests"
-version = "0.2.3"
+version = "0.2.2"
 dependencies = [
  "futures-util",
  "ring",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "vestad"
-version = "0.2.3"
+version = "0.2.2"
 dependencies = [
  "async-stream",
  "axum",

--- a/vestad/Cargo.toml
+++ b/vestad/Cargo.toml
@@ -23,7 +23,7 @@ unimplemented = "deny"
 
 [package]
 name = "vestad"
-version = "0.2.3"
+version = "0.2.2"
 license = "MIT"
 repository = "https://github.com/elyxlz/vesta"
 authors = ["elyxlz"]

--- a/vestad/tests-integration/Cargo.toml
+++ b/vestad/tests-integration/Cargo.toml
@@ -3,7 +3,7 @@
 # them (CARGO_BIN_EXE_vestad); vestad dev-depends on this crate for the harness.
 [package]
 name = "vesta-tests"
-version = "0.2.3"
+version = "0.2.2"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Reverts the orphaned `Bump version to 0.2.3` commit (`7db6a8fb`).

## Why

The 0.2.3 release (Aug 13) cut its `v0.2.3` prerelease, but the release pipeline then failed and its `Release · Revert failed release` job deleted the tag and prerelease. Per the unrelease design the version-bump commit is normally left on `master` and the number is burned, so `master` now carries `version = "0.2.3"` across every manifest with no `v0.2.3` release behind it (latest published is `v0.2.2`).

Both pipeline failures were environmental, not code defects:
- **Live e2e gate:** the `CLAUDE_CREDENTIALS` OAuth token expired mid-run (`OAuth session expired and could not be refreshed` -> provider flipped to `not_authenticated`), so the 4 live tests needing a timely real reply timed out. Credentials have since been refreshed by the scheduled workflow.
- **Agent image warm build cache:** a transient TLS error (`curl … claude.ai/install.sh … exit code 35`) fetching the Claude CLI during the image build.

This revert returns `master` to 0.2.2 so the 0.2.3 number is reclaimed and the next `./release.sh` cuts a clean 0.2.3 rather than skipping to 0.2.4.

## Change

Pure inverse of the bot bump: 10 files (Cargo.toml/lock, pyproject + uv.lock, the app package.json/lock files, mobile app.config.ts, tests-integration Cargo.toml) back to 0.2.2. No code touched.
