### PR TITLE
fix(vestad): install gh from GitHub's apt repository

### DIFF
--- a/vestad/Dockerfile
+++ b/vestad/Dockerfile
@@ -23,10 +23,20 @@ LABEL org.opencontainers.image.title="Vesta" \
 # without them every `browser launch` exits 255 before BiDi. The t64 names are trixie's time_t
 # rename; gdk-pixbuf comes in via GTK3.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl git gh ca-certificates tzdata gnupg screen tmux \
+    curl git ca-certificates tzdata gnupg screen tmux \
     libgtk-3-0t64 libx11-xcb1 libdbus-glib-1-2 libxtst6 libasound2t64 && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# gh from GitHub's own apt repository, not Debian's: trixie ships 2.46, whose `pr edit` queries a
+# sunset GraphQL field, prints the error, and exits 0 without applying the edit. GitHub's package
+# tracks the current release, so the upstream skill's documented commands keep working.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
     rm -rf /var/lib/apt/lists/*
 
 # ── browser handover: stream a headed Camoufox to the user so they sign in by hand ──


### PR DESCRIPTION
## Problem

The agent image installs `gh` from Debian trixie's apt (2.46.0). That version's `pr edit` selects `repository.pullRequest.projectCards`, a Projects classic field GitHub has sunset, so the query prints a GraphQL error, exits 0, and never applies the edit. `agent/skills/upstream/SKILL.md` tells agents to correct a PR's title and body with `upstream gh pr edit`, so the documented path fails in the one way an agent cannot notice. Reproduced and reported by #2162 (issue #2161), which re-implemented `pr edit` over REST in the wrapper to route around the stale package; every other sunset field in that gh stayed broken.

## Change

- `vestad/Dockerfile`: drop `gh` from the Debian package list and install it from GitHub's own apt repository (`https://cli.github.com/packages`): fetch the archive keyring into `/etc/apt/keyrings`, write `/etc/apt/sources.list.d/github-cli.list`, then `apt-get install gh`, in a RUN block shaped like the image's other package blocks.
- Fixes the root cause (a stale package) at the one layer that owns it, so no wrapper interception is needed and the upstream skill's prose is untouched.
- No version pin: the repo pins nothing from apt, and GitHub's stable channel is what keeps `gh` current against GitHub's own API.

## Evidence

- `docker run --rm debian:trixie-slim` with the exact keyring + sources + install commands: `/etc/apt/keyrings` already exists on trixie-slim, `gh version 2.99.0 (2026-09-01)` installs, and `apt-cache policy gh` shows the GitHub source (2.99.0) chosen over Debian's 2.46.0-3.
- `docker build -f vestad/Dockerfile .` from this branch: exit 0; inside the built image `gh version 2.99.0 (2026-09-01)`, `apt-cache policy gh` Installed 2.99.0, and `/etc/apt/sources.list.d/github-cli.list` present beside `debian.sources` and `nodesource.sources`.
- `./check.sh guards`: pass.

Supersedes #2162.

fixes #2161
