### PR TITLE
fix(dashboard): rebuild when the build inputs are newer than the artifacts

### DIFF
--- a/agent/skills/dashboard/SETUP.md
+++ b/agent/skills/dashboard/SETUP.md
@@ -18,7 +18,6 @@
 
 These replace step 1 above; step 2 stays yours either way.
 
-1. **Install dependencies**: `cd ~/agent/skills/dashboard/app && npm install`
-2. **Build**: `cd ~/agent/skills/dashboard/app && npx vite build`
-3. **Start the daemon**: `dashboard daemon start`. Manage it with `daemon start|stop|restart|status`. Start is idempotent and never stacks a duplicate.
-4. **Check it's alive**: `dashboard daemon status` reports `running` and the `port` it serves on; fetch that port to confirm it answers.
+1. **Install and build**: `~/agent/skills/dashboard/scripts/build.sh`. It runs `npm install` when `package-lock.json` is newer than the installed tree and `npx vite build` when a source file is newer than `dist/`, so re-running it is free; `serve` runs the same script before every launch.
+2. **Start the daemon**: `dashboard daemon start`. Manage it with `daemon start|stop|restart|status`. Start is idempotent and never stacks a duplicate.
+3. **Check it's alive**: `dashboard daemon status` reports `running` and the `port` it serves on; fetch that port to confirm it answers.

--- a/agent/skills/dashboard/SKILL.md
+++ b/agent/skills/dashboard/SKILL.md
@@ -70,9 +70,8 @@ Example, for a request like "show me my running this week":
 `vite build` does NOT typecheck: it strips types, so a data file that violates its own interface
 builds clean and renders wrong (a field under the wrong name reads as `undefined`). The symptom is a
 page showing empty cells or dead links from data that looks right; typecheck before debugging the
-page. The builder runs the real check before every build; if you ever check by hand, run
-`npx tsc --noEmit -p tsconfig.app.json` from `~/agent/skills/dashboard/app`. Never `-p .`: the root
-tsconfig is solution-style, so that compiles zero files and always passes.
+page. The builder runs the real check with every build; if you ever check by hand, run `npx tsc -b`
+from `~/agent/skills/dashboard/app`.
 
 ## Verify and relay
 

--- a/agent/skills/dashboard/dashboard
+++ b/agent/skills/dashboard/dashboard
@@ -2,8 +2,8 @@
 set -eu
 
 # `dashboard` on PATH; the skill's whole surface is its daemon. The `serve` launcher
-# rebuilds node_modules/dist when a checkout or clean dropped them, and the service is
-# private, so the app reaches it with a service key rather than the link alone.
+# reinstalls node_modules and rebuilds dist whenever their inputs are newer (scripts/build.sh),
+# and the service is private, so the app reaches it with a service key rather than the link alone.
 
 PIDFILE="$HOME/agent/data/daemons/dashboard.pid"
 PORTFILE="$HOME/agent/data/daemons/dashboard.port"

--- a/agent/skills/dashboard/dashboard-builder.md
+++ b/agent/skills/dashboard/dashboard-builder.md
@@ -66,7 +66,7 @@ Subagent (general-purpose):
     ## Build and verify (required before you report)
 
     ```bash
-    cd ~/agent/skills/dashboard/app && { [ -d node_modules ] || npm install; } && npx tsc --noEmit -p tsconfig.app.json && npx vite build
+    cd ~/agent/skills/dashboard/app && ../scripts/build.sh && npx tsc -b
     dashboard daemon restart
     STATUS=$(dashboard daemon status); echo "$STATUS"
     PORT=$(echo "$STATUS" | python3 -c 'import sys, json; print(json.load(sys.stdin)["port"])')
@@ -74,9 +74,9 @@ Subagent (general-purpose):
     curl -sk -X POST https://$BOX_HOST:$VESTAD_PORT/agents/$AGENT_NAME/services/dashboard/invalidate -H "X-Agent-Token: $AGENT_TOKEN"
     ```
 
