### PR TITLE
fix(web): rebuild the sync controller when an effect remount closes it

### DIFF
--- a/apps/web/src/providers/ControllerProvider/index.test.tsx
+++ b/apps/web/src/providers/ControllerProvider/index.test.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from "react";
+import { StrictMode, useContext, useEffect } from "react";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import {
   afterAll,
@@ -102,6 +102,12 @@ const appBehindHelloFrame = JSON.stringify({
 const gatewayBehindHelloFrame = JSON.stringify({
   type: "hello",
   version: "0.0.1",
+  min_supported: "0.0.0",
+});
+// A window containing the client (__CLIENT_VERSION__), so the socket proceeds to "open".
+const openHelloFrame = JSON.stringify({
+  type: "hello",
+  version: "9.9.9",
   min_supported: "0.0.0",
 });
 const snapshotFrame = JSON.stringify({
@@ -266,6 +272,40 @@ describe("ControllerProvider", () => {
           (frame) => (JSON.parse(frame) as { type: string }).type === "reauth",
         ),
       ).toBe(true);
+    });
+  });
+
+  // StrictMode's double effect pass (setup, cleanup, setup with preserved state) is the same
+  // sequence React Fast Refresh runs on a hot update, so this pins the dev-mode bug where a
+  // hot reload closed the state-held controller for good and /sync never reconnected.
+  it("keeps a live controller across an effect remount (StrictMode / Fast Refresh)", async () => {
+    let controller: Controller | null = null;
+
+    render(
+      <StrictMode>
+        <ControllerProvider>
+          <Probe
+            onReady={(c) => {
+              controller = c;
+            }}
+          />
+        </ControllerProvider>
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances.length).toBeGreaterThan(0);
+    });
+    const socket = FakeWebSocket.instances.at(-1);
+    if (!socket) throw new Error("socket not constructed");
+
+    act(() => {
+      socket.onopen?.();
+      socket.onmessage?.({ data: openHelloFrame });
+    });
+
+    await waitFor(() => {
+      expect(controller?.getSyncState()).toBe("open");
     });
   });
 

--- a/apps/web/src/providers/ControllerProvider/index.tsx
+++ b/apps/web/src/providers/ControllerProvider/index.tsx
@@ -59,23 +59,40 @@ function ActiveController({ children }: { children: ReactNode }) {
   );
 }
 
-// One live controller for the lifetime of a session mount. Built once via a lazy useState
-// initializer (run exactly once per mount and never discarded, so it avoids the
-// useMemo-side-effect-in-render caveat), closed on unmount. Reauth rotates the socket's token
-// in-band before it expires; the overlay tracks the sync sub-store. Like mobile, the desktop
-// app is a drifting client: it opens /sync and the served version window (min_supported..version)
-// decides compatibility. GatewayProvider turns incompatible states into blocking screens while
-// keeping the gateway context mounted for their shared UI.
+// One live controller for the lifetime of a session mount, created by the effect whose cleanup
+// closes it so the two lifetimes cannot diverge: Fast Refresh and StrictMode re-run effects
+// while preserving state, and a render-owned controller would be closed by the re-run's cleanup
+// and stranded terminal (sync state "closed", which never reconnects). Here the re-run builds a
+// live replacement instead. Children wait out the one pre-effect render with no controller.
 function ControllerSession({ children }: { children: ReactNode }) {
-  const [controller] = useState(buildController);
-  const syncState = useSyncState(controller);
-  const [showDisconnected, setShowDisconnected] = useState(false);
+  const [controller, setController] = useState<Controller | null>(null);
 
   useEffect(() => {
+    const created = buildController();
+    setController(created);
     return () => {
-      controller.close();
+      created.close();
     };
-  }, [controller]);
+  }, []);
+
+  if (controller === null) return null;
+  return <LiveSession controller={controller}>{children}</LiveSession>;
+}
+
+// Reauth rotates the socket's token in-band before it expires; the overlay tracks the sync
+// sub-store. Like mobile, the desktop app is a drifting client: it opens /sync and the served
+// version window (min_supported..version) decides compatibility. GatewayProvider turns
+// incompatible states into blocking screens while keeping the gateway context mounted for
+// their shared UI.
+function LiveSession({
+  controller,
+  children,
+}: {
+  controller: Controller;
+  children: ReactNode;
+}) {
+  const syncState = useSyncState(controller);
+  const [showDisconnected, setShowDisconnected] = useState(false);
 
   useEffect(() => {
     // Also on mount, not just every poll: a session restored with an already-expired token


### PR DESCRIPTION
## Problem

During dev, a hot reload could kill the gateway connection for good: the red pill turned on, message send stayed gated, and only an app relaunch recovered it. Everything else (chat, logs, dashboard, cached roster) kept working, so the app looked healthy while `/sync` was dead.

## Root cause

`ControllerSession` built its controller in a `useState` initializer and closed it in an effect cleanup. React Fast Refresh (and StrictMode) re-runs effects while preserving state: the re-run's cleanup called `controller.close()`, which is terminal (`SyncState` "closed" never reconnects), and the preserved state kept handing out that same dead controller. "closed" renders no `DisconnectedOverlay` (it only shows for connecting/reconnecting), so the failure was silent apart from the pill. The only revive path was the gateway-update epoch bump, which no user-facing control reaches.

## Fix

The effect now owns the controller lifetime end to end: it builds the controller, stores it in state, and its cleanup closes that same instance. An effect re-run closes the old controller and builds a live replacement. The hooks that need a non-null controller moved to an inner `LiveSession` component behind a null gate. This is the same shape mobile's `ControllerProvider` already uses, so web and mobile now match.

## Test

New regression test mounts the provider in `StrictMode`, whose setup/cleanup/setup pass is the same sequence Fast Refresh runs. It failed on the old code with sync state `closed` and now reaches `open`. `./check.sh app-web` is green (333 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)