### PR TITLE
feat(web): voice mute, TTS-gated conversation, space-to-dictate + macOS desktop mic

### DIFF
--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- Electron's hardened-runtime defaults (JIT + library validation). -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <!-- Voice input: the hardened runtime blocks the microphone without this, whatever the
+         TCC grant or the renderer permission handler say. -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <!-- The connection QR scanner reads the camera. -->
+    <key>com.apple.security.device.camera</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -23,6 +23,8 @@ mac:
       arch: [arm64]
   hardenedRuntime: true
   notarize: true
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     NSMicrophoneUsageDescription: Vesta uses your microphone for voice input to your agent.
     NSLocationWhenInUseUsageDescription: Vesta shares this device's location with your agents so they follow your travel.

--- a/apps/desktop/src/window.test.ts
+++ b/apps/desktop/src/window.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveBundlePath } from "./window";
+import { resolveBundlePath, rendererPermissionDecision } from "./window";
 
 const WEB_DIST = path.join(path.sep, "app", "web");
 const INDEX = path.join(WEB_DIST, "index.html");
@@ -19,5 +19,16 @@ describe("resolveBundlePath", () => {
     { pathname: "/../webX/secrets.txt", expected: null },
   ])("$pathname -> $expected", ({ pathname, expected }) => {
     expect(resolveBundlePath(WEB_DIST, pathname)).toBe(expected);
+  });
+});
+
+describe("rendererPermissionDecision", () => {
+  it.each([
+    { permission: "geolocation", expected: "grant" },
+    { permission: "media", expected: "media" },
+    { permission: "notifications", expected: "deny" },
+    { permission: "clipboard-read", expected: "deny" },
+  ])("maps $permission to $expected", ({ permission, expected }) => {
+    expect(rendererPermissionDecision(permission)).toBe(expected);
   });
 });

