### PR TITLE
feat: show saved gateways while disconnected

### DIFF
--- a/apps/web/src/components/Connect/index.test.tsx
+++ b/apps/web/src/components/Connect/index.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useSwitchGateway } from "@/stores/use-switch-gateway";
+import { Connect } from "./index";
+
+const { auth } = vi.hoisted(() => ({
+  auth: {
+    connected: false,
+    sessionExpired: false,
+    connect: vi.fn(),
+  },
+}));
+
+vi.mock("@/providers/AuthProvider", () => ({
+  useAuth: () => auth,
+}));
+
+vi.mock("@/providers/RuntimeProvider", () => ({
+  useRuntime: () => ({ isDesktopApp: false }),
+}));
+
+const SAVED_GATEWAY = {
+  id: "gateway-a",
+  url: "https://a.example",
+  hosted: false,
+  lastConnectedAt: 1,
+  connection: {
+    url: "https://a.example",
+    accessToken: "access-token",
+    refreshToken: "refresh-token",
+    expiresAt: 4_102_444_800_000,
+  },
+};
+
+describe("Connect recent gateways", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSwitchGateway.setState({ open: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("opens the recent gateway picker when a saved gateway exists", async () => {
+    localStorage.setItem(
+      "vesta-recent-gateways",
+      JSON.stringify([SAVED_GATEWAY]),
+    );
+
+    render(<Connect />);
+
+    const trigger = await screen.findByRole("button", {
+      name: "recent gateways",
+    });
+    await userEvent.click(trigger);
+
+    expect(useSwitchGateway.getState().open).toBe(true);
+  });
+
+  it("hides the picker when there are no saved gateways", async () => {
+    render(<Connect />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "recent gateways" }),
+      ).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/components/Connect/index.tsx
+++ b/apps/web/src/components/Connect/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Navigate } from "react-router-dom";
 import { AnimatePresence, motion } from "motion/react";
-import { Eye, EyeOff } from "lucide-react";
+import { Eye, EyeOff, History } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Field, FieldLabel, FieldDescription } from "@/components/ui/field";
@@ -12,7 +12,9 @@ import { errorMessage } from "@/lib/utils";
 import { startHostedLogin } from "@/lib/pkce";
 import { native } from "@/lib/native";
 import { parseConnectLink } from "@/lib/connection";
+import { readRecentGateways } from "@/lib/recent-gateways";
 import { useAuth } from "@/providers/AuthProvider";
+import { useSwitchGateway } from "@/stores/use-switch-gateway";
 
 // VITE_VESTAD_HOSTED=true means the SPA was bundled by vestad itself, so
 // window.location.origin already points at the right vestad instance.
@@ -35,12 +37,16 @@ function HostedSignInCard({
   error,
   onSignIn,
   onSelfHost,
+  hasRecentGateways,
+  onRecentGateways,
 }: {
   sessionExpired: boolean;
   busy: boolean;
   error: string;
   onSignIn: () => void;
   onSelfHost: () => void;
+  hasRecentGateways: boolean;
+  onRecentGateways: () => void;
 }) {
   return (
     <div className="flex h-full flex-col p-page">
@@ -78,6 +84,9 @@ function HostedSignInCard({
               </motion.p>
             )}
           </AnimatePresence>
+          {hasRecentGateways && (
+            <RecentGatewaysButton onClick={onRecentGateways} />
+          )}
           {isDesktopApp && (
             <button
               type="button"
@@ -93,6 +102,28 @@ function HostedSignInCard({
   );
 }
 
+function RecentGatewaysButton({
+  onClick,
+  visible = true,
+}: {
+  onClick: () => void;
+  visible?: boolean;
+}) {
+  if (!visible) return null;
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={onClick}
+      className="text-xs text-muted-foreground"
+    >
+      <History />
+      recent gateways
+    </Button>
+  );
+}
+
 function ConnectHeader() {
   return (
     <div className="flex flex-col items-center gap-1.5">
@@ -104,12 +135,37 @@ function ConnectHeader() {
   );
 }
 
+function useHasRecentGateways(dialogOpen: boolean): boolean {
+  const [hasRecentGateways, setHasRecentGateways] = useState(false);
+
+  useEffect(() => {
+    if (dialogOpen) return;
+    let active = true;
+    void readRecentGateways()
+      .then((gateways) => {
+        if (active) setHasRecentGateways(gateways.length > 0);
+      })
+      .catch((cause: unknown) => {
+        console.warn("could not read saved gateways", cause);
+        if (active) setHasRecentGateways(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [dialogOpen]);
+
+  return hasRecentGateways;
+}
+
 export function Connect() {
   const { connected, connect, sessionExpired } = useAuth();
   const [value, setValue] = useState("");
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
   const [revealed, setRevealed] = useState(false);
+  const switchGatewayOpen = useSwitchGateway((state) => state.open);
+  const setSwitchGatewayOpen = useSwitchGateway((state) => state.setOpen);
+  const hasRecentGateways = useHasRecentGateways(switchGatewayOpen);
   const inputRef = useRef<HTMLInputElement>(null);
   // In the desktop app (and any vesta-account surface) we lead with "continue
   // with vesta account"; `selfHost` flips to the connect-link form for people
@@ -223,6 +279,8 @@ export function Connect() {
           setError("");
           setSelfHost(true);
         }}
+        hasRecentGateways={hasRecentGateways}
+        onRecentGateways={() => setSwitchGatewayOpen(true)}
       />
     );
   }
@@ -284,6 +342,11 @@ export function Connect() {
           >
             {busy ? "connecting..." : "connect"}
           </Button>
+
+          <RecentGatewaysButton
+            visible={hasRecentGateways}
+            onClick={() => setSwitchGatewayOpen(true)}
+          />
 
           {isDesktopApp && selfHost && (
             <button

--- a/apps/web/src/components/SwitchGatewayDialog/index.test.tsx
+++ b/apps/web/src/components/SwitchGatewayDialog/index.test.tsx
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useSwitchGateway } from "@/stores/use-switch-gateway";
+import { SwitchGatewayDialog } from "./index";
+
+const { auth, connectSavedGateway, navigate } = vi.hoisted(() => {
+  const connectSavedGateway = vi.fn();
+  return {
+    connectSavedGateway,
+    navigate: vi.fn(),
+    auth: { connected: false, connectSavedGateway },
+  };
+});
+
+vi.mock("@/providers/AuthProvider", () => ({
+  useAuth: () => auth,
+}));
+
+vi.mock("@/router", () => ({
+  router: { navigate },
+}));
+
+const SAVED_GATEWAY = {
+  id: "gateway-a",
+  url: "https://a.example",
+  hosted: false,
+  lastConnectedAt: 1,
+  connection: {
+    url: "https://a.example",
+    accessToken: "access-token",
+    refreshToken: "refresh-token",
+    expiresAt: 4_102_444_800_000,
+  },
+};
+
+describe("SwitchGatewayDialog while disconnected", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem(
+      "vesta-recent-gateways",
+      JSON.stringify([SAVED_GATEWAY]),
+    );
+    useSwitchGateway.setState({ open: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    useSwitchGateway.setState({ open: false });
+  });
+
+  it("restores a saved gateway and enters the connected app", async () => {
+    render(<SwitchGatewayDialog />);
+
+    expect(
+      await screen.findByRole("heading", { name: "recent gateways" }),
+    ).toBeTruthy();
+    await userEvent.click(
+      screen.getByRole("button", { name: "connect to a.example" }),
+    );
+
+    expect(connectSavedGateway).toHaveBeenCalledWith(SAVED_GATEWAY.connection);
+    expect(navigate).toHaveBeenCalledWith("/");
+    expect(useSwitchGateway.getState().open).toBe(false);
+  });
+});

--- a/apps/web/src/components/SwitchGatewayDialog/index.tsx
+++ b/apps/web/src/components/SwitchGatewayDialog/index.tsx
@@ -9,6 +9,7 @@ import {
   recentGatewayId,
   type RecentGateway,
 } from "@/lib/recent-gateways";
+import { useAuth } from "@/providers/AuthProvider";
 import { useControllerReconnect } from "@/providers/ControllerProvider";
 import { useSwitchGateway } from "@/stores/use-switch-gateway";
 import { Badge } from "@/components/ui/badge";
@@ -56,11 +57,13 @@ function currentGatewayId(): string | null {
 function GatewayRow({
   gateway,
   current,
+  action,
   onSwitch,
   onForget,
 }: {
   gateway: RecentGateway;
   current: boolean;
+  action: "connect" | "switch";
   onSwitch: () => void;
   onForget: () => void;
 }) {
@@ -78,7 +81,7 @@ function GatewayRow({
         disabled={current}
         onClick={onSwitch}
         aria-label={
-          current ? undefined : `switch to ${gatewayHost(gateway.url)}`
+          current ? undefined : `${action} to ${gatewayHost(gateway.url)}`
         }
         className="flex min-w-0 flex-1 items-center gap-3 rounded-xl py-2.5 pl-3 text-left disabled:cursor-default"
       >
@@ -115,6 +118,7 @@ function GatewayRow({
 // pending confirm survives a close.
 function SwitchGatewayBody({ onClose }: { onClose: () => void }) {
   const reconnect = useControllerReconnect();
+  const { connected, connectSavedGateway } = useAuth();
   const [gateways, setGateways] = useState<RecentGateway[] | null>(null);
   const [pendingForget, setPendingForget] = useState<RecentGateway | null>(
     null,
@@ -142,9 +146,13 @@ function SwitchGatewayBody({ onClose }: { onClose: () => void }) {
   // refresh flow revives them if they expired); a gateway whose tokens have
   // fully lapsed lands on the app's reauth screen, same as any dead session.
   const switchTo = (gateway: RecentGateway) => {
-    restoreConnection(gateway.connection);
+    if (connected) {
+      restoreConnection(gateway.connection);
+      reconnect();
+    } else {
+      connectSavedGateway(gateway.connection);
+    }
     void router.navigate("/");
-    reconnect();
     onClose();
   };
 
@@ -185,7 +193,9 @@ function SwitchGatewayBody({ onClose }: { onClose: () => void }) {
     return (
       <>
         <DialogHeader>
-          <DialogTitle>switch gateway</DialogTitle>
+          <DialogTitle>
+            {connected ? "switch gateway" : "recent gateways"}
+          </DialogTitle>
           <DialogDescription>
             reconnect to a gateway you've used before.
           </DialogDescription>
@@ -200,7 +210,9 @@ function SwitchGatewayBody({ onClose }: { onClose: () => void }) {
   return (
     <>
       <DialogHeader>
-        <DialogTitle>switch gateway</DialogTitle>
+        <DialogTitle>
+          {connected ? "switch gateway" : "recent gateways"}
+        </DialogTitle>
         <DialogDescription>
           reconnect to a gateway you've used before.
         </DialogDescription>
@@ -210,7 +222,9 @@ function SwitchGatewayBody({ onClose }: { onClose: () => void }) {
           <span className="flex size-11 items-center justify-center rounded-xl bg-muted text-muted-foreground">
             <Server className="size-5" />
           </span>
-          <p className="text-sm font-medium">no other gateways yet</p>
+          <p className="text-sm font-medium">
+            {connected ? "no other gateways yet" : "no saved gateways"}
+          </p>
           <p className="max-w-[15rem] text-xs text-muted-foreground">
             connect to another with its connect link and it'll show up here.
           </p>
@@ -222,6 +236,7 @@ function SwitchGatewayBody({ onClose }: { onClose: () => void }) {
               key={gateway.id}
               gateway={gateway}
               current={gateway.id === currentId}
+              action={connected ? "switch" : "connect"}
               onSwitch={() => switchTo(gateway)}
               onForget={() => setPendingForget(gateway)}
             />

--- a/apps/web/src/providers/AuthProvider/context.ts
+++ b/apps/web/src/providers/AuthProvider/context.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext } from "react";
+import type { ConnectionConfig } from "@/lib/connection";
 
 // Context + hook live here, separate from the AuthProvider component, so the
 // AuthContext identity is stable across Fast Refresh. Co-locating them with the
@@ -13,6 +14,7 @@ export interface AuthContextValue {
   sessionExpired: boolean;
   setLoading: (loading: boolean) => void;
   connect: (url: string, apiKey: string) => Promise<void>;
+  connectSavedGateway: (connection: ConnectionConfig) => void;
   disconnect: () => void;
   expireSession: () => void;
 }

--- a/apps/web/src/providers/AuthProvider/index.tsx
+++ b/apps/web/src/providers/AuthProvider/index.tsx
@@ -5,6 +5,8 @@ import {
   getConnection,
   initConnection,
   parseConnectKey,
+  restoreConnection,
+  type ConnectionConfig,
 } from "@/lib/connection";
 import { AuthContext } from "./context";
 
@@ -70,6 +72,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setConnected(true);
   };
 
+  const connectSavedGateway = useCallback((connection: ConnectionConfig) => {
+    restoreConnection(connection);
+    setSessionExpired(false);
+    setConnected(true);
+  }, []);
+
   const disconnect = () => {
     clearConnection();
     setSessionExpired(false);
@@ -90,6 +98,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     sessionExpired,
     setLoading,
     connect,
+    connectSavedGateway,
     disconnect,
     expireSession,
   };

--- a/apps/web/visual/drives/app-settings.ts
+++ b/apps/web/visual/drives/app-settings.ts
@@ -210,6 +210,33 @@ async function submitLink(page: Page): Promise<void> {
 
 const SIGNED_OUT: ScenarioState = { route: "/connect", connection: false };
 
+const RECENT_GATEWAYS = [
+  {
+    id: "gateway-luna",
+    url: "https://luna.example.com",
+    hosted: false,
+    lastConnectedAt: FIXED_TIME.getTime(),
+    connection: {
+      url: "https://luna.example.com",
+      accessToken: "visual-access-token",
+      refreshToken: "visual-refresh-token",
+      expiresAt: FIXED_TIME.getTime() + 3_600_000,
+    },
+  },
+  {
+    id: "gateway-home",
+    url: "https://home.example.com",
+    hosted: false,
+    lastConnectedAt: FIXED_TIME.getTime() - 86_400_000,
+    connection: {
+      url: "https://home.example.com",
+      accessToken: "visual-access-token",
+      refreshToken: "visual-refresh-token",
+      expiresAt: FIXED_TIME.getTime() + 3_600_000,
+    },
+  },
+];
+
 export const APP_SETTINGS: Record<string, Scenario> = {
   "app-settings": {
     state: settingsState(),
@@ -355,6 +382,25 @@ export const APP_SETTINGS: Record<string, Scenario> = {
       await expect(
         page.getByRole("button", { name: "connect", exact: true }),
       ).toBeVisible();
+    },
+  },
+  "connect-recent-gateways": {
+    state: {
+      ...SIGNED_OUT,
+      storage: {
+        "vesta-recent-gateways": JSON.stringify(RECENT_GATEWAYS),
+      },
+    },
+    drive: async (page) => {
+      const trigger = page.getByRole("button", { name: "recent gateways" });
+      await expect(trigger).toBeVisible();
+      await trigger.click();
+    },
+    settle: async (page) => {
+      const dialog = page.getByRole("dialog", { name: "recent gateways" });
+      await expect(dialog).toBeVisible();
+      await expect(dialog.getByText("luna.example.com")).toBeVisible();
+      await expect(dialog.getByText("home.example.com")).toBeVisible();
     },
   },
   "connect-connecting": {

--- a/apps/web/visual/scenarios.json
+++ b/apps/web/visual/scenarios.json
@@ -768,6 +768,12 @@
       "group": "Connect"
     },
     {
+      "id": "connect-recent-gateways",
+      "title": "Connect, recent gateways",
+      "description": "The disconnected gateway picker with previously used gateways available to reconnect.",
+      "group": "Connect"
+    },
+    {
       "id": "connect-connecting",
       "title": "Connect, connecting",
       "description": "The connect page while the health check runs.",


### PR DESCRIPTION
## Summary

- show a Recent gateways action on the disconnected web and desktop connect screens when saved gateways exist
- reuse the existing gateway picker for disconnected reconnect and forget flows
- restore the selected saved connection through AuthProvider before entering the app
- add component tests and a cross-platform visual scenario

This completes the disconnected entry point missed in #2269.

## Validation

- ./check.sh app-web
- ./check.sh app-desktop
- ./check.sh app-visual guards
- browser and desktop visual capture for connect-recent-gateways