### PR TITLE
ci: keep whatsmeow current via daily Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,7 +55,7 @@ updates:
   - package-ecosystem: gomod
     directory: /agent/skills/whatsapp/cli
     schedule:
-      interval: weekly
+      interval: daily
     groups:
       whatsapp-deps:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,17 @@ updates:
       - dependency-name: "eslint-config-expo"
         update-types: ["version-update:semver-major"]
 
+  # Keeps whatsmeow (and the rest of the whatsapp CLI's Go deps) current through
+  # a reviewed PR gated by CI, never a runtime @latest float: the launcher pins
+  # whatsmeow deliberately because a mid-session bump can log the device out.
+  - package-ecosystem: gomod
+    directory: /agent/skills/whatsapp/cli
+    schedule:
+      interval: weekly
+    groups:
+      whatsapp-deps:
+        patterns: ["*"]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## What

Add a `gomod` Dependabot entry for `agent/skills/whatsapp/cli`, scheduled **daily**, so whatsmeow (and the CLI's other Go dependencies) tracks upstream as closely as Dependabot allows.

## Why

whatsmeow's protocol code ages and WhatsApp periodically breaks old versions (issue #1073). Dependabot did not cover any of the Go modules, so the pin only moved when someone ran `whatsapp update-deps` by hand.

This keeps it current through a **reviewed, CI-gated PR** rather than a runtime `@latest` float. The launcher (`agent/skills/whatsapp/whatsapp`) pins whatsmeow deliberately: a mid-session bump can invalidate a multi-device session and log the companion device out, and an on-every-serve recompile turned a keepalive into a churn loop. Dependabot bumps `go.mod`/`go.sum` on master; each bump is gated by `./check.sh whatsapp` (Go lint + build + test), and the fleet rebuilds against the new pin on the next daemon restart via upstream sync. Daily is Dependabot's finest cadence.

## Scope

Only the whatsapp CLI module. `telegram/cli` and `otp/cli` are left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdguFimBQw8xLJNn1zaMG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdguFimBQw8xLJNn1zaMG1)_