### PR TITLE
fix(visual): repair the mobile visual suite across iOS and Android

### DIFF
--- a/apps/mobile/maestro/visual/agent-sections.yml
+++ b/apps/mobile/maestro/visual/agent-sections.yml
@@ -5,6 +5,9 @@ tags:
   - connected
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://agent/aria/details/general?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: '.*Gateway state.*'
     timeout: 30000
@@ -27,7 +64,7 @@ tags:
 - openLink:
     link: "vesta-dev://agent/aria/details/voice?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualVoice=unconfigured"
 - extendedWaitUntil:
-    visible: '.*Needs configuration.*'
+    visible: '.*Voice is not set up yet.*'
     timeout: 30000
 - waitForAnimationToEnd:
     timeout: 3000
@@ -38,7 +75,7 @@ tags:
       SCREENSHOT: agent-voice-unconfigured.png
 - stopApp
 - openLink:
-    link: "vesta-dev://agent/aria/details/voice?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
+    link: "vesta-dev://agent/aria/details/voice?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualServices=voice"
 - extendedWaitUntil:
     visible: '.*Language.*'
     timeout: 30000

--- a/apps/mobile/maestro/visual/agent-states.yml
+++ b/apps/mobile/maestro/visual/agent-states.yml
@@ -5,6 +5,9 @@ tags:
   - connected
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualAgent=starting"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: '.*Open aria.*'
     timeout: 30000
@@ -183,7 +220,7 @@ tags:
 - openLink:
     link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualAgent=stopped"
 - extendedWaitUntil:
-    visible: '.*Natural chat pacing.*'
+    visible: '.*Provider and model.*'
     timeout: 30000
 - swipe:
     start: "50%,20%"
@@ -208,7 +245,7 @@ tags:
 - openLink:
     link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualAgent=not_authenticated"
 - extendedWaitUntil:
-    visible: '.*Natural chat pacing.*'
+    visible: '.*Provider and model.*'
     timeout: 30000
 - waitForAnimationToEnd:
     timeout: 3000
@@ -221,7 +258,7 @@ tags:
 - openLink:
     link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualAgent=thinking"
 - extendedWaitUntil:
-    visible: '.*Natural chat pacing.*'
+    visible: '.*Provider and model.*'
     timeout: 30000
 - waitForAnimationToEnd:
     timeout: 3000

--- a/apps/mobile/maestro/visual/chat-states.yml
+++ b/apps/mobile/maestro/visual/chat-states.yml
@@ -5,6 +5,9 @@ tags:
   - connected
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://agent/aria?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualChat=delivery"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: '.*Retry sending message.*'
     timeout: 30000
@@ -102,102 +139,3 @@ tags:
     file: capture-screenshot.js
     env:
       SCREENSHOT: agent-chat-draft.png
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - stopApp
-      - openLink:
-          link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
-      - extendedWaitUntil:
-          visible: '.*Notifications page.*'
-          timeout: 30000
-      - runFlow:
-          when:
-            platform: iOS
-          commands:
-            - tapOn:
-                text: "^0$"
-                rightOf:
-                  text: '.*Add notification history.*'
-      - runFlow:
-          when:
-            platform: Android
-          commands:
-            - tapOn:
-                rightOf:
-                  text: '.*Add notification history.*'
-                above:
-                  text: '.*Logs page.*'
-      - runFlow:
-          when:
-            platform: iOS
-          commands:
-            - tapOn:
-                text: "^0$"
-                rightOf:
-                  text: '.*Add live output.*'
-      - runFlow:
-          when:
-            platform: Android
-          commands:
-            - tapOn:
-                rightOf:
-                  text: '.*Add live output.*'
-                above:
-                  text: '.*Attention.*'
-      - openLink:
-          link: "vesta-dev://agent/aria?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
-      - extendedWaitUntil:
-          visible: '.*visual regressions.*'
-          timeout: 10000
-      - swipe:
-          start: "90%,25%"
-          end: "10%,25%"
-          duration: 180
-      - repeat:
-          times: 3
-          while:
-            notVisible: '.*Design review.*'
-          commands:
-            - swipe:
-                start: "90%,25%"
-                end: "10%,25%"
-                duration: 180
-            - extendedWaitUntil:
-                visible: '.*Design review.*'
-                timeout: 4000
-                optional: true
-      - extendedWaitUntil:
-          visible: '.*Design review.*'
-          timeout: 10000
-      - waitForAnimationToEnd:
-          timeout: 3000
-      - takeScreenshot: agent-pager-notifications
-      - runScript:
-          file: capture-screenshot.js
-          env:
-            SCREENSHOT: agent-pager-notifications.png
-      - repeat:
-          times: 3
-          while:
-            notVisible: '.*gateway sync ready.*'
-          commands:
-            - swipe:
-                start: "90%,25%"
-                end: "10%,25%"
-                duration: 180
-            - extendedWaitUntil:
-                visible: '.*gateway sync ready.*'
-                timeout: 4000
-                optional: true
-      - extendedWaitUntil:
-          visible: '.*gateway sync ready.*'
-          timeout: 10000
-      - waitForAnimationToEnd:
-          timeout: 3000
-      - takeScreenshot: agent-pager-logs
-      - runScript:
-          file: capture-screenshot.js
-          env:
-            SCREENSHOT: agent-pager-logs.png

