### PR TITLE
feat(web): cap the chat content column at 830px on both desktop layouts

### DIFF
--- a/apps/web/src/components/Chat/ChatMessageArea/index.tsx
+++ b/apps/web/src/components/Chat/ChatMessageArea/index.tsx
@@ -13,7 +13,7 @@ import { cn } from "@/lib/utils";
 import { stepTransition } from "@/lib/motion";
 import { bubbleRadiusStyle } from "../bubble-radius";
 import { ChatBubble, type RetryHandler } from "../ChatBubble";
-import { CHAT_CONTENT_WIDTH } from "../content-width";
+import { CHAT_CONTENT_COLUMN } from "../content-column";
 import { buildDecorated, lastSeenIndex, type DecoratedRow } from "./rows";
 import { useChatScroll } from "./use-chat-scroll";
 
@@ -239,14 +239,13 @@ export const ChatMessageArea = memo(function ChatMessageArea({
   bottomOverhang = 0,
   onAtBottomChange,
 }: ChatMessageAreaProps) {
-  // Desktop treatment (floating-composer inset, spacious gaps, sizes) applies to both the
-  // fullscreen and split-panel chats; only mobile keeps the plain layout. The narrow centered
-  // column is fullscreen-only, the split-panel chat fills its panel.
-  const floating = !isMobile;
-  const centered = Boolean(fullscreen) && !isMobile;
+  // Desktop treatment (floating-composer inset, spacious gaps, sizes, the capped centered
+  // column) applies to both the fullscreen and split-panel chats; only mobile keeps the plain,
+  // full-width layout.
+  const isDesktop = !isMobile;
   const decorated = useMemo(
-    () => buildDecorated(chatMessages, floating),
-    [chatMessages, floating],
+    () => buildDecorated(chatMessages, isDesktop),
+    [chatMessages, isDesktop],
   );
   const count = decorated.length;
   const lastAgentText = useMemo(() => {
@@ -316,7 +315,7 @@ export const ChatMessageArea = memo(function ChatMessageArea({
           "h-full overflow-y-auto overflow-x-hidden",
           // Reserve the scrollbar gutter on both sides so the centered message column
           // shares the same center as the (scrollbar-free) floating composer.
-          floating && "[scrollbar-gutter:stable_both-edges]",
+          isDesktop && "[scrollbar-gutter:stable_both-edges]",
         )}
         // The prepend restore owns anchoring; the browser's native scroll
         // anchoring would compensate the same prepend a second time.
@@ -331,7 +330,7 @@ export const ChatMessageArea = memo(function ChatMessageArea({
         }}
       >
         <div
-          className={cn(centered && CHAT_CONTENT_WIDTH)}
+          className={cn(isDesktop && CHAT_CONTENT_COLUMN)}
           style={{ paddingBottom: bottomInset }}
         >
           <div style={{ paddingTop: topPad }}>

--- a/apps/web/src/components/Chat/content-column.ts
+++ b/apps/web/src/components/Chat/content-column.ts
@@ -1,0 +1,3 @@
+// Desktop chats (fullscreen and split-panel) center their bubbles and composer in this column:
+// the full container width, capped so a wide window or panel never stretches the line length.
+export const CHAT_CONTENT_COLUMN = "mx-auto w-full max-w-[830px]";

--- a/apps/web/src/components/Chat/content-width.ts
+++ b/apps/web/src/components/Chat/content-width.ts
@@ -1,3 +1,0 @@
-// Desktop chats (fullscreen and split-panel) center their bubbles and composer in this column:
-// 60% of the container, but never narrower than the floor (nor wider than the container itself).
-export const CHAT_CONTENT_WIDTH = "mx-auto w-3/5 min-w-[min(640px,100%)]";

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -12,7 +12,7 @@ import { useLocation } from "react-router-dom";
 import { ArrowDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { CHAT_CONTENT_WIDTH } from "./content-width";
+import { CHAT_CONTENT_COLUMN } from "./content-column";
 import { useToast } from "@/stores/use-toast";
 import { useLayout } from "@/stores/use-layout";
 import { useAgentSocket } from "@/providers/AgentSocketProvider";
@@ -213,7 +213,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
         <div
           ref={composerRef}
           // px-3 mirrors the message list's 12px scrollbar-gutter on each side, so the
-          // composer's w-3/5 column computes from the same width and lines up with the bubbles.
+          // composer's capped column computes from the same width and lines up with the bubbles.
           className={cn("absolute inset-x-0 bottom-0", !isMobile && "px-3")}
         >
           {chatMessages.length > 0 && (
@@ -236,8 +236,8 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
           <div
             className={cn(
               "relative",
-              // 60% centered column is fullscreen-only; the split-panel composer fills its panel.
-              fullscreen && !isMobile && CHAT_CONTENT_WIDTH,
+              // The capped centered column is shared by both desktop chats; only mobile fills full width.
+              !isMobile && CHAT_CONTENT_COLUMN,
             )}
           >
             <BottomBanner error={voiceError} />


### PR DESCRIPTION
## What

Unify the chat width rule across the two desktop chat forms so both share one centered column: **full width, capped at 830px**.

- **Fullscreen page chat** and **resizable split-panel chat** now use the same `CHAT_CONTENT_COLUMN` (`mx-auto w-full max-w-[830px]`).
- Previously the column was fullscreen-only at `w-3/5` (60%); the split-panel chat filled its whole panel with no cap, so a wide panel or window stretched the line length.

## Why

A very wide panel (or a wide window in fullscreen) made chat lines uncomfortably long. One shared cap keeps line length readable everywhere. Mobile is unchanged: it still fills full width.

## Renames for clarity

- `CHAT_CONTENT_WIDTH` -> `CHAT_CONTENT_COLUMN` (file `content-width.ts` -> `content-column.ts`): it is a centered capped column, not just a width value.
- `ChatMessageArea` local `floating` -> `isDesktop`: the flag is literally `!isMobile` and now gates the column, spacing, scrollbar gutter, and floating composer alike.

## Test

`./check.sh app-web` green: lint, prettier, tsc, 357 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)