### PR TITLE
feat(web,mobile): make natural chat pacing a per-agent switch everywhere

### DIFF
--- a/apps/mobile/src/preferences/model.test.ts
+++ b/apps/mobile/src/preferences/model.test.ts
@@ -9,7 +9,6 @@ describe("preference persistence", () => {
   it("uses first-run defaults only when no preferences exist", () => {
     expect(readStoredPreferences(null)).toEqual(initialPreferences);
     expect(initialPreferences.remoteNotifications).toBe(true);
-    expect(initialPreferences.naturalChatPacingDefault).toBe(true);
     expect(initialPreferences.naturalChatPacingByAgent).toEqual({});
     expect(initialPreferences.showNotificationsPage).toBe(false);
     expect(initialPreferences.showLogsPage).toBe(false);
@@ -69,7 +68,6 @@ describe("preference persistence", () => {
   it("restores natural chat pacing independently for each agent", () => {
     const preferences = readStoredPreferences(
       JSON.stringify({
-        naturalChatPacingDefault: true,
         naturalChatPacingByAgent: {
           Ada: false,
           Ben: true,
@@ -85,14 +83,5 @@ describe("preference persistence", () => {
     expect(getNaturalChatPacingForAgent(preferences, "Ada")).toBe(false);
     expect(getNaturalChatPacingForAgent(preferences, "Ben")).toBe(true);
     expect(getNaturalChatPacingForAgent(preferences, "New agent")).toBe(true);
-  });
-
-  it("migrates the global natural chat pacing preference", () => {
-    const preferences = readStoredPreferences(
-      JSON.stringify({ naturalChatPacing: false }),
-    );
-
-    expect(preferences.naturalChatPacingDefault).toBe(false);
-    expect(getNaturalChatPacingForAgent(preferences, "Ada")).toBe(false);
   });
 });

--- a/apps/mobile/src/preferences/model.ts
+++ b/apps/mobile/src/preferences/model.ts
@@ -5,7 +5,6 @@ export const PREFERENCES_KEY = "vesta.preferences.v1";
 
 export interface PreferencesState {
   theme: ThemePreference;
-  naturalChatPacingDefault: boolean;
   naturalChatPacingByAgent: Record<string, boolean>;
   showChatPage: boolean;
   showDashboardPage: boolean;
@@ -22,7 +21,6 @@ export interface PreferencesState {
 
 export const initialPreferences: PreferencesState = {
   theme: "system",
-  naturalChatPacingDefault: true,
   naturalChatPacingByAgent: {},
   showChatPage: true,
   showDashboardPage: true,
@@ -49,16 +47,10 @@ function readBooleanRecord(value: unknown): Record<string, boolean> {
 }
 
 export function getNaturalChatPacingForAgent(
-  preferences: Pick<
-    PreferencesState,
-    "naturalChatPacingDefault" | "naturalChatPacingByAgent"
-  >,
+  preferences: Pick<PreferencesState, "naturalChatPacingByAgent">,
   agentName: string,
 ): boolean {
-  return (
-    preferences.naturalChatPacingByAgent[agentName] ??
-    preferences.naturalChatPacingDefault
-  );
+  return preferences.naturalChatPacingByAgent[agentName] ?? true;
 }
 
 export function readStoredPreferences(value: string | null): PreferencesState {
@@ -67,12 +59,6 @@ export function readStoredPreferences(value: string | null): PreferencesState {
     const parsed: Record<string, unknown> = JSON.parse(value);
     return {
       theme: isThemePreference(parsed.theme) ? parsed.theme : "system",
-      naturalChatPacingDefault:
-        typeof parsed.naturalChatPacingDefault === "boolean"
-          ? parsed.naturalChatPacingDefault
-          : typeof parsed.naturalChatPacing === "boolean"
-            ? parsed.naturalChatPacing
-            : true,
       naturalChatPacingByAgent: readBooleanRecord(
         parsed.naturalChatPacingByAgent,
       ),

--- a/apps/web/src/components/AgentSettings/ChatCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ChatCard/index.tsx
@@ -1,0 +1,41 @@
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+} from "@/components/ui/field";
+import { MenuSection } from "@/components/ui/menu-section";
+import { Switch } from "@/components/ui/switch";
+import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
+import { useChatPacing } from "@/stores/use-chat-pacing";
+
+export function ChatCard() {
+  const { name } = useSelectedAgent();
+  const natural = useChatPacing((s) => s.byAgent[name] ?? true);
+  const setNatural = useChatPacing((s) => s.setNatural);
+
+  return (
+    <Card size="sm">
+      <CardContent>
+        <MenuSection title="chat">
+          <Field
+            orientation="horizontal"
+            className="items-center justify-between"
+          >
+            <FieldContent>
+              <FieldLabel className="text-base">natural pacing</FieldLabel>
+              <FieldDescription>
+                simulate typing delay before this agent's replies appear
+              </FieldDescription>
+            </FieldContent>
+            <Switch
+              checked={natural}
+              onCheckedChange={(value) => setNatural(name, value)}
+            />
+          </Field>
+        </MenuSection>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/AgentSettings/index.tsx
+++ b/apps/web/src/components/AgentSettings/index.tsx
@@ -14,6 +14,7 @@ import { useLayout } from "@/stores/use-layout";
 import { cn } from "@/lib/utils";
 import { ActionsCard } from "./ActionsCard";
 import { BackupsCard } from "./BackupsCard";
+import { ChatCard } from "./ChatCard";
 import { DeleteCard } from "./DeleteCard";
 import { NotificationInterruptRulesCard } from "./NotificationInterruptRulesCard";
 import { NotificationsCard } from "./NotificationsCard";
@@ -58,6 +59,7 @@ export function AgentSettings() {
       >
         <ActionsCard />
         <ProviderCard />
+        <ChatCard />
         <ServicesCard />
         <BackupsCard />
         <SttCard />

--- a/apps/web/src/components/Settings/index.tsx
+++ b/apps/web/src/components/Settings/index.tsx
@@ -17,14 +17,12 @@ import { useAuth } from "@/providers/AuthProvider";
 import { useGateway } from "@/providers/GatewayProvider";
 import { connectionHostname } from "@/lib/connection";
 import { StatusPill } from "@/components/StatusPill";
-import { Switch } from "@/components/ui/switch";
 import {
   Field,
   FieldContent,
   FieldDescription,
   FieldLabel,
 } from "@/components/ui/field";
-import { useChatPacing } from "@/stores/use-chat-pacing";
 import { useSwitchGateway } from "@/stores/use-switch-gateway";
 import { openExternalUrl } from "@/lib/open-external-url";
 import { KeybindsCard } from "@/components/Settings/KeybindsSection";
@@ -48,8 +46,6 @@ export function AppSettings() {
   const { theme, setTheme } = useTheme();
   const { disconnect } = useAuth();
   const { reachable, managed, gatewayVersion } = useGateway();
-  const naturalPacing = useChatPacing((s) => s.natural);
-  const setNaturalPacing = useChatPacing((s) => s.setNatural);
   const hostname = connectionHostname();
   const gatewaySetup = useGatewaySetup();
   const openSwitchGateway = useSwitchGateway((s) => s.setOpen);
@@ -61,28 +57,6 @@ export function AppSettings() {
         <CardContent>
           <MenuSection title="appearance">
             <AppearancePicker value={theme} onChange={setTheme} />
-          </MenuSection>
-        </CardContent>
-      </Card>
-
-      <Card size="sm">
-        <CardContent>
-          <MenuSection title="chat">
-            <Field
-              orientation="horizontal"
-              className="items-center justify-between"
-            >
-              <FieldContent>
-                <FieldLabel className="text-base">natural pacing</FieldLabel>
-                <FieldDescription>
-                  simulate typing delay before assistant messages appear
-                </FieldDescription>
-              </FieldContent>
-              <Switch
-                checked={naturalPacing}
-                onCheckedChange={setNaturalPacing}
-              />
-            </Field>
           </MenuSection>
         </CardContent>
       </Card>

--- a/apps/web/src/providers/AgentSocketProvider/use-agent-socket.test.tsx
+++ b/apps/web/src/providers/AgentSocketProvider/use-agent-socket.test.tsx
@@ -146,7 +146,7 @@ beforeEach(() => {
   tokenBuilds = 0;
   fetchHistoryMock.mockReset();
   fetchHistoryMock.mockResolvedValue({ events: [], cursor: null });
-  useChatPacing.setState({ natural: true });
+  useChatPacing.setState({ byAgent: {} });
 });
 
 afterEach(() => {
@@ -389,7 +389,7 @@ describe("useAgentSocketState", () => {
   // Pacing is a feel, not a contract: with natural pacing off every event commits at once, and a
   // burst past the flush threshold is dumped after the first delay rather than typed out one by one.
   it("commits at once with natural pacing off", async () => {
-    useChatPacing.setState({ natural: false });
+    useChatPacing.setState({ byAgent: { [AGENT]: false } });
     const { controller } = makeController();
     const { result } = render(controller);
     await openAndFlush();

--- a/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
+++ b/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
@@ -118,7 +118,7 @@ export function useAgentSocketState({
       }
       if (
         queue.length > PACING.flushThreshold ||
-        !useChatPacing.getState().natural
+        !useChatPacing.getState().naturalFor(name ?? "")
       ) {
         flushQueue();
         return;

--- a/apps/web/src/stores/use-chat-pacing.test.tsx
+++ b/apps/web/src/stores/use-chat-pacing.test.tsx
@@ -1,0 +1,23 @@
+// Exercises the real persisted store, so it runs in the jsdom project (localStorage present).
+import { beforeEach, describe, expect, it } from "vitest";
+import { useChatPacing } from "./use-chat-pacing";
+
+beforeEach(() => {
+  localStorage.clear();
+  useChatPacing.setState({ byAgent: {} });
+});
+
+describe("useChatPacing", () => {
+  it("defaults every agent to natural pacing", () => {
+    expect(useChatPacing.getState().naturalFor("ada")).toBe(true);
+  });
+
+  it("keeps each agent's switch independent and persists it", () => {
+    useChatPacing.getState().setNatural("ada", false);
+    expect(useChatPacing.getState().naturalFor("ada")).toBe(false);
+    expect(useChatPacing.getState().naturalFor("ben")).toBe(true);
+    expect(localStorage.getItem("chat-natural-pacing-by-agent")).toBe(
+      JSON.stringify({ ada: false }),
+    );
+  });
+});

--- a/apps/web/src/stores/use-chat-pacing.ts
+++ b/apps/web/src/stores/use-chat-pacing.ts
@@ -1,16 +1,38 @@
 import { create } from "zustand";
 
-const STORAGE_KEY = "chat-natural-pacing";
+// Natural pacing is a per-agent, per-device feel (default on): the switch lives on each agent's
+// settings page and nothing sets it fleet-wide.
+const STORAGE_KEY = "chat-natural-pacing-by-agent";
 
 interface ChatPacingState {
-  natural: boolean;
-  setNatural: (natural: boolean) => void;
+  byAgent: Record<string, boolean>;
+  naturalFor: (agent: string) => boolean;
+  setNatural: (agent: string, natural: boolean) => void;
 }
 
-export const useChatPacing = create<ChatPacingState>((set) => ({
-  natural: localStorage.getItem(STORAGE_KEY) !== "off",
-  setNatural: (natural) => {
-    localStorage.setItem(STORAGE_KEY, natural ? "on" : "off");
-    set({ natural });
+function readStored(): Record<string, boolean> {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+      return {};
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, boolean] => typeof entry[1] === "boolean",
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export const useChatPacing = create<ChatPacingState>((set, get) => ({
+  byAgent: readStored(),
+  naturalFor: (agent) => get().byAgent[agent] ?? true,
+  setNatural: (agent, natural) => {
+    const byAgent = { ...get().byAgent, [agent]: natural };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(byAgent));
+    set({ byAgent });
   },
 }));


### PR DESCRIPTION
## Summary

Closes the "Natural chat pacing" parity row in `docs/client-feature-parity-report.md`: one per-agent switch on every client, default on, no global default anywhere.

- **Web/desktop**: `use-chat-pacing.ts` becomes a per-agent record (`byAgent`, `naturalFor`, `setNatural`) persisted under `chat-natural-pacing-by-agent`. The switch moves from App Settings to a new `ChatCard` on the agent's settings page (general tab, after Provider). `use-agent-socket` reads its own agent's switch.
- **Mobile**: `naturalChatPacingDefault` and the legacy `naturalChatPacing` migration are removed; `getNaturalChatPacingForAgent` is `byAgent[name] ?? true`. The existing per-agent switch is unchanged.

Not carried over: the old web global `chat-natural-pacing` localStorage value. It was a device-wide feel with no per-agent meaning, so a user who had it off starts with pacing on again for each agent. The same reset applies on mobile: a device that only set the old global default off gets pacing on per agent.

## Test plan

- [x] `./check.sh app-web` (new `use-chat-pacing` store test; socket test updated to the per-agent shape)
- [x] `./check.sh app-mobile`
- [x] `./check.sh app-desktop`
- [x] `./check.sh guards`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FE72XNhoW6qFTDLZ5Hvjtu