### PR TITLE
feat(web): autofocus the chat composer when chat is visible

### DIFF
--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -8,6 +8,7 @@ import {
   type ChangeEvent,
   type KeyboardEvent,
 } from "react";
+import { useLocation } from "react-router-dom";
 import { ArrowDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -25,6 +26,7 @@ import { ChatComposer } from "./ChatComposer";
 import { ChatHeaderActions } from "./ChatHeaderActions";
 import { ChatMessageArea, type ChatScrollHandle } from "./ChatMessageArea";
 import { useChatKeyboardFocus } from "./use-chat-keyboard-focus";
+import { agentSubpage } from "@/lib/agent-subpage";
 import { TRIM_HISTORY_SETTLE_MS, agentNeedsUser } from "@vesta/core";
 
 // Breathing room between the last bubble and the floating composer, folded into
@@ -84,6 +86,17 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   const scrollRef = useRef<ChatScrollHandle>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   useChatKeyboardFocus(textareaRef);
+
+  // Focus the composer whenever the chat becomes the visible surface: on mount,
+  // and again when a logs/settings subpage closes (the pane stays mounted, so a
+  // mount-time autofocus never refires). Skipped on mobile, where autofocus
+  // would raise the keyboard on every open. A fullscreen and a panel Chat can
+  // both be mounted; focus() is a no-op on the visibility-hidden one.
+  const { pathname } = useLocation();
+  useEffect(() => {
+    if (isMobile || agentSubpage(pathname, name) !== null) return;
+    textareaRef.current?.focus({ preventScroll: true });
+  }, [isMobile, pathname, name]);
 
   // Every chat floats the composer over the message list; the messages reserve
   // its live height plus the gap at the bottom so the last one always clears it,


### PR DESCRIPTION
## What

On the web and desktop app, the chat composer now takes focus as soon as the chat is the visible surface, so you can type right away without clicking into the field.

## How

One effect in `Chat` (`apps/web/src/components/Chat/index.tsx`) focuses `textareaRef`:

- **On mount**: initial load, agent switch, expanding the collapsed chat panel, opening fullscreen chat.
- **On subpage close**: returning from logs or settings. Those panes stay mounted (hidden), so a mount-time `autoFocus` never refires; the effect re-runs on the `pathname` change instead.
- **Mobile is excluded**: autofocus there would raise the keyboard on every open.
- **`preventScroll: true`**: no list jump when focus lands.

A fullscreen `Chat` and a split-panel `Chat` can both be mounted; the hidden one sits under `visibility: hidden`, where `focus()` is a browser no-op, so only the on-screen instance takes focus. A signed-out disabled textarea silently refuses focus.

## Testing

`./check.sh app-web` green (tsc, eslint, prettier, 356 tests).

Note: the composer now shows its focus ring on chat open, so the visual QA chat gallery shots pick up the ring on next capture. No drive assertions change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)