### PR TITLE
docs(contacts,whatsapp): the live channel is where they last wrote to you

### DIFF
--- a/agent/skills/contacts/SKILL.md
+++ b/agent/skills/contacts/SKILL.md
@@ -57,7 +57,9 @@ Only fill what's real. A near-stranger might be three lines. Someone central mig
 
 - **Someone new appears** (a new sender, a name the user mentions, a person on the calendar): add a file, even if it's just a stub.
 - **You learn something**: append it to their file. A preference, a date, a mood, a fact, a thing they're going through. Small and often beats a big rewrite.
-- **Before reaching out**: read their file so you match their style and remember what's open.
+- **Before reaching out**: read their file so you match their style and remember what's open. Then pick the channel by where they last wrote to you, never by where you last wrote to them: a channel whose recent traffic is all yours is dead, and silence from a dead channel reads exactly like an answer.
+  - Check with that channel's own command: `whatsapp messages --to <name>`, `telegram messages --to <name>`, `app-chat history` (the user's own screen), or `recall "<name>"` for a channel with no command.
+  - Record the answer on their `Channels:` line, marking the live one and when they last wrote there (`whatsapp +39... (live, last inbound 2026-08-30)`), so the next reach-out starts from it.
 - **The user asks about someone**: their file is your first stop, then `recall` for anything not captured yet.
 
 ## Keeping contacts current

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -105,6 +105,10 @@ device you hold no session for happens in the provider's infrastructure rather t
 so two agents holding an identical device set for the same recipient can get opposite results.
 Falling back to another channel is the entire remedy available to you.
 
+Pick the fallback channel by their last inbound there, never by your own last outbound: a channel
+whose recent traffic is all yours is dead, and silence from it reads exactly like an answer. Read
+it with that channel's own command (`telegram messages --to <name>`, `app-chat history`) first.
+
 ## Read
 
 - `whatsapp messages [--to <name>] [--query <text>] [--after <RFC3339>] [--limit N]` reads the local DB.


### PR DESCRIPTION
## Problem

An agent with more than one channel to a person reads a channel as live because it carries recent traffic, when that traffic is all the agent's own outbound: the person left that channel days ago and reads another. The send lands where nobody looks, gets no reply, and the silence is then recorded as the person's answer (#1929 reports exactly this on a failed-send fallback; #2147 reports it on a scheduled send and adds a script to answer "which channel are they reading"). The only signal that says where someone is right now is where they last wrote to you, and the repo states that rule nowhere.

## Change

- `agent/skills/contacts/SKILL.md`, the "Before reaching out" step: pick the channel by where they last wrote to you, never by where you last wrote to them; a channel whose recent traffic is all yours is dead; check with that channel's own command (`whatsapp messages --to`, `telegram messages --to`, `app-chat history`, `recall`); record the answer on the contact's `Channels:` line so the next reach-out starts from it.
- `agent/skills/whatsapp/SKILL.md`, right after the failed-send fallback rule: pick the fallback channel by their last inbound there, not your own last outbound, and read it with that channel's command first.
- The rule sits at the two points where a channel is chosen, not in `personality`'s voice invariants (per the maintainer's thread comment on #1929: a routing rule, not a voice rule, and unscoped there it also read as governing replies, where the arriving channel must win). No script, no `VESTA_OWNER`: the channel skills already expose inbound history through the commands named, and the contacts skill's body says no CLI and no database.

## Evidence

- Each command named exists on master with those flags: `whatsapp list-messages` (alias `messages`, positional/`--to`, `agent/skills/whatsapp/cli/cli.go:442`), `telegram list-messages` (alias `messages`, `--to`, `agent/skills/telegram/cli/main.go:43`, `cli.go:453`), `app-chat history` (`agent/skills/app-chat/cli/src/app_chat_cli/cli.py:81`), `recall` (`agent/skills/recall/SKILL.md`).
- `./check.sh guards`: exit 0.
- `uv run pytest ../tests/test_deployment.py -k dash` from `agent/core`: 2 passed (`test_no_em_or_en_dashes_in_prompt_and_skill_files`).
- `grep -rnP '\x{2014}|\x{2013}'` on both changed files: empty.

Supersedes #2147, #1929.

fixes #2146
