### PR TITLE
perf(web): window the log viewers to bound the DOM

### DIFF
--- a/apps/web/src/components/Console/index.tsx
+++ b/apps/web/src/components/Console/index.tsx
@@ -1,17 +1,9 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useSyncExternalStore,
-} from "react";
+import { useEffect, useRef, useSyncExternalStore } from "react";
 import { useLayout } from "@/stores/use-layout";
 import type { LogStreamState } from "@/lib/log-session";
+import { useLogWindow } from "@/lib/use-log-window";
 import { useAgentLogSession } from "@/providers/AgentLogStreamProvider";
 import { cn } from "@/lib/utils";
-
-// How close to the bottom still counts as pinned for follow-on-append.
-const AT_BOTTOM_THRESHOLD_PX = 80;
 
 const STREAM_NOTICE: Record<Exclude<LogStreamState, "live">, string> = {
   stopped: "— agent stopped —",
@@ -55,33 +47,13 @@ export function Console({ fullscreen }: { fullscreen?: boolean }) {
     session.start();
   }, [session]);
 
-  // Follow the tail unless the user has scrolled up; true whenever the list is (re)filled.
-  const pinnedRef = useRef(true);
   const parentRef = useRef<HTMLDivElement>(null);
-  const count = lines.length;
-  // `count` stops changing once the scrollback cap is full, but the tail still
-  // advances as old lines are dropped. Key follow-on-append to the newest line
-  // instead so a full console continues to follow live output.
-  const newestLineId = lines.at(-1)?.id;
-
-  useEffect(() => {
-    if (count === 0) pinnedRef.current = true;
-  }, [count]);
-
-  const updatePinned = useCallback(() => {
-    const el = parentRef.current;
-    if (!el) return;
-    pinnedRef.current =
-      el.scrollHeight - el.scrollTop - el.clientHeight <=
-      AT_BOTTOM_THRESHOLD_PX;
-  }, []);
-
-  // Follow the tail on append, and jump to the bottom when the buffered tail first
-  // lands or the list refills after an agent switch/resume, unless the user scrolled up.
-  useLayoutEffect(() => {
-    const el = parentRef.current;
-    if (el && count > 0 && pinnedRef.current) el.scrollTop = el.scrollHeight;
-  }, [count, newestLineId]);
+  const { visibleCount, onScroll } = useLogWindow({
+    parentRef,
+    count: lines.length,
+    newestId: lines.at(-1)?.id,
+  });
+  const visible = lines.slice(-visibleCount);
 
   const lineClass = cn(
     "break-words whitespace-pre-wrap",
@@ -98,7 +70,7 @@ export function Console({ fullscreen }: { fullscreen?: boolean }) {
       <div className="flex-1 min-h-0">
         <div
           ref={parentRef}
-          onScroll={updatePinned}
+          onScroll={onScroll}
           className="h-full overflow-y-auto overflow-x-hidden font-mono text-xs leading-[1.6] text-white/70"
           style={
             fullscreen
@@ -108,7 +80,7 @@ export function Console({ fullscreen }: { fullscreen?: boolean }) {
               : undefined
           }
         >
-          {count === 0 ? (
+          {lines.length === 0 ? (
             <StreamingPlaceholder state={streamState} />
           ) : (
             <>
@@ -121,12 +93,12 @@ export function Console({ fullscreen }: { fullscreen?: boolean }) {
               ) : (
                 <div className="h-6" />
               )}
-              {/* Every log line stays in the DOM (no windowing) so a native text selection
-                  survives scrolling and copies the full range. Rows must lay out for real,
-                  not behind a content-visibility size estimate: lines wrap to unpredictable
-                  heights, and an estimate makes scrollHeight shift mid-scroll, so scrolling
-                  jumps. */}
-              {lines.map((line) => (
+              {/* Only the tail window renders (useLogWindow); scrolling up grows it from the
+                  buffer and settling at the bottom trims it back, so the DOM stays bounded.
+                  Rows lay out for real, not behind a content-visibility size estimate: lines
+                  wrap to unpredictable heights, so an estimate would shift scrollHeight
+                  mid-scroll and make scrolling jump. */}
+              {visible.map((line) => (
                 <div
                   key={line.id}
                   className={lineClass}

--- a/apps/web/src/components/GatewayLogsViewer/index.tsx
+++ b/apps/web/src/components/GatewayLogsViewer/index.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Copy, RefreshCw } from "lucide-react";
 import { streamGatewayLogs, stopGatewayLogs } from "@/api/gateway";
+import { LOG_SCROLLBACK_LINES } from "@/lib/log-stream-policy";
+import { useLogWindow } from "@/lib/use-log-window";
 import {
   Dialog,
   DialogContent,
@@ -40,36 +42,52 @@ interface GatewayLogsViewerProps {
   onOpenChange: (open: boolean) => void;
 }
 
-const AUTOSCROLL_THRESHOLD_PX = 40;
 // Copy grabs only the most recent lines — enough to paste into a bug report without
 // dumping a whole follow session's worth of output.
 const COPY_TAIL_LINES = 200;
+
+interface GatewayLogLine {
+  id: number;
+  text: string;
+}
 
 export function GatewayLogsViewer({
   open,
   onOpenChange,
 }: GatewayLogsViewerProps) {
-  const [lines, setLines] = useState<string[]>([]);
+  const [lines, setLines] = useState<GatewayLogLine[]>([]);
   const [follow, setFollow] = useState(true);
   const [refreshEpoch, setRefreshEpoch] = useState(0);
-  const linesEndRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const shouldAutoScrollRef = useRef(true);
+  const nextIdRef = useRef(0);
+  const { visibleCount, onScroll } = useLogWindow({
+    parentRef: scrollRef,
+    count: lines.length,
+    newestId: lines.at(-1)?.id,
+  });
 
   useEffect(() => {
     if (!open) return;
     setLines([]);
-    shouldAutoScrollRef.current = true;
+    nextIdRef.current = 0;
     let active = true;
+
+    const append = (text: string) =>
+      setLines((prev) => {
+        const next = [...prev, { id: nextIdRef.current++, text }];
+        return next.length > LOG_SCROLLBACK_LINES
+          ? next.slice(-LOG_SCROLLBACK_LINES)
+          : next;
+      });
 
     const handleEvent = (event: LogEvent) => {
       if (!active) return;
       switch (event.kind) {
         case "Line":
-          setLines((prev) => [...prev, event.text]);
+          append(event.text);
           break;
         case "Error":
-          setLines((prev) => [...prev, event.message]);
+          append(event.message);
           break;
         case "End":
           break;
@@ -85,24 +103,16 @@ export function GatewayLogsViewer({
     };
   }, [open, follow, refreshEpoch]);
 
-  useEffect(() => {
-    if (shouldAutoScrollRef.current && linesEndRef.current) {
-      linesEndRef.current.scrollIntoView({ behavior: "auto" });
-    }
-  }, [lines]);
-
-  const handleScroll = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const dist = el.scrollHeight - el.scrollTop - el.clientHeight;
-    shouldAutoScrollRef.current = dist < AUTOSCROLL_THRESHOLD_PX;
-  }, []);
-
   const handleCopy = () => {
     void navigator.clipboard.writeText(
-      lines.slice(-COPY_TAIL_LINES).join("\n"),
+      lines
+        .slice(-COPY_TAIL_LINES)
+        .map((line) => line.text)
+        .join("\n"),
     );
   };
+
+  const visible = lines.slice(-visibleCount);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -133,13 +143,12 @@ export function GatewayLogsViewer({
           </div>
         </div>
 
-        <div ref={scrollRef} onScroll={handleScroll} style={styles.scroll}>
+        <div ref={scrollRef} onScroll={onScroll} style={styles.scroll}>
           {lines.length === 0 ? (
             <span style={styles.empty}>No logs yet.</span>
           ) : (
-            lines.map((line, index) => <LogLine key={index} text={line} />)
+            visible.map((line) => <LogLine key={line.id} text={line.text} />)
           )}
-          <div ref={linesEndRef} />
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/lib/log-window.test.ts
+++ b/apps/web/src/lib/log-window.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import {
+  AT_BOTTOM_THRESHOLD_PX,
+  BASE_WINDOW_LINES,
+  LOAD_OLDER_SCREENS,
+  WINDOW_STEP_LINES,
+  distanceFromEnd,
+  grownWindow,
+  isAtBottom,
+  shouldGrow,
+} from "./log-window";
+
+function metrics(scrollTop: number, scrollHeight = 20000, clientHeight = 600) {
+  return { scrollTop, scrollHeight, clientHeight };
+}
+
+describe("distanceFromEnd", () => {
+  it("measures the gap between the viewport bottom and the content end", () => {
+    expect(distanceFromEnd(metrics(19400))).toBe(0);
+    expect(distanceFromEnd(metrics(19000))).toBe(400);
+  });
+});
+
+describe("isAtBottom", () => {
+  it("counts a viewport within the threshold of the end as pinned", () => {
+    expect(isAtBottom(metrics(19400 - AT_BOTTOM_THRESHOLD_PX))).toBe(true);
+    expect(isAtBottom(metrics(19400 - AT_BOTTOM_THRESHOLD_PX - 1))).toBe(false);
+  });
+});
+
+describe("shouldGrow", () => {
+  it("grows when hidden lines remain and the user is within the preload margin", () => {
+    const nearTop = metrics(600 * LOAD_OLDER_SCREENS - 1);
+    expect(shouldGrow(nearTop, true)).toBe(true);
+  });
+
+  it("does not grow past the preload margin", () => {
+    const deep = metrics(600 * LOAD_OLDER_SCREENS + 1);
+    expect(shouldGrow(deep, true)).toBe(false);
+  });
+
+  it("does not grow when the whole buffer is already rendered", () => {
+    const nearTop = metrics(0);
+    expect(shouldGrow(nearTop, false)).toBe(false);
+  });
+});
+
+describe("grownWindow", () => {
+  it("adds one step", () => {
+    expect(grownWindow(BASE_WINDOW_LINES, 5000)).toBe(
+      BASE_WINDOW_LINES + WINDOW_STEP_LINES,
+    );
+  });
+
+  it("never renders more lines than the buffer holds", () => {
+    expect(grownWindow(4900, 5000)).toBe(5000);
+    expect(grownWindow(5000, 5000)).toBe(5000);
+  });
+});

--- a/apps/web/src/lib/log-window.ts
+++ b/apps/web/src/lib/log-window.ts
@@ -1,0 +1,48 @@
+// Pure decision logic for the log render window: how many lines to render, when to grow
+// the window as the user scrolls up, and whether the viewport sits at the tail. The Console
+// and the gateway log viewer share it so both bound the DOM the same way, without any list
+// virtualization. Kept separate from the hook so the decisions are unit-testable.
+
+// The tail the viewer renders before the user scrolls, and the size it trims back to after
+// settling at the bottom.
+export const BASE_WINDOW_LINES = 300;
+// Each grow renders this many more older lines from the buffer already in memory.
+export const WINDOW_STEP_LINES = 300;
+// Preload margin: within this many viewport heights of the top, the window grows, so more
+// lines land before the user reaches the top of the rendered range.
+export const LOAD_OLDER_SCREENS = 3;
+// How close to the bottom (px) still counts as pinned, driving follow-on-append and the trim.
+export const AT_BOTTOM_THRESHOLD_PX = 80;
+// How long the viewport must sit at the bottom before the grown window trims back to the base.
+export const SETTLE_MS = 30_000;
+
+export interface WindowMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+export function distanceFromEnd(metrics: WindowMetrics): number {
+  return metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight;
+}
+
+export function isAtBottom(metrics: WindowMetrics): boolean {
+  return distanceFromEnd(metrics) <= AT_BOTTOM_THRESHOLD_PX;
+}
+
+// Grow while older buffered lines remain unrendered and the viewport is within the preload
+// margin of the top. Growing before the top is reached keeps native scroll anchoring away
+// from scrollTop 0, where it stops holding position.
+export function shouldGrow(
+  metrics: WindowMetrics,
+  hasHidden: boolean,
+): boolean {
+  return (
+    hasHidden && metrics.scrollTop < metrics.clientHeight * LOAD_OLDER_SCREENS
+  );
+}
+
+// One step larger, never past the buffered line count.
+export function grownWindow(visibleCount: number, count: number): number {
+  return Math.min(count, visibleCount + WINDOW_STEP_LINES);
+}

--- a/apps/web/src/lib/use-log-window.ts
+++ b/apps/web/src/lib/use-log-window.ts
@@ -1,0 +1,82 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import {
+  BASE_WINDOW_LINES,
+  SETTLE_MS,
+  grownWindow,
+  isAtBottom,
+  shouldGrow,
+} from "./log-window";
+
+interface LogWindowArgs {
+  parentRef: RefObject<HTMLDivElement | null>;
+  // Total buffered lines. `slice(-visibleCount)` renders the tail window of them.
+  count: number;
+  // The newest line's id. At the scrollback cap `count` stops changing while the tail keeps
+  // advancing, so follow-on-append keys on this instead.
+  newestId: number | undefined;
+}
+
+// The one owner of the log scroller's window and position, shared by the Console and the
+// gateway log viewer. It renders only the tail window, grows it as the user scrolls up, and
+// trims it back once they settle at the bottom, so the DOM stays bounded with no list
+// virtualization. Native CSS scroll anchoring (overflow-anchor, left at its default on the
+// scroller) holds the viewport still across a grow, a trim, and the rolling-cap front drop,
+// so no manual restore math is needed; the hook writes the scroll position only to follow
+// the tail while pinned.
+export function useLogWindow({ parentRef, count, newestId }: LogWindowArgs) {
+  const [visibleCount, setVisibleCount] = useState(BASE_WINDOW_LINES);
+  const [atBottom, setAtBottom] = useState(true);
+  const atBottomRef = useRef(true);
+
+  const setPinned = useCallback((pinned: boolean) => {
+    atBottomRef.current = pinned;
+    setAtBottom((prev) => (prev === pinned ? prev : pinned));
+  }, []);
+
+  // A refilled list (agent switch/resume, viewer reopen) re-pins to the tail.
+  useEffect(() => {
+    if (count === 0) setPinned(true);
+  }, [count, setPinned]);
+
+  // Follow the tail on append, land on the bottom when the buffer first fills, and re-pin
+  // after a trim, unless the user scrolled up. Growing runs only while unpinned, so this
+  // never fights an upward scroll.
+  useLayoutEffect(() => {
+    const el = parentRef.current;
+    if (el && count > 0 && atBottomRef.current) el.scrollTop = el.scrollHeight;
+  }, [count, newestId, visibleCount, parentRef]);
+
+  const onScroll = useCallback(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    const metrics = {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    };
+    setPinned(isAtBottom(metrics));
+    if (shouldGrow(metrics, visibleCount < count)) {
+      setVisibleCount((current) => grownWindow(current, count));
+    }
+  }, [parentRef, count, visibleCount, setPinned]);
+
+  // Settling at the bottom trims the grown history back to the base tail. Scrolling up
+  // regrows it through the ordinary path.
+  useEffect(() => {
+    if (!atBottom || visibleCount <= BASE_WINDOW_LINES) return;
+    const timer = setTimeout(
+      () => setVisibleCount(BASE_WINDOW_LINES),
+      SETTLE_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [atBottom, visibleCount]);
+
+  return { visibleCount, onScroll };
+}


### PR DESCRIPTION
## Problem

The web log viewers loaded far too many rows into the DOM. The agent **Console** renders every buffered line as a `<div dangerouslySetInnerHTML>`, up to the 5000-line scrollback, so opening the logs mounts thousands of nodes at once. The **GatewayLogsViewer** is worse: it appended every line with no cap, so its buffer grew without bound while following the tail.

## Fix

Render only a tail window, mirroring chat's no-virtualization strategy. Because logs have no server cursor (the lines are already fully in the client buffer), "load an older page" collapses to "render more of the buffer I already hold" — synchronous, no backend change.

- **`lib/log-window.ts`** (new, unit-tested): pure window decisions (at-bottom, grow trigger, grow step) and constants — base/step 300 lines, 3-screen preload, 80px at-bottom, 30s settle.
- **`lib/use-log-window.ts`** (new): shared hook owning the window size, scroll handler, follow-on-append, and the settle-trim timer. Both viewers use it.
- **`Console`**: renders `lines.slice(-visibleCount)`; removed its bespoke pin/follow logic.
- **`GatewayLogsViewer`**: also fixed its uncapped buffer (added the shared 5000-line cap) and gave rows stable ids.

## Design note

The scrollers leave the browser's native `overflow-anchor` enabled (the Console already did), so a window grow, a trim, and the rolling-cap front-drop all lean on native scroll anchoring — no manual restore/latch machinery needed. The 3-screen preload keeps the grow away from `scrollTop: 0`, where native anchoring stops holding.

Mobile is unaffected: it already windows through `FlatList`.

## Tradeoff

A text-selection drag now spans only mounted rows. Grow-ahead-on-scroll-up plus trim-only-after-bottom-settle keep rows mounted during an upward drag, and the Console's Copy reads the buffer (not the DOM), so copy stays whole.

## Testing

`./check.sh app-web` green: format, types, lint (0 errors), 364 tests pass (incl. 7 new for `log-window`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)