### PR TITLE
fix(vestad): validate the agent name before the token check reads an env file

### DIFF
--- a/vestad/src/auth.rs
+++ b/vestad/src/auth.rs
@@ -258,9 +258,10 @@ pub(crate) async fn proxy_authorized(
     )
 }
 
+/// The segment must pass `validate_name`, so a malformed one never names an env file to read.
 fn extract_agent_name(path: &str) -> Option<String> {
     let parts: Vec<&str> = path.trim_start_matches('/').split('/').collect();
-    if parts.len() >= 2 && parts[0] == "agents" {
+    if parts.len() >= 2 && parts[0] == "agents" && crate::docker::validate_name(parts[1]).is_ok() {
         Some(parts[1].to_string())
     } else {
         None
@@ -448,6 +449,17 @@ mod agent_name_extraction {
         assert_eq!(extract_agent_name("/vesta-cloud/pair"), None);
         assert_eq!(extract_agent_name("/health"), None);
         assert_eq!(extract_agent_name("/agents"), None);
+    }
+
+    #[test]
+    fn malformed_segments_name_no_agent_and_so_no_env_file() {
+        for segment in ["..", "Alpha", "a%2Fb", "-bad", "alpha.env", ""] {
+            assert_eq!(
+                extract_agent_name(&format!("/agents/{segment}/status")),
+                None,
+                "segment: {segment:?}"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
The agent-token middleware extracted the path segment after `/agents/` and read `agents_dir/<segment>.env` before any validation. A path segment cannot contain a slash, so the read could not leave the directory and the content was only compared to the header. It was still the one boundary that reached the filesystem with an unvalidated name, while every request handler runs `validate_name` first.

`extract_agent_name` now applies `validate_name`, so a malformed segment names no agent and both middleware tiers refuse before any file read. The new test covers dot-dot, uppercase, an encoded slash, a leading hyphen, a file suffix, and an empty segment.

Context: CodeQL reported 31 `rust/path-injection` alerts on master. Reviewed today: 14 trace `config_dir`, which comes from `HOME`, and 17 trace agent names that `validate_name` restricts to `[a-z0-9-]`, so none can leave its directory. All 31 are dismissed as false positives with that reason recorded on each alert. This PR closes the one inconsistency the review found.

Checks: `./check.sh vestad` green (clippy clean, 497 tests plus the new one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)