### PR TITLE
feat(voice): a transcribe command every skill can call

### DIFF
--- a/agent/core/migrations/2026-09-voice-transcribe-command.md
+++ b/agent/core/migrations/2026-09-voice-transcribe-command.md
@@ -1,0 +1,36 @@
+`transcribe <file> [--language <code>]` turns an audio file into text: it asks the STT provider
+configured in the voice skill first and falls back to the whisper skill's local whisper.cpp, and
+the whatsapp daemon shells it for every incoming voice note. It is a console script of the voice
+skill's CLI, so the installed tool needs one refresh for the command to exist on this box. Safe to
+run more than once.
+
+### 1. Refresh the voice CLI
+
+```bash
+uv tool install --editable ~/agent/skills/voice/cli
+command -v transcribe
+```
+
+The install is transactional and a re-run over an existing install is a no-op. The last line must
+print a path under `~/.local/bin`. If it fails, STOP, leave this migration unmarked, and report it
+to the user.
+
+### 2. Check that one transcription path works
+
+Skip this step when the whatsapp skill is not active. Otherwise `transcribe` needs either an
+enabled STT provider or the local whisper fallback:
+
+```bash
+voice-keys status
+command -v whisper-cli || echo "no whisper-cli"
+```
+
+An enabled provider shows as `"stt": {..., "enabled": true}` in the first output. If there is none
+and the second line prints `no whisper-cli`, incoming voice notes cannot be transcribed on this
+box: follow `~/agent/skills/whisper/SETUP.md` to build `whisper-cli` (the `ggml-small.bin` model
+is already present when the whatsapp skill's `setup.sh` ran), or offer the user Deepgram through
+the voice skill.
+
+### 3. Mark this migration applied
+
+Call `mark_migration_applied` with `name="2026-09-voice-transcribe-command"`.

--- a/agent/core/migrations/2026-09-voice-transcribe-command.md
+++ b/agent/core/migrations/2026-09-voice-transcribe-command.md
@@ -1,8 +1,8 @@
 `transcribe <file> [--language <code>]` turns an audio file into text: it asks the STT provider
-configured in the voice skill first and falls back to the whisper skill's local whisper.cpp, and
-the whatsapp daemon shells it for every incoming voice note. It is a console script of the voice
-skill's CLI, so the installed tool needs one refresh for the command to exist on this box. Safe to
-run more than once.
+configured in the voice skill first and falls back to a local whisper.cpp build, and the whatsapp
+daemon shells it for every incoming voice note. This box needs the console script on PATH and,
+for the fallback, the `whisper-cli` binary and a model on disk. Every step checks before acting, so
+this is safe to run more than once.
 
 ### 1. Refresh the voice CLI
 
@@ -15,21 +15,28 @@ The install is transactional and a re-run over an existing install is a no-op. T
 print a path under `~/.local/bin`. If it fails, STOP, leave this migration unmarked, and report it
 to the user.
 
-### 2. Check that one transcription path works
+### 2. Build the local whisper fallback if it is missing
 
-Skip this step when the whatsapp skill is not active. Otherwise `transcribe` needs either an
-enabled STT provider or the local whisper fallback:
+The fallback needs `whisper-cli` and `/usr/local/share/ggml-small.bin`. Check both, and build only
+what is absent (the compile takes a few minutes; the model is 488 MB):
 
 ```bash
-voice-keys status
-command -v whisper-cli || echo "no whisper-cli"
+command -v whisper-cli || {
+  apt-get update && apt-get install -y build-essential cmake ffmpeg &&
+  git clone https://github.com/ggerganov/whisper.cpp.git /opt/whisper.cpp 2>/dev/null;
+  cd /opt/whisper.cpp && git pull --ff-only &&
+  cmake -B build && cmake --build build --config Release -j"$(nproc)" &&
+  cp build/bin/whisper-cli /usr/local/bin/
+}
+[ -f /usr/local/share/ggml-small.bin ] || curl -L -o /usr/local/share/ggml-small.bin \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin
+command -v whisper-cli && [ -f /usr/local/share/ggml-small.bin ] && echo fallback-ready
 ```
 
-An enabled provider shows as `"stt": {..., "enabled": true}` in the first output. If there is none
-and the second line prints `no whisper-cli`, incoming voice notes cannot be transcribed on this
-box: follow `~/agent/skills/whisper/SETUP.md` to build `whisper-cli` (the `ggml-small.bin` model
-is already present when the whatsapp skill's `setup.sh` ran), or offer the user Deepgram through
-the voice skill.
+If the last line prints `fallback-ready`, the local path works with no provider. If the build fails
+(no disk, no network), the provider path still transcribes: tell the user the local fallback is not
+built and point them at `~/agent/skills/voice/SETUP.md` section 4, then continue to step 3 anyway,
+since a failed compile will not succeed on a later boot without their help.
 
 ### 3. Mark this migration applied
 

--- a/agent/skills/voice/SETUP.md
+++ b/agent/skills/voice/SETUP.md
@@ -59,6 +59,30 @@ Each user needs their own keys: one Deepgram key for STT (voice input), one Elev
 
 **Note:** free tier is 10k characters/month. Model `eleven_flash_v2_5`, output format `mp3_22050_32`.
 
+## 4. Local transcription fallback (whisper.cpp)
+
+`transcribe` asks the configured STT provider first (Deepgram above) and falls back to a local
+whisper.cpp build when no provider is enabled or the provider call fails. The fallback needs the
+`whisper-cli` binary and one model on disk. Build them once:
+
+```bash
+# Build deps and ffmpeg
+apt-get update && apt-get install -y build-essential cmake ffmpeg
+
+# whisper.cpp
+git clone https://github.com/ggerganov/whisper.cpp.git /opt/whisper.cpp
+cd /opt/whisper.cpp && cmake -B build && cmake --build build --config Release -j"$(nproc)"
+cp build/bin/whisper-cli /usr/local/bin/
+
+# Model: multilingual ggml-small (488 MB), the default the fallback looks for
+curl -L -o /usr/local/share/ggml-small.bin \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin
+```
+
+The whatsapp skill's `setup.sh` downloads the same model, so if you already ran that only the
+binary is missing. Other model sizes and the `WHISPER_MODEL` override live in the `whisper`
+skill's SETUP.md.
+
 ## Adding a custom ElevenLabs voice
 
 1. In the dashboard, open **Voices** -> **VoiceLab** or the Voice Library.

--- a/agent/skills/voice/SETUP.md
+++ b/agent/skills/voice/SETUP.md
@@ -6,7 +6,7 @@
 uv tool install --editable ~/agent/skills/voice/cli
 ```
 
-Provides the `voice-server` and `voice-keys` commands.
+Provides the `voice-server`, `voice-keys`, and `transcribe` commands. Re-run it whenever `[project.scripts]` in `cli/pyproject.toml` gains a command: an editable install picks up code changes on its own, but a new console script exists only after a reinstall.
 
 ## 2. Start the voice server
 

--- a/agent/skills/voice/SKILL.md
+++ b/agent/skills/voice/SKILL.md
@@ -42,6 +42,8 @@ This skill is also your one voice backend: it owns the STT/TTS providers, keys, 
 
 ## Commands
 
+**Transcribe a file**: `transcribe <file> [--language <code>]` prints the transcript of any audio or video file on stdout and nothing else. It sends the file to the configured STT provider (Deepgram Nova-3, language detected unless `--language` pins one such as `it`) and, when STT is unset, disabled, or the provider fails, runs the whisper skill's local whisper.cpp instead; it prints `{"error": ...}` on stderr and exits non-zero only when both fail. Every skill that needs speech as text calls this one command (the whatsapp daemon runs it on each incoming voice note), so a transcription problem anywhere is fixed here: check `voice-keys status`, then the whisper skill's setup.
+
 **Daemon**: `voice-keys daemon start|stop|restart|status`. Start is idempotent (never stacks a duplicate) and owns the register-service call; stop is the deliberate shutdown, so it does not fire the `daemon_died` notification every other exit fires; status reports whether the server is up and on which port. Provider and enabled state come from `voice-keys status`. Manage the daemon only through these commands, never by launching `voice-server` yourself.
 
 ```bash
@@ -69,6 +71,10 @@ voice-keys remove-keyterm <term>
 # STT end-of-turn tuning
 voice-keys set-eot --threshold 0.8
 voice-keys set-eot --timeout-ms 10000
+
+# One audio or video file to text (provider first, local whisper fallback)
+transcribe ~/note.ogg
+transcribe ~/meeting.mp4 --language it
 ```
 
 ## Common asks

--- a/agent/skills/voice/cli/pyproject.toml
+++ b/agent/skills/voice/cli/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
 [project.scripts]
 voice-server = "voice.server:main"
 voice-keys = "voice.voice_keys:main"
+transcribe = "voice.transcribe:main"
 
 [dependency-groups]
 dev = ["pytest>=8.4.0"]

--- a/agent/skills/voice/cli/src/voice/config.py
+++ b/agent/skills/voice/cli/src/voice/config.py
@@ -20,6 +20,10 @@ Domain = dict[str, SettingValue]
 VoiceConfig = dict[tp.Literal["stt", "tts"], Domain | None]
 
 
+def data_dir() -> pl.Path:
+    return pl.Path.home() / ".voice"
+
+
 def config_path(data_dir: pl.Path) -> pl.Path:
     return data_dir / VOICE_CONFIG_FILENAME
 
@@ -55,6 +59,25 @@ def mutate(data_dir: pl.Path, updater: tp.Callable[[VoiceConfig], VoiceConfig]) 
     new = updater(current)
     save(data_dir, new)
     return new
+
+
+def provider_name(entry: Domain | None) -> str | None:
+    """The domain's configured provider name, or None when unset."""
+    if not entry or "provider" not in entry:
+        return None
+    name = entry["provider"]
+    return name if isinstance(name, str) and name else None
+
+
+def provider_creds(entry: Domain, provider: str) -> dict[str, str]:
+    """The credentials stored for one provider under a domain, or an empty dict."""
+    creds = _credentials(entry)
+    value = creds[provider] if provider in creds else {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def is_enabled(entry: Domain | None) -> bool:
+    return bool(entry and "enabled" in entry and entry["enabled"])
 
 
 def _credentials(entry: Domain) -> dict[str, dict[str, str]]:

--- a/agent/skills/voice/cli/src/voice/handlers.py
+++ b/agent/skills/voice/cli/src/voice/handlers.py
@@ -62,21 +62,6 @@ def _spawn_invalidation(scope: str) -> None:
     task.add_done_callback(_INVALIDATION_TASKS.discard)
 
 
-def _provider_name(entry: voice_config.Domain | None) -> str | None:
-    """The domain's configured provider name, or None when unset."""
-    if not entry or "provider" not in entry:
-        return None
-    name = entry["provider"]
-    return name if isinstance(name, str) and name else None
-
-
-def _provider_creds(entry: voice_config.Domain, provider_name: str) -> dict[str, str]:
-    creds = entry["credentials"] if "credentials" in entry else None
-    if not isinstance(creds, dict) or provider_name not in creds:
-        return {}
-    return creds[provider_name]
-
-
 def _resolve_domain(
     domain: tp.Literal["stt", "tts"],
 ) -> tuple[dict, str, tp.Any, dict[str, str]] | web.Response:
@@ -86,13 +71,13 @@ def _resolve_domain(
     """
     cfg = voice_config.load(DATA_DIR)
     entry = cfg[domain]
-    provider_name = _provider_name(entry)
+    provider_name = voice_config.provider_name(entry)
     if not entry or provider_name is None:
         return web.json_response({"error": f"{domain.upper()} not configured"}, status=503)
     provider = providers.get_stt(provider_name) if domain == "stt" else providers.get_tts(provider_name)
     if not provider:
         return web.json_response({"error": f"unknown {domain} provider: {provider_name}"}, status=500)
-    return entry, provider_name, provider, _provider_creds(entry, provider_name)
+    return entry, provider_name, provider, voice_config.provider_creds(entry, provider_name)
 
 
 async def _json_body(request: web.Request) -> dict | web.Response:
@@ -128,7 +113,7 @@ async def stt_status(_request: web.Request) -> web.Response:
     cfg = voice_config.load(DATA_DIR)
     stt_entry = cfg["stt"]
 
-    provider_name = _provider_name(stt_entry)
+    provider_name = voice_config.provider_name(stt_entry)
     if not stt_entry or provider_name is None:
         return web.json_response({"configured": False, "provider": None})
 
@@ -216,7 +201,7 @@ async def tts_status(_request: web.Request) -> web.Response:
     cfg = voice_config.load(DATA_DIR)
     tts_entry = cfg["tts"]
 
-    provider_name = _provider_name(tts_entry)
+    provider_name = voice_config.provider_name(tts_entry)
     if not tts_entry or provider_name is None:
         return web.json_response({"configured": False, "provider": None})
 

--- a/agent/skills/voice/cli/src/voice/providers/base.py
+++ b/agent/skills/voice/cli/src/voice/providers/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pathlib as pl
 import typing as tp
 
 from aiohttp import web
@@ -29,6 +30,11 @@ class SttProvider(tp.Protocol):
 
     async def relay(self, browser_ws: web.WebSocketResponse, creds: dict[str, str], stt_domain: dict) -> None:
         """Open upstream STT connection, relay audio frames <-> transcript events."""
+        ...
+
+    async def transcribe_file(self, audio_path: pl.Path, creds: dict[str, str], language: str | None) -> str:
+        """One-shot transcription of an audio file, detecting the language when none is given.
+        Returns the trimmed transcript, empty when nothing was said."""
         ...
 
     async def usage(self, creds: dict[str, str]) -> dict:

--- a/agent/skills/voice/cli/src/voice/providers/deepgram.py
+++ b/agent/skills/voice/cli/src/voice/providers/deepgram.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import pathlib as pl
 import typing as tp
 from urllib.parse import urlencode
 
@@ -19,6 +20,10 @@ MODEL = "flux-general-en"
 MODEL_MULTI = "nova-3"
 ENCODING = "linear16"
 SAMPLE_RATE = 16000
+
+# Prerecorded (one-shot file) transcription, the `transcribe` command's provider path.
+PRERECORDED_MODEL = "nova-3"
+PRERECORDED_TIMEOUT_SECS = 120
 
 
 class DeepgramStt:
@@ -106,6 +111,20 @@ class DeepgramStt:
                     await dg_ws.close()
         finally:
             await session.close()
+
+    async def transcribe_file(self, audio_path: pl.Path, creds: dict[str, str], language: str | None) -> str:
+        if "api_key" not in creds or not creds["api_key"]:
+            raise ValueError("missing deepgram api_key")
+        url = f"{DEEPGRAM_API}/v1/listen?{urlencode(_prerecorded_params(language))}"
+        headers = {"Authorization": f"Token {creds['api_key']}", "Content-Type": "audio/*"}
+        audio = await asyncio.to_thread(audio_path.read_bytes)
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(url, data=audio, headers=headers, timeout=aiohttp.ClientTimeout(total=PRERECORDED_TIMEOUT_SECS)) as resp,
+        ):
+            if resp.status != 200:
+                raise RuntimeError(f"deepgram returned {resp.status}: {(await resp.text()).strip()}")
+            return _prerecorded_transcript(await resp.json())
 
     async def _cached_project_id(self, api_key: str) -> str | None:
         if (cached := self._project_id_cache.get(api_key)) is not None:
@@ -195,6 +214,18 @@ def _listen_url(stt_domain: dict, multi_language: bool) -> str:
         params.append((keyterm_param, term))
     # Build the URL only after keyterms are appended, otherwise they are dropped.
     return f"{DEEPGRAM_WS}{listen_path}?{urlencode(params)}"
+
+
+def _prerecorded_params(language: str | None) -> list[tuple[str, str]]:
+    """Nova-3 with smart formatting; `multi` makes Deepgram detect the spoken language."""
+    return [("model", PRERECORDED_MODEL), ("smart_format", "true"), ("language", language or "multi")]
+
+
+def _prerecorded_transcript(body: dict) -> str:
+    try:
+        return body["results"]["channels"][0]["alternatives"][0]["transcript"].strip()
+    except (KeyError, IndexError, TypeError):
+        return ""
 
 
 async def _browser_to_deepgram(browser_ws: web.WebSocketResponse, dg_ws: aiohttp.ClientWebSocketResponse) -> None:

--- a/agent/skills/voice/cli/src/voice/transcribe.py
+++ b/agent/skills/voice/cli/src/voice/transcribe.py
@@ -20,8 +20,12 @@ from . import providers
 WHISPER_SCRIPT = pl.Path(__file__).resolve().parents[4] / "whisper" / "scripts" / "whisper_transcribe.sh"
 
 # whisper.cpp prints a bracketed tag ("[BLANK_AUDIO]", "[Musica]") instead of text for a
-# near-silent clip; output made only of such tags is silence, not a transcript.
-_TAG_ONLY = re.compile(r"^(\s*\[[^\[\]]+\]\s*)+$")
+# near-silent clip; output that is nothing but such tags is silence, not a transcript.
+_TAG = re.compile(r"\[[^\[\]]+\]")
+
+
+def _is_silence(text: str) -> bool:
+    return not _TAG.sub("", text).strip()
 
 
 async def _provider_transcript(path: pl.Path, language: str | None) -> str:
@@ -53,7 +57,7 @@ def _whisper_transcript(path: pl.Path, language: str | None) -> str:
         detail = " ".join(result.stderr.split()) or f"exited {result.returncode}"
         raise RuntimeError(detail)
     text = result.stdout.strip()
-    return "" if _TAG_ONLY.match(text) else text
+    return "" if _is_silence(text) else text
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/agent/skills/voice/cli/src/voice/transcribe.py
+++ b/agent/skills/voice/cli/src/voice/transcribe.py
@@ -1,0 +1,83 @@
+"""transcribe <file> [--language <code>]: one transcript on stdout, whichever backend answered.
+
+The configured STT provider goes first. When STT is unset, disabled, or the provider fails,
+the whisper skill's local whisper.cpp script transcribes instead. Only when both fail does the
+command print {"error": ...} on stderr and exit non-zero, so any skill can shell it and read
+stdout as the transcript.
+"""
+
+import argparse
+import asyncio
+import json
+import pathlib as pl
+import re
+import subprocess
+import sys
+
+from . import config as vc
+from . import providers
+
+WHISPER_SCRIPT = pl.Path(__file__).resolve().parents[4] / "whisper" / "scripts" / "whisper_transcribe.sh"
+
+# whisper.cpp prints a bracketed tag ("[BLANK_AUDIO]", "[Musica]") instead of text for a
+# near-silent clip; output made only of such tags is silence, not a transcript.
+_TAG_ONLY = re.compile(r"^(\s*\[[^\[\]]+\]\s*)+$")
+
+
+async def _provider_transcript(path: pl.Path, language: str | None) -> str:
+    """The configured STT provider's transcript. Raises on any config or provider fault."""
+    entry = vc.load(vc.data_dir())["stt"]
+    name = vc.provider_name(entry)
+    if not entry or name is None:
+        raise RuntimeError("STT not configured")
+    if not vc.is_enabled(entry):
+        raise RuntimeError("STT disabled")
+    provider = providers.get_stt(name)
+    if provider is None:
+        raise RuntimeError(f"unknown STT provider: {name}")
+    creds = vc.provider_creds(entry, name)
+    if not creds:
+        raise RuntimeError(f"no credentials for STT provider: {name}")
+    return await provider.transcribe_file(path, creds, language)
+
+
+def _whisper_transcript(path: pl.Path, language: str | None) -> str:
+    """The whisper skill's local transcript. Raises when whisper.cpp cannot run."""
+    if not WHISPER_SCRIPT.is_file():
+        raise RuntimeError(f"whisper skill script missing: {WHISPER_SCRIPT}")
+    args = [str(WHISPER_SCRIPT), str(path)]
+    if language:
+        args += ["--language", language]
+    result = subprocess.run(args, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        detail = " ".join(result.stderr.split()) or f"exited {result.returncode}"
+        raise RuntimeError(detail)
+    text = result.stdout.strip()
+    return "" if _TAG_ONLY.match(text) else text
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="transcribe",
+        description="Transcribe one audio or video file: the configured STT provider first, local whisper.cpp when it cannot answer.",
+    )
+    parser.add_argument("file", type=pl.Path)
+    parser.add_argument("--language", default=None, help="language code such as en or it; detected when omitted")
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    if not args.file.is_file():
+        print(json.dumps({"error": f"file not found: {args.file}"}), file=sys.stderr)
+        return 1
+    try:
+        transcript = asyncio.run(_provider_transcript(args.file, args.language))
+    except Exception as provider_error:
+        try:
+            transcript = _whisper_transcript(args.file, args.language)
+        except RuntimeError as whisper_error:
+            print(json.dumps({"error": f"{provider_error}; whisper: {whisper_error}"}), file=sys.stderr)
+            return 1
+    print(transcript)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent/skills/voice/cli/tests/test_transcribe.py
+++ b/agent/skills/voice/cli/tests/test_transcribe.py
@@ -1,0 +1,211 @@
+"""The transcribe command: provider first, whisper fallback, transcript-only stdout."""
+
+import functools
+import pathlib as pl
+import typing as tp
+
+import pytest
+from voice import config as vc
+from voice import transcribe
+from voice.providers import deepgram
+
+
+def test_prerecorded_transcript_reads_first_alternative() -> None:
+    body = {"results": {"channels": [{"alternatives": [{"transcript": "  ciao come stai  "}]}]}}
+    assert deepgram._prerecorded_transcript(body) == "ciao come stai"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {},
+        {"results": {"channels": []}},
+        {"results": {"channels": [{"alternatives": []}]}},
+    ],
+)
+def test_prerecorded_transcript_empty_when_nothing_recognized(body: dict) -> None:
+    assert deepgram._prerecorded_transcript(body) == ""
+
+
+def test_prerecorded_params_detect_language_when_none_given() -> None:
+    params = dict(deepgram._prerecorded_params(None))
+    assert params["model"] == deepgram.PRERECORDED_MODEL
+    assert params["smart_format"] == "true"
+    assert params["language"] == "multi"
+
+
+def test_prerecorded_params_pin_the_given_language() -> None:
+    assert dict(deepgram._prerecorded_params("it"))["language"] == "it"
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["", "   ", "\t\n", "[Musica]", "[BLANK_AUDIO]", "[Musik]", "[tk]", "[Musica]  ", "[BLANK_AUDIO][BLANK_AUDIO]", "[Musica] [Musik]"],
+)
+def test_whisper_tag_only_output_is_silence(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch, text: str) -> None:
+    _fake_whisper(tmp_path, monkeypatch, stdout=text)
+    assert transcribe._whisper_transcript(tmp_path / "note.ogg", None) == ""
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["Ciao, come stai?", "See you at [the pub] later", "[Musica] and then he said go", "uh [tk] hmm actually no", "x"],
+)
+def test_whisper_real_output_is_kept(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch, text: str) -> None:
+    _fake_whisper(tmp_path, monkeypatch, stdout=text)
+    assert transcribe._whisper_transcript(tmp_path / "note.ogg", None) == text
+
+
+class _FakeStt:
+    name = "deepgram"
+
+    def __init__(self, transcript: str | None, error: Exception | None = None) -> None:
+        self._transcript = transcript
+        self._error = error
+        self.seen: dict[str, tp.Any] = {}
+
+    async def transcribe_file(self, audio_path: pl.Path, creds: dict[str, str], language: str | None) -> str:
+        self.seen = {"audio_path": audio_path, "creds": creds, "language": language}
+        if self._error is not None:
+            raise self._error
+        assert self._transcript is not None
+        return self._transcript
+
+
+def _fake_whisper(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch, *, stdout: str = "", exit_code: int = 0, stderr: str = "") -> pl.Path:
+    """A stand-in whisper_transcribe.sh that records its arguments and answers as told."""
+    (tmp_path / "whisper_stdout").write_text(stdout)
+    (tmp_path / "whisper_stderr").write_text(stderr)
+    script = tmp_path / "whisper_transcribe.sh"
+    script.write_text(
+        "#!/bin/bash\n"
+        f'printf "%s\\n" "$@" > "{tmp_path}/whisper_args"\n'
+        f'cat "{tmp_path}/whisper_stderr" >&2\n'
+        f'cat "{tmp_path}/whisper_stdout"\n'
+        f"exit {exit_code}\n"
+    )
+    script.chmod(0o755)
+    monkeypatch.setattr(transcribe, "WHISPER_SCRIPT", script)
+    return tmp_path / "whisper_args"
+
+
+@pytest.fixture
+def home(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch) -> pl.Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def audio(tmp_path: pl.Path) -> pl.Path:
+    path = tmp_path / "note.ogg"
+    path.write_bytes(b"opus")
+    return path
+
+
+def _configure_stt(home: pl.Path, *, enabled: bool = True) -> None:
+    vc.set_key(home / ".voice", "stt", "deepgram", "dg-key")
+    vc.set_enabled(home / ".voice", "stt", enabled)
+
+
+def _leave_stt_unset(_home: pl.Path) -> None:
+    return None
+
+
+def test_provider_transcript_is_the_only_stdout(
+    home: pl.Path, audio: pl.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _configure_stt(home)
+    fake = _FakeStt("ciao come stai")
+    monkeypatch.setattr(transcribe.providers, "get_stt", lambda _name: fake)
+    whisper_args = _fake_whisper(home, monkeypatch, stdout="never used")
+
+    code = transcribe.main([str(audio), "--language", "it"])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out == "ciao come stai\n"
+    assert captured.err == ""
+    assert fake.seen == {"audio_path": audio, "creds": {"api_key": "dg-key"}, "language": "it"}
+    assert not whisper_args.exists()
+
+
+def test_empty_provider_transcript_is_silence_not_a_fallback(
+    home: pl.Path, audio: pl.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _configure_stt(home)
+    monkeypatch.setattr(transcribe.providers, "get_stt", lambda _name: _FakeStt(""))
+    whisper_args = _fake_whisper(home, monkeypatch, stdout="[BLANK_AUDIO]")
+
+    code = transcribe.main([str(audio)])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out == "\n"
+    assert not whisper_args.exists()
+
+
+@pytest.mark.parametrize(
+    ("configure", "provider"),
+    [
+        (_leave_stt_unset, _FakeStt("unused")),
+        (functools.partial(_configure_stt, enabled=False), _FakeStt("unused")),
+        (_configure_stt, _FakeStt(None, error=RuntimeError("deepgram returned 500"))),
+    ],
+    ids=["unset", "disabled", "provider error"],
+)
+def test_whisper_answers_when_the_provider_cannot(
+    home: pl.Path,
+    audio: pl.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    configure: tp.Callable[[pl.Path], None],
+    provider: _FakeStt,
+) -> None:
+    configure(home)
+    monkeypatch.setattr(transcribe.providers, "get_stt", lambda _name: provider)
+    whisper_args = _fake_whisper(home, monkeypatch, stdout="hello there")
+
+    code = transcribe.main([str(audio), "--language", "en"])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out == "hello there\n"
+    assert captured.err == ""
+    assert whisper_args.read_text().split("\n")[:3] == [str(audio), "--language", "en"]
+
+
+def test_both_failing_reports_both_reasons_on_stderr(
+    home: pl.Path, audio: pl.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _fake_whisper(home, monkeypatch, exit_code=1, stderr="Error: whisper-cli not found at /usr/local/bin/whisper-cli\nRun the setup first.")
+
+    code = transcribe.main([str(audio)])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out == ""
+    assert (
+        captured.err
+        == '{"error": "STT not configured; whisper: Error: whisper-cli not found at /usr/local/bin/whisper-cli Run the setup first."}\n'
+    )
+
+
+def test_missing_whisper_script_is_named(
+    home: pl.Path, audio: pl.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(transcribe, "WHISPER_SCRIPT", home / "nowhere.sh")
+
+    code = transcribe.main([str(audio)])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "whisper skill script missing" in captured.err
+
+
+def test_missing_audio_file_fails_before_any_backend(home: pl.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    code = transcribe.main([str(home / "absent.ogg")])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out == ""
+    assert "file not found" in captured.err

--- a/agent/skills/voice/cli/tests/test_transcribe.py
+++ b/agent/skills/voice/cli/tests/test_transcribe.py
@@ -2,6 +2,7 @@
 
 import functools
 import pathlib as pl
+import time
 import typing as tp
 
 import pytest
@@ -54,6 +55,16 @@ def test_whisper_tag_only_output_is_silence(tmp_path: pl.Path, monkeypatch: pyte
 def test_whisper_real_output_is_kept(tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch, text: str) -> None:
     _fake_whisper(tmp_path, monkeypatch, stdout=text)
     assert transcribe._whisper_transcript(tmp_path / "note.ogg", None) == text
+
+
+def test_silence_check_stays_linear_on_a_long_tag_run() -> None:
+    text = "[Z] " * 20000 + "still speech"
+
+    started = time.perf_counter()
+    silence = transcribe._is_silence(text)
+
+    assert not silence
+    assert time.perf_counter() - started < 1.0
 
 
 class _FakeStt:

--- a/agent/skills/whatsapp/SETUP.md
+++ b/agent/skills/whatsapp/SETUP.md
@@ -110,12 +110,15 @@ instances at the same account/device store.
 
 ## Transcription
 
-Voice notes transcribe in-process: the CLI downloads the audio, `ffmpeg` converts
-it to 16kHz mono WAV, and the built-in whisper.cpp bindings replace the `[audio]`
-placeholder with the text. Override the model path with the `WHISPER_MODEL` env
-var (default `/usr/local/share/ggml-small.bin`, downloaded by `setup.sh`). Set
-`WHISPER_LANGUAGE` to a whisper.cpp language code (default: auto-detect) when the
-user's voice notes are one known language, since auto-detection can misread short clips.
+Voice notes transcribe through the voice skill's `transcribe` command: the daemon
+downloads the audio and shells `transcribe <file>`, which asks the configured STT
+provider first and falls back to the whisper skill's local whisper.cpp (`whisper-cli`
+plus the `ggml-small.bin` model `setup.sh` downloads). The command exists once the
+voice CLI is installed (`uv tool install --editable ~/agent/skills/voice/cli`); a
+voice note whose transcription fails arrives as a notification naming what is missing.
+Set `WHISPER_LANGUAGE` to a language code (default: auto-detect) when the user's voice
+notes are one known language, since auto-detection can misread short clips; the daemon
+passes it to `transcribe --language`.
 
 ## Contact cards
 

--- a/agent/skills/whatsapp/SKILL.md
+++ b/agent/skills/whatsapp/SKILL.md
@@ -141,6 +141,11 @@ People change their minds after they hit send, so a message you already read can
 - **An edit** arrives as an `edit` notification whose body carries what the message says now, just like a plain message, naming the message that changed (`target_message_id`) and the text you last saw (`old_text`). The stored message is rewritten, so `list-messages` and search show only the new text. Answer again only if the edit asks something new: a fixed typo needs nothing from you.
 - **A deletion** (delete-for-everyone) arrives as a `revoke` notification with the text you last saw in `old_text`. They took it back, so treat it as unsaid and do not quote it at them.
 
+## Voice notes
+
+An incoming voice note reaches you already transcribed: the daemon runs the voice skill's `transcribe` on it (configured STT provider first, local whisper fallback). To transcribe it again, or any audio or video someone sent, download it and run `transcribe` yourself:
+`whatsapp download-media --message-id <id> --to <chat> --download-path <file>` then `transcribe <file> --language <code>` (drop `--language` to detect it). A transcription that fails names what is missing; fix it in the voice skill, since every voice note goes through the same command.
+
 ## Voice calls
 
 Hold a live call in your own voice (the `voice` skill's TTS) and hear the other person (its STT):

--- a/agent/skills/whatsapp/cli/constants.go
+++ b/agent/skills/whatsapp/cli/constants.go
@@ -50,13 +50,6 @@ const (
 	QRCodeSize                  = 256
 	MaxConcurrentTranscriptions = 3
 
-	// WhisperMaxThreads caps the compute threads a transcription may use. The Go
-	// binding defaults each context to runtime.NumCPU(), which starves the
-	// daemon's own work on a big box; whisper.cpp gains little past a handful of
-	// threads anyway. 4 matches the whisper skill's own default
-	// (skills/whisper/scripts/whisper_transcribe.sh).
-	WhisperMaxThreads = 4
-
 	TypingDelayPerChar = 25 * time.Millisecond
 	TypingDelayMin     = 1500 * time.Millisecond
 	TypingDelayMax     = 6 * time.Second
@@ -103,8 +96,6 @@ const (
 	MediaTypeVideo    = "video"
 	MediaTypeAudio    = "audio"
 	MediaTypeDocument = "document"
-
-	DefaultWhisperModelPath = "/usr/local/share/ggml-small.bin"
 )
 
 var shellEscapeReplacer = strings.NewReplacer(

--- a/agent/skills/whatsapp/cli/transcribe.go
+++ b/agent/skills/whatsapp/cli/transcribe.go
@@ -1,172 +1,58 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"sync"
-
-	"github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper"
-	wav "github.com/go-audio/wav"
 )
 
-var (
-	whisperModel     whisper.Model
-	whisperModelOnce sync.Once
-	whisperModelErr  error
-
-	// whisperProcessMu serializes all use of the whisper C context: model.NewContext
-	// hands out a fresh wrapper per call, but every wrapper shares the one underlying
-	// C model context, which whisper.cpp does not support calling concurrently.
-	whisperProcessMu sync.Mutex
-)
-
-// getLanguage returns WHISPER_LANGUAGE when set (a fixed whisper.cpp language
-// code, since auto-detection can misread short clips), defaulting to "auto".
-func getLanguage() string {
-	if l := os.Getenv("WHISPER_LANGUAGE"); l != "" {
-		return l
+// transcribeArgs builds the `transcribe` invocation: the audio file, plus the
+// language WHISPER_LANGUAGE pins (auto-detection can misread short clips).
+func transcribeArgs(audioPath, language string) []string {
+	args := []string{audioPath}
+	if language != "" {
+		args = append(args, "--language", language)
 	}
-	return "auto"
+	return args
 }
 
-func getModelPath() string {
-	if p := os.Getenv("WHISPER_MODEL"); p != "" {
-		return p
-	}
-	// Prefer multilingual models, fall back to english-only
-	if _, err := os.Stat(DefaultWhisperModelPath); err == nil {
-		return DefaultWhisperModelPath
-	}
-	fallbacks := []string{
-		"/usr/local/share/ggml-small.en.bin",
-		"/usr/local/share/ggml-tiny.bin",
-		"/usr/local/share/ggml-tiny.en.bin",
-	}
-	for _, fb := range fallbacks {
-		if _, err := os.Stat(fb); err == nil {
-			return fb
-		}
-	}
-	return DefaultWhisperModelPath
-}
-
-func loadWhisperModel() (whisper.Model, error) {
-	whisperModelOnce.Do(func() {
-		modelPath := getModelPath()
-		whisperModel, whisperModelErr = whisper.New(modelPath)
-		if whisperModelErr != nil {
-			whisperModelErr = fmt.Errorf("failed to load whisper model at %s (run ~/agent/skills/whatsapp/setup.sh to download it): %w", modelPath, whisperModelErr)
-		}
-	})
-	return whisperModel, whisperModelErr
-}
-
-// whisperThreads is the per-transcription thread budget: all of a small box's
-// cores, capped at WhisperMaxThreads on a big one.
-func whisperThreads(numCPU int) uint {
-	return uint(min(numCPU, WhisperMaxThreads))
-}
-
-// transcribeAudioBuiltIn transcribes audio using the built-in whisper.cpp bindings.
-func transcribeAudioBuiltIn(audioPath string) (string, error) {
-	model, err := loadWhisperModel()
-	if err != nil {
-		return "", err
-	}
-
-	// Convert to 16kHz mono WAV using ffmpeg
-	wavPath := audioPath + ".wav"
-	defer os.Remove(wavPath)
-
-	cmd := exec.Command("ffmpeg", "-i", audioPath, "-ar", "16000", "-ac", "1", "-f", "wav", "-y", wavPath)
-	cmd.Stderr = nil
-	cmd.Stdout = nil
+// runTranscribe shells the voice skill's `transcribe`, which owns provider
+// selection and the local whisper fallback: stdout is the transcript, and a
+// non-zero exit carries {"error"} on stderr.
+func runTranscribe(audioPath string) (string, error) {
+	cmd := exec.Command("transcribe", transcribeArgs(audioPath, os.Getenv("WHISPER_LANGUAGE"))...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("ffmpeg conversion failed: %w", err)
+		return "", transcribeError(stderr.Bytes(), err)
 	}
-
-	// Read WAV file
-	samples, err := readWAVSamples(wavPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to read WAV: %w", err)
-	}
-
-	// Create context and process
-	ctx, err := model.NewContext()
-	if err != nil {
-		return "", fmt.Errorf("failed to create whisper context: %w", err)
-	}
-
-	lang := getLanguage()
-	if err := ctx.SetLanguage(lang); err != nil {
-		return "", fmt.Errorf("failed to set language to %q: %w", lang, err)
-	}
-
-	// Cap compute threads: the binding otherwise gives the context
-	// runtime.NumCPU(). Thread count only partitions the matmuls, it is not a
-	// decoding parameter, so the transcript is unaffected.
-	ctx.SetThreads(whisperThreads(runtime.NumCPU()))
-
-	// Process and segment reads both touch the C model context shared by every
-	// context wrapper (see whisperProcessMu).
-	whisperProcessMu.Lock()
-	defer whisperProcessMu.Unlock()
-
-	if err := ctx.Process(samples, nil, nil, nil); err != nil {
-		return "", fmt.Errorf("whisper processing failed: %w", err)
-	}
-
-	var parts []string
-	for {
-		segment, err := ctx.NextSegment()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return "", fmt.Errorf("failed to get segment: %w", err)
-		}
-		parts = append(parts, segment.Text)
-	}
-
-	return strings.TrimSpace(strings.Join(parts, "")), nil
+	return strings.TrimSpace(stdout.String()), nil
 }
 
-func readWAVSamples(path string) ([]float32, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
+// transcribeError names why `transcribe` did not answer: the command is not
+// installed, the structured {error} it printed, or a bare exit failure.
+func transcribeError(stderr []byte, runErr error) error {
+	if errors.Is(runErr, exec.ErrNotFound) {
+		return errors.New("transcribe not on PATH; install it with: uv tool install --editable ~/agent/skills/voice/cli")
 	}
-	defer f.Close()
-
-	dec := wav.NewDecoder(f)
-	if !dec.IsValidFile() {
-		return nil, fmt.Errorf("invalid WAV file")
+	var resp struct {
+		Error string `json:"error"`
 	}
-
-	buf, err := dec.FullPCMBuffer()
-	if err != nil {
-		return nil, err
+	if json.Unmarshal(bytes.TrimSpace(stderr), &resp) == nil && resp.Error != "" {
+		return fmt.Errorf("transcribe: %s", resp.Error)
 	}
-
-	// Convert int samples to float32 [-1.0, 1.0]
-	samples := make([]float32, len(buf.Data))
-	bitDepth := dec.BitDepth
-	maxVal := float32(int(1)<<(bitDepth-1) - 1)
-	for i, s := range buf.Data {
-		samples[i] = float32(s) / maxVal
-	}
-
-	return samples, nil
+	return fmt.Errorf("transcribe failed: %w", runErr)
 }
 
-// Convenience wrapper used by handleMessage. Returns the transcription text and any error.
+// transcribeAudioMessage downloads a voice note and hands it to `transcribe`.
+// An empty transcript is a clean answer (silence), never an error.
 func (wac *WhatsAppClient) transcribeAudioMessage(messageID, chatJID string) (string, error) {
-	// Download audio to temp file
 	tmpFile := filepath.Join(os.TempDir(), fmt.Sprintf("wa_audio_%s.ogg", messageID))
 	defer os.Remove(tmpFile)
 
@@ -176,12 +62,11 @@ func (wac *WhatsAppClient) transcribeAudioMessage(messageID, chatJID string) (st
 		return "", fmt.Errorf("failed to download audio: %w", err)
 	}
 
-	text, err := transcribeAudioBuiltIn(path)
+	text, err := runTranscribe(path)
 	if err != nil {
-		wac.logger.Warnf("Transcription failed: %v", err)
+		wac.logger.Warnf("Transcription failed for %s: %v", messageID, err)
 		return "", err
 	}
-
 	if text != "" {
 		wac.logger.Infof("Transcribed audio %s: %s", messageID, text)
 	}

--- a/agent/skills/whatsapp/cli/transcribe_test.go
+++ b/agent/skills/whatsapp/cli/transcribe_test.go
@@ -1,24 +1,37 @@
 package main
 
-import "testing"
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
 
-// The thread budget uses every core on a small box and stays at
-// WhisperMaxThreads on a big one, so one transcription never pins a large
-// host while a single-core box still gets a worker.
-func TestWhisperThreadsClampsToMaxOnBigBoxes(t *testing.T) {
-	cases := []struct {
-		numCPU int
-		want   uint
-	}{
-		{numCPU: 1, want: 1},
-		{numCPU: 2, want: 2},
-		{numCPU: 4, want: 4},
-		{numCPU: 8, want: 4},
-		{numCPU: 32, want: 4},
+// WHISPER_LANGUAGE rides into `transcribe` as --language, so the provider and
+// the whisper fallback both honor the pin; unset, the command auto-detects.
+func TestTranscribeArgsCarryTheLanguagePin(t *testing.T) {
+	if got := strings.Join(transcribeArgs("/tmp/a.ogg", ""), " "); got != "/tmp/a.ogg" {
+		t.Errorf("no pin: args = %q, want the file alone", got)
 	}
-	for _, tc := range cases {
-		if got := whisperThreads(tc.numCPU); got != tc.want {
-			t.Errorf("whisperThreads(%d) = %d, want %d", tc.numCPU, got, tc.want)
-		}
+	if got := strings.Join(transcribeArgs("/tmp/a.ogg", "it"), " "); got != "/tmp/a.ogg --language it" {
+		t.Errorf("pinned: args = %q, want --language it", got)
+	}
+}
+
+// transcribeError names why `transcribe` did not answer: the {error} it
+// printed, a missing command (with the install line), or a bare exit failure,
+// so the notification the agent reads says what to fix.
+func TestTranscribeError(t *testing.T) {
+	exit := &exec.ExitError{}
+	notFound := &exec.Error{Name: "transcribe", Err: exec.ErrNotFound}
+
+	if err := transcribeError([]byte(`{"error":"STT not configured; whisper: whisper-cli not found"}`), exit); err == nil ||
+		!strings.Contains(err.Error(), "whisper-cli not found") {
+		t.Errorf("structured error = %v, want it to carry the stderr reason", err)
+	}
+	if err := transcribeError(nil, notFound); err == nil || !strings.Contains(err.Error(), "uv tool install") {
+		t.Errorf("missing-command error = %v, want the install line", err)
+	}
+	if err := transcribeError([]byte("not json"), exit); err == nil {
+		t.Errorf("bare failure error = nil, want a non-nil error")
 	}
 }


### PR DESCRIPTION
## Problem

WhatsApp voice notes were transcribed by whisper.cpp bindings compiled into the whatsapp Go daemon, so a user's configured STT provider (Deepgram, through the voice skill) never touched them, and a bad or truncated whisper transcript had no sanctioned way to be redone. #1997 (whose provider code this PR carries) added a provider-agnostic one-shot transcription to the voice skill and had the Go daemon try it first and fall back to whisper in Go, leaving two transcription paths and a decision table in the daemon. #2004 documented a manual Deepgram curl that read the key out of `~/.voice/voice_config.json` by hand, a recipe in the wrong skill.

## Change

- **`transcribe <file> [--language <code>]`**, a second `[project.scripts]` entry of the voice skill's CLI (`agent/skills/voice/cli/src/voice/transcribe.py`): configured STT provider first, the whisper skill's `whisper_transcribe.sh` when STT is unset, disabled, or the provider fails; transcript-only stdout, `{"error": ...}` on stderr plus a non-zero exit only when both fail. Whisper's bracketed silence tags (`[BLANK_AUDIO]`, `[Musica]`) are dropped to an empty transcript. `voice-keys` is unchanged.
- **Provider code from #1997**: `SttProvider.transcribe_file`, the Deepgram prerecorded Nova-3 implementation (`language=multi` detects the spoken language unless `--language` pins one), and the `provider_name` / `provider_creds` / `is_enabled` helpers moved into `config.py` so `handlers.py` and `transcribe` share one owner.
- **whatsapp Go**: `transcribeAudioMessage` shells `transcribe <file>` (passing `WHISPER_LANGUAGE` as `--language`) and nothing else; the in-Go whisper call, its decision table, and the `WhisperMaxThreads` / `DefaultWhisperModelPath` constants are gone. A missing command errors with the install line, so the notification the agent reads says what to fix. `go.mod` still pins the whisper.cpp binding because `build-whisper.sh` reads that pin for the static-lib build; dropping the cgo build is a separate PR.
- **Migration** `agent/core/migrations/2026-09-voice-transcribe-command.md`: re-run `uv tool install --editable ~/agent/skills/voice/cli` (a plain re-run reinstalls an editable tool and emits the new script; verified with an isolated `UV_TOOL_DIR`), then check that the box has an enabled STT provider or `whisper-cli`, since the image ships whisper.cpp only as static libs for the Go build and a box with neither would lose voice-note transcription.
- **Docs**: one paragraph plus two examples in the voice SKILL.md, the reinstall note in its SETUP.md, a `## Voice notes` section in the whatsapp SKILL.md (`download-media` then `transcribe`), and the whatsapp SETUP.md transcription section rewritten for the new mechanism.

## Evidence

- `cd agent/skills/voice/cli && uv run pytest -q`: 52 passed (17 new in `tests/test_transcribe.py`: Deepgram parsing and params, whisper tag-only vs real output, provider-only stdout, empty provider transcript stays silence, whisper answers for unset/disabled/provider-error, both-fail stderr envelope, missing script, missing file).
- `./check.sh whatsapp`: gofmt, vet, build, and tests pass (`TestTranscribeArgsCarryTheLanguagePin`, `TestTranscribeError`).
- `./check.sh guards`: pass. `uvx ruff format` + `uvx ruff check` on the voice CLI: clean. `uv run --project core pytest tests/test_migrations.py tests/test_deployment.py tests/test_config.py`: 80 passed.
- `uv tool install --editable` re-run into an isolated tool dir: "Installed 3 executables: transcribe, voice-keys, voice-server"; `transcribe --help` exits 0, `transcribe /nonexistent.ogg` prints `{"error": "file not found: ..."}` on stderr and exits 1.

Supersedes #1997, #2004.
