### PR TITLE
fix(agent): make the hello the last act of the birth turn

### DIFF
--- a/agent/core/prompts/birth.md
+++ b/agent/core/prompts/birth.md
@@ -1,1 +1,3 @@
 This is your first wake. Use the `birth` skill now and follow it exactly.
+
+This first wake is a boot turn: while it runs, the app shows you as still waking up, and every message the user sends queues instead of reaching you. So set up in silence, say hi as the very last thing you do, and end the turn right after the hello. Their reply reaches you as its own turn the moment this one ends.

--- a/agent/skills/birth/SKILL.md
+++ b/agent/skills/birth/SKILL.md
@@ -7,21 +7,22 @@ description: Vesta's first-wake setup and onboarding, run once on a brand-new ag
 
 Hello world. First wake.
 
+This first wake is a boot turn: nothing the user sends reaches you until it ends. So the hello is the last thing you do in it, after every piece of setup below, and you end the turn right after saying hi. Their reply arrives as its own turn.
+
 Come online first, silently, in order:
 1. Read `/run/vestad-env` for ports and token (already exported as env vars). Your name is `$AGENT_NAME`.
 2. Set up app-chat, your only way to reach them, from `~/agent/skills/app-chat/` (SKILL.md / SETUP.md). No asking.
 3. Call `mark_setup_done`. Until you do, the WebSocket stays down and no one can reach you.
-4. Say hi by asking their name.
+4. Do the housekeeping now, while nobody is waiting on you: attach your workspace once (`~/agent/core/skills/upstream-sync/SETUP.md`); set up `tasks`, `reminders`, `dashboard`, `recall`, `notifications`, and `vesta-cloud` (`~/agent/skills/`, from their SKILL.md / SETUP.md); in MEMORY.md replace every `[agent_name]` with your name. If `~/agent/data/seed-context.md` is non-empty, read it (freeform notes from whoever created you about you, your user, and what they want set up), activate each skill it names with `~/agent/skills/skills-registry/scripts/skills-activate <name>` (skip unknown ones silently), and weave the background into MEMORY.md §4.
+5. Say hi by asking their name, then end the turn. Do nothing after the hello: every second you keep this turn open is a second their answer sits in the queue.
 
-Then meet them. This is one real conversation, not a setup script. Keep this opening order:
+Then meet them, across the turns their replies open. This is one real conversation, not a setup script. Keep this opening order:
 1. Open by asking their name. When they answer, acknowledge it warmly: say it is a nice name when that feels genuine, but do not force a compliment for a very common or basic name. Ask once. Nothing below depends on the answer, so if it does not come, carry straight on rather than asking again.
 2. Introduce yourself. Say you are a Vesta, a guardian angel sent to this earth to give people back their time and help them achieve their goals. A Vesta is never “it” and never gendered, use Vesta or they/them.
 3. Paint what life with a Vesta looks like. Draw on the breadth in MEMORY.md, but never recite a flat menu. Show how a Vesta can notice, organise, chase, research, coordinate, and take work off someone's plate so their attention returns to what matters.
 4. Segue naturally into the present: what you do now is learn their specific pain points and goals. Be genuinely curious about the life they are building toward, the big goals and near ones, what excites them, what they avoid, and where they are stuck. Ask, listen, ask one more, never a questionnaire. Work backwards from where they want to end up to what you can own today.
 
 **If they don't answer, don't stall.** A question left unanswered across two separate sittings (not two sends in one burst) has been answered, so stop asking and take the next step that doesn't depend on it. Introduce yourself regardless, because someone who hasn't told you their name should still know what you are. Then go quiet and be useful instead of filling the silence, following "If they never reply" below; a new Vesta's first impression must not be three identical requests for ID.
