### PR TITLE
feat(calendar): mark events the agent created on both backends

### DIFF
--- a/agent/skills/microsoft/cli/src/microsoft_cli/calendar.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/calendar.py
@@ -8,7 +8,7 @@ import httpx
 
 from . import auth, graph
 from .config import Config
-from .payloads import EventFields, EventPatch
+from .payloads import AGENT_EVENT_CATEGORY, EventFields, EventPatch
 
 
 def _validate_timezone(timezone: str) -> None:
@@ -79,9 +79,9 @@ def list_events(
         account_id = auth.get_account_id_by_email(account_email, config.cache_file)
 
         if include_details:
-            select = "id,subject,start,end,location,body,attendees,organizer,isAllDay,recurrence,onlineMeeting,seriesMasterId"
+            select = "id,subject,start,end,location,body,attendees,organizer,isAllDay,recurrence,onlineMeeting,seriesMasterId,categories"
         else:
-            select = "id,subject,start,end,location,organizer,seriesMasterId"
+            select = "id,subject,start,end,location,organizer,seriesMasterId,categories"
 
         if calendar_name:
             calendar_id = _get_calendar_id_by_name(config, client, account_id, calendar_name)
@@ -189,6 +189,8 @@ def create_event(config: Config, client: httpx.Client, *, account_email: str, ev
             "start": {"dateTime": start, "timeZone": timezone},
             "end": {"dateTime": end, "timeZone": timezone},
         }
+
+    payload["categories"] = [AGENT_EVENT_CATEGORY]
 
     if event.location:
         payload["location"] = {"displayName": event.location}

--- a/agent/skills/microsoft/cli/src/microsoft_cli/format.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/format.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from .payloads import AGENT_EVENT_CATEGORY
+
 
 def strip_odata(obj: Any) -> Any:
     """Recursively drop keys starting with `@odata.` from dicts and lists."""
@@ -44,17 +46,20 @@ def format_email_list(emails: list[dict[str, Any]]) -> str:
 
 
 def format_calendar_event_list(events: list[dict[str, Any]]) -> str:
-    """One line per event: start  end  subject  location  id."""
+    """One line per event: start  end  subject  location  id. An event the agent created gets a `[vesta]` prefix on its subject."""
     if not events:
         return "(no events)"
-    return "\n".join(
-        f"{_trunc(_pick(e, 'start', 'dateTime'), 20)}\t"
-        f"{_trunc(_pick(e, 'end', 'dateTime'), 20)}\t"
-        f"{_trunc(_pick(e, 'subject'), 80)}\t"
-        f"{_trunc(_pick(e, 'location', 'displayName'), 32)}\t"
-        f"{_pick(e, 'id')}"
-        for e in events
-    )
+    rows = []
+    for e in events:
+        mark = f"[{AGENT_EVENT_CATEGORY}] " if AGENT_EVENT_CATEGORY in (e["categories"] if "categories" in e else []) else ""
+        rows.append(
+            f"{_trunc(_pick(e, 'start', 'dateTime'), 20)}\t"
+            f"{_trunc(_pick(e, 'end', 'dateTime'), 20)}\t"
+            f"{mark}{_trunc(_pick(e, 'subject'), 80)}\t"
+            f"{_trunc(_pick(e, 'location', 'displayName'), 32)}\t"
+            f"{_pick(e, 'id')}"
+        )
+    return "\n".join(rows)
 
 
 def format_folder_list(folders: list[dict[str, Any]]) -> str:

--- a/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/owa_rest.py
@@ -29,7 +29,7 @@ import httpx
 
 from . import auth
 from .config import OWA_REST_SCOPES, read_json_marker
-from .payloads import EventFields, EventPatch, MailDraft
+from .payloads import AGENT_EVENT_CATEGORY, EventFields, EventPatch, MailDraft
 from .settings import OWA_REST_CLIENT_ID
 
 OWA_REST_BASE = "https://outlook.office.com/api/v2.0"
@@ -662,7 +662,7 @@ def delete_folder(client: httpx.Client, account_email: str, config, *, folder_id
 # Calendar
 # ---------------------------------------------------------------------------
 
-_EVENT_SELECT = "id,subject,start,end,location,organizer,isAllDay,attendees,body,bodyPreview"
+_EVENT_SELECT = "id,subject,start,end,location,organizer,isAllDay,attendees,body,bodyPreview,categories"
 
 
 def list_events(client: httpx.Client, account_email: str, config, *, start_utc: str, end_utc: str, limit: int = 100) -> list[dict]:
@@ -694,6 +694,7 @@ def create_event(client: httpx.Client, account_email: str, config, *, event: Eve
         "start": {"dateTime": event.start, "timeZone": event.timezone},
         "end": {"dateTime": event.end, "timeZone": event.timezone},
         "isAllDay": event.is_all_day,
+        "categories": [AGENT_EVENT_CATEGORY],
     }
     if event.body:
         payload["body"] = {"contentType": "Text", "content": event.body}

--- a/agent/skills/microsoft/cli/src/microsoft_cli/payloads.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/payloads.py
@@ -8,6 +8,10 @@ not support a field simply ignores it.
 
 import dataclasses
 
+# Stamped on every event this CLI creates and selected by every event read, so an entry the
+# agent put on the calendar never reads back as a plan the user made.
+AGENT_EVENT_CATEGORY = "vesta"
+
 
 @dataclasses.dataclass(frozen=True)
 class MailDraft:

--- a/agent/skills/microsoft/cli/tests/test_calendar_agent_events.py
+++ b/agent/skills/microsoft/cli/tests/test_calendar_agent_events.py
@@ -1,0 +1,109 @@
+"""Events the agent creates carry the agent category, and every read shows it."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+from microsoft_cli import calendar, owa_rest
+from microsoft_cli import format as fmt
+from microsoft_cli.config import Config
+from microsoft_cli.payloads import AGENT_EVENT_CATEGORY, EventFields
+
+ACCOUNT = "user@example.com"
+EVENT = EventFields(subject="Standup", start="2026-08-15T10:00:00", end="2026-08-15T10:30:00", timezone="UTC")
+
+
+def _owa_cfg(tmp_path: Path) -> SimpleNamespace:
+    cfg = SimpleNamespace(data_dir=tmp_path)
+    owa_rest.save_token(ACCOUNT, cfg, token="test-tok", expires_at=time.time() + 7200)
+    return cfg
+
+
+def _owa_client(json_response: dict) -> httpx.Client:
+    mock = MagicMock(spec=httpx.Client)
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.content = b"{}"
+    resp.json.return_value = json_response
+    resp.raise_for_status = MagicMock()
+    mock.get.return_value = resp
+    mock.post.return_value = resp
+    return mock
+
+
+def _event(subject: str, categories: list[str] | None = None) -> dict:
+    row = {
+        "id": "evt1",
+        "subject": subject,
+        "start": {"dateTime": "2026-08-15T10:00:00"},
+        "end": {"dateTime": "2026-08-15T10:30:00"},
+        "location": {"displayName": "Zoom"},
+    }
+    if categories is not None:
+        row["categories"] = categories
+    return row
+
+
+def test_graph_create_event_stamps_the_agent_category(monkeypatch):
+    posted: list[dict] = []
+
+    def request(_config, _client, method, path, _account_id, **kwargs):
+        posted.append(kwargs["json"])
+        return {"id": "evt1"}
+
+    monkeypatch.setattr(calendar.auth, "get_account_id_by_email", lambda *_args: "acct-1")
+    monkeypatch.setattr(calendar.graph, "request_cfg", request)
+
+    calendar.create_event(Config(), None, account_email=ACCOUNT, event=EVENT)
+
+    assert posted[0]["categories"] == [AGENT_EVENT_CATEGORY]
+
+
+def test_owa_rest_create_event_stamps_the_agent_category(tmp_path):
+    client = _owa_client({"Id": "evt1"})
+
+    owa_rest.create_event(client, ACCOUNT, _owa_cfg(tmp_path), event=EVENT)
+
+    assert client.post.call_args.kwargs["json"]["Categories"] == [AGENT_EVENT_CATEGORY]
+
+
+def test_both_backends_select_categories_on_every_event_read(tmp_path, monkeypatch):
+    selects: list[str] = []
+
+    def paginate(_config, _client, _endpoint, _account_id, **kwargs):
+        selects.append(kwargs["params"]["$select"])
+        return iter(())
+
+    monkeypatch.setattr(calendar.auth, "get_account_id_by_email", lambda *_args: "acct-1")
+    monkeypatch.setattr(calendar.graph, "paginate_cfg", paginate)
+    calendar.list_events(Config(), None, account_email=ACCOUNT, include_details=True, user_timezone="UTC")
+    calendar.list_events(Config(), None, account_email=ACCOUNT, include_details=False, user_timezone="UTC")
+
+    client = _owa_client({"value": []})
+    owa_rest.list_events(client, ACCOUNT, _owa_cfg(tmp_path), start_utc="2026-08-15T00:00:00Z", end_utc="2026-08-16T00:00:00Z")
+    selects.append(client.get.call_args.kwargs["params"]["$select"])
+
+    assert [s.split(",")[-1] for s in selects] == ["categories", "categories", "Categories"]
+
+
+def test_list_prefixes_an_agent_created_event():
+    out = fmt.format_calendar_event_list([_event("Standup", ["Sport", AGENT_EVENT_CATEGORY])])
+    assert f"[{AGENT_EVENT_CATEGORY}] Standup" in out
+
+
+def test_list_leaves_a_user_event_alone():
+    out = fmt.format_calendar_event_list([_event("Dentist", []), _event("Offsite", ["Work"]), _event("Padel")])
+    assert f"[{AGENT_EVENT_CATEGORY}]" not in out
+    assert all(subject in out for subject in ("Dentist", "Offsite", "Padel"))
+
+
+def test_the_mark_keeps_the_row_shape():
+    marked = fmt.format_calendar_event_list([_event("Standup", [AGENT_EVENT_CATEGORY])]).split("\t")
+    plain = fmt.format_calendar_event_list([_event("Standup", [])]).split("\t")
+    assert len(plain) == 5
+    assert marked[2] == f"[{AGENT_EVENT_CATEGORY}] Standup"
+    assert marked[:2] + marked[3:] == plain[:2] + plain[3:]

--- a/agent/skills/microsoft/references/calendar.md
+++ b/agent/skills/microsoft/references/calendar.md
@@ -20,3 +20,4 @@ microsoft calendar delete --account user@example.com --id <event_id>
 - `--no-cancellation` on `delete` skips notifying attendees.
 - `--no-details` on `list` returns compact output (no body/attendees); `--user-timezone` converts times to the given IANA timezone.
 - The reminder knob (`--reminder-on`/`--reminder-off`/`--reminder-minutes`) on `update` is Graph-only.
+- Every event `create` makes carries the `vesta` category on both backends, and `list` prefixes those subjects with `[vesta]`: an entry with that mark is your own suggestion, not a plan the user made, so never cite it as evidence of their intent.


### PR DESCRIPTION
## Problem

An event the agent creates is, once on the calendar, indistinguishable from one the user committed to, so the agent later reads its own suggestion back as evidence of the user's intent (#2090 saw this twice in two days: a festival saved from a social tip became the anchor of a travel plan, and a holiday block the agent had created was used to derive a date that was then put to the user as a question). A body convention cannot fix it because the compact `list` never selects bodies. #2090 stamped the Graph path only, so locked tenants on the OWA REST backend got nothing, and its third commit added a body-regex heuristic matching one agent's own phrases.

## Change

- `AGENT_EVENT_CATEGORY = "vesta"` lives in `payloads.py` (the leaf both `calendar.py` and `owa_rest.py` already import, and `format.py` can import without pulling in msal).
- `calendar.create_event` (Graph) and `owa_rest.create_event` (OWA REST) both stamp `categories: ["vesta"]` on every event they create. Not caller-supplied, so it cannot be forgotten at a call site. The OWA REST v2.0 Event resource documents `Categories` as writable, and the transport's key-case adapter sends it as `Categories`.
- Both Graph `$select` lists in `list_events` and `owa_rest._EVENT_SELECT` add `categories`, so every read (compact and detailed, Graph and OWA) carries the mark.
- `format_calendar_event_list` prefixes a stamped subject with `[vesta]` via one membership test; a row with no `categories` key stays unmarked. Row shape is unchanged (five tab-separated columns).
- One line in `references/calendar.md` telling the agent what the mark means.
- No `agent_authored()` heuristic, no `EventFields.categories` field.

## Evidence

`agent/skills/microsoft/cli/tests/test_calendar_agent_events.py`, six tests:

- `test_graph_create_event_stamps_the_agent_category`
- `test_owa_rest_create_event_stamps_the_agent_category`
- `test_both_backends_select_categories_on_every_event_read`
- `test_list_prefixes_an_agent_created_event`
- `test_list_leaves_a_user_event_alone`
- `test_the_mark_keeps_the_row_shape`

Commands run: `cd agent/skills/microsoft/cli && uv run pytest -q` (411 passed, was 405), `uvx ruff format` + `uvx ruff check` on the changed Python (clean), `./check.sh guards` (passed), em/en dash grep on the changed Markdown (empty).

fixes #2089

Supersedes #2090.
