### PR TITLE
test(vestad): stop the harness pooling keep-alive connections

### DIFF
--- a/vestad/tests-integration/src/client.rs
+++ b/vestad/tests-integration/src/client.rs
@@ -124,6 +124,10 @@ impl Client {
         };
         let agent = ureq::Agent::config_builder()
             .http_status_as_error(false)
+            // No keep-alive reuse: the harness makes sequential blocking calls, so a pooled
+            // connection the gateway has since closed only surfaces as `io: Peer disconnected`
+            // on the next reuse. A fresh connection per request removes that race.
+            .max_idle_connections_per_host(0)
             .tls_config(tls_config)
             .build()
             .new_agent();


### PR DESCRIPTION
## Problem

The release pipeline for v0.2.16 flaked twice on the vestad e2e test `auth::provider_setup_and_catalogs_are_owned_by_the_named_agent` with `io: Peer disconnected`, at two different lines across the two attempts.

## Root cause

The integration harness `Client` (`vestad/tests-integration/src/client.rs`) uses one pooled `ureq::Agent` shared across every call in a test. ureq keeps idle keep-alive connections for a default 15s and reuses them. When it reuses a connection the gateway (hyper/axum) has meanwhile closed, it surfaces `io: Peer disconnected` instead of transparently reconnecting; for a POST it does not retry, so the test panics.

#2304 rewrote this test from two trivial direct gateway calls into one that creates an agent, polls `wait_until_running` for up to 180s, then fires ~8 relay calls on the shared pooled agent. That made it the first test with enough calls and wall-clock to hit the stale-reuse window.

It is a latent harness flake, not a relay regression: one of the two failures landed on `GET /manifest` with no auth, a route that 404s purely in the gateway and never reaches the agent, which pins the failure to the client-to-gateway pooled connection.

## Fix

Disable idle connection pooling in the test client (`max_idle_connections_per_host(0)`). The harness makes sequential blocking calls, so pooling buys nothing but this race; a fresh connection per request removes it at the layer that owns it. Test-only change, no product code touched.

Verified: `cargo check -p vesta-tests` passes. The full `server` suite is Docker+Linux-gated, so behavioral verification is CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)