### PR TITLE
fix(mobile): generalize location permission copy beyond plans and reminders

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -116,11 +116,11 @@ const config: ExpoConfig = {
       "expo-location",
       {
         locationWhenInUsePermission:
-          "Share where this phone is with your Vesta agents, so plans and reminders follow your travel.",
+          "Let Vesta know where you are, to help you wherever you go.",
         locationAlwaysAndWhenInUsePermission:
-          "Share where this phone is with your Vesta agents, also while the app is closed, so plans and reminders follow your travel.",
+          "Let Vesta know where you are, even while the app is closed, to help you wherever you go.",
         locationAlwaysPermission:
-          "Share where this phone is with your Vesta agents while the app is closed, so plans and reminders follow your travel.",
+          "Let Vesta know where you are while the app is closed, to help you wherever you go.",
         // The closed-app poll reads a fresh fix, which needs the always-on grant on both platforms
         // and, on iOS, the location background mode as well; the processing mode alone cannot get one.
         isIosBackgroundLocationEnabled: true,


### PR DESCRIPTION
## What

Rewrites the three iOS location purpose strings in `app.config.ts`. The old copy tied location sharing to plans and reminders. The new copy matches the generalized Settings toggle line that already ships ("Let Vesta know where you are, to help you wherever you go."), so the OS permission prompt and the Settings row now speak with one voice.

| Prompt | New string |
|---|---|
| When in use | Let Vesta know where you are, to help you wherever you go. |
| Always + when in use | Let Vesta know where you are, even while the app is closed, to help you wherever you go. |
| Always | Let Vesta know where you are while the app is closed, to help you wherever you go. |

## Why

Location now feeds more than plans and reminders, and the App Store submission needs purpose strings that describe the general capability. Copy only; no behavior change. The strings bake into the binary, so they reach users with the next release build.

## Checks

`./check.sh app-mobile` passes (lint, tsc, vitest, clean-prebuild verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)