-    The `tsc` step is what catches a data file that violates its own interface; `vite build` alone
-    strips types without checking them, and `tsc -p .` compiles zero files (solution-style root
-    tsconfig) so it passes without measuring anything. Point tsc only at `tsconfig.app.json`.
+    `build.sh` installs dependencies and rebuilds `dist/` when their inputs are newer than they
+    are. The `tsc -b` step is what catches a data file that violates its own interface; `vite
+    build` alone strips types without checking them.
 
     Do NOT pass `--base` to vite preview: the proxy strips the prefix, so assets would 404. If the
     build fails or a page is blank, fix the reported errors and confirm `app/dist/` exists before

--- a/agent/skills/dashboard/scripts/build.sh
+++ b/agent/skills/dashboard/scripts/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# node_modules/ and dist/ are untracked build artifacts, so each is compared with its inputs: one
+# that is present but older than the source it was built from is remade, and a current one is left
+# alone, which is what lets this run before every launch. `find -newer` is strictly newer; npm
+# writes node_modules/.package-lock.json last on every install and a build writes dist/index.html,
+# so a finished step reads as current on its own. Directories count as inputs too: deleting a
+# source file leaves no newer file behind, only a newer src/.
+cd "$(dirname "$0")/../app"
+
+[ -f node_modules/.package-lock.json ] && [ -z "$(find package-lock.json -newer node_modules/.package-lock.json)" ] || npm install
+[ -f dist/index.html ] && [ -z "$(find src index.html vite.config.ts package-lock.json tsconfig*.json -newer dist/index.html -print -quit)" ] || npx vite build

--- a/agent/skills/dashboard/scripts/serve
+++ b/agent/skills/dashboard/scripts/serve
@@ -1,14 +1,13 @@
 #!/bin/sh
 set -e
 
-# node_modules/ and dist/ are untracked build artifacts, so a checkout or a clean can drop
-# them while the box keeps running, leaving the preview server to serve 404s. Ensuring both
-# exist here, before every launch, lets the service rebuild itself on the next restart
-# instead of serving nothing. Idempotent: on a normal restart both are present and this goes
-# straight to the preview server.
+# node_modules/ and dist/ are untracked build artifacts: a checkout or a clean can drop them, and
+# a merge can leave them present but older than the source, either way while the box keeps
+# running. build.sh brings both up to date before every launch, so the service heals itself on
+# the next restart instead of serving 404s or a stale bundle. Idempotent: on a normal restart
+# both are current and this goes straight to the preview server.
+~/agent/skills/dashboard/scripts/build.sh
 cd ~/agent/skills/dashboard/app
-[ -d node_modules ] || npm install
-[ -d dist ] || npx vite build
 # LEGACY(remove-when: the 2026-08-daemon-pidfile migration is fleet-applied): restart lines from the
 # shipped self-heal migration launch this script directly with no PORT in the environment.
 # `dashboard daemon start` exports one, so the fallback never fires on that path.

--- a/agent/skills/dashboard/scripts/setup.sh
+++ b/agent/skills/dashboard/scripts/setup.sh
@@ -13,17 +13,8 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 mkdir -p "$HOME/.local/bin"
 ln -sf "$DIR/../dashboard" "$HOME/.local/bin/dashboard"
 
-cd "$DIR/../app"
-
-if [ ! -d node_modules ]; then
-  echo "Installing dependencies..."
-  npm install
-fi
-
-if [ ! -d dist ]; then
-  echo "Building dashboard..."
-  npx vite build
-fi
+echo "Installing dependencies and building..."
+"$DIR/build.sh"
 
 echo "Starting daemon..."
 "$DIR/../dashboard" daemon start

--- a/agent/tests/test_daemon_contract.py
+++ b/agent/tests/test_daemon_contract.py
@@ -35,6 +35,9 @@ RACE_TIMEOUT = 120
 # The whatsapp launcher answers --help off its cached binary, so this only has to outlast a cold
 # disk; the one path that would compile first is the one this probe is never taken on.
 WHATSAPP_PROBE_TIMEOUT = 120
