### PR TITLE
fix(app-chat): stop the reply waterfall when the user starts talking

### DIFF
--- a/agent/skills/app-chat/SKILL.md
+++ b/agent/skills/app-chat/SKILL.md
@@ -29,6 +29,7 @@ server (intake, history, and the live `/ws` chat socket).
 ```bash
 app-chat daemon status
 app-chat send --message 'Hello!'
+app-chat send -m "hey" -m "one thought per -m" -m "they go out as separate bubbles, paced like texting"
 app-chat send --attach ~/out/chart.png --message 'here it is!'
 app-chat history --search 'query'
 app-chat history --limit 20
@@ -65,10 +66,10 @@ app-chat attachments rm <id> [<id>...] # frees the bytes, keeps the chat history
 
 ## Notes
 - Always reply to app messages using `app-chat send`, not through any other channel
-- In a live voice conversation, `send` is refused with `the user is talking right now: ...` while the user is mid-sentence. Do what the error says: drop that reply, wait for the next `source=app-chat` notification (it arrives when they finish), and answer their whole thought in one fresh reply
-- `send` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you re-send as several short calls, one thought each. Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass
-- A numbered or bulleted list is fine to send as one message (each item is one short thought); a line-leading marker like `1.` or `2)` is not a full stop, so a list does not need `--longform`
-- Send multiple short messages instead of one long one (like texting)
+- Send a whole reply in one `app-chat send`, one `-m` per bubble. The CLI sends them in order with a beat between, like texting. It lints every bubble first, so one malformed bubble stops the reply before any of it goes out
+- In a live voice conversation the CLI yields the floor for you: it stops sending the moment the user starts talking, drops the rest of the reply, and reports `stopped_for_user`. A fresh `source=app-chat` notification arrives when they finish. Answer their whole thought fresh then
+- `send` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you split it into several bubbles, one thought each (repeat `-m`). Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass
+- A numbered or bulleted list is fine to send as one bubble (each item is one short thought); a line-leading marker like `1.` or `2)` is not a full stop, so a list does not need `--longform`
 - Lowercase, no bullets, keep messages tight, texting feel, not document feel
 - Messages render as markdown: use fenced ``` blocks for code/commands, `[label](url)` for links. Newlines work
 - The app reconnects its chat socket automatically if the daemon or agent restarts

