### PR TITLE
fix(whatsapp): name the fix for two daemon conditions status could not read

### DIFF
--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -102,8 +102,9 @@ instances at the same account/device store.
 ## Operational notes
 
 - For five minutes after a successful link, history sync locks daemon
-  stop/restart. A brief websocket EOF or `can't send presence without PushName
-  set` is normal in this window; do not bounce the daemon.
+  stop/restart. A brief websocket EOF is normal in this window; do not bounce the
+  daemon. Past the window, `can't send presence without PushName set` means no
+  push name is set and the account never appears online; run `whatsapp profile name`.
 - Use a dedicated account for the assistant. Linking a personal account grants it
   access to that account's chats.
 

--- a/agent/skills/whatsapp/cli/client.go
+++ b/agent/skills/whatsapp/cli/client.go
@@ -563,6 +563,9 @@ func (wac *WhatsAppClient) EnsureOnline() error {
 
 	if !wac.presenceActive {
 		err := wac.client.SendPresence(context.Background(), types.PresenceAvailable)
+		if errors.Is(err, whatsmeow.ErrNoPushName) {
+			return fmt.Errorf("failed to set online status: the account cannot appear online until a push name is set; run: whatsapp profile name '<name>'")
+		}
 		if err != nil {
 			return fmt.Errorf("failed to set online status: %v", err)
 		}

--- a/agent/skills/whatsapp/cli/client_test.go
+++ b/agent/skills/whatsapp/cli/client_test.go
@@ -73,6 +73,22 @@ func TestRecoverOrRestartRefusesWhenParked(t *testing.T) {
 	}
 }
 
+// TestEnsureOnlineNamesThePushNameFix: a store with no push name cannot broadcast presence,
+// so the account never appears online. The error must name the one command that fixes it,
+// since the log line is the only place the condition ever shows.
+func TestEnsureOnlineNamesThePushNameFix(t *testing.T) {
+	wac, err := NewWhatsAppClient(t.TempDir(), "", "personal", false, true, map[string]bool{}, waLog.Noop)
+	if err != nil {
+		t.Fatalf("NewWhatsAppClient: %v", err)
+	}
+	t.Cleanup(wac.Disconnect)
+
+	err = wac.EnsureOnline()
+	if err == nil || !strings.Contains(err.Error(), "whatsapp profile name") {
+		t.Fatalf("EnsureOnline without a push name must name `whatsapp profile name`, got %v", err)
+	}
+}
+
 // TestDeliberateConnectClearsPark proves a deliberate connect/link (which funnels
 // through onConnected on success) clears both the in-memory and the persisted park,
 // so a re-link ends the parked posture and lets reconnects resume.

--- a/agent/skills/whatsapp/cli/events.go
+++ b/agent/skills/whatsapp/cli/events.go
@@ -56,6 +56,12 @@ func (wac *WhatsAppClient) eventHandler(evt any) {
 	case *events.StreamError:
 		wac.logger.Errorf("WhatsApp stream error: code=%s", v.Code)
 		go wac.recoverOrRestart("stream_error:" + v.Code)
+	case *events.ClientOutdated:
+		// The server refused this client version (405) and whatsmeow stops reconnecting.
+		// The device stays linked, so record the reason for status; only a dependency
+		// bump reconnects it, never a restart or a re-pair.
+		wac.logger.Errorf("WhatsApp rejected this client version (405); run `whatsapp update-deps`, then `whatsapp daemon restart`")
+		wac.recordExit(exitClientOutdated, "WhatsApp rejected this client version (405 client outdated); the pinned whatsmeow is behind the protocol")
 	case *events.Disconnected:
 		wac.applyConnAction(classifyConnEvent(v), "")
 	case *events.StreamReplaced:
@@ -126,6 +132,10 @@ func loggedOutReason(evt *events.LoggedOut) string {
 	}
 	return "unlinked from the phone (stream:error logout)"
 }
+
+// exitClientOutdated is the exit status of a 405 rejection; status maps it to the
+// dependency bump that clears it.
+const exitClientOutdated = "client_outdated"
 
 // recordExit persists why the device session ended, so status can surface it after
 // the daemon has gone quiescent.

--- a/agent/skills/whatsapp/cli/events_test.go
+++ b/agent/skills/whatsapp/cli/events_test.go
@@ -238,6 +238,27 @@ func TestRecordDeviceLoggedOutPersistsAndNotifies(t *testing.T) {
 	}
 }
 
