### PR TITLE
feat(pdf-text): flag fonts whose extracted text is invented

### DIFF
--- a/agent/skills/pdf-text/SKILL.md
+++ b/agent/skills/pdf-text/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: pdf-text
+description: Check a PDF before quoting text extracted from it. Use before quoting a figure, formula, symbol, amount, IBAN, reference code, meter reading, or deadline from any PDF, because an extractor can print letters the page never contained.
+---
+
+# PDF text (CLI: pdf-text)
+
+A text extractor never says it could not read a character. A Type0 font with Identity-H encoding stores glyph indices, not characters, and its ToUnicode CMap is the only route from an index to a character. When that CMap is absent or maps nothing, the extractor prints the raw index as a letter: index 0x56 comes out as `V`, so a page reading `sigma = 0.75` extracts as `V 0.75`. The result is a well formed sentence with letters the author never wrote, and nothing downstream can tell. `pdffonts` reports `uni yes` for exactly this font, because its column asks whether a ToUnicode object exists, not whether it maps anything.
+
+Symbol and math fonts are where this bites: a lone capital letter where a symbol belongs is the tell.
+
+## Setup
+
+```bash
+uv tool install --editable ~/agent/skills/pdf-text/cli
+```
+
+## Usage
+
+```bash
+pdf-text paper.pdf
+```
+
+Exit 0 with no output: every Type0/Identity-H font in the file maps to Unicode, so quote the extracted text.
+
+Exit 1 with one line per font that cannot map, naming the pages that carry it:
+
+```
+UWPNAD+SymbolMT pages 12,41,42
+```
+
+The check does not know what the characters really are; only the rendered page does. For every listed page, render it and read the image instead of the extracted text:
+
+```bash
+uv run --with PyMuPDF python3 -c 'import pymupdf, sys; pymupdf.open(sys.argv[1])[int(sys.argv[2]) - 1].get_pixmap(dpi=150).save(sys.argv[3])' paper.pdf 41 /tmp/paper-p41.png
+```
+
+Then open `/tmp/paper-p41.png` with the Read tool and quote from what you see.
+
+Exit 2 with the reason on stderr: the file is missing or is not a PDF.

--- a/agent/skills/pdf-text/cli/.gitignore
+++ b/agent/skills/pdf-text/cli/.gitignore
@@ -1,0 +1,4 @@
+build/
+*.egg-info/
+__pycache__/
+*.pyc

--- a/agent/skills/pdf-text/cli/pyproject.toml
+++ b/agent/skills/pdf-text/cli/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "pdf-text"
+version = "0.1.0"
+description = "Flag PDF fonts whose extracted text is invented"
+requires-python = ">=3.11"
+dependencies = [
+    "pymupdf>=1.24.0",
+]
+
+[project.scripts]
+pdf-text = "pdf_text_cli.cli:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/pdf_text_cli"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/agent/skills/pdf-text/cli/src/pdf_text_cli/cli.py
+++ b/agent/skills/pdf-text/cli/src/pdf_text_cli/cli.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+import pymupdf
+
+USAGE = "usage: pdf-text <file.pdf>"
+
+
+def maps_to_unicode(doc: pymupdf.Document, font_xref: int) -> bool:
+    kind, value = doc.xref_get_key(font_xref, "ToUnicode")
+    if kind != "xref":
+        return False
+    cmap = doc.xref_stream(int(value.split()[0]))
+    return b"beginbfchar" in cmap or b"beginbfrange" in cmap
+
+
+def unmappable_fonts(doc: pymupdf.Document) -> dict[str, set[int]]:
+    """Base font name to the 1-based pages carrying a Type0/Identity-H font whose ToUnicode maps nothing."""
+    flagged: dict[str, set[int]] = {}
+    for page in doc:
+        for xref, _ext, kind, basefont, _name, encoding, _referencer in page.get_fonts(full=True):
+            if kind != "Type0" or encoding != "Identity-H" or maps_to_unicode(doc, xref):
+                continue
+            if basefont not in flagged:
+                flagged[basefont] = set()
+            flagged[basefont].add(page.number + 1)
+    return flagged
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 1:
+        print(USAGE, file=sys.stderr)
+        return 2
+    try:
+        doc = pymupdf.open(Path(args[0]))
+    except (pymupdf.FileNotFoundError, pymupdf.FileDataError) as exc:
+        print(f"pdf-text: {exc}", file=sys.stderr)
+        return 2
+    flagged = unmappable_fonts(doc)
+    for basefont, pages in flagged.items():
+        print(f"{basefont} pages {','.join(str(page) for page in sorted(pages))}")
+    return 1 if flagged else 0

