### PR TITLE
fix(web): reserve the composer height before a reopened chat's first paint

### DIFF
--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -34,10 +34,11 @@ import { TRIM_HISTORY_SETTLE_MS, agentNeedsUser } from "@vesta/core";
 const COMPOSER_GAP_FULLSCREEN_PX = 12;
 const COMPOSER_GAP_PANEL_PX = 8;
 
-// The empty composer's height per layout, a CSS-deterministic baseline: the 36px
-// button row plus the pill's fixed padding and border (50px), plus the wrapper's
-// bottom gap (pb-3 / pb-4 / pb-1). Seeds a cold remount so the list reserves the
-// composer's space on its first render; the real measurement then overwrites it.
+// The empty composer's height per layout, a CSS-deterministic baseline: the 50px
+// pill (a 36px button row plus its 6+6px padding and 2px border) plus the
+// wrapper's bottom gap (pb-3 12 / pb-4 16 / pb-1 4). Seeds a cold remount so the
+// list reserves the composer's space on its first render; the real measurement
+// then overwrites it.
 const COMPOSER_BASELINE_PX: Record<ComposerVariant, number> = {
   panel: 62,
   fullscreen: 66,

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { CHAT_CONTENT_WIDTH } from "./content-width";
 import { useToast } from "@/stores/use-toast";
-import { useLayout } from "@/stores/use-layout";
+import { useLayout, type ComposerVariant } from "@/stores/use-layout";
 import { useAgentSocket } from "@/providers/AgentSocketProvider";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { useVoice } from "@/stores/use-voice";
@@ -33,6 +33,16 @@ import { TRIM_HISTORY_SETTLE_MS, agentNeedsUser } from "@vesta/core";
 // the inset so the message list, skeleton, mask, and button all clear it.
 const COMPOSER_GAP_FULLSCREEN_PX = 12;
 const COMPOSER_GAP_PANEL_PX = 8;
+
+// The empty composer's height per layout, a CSS-deterministic baseline: the 36px
+// button row plus the pill's fixed padding and border (50px), plus the wrapper's
+// bottom gap (pb-3 / pb-4 / pb-1). Seeds a cold remount so the list reserves the
+// composer's space on its first render; the real measurement then overwrites it.
+const COMPOSER_BASELINE_PX: Record<ComposerVariant, number> = {
+  panel: 62,
+  fullscreen: 66,
+  mobile: 54,
+};
 
 interface ChatProps {
   onCollapse?: () => void;
@@ -101,8 +111,22 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   // Every chat floats the composer over the message list; the messages reserve
   // its live height plus the gap at the bottom so the last one always clears it,
   // and the scroll-to-bottom button parks just above it.
-  const [composerInset, setComposerInset] = useState(0);
-  const [composerHeight, setComposerHeight] = useState(0);
+  // Seed so a remounted chat (reopened from collapse) reserves the composer's space
+  // on its first render, before the async measure lands; measuring the same value
+  // then makes no re-pin, so bubbles don't snap. The cache holds the exact measured
+  // height once the composer has mounted this session; a cold mount falls back to the
+  // hardcoded baseline, which the real measurement overwrites.
+  const composerVariant: ComposerVariant = isMobile
+    ? "mobile"
+    : fullscreen
+      ? "fullscreen"
+      : "panel";
+  const setComposerBaseline = useLayout((s) => s.setComposerBaseline);
+  const seedBaseline = () =>
+    useLayout.getState().composerBaseline[composerVariant] ||
+    COMPOSER_BASELINE_PX[composerVariant];
+  const [composerInset, setComposerInset] = useState(seedBaseline);
+  const [composerHeight, setComposerHeight] = useState(seedBaseline);
   // The inset tracks the composer's collapsed baseline only: a growing draft
   // expands the pill over the (masked, opaque-covered) list instead of shifting
   // it, so measurements while a draft exists are ignored (a cleared inset, 0,
@@ -116,10 +140,18 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   });
   const composerRef = useMeasuredSize(
     "height",
-    useCallback((height: number) => {
-      setComposerHeight(height);
-      if (height === 0 || !hasDraftRef.current) setComposerInset(height);
-    }, []),
+    useCallback(
+      (height: number) => {
+        setComposerHeight(height);
+        if (height === 0 || !hasDraftRef.current) {
+          setComposerInset(height);
+          // Cache only a real, draft-free baseline; unmount reports 0, which must
+          // not overwrite the seed the next remount reads.
+          if (height > 0) setComposerBaseline(composerVariant, height);
+        }
+      },
+      [composerVariant, setComposerBaseline],
+    ),
   );
 
   const chatMessages = useMemo(

--- a/apps/web/src/stores/use-layout.ts
+++ b/apps/web/src/stores/use-layout.ts
@@ -2,20 +2,32 @@ import { create } from "zustand";
 
 const isMacOS = document.documentElement.dataset.platform === "macos";
 
+// The floating composer's baseline (empty) height, cached per layout so a remounted
+// chat reserves the right space on its first render instead of measuring it a frame
+// later and snapping the bubbles up. One slot per variant: their paddings differ.
+export type ComposerVariant = "panel" | "fullscreen" | "mobile";
+
 interface LayoutState {
   navbarHeight: number;
   bottomBarHeight: number;
   chatKeyboardFocused: boolean;
+  composerBaseline: Record<ComposerVariant, number>;
   setNavbarHeight: (height: number) => void;
   setBottomBarHeight: (height: number) => void;
   setChatKeyboardFocused: (focused: boolean) => void;
+  setComposerBaseline: (variant: ComposerVariant, height: number) => void;
 }
 
 export const useLayout = create<LayoutState>((set) => ({
   navbarHeight: isMacOS ? 68 : 44,
   bottomBarHeight: 0,
   chatKeyboardFocused: false,
+  composerBaseline: { panel: 0, fullscreen: 0, mobile: 0 },
   setNavbarHeight: (height) => set({ navbarHeight: height }),
   setBottomBarHeight: (height) => set({ bottomBarHeight: height }),
   setChatKeyboardFocused: (focused) => set({ chatKeyboardFocused: focused }),
+  setComposerBaseline: (variant, height) =>
+    set((state) => ({
+      composerBaseline: { ...state.composerBaseline, [variant]: height },
+    })),
 }));


### PR DESCRIPTION
## Problem

Reopening the chat from the navbar (after collapsing it) makes the message bubbles render in a wrong position for one frame, then snap up to their final position.

On desktop, collapsing fully **unmounts** `<Chat>` (`DesktopPanelView.tsx:74`, `{!chatCollapsed && ...}`). Reopening remounts it fresh, with the message history already loaded in the provider. The scroller then positions the bubbles in two passes:

1. **Frame 1** — the initial jump to bottom runs with `composerInset = 0` (the composer measures via an async `ResizeObserver`), so the last bubble lands where the floating composer will sit.
2. **Frame 2** — the composer's height lands, `bottomInset` grows, the list's `paddingBottom` grows, and the re-pin effect (`use-chat-scroll.ts:100-103`) snaps the bubbles up to clear the composer.

It's invisible on a normal first load because the history is still loading (skeleton showing) while the composer measures. On reopen the bubbles paint immediately and race the measurement.

React runs child layout effects before parent ones, so `ChatMessageArea` jumps before `Chat` ever measures the composer: the correct fix is to make the composer's reserved height known at the remounted chat's **first render**.

## Fix

Seed `composerInset`/`composerHeight` from a per-layout baseline instead of `0`:

- A **warm** remount (composer mounted once this session) reads the exact measured height cached in the `use-layout` store → pixel-perfect, no re-pin.
- A **cold** mount (chat kept collapsed across a reload) falls back to `COMPOSER_BASELINE_PX` (a CSS-deterministic constant: 36px button row + 50px pill padding/border + the wrapper's `pb-3`/`pb-4`/`pb-1`) → close enough to avoid a visible snap, and the real measurement overwrites the cache.

One slot per variant (`panel` / `fullscreen` / `mobile`) since their bottom gaps differ.

## Testing

- `tsc` clean, `eslint` 0 errors, 357/357 web unit tests pass.
- Verified live: collapse → reopen no longer snaps the bubbles.

The paint-timing itself isn't observable in jsdom, so there's no unit test for the frame race; the fix is verified visually. The hardcoded fallbacks are a magic-number tradeoff (they can drift if the composer's padding/button size changes), but the cache self-corrects every warm mount regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)