### PR TITLE
ci(release): revert on a cancelled delivery job too

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -364,7 +364,9 @@ jobs:
         mobile-ios,
         mobile-android,
       ]
-    if: ${{ failure() }}
+    # cancelled() too: a job that overruns timeout-minutes concludes cancelled,
+    # not failed, and a half-delivered release must revert either way.
+    if: ${{ failure() || cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Why

The release pipeline's atomicity has a hole: `revert-failed-release` is guarded by `if: ${{ failure() }}`, but a job that overruns its `timeout-minutes` concludes **cancelled**, not failed — `cancelled()` becomes true, `failure()` does not. v0.2.11 attempt 4 hit exactly this: the Android job timed out mid-gradle, the revert was skipped, and a half-delivered release stayed up (recovered forward by hand).

## What

Guard the revert with `failure() || cancelled()`. Jobs guarded on `cancelled()` still run after a run cancellation (GitHub's documented cleanup pattern), so both a timed-out delivery job and a manually cancelled release run now revert cleanly, restoring "no release unless every job is good" with no exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)