### PR TITLE
test(web): lock that muted TTS fires no pipeline

### DIFF
--- a/apps/web/src/stores/use-voice.test.ts
+++ b/apps/web/src/stores/use-voice.test.ts
@@ -452,12 +452,20 @@ describe("recording modes", () => {
     useToastStore.getState().dismiss();
   });
 
-  it("mute silences an ambient reply but a conversation speaks anyway", async () => {
+  it("mute fires no TTS pipeline at all: no prepare, no stream", async () => {
     useVoice.setState({ muted: true });
+    apiJsonMock.mockClear();
+    useVoice.getState().prefetch("would warm");
     useVoice.getState().speak("silent while idle");
     await new Promise((resolve) => setTimeout(resolve, 0));
+    // The gate is at the store's entry, before the queue: a muted reply reaches neither the
+    // prepare POST nor a streamed <audio>, rather than preparing and staying silent.
+    expect(apiJsonMock).not.toHaveBeenCalled();
     expect(FakeAudio.created).toHaveLength(0);
+  });
 
+  it("a conversation speaks even while muted", async () => {
+    useVoice.setState({ muted: true });
     await startRecording("conversation");
     useVoice.getState().speak("a conversation reply");
     await vi.waitFor(() => {


### PR DESCRIPTION
## What this does

Confirms and locks the behavior you asked about: when the user mutes text-to-speech, the pipeline does not fire and get dropped at the speaker, it never fires at all.

The store already gates `speak` and `prefetch` before the core TTS queue (`speakable` returns false when muted outside a conversation), and that queue is the only caller of `player.prepare`/`player.play`. So a muted reply reaches neither the `/tts/prepare` POST nor a streamed `<audio>`.

This pins it: the strengthened test asserts the mocked prepare call is **not** made and **no** audio element is created while muted, so a future change cannot regress it into fire-but-silent. A conversation still speaks while muted (kept as its own case).

No production code changes; behavior was already correct.

## Verification

- `./check.sh app-web`, `./check.sh guards`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Bgkkuep3ekk6Ef4EVLsCN
