### PR TITLE
fix(ci): drop the Enterprise-only TestFlight changelog from mobile delivery

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -308,10 +308,7 @@ jobs:
         working-directory: apps/mobile
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-          RELEASE_BODY: ${{ github.event.release.body }}
-        run: |
-          CHANGELOG=$(printf '%s\n' "$RELEASE_BODY" | sed -n '/<!-- whats-new -->/,/<!-- \/whats-new -->/p' | sed '1d;$d')
-          ./scripts/deliver-mobile.sh --platform ios --profile production --changelog "$CHANGELOG" --submit
+        run: ./scripts/deliver-mobile.sh --platform ios --profile production --submit
 
   mobile-android:
     name: Mobile · Build and attach Android APK

--- a/apps/mobile/scripts/deliver-mobile.sh
+++ b/apps/mobile/scripts/deliver-mobile.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'EOF'
-Usage: deliver-mobile.sh --platform ios|android --profile <name> [--changelog <text>] [--submit]
+Usage: deliver-mobile.sh --platform ios|android --profile <name> [--submit]
 
 Requires EXPO_TOKEN in the environment (EAS remote credentials, and submit).
 Prints the built artifact's absolute path on stdout on success.
@@ -18,13 +18,11 @@ EOF
 
 PLATFORM=""
 PROFILE=""
-CHANGELOG=""
 SUBMIT=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --platform) PLATFORM="${2:-}"; shift 2 ;;
     --profile) PROFILE="${2:-}"; shift 2 ;;
-    --changelog) CHANGELOG="${2:-}"; shift 2 ;;
     --submit) SUBMIT=1; shift ;;
     *) echo "unknown argument: $1" >&2; usage ;;
   esac
@@ -55,11 +53,15 @@ npx --yes eas-cli@latest build \
   --non-interactive \
   --output "$output" >&2
 
+# No --what-to-test: setting the TestFlight changelog through EAS Submit is an
+# Enterprise-plan feature, and passing it fails the whole submission.
 if [ "$PLATFORM" = ios ] && [ "$SUBMIT" = 1 ]; then
   echo "Submitting the iOS build to TestFlight..." >&2
-  submit_args=(--platform ios --path "$output" --profile "$PROFILE" --non-interactive)
-  [ -n "$CHANGELOG" ] && submit_args+=(--what-to-test "$CHANGELOG")
-  npx --yes eas-cli@latest submit "${submit_args[@]}" >&2
+  npx --yes eas-cli@latest submit \
+    --platform ios \
+    --path "$output" \
+    --profile "$PROFILE" \
+    --non-interactive >&2
 fi
 
 echo "$output"


### PR DESCRIPTION
## Why

Both v0.2.11 delivery attempts reverted on the iOS job. The build succeeded every time; `eas submit` then died with the generic `Error: GraphQL request failed.`. Reproducing the submit with `EXPO_DEBUG=1` surfaced the real server error:

> `[GraphQL] This submission specified the 'changelog' parameter. Changelog submission is currently available for Enterprise plan only.`

`deliver-mobile.sh` passed `--what-to-test "$CHANGELOG"`, which sets TestFlight's "What to test" through EAS Submit — an Enterprise-plan feature. An A/B submit of the same archive with and without the flag confirms it: without → scheduled; with → this exact failure. The previous EAS cloud workflow passed the changelog only as the *build* message (a dashboard annotation), never as `--what-to-test`, so nothing is lost by dropping it.

## What

- `deliver-mobile.sh`: remove the `--changelog` flag and the `--what-to-test` submit argument (a comment records the constraint so it does not come back).
- `release-pipeline.yml` `mobile-ios`: drop the release-body changelog extraction; call the script without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)