### PR TITLE
chore(desktop): move the app bundle id into the vesta namespace

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,4 +1,4 @@
-appId: com.vestarun.app
+appId: com.vesta.desktop
 productName: Vesta
 artifactName: "Vesta_${version}_${arch}.${ext}"
 directories:


### PR DESCRIPTION
## Summary

`appId` in `apps/desktop/electron-builder.yml` moves from `com.vestarun.app` to `com.vesta.desktop`, matching the mobile app's `com.vesta.mobile` namespace.

## Impact on existing installs

- **Auto-update keeps working.** `electron-updater` keys its manifest on `version`, `files`, and `sha512`, never the bundle id, so current installs receive the next release normally.
- **Saved connection survives.** `userData` is keyed on `productName` ("Vesta"), so `connection.json` stays where it is.
- **One-time permission re-grant on macOS.** TCC grants (location, microphone) and the Location Services entry are keyed on the bundle id, so users re-grant them once after this ships.
- **Possible one-time side-by-side install on Windows.** electron-builder derives the NSIS upgrade GUID from `appId` when no explicit `nsis.guid` is set (none is), so the release carrying this may install beside the old copy with a second uninstall entry instead of upgrading in place. Same one-time cost class as the macOS re-grant; `connection.json` survives. Pinning `nsis.guid` to the old derived value would avoid it, at the cost of a config line whose only job is masking the rename; not done here.
- Linux (deb/rpm) does not key on `appId`.

No code reads the bundle id; this is a config-only change.

## Sequencing

Merge this **before** the desktop location PR (#2260): its bundled CoreLocation helper carries an embedded `Info.plist` stamped with `com.vesta.desktop`, and CoreLocation only attributes the helper's grant to the app when the two ids match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuohZkpAcVv1rZjS5CGoVT