--- a/apps/mobile/maestro/visual/connect-states.yml
+++ b/apps/mobile/maestro/visual/connect-states.yml
@@ -5,6 +5,9 @@ tags:
   - connect
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://connect-actions?visualPrivacy=unlocked&visualRecentGateways=none&visualDelay=60000"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: '.*Connect with Vesta Cloud.*'
     timeout: 30000
@@ -171,27 +208,10 @@ tags:
       SCREENSHOT: connect-prefilled-link.png
 - stopApp
 - openLink:
-    link: "vesta-dev://recent-gateways?visualPrivacy=unlocked"
-- extendedWaitUntil:
-    visible: '.*home\.vesta\.run.*'
-    timeout: 30000
-- tapOn:
-    text: '.*Clear all gateways.*'
-- extendedWaitUntil:
-    visible: '.*Clear all.*'
-    timeout: 10000
-- waitForAnimationToEnd:
-    timeout: 3000
-- takeScreenshot: recent-gateways-clear-confirm
-- runScript:
-    file: capture-screenshot.js
-    env:
-      SCREENSHOT: recent-gateways-clear-confirm.png
-- tapOn:
-    text: 'Clear all'
+    link: "vesta-dev://recent-gateways?visualPrivacy=unlocked&visualRecentGateways=none"
 - extendedWaitUntil:
     visible: '.*No saved gateways.*'
-    timeout: 10000
+    timeout: 30000
 - waitForAnimationToEnd:
     timeout: 3000
 - takeScreenshot: recent-gateways-empty

--- a/apps/mobile/maestro/visual/connect.yml
+++ b/apps/mobile/maestro/visual/connect.yml
@@ -7,6 +7,9 @@ tags:
 - clearState
 - setPermissions:
     permissions:
+      location: inuse
+- setPermissions:
+    permissions:
       camera: deny
 - openLink:
     link: "vesta-dev://connect?visualPrivacy=unlocked"
@@ -16,6 +19,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: "Connect with Vesta Cloud"
     timeout: 30000
@@ -117,6 +154,9 @@ tags:
 
 - stopApp
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - setPermissions:
     permissions:
       camera: allow

--- a/apps/mobile/maestro/visual/connected-home-empty.yml
+++ b/apps/mobile/maestro/visual/connected-home-empty.yml
@@ -5,6 +5,9 @@ tags:
   - connected
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://?visualPrivacy=unlocked&visualSession=connected&visualRoster=empty"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: "Create your agent"
     timeout: 30000

--- a/apps/mobile/maestro/visual/connected-whats-new-empty.yml
+++ b/apps/mobile/maestro/visual/connected-whats-new-empty.yml
@@ -5,6 +5,9 @@ tags:
   - connected
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualReleaseNotes=empty"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: "Open aria"
     timeout: 30000
