### PR TITLE
fix(skills/upstream): answer --mine from one GraphQL page of PRs with their commit authors

### DIFF
--- a/agent/skills/upstream/SKILL.md
+++ b/agent/skills/upstream/SKILL.md
@@ -34,8 +34,9 @@ Three calls are intercepted and carry extra behavior:
 - `upstream gh pr list --mine [--state open|closed|all] [--limit N]`: the PRs this agent
   wrote. Every PR here is authored by `vesta-upstream[bot]`, so ownership lives in commit
   authors (`<agent-name> (vesta)`) and plain `gh pr list` cannot answer "which are mine".
-  Run it before touching any branch you did not create this session; never take an
-  author name you saw in a log as your own commit author.
+  Every PR in that state is checked, so a zero is a real zero; `--limit` only caps the
+  rows printed. Run it before touching any branch you did not create this session; never
+  take an author name you saw in a log as your own commit author.
 
 Titles are `type(scope): description`: type one of feat, fix, refactor, perf, docs, test,
 ci, chore, style, build; scope lowercase; description imperative, lowercase start, no

--- a/agent/skills/upstream/cli/src/upstream_cli/cli.py
+++ b/agent/skills/upstream/cli/src/upstream_cli/cli.py
@@ -149,53 +149,69 @@ def commit_author_name(agent_name) -> str:
     return f"{agent_name} (vesta)"
 
 
-def pr_commit_authors(token, number):
-    """(originator, all authors) for one PR, by commit author name. Every agent pushes through the
-    same GitHub App, so `pull.user.login` is `vesta-upstream[bot]` on EVERY PR in the repo and
-    identifies nobody. The commit author is the only field carrying which agent wrote it, and the
-    FIRST commit's author is the one who opened the PR."""
-    code, out = gh_api(token, f"repos/{UPSTREAM_REPO}/pulls/{number}/commits?per_page=100")
-    if code != 0:
-        return None, set()
-    commits = json.loads(out)
-    if not commits:
-        return None, set()
-    return commits[0]["commit"]["author"]["name"], {c["commit"]["author"]["name"] for c in commits}
+PR_STATES = {"open": "[OPEN]", "closed": "[CLOSED, MERGED]", "all": "[OPEN, CLOSED, MERGED]"}
+PR_PAGE_SIZE = 100
+
+
+def prs_with_authors_query(state) -> str:
+    """One page of PRs, newest first, each carrying its commit author names in order. The state list
+    is written into the query text: `gh api -f` sends every variable as a string, and GraphQL takes
+    an enum list only as a literal."""
+    owner, name = UPSTREAM_REPO.split("/", maxsplit=1)
+    return (
+        f'query($cursor: String) {{ repository(owner: "{owner}", name: "{name}") {{ pullRequests('
+        f"states: {PR_STATES[state]}, first: {PR_PAGE_SIZE}, after: $cursor, orderBy: {{field: CREATED_AT, direction: DESC}}"
+        ") { pageInfo { hasNextPage endCursor } nodes { number title url"
+        " commits(first: 100) { nodes { commit { author { name } } } } } } } }"
+    )
+
+
+def fetch_prs_with_authors(token, state):
+    """Every PR in `state`, following the cursor to the last page."""
+    fields = {"query": prs_with_authors_query(state)}
+    prs = []
+    while True:
+        code, out = gh_api(token, "graphql", method="POST", fields=fields)
+        if code != 0:
+            print(f"Error: gh api graphql failed: {out}", file=sys.stderr)
+            sys.exit(1)
+        page = json.loads(out)["data"]["repository"]["pullRequests"]
+        prs.extend(page["nodes"])
+        if not page["pageInfo"]["hasNextPage"]:
+            return prs
+        fields["cursor"] = page["pageInfo"]["endCursor"]
+
+
+def print_capped(rows, limit):
+    for row in rows[:limit]:
+        print(row)
+    if len(rows) > limit:
+        print(f"  ... {len(rows) - limit} more not printed: raise --limit to see them")
 
 
 def list_my_prs(token, agent_name, state, limit):