+# A fixed past for the dashboard rig's build inputs, so the artifacts written after them are newer
+# by construction and never by the luck of a timestamp tick.
+DASHBOARD_INPUT_MTIME = 1_600_000_000
 
 # Every registration hands out a port that is free right now, as vestad does. A constant one
 # reused across a test's starts races the kernel: the port a stopped daemon just released can be
@@ -91,17 +94,31 @@ def _rig_file_host(home: pl.Path, bin_dir: pl.Path) -> None:
 
 
 def _rig_dashboard(home: pl.Path, bin_dir: pl.Path) -> None:
-    """The app is served from build artifacts, so the skill's link is swapped for a tree
-    holding both plus the real launch script, with a fake vite standing in for the server."""
+    """The app is served from build artifacts, so the skill's link is swapped for a tree holding
+    both plus the real launch scripts, with a fake vite standing in for the server. Every build
+    input is pinned older than the artifact it feeds, so the launch gate has nothing to do, and
+    npm and npx fail loudly in case it disagrees, which keeps every row off the network."""
     skill = home / "agent/skills/dashboard"
     skill.unlink()
-    (skill / "app/dist").mkdir(parents=True)
-    (skill / "scripts").mkdir()
-    (skill / "scripts/serve").symlink_to(SKILLS_DIR / "dashboard/scripts/serve")
+    app = skill / "app"
+    (skill / "scripts").mkdir(parents=True)
+    for script in ("serve", "build.sh"):
+        (skill / "scripts" / script).symlink_to(SKILLS_DIR / "dashboard/scripts" / script)
     # The legacy forwarder execs the launcher through $HOME, so the tree carries it too.
     (skill / "dashboard").symlink_to(SKILLS_DIR / "dashboard/dashboard")
-    vite = skill / "app/node_modules/.bin/vite"
-    vite.parent.mkdir(parents=True)
+    for name in ("src/App.tsx", "index.html", "vite.config.ts", "package-lock.json", "tsconfig.json"):
+        (app / name).parent.mkdir(parents=True, exist_ok=True)
+        (app / name).write_text("")
+    for path in (app, *app.rglob("*")):
+        os.utime(path, (DASHBOARD_INPUT_MTIME, DASHBOARD_INPUT_MTIME))
+    for name in ("node_modules/.package-lock.json", "dist/index.html"):
+        (app / name).parent.mkdir(parents=True)
+        (app / name).write_text("")
+    for tool in ("npm", "npx"):
+        (bin_dir / tool).write_text(f'#!/bin/sh\necho "{tool} ran against a current tree" >&2\nexit 1\n')
+        (bin_dir / tool).chmod(0o755)
+    vite = app / "node_modules/.bin/vite"
+    vite.parent.mkdir()
     # `vite preview --port <port> --host 0.0.0.0`, so the port is the third argument.
     vite.write_text('#!/bin/sh\nexec python3 -m http.server "$3" --bind 0.0.0.0\n')
     vite.chmod(0o755)