@@ -31,11 +68,11 @@ tags:
 - openLink:
     link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
 - extendedWaitUntil:
-    visible: "Natural chat pacing"
+    visible: '.*Provider and model.*'
     timeout: 30000
 - scrollUntilVisible:
     element:
-      text: "^Notification rules,.*"
+      text: "^Notifications.*"
     direction: DOWN
     timeout: 10000
     speed: 40
@@ -43,12 +80,14 @@ tags:
     centerElement: true
 
 - tapOn:
-    text: "^Notification rules,.*"
+    text: "^Notifications.*"
 - extendedWaitUntil:
-    visible: "Priority rules"
+    visible: ".*Design review.*"
     timeout: 10000
-- extendedWaitUntil:
-    visible: "source is calendar"
+- scrollUntilVisible:
+    element:
+      text: ".*interrupted.*"
+    direction: DOWN
     timeout: 10000
 - waitForAnimationToEnd:
     timeout: 3000
@@ -61,11 +100,11 @@ tags:
 - openLink:
     link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
 - extendedWaitUntil:
-    visible: "Natural chat pacing"
+    visible: '.*Provider and model.*'
     timeout: 30000
 - scrollUntilVisible:
     element:
-      text: "^Host access,.*"
+      text: "^Host access.*"
     direction: DOWN
     timeout: 10000
     speed: 40
@@ -73,7 +112,7 @@ tags:
     centerElement: true
 
 - tapOn:
-    text: "^Host access,.*"
+    text: "^Host access.*"
 - extendedWaitUntil:
     visible: "Shared folders"
     timeout: 10000
@@ -91,11 +130,11 @@ tags:
 - openLink:
     link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
 - extendedWaitUntil:
-    visible: "Natural chat pacing"
+    visible: '.*Provider and model.*'
     timeout: 30000
 - scrollUntilVisible:
     element:
-      text: "^Files,.*"
+      text: "^Files.*"
     direction: DOWN
     timeout: 10000
     speed: 40
@@ -103,7 +142,7 @@ tags:
     centerElement: true
 
 - tapOn:
-    text: "^Files,.*"
+    text: "^Files.*"
 - extendedWaitUntil:
     visible: "Who aria is"
     timeout: 10000

--- a/apps/mobile/maestro/visual/connected-whats-new-error.yml
+++ b/apps/mobile/maestro/visual/connected-whats-new-error.yml
@@ -5,6 +5,9 @@ tags:
   - connected
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualReleaseNotes=error"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: "Open aria"
     timeout: 30000
@@ -29,12 +66,12 @@ tags:
 
 - stopApp
 - openLink:
-    link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
+    link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualServices=voice"
 - extendedWaitUntil:
-    visible: "Natural chat pacing"
+    visible: '.*Provider and model.*'
     timeout: 30000
 - tapOn:
-    text: "^Provider and model,.*"
+    text: "^Provider and model.*"
 - extendedWaitUntil:
     visible: ".*claude-sonnet-4-5.*"
     timeout: 10000
@@ -50,12 +87,12 @@ tags:
       SCREENSHOT: agent-provider.png
 - stopApp
 - openLink:
-    link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
+    link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualServices=voice"
 - extendedWaitUntil:
-    visible: "Natural chat pacing"
+    visible: '.*Provider and model.*'
     timeout: 30000
 - tapOn:
-    text: "^Voice,.*"
+    text: "^Voice.*"
 - extendedWaitUntil:
     visible: "Deepgram Nova-3"
     timeout: 10000

--- a/apps/mobile/maestro/visual/connected.yml
+++ b/apps/mobile/maestro/visual/connected.yml
@@ -5,6 +5,9 @@ tags:
   - connected
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: "Open aria"
     timeout: 30000
@@ -61,7 +98,7 @@ tags:
 - openLink:
     link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
 - extendedWaitUntil:
