### PR TITLE
docs(notifications): how to verify a rule fires

### DIFF
--- a/agent/skills/notifications/SKILL.md
+++ b/agent/skills/notifications/SKILL.md
@@ -59,6 +59,13 @@ notification's other fields. Every field/condition you set must hold (AND); what
   greetings, dreamer, proactive checks) are never affected by rules.
 - To make a source usually not interrupt, add a broad `--source X --action snooze` rule with the exceptions
   (narrower interrupt rules) above it; auto-placement usually handles the ordering.
+- **A rule in `list` is not a rule that fires; check for the effect.** A firing `trash` rule moves the
+  notification file into `~/agent/notifications/trash/`, so after a notification that should have matched,
+  look for it there: absent means the rule never matched, whatever `list` shows. Test a regex offline before
+  installing it, against values that must match and values that must not (`~=` is `re.search`, case-insensitive:
+  `python3 -c "import re; print(bool(re.search(r'@mkt\.', 'bill@utility.example', re.I)))"` must print
+  `False`), and prefer the narrowest pattern that does the job: a broad `trash` rule drops what mattered as
+  quietly as it drops the noise.
 
 ## Usage
 


### PR DESCRIPTION
## Problem

A `trash` rule that matches nothing is indistinguishable from a quiet inbox: `notifications list` shows the rule, nothing reaches the agent, and the quiet reads as "the rules work". #1966 (dory, v0.1.188) hit exactly that on a live box and proposed a 40-line "How to verify a rule is actually firing" section with two snippets. The notifications skill has no line telling the agent where a firing rule leaves evidence, or to test a pattern before installing it.

## Change

- One bullet at the end of "How matching works" in `agent/skills/notifications/SKILL.md`, matching the section's wrapped-bullet style: a rule in `list` is not a rule that fires; a firing `trash` rule moves the file into `~/agent/notifications/trash/` (`VestaConfig.notif_trash_dir`), so that folder is the positive control after a notification that should have matched; test a regex offline against values that must match and must not (`~=` is `re.search`, case-insensitive, with a one-line example that must print `False`); prefer the narrowest pattern, since a broad `trash` rule drops what mattered as quietly as the noise.
- Dropped #1966's "`sender` is the display name, `sender_address` is the address, put domains on `sender_address`" bullet. On master the `sender` alias already spans `sender_address` (`_IDENTITY_FIELDS` in `agent/core/notification_interrupt_policy.py`), and only the microsoft skill writes that field, so a rule targeting `sender_address` directly is the never-firing rule the section warns about.
- Dropped the two snippets: the config-readback one re-implemented `notifications list` over raw `/config`, and the trash-folder loop is replaced by naming the folder (`ls` is enough).
- Mechanism and constraint only, no incident narrative, per the `agent/` prose rule.

## Evidence

- `./check.sh guards`: exit 0 (ruff, format, conventions, shellcheck, dashboard sync).
- `grep -rnP '\x{2014}|\x{2013}' agent/skills/notifications/SKILL.md`: empty.
- The documented one-liner run locally prints `False`.
- Paths verified on master: `notif_trash_dir` = `notifications_dir / "trash"` = `~/agent/notifications/trash/` (`agent/core/config.py:565`), `_IDENTITY_FIELDS` includes `sender_address` (`agent/core/notification_interrupt_policy.py:36`).
- Docs only; no code paths touched.

fixes #1965

Supersedes #1966.
