### PR TITLE
fix(skills): maps search follows the user's location and country

### DIFF
--- a/agent/skills/maps/SETUP.md
+++ b/agent/skills/maps/SETUP.md
@@ -26,8 +26,10 @@ exits 0 when all pass and 1 with the failing checks named otherwise.
 ## How it works
 
 The skill replays Google Maps' own public web endpoints over plain HTTP (no browser, no account,
-no API key). It reads the country and language from `--locale`/`--country`, so pass the user's
-own values for results and formatting that match where they are.
+no API key). The country defaults from the box's timezone (`TZ`, which the agent's configured
+timezone sets, mapped through tzdata's `zone.tab`), so results and formatting follow where the
+user lives with no flags; `--country` overrides it for a query about another country, and
+`--locale` sets the language.
 
 `search`, `show`, and `itinerary` print a human table by default and structured JSON with
 `--json` / `--json-pretty`; the other commands always print JSON.

--- a/agent/skills/maps/SKILL.md
+++ b/agent/skills/maps/SKILL.md
@@ -25,7 +25,8 @@ answer at request time; null when the place publishes no hours), and a `links` b
 opens the exact place; `directions_url` is a ready directions link). The table shows each
 result's `cid`, which you pass to `show` or `directions`, and marks a currently closed place.
 Filter with `--min-rating`, `--category`, and `--sort rating`.
-`--near` takes an address or `lat,lng`; `--radius-km` and `--sort distance` measure from `--near`,
+`--near` takes an address or `lat,lng`; a coordinate centres the search on that point, so pass
+the user's position when you have it. `--radius-km` and `--sort distance` measure from `--near`,
 so they need it as `lat,lng` (a coordinate, not a place name).
 
 Send the user the `place_url` for a single pick. It opens the exact place on the web and the

--- a/agent/skills/maps/SKILL.md
+++ b/agent/skills/maps/SKILL.md
@@ -9,9 +9,10 @@ Find places on Google Maps and hand the user a link that opens the exact place, 
 opens the whole trip. You refer to a place across commands by its `cid` (a durable Google id).
 
 `search`, `show`, and `itinerary` print a human table by default; add `--json` (or
-`--json-pretty`) to read a result programmatically. The other commands always print JSON. Set
-the user's locale and country so results and formatting match where they are:
-`maps --locale it-IT --country it search ...`.
+`--json-pretty`) to read a result programmatically. The other commands always print JSON.
+`--country` defaults from the box's timezone, so results and formatting already match where the
+user lives; pass it only for a query about another country. Set `--locale` when the user's
+language is not English: `maps --locale it-IT search ...`.
 
 ## Find places
 

--- a/agent/skills/maps/cli/src/gmaps_cli/cli.py
+++ b/agent/skills/maps/cli/src/gmaps_cli/cli.py
@@ -18,6 +18,7 @@ from . import cache
 from .client import DOCTOR_ANCHOR_NAME, BlockedError, DriftError, SearchFilters, directions, doctor, itinerary, reverse, search, show
 from .format import format_itinerary, format_place_detail, format_search_table
 from .links import Stop, directions_url, route_url, transit_time_url
+from .region import default_country
 
 
 def _emit(payload: dict[str, object]) -> None:
@@ -228,7 +229,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # agent naturally types (`maps search "..." --locale it-IT`).
     locale = argparse.ArgumentParser(add_help=False)
     locale.add_argument("--locale", default="en-US")
-    locale.add_argument("--country", default="us")
+    locale.add_argument("--country", default=None)
 
     s = sub.add_parser("search", help="find places", parents=[locale])
     s.add_argument("query")
@@ -286,6 +287,8 @@ def _build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     parser = _build_parser()
     args = parser.parse_args()
+    if "country" in vars(args) and args.country is None:
+        args.country = default_country()
     try:
         result: int = args.func(args)
         return result

--- a/agent/skills/maps/cli/src/gmaps_cli/client.py
+++ b/agent/skills/maps/cli/src/gmaps_cli/client.py
@@ -73,11 +73,11 @@ def _get(client: httpx.Client, url: str) -> str:
     return resp.text
 
 
-def _search_feed(client: httpx.Client, query: str, *, lang: str, country: str) -> object:
+def _search_feed(client: httpx.Client, query: str, *, lang: str, country: str, near_latlng: tuple[float, float] | None = None) -> object:
     quoted = urllib.parse.quote(query)
     page = _get(client, f"https://www.google.com/maps/search/{quoted}?hl={lang}&gl={country}")
     token = extract_session_token(page)
