### PR TITLE
perf(app): replace chat virtualization with a plain always-mounted scroller

### DIFF
--- a/apps/core/src/chat/chat-stream-model.test.ts
+++ b/apps/core/src/chat/chat-stream-model.test.ts
@@ -8,6 +8,7 @@ import {
   markSend,
   prependPage,
   seedTail,
+  trimTail,
   type ChatMessage,
   type ChatState,
 } from "./chat-stream-model"
@@ -209,5 +210,45 @@ describe("chat-stream-model", () => {
     expect(state.messages).toHaveLength(0)
     expect(state.pendingIntents.size).toBe(0)
     expect(next).not.toBe(state)
+  })
+
+  it("trimTail drops older rows, restores the cursor, and shrinks the dedup set", () => {
+    let state = seedTail(initialChatState(), {
+      events: [chat(10, "a"), chat(11, "b"), chat(12, "c"), chat(13, "d")],
+      cursor: 10,
+    })
+    state = prependPage(state, [chat(5, "old"), chat(6, "older")], 5)
+    const trimmed = trimTail(state, 3)
+    expect(trimmed.messages.map((m) => m.id)).toEqual([11, 12, 13])
+    expect(trimmed.cursor).toBe(11)
+    expect(trimmed.shownIds.has(5)).toBe(false)
+    expect(trimmed.shownIds.has(11)).toBe(true)
+  })
+
+  it("trimTail keeps an optimistic bubble in the retained tail", () => {
+    let state = seedTail(initialChatState(), {
+      events: [chat(10, "a"), chat(11, "b"), chat(12, "c")],
+      cursor: null,
+    })
+    state = beginSend(state, "hi", "typed", "i-1")
+    const trimmed = trimTail(state, 2)
+    expect(trimmed.messages.map((m) => m.id)).toEqual([12, undefined])
+    expect(trimmed.cursor).toBe(12)
+    expect(trimmed.pendingIntents.has("i-1")).toBe(true)
+  })
+
+  it("trimTail is a no-op at or under the keep size", () => {
+    const state = seedTail(initialChatState(), {
+      events: [chat(10, "a"), chat(11, "b")],
+      cursor: null,
+    })
+    expect(trimTail(state, 2)).toBe(state)
+  })
+
+  it("trimTail is a no-op when no retained row has a persisted id", () => {
+    let state = initialChatState()
+    state = beginSend(state, "hi", "typed", "i-1")
+    state = beginSend(state, "yo", "typed", "i-2")
+    expect(trimTail(state, 1)).toBe(state)
   })
 })

--- a/apps/core/src/chat/chat-stream-model.ts
+++ b/apps/core/src/chat/chat-stream-model.ts
@@ -209,12 +209,11 @@ export const TRIM_HISTORY_SETTLE_MS = 30_000
 // conversation forever. The cursor moves to the oldest kept persisted id (ids page exclusively
 // below the cursor), so loadMore refetches exactly what was dropped, and the dedup set shrinks to
 // the kept range. Optimistic bubbles are the newest rows, so the kept slice always contains them.
