### PR TITLE
feat(skills): vesta-agent-retro, reconstruct a live agent's transcript

### DIFF
--- a/.claude/skills/vesta-agent-retro/SKILL.md
+++ b/.claude/skills/vesta-agent-retro/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: vesta-agent-retro
+description: >
+  Use when you need to know what a running Vesta agent actually did, for a
+  retrospective, postmortem, or "why did the agent do X" question, and a summary is
+  not enough because you need its real reasoning and the output its tools returned.
+  Triggers: "retrospective on <agent>", "what did <agent> do", "pull/extract the
+  agent's transcript", "why did the agent <X>". On the host, needs sudo docker to a
+  running vesta-* container.
+---
+
+# vesta-agent-retro
+
+Reconstruct a slice of a running Vesta agent's session as a redacted, human-readable
+transcript, then write the retrospective on top of it. The agent runs Claude inside a
+Docker container; this pulls the real record of a time window out of that container.
+
+Paths below are relative to the repo root. The driver is
+`.claude/skills/vesta-agent-retro/extract-retro.sh`.
+
+## The one thing to know first
+
+Two stores hold the agent's history, and only one has tool output:
+
+- `~/agent/data/events.db` (SQLite) has user/assistant messages, **thinking**, and
+  **tool calls**, but for a tool it records only that it ran, never what it returned.
+- `~/.claude/projects/<slug>/<session_id>.jsonl` (the raw Claude session) has
+  **everything**: thinking, tool_use with full input, and **tool_result with full
+  output**. This is the source of truth for a retrospective.
+
+So the transcript comes from the `.jsonl`. `events.db` is only useful for a fast
+keyword search to find the time window (below).
+
+## Prerequisites
+
+- Run on the host, not inside a container. Docker access. The driver calls `sudo docker`
+  itself; on a rootless-docker host, or when you are already root, drop the `sudo` from
+  `extract-retro.sh` (it is a thin wrapper).
+- A running agent container. List them: `sudo docker ps --format '{{.Names}}' | grep '^vesta-'`.
+
+## Run (the driver)
+
+```bash
+# extract-retro.sh <container> <since-iso-utc> <until-iso-utc> [outfile]
+.claude/skills/vesta-agent-retro/extract-retro.sh \
+  vesta-lucadv-gianfranco 2026-08-17T17:03:00 2026-08-17T17:25:00 retro.txt
+```
+
+It reads the agent's live `session_id` from `state.json`, finds the matching `.jsonl`,
+runs `extract-transcript.py` inside the container (where the 150MB+ file is local), and
+streams back only the filtered slice. Timestamps are **UTC, inclusive, string-compared**,
+so keep them zero-padded. Every rendered field is scrubbed for secrets (`wak_` keys, API
+keys, tokens); the driver prints a `leak-check:` line to stderr, treat a **non-zero secret
+count** as a stop-and-inspect (the same line also reports events rendered, which is not a
+warning).
+
+Each record renders as one entry: `USER/CONTEXT`, `THINKING`, `ASSISTANT`, `TOOL CALL
+[name]` with its input, or `  -> RESULT:` with the tool output. A multi-line tool output
+wraps across several physical lines, so the file's `wc -l` exceeds the "lines rendered"
+(logical-event) count in the leak-check line.
+
+## Find the time window
+
+The agent's own timestamps are UTC. To locate a flow by the user's words, search
+`events.db` (its FTS indexes inbound messages):
+
+```bash
+# -i is required: without it docker exec never attaches the heredoc to python's stdin.
+sudo docker exec -i <container> /root/agent/.venv/bin/python - <<'PY'
+import sqlite3
+db = sqlite3.connect("/root/agent/data/events.db")
+q = 'select ts,substr(data,1,80) from events where lower(data) like "%set up whatsapp%" order by id limit 20'
+for ts, preview in db.execute(q):
+    print(ts, preview)
+PY
+```
+
+Take the first hit as `since` and a point after the flow ended as `until`. A daemon log
+under `~/agent/logs/` often brackets an operation too, but its timestamps may be the
+container's local zone, not UTC; the `.jsonl` and `events.db` are UTC.
+
+## Write the retrospective
+
+The transcript is the evidence; the retrospective is the analysis on top. Read the whole
+slice, then write a report that cites timestamps: outcome, a timeline table, what worked,
+and findings (friction, bugs, doc gaps) each with its evidence line. Keep the raw
+transcript as a companion file so each claim is checkable.
+
+## Gotchas
+
+- **`events.db` tool_end rows carry no output.** If you build a transcript from `events.db`
+  alone, every tool result is missing and you will not notice, the rows exist, they are
+  just empty of output. Use the `.jsonl`.
+- **A pasted secret lands in three places.** A key the user typed into chat sits in the
+  `.jsonl`, `events.db`, AND the app-chat store; the agent scrubbing one does not clear the
+  others. The extractor redacts on the way out, so the transcript is safe to share even
+  when the raw stores are not.
+- **Shared host with live agents.** These are real users' agents. Read only; never write to
+  a container's stores. A process listing can spill another agent's system prompt, do not
+  paste container internals around.
+- **The session slug is not fixed.** The `.jsonl` lives under a per-project slug directory
+  (e.g. `-root-agent`); the driver globs for `<session_id>.jsonl` rather than assuming it.
+- **Only the `[HH:MM:SS]` prefix is UTC.** That prefix is normalized; a timestamp *inside* a
+  rendered payload (a channel `timestamp=` attribute, a daemon-log line) is verbatim and may
+  carry the container's local offset, so do not read it as the window being wrong.
+
+## Troubleshooting
+
+- `no session transcript for <id>`: the agent compacted or restarted into a new session,
+  so an old window may live in a rotated `.jsonl`. List them (the glob must run
+  container-side): `sudo docker exec <container> sh -c 'ls -la /root/.claude/projects/*/'`.
+- Empty output: the window matched nothing. Timestamps are UTC and string-compared, a
+  local-zone `since` silently misses. Re-derive the window from `events.db`.

