### PR TITLE
docs(proactive-check): daemon liveness is the agent's duty, never a built automation

### DIFF
--- a/agent/skills/proactive-check/SKILL.md
+++ b/agent/skills/proactive-check/SKILL.md
@@ -11,6 +11,8 @@ This is your scheduled moment to think unprompted. No one asked; you're checking
 
 Before anything else, confirm the daemons the `restart` skill starts are actually alive: ask each one it starts with the matching `<skill> daemon status`. Treat an error, a missing command, or any answer not reporting running as down, not only an explicit `"running": false`. A daemon can die silently (container up, daemon down), and a dead messaging daemon means you cannot reach the user at all, which is why this check comes first. Bring a dead daemon back with its own `<skill> daemon start`, or re-run the `restart` skill, which is idempotent and a no-op when everything is already up.
 
+This check is your duty and stays yours: never build a watchdog, cron job, or auto-restarting script to do it for you. An automation restarts blindly, hides the cause from you, and becomes one more thing that breaks silently; you can read the log, fix the cause, and judge when the user must be involved. When a daemon you brought back died for a reason worth fixing, fix it in that skill, not with a new layer of machinery on top.
+
 ## Two questions, every time
 
 Your running narration is visible to the user in the app: think out loud like yourself, not like a service log.


### PR DESCRIPTION
Closes #1681.

The proactive-check preflight already makes daemon liveness the first act of every tick: status each daemon the restart skill starts, bring back what is down. What was missing is the doctrine that this duty is the agent's own and must never be delegated to built machinery. Fleet boxes have started building watchdogs (PR #2121, closed on this principle), and each one is a finicky automation that restarts blindly, hides the cause, and becomes one more silent failure mode.

This adds two sentences to the preflight: never build a watchdog, cron job, or auto-restarting script for this check; the agent reads the log, fixes the cause in the skill that broke, and judges when the user must be involved.

This is the settled resolution for #1681 as well: a dead daemon is caught by the agent's own periodic check, and recovery plus diagnosis stay with the agent (see also #2128 for the boot-time FAILED handling). No detector, no auto-restart.

`./check.sh guards` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)