### PR TITLE
chore(agent): ignore only the runtime data dir, not every data/

### DIFF
--- a/agent/.gitignore
+++ b/agent/.gitignore
@@ -21,8 +21,9 @@ htmlcov/
 .hypothesis/
 .tox/
 
-# Runtime data (local research, session state, secrets)
-data/
+# Runtime data (local research, session state, secrets), anchored so a nested data/ such as
+# skills/dashboard/app/src/data stays tracked
+/data/
 
 # Runtime memory (created at startup, not tracked)
 memory/conversations/


### PR DESCRIPTION
## Problem

`agent/.gitignore` line 25 read `data/`, an unanchored rule that matches every directory named `data` under `agent/`, when the only runtime data dir is the workspace root's `agent/data` (`VestaConfig.data_dir` is `agent_dir / "data"` in `core/config.py`). #2264 (by aria) hit the consequence on a real build: a dashboard page data file placed at `skills/dashboard/app/src/data/*.json` was silently untracked, never committed, and a clean checkout or reset lost it while the local build kept working because the file was on disk. #2264 documented the pitfall in the dashboard `SKILL.md`; this PR removes it instead. The repo fixed the same class once already when `/notifications/` was anchored in #890.

## Change

- `agent/.gitignore`: `data/` becomes `/data/`, so only `agent/data` (the runtime dir) is ignored and a nested `data/` such as `skills/dashboard/app/src/data` is tracked. The comment states the constraint (anchored, nested `data/` stays tracked) and nothing about the history.
- No docs change: with the rule anchored there is no pitfall to warn about, so the `SKILL.md` note from #2264 is not needed.

## Evidence

Premise on `master` (`9b83f62c`):
- `git check-ignore -v agent/skills/dashboard/app/src/data/x.json` matched `agent/.gitignore:25:data/`.
- `find agent -type d -name data -not -path '*/node_modules/*'` returned nothing, and `git ls-files agent | grep -E '(^|/)data/'` returned nothing: no nested `data/` exists or is tracked today.
- A grep of `agent/core` and `agent/skills` for code writing a nested `data/` found none: core writes `agent_dir / "data"`, app-chat defaults to `~/.app-chat`, microsoft to `~/.microsoft`, and the flat-checkout migration runs `mkdir -p agent/data` (the root runtime dir).

After the change:
- `git check-ignore -v agent/skills/dashboard/app/src/data/x.json` exits 1 (not ignored); `agent/core/data/x` and `agent/skills/foo/data/x` also exit 1.
- `git check-ignore -v agent/data/state.json agent/data/config.json` matches `agent/.gitignore:26:/data/` (still ignored).
- `./check.sh guards` exit 0.
- `grep -nP '\x{2014}|\x{2013}' agent/.gitignore` reports only the pre-existing #890 comment on line 35, untouched here.

Supersedes #2264.
