### PR TITLE
chore: revert the re-burned 0.2.3 version bump

### DIFF
--- a/agent/core/pyproject.toml
+++ b/agent/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vesta"
-version = "0.2.3"
+version = "0.2.2"
 description = "AI guardian angel that works autonomously on your behalf"
 license = "MIT"
 authors = [

--- a/agent/core/uv.lock
+++ b/agent/core/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "vesta"
-version = "0.2.3"
+version = "0.2.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vesta/desktop",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.2",
   "description": "Vesta desktop app (Electron wrapper around @vesta/web)",
   "author": "elyxlz <58893694+elyxlz@users.noreply.github.com>",
   "license": "MIT",

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -33,7 +33,7 @@ const config: ExpoConfig = {
   name: isDevelopment ? "Vesta Dev" : "Vesta",
   owner: "vesta-cloud",
   slug: "vesta",
-  version: "0.2.3",
+  version: "0.2.2",
   scheme: isDevelopment ? "vesta-dev" : "vesta",
   orientation: "portrait",
   icon: appIcon,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vesta/mobile",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.2",
   "description": "Vesta native mobile app for iOS and Android",
   "license": "MIT",
   "main": "expo-router/entry",

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -141,7 +141,7 @@
     },
     "desktop": {
       "name": "@vesta/desktop",
-      "version": "0.2.3",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9"
@@ -254,7 +254,7 @@
     },
     "mobile": {
       "name": "@vesta/mobile",
-      "version": "0.2.3",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -25709,7 +25709,7 @@
     },
     "web": {
       "name": "@vesta/web",
-      "version": "0.2.3",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-rc.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vesta/web",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.2",
   "description": "Vesta web app (served by vestad at /app)",
   "license": "MIT",
   "repository": {

--- a/vestad/Cargo.lock
+++ b/vestad/Cargo.lock
@@ -3308,7 +3308,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesta-tests"
-version = "0.2.3"
+version = "0.2.2"
 dependencies = [
  "futures-util",
  "ring",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "vestad"
-version = "0.2.3"
+version = "0.2.2"
 dependencies = [
  "async-stream",
  "axum",

--- a/vestad/Cargo.toml
+++ b/vestad/Cargo.toml
@@ -23,7 +23,7 @@ unimplemented = "deny"
 
 [package]
 name = "vestad"
-version = "0.2.3"
+version = "0.2.2"
 license = "MIT"
 repository = "https://github.com/elyxlz/vesta"
 authors = ["elyxlz"]

--- a/vestad/tests-integration/Cargo.toml
+++ b/vestad/tests-integration/Cargo.toml
@@ -3,7 +3,7 @@
 # them (CARGO_BIN_EXE_vestad); vestad dev-depends on this crate for the harness.
 [package]
 name = "vesta-tests"
-version = "0.2.3"
+version = "0.2.2"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Reverts the second stranded `Bump version to 0.2.3` (`a6996480`), left on master when the v0.2.3 retry failed at pipeline startup (missing `actions: read`, fixed in #2049) and release.sh pulled the beta.

Returns master to 0.2.2 so, once #2049 lands, the next `./release.sh` cuts a clean 0.2.3. Pure inverse of the bot bump: 10 version/lock files, no code touched. Same as the prior reconcile #2048, needed again after the second failed attempt.