### PR TITLE
feat(provider): show the signed-in account in provider settings

### DIFF
--- a/agent/core/api.py
+++ b/agent/core/api.py
@@ -3,7 +3,7 @@
 Routes:
   - WS   /ws                   bidirectional event bus
   - GET  /history              paginated event history (cursor optional), or full-text search with ?q=
-  - GET  /usage                normalized, provider-agnostic plan usage
+  - GET  /usage                normalized, provider-agnostic plan usage plus the signed-in account
   - GET  /status               operational readiness: {authed, setup_complete, boot_complete} (vestad polls this)
   - GET  /config               prefs + notification_rules (personality, timezone, seed_context, operational)
   - PUT  /config               update prefs and/or notification_rules (provider is set via /provider)
@@ -203,7 +203,8 @@ async def _history_handler(request: web.Request) -> web.Response:
 
 
 async def _usage_handler(request: web.Request) -> web.Response:
-    """Report normalized, provider-agnostic plan usage for the agent's active provider."""
+    """Report normalized, provider-agnostic plan usage plus the signed-in account for the active
+    provider."""
     config = request.app["config"]
     try:
         usage = await get_usage(config)

--- a/agent/core/provider.py
+++ b/agent/core/provider.py
@@ -414,9 +414,23 @@ class UsageCredits:
 
 
 @dc.dataclass
+class Account:
+    """The account behind the active provider, best-effort. A field the provider does not expose
+    stays None, and a provider with no identity endpoint (a key or subscription plan) reports an
+    all-None account or none at all."""
+
+    name: str | None
+    email: str | None
+    plan: str | None
+    organization: str | None
+    created_at: str | None
+
+
+@dc.dataclass
 class Usage:
     meters: list[UsageMeter]
     credits: UsageCredits | None
+    account: Account | None
 
 
 class UsageError(Exception):
@@ -450,14 +464,15 @@ def _read_oauth_token() -> str | None:
 
 
 async def get_usage(config: VestaConfig) -> Usage:
-    """Provider-agnostic plan usage for the agent's active provider. Returns empty usage when no
-    provider is configured; raises UsageError when an upstream fetch fails."""
+    """Provider-agnostic plan usage plus the signed-in account for the agent's active provider.
+    Returns an empty result when no provider is configured; raises UsageError when the usage fetch
+    fails. The account is best-effort and never blocks the usage it ships beside."""
     kind, _ = _derive_kind_and_auth(config)
     if kind == "claude":
         return await _claude_usage()
     if kind == "openrouter":
         return await _openrouter_usage(config)
-    return Usage(meters=[], credits=None)
+    return Usage(meters=[], credits=None, account=None)
 
 
 async def _claude_usage() -> Usage:
@@ -493,7 +508,31 @@ async def _claude_usage() -> Usage:
         used = used_credits / 100 if used_credits is not None else None
         limit = monthly_limit / 100 if monthly_limit is not None else None
         usage_credits = UsageCredits(used=used, limit=limit)
-    return Usage(meters=meters, credits=usage_credits)
+    account = await _claude_account(headers)
+    return Usage(meters=meters, credits=usage_credits, account=account)
+
+
+async def _claude_account(headers: dict[str, str]) -> Account | None:
+    """The Claude profile behind the OAuth token, from /api/oauth/profile. Best-effort: a failed
+    profile fetch returns None so a working usage fetch still reports its meters."""
+    try:
+        data = await _fetch_usage_json(f"{ANTHROPIC_API_URL}/api/oauth/profile", headers=headers)
+    except UsageError:
+        return None
+    account_raw = data["account"] if "account" in data else None
+    account = account_raw if isinstance(account_raw, dict) else {}
+    org_raw = data["organization"] if "organization" in data else None
+    org = org_raw if isinstance(org_raw, dict) else {}
+    has_max = "has_claude_max" in account and account["has_claude_max"]
+    has_pro = "has_claude_pro" in account and account["has_claude_pro"]
+    plan = "Claude Max" if has_max else "Claude Pro" if has_pro else None
+    return Account(
+        name=_as_str(account["full_name"]) if "full_name" in account else None,
+        email=_as_str(account["email"]) if "email" in account else None,
+        plan=plan,
+        organization=_as_str(org["name"]) if "name" in org else None,
+        created_at=_as_str(account["created_at"]) if "created_at" in account else None,
+    )
 
 
 async def _openrouter_usage(config: VestaConfig) -> Usage:
