### PR TITLE
fix(microsoft): refresh each account with the client that signed it in

### DIFF
--- a/agent/skills/microsoft/SETUP.md
+++ b/agent/skills/microsoft/SETUP.md
@@ -28,6 +28,14 @@ https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBla
 Then copy the **Application (client) ID** and set `MICROSOFT_MCP_CLIENT_ID=<your-client-id>`
 (a custom client uses `.default`, i.e. exactly the permissions you configured above).
 
+To put a single account on its own app while the other accounts stay on the default client, set the
+variable on the sign-in commands only: `MICROSOFT_MCP_CLIENT_ID=<app-id> microsoft auth login`, then
+`MICROSOFT_MCP_CLIENT_ID=<app-id> microsoft auth complete --flow-cache <cache>`. The MSAL cache
+records which client minted each account's refresh token, and every later call (the daemon, `email`,
+`calendar`) refreshes that account with that client and its `.default` scope on its own, so no
+variable is needed afterwards. This is how an agent mailbox on an app granted `Mail.Send` and a user
+mailbox on the default client live side by side in one agent.
+
 ## Authentication
 
 **Run one command: `microsoft auth setup --account <email>`.** It provisions mail and calendar,

--- a/agent/skills/microsoft/cli/src/microsoft_cli/auth.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/auth.py
@@ -4,7 +4,8 @@ from typing import NamedTuple
 import msal
 
 from .backend import GraphUnavailableError
-from .settings import get_settings
+from .config import scopes_for
+from .settings import OWA_REST_CLIENT_ID, get_settings
 
 
 class Account(NamedTuple):
