### PR TITLE
fix(reminders): give reminder notifications a meaningful type

### DIFF
--- a/agent/core/migrations/2026-08-reminder-notification-type.md
+++ b/agent/core/migrations/2026-08-reminder-notification-type.md
@@ -1,0 +1,40 @@
+The reminders daemon emits two notification types with `source=reminders`: `type=reminder_due`
+when a reminder fires on schedule, and `type=reminder_missed` when a one-shot is replayed on
+restart because its time passed while the daemon was down. Skill code that ran before this boot
+emitted both as `type=reminder`, so anything on this box keyed to `source=reminders` with
+`type=reminder` now points at a type the daemon no longer writes. If the reminders skill is not
+active on this box, every step below is a no-op.
+
+### 1. Restart the reminders daemon
+
+The daemon loaded its code when it started, so until it restarts it keeps emitting the old type:
+
+```bash
+reminders daemon restart
+```
+
+### 2. Update notification rules that target the old pairing
+
+```bash
+notifications list
+```
+
+A rule with `type=reminder` that catches the reminders skill (either `source=reminders` or no
+`source`) no longer matches anything. The old `type=reminder` caught every reminder, on-schedule
+and missed alike, so decide what the rule was for and re-create it with `notifications remove <id>`
+then `notifications add` (same action and conditions, `--before`/`--after` to keep its position):
+
+- Only on-schedule reminders: `--source reminders --type reminder_due`.
+- Only missed one-shots: `--source reminders --type reminder_missed`.
+- Both, as before: re-create it for `reminder_due` and add a second rule for `reminder_missed`.
+
+Ask the user when the intent is not clear from the rule.
+
+### 3. Sweep your own references to the old pairing
+
+```bash
+grep -rniE "type[\"'=: ]+reminder\b" ~/agent/MEMORY.md ~/agent/skills --exclude-dir=cli --exclude-dir=.venv
+```
+
+Each hit that means a reminders notification now spells `type=reminder_due` (on-schedule) or
+`type=reminder_missed` (missed). Rewrite it to the one it meant. No hits means nothing to rewrite.

--- a/agent/skills/reminders/SKILL.md
+++ b/agent/skills/reminders/SKILL.md
@@ -71,7 +71,8 @@ Prefer a TASK's metadata file when a task already exists, and have the reminder 
 
 ## What the daemon does on its own
 
-- **Missed one-shots**: a reminder that should have fired while the daemon was down is sent on restart marked `missed`; missed recurring fires are skipped.
+- A reminder firing on schedule arrives as a `type=reminder_due` notification. To route reminders with a `notifications` rule, key it on `source=reminders` plus `type=reminder_due` (on-schedule) or `type=reminder_missed` (below).
+- **Missed one-shots**: a reminder that should have fired while the daemon was down is sent on restart as a `type=reminder_missed` notification; missed recurring fires are skipped.
 - A fired one-shot is marked completed and drops off `reminders list`; `--show-completed` brings it back so a self-chaining reminder can re-read its own body.
 
 ## Data

--- a/agent/skills/reminders/cli/src/reminders_cli/commands.py
+++ b/agent/skills/reminders/cli/src/reminders_cli/commands.py
@@ -350,7 +350,7 @@ def _restore_row(scheduler: BackgroundScheduler, row, now: datetime, notif_dir: 
                         notif_dir,
                         reminder_id,
                         row["message"],
-                        extra={"missed": True},
+                        notif_type="reminder_missed",
                         snooze_hint=True,
                     )
                 conn.execute("UPDATE reminders SET completed = 1 WHERE id = ?", (reminder_id,))

--- a/agent/skills/reminders/cli/src/reminders_cli/scheduler.py
+++ b/agent/skills/reminders/cli/src/reminders_cli/scheduler.py
@@ -41,13 +41,15 @@ def write_reminder_notification(
     reminder_id: str,
     message: str,
     *,
-    extra: dict | None = None,
+    notif_type: str = "reminder_due",
     snooze_hint: bool = False,
 ):
