### PR TITLE
feat(desktop): resolve location through the OS provider on Windows and Linux

### DIFF
--- a/apps/desktop/src/geolocation.test.ts
+++ b/apps/desktop/src/geolocation.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseObjectPath,
+  parseVariantNumber,
+  parseWindowsFix,
+  resolveNativeFix,
+} from "./geolocation";
+
+const instantSleep = () => Promise.resolve();
+
+describe("parseWindowsFix", () => {
+  it("parses the invariant lat|lon|accuracy line", () => {
+    expect(parseWindowsFix("39.2238|9.1217|25\r\n")).toEqual({
+      latitude: 39.2238,
+      longitude: 9.1217,
+      accuracyM: 25,
+    });
+  });
+
+  it("keeps the fix when only the accuracy is malformed", () => {
+    expect(parseWindowsFix("39.2238|9.1217|NaN")).toEqual({
+      latitude: 39.2238,
+      longitude: 9.1217,
+      accuracyM: null,
+    });
+  });
+
+  it("rejects malformed output", () => {
+    expect(parseWindowsFix("")).toBeNull();
+    expect(parseWindowsFix("error: denied")).toBeNull();
+    expect(parseWindowsFix("a|b|c")).toBeNull();
+  });
+});
+
+describe("gdbus parsing", () => {
+  it("extracts an object path from a call reply", () => {
+    expect(
+      parseObjectPath("(objectpath '/org/freedesktop/GeoClue2/Client/1',)\n"),
+    ).toBe("/org/freedesktop/GeoClue2/Client/1");
+    expect(parseObjectPath("(<objectpath '/'>,)\n")).toBe("/");
+    expect(parseObjectPath("()")).toBeNull();
+  });
+
+  it("extracts a number from a variant reply", () => {
+    expect(parseVariantNumber("(<39.2238>,)\n")).toBe(39.2238);
+    expect(parseVariantNumber("(<double -0.1278>,)\n")).toBe(-0.1278);
+    expect(parseVariantNumber("(<'text'>,)")).toBeNull();
+  });
+});
+
+describe("resolveNativeFix", () => {
+  it("answers null on macOS so the renderer keeps its CoreLocation path", async () => {
+    const run = () => Promise.reject(new Error("must not be called"));
+    expect(await resolveNativeFix("darwin", run)).toBeNull();
+  });
+
+  it("resolves a Windows fix through powershell", async () => {
+    const commands: string[][] = [];
+    const run = (command: string, args: string[]) => {
+      commands.push([command, ...args.slice(0, 2)]);
+      return Promise.resolve("51.5074|-0.1278|30");
+    };
+    expect(await resolveNativeFix("win32", run)).toEqual({
+      latitude: 51.5074,
+      longitude: -0.1278,
+      accuracyM: 30,
+    });
+    expect(commands).toEqual([
+      ["powershell.exe", "-NoProfile", "-NonInteractive"],
+    ]);
+  });
+
+  it("walks the GeoClue client to a fix on Linux and stops it after", async () => {
+    const calls: string[] = [];
+    const client = "/org/freedesktop/GeoClue2/Client/7";
+    const location = "/org/freedesktop/GeoClue2/Location/0";
+    const run = (_command: string, args: string[]) => {
+      const call = args.join(" ");
+      calls.push(call);
+      if (call.includes("Manager.GetClient")) {
+        return Promise.resolve(`(objectpath '${client}',)`);
+      }
+      if (call.endsWith("Client Location")) {
+        // First poll: no fix yet; second poll: the location object exists.
+        const polls = calls.filter((c) => c.endsWith("Client Location")).length;
+        return Promise.resolve(
+          polls === 1 ? "(<objectpath '/'>,)" : `(<objectpath '${location}'>,)`,
+        );
+      }
+      if (call.endsWith("Latitude")) return Promise.resolve("(<39.2238>,)");
+      if (call.endsWith("Longitude")) return Promise.resolve("(<9.1217>,)");
+      if (call.endsWith("Accuracy")) return Promise.resolve("(<25.0>,)");
+      return Promise.resolve("()");
+    };
+    expect(await resolveNativeFix("linux", run, instantSleep)).toEqual({
+      latitude: 39.2238,
+      longitude: 9.1217,
+      accuracyM: 25,
+    });
+    expect(calls.some((c) => c.includes("Client.Start"))).toBe(true);
+    expect(calls.at(-1)).toContain("Client.Stop");
+  });
+
+  it("resolves null when the provider is missing or refuses", async () => {
+    const run = () => Promise.reject(new Error("gdbus: command not found"));
+    expect(await resolveNativeFix("linux", run, instantSleep)).toBeNull();
+    expect(await resolveNativeFix("win32", run)).toBeNull();
+  });
+});

