### PR TITLE
fix(skills/app-chat): send message bodies through stdin, one bubble per paragraph

### DIFF
--- a/agent/skills/app-chat/SKILL.md
+++ b/agent/skills/app-chat/SKILL.md
@@ -28,13 +28,27 @@ server (intake, history, and the live `/ws` chat socket).
 ## Quick Reference
 ```bash
 app-chat daemon status
-app-chat send --message 'Hello!'
-app-chat send -m "hey" -m "one thought per -m" -m "they go out as separate bubbles, paced like texting"
-app-chat send --attach ~/out/chart.png --message 'here it is!'
+
+# The one shape to use for any message body. Replace only the middle lines: a blank line starts the next bubble.
+app-chat send --message - <<'MSG'
+hey, one thought per paragraph
+
+they go out as separate bubbles, paced like texting
+MSG
+
+app-chat send --attach ~/out/chart.png --message - <<'MSG'
+here it is!
+MSG
+
+app-chat send --longform --message - <<'MSG'   # a brief or list they asked for: the whole body is one bubble
+<the brief, blank lines and all>
+MSG
 app-chat history --search 'query'
 app-chat history --limit 20
 app-chat attachments list
 ```
+
+Send every message body through `--message -` and a quoted heredoc, as above. The shell expands nothing inside `<<'MSG'`, so apostrophes, quotes, backticks, `$(...)`, `$200` and newlines all pass through untouched. An inline `--message 'text'` breaks on the first apostrophe, so use it only for text you can see has none.
 
 ## How it works
 - The daemon is a registered service: it owns the `app-chat` channel, serving `POST /message` (intake) and `GET /history` on its registered port, backed by its own store (`~/.app-chat/app-chat.db`)
@@ -66,9 +80,9 @@ app-chat attachments rm <id> [<id>...] # frees the bytes, keeps the chat history
 
 ## Notes
 - Always reply to app messages using `app-chat send`, not through any other channel
-- Send a whole reply in one `app-chat send`, one `-m` per bubble. The CLI sends them in order with a beat between, like texting. It lints every bubble first, so one malformed bubble stops the reply before any of it goes out
+- Send a whole reply in one `app-chat send`, one paragraph per bubble in the heredoc (or one `-m` per bubble for text without apostrophes). The CLI sends them in order with a beat between, like texting. It lints every bubble first, so one malformed bubble stops the reply before any of it goes out
 - In a live voice conversation the CLI yields the floor for you: it stops sending the moment the user starts talking, drops the rest of the reply, and reports `stopped_for_user`. A fresh `source=app-chat` notification arrives when they finish. Answer their whole thought fresh then