-    """Write a reminder notification JSON file. `snooze_hint` appends the snooze tip; set it for
-    one-shot reminders only (recurring ones fire again anyway)."""
+    """Write a reminder notification JSON file. `notif_type` names the event: `reminder_due` for a
+    reminder firing on schedule, `reminder_missed` for one replayed after its time passed while the
+    daemon was down. `snooze_hint` appends the snooze tip; set it for one-shot reminders only
+    (recurring ones fire again anyway)."""
     if not reminder_id or not message:
         raise ValueError("reminder_id and message required")
 
     full_message = f"{message}\n{_SNOOZE_HINT.format(rid=reminder_id)}" if snooze_hint else message
-    write_notification(notif_dir, "reminder", message=full_message, reminder_id=reminder_id, **(extra or {}))
+    write_notification(notif_dir, notif_type, message=full_message, reminder_id=reminder_id)

--- a/agent/skills/reminders/cli/tests/test_e2e.py
+++ b/agent/skills/reminders/cli/tests/test_e2e.py
@@ -291,7 +291,7 @@ class TestDaemonNotifications:
             rid = s["id"]
             time.sleep(6)
 
-            notif_files = list(notif_dir.glob("*-reminders-reminder.json"))
+            notif_files = list(notif_dir.glob("*-reminders-reminder_due.json"))
             assert len(notif_files) >= 1
             found = False
             for f in notif_files:
@@ -332,7 +332,7 @@ class TestDaemonNotifications:
             deadline = time.time() + 15
             found = False
             while time.time() < deadline and not found:
-                found = any(json.loads(f.read_text())["reminder_id"] == s["id"] for f in notif_dir.glob("*-reminders-reminder.json"))
+                found = any(json.loads(f.read_text())["reminder_id"] == s["id"] for f in notif_dir.glob("*-reminders-reminder_due.json"))
                 time.sleep(0.5)
             assert found, "snoozed reminder did not fire at its new time"
         finally:
@@ -363,11 +363,11 @@ class TestMissedReminders:
         proc = start_daemon(home, notif_dir)
         try:
             time.sleep(3)
-            notif_files = list(notif_dir.glob("*-reminders-reminder.json"))
+            notif_files = list(notif_dir.glob("*-reminders-reminder_missed.json"))
             assert len(notif_files) >= 1
             data = json.loads(notif_files[0].read_text())
             assert data["message"].splitlines()[0] == "you missed this"
-            assert data["missed"] is True
+            assert data["type"] == "reminder_missed"
 
             items = parse(remind_cli(home, "list", "--json"))
             assert not any(i["id"] == "pastdue01" for i in items)
@@ -390,7 +390,7 @@ class TestMissedReminders:
             time.sleep(3)
             items = parse(remind_cli(home, "list", "--json"))
             assert any(i["id"] == "recur01" for i in items)
-            notif_files = list(notif_dir.glob("*-reminders-reminder.json"))
+            notif_files = list(notif_dir.glob("*-reminders-reminder_*.json"))
             missed = [f for f in notif_files if json.loads(f.read_text()).get("reminder_id") == "recur01"]
             assert len(missed) == 0
         finally:
@@ -497,7 +497,7 @@ class TestRecurringNextRun:
 
         send_reminder_job("ghost99", message="nope", data_dir=str(data_dir), notif_dir=str(notif_dir))
 
-        notif_files = list(notif_dir.glob("*-reminders-reminder.json"))
+        notif_files = list(notif_dir.glob("*-reminders-reminder_*.json"))
         assert not any(json.loads(f.read_text())["reminder_id"] == "ghost99" for f in notif_files)
 
     def test_null_trigger_data_still_fires_notification(self, test_home):
@@ -514,7 +514,7 @@ class TestRecurringNextRun:
 
         send_reminder_job("null_td", message="no trigger", data_dir=str(home / ".reminders"), notif_dir=str(notif_dir))
 
