### PR TITLE
fix(app): render user notifications as title: body on the pill surfaces

### DIFF
--- a/agent/skills/vestad/scripts/user-notification
+++ b/agent/skills/vestad/scripts/user-notification
@@ -6,8 +6,9 @@ set -euo pipefail
 # AGENT_NAME. Best-effort: a transport failure never surfaces (the caller's durable work already happened).
 #
 # Usage: user-notification <kind> <title> [body]    (kind in: message needs_user task)
-# The title is the whole one-line message; pass a body only when it adds information the
-# title cannot carry (a message preview, an instruction).
+# Clients render each notification as one line: the title alone, or "title: body" when a
+# body is present. Keep the title a short headline (who or what happened) and put the
+# detail in the body (a message preview, an instruction).
 
 KIND="${1:?Usage: user-notification <kind> <title> [body]}"
 TITLE="${2:?Usage: user-notification <kind> <title> [body]}"

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -40,6 +40,7 @@ export type { UserNotificationDelta, DevicesDelta, Delta } from "./protocol/delt
 export {
   PILL_FALLBACK_ICON,
   PILL_KIND_ICONS,
+  pillDisplayLine,
   type PillContent,
   type PillNotification,
 } from "./notifications-pill/notifications-pill"

--- a/apps/core/src/notifications-pill/notifications-pill.test.ts
+++ b/apps/core/src/notifications-pill/notifications-pill.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   enqueuePillNotification,
   pillContentFromDelta,
+  pillDisplayLine,
   pillVisibleWhileViewing,
   type PillNotification,
 } from "./notifications-pill"
@@ -46,6 +47,16 @@ describe("pillVisibleWhileViewing", () => {
     for (const kind of ["needs_user", "task", "agent_status"]) {
       expect(pillVisibleWhileViewing(item(0, kind, "aria"), "aria")).toBe(true)
     }
+  })
+})
+
+describe("pillDisplayLine", () => {
+  it("joins a title and body as title: body", () => {
+    expect(pillDisplayLine({ title: "aria", body: "hi there" })).toBe("aria: hi there")
+  })
+
+  it("renders a bodiless notification as the title alone", () => {
+    expect(pillDisplayLine({ title: "aria stopped", body: "" })).toBe("aria stopped")
   })
 })
 

--- a/apps/core/src/notifications-pill/notifications-pill.ts
+++ b/apps/core/src/notifications-pill/notifications-pill.ts
@@ -69,6 +69,15 @@ export function enqueuePillNotification(
   return [...queue, item]
 }
 
+/**
+ * The one-line rendering of a notification on a pill surface: the title alone,
+ * or "title: body" when a body carries detail (a message preview under the
+ * agent-name title). One owner, so every view joins the pair identically.
+ */
+export function pillDisplayLine(item: Pick<PillContent, "title" | "body">): string {
+  return item.body ? `${item.title}: ${item.body}` : item.title
+}
+
 /** The `user_notification` payload as a pill item, or null for any other delta. */
 export function pillContentFromDelta(delta: Delta): PillContent | null {
   if (delta.type !== "user_notification") return null

--- a/apps/web/src/components/Navbar/NotificationsPill/index.tsx
+++ b/apps/web/src/components/Navbar/NotificationsPill/index.tsx
@@ -14,6 +14,7 @@ import { Fragment, useContext, useLayoutEffect, useRef } from "react";
 import {
   PILL_FALLBACK_ICON,
   PILL_KIND_ICONS,
+  pillDisplayLine,
   type LoggedUserNotification,
   type PillNotification,
 } from "@vesta/core";
@@ -381,7 +382,7 @@ function NotificationRow({
           compact ? "text-[13px]" : "text-sm",
         )}
       >
-        {entry.title}
+        {pillDisplayLine(entry)}
       </div>
       {timestamp && (
         <span className="shrink-0 text-[10px] text-muted-foreground">
@@ -512,7 +513,7 @@ function MorphingPill({
                 <PillKindIcon kind={current.kind} />
               )}
               <span className="min-w-0 truncate text-[13px]">
-                {current.title}
+                {pillDisplayLine(current)}
               </span>
             </>
           ) : (


### PR DESCRIPTION
## What

Agent replies surfaced through the new notifications pill showed only the orb and the agent name: the `message` kind carries the agent name as its `title` and the reply preview in `body`, and the pill line and history rows rendered the title alone.

## How

The title/body split stays (it matches the OS push shape, where both fields render natively). The pill surfaces now join the pair:

- `pillDisplayLine` in `@vesta/core` owns the one-line rendering: the title alone, or `title: body` when a body carries detail. One owner, so every view joins identically.
- The web NotificationsPill uses it in the morphing pill line and in the history rows (popover + dialog).
- The `user-notification` script's usage comment states the render rule, so agent-authored callers pick a headline title and put detail in the body.

Mobile's OS notifications and the web/desktop local notifications keep their native title/body split and are untouched.

## Checks

`check.sh app-core`, `app-web`, and `guards` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)