-    """Print the PRs this agent opened, and separately the ones it only pushed commits to."""
+    """Print the PRs this agent opened, and separately the ones it only pushed commits to. Every
+    agent files through the same GitHub App, so `user.login` is `vesta-upstream[bot]` on EVERY PR
+    and identifies nobody; the commit authors are the only field naming the agent, and the FIRST
+    commit's author opened the PR. Every PR in `state` is classified; `limit` caps the printed rows."""
     me = commit_author_name(agent_name)
-    query = f"state={quote(state)}&per_page={min(limit, 100)}&sort=created&direction=desc"
-    code, out = gh_api(token, f"repos/{UPSTREAM_REPO}/pulls?{query}")
-    if code != 0:
-        print(f"Error: gh api failed: {out}", file=sys.stderr)
-        sys.exit(1)
-    candidates = json.loads(out)[:limit]
-    opened, touched, unreadable = [], [], []
-    for pr in candidates:
-        originator, authors = pr_commit_authors(token, pr["number"])
-        if originator == me:
-            opened.append((pr, originator))
+    prs = fetch_prs_with_authors(token, state)
+    opened, touched = [], []
+    for pr in prs:
+        authors = [node["commit"]["author"]["name"] for node in pr["commits"]["nodes"]]
+        if authors[:1] == [me]:
+            opened.append(f"  #{pr['number']}  {pr['title'][:72]}\n      {pr['url']}")
         elif me in authors:
-            touched.append((pr, originator))
-        elif originator is None:
-            unreadable.append(pr)
+            touched.append(f"  #{pr['number']}  opened by {authors[0]}: {pr['title'][:56]}\n      {pr['url']}")
 
-    print(f"Checked the {len(candidates)} most recent {state} PR(s) as {me}.")
+    print(f"Checked all {len(prs)} {state} PR(s) as {me}.")
     print(f"\nOpened by you ({len(opened)}):")
-    for pr, _ in opened:
-        print(f"  #{pr['number']}  {pr['title'][:72]}\n      {pr['html_url']}")
+    print_capped(opened, limit)
     if not opened:
         print("  (none: every PR here was opened by a different agent through the same bot account)")
     if touched:
         print(f"\nNot yours, but you have commits on them ({len(touched)}):")
-        for pr, originator in touched:
-            print(f"  #{pr['number']}  opened by {originator}: {pr['title'][:56]}\n      {pr['html_url']}")
-    if unreadable:
-        print(f"\nCould not read commit authors for {len(unreadable)} PR(s), so ownership is unknown, not ruled out:")
-        for pr in unreadable:
-            print(f"  #{pr['number']}  {pr['title'][:72]}")
+        print_capped(touched, limit)
 
 
 GUARD_BRANCH_REF = "refs/vesta-guard/branch"
