### PR TITLE
fix(desktop): resolve macOS location through a bundled CoreLocation helper

### DIFF
--- a/apps/.gitignore
+++ b/apps/.gitignore
@@ -4,6 +4,8 @@ dist/
 
 # Electron build artifacts
 desktop/dist-electron/
+desktop/native/vesta-location
+desktop/native/vesta-location.*64
 
 # Expo mobile build artifacts
 mobile/.expo/

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -10,7 +10,11 @@ files:
 extraResources:
   - from: ../web/dist
     to: web
+beforePack: scripts/build-native.mjs
 mac:
+  extraResources:
+    - from: native/vesta-location
+      to: vesta-location
   category: public.app-category.productivity
   target:
     - target: dmg

--- a/apps/desktop/native/vesta-location.plist
+++ b/apps/desktop/native/vesta-location.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>com.vesta.desktop</string>
+  <key>CFBundleName</key>
+  <string>Vesta</string>
+  <key>NSLocationWhenInUseUsageDescription</key>
+  <string>Vesta shares this device's location with your agents so they follow your travel.</string>
+</dict>
+</plist>

--- a/apps/desktop/native/vesta-location.swift
+++ b/apps/desktop/native/vesta-location.swift
@@ -7,7 +7,9 @@ import Foundation
 // WinRT on Windows and GeoClue2 on Linux. Any failure exits non-zero with a reason on stderr; the
 // caller falls back to timezone-only.
 
-let TIMEOUT_SECONDS: TimeInterval = 15
+// Shorter than the caller's exec budget (NATIVE_FIX_TIMEOUT_MS in geolocation.ts), so a stall
+// ends with this reason on stderr rather than the caller's SIGTERM.
+let TIMEOUT_SECONDS: TimeInterval = 12
 
 func fail(_ reason: String) -> Never {
   FileHandle.standardError.write(Data("\(reason)\n".utf8))

--- a/apps/desktop/native/vesta-location.swift
+++ b/apps/desktop/native/vesta-location.swift
@@ -1,0 +1,57 @@
+import CoreLocation
+import Foundation
+
+// A one-shot CoreLocation fix for the main process, printed as culture-invariant "lat|lon|accuracy"
+// on stdout (Swift's Double description is always dot-decimal). macOS geolocation in Electron's
+// renderer hangs with no callback, so the app resolves a fix here instead, the same way it shells
+// WinRT on Windows and GeoClue2 on Linux. Any failure exits non-zero with a reason on stderr; the
+// caller falls back to timezone-only.
+
+let TIMEOUT_SECONDS: TimeInterval = 15
+
+func fail(_ reason: String) -> Never {
+  FileHandle.standardError.write(Data("\(reason)\n".utf8))
+  exit(1)
+}
+
+final class OneShotLocation: NSObject, CLLocationManagerDelegate {
+  private let manager = CLLocationManager()
+
+  func start() {
+    manager.delegate = self
+    manager.desiredAccuracy = kCLLocationAccuracyBest
+    // Setting the delegate delivers the current authorization status on the next run-loop turn,
+    // which is what drives the request below.
+  }
+
+  func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+    switch manager.authorizationStatus {
+    case .notDetermined:
+      manager.requestWhenInUseAuthorization()
+    case .authorizedAlways, .authorizedWhenInUse:
+      manager.requestLocation()
+    case .denied, .restricted:
+      fail("denied")
+    @unknown default:
+      fail("unknown-authorization")
+    }
+  }
+
+  func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    guard let location = locations.last else { return }
+    let coord = location.coordinate
+    print("\(coord.latitude)|\(coord.longitude)|\(location.horizontalAccuracy)")
+    exit(0)
+  }
+
+  func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+    fail("error: \(error.localizedDescription)")
+  }
+}
+
+let fetcher = OneShotLocation()
+fetcher.start()
+DispatchQueue.main.asyncAfter(deadline: .now() + TIMEOUT_SECONDS) {
+  fail("timeout")
+}
+RunLoop.main.run()

