### PR TITLE
fix(mobile): enable iOS background location for the closed-app poll

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -121,9 +121,9 @@ const config: ExpoConfig = {
           "Share where this phone is with your Vesta agents, also while the app is closed, so plans and reminders follow your travel.",
         locationAlwaysPermission:
           "Share where this phone is with your Vesta agents while the app is closed, so plans and reminders follow your travel.",
-        // Reading a fix from the closed-app poll needs the always-on grant on both platforms; the iOS
-        // location background mode is not needed, since the poll runs under the processing mode.
-        isIosBackgroundLocationEnabled: false,
+        // The closed-app poll reads a fresh fix, which needs the always-on grant on both platforms
+        // and, on iOS, the location background mode as well; the processing mode alone cannot get one.
+        isIosBackgroundLocationEnabled: true,
         isAndroidBackgroundLocationEnabled: true,
       },
     ],


### PR DESCRIPTION
## Problem

Every time you open the app after moving, the agent gets a `user-location` "you moved" notification, even though you were in the new place for a while with the app closed. The background poll never delivered the move.

Confirmed on the gateway: every `user-location` your agents received fired 2 to 12 seconds **before** the app's socket connected, i.e. on the foreground open, never during the closed-app window. Across a ~12-hour overnight closed-app gap there were zero location updates.

## Root cause

The closed-app poll (`device-context/background-report.ts` → `readFix("background")`) takes a fresh fix via `getCurrentPositionAsync` inside a `BGProcessingTask`. On iOS, without the `location` background mode, Core Location does not deliver a fix to a backgrounded app **even with the "Always" grant**. The `freshFix` times out and the poll falls back to `getLastKnownPositionAsync({ maxAge: 60min })`, which is stale/empty when the phone sat idle. The report degrades to timezone-only, so the position only reaches the agent on the next foreground read.

Android is unaffected: `isAndroidBackgroundLocationEnabled: true` already lets the background fix succeed there.

## Fix

Set `isIosBackgroundLocationEnabled: true` so the expo-location plugin adds the `location` background mode and the background fresh fix can succeed.

## ⚠️ Verification status

**This is a native-behavior change that CI green does not prove.** CI only confirms it compiles and prebuilds. The actual fix can only be confirmed on a physical iOS device: grant "Always" location, move ~25km with the app fully closed, and confirm the agent gets the `user-location` notification before you reopen the app.

Note: declaring the `location` background mode draws extra App Store review scrutiny (justify background location). Not an immediate blocker since delivery is internal TestFlight, but relevant before public App Store submission. iOS may also show the background-location indicator during a poll.

## Follow-up (not in this PR)

The poll is time-based (`minimumInterval: 60`, an OS floor), so even fixed it notifies on a timer, not the moment you arrive. Significant-location-change monitoring is the movement-triggered mechanism that would notify on arrival on both platforms. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)