### PR TITLE
fix(migrations): repoint tasks remind notes and restart into the reminders skill

### DIFF
--- a/agent/core/migrations/2026-08-reminders-skill-split.md
+++ b/agent/core/migrations/2026-08-reminders-skill-split.md
@@ -62,6 +62,20 @@ If that list holds a recurring reminder whose message is about updating contacts
 
 Look at the end of `~/agent/skills/tasks/SKILL.md`. If it still has a `### Reminder Patterns` section holding notes you wrote (not just the bare placeholder), move that body under `### Reminder Patterns` at the end of `~/agent/skills/reminders/SKILL.md`, then delete the section from the tasks file. If there is no such section, or only the placeholder, nothing to do.
 
-### 8. Mark this migration applied
+### 8. Repoint your own notes
+
+There is no `tasks remind` command: `tasks` refuses it with a usage error. Any note of yours that still spells it out is an instruction you will follow into that error, so find every one:
+
+```bash
+grep -rn 'tasks remind' ~/agent/MEMORY.md ~/agent/skills --exclude-dir=cli --exclude-dir=.venv
+```
+
+Rewrite each hit in place. `tasks remind "..." <flags>` becomes `reminders create "..." <flags>`; `tasks remind list|snooze|update|delete` becomes `reminders list|snooze|update|delete`. A `--task <id>` flag has no equivalent: drop it and name the task in the message instead. No hits means nothing to do.
+
+### 9. Mark this migration applied
 
 Call `mark_migration_applied` with `name="2026-08-reminders-skill-split"`.
+
+### 10. Restart to load the reminders skill
+
+Activation only lists the skill; the boot entrypoint is what links it into `~/.claude/skills`, so until the next boot the daemon runs but the skill body is not in your skill list. Call `restart_vesta` now. Do it only after step 9, so this migration does not run again on the way back up.


### PR DESCRIPTION
## Summary

Follow-up to #2061. The `2026-08-reminders-skill-split` migration installs, activates, and starts the reminders skill, but on an upgrading box two things stayed unconverged:

- **Agent-authored `tasks remind` references.** The command no longer exists and the tasks CLI has no alias, so any note in `MEMORY.md` or a skill file the agent wrote is an instruction that fails with a usage error. New step 8: grep `~/agent/MEMORY.md` and `~/agent/skills` (excluding `cli/`) and rewrite each hit (`tasks remind ...` to `reminders create ...`, `list|snooze|update|delete` map one to one, `--task <id>` is dropped and the task goes in the message). Stock skill text is already clean on master, so hits are the agent's own.
- **Skill discovery.** `skills-activate` only lists the skill; the boot entrypoint links it into `~/.claude/skills`. New step 10 calls `restart_vesta` after the mark step, matching the precedent in `2026-07-manual-upstream-review` and `2026-07-workspace-resync`.

The migration is unreleased (latest release v0.2.3 predates #2061), so it is edited in place rather than shipped as a second migration.

## Verify

- `uv run --project core pytest tests/test_migrations.py`: 30 passed
- `./check.sh guards`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)