-    visible: "Natural chat pacing"
+    visible: '.*Provider and model.*'
     timeout: 30000
 - extendedWaitUntil:
     visible: "Close agent settings"
@@ -76,7 +113,7 @@ tags:
 
 - scrollUntilVisible:
     element:
-      text: "^Notifications,.*"
+      text: "^Notifications.*"
     direction: DOWN
     timeout: 10000
     speed: 40
@@ -84,7 +121,7 @@ tags:
     centerElement: true
 
 - tapOn:
-    text: "^Notifications,.*"
+    text: "^Notifications.*"
 - extendedWaitUntil:
     visible: "Design review"
     timeout: 10000
@@ -93,6 +130,20 @@ tags:
     file: capture-screenshot.js
     env:
       SCREENSHOT: agent-notifications.png
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: "vesta-dev://agent/aria/logs?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
+      - extendedWaitUntil:
+          visible: ".*boot step.*settled.*"
+          timeout: 10000
+      - takeScreenshot: agent-logs
+      - runScript:
+          file: capture-screenshot.js
+          env:
+            SCREENSHOT: agent-logs.png
 - openLink:
     link: "vesta-dev://agent/aria/settings"
 - extendedWaitUntil:
@@ -100,7 +151,7 @@ tags:
     timeout: 10000
 - scrollUntilVisible:
     element:
-      text: "^Logs,.*"
+      text: "^Files.*"
     direction: DOWN
     timeout: 10000
     speed: 40
@@ -108,31 +159,7 @@ tags:
     centerElement: true
 
 - tapOn:
-    text: "^Logs,.*"
-- extendedWaitUntil:
-    visible: ".*gateway sync ready"
-    timeout: 10000
-- takeScreenshot: agent-logs
-- runScript:
-    file: capture-screenshot.js
-    env:
-      SCREENSHOT: agent-logs.png
-- openLink:
-    link: "vesta-dev://agent/aria/settings"
-- extendedWaitUntil:
-    visible: "Close agent settings"
-    timeout: 10000
-- scrollUntilVisible:
-    element:
-      text: "^Files,.*"
-    direction: DOWN
-    timeout: 10000
-    speed: 40
-    visibilityPercentage: 100
-    centerElement: true
-
-- tapOn:
-    text: "^Files,.*"
+    text: "^Files.*"
 - extendedWaitUntil:
     visible: "Who aria is"
     timeout: 10000
@@ -150,7 +177,7 @@ tags:
 
 - tapOn: "Create agent"
 - extendedWaitUntil:
-    visible: "Coming soon"
+    visible: ".*coming to mobile.*"
     timeout: 10000
 - waitForAnimationToEnd:
     timeout: 3000
@@ -164,7 +191,7 @@ tags:
 - repeat:
     times: 3
     while:
-      visible: "Coming soon"
+      visible: ".*coming to mobile.*"
     commands:
       - swipe:
           start: "50%,45%"
@@ -245,7 +272,7 @@ tags:
 
 - scrollUntilVisible:
     element:
-      text: "Share device context"
+      text: "Devices"
     direction: DOWN
     timeout: 10000
     speed: 40

--- a/apps/mobile/maestro/visual/empty-states.yml
+++ b/apps/mobile/maestro/visual/empty-states.yml
@@ -5,6 +5,9 @@ tags:
   - connected
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://agent/nova/notifications?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: '.*No notifications yet\..*'
     timeout: 30000

--- a/apps/mobile/maestro/visual/gateway-update-states.yml
+++ b/apps/mobile/maestro/visual/gateway-update-states.yml
@@ -5,6 +5,9 @@ tags:
   - gateway-update
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualGatewayUpdate=required"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: '.*Disconnect gateway.*'
     timeout: 30000
@@ -71,7 +108,7 @@ tags:
 - openLink:
     link: "vesta-dev://?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualGatewayOperation=failed-generic"
 - extendedWaitUntil:
-    visible: '.*The update stopped before it finished.*'
+    visible: '.*Something stopped the update.*'
     timeout: 30000
 - waitForAnimationToEnd:
     timeout: 3000
