### PR TITLE
fix(desktop): install the app update on relaunch on macOS

### DIFF
--- a/apps/desktop/src/lifecycle.test.ts
+++ b/apps/desktop/src/lifecycle.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { trackQuitIntent } from "./lifecycle";
+
+function fakeApp() {
+  const handlers: Record<string, () => void> = {};
+  return {
+    on(event: string, listener: () => void): void {
+      handlers[event] = listener;
+    },
+    emit(event: string): void {
+      handlers[event]?.();
+    },
+  };
+}
+
+describe("trackQuitIntent", () => {
+  it("starts not quitting", () => {
+    const app = fakeApp();
+    const isQuitting = trackQuitIntent(app);
+    expect(isQuitting()).toBe(false);
+  });
+
+  it("flips on before-quit", () => {
+    const app = fakeApp();
+    const isQuitting = trackQuitIntent(app);
+    app.emit("before-quit");
+    expect(isQuitting()).toBe(true);
+  });
+
+  it("flips on before-quit-for-update, so an update relaunch lifts the macOS close guard", () => {
+    const app = fakeApp();
+    const isQuitting = trackQuitIntent(app);
+    app.emit("before-quit-for-update");
+    expect(isQuitting()).toBe(true);
+  });
+});

--- a/apps/desktop/src/lifecycle.ts
+++ b/apps/desktop/src/lifecycle.ts
@@ -1,0 +1,22 @@
+/**
+ * Tracks whether a real quit is underway. On macOS the window's close is turned into hide
+ * (keep-in-dock), and that guard must lift once the app is genuinely quitting. quitAndInstall()
+ * emits before-quit-for-update, not before-quit, so both events must flip the flag or an update
+ * relaunch only hides the window and never installs.
+ */
+interface QuitLifecycleApp {
+  on(
+    event: "before-quit" | "before-quit-for-update",
+    listener: () => void,
+  ): unknown;
+}
+
+export function trackQuitIntent(app: QuitLifecycleApp): () => boolean {
+  let quitting = false;
+  const onQuit = () => {
+    quitting = true;
+  };
+  app.on("before-quit", onQuit);
+  app.on("before-quit-for-update", onQuit);
+  return () => quitting;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, Menu, app, ipcMain, nativeTheme, shell } from "electron";
 import path from "node:path";
 import { readNativeGeolocation } from "./geolocation";
+import { trackQuitIntent } from "./lifecycle";
 import { cancelLoopback, startLoopback } from "./oauth-loopback";
 import { clearConnection, readConnection, writeConnection } from "./store";
 import { createMainWindow, registerAppScheme, showMainWindow } from "./window";
@@ -12,7 +13,7 @@ if (!gotLock) {
   app.quit();
 } else {
   let mainWindow: BrowserWindow | null = null;
-  let quitting = false;
+  const isQuitting = trackQuitIntent(app);
 
   const buildMenu = () => {
     if (process.platform !== "darwin") {
@@ -86,10 +87,6 @@ if (!gotLock) {
     if (mainWindow) showMainWindow(mainWindow);
   });
 
-  app.on("before-quit", () => {
-    quitting = true;
-  });
-
   app.on("window-all-closed", () => {
     if (process.platform !== "darwin") app.quit();
   });
@@ -109,7 +106,7 @@ if (!gotLock) {
     mainWindow = createMainWindow();
     // macOS convention: closing the window keeps Vesta in the dock.
     mainWindow.on("close", (event) => {
-      if (process.platform === "darwin" && !quitting) {
+      if (process.platform === "darwin" && !isQuitting()) {
         event.preventDefault();
         mainWindow?.hide();
       }


### PR DESCRIPTION
## Problem

On macOS, clicking **Relaunch to finish** for an app update just hid the window: the app stayed in the dock and neither relaunched nor quit, so the downloaded update never installed.

## Root cause

The macOS keep-in-dock behavior turns a window close into a hide unless a `quitting` flag is set (`main.ts`):

```ts
mainWindow.on("close", (event) => {
  if (process.platform === "darwin" && !quitting) {
    event.preventDefault();
    mainWindow?.hide();
  }
});
```

That flag flipped **only** on `before-quit`. But `updater.quitAndInstall()` (Electron's native Squirrel.Mac path) emits `before-quit-for-update`, **not** `before-quit`, then closes windows and quits once they are gone. So `quitting` stayed `false`, the close guard hid the window instead of closing it, and the quit-after-windows-closed never completed. Result: window hides, app stays in dock, update never installs.

macOS only: Windows (NSIS) and Linux (`app.relaunch()` + `app.quit()`) have no darwin close guard, so they were unaffected.

## Fix

Track quit intent from both `before-quit` and `before-quit-for-update`, extracted into a small testable `trackQuitIntent` helper (`main.ts` has no unit coverage as the Electron entry point).

## Testing

- `./check.sh app-desktop` green (lint + tsc + vitest, 35 tests, 3 new).
- Windows/Linux verified by code analysis only (I only have a Mac); both paths bypass the darwin close guard, so behavior is unchanged there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qdsHPLyP6moGXtPuwdHsu