### PR TITLE
feat(mobile): serve every agent-settings section on Android

### DIFF
--- a/apps/mobile/app/agent/[name]/_layout.tsx
+++ b/apps/mobile/app/agent/[name]/_layout.tsx
@@ -55,7 +55,7 @@ export default function AgentLayout() {
         <Stack.Screen name="logs" options={androidSheetOptions} />
         <Stack.Screen name="notifications" options={androidSheetOptions} />
         <Stack.Screen name="file" />
-        <Stack.Screen name="details/[section]" />
+        <Stack.Screen name="details/[section]" options={androidSheetOptions} />
       </Stack>
     </AgentProvider>
   );

--- a/apps/mobile/app/agent/[name]/details/[section].tsx
+++ b/apps/mobile/app/agent/[name]/details/[section].tsx
@@ -9,13 +9,14 @@ import { HostAccessSection } from "@/agent/settings/HostAccessSection";
 import { NotificationsSection } from "@/agent/settings/NotificationsSection";
 import { ProviderSection } from "@/agent/settings/ProviderSection";
 import {
-  sectionAvailability,
+  findSection,
   sectionTitle,
   type AgentSettingsSectionKey,
 } from "@/agent/settings/sections-model";
 import { VoiceSection } from "@/agent/settings/VoiceSection";
 import { Screen } from "@/components/layout/Screen";
 import { NativeSheetCloseButton } from "@/components/native-sheet-close-button";
+import { SheetChrome } from "@/components/sheet-chrome";
 import { Text } from "@/components/ui/Typography";
 import { usePreferences } from "@/preferences/PreferencesProvider";
 