-- `send` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you split it into several bubbles, one thought each (repeat `-m`). Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass
+- `send` enforces short-bubble texting: a wall (over ~220 chars, or any text after a full stop) is rejected so you split it into several bubbles, one thought each (a blank line between them). Don't use full stops at all: a `.`, `!` or `?` may only close a bubble, never carry text after it. Ellipses stay free, they're a beat rather than a stop. For genuine reference material the user asked for (a brief, a code block, a list), pass `--longform` to bypass
 - A numbered or bulleted list is fine to send as one bubble (each item is one short thought); a line-leading marker like `1.` or `2)` is not a full stop, so a list does not need `--longform`
 - Lowercase, no bullets, keep messages tight, texting feel, not document feel
 - Messages render as markdown: use fenced ``` blocks for code/commands, `[label](url)` for links. Newlines work

--- a/agent/skills/app-chat/cli/src/app_chat_cli/cli.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/cli.py
@@ -42,7 +42,10 @@ def _build_parser() -> argparse.ArgumentParser:
         "-m",
         action="append",
         default=None,
-        help="One bubble; repeat -m for a multi-bubble reply, sent in order. '-' (as the only -m) reads one bubble from stdin",
+        help=(
+            "One bubble; repeat -m for a multi-bubble reply, sent in order. '-' (as the only -m) reads the reply from stdin, "
+            "one bubble per blank-line-separated paragraph (one bubble in all under --longform)"
+        ),
     )
     send_p.add_argument(
         "--gap",

--- a/agent/skills/app-chat/cli/src/app_chat_cli/commands.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/commands.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import os
 import pathlib as pl
+import re
 import sqlite3
 import sys
 import typing as tp
@@ -23,18 +24,20 @@ def _fail(payload: dict[str, object]) -> None:
 _DEFAULT_GAP_SECS = 2.5
 
 
-def _collect_bubbles(message: list[str] | None) -> list[str]:
-    """The reply's bubbles, in order. A lone `-` reads one bubble from stdin, so a reply with
+def _collect_bubbles(message: list[str] | None, longform: bool) -> list[str]:
+    """The reply's bubbles, in order. A lone `-` reads the whole reply from stdin, one bubble per
+    blank-line-separated paragraph (one bubble in all under --longform), so a reply with
     apostrophes, quotes or newlines rides a quoted heredoc. Blank bubbles are dropped so a stray
     empty -m never sends an empty message."""
     raw = message or []
     if raw == ["-"]:
-        raw = [sys.stdin.read().rstrip("\r\n")]
+        body = sys.stdin.read()
+        raw = [paragraph.strip("\r\n") for paragraph in ([body] if longform else re.split(r"\n\s*\n", body))]
     return [bubble for bubble in raw if bubble.strip()]
 
 
 def cmd_send(args: argparse.Namespace) -> None:
-    bubbles = _collect_bubbles(args.message)
+    bubbles = _collect_bubbles(args.message, args.longform)
     # Absolute paths cross the socket: the daemon's cwd is wherever `daemon start` ran, never the
     # sender's, so a relative --attach would resolve against the wrong directory.
     attach: list[str] = [str(pl.Path(path).expanduser().resolve()) for path in args.attach or []]

--- a/agent/skills/app-chat/cli/tests/test_daemon.py
+++ b/agent/skills/app-chat/cli/tests/test_daemon.py
@@ -4,6 +4,7 @@ start/stop/restart/status verbs against the pid and port records."""
 import argparse
 import asyncio
 import functools
+import io
 import json
 import os
 import signal
@@ -541,6 +542,23 @@ def test_cmd_send_paces_bubbles_in_order_and_honors_the_gap(tmp_path, monkeypatc
     out = json.loads(capsys.readouterr().out)
     assert out["stopped_for_user"] is False
     assert [bubble["message"] for bubble in out["sent"]] == ["one", "two", "three"]
+
+
+@pytest.mark.parametrize(
+    ("longform", "bubbles"),
+    [
+        (False, ["can't wait", "see you at 8"]),
+        (True, ["can't wait\n\nsee you at 8"]),
+    ],
+)
+def test_cmd_send_reads_a_stdin_reply_as_one_bubble_per_paragraph(tmp_path, monkeypatch, capsys, longform, bubbles):
+    sent = _capture_socket_request(monkeypatch)
+    monkeypatch.setattr(commands.sys, "stdin", io.StringIO("can't wait\n\nsee you at 8\n"))
+
+    commands.cmd_send(_send_args(tmp_path, message=["-"], gap=0, longform=longform))
+
+    assert [message for message, _ in sent] == bubbles
+    assert [bubble["message"] for bubble in json.loads(capsys.readouterr().out)["sent"]] == bubbles
 
 
 def test_cmd_send_stops_the_waterfall_when_the_user_starts_talking(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Problem

Message bodies for `app-chat send` went through shell word-splitting because `agent/skills/app-chat/SKILL.md` showed only inline quoting (`--message 'Hello!'`). #2291 reports `$200` inside a double-quoted body reaching the user as `00`; #2316 reports `luna's` in a single-quoted body reaching the user as `luna\s` after a botched `'\''` escape. Both are plain bash behaviour, and no quoting rule fixes both: single quotes break on `'`, double quotes break on `$`, backtick and `\`. The CLI already had the right layer (`--message -` reads the body from stdin, and the daemon's notification names `app-chat send --message -` as the `reply_command`), but the skill never showed it, and `-` read stdin as exactly one bubble, so a multi-bubble reply containing an apostrophe had no shell-safe shape at all.

## Change

- `agent/skills/app-chat/SKILL.md`: the Quick Reference now uses the same quoted-heredoc block whatsapp and telegram document as "the one shape to use for any message body", plus the note that `<<'MSG'` expands nothing and that inline `--message 'text'` is only for text visibly without apostrophes. The Notes bullets on bubbles now say "one paragraph per bubble" alongside `-m`.
- `_collect_bubbles` (`commands.py`): `--message -` splits stdin on blank lines into one bubble per paragraph, so a whole paced reply rides one heredoc; under `--longform` stdin stays one bubble, since a brief or list legitimately contains blank lines. `--message` help text in `cli.py` states the same rule.
- No shell-quoting rule anywhere: the fix is at the one layer (stdin) where the shell cannot touch the body.

## Evidence

- New test `test_cmd_send_reads_a_stdin_reply_as_one_bubble_per_paragraph` (parametrized: split without `--longform`, one bubble with it) in `agent/skills/app-chat/cli/tests/test_daemon.py`. Fails on the previous `_collect_bubbles` (the paragraph-split case), passes now.
- `cd agent/skills/app-chat/cli && uv run pytest -q`: 129 passed.
- `./check.sh guards`: all checks passed. `grep -rnP '\x{2014}|\x{2013}' agent/skills/app-chat/SKILL.md`: empty.

Supersedes #2291, #2316.
