### PR TITLE
feat(mobile): hide Vesta Cloud sign-in in production builds

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -152,6 +152,10 @@ const config: ExpoConfig = {
   extra: {
     apiCompat: "0.2",
     appVariant,
+    // Vesta Cloud is not open to the public yet: production builds offer
+    // self-hosted connection only, so App Review never meets a sign-in it
+    // cannot complete. Flip to true when cloud sign-up opens.
+    cloudSignInEnabled: isDevelopment,
     pushNotificationsEnabled: !localIosNoPush,
     ...(easProjectId ? { eas: { projectId: easProjectId } } : {}),
   },

--- a/apps/mobile/app/connect-actions.tsx
+++ b/apps/mobile/app/connect-actions.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { StyleSheet } from "react-native";
 import { useRouter } from "expo-router";
+import { cloudSignInEnabled } from "@/api/auth";
 import { AuthPrimaryButton } from "@/components/auth-primary-button";
 import { AuthSheet } from "@/components/auth-sheet";
 import { useToast } from "@/components/native-toast";
@@ -28,27 +29,40 @@ export default function ConnectActionsScreen() {
 
   return (
     <AuthSheet gap={16}>
-      <AuthPrimaryButton
-        accessibilityLabel="Connect with Vesta Cloud"
-        icon="person-circle-outline"
-        iconSize={20}
-        loading={busy}
-        loadingLabel="Connecting…"
-        onPress={() => void signInWithAccount()}
-      >
-        Connect with Vesta Cloud
-      </AuthPrimaryButton>
-      <Button
-        pill
-        size="large"
-        variant="secondary"
-        accessibilityLabel="Connect to self-hosted Vesta"
-        icon="server-outline"
-        labelStyle={styles.actionLabel}
-        onPress={() => router.push("/connect-link")}
-      >
-        Connect to self-hosted Vesta
-      </Button>
+      {cloudSignInEnabled ? (
+        <>
+          <AuthPrimaryButton
+            accessibilityLabel="Connect with Vesta Cloud"
+            icon="person-circle-outline"
+            iconSize={20}
+            loading={busy}
+            loadingLabel="Connecting…"
+            onPress={() => void signInWithAccount()}
+          >
+            Connect with Vesta Cloud
+          </AuthPrimaryButton>
+          <Button
+            pill
+            size="large"
+            variant="secondary"
+            accessibilityLabel="Connect to self-hosted Vesta"
+            icon="server-outline"
+            labelStyle={styles.actionLabel}
+            onPress={() => router.push("/connect-link")}
+          >
+            Connect to self-hosted Vesta
+          </Button>
+        </>
+      ) : (
+        <AuthPrimaryButton
+          accessibilityLabel="Connect to self-hosted Vesta"
+          icon="server-outline"
+          iconSize={20}
+          onPress={() => router.push("/connect-link")}
+        >
+          Connect to self-hosted Vesta
+        </AuthPrimaryButton>
+      )}
       {hasRecentGateways ? (
         <Button
           pill

--- a/apps/mobile/app/connect.tsx
+++ b/apps/mobile/app/connect.tsx
@@ -7,6 +7,7 @@ import {
   useSegments,
 } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { cloudSignInEnabled } from "@/api/auth";
 import { AgentOrb } from "@/components/AgentOrb";
 import {
   BootTransitionTarget,
@@ -41,7 +42,8 @@ function ConnectContent() {
   const privacyBlocked = usePrivacyBlocked();
   const initialDrawerOpened = useRef(false);
   const nextScreenOpened = useRef(false);
-  const estimatedActionSheetHeight = recentGateways?.length ? 186 : 156;
+  const estimatedActionSheetHeight =
+    (recentGateways?.length ? 186 : 156) - (cloudSignInEnabled ? 0 : 68);
   const canPresentSheet =
     !privacyBlocked &&
     (!bootTransition.active || bootTransition.pageRevealed);

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -278,7 +278,7 @@ export default function SettingsScreen() {
         <ConfirmDialog
           visible={activeConfirm === "disconnect"}
           title="Disconnect from Vesta?"
-          message="You can reconnect using your account or tunnel link."
+          message="You can reconnect with your gateway link at any time."
           confirmLabel="Disconnect"
           destructive
           onConfirm={() => {

--- a/apps/mobile/src/api/auth.test.ts
+++ b/apps/mobile/src/api/auth.test.ts
@@ -9,6 +9,9 @@ const { openAuthSessionAsync } = vi.hoisted(() => ({
   openAuthSessionAsync: vi.fn(),
 }));
 
+vi.mock("expo-constants", () => ({
+  default: { expoConfig: { extra: { cloudSignInEnabled: true } } },
+}));
 vi.mock("expo-crypto", () => ({
   randomUUID: () => "00000000-0000-4000-8000-000000000000",
   digestStringAsync: () => Promise.resolve("challenge=="),

--- a/apps/mobile/src/api/auth.ts
+++ b/apps/mobile/src/api/auth.ts
@@ -1,6 +1,10 @@
+import Constants from "expo-constants";
 import * as Crypto from "expo-crypto";
 import * as WebBrowser from "expo-web-browser";
 import type { ConnectionConfig } from "./types";
+
+export const cloudSignInEnabled =
+  Constants.expoConfig?.extra?.cloudSignInEnabled === true;
 
 const CONTROL_APEX = "https://vesta.run";
 const NATIVE_CLIENT_ID = "vesta-app";


### PR DESCRIPTION
## What

Vesta Cloud is not open to the public yet, so production builds now offer self-hosted connection only. One new flag owns the decision: `extra.cloudSignInEnabled` in `app.config.ts`, true for the development variant and false for production. When cloud sign-up opens, flipping that one expression restores the button.

- `connect-actions.tsx`: with the flag off, the sheet shows "Connect to self-hosted Vesta" as the primary button (plus recent gateways). With the flag on, the current two-button layout is unchanged.
- `connect.tsx`: the hero's sheet-height estimate shrinks by one button when cloud is hidden.
- `settings.tsx`: the disconnect dialog no longer says "account or tunnel link"; it now says "You can reconnect with your gateway link at any time."
- The PKCE flow, `hosted` connection handling, and the oauth universal link all stay: this hides the entry point, it deletes nothing.

## Why

The primary button on the first screen led to an invite-only sign-in that App Review cannot complete, a standard Guideline 2.1 rejection. A visible account system also invites the account-deletion (5.1.1) and purchase (3.1.1) questions. A pure self-hosted client has none of those, and the Settings "Account" section was already gated on `roster.managed`.

## Notes

- The maestro visual flows asserting "Connect with Vesta Cloud" run the development variant, where the flag stays on, so they are unaffected.
- Not visually verified: I could not run a simulator in this environment. The changed layout is the connect sheet with the flag off (production).

## Checks

`./check.sh app-mobile` passes (lint, tsc, vitest, clean-prebuild verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)