### PR TITLE
feat(web): instant notification popover, fuller dialog, honest bell dot

### DIFF
--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -57,6 +57,7 @@ export {
   EMPTY_FEED,
   feedNeedsMarkSeen,
   feedSections,
+  feedUnseen,
   feedView,
   reduceFeed,
   type FeedAction,

--- a/apps/core/src/notifications-pill/notification-feed.test.ts
+++ b/apps/core/src/notifications-pill/notification-feed.test.ts
@@ -3,6 +3,7 @@ import {
   EMPTY_FEED,
   feedNeedsMarkSeen,
   feedSections,
+  feedUnseen,
   feedView,
   reduceFeed,
   type FeedAction,
@@ -27,9 +28,9 @@ function ids(feed: NotificationFeed): number[] {
 describe("reduceFeed: the live edge", () => {
   it("lands a live arrival at the top, once, and remembers it as live", () => {
     const feed = run([
-      { type: "arrived", entry: entry(5) },
-      { type: "arrived", entry: entry(5) },
-      { type: "arrived", entry: entry(6) },
+      { type: "arrived", readInPlace: false, entry: entry(5) },
+      { type: "arrived", readInPlace: false, entry: entry(5) },
+      { type: "arrived", readInPlace: false, entry: entry(6) },
     ])
     expect(ids(feed)).toEqual([6, 5])
     expect(feed.liveIds).toEqual([5, 6])
@@ -39,7 +40,7 @@ describe("reduceFeed: the live edge", () => {
 describe("reduceFeed: pages", () => {
   it("merges the newest page into what the live edge already delivered, by id", () => {
     const feed = run([
-      { type: "arrived", entry: entry(6) },
+      { type: "arrived", readInPlace: false, entry: entry(6) },
       { type: "page_loading" },
       { type: "page_loaded", page: [entry(6), entry(5), entry(4)], pageSize: PAGE_SIZE },
     ])
@@ -61,7 +62,7 @@ describe("reduceFeed: pages", () => {
   it("keeps the archive exhausted when a later newest page comes back full", () => {
     const feed = run([
       { type: "page_loaded", page: [entry(2), entry(1)], pageSize: PAGE_SIZE },
-      { type: "arrived", entry: entry(3) },
+      { type: "arrived", readInPlace: false, entry: entry(3) },
       { type: "page_loaded", page: [entry(3), entry(2), entry(1)], pageSize: PAGE_SIZE },
     ])
     expect(feed.older).toBe("exhausted")
@@ -107,7 +108,7 @@ describe("reduceFeed: the catch-up session", () => {
   it("re-snapshots the watermark on the next open and forgets which rows were live", () => {
     const feed = run([
       { type: "open", seenAt: 150 },
-      { type: "arrived", entry: entry(3) },
+      { type: "arrived", readInPlace: false, entry: entry(3) },
       { type: "close" },
       { type: "open", seenAt: 300 },
     ])
@@ -121,11 +122,49 @@ describe("feedNeedsMarkSeen", () => {
     const held = run([{ type: "open", seenAt: 150 }, { type: "close" }])
     expect(feedNeedsMarkSeen(held, 200)).toBe(true)
     expect(feedNeedsMarkSeen(held, 150)).toBe(false)
-    expect(feedNeedsMarkSeen(run([{ type: "arrived", entry: entry(2) }], held), 150)).toBe(true)
+    expect(
+      feedNeedsMarkSeen(run([{ type: "arrived", readInPlace: false, entry: entry(2) }], held), 150),
+    ).toBe(true)
   })
 
   it("never asks before a session ever opened", () => {
-    expect(feedNeedsMarkSeen(run([{ type: "arrived", entry: entry(2) }]), 500)).toBe(false)
+    expect(
+      feedNeedsMarkSeen(run([{ type: "arrived", readInPlace: false, entry: entry(2) }]), 500),
+    ).toBe(false)
+  })
+})
+
+describe("feedUnseen", () => {
+  // A loaded feed is the precondition for discounting anything, so each case
+  // starts from a ready newest page.
+  function loaded(actions: FeedAction[]): NotificationFeed {
+    return run([{ type: "page_loaded", page: [], pageSize: PAGE_SIZE }, ...actions])
+  }
+
+  it("does not raise the dot for a notification the user read in the chat", () => {
+    const feed = loaded([{ type: "arrived", readInPlace: true, entry: entry(3, 300) }])
+    expect(feedUnseen(feed, 300, 200)).toBe(false)
+  })
+
+  it("still raises the dot for anything alongside it the user has not read", () => {
+    const feed = loaded([
+      { type: "arrived", readInPlace: false, entry: entry(3, 300) },
+      { type: "arrived", readInPlace: true, entry: entry(4, 400) },
+    ])
+    expect(feedUnseen(feed, 400, 200)).toBe(true)
+  })
+
+  it("keeps the dot for what it cannot account for: an unloaded feed or a stamp above every row", () => {
+    const unloaded = run([{ type: "arrived", readInPlace: true, entry: entry(3, 300) }])
+    expect(feedUnseen(unloaded, 300, 200)).toBe(true)
+    const feed = loaded([{ type: "arrived", readInPlace: true, entry: entry(3, 300) }])
+    expect(feedUnseen(feed, 400, 200)).toBe(true)
+  })
+
+  it("stays down while the gateway's scalars report nothing new", () => {
+    const feed = loaded([{ type: "arrived", readInPlace: false, entry: entry(3, 300) }])
+    expect(feedUnseen(feed, 300, 300)).toBe(false)
+    expect(feedUnseen(feed, null, 0)).toBe(false)
   })
 })
 
@@ -146,9 +185,11 @@ describe("feedView", () => {
     expect(feedView(run([{ type: "page_loading" }]))).toBe("loading")
     expect(feedView(run([{ type: "page_failed" }]))).toBe("failed")
     expect(feedView(run([{ type: "page_loaded", page: [], pageSize: PAGE_SIZE }]))).toBe("empty")
-    expect(feedView(run([{ type: "arrived", entry: entry(1) }]))).toBe("rows")
-    expect(feedView(run([{ type: "arrived", entry: entry(1) }, { type: "page_failed" }]))).toBe(
-      "rows",
-    )
+    expect(feedView(run([{ type: "arrived", readInPlace: false, entry: entry(1) }]))).toBe("rows")
+    expect(
+      feedView(
+        run([{ type: "arrived", readInPlace: false, entry: entry(1) }, { type: "page_failed" }]),
+      ),
+    ).toBe("rows")
   })
 })

--- a/apps/core/src/notifications-pill/notification-feed.ts
+++ b/apps/core/src/notifications-pill/notification-feed.ts
@@ -15,6 +15,8 @@ export interface NotificationFeed {
   entries: LoggedUserNotification[]
   /** Rows that arrived over the socket during this session (the ones a view animates in). */
   liveIds: number[]
+  /** Rows the user watched arrive in the chat, which is why they never raise the bell's dot. */
+  readIds: number[]
   newest: NewestPageStatus
   older: OlderPagesStatus
   /** A history surface is on screen. */
@@ -30,6 +32,7 @@ export interface NotificationFeed {
 export const EMPTY_FEED: NotificationFeed = {
   entries: [],
   liveIds: [],
+  readIds: [],
   newest: "idle",
   older: "more",
   open: false,
@@ -39,7 +42,7 @@ export const EMPTY_FEED: NotificationFeed = {
 export type FeedAction =
   | { type: "open"; seenAt: number }
   | { type: "close" }
-  | { type: "arrived"; entry: LoggedUserNotification }
+  | { type: "arrived"; entry: LoggedUserNotification; readInPlace: boolean }
   | { type: "page_loading"; before?: number }
   | { type: "page_loaded"; page: LoggedUserNotification[]; before?: number; pageSize: number }
   | { type: "page_failed"; before?: number }
@@ -47,8 +50,10 @@ export type FeedAction =
 export function reduceFeed(feed: NotificationFeed, action: FeedAction): NotificationFeed {
   switch (action.type) {
     case "open":
+      // Both annotations are dropped: closing this session marks the whole feed
+      // seen, so nothing loaded now can raise the dot again.
       if (feed.open) return feed
-      return { ...feed, open: true, seenAt: action.seenAt, liveIds: [] }
+      return { ...feed, open: true, seenAt: action.seenAt, liveIds: [], readIds: [] }
     case "close":
       return { ...feed, open: false }
     case "arrived":
@@ -57,6 +62,7 @@ export function reduceFeed(feed: NotificationFeed, action: FeedAction): Notifica
         ...feed,
         entries: merge(feed.entries, [action.entry]),
         liveIds: [...feed.liveIds, action.entry.id],
+        readIds: action.readInPlace ? [...feed.readIds, action.entry.id] : feed.readIds,
       }
     case "page_loading":
       return action.before === undefined
@@ -95,6 +101,27 @@ export function feedNeedsMarkSeen(feed: NotificationFeed, lastAt: number | null)
   if (feed.seenAt === null) return false
   const seenAt = feed.seenAt
   return feedHasUnseen(lastAt, seenAt) || feed.entries.some((item) => item.at > seenAt)
+}
+
+/**
+ * Whether the bell wears its dot: something past the gateway's watermark that the
+ * user has not already read where it happened. The gateway's two scalars answer
+ * first, and the loaded rows then discount the ones read in the chat. Anything the
+ * client cannot account for (the newest page not loaded yet, or a stamp above every
+ * row it holds) keeps the dot, so the derivation only ever hides a row it has.
+ */
+export function feedUnseen(
+  feed: NotificationFeed,
+  lastAt: number | null | undefined,
+  seenAt: number | undefined,
+): boolean {
+  if (!feedHasUnseen(lastAt, seenAt)) return false
+  if (feed.newest !== "ready") return true
+  const newest = feed.entries[0]
+  if ((lastAt ?? 0) > (newest === undefined ? 0 : newest.at)) return true
+  const read = new Set(feed.readIds)
+  const watermark = seenAt ?? 0
+  return feed.entries.some((item) => item.at > watermark && !read.has(item.id))
 }
 
 /** The unseen/seen split, or null when the feed renders as one plain list. */

--- a/apps/core/src/notifications-pill/notifications-pill.ts
+++ b/apps/core/src/notifications-pill/notifications-pill.ts
@@ -52,6 +52,21 @@ export function pillVisibleWhileViewing(item: PillContent, viewedAgent: string |
 }
 
 /**
+ * Whether the user watched this notification arrive where it happened: a message
+ * from the agent whose page is open on a focused window is read in the chat as it
+ * lands, so it is not news. The window must be focused, which is what separates it
+ * from the pill's rule: an app left open on an agent's page behind another window
+ * shows nobody anything.
+ */
+export function notificationReadInPlace(
+  item: PillContent,
+  viewedAgent: string | null,
+  focused: boolean,
+): boolean {
+  return focused && item.kind === "message" && item.agent === viewedAgent
+}
+
+/**
  * Insert after the last queued item of the same kind, so pending notifications
  * cluster by kind: the pill rotates through one kind per open, and a late
  * arrival of a kind already pending joins its group instead of splitting it.

--- a/apps/core/src/react/use-notification-feed.test.tsx
+++ b/apps/core/src/react/use-notification-feed.test.tsx
@@ -49,15 +49,22 @@ function harness(pages: Record<string, LoggedUserNotification[] | Error>) {
   const emit = (item: LoggedUserNotification): void => {
     for (const listener of listeners) listener({ type: "user_notification", ...item })
   }
-  const hook = renderHook(() =>
-    useNotificationFeed(controller, { pageSize: PAGE_SIZE, minLoadingMs: 0 }),
-  )
+  const hook = renderHook(() => useNotificationFeed(controller, { pageSize: PAGE_SIZE }))
   return { ...hook, emit, requests }
 }
 
 afterEach(cleanup)
 
 describe("useNotificationFeed", () => {
+  it("prefetches the newest page before any surface opens", async () => {
+    const h = harness({ "/notifications?limit=2": [entry(3), entry(2)] })
+    await waitFor(() => {
+      expect(h.result.current.feed.newest).toBe("ready")
+    })
+    expect(h.result.current.feed.entries.map((item) => item.id)).toEqual([3, 2])
+    expect(h.result.current.feed.open).toBe(false)
+  })
+
   it("joins a live arrival to the page that later contains it", async () => {
     const h = harness({ "/notifications?limit=2": [entry(3), entry(2)] })
     act(() => {

--- a/apps/core/src/react/use-notification-feed.test.tsx
+++ b/apps/core/src/react/use-notification-feed.test.tsx
@@ -14,7 +14,13 @@ function entry(id: number): LoggedUserNotification {
   return { id, at: id * 100, agent: "aria", kind: "message", title: "aria", body: `n${String(id)}` }
 }
 
-function harness(pages: Record<string, LoggedUserNotification[] | Error>) {
+function harness(
+  pages: Record<string, LoggedUserNotification[] | Error>,
+  viewing: { viewedAgent: string | null; focused: boolean } = {
+    viewedAgent: null,
+    focused: true,
+  },
+) {
   const listeners = new Set<(delta: Delta) => void>()
   const requests: string[] = []
   const controller: Controller = {
@@ -49,7 +55,9 @@ function harness(pages: Record<string, LoggedUserNotification[] | Error>) {
   const emit = (item: LoggedUserNotification): void => {
     for (const listener of listeners) listener({ type: "user_notification", ...item })
   }
-  const hook = renderHook(() => useNotificationFeed(controller, { pageSize: PAGE_SIZE }))
+  const hook = renderHook(() =>
+    useNotificationFeed(controller, { pageSize: PAGE_SIZE, ...viewing }),
+  )
   return { ...hook, emit, requests }
 }
 
@@ -63,6 +71,33 @@ describe("useNotificationFeed", () => {
     })
     expect(h.result.current.feed.entries.map((item) => item.id)).toEqual([3, 2])
     expect(h.result.current.feed.open).toBe(false)
+  })
+
+  it("marks a message read in place when it lands on that agent's focused page", () => {
+    const h = harness({ "/notifications?limit=2": [] }, { viewedAgent: "aria", focused: true })
+    act(() => {
+      h.emit(entry(3))
+    })
+    expect(h.result.current.feed.readIds).toEqual([3])
+  })
+
+  it("does not mark one read in place on another page, or behind an unfocused window", () => {
+    const elsewhere = harness(
+      { "/notifications?limit=2": [] },
+      { viewedAgent: "nova", focused: true },
+    )
+    act(() => {
+      elsewhere.emit(entry(3))
+    })
+    expect(elsewhere.result.current.feed.readIds).toEqual([])
+    const blurred = harness(
+      { "/notifications?limit=2": [] },
+      { viewedAgent: "aria", focused: false },
+    )
+    act(() => {
+      blurred.emit(entry(4))
+    })
+    expect(blurred.result.current.feed.readIds).toEqual([])
   })
 
   it("joins a live arrival to the page that later contains it", async () => {

--- a/apps/core/src/react/use-notification-feed.ts
+++ b/apps/core/src/react/use-notification-feed.ts
@@ -37,7 +37,8 @@ export interface NotificationFeedHandle {
  * lands), the newest page is prefetched the moment the controller exists (so
  * the first open renders from memory, never a skeleton), each open refetches
  * that page and merges it by id, and the gateway's watermark is what "seen"
- * means.
+ * means. Each arrival is also judged against where the user was standing when
+ * it landed, which is what `feedUnseen` reads to keep the dot honest.
  */
 export function useNotificationFeed(
   controller: Controller | null,

--- a/apps/core/src/react/use-notification-feed.ts
+++ b/apps/core/src/react/use-notification-feed.ts
@@ -15,11 +15,6 @@ import {
 
 export interface NotificationFeedOptions {
   pageSize: number
-  /**
-   * A newest page loaded into an empty feed shows its skeletons for at least
-   * this long, so a near-instant answer reads as a loading state, not a flash.
-   */
-  minLoadingMs: number
 }
 
 export interface NotificationFeedHandle {
@@ -34,12 +29,14 @@ export interface NotificationFeedHandle {
 /**
  * The feed's whole behavior, shared by every view: the live edge always flows
  * in (open or closed, so a reopened surface is current before its refresh
- * lands), each open refetches the newest page and merges it by id, and the
- * gateway's watermark is what "seen" means.
+ * lands), the newest page is prefetched the moment the controller exists (so
+ * the first open renders from memory, never a skeleton), each open refetches
+ * that page and merges it by id, and the gateway's watermark is what "seen"
+ * means.
  */
 export function useNotificationFeed(
   controller: Controller | null,
-  { pageSize, minLoadingMs }: NotificationFeedOptions,
+  { pageSize }: NotificationFeedOptions,
 ): NotificationFeedHandle {
   const [feed, dispatch] = useReducer(reduceFeed, EMPTY_FEED)
 
@@ -51,25 +48,29 @@ export function useNotificationFeed(
     })
   }, [controller])
 
-  const empty = feed.entries.length === 0
   const loadPage = useCallback(
     (before?: number) => {
       if (!controller) return
       dispatch({ type: "page_loading", before })
-      const hold = before === undefined && empty ? minLoadingMs : 0
-      const held = new Promise((resolve) => setTimeout(resolve, hold))
-      const page = fetchUserNotifications(controller.http, { before, limit: pageSize })
-      // allSettled, never all: a failing fetch still waits out the skeletons' hold.
-      void Promise.allSettled([page, held]).then(([result]) => {
-        if (result.status === "fulfilled") {
-          dispatch({ type: "page_loaded", page: result.value, before, pageSize })
-        } else {
+      void fetchUserNotifications(controller.http, { before, limit: pageSize }).then(
+        (page) => {
+          dispatch({ type: "page_loaded", page, before, pageSize })
+        },
+        () => {
           dispatch({ type: "page_failed", before })
-        }
-      })
+        },
+      )
     },
-    [controller, empty, minLoadingMs, pageSize],
+    [controller, pageSize],
   )
+
+  // The prefetch: one newest-page load as soon as the controller is there,
+  // before any surface opens. A failed prefetch stays "failed" (no retry loop);
+  // the next open refetches as every open does.
+  const newestStatus = feed.newest
+  useEffect(() => {
+    if (newestStatus === "idle") loadPage()
+  }, [newestStatus, loadPage])
 
   const open = useCallback(
     (seenAt: number) => {

--- a/apps/core/src/react/use-notification-feed.ts
+++ b/apps/core/src/react/use-notification-feed.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer } from "react"
+import { useCallback, useEffect, useReducer, useRef } from "react"
 import type { Controller } from "../controller/controller"
 import type { Delta } from "../protocol/deltas"
 import {
@@ -12,9 +12,14 @@ import {
   loggedFromDelta,
   markUserNotificationsSeen,
 } from "../notifications-pill/user-notification-feed"
+import { notificationReadInPlace } from "../notifications-pill/notifications-pill"
 
 export interface NotificationFeedOptions {
   pageSize: number
+  /** The agent whose page is open, if any. */
+  viewedAgent: string | null
+  /** Whether this client's window has the user's attention right now. */
+  focused: boolean
 }
 
 export interface NotificationFeedHandle {
@@ -36,15 +41,29 @@ export interface NotificationFeedHandle {
  */
 export function useNotificationFeed(
   controller: Controller | null,
-  { pageSize }: NotificationFeedOptions,
+  options: NotificationFeedOptions,
 ): NotificationFeedHandle {
+  const { pageSize } = options
   const [feed, dispatch] = useReducer(reduceFeed, EMPTY_FEED)
+
+  // Read through a ref, as the pill does: the subscription outlives every route
+  // and focus change, and each arrival is judged against the moment it landed.
+  const optionsRef = useRef(options)
+  useEffect(() => {
+    optionsRef.current = options
+  })
 
   useEffect(() => {
     if (!controller) return
     return controller.subscribeDeltas((delta: Delta) => {
       const entry = loggedFromDelta(delta)
-      if (entry) dispatch({ type: "arrived", entry })
+      if (!entry) return
+      const { viewedAgent, focused } = optionsRef.current
+      dispatch({
+        type: "arrived",
+        entry,
+        readInPlace: notificationReadInPlace(entry, viewedAgent, focused),
+      })
     })
   }, [controller])
 

--- a/apps/web/src/components/Navbar/NotificationsPill/index.tsx
+++ b/apps/web/src/components/Navbar/NotificationsPill/index.tsx
@@ -67,8 +67,9 @@ import {
 const RESIZE_DELAY_S = 0.35;
 const PILL_MAX_WIDTH = 340;
 const HISTORY_SKELETON_ROWS = 5;
-// The compact popover under the bell shows this many before "see more".
-const POPOVER_ROWS = 6;
+// The compact popover under the bell is a taster: at most this many rows,
+// with "see all" opening the full dialog.
+const POPOVER_ROWS = 4;
 
 // This app's rendering of the core icon names (PILL_KIND_ICONS): the shared
 // vocabulary is view-independent, and each view maps it onto its own icon set.
@@ -163,6 +164,7 @@ function HistoryList({
                 timestamp={timestamps}
                 compact={compact}
                 dimmed={dimmed}
+                banded={timestamps && index % 2 === 0}
                 onOpen={onOpen}
               />
             </motion.div>
@@ -195,11 +197,10 @@ function emptyCaption(
   return emptyLabel;
 }
 
-// Whether the archive holds more than the popover is showing, which is what
+// Whether the archive holds more than the popover's taster, which is what
 // earns the "see all" footer. Read from the cached rows alone, never the
 // refetch every open starts, so the footer is there the instant the popover
-// is. Before the first-ever catch-up (no sections) the popover caps at
-// POPOVER_ROWS, so the archive extends past it sooner.
+// is.
 function archiveExtendsBeyond(
   feed: NotificationFeed,
   sections: FeedSections,
@@ -306,11 +307,12 @@ function ConnectedNotificationsPill({
   const sections = feedSections(feed);
   const view = feedView(feed);
 
-  // The popover shows the whole unseen set (scrolling past its cap), or, before
-  // the first-ever catch-up, the newest page the way the dialog would.
-  const popoverEntries = sections
-    ? sections.unseen
-    : feed.entries.slice(0, POPOVER_ROWS);
+  // The popover is a taster: the newest unseen rows (or, before the first-ever
+  // catch-up, the newest rows), capped; "see all" is where the rest lives.
+  const popoverEntries = (sections ? sections.unseen : feed.entries).slice(
+    0,
+    POPOVER_ROWS,
+  );
 
   // "see all" opens the dialog over the full archive; it rides the same slide
   // the rows do, one block.
@@ -368,9 +370,9 @@ function ConnectedNotificationsPill({
             whose traffic-light inset centers the bell on its own island. */}
         <PopoverContent
           align={isDesktopApp && isMacOS ? "center" : "start"}
-          className="z-[100000] w-58 p-2"
+          className="z-[100000] w-72 p-2"
         >
-          <div className="max-h-[60vh] space-y-1 overflow-y-auto">
+          <div className="space-y-1">
             <HistoryList
               view={view}
               liveIds={feed.liveIds}
@@ -392,7 +394,7 @@ function ConnectedNotificationsPill({
           showSurface(open ? "dialog" : "none");
         }}
       >
-        <DialogContent className="max-w-md">
+        <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>notifications</DialogTitle>
           </DialogHeader>
@@ -465,6 +467,7 @@ const NotificationRow = memo(function NotificationRow({
   timestamp,
   compact,
   dimmed,
+  banded,
   onOpen,
 }: {
   entry: LoggedUserNotification;
@@ -474,6 +477,8 @@ const NotificationRow = memo(function NotificationRow({
   compact: boolean;
   /** Already-seen rows in the dialog sit back; hovering lifts them for reading. */
   dimmed: boolean;
+  /** Alternating dialog rows carry a faint band, as the backups list does. */
+  banded: boolean;
   onOpen: (entry: LoggedUserNotification) => void;
 }) {
   // The pill's leading-glyph rule, identically: the orb when the notification
@@ -484,9 +489,10 @@ const NotificationRow = memo(function NotificationRow({
     <button
       type="button"
       className={cn(
-        "flex w-full items-center gap-2.5 overflow-hidden rounded-xl px-2 text-left hover:bg-muted",
-        compact ? "py-1.5" : "py-2",
+        "flex w-full gap-2.5 overflow-hidden rounded-xl px-2 text-left hover:bg-muted",
+        compact ? "items-center py-1.5" : "items-start py-2.5",
         dimmed && "opacity-60 transition-opacity hover:opacity-100",
+        banded && "bg-foreground/[0.07]",
       )}
       onClick={() => {
         onOpen(entry);
@@ -505,16 +511,24 @@ const NotificationRow = memo(function NotificationRow({
       ) : (
         <PillKindIcon kind={entry.kind} />
       )}
-      <div
-        className={cn(
-          "min-w-0 flex-1 truncate",
-          compact ? "text-[13px]" : "text-sm",
-        )}
-      >
-        {pillDisplayLine(entry)}
-      </div>
+      {compact ? (
+        <div className="min-w-0 flex-1 truncate text-[13px]">
+          {pillDisplayLine(entry)}
+        </div>
+      ) : (
+        // The dialog reads in full: the title on its own line, the body
+        // wrapping below it up to a few lines.
+        <div className="min-w-0 flex-1 text-sm">
+          <div className="truncate font-medium">{entry.title}</div>
+          {entry.body && (
+            <div className="mt-0.5 line-clamp-3 text-[13px] text-muted-foreground">
+              {entry.body}
+            </div>
+          )}
+        </div>
+      )}
       {timestamp && (
-        <span className="shrink-0 text-[10px] text-muted-foreground">
+        <span className="shrink-0 pt-0.5 text-[10px] text-muted-foreground">
           {formatTimestamp(entry.at)}
         </span>
       )}

--- a/apps/web/src/providers/NotificationsPillProvider/index.tsx
+++ b/apps/web/src/providers/NotificationsPillProvider/index.tsx
@@ -22,9 +22,6 @@ import {
 } from "./context";
 
 const HISTORY_PAGE_SIZE = 50;
-// A near-instant first fetch still shows the skeletons for at least this long,
-// so they read as a loading state instead of a flash.
-const HISTORY_MIN_LOADING_MS = 500;
 
 // Owns every piece of the notifications pill's state, mounted once above the
 // route layouts (NavigationGuard): the queue survives page navigation even
@@ -45,7 +42,6 @@ export function NotificationsPillProvider({
     useGateway();
   const { feed, open, close, loadOlder } = useNotificationFeed(controller, {
     pageSize: HISTORY_PAGE_SIZE,
-    minLoadingMs: HISTORY_MIN_LOADING_MS,
   });
 
   // One catch-up session spans both surfaces: it opens with the first surface

--- a/apps/web/src/providers/NotificationsPillProvider/index.tsx
+++ b/apps/web/src/providers/NotificationsPillProvider/index.tsx
@@ -9,8 +9,9 @@ import {
 } from "react";
 import { useMotionValue } from "motion/react";
 import { useMatch, useNavigate } from "react-router-dom";
-import { feedHasUnseen, type LoggedUserNotification } from "@vesta/core";
+import { feedUnseen, type LoggedUserNotification } from "@vesta/core";
 import { useNotificationFeed, useNotificationsPill } from "@vesta/core/react";
+import { useWindowFocus } from "@/hooks/use-window-focus";
 import { ControllerContext } from "@/providers/ControllerProvider/context";
 import { useGateway } from "@/providers/GatewayProvider/context";
 import { getAgentVisualStatus } from "@/components/Orb/styles";
@@ -38,10 +39,14 @@ export function NotificationsPillProvider({
   const [surface, setSurface] = useState<HistorySurface>("none");
   const historyOpen = surface !== "none";
 
+  const focused = useWindowFocus();
+
   const { agents, userNotificationsSeenAt, lastUserNotificationAt } =
     useGateway();
   const { feed, open, close, loadOlder } = useNotificationFeed(controller, {
     pageSize: HISTORY_PAGE_SIZE,
+    viewedAgent,
+    focused,
   });
 
   // One catch-up session spans both surfaces: it opens with the first surface
@@ -59,11 +64,12 @@ export function NotificationsPillProvider({
   );
 
   // The bell's dot is derived, never stored: anything logged past the synced
-  // watermark is unseen, so another device catching up clears it here too. It
-  // hides the moment a history surface opens (the user is looking); the synced
-  // truth catches up when the session closes and marks seen.
+  // watermark that the user has not already read in the chat, so another device
+  // catching up clears it here too. It hides the moment a history surface opens
+  // (the user is looking); the synced truth catches up when the session closes
+  // and marks seen.
   const unseen =
-    feedHasUnseen(lastUserNotificationAt, userNotificationsSeenAt) &&
+    feedUnseen(feed, lastUserNotificationAt, userNotificationsSeenAt) &&
     !historyOpen;
 
   const agentsRef = useRef(agents);

--- a/apps/web/visual/drives/home.ts
+++ b/apps/web/visual/drives/home.ts
@@ -6,7 +6,11 @@ import type {
   GatewayOperation,
 } from "@vesta/core";
 import { AGENT } from "../harness/http-fixtures";
-import type { Scenario, ScenarioState } from "../harness/scenario-state";
+import {
+  FIXED_TIME,
+  type Scenario,
+  type ScenarioState,
+} from "../harness/scenario-state";
 import { agentNode, gatewayDelta } from "../harness/sync-fixtures";
 
 const HOME_ROUTE = "/";
@@ -88,6 +92,86 @@ function updateScreen(
 }
 
 const UPDATE_TITLE = `updating to v${LATEST_VERSION}`;
+
+// The notification history, both surfaces: the bell's popover taster and the
+// "see all" dialog over the same log. The watermark sits between entry 4 and
+// 3, so three rows are unseen and the dialog carries the new/earlier split.
+const NOTIFICATIONS_SEEN_AT = FIXED_TIME.getTime() / 1000 - 5400;
+const NEWEST_NOTIFICATION_AT = NOTIFICATIONS_SEEN_AT + 5100;
+const LOGGED_NOTIFICATIONS = [
+  {
+    id: 6,
+    at: NEWEST_NOTIFICATION_AT,
+    agent: AGENT,
+    kind: "message",
+    title: AGENT,
+    body: "the flight to lisbon moved to 6:40am, so i pushed the taxi to 4:15 and told the hotel you land early. the boarding pass is in your email.",
+  },
+  {
+    id: 5,
+    at: NOTIFICATIONS_SEEN_AT + 3300,
+    agent: AGENT,
+    kind: "task",
+    title: AGENT,
+    body: "finished the quarterly expense report and filed it. two receipts were missing, so i flagged them in the sheet for you.",
+  },
+  {
+    id: 4,
+    at: NOTIFICATIONS_SEEN_AT + 900,
+    agent: AGENT,
+    kind: "needs_user",
+    title: AGENT,
+    body: "the calendar sign-in expired, so i cannot read your week. sign in again when you have a minute.",
+  },
+  {
+    id: 3,
+    at: NOTIFICATIONS_SEEN_AT - 1800,
+    agent: "",
+    kind: "update_available",
+    title: "Vesta",
+    body: `version ${LATEST_VERSION} is ready to install`,
+  },
+  {
+    id: 2,
+    at: NOTIFICATIONS_SEEN_AT - 7200,
+    agent: AGENT,
+    kind: "message",
+    title: AGENT,
+    body: "your mother called while you were in the review. she asked about sunday lunch and i said you would call back tonight.",
+  },
+  {
+    id: 1,
+    at: NOTIFICATIONS_SEEN_AT - 90000,
+    agent: AGENT,
+    kind: "agent_status",
+    title: AGENT,
+    body: "recovered and back online",
+  },
+];
+
+function notificationsState(): ScenarioState {
+  return {
+    route: HOME_ROUTE,
+    sync: {
+      agents: { [AGENT]: agentNode() },
+      gateway: {
+        userNotificationsSeenAt: NOTIFICATIONS_SEEN_AT,
+        lastUserNotificationAt: NEWEST_NOTIFICATION_AT,
+      },
+    },
+    routes: [
+      {
+        path: "/notifications",
+        method: "GET",
+        json: { notifications: LOGGED_NOTIFICATIONS },
+      },
+    ],
+  };
+}
+
+function openNotifications(page: Page): Promise<void> {
+  return page.getByRole("button", { name: "notifications" }).click();
+}
 
 // The navbar pill repeats the operation's word, so the screen's own copy is
 // read inside the operation body.
@@ -179,6 +263,24 @@ export const HOME: Record<string, Scenario> = {
       const card = page.getByRole("button", { name: `open ${AGENT}` });
       await expect(card).toBeVisible();
       await expect(card.getByText(START_REFUSED)).toBeVisible();
+    },
+  },
+  "notifications-popover": {
+    state: notificationsState(),
+    drive: openNotifications,
+    settle: async (page) => {
+      await expect(page.getByRole("button", { name: "see all" })).toBeVisible();
+    },
+  },
+  "notifications-dialog": {
+    state: notificationsState(),
+    drive: async (page) => {
+      await openNotifications(page);
+      await page.getByRole("button", { name: "see all" }).click();
+    },
+    settle: async (page) => {
+      await expect(page.getByRole("dialog")).toBeVisible();
+      await expect(page.getByText("earlier")).toBeVisible();
     },
   },
   "update-snapshotting": updateScreen(gatewayOperation(), async (page) => {

--- a/apps/web/visual/scenarios.json
+++ b/apps/web/visual/scenarios.json
@@ -248,6 +248,18 @@
       "group": "Home"
     },
     {
+      "id": "notifications-popover",
+      "title": "Notifications, popover",
+      "description": "The bell's taster of the newest unseen notifications.",
+      "group": "Home"
+    },
+    {
+      "id": "notifications-dialog",
+      "title": "Notifications, dialog",
+      "description": "The full history behind \"see all\", split on the seen watermark.",
+      "group": "Home"
+    },
+    {
       "id": "update-snapshotting",
       "title": "Update, backing up all",
       "description": "The update screen while every agent is snapshotted.",


### PR DESCRIPTION
## Why

Three things about the bell were wrong.

1. **Opening the popover was slow.** The first open started a `GET /notifications` fetch *and* held its skeletons for a minimum 500ms, so the surface took most of a second to show anything.
2. **Both surfaces showed the wrong amount.** The popover rendered the entire unseen set; the "see all" dialog truncated every notification to a single line.
3. **The dot lied.** It was derived from the gateway's two watermark scalars alone, so a message from the agent whose page you have open raised it, even though the pill deliberately hides that message because the chat renders it. The dot then stayed up until you opened a history surface.

## What

**Instant open.** `useNotificationFeed` prefetches the newest page as soon as the controller exists, before any surface opens, so the popover renders from memory. With a prefetch in place the `minLoadingMs` hold has nothing left to protect against (skeletons now show only while a fetch is genuinely in flight), so it is deleted along with its `Promise.allSettled` dance and the web provider's constant.

**The popover is a taster.** At most four of the newest unseen rows, with "see all" carrying the rest. It no longer needs its own scroll region.

**The dialog reads in full.** The title on its own line, the body wrapping below it up to three lines, more row spacing, and the alternating row bands the backups list uses.

**The dot counts only what is truly new.** The feed records, at arrival, which rows the user watched land in the chat (`notificationReadInPlace`: a `message` from the viewed agent, on a focused window), and the new `feedUnseen` discounts them. The decision is taken at arrival, not at render, so navigating away does not resurrect the dot. Anything the client cannot account for keeps the dot: an unloaded feed, or a gateway stamp above every row it holds. Nothing leaves the history, and the gateway's watermark is untouched, so no other notification can be masked.

## Verification

- `./check.sh app-core`, `app-web`, `app-desktop`, `app-visual`, `guards`: green.
- New tests: the prefetch (`use-notification-feed.test.tsx`), the read-in-place rule at arrival including the unfocused and other-page cases, and four `feedUnseen` cases covering the discount, the alongside-unread case, and both cannot-account-for fallbacks.
- Two new visual scenarios, `notifications-popover` and `notifications-dialog`, capture both surfaces on every web platform; captured and inspected on `web` and `web-narrow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