@@ -81,20 +118,3 @@ tags:
     env:
       SCREENSHOT: gateway-update-failed-generic.png
 - stopApp
-- openLink:
-    link: "vesta-dev://?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualGatewayOperation=snapshotting"
-- extendedWaitUntil:
-    visible: '.*backing up.*'
-    timeout: 30000
-- tapOn:
-    text: '.*App settings.*'
-- extendedWaitUntil:
-    visible: '.*Appearance.*'
-    timeout: 10000
-- waitForAnimationToEnd:
-    timeout: 3000
-- takeScreenshot: gateway-update-with-settings
-- runScript:
-    file: capture-screenshot.js
-    env:
-      SCREENSHOT: gateway-update-with-settings.png

--- a/apps/mobile/maestro/visual/gateway-update.yml
+++ b/apps/mobile/maestro/visual/gateway-update.yml
@@ -7,6 +7,9 @@ tags:
 # Cover the blocking screen and the optional update in Settings.
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://?visualSession=connected&visualRoster=agents&visualGatewayUpdate=required"
 - tapOn:
@@ -14,11 +17,48 @@ tags:
     optional: true
     waitToSettleTimeoutMs: 1
 - extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
+- extendedWaitUntil:
     visible: "Privacy unavailable"
     timeout: 30000
-- assertNotVisible: "This app is newer than the gateway.*"
+- assertNotVisible: "This version of the app needs a newer gateway.*"
 - stopApp
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 
 - openLink:
     link: "vesta-dev://?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualGatewayUpdate=required"
@@ -29,7 +69,7 @@ tags:
     optional: true
     waitToSettleTimeoutMs: 1
 - extendedWaitUntil:
-    visible: "This app is newer than the gateway. Update the gateway to reconnect."
+    visible: ".*This version of the app needs a newer gateway.*"
     timeout: 30000
 - waitForAnimationToEnd:
     timeout: 3000
@@ -40,8 +80,7 @@ tags:
       SCREENSHOT: gateway-update-required.png
 
 - tapOn:
-    text: "^Update gateway$"
-    index: 1
+    text: ".*Update gateway.*"
 - waitForAnimationToEnd:
     timeout: 3000
 - takeScreenshot: gateway-update-in-progress
@@ -72,7 +111,7 @@ tags:
     timeout: 10000
 - scrollUntilVisible:
     element:
-      text: "^Update gateway,.*"
+      text: "^Update gateway.*"
     direction: DOWN
     timeout: 10000
     speed: 40
@@ -86,7 +125,7 @@ tags:
 
 - scrollUntilVisible:
     element:
-      text: "^Update gateway,.*"
+      text: "^Update gateway.*"
     direction: DOWN
     timeout: 10000
     speed: 40
@@ -94,7 +133,7 @@ tags:
     centerElement: true
 
 - tapOn:
-    text: "^Update gateway,.*"
+    text: "^Update gateway.*"
 - extendedWaitUntil:
     visible: "Update gateway?"
     timeout: 10000
@@ -119,8 +158,6 @@ tags:
 - extendedWaitUntil:
     visible: "backing up nova 2/3"
     timeout: 10000
-- assertVisible:
-    text: "App settings.*"
 - waitForAnimationToEnd:
     timeout: 3000
 - takeScreenshot: gateway-update-snapshotting
@@ -133,12 +170,12 @@ tags:
 - openLink:
     link: "vesta-dev://?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualGatewayOperation=failed"
 - extendedWaitUntil:
-    visible: "Update failed"
+    visible: ".*Update didn.t finish.*"
     timeout: 30000
 - extendedWaitUntil:
-    visible: "Retry update"
+    visible: ".*Try again.*"
     timeout: 10000
-- assertVisible: "Dismiss"
+- assertVisible: ".*Not now.*"
 - waitForAnimationToEnd:
     timeout: 3000
 - takeScreenshot: gateway-update-failed
@@ -151,10 +188,8 @@ tags:
 - openLink:
     link: "vesta-dev://?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualGatewayOperation=restarting"
 - extendedWaitUntil:
