### PR TITLE
refactor(web): remove tooltips from home page agent orbs

### DIFF
--- a/apps/web/src/components/AgentCard/index.tsx
+++ b/apps/web/src/components/AgentCard/index.tsx
@@ -6,11 +6,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { Orb } from "@/components/Orb";
 import type { AgentRow } from "@/lib/types";
 import { useNavigate } from "react-router-dom";
@@ -43,18 +38,13 @@ export function AgentCard({ agent }: AgentCardProps) {
         className="flex h-full w-full items-center justify-center rounded-squircle-md border border-transparent [corner-shape:squircle] outline-none transition-all hover:bg-muted/40 active:scale-[0.99] focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30"
       >
         <CardContent className="flex flex-col items-center gap-3 px-5 pt-0 pb-0">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <Orb
-                  state={orbState}
-                  size={112}
-                  label={`${agent.name}: ${label}`}
-                />
-              </span>
-            </TooltipTrigger>
-            {label && <TooltipContent>{label}</TooltipContent>}
-          </Tooltip>
+          <span className="inline-flex">
+            <Orb
+              state={orbState}
+              size={112}
+              label={`${agent.name}: ${label}`}
+            />
+          </span>
           <CardTitle className="font-serif text-center text-2xl -mt-3 font-medium tracking-tight text-foreground">
             {agent.name}
           </CardTitle>


### PR DESCRIPTION
## What

Remove the hover tooltip from the agent orbs on the home page.

Each orb on the home page (`AgentCard`, rendered through `Home/AgentsCarousel`) was wrapped in a `Tooltip` that showed the agent status label on hover. The orb already exposes that same information through its `label` aria attribute, and the card renders the agent name below it, so the tooltip added no information.

## Change

- Drop the `Tooltip`/`TooltipTrigger`/`TooltipContent` wrapper around the `Orb` in `AgentCard`.
- Keep the orb's accessible `label` and the surrounding `span`, so the accessibility surface is unchanged.

No other orb usages (agent island, navbar) are touched.

## Verification

- `./check.sh app-web` passes (lint, format, tsc, 357 vitest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Un1w1HZP5ST7YfgizjUh7E