### PR TITLE
fix(enable-banking): key transactions on entry_reference and report amount revisions

### DIFF
--- a/agent/skills/enable-banking/SKILL.md
+++ b/agent/skills/enable-banking/SKILL.md
@@ -36,6 +36,7 @@ finance daemon start
 ```
 
 - **Seen transactions**: tracked in `~/.finance/seen_transactions.json`
+- **Revised amounts**: a pending card authorisation keeps its `entry_reference` while its amount moves, so the seen set is keyed on that reference. A known reference reappearing with a different amount notifies as `Revised transaction (not a new charge)`, naming both amounts: it supersedes the earlier one, it is not a second charge at the same merchant.
 - **First-run seeding**: on first start, if no seen file exists, it seeds all transactions from the last 30 days so old ones don't trigger notifications
 - **Manual seed**: `/root/.local/share/uv/tools/finance/bin/python -m finance_cli.transaction_watcher seed`
 

--- a/agent/skills/enable-banking/cli/src/finance_cli/transaction_watcher.py
+++ b/agent/skills/enable-banking/cli/src/finance_cli/transaction_watcher.py
@@ -23,20 +23,44 @@ def atomic_write_text(path: Path, text: str) -> None:
     tmp.replace(path)
 
 
-def load_seen() -> set[str]:
+def load_seen() -> dict[str, str]:
+    """The seen transactions as {id: last seen amount}."""
     if SEEN_FILE.exists():
-        return set(json.loads(SEEN_FILE.read_text()))
-    return set()
+        return json.loads(SEEN_FILE.read_text())
+    return {}
 
 
-def save_seen(seen: set[str]) -> None:
+def save_seen(seen: dict[str, str]) -> None:
     SEEN_FILE.parent.mkdir(parents=True, exist_ok=True)
-    SEEN_FILE.write_text(json.dumps(list(seen)))
+    SEEN_FILE.write_text(json.dumps(seen))
+
+
+def seen_file_is_current() -> bool:
+    # LEGACY(remove-when: no fleet seen_transactions.json is a JSON list): a list holds ids with no
+    # amounts, so the poller cannot read it and re-seeds instead, once and silently.
+    return SEEN_FILE.exists() and isinstance(json.loads(SEEN_FILE.read_text()), dict)
+
+
+def tx_amount(tx: dict) -> str:
+    return str(tx["transaction_amount"]["amount"])
 
 
 def make_tx_id(tx: dict) -> str:
-    """Create a unique ID for a transaction."""
-    return f"{tx.get('entry_reference', '')}-{tx.get('booking_date', '')}-{tx.get('transaction_amount', {}).get('amount', '')}"
+    """Identity of a transaction, stable across in-place revisions.
+
+    `entry_reference` is the provider's own unique reference for the record, so it is the whole id
+    whenever it is present. A pending card authorisation keeps its reference while its amount moves
+    as the merchant finalises, so an amount inside the key makes that revision read as a brand new
+    transaction. The date-amount composite is the fallback for providers that send no reference."""
+    reference = tx["entry_reference"] if "entry_reference" in tx else ""
+    if reference:
+        return reference
+    booking_date = tx["booking_date"] if "booking_date" in tx else ""
+    return f"{booking_date}-{tx_amount(tx)}"
+
+
+def currency_symbol(currency: str) -> str:
+    return {"GBP": "£", "EUR": "€", "USD": "$"}.get(currency, currency + " ")
 
 
 def format_tx(tx: dict) -> str:
@@ -64,15 +88,12 @@ def format_tx(tx: dict) -> str:
     credit_debit = tx.get("credit_debit_indicator", "")
     sign = "+" if credit_debit == "CRDT" else "-" if credit_debit == "DBIT" else ""
 
-    # Currency symbol
-    symbols = {"GBP": "£", "EUR": "€", "USD": "$"}
-    sym = symbols.get(currency, currency + " ")
-
-    return f"{sign}{sym}{amount} — {details}"
+    return f"{sign}{currency_symbol(currency)}{amount} — {details}"
 
 
 def poll_once() -> list[dict]:
-    """Check for new transactions. Returns list of new ones."""
+    """Check for transactions to report: the ones never seen, plus the ones whose amount moved
+    since the last poll, tagged with `_previous_amount`."""
     from finance_cli.enablebanking import get_transactions
 
     config_path = Path.home() / ".finance" / "config.json"
@@ -84,7 +105,7 @@ def poll_once() -> list[dict]:
         return []
 
     seen = load_seen()
-    new_txs = []
+    new_txs: list[dict] = []
 
     # Only check last 2 days to keep it fast
     date_from = (datetime.now(UTC) - timedelta(days=2)).strftime("%Y-%m-%d")
@@ -95,10 +116,15 @@ def poll_once() -> list[dict]:
             txs = get_transactions(conf, account["uid"], date_from=date_from, date_to=date_to)
             for tx in txs:
                 tx_id = make_tx_id(tx)
-                if tx_id and tx_id not in seen:
-                    seen.add(tx_id)
-                    tx["_account_currency"] = account.get("currency", "")
-                    new_txs.append(tx)
+                amount = tx_amount(tx)
+                previous = seen[tx_id] if tx_id in seen else None
+                seen[tx_id] = amount
+                if previous == amount:
+                    continue
+                if previous is not None:
+                    tx["_previous_amount"] = previous
+                tx["_account_currency"] = account.get("currency", "")
+                new_txs.append(tx)
         except Exception as e:
             print(f"Error checking account {account.get('uid', '?')}: {e}", file=sys.stderr)
 
@@ -106,9 +132,18 @@ def poll_once() -> list[dict]:
     return new_txs
 
 
-def write_notification(tx: dict) -> None:
-    """Write a notification JSON for a new transaction."""
+def notification_message(tx: dict) -> str:
+    """A revision names both amounts and says it supersedes the earlier one, so a revised
+    authorisation never reads as a second, duplicate charge."""
     formatted = format_tx(tx)
+    if "_previous_amount" not in tx:
+        return f"New transaction: {formatted}"
+    was = f"{currency_symbol(tx['transaction_amount']['currency'])}{tx['_previous_amount']}"
+    return f"Revised transaction (not a new charge): {formatted}, updated from {was}"
+
+
+def write_notification(tx: dict) -> None:
+    """Write a notification JSON for a new or revised transaction."""
     notification = {
         "type": "finance",
         "source": "finance",
@@ -116,7 +151,7 @@ def write_notification(tx: dict) -> None:
         # pools by default. The user can add an interrupt rule for e.g. large amounts if they want.
         "interrupt": False,
         "timestamp": datetime.now(UTC).replace(microsecond=0).isoformat(),
-        "message": f"New transaction: {formatted}",
+        "message": notification_message(tx),
     }
 
     filename = f"{time.time_ns()}-finance-message.json"
@@ -130,7 +165,7 @@ def seed_seen() -> None:
     config_path = Path.home() / ".finance" / "config.json"
     conf = json.loads(config_path.read_text())
 
-    seen = set()
+    seen: dict[str, str] = {}
     date_from = (datetime.now(UTC) - timedelta(days=30)).strftime("%Y-%m-%d")
     date_to = datetime.now(UTC).strftime("%Y-%m-%d")
 
@@ -138,9 +173,7 @@ def seed_seen() -> None:
         try:
             txs = get_transactions(conf, account["uid"], date_from=date_from, date_to=date_to)
             for tx in txs:
-                tx_id = make_tx_id(tx)
-                if tx_id:
-                    seen.add(tx_id)
+                seen[make_tx_id(tx)] = tx_amount(tx)
         except Exception as e:
             print(f"Error seeding account {account.get('uid', '?')}: {e}", file=sys.stderr)
 
@@ -203,10 +236,9 @@ def _poll_forever() -> None:
         try:
             # The seed is what keeps the first poll quiet, and it needs the config a watcher
             # started before sign-in does not have yet, so a failure just waits a cycle.
-            if SEEN_FILE.exists():
+            if seen_file_is_current():
                 for tx in poll_once():
-                    formatted = format_tx(tx)
-                    print(f"New: {formatted}")
+                    print(notification_message(tx))
                     write_notification(tx)
             else:
                 print("First run — seeding existing transactions...")

--- a/agent/skills/enable-banking/cli/tests/test_transaction_watcher.py
+++ b/agent/skills/enable-banking/cli/tests/test_transaction_watcher.py
@@ -1,8 +1,11 @@
 """Behavior-locking tests for the transaction watcher's notification write path."""
 
 import json
+import sys
+import types
 from pathlib import Path
 
+import pytest
 from finance_cli import transaction_watcher as tw
 
 
@@ -53,3 +56,112 @@ def test_successive_notification_filenames_sort_in_send_order(tmp_path, monkeypa
         written_order.append(latest.name)
 
     assert sorted(written_order) == written_order
+
+
+def pending(reference, amount, details="Coffee Shop"):
+    return {
+        "entry_reference": reference,
+        "booking_date": "2026-08-30",
+        "status": "PDNG",
+        "transaction_amount": {"amount": amount, "currency": "GBP"},
+        "remittance_information_unstructured": details,
+        "credit_debit_indicator": "DBIT",
+    }
+
+
+def provider(tmp_path, monkeypatch, batches) -> Path:
+    """A signed-in config under tmp_path and a fake provider answering successive fetches with
+    `batches` in order. Returns the seen file the watcher will read and write."""
+    monkeypatch.setattr(tw, "SEEN_FILE", tmp_path / "seen_transactions.json")
+    module = types.ModuleType("finance_cli.enablebanking")
+    pending_batches = list(batches)
+    module.get_transactions = lambda *args, **kwargs: pending_batches.pop(0)
+    monkeypatch.setitem(sys.modules, "finance_cli.enablebanking", module)
+    monkeypatch.setattr(tw.Path, "home", staticmethod(lambda: tmp_path))
+    config = tmp_path / ".finance" / "config.json"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(json.dumps({"session_id": "s", "accounts": [{"uid": "a", "currency": "GBP"}]}))
+    return tw.SEEN_FILE
+
+
+def run_poll(tmp_path, monkeypatch, batches):
+    """Drive poll_once over successive provider responses against one seen file."""
+    provider(tmp_path, monkeypatch, batches)
+    return [tw.poll_once() for _ in batches]
+
+
+def stop_after_one_cycle(_seconds):
+    raise KeyboardInterrupt
+
+
+def test_id_is_the_provider_reference_when_there_is_one():
+    """The amount must stay out of the identity: a pending authorisation mutates its amount in
+    place while keeping its reference, and an amount in the key makes that read as a new charge."""
+    reference = "6a93f9da-32c0-aabf-92ec-971c6ea9b82f"
+    assert tw.make_tx_id(pending(reference, "88.67")) == reference
+    assert tw.make_tx_id(pending(reference, "25.76")) == reference
+
+
+def test_id_falls_back_to_the_composite_without_a_reference():
+    tx = pending("", "12.50")
+    assert tw.make_tx_id(tx) == "2026-08-30-12.50"
+    assert tw.make_tx_id(pending("", "9.99")) != tw.make_tx_id(tx)
+
+
+def test_revised_pending_amount_is_reported_as_a_revision_not_a_new_transaction(tmp_path, monkeypatch):
+    reference = "6a93f9da-32c0-aabf-92ec-971c6ea9b82f"
+    first, second = run_poll(tmp_path, monkeypatch, [[pending(reference, "88.67")], [pending(reference, "25.76")]])
+
+    assert [tw.notification_message(tx) for tx in first] == ["New transaction: -£88.67 — Coffee Shop"]
+    (revision,) = second
+    assert revision["_previous_amount"] == "88.67"
+    message = tw.notification_message(revision)
+    assert "£25.76" in message and "£88.67" in message
+    assert not message.startswith("New transaction")
+
+
+def test_unchanged_pending_transaction_is_silent(tmp_path, monkeypatch):
+    reference = "6a93f9da-32c0-aabf-92ec-971c6ea9b82f"
+    _, second, third = run_poll(tmp_path, monkeypatch, [[pending(reference, "88.67")]] * 3)
+    assert second == [] and third == []
+
+
+def test_a_genuinely_new_reference_still_notifies(tmp_path, monkeypatch):
+    old, new = "6a93f9da-32c0-aabf-92ec-971c6ea9b82f", "1b0c77ae-5d21-4f0a-9a3c-2f1e6d4b8c90"
+    _, second = run_poll(tmp_path, monkeypatch, [[pending(old, "88.67")], [pending(old, "88.67"), pending(new, "4.20")]])
+    assert [tx["entry_reference"] for tx in second] == [new]
+    assert tw.notification_message(second[0]) == "New transaction: -£4.20 — Coffee Shop"
+
+
+def test_a_list_format_seen_file_is_reseeded_not_polled(tmp_path, monkeypatch):
+    """A list cannot carry amounts, so the loop treats it as no seen file: one silent 30-day seed,
+    no notification for anything the seed covers."""
+    reference = "6a93f9da-32c0-aabf-92ec-971c6ea9b82f"
+    seen_file = provider(tmp_path, monkeypatch, [[pending(reference, "88.67")]])
+    seen_file.write_text(json.dumps([f"{reference}-2026-08-30-88.67"]))
+    monkeypatch.setattr(tw, "NOTIFICATIONS_DIR", tmp_path / "notifications")
+    monkeypatch.setattr(tw.time, "sleep", stop_after_one_cycle)
+
+    with pytest.raises(KeyboardInterrupt):
+        tw._poll_forever()
+
+    assert json.loads(seen_file.read_text()) == {reference: "88.67"}
+    assert not (tmp_path / "notifications").exists()
+
+
+def test_seed_seen_keys_the_file_the_same_way_as_the_poller(tmp_path, monkeypatch):
+    reference = "6a93f9da-32c0-aabf-92ec-971c6ea9b82f"
+    seen_file = provider(tmp_path, monkeypatch, [[pending(reference, "88.67")]] * 2)
+
+    tw.seed_seen()
+    assert json.loads(seen_file.read_text()) == {reference: "88.67"}
+    assert tw.poll_once() == []
+
+
+def test_write_notification_carries_the_revision_wording(tmp_path, monkeypatch):
+    monkeypatch.setattr(tw, "NOTIFICATIONS_DIR", tmp_path / "notifications")
+    tx = pending("ref", "25.76") | {"_previous_amount": "88.67"}
+    tw.write_notification(tx)
+    (written,) = (tmp_path / "notifications").iterdir()
+    message = json.loads(written.read_text())["message"]
+    assert "£25.76" in message and "£88.67" in message and "New transaction" not in message


### PR DESCRIPTION
## Problem

A pending card authorisation keeps its `entry_reference` while the merchant finalises the amount. `make_tx_id` keyed on reference, booking date and amount, so each revision computed a fresh id, missed the seen set, and fired as a new transaction. One terminal produced four notifications in one afternoon, and the agent nearly reported them to the user as double billing. Found and diagnosed in #2319.

## Change

- `make_tx_id` returns `entry_reference` when the provider sends one, else a `booking_date-amount` composite. The amount is out of the identity, so an in-place revision keeps its id.
- The seen file becomes `dict[id, amount]`. `poll_once` skips a known id at the same amount, and tags `_previous_amount` on a known id at a new amount.
- `notification_message` renders a revision as `Revised transaction (not a new charge): <new>, updated from <old>`, naming both amounts so it cannot read as a second charge. `currency_symbol` is extracted so both the line and `format_tx` share the one table.
- `_poll_forever` gates on `seen_file_is_current()` instead of `SEEN_FILE.exists()`: a list-format seen file has no amounts to compare, so the loop treats it as absent and runs the existing silent 30-day seed once. Marked `LEGACY(remove-when: no fleet seen_transactions.json is a JSON list)`. No regex migration: polls look back only two days, so re-seeding is strictly quiet.
- SKILL.md gains one bullet describing the revision notification so the agent reads it as a supersession, not a duplicate.

## Evidence

`cd agent/skills/enable-banking/cli && uv run pytest -q`: 30 passed (12 in `test_transaction_watcher.py`, 7 of which fail on master).

Carried over from #2319 with the same assertions: `test_id_is_the_provider_reference_when_there_is_one`, `test_id_falls_back_to_the_composite_without_a_reference` (expected value updated to the shorter composite), `test_revised_pending_amount_is_reported_as_a_revision_not_a_new_transaction`, `test_unchanged_pending_transaction_is_silent`, `test_a_genuinely_new_reference_still_notifies`, `test_seed_seen_keys_the_file_the_same_way_as_the_poller`, `test_write_notification_carries_the_revision_wording`.

New: `test_a_list_format_seen_file_is_reseeded_not_polled` drives one `_poll_forever` cycle against a list-format file and asserts the file is rewritten as `{reference: amount}` with no notification written. It replaces #2319's two migration tests.

`./check.sh guards`: All checks passed. `ruff format --check`: clean. No em or en dashes in the changed SKILL.md.

Supersedes #2319.
