### PR TITLE
fix(ci): grant actions:read to the release pipeline for the live-tests preflight

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -12,6 +12,9 @@ permissions:
   # ci.yml (called below) requests pull-requests: read; a reusable workflow
   # cannot request more than its caller grants, so grant it here too.
   pull-requests: read
+  # live-tests.yml (called below) requests actions: read for its credentials
+  # preflight, same reusable-workflow rule: grant it here too.
+  actions: read
 
 concurrency:
   group: release-pipeline-${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Problem

The v0.2.3 release pipeline failed with `startup_failure` (run 31829866677), so it never ran a single job. Root cause: a reusable-workflow permission escalation.

`#2038` added `actions: read` to `live-tests.yml` (its credentials preflight now calls `gh run list --workflow=refresh-credentials.yml`). `release-pipeline.yml` calls `live-tests.yml` as a reusable workflow. GitHub rejects a called workflow that requests more permission than its caller grants, and the pipeline's top-level `permissions` grants `contents/packages/pull-requests: read` but not `actions: read`, so the entire pipeline is rejected at launch.

`#2038`'s own PR CI could not catch this: `live-tests.yml` is invoked only by the release pipeline, never on PRs, and no static check validates a cross-workflow permission escalation (GitHub validates it only at run launch).

## Fix

Grant `actions: read` in `release-pipeline.yml`'s top-level `permissions`, exactly mirroring the `pull-requests: read` precedent (and its explanatory comment) one line above. One line plus a comment, no logic change.

## Verification

The failure is a launch-time validation, reproducible only by cutting a release. This grant makes the caller's permission set a superset of `live-tests.yml`'s request, which is the documented requirement. After this merges, the next release re-run launches the pipeline instead of `startup_failure`.
