### PR TITLE
feat(mobile): add agent rename

### DIFF
--- a/apps/mobile/app/agent/[name]/settings.tsx
+++ b/apps/mobile/app/agent/[name]/settings.tsx
@@ -121,6 +121,7 @@ function AgentSettingsContent() {
       />
       <FormGroup>
         <FormSection title="Agent">
+          <FormRow label="Name" value={name} onPress={() => open("general")} />
           <FormRow
             label={sectionTitle("provider")}
             onPress={() => open("provider")}

--- a/apps/mobile/maestro/visual/agent-sections.yml
+++ b/apps/mobile/maestro/visual/agent-sections.yml
@@ -60,6 +60,17 @@ tags:
     file: capture-screenshot.js
     env:
       SCREENSHOT: agent-general.png
+- tapOn:
+    text: "New agent name"
+- eraseText: 4
+- inputText: "Nova_Prime"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: agent-rename
+- runScript:
+    file: capture-screenshot.js
+    env:
+      SCREENSHOT: agent-rename.png
 - stopApp
 - openLink:
     link: "vesta-dev://agent/aria/details/voice?visualPrivacy=unlocked&visualSession=connected&visualRoster=agents&visualVoice=unconfigured"

--- a/apps/mobile/src/agent/settings/GeneralSection.tsx
+++ b/apps/mobile/src/agent/settings/GeneralSection.tsx
@@ -1,20 +1,59 @@
-import { resolveProviderIdentity } from "@vesta/core";
-import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { agentStatusKind, resolveProviderIdentity } from "@vesta/core";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { StyleSheet, View } from "react-native";
-import { fetchManifest, getProvider } from "@/api/endpoints";
+import { useRouter } from "expo-router";
+import { fetchManifest, getProvider, renameAgent } from "@/api/endpoints";
 import { useAgent } from "@/agent/AgentProvider";
+import {
+  agentRenameError,
+  normalizeAgentName,
+} from "@/agent/settings/agent-name";
 import { AgentOrb } from "@/components/AgentOrb";
 import { ProviderPill } from "@/components/ProviderPill";
+import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
-import { FormRow, FormSection } from "@/components/ui/Form";
+import { Field, FormRow, FormSection } from "@/components/ui/Form";
 import { Text } from "@/components/ui/Typography";
 import { usePreferences } from "@/preferences/PreferencesProvider";
 import { useSession } from "@/session/SessionProvider";
 
 export function GeneralSection() {
+  const router = useRouter();
   const { name, agent, activityState, socket } = useAgent();
   const { colors } = usePreferences();
   const { api } = useSession();
+  const [proposedName, setProposedName] = useState(name);
+  const [edited, setEdited] = useState(false);
+  const [requestError, setRequestError] = useState<string | null>(null);
+  const normalizedName = normalizeAgentName(proposedName);
+  const validationError = agentRenameError(name, proposedName);
+  const lifecycleBusy =
+    agent === null ||
+    agent.operation !== null ||
+    agentStatusKind(agent.status) === "working";
+  const rename = useMutation({
+    mutationFn: () => renameAgent(api, name, normalizedName),
+    onSuccess: (finalName) => {
+      setProposedName(finalName);
+      setEdited(false);
+      setRequestError(null);
+      router.replace({
+        pathname: "/agent/[name]/details/[section]",
+        params: { name: finalName, section: "general" },
+      });
+    },
+    onError: (error) => {
+      setRequestError(
+        error instanceof Error ? error.message : "The rename failed.",
+      );
+    },
+  });
+  const submitRename = () => {
+    if (validationError || lifecycleBusy || rename.isPending) return;
+    setRequestError(null);
+    rename.mutate();
+  };
   const provider = useQuery({
     queryKey: ["provider", name],
     queryFn: () => getProvider(api, name),
@@ -56,6 +95,48 @@ export function GeneralSection() {
           </View>
         </View>
       </Card>
+      <FormSection
+        title="Identity"
+        footer={`Renaming restarts ${name}. Their memory, settings, and backups carry over.`}
+        actions={
+          <Button
+            loading={rename.isPending}
+            loadingLabel="Renaming…"
+            disabled={Boolean(validationError) || lifecycleBusy}
+            accessibilityLabel={`Rename ${name}`}
+            onPress={submitRename}
+          >
+            Rename agent
+          </Button>
+        }
+      >
+        <View style={styles.renameForm}>
+          <Field
+            label="Name"
+            description={
+              normalizedName && normalizedName !== proposedName.trim()
+                ? `This will be saved as ${normalizedName}.`
+                : "Use letters, numbers, spaces, or hyphens."
+            }
+            error={
+              requestError ??
+              (edited ? (validationError ?? undefined) : undefined)
+            }
+            value={proposedName}
+            editable={!rename.isPending && !lifecycleBusy}
+            accessibilityLabel="New agent name"
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="done"
+            onChangeText={(value) => {
+              setProposedName(value);
+              setEdited(true);
+              setRequestError(null);
+            }}
+            onSubmitEditing={submitRename}
+          />
+        </View>
+      </FormSection>
       <FormSection title="Status">
         <FormRow
           label="Gateway state"
@@ -84,4 +165,5 @@ const styles = StyleSheet.create({
   identity: { flex: 1, gap: 4 },
   name: { fontSize: 28, fontWeight: "500" },
   detail: { fontSize: 15 },
+  renameForm: { paddingVertical: 10 },
 });

--- a/apps/mobile/src/agent/settings/agent-name.test.ts
+++ b/apps/mobile/src/agent/settings/agent-name.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { agentRenameError, normalizeAgentName } from "./agent-name";
+
+describe("normalizeAgentName", () => {
+  it("matches the gateway's lowercase, separator, and character rules", () => {
+    expect(normalizeAgentName("  Luna__Prime!!  ")).toBe("luna-prime");
+    expect(normalizeAgentName("--luna---prime--")).toBe("luna-prime");
+  });
+
+  it("truncates to 32 characters without leaving a trailing hyphen", () => {
+    expect(normalizeAgentName(`${"a".repeat(31)}-tail`)).toBe("a".repeat(31));
+  });
+});
+
+describe("agentRenameError", () => {
+  it("rejects an empty or canonically unchanged name", () => {
+    expect(agentRenameError("luna", "!!!")).toBe("Enter a name.");
+    expect(agentRenameError("luna", " LUNA ")).toBe("Choose a different name.");
+  });
+
+  it("matches the reserved-name rule while allowing the exact agent name", () => {
+    expect(agentRenameError("luna", "my-vesta")).toBe(
+      'Names cannot contain "vesta".',
+    );
+    expect(agentRenameError("luna", "vesta")).toBeNull();
+  });
+});

--- a/apps/mobile/src/agent/settings/agent-name.ts
+++ b/apps/mobile/src/agent/settings/agent-name.ts
@@ -1,0 +1,28 @@
+const AGENT_NAME_MAX_LENGTH = 32;
+
+// Mirrors vestad's normalize_name so the form can preview and validate the
+// canonical name before starting the restart-backed rename operation.
+export function normalizeAgentName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]/gu, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-+/g, "-")
+    .slice(0, AGENT_NAME_MAX_LENGTH)
+    .replace(/-+$/g, "");
+}
+
+export function agentRenameError(
+  currentName: string,
+  proposedName: string,
+): string | null {
+  const normalized = normalizeAgentName(proposedName);
+  if (!normalized) return "Enter a name.";
+  if (normalized === currentName) return "Choose a different name.";
+  if (normalized !== "vesta" && normalized.includes("vesta")) {
+    return 'Names cannot contain "vesta".';
+  }
+  return null;
+}

--- a/apps/mobile/src/api/endpoints.test.ts
+++ b/apps/mobile/src/api/endpoints.test.ts
@@ -3,6 +3,7 @@ import { RESTART_REASONS, restartBody } from "@vesta/core";
 import type { ApiClient } from "./client";
 import {
   fetchClaudeModels,
+  renameAgent,
   restartAgent,
   setAgentBackupSettings,
 } from "./endpoints";
@@ -40,6 +41,29 @@ describe("restartAgent", () => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(restartBody(RESTART_REASONS.context)),
+    });
+  });
+});
+
+describe("renameAgent", () => {
+  it("PATCHes the encoded agent path and returns the canonical name", async () => {
+    const json = vi.fn().mockResolvedValue({ name: "luna-prime" });
+    const api = {
+      json,
+      jsonInit: (method: string, body: unknown) => ({
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    } as unknown as ApiClient;
+
+    await expect(renameAgent(api, "luna one", "Luna Prime")).resolves.toBe(
+      "luna-prime",
+    );
+    expect(json).toHaveBeenCalledWith("/agents/luna%20one", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ new_name: "Luna Prime" }),
     });
   });
 });