+// TestClientOutdatedSurfacesUpdateDepsOnStatus: a 405 leaves the daemon up but disconnected,
+// with the device still linked, so status must point at the dependency bump rather than
+// reading as a lost link that invites a re-pair.
+func TestClientOutdatedSurfacesUpdateDepsOnStatus(t *testing.T) {
+	dir := t.TempDir()
+	wac := &WhatsAppClient{state: newStateStore(dir), logger: waLog.Noop}
+
+	wac.eventHandler(&events.ClientOutdated{})
+
+	got := simpleStatus(map[string]any{"logged_in": false}, dir)
+	if got["linked"] != true || got["connected"] != false {
+		t.Fatalf("an outdated client keeps its link: %#v", got)
+	}
+	if got["next"] != "whatsapp update-deps, then whatsapp daemon restart" {
+		t.Errorf("next = %v, want the update-deps hint", got["next"])
+	}
+	if reason, _ := got["reason"].(string); !strings.Contains(reason, "405") {
+		t.Errorf("reason = %v, want the recorded 405 rejection", got["reason"])
+	}
+}
+
 func TestLoggedOutReason(t *testing.T) {
 	onConnect := loggedOutReason(&events.LoggedOut{OnConnect: true, Reason: events.ConnectFailureLoggedOut})
 	if onConnect == "" {

--- a/agent/skills/whatsapp/cli/status.go
+++ b/agent/skills/whatsapp/cli/status.go
@@ -78,16 +78,26 @@ func daemonDownStatus(dataDir string) map[string]any {
 	return result
 }
 
+// clientOutdatedNext is the one recovery for a client version the server rejects: a
+// restart or a re-link hits the same 405 until the pinned whatsmeow is bumped.
+const clientOutdatedNext = "whatsapp update-deps, then whatsapp daemon restart"
+
 // notLinkedStatus is the not-linked verdict, carrying the last logout/conflict
-// reason so the agent sees why it is not linked.
+// reason so the agent sees why it is not linked. A 405 rejection is the exception:
+// the device is still linked, so the verdict points at the dependency bump instead
+// of a connect that would re-pair.
 func notLinkedStatus(dataDir string) map[string]any {
+	st := loadStateFromDisk(dataDir)
+	if st.ExitStatus == exitClientOutdated {
+		return map[string]any{"linked": true, "connected": false, "reason": st.ExitReason, "next": clientOutdatedNext}
+	}
 	result := map[string]any{
 		"linked":    false,
 		"connected": false,
 		"next":      "run: whatsapp connect --source <vesta-cloud|doubletick|self-managed>",
 	}
-	if reason := loadStateFromDisk(dataDir).ExitReason; reason != "" {
-		result["reason"] = reason
+	if st.ExitReason != "" {
+		result["reason"] = st.ExitReason
 	}
 	return result
 }


### PR DESCRIPTION
## Problem

Two whatsapp daemon conditions were opaque to the agent, and the skill docs steered it wrong on both. #2020 found that `SETUP.md` calls the `can't send presence without PushName set` warning normal, which is true only inside the five minute post-link sync window; past it the store has no push name and the account never appears online (223 repeats over twelve days on one box, dismissed as known noise). The producer is `EnsureOnline` wrapping `whatsmeow.ErrNoPushName` without naming the fix. #2083 reported a connected-but-dead link on an outdated whatsmeow and proposed a SKILL.md exception to "never restart the daemon"; the real signature of an outdated client is a 405 on connect (`events.ClientOutdated`), after which whatsmeow stops reconnecting and the daemon stays up disconnected. The CLI never handled that event, so `whatsapp status` answered `linked:false` with the connect hint: the re-pair the linking rule forbids, spending a rate-limited pairing attempt for nothing.

## Change

- `EnsureOnline` (`cli/client.go`): `errors.Is(err, whatsmeow.ErrNoPushName)` returns an error that states the constraint and the one command that clears it (`whatsapp profile name '<name>'`), so the log line the agent reads is the fix.
- `SETUP.md`: the sync-window note keeps the websocket EOF as normal and says in one sentence what the PushName warning means past the window and what to run.
- `eventHandler` (`cli/events.go`): handles `*events.ClientOutdated` by logging the recovery and recording a `client_outdated` exit through `recordExit`, the same plumbing `applyConnAction` uses for yields, so the reason survives until the next successful connect clears it.
- `notLinkedStatus` (`cli/status.go`): a recorded `client_outdated` exit is the one not-logged-in state where the device is still linked, so the verdict is `{"linked":true,"connected":false,"reason":...,"next":"whatsapp update-deps, then whatsapp daemon restart"}` instead of the connect hint. No SKILL.md prose; the restart rule is unchanged and the CLI hands out the recovery where the agent already looks.

## Evidence

- `TestEnsureOnlineNamesThePushNameFix` (`client_test.go`): a real client over a temp store with no push name; `EnsureOnline` must name `whatsapp profile name`. Failed before with the raw whatsmeow text.
- `TestClientOutdatedSurfacesUpdateDepsOnStatus` (`events_test.go`): dispatches `&events.ClientOutdated{}` through `eventHandler`, then reads `simpleStatus` for a not-logged-in daemon; asserts `linked:true`, `connected:false`, the update-deps `next`, and a reason naming the 405. Failed before with `linked:false` and the connect hint.
- `./check.sh whatsapp`: gofmt, vet, build, test, `ok whatsapp 20.5s`.
- `./check.sh guards`: all checks passed. No em or en dashes in the changed files.

#1961 is fixed on master by #1798 (`canonicalChatKey` keys every write, and the author confirmed a LID send lands on the phone-JID row with `delivery_status=read`); closed without change. #2002 states a false mechanism (Go's `flag` accepts `-x` and `--x` identically; the failures were a nonexistent `--output` flag and a positional id); closed without change.

fixes #2082

Supersedes #2020, #2083.