@@ -86,8 +87,23 @@ def account_in_cache(cache_file: pl.Path, account_email: str, *, client_id: str 
     return any((a["username"] or "").lower() == account_email.lower() for a in app.get_accounts())
 
 
+def _refresh_client_id(app: msal.PublicClientApplication, home_account_id: str) -> str:
+    """The client whose refresh token can mint this account's Graph tokens.
+
+    A refresh token is bound to the client that minted it, and the cache lists accounts
+    independently of client id, so an account signed in under another app (`MICROSOFT_MCP_CLIENT_ID=<app>
+    microsoft auth login`) holds a refresh token this app cannot use. The app's own client wins when it
+    has one. The OWA REST sign-in stores its refresh token in the same cache under the first-party
+    Office client for the outlook.office.com resource, so that token is never a Graph candidate."""
+    refresh_tokens = app.token_cache.search(msal.TokenCache.CredentialType.REFRESH_TOKEN, query={"home_account_id": home_account_id})
+    client_ids = [rt["client_id"] for rt in refresh_tokens if rt["client_id"] != OWA_REST_CLIENT_ID]
+    if app.client_id in client_ids or not client_ids:
+        return app.client_id
+    return client_ids[0]
+
+
 def get_token(cache_file: pl.Path, scopes: list[str], *, account_id: str | None = None) -> str:
-    """Mint a Graph token from the MSAL cache, silently.
+    """Mint a Graph token from the MSAL cache, silently, with the client that signed the account in.
 
     Never starts an interactive sign-in: a data command must not mint a device code.
     When no cached token can be refreshed this raises
@@ -99,6 +115,11 @@ def get_token(cache_file: pl.Path, scopes: list[str], *, account_id: str | None 
 
     accounts = app.get_accounts()
     account = next((a for a in accounts if a["home_account_id"] == account_id), None) if account_id else (accounts[0] if accounts else None)
+    if account is not None:
+        client_id = _refresh_client_id(app, account["home_account_id"])
+        if client_id != app.client_id:
+            app = get_app(cache_file, client_id)
+            scopes = scopes_for(client_id)
 
     result = app.acquire_token_silent(scopes, account=account)
 

--- a/agent/skills/microsoft/cli/src/microsoft_cli/config.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/config.py
@@ -28,8 +28,8 @@ DEFAULT_CLIENT_SCOPES = [
 OWNED_APP_SCOPES = ["https://graph.microsoft.com/.default"]
 
 
-def resolve_scopes() -> list[str]:
-    return list(DEFAULT_CLIENT_SCOPES) if get_settings().microsoft_mcp_client_id == DEFAULT_CLIENT_ID else list(OWNED_APP_SCOPES)
+def scopes_for(client_id: str) -> list[str]:
+    return list(DEFAULT_CLIENT_SCOPES) if client_id == DEFAULT_CLIENT_ID else list(OWNED_APP_SCOPES)
 
 
 # Delegated scopes for the OWA REST fallback: tokens for the outlook.office.com resource,
@@ -58,7 +58,7 @@ FOLDERS = {
 class Config:
     data_dir: Path = Path.home() / ".microsoft"
     log_dir: Path = Path.home() / ".microsoft" / "logs"
-    scopes: list[str] = field(default_factory=resolve_scopes)
+    scopes: list[str] = field(default_factory=lambda: scopes_for(get_settings().microsoft_mcp_client_id))
     base_url: str = BASE_URL
     upload_chunk_size: int = UPLOAD_CHUNK_SIZE
     folders: dict[str, str] = field(default_factory=lambda: dict(FOLDERS))

--- a/agent/skills/microsoft/cli/tests/test_auth_no_interactive_prompt.py
+++ b/agent/skills/microsoft/cli/tests/test_auth_no_interactive_prompt.py
@@ -24,7 +24,7 @@ def _app(*, accounts: list[dict], silent_result: dict | None) -> MagicMock:
     app = MagicMock()
     app.get_accounts.return_value = accounts
     app.acquire_token_silent.return_value = silent_result
-    app.token_cache = None
+    app.token_cache = auth.msal.SerializableTokenCache()
     return app
 
 

--- a/agent/skills/microsoft/cli/tests/test_auth_refresh_client.py
+++ b/agent/skills/microsoft/cli/tests/test_auth_refresh_client.py
@@ -1,0 +1,109 @@
+"""`auth.get_token` refreshes each account with the client that signed it in.
+
+An MSAL refresh token is bound to the client id that minted it, while the cache lists accounts
+independently of client id. One cache therefore holds an account signed in under the shared default
+client next to an account signed in under an owned app registration (`MICROSOFT_MCP_CLIENT_ID=<app>
+microsoft auth login`), and `acquire_token_silent` finds only the refresh tokens of the app's own
+client. These tests run the real MSAL app over a serialized cache and pin that each account is
+refreshed through an app built for the client holding its refresh token, with that client's scopes.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib as pl
+
+import pytest
+from microsoft_cli import auth
+from microsoft_cli.config import DEFAULT_CLIENT_SCOPES, OWNED_APP_SCOPES
+from microsoft_cli.settings import DEFAULT_CLIENT_ID, OWA_REST_CLIENT_ID, get_settings
+
+OWNED_APP = "11111111-2222-3333-4444-555555555555"
+ENVIRONMENT = "login.microsoftonline.com"
+USER_ACCOUNT = "user-oid.tenant"
+AGENT_ACCOUNT = "agent-oid.tenant"
+
+
+def _account(home_account_id: str, username: str) -> dict[str, str]:
+    return {
+        "home_account_id": home_account_id,
+        "environment": ENVIRONMENT,
+        "realm": "tenant",
+        "local_account_id": home_account_id.partition(".")[0],
+        "username": username,
+        "authority_type": "MSSTS",
+    }
+
+
+def _refresh_token(home_account_id: str, client_id: str) -> dict[str, str]:
+    return {
+        "credential_type": "RefreshToken",
+        "secret": f"rt-{client_id}",
+        "home_account_id": home_account_id,
+        "environment": ENVIRONMENT,
+        "client_id": client_id,
+        "target": "openid profile offline_access",
+    }
+
+
+def _write_cache(cache_file: pl.Path, *, accounts: list[dict[str, str]], refresh_tokens: list[dict[str, str]]) -> None:
+    state = {
+        "Account": {f"account-{i}": account for i, account in enumerate(accounts)},
+        "RefreshToken": {f"rt-{i}": rt for i, rt in enumerate(refresh_tokens)},
+    }
+    cache_file.write_text(json.dumps(state))
+
+
+@pytest.fixture
+def minted(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, list[str], str]]:
+    """Replace the network refresh with a recorder: (client id, scopes, account) per mint, token = client id."""
+    calls: list[tuple[str, list[str], str]] = []
+
+    def fake_acquire_token_silent(self: auth.msal.PublicClientApplication, scopes: list[str], account: dict[str, str]) -> dict[str, str]:
+        calls.append((self.client_id, scopes, account["home_account_id"]))
+        return {"access_token": self.client_id}
+
+    monkeypatch.setattr(auth.msal.PublicClientApplication, "acquire_token_silent", fake_acquire_token_silent)
+    monkeypatch.delenv("MICROSOFT_MCP_CLIENT_ID", raising=False)
+    get_settings.cache_clear()
+    yield calls
+    get_settings.cache_clear()
+
+
+def test_each_account_mints_with_the_client_that_signed_it_in(minted: list[tuple[str, list[str], str]], tmp_path: pl.Path) -> None:
+    cache_file = tmp_path / "auth_cache.bin"
+    _write_cache(
+        cache_file,
+        accounts=[_account(USER_ACCOUNT, "user@example.org"), _account(AGENT_ACCOUNT, "agent@example.org")],
+        refresh_tokens=[_refresh_token(USER_ACCOUNT, DEFAULT_CLIENT_ID), _refresh_token(AGENT_ACCOUNT, OWNED_APP)],
+    )
+
+    assert auth.get_token(cache_file, DEFAULT_CLIENT_SCOPES, account_id=USER_ACCOUNT) == DEFAULT_CLIENT_ID
+    assert auth.get_token(cache_file, DEFAULT_CLIENT_SCOPES, account_id=AGENT_ACCOUNT) == OWNED_APP
+
+    assert minted == [
+        (DEFAULT_CLIENT_ID, DEFAULT_CLIENT_SCOPES, USER_ACCOUNT),
+        (OWNED_APP, OWNED_APP_SCOPES, AGENT_ACCOUNT),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("refresh_token_clients", "expected_client"),
+    [
+        ([OWNED_APP, DEFAULT_CLIENT_ID], DEFAULT_CLIENT_ID),
+        ([OWA_REST_CLIENT_ID], DEFAULT_CLIENT_ID),
+        ([OWA_REST_CLIENT_ID, OWNED_APP], OWNED_APP),
+    ],
+)
+def test_the_configured_client_wins_and_owa_rest_tokens_are_not_graph_candidates(
+    minted: list[tuple[str, list[str], str]], tmp_path: pl.Path, refresh_token_clients: list[str], expected_client: str
+) -> None:
+    cache_file = tmp_path / "auth_cache.bin"
+    _write_cache(
+        cache_file,
+        accounts=[_account(USER_ACCOUNT, "user@example.org")],
+        refresh_tokens=[_refresh_token(USER_ACCOUNT, client_id) for client_id in refresh_token_clients],
+    )
+
+    assert auth.get_token(cache_file, DEFAULT_CLIENT_SCOPES, account_id=USER_ACCOUNT) == expected_client
+    assert [client_id for client_id, _scopes, _account in minted] == [expected_client]

--- a/agent/skills/microsoft/cli/tests/test_settings.py
+++ b/agent/skills/microsoft/cli/tests/test_settings.py
@@ -1,6 +1,6 @@
 """Locks the single-owner settings accessor: env-derived, read once per process."""
 
-from microsoft_cli.config import DEFAULT_CLIENT_SCOPES, OWNED_APP_SCOPES, resolve_scopes
+from microsoft_cli.config import DEFAULT_CLIENT_SCOPES, OWNED_APP_SCOPES, Config
 from microsoft_cli.settings import DEFAULT_CLIENT_ID, MicrosoftSettings, get_settings
 
 
@@ -28,12 +28,12 @@ def test_defaults_to_graph_cli_client_when_env_absent(monkeypatch):
 def test_default_client_uses_dynamic_scopes(monkeypatch):
     monkeypatch.delenv("MICROSOFT_MCP_CLIENT_ID", raising=False)
     get_settings.cache_clear()
-    assert resolve_scopes() == DEFAULT_CLIENT_SCOPES
+    assert Config().scopes == DEFAULT_CLIENT_SCOPES
     get_settings.cache_clear()
 
 
 def test_custom_client_uses_default_scope(monkeypatch):
     monkeypatch.setenv("MICROSOFT_MCP_CLIENT_ID", "my-own-app")
     get_settings.cache_clear()
-    assert resolve_scopes() == OWNED_APP_SCOPES
+    assert Config().scopes == OWNED_APP_SCOPES
     get_settings.cache_clear()


### PR DESCRIPTION
## Problem

One agent wants two mailboxes on two Azure app registrations: an agent mailbox on an owned app granted `Mail.Send`, and the user's mailbox on the default client (#2333, from #2332). Sign-in already supports this per process (`MICROSOFT_MCP_CLIENT_ID=<app-id> microsoft auth login`), but `get_token` builds every MSAL app from the single global `microsoft_mcp_client_id`. An MSAL refresh token is bound to the client that minted it and `acquire_token_silent` only finds tokens for the app's own client id, so the second account can never be refreshed and every data command for it fails. #2333 re-encoded the fact in two new env-var formats plus a JSON map and a reverse email lookup; the MSAL cache already records, on each `RefreshToken` entry, which `client_id` minted it and for which `home_account_id`.

## Change

- `auth.get_token`: after selecting the account, read its refresh tokens from the cache (`token_cache.search(REFRESH_TOKEN, query={"home_account_id": ...})`). When the token belongs to a different client, rebuild the app with `get_app(cache_file, client_id)` and request that client's scope set. The configured client wins when the account holds tokens for both.
- The OWA REST sign-in stores its refresh token in the same cache under the first-party Office client (`OWA_REST_CLIENT_ID`, outlook.office.com resource), so that token is excluded from the candidates. Without the exclusion an OWA-REST-only account would start an extra Graph refresh attempt with the Office client on every call, and `--backend auto` could silently switch backends.
- `config.resolve_scopes()` becomes the one-arg pure function `scopes_for(client_id)`; `Config.scopes` derives its default from it with the configured client. No new settings, env vars, or config maps.
- `SETUP.md`: one paragraph on signing a single account in under an owned app (`auth login` and `auth complete` both under `MICROSOFT_MCP_CLIENT_ID=<app-id>`), after which every later call refreshes it with that app on its own.

## Evidence

- New `agent/skills/microsoft/cli/tests/test_auth_refresh_client.py`, run against the real MSAL app over a synthetic serialized cache (only the network refresh is replaced by a recorder):
  - `test_each_account_mints_with_the_client_that_signed_it_in`: two accounts, refresh tokens from two client ids, each mints with its own client and that client's scopes.
  - `test_the_configured_client_wins_and_owa_rest_tokens_are_not_graph_candidates` (3 cases): configured client preferred when both exist, OWA REST token ignored, OWA REST token plus owned-app token picks the owned app.
  - Red before the fix (2 of 4 cases fail), green after.
- `test_settings.py` now asserts `Config().scopes` for the default and owned-app client; `test_auth_no_interactive_prompt.py`'s fake app carries an empty `SerializableTokenCache` instead of `None`.
- `cd agent/skills/microsoft/cli && uv run pytest -q`: 386 passed.
- `uv run --project agent/core ruff format` + `ruff check` on the changed files: clean. `./check.sh guards`: passed.
- Note: the body of #2333 claimed unit tests for override resolution and scope selection; its diff contains none (the `test_settings.py` hunk is import reformatting only).

Supersedes #2333.
