### PR TITLE
feat: jitter the nightly dream and the maintenance window per night

### DIFF
--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import datetime as dt
+import hashlib
 import json
 import pathlib as pl
 import time
@@ -483,6 +484,15 @@ def check_proactive_task(*, config: cfg.VestaConfig) -> None:
 
 
 DREAMER_CATCHUP_HOURS = 6
+DREAMER_JITTER_MINUTES = 60
+
+
+def _dream_delay(night: dt.date, *, config: cfg.VestaConfig) -> dt.timedelta:
+    """Per-night start delay inside the configured hour, hashed from (agent name, night): stable
+    across restarts and checks (a fresh random would keep moving the target), different each night
+    and per agent, so dream restarts across a host never land on the same minute."""
+    digest = hashlib.sha256(f"{config.agent_name}:{night.isoformat()}".encode()).digest()
+    return dt.timedelta(minutes=int.from_bytes(digest[:4], "big") % DREAMER_JITTER_MINUTES)
 
 
 def process_nightly_memory(*, state: vm.State, config: cfg.VestaConfig) -> None:
@@ -509,6 +519,8 @@ def process_nightly_memory(*, state: vm.State, config: cfg.VestaConfig) -> None:
     night_start = now.replace(minute=0, second=0, microsecond=0) - dt.timedelta(hours=hours_since_start)
     last = state.persisted.last_dreamer_run
     if last is not None and last >= night_start:
+        return
+    if now < night_start + _dream_delay(night_start.date(), config=config):
         return
     logger.dreamer("Nightly dreamer starting...")
     prompt = load_prompt("nightly_dream", config) or ""

--- a/agent/tests/test_dreamer.py
+++ b/agent/tests/test_dreamer.py
@@ -31,7 +31,7 @@ def test_skips_dream_before_first_start_done(tmp_path):
     config = _setup(tmp_path)
     state = vm.State()
     assert state.persisted.first_start_done is False
-    fake_now = dt.datetime(2025, 6, 15, config.nightly_memory_hour, 0, 0)
+    fake_now = dt.datetime(2025, 6, 15, config.nightly_memory_hour, 59, 0)
 
     # No load_prompt patch: the first_start_done guard returns before load_prompt is reached.
     with patch("core.loops._now", return_value=fake_now):
@@ -44,7 +44,8 @@ def test_drops_dream_notification(tmp_path):
     config = _setup(tmp_path)
     state = vm.State()
     state.persisted.first_start_done = True
