### PR TITLE
feat(web,core,mobile): conversation drawer UI and yield-to-user turn gate

### DIFF
--- a/agent/skills/app-chat/SKILL.md
+++ b/agent/skills/app-chat/SKILL.md
@@ -65,6 +65,7 @@ app-chat attachments rm <id> [<id>...] # frees the bytes, keeps the chat history
 
 ## Notes
 - Always reply to app messages using `app-chat send`, not through any other channel
+- In a live voice conversation, `send` is refused with `the user is talking right now: ...` while the user is mid-sentence. Do what the error says: drop that reply, wait for the next `source=app-chat` notification (it arrives when they finish), and answer their whole thought in one fresh reply
 - `send` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass
 - A numbered or bulleted list is fine to send as one message (each item is one short thought); a line-leading marker like `1.` or `2)` is not a full stop, so a list does not need `--longform`
 - Send multiple short messages instead of one long one (like texting)

--- a/agent/skills/app-chat/cli/src/app_chat_cli/daemon.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/daemon.py
@@ -246,12 +246,12 @@ async def _ingest_attachments(state: DaemonState, attach: list[str]) -> tuple[li
 
 async def _handle_send(state: DaemonState, message: str, attach: list[str]) -> tuple[dict[str, object], str | None]:
     """One validated send: gate on the user's live turn, ingest attachments, persist + emit.
-    Returns the ack and the toast text (None when nothing went out)."""
+    Returns the response envelope (ok or error) and the toast text (None when nothing went out)."""
     if not message and not attach:
         return {"error": "empty message"}, None
-    if state.service.user_speaking():
-        # A reply now would talk over the user; the error tells the model the next move.
-        return {"error": "the user is talking right now: drop this reply, wait for their next message, then answer the whole thought"}, None
+    refusal = state.service.refuse_send_while_speaking()
+    if refusal is not None:
+        return {"error": refusal}, None
     metas, ingest_error = await _ingest_attachments(state, attach)
     if ingest_error is not None:
         return {"error": ingest_error}, None

--- a/agent/skills/app-chat/cli/src/app_chat_cli/daemon.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/daemon.py
@@ -244,6 +244,26 @@ async def _ingest_attachments(state: DaemonState, attach: list[str]) -> tuple[li
     return metas, None
 
 
+async def _handle_send(state: DaemonState, message: str, attach: list[str]) -> tuple[dict[str, object], str | None]:
+    """One validated send: gate on the user's live turn, ingest attachments, persist + emit.
+    Returns the ack and the toast text (None when nothing went out)."""
+    if not message and not attach:
+        return {"error": "empty message"}, None
+    if state.service.user_speaking():
+        # A reply now would talk over the user; the error tells the model the next move.
+        return {"error": "the user is talking right now: drop this reply, wait for their next message, then answer the whole thought"}, None
+    metas, ingest_error = await _ingest_attachments(state, attach)
+    if ingest_error is not None:
+        return {"error": ingest_error}, None
+    event: StoredEvent = {"type": "chat", "ts": datetime.now(UTC).isoformat(), "text": message}
+    if metas:
+        event["attachments"] = metas
+    state.service.store.append(event)
+    state.service.emit(event)
+    # An attachment-only reply still deserves its toast: fall back to the filenames.
+    return {"ok": True, "message": message, "id": event["id"]}, message or ", ".join(meta["name"] for meta in metas)
+
+
 async def _handle_socket_conn(state: DaemonState, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
     try:
         data = await asyncio.wait_for(reader.read(65536), timeout=30.0)
@@ -258,21 +278,8 @@ async def _handle_socket_conn(state: DaemonState, reader: asyncio.StreamReader, 
             attach = attach_raw if isinstance(attach_raw, list) and all(isinstance(one, str) for one in attach_raw) else None
             if attach is None:
                 response = {"error": "attach must be a list of paths"}
-            elif not message and not attach:
-                response = {"error": "empty message"}
             else:
-                metas, ingest_error = await _ingest_attachments(state, attach)
-                if ingest_error is not None:
-                    response = {"error": ingest_error}
-                else:
-                    event: StoredEvent = {"type": "chat", "ts": datetime.now(UTC).isoformat(), "text": message}
-                    if metas:
-                        event["attachments"] = metas
-                    state.service.store.append(event)
-                    state.service.emit(event)
-                    response = {"ok": True, "message": message, "id": event["id"]}
-                    # An attachment-only reply still deserves its toast: fall back to the filenames.
-                    notify_message = message or ", ".join(meta["name"] for meta in metas)
+                response, notify_message = await _handle_send(state, message, attach)
         elif command == "status":
             response = {"ok": True, "port": state.port, "clients": len(state.service.subscribers)}
         else:

--- a/agent/skills/app-chat/cli/src/app_chat_cli/service.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/service.py
@@ -60,6 +60,13 @@ class ServiceState:
         self.attachments_root = attachments_root
         self.seen_intent_ids: collections.OrderedDict[str, None] = collections.OrderedDict()
         self.subscribers: set[asyncio.Queue[StoredEvent]] = set()
+        # Connections whose client reported the user talking into a live voice conversation.
+        # Keyed by the connection's queue and cleared with it, so a dropped client can never
+        # wedge the send gate; no timers, the socket lifecycle owns the entry.
+        self.speaking: set[asyncio.Queue[StoredEvent]] = set()
+
+    def user_speaking(self) -> bool:
+        return bool(self.speaking)
 
     def remember(self, intent_id: str) -> None:
         self.seen_intent_ids[intent_id] = None
@@ -211,10 +218,28 @@ async def health_handler(_: web.Request) -> web.Response:
     return web.Response(text="ok")
 
 
+def _apply_client_frame(state: ServiceState, queue: asyncio.Queue[StoredEvent], raw: str) -> None:
+    """One inbound report rides the chat socket: {"type": "speaking", "active": bool}, true while
+    the user is talking into a live voice conversation. Every other inbound frame is ignored, so
+    clients can add frames without breaking older daemons."""
+    try:
+        frame = json.loads(raw)
+    except json.JSONDecodeError:
+        return
+    if not isinstance(frame, dict) or "type" not in frame or frame["type"] != "speaking":
+        return
+    if "active" not in frame or not isinstance(frame["active"], bool):
+        return
+    if frame["active"]:
+        state.speaking.add(queue)
+    else:
+        state.speaking.discard(queue)
+
+
 async def ws_handler(request: web.Request) -> web.WebSocketResponse:
     """Per-connection live chat stream: every event appended after connect (user echo, agent reply),
     no replay. Clients seed history over GET /history and reconcile this live edge by id. The inbound
-    half is drained only to notice a client close."""
+    half carries the speaking report and notices a client close."""
     state = request.app[_STATE_KEY]
     ws = web.WebSocketResponse(heartbeat=30.0)
     await ws.prepare(request)
@@ -229,6 +254,8 @@ async def ws_handler(request: web.Request) -> web.WebSocketResponse:
     sender = asyncio.create_task(pump())
     try:
         async for msg in ws:
+            if msg.type == web.WSMsgType.TEXT:
+                _apply_client_frame(state, queue, msg.data)
             if msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):
                 break
     finally:
@@ -240,6 +267,7 @@ async def ws_handler(request: web.Request) -> web.WebSocketResponse:
         except (ConnectionResetError, RuntimeError) as exc:
             logger.debug("chat-socket pump ended on a dead client: %s", exc)
         state.subscribers.discard(queue)
+        state.speaking.discard(queue)
     return ws
 
 

--- a/agent/skills/app-chat/cli/src/app_chat_cli/service.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/service.py
@@ -64,9 +64,34 @@ class ServiceState:
         # Keyed by the connection's queue and cleared with it, so a dropped client can never
         # wedge the send gate; no timers, the socket lifecycle owns the entry.
         self.speaking: set[asyncio.Queue[StoredEvent]] = set()
+        # True once a send was refused during the live turn. The refusal tells the model a
+        # notification follows when the user finishes; a turn can end without producing one (an
+        # empty transcript, a dropped connection), so the floor-clear below writes it itself.
+        self.reply_refused = False
 
-    def user_speaking(self) -> bool:
-        return bool(self.speaking)
+    def refuse_send_while_speaking(self) -> str | None:
+        """The send gate, whole: while the user talks a reply is refused with the instruction
+        below and the marker set, and set_speaking repays the drop with the turn-end
+        notification once the floor clears; both halves of that contract live here."""
+        if not self.speaking:
+            return None
+        self.reply_refused = True
+        return "the user is talking right now: drop this reply, wait for their next message, then answer the whole thought"
+
+    def set_speaking(self, queue: asyncio.Queue[StoredEvent], active: bool) -> None:
+        """The one owner of the speaking set: every add and clear (frame or disconnect) routes
+        through here, so the refused-reply re-wake fires exactly when the floor clears."""
+        if active:
+            self.speaking.add(queue)
+            return
+        self.speaking.discard(queue)
+        if self.speaking or not self.reply_refused:
+            return
+        self.reply_refused = False
+        try:
+            _write_turn_end_notification(self)
+        except OSError as exc:
+            logger.error("failed to write app-chat turn-end notification: %s", exc)
 
     def remember(self, intent_id: str) -> None:
         self.seen_intent_ids[intent_id] = None
@@ -97,27 +122,47 @@ def _attachment_line(state: ServiceState, metas: list[attachments.AttachmentMeta
     return "; ".join(parts)
 
 
+def _emit_notification(state: ServiceState, type_: str, fields: dict[str, object]) -> None:
+    """The one writer of the monitor-loop file contract for this service: envelope basics, the
+    time-ns filename, and the atomic tmp+replace, shared by every notification type it emits."""
+    directory = state.notifications_dir
+    directory.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, object] = {
+        "timestamp": dt.datetime.now().isoformat(),
+        "source": "app-chat",
+        "type": type_,
+        "interrupt": True,
+        "reply_command": "app-chat send --message -",
+        **fields,
+    }
+    path = directory / f"{time.time_ns()}-app-chat-{type_}.json"
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload))
+    tmp.replace(path)
+
+
 def _write_notification(state: ServiceState, text: str, metas: list[attachments.AttachmentMeta]) -> None:
     """Persist an inbound app message as the source=app-chat notification the monitor loop turns into a
     model turn. The structured reply command and behavioral hint ride along so the model receives the
     producer-owned response guidance. The client-only intent ID stays on the chat event."""
-    directory = state.notifications_dir
-    directory.mkdir(parents=True, exist_ok=True)
     fields: dict[str, object] = {
-        "timestamp": dt.datetime.now().isoformat(),
-        "source": "app-chat",
-        "type": "message",
         "message": text,
-        "interrupt": True,
-        "reply_command": "app-chat send --message -",
         "reply_hint": "think about how you can best show your personality",
     }
     if metas:
         fields["attachments"] = _attachment_line(state, metas)
-    path = directory / f"{time.time_ns()}-app-chat-message.json"
-    tmp = path.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(fields))
-    tmp.replace(path)
+    _emit_notification(state, "message", fields)
+
+
+def _write_turn_end_notification(state: ServiceState) -> None:
+    """The re-wake behind the send gate: a refused reply was dropped by the model on the promise
+    that a notification follows the turn, so the floor clearing delivers one even when the turn
+    itself produced no message."""
+    _emit_notification(
+        state,
+        "user_finished_talking",
+        {"message": "the user finished talking; a reply of yours was refused mid-turn and dropped. Answer their whole thought fresh now"},
+    )
 
 
 def _build_message_event(body: dict[str, object]) -> tuple[StoredEvent, list[str]] | str:
