### PR TITLE
fix(notifications): title gateway and rate-limit notifications with plain names

### DIFF
--- a/apps/web/src/providers/NotificationProvider/index.test.tsx
+++ b/apps/web/src/providers/NotificationProvider/index.test.tsx
@@ -298,9 +298,7 @@ describe("NotificationProvider", () => {
       });
     });
 
-    expect(built).toEqual([
-      { title: "ada hit a Claude rate limit", body: "resets at 3pm" },
-    ]);
+    expect(built).toEqual([{ title: "ada", body: "resets at 3pm" }]);
   });
 
   it("toasts the gateway's update announcement with the title the gateway chose", async () => {

--- a/apps/web/src/providers/NotificationProvider/index.tsx
+++ b/apps/web/src/providers/NotificationProvider/index.tsx
@@ -209,7 +209,7 @@ export function NotificationProvider({
     (agentName: string, text: string) => {
       if (!permissionRef.current) return;
       try {
-        const n = new Notification(`${agentName} hit a Claude rate limit`, {
+        const n = new Notification(agentName, {
           body: text,
           tag: `${agentName}-rate-limited`,
         });
@@ -263,7 +263,7 @@ export function NotificationProvider({
         : `${agent.name} needs to sign in again`;
       const body = unprovisioned
         ? "Tap to choose a provider and sign in."
-        : "vesta lost the provider credentials. Tap to re-authenticate.";
+        : "The provider sign-in was lost. Tap to re-authenticate.";
       try {
         const n = new Notification(title, {
           body,

--- a/vestad/src/mobile_app.rs
+++ b/vestad/src/mobile_app.rs
@@ -412,7 +412,7 @@ fn message_for(
     let (title, body, route) = match text_field(event, "type") {
         Some("gateway_updated") => (
             // The gateway decides its own text: there is no agent to name and nowhere to navigate.
-            text_field(event, "title").unwrap_or("Gateway updated").to_string(),
+            text_field(event, "title").unwrap_or("Vesta").to_string(),
             text_field(event, "body").unwrap_or("Your gateway updated.").to_string(),
             "/".to_string(),
         ),

--- a/vestad/src/update.rs
+++ b/vestad/src/update.rs
@@ -429,7 +429,7 @@ pub fn announcement(recovery: &BootRecovery) -> Option<(String, String)> {
         format!(" Backup warnings: {}.", warnings.join("; "))
     };
     Some((
-        format!("Updated to v{version}"),
+        "Vesta".to_string(),
         format!("Your gateway updated to v{version}.{backup_warnings}"),
     ))
 }
@@ -955,7 +955,7 @@ mod tests {
                 version: "0.1.190".into(),
                 warnings: Vec::new(),
             }),
-            Some(("Updated to v0.1.190".into(), "Your gateway updated to v0.1.190.".into()))
+            Some(("Vesta".into(), "Your gateway updated to v0.1.190.".into()))
         );
     }
 
@@ -966,7 +966,7 @@ mod tests {
             warnings: vec!["axel: snapshot timed out".into(), "mona: disk full".into()],
         })
         .expect("an update that landed announces");
-        assert_eq!(title, "Updated to v0.1.190");
+        assert_eq!(title, "Vesta");
         assert_eq!(
             body,
             "Your gateway updated to v0.1.190. Backup warnings: axel: snapshot timed out; mona: disk full."

--- a/vestad/tests/server/gateway_update.rs
+++ b/vestad/tests/server/gateway_update.rs
@@ -464,10 +464,7 @@ async fn an_update_walks_its_phases_and_the_next_boot_reports_the_new_version() 
         Some(""),
         "a gateway-owned notification names no agent"
     );
-    assert_eq!(
-        announcement["title"].as_str(),
-        Some(format!("Updated to v{NEWER_VERSION}").as_str())
-    );
+    assert_eq!(announcement["title"].as_str(), Some("Vesta"));
     assert_eq!(
         announcement["body"].as_str(),
         Some(format!("Your gateway updated to v{NEWER_VERSION}.").as_str())


### PR DESCRIPTION
## What

Copy cleanup on three user-facing notifications, from the notification map review:

1. **Gateway updated** (`update.rs`): the title is now `Vesta` instead of `Updated to v{version}`. The body keeps the version: `Your gateway updated to v{version}.` The Expo-push fallback title in `mobile_app.rs` aligns to `Vesta` too.
2. **Rate limited** (web `NotificationProvider`): the title is now the agent's name alone, instead of `{agent} hit a Claude rate limit`. The body already says what happened (`Claude rate limit hit: ...`). This matches the mobile local notification, which already titles with the agent name.
3. **Re-sign-in** (web `NotificationProvider`): the body `vesta lost the provider credentials. Tap to re-authenticate.` becomes `The provider sign-in was lost. Tap to re-authenticate.` The old copy was lowercase and named the product where every sibling string names the agent.

Wire shape is unchanged: only string values move, so no `min_supported` bump.

## Tests

Updated the assertions that pin the old strings: `update.rs` unit tests, the `gateway_update.rs` e2e assertion, and the web `NotificationProvider` test. Not run locally (no cargo/npm on this machine); CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)