### PR TITLE
test(vestad): harden the two flaky gateway_update integration races

### DIFF
--- a/vestad/tests-integration/src/lib.rs
+++ b/vestad/tests-integration/src/lib.rs
@@ -44,6 +44,13 @@ static TEST_AGENT_COUNTER: AtomicU32 = AtomicU32::new(0);
 /// curl flags that absorb transient GitHub API/CDN flakes during integration tests.
 const CURL_RETRY_ARGS: &[&str] = &["--retry", "5", "--retry-all-errors", "--retry-delay", "2"];
 
+/// A gateway update swaps the very binary the next boot exec's; the swap's writer can still hold
+/// the file when the boot spawns it, which the kernel reports as ETXTBSY (errno 26). The busy
+/// window closes the instant that handle drops, so a short bounded retry absorbs it.
+const ETXTBSY: i32 = 26;
+const SPAWN_ETXTBSY_BUDGET: Duration = Duration::from_secs(5);
+const SPAWN_ETXTBSY_BACKOFF: Duration = Duration::from_millis(50);
+
 /// Generate a unique user name for test isolation. Includes PID for cross-run
 /// uniqueness and an atomic counter for intra-run uniqueness. This prevents
 /// tests from seeing each other's Docker containers (vestad scopes by
@@ -269,7 +276,19 @@ impl TestServer {
             cmd.env(key, value);
         }
 
-        let process = cmd.spawn().map_err(|e| format!("spawn vestad: {e}"))?;
+        let spawn_deadline = std::time::Instant::now() + SPAWN_ETXTBSY_BUDGET;
+        let process = loop {
+            match cmd.spawn() {
+                Ok(child) => break child,
+                Err(e)
+                    if e.raw_os_error() == Some(ETXTBSY)
+                        && std::time::Instant::now() < spawn_deadline =>
+                {
+                    std::thread::sleep(SPAWN_ETXTBSY_BACKOFF);
+                }
+                Err(e) => return Err(format!("spawn vestad: {e}")),
+            }
+        };
 
         let config_dir = home.join(".config/vesta/vestad");
         let port_path = config_dir.join("port");

--- a/vestad/tests/server/gateway_update.rs
+++ b/vestad/tests/server/gateway_update.rs
@@ -286,6 +286,13 @@ async fn collect_until_phase(
         if operation.is_null() {
             continue;
         }
+        // A retried update watches a socket whose projection still carries the prior attempt's
+        // terminal `failed`. That residual precedes the fresh walk, so drop it while nothing else
+        // has been seen: a terminal state never opens a forward walk, and counting it would read as
+        // the update going backwards. A walk deliberately ending on `failed` keeps it.
+        if seen.is_empty() && operation["phase"].as_str() == Some("failed") && phase != "failed" {
+            continue;
+        }
         let reached = operation["phase"].as_str() == Some(phase);
         seen.push(operation);
         if reached {


### PR DESCRIPTION
## Problem

The v0.2.3 release pipeline's `vestad · Run end-to-end integration tests` job failed twice, each on a **different** `gateway_update` test (64/65 passing every run). Neither is a product defect: both are races in the test harness.

### 1. `spawn vestad: Text file busy (os error 26)`
`Gateway::install` copies the vestad binary, and an update **swaps that exact file**. The next boot exec's it, and the swap's writer can still hold the file open when the boot spawns it, which the kernel reports as `ETXTBSY`. In production this cannot happen: systemd fully exits the old process before exec. It is a harness-only race, so the harness spawn (`tests-integration/src/lib.rs`) now retries briefly on `ETXTBSY` within a 5s budget. The busy window closes the instant the writer's handle drops.

### 2. `the update walked backwards`
`an_interrupted_update_is_recovered_swept_and_retryable` interrupts an update (leaving a terminal `failed` projection), then retries on the **same** `/sync` socket. `collect_until_phase` read that residual `failed` before the retry's fresh `snapshotting -> applying -> restarting`, so `assert_phases_in_order` saw rank 3 -> 0 and failed. The observed sequence was literally `[failed, snapshotting, snapshotting, applying, restarting]`.

`collect_until_phase` now drops a leading terminal `failed` (a terminal state never opens a forward walk). The failure tests are unaffected: they assert `failed` via the snapshot/handshake, and a walk deliberately ending on `failed` (the dismiss test) still keeps it because the drop only applies while nothing else has been collected and the target phase is not `failed`.

## Scope

Test-harness only, no product code. Two files: the spawn retry in `tests-integration/src/lib.rs`, the residual drop in `tests/server/gateway_update.rs`.

## Verification

- `cargo clippy -p vesta-tests --all-targets -D warnings`: clean.
- `cargo test -p vestad --test server --no-run`: compiles.
- The Docker integration suite runs in this PR's CI (`check.sh integration`), the same job that flaked.

The behavioral proof of a flake fix is repeated green runs. This PR's CI is one; a local multi-run of just the `gateway_update` tests can add confidence, but it spins Docker on a shared host with live agents, so I have not run it without asking.