--- a/apps/desktop/src/window.ts
+++ b/apps/desktop/src/window.ts
@@ -1,4 +1,12 @@
-import { BrowserWindow, app, net, protocol, session, shell } from "electron";
+import {
+  BrowserWindow,
+  app,
+  net,
+  protocol,
+  session,
+  shell,
+  systemPreferences,
+} from "electron";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -59,10 +67,37 @@ function handleAppProtocol(): void {
 
 // Microphone (voice) and geolocation (the "share this device's location" opt-in) are the only
 // permissions the renderer may request; everything else is denied.
+export function rendererPermissionDecision(
+  permission: string,
+): "grant" | "media" | "deny" {
+  if (permission === "geolocation") return "grant";
+  if (permission === "media") return "media";
+  return "deny";
+}
+
 function allowRendererPermissions(): void {
   session.defaultSession.setPermissionRequestHandler(
     (_wc, permission, callback) => {
-      callback(permission === "media" || permission === "geolocation");
+      const decision = rendererPermissionDecision(permission);
+      if (decision !== "media") {
+        callback(decision === "grant");
+        return;
+      }
+      // The hardened-runtime entitlement lets the app reach the microphone; this obtains the
+      // OS grant (the TCC prompt) that Chromium's getUserMedia needs on top of it. macOS only;
+      // other platforms gate on the renderer callback alone.
+      if (process.platform !== "darwin") {
+        callback(true);
+        return;
+      }
+      void systemPreferences.askForMediaAccess("microphone").then(
+        (granted) => {
+          callback(granted);
+        },
+        () => {
+          callback(false);
+        },
+      );
     },
   );
 }

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -99,7 +99,6 @@ interface ChatComposerProps {
   fullscreen?: boolean;
   agentName: string;
   notAuthenticated: boolean;
-  sttAvailable: boolean;
   recordingMode: VoiceMode | null;
   listening: boolean;
   isSpeaking: boolean;
@@ -118,7 +117,6 @@ export function ChatComposer({
   fullscreen,
   agentName,
   notAuthenticated,
-  sttAvailable,
   recordingMode,
   listening,
   isSpeaking,
@@ -148,7 +146,6 @@ export function ChatComposer({
     agentName,
   });
   const controls: ComposerControls = {
-    sttAvailable,
     recordingMode,
     inputDisabled,
     slot: rightSlot({ input, recordingMode }),
@@ -177,7 +174,6 @@ export function ChatComposer({
 }
 
 interface ComposerControls {
-  sttAvailable: boolean;
   recordingMode: VoiceMode | null;
   inputDisabled: boolean;
   slot: "conversation" | "send";
@@ -315,7 +311,6 @@ const RECORDING_BUTTON = "bg-red-500 text-white hover:bg-red-600";
 
 function VoiceButtons({ controls }: { controls: ComposerControls }) {
   const {
-    sttAvailable,
     recordingMode,
     inputDisabled,
     slot,
@@ -325,10 +320,6 @@ function VoiceButtons({ controls }: { controls: ComposerControls }) {
     onConversation,
     onSend,
   } = controls;
-
-  if (!sttAvailable) {
-    return <SendButton disabled={inputDisabled} onSend={onSend} />;
-  }
 
   if (recordingMode === "dictation") {
     return (

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -288,6 +288,7 @@ function FloatingComposer({
             onChange={onInputChange}
             onKeyDown={onKeyDown}
             readOnly={readOnly}
+            data-voice-dictate="true"
             placeholder={placeholder}
             disabled={inputDisabled}
             rows={1}

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -99,6 +99,7 @@ interface ChatComposerProps {
   fullscreen?: boolean;
   agentName: string;
   notAuthenticated: boolean;
+  voiceConfigured: boolean;
   recordingMode: VoiceMode | null;
   listening: boolean;
   isSpeaking: boolean;
@@ -117,6 +118,7 @@ export function ChatComposer({
   fullscreen,
   agentName,
   notAuthenticated,
+  voiceConfigured,
   recordingMode,
   listening,
   isSpeaking,
@@ -146,6 +148,7 @@ export function ChatComposer({
     agentName,
   });
   const controls: ComposerControls = {
+    voiceConfigured,
     recordingMode,
     inputDisabled,
     slot: rightSlot({ input, recordingMode }),
@@ -174,6 +177,7 @@ export function ChatComposer({
 }
 
 interface ComposerControls {
+  voiceConfigured: boolean;
   recordingMode: VoiceMode | null;
   inputDisabled: boolean;
   slot: "conversation" | "send";
@@ -311,6 +315,7 @@ const RECORDING_BUTTON = "bg-red-500 text-white hover:bg-red-600";
 
 function VoiceButtons({ controls }: { controls: ComposerControls }) {
   const {
+    voiceConfigured,
     recordingMode,
     inputDisabled,
     slot,
@@ -320,6 +325,11 @@ function VoiceButtons({ controls }: { controls: ComposerControls }) {
     onConversation,
     onSend,
   } = controls;
+
+  // Voice never set up: the composer is a plain send box.
+  if (!voiceConfigured) {
+    return <SendButton disabled={inputDisabled} onSend={onSend} />;
+  }
 
   if (recordingMode === "dictation") {
     return (

--- a/apps/web/src/components/Chat/ChatHeaderActions/index.tsx
+++ b/apps/web/src/components/Chat/ChatHeaderActions/index.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { cn } from "@/lib/utils";
-import { setTtsEnabled } from "@/lib/voice";
 import { useLayout } from "@/stores/use-layout";
 import { useVoice } from "@/stores/use-voice";
 
@@ -19,10 +18,10 @@ export function ChatHeaderActions({
   agentName,
 }: ChatHeaderActionsProps) {
   const navigate = useNavigate();
-  const ttsConfigured = useVoice((s) => s.ttsStatus?.configured ?? false);
+  const speechEnabled = useVoice((s) => s.speechEnabled);
   const navbarHeight = useLayout((s) => s.navbarHeight);
 
-  if (fullscreen && !ttsConfigured) return null;
+  if (fullscreen && !speechEnabled) return null;
 
   // The fullscreen chat sits under the absolute navbar, so the actions start below it.
   return (
@@ -31,7 +30,7 @@ export function ChatHeaderActions({
       style={{ top: fullscreen ? navbarHeight + 12 : 12 }}
     >
       <ButtonGroup>
-        {ttsConfigured && <SpeechButton agentName={agentName} />}
+        {speechEnabled && <SpeechButton />}
         {!fullscreen && (
           <>
             <Button
@@ -59,36 +58,28 @@ export function ChatHeaderActions({
   );
 }
 
-// Mutes and unmutes the agent's voice. Muting also cuts the reply being read out, and the
-// store's patch is the optimistic write, with a failed save re-read from the agent.
-function SpeechButton({ agentName }: { agentName: string }) {
-  const enabled = useVoice((s) => s.speechEnabled);
+// A per-device mute of spoken replies: red while muted. A conversation speaks regardless, so
+// this only silences the ambient read-aloud outside one.
+function SpeechButton() {
+  const muted = useVoice((s) => s.muted);
   const speaking = useVoice((s) => s.isSpeaking);
-  const { patchTts, refreshVoiceStatus, stopSpeech } = useVoice.getState();
-
-  const toggle = () => {
-    const next = !enabled;
-    if (!next) stopSpeech();
-    patchTts({ enabled: next });
-    setTtsEnabled(agentName, next).catch(() => {
-      refreshVoiceStatus();
-    });
-  };
+  const toggleMuted = useVoice((s) => s.toggleMuted);
 
   return (
     <Button
       variant="outline"
       size="icon-sm"
-      aria-pressed={enabled}
-      aria-label={enabled ? "mute voice" : "unmute voice"}
-      title={enabled ? "mute voice" : "unmute voice"}
+      aria-pressed={muted}
+      aria-label={muted ? "unmute voice" : "mute voice"}
+      title={muted ? "unmute voice" : "mute voice"}
       className={cn(
-        "text-muted-foreground",
-        enabled && speaking && "text-foreground",
+        muted
+          ? "text-red-500 hover:text-red-600"
+          : cn("text-muted-foreground", speaking && "text-foreground"),
       )}
-      onClick={toggle}
+      onClick={toggleMuted}
     >
-      {enabled ? <Volume2 /> : <VolumeX />}
+      {muted ? <VolumeX /> : <Volume2 />}
     </Button>
   );
 }

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -58,7 +58,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   const toast = useToast();
   const navbarHeight = useLayout((s) => s.navbarHeight);
   const {
-    sttAvailable,
     recordingMode,
     listening,
     isSpeaking,
@@ -282,7 +281,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
               fullscreen={fullscreen}
               agentName={name}
               notAuthenticated={notAuthenticated}
-              sttAvailable={sttAvailable}
               recordingMode={recordingMode}
               listening={listening}
               isSpeaking={isSpeaking}

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -58,6 +58,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   const toast = useToast();
   const navbarHeight = useLayout((s) => s.navbarHeight);
   const {
+    voiceConfigured,
     recordingMode,
     listening,
     isSpeaking,
@@ -281,6 +282,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
               fullscreen={fullscreen}
               agentName={name}
               notAuthenticated={notAuthenticated}
+              voiceConfigured={voiceConfigured}
               recordingMode={recordingMode}
               listening={listening}
               isSpeaking={isSpeaking}

--- a/apps/web/src/providers/KeybindProvider/index.tsx
+++ b/apps/web/src/providers/KeybindProvider/index.tsx
@@ -8,6 +8,40 @@ function isButtonTarget(target: EventTarget | null): boolean {
   return target instanceof Element && target.closest("button") !== null;
 }
 
+// The chat composer textarea, when the event is on it; null for any other target. Marked so
+// Space can dictate from an empty composer without also firing in unrelated inputs.
+function composerTextarea(
+  target: EventTarget | null,
+): HTMLTextAreaElement | null {
+  return target instanceof HTMLTextAreaElement &&
+    target.dataset.voiceDictate === "true"
+    ? target
+    : null;
+}
+
+function handleDictationKey(
+  event: KeyboardEvent,
+  editable: boolean,
+  activation: "hold" | "toggle",
+): void {
+  const { sttAvailable, recordingMode, startVoice, stopVoice } =
+    useVoice.getState();
+  if (!sttAvailable) return;
+  // A focused composer button (discard, confirm, end conversation) owns its own Space.
+  if (recordingMode !== null && isButtonTarget(event.target)) return;
+  if (editable) {
+    const composer = composerTextarea(event.target);
+    // Dictate from the composer only when it is empty (so a typed space still lands) or while
+    // a dictation it started is running; every other focused field types the space.
+    if (!composer || (recordingMode === null && composer.value.trim() !== ""))
+      return;
+  }
+  event.preventDefault();
+  if (recordingMode === null) startVoice("dictation");
+  else if (recordingMode === "dictation" && activation === "toggle")
+    stopVoice();
+}
+
 export function KeybindProvider({ children }: { children: ReactNode }) {
   const { cycleTheme } = useTheme();
   const activation = useVoiceActivation((s) => s.mode);
@@ -18,30 +52,19 @@ export function KeybindProvider({ children }: { children: ReactNode }) {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.repeat) return;
       if (event.metaKey || event.ctrlKey || event.altKey) return;
-      if (isEditableTarget(event.target)) return;
+      const editable = isEditableTarget(event.target);
 
       if (event.key === " ") {
-        const { sttAvailable, recordingMode, startVoice, stopVoice } =
-          useVoice.getState();
-        if (!sttAvailable) return;
-        // A focused composer button (discard, confirm, end conversation) owns its own Space.
-        if (recordingMode !== null && isButtonTarget(event.target)) return;
-        event.preventDefault();
-        if (recordingMode === null) startVoice("dictation");
-        else if (recordingMode === "dictation" && activation === "toggle")
-          stopVoice();
+        handleDictationKey(event, editable, activation);
         return;
       }
 
-      if (event.key.toLowerCase() === "d") {
-        cycleTheme();
-        return;
-      }
+      if (editable) return;
+      if (event.key.toLowerCase() === "d") cycleTheme();
     };
 
     const handleKeyUp = (event: KeyboardEvent) => {
       if (event.key !== " " || activation !== "hold") return;
-      if (isEditableTarget(event.target)) return;
       const { recordingMode, stopVoice } = useVoice.getState();
       if (recordingMode === "dictation") stopVoice();
     };

--- a/apps/web/src/stores/use-voice.test.ts
+++ b/apps/web/src/stores/use-voice.test.ts
@@ -80,6 +80,7 @@ beforeEach(() => {
   useVoice.getState()._setAgentContext("test-agent", {}, undefined);
   useVoice.getState()._setSttStatus(null);
   useVoice.getState()._setTtsStatus(null);
+  useVoice.setState({ muted: false });
   FakeAudio.created = [];
   FakeSocket.urls = [];
   vi.stubGlobal("Audio", FakeAudio);
@@ -270,6 +271,7 @@ describe("recording modes", () => {
     vi.stubGlobal("AudioContext", FakeAudioContext);
     vi.stubGlobal("AudioWorkletNode", FakeWorkletNode);
     useVoice.getState()._setSttStatus(ENABLED_STT);
+    useVoice.getState()._setTtsStatus(ENABLED_TTS);
     send = vi.fn<(text: string) => void>();
     clearInput = vi.fn<() => void>();
     useVoice.getState().registerChat(send, clearInput);
@@ -418,5 +420,38 @@ describe("recording modes", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(useVoice.getState().recordingMode).toBeNull();
     expect(RecordingSocket.instances).toHaveLength(0);
+  });
+
+  it("refuses a conversation and points at setup when TTS is not configured", () => {
+    useVoice.getState()._setTtsStatus(null);
+    useVoice.getState().startVoice("conversation");
+    expect(useVoice.getState().recordingMode).toBeNull();
+    expect(useToastStore.getState().current?.title).toBe(
+      "set up text-to-speech in the settings",
+    );
+    useToastStore.getState().dismiss();
+  });
+
+  it("refuses a conversation and points at enabling when TTS is off", () => {
+    useVoice.getState()._setTtsStatus({ ...ENABLED_TTS, enabled: false });
+    useVoice.getState().startVoice("conversation");
+    expect(useVoice.getState().recordingMode).toBeNull();
+    expect(useToastStore.getState().current?.title).toBe(
+      "enable text-to-speech in the settings",
+    );
+    useToastStore.getState().dismiss();
+  });
+
+  it("mute silences an ambient reply but a conversation speaks anyway", async () => {
+    useVoice.setState({ muted: true });
+    useVoice.getState().speak("silent while idle");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(FakeAudio.created).toHaveLength(0);
+
+    await startRecording("conversation");
+    useVoice.getState().speak("a conversation reply");
+    await vi.waitFor(() => {
+      expect(FakeAudio.created.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/apps/web/src/stores/use-voice.test.ts
+++ b/apps/web/src/stores/use-voice.test.ts
@@ -422,6 +422,16 @@ describe("recording modes", () => {
     expect(RecordingSocket.instances).toHaveLength(0);
   });
 
+  it("refuses dictation and points at speech-to-text when STT is off", () => {
+    useVoice.getState()._setSttStatus({ ...ENABLED_STT, enabled: false });
+    useVoice.getState().startVoice("dictation");
+    expect(useVoice.getState().recordingMode).toBeNull();
+    expect(useToastStore.getState().current?.title).toBe(
+      "enable speech-to-text in the settings",
+    );
+    useToastStore.getState().dismiss();
+  });
+
   it("refuses a conversation and points at setup when TTS is not configured", () => {
     useVoice.getState()._setTtsStatus(null);
     useVoice.getState().startVoice("conversation");

--- a/apps/web/src/stores/use-voice.ts
+++ b/apps/web/src/stores/use-voice.ts
@@ -38,6 +38,9 @@ interface VoiceState {
   ttsStatus: TtsStatus | null;
   sttAvailable: boolean;
   speechEnabled: boolean;
+  // Voice has been set up at all (either service configured), the gate for showing the
+  // composer's voice buttons; being configured but off is a per-click toast, not a hide.
+  voiceConfigured: boolean;
 
   // Recording (set at press time so a release that beats the microphone still lands).
   recordingMode: VoiceMode | null;
@@ -110,7 +113,9 @@ function boolSetting(
 function deriveStatus(stt: SttStatus | null, tts: TtsStatus | null) {
   const sttAvailable = (stt?.configured && stt.enabled) ?? false;
   const speechEnabled = (tts?.configured && tts.enabled) ?? false;
-  return { sttAvailable, speechEnabled };
+  const voiceConfigured =
+    (stt?.configured ?? false) || (tts?.configured ?? false);
+  return { sttAvailable, speechEnabled, voiceConfigured };
 }
 
 // A reply is spoken when text-to-speech is available and either a conversation is running (it
@@ -168,6 +173,7 @@ export const useVoice = create<VoiceState>((set, get) => {
     ttsStatus: null,
     sttAvailable: false,
     speechEnabled: false,
+    voiceConfigured: false,
 
     recordingMode: null,
     listening: false,

--- a/apps/web/src/stores/use-voice.ts
+++ b/apps/web/src/stores/use-voice.ts
@@ -48,6 +48,9 @@ interface VoiceState {
 
   // TTS
   isSpeaking: boolean;
+  // A per-device mute of spoken replies. A conversation speaks regardless; this silences the
+  // ambient read-aloud of replies outside one.
+  muted: boolean;
 
   // Actions
   startVoice: (mode: VoiceMode) => void;
@@ -58,6 +61,7 @@ interface VoiceState {
   prefetch: (text: string) => void;
   speak: (text: string) => void;
   stopSpeech: () => void;
+  toggleMuted: () => void;
   // The chat's send, and its input reset: a voice mode takes the composer over, so typed
   // text is dropped when one starts.
   registerChat: (
@@ -88,6 +92,12 @@ let sendCallback: ((text: string, inputMethod?: InputMethod) => void) | null =
   null;
 let clearInputCallback: (() => void) | null = null;
 
+const MUTE_STORAGE_KEY = "voice-muted";
+function loadMuted(): boolean {
+  if (typeof localStorage === "undefined") return false;
+  return localStorage.getItem(MUTE_STORAGE_KEY) === "1";
+}
+
 function boolSetting(
   status: SttStatus | TtsStatus | null,
   key: string,
@@ -101,6 +111,17 @@ function deriveStatus(stt: SttStatus | null, tts: TtsStatus | null) {
   const sttAvailable = (stt?.configured && stt.enabled) ?? false;
   const speechEnabled = (tts?.configured && tts.enabled) ?? false;
   return { sttAvailable, speechEnabled };
+}
+
+// A reply is spoken when text-to-speech is available and either a conversation is running (it
+// always speaks) or the user has not muted the ambient read-aloud.
+function speakable(state: {
+  speechEnabled: boolean;
+  muted: boolean;
+  recordingMode: VoiceMode | null;
+}): boolean {
+  if (!state.speechEnabled) return false;
+  return state.recordingMode === "conversation" || !state.muted;
 }
 
 export const useVoice = create<VoiceState>((set, get) => {
@@ -154,14 +175,28 @@ export const useVoice = create<VoiceState>((set, get) => {
     voiceError: null,
 
     isSpeaking: false,
+    muted: loadMuted(),
 
     startVoice: (mode) => {
       if (session.mode() !== null) return;
-      const { sttAvailable, agentName } = get();
+      const { sttAvailable, agentName, ttsStatus } = get();
       if (!sttAvailable || !agentName) {
         set({
           voiceError: "Voice input not configured — ask the agent to set it up",
         });
+        return;
+      }
+      // A conversation speaks back, so it needs text-to-speech ready. Point the user at the
+      // fix (set up, or enable) rather than starting a session that stays silent.
+      if (mode === "conversation" && !get().speechEnabled) {
+        useToastStore
+          .getState()
+          .show(
+            "error",
+            ttsStatus?.configured
+              ? "enable text-to-speech in the settings"
+              : "set up text-to-speech in the settings",
+          );
         return;
       }
       set({ voiceError: null });
@@ -178,14 +213,21 @@ export const useVoice = create<VoiceState>((set, get) => {
     cancelVoice: () => session.cancel(),
 
     prefetch: (text) => {
-      if (!get().speechEnabled) return;
+      if (!speakable(get())) return;
       session.prefetch(text);
     },
     speak: (text) => {
-      if (!get().speechEnabled) return;
+      if (!speakable(get())) return;
       session.speak(text);
     },
     stopSpeech: () => session.stopSpeech(),
+    toggleMuted: () => {
+      const next = !get().muted;
+      if (typeof localStorage !== "undefined")
+        localStorage.setItem(MUTE_STORAGE_KEY, next ? "1" : "0");
+      if (next) session.stopSpeech();
+      set({ muted: next });
+    },
 
     registerChat: (send, clearInput) => {
       sendCallback = send;

--- a/apps/web/src/stores/use-voice.ts
+++ b/apps/web/src/stores/use-voice.ts
@@ -179,16 +179,24 @@ export const useVoice = create<VoiceState>((set, get) => {
 
     startVoice: (mode) => {
       if (session.mode() !== null) return;
-      const { sttAvailable, agentName, ttsStatus } = get();
-      if (!sttAvailable || !agentName) {
-        set({
-          voiceError: "Voice input not configured — ask the agent to set it up",
-        });
+      const { sttAvailable, speechEnabled, agentName, sttStatus, ttsStatus } =
+        get();
+      if (!agentName) return;
+      // The voice buttons always show; a mode the settings do not allow points the user at the
+      // fix (set up, or enable) with a toast rather than starting a silent or dead session.
+      if (!sttAvailable) {
+        useToastStore
+          .getState()
+          .show(
+            "error",
+            sttStatus?.configured
+              ? "enable speech-to-text in the settings"
+              : "set up speech-to-text in the settings",
+          );
         return;
       }
-      // A conversation speaks back, so it needs text-to-speech ready. Point the user at the
-      // fix (set up, or enable) rather than starting a session that stays silent.
-      if (mode === "conversation" && !get().speechEnabled) {
+      // A conversation speaks back, so it also needs text-to-speech ready.
+      if (mode === "conversation" && !speechEnabled) {
         useToastStore
           .getState()
           .show(


### PR DESCRIPTION
## What this does

A batch of voice refinements in one PR (web chat voice + the macOS desktop mic fix).

### Web chat voice

- **Local mute** (header speaker button): now a per-device mute of spoken replies, not a provider toggle. Shown only when text-to-speech is enabled, so turning TTS off in settings hides the control (previously nothing changed in the chat UI). Red while muted. A conversation always speaks back and ignores the mute; the mute only silences the ambient read-aloud of replies outside a conversation.
- **TTS-gated conversation**: starting a conversation needs text-to-speech, so the conversation button now refuses when TTS is off or unconfigured and toasts the fix, "enable text-to-speech in the settings" or "set up text-to-speech in the settings", instead of opening a silent session. The button still shows either way.
- **Space to dictate from the empty composer**: pressing Space in the composer when it is empty starts dictation without typing a space; a composer with text, or any other focused field, types the space as before. The composer textarea is marked so this never fires in unrelated inputs.

### macOS desktop microphone

Folded in from the desktop mic fix (the packaged app never captured audio): a custom `entitlements.mac.plist` adds `com.apple.security.device.audio-input` (and camera) under the hardened runtime, wired via `mac.entitlements`/`entitlementsInherit`, plus `systemPreferences.askForMediaAccess` for the OS grant. Verified the entitlement embeds under codesign.

## Verification

- `./check.sh app-web` (voice store tests updated; new tests: the two conversation TTS-gate toasts, and mute silencing an ambient reply while a conversation speaks anyway), `./check.sh app-desktop`, `./check.sh guards`.
- Desktop dev-app run confirmed mic capture; entitlement embedding confirmed via `codesign -d --entitlements`. The desktop end-to-end gate remains a mic test on the next signed release.

Supersedes #2305 (the desktop mic fix is included here). Mobile voice parity stays separate in #2303, which is blocked on a device pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Bgkkuep3ekk6Ef4EVLsCN