--- a/apps/mobile/src/api/endpoints.ts
+++ b/apps/mobile/src/api/endpoints.ts
@@ -210,6 +210,18 @@ export async function deleteAgent(api: ApiClient, name: string): Promise<void> {
   });
 }
 
+export async function renameAgent(
+  api: ApiClient,
+  name: string,
+  newName: string,
+): Promise<string> {
+  const response = await api.json<{ name: string }>(
+    `/agents/${encodeURIComponent(name)}`,
+    api.jsonInit("PATCH", { new_name: newName }),
+  );
+  return response.name;
+}
+
 export async function createBackup(
   api: ApiClient,
   name: string,

--- a/apps/mobile/visual/scenarios.json
+++ b/apps/mobile/visual/scenarios.json
@@ -569,7 +569,13 @@
     {
       "id": "agent-general",
       "title": "General section",
-      "description": "The agent's identity hero with status rows.",
+      "description": "The agent's identity hero with rename controls and status rows.",
+      "group": "Agent settings"
+    },
+    {
+      "id": "agent-rename",
+      "title": "Rename agent",
+      "description": "The native rename form previewing the canonical name before its restart-backed mutation.",
       "group": "Agent settings"
     },
     {


### PR DESCRIPTION
## Summary

- add the authenticated agent rename mutation to the shared iOS/Android app
- expose Name from Agent settings and add a native General-screen rename form
- preview the gateway-canonical name, enforce reserved-name rules, block lifecycle conflicts, and follow the returned identity after rename
- add endpoint/model tests and a deterministic rename visual state

## Validation

- ./check.sh app-mobile app-visual guards
- npm -w @vesta/mobile test -- src/agent/settings/agent-name.test.ts src/api/endpoints.test.ts
- npm run mobile:visual:capture -- --device "iPhone 17" --gentle (17/17 flows, 150 screenshots)
- inspected ios/agent-rename.png at original resolution

No version bump.