--- a/agent/skills/app-chat/cli/src/app_chat_cli/cli.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/cli.py
@@ -40,8 +40,15 @@ def _build_parser() -> argparse.ArgumentParser:
     send_p.add_argument(
         "--message",
         "-m",
-        default="",
-        help="Message text, or '-' to read the body from stdin (use a <<'MSG' heredoc for anything with apostrophes, quotes or newlines)",
+        action="append",
+        default=None,
+        help="One bubble; repeat -m for a multi-bubble reply, sent in order. '-' (as the only -m) reads one bubble from stdin",
+    )
+    send_p.add_argument(
+        "--gap",
+        type=float,
+        default=None,
+        help="Seconds between bubbles of a multi-bubble reply (default ~2.5s); pass 0 for no beat",
     )
     send_p.add_argument(
         "--attach",

--- a/agent/skills/app-chat/cli/src/app_chat_cli/commands.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/commands.py
@@ -20,30 +20,64 @@ def _fail(payload: dict[str, object]) -> None:
     sys.exit(1)
 
 
+_DEFAULT_GAP_SECS = 2.5
+
+
+def _collect_bubbles(message: list[str] | None) -> list[str]:
+    """The reply's bubbles, in order. A lone `-` reads one bubble from stdin, so a reply with
+    apostrophes, quotes or newlines rides a quoted heredoc. Blank bubbles are dropped so a stray
+    empty -m never sends an empty message."""
+    raw = message or []
+    if raw == ["-"]:
+        raw = [sys.stdin.read().rstrip("\r\n")]
+    return [bubble for bubble in raw if bubble.strip()]
+
+
 def cmd_send(args: argparse.Namespace) -> None:
-    # `-` reads the body from stdin, so a reply with apostrophes, quotes or newlines can be passed
-    # through a quoted heredoc instead of being escaped into an inline argument.
-    message = sys.stdin.read().rstrip("\r\n") if args.message == "-" else args.message
+    bubbles = _collect_bubbles(args.message)
     # Absolute paths cross the socket: the daemon's cwd is wherever `daemon start` ran, never the
     # sender's, so a relative --attach would resolve against the wrong directory.
     attach: list[str] = [str(pl.Path(path).expanduser().resolve()) for path in args.attach or []]
-    if not message and not attach:
+    if not bubbles and not attach:
         _fail({"error": "--message is empty (pass '-' and a <<'MSG' heredoc to read the body from stdin, or --attach a file)"})
 
-    if message and not args.longform:
-        reason = bubble_lint_reason(message)
-        if reason:
-            _fail({"error": reason})
+    if not args.longform:
+        # Lint every bubble before sending any of it, so a malformed bubble never leaves a
+        # half-sent waterfall behind.
+        for bubble in bubbles:
+            reason = bubble_lint_reason(bubble)
+            if reason:
+                _fail({"error": reason})
 
     sock_path = pl.Path(args.socket or (pl.Path.home() / ".app-chat" / "app-chat.sock"))
 
     if not sock_path.exists():
         _fail({"error": f"daemon not running (no socket at {sock_path})"})
 
-    result = asyncio.run(_send_via_socket(sock_path, message, attach))
+    gap = _DEFAULT_GAP_SECS if args.gap is None else args.gap
+    result = asyncio.run(_send_bubbles(sock_path, bubbles, attach, gap))
     if "error" in result:
         _fail(result)
     print(json.dumps(result))
+
+
+async def _send_bubbles(sock_path: pl.Path, bubbles: list[str], attach: list[str], gap: float) -> dict[str, object]:
+    """Send a reply as one paced, interruptible stream: bubbles go out in order with `gap` seconds
+    between them, the attachments ride the last one, and the first refusal while the user is talking
+    stops the rest (the daemon re-wakes the agent once the floor clears)."""
+    outbound = bubbles or [""]  # an attachment-only reply is one empty-text bubble carrying the file
+    sent: list[dict[str, object]] = []
+    for index, bubble in enumerate(outbound):
+        last = index == len(outbound) - 1
+        result = await _send_via_socket(sock_path, bubble, attach if last else [])
+        if "user_speaking" in result:
+            return {"ok": True, "sent": sent, "stopped_for_user": True}
+        if "error" in result:
+            return result
+        sent.append({"id": result["id"], "message": bubble})
+        if not last:
+            await asyncio.sleep(gap)
+    return {"ok": True, "sent": sent, "stopped_for_user": False}
 
 
 async def _send_via_socket(sock_path: pl.Path, message: str, attach: list[str]) -> dict[str, object]:

--- a/agent/skills/app-chat/cli/src/app_chat_cli/daemon.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/daemon.py
@@ -251,7 +251,9 @@ async def _handle_send(state: DaemonState, message: str, attach: list[str]) -> t
         return {"error": "empty message"}, None
     refusal = state.service.refuse_send_while_speaking()
     if refusal is not None:
-        return {"error": refusal}, None
+        # `user_speaking` marks the one refusal the sender must treat as "floor yielded", not an
+        # error: `send` stops the rest of a paced reply on it and exits clean.
+        return {"error": refusal, "user_speaking": True}, None
     metas, ingest_error = await _ingest_attachments(state, attach)
     if ingest_error is not None:
         return {"error": ingest_error}, None

--- a/agent/skills/app-chat/cli/tests/test_daemon.py
+++ b/agent/skills/app-chat/cli/tests/test_daemon.py
@@ -222,7 +222,10 @@ def test_send_is_refused_while_the_user_is_talking(tmp_path, monkeypatch):
 
     refused = asyncio.run(_socket_command(state, {"command": "send", "message": "mid-turn reply"}))
 
-    assert refused == {"error": "the user is talking right now: drop this reply, wait for their next message, then answer the whole thought"}
+    assert refused == {
+        "error": "the user is talking right now: drop this reply, wait for their next message, then answer the whole thought",
+        "user_speaking": True,
+    }
     assert state.service.store.page()[0] == []
 
     state.service.speaking.discard(speaking_conn)
@@ -473,7 +476,7 @@ def test_send_attach_only_is_valid_and_notifies_with_the_filename(tmp_path, monk
 def _send_args(tmp_path, **overrides):
     sock = tmp_path / "app-chat.sock"
     sock.touch()
-    defaults = {"message": "", "socket": str(sock), "longform": False, "attach": []}
+    defaults = {"message": None, "socket": str(sock), "longform": False, "attach": [], "gap": None}
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
 
@@ -503,7 +506,7 @@ def test_cmd_send_still_lints_text_when_attaching(tmp_path, monkeypatch, capsys)
     wall = "x" * 300
 
     with pytest.raises(SystemExit):
-        commands.cmd_send(_send_args(tmp_path, message=wall, attach=["/tmp/chart.png"]))
+        commands.cmd_send(_send_args(tmp_path, message=[wall], attach=["/tmp/chart.png"]))
     assert "error" in json.loads(capsys.readouterr().err)
 
 
@@ -512,6 +515,59 @@ def test_cmd_send_requires_text_or_attach(tmp_path, monkeypatch, capsys):
 
     with pytest.raises(SystemExit):
         commands.cmd_send(_send_args(tmp_path))
+    assert "error" in json.loads(capsys.readouterr().err)
+
+
+def test_cmd_send_paces_bubbles_in_order_and_honors_the_gap(tmp_path, monkeypatch, capsys):
+    sent: list[str] = []
+
+    async def fake_send(sock_path, message, attach):
+        sent.append(message)
+        return {"ok": True, "message": message, "id": len(sent)}
+
+    monkeypatch.setattr(commands, "_send_via_socket", fake_send)
+    gaps: list[float] = []
+
+    async def fake_sleep(secs):
+        gaps.append(secs)
+
+    monkeypatch.setattr(commands.asyncio, "sleep", fake_sleep)
+
+    commands.cmd_send(_send_args(tmp_path, message=["one", "two", "three"]))
+
+    assert sent == ["one", "two", "three"]
+    # a beat between each bubble, none after the last
+    assert gaps == [commands._DEFAULT_GAP_SECS, commands._DEFAULT_GAP_SECS]
+    out = json.loads(capsys.readouterr().out)
+    assert out["stopped_for_user"] is False
+    assert [bubble["message"] for bubble in out["sent"]] == ["one", "two", "three"]
+
+
+def test_cmd_send_stops_the_waterfall_when_the_user_starts_talking(tmp_path, monkeypatch, capsys):
+    sent: list[str] = []
+
+    async def fake_send(sock_path, message, attach):
+        sent.append(message)
+        if message == "two":
+            return {"error": "the user is talking right now: ...", "user_speaking": True}
+        return {"ok": True, "message": message, "id": len(sent)}
+
+    monkeypatch.setattr(commands, "_send_via_socket", fake_send)
+
+    commands.cmd_send(_send_args(tmp_path, message=["one", "two", "three"], gap=0))
+
+    assert sent == ["one", "two"]  # the refusal on "two" drops "three" before it is attempted
+    out = json.loads(capsys.readouterr().out)
+    assert out == {"ok": True, "sent": [{"id": 1, "message": "one"}], "stopped_for_user": True}
+
+
+def test_cmd_send_pre_lints_every_bubble_and_sends_nothing_on_a_wall(tmp_path, monkeypatch, capsys):
+    sent = _capture_socket_request(monkeypatch)
+    wall = "x" * 300
+
+    with pytest.raises(SystemExit):
+        commands.cmd_send(_send_args(tmp_path, message=["a quick one", wall]))
+    assert sent == []  # a malformed bubble stops the whole reply before anything is sent
     assert "error" in json.loads(capsys.readouterr().err)
 
 


### PR DESCRIPTION
## What

In a live voice conversation, a stray bubble still landed **right as the user stopped speaking**, because the agent's reply went out as many independent `app-chat send` calls paced by shell `sleep`. The daemon's speaking gate is checked per call and reopens the instant the user stops, so a later bubble of an already-interrupted reply slipped through: the trailing bubble in the window after the floor cleared but before the agent's fresh reply, or a bubble that landed during a brief pause. The gate could refuse one bubble but never recall the in-flight shell loop.

Found by retro'ing `eleven`'s logs on a real conversation: the first bubble of a reply was refused (`the user is talking right now`), then a later bubble of the same reply still persisted and was spoken.

## Fix

Move the waterfall into the CLI so it can be stopped as a unit:

- **`app-chat send` takes the whole reply** as repeated `-m` bubbles. The CLI sends them in order with a beat (`--gap` overrides the default), and the moment one is refused because the user is talking it drops the rest and returns `stopped_for_user`. The reply drops as a unit, so no stray bubble lands as the user stops. The daemon re-wakes the agent with the existing `user_finished_talking` notification when the floor clears.
- **Pre-lint all bubbles up front**, so a malformed bubble never leaves a half-sent reply.
- **Daemon:** one additive line, the refusal envelope carries `user_speaking` so the CLI distinguishes a yielded floor from a real error. The per-call gate and the turn-end re-wake are unchanged.
- Single `-m` still works, so nothing regresses. No client change, no wire-contract change.

No reply-id needed: sequential send + stop-on-refusal means there is no independent tail to poison.

## Testing

- `./check.sh app-chat` → 125 passed (4 new: pacing+order, stop-on-talk, pre-lint-all, refusal marker).
- `pytest tests/test_daemon_contract.py -k app-chat` → 12 passed (real daemon lifecycle intact).
- `./check.sh guards` → all checks passed.

## Out of scope

The client still flushes held bubbles at `onTurnEnd` (`voice-session.ts`) instead of dropping them. With this fix the residual is tiny (a single bubble emitted in the sub-second before the daemon sees `speaking:true`); a follow-up can flip flush to drop if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)