@@ -35,23 +36,19 @@ export default function AgentDetailScreen() {
   const section =
     typeof parameters.section === "string" ? parameters.section : "general";
   const title = sectionTitle(section);
-  const availability = sectionAvailability(section);
-  const Section =
-    availability.state === "available"
-      ? SECTION_CONTENT[availability.section.key]
-      : null;
+  const found = findSection(section);
+  const Section = found ? SECTION_CONTENT[found.key] : null;
   return (
     <>
       <Stack.Title>{title}</Stack.Title>
       <NativeSheetCloseButton accessibilityLabel={`Close ${title}`} />
+      <SheetChrome title={title} closeLabel={`Close ${title}`} />
       <Screen contentStyle={styles.content}>
         {Section ? (
           <Section />
         ) : (
           <Text style={[styles.unknown, { color: colors.secondaryText }]}>
-            {availability.state === "hidden"
-              ? "This settings section is not available on Android yet."
-              : "This settings section does not exist."}
+            This settings section does not exist.
           </Text>
         )}
       </Screen>

--- a/apps/mobile/app/agent/[name]/settings.tsx
+++ b/apps/mobile/app/agent/[name]/settings.tsx
@@ -10,10 +10,7 @@ import {
   stopAgent,
 } from "@/api/endpoints";
 import { useAgent } from "@/agent/AgentProvider";
-import {
-  sectionTitle,
-  showsAdvancedSections,
-} from "@/agent/settings/sections-model";
+import { sectionTitle } from "@/agent/settings/sections-model";
 import { AgentPagesSettingsSection } from "@/components/AgentPagesSettingsSection";
 import { AgentIdentityCard } from "@/components/agent-identity-card";
 import { Screen } from "@/components/layout/Screen";
@@ -25,8 +22,6 @@ import { Button, ButtonGroup } from "@/components/ui/Button";
 import { FormSection, SwitchRow } from "@/components/ui/Form";
 import { usePreferences } from "@/preferences/PreferencesProvider";
 import { useSession } from "@/session/SessionProvider";
-
-const SHOWS_ADVANCED_SECTIONS = showsAdvancedSections();
 
 function AgentSettingsContent() {
   const router = useRouter();
@@ -80,16 +75,14 @@ function AgentSettingsContent() {
       <FormSection
         title="Agent"
         actions={
-          SHOWS_ADVANCED_SECTIONS ? (
-            <>
-              <Button pill variant="card" onPress={() => open("provider")}>
-                {sectionTitle("provider")}
-              </Button>
-              <Button pill variant="card" onPress={() => open("voice")}>
-                {sectionTitle("voice")}
-              </Button>
-            </>
-          ) : undefined
+          <>
+            <Button pill variant="card" onPress={() => open("provider")}>
+              {sectionTitle("provider")}
+            </Button>
+            <Button pill variant="card" onPress={() => open("voice")}>
+              {sectionTitle("voice")}
+            </Button>
+          </>
         }
       >
         <SwitchRow
@@ -105,33 +98,7 @@ function AgentSettingsContent() {
       <FormSection
         title="Attention"
         actions={
-          SHOWS_ADVANCED_SECTIONS ? (
-            <>
-              <ButtonGroup>
-                <Button
-                  variant="cardGrouped"
-                  onPress={() => openPage("notifications")}
-                >
-                  Notifications
-                </Button>
-                <Button
-                  variant="cardGrouped"
-                  onPress={() => open("notifications")}
-                >
-                  {sectionTitle("notifications")}
-                </Button>
-              </ButtonGroup>
-              <Button pill variant="card" onPress={() => openPage("logs")}>
-                Logs
-              </Button>
-              <Button pill variant="card" onPress={() => open("files")}>
-                {sectionTitle("files")}
-              </Button>
-              <Button pill variant="card" onPress={() => open("host-access")}>
-                {sectionTitle("host-access")}
-              </Button>
-            </>
-          ) : (
+          <>
             <ButtonGroup>
               <Button
                 variant="cardGrouped"
@@ -139,41 +106,41 @@ function AgentSettingsContent() {
               >
                 Notifications
               </Button>
-              <Button variant="cardGrouped" onPress={() => openPage("logs")}>
-                Logs
+              <Button
+                variant="cardGrouped"
+                onPress={() => open("notifications")}
+              >
+                {sectionTitle("notifications")}
               </Button>
             </ButtonGroup>
-          )
+            <Button pill variant="card" onPress={() => openPage("logs")}>
+              Logs
+            </Button>
+            <Button pill variant="card" onPress={() => open("files")}>
+              {sectionTitle("files")}
+            </Button>
+            <Button pill variant="card" onPress={() => open("host-access")}>
+              {sectionTitle("host-access")}
+            </Button>
+          </>
         }
       />
       <FormSection
         title="Backups"
         actions={
-          SHOWS_ADVANCED_SECTIONS ? (
-            <ButtonGroup>
-              <Button variant="cardGrouped" onPress={() => open("backups")}>
-                Manage backups
-              </Button>
-              <Button
-                variant="cardGrouped"
-                disabled={action.isPending}
-                loading={action.isPending && action.variables === "backup"}
-                onPress={() => action.mutate("backup")}
-              >
-                Back up now
-              </Button>
-            </ButtonGroup>
-          ) : (
+          <ButtonGroup>
+            <Button variant="cardGrouped" onPress={() => open("backups")}>
+              Manage backups
+            </Button>
             <Button
-              pill
-              variant="card"
+              variant="cardGrouped"
               disabled={action.isPending}
               loading={action.isPending && action.variables === "backup"}
               onPress={() => action.mutate("backup")}
             >
               Back up now
             </Button>
-          )
+          </ButtonGroup>
         }
       />
       <FormSection

--- a/apps/mobile/src/agent/settings/sections-model.test.ts
+++ b/apps/mobile/src/agent/settings/sections-model.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   AGENT_SETTINGS_SECTIONS,
-  sectionAvailability,
+  findSection,
   sectionTitle,
-  showsAdvancedSections,
 } from "./sections-model";
 
 describe("sectionTitle", () => {
@@ -24,40 +23,14 @@ describe("sectionTitle", () => {
   });
 });
 
-describe("showsAdvancedSections", () => {
-  it.each([
-    ["ios", true],
-    ["android", false],
-    [undefined, false],
-  ])("on %s answers %s", (os, shows) => {
-    expect(showsAdvancedSections(os)).toBe(shows);
-  });
-});
-
-describe("sectionAvailability", () => {
-  it("serves every section on iOS, carrying the section", () => {
+describe("findSection", () => {
+  it("finds every section, carrying it for content lookup", () => {
     for (const section of AGENT_SETTINGS_SECTIONS) {
-      expect(sectionAvailability(section.key, "ios")).toEqual({
-        state: "available",
-        section,
-      });
+      expect(findSection(section.key)).toEqual(section);
     }
   });
 
-  it.each([
-    ["general", "available"],
-    ["provider", "hidden"],
-    ["voice", "hidden"],
-    ["notifications", "hidden"],
-    ["files", "hidden"],
-    ["host-access", "hidden"],
-    ["backups", "hidden"],
-  ])("on Android answers %s -> %s", (key, availability) => {
-    expect(sectionAvailability(key, "android").state).toBe(availability);
-  });
-
-  it("reports an unknown key on both platforms", () => {
-    expect(sectionAvailability("time-travel", "ios").state).toBe("unknown");
-    expect(sectionAvailability("time-travel", "android").state).toBe("unknown");
+  it("returns null for an unknown deep-link key", () => {
+    expect(findSection("time-travel")).toBeNull();
   });
 });

--- a/apps/mobile/src/agent/settings/sections-model.ts
+++ b/apps/mobile/src/agent/settings/sections-model.ts
@@ -1,11 +1,11 @@
 const SECTIONS = [
-  { key: "general", title: "General", advanced: false },
-  { key: "provider", title: "Provider and model", advanced: true },
-  { key: "voice", title: "Voice", advanced: true },
-  { key: "notifications", title: "Notification rules", advanced: true },
-  { key: "files", title: "Files", advanced: true },
-  { key: "host-access", title: "Host access", advanced: true },
-  { key: "backups", title: "Backups", advanced: true },
+  { key: "general", title: "General" },
+  { key: "provider", title: "Provider and model" },
+  { key: "voice", title: "Voice" },
+  { key: "notifications", title: "Notification rules" },
+  { key: "files", title: "Files" },
+  { key: "host-access", title: "Host access" },
+  { key: "backups", title: "Backups" },
 ] as const;
 
 export type AgentSettingsSectionKey = (typeof SECTIONS)[number]["key"];
@@ -13,37 +13,16 @@ export type AgentSettingsSectionKey = (typeof SECTIONS)[number]["key"];
 export interface AgentSettingsSection {
   key: AgentSettingsSectionKey;
   title: string;
-  advanced: boolean;
 }
 
 export const AGENT_SETTINGS_SECTIONS: readonly AgentSettingsSection[] = SECTIONS;
 
-// Agent settings on Android carry only the simple critical controls, so a
-// deep link into a hidden section lands on the fallback, never a broken page.
-export function showsAdvancedSections(
-  os: string | undefined = process.env.EXPO_OS,
-): boolean {
-  return os === "ios";
-}
-
 export function sectionTitle(key: string): string {
-  const section = AGENT_SETTINGS_SECTIONS.find((entry) => entry.key === key);
-  return section?.title ?? "Settings";
+  return findSection(key)?.title ?? "Settings";
 }
 
 // Carrying the found section lets a caller index a Record<AgentSettingsSectionKey, ...>
-// without re-deriving which keys exist.
-export type SectionAvailability =
-  | { state: "available"; section: AgentSettingsSection }
-  | { state: "hidden" }
-  | { state: "unknown" };
-
-export function sectionAvailability(
-  key: string,
-  os: string | undefined = process.env.EXPO_OS,
-): SectionAvailability {
-  const section = AGENT_SETTINGS_SECTIONS.find((entry) => entry.key === key);
-  if (!section) return { state: "unknown" };
-  if (section.advanced && !showsAdvancedSections(os)) return { state: "hidden" };
-  return { state: "available", section };
+// without re-deriving which keys exist; an unknown deep-link key returns null.
+export function findSection(key: string): AgentSettingsSection | null {
+  return AGENT_SETTINGS_SECTIONS.find((entry) => entry.key === key) ?? null;
 }


### PR DESCRIPTION
Stacked on #2095 (base is `refactor/mobile-polish`; retarget to `master` once #2095 merges).

The Android port shipped the agent-settings hub with the advanced sections gated to iOS (`showsAdvancedSections`), so provider/model, voice, notification rules, files, host access, and backup management had no Android page. Every section component already builds on cross-platform primitives (Form rows, Button, Card, toast), so this PR turns them on:

- `details/[section]` presents as a Material form sheet on Android (the same `androidSheetOptions` the logs and notifications routes use) and renders the in-content `SheetChrome` title + close button, which iOS renders natively.
- The platform gate is deleted, not widened: `sections-model` shrinks to the section list plus `findSection`, the `advanced` flag and the "hidden" availability state are gone, and `settings.tsx` renders one layout on both platforms.
- Net deletion: the "not available on Android yet" fallback can no longer be reached and is removed.

Verified with `./check.sh app-mobile` (lint, tsc, 295 vitest tests, clean prebuild). On-device Android walkthrough of the six sections is worth a pass before release; the visual-harness coverage PR that follows adds these screens to the Android catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01367FvVt2ot8i47NQPYQ1Ym