### PR TITLE
fix(web): let clicks reach agent cards in the drag carousel

### DIFF
--- a/apps/web/src/components/Home/AgentsCarousel/use-drag-scroll.ts
+++ b/apps/web/src/components/Home/AgentsCarousel/use-drag-scroll.ts
@@ -1,6 +1,7 @@
 import { useEffect, type RefObject } from "react";
 
-// Past this much movement a press counts as a drag, so the trailing click is swallowed.
+// Past this much movement a press becomes a drag; only then does it capture the pointer and take
+// over scrolling, so a plain click (which never moves this far) passes straight through to the card.
 const DRAG_THRESHOLD_PX = 5;
 // Fallback for restoring snap when `scrollend` never fires (unsupported, or the release already sat
 // on a snap point so the smooth scroll is a no-op).
@@ -9,10 +10,10 @@ const SETTLE_FALLBACK_MS = 500;
 export type DragPhase = "idle" | "dragging" | "settling";
 
 // Mouse click-drag to scroll the carousel; touch already scrolls it natively, so this binds only for
-// the mouse. During the drag it drives scrollLeft directly and reports "dragging" so the caller drops
-// CSS scroll snapping (a free drag). On release it smooth-scrolls to the nearest card itself and only
-// restores snapping once that settles, so the release glides instead of hard-snapping. It also
-// swallows the click that ends a real drag so releasing never opens the card underneath.
+// the mouse. It captures the pointer and reports "dragging" only once the press has moved past the
+// threshold, so a click reaches the card underneath, then drives scrollLeft directly (snapping off).
+// On release it smooth-scrolls to the nearest card and restores snapping once that settles, and it
+// swallows the click that ends a real drag so releasing never opens the card.
 export function useDragScroll(
   ref: RefObject<HTMLElement | null>,
   stride: number,
@@ -21,10 +22,12 @@ export function useDragScroll(
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    let active = false;
-    let moved = false;
+    let pressed = false;
+    let dragging = false;
+    let suppressNextClick = false;
     let startX = 0;
     let startScroll = 0;
+    let pointerId = -1;
     let settleCleanup: (() => void) | null = null;
 
     const clearSettle = () => {
@@ -51,35 +54,43 @@ export function useDragScroll(
     const onPointerDown = (event: PointerEvent) => {
       if (event.pointerType !== "mouse" || event.button !== 0) return;
       clearSettle();
-      active = true;
-      moved = false;
+      pressed = true;
+      dragging = false;
+      suppressNextClick = false;
       startX = event.clientX;
       startScroll = el.scrollLeft;
-      el.setPointerCapture(event.pointerId);
-      onPhaseChange("dragging");
+      pointerId = event.pointerId;
+      // No capture and no drag state yet: a press that never moves must click through to the card.
     };
     const onPointerMove = (event: PointerEvent) => {
-      if (!active) return;
+      if (!pressed) return;
       const dx = event.clientX - startX;
-      if (Math.abs(dx) > DRAG_THRESHOLD_PX) moved = true;
+      if (!dragging) {
+        if (Math.abs(dx) <= DRAG_THRESHOLD_PX) return;
+        dragging = true;
+        el.setPointerCapture(pointerId);
+        onPhaseChange("dragging");
+      }
       el.scrollLeft = startScroll - dx;
     };
-    const stop = (event: PointerEvent) => {
-      if (!active) return;
-      active = false;
-      if (el.hasPointerCapture(event.pointerId))
-        el.releasePointerCapture(event.pointerId);
+    const stop = () => {
+      if (!pressed) return;
+      pressed = false;
+      if (!dragging) return;
+      dragging = false;
+      suppressNextClick = true;
+      if (el.hasPointerCapture(pointerId)) el.releasePointerCapture(pointerId);
       settle();
     };
     const onClickCapture = (event: MouseEvent) => {
-      if (!moved) return;
-      moved = false;
+      if (!suppressNextClick) return;
+      suppressNextClick = false;
       event.preventDefault();
       event.stopPropagation();
     };
     // A drag over a card image/link would otherwise start a native drag-and-drop ghost.
     const onDragStart = (event: Event) => {
-      if (active) event.preventDefault();
+      if (pressed) event.preventDefault();
     };
 
     el.addEventListener("pointerdown", onPointerDown);


### PR DESCRIPTION
Regression from #2330's carousel mouse-drag: agent cards became unclickable because every press read as a drag.

## Cause
`useDragScroll` called `setPointerCapture` on `pointerdown`. Chromium retargets the subsequent `click` to the capturing element, so the click landed on the scroller, not the card, and the press flipped the carousel into its dragging state.

## Fix
Capture the pointer and enter the `dragging` state only once the press moves past the drag threshold. A plain click never captures, so it passes straight through to the card's `onClick`; a real drag captures, scrolls, and swallows just the click that ends it.

## Verification
TSC + ESLint clean. This is pointer-capture behavior that jsdom doesn't reproduce and the host is headless, so please confirm interactively that a click opens an agent card and a drag still scrolls without opening one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZPP58ESDFUduSKG8vpH2v