### PR TITLE
docs(skills/upstream): name the checks that separate a mergeable fix from a rewrite

### DIFF
--- a/agent/skills/upstream/SKILL.md
+++ b/agent/skills/upstream/SKILL.md
@@ -72,21 +72,53 @@ part; leave the personal remainder local.
 
 ## Before filing (REQUIRED)
 
+The maintainer merges a small fix at the right layer the same day. A fix that adds state,
+a script, a flag, or a config format waits weeks and is usually rewritten, because the
+clean fix is visible from the maintainer's full checkout and not from a box. These checks
+are what separate the two.
+
 - **Does it already exist?** `grep -rn` the codebase for the mechanism first, by feature
   name across all skills and core. Improve the existing one; never add a second.
 - **Your box is a stale snapshot.** Any claim about what upstream does must be checked
   against `upstream/master` (`git -C ~ show upstream/master:<path>`), never your local
   copy, or the PR is a revert dressed as a fix.
+- **Find the fact before adding state.** If the fix adds a variable, file, marker, timer,
+  flag, env var, or config format, first name the thing on `upstream/master` that already
+  holds that fact: a marker the same handler writes, a cache entry, a helper's return
+  value, an artifact's mtime. Read the whole module and its callers, not the failing line.
+  When that thing exists, the fix reads it; new state beside it is the shape that gets
+  rewritten.
+- **Fix the producer, not the line.** A guard in front of the failing line (`if value:`)
+  treats one symptom. Follow the value to where it was produced and fix it there, once.
+  If a second guard elsewhere seems necessary, the cause is still unfound.
+- **Copy the neighbours' guards.** When adding an entry to a list of rules (a regex, a
+  threshold, a column, a probe), read what the sibling entries carry (a case anchor, a
+  digit lookahead, a `LEGACY(` marker, a matching test fixture) and carry the same. The
+  siblings encode the false positives already paid for.
+- **Size is a design signal.** A fix over about 40 lines, a new script, a new flag, or a new
+  config format is a design decision, not a fix. File an issue instead of the PR, with the
+  cause, file, line, and the change you would make; the maintainer shapes it from the full
+  tree. Two symptoms of one mechanism (a stale install and a stale build behind the same
+  gate) are one fix and one PR, never two.
 - **One file, one PR.** List your open PRs and their files before opening; two changes to
-  one file belong in one PR. Do not check what other agents filed; duplicates are cheap
-  confirmation.
+  one file belong in one PR. Search open PRs for your scope
+  (`upstream gh pr list --state open --search "in:title <scope>"`); when one already names
+  your problem, do not file a second: the maintainer keeps one fix per problem and closes
+  the rest, so the duplicate costs a consolidation and adds nothing. Add your evidence as
+  an issue if it is new.
 - **Issue, PR, or both?** Fix in your workspace: PR + issue, with `fixes #N` on its own
   line in the PR body (never the commit). Problem in `agent/core/` (read-only): issue
   only, with cause, file, line, and the fix you would make. No fix yet: issue only.
 - **Strip the story.** Agent-facing files state mechanism and constraint, never what
-  changed or the incident behind it; that goes in the commit and PR body.
+  changed or the incident behind it; that goes in the commit and PR body. A code comment
+  states the rule in one line, with no date and no PR number; a comment that needs a
+  paragraph means the code needs simplifying.
 - **Strip personal information.** Upstream is public: no names, addresses, credentials,
-  or one user's quirks. Describe the pattern, not the instance.
+  or one user's quirks. Describe the pattern, not the instance. A script that encodes your
+  user's file names, language, headings, or box paths is workspace tooling: keep it local.
+- **Evidence names what is in the diff.** Every test the PR body mentions exists in the
+  diff by name, and the body pastes the run's count. A claim the diff does not contain is
+  read as the behavior being untested, and it costs the PR its credibility.
 
 ## Creating a PR
 


### PR DESCRIPTION
## Problem

A triage of 34 agent-filed PRs (16 open, 18 folded in #2062) gave 15 REWRITE and 7 CLOSE verdicts, almost all for six recurring shapes the agent could have checked from its box: state added beside an existing fact (#2339 throttle dict vs the marker file; #2333 config map vs the MSAL cache), a guard at the symptom line (#2296), a list entry without its siblings' guards (#2289 case anchor, #2328 digit lookahead), a fix an order of magnitude larger than the problem (#2319 204 lines for a 35-line change; #2003 1,403 lines), one user's layout in an upstream script (#2033), and test claims absent from the diff (#2333). Two PRs filed the same problem with contradicting one-line fixes (#2291, #2316) and two filed one gate's two symptoms separately (#2187, #2190).

## Change

`agent/skills/upstream/SKILL.md`, Before filing section only: a two-sentence framing of what merges fast versus what gets rewritten, then six new checks (find the fact before adding state; fix the producer, not the line; copy the neighbours' guards; size is a design signal, over ~40 lines or a new script/flag/format files an issue instead; evidence names what is in the diff) and three tightened ones (one-line comments with no date or PR number; personal layout is workspace tooling; one file, one PR now says to search open PR titles for the scope and not file a second). Each check carries its reason. Written per `vesta-prompt-guide`: mechanism and constraint, no history.

One deliberate reversal for the maintainer to confirm: the previous text said "Do not check what other agents filed; duplicates are cheap confirmation." Consolidating the duplicate pairs above cost a review, a fresh PR, and two close comments each, so the new text asks for one title search and no second PR.

## Evidence

- `./check.sh guards` green. No em or en dashes (`grep -rnP '\x{2014}|\x{2013}'` empty).
- The reversed rule and the size bar are the two judgment calls; the rest restate AGENTS.md principles the triage found violated, in the agent's own vocabulary.