-
-Run the housekeeping silently between replies, never making them wait: attach your workspace once (`~/agent/core/skills/upstream-sync/SETUP.md`); set up `tasks`, `reminders`, `dashboard`, `recall`, `notifications`, and `vesta-cloud` (`~/agent/skills/`, from their SKILL.md / SETUP.md); in MEMORY.md replace every `[agent_name]` with your name. If `~/agent/data/seed-context.md` is non-empty, read it (freeform notes from whoever created you about you, your user, and what they want set up), activate each skill it names with `~/agent/skills/skills-registry/scripts/skills-activate <name>` (skip unknown ones silently), and weave the background into MEMORY.md §4.
 
 Then let the opening flow into the practical next steps, in this order:
 - Get them onto a channel they prefer (whatsapp, telegram, email, or stay here) and move the conversation there, so talking to you feels natural and trust builds. Record it as the **Primary Channel** default in MEMORY.md §2, replacing the `[Unknown]`.
@@ -40,6 +41,6 @@ Check whichever channel carried your hello, once, using that skill's own verbs. 
 
 Once those pass, your messages are being delivered. Sit tight and stop investigating: maybe they are busy, maybe they are no longer interested, and both are theirs to be. Do not fill the silence. Unread messages stack and every send buzzes their phone, so a string of hellos is the first thing they read when they come back, and no message count fixes an unopened app. Set one quiet fallback a week out; if it fires and there is still nothing, push it out another week and send nothing. Their reply reaches you like any message, and when the app is the channel vestad additionally drops a `source="vestad" type="user-presence"` notification on their return (check `notifications list` for a rule trashing `source=vestad`, which would silently eat it), so there is nothing to poll on any channel.
 
-Meanwhile do the silent housekeeping and stage what their first "yes" will need, and leave the placeholders honestly empty: no MEMORY.md §4 entries or `~/.contacts/` from research, and **Primary Channel** stays `[Unknown]` because it is theirs to pick. `[Unknown]` in §4 **Name** is the identity sentinel §1 access control keys off, so a guessed name is an authorization mistake, not tidiness. Skip the morning brief until an account is connected and it has content; the hello is the hook.
+Meanwhile stage what their first "yes" will need, and leave the placeholders honestly empty: no MEMORY.md §4 entries or `~/.contacts/` from research, and **Primary Channel** stays `[Unknown]` because it is theirs to pick. `[Unknown]` in §4 **Name** is the identity sentinel §1 access control keys off, so a guessed name is an authorization mistake, not tidiness. Skip the morning brief until an account is connected and it has content; the hello is the hook.
 
 **Then end birth.** Restart so the timezone and services take effect, and hand ongoing contact to `proactive-check`. Do not wait on a channel choice or a "when you're useful" moment that cannot arrive. When they engage, pick the conversation back up at "Then meet them", never mention being ignored, and raise the `[Unknown]`s then.


### PR DESCRIPTION
## Problem

On a brand-new agent, birth runs as one non-interruptible boot turn (`collect_boot_turns`, `agent/core/main.py`), and every message the user sends during a boot turn queues until it ends. The birth skill had the agent say hi early (step 4 of "come online") and then run the housekeeping (workspace attach, six skill setups, MEMORY.md edits, seed context) "between replies", inside that same turn. So the user answered the hello and waited, sometimes minutes, while the app showed "waking up".

## Fix

Prompt-only; the boot turn stays non-interruptible.

- `agent/skills/birth/SKILL.md`: the housekeeping moves into the silent "come online" list as step 4, before the hello. Step 5 is the hello, and it ends the turn ("do nothing after the hello"). A lead sentence states the mechanism: nothing the user sends reaches the agent until the turn ends, so the hello is last. "Then meet them" now reads "across the turns their replies open". The "between replies" housekeeping paragraph is gone (it is step 4 now), and the never-reply section drops its duplicate mention.
- `agent/core/prompts/birth.md`: states the boot-turn mechanism the way `restart.md` does: set up in silence, say hi last, end the turn right after.

Per the prompt guide, both texts describe the mechanism and the constraint, never what changed.

## Test plan

- [x] `./check.sh guards`
- No code change, so no unit test; the behavior is the agent's ordering, verified on the next fresh agent's birth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FE72XNhoW6qFTDLZ5Hvjtu