-    pb = build_search_pb(query, token)
+    pb = build_search_pb(query, token, near=near_latlng)
     # The `q` param is load-bearing: without it Google serves the HTML page, not the map RPC.
     raw = _get(client, f"https://www.google.com/search?tbm=map&authuser=0&hl={lang}&gl={country}&q={quoted}&pb={pb}")
     return json.loads(strip_envelope(raw))
@@ -89,8 +89,9 @@ def search(query: str, *, near: str | None, filters: SearchFilters, locale: str,
         raise ValueError("--radius-km and --sort distance need --near as lat,lng")
     lang = locale.split("-", maxsplit=1)[0]
     with _client(locale) as client:
-        full_query = f"{query} {near}" if near else query
-        feed = _search_feed(client, full_query, lang=lang, country=country)
+        # A coordinate `--near` rides the pb as a viewport; only a place name is worth query text.
+        full_query = f"{query} {near}" if near and near_latlng is None else query
+        feed = _search_feed(client, full_query, lang=lang, country=country, near_latlng=near_latlng)
         places = parse_search(feed)
         if not places:
             # Drift canary: a known-good query that comes back empty means the schema moved.

--- a/agent/skills/maps/cli/src/gmaps_cli/pb.py
+++ b/agent/skills/maps/cli/src/gmaps_cli/pb.py
@@ -90,6 +90,16 @@ def extract_session_token(page_html: str) -> str:
     return match.group(1)
 
 
-def build_search_pb(query: str, token: str) -> str:
+# The viewport block Google reads as "search this area"; the RPC ranks results inside it even
+# when `gl=` names another country. Scale 3000 biases to roughly a town and its surroundings.
+_VIEWPORT_SCALE = 3000
+_VIEWPORT_TEMPLATE = "!4m12!1m3!1d{scale}!2d{lng}!3d{lat}!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1"
+
+
+def build_search_pb(query: str, token: str, near: tuple[float, float] | None = None) -> str:
     template = _TEMPLATE_PATH.read_text(encoding="utf-8").strip()
-    return template.replace("{QUERY}", urllib.parse.quote(query)).replace("{TOKEN}", token)
+    pb = template.replace("{QUERY}", urllib.parse.quote(query)).replace("{TOKEN}", token)
+    if near is None:
+        return pb
+    lat, lng = near
+    return _VIEWPORT_TEMPLATE.format(scale=_VIEWPORT_SCALE, lng=lng, lat=lat) + pb

--- a/agent/skills/maps/cli/src/gmaps_cli/region.py
+++ b/agent/skills/maps/cli/src/gmaps_cli/region.py
@@ -1,0 +1,45 @@
+"""The default `--country`, inferred from the box's IANA timezone.
+
+The agent process exports `TZ` from its configured timezone and every maps invocation inherits
+it, so the user's zone is already in the environment. tzdata's `zone.tab` maps a zone name to
+exactly one country, and it keeps the per-country names devices actually report (`Europe/Oslo`,
+`Europe/Vatican`), which `zone1970.tab` folds into multi-country lines. An explicit `--country`
+always wins, and a box with no resolvable zone keeps the `us` fallback.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+FALLBACK_COUNTRY = "us"
+ZONE_TAB = Path("/usr/share/zoneinfo/zone.tab")
+LOCALTIME = Path("/etc/localtime")
+
+
+def local_zone() -> str | None:
+    zone = os.environ.get("TZ")
+    if zone:
+        return zone
+    if LOCALTIME.is_symlink():
+        target = os.fspath(LOCALTIME.readlink())
+        if "zoneinfo/" in target:
+            return target.split("zoneinfo/", maxsplit=1)[1]
+    return None
+
+
+def country_for_zone(zone: str | None, tab: Path | None = None) -> str:
+    tab = ZONE_TAB if tab is None else tab
+    if zone is None or not tab.exists():
+        return FALLBACK_COUNTRY
+    for line in tab.read_text(encoding="utf-8").splitlines():
+        if line.startswith("#"):
+            continue
+        fields = line.split("\t")
+        if len(fields) >= 3 and fields[2] == zone:
+            return fields[0].lower()
+    return FALLBACK_COUNTRY
+
+
+def default_country() -> str:
+    return country_for_zone(local_zone())

--- a/agent/skills/maps/cli/tests/test_pb.py
+++ b/agent/skills/maps/cli/tests/test_pb.py
@@ -23,3 +23,16 @@ def test_build_search_pb_slots_query_and_token():
     assert "1sTOK123" in pb
     assert "{QUERY}" not in pb
     assert "{TOKEN}" not in pb
+
+
+def test_build_search_pb_near_prepends_viewport():
+    pb = build_search_pb("gelato", "TOK123", near=(40.5589, 8.3138))
+    assert pb.startswith("!4m12!1m3!1d")
+    assert "!2d8.3138!3d40.5589" in pb
+    assert "1sgelato" in pb
+    assert "1sTOK123" in pb
+
+
+def test_build_search_pb_without_near_has_no_viewport():
+    pb = build_search_pb("gelato", "TOK123")
+    assert not pb.startswith("!4m")

--- a/agent/skills/maps/cli/tests/test_region.py
+++ b/agent/skills/maps/cli/tests/test_region.py
@@ -1,0 +1,74 @@
+import sys
+
+from gmaps_cli import cli, region
+
+TAB = "# tzdb zone descriptions\nIT\t+4154+01229\tEurope/Rome\nNO\t+5955+01045\tEurope/Oslo\nGB\t+513030-0000731\tEurope/London\n"
+
+
+def test_country_for_zone_maps_a_zone_to_its_one_country(tmp_path):
+    tab = tmp_path / "zone.tab"
+    tab.write_text(TAB, encoding="utf-8")
+    assert region.country_for_zone("Europe/Rome", tab=tab) == "it"
+    assert region.country_for_zone("Europe/London", tab=tab) == "gb"
+
+
+def test_country_for_zone_keeps_per_country_zone_names_distinct(tmp_path):
+    # Europe/Oslo shares Berlin's clocks in tzdb, but the reported name still means Norway.
+    tab = tmp_path / "zone.tab"
+    tab.write_text(TAB, encoding="utf-8")
+    assert region.country_for_zone("Europe/Oslo", tab=tab) == "no"
+
+
+def test_country_for_zone_falls_back_on_unknown_zone_or_missing_tab(tmp_path):
+    tab = tmp_path / "zone.tab"
+    tab.write_text(TAB, encoding="utf-8")
+    assert region.country_for_zone("Mars/Olympus", tab=tab) == "us"
+    assert region.country_for_zone("Europe/Rome", tab=tmp_path / "absent.tab") == "us"
+    assert region.country_for_zone(None, tab=tab) == "us"
+
+
+def test_local_zone_prefers_tz_env(monkeypatch):
+    monkeypatch.setenv("TZ", "Europe/Rome")
+    assert region.local_zone() == "Europe/Rome"
+
+
+def test_local_zone_reads_the_localtime_symlink(monkeypatch, tmp_path):
+    monkeypatch.delenv("TZ", raising=False)
+    zone_file = tmp_path / "zoneinfo" / "Europe" / "Rome"
+    zone_file.parent.mkdir(parents=True)
+    zone_file.touch()
+    localtime = tmp_path / "localtime"
+    localtime.symlink_to(zone_file)
+    monkeypatch.setattr(region, "LOCALTIME", localtime)
+    assert region.local_zone() == "Europe/Rome"
+
+
+def test_cli_country_defaults_from_the_box_timezone(monkeypatch, tmp_path):
+    tab = tmp_path / "zone1970.tab"
+    tab.write_text(TAB, encoding="utf-8")
+    monkeypatch.setattr(region, "ZONE_TAB", tab)
+    monkeypatch.setenv("TZ", "Europe/Rome")
+    captured = {}
+
+    def fake_search(query, *, near, filters, locale, country):
+        captured["country"] = country
+        return []
+
+    monkeypatch.setattr(cli, "search", fake_search)
+    monkeypatch.setattr(sys, "argv", ["maps", "search", "coffee"])
+    cli.main()
+    assert captured["country"] == "it"
+
+
+def test_cli_country_flag_wins_over_the_timezone(monkeypatch):
+    monkeypatch.setenv("TZ", "Europe/Rome")
+    captured = {}
+
+    def fake_search(query, *, near, filters, locale, country):
+        captured["country"] = country
+        return []
+
+    monkeypatch.setattr(cli, "search", fake_search)
+    monkeypatch.setattr(sys, "argv", ["maps", "search", "coffee", "--country", "fr"])
+    cli.main()
+    assert captured["country"] == "fr"

--- a/agent/skills/maps/cli/tests/test_search_near.py
+++ b/agent/skills/maps/cli/tests/test_search_near.py
@@ -1,0 +1,39 @@
+import urllib.parse
+from pathlib import Path
+
+from gmaps_cli import client
+from gmaps_cli.client import SearchFilters
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _fake_transport(monkeypatch) -> list[str]:
+    urls: list[str] = []
+    page = (FIXTURES / "search_page.html").read_text(encoding="utf-8")
+    feed = (FIXTURES / "search_alghero.json").read_text(encoding="utf-8")
+
+    def fake_get(_client, url: str) -> str:
+        urls.append(url)
+        return page if "/maps/search/" in url else feed
+
+    monkeypatch.setattr(client, "_get", fake_get)
+    return urls
+
+
+def test_coordinate_near_becomes_a_viewport_not_query_text(monkeypatch):
+    urls = _fake_transport(monkeypatch)
+    places = client.search("frozen yogurt", near="40.5589,8.3138", filters=SearchFilters(), locale="en-US", country="us")
+    assert places
+    rpc = next(u for u in urls if "tbm=map" in u)
+    query_part, pb_part = rpc.split("&pb=", maxsplit=1)
+    assert "!2d8.3138!3d40.5589" in urllib.parse.unquote(pb_part)
+    assert "40.5589" not in urllib.parse.unquote(query_part)
+
+
+def test_place_name_near_stays_in_the_query_text(monkeypatch):
+    urls = _fake_transport(monkeypatch)
+    client.search("gelateria", near="Alghero, Italy", filters=SearchFilters(), locale="en-US", country="us")
+    rpc = next(u for u in urls if "tbm=map" in u)
+    query_part, pb_part = rpc.split("&pb=", maxsplit=1)
+    assert "Alghero" in urllib.parse.unquote(query_part)
+    assert not urllib.parse.unquote(pb_part).startswith("!4m12!1m3!1d")


### PR DESCRIPTION
## What

Two region-correctness fixes for the maps skill, from its first real fleet use (an agent handling "bring me to the nearest frozen yoghurt" in Alghero got 20 US froyo chains):

1. A coordinate `--near` on `maps search` now actually centres the search on that point.
2. `--country` now defaults from the box's timezone instead of hardcoded `us`, so every command follows where the user lives with no flags and nothing for the agent to manage.

## Why / root cause

`--near` reached Google only as literal text appended to the query, which Google ignores for a bare coordinate, and the captured `search_pb.txt` template carries no location, so the only geographic signal was `gl=`, defaulting to `us` (and the natural first call omits `--country`).

## How

**Viewport (`--near`):** the search RPC reads a viewport block in the `pb` parameter, the same mechanism the Maps site uses for "search this area", and it overrides the `gl` country default (verified empirically before writing the fix: same query/token/`gl=us`, US chains without the block, Alghero gelaterie with it). `build_search_pb` takes an optional `near` coordinate and prepends the block; `search()` routes a `lat,lng` `--near` into the pb and keeps it out of the query text; a place-name `--near` keeps riding the query text, which works.

**Country inference:** the agent process exports `TZ` from its configured timezone (`main.py`), so every maps invocation inherits the user's IANA zone, kept fresh fleet-wide by the user-timezone notification flow. tzdata's `zone.tab` maps the zone to one country offline. Chain: `--country` flag > `TZ` (falling back to the `/etc/localtime` symlink) > `zone.tab` > today's `us`. `zone.tab` over `zone1970.tab` is deliberate: devices report per-country zone names (`Europe/Oslo`) that `zone1970.tab` folds into multi-country lines (`DE,DK,NO,SE,SJ -> Europe/Berlin`), while `zone.tab` keeps one country per reported name (`Europe/Oslo -> NO`, `Europe/Vatican -> VA`).

SKILL.md/SETUP.md state the new behavior: pass `--country` only for a query about another country, `--locale` for language.

## Verification

- TDD throughout, every behavior test watched failing first. 58 CLI tests pass; ruff check + format clean.
- Live A: the exact incident command `maps search "frozen yogurt" --near "40.5589,8.3138"` went from Oklahoma Menchie's to Alghero gelaterie.
- Live B: `TZ=Europe/Rome maps search "gelateria"` with no flags returns Rome results.
- Real-`zone.tab` spot check: Rome->it, Oslo->no, Stockholm->se, Vatican->va, New_York->us, UTC->us (fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)