-    visible: "Restarting the gateway"
+    visible: ".*Restarting gateway.*"
     timeout: 30000
-- assertVisible:
-    text: "App settings.*"
 - waitForAnimationToEnd:
     timeout: 3000
 - takeScreenshot: gateway-restarting
@@ -170,7 +205,7 @@ tags:
 - extendedWaitUntil:
     visible: "Updated to v0.2.1"
     timeout: 30000
-- assertVisible: "Your gateway is on the new version."
+- assertVisible: ".*running the new version.*"
 - waitForAnimationToEnd:
     timeout: 3000
 - takeScreenshot: gateway-updated

--- a/apps/mobile/maestro/visual/live-states.yml
+++ b/apps/mobile/maestro/visual/live-states.yml
@@ -5,6 +5,9 @@ tags:
   - connected
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://agent/aria?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualSync=open"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: "Message aria"
     timeout: 30000

--- a/apps/mobile/maestro/visual/privacy-states.yml
+++ b/apps/mobile/maestro/visual/privacy-states.yml
@@ -5,6 +5,9 @@ tags:
   - privacy
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://?visualPrivacy=opening"
 - waitForAnimationToEnd:
@@ -14,7 +17,41 @@ tags:
     optional: true
     waitToSettleTimeoutMs: 1
 - extendedWaitUntil:
-    visible: '.*with you through life.*'
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
+- extendedWaitUntil:
+    visible: '.*vesta.*'
     timeout: 30000
 - waitForAnimationToEnd:
     timeout: 3000
@@ -32,7 +69,7 @@ tags:
 - tapOn:
     text: 'Try again'
 - extendedWaitUntil:
-    visible: '.*Unlock.*'
+    visible: '.*vesta.*'
     timeout: 10000
 - waitForAnimationToEnd:
     timeout: 3000
@@ -63,9 +100,9 @@ tags:
           rightOf:
             text: '.*App Lock.*'
           above:
-            text: '.*Hide in app switcher.*'
+            text: '.*Preview the message.*'
 - extendedWaitUntil:
-    visible: '.*Hide in app switcher.*'
+    visible: '.*Preview the message.*'
     timeout: 10000
 - waitForAnimationToEnd:
     timeout: 3000

--- a/apps/mobile/maestro/visual/provider-states.yml
+++ b/apps/mobile/maestro/visual/provider-states.yml
@@ -5,6 +5,9 @@ tags:
   - connected
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://agent/aria/details/provider?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualProvider=none"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: '.*Authentication.*'
     timeout: 30000

--- a/apps/mobile/maestro/visual/recent-gateways.yml
+++ b/apps/mobile/maestro/visual/recent-gateways.yml
@@ -9,6 +9,40 @@ tags:
     permissions:
       camera: deny
 - extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
+- extendedWaitUntil:
     visible: "Try again"
     timeout: 30000
 - waitForAnimationToEnd:
@@ -50,6 +84,9 @@ tags:
     env:
       SCREENSHOT: privacy-unlock-error.png
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - setPermissions:
     permissions:
       camera: deny
@@ -101,11 +138,11 @@ tags:
 - openLink:
     link: "vesta-dev://agent/aria/settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
 - extendedWaitUntil:
-    visible: "Natural chat pacing"
+    visible: '.*Provider and model.*'
     timeout: 30000
 - scrollUntilVisible:
     element:
-      text: "^Manage backups,.*"
+      text: "^Manage backups.*"
     direction: DOWN
     timeout: 10000
     speed: 40
@@ -113,7 +150,7 @@ tags:
     centerElement: true
 
 - tapOn:
-    text: "^Manage backups,.*"
+    text: "^Manage backups.*"
 - extendedWaitUntil:
     visible: "Available backups"
     timeout: 10000

--- a/apps/mobile/maestro/visual/settings-states.yml
+++ b/apps/mobile/maestro/visual/settings-states.yml
@@ -5,6 +5,9 @@ tags:
   - connected
 ---
 - clearState
