### PR TITLE
feat(agent): allow disabling proactive checks with proactive_check_interval 0

### DIFF
--- a/agent/core/config.py
+++ b/agent/core/config.py
@@ -489,7 +489,7 @@ class VestaConfig(pyd_settings.BaseSettings):
 
     Key env overrides (operational scalars only; provider fields live in the nested store, not env):
         LOG_LEVEL                - DEBUG | INFO | WARNING | ERROR (default: "INFO")
-        PROACTIVE_CHECK_INTERVAL - seconds between proactive checks (default: 60)
+        PROACTIVE_CHECK_INTERVAL - minutes between proactive checks, 0 to disable (default: 60)
         NIGHTLY_MEMORY_HOUR      - hour 0-23 for nightly dream, unset to disable (default: 3)
         RESPONSE_TIMEOUT         - max seconds for a single response (default: 600)
     """
@@ -514,7 +514,9 @@ class VestaConfig(pyd_settings.BaseSettings):
     ephemeral: bool = False
     log_level: tp.Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
     monitor_tick_interval: int = pyd.Field(default=2, ge=1)
-    proactive_check_interval: int = pyd.Field(default=60, ge=1)
+    # Minutes between proactive checks; 0 disables them (a value PUT /config can express, unlike
+    # null, which the store treats as revert-to-default).
+    proactive_check_interval: int = pyd.Field(default=60, ge=0)
     notif_snooze_idle_grace_seconds: float = pyd.Field(default=30.0, gt=0)
     query_timeout: int = pyd.Field(default=120, ge=1)
     response_timeout: int = pyd.Field(default=600, ge=1)

--- a/agent/core/loops.py
+++ b/agent/core/loops.py
@@ -643,7 +643,7 @@ async def monitor_loop(queue: asyncio.Queue[vm.QueuedTurn], *, state: vm.State, 
 
             now = _now()
 
-            if (now - last_proactive).total_seconds() >= config.proactive_check_interval * 60:
+            if config.proactive_check_interval and (now - last_proactive).total_seconds() >= config.proactive_check_interval * 60:
                 if state.processor_busy or not queue.empty():
                     if not proactive_defer_logged:
                         logger.debug("Proactive check deferred: agent busy, will run when idle")

--- a/agent/tests/test_notifications.py
+++ b/agent/tests/test_notifications.py
@@ -622,6 +622,43 @@ async def test_proactive_check_skipped_while_busy_fires_on_first_idle_tick(tmp_p
 
 
 @pytest.mark.anyio
+async def test_proactive_check_interval_zero_disables_checks(tmp_path, monkeypatch):
+    """proactive_check_interval=0 turns proactive checks off: however far the clock advances on an
+    idle agent, no proactive-check notification is ever dropped."""
+    config = _passive_config(tmp_path, monkeypatch)
+    config.proactive_check_interval = 0
+    state = vm.State()
+    state.shutdown_event = asyncio.Event()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    t0 = dt.datetime(2025, 1, 1, 12, 0, 0)
+    clock = [t0]
+    ticks = [0]
+    real_load = load_notifications
+
+    async def counting_load(*, config):
+        ticks[0] += 1
+        return await real_load(config=config)
+
+    with (
+        patch("core.loops._now", side_effect=lambda: clock[0]),
+        patch("core.loops.load_prompt", return_value="check in"),
+        patch("core.loops.load_notifications", counting_load),
+    ):
+        task = asyncio.create_task(monitor_loop(queue, state=state, config=config))
+        try:
+            await wait_for_condition(lambda: ticks[0] >= 1, message="monitor_loop never ticked")
+            clock[0] = t0 + dt.timedelta(days=7)
+            seen = ticks[0]
+            await wait_for_condition(lambda: ticks[0] >= seen + 2, message="monitor_loop did not tick past the jump")
+            assert list(config.notifications_dir.glob("proactive_check-*.json")) == []
+        finally:
+            state.shutdown_event.set()
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.anyio
 async def test_monitor_loop_emits_each_notification_once_across_ticks(tmp_path, monkeypatch):
     """A persisted file re-read every tick must emit a single 'notification' event, not one
     per tick. Files kept on disk (e.g. deferred while unauthenticated) re-emitting every 2s


### PR DESCRIPTION
## What

`proactive_check_interval` now accepts `0`, which disables proactive checks entirely. The monitor loop skips the proactive branch when the interval is 0. Also corrects the config docstring: the value is minutes, not seconds (the loop multiplies by 60).

## Why

The nightly dream is disableable (`nightly_memory_hour: null`) but proactive checks had no off switch; the only workaround was an absurdly large interval. A demo/kiosk agent (like the App Store review gateway) wants no self-directed wakeups at all.

`0` rather than `null`, deliberately: the config store treats a JSON `null` as "clear the key, revert to default" (pinned by `test_update_merges_and_clear_reverts`), so a nullable field's off state cannot be expressed through `PUT /config`; the dream hour has exactly this gap today. `0` is a plain storable value, and unlike the hour field (where 0 means midnight) it cannot collide with a real interval.

## Tests

- New: `test_proactive_check_interval_zero_disables_checks`, interval 0 plus a 7-day clock jump on an idle agent drops no proactive-check notification. This also pins that 0 does not mean "fire every tick", which is what the unguarded `elapsed >= 0 * 60` comparison would do.
- `./check.sh agent`: 1144 passed; the 2 failures are the known local-only `tag.gpgsign` issue in `test_migrations.py` workspace-repair tests (host git config signs tags; green in CI).
- `./check.sh guards` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)