### PR TITLE
fix(desktop): grant microphone under the macOS hardened runtime

### DIFF
--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- Electron's hardened-runtime defaults (JIT + library validation). -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <!-- Voice input: the hardened runtime blocks the microphone without this, whatever the
+         TCC grant or the renderer permission handler say. -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <!-- The connection QR scanner reads the camera. -->
+    <key>com.apple.security.device.camera</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -23,6 +23,8 @@ mac:
       arch: [arm64]
   hardenedRuntime: true
   notarize: true
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     NSMicrophoneUsageDescription: Vesta uses your microphone for voice input to your agent.
     NSLocationWhenInUseUsageDescription: Vesta shares this device's location with your agents so they follow your travel.

--- a/apps/desktop/src/window.test.ts
+++ b/apps/desktop/src/window.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveBundlePath } from "./window";
+import { resolveBundlePath, rendererPermissionDecision } from "./window";
 
 const WEB_DIST = path.join(path.sep, "app", "web");
 const INDEX = path.join(WEB_DIST, "index.html");
@@ -19,5 +19,16 @@ describe("resolveBundlePath", () => {
     { pathname: "/../webX/secrets.txt", expected: null },
   ])("$pathname -> $expected", ({ pathname, expected }) => {
     expect(resolveBundlePath(WEB_DIST, pathname)).toBe(expected);
+  });
+});
+
+describe("rendererPermissionDecision", () => {
+  it.each([
+    { permission: "geolocation", expected: "grant" },
+    { permission: "media", expected: "media" },
+    { permission: "notifications", expected: "deny" },
+    { permission: "clipboard-read", expected: "deny" },
+  ])("maps $permission to $expected", ({ permission, expected }) => {
+    expect(rendererPermissionDecision(permission)).toBe(expected);
   });
 });

--- a/apps/desktop/src/window.ts
+++ b/apps/desktop/src/window.ts
@@ -1,4 +1,12 @@
-import { BrowserWindow, app, net, protocol, session, shell } from "electron";
+import {
+  BrowserWindow,
+  app,
+  net,
+  protocol,
+  session,
+  shell,
+  systemPreferences,
+} from "electron";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -59,10 +67,37 @@ function handleAppProtocol(): void {
 
 // Microphone (voice) and geolocation (the "share this device's location" opt-in) are the only
 // permissions the renderer may request; everything else is denied.
+export function rendererPermissionDecision(
+  permission: string,
+): "grant" | "media" | "deny" {
+  if (permission === "geolocation") return "grant";
+  if (permission === "media") return "media";
+  return "deny";
+}
+
 function allowRendererPermissions(): void {
   session.defaultSession.setPermissionRequestHandler(
     (_wc, permission, callback) => {
-      callback(permission === "media" || permission === "geolocation");
+      const decision = rendererPermissionDecision(permission);
+      if (decision !== "media") {
+        callback(decision === "grant");
+        return;
+      }
+      // The hardened-runtime entitlement lets the app reach the microphone; this obtains the
+      // OS grant (the TCC prompt) that Chromium's getUserMedia needs on top of it. macOS only;
+      // other platforms gate on the renderer callback alone.
+      if (process.platform !== "darwin") {
+        callback(true);
+        return;
+      }
+      void systemPreferences.askForMediaAccess("microphone").then(
+        (granted) => {
+          callback(granted);
+        },
+        () => {
+          callback(false);
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
## What this does

Voice input never captured on the packaged macOS desktop app. Root cause: `electron-builder.yml` sets `hardenedRuntime: true` but ships no custom entitlements, so electron-builder's default entitlements apply, which contain only the JIT and library-validation keys, **not** `com.apple.security.device.audio-input`. Under the hardened runtime, macOS blocks the microphone without that entitlement, whatever the renderer permission handler (already allows `media`) or the Info.plist `NSMicrophoneUsageDescription` say.

## The fix

- Add `apps/desktop/build/entitlements.mac.plist`: the three Electron hardened-runtime defaults plus `com.apple.security.device.audio-input` and `com.apple.security.device.camera` (the connection QR scanner). Point `mac.entitlements` and `mac.entitlementsInherit` at it.
- In the main process, request the OS microphone grant via `systemPreferences.askForMediaAccess("microphone")` when the renderer asks for `media`, so the TCC prompt appears when voice is first used. The permission decision is a pure `rendererPermissionDecision` helper with a unit test.

## Verification

- `./check.sh app-desktop` (tsc, lint, vitest incl. the new permission-decision test) and `./check.sh guards`.
- Ran the dev Electron app: voice captures, and the media path/permission handler are exercised.
- Confirmed the entitlement embeds by codesigning the packed app with the new file: `codesign -d --entitlements` shows `com.apple.security.device.audio-input` and `camera`. electron-builder applies `mac.entitlements` the same way in a signed build.
- The full end-to-end gate is a microphone test on the next **signed + notarized** release build (the entitlement only takes effect there; dev runs unsigned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Bgkkuep3ekk6Ef4EVLsCN