--- a/apps/desktop/scripts/build-native.mjs
+++ b/apps/desktop/scripts/build-native.mjs
@@ -1,0 +1,46 @@
+// electron-builder beforePack hook: compile the macOS CoreLocation helper
+// (native/vesta-location.swift) into native/vesta-location, which electron-builder then ships
+// beside the web bundle in Resources and signs with the app. macOS only; other platforms have
+// no helper and skip it. The helper's embedded Info.plist stamps it with the app's identity so
+// CoreLocation prompts and grants under the app, never a separate entry.
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const nativeDir = fileURLToPath(new URL("../native", import.meta.url));
+
+export default function buildNative(context) {
+  if (context.electronPlatformName !== "darwin") return;
+  const archs = archNames(context.arch);
+  const output = path.join(nativeDir, "vesta-location");
+  const source = path.join(nativeDir, "vesta-location.swift");
+  const plist = path.join(nativeDir, "vesta-location.plist");
+  const slices = archs.map((arch) => {
+    const slice = `${output}.${arch}`;
+    execFileSync("swiftc", [
+      "-O",
+      "-target",
+      `${arch}-apple-macosx11.0`,
+      source,
+      "-o",
+      slice,
+      "-Xlinker",
+      "-sectcreate",
+      "-Xlinker",
+      "__TEXT",
+      "-Xlinker",
+      "__info_plist",
+      "-Xlinker",
+      plist,
+    ]);
+    return slice;
+  });
+  execFileSync("lipo", ["-create", ...slices, "-output", output]);
+}
+
+// electron-builder's Arch enum: 0 ia32, 1 x64, 2 armv7l, 3 arm64, 4 universal.
+function archNames(arch) {
+  if (arch === 4) return ["arm64", "x86_64"];
+  if (arch === 1) return ["x86_64"];
+  return ["arm64"];
+}

