### PR TITLE
fix(dream): gate the du-timeout RED on df and skip agent narration in the error count

### DIFF
--- a/agent/skills/dream/scripts/reality_check.sh
+++ b/agent/skills/dream/scripts/reality_check.sh
@@ -42,25 +42,30 @@ usage=$(df -P "$HOME" | awk 'NR==2 {gsub("%","",$5); print $5}')
 du_lines=$(timeout "$DU_TIMEOUT_SECS" du -sm "$HOME" /tmp 2>/dev/null)
 du_status=$?
 mine=$(printf '%s\n' "$du_lines" | awk '{t+=$1} END {print t+0}')
-if [ "$du_status" -eq 124 ]; then
-    bad "sizing \$HOME and /tmp took over ${DU_TIMEOUT_SECS}s: the tree is enormous or a filesystem is stuck; investigate tonight"
+if [ "$du_status" -eq 124 ]; then share="unmeasured"; else share="${mine}MB"; fi
+# A du walk a busy host starves says nothing about the disk; df decides whether the share matters.
+if [ "$du_status" -eq 124 ] && [ "${usage:-0}" -ge "$HOST_DISK_PRESSURE_PERCENT" ]; then
+    bad "sizing \$HOME and /tmp took over ${DU_TIMEOUT_SECS}s with the disk at ${usage}%: this agent's share is unmeasured while it matters; investigate tonight"
+elif [ "$du_status" -eq 124 ]; then
+    ok "sizing \$HOME and /tmp took over ${DU_TIMEOUT_SECS}s: footprint unmeasured, disk at ${usage:-unknown}%"
 elif [ "${mine:-0}" -ge "$OWN_USAGE_RED_MB" ] && [ "${usage:-0}" -ge "$HOST_DISK_PRESSURE_PERCENT" ]; then
     bad "disk at ${usage}% and this agent holds ${mine}MB of it: clean up tonight (workspace cleanup)"
 elif [ "${mine:-0}" -ge "$OWN_USAGE_RED_MB" ]; then
     ok "this agent holds ${mine}MB, but the disk is only at ${usage:-unknown}%: size without pressure, nothing to clear"
 fi
 if [ "${usage:-0}" -ge "$HOST_DISK_RED_PERCENT" ]; then
-    bad "host disk at ${usage}%, ${mine}MB of it this agent's: cleanup here cannot fix it, tell the user tonight; writes will start failing across the box"
+    bad "host disk at ${usage}%, $share of it this agent's: cleanup here cannot fix it, tell the user tonight; writes will start failing across the box"
 elif [ "${usage:-0}" -ge "$HOST_DISK_PRESSURE_PERCENT" ]; then
-    ok "host disk at ${usage}%, ${mine}MB of it this agent's; the rest is the host, not yours to clear"
+    ok "host disk at ${usage}%, $share of it this agent's; the rest is the host, not yours to clear"
 else
-    ok "host disk at ${usage:-unknown}%, ${mine}MB of it this agent's"
+    ok "host disk at ${usage:-unknown}%, $share of it this agent's"
 fi
 
 # Error storms: a component can log thousands of errors without one of them reaching a notification.
 # Only lines dated today or yesterday count (an undated line takes the date of the line above it),
 # a line whose only count is zero ("0 error(s)", "no errors") reports success and is skipped, and
-# the file's colour codes are stripped first so a dated line is seen as dated.
+# the file's colour codes are stripped first so a dated line is seen as dated. vesta.log interleaves
+# daemon output with the agent's own [AGENT] narration, which is prose, not a component's failure.
 today=$(date +%F)
 yesterday=$(date -d yesterday +%F)
 esc=$(printf '\033')
