### PR TITLE
fix(agent): flip turnless activity state on thinking ticks

### DIFF
--- a/agent/core/client.py
+++ b/agent/core/client.py
@@ -214,23 +214,25 @@ async def _dispatch_message(msg: Message, *, state: vm.State, config: cfg.VestaC
     running as its own turn, a CLI-initiated continuation, or an interrupted turn's wind-down)
     still emit, nothing is ever lost, and their ResultMessage is dropped."""
     diagnostics.touch_activity(state, "sdk_message")
+    # The CLI ticks a thinking counter while the model reasons; diagnostics turns it into an open
+    # turn's liveness narrative ("Thinking..." on the first tick, interval notes from the wait loop).
+    thinking_estimate = sdk_parsing.thinking_tokens_estimate(msg)
     turn = state.turn
     if turn:
         turn.last_message_at = time.monotonic()
-    # Turnless CLI activity (a delivered preempt running as its own turn, or a
-    # CLI-initiated turn such as a background task notification): keep the activity state
-    # honest, since it drives the snoozed-batch flush and the proactive-check gate.
-    elif isinstance(msg, AssistantMessage):
+        if thinking_estimate is not None:
+            diagnostics.note_thinking_tick(turn, tokens=thinking_estimate)
+    # Turnless CLI activity (a delivered preempt running as its own turn, or a CLI-initiated
+    # turn such as a background task notification): keep the activity state honest, since it
+    # drives the snoozed-batch flush and the proactive-check gate. The thinking ticks count as
+    # activity here because extended thinking precedes the turn's first AssistantMessage, and
+    # without them the state reads idle for that whole stretch.
+    elif isinstance(msg, AssistantMessage) or thinking_estimate is not None:
         state.event_bus.set_state("thinking")
     elif isinstance(msg, ResultMessage):
         state.event_bus.set_state("idle")
     if isinstance(msg, AssistantMessage):
         state.compacting = False
-    # The CLI ticks a thinking counter while the model reasons; diagnostics turns it into the
-    # turn's liveness narrative ("Thinking..." on the first tick, interval notes from the wait loop).
-    thinking_estimate = sdk_parsing.thinking_tokens_estimate(msg)
-    if turn and thinking_estimate is not None:
-        diagnostics.note_thinking_tick(turn, tokens=thinking_estimate)
     state.resolved_model = sdk_parsing.init_resolved_model(msg) or state.resolved_model
     texts, thinking_blocks, session_id, error_texts = sdk_parsing.parse_sdk_message(msg)
     if session_id and session_id != state.persisted.session_id:

--- a/agent/tests/test_preempt.py
+++ b/agent/tests/test_preempt.py
@@ -440,13 +440,19 @@ async def test_burst_of_preempts_with_merged_results_never_wedges(tmp_path):
 async def test_turnless_stream_activity_drives_state():
     """Output with no open Vesta turn (a delivered preempt running as its own CLI turn, or a
     CLI-initiated turn) flips the activity state to thinking, and its result flips it back to
-    idle. The state drives the snoozed-batch flush and the proactive gate, so it must track
-    the stream, not Vesta's turn bookkeeping."""
-    from claude_agent_sdk import TextBlock
+    idle. Extended thinking's token ticks count too: they precede the turn's first
+    AssistantMessage, and a state stuck on idle through them would flush the snoozed batch
+    into a busy CLI. The state drives the snoozed-batch flush and the proactive gate, so it
+    must track the stream, not Vesta's turn bookkeeping."""
+    from claude_agent_sdk import SystemMessage, TextBlock
 
     state, config, _, _, message_queue, _ = make_stream_harness()
     async with consuming(state, config):
+        await message_queue.put(SystemMessage(subtype="thinking_tokens", data={"estimated_tokens": 312, "estimated_tokens_delta": 5}))
+        await wait_for_condition(lambda: state.event_bus.state == "thinking", message="turnless thinking tick never set thinking")
+        await message_queue.put(result_msg())
+        await wait_for_condition(lambda: state.event_bus.state == "idle", message="turnless result never set idle")
         await message_queue.put(assistant_msg([TextBlock("turnless reply")]))
         await wait_for_condition(lambda: state.event_bus.state == "thinking", message="turnless activity never set thinking")
         await message_queue.put(result_msg())
-        await wait_for_condition(lambda: state.event_bus.state == "idle", message="turnless result never set idle")
+        await wait_for_condition(lambda: state.event_bus.state == "idle", message="the second turnless result never set idle")


### PR DESCRIPTION
## Problem

Observed on agent axel (2026-08-24 trace): a preempt ended the running turn, and the CLI then ran the preempted message as a turn of its own. That turn opened with ~68s of extended thinking, which streams only `SystemMessage(subtype="thinking_tokens")` ticks until the first complete `AssistantMessage`. With no open Vesta turn, `_dispatch_message` flips the activity state to thinking only on an `AssistantMessage`, so the event-bus state read **idle** for the entire thinking stretch.

That state is load-bearing: it gates the snoozed-batch flush, the proactive check, and the deferred-compaction drain (`loops.py`). A snoozed batch coming due inside such a gap would see "idle" and fire into a busy CLI.

## Fix

One condition at the one owner of the decision (`_dispatch_message`): a turnless thinking tick now counts as activity and sets the state to thinking; the turn's own `ResultMessage` still sets idle. `set_state` dedupes on change, so the frequent ticks emit no event spam. An open turn's tick handling (`note_thinking_tick` liveness narrative) is unchanged.

## Tests

Extended `test_turnless_stream_activity_drives_state` (tests/test_preempt.py): a bare turnless tick flips to thinking and the result flips back to idle, then the existing assistant-message cycle is asserted independently.

`test_preempt.py`, `test_watchdog.py`, `test_interrupts.py`, `test_notifications.py`, `test_crash_recovery.py`, ruff, and ty all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)