--- a/agent/tests/test_dashboard_build.py
+++ b/agent/tests/test_dashboard_build.py
@@ -1,0 +1,103 @@
+"""Exercises the REAL dashboard build gate (agent/skills/dashboard/scripts/build.sh) against
+fake `npm` and `npx` commands: dependencies are reinstalled only when the lockfile outdates the
+installed tree, and dist/ is rebuilt only when a build input outdates it."""
+
+import os
+import pathlib as pl
+import shutil
+import subprocess
+
+import pytest
+
+REPO_ROOT = pl.Path(__file__).resolve().parents[2]
+BUILD_SCRIPT = REPO_ROOT / "agent/skills/dashboard/scripts/build.sh"
+
+# Fixed, explicit mtimes so the gate decision never rides on wall-clock ordering: every input
+# pinned OLD, both artifacts NEWER, and a single bumped path.
+OLD_INPUT_MTIME = 1_600_000_000
+ARTIFACT_MTIME = 1_700_000_000
+BUMPED_MTIME = ARTIFACT_MTIME + 100
+
+FAKE_TOOL = """#!/bin/sh
+echo "$(basename "$0") $*" >> "$TOOL_LOG"
+exit "${TOOL_EXIT:-0}"
+"""
+
+INPUTS = ("src/App.tsx", "index.html", "vite.config.ts", "package-lock.json", "tsconfig.json", "tsconfig.app.json")
+ARTIFACTS = ("node_modules/.package-lock.json", "dist/index.html")
+# shadcn's registry config sits beside the inputs and never reaches the bundle.
+UNRELATED = "components.json"
+
+
+def _fake_skill(tmp_path) -> pl.Path:
+    """A byte copy of the real script beside a minimal fake app/ tree, every input pinned old and
+    both artifacts newer, so the repo's own app stays untouched."""
+    skill = tmp_path / "skill"
+    app = skill / "app"
+    (skill / "scripts").mkdir(parents=True)
+    script = skill / "scripts/build.sh"
+    script.write_text(BUILD_SCRIPT.read_text())
+    script.chmod(0o755)
+    for name in (*INPUTS, *ARTIFACTS, UNRELATED):
+        (app / name).parent.mkdir(parents=True, exist_ok=True)
+        (app / name).write_text("")
+    for path in (app, *app.rglob("*")):
+        os.utime(path, (OLD_INPUT_MTIME, OLD_INPUT_MTIME))
+    for name in ARTIFACTS:
+        os.utime(app / name, (ARTIFACT_MTIME, ARTIFACT_MTIME))
+    return skill
+
+
+def _run(tmp_path, skill, tool_exit="0") -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir(exist_ok=True)
+    for tool in ("npm", "npx"):
+        (fakebin / tool).write_text(FAKE_TOOL)
+        (fakebin / tool).chmod(0o755)
+    log = tmp_path / "tools.log"
+    env = os.environ | {"PATH": f"{fakebin}:{os.environ['PATH']}", "TOOL_LOG": str(log), "TOOL_EXIT": tool_exit}
+    result = subprocess.run([str(skill / "scripts/build.sh")], env=env, capture_output=True, text=True, cwd=tmp_path, check=False)
+    calls = log.read_text().splitlines() if log.exists() else []
+    return result, calls
+
+
+@pytest.mark.parametrize(
+    "bumped, expected_calls",
+    [
+        pytest.param(UNRELATED, [], id="current-artifacts-run-nothing"),
+        pytest.param("package-lock.json", ["npm install", "npx vite build"], id="newer-lockfile-reinstalls-then-rebuilds"),
+        pytest.param("src/App.tsx", ["npx vite build"], id="newer-source-rebuilds"),
+        pytest.param("src", ["npx vite build"], id="removed-source-leaves-a-newer-directory-and-rebuilds"),
+        pytest.param("index.html", ["npx vite build"], id="newer-entry-page-rebuilds"),
+        pytest.param("tsconfig.app.json", ["npx vite build"], id="newer-tsconfig-rebuilds"),
+    ],
+)
+def test_each_step_runs_only_when_an_input_outdates_its_artifact(tmp_path, bumped, expected_calls):
+    skill = _fake_skill(tmp_path)
+    os.utime(skill / "app" / bumped, (BUMPED_MTIME, BUMPED_MTIME))
+    result, calls = _run(tmp_path, skill)
+    assert result.returncode == 0, result.stderr
+    assert calls == expected_calls
+
+
+@pytest.mark.parametrize(
+    "removed, expected_calls",
+    [
+        pytest.param("node_modules", ["npm install"], id="missing-node-modules-installs"),
+        pytest.param("dist", ["npx vite build"], id="missing-dist-builds"),
+    ],
+)
+def test_a_missing_artifact_is_made(tmp_path, removed, expected_calls):
+    skill = _fake_skill(tmp_path)
+    shutil.rmtree(skill / "app" / removed)
+    result, calls = _run(tmp_path, skill)
+    assert result.returncode == 0, result.stderr
+    assert calls == expected_calls
+
+
+def test_a_failed_install_stops_before_the_build(tmp_path):
+    skill = _fake_skill(tmp_path)
+    os.utime(skill / "app/package-lock.json", (BUMPED_MTIME, BUMPED_MTIME))
+    result, calls = _run(tmp_path, skill, tool_exit="1")
+    assert result.returncode != 0
+    assert calls == ["npm install"]