--- a/apps/desktop/src/geolocation.test.ts
+++ b/apps/desktop/src/geolocation.test.ts
@@ -49,9 +49,27 @@ describe("gdbus parsing", () => {
 });
 
 describe("resolveNativeFix", () => {
-  it("answers null on macOS so the renderer keeps its CoreLocation path", async () => {
-    const run = () => Promise.reject(new Error("must not be called"));
-    expect(await resolveNativeFix("darwin", run)).toBeNull();
+  it("resolves a macOS fix through the bundled CoreLocation helper", async () => {
+    const commands: string[][] = [];
+    const run = (command: string, args: string[]) => {
+      commands.push([command, ...args]);
+      return Promise.resolve("39.2238|9.1217|25\n");
+    };
+    expect(
+      await resolveNativeFix("darwin", run, undefined, "/app/vesta-location"),
+    ).toEqual({
+      latitude: 39.2238,
+      longitude: 9.1217,
+      accuracyM: 25,
+    });
+    expect(commands).toEqual([["/app/vesta-location"]]);
+  });
+
+  it("raises the helper's own reason when it refuses on macOS", async () => {
+    const run = () => Promise.reject(new Error("Command failed: denied"));
+    await expect(
+      resolveNativeFix("darwin", run, undefined, "/app/vesta-location"),
+    ).rejects.toThrow("denied");
   });
 
   it("resolves a Windows fix through powershell", async () => {
@@ -101,9 +119,18 @@ describe("resolveNativeFix", () => {
     expect(calls.at(-1)).toContain("Client.Stop");
   });
 
-  it("resolves null when the provider is missing or refuses", async () => {
+  it("raises the provider's reason when it is missing or refuses", async () => {
     const run = () => Promise.reject(new Error("gdbus: command not found"));
-    expect(await resolveNativeFix("linux", run, instantSleep)).toBeNull();
-    expect(await resolveNativeFix("win32", run)).toBeNull();
+    await expect(resolveNativeFix("linux", run, instantSleep)).rejects.toThrow(
+      "gdbus: command not found",
+    );
+    await expect(resolveNativeFix("win32", run)).rejects.toThrow(
+      "gdbus: command not found",
+    );
+  });
+
+  it("answers null on a platform with no provider", async () => {
+    const run = () => Promise.reject(new Error("must not be called"));
+    expect(await resolveNativeFix("freebsd", run)).toBeNull();
   });
 });

--- a/apps/desktop/src/geolocation.ts
+++ b/apps/desktop/src/geolocation.ts
@@ -6,8 +6,9 @@ import { promisify } from "node:util";
 // waiting for an authorization prompt Electron never raises, and the network provider needs a
 // Google API key. So every platform resolves here: macOS through the bundled Swift CoreLocation
 // helper (which raises the prompt itself, carrying the app's identity), Windows through the in-box
-// WinRT Geolocator (PowerShell), Linux through GeoClue2 over the system D-Bus (gdbus). Every
-// failure (no provider, denied, timeout) resolves to null; the caller falls back to timezone-only.
+// WinRT Geolocator (PowerShell), Linux through GeoClue2 over the system D-Bus (gdbus). A
+// platform with no provider answers null; a provider that fails (denied, timeout, no service)
+// raises its own reason, and the renderer falls back to timezone-only either way.
 
 export interface NativeFix {
   latitude: number;

--- a/apps/desktop/src/geolocation.ts
+++ b/apps/desktop/src/geolocation.ts
@@ -2,11 +2,12 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 // The one owner of native OS geolocation for the main process. The renderer's
-// navigator.geolocation resolves only on macOS (CoreLocation), so this module answers for the
-// other two platforms: Windows through the in-box WinRT Geolocator (PowerShell, no packaging or
-// API key needed), Linux through GeoClue2 over the system D-Bus (gdbus, present on most
-// desktops). macOS answers null so the renderer keeps its CoreLocation path. Every failure
-// (no provider, denied, timeout) resolves to null; the caller falls back to timezone-only.
+// navigator.geolocation cannot be relied on: Chromium's CoreLocation provider on macOS stalls
+// waiting for an authorization prompt Electron never raises, and the network provider needs a
+// Google API key. So every platform resolves here: macOS through the bundled Swift CoreLocation
+// helper (which raises the prompt itself, carrying the app's identity), Windows through the in-box
+// WinRT Geolocator (PowerShell), Linux through GeoClue2 over the system D-Bus (gdbus). Every
+// failure (no provider, denied, timeout) resolves to null; the caller falls back to timezone-only.
 
 export interface NativeFix {
   latitude: number;
@@ -23,16 +24,32 @@ type Run = (command: string, args: string[]) => Promise<string>;
 
 const execFileAsync = promisify(execFile);
 
+// A failing provider explains itself on stderr (the helper's reason, PowerShell's exception,
+// gdbus's D-Bus error); re-raise that text so the renderer can show why there is no fix.
 async function runWithTimeout(
   command: string,
   args: string[],
   timeoutMs: number,
 ): Promise<string> {
-  const { stdout } = await execFileAsync(command, args, {
-    timeout: timeoutMs,
-    windowsHide: true,
-  });
-  return stdout;
+  try {
+    const { stdout } = await execFileAsync(command, args, {
+      timeout: timeoutMs,
+      windowsHide: true,
+    });
+    return stdout;
+  } catch (error) {
+    const stderr =
+      typeof error === "object" &&
+      error !== null &&
+      "stderr" in error &&
+      typeof error.stderr === "string"
+        ? error.stderr.trim()
+        : "";
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(stderr === "" ? message : `${message}: ${stderr}`, {
+      cause: error,
+    });
+  }
 }
 
 // Culture-invariant "lat|lon|accuracy" so a comma-decimal locale cannot corrupt the numbers.
@@ -177,26 +194,38 @@ async function readLocation(
   return { latitude, longitude, accuracyM: accuracy };
 }
 
+// The helper prints the same invariant "lat|lon|accuracy" line as the Windows script and exits
+// non-zero on any failure, so the run rejecting is what a denied or timed-out fix looks like.
+async function macFix(run: Run, helperPath: string): Promise<NativeFix | null> {
+  return parseWindowsFix(await run(helperPath, []));
+}
+
+// Null means the platform has no provider or it answered nothing usable; a provider that failed
+// outright throws, carrying its own reason, and the renderer decides how to surface that.
 export async function resolveNativeFix(
   platform: NodeJS.Platform,
   run: Run,
   sleep?: (ms: number) => Promise<void>,
+  macHelperPath?: string,
 ): Promise<NativeFix | null> {
-  try {
-    if (platform === "win32") return await windowsFix(run);
-    if (platform === "linux") return await linuxFix(run, sleep);
-    return null;
-  } catch {
-    return null;
+  if (platform === "darwin" && macHelperPath !== undefined) {
+    return macFix(run, macHelperPath);
   }
+  if (platform === "win32") return windowsFix(run);
+  if (platform === "linux") return linuxFix(run, sleep);
+  return null;
 }
 
-export function readNativeGeolocation(): Promise<NativeFix | null> {
+// The one-shot providers (macOS helper, Windows script) own the full fix budget; the Linux walk is
+// many short gdbus calls, each bounded on its own.
+export function readNativeGeolocation(
+  macHelperPath: string,
+): Promise<NativeFix | null> {
   const run: Run = (command, args) =>
     runWithTimeout(
       command,
       args,
-      process.platform === "win32" ? NATIVE_FIX_TIMEOUT_MS : EXEC_TIMEOUT_MS,
+      process.platform === "linux" ? EXEC_TIMEOUT_MS : NATIVE_FIX_TIMEOUT_MS,
     );
-  return resolveNativeFix(process.platform, run);
+  return resolveNativeFix(process.platform, run, undefined, macHelperPath);
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,4 +1,11 @@
-import { BrowserWindow, Menu, app, ipcMain, nativeTheme, shell } from "electron";
+import {
+  BrowserWindow,
+  Menu,
+  app,
+  ipcMain,
+  nativeTheme,
+  shell,
+} from "electron";
 import path from "node:path";
 import { readNativeGeolocation } from "./geolocation";
 import { trackQuitIntent } from "./lifecycle";
@@ -46,7 +53,8 @@ if (!gotLock) {
       () => mainWindow?.isMaximized() ?? false,
     );
     ipcMain.on("set-theme", (_event, theme: unknown) => {
-      if (theme === "light" || theme === "dark") nativeTheme.themeSource = theme;
+      if (theme === "light" || theme === "dark")
+        nativeTheme.themeSource = theme;
     });
     ipcMain.handle("open-external", (_event, url: unknown) => {
       if (typeof url === "string" && /^https?:\/\//.test(url))
@@ -75,12 +83,21 @@ if (!gotLock) {
     );
     ipcMain.handle("store:clear", () => clearConnection());
     ipcMain.handle("oauth:start", () =>
-      startLoopback((url) => mainWindow?.webContents.send("oauth:callback", url)),
+      startLoopback((url) =>
+        mainWindow?.webContents.send("oauth:callback", url),
+      ),
     );
     ipcMain.handle("oauth:cancel", (_event, port: unknown) => {
       if (typeof port === "number") cancelLoopback(port);
     });
-    ipcMain.handle("geolocation:read", () => readNativeGeolocation());
+    // The macOS CoreLocation helper ships beside the web bundle in Resources; in dev it is the
+    // `native/` build output.
+    const macHelperPath = app.isPackaged
+      ? path.join(process.resourcesPath, "vesta-location")
+      : path.join(app.getAppPath(), "native", "vesta-location");
+    ipcMain.handle("geolocation:read", () =>
+      readNativeGeolocation(macHelperPath),
+    );
   };
 
   app.on("second-instance", () => {

--- a/apps/web/src/components/Settings/DevicesCard/index.tsx
+++ b/apps/web/src/components/Settings/DevicesCard/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { Monitor, Smartphone, Globe, HelpCircle, Circle } from "lucide-react";
 import type { DeviceInfo, DeviceKind } from "@vesta/core";
 import { Card, CardContent } from "@/components/ui/card";
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/field";
 import { MenuSection } from "@/components/ui/menu-section";
 import { Switch } from "@/components/ui/switch";
+import { probeGeolocation } from "@/lib/device-context";
 import { useGateway } from "@/providers/GatewayProvider";
 import { useShareLocation } from "@/stores/use-share-location";
 import { contextLine } from "./context-line";
@@ -41,24 +42,55 @@ function lastSeenLabel(lastSeen: string): string {
 function LocationToggle() {
   const enabled = useShareLocation((s) => s.enabled);
   const setEnabled = useShareLocation((s) => s.setEnabled);
+  // TEMPORARY diagnostic (remove after debugging desktop location): probe on enable and show why a
+  // fix is null, so the real per-platform error can be copied back.
+  const [probe, setProbe] = useState<{
+    status: "idle" | "probing" | "error";
+    detail: string;
+  }>({ status: "idle", detail: "" });
+
+  const onToggle = (checked: boolean) => {
+    setEnabled(checked);
+    if (!checked) {
+      setProbe({ status: "idle", detail: "" });
+      return;
+    }
+    setProbe({ status: "probing", detail: "" });
+    void probeGeolocation().then((result) => {
+      setProbe(
+        result.ok
+          ? { status: "idle", detail: "" }
+          : { status: "error", detail: result.detail },
+      );
+    });
+  };
 
   return (
-    <Field
-      orientation="horizontal"
-      className="mt-3 items-center justify-between"
-    >
-      <FieldContent>
-        <FieldLabel className="text-sm">
-          share this device&apos;s location
-        </FieldLabel>
-        <FieldDescription>
-          let your agents see where this device is, from its precise location;
-          the system asks permission the first time, and switching off forgets
-          what this device shared
-        </FieldDescription>
-      </FieldContent>
-      <Switch checked={enabled} onCheckedChange={setEnabled} />
-    </Field>
+    <div className="mt-3 flex flex-col gap-2">
+      <Field orientation="horizontal" className="items-center justify-between">
+        <FieldContent>
+          <FieldLabel className="text-sm">
+            share this device&apos;s location
+          </FieldLabel>
+          <FieldDescription>
+            let your agents see where this device is, from its precise location;
+            the system asks permission the first time, and switching off forgets
+            what this device shared
+          </FieldDescription>
+        </FieldContent>
+        <Switch checked={enabled} onCheckedChange={onToggle} />
+      </Field>
+      {probe.status === "probing" && (
+        <span className="text-xs text-muted-foreground">
+          checking location…
+        </span>
+      )}
+      {probe.status === "error" && (
+        <pre className="whitespace-pre-wrap rounded-md bg-destructive/10 p-2 text-xs text-destructive">
+          {`couldn't read a location fix:\n${probe.detail}`}
+        </pre>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/src/lib/device-context.test.ts
+++ b/apps/web/src/lib/device-context.test.ts
@@ -97,16 +97,25 @@ describe("readBrowserDeviceContext", () => {
     expect(getCurrentPosition).not.toHaveBeenCalled();
   });
 
-  it("falls through to the renderer's geolocation when the bridge answers null", async () => {
+  it("treats the desktop bridge's null as final and never asks the renderer", async () => {
     stubOsZone("America/New_York");
-    stubGeolocation((success) => {
-      success({
-        coords: { latitude: 39.2238, longitude: 9.1217, accuracy: 20 },
-      });
-    });
+    const getCurrentPosition = vi.fn();
+    stubGeolocation(getCurrentPosition);
     bridge.readGeolocation = () => Promise.resolve(null);
-    await expect(readBrowserDeviceContext(true)).resolves.toMatchObject({
-      timezone: "Europe/Rome",
+    await expect(readBrowserDeviceContext(true)).resolves.toEqual({
+      timezone: "America/New_York",
     });
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+  });
+
+  it("treats a refusing desktop provider as no fix and never asks the renderer", async () => {
+    stubOsZone("America/New_York");
+    const getCurrentPosition = vi.fn();
+    stubGeolocation(getCurrentPosition);
+    bridge.readGeolocation = () => Promise.reject(new Error("denied"));
+    await expect(readBrowserDeviceContext(true)).resolves.toEqual({
+      timezone: "America/New_York",
+    });
+    expect(getCurrentPosition).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/device-context.ts
+++ b/apps/web/src/lib/device-context.ts
@@ -52,19 +52,19 @@ function browserFix(): Promise<Fix | null> {
 }
 
 // A fix, or null when geolocation is unavailable, denied, or slow: the report then carries the OS
-// zone alone. In the desktop app the main process resolves through the OS provider first (WinRT on
-// Windows, GeoClue2 on Linux); a null answer (macOS, no provider, refused) falls through to the
-// renderer's own geolocation, whose prompt this call itself raises, so the opt-in toggle gates both.
+// zone alone. The desktop app resolves through the OS provider in its main process on every
+// platform, and that answer is final: the renderer's own geolocation is never a fallback there,
+// since in Electron it hangs on macOS and needs a Google API key elsewhere. Only a plain browser
+// asks navigator.geolocation, whose prompt this call itself raises, so the opt-in toggle gates it.
 async function readFix(): Promise<Fix | null> {
   if (native.readGeolocation) {
     const fix = await native.readGeolocation().catch(() => null);
-    if (fix) {
-      return {
-        latitude: fix.latitude,
-        longitude: fix.longitude,
-        accuracy: fix.accuracyM,
-      };
-    }
+    if (fix === null) return null;
+    return {
+      latitude: fix.latitude,
+      longitude: fix.longitude,
+      accuracy: fix.accuracyM,
+    };
   }
   return browserFix();
 }

--- a/apps/web/src/lib/device-context.ts
+++ b/apps/web/src/lib/device-context.ts
@@ -69,6 +69,101 @@ async function readFix(): Promise<Fix | null> {
   return browserFix();
 }
 
+// TEMPORARY diagnostic (remove after debugging desktop location): on enable, report exactly why a
+// fix is null on this platform, both the native-provider outcome and the navigator.geolocation
+// error, so the failure the renderer actually sees can be pasted back.
+export interface GeoProbe {
+  ok: boolean;
+  detail: string;
+}
+
+function geoErrorName(code: number): string {
+  if (code === 1) return "PERMISSION_DENIED";
+  if (code === 2) return "POSITION_UNAVAILABLE";
+  if (code === 3) return "TIMEOUT";
+  return "UNKNOWN";
+}
+
+// Electron's macOS getCurrentPosition can hang with no callback and ignore its own timeout option,
+// so each step gets a hard cap and "hung" is itself a reported outcome.
+const PROBE_STEP_MS = 10_000;
+
+function probeTimeout<T>(value: T): Promise<T> {
+  return new Promise((resolve) =>
+    setTimeout(() => resolve(value), PROBE_STEP_MS),
+  );
+}
+
+function browserFixDetailed(): Promise<{
+  fix: Fix | null;
+  error: string | null;
+}> {
+  if (typeof navigator === "undefined" || !("geolocation" in navigator)) {
+    return Promise.resolve({
+      fix: null,
+      error: "navigator.geolocation unavailable",
+    });
+  }
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      resolve({
+        fix: null,
+        error: "no callback within 10s (getCurrentPosition hung)",
+      });
+    }, PROBE_STEP_MS);
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        clearTimeout(timer);
+        const { latitude, longitude, accuracy } = position.coords;
+        resolve({ fix: { latitude, longitude, accuracy }, error: null });
+      },
+      (error) => {
+        clearTimeout(timer);
+        resolve({
+          fix: null,
+          error: `code ${String(error.code)} ${geoErrorName(error.code)}: ${error.message}`,
+        });
+      },
+      { timeout: PROBE_STEP_MS },
+    );
+  });
+}
+
+export async function probeGeolocation(): Promise<GeoProbe> {
+  const lines: string[] = [
+    `runtime=${native.runtime} platform=${native.platform}`,
+  ];
+  if (native.readGeolocation) {
+    const outcome = await Promise.race([
+      native.readGeolocation().then(
+        (fix) => ({ kind: "fix" as const, fix }),
+        (error: unknown) => ({ kind: "throw" as const, error }),
+      ),
+      probeTimeout({ kind: "timeout" as const }),
+    ]);
+    if (outcome.kind === "fix") {
+      if (outcome.fix) return { ok: true, detail: "" };
+      lines.push("native provider: returned null");
+    } else if (outcome.kind === "throw") {
+      // Electron prefixes a main-process throw with the IPC channel; keep only the provider's reason.
+      const raw =
+        outcome.error instanceof Error
+          ? outcome.error.message
+          : String(outcome.error);
+      const reason = raw.replace(/^Error invoking remote method '[^']*': /, "");
+      lines.push(`native provider: threw ${reason}`);
+    } else {
+      lines.push("native provider: no response within 10s");
+    }
+  } else {
+    lines.push("native provider: not available (browser runtime)");
+  }
+  const browser = await browserFixDetailed();
+  if (browser.fix) return { ok: true, detail: "" };
+  lines.push(`navigator.geolocation: ${browser.error ?? "no fix"}`);
+  return { ok: false, detail: lines.join("\n") };
+}
+
 // With sharing off the report carries `position: null`, which retracts any position the gateway
 // holds for this device; with sharing on but no fix, the position is absent and the stored one
 // stands. The browser has no offline reverse geocoder, so the position names no place.

--- a/apps/web/src/lib/native/types.ts
+++ b/apps/web/src/lib/native/types.ts
@@ -17,8 +17,9 @@ export interface OauthLoopback {
   cancel(port: number): Promise<void>;
 }
 
-// A fix the desktop main process resolved through the OS location provider (WinRT on Windows,
-// GeoClue2 on Linux); macOS answers null and the renderer's own geolocation covers it.
+// A fix the desktop main process resolved through the OS location provider (CoreLocation on
+// macOS, WinRT on Windows, GeoClue2 on Linux); that answer is final, the renderer never falls
+// back to its own geolocation in the desktop app.
 export interface NativeGeolocationFix {
   latitude: number;
   longitude: number;


### PR DESCRIPTION
## Problem

No desktop client ever saves a position to the gateway. The macOS cause is confirmed on a packaged, signed build: the renderer's `navigator.geolocation.getCurrentPosition` hangs with no callback at all (its own `timeout` option never fires). vestad and the client frame path are symmetric across platforms and store whatever position a client sends, so the loss is the fix read itself.

Why the renderer path is a dead end on macOS, from Electron's docs and the Chromium source:
- Electron's geolocation defaults to Google's network provider and **ships no API key**, so that provider fails.
- Chromium's built-in CoreLocation provider needs its `GeolocationSystemPermissionManager` to drive the macOS authorization prompt, which Electron does not implement. The prompt never appears and the request stalls. Tracked, unresolved: electron/electron#45290, #46013.

## Fix

macOS now resolves in the **main process**, the same shape Windows (WinRT) and Linux (GeoClue2) already use in `geolocation.ts`:
- `native/vesta-location.swift`: a one-shot CoreLocation helper. It calls `requestWhenInUseAuthorization()` itself (raising the macOS prompt), reads a fix, prints the same invariant `lat|lon|accuracy` line the Windows script does, and exits non-zero with a reason (`denied`, `timeout`, `error: …`) on failure. `parseWindowsFix` covers it unchanged.
- `native/vesta-location.plist`: embedded `Info.plist` stamping the helper with the app's bundle id and usage string, so CoreLocation prompts and grants **as Vesta**, not as a separate entry.
- `scripts/build-native.mjs`: electron-builder `beforePack` hook compiling the helper (macOS builds only, arm64 or universal per build arch) into `Resources`, where electron-builder signs it with the app. Runs on every packaging path, so CI needs no workflow change.
- `geolocation.ts` gains the `darwin` branch; `main.ts` resolves the helper in `Resources` when packaged, `native/` in dev.

## Failures now explain themselves

`runWithTimeout` captures the provider's stderr and `resolveNativeFix` re-raises it instead of collapsing every failure to `null`: the helper's exit reason on macOS, PowerShell's exception on Windows, gdbus's D-Bus error on Linux. `null` now means only "no provider on this platform". The renderer's `readFix` already catches to `null`, so normal behavior is unchanged. Verified with a throwaway Electron app that the message survives the IPC boundary intact.

## TEMPORARY diagnostic, for the release test

Toggling *share this device's location* on runs a probe of both paths and renders the exact per-platform outcome under the toggle (grep `TEMPORARY`). Windows also reports no position, but its code path never touches the renderer (it is WinRT in the main process), so its cause is separate and still unobserved. The probe's `native provider: threw <reason>` line will name it. Remove the probe once both platforms are confirmed.

## Validation

The one piece not verifiable locally is whether macOS attributes the helper's grant to the app: that needs a real Developer-ID-signed build, since ad-hoc signing gives TCC no stable identity. Standalone runs of the helper time out by design (a headless CLI has no app identity to prompt from). Validated on the next official release on macOS and Windows.

Locally: `./check.sh app-desktop` green (37 tests); web `tsc`, `eslint`, `prettier` green; a `--dir` build confirmed the hook compiles the helper and lands it in `Contents/Resources/vesta-location` with the embedded plist.

## Sequencing

**Depends on #2259** (bundle id → `com.vesta.desktop`): the helper's plist carries that id, and CoreLocation only attributes the grant to the app when the two match. Merge #2259 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuohZkpAcVv1rZjS5CGoVT
