### PR TITLE
ci(mobile): give the Android build a real budget and a gradle cache

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -1,5 +1,11 @@
 name: Mobile build
 
+# Manual mobile delivery on GitHub-hosted runners through the same
+# apps/mobile/scripts/deliver-mobile.sh the release pipeline runs (eas build
+# --local, signing from EAS remote credentials). Dispatch with a tag ref plus
+# attach_to_release to rebuild one platform for an existing release, e.g. after
+# a delivery job died mid-pipeline.
+
 on:
   workflow_dispatch:
     inputs:
@@ -7,23 +13,38 @@ on:
         description: Platform to build
         type: choice
         required: true
-        default: all
+        default: android
         options:
-          - all
           - ios
           - android
       profile:
         description: EAS build profile
         type: choice
         required: true
-        default: preview
+        default: android-internal
         options:
           - development
           - preview
           - production
+          - android-internal
+      ref:
+        description: Tag or ref to build (defaults to the dispatched branch)
+        type: string
+        required: false
+        default: ""
+      submit:
+        description: Submit the iOS build to TestFlight
+        type: boolean
+        required: true
+        default: false
+      attach_to_release:
+        description: Release tag to attach the Android APK to (vesta-android.apk)
+        type: string
+        required: false
+        default: ""
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: mobile-build-${{ inputs.platform }}-${{ inputs.profile }}
@@ -32,12 +53,12 @@ concurrency:
 jobs:
   build:
     name: Mobile · Build (${{ inputs.platform }}, ${{ inputs.profile }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      EXPO_PUBLIC_EAS_PROJECT_ID: ${{ vars.EXPO_PROJECT_ID }}
+    runs-on: ${{ inputs.platform == 'ios' && 'macos-latest' || 'ubuntu-latest' }}
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - uses: actions/setup-node@v7
         with:
@@ -45,19 +66,34 @@ jobs:
           cache: npm
           cache-dependency-path: apps/package-lock.json
 
-      - name: Install dependencies
+      - uses: actions/cache@v4
+        if: inputs.platform == 'android'
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('apps/package-lock.json') }}
+          restore-keys: gradle-${{ runner.os }}-
+
+      - name: Install app deps
         run: npm --prefix apps ci
 
-      - name: Validate mobile app
-        run: ./check.sh app-mobile
-
-      - name: Set up EAS
-        uses: expo/expo-github-action@v9
-        with:
-          eas-version: latest
-          packager: npm
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Queue EAS build
+      - name: Build on this runner
+        id: build
         working-directory: apps/mobile
-        run: eas build --platform "${{ inputs.platform }}" --profile "${{ inputs.profile }}" --non-interactive --no-wait
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          args=(--platform "${{ inputs.platform }}" --profile "${{ inputs.profile }}")
+          [ "${{ inputs.submit }}" = "true" ] && args+=(--submit)
+          artifact=$(./scripts/deliver-mobile.sh "${args[@]}")
+          echo "artifact=$artifact" >> "$GITHUB_OUTPUT"
+
+      - name: Attach the Android APK to the release
+        if: inputs.platform == 'android' && inputs.attach_to_release != ''
+        working-directory: apps/mobile
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cp "${{ steps.build.outputs.artifact }}" vesta-android.apk
+          gh release upload "${{ inputs.attach_to_release }}" vesta-android.apk --clobber

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -319,13 +319,23 @@ jobs:
       ${{ !failure() && !cancelled() &&
       contains(github.event.release.body, '<!-- mobile-delivery: testflight -->') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # A cold gradle release build overruns 60 minutes on the hosted runner; the
+    # cache below brings warm builds well under it.
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v7
         with:
           node-version: 22
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('apps/package-lock.json') }}
+          restore-keys: gradle-${{ runner.os }}-
 
       - name: Install app deps
         run: npm --prefix apps ci


### PR DESCRIPTION
## Why

v0.2.11 attempt 4: iOS built and submitted to TestFlight (the #2239 fix works), but the Android job hit its **60-minute `timeout-minutes` mid-gradle** — a cold RN release build overruns it on the hosted runner. The cancellation ended the run as `cancelled` (so the revert was skipped and the release survived), but `vesta-android.apk` never got attached.

## What

- `release-pipeline.yml` `mobile-android`: `timeout-minutes` 60 → 120, plus an `actions/cache` on `~/.gradle` (keyed on `apps/package-lock.json`) so warm builds land far under the old budget.
- `mobile-build.yml` (manual dispatch): reworked onto the same local-build path — `deliver-mobile.sh` on a hosted runner (macOS for iOS, ubuntu for Android), with a `ref` input and an `attach_to_release` input so one dispatch can rebuild a platform for an existing release. The old job queued an EAS **cloud** build, which the plan's quota blocks.

## Follow-up once merged

Dispatch `mobile-build.yml` with `platform=android, profile=android-internal, ref=v0.2.11, attach_to_release=v0.2.11` to attach the missing APK to the live prerelease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)