### PR TITLE
feat(skills): make maps a default skill and install its CLI on update

### DIFF
--- a/agent/core/default-skills.txt
+++ b/agent/core/default-skills.txt
@@ -7,6 +7,7 @@ dashboard
 dream
 email-client
 emergency
+maps
 microsoft
 nap
 notifications

--- a/agent/core/migrations/2026-08-install-maps-cli.md
+++ b/agent/core/migrations/2026-08-install-maps-cli.md
@@ -1,0 +1,29 @@
+---
+interruptible: true
+---
+
+The `maps` skill (find real places, Google Maps links, directions, day plans) is a default
+skill, so it activates on every boot. Its command needs one install on this box.
+
+### 1. Install the `maps` command
+
+```bash
+uv tool install --editable ~/agent/skills/maps/cli
+command -v maps
+```
+
+The last line must print a path under `~/.local/bin`. The install is transactional and safe to
+run more than once. If it fails, STOP, leave this migration unmarked, and report it to the user.
+
+### 2. Verify with one probe
+
+```bash
+maps doctor || true
+```
+
+`doctor` probes each Maps RPC once and names any failing check. A network failure here is not an
+install failure: the command is on PATH either way, so continue.
+
+### 3. Mark this migration applied
+
+Call `mark_migration_applied` with this migration's name.


### PR DESCRIPTION
## What

Makes the new `maps` skill (#2139) active for every agent.

- `agent/core/default-skills.txt` gains `maps`: boot unions the defaults into `active_skills` and rebuilds the skill links, so the skill is discoverable on every box after its next restart, new and existing alike.
- One idempotent prompt migration, `2026-08-install-maps-cli.md` (after-sync, interruptible): `uv tool install --editable ~/agent/skills/maps/cli`, verify the command is on PATH, then one `maps doctor` probe. A doctor failure from a network condition does not block the migration; a failed install stops it unmarked, so it retries next boot.

## Why a migration

Activation only links the SKILL.md; a skill's CLI is installed by its own setup. Fresh agents pre-mark every shipping migration and install lazily from SETUP.md on first use, the same way other default skills with a CLI do; the migration exists to converge the boxes that already ran their birth.

## Tested

Migration- and skill-scoped agent tests pass locally (the two workspace-repair failures are the known host `tag.gpgsign` local-only issue, green in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7kVZzxNftyb8DxQdNCSwQ