### PR TITLE
fix(dream): harden the reality_check probes

### DIFF
--- a/agent/skills/dream/scripts/reality_check.sh
+++ b/agent/skills/dream/scripts/reality_check.sh
@@ -4,12 +4,16 @@
 # one OK/RED line per probe and exits 1 if anything is RED. Probes read only fleet-generic state
 # (daemon records, logs, disk, the events DB, the notifications dir), so a RED is real on any box.
 
-# Disk-probe knobs: RED once this agent's own files could plausibly fill a disk, note the host's
-# percentage as context past the note threshold, and bound the du walk so a pathological tree or a
-# stuck filesystem can never hang the dream that runs this probe.
+# Disk knobs: own usage is RED only while the host is also at the pressure percent, the host alone
+# is RED at the RED percent, and the du walk is bounded so a stuck filesystem cannot hang the dream.
 OWN_USAGE_RED_MB=20000
-HOST_DISK_NOTE_PERCENT=90
+HOST_DISK_PRESSURE_PERCENT=85
+HOST_DISK_RED_PERCENT=97
 DU_TIMEOUT_SECS=120
+# A nightly cadence is 24h and a missed night reads as 48h, so the lapse bound sits between them.
+DREAM_LAPSE_HOURS=30
+# One or two refused turns are a transient the next turn absorbs; three in a day is a window binding.
+REFUSED_TURNS_RED=3
 
 red=0
 ok() { printf 'OK  %s\n' "$1"; }