@@ -387,7 +403,7 @@ def pr_list_mine(rest):
     args = _parse_intercepted(
         {
             "--mine": {"action": "store_true"},
-            "--state": {"default": "open"},
+            "--state": {"default": "open", "choices": list(PR_STATES)},
             "--limit": {"type": int, "default": 40},
         },
         rest,

--- a/agent/skills/upstream/cli/tests/test_auth.py
+++ b/agent/skills/upstream/cli/tests/test_auth.py
@@ -1,5 +1,4 @@
 import base64
-import json
 import os
 import subprocess
 import sys
@@ -80,14 +79,6 @@ def test_main_scrubs_a_leaked_token_and_never_writes_one_to_git_config(repo, mon
     assert SENTINEL not in " ".join(pushed["cmd"])
     delivered = pushed["env"]["GIT_CONFIG_VALUE_0"].split("Basic ")[1]
     assert base64.b64decode(delivered).decode() == f"x-access-token:{SENTINEL}"
-
-
-def _commits(*names):
-    return [{"commit": {"author": {"name": name}}} for name in names]
-
-
-def _stub_gh_api(monkeypatch, payload, code=0):
-    monkeypatch.setattr(cli, "gh_api", lambda *a, **k: (code, json.dumps(payload)))
 
 
 def _stub_authors(monkeypatch, authors):
@@ -215,81 +206,7 @@ def test_adopt_skips_the_ownership_guard(repo, monkeypatch):
     assert guard_calls == []
 
 
-def test_pr_commit_authors_reads_the_first_commit_as_the_opener(monkeypatch):
-    _stub_gh_api(monkeypatch, _commits("dory (vesta)", "vesta (vesta)"))
-    assert cli.pr_commit_authors("tok", 7) == ("dory (vesta)", {"dory (vesta)", "vesta (vesta)"})
-
-
-def test_pr_commit_authors_reports_unknown_on_an_api_error(monkeypatch):
-    _stub_gh_api(monkeypatch, [], code=1)
-    assert cli.pr_commit_authors("tok", 7) == (None, set())
-
-
 def test_agent_identity_rejects_a_blank_agent_name(monkeypatch):
     monkeypatch.setenv("AGENT_NAME", "  ")
     with pytest.raises(SystemExit):
         cli.resolve_agent_identity()
-
-
-def test_mine_separates_prs_you_opened_from_prs_you_only_pushed_to(monkeypatch, capsys):
-    prs = [
-        {"number": 1, "title": "yours", "html_url": "u1"},
-        {"number": 2, "title": "theirs, you pushed", "html_url": "u2"},
-        {"number": 3, "title": "theirs", "html_url": "u3"},
-    ]
-    authors = {
-        1: ("vesta (vesta)", {"vesta (vesta)"}),
-        2: ("bazella (vesta)", {"bazella (vesta)", "vesta (vesta)"}),
-        3: ("dory (vesta)", {"dory (vesta)"}),
-    }
-    _stub_gh_api(monkeypatch, prs)
-    monkeypatch.setattr(cli, "pr_commit_authors", lambda token, number: authors[number])
-
-    cli.list_my_prs("tok", "vesta", "open", 40)
-    out = capsys.readouterr().out
-    assert "Opened by you (1)" in out
-    assert "#1" in out.split("Opened by you")[1].split("Not yours")[0]
-    assert "Not yours, but you have commits on them (1)" in out
-    assert "#2  opened by bazella (vesta)" in out
-    assert "#3" not in out
-
-
-def test_mine_matches_the_full_author_name_never_a_prefix(monkeypatch, capsys):
-    # Agent "dor" must not claim PRs authored by "dory (vesta)".
-    prs = [{"number": 1, "title": "t", "html_url": "u"}]
-    _stub_gh_api(monkeypatch, prs)
-    monkeypatch.setattr(cli, "pr_commit_authors", lambda token, number: ("dory (vesta)", {"dory (vesta)"}))
-
-    cli.list_my_prs("tok", "dor", "open", 40)
-    out = capsys.readouterr().out
-    assert "Opened by you (0)" in out
-    assert "you have commits on them" not in out
-
-
-def test_mine_respects_the_limit_and_surfaces_unreadable_prs(monkeypatch, capsys):
-    prs = [{"number": n, "title": f"t{n}", "html_url": f"u{n}"} for n in (1, 2, 3)]
-    checked = []
-
-    def unreadable_authors(token, number):
-        checked.append(number)
-        return (None, set())
-
-    _stub_gh_api(monkeypatch, prs)
-    monkeypatch.setattr(cli, "pr_commit_authors", unreadable_authors)
-
-    cli.list_my_prs("tok", "vesta", "open", 2)
-    out = capsys.readouterr().out
-    assert checked == [1, 2]
-    assert "Could not read commit authors for 2 PR(s)" in out
-
-
-def test_mine_passes_the_requested_state_to_the_api(monkeypatch, capsys):
-    seen = []
-
-    def fake_gh_api(token, path, **kwargs):
-        seen.append(path)
-        return 0, "[]"
-
-    monkeypatch.setattr(cli, "gh_api", fake_gh_api)
-    cli.list_my_prs("tok", "vesta", "all", 40)
-    assert "state=all" in seen[0]

--- a/agent/skills/upstream/cli/tests/test_dispatch.py
+++ b/agent/skills/upstream/cli/tests/test_dispatch.py
@@ -99,7 +99,8 @@ def test_pr_list_without_mine_passes_through(monkeypatch, fake_gh):
 @pytest.mark.parametrize("verb", ["list", "ls"])
 def test_pr_list_mine_is_intercepted_under_either_spelling(monkeypatch, fake_gh, agent_identity, capsys, verb):
     record, response, _ = fake_gh
-    response.write_text("[]")
+    empty_page = {"pageInfo": {"hasNextPage": False, "endCursor": None}, "nodes": []}
+    response.write_text(json.dumps({"data": {"repository": {"pullRequests": empty_page}}}))
     assert run_main(monkeypatch, ["gh", "pr", verb, "--mine"]) == 0
     assert json.loads(record.read_text())["argv"][0] == "api"
     assert "as tester (vesta)" in capsys.readouterr().out

--- a/agent/skills/upstream/cli/tests/test_list_my_prs.py
+++ b/agent/skills/upstream/cli/tests/test_list_my_prs.py
@@ -1,0 +1,127 @@
+"""`--mine` classifies every PR of the requested state, so a PR of yours is never outside a window.
+
+Every case runs against a fake repo of known ownership, one GraphQL page per `gh_api` call, so the
+right answer is known in advance and a wrong one is visible.
+"""
+
+import json
+
+import pytest
+from upstream_cli import cli
+
+ME = "tester (vesta)"
+OTHER = "someone-else (vesta)"
+
+
+def _pr_node(number, authors):
+    return {
+        "number": number,
+        "title": f"pr {number}",
+        "url": f"https://x/{number}",
+        "commits": {"nodes": [{"commit": {"author": {"name": name}}} for name in authors]},
+    }
+
+
+@pytest.fixture
+def repo_with(monkeypatch):
+    """Route `gh_api` at a fake repo. `authors_per_pr` lists each PR's commit authors in order, newest
+    PR first; numbers count down so the newest PR carries the highest, as GitHub orders them. The
+    cursor is the offset of the next page. Returns the (path, method, fields) of every call."""
+
+    def build(authors_per_pr, page_size=cli.PR_PAGE_SIZE):
+        total = len(authors_per_pr)
+        nodes = [_pr_node(total - i, authors) for i, authors in enumerate(authors_per_pr)]
+        calls = []
+
+        def fake_gh_api(token, path, *, method="GET", fields=None):
+            calls.append((path, method, dict(fields)))
+            start = int(fields["cursor"]) if "cursor" in fields else 0
+            end = start + page_size
+            page = {"pageInfo": {"hasNextPage": end < total, "endCursor": str(end)}, "nodes": nodes[start:end]}
+            return 0, json.dumps({"data": {"repository": {"pullRequests": page}}})
+
+        monkeypatch.setattr(cli, "gh_api", fake_gh_api)
+        return calls
+
+    return build
+
+
+def run_listing(capsys, agent="tester", state="open", limit=40):
+    cli.list_my_prs("token", agent, state, limit)
+    return capsys.readouterr().out
+
+
+def opened_section(out):
+    return out.split("Opened by you")[1].split("Not yours")[0]
+
+
+def numbers_listed(section):
+    return [int(word[1:]) for word in section.split() if word.startswith("#")]
+
+
+def test_a_pr_three_pages_deep_is_found(repo_with, capsys):
+    """Two PRs are the caller's: the newest, and one at position 200 of 250, which only a listing
+    that walks every page before classifying can reach."""
+    authors = [[OTHER]] * 250
+    authors[0] = [ME]
+    authors[200] = [ME]
+    calls = repo_with(authors)
+    out = run_listing(capsys)
+    assert sorted(numbers_listed(opened_section(out))) == [50, 250]
+    assert f"Checked all 250 open PR(s) as {ME}." in out
+    assert len(calls) == 3
+
+
+def test_pages_follow_the_cursor_and_the_first_request_carries_none(repo_with, capsys):
+    calls = repo_with([[OTHER]] * 250)
+    run_listing(capsys)
+    assert [(path, method) for path, method, _ in calls] == [("graphql", "POST")] * 3
+    assert "cursor" not in calls[0][2]
+    assert [fields["cursor"] for _, _, fields in calls[1:]] == ["100", "200"]
+
+
+def test_mine_separates_prs_you_opened_from_prs_you_only_pushed_to(repo_with, capsys):
+    """Ownership is the FIRST commit's author; appearing later is a different relationship."""
+    repo_with([[ME], [OTHER, ME], [OTHER]])
+    out = run_listing(capsys)
+    assert "Opened by you (1)" in out
+    assert numbers_listed(opened_section(out)) == [3]
+    assert "Not yours, but you have commits on them (1)" in out
+    assert f"#2  opened by {OTHER}" in out
+    assert "#1" not in out
+
+
+def test_mine_matches_the_full_author_name_never_a_prefix(repo_with, capsys):
+    # Agent "test" must not claim PRs authored by "tester (vesta)".
+    repo_with([[ME]])
+    out = run_listing(capsys, agent="test")
+    assert "Opened by you (0)" in out
+    assert "you have commits on them" not in out
+
+
+def test_limit_caps_the_printed_rows_not_the_prs_checked(repo_with, capsys):
+    repo_with([[ME]] * 10)
+    out = run_listing(capsys, limit=3)
+    assert "Checked all 10 open PR(s)" in out
+    assert "Opened by you (10)" in out
+    assert numbers_listed(opened_section(out)) == [10, 9, 8]
+    assert "7 more not printed" in out
+
+
+@pytest.mark.parametrize(
+    ("state", "states"),
+    [("open", "[OPEN]"), ("closed", "[CLOSED, MERGED]"), ("all", "[OPEN, CLOSED, MERGED]")],
+)
+def test_state_selects_the_graphql_state_set(repo_with, capsys, state, states):
+    calls = repo_with([])
+    out = run_listing(capsys, state=state)
+    assert f"states: {states}," in calls[0][2]["query"]
+    assert f"Checked all 0 {state} PR(s)" in out
+
+
+def test_a_failed_query_exits_instead_of_reporting_nothing_of_yours(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "gh_api", lambda *a, **k: (1, "gh: HTTP 502"))
+    with pytest.raises(SystemExit) as stop:
+        cli.list_my_prs("token", "tester", "open", 40)
+    assert stop.value.code == 1
+    assert "HTTP 502" in capsys.readouterr().err


### PR DESCRIPTION
## Problem

`upstream gh pr list --mine` fetched one REST page of the repo's PRs, sliced it to `--limit`, and only then tested ownership through one `pulls/{n}/commits` call per PR. A PR of the agent's older than that window read as gone. #2063 measured 1 open PR reported when 7 were open; #2313 saw the same `--limit 12` answer 2 in the morning and 0 five hours later as other agents filed over it. Every PR is authored by `vesta-upstream[bot]`, so `--mine` is the only way an agent learns what it owns, and a silent windowed zero tells it "you filed nothing", which invites a second PR on a file an open PR already touches.

## Change

- `list_my_prs` walks `pullRequests(states, first:100, after:$cursor, orderBy CREATED_AT DESC)` through the existing `gh_api` seam (`gh api graphql`) until `hasNextPage` is false, so every PR in the requested state is classified. One query returns 100 PRs with all their commit authors at rate-limit cost 1 (verified live: all 83 open PRs in one page; `all` is 18 pages instead of 1700+ REST calls).
- Ownership comes from `commits.nodes` in the same response: the first commit's author opened the PR, any later author touched it. `pr_commit_authors` and its per-PR REST calls are deleted, along with the unreadable-ownership branch that only a per-PR failure could reach.
- `--state open|closed|all` maps to `[OPEN]`, `[CLOSED, MERGED]`, and all three, and argparse now refuses any other value. The state list is inlined in the query text because `gh api -f` sends every variable as a string and GraphQL takes an enum list only as a literal.
- Header reads `Checked all N {state} PR(s) as {me}.`; `--limit` only caps the rows printed per section, with a one-line "N more not printed" note.
- SKILL.md `--mine` bullet states that every PR in the state is checked and what `--limit` caps.

## Evidence

- New `agent/skills/upstream/cli/tests/test_list_my_prs.py` (8 cases) ports the fixture design of #2063 to one stubbed GraphQL response per page: a PR of the caller's three pages deep is found; pages follow the cursor and the first request carries none; opened vs. touched; full author name never a prefix; `--limit` caps printed rows, not PRs checked; each state maps to its GraphQL state set; a failed query exits 1.
- `tests/test_auth.py`: the two `pr_commit_authors` tests and the four REST-shaped `--mine` tests are removed (their behavior lives in the new file); `tests/test_dispatch.py` stubs an empty GraphQL page.
- `cd agent/skills/upstream/cli && uv run pytest -q`: 56 passed.
- `./check.sh guards`: passed. Pinned `ruff format` and `ruff check` clean on the changed files. No em or en dashes under `agent/`.
- Live check with a personal `gh` login: the exact query string the code builds runs for all three states and its `commit.author.name` values match `pulls/{n}/commits`. GitHub documents that an App installation token "will work with both the GraphQL API and the REST API".

Supersedes #2063, #2313.