### PR DESCRIPTION
## Problem

`agent/skills/dashboard/scripts/serve` and `setup.sh` gated `npm install` and `npx vite build` on `node_modules/` and `dist/` merely existing. A release that adds a dependency or changes `src/` leaves both present but stale, and the box silently serves the previous bundle: #2187 reproduced the v0.2.7 `react-markdown` release dying on an unresolved import, and #2190 showed the same bundle hash served before and after the new tree landed. `serve` runs on every container restart and upstream-sync restarts after a merge, so the launch is the one layer that can heal this. Both PRs fixed it there, with two scripts, two content stamps and a sorted `sha256sum` pipeline; this PR is the same fix in the repo's existing shape (`agent/skills/whatsapp/whatsapp`: a `find -newer` gate, no stamp).

## Change

- New `scripts/build.sh`, called by `serve`, `setup.sh` and the builder prompt: reinstall when `package-lock.json` is newer than `node_modules/.package-lock.json`; rebuild when any of `src/`, `index.html`, `vite.config.ts`, `package-lock.json`, `tsconfig*.json` is newer than `dist/index.html`. Directories count as inputs, so a deleted source file (a newer `src/` with no newer file in it) still rebuilds.
- No stamp files: a no-op `npm install` rewrites `node_modules/.package-lock.json` about 60 ms after `package-lock.json` (measured on npm 10.9.8), so a finished install reads as current on its own, and a build writes `dist/index.html`. The `touch` fallback the triage allowed for is not needed.
- The `dashboard` header, the `SETUP.md` manual steps and the `serve` comment describe the gate as it now is.
- `SKILL.md` and `dashboard-builder.md` switch the typecheck to `npx tsc -b` (the root is solution-style and `-b` walks both references, which #2185 made possible) and drop the paragraphs explaining why `-p .` compiled nothing. The builder's build line becomes `../scripts/build.sh && npx tsc -b`: deps and bundle first, then the type check, one build instead of two.
- `_rig_dashboard` in the daemon contract harness writes the build inputs pinned old and the artifacts new, and plants failing `npm`/`npx`, so a gate that misfires fails the row loudly instead of reaching for the network.

## Evidence

- `agent/tests/test_dashboard_build.py` (new, 9 tests): current artifacts run nothing; a newer lockfile installs then rebuilds; a newer `src/App.tsx`, `index.html` or `tsconfig.app.json` rebuilds; a removed source (newer `src/` only) rebuilds; missing `node_modules` installs and missing `dist` builds; a failed install stops before the build. With the existence gates substituted back into `build.sh`, 6 of the 9 fail.
- `uv run --project core pytest tests/test_daemon_contract.py -k dashboard`: 11 passed, 2 skipped (the rows' existing daemon-died skips).
- Real app in the worktree: `build.sh` with `dist/` missing builds in 3.5 s; a second run is a 5 ms no-op; after `touch src/App.tsx` it rebuilds once. `npx tsc -b` passes.
- `./check.sh guards` passes (shellcheck included); `bash -n` on every changed shell file; ruff format and check clean; no em or en dashes under `agent/`.

fixes #2186
fixes #2189

Supersedes #2187, #2190.
