### PR TITLE
ci(mobile): size the gradle daemon for the hosted runner

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -75,6 +75,14 @@ jobs:
           key: gradle-${{ runner.os }}-${{ hashFiles('apps/package-lock.json') }}
           restore-keys: gradle-${{ runner.os }}-
 
+      # The user-home gradle.properties overrides the Expo template's, whose
+      # 512m Metaspace cap OOMs the daemon on this build.
+      - name: Size the gradle daemon for the runner
+        if: inputs.platform == 'android'
+        run: |
+          mkdir -p ~/.gradle
+          printf 'org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1536m\n' >> ~/.gradle/gradle.properties
+
       - name: Install app deps
         run: npm --prefix apps ci
 

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -337,6 +337,13 @@ jobs:
           key: gradle-${{ runner.os }}-${{ hashFiles('apps/package-lock.json') }}
           restore-keys: gradle-${{ runner.os }}-
 
+      # The user-home gradle.properties overrides the Expo template's, whose
+      # 512m Metaspace cap OOMs the daemon on this build.
+      - name: Size the gradle daemon for the runner
+        run: |
+          mkdir -p ~/.gradle
+          printf 'org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1536m\n' >> ~/.gradle/gradle.properties
+
       - name: Install app deps
         run: npm --prefix apps ci
 


### PR DESCRIPTION
## Why

The v0.2.11 Android recovery build's live log shows the gradle daemon drowning in `java.lang.OutOfMemoryError: Metaspace` mid-compile. `expo prebuild` generates the project with the Expo template's `org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m`, far under what this module set (full Expo modules + KSP + Kotlin + New-Arch C++) needs on a 16 GB runner. The memory-starved daemon is also what dragged the earlier release build past its 60-minute budget.

## What

Gradle gives the user-home `gradle.properties` precedence over the project's, so both mobile workflows (`release-pipeline.yml` `mobile-android`, `mobile-build.yml`) write `-Xmx4096m -XX:MaxMetaspaceSize=1536m` to `~/.gradle/gradle.properties` before building. CI-only; no app files change, and a developer's own machine is untouched (the shared script never writes global gradle config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)