### PR TITLE
fix(web): dismiss open overlays when clicking the titlebar drag region

### DIFF
--- a/agent/skills/dashboard/app/src/index.css
+++ b/agent/skills/dashboard/app/src/index.css
@@ -46,10 +46,18 @@ html[data-platform="android"] {
 .desktop [data-drag-region] [role="button"] {
   -webkit-app-region: no-drag;
 }
-/* While a popover-like control in the titlebar is open (the expanded agent
-   island), the navbar stops dragging so an outside click on it dismisses,
-   the way a native popover closes when you click the title bar. */
-.desktop [data-drag-region]:has([aria-expanded="true"]) {
+/* While anything dismissable is open (the expanded agent island or another
+   control in the titlebar, or any portaled overlay: dialogs put a
+   data-state="open" element directly under body, popovers/dropdowns a popper
+   wrapper), every drag region stops dragging so a click on the titlebar
+   reaches the page and dismisses it, the way a native popover closes when
+   you click the title bar. */
+.desktop:has(
+    [data-drag-region] [aria-expanded="true"],
+    body > [data-state="open"],
+    body > [data-radix-popper-content-wrapper]
+  )
+  [data-drag-region] {
   -webkit-app-region: no-drag;
 }
 

--- a/apps/web/src/drag-regions.test.tsx
+++ b/apps/web/src/drag-regions.test.tsx
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+
+// The desktop drag-region dismissal rule in index.css matches open overlays
+// with `body > [data-state="open"]` and `body > [data-radix-popper-content-wrapper]`,
+// relying on Radix portals rendering them as direct body children (their
+// internal Portal uses asChild). Pin that DOM shape across Radix upgrades.
+describe("portaled overlay DOM shape (index.css drag-region rule)", () => {
+  it("open dialog puts data-state=open elements directly under body", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>probe</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(
+      document.querySelectorAll('body > [data-state="open"]').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("open dropdown puts the popper wrapper directly under body", () => {
+    render(
+      <DropdownMenu open>
+        <DropdownMenuContent>
+          <DropdownMenuItem>probe</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    expect(
+      document.querySelectorAll("body > [data-radix-popper-content-wrapper]")
+        .length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -43,10 +43,18 @@ html[data-platform="android"] {
 .desktop [data-drag-region] [role="button"] {
   -webkit-app-region: no-drag;
 }
-/* While a popover-like control in the titlebar is open (the expanded agent
-   island), the navbar stops dragging so an outside click on it dismisses,
-   the way a native popover closes when you click the title bar. */
-.desktop [data-drag-region]:has([aria-expanded="true"]) {
+/* While anything dismissable is open (the expanded agent island or another
+   control in the titlebar, or any portaled overlay: dialogs put a
+   data-state="open" element directly under body, popovers/dropdowns a popper
+   wrapper), every drag region stops dragging so a click on the titlebar
+   reaches the page and dismisses it, the way a native popover closes when
+   you click the title bar. */
+.desktop:has(
+    [data-drag-region] [aria-expanded="true"],
+    body > [data-state="open"],
+    body > [data-radix-popper-content-wrapper]
+  )
+  [data-drag-region] {
   -webkit-app-region: no-drag;
 }
 


### PR DESCRIPTION
## Problem

In the desktop app, clicking the navbar while the agent island (or any popover/dropdown/dialog) is open drags the window instead of dismissing the component.

Two holes in the drag-region rule in `apps/web/src/index.css`:

1. The navbar nests sibling `data-drag-region` divs, and `[data-drag-region]:has([aria-expanded="true"])` only un-drags **ancestors** of the open control. The left/right half divs (most of the navbar surface) stayed draggable, and a drag region consumes the mousedown at the window level, so the page never received the pointerdown that outside-click dismissal listens for.
2. Portaled overlays never matched at all: the island modals are controlled dialogs with no trigger in the navbar, and Radix portals content to `document.body`, outside every drag region.

## Fix

Root-scope the rule: while anything dismissable is open, **every** drag region turns no-drag, so the titlebar click reaches the page and the normal outside-click dismissal fires. Conditions:

- `[data-drag-region] [aria-expanded="true"]`: the expanded island or a menu opened from the titlebar
- `body > [data-state="open"]`: an open Radix dialog/alert-dialog/drawer (overlay and content portal as direct body children and unmount on close)
- `body > [data-radix-popper-content-wrapper]`: an open popover/dropdown/select (the wrapper only exists while open)

Once the component closes, the navbar drags again, matching the native macOS titlebar-click-dismisses-popover behavior. Deliberate side effects: a modal dialog blocks navbar dragging while open (the click closes it via the overlay instead), and the delete confirm still ignores outside clicks because alert dialogs never dismiss on outside click.

## Testing

- `./check.sh app-web` green (lint, format, tsc, 357 tests)
- Drag regions only exist in the real Electron window, so please confirm the dismiss behavior in the desktop app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXZyXa2W3Ruv7wDux2XSvE
