### PR TITLE
docs: add app privacy policy for store listings

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,34 @@
+# Vesta App Privacy Policy
+
+Effective date: 2026-08-23
+
+Vesta is an open source project. The Vesta apps (iOS, Android, desktop, web) are clients for a Vesta gateway that you run on your own hardware. The project does not operate servers that receive your personal data.
+
+## What the app sends, and where
+
+Everything you do in the app (messages, voice recordings, files, settings) is sent to your own gateway and nowhere else. Your gateway runs on your machine, under your control. The project maintainers have no access to it.
+
+**Location** is optional and off by default at the OS level. If you enable location sharing, the app sends your phone's position to your own gateway only, so your agents can account for where you are. Turning the toggle off removes what the phone shared from your gateway.
+
+**Push notifications**: when your gateway sends you a notification (for example, a chat reply), it is routed through Expo's push service and Apple's or Google's push infrastructure. Your device's push token is processed for delivery only. If you allow message previews, the notification content transits those services in order to be displayed; you can disable previews in the app's settings.
+
+**App Lock (Face ID / biometrics)** happens entirely on your device. The app never receives or stores biometric data.
+
+## What the app does not do
+
+- No analytics or telemetry
+- No advertising and no tracking
+- No selling or sharing of data with third parties
+- No accounts on project servers
+
+## Your data is on your gateway
+
+Chat history, memory, and files live on the machine that runs your gateway. Deleting them, backing them up, and moving them is entirely in your hands. Uninstalling the app removes everything the app stored on the device; it does not touch your gateway.
+
+## Vesta Cloud
+
+Vesta Cloud, the optional hosted service at vesta.run, is a separate offering with its own privacy policy at https://vesta.run/privacy. This document covers the apps and self-hosted gateways only.
+
+## Contact
+
+Questions about privacy: privacy@vesta.run, or open an issue at https://github.com/elyxlz/vesta/issues.

--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ Copy the connect link from the server output, then reach your agent one of three
 - **Web app**: open the gateway URL from the server output in a browser (vestad serves the app at `/app`).
 - **Desktop app**: paste the connect link on the onboarding screen (macOS, Windows, Linux).
 - **Mobile app** (iOS and Android): paste the connect link to connect to the same gateway.
+
+## Support
+
+Open an [issue](https://github.com/elyxlz/vesta/issues), or email support@vesta.run.


### PR DESCRIPTION
## What

Adds `PRIVACY.md` at the repo root: a privacy policy written for the Vesta apps and self-hosted gateways, for use as the App Store listing's privacy policy URL.

## Why

The App Store listing needs a privacy policy URL, and vesta.run/privacy describes Vesta Cloud, the hosted service. The app being submitted is the open-source self-hosted client (production builds hide cloud sign-in as of #2193), so pointing reviewers at the cloud policy would contradict the app's actual data practices. This policy states them: everything goes to the user's own gateway, push tokens transit Expo/APNs/FCM for delivery only, no analytics or tracking, and Vesta Cloud is explicitly scoped out with a pointer to its own policy.

The listing URLs then become: marketing https://github.com/elyxlz/vesta, support https://github.com/elyxlz/vesta/issues, privacy policy https://github.com/elyxlz/vesta/blob/master/PRIVACY.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)