### PR TITLE
fix(tasks): stamp checkpoints on create and keep the offset on daily reminders

### DIFF
--- a/agent/skills/reminders/cli/src/reminders_cli/commands.py
+++ b/agent/skills/reminders/cli/src/reminders_cli/commands.py
@@ -238,7 +238,9 @@ def _parse_local_dt(datetime_str: str, timezone_str: str | None, *, allow_bare_t
         except ValueError:
             pass
         else:
-            return datetime.combine(datetime.now(local_tz).date(), bare, tzinfo=local_tz)
+            # combine keeps the bare time's own offset when it carries one, so it lands below like any aware datetime.
+            parsed = datetime.combine(datetime.now(local_tz).date(), bare)
+            return parsed.astimezone(local_tz) if parsed.tzinfo is not None else parsed.replace(tzinfo=local_tz)
 
     parsed = datetime.fromisoformat(datetime_str)
     if parsed.tzinfo is not None:

--- a/agent/skills/reminders/cli/tests/test_interface.py
+++ b/agent/skills/reminders/cli/tests/test_interface.py
@@ -66,6 +66,13 @@ def test_daily_reminder_bare_time_with_tz_keeps_the_pinned_zone_in_the_label(tmp
     assert result["schedule"] == "daily at 21:30 Europe/Rome"
 
 
+def test_daily_reminder_bare_time_keeps_its_own_offset(tmp_config: Config, monkeypatch):
+    """A bare time carrying an offset is that wall clock in that offset, not in the agent's zone."""
+    monkeypatch.setenv("TZ", "UTC")
+    result = commands.remind_set(tmp_config, commands.ReminderSpec(message="wind down", recurring="daily", scheduled_datetime="21:30+02:00"))
+    assert result["schedule"] == "daily at 19:30"
+
+
 def test_weekly_reminder_still_requires_a_date(tmp_config: Config):
     """A weekly schedule takes its weekday from the date, so a bare time carries too little."""
     with pytest.raises(ValueError):

--- a/agent/skills/tasks/cli/src/tasks_cli/commands.py
+++ b/agent/skills/tasks/cli/src/tasks_cli/commands.py
@@ -203,10 +203,13 @@ def add_task(
     task_id = str(uuid.uuid4())[:8]
     due_date = _compute_due_date(due)
 
+    # The ladder starts when its date is set (see update_task): the marker is the instant after the
+    # due date was computed, so a rung landing at creation (--in-days 1 has its due-1d rung right
+    # here) is not read as already passed.
     with closing(db.get_db(config.data_dir)) as conn:
         conn.execute(
-            "INSERT INTO tasks (id, subject, priority, due_date) VALUES (?, ?, ?, ?)",
-            (task_id, subject, priority, due_date),
+            "INSERT INTO tasks (id, subject, priority, due_date, checkpoint_fired_through) VALUES (?, ?, ?, ?, ?)",
+            (task_id, subject, priority, due_date, _now_utc().isoformat()),
         )
         conn.commit()
 

--- a/agent/skills/tasks/cli/tests/test_checkpoints.py
+++ b/agent/skills/tasks/cli/tests/test_checkpoints.py
@@ -78,6 +78,16 @@ def test_lead_checkpoint_fires_once_and_advances_the_marker(tmp_config: Config, 
     assert notifs[0]["task_id"] == task["id"]
 
 
+def test_creating_a_task_fires_no_rung_that_lands_at_creation(tmp_config: Config, tmp_path: Path):
+    """--in-days 1 puts the due-1d rung at the creation instant; created_at is second-truncated,
+    so without the marker that rung reads as already passed and fires on the first tick."""
+    notif_dir = tmp_path / "notifs"
+    notif_dir.mkdir()
+    commands.add_task(tmp_config, subject="fresh", due=commands.DueSpec(due_in_days=1))
+
+    assert commands.fire_due_checkpoints(tmp_config, notif_dir, now=datetime.now(UTC) + timedelta(seconds=2)) == 0
+
+
 def test_at_due_fires_the_decision_menu(tmp_config: Config, tmp_path: Path):
     notif_dir = tmp_path / "notifs"
     notif_dir.mkdir()


### PR DESCRIPTION
## Summary

Two bug fixes the polish pass on #2061 found and pushed to `epic/tasks-2` after that PR had already been squash-merged, so they never reached master (`f35fcc33` on the merged branch, cherry-picked here).

- **tasks**: `tasks create --in-days 1` fired "due in 1 day" on the daemon's first tick, because `create` did not stamp `checkpoint_fired_through` the way every other due-date write does. Now it does. Regression test in `test_checkpoints.py`.
- **reminders**: `reminders create --at "21:30+02:00"` silently dropped the offset from a bare daily time. Fixed, with a test in `test_interface.py`.

## Verify

- tasks CLI suite: 146 passed
- reminders CLI suite: 146 passed
- `./check.sh guards`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)