--- a/.claude/skills/vesta-agent-retro/extract-retro.sh
+++ b/.claude/skills/vesta-agent-retro/extract-retro.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Pull a redacted slice of a live Vesta agent's Claude session transcript (thinking +
+# tool calls + tool RESULTS) for a retrospective. Runs the extractor inside the
+# container, where the 150MB+ .jsonl is local, and streams back only the filtered result.
+#
+# Usage: extract-retro.sh <container> <since-iso> <until-iso> [outfile]
+#   extract-retro.sh vesta-lucadv-gianfranco 2026-08-17T17:03:00 2026-08-17T17:25:00 retro.txt
+# Timestamps are UTC, inclusive, string-compared, so keep them zero-padded.
+set -euo pipefail
+
+CONTAINER="${1:?container name required}"
+SINCE="${2:?since ISO timestamp required}"
+UNTIL="${3:?until ISO timestamp required}"
+OUT="${4:-/dev/stdout}"
+SKILL_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# The agent persists its live session id; the transcript is named after it.
+SESSION="$(sudo docker exec "$CONTAINER" cat /root/agent/data/state.json \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')"
+JSONL="$(sudo docker exec "$CONTAINER" sh -c "ls /root/.claude/projects/*/${SESSION}.jsonl 2>/dev/null | head -1")"
+if [ -z "$JSONL" ]; then
+  echo "no session transcript for $SESSION in $CONTAINER" >&2
+  exit 1
+fi
+
+sudo docker cp "$SKILL_DIR/extract-transcript.py" "$CONTAINER:/tmp/extract-transcript.py"
+# Capture, then write with an unprivileged redirect, so the redirect is not sudo's (SC2024).
+result="$(sudo docker exec -e JSONL="$JSONL" -e SINCE="$SINCE" -e UNTIL="$UNTIL" \
+  "$CONTAINER" /root/agent/.venv/bin/python /tmp/extract-transcript.py)"
+printf '%s\n' "$result" >"$OUT"
+sudo docker exec "$CONTAINER" rm -f /tmp/extract-transcript.py
+echo "wrote $OUT (session $SESSION)" >&2

--- a/.claude/skills/vesta-agent-retro/extract-transcript.py
+++ b/.claude/skills/vesta-agent-retro/extract-transcript.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Render a redacted slice of a Vesta agent's Claude session transcript.
+
+Runs INSIDE the agent container, where the 150MB+ session .jsonl is a local file.
+Reads env: JSONL (path to the session transcript), SINCE / UNTIL (ISO timestamps,
+inclusive, compared as strings so pass them zero-padded UTC). Writes the transcript
+to stdout and a one-line leak check to stderr.
+
+The .jsonl is the ONLY place tool results live. The agent's events.db has thinking,
+tool calls, and messages, but records only that a tool ran, never its output.
+"""
+
+import json
+import os
+import pathlib
+import re
+import sys
+
+JSONL = os.environ["JSONL"]
+SINCE = os.environ["SINCE"]
+UNTIL = os.environ["UNTIL"]
+
+# One secret can sit in a pasted user message, a tool_use input (an env-file heredoc),
+# and a tool_result at once, so redact every rendered field, not just chat.
+_SECRET_PATTERNS = [
+    (re.compile(r"wak_[A-Za-z0-9_\-]{6,}"), "wak_REDACTED"),
+    (re.compile(r"sk-[A-Za-z0-9_\-]{16,}"), "sk-REDACTED"),
+    (
+        re.compile(
+            r"(?i)\b(api[_-]?key|key[_-]?secret|secret|token|password|passwd|authorization|bearer)"
+            r"(['\"]?\s*[=:]\s*['\"]?)([^\s'\",}]+)"
+        ),
+        r"\1\2REDACTED",
+    ),
+]
+
+
+def redact(value):
+    text = value if isinstance(value, str) else json.dumps(value)
+    for pattern, replacement in _SECRET_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+def in_window(ts):
+    return bool(ts) and SINCE <= ts <= UNTIL
+
+
+def hhmm(ts):
+    return ts[11:19] if len(ts) >= 19 else ts
+
+
+def result_text(content):
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+            else:
+                parts.append(json.dumps(block))
+        return "\n".join(parts)
+    return json.dumps(content)
+
+
+def render(out):
+    with pathlib.Path(JSONL).open(encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts = entry.get("timestamp", "")
+            if not in_window(ts) or entry.get("type") not in ("user", "assistant"):
+                continue
+            message = entry.get("message")
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content")
+            if isinstance(content, str):
+                body = re.sub(r"^\[Current time:[^\]]*\]\s*", "", redact(content).strip())
+                if body:
+                    out.append(f"\n[{hhmm(ts)}] USER/CONTEXT: {body[:900]}")
+                continue
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                kind = block.get("type")
+                if kind == "thinking":
+                    out.append(f"[{hhmm(ts)}] THINKING:")
+                    out.append(redact(block.get("thinking", "")).rstrip())
+                elif kind == "text":
+                    out.append(f"[{hhmm(ts)}] ASSISTANT: {redact(block.get('text', '')).strip()}")
+                elif kind == "tool_use":
+                    inp = block.get("input", {})
+                    cmd = inp["command"] if isinstance(inp, dict) and "command" in inp else json.dumps(inp)
+                    out.append(f"[{hhmm(ts)}] TOOL CALL [{block.get('name', '')}]:")
+                    out.append(redact(cmd)[:2000].rstrip())
+                elif kind == "tool_result":
+                    out.append(f"[{hhmm(ts)}]   -> RESULT: {redact(result_text(block.get('content')))[:3000].rstrip()}")
+
+
+def main():
+    out = []
+    render(out)
+    text = "\n".join(out) + "\n"
+    sys.stdout.write(text)
+    leaks = re.findall(r"wak_[A-Za-z0-9]{20,}", text) + re.findall(r"sk-[A-Za-z0-9]{24,}", text)
+    sys.stderr.write(f"leak-check: {len(leaks)} possible unredacted secret(s); {len(out)} lines rendered\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A dev skill that captures the workflow used to build the Gianfranco WhatsApp retrospective: reconstruct what a running Vesta agent actually did, its full transcript with thinking, tool calls, and tool **results**, for a retrospective or postmortem.

## Why

The obvious source, `~/agent/data/events.db`, has thinking and tool calls but records only that a tool ran, never its output. The tool **results** live only in the raw Claude session `~/.claude/projects/<slug>/<session_id>.jsonl`. That non-obvious split is the whole reason a naive `events.db` dump silently loses every tool output. The skill encodes it.

## What's here

- `extract-retro.sh` (host wrapper): reads the agent's live `session_id`, finds the `.jsonl`, runs the extractor **inside** the container where the 150MB+ file is local, streams back only the filtered slice.
- `extract-transcript.py` (in-container, stdlib only): renders a time-windowed slice as `THINKING` / `TOOL CALL [name]` / `-> RESULT`, redacting `wak_`/API-key/token secrets on the way out, with a stderr leak-check.
- `SKILL.md`: the man page, auto-loads on "retrospective on the agent", "what did <agent> do", "pull the transcript".

## Verified

Every command was run against a live agent this session:
- `extract-retro.sh vesta-lucadv-gianfranco 2026-08-17T17:03:00 2026-08-17T17:25:00` → 185 lines, **0 unredacted secrets** (the API key the user pasted mid-flow renders as `wak_REDACTED`).
- The `events.db` window-finding query (with `-i`) and the projects listing.
- Synthetic run confirms thinking/tool_use/tool_result rendering and redaction. `check.sh guards` green (ruff + shellcheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7kVZzxNftyb8DxQdNCSwQ