### PR TITLE
fix(skills/google): log the calendar auth error once per outage

### DIFF
--- a/agent/skills/google/cli/src/google_cli/monitor.py
+++ b/agent/skills/google/cli/src/google_cli/monitor.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
@@ -101,12 +102,15 @@ def _poll_unit(ctx: GoogleContext, state: MonitorState, unit: str, new_check_tim
     units[unit] = new_check_time.isoformat() if read else query_since.isoformat()
 
 
-def notify_broken_once(ctx: GoogleContext, marker_name: str, notif_type: str, error: Exception) -> None:
+def notify_broken_once(ctx: GoogleContext, marker_name: str, notif_type: str, error: Exception) -> bool:
+    """Return True on the cycle that reports the failure, so the caller logs it at ERROR exactly once
+    and at DEBUG while the marker stands: a terminal failure repeats every cycle until the user acts."""
     marker = ctx.monitor_base_dir / marker_name
     if marker.exists():
-        return
+        return False
     notifications.write_notification(ctx.notif_dir, notif_type, interrupt=True, error=str(error))
     marker.write_text(datetime.now(UTC).isoformat())
+    return True
 
 
 def clear_broken_marker(ctx: GoogleContext, marker_name: str) -> None:
@@ -267,8 +271,8 @@ def _poll_calendar(ctx: GoogleContext, new_check_time: datetime, query_since: da
         # Calendar is terminally refused (e.g. a token minted under the old
         # shared client, whose project has the Calendar API disabled) while
         # Gmail still works: tell the agent once, keep polling mail.
-        logger.error("Error fetching calendar: %s", e)
-        notify_broken_once(ctx, CALENDAR_BROKEN_MARKER, "calendar_auth_broken", e)
+        reported = notify_broken_once(ctx, CALENDAR_BROKEN_MARKER, "calendar_auth_broken", e)
+        logger.log(logging.ERROR if reported else logging.DEBUG, "Error fetching calendar: %s", e)
         return False
     except Exception as e:
         # A calendar failure must not sink the whole poll cycle (Gmail still ran).
@@ -294,8 +298,8 @@ def run(ctx: GoogleContext):
                 # Terminal auth failure (no token, dead refresh): every poll would
                 # fail, so tell the agent once and leave every watermark parked; the
                 # next healthy cycle re-reads the gap (clamped to MAX_CATCHUP_LOOKBACK).
-                logger.error("Google auth is broken: %s", e)
-                notify_broken_once(ctx, AUTH_BROKEN_MARKER, "auth_broken", e)
+                reported = notify_broken_once(ctx, AUTH_BROKEN_MARKER, "auth_broken", e)
+                logger.log(logging.ERROR if reported else logging.DEBUG, "Google auth is broken: %s", e)
                 if ctx.monitor_stop_event.wait(45):
                     break
                 continue

--- a/agent/skills/google/cli/tests/test_monitor.py
+++ b/agent/skills/google/cli/tests/test_monitor.py
@@ -65,8 +65,8 @@ def test_notify_broken_once_writes_a_single_interrupt_notification(tmp_path):
     ctx = _ctx(tmp_path)
     error = ValueError("Token refresh failed. run 'google auth login' to sign in again.")
 
-    monitor.notify_broken_once(ctx, monitor.AUTH_BROKEN_MARKER, "auth_broken", error)
-    monitor.notify_broken_once(ctx, monitor.AUTH_BROKEN_MARKER, "auth_broken", error)
+    assert monitor.notify_broken_once(ctx, monitor.AUTH_BROKEN_MARKER, "auth_broken", error) is True
+    assert monitor.notify_broken_once(ctx, monitor.AUTH_BROKEN_MARKER, "auth_broken", error) is False
 
     files = _notif_files(ctx, "auth_broken")
     assert len(files) == 1
@@ -107,6 +107,31 @@ def test_run_surfaces_terminal_auth_failure_once_and_keeps_quiet(tmp_path, monke
     assert len(_notif_files(ctx, "auth_broken")) == 1
 
 
+def _levels(caplog, message_prefix: str) -> list[int]:
+    return [record.levelno for record in caplog.records if record.getMessage().startswith(message_prefix)]
+
+
+def test_repeated_google_auth_failure_logs_error_once_then_debug_until_the_marker_clears(tmp_path, monkeypatch, caplog):
+    ctx = _ctx(tmp_path)
+
+    def broken_auth(config):
+        ctx.monitor_stop_event.set()
+        raise ValueError("Token refresh failed. run 'google auth login' to sign in again.")
+
+    monkeypatch.setattr(monitor.api, "gmail_service", broken_auth)
+
+    with caplog.at_level(logging.DEBUG, logger=ctx.monitor_logger.name):
+        monitor.run(ctx)
+        ctx.monitor_stop_event.clear()
+        monitor.run(ctx)
+        assert _levels(caplog, "Google auth is broken") == [logging.ERROR, logging.DEBUG]
+
+        monitor.clear_broken_marker(ctx, monitor.AUTH_BROKEN_MARKER)  # auth recovered, then broke again
+        ctx.monitor_stop_event.clear()
+        monitor.run(ctx)
+        assert _levels(caplog, "Google auth is broken") == [logging.ERROR, logging.DEBUG, logging.ERROR]
+
+
 class _FakeGmail:
     """Minimal chainable gmail service returning an empty inbox."""
 
@@ -144,6 +169,28 @@ def test_run_surfaces_calendar_auth_error_once_while_gmail_works(tmp_path, monke
     assert "google auth login" in payload["error"]
     # Gmail auth is fine, so the auth_broken path never fired.
     assert _notif_files(ctx, "auth_broken") == []
+
+
+def test_repeated_calendar_auth_error_logs_error_once_then_debug_until_the_marker_clears(tmp_path, monkeypatch, caplog):
+    ctx = _ctx(tmp_path)
+    monkeypatch.setattr(monitor.api, "gmail_service", lambda config: _FakeGmail())
+
+    def broken_calendar(config, **kwargs):
+        ctx.monitor_stop_event.set()
+        raise calendar.CalendarAuthError("Calendar API disabled for this client; run 'google auth login'")
+
+    monkeypatch.setattr(monitor.calendar, "list_events_between", broken_calendar)
+
+    with caplog.at_level(logging.DEBUG, logger=ctx.monitor_logger.name):
+        monitor.run(ctx)
+        ctx.monitor_stop_event.clear()
+        monitor.run(ctx)
+        assert _levels(caplog, "Error fetching calendar") == [logging.ERROR, logging.DEBUG]
+
+        monitor.clear_broken_marker(ctx, monitor.CALENDAR_BROKEN_MARKER)  # calendar recovered, then broke again
+        ctx.monitor_stop_event.clear()
+        monitor.run(ctx)
+        assert _levels(caplog, "Error fetching calendar") == [logging.ERROR, logging.DEBUG, logging.ERROR]
 
 
 # -- outage-gap recovery: a failed poll parks its own watermark ---------------


### PR DESCRIPTION
## Problem

`calendar.CalendarAuthError` is Google terminally refusing the calendar (for example the Calendar API disabled on the Cloud project behind the OAuth client). It cannot clear itself, so the 45 second poll loop raises it again on every cycle, correctly still polling Gmail. The handler already tells the agent exactly once through `notify_broken_once` and its `CALENDAR_BROKEN_MARKER`, but the `logger.error` beside it had no guard, so every cycle appended another identical line. On one box that produced 61,819 identical ERROR lines and 67 MB of `google.log` from one known condition, burying every other error and making a nightly error-count probe report the already-notified failure as fresh every night. Diagnosis and evidence from #2339 (mozzy).

## Change

- `notify_broken_once` returns `bool`: True on the cycle that wrote the notification and the marker, False while the marker stands. The marker file already encodes "this failure is known and reported", so the log line reuses that decision instead of growing a timer or module-level state.
- The `CalendarAuthError` branch of `_poll_calendar` logs at ERROR when `notify_broken_once` returns True and at DEBUG otherwise. `clear_broken_marker` on a healthy read re-arms both the notification and the ERROR line, so a later break is loud again with no separate reset.
- The `gmail_service` `ValueError` branch in `run()` had the same shape (an unguarded `logger.error` next to the same `notify_broken_once` on `AUTH_BROKEN_MARKER`), so it gets the identical two-line treatment. Same root cause, same fix, no second mechanism.
- The generic `Exception` branch in `_poll_calendar` is unchanged: those failures are transient and each one is news.

## Evidence

`agent/skills/google/cli`: `uv run pytest -q` passes, 94 tests (92 before, 2 new). New tests, written failing first:

- `test_repeated_calendar_auth_error_logs_error_once_then_debug_until_the_marker_clears`: two failing cycles log `[ERROR, DEBUG]`; after `clear_broken_marker` a third failing cycle logs `[ERROR, DEBUG, ERROR]`.
- `test_repeated_google_auth_failure_logs_error_once_then_debug_until_the_marker_clears`: the same sequence through the `run()` auth branch.
- `test_notify_broken_once_writes_a_single_interrupt_notification` now also pins the return contract (`True` then `False`).

`./check.sh guards` passes. `ruff format --check` and `ruff check` clean on both changed files. No em or en dashes in the changed files.

fixes #2338

Supersedes #2339.