@@ -506,7 +545,12 @@ async def _openrouter_usage(config: VestaConfig) -> Usage:
     payload = payload_raw if isinstance(payload_raw, dict) else {}
     used = _as_float(payload["usage"]) if "usage" in payload else None
     limit = _as_float(payload["limit"]) if "limit" in payload else None
-    return Usage(meters=[], credits=UsageCredits(used=used, limit=limit))
+    label = _as_str(payload["label"]) if "label" in payload else None
+    is_free = "is_free_tier" in payload and payload["is_free_tier"]
+    account = (
+        None if label is None else Account(name=label, email=None, plan="Free tier" if is_free else "Paid", organization=None, created_at=None)
+    )
+    return Usage(meters=[], credits=UsageCredits(used=used, limit=limit), account=account)
 
 
 async def _fetch_usage_json(url: str, *, headers: dict[str, str]) -> dict[str, pyd.JsonValue]:

--- a/agent/core/provider.py
+++ b/agent/core/provider.py
@@ -1,5 +1,6 @@
 """Per-agent LLM-provider auth and subscription credentials."""
 
+import asyncio
 import dataclasses as dc
 import enum
 import json
@@ -485,7 +486,10 @@ async def _claude_usage() -> Usage:
         "Content-Type": "application/json",
         "User-Agent": _USAGE_USER_AGENT,
     }
-    data = await _fetch_usage_json(f"{ANTHROPIC_API_URL}/api/oauth/usage", headers=headers)
+    data, account = await asyncio.gather(
+        _fetch_usage_json(f"{ANTHROPIC_API_URL}/api/oauth/usage", headers=headers),
+        _claude_account(headers),
+    )
     meters = []
     for key, label in _CLAUDE_USAGE_METERS:
         bucket_raw = data[key] if key in data else None
@@ -508,7 +512,6 @@ async def _claude_usage() -> Usage:
         used = used_credits / 100 if used_credits is not None else None
         limit = monthly_limit / 100 if monthly_limit is not None else None
         usage_credits = UsageCredits(used=used, limit=limit)
-    account = await _claude_account(headers)
     return Usage(meters=meters, credits=usage_credits, account=account)
 
 

