### PR TITLE
feat: secure saved gateway switching

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -10,7 +10,14 @@ import path from "node:path";
 import { readNativeGeolocation } from "./geolocation";
 import { trackQuitIntent } from "./lifecycle";
 import { cancelLoopback, startLoopback } from "./oauth-loopback";
-import { clearConnection, readConnection, writeConnection } from "./store";
+import {
+  clearConnection,
+  clearRecentGateways,
+  readConnection,
+  readRecentGateways,
+  writeConnection,
+  writeRecentGateways,
+} from "./store";
 import { createMainWindow, registerAppScheme, showMainWindow } from "./window";
 
 registerAppScheme();
@@ -84,6 +91,11 @@ if (!gotLock) {
       writeConnection(value),
     );
     ipcMain.handle("store:clear", () => clearConnection());
+    ipcMain.handle("recent-store:read", () => readRecentGateways());
+    ipcMain.handle("recent-store:write", (_event, value: unknown) =>
+      writeRecentGateways(value),
+    );
+    ipcMain.handle("recent-store:clear", () => clearRecentGateways());
     ipcMain.handle("oauth:start", () =>
       startLoopback((url) =>
         mainWindow?.webContents.send("oauth:callback", url),

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -28,6 +28,10 @@ contextBridge.exposeInMainWorld("vestaNative", {
   storeRead: () => ipcRenderer.invoke("store:read"),
   storeWrite: (value: unknown) => ipcRenderer.invoke("store:write", value),
   storeClear: () => ipcRenderer.invoke("store:clear"),
+  recentStoreRead: () => ipcRenderer.invoke("recent-store:read"),
+  recentStoreWrite: (value: unknown) =>
+    ipcRenderer.invoke("recent-store:write", value),
+  recentStoreClear: () => ipcRenderer.invoke("recent-store:clear"),
   oauthStart: () => ipcRenderer.invoke("oauth:start"),
   onOauthCallback: (cb: (url: string) => void) =>
     subscribe("oauth:callback", (_event, url: string) => {

--- a/apps/desktop/src/store.test.ts
+++ b/apps/desktop/src/store.test.ts
@@ -7,6 +7,7 @@ import {
   clearRecentGateways,
   readConnection,
   readRecentGateways,
+  storageBackendIsSecure,
   writeConnection,
   writeRecentGateways,
 } from "./store";
@@ -22,7 +23,42 @@ beforeEach(async () => {
 
 afterEach(async () => {
   delete process.env.VESTA_TEST_USER_DATA;
+  delete process.env.VESTA_TEST_ENCRYPTION_AVAILABLE;
+  delete process.env.VESTA_TEST_STORAGE_BACKEND;
   await fs.rm(userDataDir, { recursive: true, force: true });
+});
+
+describe("secure storage availability", () => {
+  it.each<[string, string, boolean, string, boolean]>([
+    [
+      "rejects an unavailable encryption service",
+      "darwin",
+      false,
+      "unknown",
+      false,
+    ],
+    [
+      "rejects Electron's Linux plaintext fallback",
+      "linux",
+      true,
+      "basic_text",
+      false,
+    ],
+    ["rejects an unknown Linux backend", "linux", true, "unknown", false],
+    ["accepts a Linux secret store", "linux", true, "gnome_libsecret", true],
+    ["accepts Keychain encryption", "darwin", true, "unknown", true],
+    ["accepts DPAPI encryption", "win32", true, "unknown", true],
+  ])("%s", (_name, platform, available, backend, expected) => {
+    expect(storageBackendIsSecure(platform, available, backend)).toBe(expected);
+  });
+
+  it("rejects writes when encryption is unavailable", async () => {
+    process.env.VESTA_TEST_ENCRYPTION_AVAILABLE = "false";
+
+    await expect(writeConnection(CONNECTION)).rejects.toThrow(
+      "secure credential storage is unavailable",
+    );
+  });
 });
 
 describe("connection store", () => {

--- a/apps/desktop/src/store.test.ts
+++ b/apps/desktop/src/store.test.ts
@@ -2,7 +2,14 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { clearConnection, readConnection, writeConnection } from "./store";
+import {
+  clearConnection,
+  clearRecentGateways,
+  readConnection,
+  readRecentGateways,
+  writeConnection,
+  writeRecentGateways,
+} from "./store";
 
 const CONNECTION = { url: "https://box.example", accessToken: "at" };
 
@@ -22,6 +29,11 @@ describe("connection store", () => {
   it("round-trips a written connection", async () => {
     await writeConnection(CONNECTION);
     expect(await readConnection()).toEqual(CONNECTION);
+    const stored = await fs.readFile(
+      path.join(userDataDir, "connection.json"),
+      "utf8",
+    );
+    expect(stored).not.toContain(CONNECTION.accessToken);
   });
 
   it("reads null when nothing has been written", async () => {
@@ -33,6 +45,16 @@ describe("connection store", () => {
     expect(await readConnection()).toBeNull();
   });
 
+  it("migrates a plaintext connection to encrypted storage", async () => {
+    const target = path.join(userDataDir, "connection.json");
+    await fs.writeFile(target, JSON.stringify(CONNECTION));
+
+    expect(await readConnection()).toEqual(CONNECTION);
+    expect(await fs.readFile(target, "utf8")).not.toContain(
+      CONNECTION.accessToken,
+    );
+  });
+
   it("clears a stored connection", async () => {
     await writeConnection(CONNECTION);
     await clearConnection();
@@ -41,5 +63,25 @@ describe("connection store", () => {
 
   it("clears an absent connection without throwing", async () => {
     await expect(clearConnection()).resolves.toBeUndefined();
+  });
+});
+
+describe("recent gateway store", () => {
+  it("round-trips encrypted saved gateways", async () => {
+    const gateways = [{ connection: CONNECTION, lastConnectedAt: 1 }];
+    await writeRecentGateways(gateways);
+
+    expect(await readRecentGateways()).toEqual(gateways);
+    const stored = await fs.readFile(
+      path.join(userDataDir, "recent-gateways.json"),
+      "utf8",
+    );
+    expect(stored).not.toContain(CONNECTION.accessToken);
+  });
+
+  it("clears saved gateways", async () => {
+    await writeRecentGateways([]);
+    await clearRecentGateways();
+    expect(await readRecentGateways()).toBeNull();
   });
 });

--- a/apps/desktop/src/store.ts
+++ b/apps/desktop/src/store.ts
@@ -1,33 +1,111 @@
-import { app } from "electron";
+import { app, safeStorage } from "electron";
 import fs from "node:fs/promises";
 import path from "node:path";
 
-function storePath(): string {
-  return path.join(app.getPath("userData"), "connection.json");
+const STORE_VERSION = 1;
+const CONNECTION_FILE = "connection.json";
+const RECENT_GATEWAYS_FILE = "recent-gateways.json";
+
+interface EncryptedStore {
+  version: number;
+  encrypted: string;
 }
 
-export async function readConnection(): Promise<unknown> {
-  let raw: string;
+function storePath(filename: string): string {
+  return path.join(app.getPath("userData"), filename);
+}
+
+function encryptedPayload(value: unknown): EncryptedStore {
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error("secure credential storage is unavailable");
+  }
+  return {
+    version: STORE_VERSION,
+    encrypted: safeStorage
+      .encryptString(JSON.stringify(value))
+      .toString("base64"),
+  };
+}
+
+function parseEncryptedStore(value: unknown): EncryptedStore | null {
+  if (value === null || typeof value !== "object") return null;
+  const record = value as { version?: unknown; encrypted?: unknown };
+  if (
+    record.version !== STORE_VERSION ||
+    typeof record.encrypted !== "string"
+  ) {
+    return null;
+  }
+  return { version: STORE_VERSION, encrypted: record.encrypted };
+}
+
+async function writeStore(filename: string, value: unknown): Promise<void> {
+  const target = storePath(filename);
+  await fs.mkdir(path.dirname(target), { recursive: true, mode: 0o700 });
+  const temporary = `${target}.tmp`;
+  await fs.writeFile(temporary, JSON.stringify(encryptedPayload(value)), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await fs.rename(temporary, target);
+}
+
+async function readStore(filename: string): Promise<unknown> {
+  let parsed: unknown;
   try {
-    raw = await fs.readFile(storePath(), "utf8");
+    parsed = JSON.parse(await fs.readFile(storePath(filename), "utf8"));
   } catch {
     return null;
   }
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
+
+  const encrypted = parseEncryptedStore(parsed);
+  if (encrypted) {
+    try {
+      const decrypted = safeStorage.decryptString(
+        Buffer.from(encrypted.encrypted, "base64"),
+      );
+      return JSON.parse(decrypted);
+    } catch {
+      return null;
+    }
   }
+
+  // LEGACY(remove-when: MIN_SUPPORTED_CLIENT_VERSION exceeds 0.2.13):
+  // Re-encrypt stores written by desktop releases that persisted plain JSON.
+  if (safeStorage.isEncryptionAvailable()) {
+    try {
+      await writeStore(filename, parsed);
+    } catch (cause) {
+      console.warn(`could not encrypt legacy ${filename}`, cause);
+    }
+  }
+  return parsed;
 }
 
-export async function writeConnection(value: unknown): Promise<void> {
-  const target = storePath();
-  await fs.mkdir(path.dirname(target), { recursive: true });
-  const tmp = `${target}.tmp`;
-  await fs.writeFile(tmp, JSON.stringify(value), "utf8");
-  await fs.rename(tmp, target);
+async function clearStore(filename: string): Promise<void> {
+  await fs.rm(storePath(filename), { force: true });
 }
 
-export async function clearConnection(): Promise<void> {
-  await fs.rm(storePath(), { force: true });
+export function readConnection(): Promise<unknown> {
+  return readStore(CONNECTION_FILE);
+}
+
+export function writeConnection(value: unknown): Promise<void> {
+  return writeStore(CONNECTION_FILE, value);
+}
+
+export function clearConnection(): Promise<void> {
+  return clearStore(CONNECTION_FILE);
+}
+
+export function readRecentGateways(): Promise<unknown> {
+  return readStore(RECENT_GATEWAYS_FILE);
+}
+
+export function writeRecentGateways(value: unknown): Promise<void> {
+  return writeStore(RECENT_GATEWAYS_FILE, value);
+}
+
+export function clearRecentGateways(): Promise<void> {
+  return clearStore(RECENT_GATEWAYS_FILE);
 }

--- a/apps/desktop/src/store.ts
+++ b/apps/desktop/src/store.ts
@@ -15,8 +15,32 @@ function storePath(filename: string): string {
   return path.join(app.getPath("userData"), filename);
 }
 
+export function storageBackendIsSecure(
+  platform: string,
+  encryptionAvailable: boolean,
+  linuxBackend: string,
+): boolean {
+  if (!encryptionAvailable) return false;
+  if (platform !== "linux") return true;
+  return ["gnome_libsecret", "kwallet", "kwallet5", "kwallet6"].includes(
+    linuxBackend,
+  );
+}
+
+function secureStorageAvailable(): boolean {
+  const linuxBackend =
+    process.platform === "linux"
+      ? safeStorage.getSelectedStorageBackend()
+      : "unknown";
+  return storageBackendIsSecure(
+    process.platform,
+    safeStorage.isEncryptionAvailable(),
+    linuxBackend,
+  );
+}
+
 function encryptedPayload(value: unknown): EncryptedStore {
-  if (!safeStorage.isEncryptionAvailable()) {
+  if (!secureStorageAvailable()) {
     throw new Error("secure credential storage is unavailable");
   }
   return {
@@ -72,7 +96,7 @@ async function readStore(filename: string): Promise<unknown> {
 
   // LEGACY(remove-when: MIN_SUPPORTED_CLIENT_VERSION exceeds 0.2.13):
   // Re-encrypt stores written by desktop releases that persisted plain JSON.
-  if (safeStorage.isEncryptionAvailable()) {
+  if (secureStorageAvailable()) {
     try {
       await writeStore(filename, parsed);
     } catch (cause) {

--- a/apps/desktop/test/electron-stub.ts
+++ b/apps/desktop/test/electron-stub.ts
@@ -10,7 +10,7 @@ export const safeStorage = {
   isEncryptionAvailable: (): boolean =>
     process.env.VESTA_TEST_ENCRYPTION_AVAILABLE !== "false",
   getSelectedStorageBackend: (): string =>
-    process.env.VESTA_TEST_STORAGE_BACKEND ?? "unknown",
+    process.env.VESTA_TEST_STORAGE_BACKEND ?? "gnome_libsecret",
   encryptString: (value: string): Buffer =>
     Buffer.from(`${ENCRYPTION_PREFIX}${value}`, "utf8"),
   decryptString: (value: Buffer): string => {

--- a/apps/desktop/test/electron-stub.ts
+++ b/apps/desktop/test/electron-stub.ts
@@ -7,7 +7,10 @@ export const app = {
 const ENCRYPTION_PREFIX = "encrypted:";
 
 export const safeStorage = {
-  isEncryptionAvailable: (): boolean => true,
+  isEncryptionAvailable: (): boolean =>
+    process.env.VESTA_TEST_ENCRYPTION_AVAILABLE !== "false",
+  getSelectedStorageBackend: (): string =>
+    process.env.VESTA_TEST_STORAGE_BACKEND ?? "unknown",
   encryptString: (value: string): Buffer =>
     Buffer.from(`${ENCRYPTION_PREFIX}${value}`, "utf8"),
   decryptString: (value: Buffer): string => {

--- a/apps/desktop/test/electron-stub.ts
+++ b/apps/desktop/test/electron-stub.ts
@@ -3,3 +3,18 @@ import os from "node:os";
 export const app = {
   getPath: (): string => process.env.VESTA_TEST_USER_DATA ?? os.tmpdir(),
 };
+
+const ENCRYPTION_PREFIX = "encrypted:";
+
+export const safeStorage = {
+  isEncryptionAvailable: (): boolean => true,
+  encryptString: (value: string): Buffer =>
+    Buffer.from(`${ENCRYPTION_PREFIX}${value}`, "utf8"),
+  decryptString: (value: Buffer): string => {
+    const stored = value.toString("utf8");
+    if (!stored.startsWith(ENCRYPTION_PREFIX)) {
+      throw new Error("invalid encrypted value");
+    }
+    return stored.slice(ENCRYPTION_PREFIX.length);
+  },
+};

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -274,6 +274,17 @@ function SessionNavigation() {
                 }}
               />
               <Stack.Screen
+                name="switch-gateway"
+                options={{
+                  headerShown: false,
+                  presentation: "formSheet",
+                  ...formSheetCorners,
+                  sheetAllowedDetents: "fitToContents",
+                  sheetGrabberVisible: true,
+                  contentStyle: { backgroundColor: colors.card },
+                }}
+              />
+              <Stack.Screen
                 name="whats-new"
                 options={{
                   title: "What’s new",

--- a/apps/mobile/app/recent-gateways.tsx
+++ b/apps/mobile/app/recent-gateways.tsx
@@ -13,7 +13,10 @@ import { Button } from "@/components/ui/Button";
 import { Text } from "@/components/ui/Typography";
 import { usePreferences } from "@/preferences/PreferencesProvider";
 import { useSession } from "@/session/SessionProvider";
-import type { RecentGateway } from "@/storage/recent-gateway-model";
+import {
+  recentGatewayId,
+  type RecentGateway,
+} from "@/storage/recent-gateway-model";
 import { radii } from "@/theme/layout";
 
 const CONNECTION_PROGRESS_DELAY_MS = 150;
@@ -48,6 +51,8 @@ function lastConnectedLabel(timestamp: number): string {
 
 export default function RecentGatewaysScreen() {
   const {
+    status,
+    connection,
     recentGateways,
     connectRecentGateway,
     forgetRecentGateway,
@@ -67,6 +72,7 @@ export default function RecentGatewaysScreen() {
   const isConnecting = connectionAttempt?.status === "connecting";
   const showsConnectionState =
     showConnectionState && connectionAttempt !== null;
+  const currentGatewayId = connection ? recentGatewayId(connection.url) : null;
 
   useEffect(
     () => () => {
@@ -97,6 +103,7 @@ export default function RecentGatewaysScreen() {
 
     try {
       await connectRecentGateway(gateway.id);
+      if (status === "connected") router.dismissTo("/");
     } catch (cause) {
       if (connectionProgressTimer.current) {
         clearTimeout(connectionProgressTimer.current);
@@ -132,7 +139,13 @@ export default function RecentGatewaysScreen() {
   return (
     <AuthSheet
       mode={showsConnectionState ? "plain" : "scroll"}
-      title={showsConnectionState ? undefined : "Recent gateways"}
+      title={
+        showsConnectionState
+          ? undefined
+          : status === "connected"
+            ? "Switch gateway"
+            : "Recent gateways"
+      }
       hasGrabber
     >
       {showsConnectionState ? (
@@ -212,35 +225,24 @@ export default function RecentGatewaysScreen() {
           exiting={FadeOut.duration(CONTENT_TRANSITION_MS)}
         >
           {recentGateways === null ? (
-            <LoadingSpinner
-              style={styles.loading}
-              color={colors.interactive}
-            />
+            <LoadingSpinner style={styles.loading} color={colors.interactive} />
           ) : recentGateways.length === 0 ? (
             <Text style={[styles.empty, { color: colors.secondaryText }]}>
               No saved gateways.
             </Text>
           ) : (
             <View style={styles.listContent}>
-              {recentGateways.map((gateway) => (
-                <NativeDeleteRow
-                  key={gateway.id}
-                  containerStyle={[
-                    styles.gateway,
-                    {
-                      backgroundColor: colors.input,
-                      borderColor: colors.border,
-                    },
-                  ]}
-                  deleteAccessibilityLabel={`Forget ${gatewayName(gateway)}`}
-                  dangerColor={colors.danger}
-                  disabled={isConnecting}
-                  onDelete={() => confirmForget(gateway)}
-                >
+              {recentGateways.map((gateway) => {
+                const current = gateway.id === currentGatewayId;
+                const row = (
                   <Pressable
                     accessibilityRole="button"
-                    accessibilityLabel={`Connect to ${gatewayName(gateway)}`}
-                    disabled={isConnecting}
+                    accessibilityLabel={
+                      current
+                        ? `${gatewayName(gateway)}, current gateway`
+                        : `Connect to ${gatewayName(gateway)}`
+                    }
+                    disabled={isConnecting || current}
                     onPress={() => void connect(gateway)}
                     style={({ pressed }) => [
                       styles.gatewayMain,
@@ -279,14 +281,51 @@ export default function RecentGatewaysScreen() {
                         {lastConnectedLabel(gateway.lastConnectedAt)}
                       </Text>
                     </View>
-                    <Ionicons
-                      name="chevron-forward"
-                      size={17}
-                      color={colors.tertiaryText}
-                    />
+                    {current ? (
+                      <Text
+                        style={[
+                          styles.currentLabel,
+                          {
+                            backgroundColor: colors.accentSoft,
+                            color: colors.accent,
+                          },
+                        ]}
+                      >
+                        Current
+                      </Text>
+                    ) : (
+                      <Ionicons
+                        name="chevron-forward"
+                        size={17}
+                        color={colors.tertiaryText}
+                      />
+                    )}
                   </Pressable>
-                </NativeDeleteRow>
-              ))}
+                );
+                const containerStyle = [
+                  styles.gateway,
+                  {
+                    backgroundColor: colors.input,
+                    borderColor: colors.border,
+                  },
+                ];
+                return current ? (
+                  <View key={gateway.id} style={containerStyle}>
+                    {row}
+                  </View>
+                ) : (
+                  <NativeDeleteRow
+                    key={gateway.id}
+                    containerStyle={containerStyle}
+                    deleteAccessibilityLabel={`Forget ${gatewayName(gateway)}`}
+                    dangerColor={colors.danger}
+                    disabled={isConnecting}
+                    onDelete={() => confirmForget(gateway)}
+                  >
+                    {row}
+                  </NativeDeleteRow>
+                );
+              })}
             </View>
           )}
 
@@ -381,6 +420,15 @@ const styles = StyleSheet.create({
   gatewayCopy: { flex: 1, gap: 2 },
   gatewayName: { fontSize: 16, lineHeight: 20, fontWeight: "500" },
   gatewayDetail: { fontSize: 13, lineHeight: 18 },
+  currentLabel: {
+    borderRadius: radii.pill,
+    overflow: "hidden",
+    paddingHorizontal: 9,
+    paddingVertical: 4,
+    fontSize: 12,
+    lineHeight: 16,
+    fontWeight: "600",
+  },
   footerActions: { marginTop: 16 },
   footerActionLabel: { fontSize: 13, lineHeight: 18, fontWeight: "500" },
 });

--- a/apps/mobile/app/recent-gateways.tsx
+++ b/apps/mobile/app/recent-gateways.tsx
@@ -85,6 +85,7 @@ export default function RecentGatewaysScreen() {
 
   const connect = async (gateway: RecentGateway, showImmediately = false) => {
     if (isConnecting) return;
+    const dismissAfterConnect = status === "connected";
     if (connectionProgressTimer.current) {
       clearTimeout(connectionProgressTimer.current);
       connectionProgressTimer.current = null;
@@ -103,7 +104,7 @@ export default function RecentGatewaysScreen() {
 
     try {
       await connectRecentGateway(gateway.id);
-      if (status === "connected") router.dismissTo("/");
+      if (dismissAfterConnect) router.dismissTo("/");
     } catch (cause) {
       if (connectionProgressTimer.current) {
         clearTimeout(connectionProgressTimer.current);

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -374,6 +374,11 @@ export default function SettingsScreen() {
               }
             />
             <FormRow
+              label="Switch gateway"
+              detail="Connect to a gateway saved on this device."
+              onPress={() => router.push("/switch-gateway")}
+            />
+            <FormRow
               label="Version"
               value={roster.gatewayVersion ?? "unknown"}
             />

--- a/apps/mobile/app/switch-gateway.tsx
+++ b/apps/mobile/app/switch-gateway.tsx
@@ -1,0 +1,1 @@
+export { default } from "./recent-gateways";

--- a/apps/mobile/src/controller/gateway-update-gate.tsx
+++ b/apps/mobile/src/controller/gateway-update-gate.tsx
@@ -16,6 +16,7 @@ const NATIVE_SHEET_ROUTES = new Set([
   "recent-gateways",
   "scan",
   "settings",
+  "switch-gateway",
   "whats-new",
 ]);
 

--- a/apps/mobile/src/privacy/privacy-gate.tsx
+++ b/apps/mobile/src/privacy/privacy-gate.tsx
@@ -23,6 +23,7 @@ const NATIVE_SHEET_ROUTES = new Set([
   "recent-gateways",
   "scan",
   "settings",
+  "switch-gateway",
   "whats-new",
 ]);
 

--- a/apps/web/src/api/server.ts
+++ b/apps/web/src/api/server.ts
@@ -1,5 +1,5 @@
 import { getConnection, setConnection } from "@/lib/connection";
-import { rememberGateway } from "@/lib/recent-gateways";
+import { rememberGatewayAfterConnect } from "@/lib/recent-gateways";
 import { jsonInit } from "./client";
 
 export async function connectToServer(
@@ -36,5 +36,5 @@ export async function connectToServer(
     data.expires_in,
   );
   const connection = getConnection();
-  if (connection) await rememberGateway(connection);
+  if (connection) await rememberGatewayAfterConnect(connection);
 }

--- a/apps/web/src/api/server.ts
+++ b/apps/web/src/api/server.ts
@@ -36,5 +36,5 @@ export async function connectToServer(
     data.expires_in,
   );
   const connection = getConnection();
-  if (connection) rememberGateway(connection);
+  if (connection) await rememberGateway(connection);
 }

--- a/apps/web/src/components/SwitchGatewayDialog/index.tsx
+++ b/apps/web/src/components/SwitchGatewayDialog/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Cloud, Server, Trash2 } from "lucide-react";
 import { router } from "@/router";
 import { getConnection, restoreConnection } from "@/lib/connection";
@@ -115,13 +115,28 @@ function GatewayRow({
 // pending confirm survives a close.
 function SwitchGatewayBody({ onClose }: { onClose: () => void }) {
   const reconnect = useControllerReconnect();
-  const [gateways, setGateways] = useState<RecentGateway[]>(readRecentGateways);
+  const [gateways, setGateways] = useState<RecentGateway[] | null>(null);
   const [pendingForget, setPendingForget] = useState<RecentGateway | null>(
     null,
   );
   const currentId = useMemo(() => currentGatewayId(), []);
 
-  const others = gateways.filter((gateway) => gateway.id !== currentId);
+  const others = gateways?.filter((gateway) => gateway.id !== currentId) ?? [];
+
+  useEffect(() => {
+    let active = true;
+    void readRecentGateways()
+      .then((saved) => {
+        if (active) setGateways(saved);
+      })
+      .catch((cause: unknown) => {
+        console.warn("could not read saved gateways", cause);
+        if (active) setGateways([]);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   // Restore the saved short-lived tokens and let the controller reconnect (the
   // refresh flow revives them if they expired); a gateway whose tokens have
@@ -137,7 +152,11 @@ function SwitchGatewayBody({ onClose }: { onClose: () => void }) {
     const gateway = pendingForget;
     setPendingForget(null);
     if (!gateway) return;
-    setGateways(forgetRecentGateway(gateway.id));
+    void forgetRecentGateway(gateway.id)
+      .then(setGateways)
+      .catch((cause: unknown) =>
+        console.warn("could not forget saved gateway", cause),
+      );
   };
 
   if (pendingForget) {
@@ -158,6 +177,22 @@ function SwitchGatewayBody({ onClose }: { onClose: () => void }) {
             forget
           </Button>
         </DialogFooter>
+      </>
+    );
+  }
+
+  if (gateways === null) {
+    return (
+      <>
+        <DialogHeader>
+          <DialogTitle>switch gateway</DialogTitle>
+          <DialogDescription>
+            reconnect to a gateway you've used before.
+          </DialogDescription>
+        </DialogHeader>
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          loading saved gateways...
+        </p>
       </>
     );
   }

--- a/apps/web/src/lib/connection-persistence.test.tsx
+++ b/apps/web/src/lib/connection-persistence.test.tsx
@@ -1,0 +1,55 @@
+// Exercises localStorage, so it runs in the jsdom project (.test.tsx include).
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getConnection, setConnection } from "./connection";
+import { native } from "./native";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("connection persistence", () => {
+  it("keeps a connected session when persistent storage throws", async () => {
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
+      throw new Error("storage unavailable");
+    });
+
+    expect(() =>
+      setConnection("https://box.example/", "access", "refresh", 60),
+    ).not.toThrow();
+    expect(getConnection()).toMatchObject({
+      url: "https://box.example",
+      accessToken: "access",
+      refreshToken: "refresh",
+    });
+
+    await vi.waitFor(() => {
+      expect(warning).toHaveBeenCalledWith(
+        "could not save the active gateway",
+        expect.any(Error),
+      );
+    });
+  });
+
+  it("keeps a connected session when an Electron-style write rejects", async () => {
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    vi.spyOn(native.connectionStore, "write").mockRejectedValueOnce(
+      new Error("secure storage unavailable"),
+    );
+
+    setConnection("https://box.example", "access", "refresh", 60);
+    expect(getConnection()?.accessToken).toBe("access");
+
+    await vi.waitFor(() => {
+      expect(warning).toHaveBeenCalledWith(
+        "could not save the active gateway",
+        expect.any(Error),
+      );
+    });
+  });
+});

--- a/apps/web/src/lib/connection.ts
+++ b/apps/web/src/lib/connection.ts
@@ -45,6 +45,12 @@ export interface ConnectionConfig {
 // AuthProvider awaits initConnection before anything reads it.
 let cached: ConnectionConfig | null | undefined;
 
+function persist(operation: () => Promise<void>, failureMessage: string): void {
+  void Promise.resolve()
+    .then(operation)
+    .catch((cause: unknown) => console.warn(failureMessage, cause));
+}
+
 // ── Public API ─────────────────────────────────────────────────
 
 export async function initConnection(): Promise<void> {
@@ -83,7 +89,10 @@ export function setConnection(
     expiresAt,
   };
   cached = config;
-  void native.connectionStore.write(config);
+  persist(
+    () => native.connectionStore.write(config),
+    "could not save the active gateway",
+  );
 }
 
 /**
@@ -105,7 +114,10 @@ export function setHostedConnection(
     hosted: true,
   };
   cached = config;
-  void native.connectionStore.write(config);
+  persist(
+    () => native.connectionStore.write(config),
+    "could not save the active gateway",
+  );
 }
 
 /** Write a whole stored config back as the active connection, so switching to a
@@ -113,7 +125,10 @@ export function setHostedConnection(
  * re-deriving them. The refresh flow revives an expired one on the next call. */
 export function restoreConnection(config: ConnectionConfig): void {
   cached = config;
-  void native.connectionStore.write(config);
+  persist(
+    () => native.connectionStore.write(config),
+    "could not save the active gateway",
+  );
 }
 
 export function updateTokens(
@@ -128,7 +143,10 @@ export function updateTokens(
 
 export function clearConnection(): void {
   cached = null;
-  void native.connectionStore.clear();
+  persist(
+    () => native.connectionStore.clear(),
+    "could not clear the active gateway",
+  );
 }
 
 export function isTokenExpiringSoon(): boolean {

--- a/apps/web/src/lib/native/browser.ts
+++ b/apps/web/src/lib/native/browser.ts
@@ -4,6 +4,18 @@ import { parseConnectionConfig } from "./parse-connection-config";
 import type { NativeBridge } from "./types";
 
 const STORAGE_KEY = "vesta-connection";
+const RECENT_GATEWAYS_STORAGE_KEY = "vesta-recent-gateways";
+
+function readStoredJson(key: string): unknown {
+  const raw = localStorage.getItem(key);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    localStorage.removeItem(key);
+    return null;
+  }
+}
 
 export function parseConnection(raw: string): ConnectionConfig | null {
   try {
@@ -28,6 +40,22 @@ export function createBrowserBridge(): NativeBridge {
       },
       clear() {
         localStorage.removeItem(STORAGE_KEY);
+        return Promise.resolve();
+      },
+    },
+    recentGatewayStore: {
+      read() {
+        return Promise.resolve(readStoredJson(RECENT_GATEWAYS_STORAGE_KEY));
+      },
+      write(value) {
+        localStorage.setItem(
+          RECENT_GATEWAYS_STORAGE_KEY,
+          JSON.stringify(value),
+        );
+        return Promise.resolve();
+      },
+      clear() {
+        localStorage.removeItem(RECENT_GATEWAYS_STORAGE_KEY);
         return Promise.resolve();
       },
     },

--- a/apps/web/src/lib/native/electron.ts
+++ b/apps/web/src/lib/native/electron.ts
@@ -14,6 +14,18 @@ const NODE_PLATFORM_MAP: Record<string, Platform> = {
   win32: "windows",
   linux: "linux",
 };
+const LEGACY_RECENT_GATEWAYS_KEY = "vesta-recent-gateways";
+
+function readLegacyRecentGateways(): unknown {
+  const raw = localStorage.getItem(LEGACY_RECENT_GATEWAYS_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    localStorage.removeItem(LEGACY_RECENT_GATEWAYS_KEY);
+    return null;
+  }
+}
 
 // Parse at the boundary: the preload answer is untyped IPC, so validate the shape here.
 export function parseNativeFix(value: unknown): NativeGeolocationFix | null {
@@ -57,6 +69,21 @@ export function createElectronBridge(api: VestaNativeApi): NativeBridge {
       async clear() {
         await api.storeClear();
       },
+    },
+    recentGatewayStore: {
+      async read() {
+        const stored = await api.recentStoreRead();
+        if (stored !== null) return stored;
+        // LEGACY(remove-when: MIN_SUPPORTED_CLIENT_VERSION exceeds 0.2.13):
+        // Move renderer records into the encrypted main-process store.
+        const legacy = readLegacyRecentGateways();
+        if (legacy === null) return null;
+        await api.recentStoreWrite(legacy);
+        localStorage.removeItem(LEGACY_RECENT_GATEWAYS_KEY);
+        return legacy;
+      },
+      write: (value) => api.recentStoreWrite(value),
+      clear: () => api.recentStoreClear(),
     },
     openExternal: (url) => api.openExternal(url),
     focusWindow: () => api.focusWindow(),

--- a/apps/web/src/lib/native/native.test.tsx
+++ b/apps/web/src/lib/native/native.test.tsx
@@ -27,6 +27,15 @@ describe("browser bridge", () => {
     expect(await bridge.connectionStore.read()).toBeNull();
   });
 
+  it("round-trips recent gateways through localStorage", async () => {
+    const bridge = createBrowserBridge();
+    const gateways = [{ connection: CONFIG, lastConnectedAt: 1 }];
+    await bridge.recentGatewayStore.write(gateways);
+    expect(await bridge.recentGatewayStore.read()).toEqual(gateways);
+    await bridge.recentGatewayStore.clear();
+    expect(await bridge.recentGatewayStore.read()).toBeNull();
+  });
+
   it("rejects a stored connection missing tokens", async () => {
     localStorage.setItem("vesta-connection", JSON.stringify({ url: "x" }));
     expect(await createBrowserBridge().connectionStore.read()).toBeNull();
@@ -82,6 +91,9 @@ describe("electron bridge", () => {
       storeRead: vi.fn(() => Promise.resolve(null)),
       storeWrite: vi.fn(() => Promise.resolve()),
       storeClear: vi.fn(() => Promise.resolve()),
+      recentStoreRead: vi.fn(() => Promise.resolve(null)),
+      recentStoreWrite: vi.fn(() => Promise.resolve()),
+      recentStoreClear: vi.fn(() => Promise.resolve()),
       oauthStart: vi.fn(() => Promise.resolve(4242)),
       onOauthCallback: vi.fn(() => noopUnsubscribe),
       oauthCancel: vi.fn(() => Promise.resolve()),
@@ -115,6 +127,22 @@ describe("electron bridge", () => {
     expect(await createElectronBridge(good).connectionStore.read()).toEqual(
       CONFIG,
     );
+  });
+
+  it("migrates plaintext renderer gateway records to the native store", async () => {
+    const gateways = [{ connection: CONFIG, lastConnectedAt: 1 }];
+    localStorage.setItem("vesta-recent-gateways", JSON.stringify(gateways));
+    const recentStoreWrite = vi.fn(() => Promise.resolve());
+    const bridge = createElectronBridge(
+      fakeApi({
+        recentStoreRead: vi.fn(() => Promise.resolve(null)),
+        recentStoreWrite,
+      }),
+    );
+
+    expect(await bridge.recentGatewayStore.read()).toEqual(gateways);
+    expect(recentStoreWrite).toHaveBeenCalledWith(gateways);
+    expect(localStorage.getItem("vesta-recent-gateways")).toBeNull();
   });
 
   it("rejects a stored connection whose url is not an http origin", async () => {

--- a/apps/web/src/lib/native/types.ts
+++ b/apps/web/src/lib/native/types.ts
@@ -9,6 +9,12 @@ export interface ConnectionStore {
   clear(): Promise<void>;
 }
 
+export interface ValueStore {
+  read(): Promise<unknown>;
+  write(value: unknown): Promise<void>;
+  clear(): Promise<void>;
+}
+
 export interface OauthLoopback {
   /** Start the loopback HTTP server; resolves with the bound port. */
   start(): Promise<number>;
@@ -53,6 +59,7 @@ export interface NativeBridge {
   runtime: Runtime;
   platform: Platform;
   connectionStore: ConnectionStore;
+  recentGatewayStore: ValueStore;
   openExternal(url: string): Promise<void>;
   focusWindow(): Promise<void>;
   /** Force the window's scheme, or hand it back to the OS with "system". */
@@ -85,6 +92,9 @@ export interface VestaNativeApi {
   storeRead(): Promise<unknown>;
   storeWrite(value: unknown): Promise<void>;
   storeClear(): Promise<void>;
+  recentStoreRead(): Promise<unknown>;
+  recentStoreWrite(value: unknown): Promise<void>;
+  recentStoreClear(): Promise<void>;
   oauthStart(): Promise<number>;
   onOauthCallback(cb: (url: string) => void): () => void;
   oauthCancel(port: number): Promise<void>;

--- a/apps/web/src/lib/recent-gateways.test.tsx
+++ b/apps/web/src/lib/recent-gateways.test.tsx
@@ -1,11 +1,12 @@
 // Exercises localStorage, so it runs in the jsdom project (.test.tsx include).
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ConnectionConfig } from "@/lib/connection";
 import {
   forgetRecentGateway,
   readRecentGateways,
   recentGatewayId,
   rememberGateway,
+  rememberGatewayAfterConnect,
   removeRecentGateway,
   upsertRecentGateway,
   type RecentGateway,
@@ -26,6 +27,7 @@ function conn(
 
 afterEach(() => {
   localStorage.clear();
+  vi.restoreAllMocks();
 });
 
 describe("recentGatewayId", () => {
@@ -136,5 +138,22 @@ describe("localStorage round-trip", () => {
 
     localStorage.setItem("vesta-recent-gateways", "{ broken");
     expect(await readRecentGateways()).toEqual([]);
+  });
+
+  it("does not fail a successful connection when saving recents throws", async () => {
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
+      throw new Error("storage unavailable");
+    });
+
+    await expect(
+      rememberGatewayAfterConnect(conn("https://a.example")),
+    ).resolves.toBeUndefined();
+    expect(warning).toHaveBeenCalledWith(
+      "could not save the recent gateway",
+      expect.any(Error),
+    );
   });
 });

--- a/apps/web/src/lib/recent-gateways.test.tsx
+++ b/apps/web/src/lib/recent-gateways.test.tsx
@@ -107,17 +107,17 @@ describe("removeRecentGateway", () => {
 });
 
 describe("localStorage round-trip", () => {
-  it("remembers, reads back, and forgets a gateway", () => {
-    rememberGateway(conn("https://a.example"));
-    const read = readRecentGateways();
+  it("remembers, reads back, and forgets a gateway", async () => {
+    await rememberGateway(conn("https://a.example"));
+    const read = await readRecentGateways();
     expect(read).toHaveLength(1);
     expect(read[0]?.url).toBe("https://a.example");
 
-    forgetRecentGateway(recentGatewayId("https://a.example"));
-    expect(readRecentGateways()).toEqual([]);
+    await forgetRecentGateway(recentGatewayId("https://a.example"));
+    expect(await readRecentGateways()).toEqual([]);
   });
 
-  it("drops invalid records and survives corrupt json", () => {
+  it("drops invalid records and survives corrupt json", async () => {
     localStorage.setItem(
       "vesta-recent-gateways",
       JSON.stringify([
@@ -130,11 +130,11 @@ describe("localStorage round-trip", () => {
         { nonsense: true },
       ]),
     );
-    expect(readRecentGateways().map((g) => g.url)).toEqual([
+    expect((await readRecentGateways()).map((g) => g.url)).toEqual([
       "https://good.example",
     ]);
 
     localStorage.setItem("vesta-recent-gateways", "{ broken");
-    expect(readRecentGateways()).toEqual([]);
+    expect(await readRecentGateways()).toEqual([]);
   });
 });

--- a/apps/web/src/lib/recent-gateways.ts
+++ b/apps/web/src/lib/recent-gateways.ts
@@ -116,6 +116,16 @@ export async function rememberGateway(
   return next;
 }
 
+export async function rememberGatewayAfterConnect(
+  connection: ConnectionConfig,
+): Promise<void> {
+  try {
+    await rememberGateway(connection);
+  } catch (cause) {
+    console.warn("could not save the recent gateway", cause);
+  }
+}
+
 export async function forgetRecentGateway(
   id: string,
 ): Promise<RecentGateway[]> {

--- a/apps/web/src/lib/recent-gateways.ts
+++ b/apps/web/src/lib/recent-gateways.ts
@@ -1,13 +1,12 @@
 import type { ConnectionConfig } from "./connection";
+import { native } from "./native";
 import { parseConnectionConfig } from "./native/parse-connection-config";
 
 // Recently connected gateways, so the app can switch between them without
 // re-pasting a connect link. A client convenience list (like the theme and
-// mode prefs) held in localStorage, separate from the single active connection
-// the native bridge owns. Web has no keychain, so the credential rides in the
-// same record; that matches the plaintext tier the active connection already
-// lives in.
-const STORAGE_KEY = "vesta-recent-gateways";
+// mode prefs) held separately from the single active connection. The native
+// bridge protects credentials with the OS credential store on desktop and
+// uses the browser's same-origin storage for the web app.
 
 export interface RecentGateway {
   id: string;
@@ -89,19 +88,10 @@ function parseRecentGateway(value: unknown): RecentGateway | null {
   };
 }
 
-export function readRecentGateways(): RecentGateway[] {
-  if (typeof localStorage === "undefined") return [];
-  const raw = localStorage.getItem(STORAGE_KEY);
-  if (!raw) return [];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    localStorage.removeItem(STORAGE_KEY);
-    return [];
-  }
+export async function readRecentGateways(): Promise<RecentGateway[]> {
+  const parsed = await native.recentGatewayStore.read();
   if (!Array.isArray(parsed)) {
-    localStorage.removeItem(STORAGE_KEY);
+    if (parsed !== null) await native.recentGatewayStore.clear();
     return [];
   }
   return parsed
@@ -109,26 +99,27 @@ export function readRecentGateways(): RecentGateway[] {
     .filter((gateway): gateway is RecentGateway => gateway !== null);
 }
 
-function writeRecentGateways(gateways: RecentGateway[]): void {
-  if (typeof localStorage === "undefined") return;
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(gateways));
+function writeRecentGateways(gateways: RecentGateway[]): Promise<void> {
+  return native.recentGatewayStore.write(gateways);
 }
 
-export function rememberGateway(
+export async function rememberGateway(
   connection: ConnectionConfig,
   options: { touch?: boolean } = {},
-): RecentGateway[] {
+): Promise<RecentGateway[]> {
   const next = upsertRecentGateway(
-    readRecentGateways(),
+    await readRecentGateways(),
     { connection },
     { touch: options.touch ?? true, now: Date.now() },
   );
-  writeRecentGateways(next);
+  await writeRecentGateways(next);
   return next;
 }
 
-export function forgetRecentGateway(id: string): RecentGateway[] {
-  const next = removeRecentGateway(readRecentGateways(), id);
-  writeRecentGateways(next);
+export async function forgetRecentGateway(
+  id: string,
+): Promise<RecentGateway[]> {
+  const next = removeRecentGateway(await readRecentGateways(), id);
+  await writeRecentGateways(next);
   return next;
 }

--- a/apps/web/src/pages/Callback/index.tsx
+++ b/apps/web/src/pages/Callback/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { getConnection, setHostedConnection } from "@/lib/connection";
-import { rememberGateway } from "@/lib/recent-gateways";
+import { rememberGatewayAfterConnect } from "@/lib/recent-gateways";
 import { completeHostedLogin } from "@/lib/pkce";
 
 // OAuth redirect target for the hosted login handoff (issue #19). The control
@@ -34,7 +34,7 @@ export function Callback() {
         );
         setHostedConnection(window.location.origin, accessToken, expiresIn);
         const connection = getConnection();
-        if (connection) await rememberGateway(connection);
+        if (connection) await rememberGatewayAfterConnect(connection);
         // Strip the code/state from the URL, then enter the app with a full
         // load so providers re-read the now-present connection.
         window.history.replaceState(null, "", "/");

--- a/apps/web/src/pages/Callback/index.tsx
+++ b/apps/web/src/pages/Callback/index.tsx
@@ -34,7 +34,7 @@ export function Callback() {
         );
         setHostedConnection(window.location.origin, accessToken, expiresIn);
         const connection = getConnection();
-        if (connection) rememberGateway(connection);
+        if (connection) await rememberGateway(connection);
         // Strip the code/state from the URL, then enter the app with a full
         // load so providers re-read the now-present connection.
         window.history.replaceState(null, "", "/");

--- a/apps/web/visual/harness/native-stub.ts
+++ b/apps/web/visual/harness/native-stub.ts
@@ -15,6 +15,9 @@ interface VestaNativeApi {
   storeRead(): Promise<unknown>;
   storeWrite(value: unknown): Promise<void>;
   storeClear(): Promise<void>;
+  recentStoreRead(): Promise<unknown>;
+  recentStoreWrite(value: unknown): Promise<void>;
+  recentStoreClear(): Promise<void>;
   oauthStart(): Promise<number>;
   onOauthCallback(cb: (url: string) => void): () => void;
   oauthCancel(port: number): Promise<void>;
@@ -55,6 +58,7 @@ export async function installNativeStub(
         });
       }
       let stored: unknown = connection;
+      let recentStored: unknown = null;
       const noop = (): void => undefined;
       const resolved = (): Promise<void> => Promise.resolve();
       window.vestaNative = {
@@ -74,6 +78,15 @@ export async function installNativeStub(
         },
         storeClear: () => {
           stored = null;
+          return Promise.resolve();
+        },
+        recentStoreRead: () => Promise.resolve(recentStored),
+        recentStoreWrite: (value: unknown) => {
+          recentStored = value;
+          return Promise.resolve();
+        },
+        recentStoreClear: () => {
+          recentStored = null;
           return Promise.resolve();
         },
         oauthStart: () => Promise.resolve(0),


### PR DESCRIPTION
## Summary

- adds a connected mobile gateway switcher for iOS and Android, reachable from Settings
- marks the current gateway and prevents forgetting or reconnecting to the active entry
- encrypts desktop active-session and saved-gateway credentials with Electron safeStorage
- migrates legacy desktop connection files and renderer localStorage records into encrypted main-process storage
- keeps browser storage behavior behind the same native bridge contract

## Validation

- `./check.sh app-desktop`
- `./check.sh app-web`
- `./check.sh app-mobile`
- `./check.sh app-visual guards`