@@ -71,7 +76,7 @@ for log in "$HOME"/agent/logs/*.log; do
         BEGIN { recent = 1 }
         /^\[?[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/ { recent = ($0 ~ ("^\\[?" today)) || ($0 ~ ("^\\[?" yesterday)) }
         { low = tolower($0) }
-        recent && !((low ~ /(^|[^0-9])0 (errors|error\(s\)|warnings|warning\(s\))/ || low ~ /no errors/) && low !~ /[1-9][0-9]* (error|warning)/)' \
+        recent && $0 !~ /\[AGENT\]/ && !((low ~ /(^|[^0-9])0 (errors|error\(s\)|warnings|warning\(s\))/ || low ~ /no errors/) && low !~ /[1-9][0-9]* (error|warning)/)' \
         | grep -icE 'error|traceback')
     if [ "$errors" -gt 200 ]; then
         bad "$(basename "$log"): $errors error lines in the last 2 days; read it and find the producer"

--- a/agent/tests/test_reality_check.py
+++ b/agent/tests/test_reality_check.py
@@ -98,6 +98,41 @@ def test_error_storm_in_a_recent_log_goes_red(tmp_path):
     assert "RED stormy.log" in run.stdout
 
 
+def test_error_storm_survives_nul_bytes_in_the_log(tmp_path):
+    # An unclean write leaves NUL bytes in a log, which grep reads as binary; the storm still counts.
+    home = _healthy_home(tmp_path)
+    (home / "agent" / "logs" / "truncated.log").write_bytes(b"INFO fine\n" * 10 + b"\x00" * 200 + b"\nERROR boom\n" * 300)
+
+    run = _run(home)
+
+    assert run.returncode == 1, run.stdout + run.stderr
+    assert "RED truncated.log" in run.stdout
+
+
+def test_agent_narration_does_not_count_as_an_error_storm(tmp_path):
+    # vesta.log interleaves daemon output with the agent's own narration, so a day spent reading
+    # about ERROR correction must not be indistinguishable from a component failing all night.
+    home = _healthy_home(tmp_path)
+    (home / "agent" / "logs" / "vesta.log").write_text("[AGENT] reading about Reed-Solomon ERROR correction\n" * 260)
+
+    run = _run(home)
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "OK  vesta.log: 0 error lines in the last 2 days" in run.stdout
+
+
+def test_an_untagged_daemon_log_still_storms(tmp_path):
+    # The exclusion subtracts [AGENT]; it must not become a whitelist for [SYSTEM], or the five
+    # daemon logs that carry neither tag would score zero forever and never RED again.
+    home = _healthy_home(tmp_path)
+    (home / "agent" / "logs" / "whatsapp.log").write_text("ERROR send failed\n" * 260)
+
+    run = _run(home)
+
+    assert run.returncode == 1, run.stdout + run.stderr
+    assert "RED whatsapp.log" in run.stdout
+
+
 def test_quiet_recent_log_stays_green(tmp_path):
     home = _healthy_home(tmp_path)
     (home / "agent" / "logs" / "calm.log").write_text("INFO fine\n" * 300)
@@ -285,18 +320,37 @@ def test_a_full_host_disk_reports_even_when_this_agent_is_also_over(tmp_path):
     assert "RED host disk at 99%" in run.stdout
 
 
-def test_a_du_walk_that_never_finishes_goes_red(tmp_path):
+def _fake_du_timeout(home: pl.Path) -> None:
     # The walk is bounded by `timeout`, so a pathological tree or a stuck filesystem cannot hang
     # the dream; the shim stands in for the bound firing (exit 124) without waiting it out.
-    home = _healthy_home(tmp_path)
     fake_timeout = home / "bin" / "timeout"
     fake_timeout.write_text("#!/bin/sh\nexit 124\n")
     fake_timeout.chmod(0o755)
+
+
+def test_a_du_walk_that_never_finishes_on_a_healthy_disk_stays_green(tmp_path):
+    # df is the disk-full signal; du only sizes this agent's share, and a slow walk over a large
+    # tree on a busy host says nothing about disk health. The share is reported as unmeasured, not 0.
+    home = _healthy_home(tmp_path)
+    _fake_du_timeout(home)
+
+    run = _run(home)
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "footprint unmeasured, disk at 42%" in run.stdout
+    assert "0MB" not in run.stdout
+
+
+def test_a_du_walk_that_never_finishes_on_a_full_disk_goes_red(tmp_path):
+    home = _healthy_home(tmp_path)
+    _fake_disk_usage(home, 90)
+    _fake_du_timeout(home)
 
     run = _run(home)
 
     assert run.returncode == 1, run.stdout + run.stderr
     assert "RED sizing" in run.stdout
+    assert "0MB" not in run.stdout
 
 
 def test_wal_only_writes_keep_events_db_green(tmp_path):


### PR DESCRIPTION
## Problem

The dream's reality check reports two REDs that are noise. A `du` walk of `$HOME` and `/tmp` that a busy host starves past the 120s bound is asserted as a local fault ("the tree is enormous or a filesystem is stuck") and the host lines then print `0MB of it this agent's`, which is false (#2101, #2143). The error-storm probe counts the agent's own `[AGENT]` narration in `vesta.log`, so a day spent reading about ERROR correction reads as a component failing all night; measured at 98 of 290 matches on one box, which pushed a real 192 over the 200 threshold (#2178, issue #2177). #2219 documents that a filtering `grep` stage between `tail` and the counting `grep` reports 0 on a log carrying NUL bytes under GNU grep, so the narration exclusion must not take that shape.

## Change

- The du-timeout RED is gated on `HOST_DISK_PRESSURE_PERCENT`, the same 85% gate the own-usage RED already uses: `df` decides whether the disk is in trouble, `du` only sizes this agent's share. A timeout with the disk below the gate is an OK line reading "footprint unmeasured, disk at N%"; at or above it stays RED. After a timeout the host lines print `unmeasured` instead of `0MB`.
- `$0 !~ /\[AGENT\]/` joins the awk line filter that already ages and de-summarizes lines, so the agent's narration never reaches the count. The other daemon logs carry no tag and are untouched; no `grep -v` stage is added.
- `test_error_storm_survives_nul_bytes_in_the_log` pins that a log with NUL bytes and 300 ERROR lines still counts RED.

## Evidence

`cd agent && uv run --project core pytest tests/test_reality_check.py -q`: 30 passed. New or changed tests: `test_a_du_walk_that_never_finishes_on_a_healthy_disk_stays_green` (df=42, timeout, exit 0, no `0MB`), `test_a_du_walk_that_never_finishes_on_a_full_disk_goes_red` (df=90, timeout, exit 1), `test_agent_narration_does_not_count_as_an_error_storm`, `test_an_untagged_daemon_log_still_storms`, `test_error_storm_survives_nul_bytes_in_the_log`. With the script change stashed, the two du tests and the narration test fail against master's script; the untagged-log and NUL tests pass on master by design (regression pins). `bash -n`, `shellcheck -S warning`, `ruff format` + `ruff check`, and `./check.sh guards` are clean.

Per superseded PR: #2143's rule is kept, rebased onto the 85% pressure gate with the "unmeasured" wording and both tests. #2178's concept and both tests are kept; the `grep -v` stage is replaced by the awk clause. #2101 is the same concern as #2143 with a PSI discriminator that does not discriminate (PSI `some` measures this cgroup's own stall); only its observation that `0MB` after a timeout is false is carried. #2219: parts 3 and 4 (zero-count filter, dreamer probe) landed in #2351; part 1 (empty-count fallthrough) is not reproducible on master, where the awk filter feeds a `grep -c` that always prints; part 2 (running daemon, stale log) would RED every stable box nightly since stock daemons log startup only; its NUL test is the one part carried.

fixes #2177

Supersedes #2101, #2143, #2178, #2219.