--- a/agent/tests/test_provider.py
+++ b/agent/tests/test_provider.py
@@ -20,6 +20,7 @@ from core.config import (
     update_config_store,
 )
 from core.provider import (
+    Account,
     ProviderAuthState,
     UsageCredits,
     UsageError,
@@ -454,66 +455,99 @@ def test_runtime_failure_clears_reported_model(prov):
     assert flipped.model is None
 
 
-# --- provider-agnostic plan usage ---
+# --- provider-agnostic plan usage + account ---
+
+
+def _write_claude_creds(provider_mod):
+    provider_mod.CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    provider_mod.CREDENTIALS_PATH.write_text(json.dumps({"claudeAiOauth": {"accessToken": "tok", "refreshToken": "r"}}))
 
 
 @pytest.mark.anyio
 async def test_get_usage_empty_when_no_provider(prov):
     # No credentials on disk and no openrouter key -> kind none -> nothing to report (not an error).
-    usage = await get_usage(cfg.VestaConfig())
-    assert usage.meters == []
-    assert usage.credits is None
+    status = await get_usage(cfg.VestaConfig())
+    assert status.meters == []
+    assert status.credits is None
+    assert status.account is None
 
 
 @pytest.mark.anyio
-async def test_get_usage_claude_normalizes_buckets_and_credits(prov, monkeypatch):
+async def test_get_usage_claude_normalizes_buckets_credits_and_account(prov, monkeypatch):
     from core import provider as provider_mod
 
     update_config_store({"provider": {"kind": "claude", "model": "opus"}})
-    provider_mod.CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    provider_mod.CREDENTIALS_PATH.write_text(json.dumps({"claudeAiOauth": {"accessToken": "tok", "refreshToken": "r"}}))
-    sample = {
+    _write_claude_creds(provider_mod)
+    usage_sample = {
         "five_hour": {"utilization": 42, "resets_at": "2026-06-22T12:00:00Z"},
         "seven_day": {"utilization": 10, "resets_at": "2026-06-28T00:00:00Z"},
         "seven_day_opus": {"utilization": 5, "resets_at": "2026-06-28T00:00:00Z"},
         "extra_usage": {"is_enabled": True, "used_credits": 1234, "monthly_limit": 5000},
     }
+    profile_sample = {
+        "account": {"full_name": "Ada L", "email": "ada@example.com", "has_claude_max": True, "created_at": "2023-07-18T19:44:58Z"},
+        "organization": {"name": "Ada's Org"},
+    }
 
     async def fake_fetch(url, *, headers):
+        if "oauth/profile" in url:
+            return profile_sample
         assert "oauth/usage" in url
-        return sample
+        return usage_sample
 
     monkeypatch.setattr(provider_mod, "_fetch_usage_json", fake_fetch)
-    usage = await get_usage(cfg.VestaConfig())
-    assert [m.label for m in usage.meters] == ["current session", "current week", "current week (opus)"]
-    assert usage.meters[0].used_pct == 42
-    assert usage.meters[0].resets_at == "2026-06-22T12:00:00Z"
-    assert usage.credits == UsageCredits(used=12.34, limit=50.0)
+    status = await get_usage(cfg.VestaConfig())
+    assert [m.label for m in status.meters] == ["current session", "current week", "current week (opus)"]
+    assert status.meters[0].used_pct == 42
+    assert status.meters[0].resets_at == "2026-06-22T12:00:00Z"
+    assert status.credits == UsageCredits(used=12.34, limit=50.0)
+    assert status.account == Account(
+        name="Ada L", email="ada@example.com", plan="Claude Max", organization="Ada's Org", created_at="2023-07-18T19:44:58Z"
+    )
 
 
 @pytest.mark.anyio
-async def test_get_usage_openrouter_normalizes_credits(prov, monkeypatch):
+async def test_get_usage_account_best_effort_when_profile_fails(prov, monkeypatch):
+    from core import provider as provider_mod
+
+    update_config_store({"provider": {"kind": "claude", "model": "opus"}})
+    _write_claude_creds(provider_mod)
+
+    async def fake_fetch(url, *, headers):
+        # A failed profile fetch must not blank the usage meters that fetched successfully.
+        if "oauth/profile" in url:
+            raise UsageError("upstream returned 401")
+        return {"five_hour": {"utilization": 5, "resets_at": "2026-06-22T12:00:00Z"}}
+
+    monkeypatch.setattr(provider_mod, "_fetch_usage_json", fake_fetch)
+    status = await get_usage(cfg.VestaConfig())
+    assert [m.label for m in status.meters] == ["current session"]
+    assert status.account is None
+
+
+@pytest.mark.anyio
+async def test_get_usage_openrouter_normalizes_credits_and_account(prov, monkeypatch):
     from core import provider as provider_mod
 
     set_key_provider("openrouter", "sk-or-v1-secret", "deepseek/deepseek-v4-flash", None, config=prov)
 
     async def fake_fetch(url, *, headers):
         assert url == provider_mod.OPENROUTER_KEY_URL
-        return {"data": {"usage": 3.5, "limit": 10.0}}
+        return {"data": {"usage": 3.5, "limit": 10.0, "label": "sk-or key", "is_free_tier": False}}
 
     monkeypatch.setattr(provider_mod, "_fetch_usage_json", fake_fetch)
-    usage = await get_usage(cfg.VestaConfig())
-    assert usage.meters == []
-    assert usage.credits == UsageCredits(used=3.5, limit=10.0)
+    status = await get_usage(cfg.VestaConfig())
+    assert status.meters == []
+    assert status.credits == UsageCredits(used=3.5, limit=10.0)
+    assert status.account == Account(name="sk-or key", email=None, plan="Paid", organization=None, created_at=None)
 
 
 @pytest.mark.anyio
-async def test_get_usage_propagates_fetch_error(prov, monkeypatch):
+async def test_get_usage_propagates_usage_fetch_error(prov, monkeypatch):
     from core import provider as provider_mod
 
     update_config_store({"provider": {"kind": "claude", "model": "opus"}})
-    provider_mod.CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    provider_mod.CREDENTIALS_PATH.write_text(json.dumps({"claudeAiOauth": {"accessToken": "tok", "refreshToken": "r"}}))
+    _write_claude_creds(provider_mod)
 
     async def fake_fetch(url, *, headers):
         raise UsageError("upstream returned 500")

--- a/apps/mobile/src/agent/settings/ProviderSection.tsx
+++ b/apps/mobile/src/agent/settings/ProviderSection.tsx
@@ -31,8 +31,43 @@ import { Field, FormRow, FormSection } from "@/components/ui/Form";
 import { ErrorState, LoadingState } from "@/components/ui/States";
 import { usePreferences } from "@/preferences/PreferencesProvider";
 import { useSession } from "@/session/SessionProvider";
+import type { Account } from "@/api/types";
 
 type KeyProviderKind = Extract<ProviderSelection, { key: string }>["kind"];
+
+function formatMemberSince(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+  });
+}
+
+function AccountSection({ account }: { account: Account }) {
+  const rows = [
+    { label: "Name", value: account.name },
+    { label: "Email", value: account.email },
+    { label: "Plan", value: account.plan },
+    { label: "Organization", value: account.organization },
+    {
+      label: "Member since",
+      value: account.created_at ? formatMemberSince(account.created_at) : null,
+    },
+  ].filter(
+    (row): row is { label: string; value: string } => row.value !== null,
+  );
+
+  if (rows.length === 0) return null;
+
+  return (
+    <FormSection title="Account">
+      {rows.map((row) => (
+        <FormRow key={row.label} label={row.label} value={row.value} />
+      ))}
+    </FormSection>
+  );
+}
 
 function isKeyProviderKind(kind: ProviderKind): kind is KeyProviderKind {
   return kind === "openrouter" || kind === "zai" || kind === "kimi";
@@ -293,6 +328,10 @@ export function ProviderSection() {
           }
         />
       </FormSection>
+
+      {usage.data?.account ? (
+        <AccountSection account={usage.data.account} />
+      ) : null}
 
       {usage.data ? (
         <FormSection title="Usage">

--- a/apps/mobile/src/api/types.ts
+++ b/apps/mobile/src/api/types.ts
@@ -49,9 +49,18 @@ export interface UsageMeter {
   resets_at: string | null;
 }
 
+export interface Account {
+  name: string | null;
+  email: string | null;
+  plan: string | null;
+  organization: string | null;
+  created_at: string | null;
+}
+
 export interface Usage {
   meters: UsageMeter[];
   credits: { used: number | null; limit: number | null } | null;
+  account: Account | null;
 }
 
 export interface FieldPredicate {

--- a/apps/mobile/visual/harness/session-provider.tsx
+++ b/apps/mobile/visual/harness/session-provider.tsx
@@ -145,6 +145,13 @@ const usage: Usage = {
     { label: "Weekly allowance", used_pct: 61, resets_at: null },
   ],
   credits: null,
+  account: {
+    name: "Ada Lovelace",
+    email: "ada@example.com",
+    plan: "Claude Max",
+    organization: "Ada's Organization",
+    created_at: "2023-07-18T19:44:58Z",
+  },
 };
 const notificationRules: NotificationInterruptRule[] = [
   {

--- a/apps/web/src/api/agents.ts
+++ b/apps/web/src/api/agents.ts
@@ -282,9 +282,20 @@ export interface UsageCredits {
   limit: number | null;
 }
 
+/// The account behind the active provider (best-effort). Providers with no identity endpoint
+/// report null, and any field the provider does not expose stays null.
+export interface Account {
+  name: string | null;
+  email: string | null;
+  plan: string | null;
+  organization: string | null;
+  created_at: string | null;
+}
+
 export interface Usage {
   meters: UsageMeter[];
   credits: UsageCredits | null;
+  account: Account | null;
 }
 
 export async function fetchUsage(name: string): Promise<Usage> {

--- a/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
@@ -46,8 +46,10 @@ import {
   setModel,
   setContextWindow,
   signOutProvider,
+  type Account,
   type ProviderInfo,
   type Usage,
+  type UsageCredits,
   type UsageMeter,
 } from "@/api/agents";
 import { fetchAgentClaudeModels } from "@/api/providers/claude";
@@ -69,6 +71,49 @@ function formatResetsAt(iso: string): string {
   const mins = Math.floor((diff % 3_600_000) / 60_000);
   if (hours > 0) return `in ${String(hours)}h ${String(mins)}m`;
   return `in ${String(mins)}m`;
+}
+
+function formatMemberSince(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+  });
+}
+
+function AccountSection({ account }: { account: Account }) {
+  const rows = [
+    { label: "name", value: account.name },
+    { label: "email", value: account.email },
+    { label: "plan", value: account.plan },
+    { label: "organization", value: account.organization },
+    {
+      label: "member since",
+      value: account.created_at ? formatMemberSince(account.created_at) : null,
+    },
+  ].filter(
+    (row): row is { label: string; value: string } => row.value !== null,
+  );
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      <span className="text-xs font-medium text-muted-foreground">account</span>
+      <div className="flex flex-col gap-1.5">
+        {rows.map((row) => (
+          <div
+            key={row.label}
+            className="flex items-center justify-between gap-4 text-xs"
+          >
+            <span className="text-muted-foreground">{row.label}</span>
+            <span className="text-foreground truncate">{row.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 function UsageBar({ meter }: { meter: UsageMeter }) {
@@ -199,6 +244,57 @@ function ProviderIdentity({
   );
 }
 
+function UsageBody({
+  meters,
+  credits,
+  loading,
+  error,
+}: {
+  meters: UsageMeter[];
+  credits: UsageCredits | null;
+  loading: boolean;
+  error: boolean;
+}) {
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-3 w-8" />
+        </div>
+        <Skeleton className="h-1.5 w-full" />
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <p className="text-xs text-muted-foreground">failed to load usage data</p>
+    );
+  }
+  if (meters.length === 0 && !credits) {
+    return (
+      <p className="text-xs text-muted-foreground">no usage data available</p>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2.5">
+      {meters.map((m) => (
+        <UsageBar key={m.label} meter={m} />
+      ))}
+      {credits && (
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">credits</span>
+          <span className="text-foreground tabular-nums">
+            {credits.used != null
+              ? `$${credits.used.toFixed(2)}${credits.limit != null ? ` / $${credits.limit.toFixed(2)}` : ""}`
+              : "—"}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function UsageSection({
   usage,
   loading,
@@ -212,52 +308,33 @@ function UsageSection({
 }) {
   const meters = usage?.meters ?? [];
   const credits = usage?.credits ?? null;
+  const account = usage?.account ?? null;
 
   return (
-    <div className="flex flex-col gap-2.5">
-      <div className="flex items-center justify-between">
-        <span className="text-xs font-medium text-muted-foreground">
-          plan usage
-        </span>
-        <button
-          onClick={onRefresh}
-          aria-label="refresh usage"
-          className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-        >
-          <RefreshCw className={`size-3.5 ${loading ? "animate-spin" : ""}`} />
-        </button>
+    <div className="flex flex-col gap-4">
+      {!loading && !error && account && <AccountSection account={account} />}
+      <div className="flex flex-col gap-2.5">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium text-muted-foreground">
+            plan usage
+          </span>
+          <button
+            onClick={onRefresh}
+            aria-label="refresh usage"
+            className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+          >
+            <RefreshCw
+              className={`size-3.5 ${loading ? "animate-spin" : ""}`}
+            />
+          </button>
+        </div>
+        <UsageBody
+          meters={meters}
+          credits={credits}
+          loading={loading}
+          error={error}
+        />
       </div>
-      {loading ? (
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center justify-between">
-            <Skeleton className="h-3 w-24" />
-            <Skeleton className="h-3 w-8" />
-          </div>
-          <Skeleton className="h-1.5 w-full" />
-        </div>
-      ) : error ? (
-        <p className="text-xs text-muted-foreground">
-          failed to load usage data
-        </p>
-      ) : meters.length === 0 && !credits ? (
-        <p className="text-xs text-muted-foreground">no usage data available</p>
-      ) : (
-        <div className="flex flex-col gap-2.5">
-          {meters.map((m) => (
-            <UsageBar key={m.label} meter={m} />
-          ))}
-          {credits && (
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-muted-foreground">credits</span>
-              <span className="text-foreground tabular-nums">
-                {credits.used != null
-                  ? `$${credits.used.toFixed(2)}${credits.limit != null ? ` / $${credits.limit.toFixed(2)}` : ""}`
-                  : "—"}
-              </span>
-            </div>
-          )}
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
@@ -312,7 +312,7 @@ function UsageSection({
 
   return (
     <div className="flex flex-col gap-4">
-      {!loading && !error && account && <AccountSection account={account} />}
+      {account && <AccountSection account={account} />}
       <div className="flex flex-col gap-2.5">
         <div className="flex items-center justify-between">
           <span className="text-xs font-medium text-muted-foreground">


### PR DESCRIPTION
## What

Adds a "Connected account" panel to each agent's provider settings (web + mobile) that shows the account the agent is signed into for its active provider: name, email, plan, organization, and member-since date.

The data is fetched live, per agent, per provider, and rides on the existing `/usage` resource rather than a new endpoint: the agent's `Usage` gains an optional `account` field, so it is one fetch, one hook, one refresh, one failure state, and one section in the UI.

## How

- **agent/core/provider.py**: new `Account` dataclass (all fields optional) and an `account` field on `Usage`. `get_usage` now also resolves the signed-in account per provider:
  - Claude: `GET /api/oauth/profile` (name, email, plan from `has_claude_max`/`has_claude_pro`, org, created_at).
  - OpenRouter: the key endpoint's `label` and `is_free_tier` (single call, already fetched for usage).
  - Z.AI / Kimi / OpenAI: no identity endpoint, so `account` is null (same as usage already returns empty for them).
  - The account fetch is **best-effort**: a failed profile fetch returns null and never blanks the usage meters that fetched successfully.
- **agent/core/api.py**: `GET /usage` now serializes the account alongside meters/credits (additive; no contract break, `min_supported` unchanged).
- **apps/web** + **apps/mobile**: `Usage` gains `account`; a new `AccountSection` renders the non-null identity rows above the usage bars.

## Why this shape

`Usage` and account identity are the same kind of thing (live, per-provider, external, same auth, same failure mode), so unifying them removes concepts rather than adding a parallel `/account` stack. The type keeps the name `Usage` because `ProviderStatus` is already taken by the auth-status dataclass.

## Tests

- `agent/tests/test_provider.py`: Claude account mapping from a profile fixture, OpenRouter account mapping, best-effort (profile fails, usage survives, account null), and the existing usage-fetch-error propagation.
- Web/mobile covered by tsc + existing component suites; mobile visual-QA fixture seeded with a sample account so the new section renders in the gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