-    fake_now = dt.datetime(2025, 6, 15, config.nightly_memory_hour, 0, 0)
+    # Minute 59 is at or past every possible jitter instant, so this pins the drop itself.
+    fake_now = dt.datetime(2025, 6, 15, config.nightly_memory_hour, 59, 0)
 
     with (
         patch("core.loops._now", return_value=fake_now),
@@ -65,7 +66,7 @@ def test_drops_dream_notification(tmp_path):
 @pytest.mark.parametrize(
     "dreamer_hour,last_dreamer_run,now,expected_files",
     [
-        (4, dt.datetime(2025, 6, 15, 4, 0, 0), dt.datetime(2025, 6, 15, 4, 0, 0), 0),  # already ran today
+        (4, dt.datetime(2025, 6, 15, 4, 0, 0), dt.datetime(2025, 6, 15, 4, 59, 0), 0),  # already ran today
         (4, None, dt.datetime(2025, 6, 15, 2, 0, 0), 0),  # before the dreamer hour
         (4, dt.datetime(2025, 6, 14, 4, 0, 0), dt.datetime(2025, 6, 15, 7, 30, 0), 1),  # not done today, retry past the hour
         # Late dreamer_hour (22:00) must catch up after midnight: the window is circular (modulo-24), so
@@ -75,7 +76,7 @@ def test_drops_dream_notification(tmp_path):
         # Completion is judged against the night the window opened, not the calendar day, so a dream
         # that finished before midnight suppresses the rest of its own night and only its own night.
         (22, dt.datetime(2025, 6, 15, 22, 30, 0), dt.datetime(2025, 6, 16, 0, 0, 0), 0),  # same night, past midnight
-        (22, dt.datetime(2025, 6, 15, 22, 30, 0), dt.datetime(2025, 6, 16, 22, 0, 0), 1),  # the next night still fires
+        (22, dt.datetime(2025, 6, 15, 22, 30, 0), dt.datetime(2025, 6, 16, 22, 59, 0), 1),  # the next night still fires
         # Checks land at an arbitrary minute: a completion earlier in its hour still counts as this night's.
         (4, dt.datetime(2025, 6, 15, 4, 10, 0), dt.datetime(2025, 6, 15, 5, 50, 0), 0),  # unaligned check
         (4, None, dt.datetime(2025, 6, 15, 7, 30, 0), 1),  # never marked complete: retries inside the window
@@ -122,8 +123,8 @@ def _dream_files(config):
 @pytest.mark.parametrize(
     "dreamer_hour,first,second",
     [
-        (4, dt.datetime(2025, 6, 15, 4, 0, 0), dt.datetime(2025, 6, 15, 4, 20, 0)),
-        (22, dt.datetime(2025, 6, 14, 22, 0, 0), dt.datetime(2025, 6, 15, 1, 0, 0)),
+        (4, dt.datetime(2025, 6, 15, 4, 59, 0), dt.datetime(2025, 6, 15, 5, 20, 0)),
+        (22, dt.datetime(2025, 6, 14, 22, 59, 0), dt.datetime(2025, 6, 15, 1, 0, 0)),
     ],
     ids=["same-day", "catchup-past-midnight"],
 )
@@ -146,8 +147,8 @@ def test_unconsumed_dream_from_yesterday_does_not_suppress_today(tmp_path):
     state = vm.State()
     state.persisted.first_start_done = True
 
-    _drop_dream(config, state, dt.datetime(2025, 6, 15, 4, 0, 0))
-    _drop_dream(config, state, dt.datetime(2025, 6, 16, 4, 0, 0))
+    _drop_dream(config, state, dt.datetime(2025, 6, 15, 4, 59, 0))
+    _drop_dream(config, state, dt.datetime(2025, 6, 16, 4, 59, 0))
 
     assert _dream_files(config) == ["nightly_dream-2025-06-15.json", "nightly_dream-2025-06-16.json"]
 
@@ -158,12 +159,52 @@ def test_consumed_dream_is_recreated_by_the_catchup_retry(tmp_path):
     state = vm.State()
     state.persisted.first_start_done = True
 
-    _drop_dream(config, state, dt.datetime(2025, 6, 15, 4, 0, 0))
+    _drop_dream(config, state, dt.datetime(2025, 6, 15, 4, 59, 0))
     for dream in config.notifications_dir.glob("nightly_dream-*.json"):
         dream.unlink()
     _drop_dream(config, state, dt.datetime(2025, 6, 15, 7, 30, 0))
 
     assert _dream_files(config) == ["nightly_dream-2025-06-15.json"]
+
+
+# --- nightly jitter: each night's dream starts at a per-night minute, never at the hour sharp ---
+
+
+def _jitter_setup(tmp_path):
+    config = cfg.VestaConfig(agent_dir=tmp_path / "agent", agent_name="dreamer-test", nightly_memory_hour=4)
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+    config.notifications_dir.mkdir(parents=True, exist_ok=True)
+    state = vm.State()
+    state.persisted.first_start_done = True
+    return config, state
+
+
+@pytest.mark.parametrize(
+    "now,expected_files",
+    [
+        (dt.datetime(2025, 6, 15, 4, 0, 0), 0),  # window open, jitter instant not reached
+        (dt.datetime(2025, 6, 15, 4, 42, 0), 0),  # one minute short of the jitter instant
+        (dt.datetime(2025, 6, 15, 4, 43, 0), 1),  # sha256("dreamer-test:2025-06-15") % 60 == 43
+    ],
+    ids=["at-the-hour", "minute-before-jitter", "at-jitter-instant"],
+)
+def test_dream_waits_for_its_per_night_jitter_instant(tmp_path, now, expected_files):
+    config, state = _jitter_setup(tmp_path)
+
+    _drop_dream(config, state, now)
+
+    assert len(_dream_files(config)) == expected_files
+
+
+def test_jitter_instant_changes_across_nights(tmp_path):
+    """The delay derives from (agent name, night): the 16th fires at 4:31 where the 15th held to 4:43,
+    so a fleet's dreams land on different minutes each night rather than re-synchronizing."""
+    config, state = _jitter_setup(tmp_path)
+
+    # sha256("dreamer-test:2025-06-16") % 60 == 31
+    _drop_dream(config, state, dt.datetime(2025, 6, 16, 4, 31, 0))
+
+    assert _dream_files(config) == ["nightly_dream-2025-06-16.json"]
 
 
 # --- mark_dreamer_complete: keep the session, then compact + restart (not a hard reset) ---

--- a/vestad/src/maintenance_window.rs
+++ b/vestad/src/maintenance_window.rs
@@ -14,7 +14,9 @@ const WINDOW_END_HOUR: i8 = 5;
 const SCAN_HORIZON_HOURS: i64 = 24;
 const SCAN_STEP_MINUTES: i64 = 15;
 /// Upper bound on the per-night open jitter: the effective window keeps at least 30 minutes,
-/// so an idle-gated poll and the closing poll both still fit before the fixed 5:00 close.
+/// so an idle-gated poll and the closing poll both still fit before the fixed 5:00 close. This
+/// must stay above `2 * SCAN_STEP_MINUTES`; raising the jitter cap or the poll step without the
+/// other can shrink the window below room for both polls.
 const WINDOW_JITTER_MINUTES: u64 = 30;
 
 /// The minute past 4:00 the window opens on `date`'s night, hashed (FNV-1a) from the zone-local

--- a/vestad/src/maintenance_window.rs
+++ b/vestad/src/maintenance_window.rs
@@ -13,6 +13,23 @@ const WINDOW_START_HOUR: i8 = 4;
 const WINDOW_END_HOUR: i8 = 5;
 const SCAN_HORIZON_HOURS: i64 = 24;
 const SCAN_STEP_MINUTES: i64 = 15;
+/// Upper bound on the per-night open jitter: the effective window keeps at least 30 minutes,
+/// so an idle-gated poll and the closing poll both still fit before the fixed 5:00 close.
+const WINDOW_JITTER_MINUTES: u64 = 30;
+
+/// The minute past 4:00 the window opens on `date`'s night, hashed (FNV-1a) from the zone-local
+/// date: stable across polls and vestad restarts, different each night, so the pass never lands
+/// on the same clock minute night after night.
+fn jitter_minutes(date: jiff::civil::Date) -> i8 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = FNV_OFFSET;
+    for byte in date.to_string().bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    i8::try_from(hash % WINDOW_JITTER_MINUTES).expect("jitter is below 30")
+}
 
 /// Resolve an agent's reported IANA timezone name to a zone, falling back to the vestad host's
 /// local zone when the agent reported none (pre-upstream-sync fleet) or the name doesn't parse.
@@ -21,10 +38,11 @@ pub fn resolve_zone(name: Option<&str>) -> TimeZone {
     name.and_then(|name| TimeZone::get(name).ok()).unwrap_or_else(TimeZone::system)
 }
 
-/// Whether `at` falls inside the `[4:00, 5:00)` local window for `zone`.
+/// Whether `at` falls inside the `[4:JJ, 5:00)` local window for `zone`, `JJ` being the night's
+/// jitter minute. The single-hour window makes the minute check apply exactly at the open hour.
 fn in_window(zone: &TimeZone, at: Timestamp) -> bool {
-    let hour = at.to_zoned(zone.clone()).hour();
-    (WINDOW_START_HOUR..WINDOW_END_HOUR).contains(&hour)
+    let zoned = at.to_zoned(zone.clone());
+    (WINDOW_START_HOUR..WINDOW_END_HOUR).contains(&zoned.hour()) && zoned.minute() >= jitter_minutes(zoned.date())
 }
 
 /// How long to wait from `now` before running maintenance so it lands in the upcoming 4-5am
@@ -65,44 +83,59 @@ mod tests {
     }
 
     #[test]
-    fn in_window_utc_boundaries_are_half_open() {
+    fn in_window_utc_boundaries_open_at_the_jitter_minute() {
+        // fnv1a("2026-01-01") % 30 == 19: this night's window is [4:19, 5:00).
         let utc = zone("UTC");
         assert!(!in_window(&utc, ts("2026-01-01T03:59:00Z")));
-        assert!(in_window(&utc, ts("2026-01-01T04:00:00Z")));
+        assert!(!in_window(&utc, ts("2026-01-01T04:18:00Z")));
+        assert!(in_window(&utc, ts("2026-01-01T04:19:00Z")));
         assert!(in_window(&utc, ts("2026-01-01T04:59:00Z")));
         assert!(!in_window(&utc, ts("2026-01-01T05:00:00Z")));
     }
 
     #[test]
+    fn window_open_minute_changes_across_nights() {
+        // fnv1a("2026-01-02") % 30 == 20: the next night opens one minute later, so the pass
+        // cannot land on the same clock minute night after night. The close edge stays 5:00.
+        let utc = zone("UTC");
+        assert!(!in_window(&utc, ts("2026-01-02T04:19:00Z")));
+        assert!(in_window(&utc, ts("2026-01-02T04:20:00Z")));
+        assert!(in_window(&utc, ts("2026-01-02T04:59:00Z")));
+        assert!(!in_window(&utc, ts("2026-01-02T05:00:00Z")));
+    }
+
+    #[test]
     fn in_window_respects_offset_zone_in_winter() {
-        // New York is UTC-5 in January, so 04:00 EST == 09:00 UTC.
+        // New York is UTC-5 in January, so 04:19 EST (the night's open, jitter 19) == 09:19 UTC.
         let ny = zone("America/New_York");
-        assert!(in_window(&ny, ts("2026-01-01T09:00:00Z")));
-        assert!(!in_window(&ny, ts("2026-01-01T06:00:00Z"))); // 01:00 EST
+        assert!(in_window(&ny, ts("2026-01-01T09:19:00Z")));
+        assert!(!in_window(&ny, ts("2026-01-01T06:19:00Z"))); // 01:19 EST
     }
 
     #[test]
     fn in_window_respects_dst_shift_in_summer() {
-        // New York is UTC-4 in July (EDT): 04:00 EDT == 08:00 UTC is in-window, while 09:00 UTC ==
-        // 05:00 EDT is out -- the very same 09:00 UTC instant that IS in-window in winter (04:00 EST,
-        // asserted above), so the zone's DST offset is being applied, not a fixed one.
+        // New York is UTC-4 in July (EDT): 04:29 EDT (jitter 29) == 08:29 UTC is in-window, while
+        // 09:29 UTC == 05:29 EDT is out -- in winter that same wall-clock check sat an hour later in
+        // UTC (asserted above), so the zone's DST offset is being applied, not a fixed one.
         let ny = zone("America/New_York");
-        assert!(in_window(&ny, ts("2026-07-01T08:00:00Z")));
-        assert!(!in_window(&ny, ts("2026-07-01T09:00:00Z")));
+        assert!(in_window(&ny, ts("2026-07-01T08:29:00Z")));
+        assert!(!in_window(&ny, ts("2026-07-01T09:29:00Z")));
     }
 
     #[test]
     fn wait_until_best_window_picks_the_least_disruptive_upcoming_window() {
+        // Jan 1's window opens at 4:19 (jitter 19), so on-the-hour scans reach it at the 4:30 step;
+        // Jul 1 opens at 4:29, reached at the 4:30 local step.
         let cases: [(&str, Vec<TimeZone>, &str, SignedDuration); 7] = [
             ("already inside the window applies now", vec![zone("UTC")], "2026-01-01T04:30:00Z", SignedDuration::ZERO),
-            ("waits for the next window to open", vec![zone("UTC")], "2026-01-01T01:00:00Z", SignedDuration::from_hours(3)),
-            // July: NY's 04:00 EDT window opens at 08:00 UTC (not 09:00), so 4h from 04:00 UTC.
-            ("targets the DST-shifted window in summer", vec![zone("America/New_York")], "2026-07-01T04:00:00Z", SignedDuration::from_hours(4)),
-            ("same-zone agents share one window", vec![zone("UTC"), zone("UTC"), zone("UTC")], "2026-01-01T00:00:00Z", SignedDuration::from_hours(4)),
-            // Two UTC agents outrank the lone NY agent, so aim at UTC's 04:00 window (4h) not NY's.
-            ("picks the window covering the most agents", vec![zone("UTC"), zone("UTC"), zone("America/New_York")], "2026-01-01T00:00:00Z", SignedDuration::from_hours(4)),
-            // Neither window covers more than one, so take the earliest: UTC's 04:00 (4h) beats NY's 09:00 UTC (9h).
-            ("disjoint single zones take the earliest window", vec![zone("UTC"), zone("America/New_York")], "2026-01-01T00:00:00Z", SignedDuration::from_hours(4)),
+            ("waits for the next window to open", vec![zone("UTC")], "2026-01-01T01:00:00Z", SignedDuration::from_mins(210)),
+            // July: NY's 04:29 EDT open sits at 08:29 UTC (not 09:29), so the 08:30 step, 270m from 04:00 UTC.
+            ("targets the DST-shifted window in summer", vec![zone("America/New_York")], "2026-07-01T04:00:00Z", SignedDuration::from_mins(270)),
+            ("same-zone agents share one window", vec![zone("UTC"), zone("UTC"), zone("UTC")], "2026-01-01T00:00:00Z", SignedDuration::from_mins(270)),
+            // Two UTC agents outrank the lone NY agent, so aim at UTC's 04:30 step (270m) not NY's.
+            ("picks the window covering the most agents", vec![zone("UTC"), zone("UTC"), zone("America/New_York")], "2026-01-01T00:00:00Z", SignedDuration::from_mins(270)),
+            // Neither window covers more than one, so take the earliest: UTC's 04:30 step (270m) beats NY's 09:30 UTC (570m).
+            ("disjoint single zones take the earliest window", vec![zone("UTC"), zone("America/New_York")], "2026-01-01T00:00:00Z", SignedDuration::from_mins(270)),
             ("no agents applies immediately", vec![], "2026-01-01T12:00:00Z", SignedDuration::ZERO),
         ];
         for (desc, zones, now, expected) in cases {


### PR DESCRIPTION
## What

Two nightly automations fired on rigid, repeating instants. Both now start at a per-night pseudorandom minute, with no new config, no persisted state, and no wire change.

**Dream (agent)**: the nightly dream fired at the first hourly check after `nightly_memory_hour`, so every agent on a host compacted and restarted in the same hour-aligned burst. Each night now starts at a minute in `[hour:00, hour:59]`, hashed from (agent name, night date) in `agent/core/loops.py`. The hash (not `random`) keeps the instant stable across the hourly checks and across restarts, while varying it per night and per agent.

**Maintenance window (vestad)**: the pass polled on a boot-anchored 15-minute grid from 4:00 local, so it landed on the same clock minute night after night. The window now opens at `[4:00, 4:30)` plus a per-night minute hashed (inline FNV-1a, no new dependency) from the zone-local date in `vestad/src/maintenance_window.rs`. The 5:00 close stays fixed, so an idle-gated poll and the closing poll always fit, and the pass still always lands inside its window. `in_window` is the one owner of the window shape, so the 24h coverage scan and the live poll shift together and `serve.rs` is untouched.

The two compose: a dream can now run past 4:00, and the maintenance idle gate already defers the pass while an agent dreams.

## Why

Retro on an agent that crash-looped during last night's dream restart under host IO saturation: hour-aligned dream restarts and a fixed-minute maintenance pass concentrate nightly load spikes. Jitter spreads them. (The IO saturation itself is a separate issue.)

## Testing

- `./check.sh guards` green.
- `./check.sh agent` green (1151 passed; the 2 `test_migrations.py` workspace-repair failures are the known host `tag.gpgsign` artifact, and pass with `GIT_CONFIG_GLOBAL=/dev/null`).
- `cargo clippy -p vestad -- -D warnings` and `cargo test -p vestad --bins` (483 passed) green.
- TDD: new tests pin hashed instants (`sha256("dreamer-test:2025-06-15") % 60 == 43`; `fnv1a("2026-01-01") % 30 == 19`), hold-before/fire-after boundaries, and that consecutive nights differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)