### PR TITLE
fix(install): use the published RPM artifact name

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -165,7 +165,7 @@ EOF
         x86_64) local pkg_arch="x86_64" ;;
         aarch64) local pkg_arch="aarch64" ;;
       esac
-      local artifact="Vesta-${VERSION}-1.${pkg_arch}.rpm"
+      local artifact="Vesta_${VERSION}_${pkg_arch}.rpm"
       echo "Downloading desktop app (RPM)..."
       curl -fsSL -o "$WORK_DIR/vesta.rpm" "https://github.com/${REPO}/releases/download/v${VERSION}/${artifact}"
       verify_checksum "$WORK_DIR/vesta.rpm" "$artifact"


### PR DESCRIPTION
\`install.sh --app\` on an rpm host asks for \`Vesta-<version>-1.<arch>.rpm\` and gets a 404. electron-builder publishes \`artifactName: Vesta_\${version}_\${arch}.\${ext}\` (`apps/desktop/electron-builder.yml:3`), so v0.2.6 ships `Vesta_0.2.6_aarch64.rpm` and `Vesta_0.2.6_x86_64.rpm`.

The deb branch two lines above already used the correct pattern. This makes the rpm branch match.

Reproduced on Fedora aarch64:

```
Downloading desktop app (RPM)...
curl: (22) The requested URL returned error: 404
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UseTuZoyWX2PLesRFviY8h