### PR TITLE
fix(whatsapp): smooth the Double Tick setup flow

### DIFF
--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -31,10 +31,10 @@ pick the source and pass it explicitly as `--source`; the CLI never guesses.
 3. **`DOUBLETICK_API_URL` and `DOUBLETICK_API_KEY` both set?** Run
    `whatsapp connect --source doubletick --opener '<text>'`. See the
    [Double Tick WhatsApp account](SETUP_DOUBLETICK.md) guide.
-4. **Otherwise, ask the user** which they want, then run that one command:
-   - Double Tick credentials in hand:
-     `whatsapp connect --source doubletick --opener '<text>'`. A provisioning
-     service that hands the agent a ready headless account. See the
+4. **Otherwise, ask the user** which they want:
+   - **Double Tick**, a provisioning service that hands the agent a ready headless
+     account: ask whether they have Double Tick credentials. When they do, get the
+     API URL and key from them, then follow the
      [Double Tick WhatsApp account](SETUP_DOUBLETICK.md) guide.
    - Their own account: `whatsapp connect --source self-managed`. The user
      supplies a dedicated WhatsApp account on their own SIM (a second account on

--- a/agent/skills/whatsapp/SETUP_DOUBLETICK.md
+++ b/agent/skills/whatsapp/SETUP_DOUBLETICK.md
@@ -6,48 +6,54 @@ Use this when a non-cloud agent points at such a service.
 
 ## Prerequisites
 
-The operator provides the API base and one account-scoped key:
-
-```bash
-export DOUBLETICK_API_URL='https://doubletick.example'
-export DOUBLETICK_API_KEY='wak_account-scoped-key'
-```
-
-Set both or neither, and keep the key out of chat, logs, commits, and command
-output. Never ask the user to paste it into a conversation and never add it to
-`.bashrc`. If it is absent, ask the operator to set it outside chat and tell you
-when the environment is ready.
-
-For an already-running Vesta container, the operator can create a temporary
-mode-`0600` env file on the host containing the two values, then run:
-
-```bash
-docker exec --env-file /secure/path/doubletick.env <agent-container> \
-  whatsapp connect --source doubletick --opener '<text>'
-```
-
-The key enters only that CLI process, crosses the owner-only WhatsApp socket, and
-is saved in owner-only state for later daemon boots. Remove the temporary host file
-after the command. The agent should then use `whatsapp status`; do not ask for the
-file contents or repeat the connect command.
+The user has the Double Tick API base URL and one account-scoped key. If both are
+already set in the environment (`DOUBLETICK_API_URL` and `DOUBLETICK_API_KEY`), use
+them. Otherwise ask the user for both, then connect.
 
 Run `whatsapp status` first; stop if linked or connecting.
 
 ## Connect
 
-Compose a short, natural opener from the user's perspective, then run:
+Compose a short, natural opener from the user's perspective. Set the two values for
+this one command; the daemon saves them in owner-only state for later boots, so
+they need no export:
+
+```bash
+DOUBLETICK_API_URL='https://doubletick.example' \
+DOUBLETICK_API_KEY='wak_account-scoped-key' \
+  whatsapp connect --source doubletick --opener 'Hi, it is me, nice to meet you here'
+```
+
+When both values are already exported, the bare command works:
 
 ```bash
 whatsapp connect --source doubletick --opener 'Hi, it is me, nice to meet you here'
 ```
 
+Pass an opener that has an apostrophe or newline through stdin with `--opener -`,
+the same heredoc form `send --message -` uses:
+
+```bash
+whatsapp connect --source doubletick --opener - <<'OPENER'
+hey it's me, let's talk here from now on
+OPENER
+```
+
 The CLI authenticates to Double Tick with the `wak_` key, provisions or recovers
 the account, and pairs the companion over the account's
-[residential proxy lease](HEADLESS.md#residential-proxy-lease).
+[residential proxy lease](HEADLESS.md#residential-proxy-lease). It saves the
+credentials in mode-`0600` WhatsApp state, so do not restart the daemon to make new
+credentials visible.
 
-`connect` carries credentials to an already-running daemon over its private Unix
-socket and saves them in mode-`0600` WhatsApp state. Do not restart the daemon to
-make new credentials visible.
+Link this alongside another account, or when the default instance is held or in
+use, by putting it on its own named instance: start that instance's daemon first,
+keep `--instance` on every later command, and add its `whatsapp daemon start` line
+to your restart daemons. See [Named instances](SETUP.md#named-instances).
+
+```bash
+whatsapp daemon start --instance work
+whatsapp connect --source doubletick --instance work --opener 'Hi, it is me'
+```
 
 Follow the returned `next`. Reply-first behavior is in [SKILL.md](SKILL.md);
 recovery outcomes are in [SETUP.md](SETUP.md#status-and-recovery). Use the Double

--- a/agent/skills/whatsapp/cli/connect.go
+++ b/agent/skills/whatsapp/cli/connect.go
@@ -3,7 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 )
 
 // The three account sources the agent chooses between with `--source`.
@@ -181,6 +183,22 @@ func canonicalConnectArgs(program string, opts connectOptions) []string {
 	return args
 }
 
+// resolveOpenerStdin swaps a "--opener -" for the stdin body, so an opener can
+// carry apostrophes and newlines untouched through a heredoc, the same `-`
+// convention `send --message -` uses. connect does not route through runOneShot,
+// so it resolves the sentinel here before the value reaches the daemon.
+func resolveOpenerStdin(opts *connectOptions) error {
+	if !opts.openerSet || opts.opener != "-" {
+		return nil
+	}
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return err
+	}
+	opts.opener = strings.TrimRight(string(data), "\r\n")
+	return nil
+}
+
 // runConnect is the agent's single WhatsApp setup verb. The agent states the account
 // source with --source (vesta-cloud, doubletick, or self-managed); the CLI validates that
 // the box environment can satisfy it and routes to the matching path, erring clearly
@@ -189,6 +207,9 @@ func canonicalConnectArgs(program string, opts connectOptions) []string {
 func runConnect() {
 	opts, err := parseConnectOptions("connect", os.Args[1:])
 	if err != nil {
+		failJSON("%s", err.Error())
+	}
+	if err := resolveOpenerStdin(&opts); err != nil {
 		failJSON("%s", err.Error())
 	}
 	route, err := resolveConnect(opts, managedConfigFromEnvAndState())
@@ -217,6 +238,9 @@ func dispatchConnectRoute(route connectRoute) {
 func runConnectAlias(name string, provision bool) {
 	opts, err := parseConnectOptions(name, os.Args[1:])
 	if err != nil {
+		failJSON("%s", err.Error())
+	}
+	if err := resolveOpenerStdin(&opts); err != nil {
 		failJSON("%s", err.Error())
 	}
 	os.Args = canonicalConnectArgs(os.Args[0], opts)

--- a/agent/skills/whatsapp/cli/notifications.go
+++ b/agent/skills/whatsapp/cli/notifications.go
@@ -303,43 +303,59 @@ func wasPreviouslyLinked(instance string) bool {
 	return st.OnboardedMSISDN != "" || !st.LinkedAt.IsZero() || st.AuthStatus == "logged_out" || st.ExitStatus != ""
 }
 
-func notificationSource(instance string) (string, string) {
+// notificationSource picks the account source for a reconnect hint. confident is
+// true when persisted state or the box environment determines the source; it is
+// false for the final catch-all, where the source is only a guess the caller must
+// not present as a settled fact on a first link.
+func notificationSource(instance string) (source string, configError string, confident bool) {
 	st := loadStateFromDisk(stateDataDirFor(instance))
 	cfg := notificationManagedConfig(instance)
 	switch st.AccountSource {
 	case sourceVestaCloud:
 		if cfg.isManagedVM() {
-			return sourceVestaCloud, ""
+			return sourceVestaCloud, "", true
 		}
 	case sourceDoubletick:
 		if cfg.isDirect() {
-			return sourceDoubletick, ""
+			return sourceDoubletick, "", true
 		}
 	case sourceSelfManaged:
 		if !cfg.isManagedVM() && !cfg.isDirect() && cfg.configError == "" {
-			return sourceSelfManaged, ""
+			return sourceSelfManaged, "", true
 		}
 	}
 	// Migration fallback follows the setup decision order. A managed VM uses its
 	// cloud entitlement even when stale direct credentials are also present.
 	if cfg.isManagedVM() {
-		return sourceVestaCloud, ""
+		return sourceVestaCloud, "", true
 	}
 	if cfg.isDirect() {
-		return sourceDoubletick, ""
+		return sourceDoubletick, "", true
 	}
 	if cfg.configError != "" {
-		return "", cfg.configError
+		return "", cfg.configError, false
 	}
-	return sourceSelfManaged, ""
+	return sourceSelfManaged, "", false
 }
 
 func connectCommand(instance string) string {
-	source, _ := notificationSource(instance)
+	source, _, _ := notificationSource(instance)
 	if source == "" {
 		return ""
 	}
 	command := "whatsapp connect --source " + source
+	if instance != "" {
+		command += " --instance " + quoteReplyArg(instance)
+	}
+	return command
+}
+
+// sourceChoiceCommand is the reconnect hint for a first link whose source the
+// daemon cannot determine (no credentials in its environment, none persisted
+// yet). It lists the choices for the agent to fill in from the source it sets up,
+// rather than asserting one guess the agent might follow into the wrong flow.
+func sourceChoiceCommand(instance string) string {
+	command := "whatsapp connect --source <vesta-cloud|doubletick|self-managed>"
 	if instance != "" {
 		command += " --instance " + quoteReplyArg(instance)
 	}
@@ -352,7 +368,7 @@ func connectCommand(instance string) string {
 // under the linking rule. A self-managed first link waits for user participation.
 func WriteUnpairedNotification(notifDir, instance string) error {
 	priorLink := wasPreviouslyLinked(instance)
-	source, configError := notificationSource(instance)
+	source, configError, confident := notificationSource(instance)
 	managed := source == sourceVestaCloud || source == sourceDoubletick
 	command := connectCommand(instance)
 	recovery := "first_link"
@@ -373,6 +389,13 @@ func WriteUnpairedNotification(notifDir, instance string) error {
 	}
 	if managed {
 		message += " The headless flow needs no phone or QR step."
+	}
+	if !priorLink && !managed && configError == "" && !confident {
+		// A first link whose source is undetermined: the daemon holds no
+		// credentials and none is persisted, so it must not assert one source.
+		// The agent fills in --source from the account it sets up.
+		command = sourceChoiceCommand(instance)
+		message = "WhatsApp daemon started without a paired device session. Choose the account source, then run the next_command with that --source filled in, when the user is ready."
 	}
 	n := authNotif{
 		Source:               "whatsapp",
@@ -395,7 +418,7 @@ func WriteLoggedOutNotification(notifDir, instance, reason string) error {
 	if reason != "" {
 		message += " (" + reason + ")"
 	}
-	source, configError := notificationSource(instance)
+	source, configError, _ := notificationSource(instance)
 	if configError != "" {
 		message += ". Reconnect is blocked because " + configError + ". Fix the operator-managed configuration outside chat, then ask the user for explicit approval before reconnecting. Do not retry-loop pairing."
 	} else if source == sourceVestaCloud || source == sourceDoubletick {

--- a/agent/skills/whatsapp/cli/notifications_test.go
+++ b/agent/skills/whatsapp/cli/notifications_test.go
@@ -229,6 +229,33 @@ func prepareAuthNotificationTest(t *testing.T) string {
 	return t.TempDir()
 }
 
+func TestFreshUnknownSourceUnpairedAsksToChooseSource(t *testing.T) {
+	dir := prepareAuthNotificationTest(t)
+	// No credentials in the environment, none persisted, and no prior link: the
+	// daemon cannot know which source this first link uses, so the hint must ask
+	// the agent to choose rather than assert one it would then follow blindly.
+	if err := WriteUnpairedNotification(dir, "work"); err != nil {
+		t.Fatal(err)
+	}
+	fields := soleNotifFields(t, dir)
+	if _, present := fields["requires_user_approval"]; present {
+		t.Fatal("a fresh first link must not be labeled a recovery requiring approval")
+	}
+	var recovery, command, message string
+	_ = json.Unmarshal(fields["recovery"], &recovery)
+	_ = json.Unmarshal(fields["next_command"], &command)
+	_ = json.Unmarshal(fields["message"], &message)
+	if recovery != "first_link" {
+		t.Fatalf("recovery = %q, want first_link", recovery)
+	}
+	if command != "whatsapp connect --source <vesta-cloud|doubletick|self-managed> --instance 'work'" {
+		t.Fatalf("next_command asserted a source it cannot determine: %q", command)
+	}
+	if !strings.Contains(message, "Choose the account source") {
+		t.Fatalf("message should tell the agent to choose the source, got %q", message)
+	}
+}
+
 func TestFreshManagedUnpairedCanConnectWithoutApproval(t *testing.T) {
 	dir := prepareAuthNotificationTest(t)
 	t.Setenv("DOUBLETICK_API_URL", "https://doubletick.example")

--- a/agent/skills/whatsapp/cli/stdin_args_test.go
+++ b/agent/skills/whatsapp/cli/stdin_args_test.go
@@ -104,3 +104,27 @@ func TestResolveStdinArgsDoesNotMutateItsInput(t *testing.T) {
 		t.Fatalf("resolveStdinArgs aliased its input")
 	}
 }
+
+// connect bypasses runOneShot, so it resolves `--opener -` on its own path. An
+// opener with an apostrophe or newline must survive intact from the heredoc.
+func TestResolveOpenerStdinReadsHeredocBody(t *testing.T) {
+	opts := connectOptions{opener: "-", openerSet: true}
+	withStdin(t, "hey it's me\nlet's talk\n", func() {
+		if err := resolveOpenerStdin(&opts); err != nil {
+			t.Fatalf("resolveOpenerStdin: %v", err)
+		}
+	})
+	if opts.opener != "hey it's me\nlet's talk" {
+		t.Fatalf("opener = %q, want the stdin body with the trailing newline trimmed", opts.opener)
+	}
+}
+
+func TestResolveOpenerStdinLeavesALiteralOpenerAlone(t *testing.T) {
+	opts := connectOptions{opener: "hi there", openerSet: true}
+	if err := resolveOpenerStdin(&opts); err != nil {
+		t.Fatalf("resolveOpenerStdin: %v", err)
+	}
+	if opts.opener != "hi there" {
+		t.Fatalf("a literal opener must be left alone, got %q", opts.opener)
+	}
+}


### PR DESCRIPTION
From a retrospective on a real Double Tick WhatsApp setup, four friction points, each fixed here. (A fifth finding, an `app-chat send` false failure, is a separate subsystem and ships in its own PR.)

## Changes

**F1: the user holds the credentials, so ask them.** `SETUP_DOUBLETICK.md` previously modeled only an operator setting `DOUBLETICK_API_URL`/`DOUBLETICK_API_KEY` outside chat, which left the agent no path when the user held the key on mobile. Now: if the two values are not already in the environment, the agent asks the user for both, then connects with them set inline for that one command (the daemon persists them in owner-only state). `SETUP.md` step 4 now offers Double Tick by asking whether the user has credentials.

**F2: the unpaired notification no longer asserts a wrong `--source`.** On a first link whose account source the daemon cannot determine (no credentials in its own environment, none persisted yet), the reconnect hint listed `--source self-managed` as a guess. It now emits `whatsapp connect --source <vesta-cloud|doubletick|self-managed>` for the agent to fill in. Confident cases (persisted source, or clear env) and the logged-out/relink paths are unchanged, with their tests intact.

**F3: `--opener -` reads the opener from stdin.** `connect` now accepts the same `-`/heredoc convention `send --message -` uses, so an opener keeps its apostrophes and newlines instead of being reworded to survive inline single-quoting.

**F4: named-instance setup is documented.** `SETUP_DOUBLETICK.md` now shows how to link a second account, or one when the default instance is held or in use, on its own named instance.

## Tests

- `TestFreshUnknownSourceUnpairedAsksToChooseSource` (F2): a fresh, credential-less first link emits the choose-source hint, not `self-managed`.
- `TestResolveOpenerStdinReadsHeredocBody` / `...LeavesALiteralOpenerAlone` (F3).
- `check.sh whatsapp` green (lint + build + test); `check.sh guards` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7kVZzxNftyb8DxQdNCSwQ