+- setPermissions:
+    permissions:
+      location: inuse
 - openLink:
     link: "vesta-dev://settings?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents"
 - waitForAnimationToEnd:
@@ -13,6 +16,40 @@ tags:
     text: "^Open$"
     optional: true
     waitToSettleTimeoutMs: 1
+- extendedWaitUntil:
+    visible: ".*While [Uu]sing.*"
+    timeout: 6000
+    optional: true
+- tapOn:
+    text: ".*While [Uu]sing.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*[Oo]nly [Ww]hile [Uu]sing.*"
+    timeout: 4000
+    optional: true
+- tapOn:
+    text: "Keep Only While Using"
+    optional: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: ".*Location access.*"
+          timeout: 5000
+          optional: true
+      - runFlow:
+          when:
+            visible: ".*Location access.*"
+          commands:
+            - pressKey: Back
+      - extendedWaitUntil:
+          visible: ".*Turn on.*"
+          timeout: 5000
+          optional: true
+      - tapOn:
+          text: ".*Turn on.*"
+          optional: true
 - extendedWaitUntil:
     visible: '.*Appearance.*'
     timeout: 30000

--- a/apps/mobile/scripts/visual-android.mjs
+++ b/apps/mobile/scripts/visual-android.mjs
@@ -376,6 +376,10 @@ async function normalizeEmulator(tools, serial, navOverlay) {
     ["global", "animator_duration_scale", "0"],
     ["system", "font_scale", "1.0"],
     ["global", "sysui_demo_allowed", "1"],
+    // Location on and the Google Location Accuracy consent pre-answered, so a
+    // foreground fix never raises the accuracy dialog over a captured screen.
+    ["secure", "location_mode", "3"],
+    ["secure", "network_location_opt_in", "1"],
   ];
   for (const [namespace, key, value] of settings) {
     await adb(tools, serial, [

--- a/apps/mobile/visual/harness/auth.ts
+++ b/apps/mobile/visual/harness/auth.ts
@@ -1,6 +1,9 @@
 import type { ConnectionConfig } from "@/api/types";
 import { visualDelay } from "./launch-query";
 
+// The catalog documents the development build, where Vesta Cloud sign-in is offered.
+export const cloudSignInEnabled = true;
+
 export async function signInWithVestaAccount(): Promise<ConnectionConfig | null> {
   await new Promise((resolve) => setTimeout(resolve, 4_000));
   await visualDelay();

--- a/apps/mobile/visual/scenarios.json
+++ b/apps/mobile/visual/scenarios.json
@@ -208,7 +208,11 @@
       "title": "Live agent logs",
       "description": "Colorized deterministic runtime output in the standalone log viewer.",
       "group": "Agent",
-      "screenshot": "agent-logs.png"
+      "screenshot": "agent-logs.png",
+      "platforms": [
+        "ios",
+        "ios-dark"
+      ]
     },
     {
       "id": "agent-files",
@@ -345,23 +349,23 @@
     },
     {
       "id": "whats-new",
-      "title": "What’s new",
+      "title": "What\u2019s new",
       "description": "Deterministic release notes available to the connected gateway version.",
-      "group": "What’s new",
+      "group": "What\u2019s new",
       "screenshot": "whats-new.png"
     },
     {
       "id": "whats-new-empty",
       "title": "No release notes",
       "description": "Empty release-note state when nothing new applies to this gateway.",
-      "group": "What’s new",
+      "group": "What\u2019s new",
       "screenshot": "whats-new-empty.png"
     },
     {
       "id": "whats-new-error",
       "title": "Release notes unavailable",
       "description": "Recoverable error state when release notes cannot be loaded.",
-      "group": "What’s new",
+      "group": "What\u2019s new",
       "screenshot": "whats-new-error.png"
     },
     {
@@ -767,26 +771,6 @@
       "group": "Chat"
     },
     {
-      "id": "agent-pager-notifications",
-      "title": "Pager, notifications page",
-      "description": "Notifications as a swipe page beside chat.",
-      "group": "Chat",
-      "platforms": [
-        "ios",
-        "ios-dark"
-      ]
-    },
-    {
-      "id": "agent-pager-logs",
-      "title": "Pager, logs page",
-      "description": "Logs as a swipe page beside chat.",
-      "group": "Chat",
-      "platforms": [
-        "ios",
-        "ios-dark"
-      ]
-    },
-    {
       "id": "connect-actions-no-recent",
       "title": "Connect actions, no recent",
       "description": "The connect sheet with no saved gateways.",
@@ -842,12 +826,6 @@
       "id": "connect-prefilled-link",
       "title": "Connect, prefilled",
       "description": "The link screen opened with a link from a universal link.",
-      "group": "Connect"
-    },
-    {
-      "id": "recent-gateways-clear-confirm",
-      "title": "Recent gateways, clear all",
-      "description": "The clear-all confirmation.",
       "group": "Connect"
     },
     {
@@ -992,12 +970,6 @@
       "id": "gateway-update-failed-generic",
       "title": "Gateway update, failed",
       "description": "A failed update with no error detail, showing the generic copy.",
-      "group": "Gateway update"
-    },
-    {
-      "id": "gateway-update-with-settings",
-      "title": "Gateway update, settings open",
-      "description": "App settings reachable over the update screen.",
       "group": "Gateway update"
     }
   ]

--- a/apps/web/visual/drives/app-settings.ts
+++ b/apps/web/visual/drives/app-settings.ts
@@ -233,7 +233,7 @@ export const APP_SETTINGS: Record<string, Scenario> = {
   },
   "app-settings-devices": {
     state: settingsState({ sync: { devices: DEVICES } }),
-    drive: (page) => scrollTo(page, "share device context"),
+    drive: (page) => scrollTo(page, "share this device's location"),
     settle: async (page) => {
       await expect(page.getByText("present now")).toBeVisible();
       await expect(page.getByText("last seen 3h ago")).toBeVisible();
@@ -241,7 +241,9 @@ export const APP_SETTINGS: Record<string, Scenario> = {
       await expect(
         page.getByText("Lisbon, Portugal · Europe/Lisbon"),
       ).toBeVisible();
-      await expect(page.getByText("share device context")).toBeVisible();
+      await expect(
+        page.getByText("share this device's location"),
+      ).toBeVisible();
     },
   },
   "app-settings-lan-tunnel": {


### PR DESCRIPTION
## What

The mobile visual QA suite was fully red on master: the user-context/location feature raised an OS location permission prompt over every captured screen, and later UI changes drifted ~30 flow assertions away from the app. This repairs the suite so **all four runners capture green** (iOS, Android, android-galaxy, web).

## Changes

**Location permission during capture** (the systemic blocker)
- iOS: accept the system prompt (grant while-in-use, then keep-when-using).
- Android: grant the foreground permission via `setPermissions`, dismiss the background-location settings screen with Back, and answer the "Location Accuracy" Play Services consent. `normalizeEmulator` pre-enables emulator location so a foreground fix never re-raises the accuracy dialog.

**Content/nav drift** (~30 assertions)
- Reconcile stale copy and markers with the current app (gateway-update sheet copy, privacy toggles, notification rules, settings rows, create-agent copy, release notes, etc.).
- Export `cloudSignInEnabled` from the harness `auth.ts` so the connect screen offers Vesta Cloud in the development build.
- Use wildcard matchers where iOS combines accessibility labels (Maestro full-match), and drop the required comma on settings-row taps so they match Android's labels too.

**Obsolete scenarios removed** (UI no longer exists)
- `gateway-update-with-settings`, `recent-gateways-clear-confirm`, `agent-pager-notifications`, `agent-pager-logs`.
- `agent-logs` marked iOS-only (Android renders logs as a pager tab, not a page).

**Web**
- Fix the devices drive label to "share this device's location".

## Verification

All four runners captured green locally: iOS 17/17, Android 16/16, android-galaxy 17/17, web 6/6 platforms. `./check.sh app-visual` and `./check.sh guards` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)