@@ -31,35 +35,60 @@ for pid_file in "$HOME"/agent/data/daemons/*.pid; do
     fi
 done
 
-# Disk: a full disk fails writes quietly all over the box, never loudly in one place. On a shared
-# host the filesystem under $HOME is the host's, so its percentage is mostly other tenants and no
-# amount of cleanup here moves it. RED only on what this agent can actually act on, and report the
-# host figure as context, so the probe never hands you a RED you cannot clear.
+# Disk: a full disk fails writes quietly all over the box. The filesystem under $HOME is the host's,
+# so its percentage is mostly other tenants: own usage is a RED to clear here only under host
+# pressure, the host alone is a RED to escalate once writes are about to fail, reported separately.
 usage=$(df -P "$HOME" | awk 'NR==2 {gsub("%","",$5); print $5}')
 du_lines=$(timeout "$DU_TIMEOUT_SECS" du -sm "$HOME" /tmp 2>/dev/null)
 du_status=$?
 mine=$(printf '%s\n' "$du_lines" | awk '{t+=$1} END {print t+0}')
 if [ "$du_status" -eq 124 ]; then
     bad "sizing \$HOME and /tmp took over ${DU_TIMEOUT_SECS}s: the tree is enormous or a filesystem is stuck; investigate tonight"
+elif [ "${mine:-0}" -ge "$OWN_USAGE_RED_MB" ] && [ "${usage:-0}" -ge "$HOST_DISK_PRESSURE_PERCENT" ]; then
+    bad "disk at ${usage}% and this agent holds ${mine}MB of it: clean up tonight (workspace cleanup)"
 elif [ "${mine:-0}" -ge "$OWN_USAGE_RED_MB" ]; then
-    bad "this agent is using ${mine}MB across \$HOME and /tmp: clean up tonight (workspace cleanup)"
-elif [ "${usage:-0}" -ge "$HOST_DISK_NOTE_PERCENT" ]; then
-    ok "disk at ${usage}% but only ${mine}MB is this agent's; the rest is the host, not yours to clear"
+    ok "this agent holds ${mine}MB, but the disk is only at ${usage:-unknown}%: size without pressure, nothing to clear"
+fi
+if [ "${usage:-0}" -ge "$HOST_DISK_RED_PERCENT" ]; then
+    bad "host disk at ${usage}%, ${mine}MB of it this agent's: cleanup here cannot fix it, tell the user tonight; writes will start failing across the box"
+elif [ "${usage:-0}" -ge "$HOST_DISK_PRESSURE_PERCENT" ]; then
+    ok "host disk at ${usage}%, ${mine}MB of it this agent's; the rest is the host, not yours to clear"
 else
-    ok "disk at ${usage:-unknown}%, ${mine}MB of it this agent's"
+    ok "host disk at ${usage:-unknown}%, ${mine}MB of it this agent's"
 fi
 
 # Error storms: a component can log thousands of errors without one of them reaching a notification.
+# Only lines dated today or yesterday count (an undated line takes the date of the line above it),
+# a line whose only count is zero ("0 error(s)", "no errors") reports success and is skipped, and
+# the file's colour codes are stripped first so a dated line is seen as dated.
+today=$(date +%F)
+yesterday=$(date -d yesterday +%F)
+esc=$(printf '\033')
 for log in "$HOME"/agent/logs/*.log; do
     [ -e "$log" ] || continue
     [ -n "$(find "$log" -mmin -1440 2>/dev/null)" ] || continue
-    errors=$(tail -n 2000 "$log" | grep -icE 'error|traceback')
+    errors=$(tail -n 2000 "$log" | sed "s/$esc\[[0-9;]*m//g" | awk -v today="$today" -v yesterday="$yesterday" '
+        BEGIN { recent = 1 }
+        /^\[?[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/ { recent = ($0 ~ ("^\\[?" today)) || ($0 ~ ("^\\[?" yesterday)) }
+        { low = tolower($0) }
+        recent && !((low ~ /(^|[^0-9])0 (errors|error\(s\)|warnings|warning\(s\))/ || low ~ /no errors/) && low !~ /[1-9][0-9]* (error|warning)/)' \
+        | grep -icE 'error|traceback')
     if [ "$errors" -gt 200 ]; then
-        bad "$(basename "$log"): $errors error lines in its recent tail; read it and find the producer"
+        bad "$(basename "$log"): $errors error lines in the last 2 days; read it and find the producer"
     else
-        ok "$(basename "$log"): $errors error lines in its recent tail"
+        ok "$(basename "$log"): $errors error lines in the last 2 days"
     fi
 done
+
+# Refused turns: a turn the provider refused logs in=0 out=0 cache_read=0, since nothing ran, while
+# a turn that ran and chose silence still reads its cache. That usage line is the one trace every
+# refusal leaves, so count those lines rather than the daemon's rate-limit warnings.
+refused=$(grep -h "$today .*\[USAGE\] in=0 out=0 cache_read=0 " "$HOME"/agent/logs/vesta.log* 2>/dev/null | wc -l)
+if [ "$refused" -ge "$REFUSED_TURNS_RED" ]; then
+    bad "the provider refused $refused turns today: each was a message or a job that never ran; find the window in vesta.log and what it dropped"
+else
+    ok "the provider refused $refused turns today"
+fi
 
 # Events DB freshness: the store is written on every turn, but it runs in WAL mode, so between
 # checkpoints the recent commits touch only the -wal sibling; judge by the newest of the pair.
@@ -79,6 +108,17 @@ if mkdir -p "$notif" 2>/dev/null && touch "$notif/.reality_check" 2>/dev/null; t
     ok "notifications dir is writable"
 else
     bad "notifications dir is not writable: every producer is silently mute"
+fi
+
+# Dream cadence: every dream writes a summary, so no summary newer than the lapse bound means a night
+# was missed; a box with no summaries yet has no cadence to break.
+dreamer="$HOME/agent/dreamer"
+if [ -z "$(find "$dreamer" -name '*.md' 2>/dev/null)" ]; then
+    ok "no dreamer summaries yet, so there is no cadence to have broken"
+elif [ -n "$(find "$dreamer" -name '*.md' -mmin -$((DREAM_LAPSE_HOURS * 60)) 2>/dev/null)" ]; then
+    ok "a dreamer summary was written within ${DREAM_LAPSE_HOURS}h, cadence intact"
+else
+    bad "no dreamer summary written in ${DREAM_LAPSE_HOURS}h: a night was missed"
 fi
 
 if [ "$red" -gt 0 ]; then

--- a/agent/tests/test_reality_check.py
+++ b/agent/tests/test_reality_check.py
@@ -3,8 +3,13 @@
 import os
 import pathlib as pl
 import subprocess
+import time
 
 SCRIPT = pl.Path(__file__).resolve().parents[1] / "skills" / "dream" / "scripts" / "reality_check.sh"
+
+# The agent log's file formatter colours every line, so a real line never starts with its date.
+GREEN = "\x1b[2;32m"
+RESET = "\x1b[0m"
 
 
 def _run(home: pl.Path) -> subprocess.CompletedProcess[str]:
@@ -39,6 +44,14 @@ def _healthy_home(tmp_path: pl.Path) -> pl.Path:
     _fake_disk_usage(tmp_path, 42)
     _fake_own_usage(tmp_path, 512)
     return tmp_path
+
+
+def _day(days_ago: int) -> str:
+    return time.strftime("%Y-%m-%d", time.localtime(time.time() - days_ago * 86400))
+
+
+def _usage_line(day: str, *, cache_read: int) -> str:
+    return f"{GREEN}{day} 03:00:00 [SYSTEM] [USAGE] in=0 out=0 cache_read={cache_read} cache_write=0 | duration=2.1s{RESET}\n"
 
 
 def test_healthy_box_exits_green(tmp_path):
@@ -95,6 +108,112 @@ def test_quiet_recent_log_stays_green(tmp_path):
     assert "OK  calm.log" in run.stdout
 
 
+def test_undated_traceback_lines_count_with_the_dated_line_above_them(tmp_path):
+    """A traceback's body carries no timestamp of its own, so requiring the date on every counted
+    line hides a live multi-line storm under the threshold."""
+    home = _healthy_home(tmp_path)
+    block = f"{_day(0)} 01:00:00 ERROR boom\nTraceback (most recent call last):\n  raise ValueError\n"
+    (home / "agent" / "logs" / "tb.log").write_text(block * 80)
+
+    run = _run(home)
+
+    assert run.returncode == 1, run.stdout + run.stderr
+    assert "RED tb.log" in run.stdout
+
+
+def test_errors_dated_days_ago_age_out_of_a_still_fresh_log(tmp_path):
+    # The count is aged by the line dates, not the file mtime: a component fixed days ago keeps
+    # appending healthy lines to the same file, and its old storm must not stay loud.
+    home = _healthy_home(tmp_path)
+    lines = f"{_day(3)} 01:00:00 ERROR boom\n" * 300 + f"{_day(0)} 01:00:00 INFO recovered\n"
+    (home / "agent" / "logs" / "healed.log").write_text(lines)
+
+    run = _run(home)
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "OK  healed.log" in run.stdout
+
+
+def test_a_colour_coded_log_still_ages_by_its_dates(tmp_path):
+    # The agent log's own lines start with a colour code, not the date; the aging pass must still
+    # see the date behind it, or every old storm in vesta.log counts forever.
+    home = _healthy_home(tmp_path)
+    lines = f"{GREEN}{_day(3)} 01:00:00 [SYSTEM] [RUNTIME] ERROR boom{RESET}\n" * 300
+    (home / "agent" / "logs" / "vesta.log").write_text(lines)
+
+    run = _run(home)
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "OK  vesta.log: 0 error lines" in run.stdout
+
+
+def test_healthy_zero_count_summaries_do_not_count_as_errors(tmp_path):
+    # "45 matching, 0 new, 0 error(s)" carries the word without reporting a failure.
+    home = _healthy_home(tmp_path)
+    (home / "agent" / "logs" / "sync.log").write_text("45 matching, 0 new, 0 error(s)\n" * 300)
+
+    run = _run(home)
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "OK  sync.log: 0 error lines" in run.stdout
+
+
+def test_a_zero_count_next_to_a_nonzero_count_still_counts(tmp_path):
+    """The healthy-summary filter must not overshoot: a line naming a real nonzero count alongside
+    a zero one is a storm, not a healthy summary."""
+    home = _healthy_home(tmp_path)
+    (home / "agent" / "logs" / "mixed.log").write_text("summary: 0 warnings, 47 errors this cycle\n" * 300)
+
+    run = _run(home)
+
+    assert run.returncode == 1, run.stdout + run.stderr
+    assert "RED mixed.log" in run.stdout
+
+
+def test_a_zero_identifier_before_the_word_error_still_counts(tmp_path):
+    # "worker 0 error: connection refused" is a real error whose worker id happens to be zero.
+    home = _healthy_home(tmp_path)
+    (home / "agent" / "logs" / "worker.log").write_text("worker 0 error: connection refused\n" * 300)
+
+    run = _run(home)
+
+    assert run.returncode == 1, run.stdout + run.stderr
+    assert "RED worker.log" in run.stdout
+
+
+def test_a_day_of_refused_turns_goes_red(tmp_path):
+    home = _healthy_home(tmp_path)
+    (home / "agent" / "logs" / "vesta.log").write_text(_usage_line(_day(0), cache_read=0) * 3)
+
+    run = _run(home)
+
+    assert run.returncode == 1, run.stdout + run.stderr
+    assert "RED the provider refused 3 turns today" in run.stdout
+
+
+def test_a_lone_refused_turn_stays_green(tmp_path):
+    home = _healthy_home(tmp_path)
+    (home / "agent" / "logs" / "vesta.log").write_text(_usage_line(_day(0), cache_read=0))
+
+    run = _run(home)
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "OK  the provider refused 1 turns today" in run.stdout
+
+
+def test_turns_that_ran_and_yesterdays_refusals_are_not_refused_turns(tmp_path):
+    # A turn that ran and chose silence still reads its cache; a refusal on another day is that
+    # day's finding, not tonight's.
+    home = _healthy_home(tmp_path)
+    lines = _usage_line(_day(0), cache_read=433470) * 5 + _usage_line(_day(1), cache_read=0) * 5
+    (home / "agent" / "logs" / "vesta.log").write_text(lines)
+
+    run = _run(home)
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "OK  the provider refused 0 turns today" in run.stdout
+
+
 def test_this_agent_filling_the_disk_goes_red(tmp_path):
     home = _healthy_home(tmp_path)
     _fake_disk_usage(home, 95)
@@ -106,7 +225,22 @@ def test_this_agent_filling_the_disk_goes_red(tmp_path):
     assert "25000MB" in run.stdout
 
 
-def test_a_full_host_disk_this_agent_did_not_fill_stays_green(tmp_path):
+def test_a_large_footprint_without_disk_pressure_stays_green(tmp_path):
+    """Own usage alone is a size, not a problem: a corpus-holding agent on a half-empty disk must
+    not read RED every night, because a permanent RED teaches the reader to skim the one output
+    that exists to stop skimming."""
+    home = _healthy_home(tmp_path)
+    _fake_disk_usage(home, 50)
+    _fake_own_usage(home, 25_000)
+
+    run = _run(home)
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "size without pressure" in run.stdout
+    assert "25000MB" in run.stdout
+
+
+def test_a_busy_host_disk_this_agent_did_not_fill_stays_green(tmp_path):
     """A RED the agent cannot clear teaches it to carry REDs, which is the one thing the probe
     forbids. The host figure still gets reported, as context rather than as a fault."""
     home = _healthy_home(tmp_path)
@@ -120,6 +254,35 @@ def test_a_full_host_disk_this_agent_did_not_fill_stays_green(tmp_path):
     assert "300MB" in run.stdout
     # Pins the context branch itself: dropping to the plain OK line would also pass the figures.
     assert "not yours to clear" in run.stdout
+
+
+def test_a_host_disk_at_the_ceiling_goes_red(tmp_path):
+    """Above the context band the host figure is the agent's problem too, because writes start
+    failing everywhere; the probe exists to catch exactly that, so a full host cannot read green."""
+    home = _healthy_home(tmp_path)
+    _fake_disk_usage(home, 100)
+    _fake_own_usage(home, 300)
+
+    run = _run(home)
+
+    assert run.returncode == 1, run.stdout + run.stderr
+    assert "100%" in run.stdout
+    # Pins the escalation, since the own-usage RED would also fire on a returncode check alone.
+    assert "tell the user tonight" in run.stdout
+
+
+def test_a_full_host_disk_reports_even_when_this_agent_is_also_over(tmp_path):
+    """The two facts are independent, so a large own footprint must not swallow the host reading:
+    the night both are true is the night the host figure matters most."""
+    home = _healthy_home(tmp_path)
+    _fake_disk_usage(home, 99)
+    _fake_own_usage(home, 25_000)
+
+    run = _run(home)
+
+    assert run.returncode == 1, run.stdout + run.stderr
+    assert "RED disk at 99% and this agent holds 25000MB" in run.stdout
+    assert "RED host disk at 99%" in run.stdout
 
 
 def test_a_du_walk_that_never_finishes_goes_red(tmp_path):
@@ -161,3 +324,54 @@ def test_stale_events_db_goes_red(tmp_path):
 
     assert run.returncode == 1
     assert "RED events.db" in run.stdout
+
+
+def _dreamer_summary(home: pl.Path, hours_old: float) -> pl.Path:
+    summary = home / "agent" / "dreamer"
+    summary.mkdir(parents=True, exist_ok=True)
+    written = summary / "2026-01-01T0300.md"
+    written.write_text("summary")
+    aged = time.time() - hours_old * 3600
+    os.utime(written, (aged, aged))
+    return written
+
+
+def test_a_recent_dreamer_summary_stays_green(tmp_path):
+    home = _healthy_home(tmp_path)
+    _dreamer_summary(home, 17)
+
+    run = _run(home)
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "cadence intact" in run.stdout
+
+
+def test_a_summary_a_night_late_stays_green(tmp_path):
+    # The bound is 30h rather than 24h on purpose: a nightly cadence is exactly 24h, so a run that
+    # slips a few hours would report RED on a box that never missed a night.
+    home = _healthy_home(tmp_path)
+    _dreamer_summary(home, 26)
+
+    run = _run(home)
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "cadence intact" in run.stdout
+
+
+def test_a_missed_night_goes_red(tmp_path):
+    home = _healthy_home(tmp_path)
+    _dreamer_summary(home, 40)
+
+    run = _run(home)
+
+    assert run.returncode == 1, run.stdout + run.stderr
+    assert "RED no dreamer summary written in 30h: a night was missed" in run.stdout
+
+
+def test_a_box_that_has_never_dreamed_stays_green(tmp_path):
+    """A fresh box has no summaries at all, and a probe that reads that as a missed night is red
+    from birth with nothing the agent can do about it."""
+    run = _run(_healthy_home(tmp_path))
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "no dreamer summaries yet" in run.stdout


### PR DESCRIPTION
## Problem

`reality_check.sh` is the dream's one probe of the running system, and five closed PRs each found a way it lies. #1909: the error-storm count reads the last 2000 lines with no age, so a component healed days ago stays RED until healthy lines push the storm out. #1919: the disk chain ends at the 90% note, so a host at 100% prints OK. #1973: a healthy `0 error(s)` summary line counts as an error, so a polling daemon is RED every night. #2015: own usage is RED on size alone, so a corpus-holding agent on a 69% disk is RED forever. #1955: nothing notices a missed night. #1926 adds a sixth: a refused turn's one durable trace is its `[SYSTEM] [USAGE] in=0 out=0 cache_read=0` line, and the daemon's rate-limit warnings are not a census, so a day the provider refused goes undiagnosed unless something counts those lines. A probe that is RED on a healthy box, or green on a broken one, teaches the reader to skim the one output that exists to stop skimming.

## Change

- Error storms: one awk pass ages the window by line date (today or yesterday, an undated line inheriting the date above it), drops lines whose only count is zero (`0 error(s)`, `no errors`) while keeping `0 warnings, 47 errors` and `worker 0 error`, then the existing `grep -icE`. Colour codes are stripped first: the agent log's file formatter prefixes every line with ANSI, so a `^date` anchor never matches `vesta.log` (the epic's aging pass would have classed it undated and counted the whole tail).
- Disk: own usage is RED only when the host is also at `HOST_DISK_PRESSURE_PERCENT=85` (the `&&` gate from #2015), the host alone is RED at `HOST_DISK_RED_PERCENT=97` (#1919), 85 doubles as the note band, and the two facts print as two lines. The 90% knob, the df-failure branch, and the `mine_str` indirection are gone.
- Refused turns (new, from #1926's diagnosis): count today's `[USAGE] in=0 out=0 cache_read=0` lines across `vesta.log*`, RED at `REFUSED_TURNS_RED=3`. One or two are a transient the next turn absorbs; three in a day means a rate-limit window bound for part of the day and messages went unanswered. A live throttled box on this host shows 6 to 15 on a bad day.
- Dream cadence (#1955): `find -mmin` over `~/agent/dreamer/*.md` against `DREAM_LAPSE_HOURS=30`; no summaries at all is OK (nothing to have broken). RED text ends at "a night was missed".
- Not taken: `reality-history.tsv` (a lapse is already the dream-cadence probe's finding), the unprotected-state probe and `unprotected-accepted.txt` (vestad backs up the whole container; a per-box decisions file inside an upstream-owned skill dir conflicts on every sync), the df-failure branch, and the SKILL.md-parsing test.
- Every comment block states the rule in one line: the mechanism and the constraint, no history.

## Evidence

- `cd agent && uv run --project core pytest tests/test_reality_check.py -q`: 26 passed (master: 10). Carried from the epic: `test_undated_traceback_lines_count_with_the_dated_line_above_them`, `test_errors_dated_days_ago_age_out_of_a_still_fresh_log`, the three zero-count filter tests, `test_a_large_footprint_without_disk_pressure_stays_green`, `test_a_host_disk_at_the_ceiling_goes_red`, `test_a_full_host_disk_reports_even_when_this_agent_is_also_over`, and the four dream-cadence tests. New: `test_a_colour_coded_log_still_ages_by_its_dates`, `test_a_day_of_refused_turns_goes_red`, `test_a_lone_refused_turn_stays_green`, `test_turns_that_ran_and_yesterdays_refusals_are_not_refused_turns`.
- The same suite against master's script: 13 failed, 13 passed (the healed-log, colour-coded-log, zero-count, pressure-gate, ceiling, both-over, lapse, and refused-turn cases are all red there).
- Run once inside a live container (dash, mawk 1.3.4) against its real `vesta.log` with `today` pinned to the log's last day: `OK vesta.log: 0 error lines in the last 2 days`, `RED the provider refused 6 turns today`, `OK a dreamer summary was written within 30h`.
- `shellcheck -S warning`, `sh -n`, `bash -n`, `ruff format` + `ruff check`, `./check.sh guards`: all clean.

fixes #1918
fixes #1972
fixes #2014
fixes #1954

Supersedes #1909, #1919, #1973, #2015, #1955, and the reality_check slice of #2062. The refused-turn probe comes from the diagnosis in #1926, whose prose changes ride separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