@@ -230,10 +275,7 @@ def _apply_client_frame(state: ServiceState, queue: asyncio.Queue[StoredEvent], 
         return
     if "active" not in frame or not isinstance(frame["active"], bool):
         return
-    if frame["active"]:
-        state.speaking.add(queue)
-    else:
-        state.speaking.discard(queue)
+    state.set_speaking(queue, frame["active"])
 
 
 async def ws_handler(request: web.Request) -> web.WebSocketResponse:
@@ -267,7 +309,7 @@ async def ws_handler(request: web.Request) -> web.WebSocketResponse:
         except (ConnectionResetError, RuntimeError) as exc:
             logger.debug("chat-socket pump ended on a dead client: %s", exc)
         state.subscribers.discard(queue)
-        state.speaking.discard(queue)
+        state.set_speaking(queue, False)
     return ws
 
 

--- a/agent/skills/app-chat/cli/tests/test_daemon.py
+++ b/agent/skills/app-chat/cli/tests/test_daemon.py
@@ -214,6 +214,24 @@ def test_send_command_persists_chat_event_and_fans_it_to_subscribers(tmp_path, m
     state.service.store.close()
 
 
+def test_send_is_refused_while_the_user_is_talking(tmp_path, monkeypatch):
+    monkeypatch.delenv("AGENT_NAME", raising=False)
+    state = _daemon_state(tmp_path)
+    speaking_conn: asyncio.Queue[StoredEvent] = asyncio.Queue()
+    state.service.speaking.add(speaking_conn)
+
+    refused = asyncio.run(_socket_command(state, {"command": "send", "message": "mid-turn reply"}))
+
+    assert refused == {"error": "the user is talking right now: drop this reply, wait for their next message, then answer the whole thought"}
+    assert state.service.store.page()[0] == []
+
+    state.service.speaking.discard(speaking_conn)
+    accepted = asyncio.run(_socket_command(state, {"command": "send", "message": "after the turn"}))
+
+    assert accepted == {"ok": True, "message": "after the turn", "id": 1}
+    state.service.store.close()
+
+
 def test_send_acks_the_client_before_the_user_notification_finishes(tmp_path, monkeypatch):
     # The user notification can block up to its timeout. The durable ack must reach the client
     # first, so a blocking notification must not stall the send response. A read that waited on

--- a/agent/skills/app-chat/cli/tests/test_daemon.py
+++ b/agent/skills/app-chat/cli/tests/test_daemon.py
@@ -232,6 +232,29 @@ def test_send_is_refused_while_the_user_is_talking(tmp_path, monkeypatch):
     state.service.store.close()
 
 
+def test_refused_send_rewakes_the_agent_when_the_floor_clears(tmp_path, monkeypatch):
+    # The refusal promises a follow-up notification, and a turn can end without producing one
+    # (an empty transcript), so the floor clearing after a refusal must write it itself.
+    monkeypatch.delenv("AGENT_NAME", raising=False)
+    state = _daemon_state(tmp_path)
+    speaking_conn: asyncio.Queue[StoredEvent] = asyncio.Queue()
+    state.service.set_speaking(speaking_conn, True)
+
+    asyncio.run(_socket_command(state, {"command": "send", "message": "mid-turn reply"}))
+    state.service.set_speaking(speaking_conn, False)
+
+    files = list((tmp_path / "notifications").glob("*-app-chat-user_finished_talking.json"))
+    assert len(files) == 1
+    fields = json.loads(files[0].read_text())
+    assert fields["source"] == "app-chat" and fields["type"] == "user_finished_talking" and fields["interrupt"] is True
+
+    # A turn with no refusal clears silently: the marker was consumed by the one nudge above.
+    state.service.set_speaking(speaking_conn, True)
+    state.service.set_speaking(speaking_conn, False)
+    assert len(list((tmp_path / "notifications").glob("*-app-chat-user_finished_talking.json"))) == 1
+    state.service.store.close()
+
+
 def test_send_acks_the_client_before_the_user_notification_finishes(tmp_path, monkeypatch):
     # The user notification can block up to its timeout. The durable ack must reach the client
     # first, so a blocking notification must not stall the send response. A read that waited on

--- a/agent/skills/app-chat/cli/tests/test_service.py
+++ b/agent/skills/app-chat/cli/tests/test_service.py
@@ -271,13 +271,13 @@ def test_ws_speaking_frames_flip_the_flag_and_junk_is_ignored(tmp_path):
         ws = await client.ws_connect("/ws")
         await _wait_for(lambda: len(state.subscribers) == 1)
         await ws.send_str(json.dumps({"type": "speaking", "active": True}))
-        await _wait_for(state.user_speaking)
+        await _wait_for(lambda: bool(state.speaking))
         await ws.send_str("not json")
         await ws.send_str(json.dumps({"type": "unknown-frame"}))
         await ws.send_str(json.dumps({"type": "speaking", "active": "yes"}))
-        assert state.user_speaking()
+        assert state.speaking
         await ws.send_str(json.dumps({"type": "speaking", "active": False}))
-        await _wait_for(lambda: not state.user_speaking())
+        await _wait_for(lambda: not state.speaking)
         await ws.close()
 
     asyncio.run(_with_client(state, scenario))
@@ -291,9 +291,26 @@ def test_ws_disconnect_clears_a_live_speaking_flag(tmp_path):
         ws = await client.ws_connect("/ws")
         await _wait_for(lambda: len(state.subscribers) == 1)
         await ws.send_str(json.dumps({"type": "speaking", "active": True}))
-        await _wait_for(state.user_speaking)
+        await _wait_for(lambda: bool(state.speaking))
         await ws.close()
-        await _wait_for(lambda: not state.user_speaking())
+        await _wait_for(lambda: not state.speaking)
+
+    asyncio.run(_with_client(state, scenario))
+    state.store.close()
+
+
+def test_ws_disconnect_after_a_refusal_writes_the_turn_end_notification(tmp_path):
+    state, notif_dir = _service_state(tmp_path)
+
+    async def scenario(client):
+        ws = await client.ws_connect("/ws")
+        await _wait_for(lambda: len(state.subscribers) == 1)
+        await ws.send_str(json.dumps({"type": "speaking", "active": True}))
+        await _wait_for(lambda: bool(state.speaking))
+        assert state.refuse_send_while_speaking() is not None
+        await ws.close()
+        await _wait_for(lambda: not state.speaking)
+        assert len(list(notif_dir.glob("*-app-chat-user_finished_talking.json"))) == 1
 
     asyncio.run(_with_client(state, scenario))
     state.store.close()

--- a/agent/skills/app-chat/cli/tests/test_service.py
+++ b/agent/skills/app-chat/cli/tests/test_service.py
@@ -264,6 +264,41 @@ def test_ws_streams_a_reply_emitted_after_connect(tmp_path):
     state.store.close()
 
 
+def test_ws_speaking_frames_flip_the_flag_and_junk_is_ignored(tmp_path):
+    state, _ = _service_state(tmp_path)
+
+    async def scenario(client):
+        ws = await client.ws_connect("/ws")
+        await _wait_for(lambda: len(state.subscribers) == 1)
+        await ws.send_str(json.dumps({"type": "speaking", "active": True}))
+        await _wait_for(state.user_speaking)
+        await ws.send_str("not json")
+        await ws.send_str(json.dumps({"type": "unknown-frame"}))
+        await ws.send_str(json.dumps({"type": "speaking", "active": "yes"}))
+        assert state.user_speaking()
+        await ws.send_str(json.dumps({"type": "speaking", "active": False}))
+        await _wait_for(lambda: not state.user_speaking())
+        await ws.close()
+
+    asyncio.run(_with_client(state, scenario))
+    state.store.close()
+
+
+def test_ws_disconnect_clears_a_live_speaking_flag(tmp_path):
+    state, _ = _service_state(tmp_path)
+
+    async def scenario(client):
+        ws = await client.ws_connect("/ws")
+        await _wait_for(lambda: len(state.subscribers) == 1)
+        await ws.send_str(json.dumps({"type": "speaking", "active": True}))
+        await _wait_for(state.user_speaking)
+        await ws.close()
+        await _wait_for(lambda: not state.user_speaking())
+
+    asyncio.run(_with_client(state, scenario))
+    state.store.close()
+
+
 def test_ws_disconnect_discards_the_subscriber(tmp_path):
     state, _ = _service_state(tmp_path)
 

--- a/apps/core/src/chat/chat-socket.test.ts
+++ b/apps/core/src/chat/chat-socket.test.ts
@@ -10,8 +10,9 @@ class FakeSocket implements SocketLike {
   onmessage: ((data: string) => void) | null = null
   onclose: (() => void) | null = null
   closed = false
-  send(): void {
-    // The chat socket is read-only; nothing is ever sent.
+  sent: string[] = []
+  send(data: string): void {
+    this.sent.push(data)
   }
   close(): void {
     this.closed = true
@@ -153,6 +154,45 @@ describe("createChatSocket", () => {
       "reconnecting",
       "connecting",
     ])
+  })
+
+  it("sends a speaking frame while open and dedups repeats", async () => {
+    const h = harness()
+    const socket = await start(h)
+    h.sockets[0]?.onopen?.()
+    socket.reportSpeaking(true)
+    socket.reportSpeaking(true)
+    socket.reportSpeaking(false)
+    expect(h.sockets[0]?.sent).toEqual([
+      JSON.stringify({ type: "speaking", active: true }),
+      JSON.stringify({ type: "speaking", active: false }),
+    ])
+  })
+
+  it("drops a speaking report with no open socket and replays a live turn on reconnect", async () => {
+    const h = harness()
+    const socket = await start(h)
+    h.sockets[0]?.onopen?.()
+    h.sockets[0]?.onclose?.()
+    socket.reportSpeaking(true)
+    expect(h.sockets[0]?.sent).toEqual([])
+    h.timers[0]?.fn()
+    await flush()
+    h.sockets[1]?.onopen?.()
+    expect(h.sockets[1]?.sent).toEqual([JSON.stringify({ type: "speaking", active: true })])
+  })
+
+  it("replays nothing on reconnect once the turn ended", async () => {
+    const h = harness()
+    const socket = await start(h)
+    h.sockets[0]?.onopen?.()
+    socket.reportSpeaking(true)
+    socket.reportSpeaking(false)
+    h.sockets[0]?.onclose?.()
+    h.timers[0]?.fn()
+    await flush()
+    h.sockets[1]?.onopen?.()
+    expect(h.sockets[1]?.sent).toEqual([])
   })
 
   it("schedules a reconnect when the url builder rejects", async () => {

--- a/apps/core/src/chat/chat-socket.ts
+++ b/apps/core/src/chat/chat-socket.ts
@@ -23,6 +23,11 @@ export interface ChatSocketCallbacks {
 }
 
 export interface ChatSocket {
+  // Reports whether the user is talking into a live voice conversation; the daemon holds the
+  // agent's replies while it is true. The latest value is cached and a true is replayed on
+  // reconnect open. With no open socket nothing is sent, which is the right answer: the daemon
+  // ties the flag to the connection that set it and clears it when that connection drops.
+  reportSpeaking: (speaking: boolean) => void
   close: () => void
 }
 
@@ -33,9 +38,13 @@ export function createChatSocket(deps: ChatSocketDeps, callbacks: ChatSocketCall
   const base = deps.baseDelayMs ?? 1000
   const max = deps.maxDelayMs ?? 30000
   let socket: SocketLike | null = null
+  let open = false
   let timer: number | null = null
   let delay = base
   let terminal = false
+  let speaking = false
+
+  const speakingFrame = (): string => JSON.stringify({ type: "speaking", active: speaking })
   // True once close() has retired this socket for good. Read through a call because a connect in
   // flight has to re-ask after awaiting its URL.
   const retired = (): boolean => terminal
@@ -80,8 +89,11 @@ export function createChatSocket(deps: ChatSocketDeps, callbacks: ChatSocketCall
     socket = current
     current.onopen = () => {
       if (socket !== current) return
+      open = true
       delay = base
       callbacks.onStateChange("open")
+      // A turn that outlived a reconnect is replayed, so the daemon's fresh connection holds it.
+      if (speaking) current.send(speakingFrame())
     }
     current.onmessage = (data) => {
       if (socket === current) handleMessage(data)
@@ -89,6 +101,7 @@ export function createChatSocket(deps: ChatSocketDeps, callbacks: ChatSocketCall
     current.onclose = () => {
       if (socket !== current) return
       socket = null
+      open = false
       if (!terminal) scheduleReconnect()
     }
   }
@@ -96,6 +109,11 @@ export function createChatSocket(deps: ChatSocketDeps, callbacks: ChatSocketCall
   void connect()
 
   return {
+    reportSpeaking: (value) => {
+      if (speaking === value) return
+      speaking = value
+      if (socket && open) socket.send(speakingFrame())
+    },
     close: () => {
       terminal = true
       if (timer !== null) {

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -221,8 +221,7 @@ export {
 export type { AgentStatusKind, OrbVisualState } from "./agent-status/agent-status"
 
 export { ORB_GRADIENT_ANGLE_DEG, orbVisual } from "./orb/orb"
-export type { OrbMotion } from "./orb/orb"
-export type { OrbHighlight, OrbPoint, OrbVisual } from "./orb/orb"
+export type { OrbHighlight, OrbMotion, OrbPoint, OrbVisual } from "./orb/orb"
 
 export {
   buildBackupTimeline,

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -221,6 +221,7 @@ export {
 export type { AgentStatusKind, OrbVisualState } from "./agent-status/agent-status"
 
 export { ORB_GRADIENT_ANGLE_DEG, orbVisual } from "./orb/orb"
+export type { OrbMotion } from "./orb/orb"
 export type { OrbHighlight, OrbPoint, OrbVisual } from "./orb/orb"
 
 export {

--- a/apps/core/src/orb/orb.ts
+++ b/apps/core/src/orb/orb.ts
@@ -37,10 +37,19 @@ const HIGHLIGHT: OrbHighlight = {
   alpha: 0.34,
 }
 
+// A live-voice overlay on top of the status: same colors and glow, different motion.
+// "listening" barely breathes; "talking" pulses hard and fast, unmistakably speech.
+export type OrbMotion = "listening" | "talking"
+
+const MOTION_CONFIG: Record<OrbMotion, Pick<OrbVisual, "pulseScale" | "pulseHalfMs">> = {
+  listening: { pulseScale: 1.03, pulseHalfMs: 2400 },
+  talking: { pulseScale: 1.16, pulseHalfMs: 430 },
+}
+
 // One owner for how the orb looks and moves; each platform renders from this.
-export function orbVisual(state: OrbVisualState): OrbVisual {
+export function orbVisual(state: OrbVisualState, motion?: OrbMotion): OrbVisual {
   const thinking = state === "thinking"
-  return {
+  const base: OrbVisual = {
     gradient: GRADIENT,
     highlight: HIGHLIGHT,
     live: orbIsLive(state),
@@ -50,6 +59,8 @@ export function orbVisual(state: OrbVisualState): OrbVisual {
     pulseHalfMs: thinking ? 1200 : 1800,
     rotationMs: thinking ? 2600 : 9000,
   }
+  if (!motion) return base
+  return { ...base, breathes: true, ...MOTION_CONFIG[motion] }
 }
 
 // CSS `linear-gradient` angle (deg) that matches the start -> end axis, with the

--- a/apps/core/src/voice/stt-session.test.ts
+++ b/apps/core/src/voice/stt-session.test.ts
@@ -123,6 +123,17 @@ describe("the STT session", () => {
     expect(cbs.transcripts.at(-1)).toBe("")
   })
 
+  it("closes a turn that transcribed nothing with an empty turn end", async () => {
+    const { socket, cbs, session } = setup(false)
+    const starting = session.start()
+    await tick()
+    socket.onopen?.()
+    await starting
+    socket.emit("StartOfTurn")
+    socket.emit("EndOfTurn")
+    expect(cbs.turns).toEqual([""])
+  })
+
   it("accumulates turns and returns the whole display, partial included, on stop", async () => {
     const { socket, cbs, session } = setup(true)
     const starting = session.start()

--- a/apps/core/src/voice/stt-session.ts
+++ b/apps/core/src/voice/stt-session.ts
@@ -33,6 +33,8 @@ export interface SttSessionDeps {
 export interface SttSessionCallbacks {
   onTranscript: (text: string) => void
   onTurnStart: () => void
+  // Fires on every turn close, with "" for a turn that transcribed nothing, so a consumer
+  // tracking the live turn (a speaker hold, a speaking report) always sees it end.
   onTurnEnd: (text: string) => void
   onError: (message: string) => void
   onActiveChange: (active: boolean) => void
@@ -140,7 +142,10 @@ export function createSttSession(
       if (event.event === "EndOfTurn") {
         const text = current.trim()
         current = ""
-        if (!text) return
+        if (!text) {
+          callbacks.onTurnEnd("")
+          return
+        }
         if (accumulate) {
           committed = committed ? `${committed} ${text}` : text
           callbacks.onTranscript(committed)

--- a/apps/core/src/voice/voice-session.test.ts
+++ b/apps/core/src/voice/voice-session.test.ts
@@ -42,6 +42,7 @@ function recorder() {
     modes: [] as (VoiceMode | null)[],
     listening: [] as boolean[],
     speaking: [] as boolean[],
+    userSpeaking: [] as boolean[],
     inactivity: 0,
   }
   const callbacks: VoiceSessionCallbacks = {
@@ -51,6 +52,7 @@ function recorder() {
     onModeChange: (m) => events.modes.push(m),
     onListeningChange: (l) => events.listening.push(l),
     onSpeakingChange: (s) => events.speaking.push(s),
+    onUserSpeakingChange: (s) => events.userSpeaking.push(s),
     onInactivityStop: () => (events.inactivity += 1),
   }
   return { events, callbacks }
@@ -73,6 +75,7 @@ function setup(overrides: Partial<VoiceSessionSettings> = {}) {
   const settings: VoiceSessionSettings = {
     interruptTts: true,
     inactivityMs: 1000,
+    yieldToUser: true,
     ...overrides,
   }
   const session = createVoiceSession(
@@ -185,6 +188,68 @@ describe("the voice session", () => {
     fireTimers()
     expect(session.mode()).toBe("dictation")
     expect(events.inactivity).toBe(0)
+  })
+
+  it("a yielding conversation reports the user's turn and closes it on turn end", async () => {
+    const { socket, events, startAnd } = setup()
+    await startAnd("conversation")
+    socket.emit("StartOfTurn")
+    expect(events.userSpeaking).toEqual([true])
+    socket.emit("EndOfTurn", "hello")
+    expect(events.userSpeaking).toEqual([true, false])
+    expect(events.sends).toEqual(["hello"])
+  })
+
+  it("an empty turn still closes the user's turn and sends nothing", async () => {
+    const { socket, events, startAnd } = setup()
+    await startAnd("conversation")
+    socket.emit("StartOfTurn")
+    socket.emit("EndOfTurn")
+    expect(events.userSpeaking).toEqual([true, false])
+    expect(events.sends).toEqual([])
+  })
+
+  it("holds a reply arriving mid-turn and speaks it once the turn ends", async () => {
+    const { socket, session, startAnd } = setup()
+    await startAnd("conversation")
+    socket.emit("StartOfTurn")
+    session.speak("held reply")
+    expect(session.speaking()).toBe(false)
+    socket.emit("EndOfTurn", "go on")
+    await vi.waitFor(() => {
+      expect(session.speaking()).toBe(true)
+    })
+  })
+
+  it("drops a held reply when the session ends mid-turn", async () => {
+    const { socket, session, events, startAnd } = setup()
+    await startAnd("conversation")
+    socket.emit("StartOfTurn")
+    session.speak("held reply")
+    session.cancel()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(session.speaking()).toBe(false)
+    expect(events.userSpeaking).toEqual([true, false])
+  })
+
+  it("yieldToUser off neither reports nor holds", async () => {
+    const { socket, session, events, startAnd } = setup({ yieldToUser: false })
+    await startAnd("conversation")
+    socket.emit("StartOfTurn")
+    session.speak("straight through")
+    await vi.waitFor(() => {
+      expect(session.speaking()).toBe(true)
+    })
+    expect(events.userSpeaking).toEqual([])
+  })
+
+  it("dictation never reports the user's turn", async () => {
+    const { socket, session, events, startAnd } = setup()
+    await startAnd("dictation")
+    socket.emit("StartOfTurn")
+    socket.emit("EndOfTurn", "noted")
+    session.stop()
+    expect(events.userSpeaking).toEqual([])
   })
 
   it("reports listening once the socket is up", async () => {

--- a/apps/core/src/voice/voice-session.ts
+++ b/apps/core/src/voice/voice-session.ts
@@ -21,6 +21,10 @@ export interface VoiceSessionSettings {
   // A conversation with no user turn for this long ends itself. 0 disables. Dictation
   // ignores it, since the user ends dictation by hand.
   inactivityMs: number
+  // A conversation yields the floor to the user: while their turn is live it reports them as
+  // speaking (onUserSpeakingChange, which clients mirror to the agent) and holds replies off
+  // the speaker until the turn ends. Off keeps the duplex free-for-all. Dictation ignores it.
+  yieldToUser: boolean
 }
 
 export interface VoiceSessionDeps {
@@ -43,6 +47,10 @@ export interface VoiceSessionCallbacks {
   onSpeakingChange: (speaking: boolean) => void
   // A conversation ended itself after the inactivity window; the client tells the user.
   onInactivityStop: () => void
+  // The user's live turn in a yielding conversation: true at turn start, false at turn end or
+  // when the session ends however it ends. Clients forward it to the agent's chat channel so
+  // the agent holds its reply while the user is talking. Never fires for dictation.
+  onUserSpeakingChange: (speaking: boolean) => void
 }
 
 export interface VoiceSession {
@@ -68,6 +76,16 @@ export function createVoiceSession(
   let stt: SttSession | null = null
   let mode: VoiceMode | null = null
   let idleTimer: number | null = null
+  // The user's live turn while a conversation yields: replies land in `held` instead of the
+  // speaker, and the change is reported so the client can mirror it to the agent.
+  let userTurn = false
+  let held: string[] = []
+
+  const setUserTurn = (value: boolean): void => {
+    if (userTurn === value) return
+    userTurn = value
+    callbacks.onUserSpeakingChange(value)
+  }
 
   const queue: TtsQueue = createTtsQueue(deps.player, {
     onSpeakingChange: callbacks.onSpeakingChange,
@@ -84,6 +102,9 @@ export function createVoiceSession(
   const clear = (): void => {
     clearIdleTimer()
     stt = null
+    // A held reply belonged to the session that just ended; it is dropped, not spoken late.
+    held = []
+    setUserTurn(false)
     if (mode !== null) {
       mode = null
       callbacks.onModeChange(null)
@@ -128,9 +149,17 @@ export function createVoiceSession(
         onTranscript: callbacks.onTranscript,
         onTurnStart: () => {
           if (conversation || settings().interruptTts) queue.stop()
+          if (conversation && settings().yieldToUser) setUserTurn(true)
         },
         onTurnEnd: (text) => {
           if (!conversation) return
+          // The floor returns before the send goes out, so the agent's speaking gate is open
+          // by the time the message reaches it; replies held during the turn play now.
+          setUserTurn(false)
+          const pending = held
+          held = []
+          for (const reply of pending) queue.speak(reply)
+          if (!text) return
           callbacks.onSend(text)
           armIdleTimer()
         },
@@ -168,12 +197,17 @@ export function createVoiceSession(
     mode: () => mode,
     listening: () => stt?.active() ?? false,
     speak: (text) => {
+      if (userTurn) {
+        held.push(text)
+        return
+      }
       queue.speak(text)
     },
     prefetch: (text) => {
       queue.prefetch(text)
     },
     stopSpeech: () => {
+      held = []
       queue.stop()
     },
     speaking: () => queue.speaking(),

--- a/apps/mobile/src/agent/ChatPage.tsx
+++ b/apps/mobile/src/agent/ChatPage.tsx
@@ -228,6 +228,7 @@ export default function ChatPage() {
         "Conversation ended after 15 minutes of silence.",
         "Voice conversation",
       ),
+    onUserSpeakingChange: socket.reportSpeaking,
   });
   const recordingMode = voice.recordingMode;
   useEffect(() => {

--- a/apps/mobile/src/chat/useAgentSocket.ts
+++ b/apps/mobile/src/chat/useAgentSocket.ts
@@ -75,6 +75,10 @@ export function useAgentSocket(
   // ref-routed so the socket effect never re-runs for it.
   const repostRef = useRef<() => void>(() => undefined);
 
+  // The live socket's speaking report, held by ref so the callback handed to the voice layer
+  // stays stable across reconnects and agent switches.
+  const reportSpeakingRef = useRef<((speaking: boolean) => void) | null>(null);
+
   // Built per connect, so a reconnect hours later dials with a freshly refreshed access token
   // rather than one captured at mount.
   const chatSocketUrl = useCallback(
@@ -296,9 +300,12 @@ export function useAgentSocket(
       },
     );
 
+    reportSpeakingRef.current = socket.reportSpeaking;
+
     return () => {
       cancelled = true;
       clearSeedRetry();
+      reportSpeakingRef.current = null;
       socket.close();
       resetTyping();
     };
@@ -359,6 +366,10 @@ export function useAgentSocket(
     repostRef.current = () => sender?.repostParked();
   }, [sender]);
 
+  const reportSpeaking = useCallback((speaking: boolean) => {
+    reportSpeakingRef.current?.(speaking);
+  }, []);
+
   const hasMore = state.cursor !== null;
 
   // Skipped while a load is in flight: trimming under an unresolved prepend would leave a hole
@@ -410,6 +421,7 @@ export function useAgentSocket(
       trimHistory,
       send,
       retry,
+      reportSpeaking,
       reseedRevision,
     }),
     [
@@ -427,6 +439,7 @@ export function useAgentSocket(
       trimHistory,
       send,
       retry,
+      reportSpeaking,
       reseedRevision,
     ],
   );

--- a/apps/mobile/src/voice/useLiveVoice.ts
+++ b/apps/mobile/src/voice/useLiveVoice.ts
@@ -30,6 +30,8 @@ interface LiveVoiceOptions {
   onSend: (text: string) => void;
   onError: (message: string) => void;
   onInactivityStop: () => void;
+  // Forwarded to the chat socket, so the agent holds its reply while the user is talking.
+  onUserSpeakingChange: (speaking: boolean) => void;
 }
 
 // A conversation with no user turn for this long ends itself, bounding the battery and
@@ -93,6 +95,7 @@ export function useLiveVoice({
   onSend,
   onError,
   onInactivityStop,
+  onUserSpeakingChange,
 }: LiveVoiceOptions) {
   const { api } = useSession();
   const [recordingMode, setRecordingMode] = useState<VoiceMode | null>(null);
@@ -102,7 +105,13 @@ export function useLiveVoice({
 
   // Live-updated refs, so the session (created once per agent) always reads the current
   // callbacks and settings.
-  const callbacksRef = useRef({ onTranscript, onSend, onError, onInactivityStop });
+  const callbacksRef = useRef({
+    onTranscript,
+    onSend,
+    onError,
+    onInactivityStop,
+    onUserSpeakingChange,
+  });
   const sttStatusRef = useRef(sttStatus);
   const ttsEnabledRef = useRef(false);
 
@@ -122,7 +131,13 @@ export function useLiveVoice({
   const playerRef = useRef(player);
 
   useEffect(() => {
-    callbacksRef.current = { onTranscript, onSend, onError, onInactivityStop };
+    callbacksRef.current = {
+      onTranscript,
+      onSend,
+      onError,
+      onInactivityStop,
+      onUserSpeakingChange,
+    };
     sttStatusRef.current = sttStatus;
     ttsEnabledRef.current = ttsEnabled;
     streamRef.current = stream;
@@ -253,11 +268,15 @@ export function useLiveVoice({
         onModeChange: setRecordingMode,
         onListeningChange: setListening,
         onSpeakingChange: setSpeaking,
+        onUserSpeakingChange: (speaking) =>
+          callbacksRef.current.onUserSpeakingChange(speaking),
         onInactivityStop: () => callbacksRef.current.onInactivityStop(),
       },
       () => ({
         interruptTts: boolSetting(sttStatusRef.current, "interrupt_tts", true),
         inactivityMs: CONVERSATION_INACTIVITY_MS,
+        // Always yields for now; the per-device toggle lands with the mobile settings pass.
+        yieldToUser: true,
       }),
     );
     sessionRef.current = session;

--- a/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
+++ b/apps/web/src/components/AgentSettings/ProviderCard/index.tsx
@@ -107,11 +107,11 @@ function AccountSection({ account }: { account: Account }) {
   return (
     <div className="flex flex-col gap-2.5">
       <span className="text-sm font-medium text-muted-foreground">account</span>
-      <div className="flex flex-col">
+      <div className="flex flex-col gap-0.5">
         {rows.map((row) => (
           <div
             key={row.label}
-            className="-mx-2 flex items-center justify-between gap-4 rounded-md px-2 py-1.5 text-sm odd:bg-foreground/[0.07]"
+            className="-mx-2 flex items-center justify-between gap-4 rounded-md px-2 py-2 text-sm odd:bg-foreground/[0.07]"
           >
             <span className="text-muted-foreground">{row.label}</span>
             <span className="truncate text-foreground">{row.value}</span>

--- a/apps/web/src/components/AgentSettings/VoiceSection/index.tsx
+++ b/apps/web/src/components/AgentSettings/VoiceSection/index.tsx
@@ -124,6 +124,7 @@ export function DictationCard() {
               {ACTIVATION_OPTIONS.map((opt) => (
                 <button
                   key={opt.value}
+                  aria-pressed={activation === opt.value}
                   className={`rounded-sm px-2.5 py-1 text-sm transition-colors ${
                     activation === opt.value
                       ? "bg-background text-foreground shadow-sm"

--- a/apps/web/src/components/AgentSettings/VoiceSection/index.tsx
+++ b/apps/web/src/components/AgentSettings/VoiceSection/index.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useRef, useState } from "react";
-import { Mic, Volume2, ChevronDown, Play, Square } from "lucide-react";
+import {
+  AudioLines,
+  ChevronDown,
+  Mic,
+  Play,
+  Square,
+  Volume2,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Collapsible,
@@ -35,6 +42,10 @@ import {
 import { useOptimisticToggle } from "./use-optimistic-toggle";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { useVoice } from "@/stores/use-voice";
+import {
+  useVoiceActivation,
+  type VoiceActivationMode,
+} from "@/stores/use-voice-activation";
 
 const DEBOUNCE_MS = 400;
 
@@ -56,6 +67,143 @@ function sttUsageSummary(usageData: SttUsage | null): string {
 }
 
 // --- Exported cards ---
+
+const ACTIVATION_OPTIONS: { value: VoiceActivationMode; label: string }[] = [
+  { value: "toggle", label: "toggle" },
+  { value: "hold", label: "hold" },
+];
+
+// How dictation behaves, apart from which provider transcribes it.
+export function DictationCard() {
+  const { name: agentName } = useSelectedAgent();
+  const { sttStatus, patchStt, refreshVoiceStatus } = useVoice();
+  const activation = useVoiceActivation((s) => s.mode);
+  const setActivation = useVoiceActivation((s) => s.setMode);
+
+  const interruptSetting = sttStatus?.settings?.find(
+    (s) => s.key === "interrupt_tts",
+  );
+  const interruptValue =
+    typeof interruptSetting?.value === "boolean"
+      ? interruptSetting.value
+      : true;
+
+  const setInterrupt = (value: boolean) => {
+    if (!sttStatus?.settings || !agentName) return;
+    patchStt({
+      settings: sttStatus.settings.map((s) =>
+        s.key === "interrupt_tts" ? { ...s, value } : s,
+      ),
+    });
+    setVoiceSetting(agentName, "stt", "interrupt_tts", value).catch(() =>
+      refreshVoiceStatus(),
+    );
+  };
+
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardTitle className="group-data-[size=sm]/card:text-base">
+          <Mic className="size-4 text-muted-foreground" />
+          dictation
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Field orientation="vertical" className="gap-3">
+          <Field
+            orientation="horizontal"
+            className="items-center justify-between"
+          >
+            <FieldContent>
+              <FieldLabel>activation</FieldLabel>
+              <FieldDescription>
+                hold the mic to talk, or tap once to start and again to send
+              </FieldDescription>
+            </FieldContent>
+            <div className="inline-flex rounded-md bg-muted p-0.5">
+              {ACTIVATION_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  className={`rounded-sm px-2.5 py-1 text-sm transition-colors ${
+                    activation === opt.value
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                  onClick={() => setActivation(opt.value)}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </Field>
+          {interruptSetting && (
+            <Field
+              orientation="horizontal"
+              className="items-center justify-between"
+            >
+              <FieldContent>
+                <FieldLabel>interrupt speech on talk</FieldLabel>
+                <FieldDescription>
+                  stop text-to-speech playback when you start speaking
+                </FieldDescription>
+              </FieldContent>
+              <Switch checked={interruptValue} onCheckedChange={setInterrupt} />
+            </Field>
+          )}
+        </Field>
+      </CardContent>
+    </Card>
+  );
+}
+
+// How a conversation behaves; a conversation always speaks back and always barges in.
+export function ConversationCard() {
+  const autoEnd = useVoice((s) => s.conversationAutoEnd);
+  const setAutoEnd = useVoice((s) => s.setConversationAutoEnd);
+  const yieldToUser = useVoice((s) => s.conversationYield);
+  const setYieldToUser = useVoice((s) => s.setConversationYield);
+
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardTitle className="group-data-[size=sm]/card:text-base">
+          <AudioLines className="size-4 text-muted-foreground" />
+          conversation
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Field orientation="vertical" className="gap-3">
+          <Field
+            orientation="horizontal"
+            className="items-center justify-between"
+          >
+            <FieldContent>
+              <FieldLabel>never interrupt you</FieldLabel>
+              <FieldDescription>
+                hold replies while you are talking, so Vesta waits for your
+                whole thought
+              </FieldDescription>
+            </FieldContent>
+            <Switch checked={yieldToUser} onCheckedChange={setYieldToUser} />
+          </Field>
+          <Field
+            orientation="horizontal"
+            className="items-center justify-between"
+          >
+            <FieldContent>
+              <FieldLabel>end after silence</FieldLabel>
+              <FieldDescription>
+                end a conversation on its own after fifteen minutes without you
+                speaking
+              </FieldDescription>
+            </FieldContent>
+            <Switch checked={autoEnd} onCheckedChange={setAutoEnd} />
+          </Field>
+        </Field>
+      </CardContent>
+    </Card>
+  );
+}
 
 export function SttCard() {
   const { name: agentName } = useSelectedAgent();
@@ -85,7 +233,7 @@ export function SttCard() {
       provider={sttStatus?.provider ?? null}
       enabled={enabled}
       onToggleEnabled={toggleEnabled}
-      settings={sttStatus?.settings}
+      settings={sttStatus?.settings?.filter((s) => s.key !== "interrupt_tts")}
       domain="stt"
       agentName={agentName}
       onSettingChange={(settings) => patchStt({ settings })}

--- a/apps/web/src/components/AgentSettings/index.tsx
+++ b/apps/web/src/components/AgentSettings/index.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import {
   Bell,
+  Cpu,
   FolderClosed,
+  Mic,
   ScrollText,
   Settings2,
   type LucideIcon,
@@ -23,10 +25,17 @@ import { FilesTab } from "./FilesTab";
 import { LogsTab } from "./LogsTab";
 import { ProviderCard } from "./ProviderCard";
 import { ServicesCard } from "./ServicesCard";
-import { SttCard, TtsCard } from "./VoiceSection";
+import {
+  ConversationCard,
+  DictationCard,
+  SttCard,
+  TtsCard,
+} from "./VoiceSection";
 
 const NAV_ITEMS: { value: string; label: string; Icon: LucideIcon }[] = [
   { value: "general", label: "general", Icon: Settings2 },
+  { value: "provider", label: "provider", Icon: Cpu },
+  { value: "voice", label: "voice", Icon: Mic },
   { value: "notifications", label: "notifications", Icon: Bell },
   { value: "files", label: "files", Icon: FolderClosed },
   { value: "logs", label: "logs", Icon: ScrollText },
@@ -58,14 +67,30 @@ export function AgentSettings() {
         className="flex flex-col gap-6 data-[state=inactive]:hidden max-md:pb-28"
       >
         <ActionsCard />
-        <ProviderCard />
         <ChatCard />
         <ServicesCard />
         <BackupsCard />
-        <SttCard />
-        <TtsCard />
         <RenameCard />
         <DeleteCard />
+      </TabsContent>
+
+      <TabsContent
+        value="provider"
+        forceMount={keepAlive("provider")}
+        className="flex flex-col gap-6 data-[state=inactive]:hidden max-md:pb-28"
+      >
+        <ProviderCard />
+      </TabsContent>
+
+      <TabsContent
+        value="voice"
+        forceMount={keepAlive("voice")}
+        className="flex flex-col gap-6 data-[state=inactive]:hidden max-md:pb-28"
+      >
+        <DictationCard />
+        <ConversationCard />
+        <SttCard />
+        <TtsCard />
       </TabsContent>
 
       <TabsContent

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -21,7 +21,10 @@ import {
 import { AnimatePresence, motion as m } from "motion/react";
 import { useMeasuredSize } from "@/hooks/use-measured-size";
 import { Button } from "@/components/ui/button";
-import { ConversationPanel } from "@/components/Chat/ConversationPanel";
+import {
+  ConversationPanel,
+  RECORDING_BUTTON,
+} from "@/components/Chat/ConversationPanel";
 import { cn } from "@/lib/utils";
 import { useVoice, type VoiceMode } from "@/stores/use-voice";
 import {
@@ -123,9 +126,9 @@ interface ChatComposerProps {
   recordingMode: VoiceMode | null;
   listening: boolean;
   liveTranscript: string;
-  // True while the pill is animating between composer and panel: the parent freezes its
-  // measurement-driven layout for the duration so the morph stays compositor-cheap.
-  onMorphingChange?: (morphing: boolean) => void;
+  // The parent freezes its measurement-driven layout when the conversation flips; this settle
+  // report is what releases the freeze once the pill's animation lands.
+  onMorphSettled?: () => void;
   onHeightAnimation?: (animating: boolean) => void;
   startVoice: (mode: VoiceMode) => void;
   stopVoice: () => void;
@@ -148,7 +151,7 @@ export function ChatComposer({
   recordingMode,
   listening,
   liveTranscript,
-  onMorphingChange,
+  onMorphSettled,
   onHeightAnimation,
   startVoice,
   stopVoice,
@@ -206,7 +209,7 @@ export function ChatComposer({
       textareaRef={textareaRef}
       controls={controls}
       attachments={attachments}
-      onMorphingChange={onMorphingChange}
+      onMorphSettled={onMorphSettled}
       onHeightAnimation={onHeightAnimation}
     />
   );
@@ -236,7 +239,7 @@ function FloatingComposer({
   textareaRef,
   controls,
   attachments,
-  onMorphingChange,
+  onMorphSettled,
   onHeightAnimation,
 }: {
   paddingClass: string;
@@ -249,7 +252,7 @@ function FloatingComposer({
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   controls: ComposerControls;
   attachments: AttachmentDrafts;
-  onMorphingChange?: (morphing: boolean) => void;
+  onMorphSettled?: () => void;
   onHeightAnimation?: (animating: boolean) => void;
 }) {
   const { inputDisabled, recordingMode } = controls;
@@ -285,21 +288,6 @@ function FloatingComposer({
   }, [value]);
 
   const inConversation = recordingMode === "conversation";
-  useEffect(() => {
-    if (!inConversation) {
-      setMorphed(false);
-      return;
-    }
-    const id = setTimeout(
-      () => setMorphed(true),
-      CONVERSATION_PANEL_ENTER_DELAY_MS,
-    );
-    return () => clearTimeout(id);
-  }, [inConversation]);
-  // The pill grows first (overflow-hidden clips its contents during the morph), so the panel's
-  // orb and controls animate in only once it has finished growing, when they are no longer
-  // masked by the growing clip window.
-  const [morphed, setMorphed] = useState(false);
   // The box animates number-to-number, but only across the row transition (the wrap point
   // flipping) and the morph: each measurement carries whether the flip caused it, and any
   // other content growth (an extra textarea line, a chips row) applies instantly like a plain
@@ -342,14 +330,14 @@ function FloatingComposer({
               ? ROW_SPRING
               : { duration: 0 }
         }
-        // The morph's start is reported by the parent on the conversation flip itself, so a
-        // typing animation never trips the freeze; completion is safe to report from here (a
-        // settle outside a morph is a no-op). The animation edges gate the parent's inset
-        // tracking, since mid-flight heights must never become the list's reservation.
+        // The morph's start is the parent's own conversation flip, so a typing animation never
+        // trips the freeze; completion is safe to report from here (a settle outside a morph is
+        // a no-op). The animation edges gate the parent's inset tracking, since mid-flight
+        // heights must never become the list's reservation.
         onAnimationStart={() => onHeightAnimation?.(true)}
         onAnimationComplete={() => {
           onHeightAnimation?.(false);
-          onMorphingChange?.(false);
+          onMorphSettled?.();
         }}
         // Contain the box so its animating height reflows only its own subtree, never the
         // chat above it.
@@ -384,7 +372,7 @@ function FloatingComposer({
               transition={{ duration: 0.2, ease: "easeOut" }}
               className="absolute inset-0"
             >
-              <ConversationPanel morphed={morphed} />
+              <ConversationPanel />
             </m.div>
           ) : (
             <m.div
@@ -422,6 +410,7 @@ function FloatingComposer({
                   the text itself never scale-distorts. */}
               <m.div
                 layout="position"
+                layoutDependency={expanded}
                 transition={{ layout: ROW_SPRING }}
                 className={cn("shrink-0", expanded ? "order-2" : "order-1")}
               >
@@ -433,6 +422,7 @@ function FloatingComposer({
 
               <m.div
                 layout="position"
+                layoutDependency={expanded}
                 transition={{ layout: ROW_SPRING }}
                 className={cn(
                   "flex min-w-0 items-center self-stretch",
@@ -457,6 +447,7 @@ function FloatingComposer({
 
               <m.div
                 layout="position"
+                layoutDependency={expanded}
                 transition={{ layout: ROW_SPRING }}
                 className={cn(
                   "flex shrink-0 items-end gap-1 order-3",
@@ -479,13 +470,8 @@ const CONVERSATION_PANEL_HEIGHT = 264;
 // One spring for the pill growing toward wrapped text and the row pieces gliding within it,
 // so the box and its contents arrive together.
 const ROW_SPRING = { type: "spring", stiffness: 520, damping: 40 } as const;
-// The pill grows first (its overflow-hidden clips the contents); the panel's orb and
-// controls animate in this long after a conversation opens, once the growth has cleared them.
-const CONVERSATION_PANEL_ENTER_DELAY_MS = 0;
 
 const ACTION_BUTTON = "size-9 rounded-full [&_svg]:size-4";
-const RECORDING_BUTTON = "bg-red-500 text-white hover:bg-red-600";
-
 function VoiceButtons({ controls }: { controls: ComposerControls }) {
   const {
     voiceConfigured,

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -1,4 +1,6 @@
 import {
+  useCallback,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -16,7 +18,10 @@ import {
   Square,
   X,
 } from "lucide-react";
+import { AnimatePresence, motion as m } from "motion/react";
+import { useMeasuredSize } from "@/hooks/use-measured-size";
 import { Button } from "@/components/ui/button";
+import { ConversationPanel } from "@/components/Chat/ConversationPanel";
 import { cn } from "@/lib/utils";
 import { useVoice, type VoiceMode } from "@/stores/use-voice";
 import {
@@ -67,22 +72,18 @@ function micHandlers(
 function placeholderText({
   recordingMode,
   listening,
-  isSpeaking,
   notAuthenticated,
   agentName,
   hasAttachments,
 }: {
   recordingMode: VoiceMode | null;
   listening: boolean;
-  isSpeaking: boolean;
   notAuthenticated: boolean;
   agentName: string;
   hasAttachments: boolean;
 }) {
-  if (recordingMode !== null) {
-    if (!listening) return "connecting...";
-    if (recordingMode === "conversation" && isSpeaking) return "speaking...";
-    return "listening...";
+  if (recordingMode === "dictation") {
+    return listening ? "listening..." : "connecting...";
   }
   if (notAuthenticated) return "sign in to chat";
   if (hasAttachments) return "add a caption";
@@ -107,8 +108,10 @@ interface ChatComposerProps {
   voiceConfigured: boolean;
   recordingMode: VoiceMode | null;
   listening: boolean;
-  isSpeaking: boolean;
   liveTranscript: string;
+  // True while the pill is animating between composer and panel: the parent freezes its
+  // measurement-driven layout for the duration so the morph stays compositor-cheap.
+  onMorphingChange?: (morphing: boolean) => void;
   startVoice: (mode: VoiceMode) => void;
   stopVoice: () => void;
   cancelVoice: () => void;
@@ -129,8 +132,8 @@ export function ChatComposer({
   voiceConfigured,
   recordingMode,
   listening,
-  isSpeaking,
   liveTranscript,
+  onMorphingChange,
   startVoice,
   stopVoice,
   cancelVoice,
@@ -145,8 +148,8 @@ export function ChatComposer({
 }: ChatComposerProps) {
   const isMobile = useIsMobile();
   const activation = useVoiceActivation((s) => s.mode);
-  // The input shows what dictation has captured so far, or a conversation's live turn.
-  const useLiveTranscript = recordingMode !== null;
+  // The input shows what dictation has captured so far; a conversation lives in its drawer.
+  const useLiveTranscript = recordingMode === "dictation";
   // Only sign-in disables the field; a dropped connection still lets you type (a send while
   // disconnected is blocked with a toast in the parent instead).
   const inputDisabled = notAuthenticated;
@@ -155,7 +158,6 @@ export function ChatComposer({
   const placeholder = placeholderText({
     recordingMode,
     listening,
-    isSpeaking,
     notAuthenticated,
     agentName,
     hasAttachments,
@@ -188,6 +190,7 @@ export function ChatComposer({
       textareaRef={textareaRef}
       controls={controls}
       attachments={attachments}
+      onMorphingChange={onMorphingChange}
     />
   );
 }
@@ -216,6 +219,7 @@ function FloatingComposer({
   textareaRef,
   controls,
   attachments,
+  onMorphingChange,
 }: {
   paddingClass: string;
   value: string;
@@ -227,6 +231,7 @@ function FloatingComposer({
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   controls: ComposerControls;
   attachments: AttachmentDrafts;
+  onMorphingChange?: (morphing: boolean) => void;
 }) {
   const { inputDisabled, recordingMode } = controls;
 
@@ -262,74 +267,162 @@ function FloatingComposer({
     });
   }, [value]);
 
+  const inConversation = recordingMode === "conversation";
+  useEffect(() => {
+    if (!inConversation) {
+      setMorphed(false);
+      return;
+    }
+    const id = setTimeout(
+      () => setMorphed(true),
+      CONVERSATION_PANEL_ENTER_DELAY_MS,
+    );
+    return () => clearTimeout(id);
+  }, [inConversation]);
+  // The pill grows first (overflow-hidden clips its contents during the morph), so the panel's
+  // orb and controls animate in only once it has finished growing, when they are no longer
+  // masked by the growing clip window.
+  const [morphed, setMorphed] = useState(false);
+  // Motion cannot tween from "auto", so the collapsed height is measured and the morph
+  // animates number-to-number in both directions. The measurement pauses while the composer
+  // content is unmounted mid-conversation (it would read 0 and must keep the last value).
+  const [composerContentHeight, setComposerContentHeight] = useState(0);
+  const measureContentRef = useMeasuredSize(
+    "height",
+    useCallback((height: number) => {
+      if (height > 0) setComposerContentHeight(height);
+    }, []),
+  );
   return (
     <div className={paddingClass}>
-      <div
+      <m.div
+        initial={false}
+        // The composer pill morphs into the conversation panel: the box spring-animates its
+        // height while the contents crossfade, so one surface reads as becoming the other.
+        animate={{
+          height: inConversation
+            ? CONVERSATION_PANEL_HEIGHT
+            : composerContentHeight > 0
+              ? composerContentHeight
+              : "auto",
+        }}
+        transition={
+          inConversation
+            ? { type: "spring", stiffness: 300, damping: 32 }
+            : { type: "spring", stiffness: 520, damping: 40 }
+        }
+        onAnimationStart={() => onMorphingChange?.(true)}
+        onAnimationComplete={() => onMorphingChange?.(false)}
+        // Contain the box so its animating height reflows only its own subtree, never the
+        // chat above it.
+        style={{ contain: "layout paint" }}
         className={cn(
-          // rounded-3xl is half the collapsed height (48px): a true pill when collapsed, the same
-          // corners as a rounded rectangle once it grows.
-          "flex flex-wrap items-end gap-1 rounded-3xl border border-border bg-popover px-2 pb-1.5 shadow-sm",
-          // Sides + bottom stay fixed so the bottom-row buttons don't move; only the top grows
-          // to give the input its own breathing room once it moves onto its own row.
-          expanded ? "pt-3" : "pt-1.5",
+          // rounded-3xl is half the collapsed height (48px): a true pill when collapsed. The
+          // morphed conversation panel takes the design system's squircle corners instead.
+          "relative overflow-hidden border border-border bg-popover shadow-sm",
+          inConversation
+            ? "rounded-squircle-sm [corner-shape:squircle]"
+            : "rounded-3xl",
           "has-[textarea:focus-visible]:ring-2 has-[textarea:focus-visible]:ring-ring/30",
-          recordingMode !== null && "border-red-500",
+          recordingMode === "dictation" && "border-red-500",
         )}
       >
-        {/* Off-screen single-line mirror of the text, to detect the wrap point. */}
-        <span
-          ref={measureRef}
-          aria-hidden
-          className="pointer-events-none invisible fixed top-0 left-[-9999px] whitespace-pre md:text-base"
-        >
-          {value || " "}
-        </span>
+        {/* Default (sync) presence, not popLayout: popLayout absolutely positions and
+            measures exiting children, forcing layout on every frame of the morph. The panel
+            is absolutely positioned instead, so the two never fight for flow. */}
+        <AnimatePresence initial={false}>
+          {inConversation ? (
+            <m.div
+              key="conversation"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0, transition: { duration: 0.12 } }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+              className="absolute inset-0"
+            >
+              <ConversationPanel morphed={morphed} />
+            </m.div>
+          ) : (
+            <m.div
+              key="composer"
+              ref={measureContentRef}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0, transition: { duration: 0.12 } }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+              className={cn(
+                "flex flex-wrap items-end gap-1 px-2 pb-1.5",
+                // Sides + bottom stay fixed so the bottom-row buttons don't move; only the top
+                // grows to give the input its own breathing room on its own row.
+                expanded ? "pt-3" : "pt-1.5",
+              )}
+            >
+              {/* Off-screen single-line mirror of the text, to detect the wrap point. */}
+              <span
+                ref={measureRef}
+                aria-hidden
+                className="pointer-events-none invisible fixed top-0 left-[-9999px] whitespace-pre md:text-base"
+              >
+                {value || " "}
+              </span>
 
-        <AttachmentChips
-          drafts={attachments.drafts}
-          previewUrl={attachments.previewUrl}
-          onRetry={attachments.retry}
-          onRemove={attachments.remove}
-        />
+              <AttachmentChips
+                drafts={attachments.drafts}
+                previewUrl={attachments.previewUrl}
+                onRetry={attachments.retry}
+                onRemove={attachments.remove}
+              />
 
-        <div className={cn("shrink-0", expanded ? "order-2" : "order-1")}>
-          <AttachMenu disabled={inputDisabled} onFiles={attachments.addFiles} />
-        </div>
+              <div className={cn("shrink-0", expanded ? "order-2" : "order-1")}>
+                <AttachMenu
+                  disabled={inputDisabled}
+                  onFiles={attachments.addFiles}
+                />
+              </div>
 
-        <div
-          className={cn(
-            "flex min-w-0 items-center self-stretch",
-            expanded ? "order-1 basis-full" : "order-2 flex-1",
+              <div
+                className={cn(
+                  "flex min-w-0 items-center self-stretch",
+                  expanded ? "order-1 basis-full" : "order-2 flex-1",
+                )}
+              >
+                <textarea
+                  ref={textareaRef}
+                  value={value}
+                  onChange={onInputChange}
+                  onKeyDown={onKeyDown}
+                  onPaste={onPaste}
+                  readOnly={readOnly}
+                  data-voice-dictate="true"
+                  placeholder={placeholder}
+                  disabled={inputDisabled}
+                  rows={1}
+                  enterKeyHint="send"
+                  className="field-sizing-content max-h-[240px] w-full resize-none bg-transparent px-1 py-1.5 leading-6 outline-none placeholder:text-muted-foreground disabled:opacity-50 md:text-base"
+                />
+              </div>
+
+              <div
+                className={cn(
+                  "flex shrink-0 items-end gap-1 order-3",
+                  expanded && "ml-auto",
+                )}
+              >
+                <VoiceButtons controls={controls} />
+              </div>
+            </m.div>
           )}
-        >
-          <textarea
-            ref={textareaRef}
-            value={value}
-            onChange={onInputChange}
-            onKeyDown={onKeyDown}
-            onPaste={onPaste}
-            readOnly={readOnly}
-            data-voice-dictate="true"
-            placeholder={placeholder}
-            disabled={inputDisabled}
-            rows={1}
-            enterKeyHint="send"
-            className="field-sizing-content max-h-[240px] w-full resize-none bg-transparent px-1 py-1.5 leading-6 outline-none placeholder:text-muted-foreground disabled:opacity-50 md:text-base"
-          />
-        </div>
-
-        <div
-          className={cn(
-            "flex shrink-0 items-end gap-1 order-3",
-            expanded && "ml-auto",
-          )}
-        >
-          <VoiceButtons controls={controls} />
-        </div>
-      </div>
+        </AnimatePresence>
+      </m.div>
     </div>
   );
 }
+
+// Height of the conversation surface the composer morphs into.
+const CONVERSATION_PANEL_HEIGHT = 264;
+// The pill grows first (its overflow-hidden clips the contents); the panel's orb and
+// controls animate in this long after a conversation opens, once the growth has cleared them.
+const CONVERSATION_PANEL_ENTER_DELAY_MS = 0;
 
 const ACTION_BUTTON = "size-9 rounded-full [&_svg]:size-4";
 const RECORDING_BUTTON = "bg-red-500 text-white hover:bg-red-600";

--- a/apps/web/src/components/Chat/ChatComposer/index.tsx
+++ b/apps/web/src/components/Chat/ChatComposer/index.tsx
@@ -101,6 +101,20 @@ function composerPadding(fullscreen: boolean | undefined, isMobile: boolean) {
   );
 }
 
+// Expand a hair before the last word would wrap so the narrow field never shows two lines
+// first; once expanded, hold until the text clearly fits again (hysteresis).
+function expandedNext(
+  prev: boolean,
+  value: string,
+  avail: number,
+  width: number,
+): boolean {
+  if (value.trim().length === 0) return false;
+  if (value.includes("\n")) return true;
+  if (avail <= 0) return prev;
+  return prev ? width > avail - 24 : width > avail - 8;
+}
+
 interface ChatComposerProps {
   fullscreen?: boolean;
   agentName: string;
@@ -112,6 +126,7 @@ interface ChatComposerProps {
   // True while the pill is animating between composer and panel: the parent freezes its
   // measurement-driven layout for the duration so the morph stays compositor-cheap.
   onMorphingChange?: (morphing: boolean) => void;
+  onHeightAnimation?: (animating: boolean) => void;
   startVoice: (mode: VoiceMode) => void;
   stopVoice: () => void;
   cancelVoice: () => void;
@@ -134,6 +149,7 @@ export function ChatComposer({
   listening,
   liveTranscript,
   onMorphingChange,
+  onHeightAnimation,
   startVoice,
   stopVoice,
   cancelVoice,
@@ -191,6 +207,7 @@ export function ChatComposer({
       controls={controls}
       attachments={attachments}
       onMorphingChange={onMorphingChange}
+      onHeightAnimation={onHeightAnimation}
     />
   );
 }
@@ -220,6 +237,7 @@ function FloatingComposer({
   controls,
   attachments,
   onMorphingChange,
+  onHeightAnimation,
 }: {
   paddingClass: string;
   value: string;
@@ -232,6 +250,7 @@ function FloatingComposer({
   controls: ComposerControls;
   attachments: AttachmentDrafts;
   onMorphingChange?: (morphing: boolean) => void;
+  onHeightAnimation?: (animating: boolean) => void;
 }) {
   const { inputDisabled, recordingMode } = controls;
 
@@ -258,12 +277,10 @@ function FloatingComposer({
     const avail = collapsedWidthRef.current;
     const width = span.scrollWidth;
     setExpanded((prev) => {
-      if (value.trim().length === 0) return false;
-      if (value.includes("\n")) return true;
-      if (avail <= 0) return prev;
-      // Expand a hair before the last word would wrap so the narrow field never shows two
-      // lines first; once expanded, hold until the text clearly fits again (hysteresis).
-      return prev ? width > avail - 24 : width > avail - 8;
+      const next = expandedNext(prev, value, avail, width);
+      // Only the row transition animates the box; growth within a state stays instant.
+      if (next !== prev) animateNextHeightRef.current = true;
+      return next;
     });
   }, [value]);
 
@@ -283,16 +300,28 @@ function FloatingComposer({
   // orb and controls animate in only once it has finished growing, when they are no longer
   // masked by the growing clip window.
   const [morphed, setMorphed] = useState(false);
-  // Motion cannot tween from "auto", so the collapsed height is measured and the morph
-  // animates number-to-number in both directions. The measurement pauses while the composer
-  // content is unmounted mid-conversation (it would read 0 and must keep the last value).
-  const [composerContentHeight, setComposerContentHeight] = useState(0);
+  // The box animates number-to-number, but only across the row transition (the wrap point
+  // flipping) and the morph: each measurement carries whether the flip caused it, and any
+  // other content growth (an extra textarea line, a chips row) applies instantly like a plain
+  // textarea. The measurement pauses while the composer content is unmounted mid-conversation
+  // (it would read 0 and must keep the last value).
+  const animateNextHeightRef = useRef(false);
+  const [contentBox, setContentBox] = useState({ height: 0, animated: false });
   const measureContentRef = useMeasuredSize(
     "height",
     useCallback((height: number) => {
-      if (height > 0) setComposerContentHeight(height);
+      if (height <= 0) return;
+      setContentBox({ height, animated: animateNextHeightRef.current });
+      animateNextHeightRef.current = false;
     }, []),
   );
+  // The exit morph renders with inConversation already false, so the previous value is what
+  // marks its one render as still animated.
+  const prevConversationRef = useRef(inConversation);
+  const leavingConversation = prevConversationRef.current && !inConversation;
+  useEffect(() => {
+    prevConversationRef.current = inConversation;
+  });
   return (
     <div className={paddingClass}>
       <m.div
@@ -302,29 +331,44 @@ function FloatingComposer({
         animate={{
           height: inConversation
             ? CONVERSATION_PANEL_HEIGHT
-            : composerContentHeight > 0
-              ? composerContentHeight
+            : contentBox.height > 0
+              ? contentBox.height
               : "auto",
         }}
         transition={
           inConversation
             ? { type: "spring", stiffness: 300, damping: 32 }
-            : { type: "spring", stiffness: 520, damping: 40 }
+            : leavingConversation || contentBox.animated
+              ? ROW_SPRING
+              : { duration: 0 }
         }
-        onAnimationStart={() => onMorphingChange?.(true)}
-        onAnimationComplete={() => onMorphingChange?.(false)}
+        // The morph's start is reported by the parent on the conversation flip itself, so a
+        // typing animation never trips the freeze; completion is safe to report from here (a
+        // settle outside a morph is a no-op). The animation edges gate the parent's inset
+        // tracking, since mid-flight heights must never become the list's reservation.
+        onAnimationStart={() => onHeightAnimation?.(true)}
+        onAnimationComplete={() => {
+          onHeightAnimation?.(false);
+          onMorphingChange?.(false);
+        }}
         // Contain the box so its animating height reflows only its own subtree, never the
         // chat above it.
         style={{ contain: "layout paint" }}
         className={cn(
           // rounded-3xl is half the collapsed height (48px): a true pill when collapsed. The
           // morphed conversation panel takes the design system's squircle corners instead.
-          "relative overflow-hidden border border-border bg-popover shadow-sm",
+          // Bottom-anchored: while the box grows toward wrapped content the clip edge reveals
+          // the new top row and the button row never moves.
+          "relative flex flex-col justify-end overflow-hidden border border-border bg-popover shadow-sm",
           inConversation
             ? "rounded-squircle-sm [corner-shape:squircle]"
             : "rounded-3xl",
           "has-[textarea:focus-visible]:ring-2 has-[textarea:focus-visible]:ring-ring/30",
-          recordingMode === "dictation" && "border-red-500",
+          // Red snaps on with the recording and fades out slowly after it: the transition
+          // class rides only the resting state, so the exit eases while the entry is instant.
+          recordingMode === "dictation"
+            ? "border-red-500"
+            : "transition-colors duration-700",
         )}
       >
         {/* Default (sync) presence, not popLayout: popLayout absolutely positions and
@@ -373,14 +417,23 @@ function FloatingComposer({
                 onRemove={attachments.remove}
               />
 
-              <div className={cn("shrink-0", expanded ? "order-2" : "order-1")}>
+              {/* position-only FLIP on the row pieces: the input glides onto its own row and
+                  the buttons slide into place on the same spring the box grows with, while
+                  the text itself never scale-distorts. */}
+              <m.div
+                layout="position"
+                transition={{ layout: ROW_SPRING }}
+                className={cn("shrink-0", expanded ? "order-2" : "order-1")}
+              >
                 <AttachMenu
                   disabled={inputDisabled}
                   onFiles={attachments.addFiles}
                 />
-              </div>
+              </m.div>
 
-              <div
+              <m.div
+                layout="position"
+                transition={{ layout: ROW_SPRING }}
                 className={cn(
                   "flex min-w-0 items-center self-stretch",
                   expanded ? "order-1 basis-full" : "order-2 flex-1",
@@ -400,16 +453,18 @@ function FloatingComposer({
                   enterKeyHint="send"
                   className="field-sizing-content max-h-[240px] w-full resize-none bg-transparent px-1 py-1.5 leading-6 outline-none placeholder:text-muted-foreground disabled:opacity-50 md:text-base"
                 />
-              </div>
+              </m.div>
 
-              <div
+              <m.div
+                layout="position"
+                transition={{ layout: ROW_SPRING }}
                 className={cn(
                   "flex shrink-0 items-end gap-1 order-3",
                   expanded && "ml-auto",
                 )}
               >
                 <VoiceButtons controls={controls} />
-              </div>
+              </m.div>
             </m.div>
           )}
         </AnimatePresence>
@@ -420,6 +475,10 @@ function FloatingComposer({
 
 // Height of the conversation surface the composer morphs into.
 const CONVERSATION_PANEL_HEIGHT = 264;
+
+// One spring for the pill growing toward wrapped text and the row pieces gliding within it,
+// so the box and its contents arrive together.
+const ROW_SPRING = { type: "spring", stiffness: 520, damping: 40 } as const;
 // The pill grows first (its overflow-hidden clips the contents); the panel's orb and
 // controls animate in this long after a conversation opens, once the growth has cleared them.
 const CONVERSATION_PANEL_ENTER_DELAY_MS = 0;

--- a/apps/web/src/components/Chat/ChatHeaderActions/index.tsx
+++ b/apps/web/src/components/Chat/ChatHeaderActions/index.tsx
@@ -2,6 +2,7 @@ import { Maximize2, PanelRightClose, Volume2, VolumeX } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
+import { recedeTransition } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 import { useLayout } from "@/stores/use-layout";
 import { useVoice } from "@/stores/use-voice";
@@ -30,7 +31,8 @@ export function ChatHeaderActions({
   return (
     <div
       className={cn(
-        "absolute right-3 z-10 [will-change:transform] transition-transform ease-[cubic-bezier(0.32,0.72,0,1)]",
+        "absolute right-3 z-10",
+        recedeTransition,
         receded ? "duration-500 -translate-y-16" : "duration-300",
       )}
       style={{ top: fullscreen ? navbarHeight + 12 : 12 }}

--- a/apps/web/src/components/Chat/ChatHeaderActions/index.tsx
+++ b/apps/web/src/components/Chat/ChatHeaderActions/index.tsx
@@ -8,12 +8,15 @@ import { useVoice } from "@/stores/use-voice";
 
 interface ChatHeaderActionsProps {
   fullscreen?: boolean;
+  // Recede in perspective with the chat while a conversation runs.
+  receded?: boolean;
   onCollapse?: () => void;
   agentName: string;
 }
 
 export function ChatHeaderActions({
   fullscreen,
+  receded,
   onCollapse,
   agentName,
 }: ChatHeaderActionsProps) {
@@ -26,7 +29,10 @@ export function ChatHeaderActions({
   // The fullscreen chat sits under the absolute navbar, so the actions start below it.
   return (
     <div
-      className="absolute right-3 z-10"
+      className={cn(
+        "absolute right-3 z-10 [will-change:transform] transition-transform ease-[cubic-bezier(0.32,0.72,0,1)]",
+        receded ? "duration-500 -translate-y-16" : "duration-300",
+      )}
       style={{ top: fullscreen ? navbarHeight + 12 : 12 }}
     >
       <ButtonGroup>

--- a/apps/web/src/components/Chat/ChatMessageArea/index.tsx
+++ b/apps/web/src/components/Chat/ChatMessageArea/index.tsx
@@ -21,6 +21,7 @@ import { useChatScroll } from "./use-chat-scroll";
 
 export interface ChatScrollHandle {
   scrollToBottom: () => void;
+  pinToLatest: () => void;
 }
 
 interface ChatMessageAreaProps {
@@ -37,6 +38,9 @@ interface ChatMessageAreaProps {
   notAuthenticated: boolean;
   isTyping: boolean;
   isMobile: boolean;
+  // A running conversation owns the viewport: the list is pinned to the latest message,
+  // scrolling is disabled outright, and the whole list recedes into depth behind the scrim.
+  scrollLocked: boolean;
   onRetry?: RetryHandler;
   onOpenAttachment?: (request: OpenViewerRequest) => void;
   // Space reserved at the end of the list so the last message clears the floating composer.
@@ -109,13 +113,32 @@ function ChatSkeleton({ bottomPad }: { bottomPad: number }) {
 // old stacked card+list pair: near-invisible within the navbar's height, then a long dissolve
 // (3.5x/1.75x the navbar) so bubbles evaporate before reaching it. The bottom stop fades behind
 // the composer.
-function scrollerMask(
-  fullscreen: boolean,
-  isMobile: boolean,
-  navbarHeight: number,
-  bottomInset: number,
-  edges: ScrollEdges,
-): string {
+// The locked conversation scroller is bottom-anchored and clipped, so the latest message
+// cannot move when bubbles rewrap; unlocked it scrolls normally.
+function scrollerClass(scrollLocked: boolean): string {
+  return scrollLocked
+    ? "flex h-full flex-col justify-end overflow-y-hidden overflow-x-hidden"
+    : "h-full overflow-y-auto overflow-x-hidden";
+}
+
+function scrollerMask({
+  fullscreen,
+  isMobile,
+  navbarHeight,
+  bottomInset,
+  edges,
+  scrollLocked,
+}: {
+  fullscreen: boolean;
+  isMobile: boolean;
+  navbarHeight: number;
+  bottomInset: number;
+  edges: ScrollEdges;
+  scrollLocked: boolean;
+}): string | undefined {
+  // No mask while locked: the conversation's own top fade overlay covers it, and a mask under
+  // an animating transform costs a full-scroller repaint every frame.
+  if (scrollLocked) return undefined;
   const top = !edges.top
     ? "black 0px"
     : fullscreen
@@ -250,6 +273,7 @@ export const ChatMessageArea = memo(function ChatMessageArea({
   notAuthenticated,
   isTyping,
   isMobile,
+  scrollLocked,
   onRetry,
   onOpenAttachment,
   bottomInset = 0,
@@ -275,26 +299,50 @@ export const ChatMessageArea = memo(function ChatMessageArea({
   const parentRef = useRef<HTMLDivElement>(null);
   const scrollFade = useScrollFade<HTMLDivElement>({ ref: parentRef });
 
-  const { handleScroll, scrollToBottom, waitingForOlder } = useChatScroll({
-    parentRef,
-    count,
-    firstKey: decorated[0]?.key ?? null,
-    bottomInset,
-    bottomOverhang,
-    hasMore,
-    loadingMore,
-    loadMore,
-    onAtBottomChange,
-  });
+  const { handleScroll, scrollToBottom, pinToLatest, waitingForOlder } =
+    useChatScroll({
+      parentRef,
+      count,
+      firstKey: decorated[0]?.key ?? null,
+      bottomInset,
+      bottomOverhang,
+      hasMore,
+      loadingMore,
+      loadMore,
+      onAtBottomChange,
+    });
 
   const prevLastIndex = useAppendBoundary(decorated);
 
-  useImperativeHandle(scrollRef, () => ({ scrollToBottom }), [scrollToBottom]);
+  useImperativeHandle(scrollRef, () => ({ scrollToBottom, pinToLatest }), [
+    scrollToBottom,
+    pinToLatest,
+  ]);
 
   const topPad = fullscreen ? navbarHeight + 16 : 32;
+  const mask = scrollerMask({
+    fullscreen: Boolean(fullscreen),
+    isMobile,
+    navbarHeight,
+    bottomInset,
+    edges: scrollFade.edges,
+    scrollLocked,
+  });
 
   return (
-    <CardContent className="flex-1 min-h-0 overflow-hidden p-0 relative">
+    <CardContent
+      className={cn(
+        "flex-1 min-h-0 overflow-hidden p-0 relative",
+        // Pushed back in space while a conversation runs: perspective tilt + shrink, the
+        // sheet-behind look. The ease matches the composer morph's settle.
+        // will-change keeps this on its own compositor layer, so the recede is a GPU
+        // transform rather than a per-frame repaint of the whole message list.
+        "origin-top [will-change:transform] transition-transform ease-[cubic-bezier(0.32,0.72,0,1)]",
+        scrollLocked
+          ? "duration-500 [transform:perspective(1000px)_rotateX(7deg)_scale(0.94)]"
+          : "duration-300",
+      )}
+    >
       {/* persistent live region so screen readers hear agent replies as they arrive */}
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {lastAgentText}
@@ -330,7 +378,7 @@ export const ChatMessageArea = memo(function ChatMessageArea({
         ref={parentRef}
         onScroll={handleScroll}
         className={cn(
-          "h-full overflow-y-auto overflow-x-hidden",
+          scrollerClass(scrollLocked),
           // Reserve the scrollbar gutter on both sides so the centered message column
           // shares the same center as the (scrollbar-free) floating composer.
           isDesktop && "[scrollbar-gutter:stable_both-edges]",
@@ -339,18 +387,20 @@ export const ChatMessageArea = memo(function ChatMessageArea({
         // anchoring would compensate the same prepend a second time.
         style={{
           overflowAnchor: "none",
-          maskImage: scrollerMask(
-            Boolean(fullscreen),
-            isMobile,
-            navbarHeight,
-            bottomInset,
-            scrollFade.edges,
-          ),
+          maskImage: mask,
         }}
       >
         <div
           className={cn(isDesktop && CHAT_CONTENT_COLUMN)}
-          style={{ paddingBottom: bottomInset }}
+          // The live composer reservation, published as a variable by the chat so the morph
+          // never re-renders this list; the React value is the pre-paint fallback.
+          style={{
+            paddingBottom: `var(--composer-inset, ${String(bottomInset)}px)`,
+            // During the morph the reservation rides this transform (its own layer, no
+            // repaint) while the padding holds still; they swap in one write at the end.
+            transform: "translateY(var(--composer-shift, 0px))",
+            willChange: "transform",
+          }}
         >
           <div style={{ paddingTop: topPad }}>
             {count > 0 && !hasMore && (

--- a/apps/web/src/components/Chat/ChatMessageArea/index.tsx
+++ b/apps/web/src/components/Chat/ChatMessageArea/index.tsx
@@ -9,9 +9,9 @@ import {
 import { AnimatePresence, motion } from "motion/react";
 import { CardContent } from "@/components/ui/card";
 import type { ChatMessage } from "@/lib/types";
+import { recedeTransition, stepTransition } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 import { useScrollFade, type ScrollEdges } from "@/hooks/use-scroll-fade";
-import { stepTransition } from "@/lib/motion";
 import { bubbleRadiusStyle } from "../bubble-radius";
 import { ChatBubble, type RetryHandler } from "../ChatBubble";
 import type { OpenViewerRequest } from "../ChatBubble/AttachmentContent";
@@ -337,7 +337,8 @@ export const ChatMessageArea = memo(function ChatMessageArea({
         // sheet-behind look. The ease matches the composer morph's settle.
         // will-change keeps this on its own compositor layer, so the recede is a GPU
         // transform rather than a per-frame repaint of the whole message list.
-        "origin-top [will-change:transform] transition-transform ease-[cubic-bezier(0.32,0.72,0,1)]",
+        "origin-top",
+        recedeTransition,
         scrollLocked
           ? "duration-500 [transform:perspective(1000px)_rotateX(7deg)_scale(0.94)]"
           : "duration-300",

--- a/apps/web/src/components/Chat/ChatMessageArea/use-chat-scroll.ts
+++ b/apps/web/src/components/Chat/ChatMessageArea/use-chat-scroll.ts
@@ -155,9 +155,21 @@ export function useChatScroll({
     latchRef.current = startFollow(el);
   }, [parentRef]);
 
+  // Instant, latch-free pin: lands flush and marks pinned, so the resize model's instant
+  // re-pins take over from there. A smooth follow here would be re-aimed on every rewrap
+  // tick of a live width resize and fling the viewport around.
+  const pinToLatest = useCallback(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    latchRef.current = IDLE_LATCH;
+    setAtBottom(true);
+  }, [parentRef, setAtBottom]);
+
   return {
     handleScroll,
     scrollToBottom,
+    pinToLatest,
     waitingForOlder: loadingMore && nearTop,
   };
 }

--- a/apps/web/src/components/Chat/ConversationPanel/index.tsx
+++ b/apps/web/src/components/Chat/ConversationPanel/index.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useRef } from "react";
+import { motion as m } from "motion/react";
+import { Mic, MicOff, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Orb } from "@/components/Orb";
+import { cn } from "@/lib/utils";
+import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
+import { useVoice } from "@/stores/use-voice";
+
+const ORB_SIZE = 168;
+
+function phaseLabel({
+  listening,
+  micMuted,
+  isSpeaking,
+  thinking,
+}: {
+  listening: boolean;
+  micMuted: boolean;
+  isSpeaking: boolean;
+  thinking: boolean;
+}): string {
+  if (!listening) return "connecting…";
+  if (isSpeaking) return "speaking";
+  if (micMuted) return "muted";
+  if (thinking) return "thinking";
+  return "listening";
+}
+
+// The live conversation surface the composer morphs into: the agent's real status orb with
+// voice motion overlaid, and one row of controls. Same width as the composer by construction.
+export function ConversationPanel({ morphed }: { morphed: boolean }) {
+  // The session is already torn down while this panel plays its exit, so what it renders is
+  // held at the last live values: reading the reset store would flash "connecting" on the
+  // way out.
+  const live = useVoice((s) => s.recordingMode === "conversation");
+  const { orbState, statusLabel } = useSelectedAgent();
+  const listening = useVoice((s) => s.listening);
+  const liveTranscript = useVoice((s) => s.liveTranscript);
+  const micMuted = useVoice((s) => s.micMuted);
+  const isSpeaking = useVoice((s) => s.isSpeaking);
+  const stopVoice = useVoice((s) => s.stopVoice);
+  const toggleMicMuted = useVoice((s) => s.toggleMicMuted);
+
+  const thinking = orbState === "thinking";
+  // Your words take the pill over as you speak, the freshest one bold so the eye can ride the
+  // stream; between turns the pill falls back to the phase.
+  const transcript = liveTranscript.trim();
+  const livePhase = phaseLabel({ listening, micMuted, isSpeaking, thinking });
+  // The status decides the look; the voice phase only decides the motion. A muted mic or a
+  // still-dialing session holds the orb still rather than pretending to listen.
+  const liveMotion = isSpeaking
+    ? ("talking" as const)
+    : listening && !micMuted
+      ? ("listening" as const)
+      : undefined;
+  const lastShownRef = useRef({
+    transcript: "",
+    phase: livePhase,
+    motion: liveMotion,
+  });
+  useEffect(() => {
+    if (live)
+      lastShownRef.current = {
+        transcript,
+        phase: livePhase,
+        motion: liveMotion,
+      };
+  });
+  const shown = live
+    ? { transcript, phase: livePhase, motion: liveMotion }
+    : lastShownRef.current;
+  const motion = shown.motion;
+  const lastSpace = shown.transcript.lastIndexOf(" ");
+  const spokenHead =
+    lastSpace === -1 ? "" : shown.transcript.slice(0, lastSpace + 1);
+  const spokenTail =
+    lastSpace === -1 ? shown.transcript : shown.transcript.slice(lastSpace + 1);
+
+  return (
+    <div className="flex h-full flex-col items-center justify-end gap-4 px-4 pt-3 pb-4">
+      {/* The orb slides up and in first; the action bar follows a beat behind. */}
+      {/* The pill has finished growing before `morphed` flips, so this slide is no longer
+          masked by the container's clip reveal. Staggered: orb first, bar a beat behind. */}
+      <m.div
+        initial={{ opacity: 0, y: 96 }}
+        animate={morphed ? { opacity: 1, y: 0 } : { opacity: 0, y: 96 }}
+        exit={{
+          opacity: 0,
+          y: 96,
+          transition: { duration: 0.27, ease: [0.32, 0.72, 0, 1] },
+        }}
+        transition={{ duration: 0.55, ease: [0.32, 0.72, 0, 1] }}
+        className="flex justify-center"
+      >
+        <Orb
+          state={orbState}
+          motion={motion}
+          size={ORB_SIZE}
+          label={statusLabel}
+        />
+      </m.div>
+      <m.div
+        initial={{ opacity: 0, y: 28 }}
+        animate={morphed ? { opacity: 1, y: 0 } : { opacity: 0, y: 28 }}
+        exit={{
+          opacity: 0,
+          y: 28,
+          transition: { duration: 0.19, ease: [0.32, 0.72, 0, 1] },
+        }}
+        transition={{ delay: 0.015, duration: 0.38, ease: [0.32, 0.72, 0, 1] }}
+        className="relative z-10 flex w-full items-end"
+      >
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          onClick={toggleMicMuted}
+          aria-pressed={micMuted}
+          aria-label={micMuted ? "unmute microphone" : "mute microphone"}
+          className={cn(
+            "size-10 rounded-full [&_svg]:size-4.5",
+            micMuted && "bg-red-500 text-white hover:bg-red-600",
+          )}
+        >
+          {micMuted ? <MicOff /> : <Mic />}
+        </Button>
+        <div className="flex min-w-0 flex-1 justify-center px-3">
+          {/* Two lines at most, clipped from the top, so the newest words are always the
+              visible ones while a long turn streams in. */}
+          <div className="w-full min-w-0 rounded-2xl bg-muted px-4 py-1.5">
+            <div
+              className={cn(
+                "flex max-h-[2lh] flex-col justify-end overflow-hidden text-sm break-words text-muted-foreground",
+                shown.transcript ? "text-left" : "text-center",
+              )}
+            >
+              {shown.transcript ? (
+                <span>
+                  {spokenHead}
+                  <span className="font-semibold text-foreground">
+                    {spokenTail}
+                  </span>
+                </span>
+              ) : (
+                shown.phase
+              )}
+            </div>
+          </div>
+        </div>
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          onClick={stopVoice}
+          aria-label="end conversation"
+          title="end conversation"
+          className="size-10 rounded-full [&_svg]:size-4.5"
+        >
+          <X />
+        </Button>
+      </m.div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Chat/ConversationPanel/index.tsx
+++ b/apps/web/src/components/Chat/ConversationPanel/index.tsx
@@ -3,6 +3,7 @@ import { motion as m } from "motion/react";
 import { Mic, MicOff, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Orb } from "@/components/Orb";
+import { sheetEase } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 import { useSelectedAgent } from "@/providers/SelectedAgentProvider";
 import { useVoice } from "@/stores/use-voice";
@@ -29,7 +30,11 @@ function phaseLabel({
 
 // The live conversation surface the composer morphs into: the agent's real status orb with
 // voice motion overlaid, and one row of controls. Same width as the composer by construction.
-export function ConversationPanel({ morphed }: { morphed: boolean }) {
+// The recording red shared by every active voice control (the composer's stop button, the
+// panel's muted mic).
+export const RECORDING_BUTTON = "bg-red-500 text-white hover:bg-red-600";
+
+export function ConversationPanel() {
   // The session is already torn down while this panel plays its exit, so what it renders is
   // held at the last live values: reading the reset store would flash "connecting" on the
   // way out.
@@ -79,18 +84,17 @@ export function ConversationPanel({ morphed }: { morphed: boolean }) {
 
   return (
     <div className="flex h-full flex-col items-center justify-end gap-4 px-4 pt-3 pb-4">
-      {/* The orb slides up and in first; the action bar follows a beat behind. */}
-      {/* The pill has finished growing before `morphed` flips, so this slide is no longer
-          masked by the container's clip reveal. Staggered: orb first, bar a beat behind. */}
+      {/* Staggered mount slide inside the still-growing clip window: orb first, action bar a
+          beat behind, both revealed by the pill's height spring as it clears them. */}
       <m.div
         initial={{ opacity: 0, y: 96 }}
-        animate={morphed ? { opacity: 1, y: 0 } : { opacity: 0, y: 96 }}
+        animate={{ opacity: 1, y: 0 }}
         exit={{
           opacity: 0,
           y: 96,
-          transition: { duration: 0.27, ease: [0.32, 0.72, 0, 1] },
+          transition: { duration: 0.27, ease: sheetEase },
         }}
-        transition={{ duration: 0.55, ease: [0.32, 0.72, 0, 1] }}
+        transition={{ duration: 0.55, ease: sheetEase }}
         className="flex justify-center"
       >
         <Orb
@@ -102,13 +106,13 @@ export function ConversationPanel({ morphed }: { morphed: boolean }) {
       </m.div>
       <m.div
         initial={{ opacity: 0, y: 28 }}
-        animate={morphed ? { opacity: 1, y: 0 } : { opacity: 0, y: 28 }}
+        animate={{ opacity: 1, y: 0 }}
         exit={{
           opacity: 0,
           y: 28,
-          transition: { duration: 0.19, ease: [0.32, 0.72, 0, 1] },
+          transition: { duration: 0.19, ease: sheetEase },
         }}
-        transition={{ delay: 0.015, duration: 0.38, ease: [0.32, 0.72, 0, 1] }}
+        transition={{ delay: 0.015, duration: 0.38, ease: sheetEase }}
         className="relative z-10 flex w-full items-end"
       >
         <Button
@@ -120,7 +124,7 @@ export function ConversationPanel({ morphed }: { morphed: boolean }) {
           aria-label={micMuted ? "unmute microphone" : "mute microphone"}
           className={cn(
             "size-10 rounded-full [&_svg]:size-4.5",
-            micMuted && "bg-red-500 text-white hover:bg-red-600",
+            micMuted && RECORDING_BUTTON,
           )}
         >
           {micMuted ? <MicOff /> : <Mic />}

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -10,6 +10,7 @@ import {
   type KeyboardEvent,
 } from "react";
 import { useLocation } from "react-router-dom";
+import { AnimatePresence, motion as m } from "motion/react";
 import { ArrowDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -31,6 +32,7 @@ import { cn } from "@/lib/utils";
 import { BottomBanner } from "./BottomBanner";
 import { ChatComposer } from "./ChatComposer";
 import { ChatHeaderActions } from "./ChatHeaderActions";
+
 import { ChatMessageArea, type ChatScrollHandle } from "./ChatMessageArea";
 import { useChatKeyboardFocus } from "./use-chat-keyboard-focus";
 import { agentSubpage } from "@/lib/agent-subpage";
@@ -68,7 +70,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     voiceConfigured,
     recordingMode,
     listening,
-    isSpeaking,
     liveTranscript,
     startVoice,
     stopVoice,
@@ -88,6 +89,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     trimHistory,
     send,
     retry,
+    reportSpeaking,
   } = useAgentSocket();
 
   const [input, setInput] = useChatDraft(name);
@@ -123,10 +125,14 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     [send, attachments],
   );
   useEffect(() => {
-    registerChat(sendWithDrafts, () => {
-      setInput("");
-    });
-  }, [registerChat, sendWithDrafts, setInput]);
+    registerChat(
+      sendWithDrafts,
+      () => {
+        setInput("");
+      },
+      reportSpeaking,
+    );
+  }, [registerChat, sendWithDrafts, setInput, reportSpeaking]);
 
   const scrollRef = useRef<ChatScrollHandle>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -170,26 +176,70 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   // the message list's scroll range, so the bubbles a tall draft covers stay
   // reachable by scrolling without the list ever shifting under the typist.
   const hasDraftRef = useRef(false);
+  const inConversationRef = useRef(false);
+  // The composer's height animates frame by frame during the conversation morph. Feeding
+  // that into React would re-pad, re-mask and re-pin the whole message list every frame, so
+  // the measurement is frozen for the morph and synced once when it settles.
+  const [morphing, setMorphing] = useState(false);
+  const morphingRef = useRef(false);
+  const composerNodeRef = useRef<HTMLDivElement | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  // The last measured composer height, and the reservation frozen at the morph's first frame.
+  const lastHeightRef = useRef(0);
+  const frozenInsetRef = useRef(0);
   useLayoutEffect(() => {
     // Attachment chips grow the pill exactly like typed text: both are drafts the
     // inset must ignore so the list never shifts under the composer.
     hasDraftRef.current = input.length > 0 || attachments.drafts.length > 0;
+    inConversationRef.current = recordingMode === "conversation";
+    morphingRef.current = morphing;
   });
   const composerRef = useMeasuredSize(
     "height",
     useCallback(
       (height: number) => {
+        lastHeightRef.current = height;
+        const card = cardRef.current;
+        // The list reserves the composer through these variables, so the reservation tracks
+        // the morph frame by frame without a React render. While morphing the padding holds
+        // still and a transform carries the same distance: changing padding inside the
+        // receding (3D, promoted) layer re-rasterizes the whole chat every frame.
+        if (morphingRef.current) {
+          card?.style.setProperty(
+            "--composer-shift",
+            `${String(frozenInsetRef.current - height)}px`,
+          );
+          return;
+        }
+        card?.style.setProperty("--composer-inset", `${String(height)}px`);
+        card?.style.setProperty("--composer-shift", "0px");
         setComposerHeight(height);
         if (height === 0 || !hasDraftRef.current) {
           setComposerInset(height);
-          // Cache only a real, draft-free baseline; unmount reports 0, which must
-          // not overwrite the seed the next remount reads.
-          if (height > 0) setComposerBaseline(composerVariant, height);
+          // Cache only a real, draft-free baseline; unmount reports 0 and the morphed
+          // conversation panel is a temporary height, and neither must overwrite the
+          // seed the next remount reads.
+          if (height > 0 && !inConversationRef.current)
+            setComposerBaseline(composerVariant, height);
         }
       },
       [composerVariant, setComposerBaseline],
     ),
   );
+
+  useEffect(() => {
+    if (morphing) return;
+    const node = composerNodeRef.current;
+    if (!node) return;
+    const height = node.getBoundingClientRect().height;
+    if (height <= 0) return;
+    // Padding and shift swap in one style write, so the handoff off the transform is unseen.
+    const card = cardRef.current;
+    card?.style.setProperty("--composer-inset", `${String(height)}px`);
+    card?.style.setProperty("--composer-shift", "0px");
+    setComposerHeight(height);
+    if (!hasDraftRef.current) setComposerInset(height);
+  }, [morphing]);
 
   const chatMessages = useMemo(
     () =>
@@ -206,6 +256,20 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   const scrollToBottom = useCallback(() => {
     scrollRef.current?.scrollToBottom();
   }, []);
+
+  // A conversation owns the viewport: pin the chat to the newest message when it opens and
+  // keep it pinned as turns land, whatever the scroll position was before. The inset tracking
+  // the morphing panel keeps it pinned through the resize itself.
+  const inConversation = recordingMode === "conversation";
+  // While locked the list is bottom-anchored structurally; on both edges of the lock the
+  // real scroller needs to sit at the end (entering: before the anchor kicks in, leaving:
+  // the resumed scroller's scrollTop is stale).
+  useEffect(() => {
+    requestAnimationFrame(() => scrollRef.current?.pinToLatest());
+    // The locked list shows only its tail, so drop the rest of the loaded history right
+    // away; scrolling up after the conversation refetches it.
+    if (inConversation) trimHistory();
+  }, [inConversation, trimHistory]);
 
   // Stable so ChatMessageArea's memo holds across per-keystroke composer re-renders.
   const handleLoadMore = useCallback(() => {
@@ -272,6 +336,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     <div className="flex h-full min-h-0 flex-col">
       <Card
         {...dropHandlers}
+        ref={cardRef}
         className={cn(
           "flex flex-col h-full gap-0 py-0 px-0 overflow-hidden relative text-base shadow-none",
           fullscreen && "ring-0",
@@ -282,6 +347,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
         <AttachmentViewer agent={name} request={viewer} onClose={closeViewer} />
         <ChatHeaderActions
           fullscreen={fullscreen}
+          receded={inConversation}
           onCollapse={onCollapse}
           agentName={name}
         />
@@ -300,6 +366,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
           notAuthenticated={notAuthenticated}
           isTyping={isTyping}
           isMobile={isMobile}
+          scrollLocked={inConversation}
           onRetry={retry}
           onOpenAttachment={openAttachment}
           bottomInset={
@@ -310,11 +377,42 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
           onAtBottomChange={setAtBottom}
         />
 
+        <AnimatePresence>
+          {recordingMode === "conversation" && (
+            <m.button
+              type="button"
+              aria-label="end conversation"
+              onClick={stopVoice}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0, transition: { duration: 0.27 } }}
+              transition={{ duration: 0.5, ease: [0.32, 0.72, 0, 1] }}
+              className="absolute inset-0 z-10 cursor-default bg-background/60"
+            />
+          )}
+          {recordingMode === "conversation" && (
+            <m.div
+              aria-hidden
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0, transition: { duration: 0.27 } }}
+              transition={{ duration: 0.5, ease: [0.32, 0.72, 0, 1] }}
+              className="pointer-events-none absolute inset-x-0 top-0 z-20 h-24 bg-gradient-to-b from-background to-transparent"
+            />
+          )}
+        </AnimatePresence>
+
         <div
-          ref={composerRef}
+          ref={(node) => {
+            composerNodeRef.current = node;
+            composerRef(node);
+          }}
           // px-3 mirrors the message list's 12px scrollbar-gutter on each side, so the
           // composer's capped column computes from the same width and lines up with the bubbles.
-          className={cn("absolute inset-x-0 bottom-0", !isMobile && "px-3")}
+          className={cn(
+            "absolute inset-x-0 bottom-0 z-20",
+            !isMobile && "px-3",
+          )}
         >
           {chatMessages.length > 0 && (
             <Button
@@ -348,8 +446,11 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
               voiceConfigured={voiceConfigured}
               recordingMode={recordingMode}
               listening={listening}
-              isSpeaking={isSpeaking}
               liveTranscript={liveTranscript}
+              onMorphingChange={(next) => {
+                if (next) frozenInsetRef.current = lastHeightRef.current;
+                setMorphing(next);
+              }}
               startVoice={startVoice}
               stopVoice={stopVoice}
               cancelVoice={cancelVoice}

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -28,6 +28,7 @@ import { AttachmentViewer } from "./AttachmentViewer";
 import type { OpenViewerRequest } from "./ChatBubble/AttachmentContent";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useMeasuredSize } from "@/hooks/use-measured-size";
+import { sheetEase } from "@/lib/motion";
 import { cn } from "@/lib/utils";
 import { BottomBanner } from "./BottomBanner";
 import { ChatComposer } from "./ChatComposer";
@@ -54,6 +55,14 @@ const COMPOSER_BASELINE_PX: Record<ComposerVariant, number> = {
   fullscreen: 66,
   mobile: 54,
 };
+
+// The scrim and top fade enter and leave with the conversation, on the shared sheet curve.
+const CONVERSATION_FADE = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0, transition: { duration: 0.27 } },
+  transition: { duration: 0.5, ease: sheetEase },
+} as const;
 
 interface ChatProps {
   onCollapse?: () => void;
@@ -182,7 +191,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   // The composer's height animates frame by frame during the conversation morph. Feeding
   // that into React would re-pad, re-mask and re-pin the whole message list every frame, so
   // the measurement is frozen for the morph and synced once when it settles.
-  const [morphing, setMorphing] = useState(false);
   const morphingRef = useRef(false);
   const composerNodeRef = useRef<HTMLDivElement | null>(null);
   const cardRef = useRef<HTMLDivElement | null>(null);
@@ -197,7 +205,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     // inset must ignore so the list never shifts under the composer.
     hasDraftRef.current = input.length > 0 || attachments.drafts.length > 0;
     inConversationRef.current = recordingMode === "conversation";
-    morphingRef.current = morphing;
   });
   const composerGap = fullscreen
     ? COMPOSER_GAP_FULLSCREEN_PX
@@ -262,9 +269,12 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     }
   }, [composerGap]);
 
-  useEffect(() => {
-    if (!morphing) resyncInset();
-  }, [morphing, resyncInset]);
+  // The composer's settle callback: the morph flag clears and the rest state lands in one step
+  // (a settle outside a morph just re-syncs, which is a no-op).
+  const onMorphSettled = useCallback(() => {
+    morphingRef.current = false;
+    resyncInset();
+  }, [resyncInset]);
 
   const handleHeightAnimation = useCallback(
     (animating: boolean) => {
@@ -303,7 +313,6 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     prevConversationRef.current = inConversation;
     frozenInsetRef.current = lastHeightRef.current;
     morphingRef.current = true;
-    setMorphing(true);
   }, [inConversation]);
   // While locked the list is bottom-anchored structurally; on both edges of the lock the
   // real scroller needs to sit at the end (entering: before the anchor kicks in, leaving:
@@ -417,25 +426,19 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
         />
 
         <AnimatePresence>
-          {recordingMode === "conversation" && (
+          {inConversation && (
             <m.button
               type="button"
               aria-label="end conversation"
               onClick={stopVoice}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0, transition: { duration: 0.27 } }}
-              transition={{ duration: 0.5, ease: [0.32, 0.72, 0, 1] }}
+              {...CONVERSATION_FADE}
               className="absolute inset-0 z-10 cursor-default bg-background/60"
             />
           )}
-          {recordingMode === "conversation" && (
+          {inConversation && (
             <m.div
               aria-hidden
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0, transition: { duration: 0.27 } }}
-              transition={{ duration: 0.5, ease: [0.32, 0.72, 0, 1] }}
+              {...CONVERSATION_FADE}
               className="pointer-events-none absolute inset-x-0 top-0 z-20 h-24 bg-gradient-to-b from-background to-transparent"
             />
           )}
@@ -486,7 +489,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
               recordingMode={recordingMode}
               listening={listening}
               liveTranscript={liveTranscript}
-              onMorphingChange={setMorphing}
+              onMorphSettled={onMorphSettled}
               onHeightAnimation={handleHeightAnimation}
               startVoice={startVoice}
               stopVoice={stopVoice}

--- a/apps/web/src/components/Chat/index.tsx
+++ b/apps/web/src/components/Chat/index.tsx
@@ -124,19 +124,21 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     },
     [send, attachments],
   );
-  useEffect(() => {
-    registerChat(
-      sendWithDrafts,
-      () => {
-        setInput("");
-      },
-      reportSpeaking,
-    );
-  }, [registerChat, sendWithDrafts, setInput, reportSpeaking]);
-
   const scrollRef = useRef<ChatScrollHandle>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   useChatKeyboardFocus(textareaRef);
+
+  // The one owner of clearing the composer: the draft AND the autosize's inline height, so a
+  // voice mode taking the field over never inherits the height of the text it just dropped.
+  const clearComposer = useCallback(() => {
+    setInput("");
+    const ta = textareaRef.current;
+    if (ta) ta.style.height = "auto";
+  }, [setInput]);
+
+  useEffect(() => {
+    registerChat(sendWithDrafts, clearComposer, reportSpeaking);
+  }, [registerChat, sendWithDrafts, clearComposer, reportSpeaking]);
 
   // Focus the composer whenever the chat becomes the visible surface: on mount,
   // and again when a logs/settings subpage closes (the pane stays mounted, so a
@@ -187,6 +189,9 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   // The last measured composer height, and the reservation frozen at the morph's first frame.
   const lastHeightRef = useRef(0);
   const frozenInsetRef = useRef(0);
+  // True while the pill's height spring runs outside a morph; mid-animation measurements are
+  // skipped and the settle resync writes the rest state.
+  const heightAnimatingRef = useRef(false);
   useLayoutEffect(() => {
     // Attachment chips grow the pill exactly like typed text: both are drafts the
     // inset must ignore so the list never shifts under the composer.
@@ -194,6 +199,9 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     inConversationRef.current = recordingMode === "conversation";
     morphingRef.current = morphing;
   });
+  const composerGap = fullscreen
+    ? COMPOSER_GAP_FULLSCREEN_PX
+    : COMPOSER_GAP_PANEL_PX;
   const composerRef = useMeasuredSize(
     "height",
     useCallback(
@@ -211,10 +219,18 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
           );
           return;
         }
-        card?.style.setProperty("--composer-inset", `${String(height)}px`);
+        // Mid-animation heights are transient (a cleared tall draft springing back down would
+        // snap the list up to its overlay height); the settle resync writes the rest state.
+        if (heightAnimatingRef.current) return;
         card?.style.setProperty("--composer-shift", "0px");
         setComposerHeight(height);
+        // The var carries the same value as the state inset (baseline + gap) and obeys the
+        // same draft rule: a growing draft expands the pill over the list, never pushes it.
         if (height === 0 || !hasDraftRef.current) {
+          card?.style.setProperty(
+            "--composer-inset",
+            `${String(height + composerGap)}px`,
+          );
           setComposerInset(height);
           // Cache only a real, draft-free baseline; unmount reports 0 and the morphed
           // conversation panel is a temporary height, and neither must overwrite the
@@ -223,23 +239,40 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
             setComposerBaseline(composerVariant, height);
         }
       },
-      [composerVariant, setComposerBaseline],
+      [composerVariant, composerGap, setComposerBaseline],
     ),
   );
 
-  useEffect(() => {
-    if (morphing) return;
+  // One resting-state write, shared by the morph settle and every height animation's end.
+  // Padding and shift swap in one style write, so the handoff off the transform is unseen.
+  const resyncInset = useCallback(() => {
     const node = composerNodeRef.current;
     if (!node) return;
     const height = node.getBoundingClientRect().height;
     if (height <= 0) return;
-    // Padding and shift swap in one style write, so the handoff off the transform is unseen.
     const card = cardRef.current;
-    card?.style.setProperty("--composer-inset", `${String(height)}px`);
     card?.style.setProperty("--composer-shift", "0px");
     setComposerHeight(height);
-    if (!hasDraftRef.current) setComposerInset(height);
-  }, [morphing]);
+    if (!hasDraftRef.current) {
+      card?.style.setProperty(
+        "--composer-inset",
+        `${String(height + composerGap)}px`,
+      );
+      setComposerInset(height);
+    }
+  }, [composerGap]);
+
+  useEffect(() => {
+    if (!morphing) resyncInset();
+  }, [morphing, resyncInset]);
+
+  const handleHeightAnimation = useCallback(
+    (animating: boolean) => {
+      heightAnimatingRef.current = animating;
+      if (!animating && !morphingRef.current) resyncInset();
+    },
+    [resyncInset],
+  );
 
   const chatMessages = useMemo(
     () =>
@@ -261,6 +294,17 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
   // keep it pinned as turns land, whatever the scroll position was before. The inset tracking
   // the morphing panel keeps it pinned through the resize itself.
   const inConversation = recordingMode === "conversation";
+  // The morph starts on the conversation flip itself (either direction), freezing the inset
+  // before motion's first frame lands; the composer reports only completion. A typing
+  // animation therefore never trips the freeze.
+  const prevConversationRef = useRef(inConversation);
+  useLayoutEffect(() => {
+    if (prevConversationRef.current === inConversation) return;
+    prevConversationRef.current = inConversation;
+    frozenInsetRef.current = lastHeightRef.current;
+    morphingRef.current = true;
+    setMorphing(true);
+  }, [inConversation]);
   // While locked the list is bottom-anchored structurally; on both edges of the lock the
   // real scroller needs to sit at the end (entering: before the anchor kicks in, leaving:
   // the resumed scroller's scrollTop is stale).
@@ -300,10 +344,8 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
     }
     const uploaded = attachments.uploaded;
     if (send(text, "typed", uploaded.length > 0 ? uploaded : undefined)) {
-      setInput("");
+      clearComposer();
       attachments.clear();
-      const ta = textareaRef.current;
-      if (ta) ta.style.height = "auto";
       requestAnimationFrame(scrollToBottom);
     }
   };
@@ -369,10 +411,7 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
           scrollLocked={inConversation}
           onRetry={retry}
           onOpenAttachment={openAttachment}
-          bottomInset={
-            composerInset +
-            (fullscreen ? COMPOSER_GAP_FULLSCREEN_PX : COMPOSER_GAP_PANEL_PX)
-          }
+          bottomInset={composerInset + composerGap}
           bottomOverhang={Math.max(0, composerHeight - composerInset)}
           onAtBottomChange={setAtBottom}
         />
@@ -447,10 +486,8 @@ export function Chat({ onCollapse, fullscreen }: ChatProps = {}) {
               recordingMode={recordingMode}
               listening={listening}
               liveTranscript={liveTranscript}
-              onMorphingChange={(next) => {
-                if (next) frozenInsetRef.current = lastHeightRef.current;
-                setMorphing(next);
-              }}
+              onMorphingChange={setMorphing}
+              onHeightAnimation={handleHeightAnimation}
               startVoice={startVoice}
               stopVoice={stopVoice}
               cancelVoice={cancelVoice}

--- a/apps/web/src/components/Orb/index.tsx
+++ b/apps/web/src/components/Orb/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { orbVisual, type OrbVisualState } from "@vesta/core";
+import { orbVisual, type OrbMotion, type OrbVisualState } from "@vesta/core";
 import { usePrefersReducedMotion } from "@/hooks/use-reduced-motion";
 import {
   orbColors,
@@ -10,6 +10,8 @@ import {
 
 interface OrbProps {
   state: OrbVisualState;
+  // Live-voice motion overlay: same colors, different breathing.
+  motion?: OrbMotion;
   size?: number;
   suppressMotion?: boolean;
   label?: string;
@@ -28,6 +30,7 @@ const GLOW_FADE_PCT = 60;
 
 export function Orb({
   state,
+  motion,
   size = 140,
   suppressMotion = false,
   label,
@@ -37,7 +40,7 @@ export function Orb({
   const shellRef = useRef<HTMLDivElement>(null);
   const prefersReducedMotion = usePrefersReducedMotion();
   const motionSuppressed = suppressMotion || prefersReducedMotion;
-  const visual = orbVisual(state);
+  const visual = orbVisual(state, motion);
   const orbSize = size * ORB_FILL;
   const orbInset = (size - orbSize) / 2;
 

--- a/apps/web/src/components/Settings/KeybindsSection/index.tsx
+++ b/apps/web/src/components/Settings/KeybindsSection/index.tsx
@@ -1,11 +1,7 @@
-import { Hand, Mic, Sun, PanelLeft } from "lucide-react";
+import { Mic, Sun, PanelLeft } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Kbd } from "@/components/ui/kbd";
 import { MenuSection } from "@/components/ui/menu-section";
-import {
-  useVoiceActivation,
-  type VoiceActivationMode,
-} from "@/stores/use-voice-activation";
 
 const isMac =
   typeof navigator !== "undefined" &&
@@ -40,15 +36,7 @@ const keybinds: Keybind[] = [
   },
 ];
 
-const modeOptions: { value: VoiceActivationMode; label: string }[] = [
-  { value: "toggle", label: "toggle" },
-  { value: "hold", label: "hold" },
-];
-
 export function KeybindsCard() {
-  const activation = useVoiceActivation((s) => s.mode);
-  const setActivation = useVoiceActivation((s) => s.setMode);
-
   return (
     <Card size="sm">
       <CardContent>
@@ -64,25 +52,6 @@ export function KeybindsCard() {
                 {bind.keys}
               </div>
             ))}
-            <div className="flex items-center gap-2.5 rounded-md px-2 py-1.5 text-base text-muted-foreground">
-              <Hand className="size-3.5" />
-              <span className="flex-1">activation mode</span>
-              <div className="inline-flex rounded-md bg-muted p-0.5">
-                {modeOptions.map((opt) => (
-                  <button
-                    key={opt.value}
-                    className={`rounded-sm px-2.5 py-1 text-sm transition-colors ${
-                      activation === opt.value
-                        ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:text-foreground"
-                    }`}
-                    onClick={() => setActivation(opt.value)}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            </div>
           </div>
         </MenuSection>
       </CardContent>

--- a/apps/web/src/lib/motion.ts
+++ b/apps/web/src/lib/motion.ts
@@ -46,6 +46,14 @@ export function floatTransition(reduced: boolean) {
   };
 }
 
+// The sheet-behind choreography curve the conversation morph's companions share (scrim, top
+// fade, panel slide, header and list recede): the motion/react form, and the tailwind
+// recede classes carrying the same curve (the scanner reads class-shaped strings anywhere in
+// source, so the one string below is the one owner of the CSS side).
+export const sheetEase: [number, number, number, number] = [0.32, 0.72, 0, 1];
+export const recedeTransition =
+  "[will-change:transform] transition-transform ease-[cubic-bezier(0.32,0.72,0,1)]";
+
 export const textSwap = {
   initial: { opacity: 0, y: 4 },
   animate: { opacity: 1, y: 0 },

--- a/apps/web/src/lib/voice.ts
+++ b/apps/web/src/lib/voice.ts
@@ -253,8 +253,9 @@ export function browserSocket(url: string): VoiceSocketLike {
   return adapter;
 }
 
-// The microphone port: raw 16 kHz mono PCM frames to onFrame until stopped.
-export function browserCapture(): AudioCapture {
+// The microphone port: raw 16 kHz mono PCM frames to onFrame until stopped. `muted` is read
+// per frame, so a conversation's mic mute stops the flow without tearing the session down.
+export function browserCapture(muted?: () => boolean): AudioCapture {
   let stream: MediaStream | null = null;
   let audioCtx: AudioContext | null = null;
 
@@ -310,6 +311,7 @@ export function browserCapture(): AudioCapture {
         channelCount: 1,
       });
       workletNode.port.onmessage = (e: MessageEvent<Float32Array>) => {
+        if (muted?.()) return;
         onFrame(floatTo16BitPCM(e.data));
       };
       source.connect(workletNode);

--- a/apps/web/src/lib/voice.ts
+++ b/apps/web/src/lib/voice.ts
@@ -254,7 +254,8 @@ export function browserSocket(url: string): VoiceSocketLike {
 }
 
 // The microphone port: raw 16 kHz mono PCM frames to onFrame until stopped. `muted` is read
-// per frame, so a conversation's mic mute stops the flow without tearing the session down.
+// per frame; a muted mic streams silence rather than nothing, so the STT stream stays alive
+// and a turn caught mid-sentence still gets its end (which releases the yield-to-user gate).
 export function browserCapture(muted?: () => boolean): AudioCapture {
   let stream: MediaStream | null = null;
   let audioCtx: AudioContext | null = null;
@@ -311,7 +312,7 @@ export function browserCapture(muted?: () => boolean): AudioCapture {
         channelCount: 1,
       });
       workletNode.port.onmessage = (e: MessageEvent<Float32Array>) => {
-        if (muted?.()) return;
+        if (muted?.()) e.data.fill(0);
         onFrame(floatTo16BitPCM(e.data));
       };
       source.connect(workletNode);

--- a/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
+++ b/apps/web/src/providers/AgentSocketProvider/use-agent-socket.ts
@@ -70,6 +70,9 @@ export function useAgentSocketState({
 
   const onAssistantMessageRef = useRef(onAssistantMessage);
   onAssistantMessageRef.current = onAssistantMessage;
+  // The live socket's speaking report, held by ref so the callback handed to the voice store
+  // stays stable across reconnects and agent switches.
+  const reportSpeakingRef = useRef<((speaking: boolean) => void) | null>(null);
   const onPrefetchRef = useRef(onPrefetch);
   onPrefetchRef.current = onPrefetch;
   const chatQueueRef = useRef<ChatMessage[]>([]);
@@ -239,12 +242,19 @@ export function useAgentSocketState({
       },
     );
 
+    reportSpeakingRef.current = socket.reportSpeaking;
+
     return () => {
       cancelled = true;
+      reportSpeakingRef.current = null;
       socket.close();
       resetTyping();
     };
   }, [active, name, commit, enqueueChatMessage]);
+
+  const reportSpeaking = useCallback((speaking: boolean) => {
+    reportSpeakingRef.current?.(speaking);
+  }, []);
 
   const send = useCallback(
     (
@@ -352,5 +362,6 @@ export function useAgentSocketState({
     trimHistory,
     send,
     retry,
+    reportSpeaking,
   };
 }

--- a/apps/web/src/stores/use-voice.test.ts
+++ b/apps/web/src/stores/use-voice.test.ts
@@ -324,6 +324,14 @@ describe("recording modes", () => {
     expect(send).toHaveBeenCalledTimes(2);
   });
 
+  it("an agent switch ends a live session instead of re-routing it", async () => {
+    await startRecording("conversation");
+    expect(useVoice.getState().recordingMode).toBe("conversation");
+    useVoice.getState()._setAgentContext("other-agent", {}, undefined);
+    expect(useVoice.getState().recordingMode).toBeNull();
+    useVoice.getState()._setAgentContext("test-agent", {}, undefined);
+  });
+
   it("discarding a dictation sends nothing", async () => {
     const socket = await startRecording("dictation");
     socket.emit("StartOfTurn", "");

--- a/apps/web/src/stores/use-voice.test.ts
+++ b/apps/web/src/stores/use-voice.test.ts
@@ -274,7 +274,7 @@ describe("recording modes", () => {
     useVoice.getState()._setTtsStatus(ENABLED_TTS);
     send = vi.fn<(text: string) => void>();
     clearInput = vi.fn<() => void>();
-    useVoice.getState().registerChat(send, clearInput);
+    useVoice.getState().registerChat(send, clearInput, () => undefined);
   });
 
   it("dials the authed STT socket url on the ws scheme", async () => {

--- a/apps/web/src/stores/use-voice.ts
+++ b/apps/web/src/stores/use-voice.ts
@@ -54,6 +54,13 @@ interface VoiceState {
   // A per-device mute of spoken replies. A conversation speaks regardless; this silences the
   // ambient read-aloud of replies outside one.
   muted: boolean;
+  // Microphone mute inside a conversation: frames stop flowing, the session stays up.
+  micMuted: boolean;
+  // End a silent conversation on its own after the inactivity window (on by default).
+  conversationAutoEnd: boolean;
+  // A conversation yields the floor: replies are held off the speaker while you talk, and the
+  // agent is told you are speaking so it waits for your whole thought (on by default).
+  conversationYield: boolean;
 
   // Actions
   startVoice: (mode: VoiceMode) => void;
@@ -65,11 +72,15 @@ interface VoiceState {
   speak: (text: string) => void;
   stopSpeech: () => void;
   toggleMuted: () => void;
-  // The chat's send, and its input reset: a voice mode takes the composer over, so typed
-  // text is dropped when one starts.
+  toggleMicMuted: () => void;
+  setConversationAutoEnd: (value: boolean) => void;
+  setConversationYield: (value: boolean) => void;
+  // The chat's send, its input reset (a voice mode takes the composer over, so typed text is
+  // dropped when one starts), and the chat socket's speaking report for a yielding conversation.
   registerChat: (
     send: (text: string, inputMethod?: InputMethod) => void,
     clearInput: () => void,
+    reportSpeaking: (speaking: boolean) => void,
   ) => void;
 
   // Status management
@@ -94,11 +105,15 @@ interface VoiceState {
 let sendCallback: ((text: string, inputMethod?: InputMethod) => void) | null =
   null;
 let clearInputCallback: (() => void) | null = null;
+let reportSpeakingCallback: ((speaking: boolean) => void) | null = null;
 
 const MUTE_STORAGE_KEY = "voice-muted";
-function loadMuted(): boolean {
-  if (typeof localStorage === "undefined") return false;
-  return localStorage.getItem(MUTE_STORAGE_KEY) === "1";
+const AUTO_END_STORAGE_KEY = "voice-conversation-auto-end";
+const YIELD_STORAGE_KEY = "voice-conversation-yield";
+function loadStoredFlag(key: string, fallback: boolean): boolean {
+  if (typeof localStorage === "undefined") return fallback;
+  const raw = localStorage.getItem(key);
+  return raw === null ? fallback : raw === "1";
 }
 
 function boolSetting(
@@ -134,7 +149,7 @@ export const useVoice = create<VoiceState>((set, get) => {
     {
       buildUrl: () => voiceWsUrl(get().agentName ?? ""),
       createSocket: browserSocket,
-      capture: browserCapture(),
+      capture: browserCapture(() => get().micMuted),
       player: browserPlayer(() => get().agentName),
       setTimer: (fn, ms) => setTimeout(fn, ms),
       clearTimer: (handle) => clearTimeout(handle),
@@ -146,10 +161,13 @@ export const useVoice = create<VoiceState>((set, get) => {
       onModeChange: (mode) =>
         set({
           recordingMode: mode,
-          ...(mode === null ? { listening: false, liveTranscript: "" } : {}),
+          ...(mode === null
+            ? { listening: false, liveTranscript: "", micMuted: false }
+            : {}),
         }),
       onListeningChange: (listening) => set({ listening }),
       onSpeakingChange: (isSpeaking) => set({ isSpeaking }),
+      onUserSpeakingChange: (speaking) => reportSpeakingCallback?.(speaking),
       onInactivityStop: () =>
         useToastStore
           .getState()
@@ -160,7 +178,8 @@ export const useVoice = create<VoiceState>((set, get) => {
     },
     () => ({
       interruptTts: boolSetting(get().sttStatus, "interrupt_tts", true),
-      inactivityMs: CONVERSATION_INACTIVITY_MS,
+      inactivityMs: get().conversationAutoEnd ? CONVERSATION_INACTIVITY_MS : 0,
+      yieldToUser: get().conversationYield,
     }),
   );
 
@@ -176,12 +195,15 @@ export const useVoice = create<VoiceState>((set, get) => {
     voiceConfigured: false,
 
     recordingMode: null,
+    micMuted: false,
+    conversationAutoEnd: loadStoredFlag(AUTO_END_STORAGE_KEY, true),
+    conversationYield: loadStoredFlag(YIELD_STORAGE_KEY, true),
     listening: false,
     liveTranscript: "",
     voiceError: null,
 
     isSpeaking: false,
-    muted: loadMuted(),
+    muted: loadStoredFlag(MUTE_STORAGE_KEY, false),
 
     startVoice: (mode) => {
       if (session.mode() !== null) return;
@@ -235,6 +257,19 @@ export const useVoice = create<VoiceState>((set, get) => {
       session.speak(text);
     },
     stopSpeech: () => session.stopSpeech(),
+    toggleMicMuted: () => {
+      set({ micMuted: !get().micMuted });
+    },
+    setConversationAutoEnd: (value) => {
+      if (typeof localStorage !== "undefined")
+        localStorage.setItem(AUTO_END_STORAGE_KEY, value ? "1" : "0");
+      set({ conversationAutoEnd: value });
+    },
+    setConversationYield: (value) => {
+      if (typeof localStorage !== "undefined")
+        localStorage.setItem(YIELD_STORAGE_KEY, value ? "1" : "0");
+      set({ conversationYield: value });
+    },
     toggleMuted: () => {
       const next = !get().muted;
       if (typeof localStorage !== "undefined")
@@ -243,9 +278,10 @@ export const useVoice = create<VoiceState>((set, get) => {
       set({ muted: next });
     },
 
-    registerChat: (send, clearInput) => {
+    registerChat: (send, clearInput, reportSpeaking) => {
       sendCallback = send;
       clearInputCallback = clearInput;
+      reportSpeakingCallback = reportSpeaking;
     },
 
     patchStt: (patch) => {

--- a/apps/web/src/stores/use-voice.ts
+++ b/apps/web/src/stores/use-voice.ts
@@ -54,7 +54,8 @@ interface VoiceState {
   // A per-device mute of spoken replies. A conversation speaks regardless; this silences the
   // ambient read-aloud of replies outside one.
   muted: boolean;
-  // Microphone mute inside a conversation: frames stop flowing, the session stays up.
+  // Microphone mute inside a conversation: silence flows instead of speech, so the session
+  // (and any live turn's endpointing) stays up while nothing the user says gets through.
   micMuted: boolean;
   // End a silent conversation on its own after the inactivity window (on by default).
   conversationAutoEnd: boolean;
@@ -315,6 +316,10 @@ export const useVoice = create<VoiceState>((set, get) => {
     },
 
     _setAgentContext: (name, services, voiceRev) => {
+      // A live session is pinned to the agent it started with; past a switch the module-level
+      // chat callbacks belong to the new agent, so a surviving session would route its sends
+      // and speaking reports to the wrong daemon. The switch ends the session instead.
+      if (name !== get().agentName && session.mode() !== null) session.cancel();
       set({ agentName: name, services, voiceRev });
     },
 


### PR DESCRIPTION
## What

Two halves of one conversation-mode overhaul:

### Conversation drawer UI (web)
- The composer card morphs into a conversation surface: a Vesta orb driven by the real agent status with extra motion configs (minimal listening pulse, obvious talking pulse), and an action bar of mic-mute, a state pill carrying the live transcript (2 lines max, latest word bold), and an icon exit button.
- The chat recedes behind a scrim with a perspective transform, locks to the bottom, trims history, and skips the fake typing delay while a conversation runs; the bottom-inset reservation rides a CSS-variable transform during the morph so the whole transition stays off the layout path (120fps-clean).
- Agent settings gain a Voice section (dictation + conversation cards), `interrupt_tts` moves out of the provider card, and the provider gets its own tab.

### Yield-to-user turn gate (core + agent + mobile)
Vesta never talks over the user, while the user can still barge in:
- **Client** (`@vesta/core` voice-session): a yielding conversation reports the user's live turn (`onUserSpeakingChange`) and holds replies off the speaker until the turn ends; the STT session now closes empty turns so the gate can never stick.
- **Wire** (chat socket): a `{"type": "speaking", "active": bool}` inbound frame, cached and replayed on reconnect. Old daemons ignore it, old clients send none — fully additive.
- **Agent** (app-chat skill): the daemon ties the flag to the connection that set it (no timers; a dropped client clears it) and refuses `app-chat send` mid-turn with "the user is talking right now: drop this reply, wait for their next message, then answer the whole thought", so Vesta answers the full thought once instead of half of it. SKILL.md documents the contract.
- **Settings**: "never interrupt you" toggle in the conversation card, per device, on by default. Mobile is wired through the same core callback (always yields; its toggle lands with the mobile polish pass).

## Checks
- `./check.sh app-core` 466 ✓, `app-web` 319 ✓, `app-desktop` ✓, `app-mobile` ✓ (incl. clean-prebuild), `guards` ✓
- `./check.sh app-chat` 58/58 ✓ (six daemon tests need a short pytest basetemp on macOS due to the AF_UNIX path limit — pre-existing, they fail identically on master locally and pass on CI's Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Bgkkuep3ekk6Ef4EVLsCN