--- a/agent/skills/pdf-text/cli/tests/test_cli.py
+++ b/agent/skills/pdf-text/cli/tests/test_cli.py
@@ -1,0 +1,73 @@
+import pathlib as pl
+
+import pymupdf
+import pytest
+from pdf_text_cli import cli
+
+EMPTY_CMAP = b"/CIDInit /ProcSet findresource begin\nbegincmap\n1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\nendcmap\nend\n"
+MAPPED_CMAP = EMPTY_CMAP.replace(b"endcmap", b"1 beginbfchar\n<0056> <03C3>\nendbfchar\nendcmap")
+BROKEN = "/Type /Font /Subtype /Type0 /BaseFont /BBBBBB+Broken /Encoding /Identity-H"
+MAPPED = "/Type /Font /Subtype /Type0 /BaseFont /CCCCCC+Mapped /Encoding /Identity-H"
+PLAIN = "/Type /Font /Subtype /TrueType /BaseFont /AAAAAA+Plain /Encoding /WinAnsiEncoding"
+
+
+def add_font(doc: pymupdf.Document, page: pymupdf.Page, resource: str, font: str, cmap: bytes | None) -> None:
+    if cmap is not None:
+        cmap_xref = doc.get_new_xref()
+        doc.update_object(cmap_xref, "<<>>")
+        doc.update_stream(cmap_xref, cmap)
+        font = f"{font} /ToUnicode {cmap_xref} 0 R"
+    font_xref = doc.get_new_xref()
+    doc.update_object(font_xref, f"<< {font} >>")
+    resources_xref = int(doc.xref_get_key(page.xref, "Resources")[1].split()[0])
+    doc.xref_set_key(resources_xref, f"Font/{resource}", f"{font_xref} 0 R")
+
+
+def write_pdf(path: pl.Path, pages: list[list[tuple[str, str, bytes | None]]]) -> pl.Path:
+    doc = pymupdf.open()
+    for fonts in pages:
+        page = doc.new_page()
+        for resource, font, cmap in fonts:
+            add_font(doc, page, resource, font, cmap)
+    doc.save(path)
+    return path
+
+
+def test_identity_h_font_with_an_empty_tounicode_is_flagged_with_its_pages(tmp_path, capsys):
+    pdf = write_pdf(
+        tmp_path / "broken.pdf",
+        [[("FOK", PLAIN, None)], [("FBAD", BROKEN, EMPTY_CMAP)], [("FBAD", BROKEN, EMPTY_CMAP), ("FOK", PLAIN, None)]],
+    )
+    assert cli.main([str(pdf)]) == 1
+    assert capsys.readouterr().out == "BBBBBB+Broken pages 2,3\n"
+
+
+def test_identity_h_font_with_no_tounicode_is_flagged(tmp_path, capsys):
+    pdf = write_pdf(tmp_path / "missing.pdf", [[("FBAD", BROKEN, None)]])
+    assert cli.main([str(pdf)]) == 1
+    assert capsys.readouterr().out == "BBBBBB+Broken pages 1\n"
+
+
+@pytest.mark.parametrize(
+    "fonts",
+    [
+        [("FOK", MAPPED, MAPPED_CMAP)],
+        [("FOK", PLAIN, None)],
+        [],
+    ],
+)
+def test_mapped_and_simple_fonts_are_silent(tmp_path, capsys, fonts):
+    pdf = write_pdf(tmp_path / "clean.pdf", [fonts])
+    assert cli.main([str(pdf)]) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_unreadable_input_fails_on_stderr(tmp_path, capsys):
+    junk = tmp_path / "junk.pdf"
+    junk.write_bytes(b"not a pdf")
+    assert cli.main([str(junk)]) == 2
+    assert cli.main([str(tmp_path / "absent.pdf")]) == 2
+    assert cli.main([]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.count("\n") == 3

--- a/agent/skills/pdf-text/cli/uv.lock
+++ b/agent/skills/pdf-text/cli/uv.lock
@@ -1,0 +1,101 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pdf-text"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pymupdf" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pymupdf", specifier = ">=1.24.0" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.4.0" }]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.28.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/fb/b6761fa2d5266f2cdb24c3b91f4023070ab7848381417678e7a289a1d52a/pymupdf-1.28.2.tar.gz", hash = "sha256:5e0be7908a715aa20333caddd73f1d6f01e4cd0c26e869fa2dd0b7f344da2249", size = 87903557, upload-time = "2026-08-06T21:43:23.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/51/550c9a75c4ff3245cb4ecb7bb95cbe2ab7374230b8e2b7a1f7259444150b/pymupdf-1.28.2-cp310-abi3-macosx_10_15_x86_64.whl", hash = "sha256:5fc315b425ff1f7afdd1ea2f348205cb19b806767daae7ce4d64115799c2bae1", size = 24645079, upload-time = "2026-08-06T21:37:25.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/3591f781b417b382a8487a2356e927acfe858b1043bab0ec47f6805bb109/pymupdf-1.28.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:7113846b35dbf0a033f088e4f4fb543dabeb4b0b12c112966a1ca1ee2d5eacae", size = 23875605, upload-time = "2026-08-06T21:37:40.369Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/86/4a68f080b71b46802178346af46486e1697508e760855ff5f3b218a6dff7/pymupdf-1.28.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3050a233dde1211efe89ada74e2add6238436434159f46097a1423aad2842545", size = 25095554, upload-time = "2026-08-06T21:37:58.485Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/06/dace3e27af26690cb20bead80dbac42941b0841eb689b8aabbd67dde16f0/pymupdf-1.28.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:397d6715c1f0df7548a92d0afd8ce370fc48fa47aeefac16be2bc04a16a8227f", size = 25762500, upload-time = "2026-08-06T21:38:17.438Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/61/4146dfa1d8172a1ce8d59f0eed94896ddefb8deb2274534d0522fbb8abf5/pymupdf-1.28.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f89fb2d86d07d643a269f17a093105057e20c79c1d06c103b53600067b6d2b01", size = 25986309, upload-time = "2026-08-06T21:38:35.472Z" },
+    { url = "https://files.pythonhosted.org/packages/52/60/1fb6e64676f7500ebe89054b9e5bbbe14d3101c92d5f1a40ac9a35227673/pymupdf-1.28.2-cp310-abi3-win32.whl", hash = "sha256:530ef543a3885b3b81cb72a854e7c5a625a9233201221132bb6c31698c6a2bdb", size = 18525353, upload-time = "2026-08-06T21:38:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/61/d563bbccba262f9dd6d2d35ccb72593648184d886188efb12d9ce8f34dd6/pymupdf-1.28.2-cp310-abi3-win_amd64.whl", hash = "sha256:ebd244918798502d7b4504c90410d1711a4d7675a32584ca30f1bab419ecbffe", size = 19826532, upload-time = "2026-08-06T21:39:00.213Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/93/08f404a1f0155fe24137cf2d3aabd3e2b4b08c62053ed89c60f2611be3e9/pymupdf-1.28.2-cp310-abi3-win_arm64.whl", hash = "sha256:ffe91a24edc75c80da2a4b62f50fc0f54632d34fc8fe4cbc48e5c7ff07cf8fb4", size = 19759252, upload-time = "2026-08-06T21:39:12.937Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8c/d897dcd32a25b58186c968b15ce4324ca029e9d96460de12325314e390be/pymupdf-1.28.2-cp313-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:2e1b574c0fd2cb238021033fd3c0f9c4388816638df064e4bfb56d9d81736dc8", size = 18399403, upload-time = "2026-08-06T21:39:25.008Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f1/de34a1c53fe2bf8c6e71db84b0ced782d408970c9810d2b456a2ae96814c/pymupdf-1.28.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:fd481ed48bef56305c41fb7e05a055c03345c899c7b101dad086258b438f8168", size = 25802333, upload-time = "2026-08-06T21:39:41.426Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]


### PR DESCRIPTION
## Problem

`pdftotext` never says it could not read a character. A Type0 font with Identity-H encoding stores glyph indices, and its ToUnicode CMap is the only route from an index to a character; when that CMap is absent or defines nothing, poppler prints the raw index as a letter (index 0x56 comes out as `V`), so a page reading `sigma = 0.75` extracts as `V 0.75` with no error, no replacement character, and a well formed sentence around it. `pdffonts` reports `uni yes` for exactly this font because its column asks whether a ToUnicode object exists, not whether it maps anything, so a one-liner cannot catch it. #2019 found and verified this on a real working paper, but shipped it as a 417-line hand-rolled PDF parser (no xref streams, no object streams, so real documents scan empty and read as clean; module-level mutable state; `.get()`; bare excepts) plus a poppler dependency the agent image does not carry.

## Change

- New opt-in `pdf-text` skill with one console script, `pdf-text <file.pdf>`, in a `cli/` uv project on PyMuPDF (the PDF library `sign-service` already uses), installed with `uv tool install --editable` like every other `cli/` skill.
- The check is 43 lines: for each page's fonts (`page.get_fonts(full=True)`) it reads the font's `ToUnicode` stream and flags a Type0/Identity-H font whose CMap is absent or has no `beginbfchar`/`beginbfrange`. One line per flagged font naming the pages that carry it, exit 1; clean file exits 0 silent; missing or non-PDF input exits 2 with the reason on stderr.
- `SKILL.md` states the mechanism, the `pdffonts` trap, and the recovery: render each flagged page with `get_pixmap` and read the image instead of the extracted text.
- Tests build the synthetic PDFs through PyMuPDF's own object API (no raw PDF bytes): an Identity-H font with an empty CMap is flagged with its page list, one with no ToUnicode is flagged, a mapped Identity-H font and a simple WinAnsi font stay silent, and bad input fails on stderr.

## Evidence

- `cd agent/skills/pdf-text/cli && uv run pytest -q`: 6 passed (`test_identity_h_font_with_an_empty_tounicode_is_flagged_with_its_pages`, `test_identity_h_font_with_no_tounicode_is_flagged`, `test_mapped_and_simple_fonts_are_silent` x3, `test_unreadable_input_fails_on_stderr`).
- `uv run pdf-text` on a synthetic broken PDF prints `BBBBBB+Broken pages 1`, exit 1; on a non-PDF prints the reason on stderr, exit 2.
- `uvx ruff format` + `uvx ruff check` clean; `./check.sh guards` passes; no em or en dashes under `agent/skills/pdf-text`.

fixes #2018

Supersedes #2019.