-        notif_files = list(notif_dir.glob("*-reminders-reminder.json"))
+        notif_files = list(notif_dir.glob("*-reminders-reminder_due.json"))
         found = any(json.loads(f.read_text())["reminder_id"] == "null_td" for f in notif_files)
         assert found, "notification should still be written even without trigger_data"
 
@@ -532,7 +532,7 @@ class TestRecurringNextRun:
 
         send_reminder_job("msg01", message="kwarg message", data_dir=str(home / ".reminders"), notif_dir=str(notif_dir))
 
-        notif_files = list(notif_dir.glob("*-reminders-reminder.json"))
+        notif_files = list(notif_dir.glob("*-reminders-reminder_due.json"))
         data = next(json.loads(f.read_text()) for f in notif_files if json.loads(f.read_text())["reminder_id"] == "msg01")
         assert data["message"].splitlines()[0] == "db message"
 

--- a/agent/skills/reminders/cli/tests/test_snooze.py
+++ b/agent/skills/reminders/cli/tests/test_snooze.py
@@ -120,7 +120,7 @@ def test_just_fired_one_shot_is_not_replayed_as_missed(tmp_config: Config, tmp_p
 
     rewind_run_date(120)
     commands.restore_jobs_by_ids(tmp_config, scheduler, {reminder["id"]}, notif_dir=notif_dir)
-    missed = list(notif_dir.glob("*-reminders-reminder.json"))
+    missed = list(notif_dir.glob("*-reminders-reminder_missed.json"))
     assert len(missed) == 1
-    assert json.loads(missed[0].read_text())["missed"] is True
+    assert json.loads(missed[0].read_text())["type"] == "reminder_missed"
     assert _row(tmp_config, reminder["id"])["completed"] == 1

--- a/agent/skills/reminders/cli/tests/test_soft_delete.py
+++ b/agent/skills/reminders/cli/tests/test_soft_delete.py
@@ -83,4 +83,4 @@ def test_fire_callback_is_a_no_op_for_a_deleted_reminder(tmp_config: Config, tmp
     reminder = commands.remind_set(tmp_config, commands.ReminderSpec(message="do not fire", in_minutes=1))
     commands.remind_delete(tmp_config, reminder_id=reminder["id"])
     send_reminder_job(reminder["id"], message="do not fire", data_dir=str(tmp_config.data_dir), notif_dir=str(notif_dir))
-    assert list(notif_dir.glob("*-reminders-reminder.json")) == []
+    assert list(notif_dir.glob("*-reminders-reminder_*.json")) == []


### PR DESCRIPTION
## The smell

Reminder notifications were written with a constant `type="reminder"` on `source="reminders"`. The `type` just restated the `source` and carried no information. Meanwhile the one real distinction, a reminder firing on schedule against a one-shot replayed late (because its time passed while the daemon was down), was smuggled into a `missed:true` payload flag.

The tasks daemon already set the precedent the other way: it recently moved off `type=reminder` to `type=task_due` (migration `2026-08-task-due-notification-type.md`).

## The fix

Name the event in the `type`:
- On-schedule fire: `type=reminder_due`
- Late replay: `type=reminder_missed` (the `missed:true` flag is gone; the type says it)

`source=reminders` notifications now carry a `type` that earns its place, and a `notifications` rule can route on-schedule and missed reminders separately.

## Fleet compatibility

`type=reminder` is now written by no skill (tasks moved to `task_due` earlier; reminders move here). A prompt migration (`2026-08-reminder-notification-type.md`) restarts the reminders daemon, re-points user notification rules keyed on the old pairing, and sweeps agent notes. The old catch-all `type=reminder` caught both on-schedule and missed reminders, so the migration explains that preserving that behavior means one rule for each new type.

## Tests

- Reminders CLI suite updated for the new type strings and filename globs; **167 passed** locally.
- The one local `test_status_rejects_a_reused_pid[reminders]` failure is a pre-existing macOS artifact (no `/proc`, so the pid record has no starttime field); it fails identically on clean `master` and passes on CI's Linux. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)