### PR TITLE
feat(design): set the app heading font to sans

### DIFF
--- a/agent/skills/dashboard/app/src/design-tokens.css
+++ b/agent/skills/dashboard/app/src/design-tokens.css
@@ -148,7 +148,7 @@
 
 @theme inline {
   --font-sans: "Archivo Variable", sans-serif;
-  --font-heading: "Source Serif 4 Variable", Georgia, serif;
+  --font-heading: "Archivo Variable", sans-serif;
   --font-serif: "Source Serif 4 Variable", Georgia, serif;
   --font-wordmark: "Source Serif 4 Variable", Georgia, serif;
   --font-mono:

--- a/apps/mobile/src/components/AgentHeader.tsx
+++ b/apps/mobile/src/components/AgentHeader.tsx
@@ -113,7 +113,7 @@ export function AgentIsland({
           size={24}
         />
       </BootTransitionTarget>
-      <Text family="heading" numberOfLines={1} style={[styles.name, { color }]}>
+      <Text family="serif" numberOfLines={1} style={[styles.name, { color }]}>
         {name}
       </Text>
     </Pressable>

--- a/apps/mobile/src/components/agent-identity-card.tsx
+++ b/apps/mobile/src/components/agent-identity-card.tsx
@@ -57,7 +57,7 @@ export function AgentIdentityCard({
             centered
           />
         ) : null}
-        <Text family="heading" style={[styles.name, { color: colors.text }]}>
+        <Text family="serif" style={[styles.name, { color: colors.text }]}>
           {name}
         </Text>
         {caption ? <View style={styles.caption}>{caption}</View> : null}

--- a/apps/mobile/src/components/ui/Typography.tsx
+++ b/apps/mobile/src/components/ui/Typography.tsx
@@ -10,7 +10,7 @@ import type { ReactNode, Ref } from "react";
 import { usePreferences } from "@/preferences/PreferencesProvider";
 import { fontNames } from "@/theme/typography";
 
-export type FontFamily = "sans" | "heading" | "wordmark" | "mono";
+export type FontFamily = "sans" | "heading" | "serif" | "wordmark" | "mono";
 
 function numericWeight(weight: TextStyle["fontWeight"]): number {
   if (typeof weight === "number") return weight;
@@ -32,6 +32,12 @@ function fontFor(family: FontFamily, weight: TextStyle["fontWeight"]): string {
     if (value >= 600) return fontNames.heading.native["600"];
     if (value >= 500) return fontNames.heading.native["500"];
     return fontNames.heading.native["400"];
+  }
+  if (family === "serif") {
+    if (value >= 700) return fontNames.serif.native["700"];
+    if (value >= 600) return fontNames.serif.native["600"];
+    if (value >= 500) return fontNames.serif.native["500"];
+    return fontNames.serif.native["400"];
   }
   if (family === "mono") {
     if (value >= 700) return fontNames.mono.native["700"];
@@ -80,12 +86,12 @@ export function TextInput({
   );
 }
 
-// An example phrase the user could say, set apart inside running copy: the heading serif in the
+// An example phrase the user could say, set apart inside running copy: the serif voice in the
 // foreground color, so a quoted prompt reads as a voice rather than more instructions.
 export function Quote({ children }: { children: ReactNode }) {
   const { colors } = usePreferences();
   return (
-    <Text family="heading" style={[styles.quote, { color: colors.text }]}>
+    <Text family="serif" style={[styles.quote, { color: colors.text }]}>
       {children}
     </Text>
   );

--- a/apps/mobile/src/theme/generated.ts
+++ b/apps/mobile/src/theme/generated.ts
@@ -131,6 +131,15 @@ export const designTokens = {
         },
       },
       heading: {
+        css: '"Archivo Variable", sans-serif',
+        native: {
+          "400": "Archivo_400Regular",
+          "500": "Archivo_500Medium",
+          "600": "Archivo_600SemiBold",
+          "700": "Archivo_700Bold",
+        },
+      },
+      serif: {
         css: '"Source Serif 4 Variable", Georgia, serif',
         native: {
           "400": "SourceSerif4_400Regular",

--- a/apps/web/src/design-tokens.css
+++ b/apps/web/src/design-tokens.css
@@ -148,7 +148,7 @@
 
 @theme inline {
   --font-sans: "Archivo Variable", sans-serif;
-  --font-heading: "Source Serif 4 Variable", Georgia, serif;
+  --font-heading: "Archivo Variable", sans-serif;
   --font-serif: "Source Serif 4 Variable", Georgia, serif;
   --font-wordmark: "Source Serif 4 Variable", Georgia, serif;
   --font-mono:

--- a/design/tokens.json
+++ b/design/tokens.json
@@ -148,6 +148,15 @@
         }
       },
       "heading": {
+        "css": "\"Archivo Variable\", sans-serif",
+        "native": {
+          "400": "Archivo_400Regular",
+          "500": "Archivo_500Medium",
+          "600": "Archivo_600SemiBold",
+          "700": "Archivo_700Bold"
+        }
+      },
+      "serif": {
         "css": "\"Source Serif 4 Variable\", Georgia, serif",
         "native": {
           "400": "SourceSerif4_400Regular",

--- a/scripts/sync-design-tokens.py
+++ b/scripts/sync-design-tokens.py
@@ -75,7 +75,7 @@ def _css(tokens: dict[str, Any]) -> str:
 @theme inline {{
   --font-sans: {families["sans"]["css"]};
   --font-heading: {families["heading"]["css"]};
-  --font-serif: {families["heading"]["css"]};
+  --font-serif: {families["serif"]["css"]};
   --font-wordmark: {families["wordmark"]["css"]};
   --font-mono:
     "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Consolas,


### PR DESCRIPTION
## What

Change the app **heading** font from the serif (Source Serif 4) to the sans face (Archivo). Section headings across every surface now render in sans.

## Scope (confirmed with the requester)

- **Headings become sans** on web, desktop, and mobile.
- **Serif branding stays serif**: the wordmark, and the agent name / branded serif voice.

## How

The `heading` typography family is the one source of truth in `design/tokens.json`. Changing its value there propagates through `scripts/sync-design-tokens.py` to every app, so no per-component web edits are needed:

- **`design/tokens.json`**: `heading` family now holds Archivo (sans); a new `serif` family holds the old Source Serif value.
- **`scripts/sync-design-tokens.py`**: `--font-serif` now reads the new `serif` family (it used to piggyback on `heading`, which is what would have dragged the branding to sans too).
- **Web / desktop**: `--font-heading` → Archivo; `--font-serif` and `--font-wordmark` stay Source Serif. No component changes; the `font-heading` utility flips automatically.
- **Mobile** (`Typography.tsx`): `family="heading"` now resolves to Archivo. Added a `serif` family and moved the branded serif consumers to it, the agent name (`AgentHeader`, `agent-identity-card`) and the example `Quote`, so they match web's `font-serif`.
- Regenerated `apps/web/src/design-tokens.css`, `apps/mobile/src/theme/generated.ts`, and the synced dashboard tokens.

## Verify

- `./check.sh app-web` — pass (357 tests)
- `./check.sh app-mobile` — pass (301 tests, clean prebuild)
- `./check.sh guards` — ruff, format, and the design-token `--check` pass; dashboard-sync is in sync once committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)