-export function trimTail(state: ChatState, keep: number): ChatState {
+export function trimTail(state: ChatState, keep = TRIM_HISTORY_KEEP): ChatState {
   if (state.messages.length <= keep) return state
   const messages = state.messages.slice(-keep)
-  const oldestKept = messages.find((message) => message.id != null)
-  if (oldestKept?.id == null) return state
-  const oldestKeptId = oldestKept.id
+  const oldestKeptId = messages.find((message) => message.id != null)?.id
+  if (oldestKeptId == null) return state
   const shownIds = new Set([...state.shownIds].filter((id) => id >= oldestKeptId))
   return { ...state, messages, shownIds, cursor: oldestKeptId }
 }

--- a/apps/core/src/chat/chat-stream-model.ts
+++ b/apps/core/src/chat/chat-stream-model.ts
@@ -197,6 +197,28 @@ export function markSend(
   return { ...state, messages }
 }
 
+// Trim policy, shared by every client: chat views outlive navigation (web pages hide instead of
+// unmounting, mobile holds persist the tail across screen pops), so paged-in history would
+// otherwise accumulate for the whole session. Settling at the latest message for the settle
+// window trims the tail to two pages; scrolling up refetches through the ordinary paging.
+export const TRIM_HISTORY_KEEP = 100
+export const TRIM_HISTORY_SETTLE_MS = 30_000
+
+// The inverse of prependPage: drop loaded older history back down to the newest `keep` rows once
+// the user has settled at the bottom, so a long-lived chat view does not hold the whole
+// conversation forever. The cursor moves to the oldest kept persisted id (ids page exclusively
+// below the cursor), so loadMore refetches exactly what was dropped, and the dedup set shrinks to
+// the kept range. Optimistic bubbles are the newest rows, so the kept slice always contains them.
+export function trimTail(state: ChatState, keep: number): ChatState {
+  if (state.messages.length <= keep) return state
+  const messages = state.messages.slice(-keep)
+  const oldestKept = messages.find((message) => message.id != null)
+  if (oldestKept?.id == null) return state
+  const oldestKeptId = oldestKept.id
+  const shownIds = new Set([...state.shownIds].filter((id) => id >= oldestKeptId))
+  return { ...state, messages, shownIds, cursor: oldestKeptId }
+}
+
 // Prepend an older history page for loadMore, recording its ids for dedup. Unlike the tail, older
 // pages are not capped: loadMore grows the visible history upward on demand.
 export function prependPage(

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -87,6 +87,8 @@ export type {
 } from "./notification-content/notification-content"
 
 export {
+  TRIM_HISTORY_KEEP,
+  TRIM_HISTORY_SETTLE_MS,
   beginSend,
   commitPacedChat,
   foldLiveEvent,
@@ -94,6 +96,7 @@ export {
   markSend,
   prependPage,
   seedTail,
+  trimTail,
 } from "./chat/chat-stream-model"
 export type { ChatMessage, ChatState, HistoryPage, SendState } from "./chat/chat-stream-model"
 

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -87,7 +87,6 @@ export type {
 } from "./notification-content/notification-content"
 
 export {
-  TRIM_HISTORY_KEEP,
   TRIM_HISTORY_SETTLE_MS,
   beginSend,
   commitPacedChat,

--- a/apps/mobile/src/agent/ChatPage.tsx
+++ b/apps/mobile/src/agent/ChatPage.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { TRIM_HISTORY_SETTLE_MS } from "@vesta/core";
 import { StyleSheet, View, type LayoutChangeEvent } from "react-native";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -125,6 +126,15 @@ export default function ChatPage() {
     () => createInvertedChatRows(socket.events, socket.isTyping),
     [socket.events, socket.isTyping],
   );
+
+  // Settled at the latest message: paged-in history far above the viewport (held for the whole
+  // session by the chat hold) is released; scrolling up refetches through the ordinary paging.
+  const trimHistory = socket.trimHistory;
+  useEffect(() => {
+    if (isAwayFromLatest) return;
+    const timer = setTimeout(trimHistory, TRIM_HISTORY_SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [isAwayFromLatest, trimHistory]);
 
   const handleComposerLayout = useCallback(
     (event: LayoutChangeEvent) => {

--- a/apps/mobile/src/chat/useAgentSocket.ts
+++ b/apps/mobile/src/chat/useAgentSocket.ts
@@ -11,7 +11,6 @@ import {
   prependPage,
   seedTail,
   sendMessage,
-  TRIM_HISTORY_KEEP,
   trimTail,
   typingDelay,
   type ChatMessage,
@@ -364,7 +363,7 @@ export function useAgentSocket(
   // so a popped screen holds two pages instead of everything the user ever paged in.
   const trimHistory = useCallback(() => {
     if (loadingMoreRef.current) return;
-    commit((current) => trimTail(current, TRIM_HISTORY_KEEP));
+    commit((current) => trimTail(current));
   }, [commit]);
 
   const loadMore = useCallback(async (): Promise<void> => {

--- a/apps/mobile/src/chat/useAgentSocket.ts
+++ b/apps/mobile/src/chat/useAgentSocket.ts
@@ -11,6 +11,8 @@ import {
   prependPage,
   seedTail,
   sendMessage,
+  TRIM_HISTORY_KEEP,
+  trimTail,
   typingDelay,
   type ChatMessage,
   type ChatState,
@@ -357,6 +359,14 @@ export function useAgentSocket(
 
   const hasMore = state.cursor !== null;
 
+  // Skipped while a load is in flight: trimming under an unresolved prepend would leave a hole
+  // between the landed page and the kept tail. The trimmed state persists to the hold via commit,
+  // so a popped screen holds two pages instead of everything the user ever paged in.
+  const trimHistory = useCallback(() => {
+    if (loadingMoreRef.current) return;
+    commit((current) => trimTail(current, TRIM_HISTORY_KEEP));
+  }, [commit]);
+
   const loadMore = useCallback(async (): Promise<void> => {
     if (
       !name ||
@@ -395,6 +405,7 @@ export function useAgentSocket(
       hasMore,
       loadingMore,
       loadMore,
+      trimHistory,
       send,
       retry,
       reseedRevision,
@@ -411,6 +422,7 @@ export function useAgentSocket(
       hasMore,
       loadingMore,
       loadMore,
+      trimHistory,
       send,
       retry,
       reseedRevision,

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -8266,33 +8266,6 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/@tanstack/react-virtual": {
-      "version": "3.14.9",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
-      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/virtual-core": "3.17.7"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@tanstack/virtual-core": {
-      "version": "3.17.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
-      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -25907,7 +25880,6 @@
         "@fontsource-variable/public-sans": "^5.3.0",
         "@fontsource-variable/source-serif-4": "^5.3.0",
         "@hookform/resolvers": "^5.8.0",
-        "@tanstack/react-virtual": "^3.14.9",
         "@vesta/core": "*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,7 +29,6 @@
     "@fontsource-variable/public-sans": "^5.3.0",
     "@fontsource-variable/source-serif-4": "^5.3.0",
     "@hookform/resolvers": "^5.8.0",
-    "@tanstack/react-virtual": "^3.14.9",
     "@vesta/core": "*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/components/AgentSettings/NotificationsCard/index.test.tsx
+++ b/apps/web/src/components/AgentSettings/NotificationsCard/index.test.tsx
@@ -28,6 +28,9 @@ function socketValue(
     loadMore: async () => {
       /* noop */
     },
+    trimHistory: () => {
+      /* noop */
+    },
     send: () => true,
     retry: () => undefined,
   };

--- a/apps/web/src/components/Chat/ChatMessageArea/index.tsx
+++ b/apps/web/src/components/Chat/ChatMessageArea/index.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useImperativeHandle,
   useLayoutEffect,
   useMemo,
@@ -13,7 +14,7 @@ import { stepTransition } from "@/lib/motion";
 import { bubbleRadiusStyle } from "../bubble-radius";
 import { ChatBubble, type RetryHandler } from "../ChatBubble";
 import { CHAT_CONTENT_WIDTH } from "../content-width";
-import { buildDecorated, type DecoratedRow } from "./rows";
+import { buildDecorated, lastSeenIndex, type DecoratedRow } from "./rows";
 import { useChatScroll } from "./use-chat-scroll";
 
 export interface ChatScrollHandle {
@@ -154,14 +155,12 @@ function ChatEmptyState({
 function MessageRow({
   row,
   index,
-  floating,
   isMobile,
   isNewAppend,
   onRetry,
 }: {
   row: DecoratedRow;
   index: number;
-  floating: boolean;
   isMobile: boolean;
   isNewAppend: boolean;
   onRetry?: RetryHandler;
@@ -182,7 +181,7 @@ function MessageRow({
           <span
             className={cn(
               "text-muted-foreground/60 select-none",
-              floating ? "text-sm" : "text-[11px]",
+              isMobile ? "text-[11px]" : "text-sm",
             )}
           >
             {row.dayLabel}
@@ -204,11 +203,24 @@ function MessageRow({
   );
 }
 
+// The index the previous commit's last row now sits at — read during render (the effect
+// hasn't advanced the ref yet), so rows past it are genuine appends and animate in,
+// while a history page landing above (which shifts indices) never does.
+function useAppendBoundary(decorated: DecoratedRow[]): number {
+  const prevLastKeyRef = useRef<string | null>(null);
+  const prevLastIndex = lastSeenIndex(decorated, prevLastKeyRef.current);
+  useLayoutEffect(() => {
+    prevLastKeyRef.current = decorated[decorated.length - 1]?.key ?? null;
+  }, [decorated]);
+  return prevLastIndex;
+}
+
 // Every fetched row stays mounted in a plain scroller: each message parses its markdown
 // once, ever, and scrolling moves static DOM (the same choice the Console makes, for the
 // same reason — no windowing, no size estimates, no remount cost). History paging bounds
-// the DOM, so long conversations stay cheap.
-export function ChatMessageArea({
+// the DOM, so long conversations stay cheap. memo keeps the parent's per-keystroke
+// composer re-renders from re-invoking every mounted row.
+export const ChatMessageArea = memo(function ChatMessageArea({
   scrollRef,
   loadMore,
   hasMore,
@@ -251,22 +263,14 @@ export function ChatMessageArea({
     count,
     firstKey: decorated[0]?.key ?? null,
     bottomInset,
+    bottomOverhang,
     hasMore,
     loadingMore,
     loadMore,
     onAtBottomChange,
   });
 
-  // Highest row index seen as of the last commit — read during render (holds the prior
-  // value, since the effect below hasn't fired yet) to tell a genuine append from a history
-  // page landing or an unrelated re-render, then advanced after commit. Gated on
-  // hadRowsRef so the first page of history never plays the entrance animation.
-  const hadRowsRef = useRef(false);
-  const maxSeenIndexRef = useRef(-1);
-  useLayoutEffect(() => {
-    hadRowsRef.current = count > 0;
-    maxSeenIndexRef.current = count - 1;
-  }, [count]);
+  const prevLastIndex = useAppendBoundary(decorated);
 
   useImperativeHandle(scrollRef, () => ({ scrollToBottom }), [scrollToBottom]);
 
@@ -345,11 +349,8 @@ export function ChatMessageArea({
                 key={row.key}
                 row={row}
                 index={index}
-                floating={floating}
                 isMobile={isMobile}
-                isNewAppend={
-                  hadRowsRef.current && index > maxSeenIndexRef.current
-                }
+                isNewAppend={prevLastIndex >= 0 && index > prevLastIndex}
                 onRetry={onRetry}
               />
             ))}
@@ -373,4 +374,4 @@ export function ChatMessageArea({
       </div>
     </CardContent>
   );
-}
+});

--- a/apps/web/src/components/Chat/ChatMessageArea/index.tsx
+++ b/apps/web/src/components/Chat/ChatMessageArea/index.tsx
@@ -1,12 +1,10 @@
 import {
-  useCallback,
   useImperativeHandle,
   useLayoutEffect,
   useMemo,
   useRef,
   type RefObject,
 } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
 import { AnimatePresence, motion } from "motion/react";
 import { CardContent } from "@/components/ui/card";
 import type { ChatMessage } from "@/lib/types";
@@ -15,20 +13,8 @@ import { stepTransition } from "@/lib/motion";
 import { bubbleRadiusStyle } from "../bubble-radius";
 import { ChatBubble, type RetryHandler } from "../ChatBubble";
 import { CHAT_CONTENT_WIDTH } from "../content-width";
-import { buildDecorated } from "./virtual";
-
-// First-paint estimate per row (actual heights are measured).
-const ESTIMATED_MESSAGE_HEIGHT = 64;
-// How close to the bottom (px) still counts as "pinned" — drives follow-on-append and
-// gates the load-older check (don't page up while sitting at the bottom).
-const AT_BOTTOM_THRESHOLD_PX = 80;
-// Scrolling within this many px of the top loads the previous page.
-const LOAD_OLDER_TOP_PX = 120;
-// Rows rendered beyond the visible window on each side — a measurement margin. Bigger =
-// rows are rendered and measured BEFORE they scroll into view, so they appear at their real
-// height instead of resizing in front of you (this is the "measure then show" that smooths
-// scroll-up and prepends). Small values make the mount/unmount visible for debugging.
-const OVERSCAN_ROWS = 12;
+import { buildDecorated, type DecoratedRow } from "./rows";
+import { useChatScroll } from "./use-chat-scroll";
 
 export interface ChatScrollHandle {
   scrollToBottom: () => void;
@@ -111,6 +97,114 @@ function ChatSkeleton({ bottomPad }: { bottomPad: number }) {
   );
 }
 
+// One mask owns both fades. Fullscreen's top approximates the old stacked card+list
+// pair: near-invisible within the navbar's height, then a long dissolve (3.5x/1.75x
+// the navbar) so bubbles evaporate before reaching it. The bottom stop fades behind
+// the composer.
+function scrollerMask(
+  fullscreen: boolean,
+  isMobile: boolean,
+  navbarHeight: number,
+  bottomInset: number,
+): string {
+  const top = fullscreen
+    ? `rgb(0 0 0 / 0) 0px, rgb(0 0 0 / 0.25) ${String(navbarHeight)}px, black ${String(Math.round(navbarHeight * (isMobile ? 1.75 : 3.5)))}px`
+    : "transparent, black 48px";
+  return `linear-gradient(to bottom, ${top}, black calc(100% - ${String(bottomInset)}px), transparent)`;
+}
+
+function ChatEmptyState({
+  connected,
+  historyLoaded,
+  notAuthenticated,
+  agentName,
+  bottomInset,
+}: {
+  connected: boolean;
+  historyLoaded: boolean;
+  notAuthenticated: boolean;
+  agentName: string;
+  bottomInset: number;
+}) {
+  if (connected && !historyLoaded) {
+    // The extra 16px mirrors the real list's trailing pb-4 (the typing
+    // indicator slot after the last row), so the skeleton's last bubble
+    // sits exactly where a real last bubble does.
+    return <ChatSkeleton bottomPad={bottomInset + 16} />;
+  }
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center"
+      style={{ paddingBottom: bottomInset + 24 }}
+    >
+      <span className="text-xs text-muted-foreground">
+        {!connected
+          ? "connecting..."
+          : notAuthenticated
+            ? `${agentName} needs to sign in`
+            : `${agentName} is setting things up`}
+      </span>
+    </div>
+  );
+}
+
+function MessageRow({
+  row,
+  index,
+  floating,
+  isMobile,
+  isNewAppend,
+  onRetry,
+}: {
+  row: DecoratedRow;
+  index: number;
+  floating: boolean;
+  isMobile: boolean;
+  isNewAppend: boolean;
+  onRetry?: RetryHandler;
+}) {
+  const bubble = (
+    <ChatBubble
+      event={row.event}
+      className={row.gap}
+      isMobile={isMobile}
+      hasTail={row.isGroupEnd}
+      onRetry={onRetry}
+    />
+  );
+  return (
+    <>
+      {row.showDayStamp && row.dayLabel && (
+        <div className={cn("flex justify-center", index > 0 && "mt-5")}>
+          <span
+            className={cn(
+              "text-muted-foreground/60 select-none",
+              floating ? "text-sm" : "text-[11px]",
+            )}
+          >
+            {row.dayLabel}
+          </span>
+        </div>
+      )}
+      {isNewAppend ? (
+        <motion.div
+          initial={{ opacity: 0, y: 6, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={stepTransition.transition}
+        >
+          {bubble}
+        </motion.div>
+      ) : (
+        bubble
+      )}
+    </>
+  );
+}
+
+// Every fetched row stays mounted in a plain scroller: each message parses its markdown
+// once, ever, and scrolling moves static DOM (the same choice the Console makes, for the
+// same reason — no windowing, no size estimates, no remount cost). History paging bounds
+// the DOM, so long conversations stay cheap.
 export function ChatMessageArea({
   scrollRef,
   loadMore,
@@ -147,115 +241,31 @@ export function ChatMessageArea({
     return "";
   }, [chatMessages]);
   const parentRef = useRef<HTMLDivElement>(null);
-  // True while pinned near the latest message, false once the user scrolls up.
-  // Recomputed on scroll and on content resize (see below); the parent renders
-  // the scroll-to-bottom button off it, notified only on change.
-  const atBottomRef = useRef(true);
-  const setAtBottom = useCallback(
-    (pinned: boolean) => {
-      if (atBottomRef.current === pinned) return;
-      atBottomRef.current = pinned;
-      onAtBottomChange(pinned);
-    },
-    [onAtBottomChange],
-  );
 
-  const getItemKey = useCallback(
-    (index: number) => decorated[index]?.key ?? String(index),
-    [decorated],
-  );
-
-  const estimateSize = useCallback(() => ESTIMATED_MESSAGE_HEIGHT, []);
-
-  const virtualizer = useVirtualizer({
+  const { handleScroll, scrollToBottom, waitingForOlder } = useChatScroll({
+    parentRef,
     count,
-    getScrollElement: () => parentRef.current,
-    estimateSize,
-    getItemKey,
-    // End-anchored chat scrolling: TanStack captures the visible keyed row before a data
-    // change and re-pins it after — keeping scroll stable across prepends (load older)
-    // and streaming growth.
-    anchorTo: "end",
-    followOnAppend: "smooth",
-    scrollEndThreshold: AT_BOTTOM_THRESHOLD_PX,
-    paddingEnd: bottomInset,
-    overscan: OVERSCAN_ROWS,
-    // Apply row positions straight to the DOM instead of through a React re-render on every
-    // scroll frame. Critical for smooth upward scrolling, where measuring newly-revealed rows
-    // constantly nudges offsets — going through React there is what stutters.
-    directDomUpdates: true,
+    firstKey: decorated[0]?.key ?? null,
+    bottomInset,
+    hasMore,
+    loadingMore,
+    loadMore,
+    onAtBottomChange,
   });
 
-  useImperativeHandle(
-    scrollRef,
-    () => ({
-      scrollToBottom: () => virtualizer.scrollToEnd({ behavior: "smooth" }),
-    }),
-    [virtualizer],
-  );
-
-  // Jump to the latest message when the first page of history arrives, and again whenever
-  // the list resets to empty (agent switch / reconnect) and repopulates.
-  const hadRowsRef = useRef(false);
-  useLayoutEffect(() => {
-    const hasRows = count > 0;
-    if (hasRows && !hadRowsRef.current) virtualizer.scrollToEnd();
-    hadRowsRef.current = hasRows;
-  }, [count, virtualizer]);
-
-  // The composer inset lands after the initial end-jump (its ResizeObserver is async) and
-  // changes while a multi-line draft grows; the virtualizer never re-anchors on a padding
-  // change, so while pinned we re-pin ourselves.
-  useLayoutEffect(() => {
-    if (atBottomRef.current) virtualizer.scrollToEnd();
-  }, [bottomInset, virtualizer]);
-
   // Highest row index seen as of the last commit — read during render (holds the prior
-  // value, since this effect hasn't fired yet) to tell a genuine append from a history
+  // value, since the effect below hasn't fired yet) to tell a genuine append from a history
   // page landing or an unrelated re-render, then advanced after commit. Gated on
   // hadRowsRef so the first page of history never plays the entrance animation.
+  const hadRowsRef = useRef(false);
   const maxSeenIndexRef = useRef(-1);
   useLayoutEffect(() => {
+    hadRowsRef.current = count > 0;
     maxSeenIndexRef.current = count - 1;
   }, [count]);
 
-  const handleScroll = useCallback(() => {
-    const el = parentRef.current;
-    if (!el) return;
-    // Distance-from-end straight off the DOM rather than virtualizer.isAtEnd(): the latter
-    // reads a measurement cache that can lag a row resize, and we recompute this from a
-    // ResizeObserver too, so a single authoritative source keeps the two in agreement.
-    const atEnd =
-      el.scrollHeight - el.scrollTop - el.clientHeight <=
-      AT_BOTTOM_THRESHOLD_PX;
-    setAtBottom(atEnd);
-    if (hasMore && !loadingMore && !atEnd && el.scrollTop < LOAD_OLDER_TOP_PX) {
-      loadMore();
-    }
-  }, [hasMore, loadingMore, loadMore]);
+  useImperativeHandle(scrollRef, () => ({ scrollToBottom }), [scrollToBottom]);
 
-  // "At bottom" depends on content height, not just scroll position: after the first paint the
-  // virtualizer measures real row heights (vs. the estimates scrollToEnd used), which moves the
-  // end without firing a scroll event. Recompute on every content resize so the button doesn't
-  // get stuck showing when we're actually pinned to the latest message.
-  useLayoutEffect(() => {
-    const el = parentRef.current;
-    const content = el?.firstElementChild;
-    if (!el || !content) return;
-    const ro = new ResizeObserver(() => {
-      const dist = el.scrollHeight - el.scrollTop - el.clientHeight;
-      const pinned = dist <= AT_BOTTOM_THRESHOLD_PX;
-      setAtBottom(pinned);
-      // Repay any shortfall a smooth follow left behind: the virtualizer skips
-      // its own end re-pin while a smooth scroll is in flight, so a row measured
-      // mid-animation lands short and would otherwise stay short.
-      if (pinned && dist > 1) virtualizer.scrollToEnd();
-    });
-    ro.observe(content);
-    return () => ro.disconnect();
-  }, [setAtBottom, virtualizer]);
-
-  const items = virtualizer.getVirtualItems();
   const topPad = fullscreen ? navbarHeight + 16 : 32;
 
   return (
@@ -264,28 +274,17 @@ export function ChatMessageArea({
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {lastAgentText}
       </span>
-      {count === 0 &&
-        (connected && !historyLoaded ? (
-          // The extra 16px mirrors the real list's trailing pb-4 (the typing
-          // indicator slot after the last row), so the skeleton's last bubble
-          // sits exactly where a real last bubble does.
-          <ChatSkeleton bottomPad={bottomInset + 16} />
-        ) : (
-          <div
-            className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center"
-            style={{ paddingBottom: bottomInset + 24 }}
-          >
-            <span className="text-xs text-muted-foreground">
-              {!connected
-                ? "connecting..."
-                : notAuthenticated
-                  ? `${agentName} needs to sign in`
-                  : `${agentName} is setting things up`}
-            </span>
-          </div>
-        ))}
+      {count === 0 && (
+        <ChatEmptyState
+          connected={connected}
+          historyLoaded={historyLoaded}
+          notAuthenticated={notAuthenticated}
+          agentName={agentName}
+          bottomInset={bottomInset}
+        />
+      )}
       <AnimatePresence>
-        {loadingMore && (
+        {waitingForOlder && (
           <motion.div
             initial={{ opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}
@@ -296,7 +295,7 @@ export function ChatMessageArea({
               fullscreen ? "top-[5rem]" : "top-10",
             )}
           >
-            <span className="rounded-full border border-muted-foreground/20 bg-muted/80 backdrop-blur-sm px-3 py-1.5 text-xs text-muted-foreground">
+            <span className="rounded-full border border-border bg-popover px-3 py-1.5 text-xs text-muted-foreground shadow-sm">
               loading...
             </span>
           </motion.div>
@@ -311,112 +310,58 @@ export function ChatMessageArea({
           // shares the same center as the (scrollbar-free) floating composer.
           floating && "[scrollbar-gutter:stable_both-edges]",
         )}
-        // One mask owns both fades. Fullscreen's top approximates the old
-        // stacked card+list pair: near-invisible within the navbar's height,
-        // then a long dissolve (3.5x/1.75x the navbar) so bubbles evaporate
-        // before reaching it. The bottom stop fades behind the composer.
+        // The prepend restore owns anchoring; the browser's native scroll
+        // anchoring would compensate the same prepend a second time.
         style={{
-          maskImage: `linear-gradient(to bottom, ${
-            fullscreen
-              ? `rgb(0 0 0 / 0) 0px, rgb(0 0 0 / 0.25) ${String(navbarHeight)}px, black ${String(Math.round(navbarHeight * (isMobile ? 1.75 : 3.5)))}px`
-              : "transparent, black 48px"
-          }, black calc(100% - ${String(bottomInset)}px), transparent)`,
+          overflowAnchor: "none",
+          maskImage: scrollerMask(
+            Boolean(fullscreen),
+            isMobile,
+            navbarHeight,
+            bottomInset,
+          ),
         }}
       >
         <div
-          ref={virtualizer.containerRef}
-          style={{ position: "relative", width: "100%" }}
+          className={cn(centered && CHAT_CONTENT_WIDTH)}
+          style={{ paddingBottom: bottomInset }}
         >
-          {items.map((item) => {
-            const row = decorated[item.index];
-            if (!row) return null;
-            const isLast = item.index === count - 1;
-            const isNewAppend =
-              hadRowsRef.current && item.index > maxSeenIndexRef.current;
-            return (
-              <div
-                key={item.key}
-                ref={virtualizer.measureElement}
-                data-index={item.index}
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: "100%",
-                }}
-              >
-                <div className={cn(centered && CHAT_CONTENT_WIDTH)}>
-                  {row.isFirst && (
-                    <div style={{ paddingTop: topPad }}>
-                      {!hasMore && (
-                        <div className="flex justify-center py-3">
-                          <span className="text-[11px] text-muted-foreground/40">
-                            beginning of conversation
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                  <div className="flex flex-col px-4">
-                    {row.showDayStamp && row.dayLabel && (
-                      <div
-                        className={cn(
-                          "flex justify-center",
-                          !row.isFirst && "mt-5",
-                        )}
-                      >
-                        <span
-                          className={cn(
-                            "text-muted-foreground/60 select-none",
-                            floating ? "text-sm" : "text-[11px]",
-                          )}
-                        >
-                          {row.dayLabel}
-                        </span>
-                      </div>
-                    )}
-                    {isNewAppend ? (
-                      <motion.div
-                        initial={{ opacity: 0, y: 6, scale: 0.98 }}
-                        animate={{ opacity: 1, y: 0, scale: 1 }}
-                        transition={stepTransition.transition}
-                      >
-                        <ChatBubble
-                          event={row.event}
-                          className={row.gap}
-                          isMobile={isMobile}
-                          hasTail={row.isGroupEnd}
-                          onRetry={onRetry}
-                        />
-                      </motion.div>
-                    ) : (
-                      <ChatBubble
-                        event={row.event}
-                        className={row.gap}
-                        isMobile={isMobile}
-                        hasTail={row.isGroupEnd}
-                        onRetry={onRetry}
-                      />
-                    )}
-                  </div>
-                  {isLast && (
-                    <div className="px-4 pb-4">
-                      {isTyping && (
-                        <div className="flex justify-start mt-2">
-                          <div className="flex items-center gap-1 bg-secondary text-secondary-foreground rounded-2xl rounded-bl-sm px-3.5 py-2.5">
-                            <span className="sr-only">typing...</span>
-                            <span className="size-1.5 rounded-full bg-secondary-foreground/45 animate-bounce motion-reduce:animate-none [animation-delay:0ms]" />
-                            <span className="size-1.5 rounded-full bg-secondary-foreground/45 animate-bounce motion-reduce:animate-none [animation-delay:150ms]" />
-                            <span className="size-1.5 rounded-full bg-secondary-foreground/45 animate-bounce motion-reduce:animate-none [animation-delay:300ms]" />
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  )}
+          <div style={{ paddingTop: topPad }}>
+            {count > 0 && !hasMore && (
+              <div className="flex justify-center py-3">
+                <span className="text-[11px] text-muted-foreground/40">
+                  beginning of conversation
+                </span>
+              </div>
+            )}
+          </div>
+          <div className="flex flex-col px-4">
+            {decorated.map((row, index) => (
+              <MessageRow
+                key={row.key}
+                row={row}
+                index={index}
+                floating={floating}
+                isMobile={isMobile}
+                isNewAppend={
+                  hadRowsRef.current && index > maxSeenIndexRef.current
+                }
+                onRetry={onRetry}
+              />
+            ))}
+          </div>
+          <div className="px-4 pb-4">
+            {isTyping && (
+              <div className="flex justify-start mt-2">
+                <div className="flex items-center gap-1 bg-secondary text-secondary-foreground rounded-2xl rounded-bl-sm px-3.5 py-2.5">
+                  <span className="sr-only">typing...</span>
+                  <span className="size-1.5 rounded-full bg-secondary-foreground/45 animate-bounce motion-reduce:animate-none [animation-delay:0ms]" />
+                  <span className="size-1.5 rounded-full bg-secondary-foreground/45 animate-bounce motion-reduce:animate-none [animation-delay:150ms]" />
+                  <span className="size-1.5 rounded-full bg-secondary-foreground/45 animate-bounce motion-reduce:animate-none [animation-delay:300ms]" />
                 </div>
               </div>
-            );
-          })}
+            )}
+          </div>
         </div>
       </div>
     </CardContent>

--- a/apps/web/src/components/Chat/ChatMessageArea/index.tsx
+++ b/apps/web/src/components/Chat/ChatMessageArea/index.tsx
@@ -37,6 +37,9 @@ interface ChatMessageAreaProps {
   onRetry?: RetryHandler;
   // Space reserved at the end of the list so the last message clears the floating composer.
   bottomInset?: number;
+  // A tall draft's extra composer height beyond the baseline inset. It extends the scroll
+  // range so covered bubbles stay reachable, without moving the pinned viewport.
+  bottomOverhang?: number;
   // Fires when pinned-to-latest flips; drives the parent's scroll-to-bottom button.
   onAtBottomChange: (atBottom: boolean) => void;
 }
@@ -221,6 +224,7 @@ export function ChatMessageArea({
   isMobile,
   onRetry,
   bottomInset = 0,
+  bottomOverhang = 0,
   onAtBottomChange,
 }: ChatMessageAreaProps) {
   // Desktop treatment (floating-composer inset, spacious gaps, sizes) applies to both the
@@ -363,6 +367,9 @@ export function ChatMessageArea({
             )}
           </div>
         </div>
+        {/* The draft's overhang sits outside the resize-observed content div, so a growing
+            draft extends the scroll range without ever triggering the pinned re-pin. */}
+        <div style={{ height: bottomOverhang }} />
       </div>
     </CardContent>
   );

--- a/apps/web/src/components/Chat/ChatMessageArea/rows.test.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/rows.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { ChatMessage } from "@/lib/types";
-import { buildDecorated, rowKey } from "./virtual";
+import { buildDecorated, rowKey } from "./rows";
 
 function userMsg(ts: string): ChatMessage {
   return { type: "user", text: "hi", ts };

--- a/apps/web/src/components/Chat/ChatMessageArea/rows.test.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/rows.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { ChatMessage } from "@/lib/types";
-import { buildDecorated, rowKey } from "./rows";
+import { buildDecorated, lastSeenIndex, rowKey } from "./rows";
 
 function userMsg(ts: string): ChatMessage {
   return { type: "user", text: "hi", ts };
@@ -64,5 +64,33 @@ describe("buildDecorated", () => {
       userMsg("not-a-date"),
     ]);
     expect(rows[1]?.gap).toBe("mt-1.5");
+  });
+});
+
+describe("lastSeenIndex", () => {
+  const rows = (...ts: string[]) => buildDecorated(ts.map(userMsg));
+
+  it("keeps the boundary on the previous last row when a prepend shifts indices", () => {
+    const before = rows("2026-06-08T10:00:00Z", "2026-06-08T10:01:00Z");
+    const prevLastKey = before[before.length - 1]?.key ?? null;
+    const after = rows(
+      "2026-06-08T09:00:00Z",
+      "2026-06-08T10:00:00Z",
+      "2026-06-08T10:01:00Z",
+    );
+    expect(lastSeenIndex(after, prevLastKey)).toBe(2);
+  });
+
+  it("marks appended rows as past the boundary", () => {
+    const before = rows("2026-06-08T10:00:00Z");
+    const prevLastKey = before[0]?.key ?? null;
+    const after = rows("2026-06-08T10:00:00Z", "2026-06-08T10:01:00Z");
+    expect(lastSeenIndex(after, prevLastKey)).toBe(0);
+  });
+
+  it("disables the boundary before the first page and after a reseed", () => {
+    const after = rows("2026-06-08T10:00:00Z");
+    expect(lastSeenIndex(after, null)).toBe(-1);
+    expect(lastSeenIndex(after, "2026-01-01T00:00:00Z-user")).toBe(-1);
   });
 });

--- a/apps/web/src/components/Chat/ChatMessageArea/rows.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/rows.ts
@@ -8,7 +8,6 @@ export interface DecoratedRow {
   gap: string;
   showDayStamp: boolean;
   dayLabel: string;
-  isFirst: boolean;
   // Last bubble of its group (next message is a different sender or a new bubble group, or
   // this is the final message). Only this bubble gets the tail corner; the rest are rounded.
   isGroupEnd: boolean;
@@ -40,8 +39,8 @@ export function buildDecorated(
 ): DecoratedRow[] {
   let lastDayKey: string | null = null;
   // rowKey (`${ts}-${type}`) is not guaranteed unique — two events can share a
-  // timestamp and type. Suffix repeats so keys stay unique, which the virtualizer's
-  // getItemKey needs to track (and re-anchor) a row across data changes.
+  // timestamp and type. Suffix repeats so keys stay unique, which React reconciliation
+  // needs to keep existing rows mounted (and un-re-rendered) across prepends.
   const seenKeys = new Map<string, number>();
   return chatMessages.map((msg, i) => {
     const prev = chatMessages[i - 1];
@@ -66,7 +65,6 @@ export function buildDecorated(
       gap,
       showDayStamp,
       dayLabel,
-      isFirst: i === 0,
       isGroupEnd,
     };
   });

--- a/apps/web/src/components/Chat/ChatMessageArea/rows.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/rows.ts
@@ -17,6 +17,22 @@ export function rowKey(event: ChatMessage, idxFallback: number): string {
   return event.ts ? `${event.ts}-${event.type}` : `i-${String(idxFallback)}`;
 }
 
+// Where the previous commit's last row now sits: rows after it are genuine appends (they
+// animate in). Index-based detection would misfire — a prepend shifts every index — so the
+// row is found by key, scanned from the end where it stays. -1 means nothing qualifies:
+// no previous commit (the first page never animates) or the row vanished in a reseed.
+export function lastSeenIndex(
+  rows: DecoratedRow[],
+  prevLastKey: string | null,
+): number {
+  if (prevLastKey !== null) {
+    for (let i = rows.length - 1; i >= 0; i--) {
+      if (rows[i]?.key === prevLastKey) return i;
+    }
+  }
+  return -1;
+}
+
 function rowGap(
   msg: ChatMessage,
   prev: ChatMessage | undefined,

--- a/apps/web/src/components/Chat/ChatMessageArea/scroll.test.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/scroll.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  AT_BOTTOM_THRESHOLD_PX,
+  IDLE_LATCH,
+  distanceFromEnd,
+  isPrepend,
+  onScrollTick,
+  restoredScrollTop,
+  startFollow,
+} from "./scroll";
+
+function metrics(scrollTop: number, scrollHeight = 2000, clientHeight = 600) {
+  return { scrollTop, scrollHeight, clientHeight };
+}
+
+describe("distanceFromEnd", () => {
+  it("measures the gap between the viewport bottom and the content end", () => {
+    expect(distanceFromEnd(metrics(1400))).toBe(0);
+    expect(distanceFromEnd(metrics(1000))).toBe(400);
+  });
+});
+
+describe("onScrollTick while idle", () => {
+  it("reports pinned within the bottom threshold", () => {
+    const tick = onScrollTick(
+      metrics(1400 - AT_BOTTOM_THRESHOLD_PX),
+      IDLE_LATCH,
+      true,
+    );
+    expect(tick.atBottom).toBe(true);
+    expect(tick.loadOlder).toBe(false);
+  });
+
+  it("reports unpinned deep in the list without loading", () => {
+    const tick = onScrollTick(metrics(5000, 10000), IDLE_LATCH, true);
+    expect(tick.atBottom).toBe(false);
+    expect(tick.loadOlder).toBe(false);
+    expect(tick.nearTop).toBe(false);
+  });
+
+  it("preloads older history while the user still has scroll runway", () => {
+    const tick = onScrollTick(metrics(1700, 10000), IDLE_LATCH, true);
+    expect(tick.loadOlder).toBe(true);
+    expect(tick.nearTop).toBe(false);
+  });
+
+  it("flags the user as waiting at the top of loaded history", () => {
+    const tick = onScrollTick(metrics(40, 10000), IDLE_LATCH, true);
+    expect(tick.loadOlder).toBe(true);
+    expect(tick.nearTop).toBe(true);
+  });
+
+  it("does not load older history when the caller cannot load", () => {
+    const tick = onScrollTick(metrics(40), IDLE_LATCH, false);
+    expect(tick.loadOlder).toBe(false);
+  });
+
+  it("does not load older history while pinned in a short conversation", () => {
+    // Content barely taller than the viewport: at-bottom and near-top at once.
+    const tick = onScrollTick(metrics(50, 700, 600), IDLE_LATCH, true);
+    expect(tick.atBottom).toBe(true);
+    expect(tick.loadOlder).toBe(false);
+  });
+});
+
+describe("onScrollTick while following a smooth scroll to the latest message", () => {
+  it("holds the pinned state while the distance shrinks", () => {
+    const latch = startFollow(metrics(1000));
+    const tick = onScrollTick(metrics(1100), latch, true);
+    expect(tick.atBottom).toBe(null);
+    expect(tick.latch.following).toBe(true);
+    expect(tick.loadOlder).toBe(false);
+  });
+
+  it("lands and reports pinned when the distance reaches the threshold", () => {
+    const latch = startFollow(metrics(1000));
+    const tick = onScrollTick(
+      metrics(1400 - AT_BOTTOM_THRESHOLD_PX),
+      latch,
+      true,
+    );
+    expect(tick.atBottom).toBe(true);
+    expect(tick.latch.following).toBe(false);
+  });
+
+  it("hands control back when the user scrolls away mid-follow", () => {
+    const latch = startFollow(metrics(1000));
+    const afterProgress = onScrollTick(metrics(1100), latch, true);
+    const tick = onScrollTick(metrics(900), afterProgress.latch, true);
+    expect(tick.atBottom).toBe(false);
+    expect(tick.latch.following).toBe(false);
+  });
+});
+
+describe("isPrepend", () => {
+  it("detects older rows landing above the existing first row", () => {
+    expect(isPrepend("k5", "k1", 10, 30)).toBe(true);
+  });
+
+  it("ignores the first page of history", () => {
+    expect(isPrepend(null, "k1", 0, 20)).toBe(false);
+  });
+
+  it("ignores appends, which keep the first row", () => {
+    expect(isPrepend("k1", "k1", 10, 11)).toBe(false);
+  });
+
+  it("ignores in-place edits that keep the count", () => {
+    expect(isPrepend("k1", "k1", 10, 10)).toBe(false);
+  });
+});
+
+describe("restoredScrollTop", () => {
+  it("replays the height the prepend added above the viewport", () => {
+    expect(restoredScrollTop({ scrollTop: 40, scrollHeight: 2000 }, 3200)).toBe(
+      1240,
+    );
+  });
+});

--- a/apps/web/src/components/Chat/ChatMessageArea/scroll.test.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/scroll.test.ts
@@ -3,7 +3,8 @@ import {
   AT_BOTTOM_THRESHOLD_PX,
   IDLE_LATCH,
   distanceFromEnd,
-  isPrepend,
+  onResizeTick,
+  onRowsChange,
   onScrollTick,
   restoredScrollTop,
   startFollow,
@@ -92,21 +93,58 @@ describe("onScrollTick while following a smooth scroll to the latest message", (
   });
 });
 
-describe("isPrepend", () => {
-  it("detects older rows landing above the existing first row", () => {
-    expect(isPrepend("k5", "k1", 10, 30)).toBe(true);
+describe("onResizeTick", () => {
+  it("re-pins a pinned viewport when content grows beneath it", () => {
+    const tick = onResizeTick(metrics(1000), IDLE_LATCH, true);
+    expect(tick.scrollToEnd).toBe("instant");
+    expect(tick.atBottom).toBe(null);
   });
 
-  it("ignores the first page of history", () => {
-    expect(isPrepend(null, "k1", 0, 20)).toBe(false);
+  it("recomputes the pinned flag for an unpinned viewport", () => {
+    const tick = onResizeTick(metrics(1000), IDLE_LATCH, false);
+    expect(tick.scrollToEnd).toBe(null);
+    expect(tick.atBottom).toBe(false);
   });
 
-  it("ignores appends, which keep the first row", () => {
-    expect(isPrepend("k1", "k1", 10, 11)).toBe(false);
+  it("re-aims a mid-flight follow whose target moved, so it cannot land short", () => {
+    const latch = startFollow(metrics(1000, 2000));
+    const tick = onResizeTick(metrics(1200, 2600), latch, true);
+    expect(tick.scrollToEnd).toBe("smooth");
+    expect(tick.latch.following).toBe(true);
+    expect(tick.latch.lastDistance).toBe(distanceFromEnd(metrics(1200, 2600)));
+    expect(tick.atBottom).toBe(null);
   });
 
-  it("ignores in-place edits that keep the count", () => {
-    expect(isPrepend("k1", "k1", 10, 10)).toBe(false);
+  it("lands a follow that the resize left within the bottom threshold", () => {
+    const latch = startFollow(metrics(1000));
+    const tick = onResizeTick(
+      metrics(1400 - AT_BOTTOM_THRESHOLD_PX),
+      latch,
+      true,
+    );
+    expect(tick.latch.following).toBe(false);
+    expect(tick.scrollToEnd).toBe(null);
+    expect(tick.atBottom).toBe(true);
+  });
+});
+
+describe("onRowsChange", () => {
+  it("restores the viewport over older rows landing above it, even while pinned", () => {
+    expect(onRowsChange("k5", "k1", 10, 30, false)).toBe("restore");
+    expect(onRowsChange("k5", "k1", 10, 30, true)).toBe("restore");
+  });
+
+  it("jumps the first page of history onto the latest message", () => {
+    expect(onRowsChange(null, "k1", 0, 20, true)).toBe("jump");
+  });
+
+  it("follows an append only while pinned", () => {
+    expect(onRowsChange("k1", "k1", 10, 11, true)).toBe("follow");
+    expect(onRowsChange("k1", "k1", 10, 11, false)).toBe("none");
+  });
+
+  it("leaves in-place edits that keep the count alone", () => {
+    expect(onRowsChange("k1", "k1", 10, 10, true)).toBe("none");
   });
 });
 

--- a/apps/web/src/components/Chat/ChatMessageArea/scroll.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/scroll.ts
@@ -1,0 +1,99 @@
+// Pure decision logic for the chat scroller: pinned-to-latest tracking, the follow latch
+// for smooth scrolls to the end, load-older triggering, and prepend anchoring math.
+
+// How close to the bottom (px) still counts as "pinned" — drives follow-on-append and
+// gates the load-older check (don't page up while sitting at the bottom).
+export const AT_BOTTOM_THRESHOLD_PX = 80;
+// Preload margin: within this many viewport heights of the top, the previous page starts
+// loading, so it lands before the user can reach the top of loaded history.
+export const LOAD_OLDER_SCREENS = 3;
+// Within this many px of the absolute top the user has outrun the fetch and is actually
+// waiting on it — the only time the loading pill shows.
+export const WAITING_AT_TOP_PX = 120;
+
+export interface ScrollMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+export function distanceFromEnd(metrics: ScrollMetrics): number {
+  return metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight;
+}
+
+// A smooth scroll to the latest message reports intermediate positions that read as "left
+// the bottom" and would flash the scroll-to-bottom button on every append. The latch rides
+// the animation by its one invariant (the distance to the end only shrinks) and hands
+// control back the moment it lands or the user scrolls the other way.
+export interface FollowLatch {
+  following: boolean;
+  lastDistance: number;
+}
+
+export const IDLE_LATCH: FollowLatch = { following: false, lastDistance: 0 };
+
+export function startFollow(metrics: ScrollMetrics): FollowLatch {
+  return { following: true, lastDistance: distanceFromEnd(metrics) };
+}
+
+export interface ScrollTick {
+  // null = leave the pinned state unchanged (a follow animation is mid-flight).
+  atBottom: boolean | null;
+  loadOlder: boolean;
+  nearTop: boolean;
+  latch: FollowLatch;
+}
+
+export function onScrollTick(
+  metrics: ScrollMetrics,
+  latch: FollowLatch,
+  canLoadOlder: boolean,
+): ScrollTick {
+  const distance = distanceFromEnd(metrics);
+  const atEnd = distance <= AT_BOTTOM_THRESHOLD_PX;
+  const nearTop = metrics.scrollTop < WAITING_AT_TOP_PX;
+  if (latch.following && atEnd) {
+    return { atBottom: true, loadOlder: false, nearTop, latch: IDLE_LATCH };
+  }
+  if (latch.following && distance <= latch.lastDistance) {
+    return {
+      atBottom: null,
+      loadOlder: false,
+      nearTop,
+      latch: { following: true, lastDistance: distance },
+    };
+  }
+  return {
+    atBottom: atEnd,
+    loadOlder:
+      canLoadOlder &&
+      !atEnd &&
+      metrics.scrollTop < metrics.clientHeight * LOAD_OLDER_SCREENS,
+    nearTop,
+    latch: { following: false, lastDistance: distance },
+  };
+}
+
+// Loading older history prepends rows above the viewport. Restoring scroll is exact, not
+// estimated: capture the scroll state just before the rows land, then replay the height
+// they added.
+export interface PrependSnapshot {
+  scrollTop: number;
+  scrollHeight: number;
+}
+
+export function isPrepend(
+  prevFirstKey: string | null,
+  firstKey: string | null,
+  prevCount: number,
+  count: number,
+): boolean {
+  return prevCount > 0 && count > prevCount && firstKey !== prevFirstKey;
+}
+
+export function restoredScrollTop(
+  snapshot: PrependSnapshot,
+  scrollHeight: number,
+): number {
+  return snapshot.scrollTop + (scrollHeight - snapshot.scrollHeight);
+}

--- a/apps/web/src/components/Chat/ChatMessageArea/scroll.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/scroll.ts
@@ -10,11 +10,24 @@ export const LOAD_OLDER_SCREENS = 3;
 // Within this many px of the absolute top the user has outrun the fetch and is actually
 // waiting on it — the only time the loading pill shows.
 export const WAITING_AT_TOP_PX = 120;
+// Sub-pixel rounding slack: a pinned viewport within this of the end is already flush,
+// so no re-pin write is issued.
+const REPIN_EPSILON_PX = 1;
 
 export interface ScrollMetrics {
   scrollTop: number;
   scrollHeight: number;
   clientHeight: number;
+}
+
+// One read of the scroller's geometry per tick, shared by the tick's decision and the
+// prepend snapshot it leaves behind, so the two can never disagree.
+export function captureMetrics(el: ScrollMetrics): ScrollMetrics {
+  return {
+    scrollTop: el.scrollTop,
+    scrollHeight: el.scrollHeight,
+    clientHeight: el.clientHeight,
+  };
 }
 
 export function distanceFromEnd(metrics: ScrollMetrics): number {
@@ -70,7 +83,46 @@ export function onScrollTick(
       !atEnd &&
       metrics.scrollTop < metrics.clientHeight * LOAD_OLDER_SCREENS,
     nearTop,
-    latch: { following: false, lastDistance: distance },
+    latch: IDLE_LATCH,
+  };
+}
+
+// A content resize fires no scroll event, so it gets its own decision: land or re-aim a
+// mid-flight follow (growth moves the target, and an animation that lands short would
+// wedge the latch forever), re-pin a pinned viewport the growth pushed off the end, or
+// recompute the pinned flag from the new geometry.
+export interface ResizeTick {
+  // null = leave the pinned state unchanged.
+  atBottom: boolean | null;
+  // Scroll to the end: an instant jump keeps a pinned viewport hugging the latest
+  // message; a smooth restart re-aims a mid-flight follow. null = stay put.
+  scrollToEnd: "instant" | "smooth" | null;
+  latch: FollowLatch;
+}
+
+export function onResizeTick(
+  metrics: ScrollMetrics,
+  latch: FollowLatch,
+  atBottom: boolean,
+): ResizeTick {
+  const distance = distanceFromEnd(metrics);
+  if (latch.following) {
+    if (distance <= AT_BOTTOM_THRESHOLD_PX) {
+      return { atBottom: true, scrollToEnd: null, latch: IDLE_LATCH };
+    }
+    return {
+      atBottom: null,
+      scrollToEnd: "smooth",
+      latch: startFollow(metrics),
+    };
+  }
+  if (atBottom && distance > REPIN_EPSILON_PX) {
+    return { atBottom: null, scrollToEnd: "instant", latch };
+  }
+  return {
+    atBottom: distance <= AT_BOTTOM_THRESHOLD_PX,
+    scrollToEnd: null,
+    latch,
   };
 }
 
@@ -82,13 +134,25 @@ export interface PrependSnapshot {
   scrollHeight: number;
 }
 
-export function isPrepend(
+// Position across a data change. Ordering is the subtle part: older rows landing above
+// the viewport (grown list, new first row) demand the exact restore even while pinned —
+// following there would fling the viewport past the history the user was reading. The
+// first page lands hard on the latest message; appends follow smoothly only while pinned.
+export type RowsChangeAction = "restore" | "jump" | "follow" | "none";
+
+export function onRowsChange(
   prevFirstKey: string | null,
   firstKey: string | null,
   prevCount: number,
   count: number,
-): boolean {
-  return prevCount > 0 && count > prevCount && firstKey !== prevFirstKey;
+  atBottom: boolean,
+): RowsChangeAction {
+  if (prevCount > 0 && count > prevCount && firstKey !== prevFirstKey) {
+    return "restore";
+  }
+  if (count > 0 && prevCount === 0) return "jump";
+  if (count > prevCount && atBottom) return "follow";
+  return "none";
 }
 
 export function restoredScrollTop(

--- a/apps/web/src/components/Chat/ChatMessageArea/use-chat-scroll.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/use-chat-scroll.ts
@@ -1,0 +1,153 @@
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import {
+  AT_BOTTOM_THRESHOLD_PX,
+  IDLE_LATCH,
+  isPrepend,
+  onScrollTick,
+  restoredScrollTop,
+  startFollow,
+  type FollowLatch,
+  type PrependSnapshot,
+} from "./scroll";
+
+interface ChatScrollArgs {
+  parentRef: RefObject<HTMLDivElement | null>;
+  count: number;
+  firstKey: string | null;
+  bottomInset: number;
+  hasMore: boolean;
+  loadingMore: boolean;
+  loadMore: () => void;
+  // Fires when pinned-to-latest flips; drives the parent's scroll-to-bottom button.
+  onAtBottomChange: (atBottom: boolean) => void;
+}
+
+// The one owner of the chat scroller's position: land the first page on the latest
+// message, keep the prepended-history viewport still, follow appends while pinned,
+// clear the composer inset, and track the pinned flag the button renders from.
+export function useChatScroll({
+  parentRef,
+  count,
+  firstKey,
+  bottomInset,
+  hasMore,
+  loadingMore,
+  loadMore,
+  onAtBottomChange,
+}: ChatScrollArgs) {
+  // True while pinned near the latest message, false once the user scrolls up.
+  // Recomputed on scroll and on content resize; the parent is notified only on change.
+  const atBottomRef = useRef(true);
+  const latchRef = useRef<FollowLatch>(IDLE_LATCH);
+  // The scroll state as of the last scroll/resize tick. A prepend can only follow a
+  // load-more, and a load-more only fires from a scroll tick, so this is always the
+  // pre-prepend state the restore needs — captured in event handlers, never in render.
+  const lastTickRef = useRef<PrependSnapshot>({
+    scrollTop: 0,
+    scrollHeight: 0,
+  });
+  const prevFirstKeyRef = useRef<string | null>(null);
+  const prevCountRef = useRef(0);
+  // True while the user sits at the very top of loaded history. Preloading means a fetch
+  // usually finishes before they get here; the loading pill shows only when it didn't.
+  const [nearTop, setNearTop] = useState(false);
+  const setAtBottom = useCallback(
+    (pinned: boolean) => {
+      if (atBottomRef.current === pinned) return;
+      atBottomRef.current = pinned;
+      onAtBottomChange(pinned);
+    },
+    [onAtBottomChange],
+  );
+
+  // Position the scroller across data changes, before paint.
+  useLayoutEffect(() => {
+    const el = parentRef.current;
+    if (el) {
+      const prepend = isPrepend(
+        prevFirstKeyRef.current,
+        firstKey,
+        prevCountRef.current,
+        count,
+      );
+      if (prepend) {
+        el.scrollTop = restoredScrollTop(lastTickRef.current, el.scrollHeight);
+      } else if (count > 0 && prevCountRef.current === 0) {
+        el.scrollTop = el.scrollHeight;
+      } else if (count > prevCountRef.current && atBottomRef.current) {
+        el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+        latchRef.current = startFollow(el);
+      }
+      lastTickRef.current = {
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+      };
+    }
+    prevFirstKeyRef.current = firstKey;
+    prevCountRef.current = count;
+  }, [count, firstKey, parentRef]);
+
+  // The composer inset lands after the initial end-jump (its ResizeObserver is async) and
+  // changes while a multi-line draft grows; while pinned, keep the latest message clear of it.
+  useLayoutEffect(() => {
+    const el = parentRef.current;
+    if (el && atBottomRef.current) el.scrollTop = el.scrollHeight;
+  }, [bottomInset, parentRef]);
+
+  const handleScroll = useCallback(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    const tick = onScrollTick(el, latchRef.current, hasMore && !loadingMore);
+    latchRef.current = tick.latch;
+    lastTickRef.current = {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+    };
+    setNearTop(tick.nearTop);
+    if (tick.atBottom !== null) setAtBottom(tick.atBottom);
+    if (tick.loadOlder) loadMore();
+  }, [hasMore, loadingMore, loadMore, setAtBottom, parentRef]);
+
+  // "At bottom" depends on content height, not just scroll position: growth beneath a pinned
+  // viewport (a rewrap on resize, late fonts) moves the end without firing a scroll event.
+  // Re-pin, unless a follow animation is mid-flight and already owns the position.
+  useLayoutEffect(() => {
+    const el = parentRef.current;
+    const content = el?.firstElementChild;
+    if (!el || !content) return;
+    const ro = new ResizeObserver(() => {
+      if (latchRef.current.following) return;
+      const dist = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (atBottomRef.current && dist > 1) {
+        el.scrollTop = el.scrollHeight;
+      } else {
+        setAtBottom(dist <= AT_BOTTOM_THRESHOLD_PX);
+      }
+      lastTickRef.current = {
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+      };
+    });
+    ro.observe(content);
+    return () => ro.disconnect();
+  }, [setAtBottom, parentRef]);
+
+  const scrollToBottom = useCallback(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+    latchRef.current = startFollow(el);
+  }, [parentRef]);
+
+  return {
+    handleScroll,
+    scrollToBottom,
+    waitingForOlder: loadingMore && nearTop,
+  };
+}

--- a/apps/web/src/components/Chat/ChatMessageArea/use-chat-scroll.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/use-chat-scroll.ts
@@ -6,9 +6,10 @@ import {
   type RefObject,
 } from "react";
 import {
-  AT_BOTTOM_THRESHOLD_PX,
   IDLE_LATCH,
-  isPrepend,
+  captureMetrics,
+  onResizeTick,
+  onRowsChange,
   onScrollTick,
   restoredScrollTop,
   startFollow,
@@ -21,6 +22,8 @@ interface ChatScrollArgs {
   count: number;
   firstKey: string | null;
   bottomInset: number;
+  // A tall draft's extra scroll range, rendered outside the resize-observed content.
+  bottomOverhang: number;
   hasMore: boolean;
   loadingMore: boolean;
   loadMore: () => void;
@@ -36,6 +39,7 @@ export function useChatScroll({
   count,
   firstKey,
   bottomInset,
+  bottomOverhang,
   hasMore,
   loadingMore,
   loadMore,
@@ -66,28 +70,26 @@ export function useChatScroll({
     [onAtBottomChange],
   );
 
-  // Position the scroller across data changes, before paint.
+  // Position the scroller across data changes, before paint; onRowsChange decides.
   useLayoutEffect(() => {
     const el = parentRef.current;
     if (el) {
-      const prepend = isPrepend(
+      const action = onRowsChange(
         prevFirstKeyRef.current,
         firstKey,
         prevCountRef.current,
         count,
+        atBottomRef.current,
       );
-      if (prepend) {
+      if (action === "restore") {
         el.scrollTop = restoredScrollTop(lastTickRef.current, el.scrollHeight);
-      } else if (count > 0 && prevCountRef.current === 0) {
+      } else if (action === "jump") {
         el.scrollTop = el.scrollHeight;
-      } else if (count > prevCountRef.current && atBottomRef.current) {
+      } else if (action === "follow") {
         el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
         latchRef.current = startFollow(el);
       }
-      lastTickRef.current = {
-        scrollTop: el.scrollTop,
-        scrollHeight: el.scrollHeight,
-      };
+      lastTickRef.current = captureMetrics(el);
     }
     prevFirstKeyRef.current = firstKey;
     prevCountRef.current = count;
@@ -100,15 +102,25 @@ export function useChatScroll({
     if (el && atBottomRef.current) el.scrollTop = el.scrollHeight;
   }, [bottomInset, parentRef]);
 
+  // The draft overhang grows the scroll range from outside the observed content div, so
+  // neither a scroll nor a resize tick fires: refresh the prepend snapshot here, or a
+  // later restore would replay the overhang's growth as if a prepend added it.
+  useLayoutEffect(() => {
+    const el = parentRef.current;
+    if (el) lastTickRef.current = captureMetrics(el);
+  }, [bottomOverhang, parentRef]);
+
   const handleScroll = useCallback(() => {
     const el = parentRef.current;
     if (!el) return;
-    const tick = onScrollTick(el, latchRef.current, hasMore && !loadingMore);
+    const metrics = captureMetrics(el);
+    const tick = onScrollTick(
+      metrics,
+      latchRef.current,
+      hasMore && !loadingMore,
+    );
     latchRef.current = tick.latch;
-    lastTickRef.current = {
-      scrollTop: el.scrollTop,
-      scrollHeight: el.scrollHeight,
-    };
+    lastTickRef.current = metrics;
     setNearTop(tick.nearTop);
     if (tick.atBottom !== null) setAtBottom(tick.atBottom);
     if (tick.loadOlder) loadMore();
@@ -116,23 +128,21 @@ export function useChatScroll({
 
   // "At bottom" depends on content height, not just scroll position: growth beneath a pinned
   // viewport (a rewrap on resize, late fonts) moves the end without firing a scroll event.
-  // Re-pin, unless a follow animation is mid-flight and already owns the position.
+  // onResizeTick decides: re-pin, land or re-aim a mid-flight follow, or recompute the flag.
   useLayoutEffect(() => {
     const el = parentRef.current;
     const content = el?.firstElementChild;
     if (!el || !content) return;
     const ro = new ResizeObserver(() => {
-      if (latchRef.current.following) return;
-      const dist = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (atBottomRef.current && dist > 1) {
-        el.scrollTop = el.scrollHeight;
-      } else {
-        setAtBottom(dist <= AT_BOTTOM_THRESHOLD_PX);
+      let metrics = captureMetrics(el);
+      const tick = onResizeTick(metrics, latchRef.current, atBottomRef.current);
+      latchRef.current = tick.latch;
+      if (tick.scrollToEnd) {
+        el.scrollTo({ top: el.scrollHeight, behavior: tick.scrollToEnd });
+        metrics = captureMetrics(el);
       }
-      lastTickRef.current = {
-        scrollTop: el.scrollTop,
-        scrollHeight: el.scrollHeight,
-      };
+      if (tick.atBottom !== null) setAtBottom(tick.atBottom);
+      lastTickRef.current = metrics;
     });
     ro.observe(content);
     return () => ro.disconnect();

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -25,7 +25,7 @@ import { ChatComposer } from "./ChatComposer";
 import { ChatHeaderActions } from "./ChatHeaderActions";
 import { ChatMessageArea, type ChatScrollHandle } from "./ChatMessageArea";
 import { useChatKeyboardFocus } from "./use-chat-keyboard-focus";
-import { agentNeedsUser } from "@vesta/core";
+import { TRIM_HISTORY_SETTLE_MS, agentNeedsUser } from "@vesta/core";
 
 // Breathing room between the last bubble and the floating composer, folded into
 // the inset so the message list, skeleton, mask, and button all clear it.
@@ -63,12 +63,19 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     hasMore,
     loadingMore,
     loadMore,
+    trimHistory,
     send,
     retry,
   } = useAgentSocket();
 
   const [input, setInput] = useState("");
   const [atBottom, setAtBottom] = useState(true);
+
+  useEffect(() => {
+    if (!atBottom) return;
+    const timer = window.setTimeout(trimHistory, TRIM_HISTORY_SETTLE_MS);
+    return () => window.clearTimeout(timer);
+  }, [atBottom, trimHistory]);
 
   useEffect(() => {
     registerChatCallbacks(send, setInput);

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -125,6 +125,11 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     scrollRef.current?.scrollToBottom();
   }, []);
 
+  // Stable so ChatMessageArea's memo holds across per-keystroke composer re-renders.
+  const handleLoadMore = useCallback(() => {
+    void loadMore();
+  }, [loadMore]);
+
   const handleSend = () => {
     const text = input.trim();
     if (!text) return;
@@ -171,9 +176,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
 
         <ChatMessageArea
           scrollRef={scrollRef}
-          loadMore={() => {
-            void loadMore();
-          }}
+          loadMore={handleLoadMore}
           fullscreen={fullscreen}
           navbarHeight={navbarHeight}
           loadingMore={loadingMore}

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -89,10 +89,14 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   // its live height plus the gap at the bottom so the last one always clears it,
   // and the scroll-to-bottom button parks just above it.
   const [composerInset, setComposerInset] = useState(0);
+  const [composerHeight, setComposerHeight] = useState(0);
   // The inset tracks the composer's collapsed baseline only: a growing draft
   // expands the pill over the (masked, opaque-covered) list instead of shifting
   // it, so measurements while a draft exists are ignored (a cleared inset, 0,
-  // always applies); send clears the draft and the next resize re-syncs.
+  // always applies); send clears the draft and the next resize re-syncs. The
+  // live height is tracked separately: its overhang beyond the baseline extends
+  // the message list's scroll range, so the bubbles a tall draft covers stay
+  // reachable by scrolling without the list ever shifting under the typist.
   const hasDraftRef = useRef(false);
   useLayoutEffect(() => {
     hasDraftRef.current = input.length > 0;
@@ -100,6 +104,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   const composerRef = useMeasuredSize(
     "height",
     useCallback((height: number) => {
+      setComposerHeight(height);
       if (height === 0 || !hasDraftRef.current) setComposerInset(height);
     }, []),
   );
@@ -185,6 +190,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
             composerInset +
             (fullscreen ? COMPOSER_GAP_FULLSCREEN_PX : COMPOSER_GAP_PANEL_PX)
           }
+          bottomOverhang={Math.max(0, composerHeight - composerInset)}
           onAtBottomChange={setAtBottom}
         />
 

--- a/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
+++ b/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
@@ -8,6 +8,7 @@ import type {
 } from "@vesta/core";
 import {
   PACING,
+  TRIM_HISTORY_KEEP,
   beginSend,
   commitPacedChat,
   createChatSocket,
@@ -17,6 +18,7 @@ import {
   prependPage,
   seedTail,
   sendMessage,
+  trimTail,
   typingDelay,
 } from "@vesta/core";
 import { useController } from "@/providers/ControllerProvider";
@@ -268,6 +270,13 @@ export function useAgentSocketState({
 
   const hasMore = state.cursor !== null;
 
+  // Skipped while a load is in flight: trimming under an unresolved prepend would leave a hole
+  // between the landed page and the kept tail.
+  const trimHistory = useCallback(() => {
+    if (loadingMoreRef.current) return;
+    commit((current) => trimTail(current, TRIM_HISTORY_KEEP));
+  }, [commit]);
+
   const loadMore = useCallback(async () => {
     if (!name || loadingMoreRef.current || stateRef.current.cursor === null)
       return;
@@ -297,6 +306,7 @@ export function useAgentSocketState({
     hasMore,
     loadingMore,
     loadMore,
+    trimHistory,
     send,
     retry,
   };

--- a/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
+++ b/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
@@ -8,7 +8,6 @@ import type {
 } from "@vesta/core";
 import {
   PACING,
-  TRIM_HISTORY_KEEP,
   beginSend,
   commitPacedChat,
   createChatSocket,
@@ -274,7 +273,7 @@ export function useAgentSocketState({
   // between the landed page and the kept tail.
   const trimHistory = useCallback(() => {
     if (loadingMoreRef.current) return;
-    commit((current) => trimTail(current, TRIM_HISTORY_KEEP));
+    commit((current) => trimTail(current));
   }, [commit]);
 
   const loadMore = useCallback(async () => {


### PR DESCRIPTION
## Summary

Fixes the chat scroll jank on web/desktop (first scroll on a fresh agent, and every load-more) by removing the cause instead of patching it: the virtualizer's remount tax. Rows now stay mounted, so each message parses its markdown once, ever, and scrolling moves static DOM.

- **Drop `@tanstack/react-virtual`** (the chat was its only consumer). The measure-and-correct machinery (size estimates, overscan, absolute row positioning, re-pin races) goes with it. The Console already made this same call for the same reason.
- **One owner for scroll position** (`use-chat-scroll`): the first page lands on the latest message before paint; prepends restore exactly from the last scroll tick (a prepend can only follow a load-more, and a load-more only fires from a scroll tick), with `overflow-anchor: none` so the browser can't double-compensate; appends follow smoothly while pinned behind a follow latch that keeps the scroll-to-bottom button from flashing.
- **Pure decision logic in `scroll.ts`**, TDD'd: pinned tracking, follow latch, load-older trigger, prepend restore math.
- **Preload margin**: older history starts fetching within 3 viewport heights of the top, so the page lands before the user reaches it; the loading pill shows only when the user actually outruns the fetch, and wears the composer's chrome (`border-border bg-popover shadow-sm`).
- **History trim (`trimTail` in `@vesta/core`)**: chat views outlive navigation (web pages hide instead of unmounting; the mobile hold persists the tail across screen pops), so paged-in history used to accumulate for the whole session. After 30s settled at the latest message, the tail trims to two pages, restoring the cursor so `loadMore` refetches exactly what was dropped. Wired on web and mobile; policy constants owned by core.
- Mobile keeps its inverted `FlatList`: RN scrolling is native-thread with async rendering, so virtualization is the right call there; the trim is what mobile needed.

## Testing

- `check.sh app-core` (390 tests, incl. 4 new `trimTail` cases), `app-web` (349, incl. 14 new `scroll.ts` cases), `app-desktop`, `app-visual`, `app-mobile` all green.
- Verified live in the Electron dev app: first scroll, load-more viewport stability, pinned follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)