### PR TITLE
feat(web): show registered services in a menu dialog and settings card

### DIFF
--- a/apps/web/src/components/AgentMenu/DesktopMenu.tsx
+++ b/apps/web/src/components/AgentMenu/DesktopMenu.tsx
@@ -14,6 +14,7 @@ export function DesktopMenu({ state, open, onOpenChange, trigger }: MenuProps) {
     showAliveActions: state.showAliveActions,
     isBusy: state.isBusy,
     onLogs: state.onLogs,
+    onServices: state.onServices,
     onToggle: state.onToggle,
     onRestart: state.onRestart,
     onBackup: state.onBackup,

--- a/apps/web/src/components/AgentMenu/MobileMenu.tsx
+++ b/apps/web/src/components/AgentMenu/MobileMenu.tsx
@@ -38,6 +38,7 @@ export function MobileMenu({ state, open, onOpenChange, trigger }: MenuProps) {
             showAliveActions={state.showAliveActions}
             isBusy={state.isBusy}
             onLogs={state.onLogs}
+            onServices={state.onServices}
             onToggle={state.onToggle}
             onRestart={state.onRestart}
             onBackup={state.onBackup}

--- a/apps/web/src/components/AgentMenu/action-sections.test.tsx
+++ b/apps/web/src/components/AgentMenu/action-sections.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { buildActionSections, type AgentActionsInput } from "./action-sections";
+
+function input(overrides: Partial<AgentActionsInput>): AgentActionsInput {
+  return {
+    isRunning: true,
+    isBusy: false,
+    onLogs: vi.fn(),
+    onToggle: vi.fn(),
+    onRestart: vi.fn(),
+    onBackup: vi.fn(),
+    ...overrides,
+  };
+}
+
+function itemKeys(sections: ReturnType<typeof buildActionSections>): string[] {
+  return sections.flatMap((section) => section.items.map((item) => item.key));
+}
+
+describe("buildActionSections services row", () => {
+  it("adds a services item in the tools section while running", () => {
+    const sections = buildActionSections(input({ onServices: vi.fn() }));
+
+    const tools = sections.find((section) => section.key === "view");
+    expect(tools?.items.map((item) => item.key)).toContain("services");
+  });
+
+  it("omits the services item when no handler is given", () => {
+    expect(itemKeys(buildActionSections(input({})))).not.toContain("services");
+  });
+
+  it("omits the services item while the agent is down", () => {
+    const sections = buildActionSections(
+      input({ isRunning: false, onServices: vi.fn() }),
+    );
+    expect(itemKeys(sections)).not.toContain("services");
+  });
+});

--- a/apps/web/src/components/AgentMenu/action-sections.tsx
+++ b/apps/web/src/components/AgentMenu/action-sections.tsx
@@ -1,6 +1,7 @@
 import {
   Archive,
   Bug,
+  Globe,
   KeyRound,
   Play,
   RefreshCw,
@@ -16,6 +17,7 @@ export interface AgentActionsInput {
   showAliveActions?: boolean;
   isBusy: boolean;
   onLogs: () => void;
+  onServices?: () => void;
   onToggle: () => void;
   onRestart: () => void;
   onBackup: () => void;
@@ -46,18 +48,23 @@ export function buildActionSections(input: AgentActionsInput): ActionSection[] {
   const sections: ActionSection[] = [];
 
   if (input.isRunning) {
-    sections.push({
-      key: "view",
-      title: "Tools",
-      items: [
-        {
-          key: "logs",
-          icon: <ScrollText data-icon="inline-start" />,
-          label: "logs",
-          onClick: input.onLogs,
-        },
-      ],
-    });
+    const toolItems: ActionItem[] = [
+      {
+        key: "logs",
+        icon: <ScrollText data-icon="inline-start" />,
+        label: "logs",
+        onClick: input.onLogs,
+      },
+    ];
+    if (input.onServices) {
+      toolItems.push({
+        key: "services",
+        icon: <Globe data-icon="inline-start" />,
+        label: "services",
+        onClick: input.onServices,
+      });
+    }
+    sections.push({ key: "view", title: "Tools", items: toolItems });
   }
 
   const controlItems: ActionItem[] = [

--- a/apps/web/src/components/AgentMenu/index.tsx
+++ b/apps/web/src/components/AgentMenu/index.tsx
@@ -13,6 +13,7 @@ import { useModals } from "@/providers/ModalsProvider";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { useGateway } from "@/providers/GatewayProvider";
 import { useAppMode } from "@/stores/use-app-mode";
+import { AgentServicesList } from "@/components/AgentServices";
 import type { MenuState } from "./types";
 import { MobileMenu } from "./MobileMenu";
 import { DesktopMenu } from "./DesktopMenu";
@@ -35,6 +36,7 @@ export function AgentMenu() {
 
   const [open, setOpen] = useState(false);
   const [debugOpen, setDebugOpen] = useState(false);
+  const [servicesOpen, setServicesOpen] = useState(false);
   const isMobile = useIsMobile();
 
   const isRunning =
@@ -52,6 +54,7 @@ export function AgentMenu() {
       else start();
     },
     onLogs: () => goTo(`/agent/${encodeURIComponent(name)}/logs`),
+    onServices: () => setServicesOpen(true),
     onAppSettings: () => {
       void navigate("/settings");
     },
@@ -110,6 +113,14 @@ export function AgentMenu() {
           trigger={trigger}
         />
       )}
+      <Dialog open={servicesOpen} onOpenChange={setServicesOpen}>
+        <DialogContent className="max-w-md" aria-describedby={undefined}>
+          <DialogHeader>
+            <DialogTitle>services</DialogTitle>
+          </DialogHeader>
+          <AgentServicesList />
+        </DialogContent>
+      </Dialog>
       <Dialog open={debugOpen} onOpenChange={setDebugOpen}>
         <DialogContent
           className="max-w-lg max-h-[80vh] overflow-auto"

--- a/apps/web/src/components/AgentMenu/types.ts
+++ b/apps/web/src/components/AgentMenu/types.ts
@@ -5,6 +5,7 @@ export interface MenuState {
   isBusy: boolean;
   onToggle: () => void;
   onLogs: () => void;
+  onServices: () => void;
   onAppSettings: () => void;
   onAgentSettings: () => void;
   onRestart: () => void;

--- a/apps/web/src/components/AgentServices/index.test.tsx
+++ b/apps/web/src/components/AgentServices/index.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { ServiceInfo } from "@vesta/core";
+import { AgentServicesList } from "./index";
+
+let services: Record<string, ServiceInfo> = {};
+
+vi.mock("@/providers/SelectedAgentProvider", () => ({
+  useSelectedAgent: () => ({
+    name: "bob",
+    agent: { services },
+  }),
+}));
+
+describe("AgentServicesList", () => {
+  afterEach(cleanup);
+
+  it("renders one row per service, sorted by name, with its port", () => {
+    services = {
+      whatsapp: { port: 9200, rev: 1 },
+      dashboard: { port: 9100, rev: 0 },
+    };
+    render(<AgentServicesList />);
+
+    const rows = screen.getAllByRole("listitem");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.textContent).toContain("dashboard");
+    expect(rows[0]?.textContent).toContain("9100");
+    expect(rows[1]?.textContent).toContain("whatsapp");
+    expect(rows[1]?.textContent).toContain("9200");
+  });
+
+  it("shows an empty state when the agent has no services", () => {
+    services = {};
+    render(<AgentServicesList />);
+
+    expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+    expect(screen.getByText(/no services yet/i)).toBeTruthy();
+  });
+
+  it("explains the list in plain words, naming the agent", () => {
+    services = { dashboard: { port: 9100, rev: 0 } };
+    render(<AgentServicesList />);
+
+    expect(screen.getByText(/ask bob/i)).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/AgentServices/index.tsx
+++ b/apps/web/src/components/AgentServices/index.tsx
@@ -1,0 +1,41 @@
+import { Globe } from "lucide-react";
+import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
+
+// Read-only view of the agent's registered services, shared by the agent-menu
+// dialog and the settings card. Live from the /sync roster, so rows appear and
+// disappear as services register and unregister.
+export function AgentServicesList() {
+  const { name, agent } = useSelectedAgent();
+  const rows = Object.entries(agent.services)
+    .map(([service, info]) => ({ name: service, port: info.port }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <div className="flex flex-col gap-3">
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">no services yet</p>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {rows.map((row) => (
+            <li
+              key={row.name}
+              className="flex items-center justify-between gap-3 rounded-md bg-muted/50 px-3 py-2"
+            >
+              <span className="flex min-w-0 items-center gap-2 text-sm">
+                <Globe className="size-4 shrink-0 text-muted-foreground" />
+                <span className="truncate font-medium">{row.name}</span>
+              </span>
+              <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                :{row.port}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <p className="text-xs text-muted-foreground">
+        these are the small apps {name} runs for you. ask {name} in chat what
+        each one does.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/AgentSettings/ServicesCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ServicesCard/index.tsx
@@ -1,0 +1,15 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { MenuSection } from "@/components/ui/menu-section";
+import { AgentServicesList } from "@/components/AgentServices";
+
+export function ServicesCard() {
+  return (
+    <Card size="sm">
+      <CardContent>
+        <MenuSection title="services">
+          <AgentServicesList />
+        </MenuSection>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/AgentSettings/index.tsx
+++ b/apps/web/src/components/AgentSettings/index.tsx
@@ -7,6 +7,7 @@ import { NotificationsCard } from "./NotificationsCard";
 import { FilesTab } from "./FilesTab";
 import { LogsTab } from "./LogsTab";
 import { ProviderCard } from "./ProviderCard";
+import { ServicesCard } from "./ServicesCard";
 import { SttCard, TtsCard } from "./VoiceSection";
 
 export function AgentSettings() {
@@ -30,6 +31,7 @@ export function AgentSettings() {
             </div>
             <div className="flex min-w-0 flex-col gap-4">
               <ProviderCard />
+              <ServicesCard />
               <BackupsCard />
               <SttCard />
               <TtsCard />


### PR DESCRIPTION
## What

A read-only view of an agent's registered services, in two places:

- A new **services** row in the agent dropdown's Tools section (next to logs, shown while the agent runs), opening a dialog on both the desktop dropdown and the mobile drawer.
- A **ServicesCard** on the agent settings general tab, between the provider and backups cards.

Both render one shared `AgentServicesList`: sorted rows of service name + port, an empty state, and a plain-language hint ("these are the small apps {name} runs for you. ask {name} in chat what each one does.").

## How

No vestad or wire changes: the `/sync` roster already carries `agent.services` live, so the list updates as services register and unregister. The dialog follows the existing debug-info dialog pattern in `AgentMenu`; the menu row is an optional `onServices` input to `buildActionSections`, so the settings-page ActionsCard shows no duplicate row.

## Tests

- `AgentServices/index.test.tsx`: sorted rows with ports, empty state, hint naming the agent.
- `AgentMenu/action-sections.test.tsx`: services row present with a handler while running, absent without a handler or while down.
- `./check.sh app-web` green (370 tests, lint, format, tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYV955Juj2ngfeQksV5URj