### PR TITLE
fix(microsoft): compose reply and forward bodies over the quoted original on every path

### DIFF
--- a/agent/skills/microsoft/SKILL.md
+++ b/agent/skills/microsoft/SKILL.md
@@ -37,9 +37,9 @@ The refusal happens in the CLI before any Graph or OWA-REST call, so it covers b
 
 ## Threaded reply DRAFT (leave unsent for the user to send)
 
-`email reply` ALWAYS sends and `email draft --reply-to` overwrites the quoted history. To leave a
-threaded reply(-all) draft the user reviews + sends themselves, use `email reply-draft`
-(createReply/createReplyAll + body placed above the preserved quote + attach, no /send):
+`email reply` ALWAYS sends. To leave a threaded reply(-all) draft the user reviews + sends
+themselves, use `email reply-draft` (createReply/createReplyAll + body placed above the preserved
+quote + attach, no /send, and the draft's recipients and attachments are read back for review):
 
 ```bash
 microsoft email reply-draft --account user@example.com --id '<latest-msg-id-in-thread>' --body "draft answer for review"

--- a/agent/skills/microsoft/cli/src/microsoft_cli/email.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/email.py
@@ -360,8 +360,9 @@ def _draft_reply_or_forward(config: Config, client: httpx.Client, account_id: st
     if not draft or "id" not in draft:
         raise ValueError("Failed to create reply/forward draft")
     draft_id = draft["id"]
+    _compose_over_quote(config, client, draft_id, account_id, mail.body, mail.html)
 
-    updates: dict[str, Any] = {"body": {"contentType": "HTML" if mail.html else "Text", "content": mail.body}}
+    updates: dict[str, Any] = {}
     if mail.subject:
         updates["subject"] = mail.subject
     if mail.to:
@@ -370,7 +371,8 @@ def _draft_reply_or_forward(config: Config, client: httpx.Client, account_id: st
         updates["ccRecipients"] = [{"emailAddress": {"address": addr}} for addr in mail.cc]
     if mail.bcc:
         updates["bccRecipients"] = [{"emailAddress": {"address": addr}} for addr in mail.bcc]
-    graph.request_cfg(config, client, "PATCH", f"/me/messages/{draft_id}", account_id, json=updates)
+    if updates:
+        graph.request_cfg(config, client, "PATCH", f"/me/messages/{draft_id}", account_id, json=updates)
 
     _attach_files(config, client, draft_id, mail.attachments, account_id)
     return {"status": "drafted", "id": draft_id, "source_id": source_id}
@@ -538,16 +540,7 @@ def reply_to_email(
             raise ValueError("Failed to create reply draft")
 
         draft_id = draft["id"]
-
-        graph.request_cfg(
-            config,
-            client,
-            "PATCH",
-            f"/me/messages/{draft_id}",
-            account_id,
-            json={"body": {"contentType": "HTML" if html else "Text", "content": body}},
-        )
-
+        _compose_over_quote(config, client, draft_id, account_id, body, html)
         _attach_files(config, client, draft_id, attachments, account_id)
 
         graph.request_cfg(config, client, "POST", f"/me/messages/{draft_id}/send", account_id)
@@ -580,6 +573,34 @@ def _reply_body_to_html(raw: str) -> str:
     return "".join(parts)
 
 
+def _quote_to_html(quote: dict[str, Any]) -> str:
+    """Graph returns the pre-filled quote of a draft as `text` when the original message was
+    plain text; inside an HTML body its line breaks would collapse into one line, so a text
+    quote is escaped and wrapped in a pre-wrap block. An HTML quote passes through as is."""
+    if quote["contentType"].casefold() == "html":
+        return quote["content"]
+    return '<pre style="white-space:pre-wrap;font-family:inherit">' + html.escape(quote["content"]) + "</pre>"
+
+
+def _compose_over_quote(config: Config, client: httpx.Client, draft_id: str, account_id: str, body: str, html: bool) -> None:
+    """Place `body` above the quoted original that createReply/createReplyAll/createForward
+    pre-filled into draft `draft_id`. PATCHing `body` replaces the whole draft body, so the
+    quote is read back first and written under the new text. A plain-text body renders through
+    `_reply_body_to_html`; an HTML body is used as is."""
+    existing = graph.request_cfg(config, client, "GET", f"/me/messages/{draft_id}", account_id, params={"$select": "body"})
+    if not existing or "body" not in existing:
+        raise ValueError("Failed to read the created draft")
+    top = body if html else _reply_body_to_html(body)
+    graph.request_cfg(
+        config,
+        client,
+        "PATCH",
+        f"/me/messages/{draft_id}",
+        account_id,
+        json={"body": {"contentType": "HTML", "content": top + "<br><br>" + _quote_to_html(existing["body"])}},
+    )
+
+
 def reply_draft(
     config: Config,
     client: httpx.Client,
@@ -593,9 +614,9 @@ def reply_draft(
 ) -> dict[str, Any]:
     """Leave an UNSENT threaded reply(-all) draft for the user to review and send.
 
-    `email reply` always sends and `email draft --reply-to` overwrites the quoted history;
-    this fills the gap. createReply/createReplyAll pre-fills recipients + the quoted thread,
-    the new body is placed above that preserved quote, files attach, and we STOP before /send.
+    `email reply` always sends; this stops before /send. createReply/createReplyAll pre-fills
+    recipients + the quoted thread, the new body is placed above that preserved quote, files
+    attach, and the draft is read back to report what the user will see.
     `--replace-draft` deletes a prior draft first so repeated edits leave exactly one draft."""
     account_id = auth.get_account_id_by_email(account_email, config.cache_file)
 
@@ -611,25 +632,7 @@ def reply_draft(
     if not draft or "id" not in draft:
         raise ValueError("Failed to create reply draft")
     draft_id = draft["id"]
-
-    existing = graph.request_cfg(
-        config, client, "GET", f"/me/messages/{draft_id}", account_id, params={"$select": "body,toRecipients,ccRecipients"}
-    )
-    if not existing or "body" not in existing:
-        raise ValueError("Failed to read the created reply draft")
-    quoted = existing["body"]["content"]
-    to = _extract_addresses(existing["toRecipients"] if "toRecipients" in existing else [])
-    cc = _extract_addresses(existing["ccRecipients"] if "ccRecipients" in existing else [])
-
-    graph.request_cfg(
-        config,
-        client,
-        "PATCH",
-        f"/me/messages/{draft_id}",
-        account_id,
-        json={"body": {"contentType": "HTML", "content": _reply_body_to_html(body) + "<br><br>" + quoted}},
-    )
-
+    _compose_over_quote(config, client, draft_id, account_id, body, False)
     _attach_files(config, client, draft_id, attachments, account_id)
 
     check = graph.request_cfg(
@@ -638,15 +641,15 @@ def reply_draft(
         "GET",
         f"/me/messages/{draft_id}",
         account_id,
-        params={"$select": "subject,isDraft", "$expand": "attachments($select=name,size)"},
+        params={"$select": "subject,isDraft,toRecipients,ccRecipients", "$expand": "attachments($select=name,size)"},
     )
     result: dict[str, Any] = {
         "status": "drafted",
         "id": draft_id,
         "subject": check["subject"] if check and "subject" in check else None,
         "isDraft": check["isDraft"] if check and "isDraft" in check else None,
-        "to": to,
-        "cc": cc,
+        "to": _extract_addresses(check["toRecipients"] if check and "toRecipients" in check else []),
+        "cc": _extract_addresses(check["ccRecipients"] if check and "ccRecipients" in check else []),
         "attachments": [a["name"] for a in (check["attachments"] if check and "attachments" in check else [])],
     }
     if warnings:
@@ -666,22 +669,19 @@ def forward_email(config: Config, client: httpx.Client, *, account_email: str, e
     account_id = auth.get_account_id_by_email(account_email, config.cache_file)
     to_recipients = [{"emailAddress": {"address": addr}} for addr in to]
 
-    # cc / html / attachments need the draft path (the one-shot forward action only
-    # takes a plain-text comment + toRecipients); the plain case keeps the quoted original.
+    # cc / html / attachments need the draft path: the one-shot forward action only
+    # takes a plain-text comment + toRecipients.
     if attachments or cc or html:
         draft = graph.request_cfg(config, client, "POST", f"/me/messages/{email_id}/createForward", account_id)
         if not draft or "id" not in draft:
             raise ValueError("Failed to create forward draft")
         draft_id = draft["id"]
 
-        updates: dict[str, Any] = {
-            "body": {"contentType": "HTML" if html else "Text", "content": body},
-            "toRecipients": to_recipients,
-        }
+        updates: dict[str, Any] = {"toRecipients": to_recipients}
         if cc:
             updates["ccRecipients"] = [{"emailAddress": {"address": addr}} for addr in cc]
         graph.request_cfg(config, client, "PATCH", f"/me/messages/{draft_id}", account_id, json=updates)
-
+        _compose_over_quote(config, client, draft_id, account_id, body, html)
         _attach_files(config, client, draft_id, attachments, account_id)
         graph.request_cfg(config, client, "POST", f"/me/messages/{draft_id}/send", account_id)
         return {"status": "sent"}

--- a/agent/skills/microsoft/cli/tests/test_draft.py
+++ b/agent/skills/microsoft/cli/tests/test_draft.py
@@ -1,9 +1,11 @@
 """Unit tests for microsoft_cli.email.create_email_draft (mocked Graph calls)."""
 
 import pytest
-from microsoft_cli import email
+from microsoft_cli import email, pending_send
 from microsoft_cli.config import Config
 from microsoft_cli.payloads import MailDraft
+
+QUOTED = "<div>quoted original</div>"
 
 
 @pytest.fixture
@@ -21,11 +23,17 @@ def patched(monkeypatch):
             return {"id": "fwd-draft"}
         if method == "POST" and path == "/me/messages":
             return {"id": "compose-draft"}
+        if method == "GET":
+            return {"body": {"contentType": "HTML", "content": QUOTED}}
         return None
 
     monkeypatch.setattr(email.auth, "get_account_id_by_email", fake_account_id)
     monkeypatch.setattr(email.graph, "request", fake_request)
     return calls
+
+
+def _body_patch(calls):
+    return next(c for c in calls if c["method"] == "PATCH" and "body" in c["json"])
 
 
 def test_compose_draft(patched):
@@ -51,10 +59,17 @@ def test_reply_draft_is_threaded_and_not_sent(patched):
     result = email.create_email_draft(Config(), None, account_email="me@example.com", mail=MailDraft(body="thanks", reply_to_id="orig-1"))
     assert result == {"status": "drafted", "id": "reply-draft", "source_id": "orig-1"}
     assert patched[0]["path"] == "/me/messages/orig-1/createReply"
-    assert patched[1]["method"] == "PATCH"
-    assert patched[1]["path"] == "/me/messages/reply-draft"
-    assert patched[1]["json"]["body"] == {"contentType": "Text", "content": "thanks"}
+    patch = _body_patch(patched)
+    assert patch["path"] == "/me/messages/reply-draft"
+    content = patch["json"]["body"]["content"]
+    assert content.index("thanks") < content.index(QUOTED)
+    assert content.endswith("<br><br>" + QUOTED)
     assert not any(c["path"].endswith("/send") for c in patched)
+
+
+def test_reply_draft_without_body_keeps_quoted_original(patched):
+    email.create_email_draft(Config(), None, account_email="me@example.com", mail=MailDraft(reply_to_id="orig-4"))
+    assert _body_patch(patched)["json"]["body"]["content"].endswith("<br><br>" + QUOTED)
 
 
 def test_forward_draft_with_recipient(patched):
@@ -63,7 +78,38 @@ def test_forward_draft_with_recipient(patched):
     )
     assert result["id"] == "fwd-draft"
     assert patched[0]["path"] == "/me/messages/orig-2/createForward"
-    assert patched[1]["json"]["toRecipients"] == [{"emailAddress": {"address": "bob@x.com"}}]
+    recipients = next(c for c in patched if c["method"] == "PATCH" and "toRecipients" in c["json"])
+    assert recipients["json"]["toRecipients"] == [{"emailAddress": {"address": "bob@x.com"}}]
+    content = _body_patch(patched)["json"]["body"]["content"]
+    assert content.index("fyi") < content.index(QUOTED)
+
+
+def test_forward_draft_html_body_sits_above_the_quote_unescaped(patched):
+    email.create_email_draft(
+        Config(), None, account_email="me@example.com", mail=MailDraft(body="<b>fyi</b>", html=True, forward_id="orig-2", to=["bob@x.com"])
+    )
+    assert _body_patch(patched)["json"]["body"] == {"contentType": "HTML", "content": "<b>fyi</b><br><br>" + QUOTED}
+
+
+def test_queued_forward_keeps_quoted_original_below_the_body(patched, tmp_path):
+    config = Config(data_dir=tmp_path)
+    assert pending_send.delay_seconds(tmp_path) > 0
+
+    result = email.forward_email(config, None, account_email="me@example.com", email_id="orig-6", mail=MailDraft(to=["bob@x.com"], body="fyi"))
+
+    assert result["status"] == "pending"
+    content = _body_patch(patched)["json"]["body"]["content"]
+    assert content.index("fyi") < content.index(QUOTED)
+    assert content.endswith("<br><br>" + QUOTED)
+
+
+def test_queued_forward_without_body_keeps_quoted_original(patched, tmp_path):
+    config = Config(data_dir=tmp_path)
+
+    result = email.forward_email(config, None, account_email="me@example.com", email_id="orig-7", mail=MailDraft(to=["bob@x.com"]))
+
+    assert result["status"] == "pending"
+    assert _body_patch(patched)["json"]["body"]["content"].endswith("<br><br>" + QUOTED)
 
 
 def test_reply_and_forward_mutually_exclusive(patched):

--- a/agent/skills/microsoft/cli/tests/test_message_actions.py
+++ b/agent/skills/microsoft/cli/tests/test_message_actions.py
@@ -5,6 +5,7 @@ from microsoft_cli import email, pending_send
 from microsoft_cli.config import Config
 from microsoft_cli.payloads import MailDraft
 
+QUOTED = "<div>quoted original</div>"
 _FOLDERS_PAGE = {
     "value": [
         {"id": "news-id", "displayName": "Newsletters", "childFolders": []},
@@ -27,6 +28,8 @@ def patched(monkeypatch):
             return {"id": "draft-1"}
         if method == "POST" and path.endswith("/move"):
             return {"id": "moved-1"}
+        if method == "GET":
+            return {"body": {"contentType": "HTML", "content": QUOTED}}
         return None
 
     monkeypatch.setattr(email.auth, "get_account_id_by_email", fake_account_id)
@@ -55,11 +58,19 @@ def test_forward_with_cc_uses_draft_path(patched, tmp_path):
         mail=MailDraft(to=["bob@x.com"], body="fyi", cc=["cc@x.com"]),
     )
     assert result == {"status": "sent"}
-    paths = [c["path"] for c in patched]
-    assert paths == ["/me/messages/m1/createForward", "/me/messages/draft-1", "/me/messages/draft-1/send"]
-    patch = patched[1]
-    assert patch["json"]["ccRecipients"] == [{"emailAddress": {"address": "cc@x.com"}}]
-    assert patch["json"]["toRecipients"] == [{"emailAddress": {"address": "bob@x.com"}}]
+    assert [(c["method"], c["path"]) for c in patched] == [
+        ("POST", "/me/messages/m1/createForward"),
+        ("PATCH", "/me/messages/draft-1"),
+        ("GET", "/me/messages/draft-1"),
+        ("PATCH", "/me/messages/draft-1"),
+        ("POST", "/me/messages/draft-1/send"),
+    ]
+    recipients = patched[1]["json"]
+    assert recipients["ccRecipients"] == [{"emailAddress": {"address": "cc@x.com"}}]
+    assert recipients["toRecipients"] == [{"emailAddress": {"address": "bob@x.com"}}]
+    content = patched[3]["json"]["body"]["content"]
+    assert content.index("fyi") < content.index(QUOTED)
+    assert content.endswith("<br><br>" + QUOTED)
 
 
 def test_forward_requires_to(patched, tmp_path):

--- a/agent/skills/microsoft/cli/tests/test_pending_send.py
+++ b/agent/skills/microsoft/cli/tests/test_pending_send.py
@@ -5,6 +5,8 @@ from microsoft_cli import backend, cli, email, owa_rest_commands, pending_send
 from microsoft_cli.config import Config
 from microsoft_cli.payloads import MailDraft
 
+QUOTED = "<div>quoted original</div>"
+
 
 def test_delay_defaults_to_thirty_seconds_and_persists(tmp_path):
     assert pending_send.delay_seconds(tmp_path) == 30
@@ -177,6 +179,8 @@ def _patch_graph(monkeypatch, calls):
             return {"id": "forward-draft"}
         if method == "POST" and path == "/me/messages":
             return {"id": "compose-draft"}
+        if method == "GET":
+            return {"body": {"contentType": "HTML", "content": QUOTED}}
         return None
 
     monkeypatch.setattr(email.graph, "request_cfg", request)
@@ -278,8 +282,38 @@ def test_graph_reply_all_creates_a_threaded_draft(tmp_path, monkeypatch):
     )
 
     assert result["status"] == "pending"
-    assert [call["path"] for call in calls] == ["/me/messages/original-1/createReplyAll", "/me/messages/reply-all-draft"]
+    assert [(call["method"], call["path"]) for call in calls] == [
+        ("POST", "/me/messages/original-1/createReplyAll"),
+        ("GET", "/me/messages/reply-all-draft"),
+        ("PATCH", "/me/messages/reply-all-draft"),
+    ]
+    assert calls[2]["json"]["body"]["content"].endswith("<br><br>" + QUOTED)
     assert pending_send.list_pending(tmp_path)[0].action == "reply-all"
+
+
+def test_graph_immediate_reply_with_attachments_sends_the_body_over_the_quote(tmp_path, monkeypatch):
+    calls = []
+    config = Config(data_dir=tmp_path)
+    pending_send.set_delay_seconds(tmp_path, 0)
+    attachment = tmp_path / "report.pdf"
+    attachment.write_bytes(b"pdf")
+    _patch_graph(monkeypatch, calls)
+
+    result = email.reply_to_email(
+        config, None, account_email="me@example.com", email_id="original-1", body="Thanks", attachments=[str(attachment)]
+    )
+
+    assert result == {"status": "sent"}
+    assert [(call["method"], call["path"]) for call in calls] == [
+        ("POST", "/me/messages/original-1/createReply"),
+        ("GET", "/me/messages/reply-draft"),
+        ("PATCH", "/me/messages/reply-draft"),
+        ("POST", "/me/messages/reply-draft/attachments"),
+        ("POST", "/me/messages/reply-draft/send"),
+    ]
+    content = calls[2]["json"]["body"]["content"]
+    assert content.index("Thanks") < content.index(QUOTED)
+    assert content.endswith("<br><br>" + QUOTED)
 
 
 def test_graph_large_attachment_is_uploaded_before_the_draft_is_queued(tmp_path, monkeypatch):

--- a/agent/skills/microsoft/cli/tests/test_reply_draft.py
+++ b/agent/skills/microsoft/cli/tests/test_reply_draft.py
@@ -7,12 +7,10 @@ from microsoft_cli import backend, cli, email
 from microsoft_cli.config import Config
 
 QUOTED = "<div>quoted original</div>"
+PLAIN_QUOTE = "________________________________\nFrom: A <a@x.com>\nSent: today\n\nbody line"
 
 
-@pytest.fixture
-def patched(monkeypatch):
-    calls: list[dict] = []
-
+def _patch_graph(monkeypatch, calls, quote):
     def fake_account_id(account_email, cache_file):
         return "acct-1"
 
@@ -22,18 +20,26 @@ def patched(monkeypatch):
             return {"id": "reply-draft"}
         if method == "POST" and path.endswith("/createReplyAll"):
             return {"id": "replyall-draft"}
-        if method == "GET" and "$select" in (kwargs["params"] if "params" in kwargs else {}) and "body" in kwargs["params"]["$select"]:
+        if method == "GET" and kwargs["params"]["$select"] == "body":
+            return {"body": quote}
+        if method == "GET":
             return {
-                "body": {"contentType": "HTML", "content": QUOTED},
+                "subject": "Re: hi",
+                "isDraft": True,
                 "toRecipients": [{"emailAddress": {"address": "sender@x.com"}}],
                 "ccRecipients": [{"emailAddress": {"address": "cc@x.com"}}],
+                "attachments": [],
             }
-        if method == "GET":
-            return {"subject": "Re: hi", "isDraft": True, "attachments": []}
         return None
 
     monkeypatch.setattr(email.auth, "get_account_id_by_email", fake_account_id)
     monkeypatch.setattr(email.graph, "request", fake_request)
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    calls: list[dict] = []
+    _patch_graph(monkeypatch, calls, {"contentType": "HTML", "content": QUOTED})
     return calls
 
 
@@ -53,6 +59,19 @@ def test_reply_draft_threads_body_above_quote_and_never_sends(patched):
     assert content.index("thanks") < content.index(QUOTED)
     assert "<li>one</li>" in content
     assert not any(c["path"].endswith("/send") for c in patched)
+
+
+def test_reply_draft_keeps_the_line_breaks_of_a_plain_text_quote(monkeypatch):
+    calls: list[dict] = []
+    _patch_graph(monkeypatch, calls, {"contentType": "text", "content": PLAIN_QUOTE})
+
+    email.reply_draft(Config(), None, account_email="me@example.com", email_id="orig-1", body="hi")
+
+    content = next(c for c in calls if c["method"] == "PATCH")["json"]["body"]["content"]
+    assert content.endswith(
+        '<br><br><pre style="white-space:pre-wrap;font-family:inherit">'
+        "________________________________\nFrom: A &lt;a@x.com&gt;\nSent: today\n\nbody line</pre>"
+    )
 
 
 def test_reply_all_uses_create_reply_all(patched):


### PR DESCRIPTION
## Problem

Graph's `createReply`, `createReplyAll`, and `createForward` return a draft whose body already holds the quoted original, and a PATCH on `body` replaces that body wholesale. Three of the four reply/forward paths in `email.py` did exactly that: the queued path (`_draft_reply_or_forward`, the default since the send delay ships at 30 seconds), the immediate reply with attachments, and the immediate forward with cc/html/attachments. The recipient got only the new text, or a subject line and nothing else when `--body` was empty, while every status signal reported success (#2296 found it by inspecting a delivered message with `body_length: 0`). Only `reply-draft` read the quote back and placed the body above it, and there the quote of a plain-text original arrives from Graph typed `text`, so its line breaks collapsed inside the HTML body (#2257).

## Change

- One helper, `_compose_over_quote`, owns the read-back and the PATCH: GET the draft body, PATCH `body` (plain text rendered through `_reply_body_to_html`, HTML used as is) above `<br><br>` plus the quote. All four paths call it, so an empty body simply leaves the quote in place and no `if body` branch exists.
- `_quote_to_html` converts a quote Graph typed as `text` into an escaped `<pre style="white-space:pre-wrap">` block so its line breaks survive; an HTML quote passes through. This is #2257 folded into the one place that composes over the quote, with its `.get()` fallback replaced by direct access.
- `_draft_reply_or_forward` PATCHes subject and recipients only when there is something to set; `reply_draft` reads the recipients it reports from its existing verification GET.
- The `reply_draft` docstring and the SKILL.md reply-draft section no longer claim that `email draft --reply-to` overwrites the quoted history.

## Evidence

Written red first (14 failed, 33 passed across the four touched suites before the source change), then green.

- `test_draft.py`: `test_queued_forward_keeps_quoted_original_below_the_body` (the `--body "fyi"` case), `test_queued_forward_without_body_keeps_quoted_original`, `test_reply_draft_without_body_keeps_quoted_original`, `test_forward_draft_html_body_sits_above_the_quote_unescaped`, and the existing reply/forward draft tests now assert the quote below the body.
- `test_pending_send.py`: `test_graph_immediate_reply_with_attachments_sends_the_body_over_the_quote`; `test_graph_reply_all_creates_a_threaded_draft` pins the GET + PATCH sequence.
- `test_message_actions.py`: `test_forward_with_cc_uses_draft_path` pins the full call sequence and the quote below the body.
- `test_reply_draft.py`: `test_reply_draft_keeps_the_line_breaks_of_a_plain_text_quote` (the #2257 case, asserted through `reply_draft`).
- Every Graph fixture in those suites now answers the draft GET with a body.

`cd agent/skills/microsoft/cli && uv run pytest -q`: 388 passed. `ruff format` + `ruff check` on the changed files: clean. `./check.sh guards`: passed.

Supersedes #2296, #2257.