--- a/apps/desktop/src/geolocation.ts
+++ b/apps/desktop/src/geolocation.ts
@@ -120,7 +120,9 @@ const defaultSleep = (ms: number) =>
 
 // GetClient, identify, Start, poll the Location property until the daemon has a fix, read the
 // coordinates off the location object, Stop. GeoClue signals a fix rather than answering one, and
-// polling a property from a one-shot CLI is the whole event loop we need.
+// polling a property from a one-shot CLI is the whole event loop we need. Some distros authorize
+// clients through an agent or a .desktop allow-list a bare DesktopId does not satisfy; there Start
+// errors and this resolves null, so such a machine degrades to timezone-only.
 async function linuxFix(
   run: Run,
   sleep: (ms: number) => Promise<void> = defaultSleep,

--- a/apps/desktop/src/geolocation.ts
+++ b/apps/desktop/src/geolocation.ts
@@ -1,0 +1,200 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+// The one owner of native OS geolocation for the main process. The renderer's
+// navigator.geolocation resolves only on macOS (CoreLocation), so this module answers for the
+// other two platforms: Windows through the in-box WinRT Geolocator (PowerShell, no packaging or
+// API key needed), Linux through GeoClue2 over the system D-Bus (gdbus, present on most
+// desktops). macOS answers null so the renderer keeps its CoreLocation path. Every failure
+// (no provider, denied, timeout) resolves to null; the caller falls back to timezone-only.
+
+export interface NativeFix {
+  latitude: number;
+  longitude: number;
+  accuracyM: number | null;
+}
+
+// A step (one process spawn) never outlives this; the Windows one-shot gets the full budget.
+export const NATIVE_FIX_TIMEOUT_MS = 15_000;
+const EXEC_TIMEOUT_MS = 5_000;
+const LINUX_POLL_INTERVAL_MS = 500;
+
+type Run = (command: string, args: string[]) => Promise<string>;
+
+const execFileAsync = promisify(execFile);
+
+async function runWithTimeout(
+  command: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<string> {
+  const { stdout } = await execFileAsync(command, args, {
+    timeout: timeoutMs,
+    windowsHide: true,
+  });
+  return stdout;
+}
+
+// Culture-invariant "lat|lon|accuracy" so a comma-decimal locale cannot corrupt the numbers.
+const WINDOWS_SCRIPT = [
+  "$ErrorActionPreference='Stop';",
+  "[Windows.Devices.Geolocation.Geolocator,Windows.Devices.Geolocation,ContentType=WindowsRuntime]|Out-Null;",
+  "Add-Type -AssemblyName System.Runtime.WindowsRuntime;",
+  "$asTask=([System.WindowsRuntimeSystemExtensions].GetMethods()|Where-Object {$_.Name -eq 'AsTask' -and $_.GetParameters().Count -eq 1 -and $_.GetParameters()[0].ParameterType.Name -eq 'IAsyncOperation`1'})[0];",
+  "$g=New-Object Windows.Devices.Geolocation.Geolocator;",
+  "$t=$asTask.MakeGenericMethod([Windows.Devices.Geolocation.Geoposition]).Invoke($null,@($g.GetGeopositionAsync()));",
+  "$t.Wait()|Out-Null;",
+  "$c=$t.Result.Coordinate;",
+  "$i=[System.Globalization.CultureInfo]::InvariantCulture;",
+  "Write-Output ($c.Point.Position.Latitude.ToString($i)+'|'+$c.Point.Position.Longitude.ToString($i)+'|'+$c.Accuracy.ToString($i))",
+].join("");
+
+export function parseWindowsFix(stdout: string): NativeFix | null {
+  const parts = stdout.trim().split("|");
+  if (parts.length !== 3) return null;
+  const latitude = Number(parts[0]);
+  const longitude = Number(parts[1]);
+  const accuracy = Number(parts[2]);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null;
+  return {
+    latitude,
+    longitude,
+    accuracyM: Number.isFinite(accuracy) ? accuracy : null,
+  };
+}
+
+async function windowsFix(run: Run): Promise<NativeFix | null> {
+  const stdout = await run("powershell.exe", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    WINDOWS_SCRIPT,
+  ]);
+  return parseWindowsFix(stdout);
+}
+
+const GEOCLUE_DEST = "org.freedesktop.GeoClue2";
+const GEOCLUE_CLIENT = "org.freedesktop.GeoClue2.Client";
+// GeoClue accuracy level EXACT: the daemon still answers with whatever its sources allow.
+const GEOCLUE_ACCURACY_EXACT = "<uint32 8>";
+
+export function parseObjectPath(stdout: string): string | null {
+  return /objectpath '([^']+)'/.exec(stdout)?.[1] ?? null;
+}
+
+export function parseVariantNumber(stdout: string): number | null {
+  const match = /<(?:double )?(-?\d+(?:\.\d+)?(?:e[+-]?\d+)?)>/i.exec(stdout);
+  if (!match) return null;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value : null;
+}
+
+function gdbus(run: Run, objectPath: string, args: string[]): Promise<string> {
+  return run("gdbus", [
+    "call",
+    "--system",
+    "--dest",
+    GEOCLUE_DEST,
+    "--object-path",
+    objectPath,
+    ...args,
+  ]);
+}
+
+function clientProperty(
+  run: Run,
+  client: string,
+  method: "Get" | "Set",
+  args: string[],
+): Promise<string> {
+  return gdbus(run, client, [
+    "--method",
+    `org.freedesktop.DBus.Properties.${method}`,
+    GEOCLUE_CLIENT,
+    ...args,
+  ]);
+}
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// GetClient, identify, Start, poll the Location property until the daemon has a fix, read the
+// coordinates off the location object, Stop. GeoClue signals a fix rather than answering one, and
+// polling a property from a one-shot CLI is the whole event loop we need.
+async function linuxFix(
+  run: Run,
+  sleep: (ms: number) => Promise<void> = defaultSleep,
+): Promise<NativeFix | null> {
+  const managerReply = await gdbus(run, "/org/freedesktop/GeoClue2/Manager", [
+    "--method",
+    "org.freedesktop.GeoClue2.Manager.GetClient",
+  ]);
+  const client = parseObjectPath(managerReply);
+  if (client === null) return null;
+  await clientProperty(run, client, "Set", ["DesktopId", "<'vesta'>"]);
+  await clientProperty(run, client, "Set", [
+    "RequestedAccuracyLevel",
+    GEOCLUE_ACCURACY_EXACT,
+  ]);
+  await gdbus(run, client, ["--method", `${GEOCLUE_CLIENT}.Start`]);
+  try {
+    const attempts = Math.floor(NATIVE_FIX_TIMEOUT_MS / LINUX_POLL_INTERVAL_MS);
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      const reply = await clientProperty(run, client, "Get", ["Location"]);
+      const location = parseObjectPath(reply);
+      if (location !== null && location !== "/") {
+        return await readLocation(run, location);
+      }
+      await sleep(LINUX_POLL_INTERVAL_MS);
+    }
+    return null;
+  } finally {
+    await gdbus(run, client, ["--method", `${GEOCLUE_CLIENT}.Stop`]).catch(
+      () => undefined,
+    );
+  }
+}
+
+async function readLocation(
+  run: Run,
+  location: string,
+): Promise<NativeFix | null> {
+  const property = (name: string) =>
+    gdbus(run, location, [
+      "--method",
+      "org.freedesktop.DBus.Properties.Get",
+      "org.freedesktop.GeoClue2.Location",
+      name,
+    ]).then(parseVariantNumber);
+  const [latitude, longitude, accuracy] = await Promise.all([
+    property("Latitude"),
+    property("Longitude"),
+    property("Accuracy"),
+  ]);
+  if (latitude === null || longitude === null) return null;
+  return { latitude, longitude, accuracyM: accuracy };
+}
+
+export async function resolveNativeFix(
+  platform: NodeJS.Platform,
+  run: Run,
+  sleep?: (ms: number) => Promise<void>,
+): Promise<NativeFix | null> {
+  try {
+    if (platform === "win32") return await windowsFix(run);
+    if (platform === "linux") return await linuxFix(run, sleep);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function readNativeGeolocation(): Promise<NativeFix | null> {
+  const run: Run = (command, args) =>
+    runWithTimeout(
+      command,
+      args,
+      process.platform === "win32" ? NATIVE_FIX_TIMEOUT_MS : EXEC_TIMEOUT_MS,
+    );
+  return resolveNativeFix(process.platform, run);
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, Menu, app, ipcMain, nativeTheme, shell } from "electron";
 import path from "node:path";
+import { readNativeGeolocation } from "./geolocation";
 import { cancelLoopback, startLoopback } from "./oauth-loopback";
 import { clearConnection, readConnection, writeConnection } from "./store";
 import { createMainWindow, registerAppScheme, showMainWindow } from "./window";
@@ -62,6 +63,7 @@ if (!gotLock) {
     ipcMain.handle("oauth:cancel", (_event, port: unknown) => {
       if (typeof port === "number") cancelLoopback(port);
     });
+    ipcMain.handle("geolocation:read", () => readNativeGeolocation());
   };
 
   app.on("second-instance", () => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -27,6 +27,7 @@ contextBridge.exposeInMainWorld("vestaNative", {
       cb(url);
     }),
   oauthCancel: (port: number) => ipcRenderer.invoke("oauth:cancel", port),
+  readGeolocation: () => ipcRenderer.invoke("geolocation:read"),
   onWindowFocus: (cb: (focused: boolean) => void) =>
     subscribe("window-focus", (_event, focused: boolean) => {
       cb(focused);

--- a/apps/web/src/components/Settings/DevicesCard/index.tsx
+++ b/apps/web/src/components/Settings/DevicesCard/index.tsx
@@ -94,8 +94,8 @@ function UserContextToggle() {
 }
 
 // This device's own opt-in to share its precise location, on top of the gateway-wide switch above.
-// Turning it on makes this browser (or the desktop app) ask for a geolocation fix, which the OS
-// prompts for; off reports only the timezone and retracts any stored position.
+// Turning it on makes this browser (or the desktop app, through its OS location provider) read a
+// geolocation fix; off reports only the timezone and retracts any stored position.
 function LocationToggle() {
   const enabled = useShareLocation((s) => s.enabled);
   const setEnabled = useShareLocation((s) => s.setEnabled);
@@ -111,7 +111,7 @@ function LocationToggle() {
         </FieldLabel>
         <FieldDescription>
           let your agents see where this device is, from its precise location;
-          your browser asks permission the first time
+          the system asks permission the first time
         </FieldDescription>
       </FieldContent>
       <Switch checked={enabled} onCheckedChange={setEnabled} />

--- a/apps/web/src/lib/device-context.test.ts
+++ b/apps/web/src/lib/device-context.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NativeGeolocationFix } from "@/lib/native";
 import { readBrowserDeviceContext } from "./device-context";
+
+// The native bridge as device-context sees it: no desktop main process here, so the default is
+// the browser's null bridge; a test hands it a fix to play the desktop app.
+const bridge = vi.hoisted(() => ({
+  readGeolocation: null as (() => Promise<NativeGeolocationFix | null>) | null,
+}));
+vi.mock("@/lib/native", () => ({ native: bridge }));
 
 type SuccessFn = (fix: {
   coords: { latitude: number; longitude: number; accuracy: number };
@@ -19,7 +27,10 @@ function stubGeolocation(
 }
 
 describe("readBrowserDeviceContext", () => {
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    bridge.readGeolocation = null;
+    vi.unstubAllGlobals();
+  });
 
   it("reports the OS zone and retracts the position when sharing is off", async () => {
     stubOsZone("America/New_York");
@@ -65,6 +76,37 @@ describe("readBrowserDeviceContext", () => {
     vi.stubGlobal("navigator", {});
     await expect(readBrowserDeviceContext(true)).resolves.toEqual({
       timezone: "America/New_York",
+    });
+  });
+
+  it("prefers the desktop bridge fix over the renderer's geolocation", async () => {
+    stubOsZone("America/New_York");
+    const getCurrentPosition = vi.fn();
+    stubGeolocation(getCurrentPosition);
+    bridge.readGeolocation = () =>
+      Promise.resolve({ latitude: 39.2238, longitude: 9.1217, accuracyM: 30 });
+    await expect(readBrowserDeviceContext(true)).resolves.toEqual({
+      timezone: "Europe/Rome",
+      position: {
+        latitude: 39.2238,
+        longitude: 9.1217,
+        accuracyM: 30,
+        place: null,
+      },
+    });
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the renderer's geolocation when the bridge answers null", async () => {
+    stubOsZone("America/New_York");
+    stubGeolocation((success) => {
+      success({
+        coords: { latitude: 39.2238, longitude: 9.1217, accuracy: 20 },
+      });
+    });
+    bridge.readGeolocation = () => Promise.resolve(null);
+    await expect(readBrowserDeviceContext(true)).resolves.toMatchObject({
+      timezone: "Europe/Rome",
     });
   });
 });

--- a/apps/web/src/lib/device-context.ts
+++ b/apps/web/src/lib/device-context.ts
@@ -1,5 +1,6 @@
 import tzlookup from "tz-lookup";
 import type { DeviceContext } from "@vesta/core";
+import { native } from "@/lib/native";
 
 // What this browser (or the desktop app around it) reports about itself: its zone always, and, with
 // the user's opt-in and a geolocation grant, its position and the zone that position falls in. A
@@ -25,9 +26,13 @@ function zoneAt(latitude: number, longitude: number): string {
   }
 }
 
-// A fix, or null when geolocation is unavailable, denied, or slow: the report then carries the OS
-// zone alone. The browser prompt is raised by this call itself, so the opt-in toggle is what gates it.
-function readFix(): Promise<GeolocationPosition | null> {
+interface Fix {
+  latitude: number;
+  longitude: number;
+  accuracy: number | null;
+}
+
+function browserFix(): Promise<Fix | null> {
   if (typeof navigator === "undefined" || !("geolocation" in navigator)) {
     return Promise.resolve(null);
   }
@@ -35,7 +40,8 @@ function readFix(): Promise<GeolocationPosition | null> {
   return new Promise((resolve) => {
     geolocation.getCurrentPosition(
       (fix) => {
-        resolve(fix);
+        const { latitude, longitude, accuracy } = fix.coords;
+        resolve({ latitude, longitude, accuracy });
       },
       () => {
         resolve(null);
@@ -45,10 +51,27 @@ function readFix(): Promise<GeolocationPosition | null> {
   });
 }
 
+// A fix, or null when geolocation is unavailable, denied, or slow: the report then carries the OS
+// zone alone. In the desktop app the main process resolves through the OS provider first (WinRT on
+// Windows, GeoClue2 on Linux); a null answer (macOS, no provider, refused) falls through to the
+// renderer's own geolocation, whose prompt this call itself raises, so the opt-in toggle gates both.
+async function readFix(): Promise<Fix | null> {
+  if (native.readGeolocation) {
+    const fix = await native.readGeolocation().catch(() => null);
+    if (fix) {
+      return {
+        latitude: fix.latitude,
+        longitude: fix.longitude,
+        accuracy: fix.accuracyM,
+      };
+    }
+  }
+  return browserFix();
+}
+
 // With sharing off the report carries `position: null`, which retracts any position the gateway
 // holds for this device; with sharing on but no fix, the position is absent and the stored one
-// stands. The browser has no offline reverse geocoder, so the position names no place; the gateway's
-// coarse IP city is the only place hint for a browser or desktop device.
+// stands. The browser has no offline reverse geocoder, so the position names no place.
 export async function readBrowserDeviceContext(
   shareLocation: boolean,
 ): Promise<DeviceContext> {
@@ -57,7 +80,7 @@ export async function readBrowserDeviceContext(
   }
   const fix = await readFix();
   if (fix === null) return { timezone: osTimezone() };
-  const { latitude, longitude, accuracy } = fix.coords;
+  const { latitude, longitude, accuracy } = fix;
   return {
     timezone: zoneAt(latitude, longitude),
     position: { latitude, longitude, accuracyM: accuracy, place: null },

--- a/apps/web/src/lib/native/browser.ts
+++ b/apps/web/src/lib/native/browser.ts
@@ -49,5 +49,6 @@ export function createBrowserBridge(): NativeBridge {
     },
     oauthLoopback: null,
     windowControls: null,
+    readGeolocation: null,
   };
 }

--- a/apps/web/src/lib/native/electron.ts
+++ b/apps/web/src/lib/native/electron.ts
@@ -2,13 +2,34 @@
 // apps/desktop/src/preload.ts, keep the two declarations identical.
 import type { Platform } from "@/lib/platform";
 import { parseConnectionConfig } from "./parse-connection-config";
-import type { NativeBridge, VestaNativeApi } from "./types";
+import type {
+  NativeBridge,
+  NativeGeolocationFix,
+  VestaNativeApi,
+} from "./types";
 
 const NODE_PLATFORM_MAP: Record<string, Platform> = {
   darwin: "macos",
   win32: "windows",
   linux: "linux",
 };
+
+// Parse at the boundary: the preload answer is untyped IPC, so validate the shape here.
+export function parseNativeFix(value: unknown): NativeGeolocationFix | null {
+  if (typeof value !== "object" || value === null) return null;
+  const fix = value as Record<string, unknown>;
+  const { latitude, longitude, accuracyM } = fix;
+  if (typeof latitude !== "number" || !Number.isFinite(latitude)) return null;
+  if (typeof longitude !== "number" || !Number.isFinite(longitude)) return null;
+  return {
+    latitude,
+    longitude,
+    accuracyM:
+      typeof accuracyM === "number" && Number.isFinite(accuracyM)
+        ? accuracyM
+        : null,
+  };
+}
 
 export function createElectronBridge(api: VestaNativeApi): NativeBridge {
   const platform = NODE_PLATFORM_MAP[api.platform] ?? "linux";
@@ -35,6 +56,7 @@ export function createElectronBridge(api: VestaNativeApi): NativeBridge {
       onCallback: (cb) => api.onOauthCallback(cb),
       cancel: (port) => api.oauthCancel(port),
     },
+    readGeolocation: async () => parseNativeFix(await api.readGeolocation()),
     // macOS keeps its native traffic lights; only Windows draws custom controls.
     windowControls:
       platform === "windows"

--- a/apps/web/src/lib/native/index.ts
+++ b/apps/web/src/lib/native/index.ts
@@ -2,7 +2,12 @@ import { createBrowserBridge } from "./browser";
 import { createElectronBridge } from "./electron";
 import type { NativeBridge } from "./types";
 
-export type { NativeBridge, Runtime, VestaNativeApi } from "./types";
+export type {
+  NativeBridge,
+  NativeGeolocationFix,
+  Runtime,
+  VestaNativeApi,
+} from "./types";
 
 export const native: NativeBridge =
   typeof window !== "undefined" && window.vestaNative

--- a/apps/web/src/lib/native/native.test.tsx
+++ b/apps/web/src/lib/native/native.test.tsx
@@ -59,8 +59,9 @@ describe("browser bridge", () => {
     expect(open).toHaveBeenCalledWith("https://vesta.run", "_blank");
   });
 
-  it("has no oauth loopback", () => {
+  it("has no oauth loopback and no native geolocation", () => {
     expect(createBrowserBridge().oauthLoopback).toBeNull();
+    expect(createBrowserBridge().readGeolocation).toBeNull();
   });
 });
 
@@ -80,6 +81,7 @@ describe("electron bridge", () => {
       oauthStart: vi.fn(() => Promise.resolve(4242)),
       onOauthCallback: vi.fn(() => noopUnsubscribe),
       oauthCancel: vi.fn(() => Promise.resolve()),
+      readGeolocation: vi.fn(() => Promise.resolve<unknown>(null)),
       onWindowFocus: vi.fn(() => noopUnsubscribe),
       windowMinimize: vi.fn(() => Promise.resolve()),
       windowToggleMaximize: vi.fn(() => Promise.resolve()),
@@ -123,6 +125,34 @@ describe("electron bridge", () => {
   it("exposes the oauth loopback", async () => {
     const bridge = createElectronBridge(fakeApi());
     expect(await bridge.oauthLoopback?.start()).toBe(4242);
+  });
+
+  it("parses the native geolocation answer at the boundary", async () => {
+    const good = fakeApi({
+      readGeolocation: vi.fn(() =>
+        Promise.resolve<unknown>({
+          latitude: 39.2238,
+          longitude: 9.1217,
+          accuracyM: 25,
+        }),
+      ),
+    });
+    expect(await createElectronBridge(good).readGeolocation?.()).toEqual({
+      latitude: 39.2238,
+      longitude: 9.1217,
+      accuracyM: 25,
+    });
+    const malformed = fakeApi({
+      readGeolocation: vi.fn(() =>
+        Promise.resolve<unknown>({ latitude: "39", longitude: 9 }),
+      ),
+    });
+    expect(
+      await createElectronBridge(malformed).readGeolocation?.(),
+    ).toBeNull();
+    expect(
+      await createElectronBridge(fakeApi()).readGeolocation?.(),
+    ).toBeNull();
   });
 
   it("routes theme and focus calls to the preload api", async () => {

--- a/apps/web/src/lib/native/types.ts
+++ b/apps/web/src/lib/native/types.ts
@@ -17,6 +17,14 @@ export interface OauthLoopback {
   cancel(port: number): Promise<void>;
 }
 
+// A fix the desktop main process resolved through the OS location provider (WinRT on Windows,
+// GeoClue2 on Linux); macOS answers null and the renderer's own geolocation covers it.
+export interface NativeGeolocationFix {
+  latitude: number;
+  longitude: number;
+  accuracyM: number | null;
+}
+
 export interface WindowControls {
   minimize(): Promise<void>;
   toggleMaximize(): Promise<void>;
@@ -39,6 +47,8 @@ export interface NativeBridge {
   oauthLoopback: OauthLoopback | null;
   /** Custom title-bar controls; null when the OS draws them (browser, macOS). */
   windowControls: WindowControls | null;
+  /** OS geolocation resolved by the desktop main process; null in the browser. */
+  readGeolocation: (() => Promise<NativeGeolocationFix | null>) | null;
 }
 
 /**
@@ -56,6 +66,7 @@ export interface VestaNativeApi {
   oauthStart(): Promise<number>;
   onOauthCallback(cb: (url: string) => void): () => void;
   oauthCancel(port: number): Promise<void>;
+  readGeolocation(): Promise<unknown>;
   onWindowFocus(cb: (focused: boolean) => void): () => void;
   windowMinimize(): Promise<void>;
   windowToggleMaximize(): Promise<void>;


### PR DESCRIPTION
Follow-up to #2140 (merged), rebased onto `master`.

## Problem

The desktop "share this device's location" opt-in only worked on macOS. The renderer's `navigator.geolocation` resolves through an OS provider Chromium picks per platform: CoreLocation exists on macOS, but Electron ships no Google geolocation API key, so on Windows and Linux the network provider answers nothing and the toggle silently fell back to timezone-only.

## Changes

**One main-process owner, `apps/desktop/src/geolocation.ts`.** The desktop app resolves the fix natively per platform:

- **Windows**: the in-box WinRT `Windows.Devices.Geolocation.Geolocator`, driven from PowerShell. No MSIX packaging, no API key; respects the Windows location setting. Output is culture-invariant (`lat|lon|accuracy`) so a comma-decimal locale cannot corrupt the numbers.
- **Linux**: GeoClue2 over the system D-Bus via `gdbus` (GetClient, identify as `vesta`, Start, poll the Location property to the fix, Stop). Present on most desktops; a machine without it degrades to timezone-only.
- **macOS**: answers null; the renderer's existing CoreLocation path stays authoritative.

**Preload bridge extension.** A new `readGeolocation` capability crosses `window.vestaNative` (both declarations updated identically); the electron bridge parses the untyped IPC answer at the boundary, the browser bridge carries `null`.

**Web reader preference.** `readBrowserDeviceContext` asks the bridge first; a null answer (macOS, no provider, refused) falls through to the renderer's own geolocation, so every platform degrades to the OS timezone rather than erroring. The zone still derives from the fix with `tz-lookup`.

Settings copy: "the system asks permission the first time" (it is the OS prompt/setting, not always a browser dialog).

## Failure behavior

Every failure resolves to null and the report carries the OS zone alone: missing `gdbus`, no GeoClue agent authorization, the Windows location toggle off, a step timeout (`NATIVE_FIX_TIMEOUT_MS`), malformed output.

## Verification

- `apps/desktop`: tsc, lint, 30 tests (new: Windows line parsing incl. locale-hostile output, gdbus reply parsing, the full GeoClue walk with Stop asserted, macOS answering null, provider-missing degradation).
- `apps/web`: tsc, lint, 292 tests (new: bridge fix preferred over renderer geolocation; null bridge answer falls through).
- Not exercised on real Windows/Linux hardware from this environment: the WinRT script and the GeoClue walk follow the documented interfaces and are covered by fakes, but a hands-on check on each OS is worth doing before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AE3jsuYkwHqBCGNzqGQ891