### PR TITLE
fix(microsoft): report a queued reply's real recipients, and two mail-reading recipes

### DIFF
--- a/agent/skills/microsoft/cli/src/microsoft_cli/email.py
+++ b/agent/skills/microsoft/cli/src/microsoft_cli/email.py
@@ -377,7 +377,7 @@ def _draft_reply_or_forward(config: Config, client: httpx.Client, account_id: st
     if not draft or "id" not in draft:
         raise ValueError("Failed to create reply/forward draft")
     draft_id = draft["id"]
-    _compose_over_quote(config, client, draft_id, account_id, mail.body, mail.html)
+    prefilled = _compose_over_quote(config, client, draft_id, account_id, mail.body, mail.html)
 
     updates: dict[str, Any] = {}
     if mail.subject:
@@ -392,7 +392,13 @@ def _draft_reply_or_forward(config: Config, client: httpx.Client, account_id: st
         graph.request_cfg(config, client, "PATCH", f"/me/messages/{draft_id}", account_id, json=updates)
 
     _attach_files(config, client, draft_id, mail.attachments, account_id)
-    return {"status": "drafted", "id": draft_id, "source_id": source_id}
+    return {
+        "status": "drafted",
+        "id": draft_id,
+        "source_id": source_id,
+        "to": ", ".join(mail.to) if mail.to else prefilled["to"],
+        "cc": ", ".join(mail.cc) if mail.cc else prefilled["cc"],
+    }
 
 
 def create_email_draft(config: Config, client: httpx.Client, *, account_email: str, mail: MailDraft) -> dict[str, Any]:
@@ -599,12 +605,15 @@ def _quote_to_html(quote: dict[str, Any]) -> str:
     return '<pre style="white-space:pre-wrap;font-family:inherit">' + html.escape(quote["content"]) + "</pre>"
 
 
-def _compose_over_quote(config: Config, client: httpx.Client, draft_id: str, account_id: str, body: str, html: bool) -> None:
+def _compose_over_quote(config: Config, client: httpx.Client, draft_id: str, account_id: str, body: str, html: bool) -> dict[str, str]:
     """Place `body` above the quoted original that createReply/createReplyAll/createForward
     pre-filled into draft `draft_id`. PATCHing `body` replaces the whole draft body, so the
     quote is read back first and written under the new text. A plain-text body renders through
-    `_reply_body_to_html`; an HTML body is used as is."""
-    existing = graph.request_cfg(config, client, "GET", f"/me/messages/{draft_id}", account_id, params={"$select": "body"})
+    `_reply_body_to_html`; an HTML body is used as is. The same read-back carries the recipients
+    Graph pre-filled (a reply goes to the source message's sender), returned as `to` and `cc`."""
+    existing = graph.request_cfg(
+        config, client, "GET", f"/me/messages/{draft_id}", account_id, params={"$select": "body,toRecipients,ccRecipients"}
+    )
     if not existing or "body" not in existing:
         raise ValueError("Failed to read the created draft")
     top = body if html else _reply_body_to_html(body)
@@ -616,6 +625,10 @@ def _compose_over_quote(config: Config, client: httpx.Client, draft_id: str, acc
         account_id,
         json={"body": {"contentType": "HTML", "content": top + "<br><br>" + _quote_to_html(existing["body"])}},
     )
+    return {
+        "to": _extract_addresses(existing["toRecipients"] if "toRecipients" in existing else []),
+        "cc": _extract_addresses(existing["ccRecipients"] if "ccRecipients" in existing else []),
+    }
 
 
 def reply_draft(
@@ -721,7 +734,8 @@ def _queue_draft(
     draft_id = str(draft["id"]) if "id" in draft else ""
     if not draft_id:
         raise ValueError("Microsoft Graph did not return an id for the pending draft")
-    recipients = ", ".join([*(mail.to or []), *(mail.cc or []), *(mail.bcc or [])]) or "thread recipients"
+    addressed = [draft["to"], draft["cc"]] if "to" in draft else [*(mail.to or []), *(mail.cc or [])]
+    recipients = ", ".join(part for part in [*addressed, *(mail.bcc or [])] if part)
     subject = mail.subject or f"{action} to {mail.reply_to_id or mail.forward_id}"
     queued = pending_send.enqueue(
         config.data_dir,

--- a/agent/skills/microsoft/cli/tests/test_draft.py
+++ b/agent/skills/microsoft/cli/tests/test_draft.py
@@ -57,7 +57,7 @@ def test_compose_requires_recipient(patched):
 
 def test_reply_draft_is_threaded_and_not_sent(patched):
     result = email.create_email_draft(Config(), None, account_email="me@example.com", mail=MailDraft(body="thanks", reply_to_id="orig-1"))
-    assert result == {"status": "drafted", "id": "reply-draft", "source_id": "orig-1"}
+    assert result == {"status": "drafted", "id": "reply-draft", "source_id": "orig-1", "to": "", "cc": ""}
     assert patched[0]["path"] == "/me/messages/orig-1/createReply"
     patch = _body_patch(patched)
     assert patch["path"] == "/me/messages/reply-draft"

--- a/agent/skills/microsoft/cli/tests/test_pending_send.py
+++ b/agent/skills/microsoft/cli/tests/test_pending_send.py
@@ -291,6 +291,43 @@ def test_graph_reply_all_creates_a_threaded_draft(tmp_path, monkeypatch):
     assert pending_send.list_pending(tmp_path)[0].action == "reply-all"
 
 
+def _patch_graph_reply_recipients(monkeypatch, calls, to, cc):
+    """Graph pre-fills a reply draft's recipients server-side; this fake reports them on the read-back."""
+    _patch_graph(monkeypatch, calls)
+    plain = email.graph.request_cfg
+
+    def request(config, client, method, path, account_id, **kwargs):
+        result = plain(config, client, method, path, account_id, **kwargs)
+        if method == "GET":
+            result["toRecipients"] = [{"emailAddress": {"address": addr}} for addr in to]
+            result["ccRecipients"] = [{"emailAddress": {"address": addr}} for addr in cc]
+        return result
+
+    monkeypatch.setattr(email.graph, "request_cfg", request)
+
+
+def test_a_queued_reply_to_the_accounts_own_message_reports_the_account_as_recipient(tmp_path, monkeypatch):
+    calls = []
+    config = Config(data_dir=tmp_path)
+    _patch_graph_reply_recipients(monkeypatch, calls, to=["me@example.com"], cc=[])
+
+    result = email.reply_to_email(config, None, account_email="me@example.com", email_id="my-sent-1", body="Following up")
+
+    assert result["status"] == "pending"
+    assert result["recipients"] == "me@example.com"
+    assert pending_send.list_pending(tmp_path)[0].public()["recipients"] == "me@example.com"
+
+
+def test_a_queued_reply_all_reports_the_threads_to_and_cc(tmp_path, monkeypatch):
+    calls = []
+    config = Config(data_dir=tmp_path)
+    _patch_graph_reply_recipients(monkeypatch, calls, to=["bob@example.com"], cc=["carol@example.com"])
+
+    result = email.reply_to_email(config, None, account_email="me@example.com", email_id="my-sent-1", body="Thanks all", reply_all=True)
+
+    assert result["recipients"] == "bob@example.com, carol@example.com"
+
+
 def test_graph_immediate_reply_with_attachments_sends_the_body_over_the_quote(tmp_path, monkeypatch):
     calls = []
     config = Config(data_dir=tmp_path)

--- a/agent/skills/microsoft/cli/tests/test_reply_draft.py
+++ b/agent/skills/microsoft/cli/tests/test_reply_draft.py
@@ -20,7 +20,7 @@ def _patch_graph(monkeypatch, calls, quote):
             return {"id": "reply-draft"}
         if method == "POST" and path.endswith("/createReplyAll"):
             return {"id": "replyall-draft"}
-        if method == "GET" and kwargs["params"]["$select"] == "body":
+        if method == "GET" and kwargs["params"]["$select"] == "body,toRecipients,ccRecipients":
             return {"body": quote}
         if method == "GET":
             return {

--- a/agent/skills/microsoft/references/email.md
+++ b/agent/skills/microsoft/references/email.md
@@ -18,6 +18,8 @@ microsoft email search --account user@example.com --query "invoice" --since 2021
 
 `send`, `reply`, and `forward` accept `--attachments file1 file2` and `--html` (treats `--body` as HTML). `forward` requires `--to` and also takes `--cc`.
 
+`reply` answers the message's sender, so when the latest message in the thread is the account's own, that sender is the account itself and the reply goes nowhere else. In that case use `--reply-all`, which addresses the original recipients, or `send --to <addr>` with the `RE:` subject; the `recipients` field of the queued send shows where it will go.
+
 ## Delayed send and undo
 
 Send, reply, and forward operations wait 30 seconds by default across all Microsoft accounts and both email backends. The delay is one persisted setting for the Microsoft client and cannot be overridden on an individual send:
@@ -106,3 +108,4 @@ microsoft email attachment --account user@example.com --id '<email_id>' --attach
 - `--no-attachments` on `email get` skips attachment metadata; `--save-to` overrides the auto-save path for the body.
 - **`email get` always saves the body to disk** under `~/.microsoft/emails/<account>/<timestamp>_<subject>_<id>.txt` (`<account>` is the `--account` address lowercased, every character that is not a letter or digit replaced by `_`) and strips it from the JSON response. The JSON returns `body: {saved_to, length, size_bytes, _note}` plus the legacy `body_saved_to`, `body_saved_size`, `body_length` fields, and a short `preview`. To inspect content, read the file at `body.saved_to`. The full `body.content` field is intentionally never returned inline to keep agent context small. Bodies over 5000 chars also surface a warning telling you to grep/crop before pasting snippets. `microsoft auth remove --account <email>` deletes that account's saved bodies together with its sign-in.
 - `--categories` on `email update` accepts multiple space-separated names; `--flagged`/`--unflagged` set or clear the follow-up flag.
+- **Which threads are waiting on whom.** "Nothing new arrived" says nothing about what already sits in a thread, so read both directions: `email list --folder sent --since <date> --limit N --json` and `email list --since <date> --limit N --json`. Group the two lists by `conversationId` and take each group's latest `receivedDateTime`. Compare that message's `from` to the account: their message last means the thread is waiting on you, your message last means you are waiting on them. A list that returns exactly `--limit` items did not read the whole window (the CLI prints a NOTE on stderr), so raise `--limit` before you call a thread unanswered.


### PR DESCRIPTION
## Problem

A queued `email reply` or `forward` reported its recipients as the literal placeholder `"thread recipients"` (#2034): Graph resolves a reply's recipients server-side from the source message, so `mail.to` is empty and the fallback always fired, on the command output and on `email pending` alike. That hides the one fact the undo window exists to expose: Graph's `createReply` addresses the source message's sender, so a reply into a thread whose latest message is the account's own goes straight back to the account, succeeds, drains, and lands in Sent Items with nothing to contradict it (#2035). Separately, #2300 (#2299) observed that "nothing new arrived" says nothing about what already sits in a thread, and asked for a command to say which conversations wait on whom; `email list --folder sent/inbox --since --json` already returns `conversationId`, `from`, and `receivedDateTime`, so the answer is a recipe, not a new command.

## Change

- `_compose_over_quote` already reads the created draft back for its quote; the same read now selects `body,toRecipients,ccRecipients` and returns the recipients Graph pre-filled as `to`/`cc`.
- `_draft_reply_or_forward` reports `to`/`cc` on its result (an explicit `--to`/`--cc` wins over the pre-fill, matching the PATCH it sends), and `_queue_draft` joins those with `--bcc` into the queued send's `recipients`, so the command output and `email pending` name the real destination. The placeholder is gone from the Graph path; the OWA REST path keeps its own draft flow and is unchanged.
- `references/email.md`: two sentences after the send/reply/forward paragraph stating that `reply` answers the sender, that this is the account itself when the latest message in the thread is its own, and to use `--reply-all` or `send --to <addr>` with the `RE:` subject instead. No new SKILL.md section, no table.
- `references/email.md` Notes: one bullet with the two-list recipe (`email list --folder sent --since <date> --limit N --json` plus `email list --since <date> --limit N --json`, group by `conversationId`, compare the latest message's `from` to the account), and the rule that exactly `--limit` items means the window was not fully read (the CLI prints a NOTE on stderr for that since #2363). No new command, no thresholds, no decisions file.

## Evidence

- New tests in `agent/skills/microsoft/cli/tests/test_pending_send.py`: `test_a_queued_reply_to_the_accounts_own_message_reports_the_account_as_recipient` (reply to the account's own sent message queues with `recipients == "me@example.com"`, on the result and on `list_pending`), `test_a_queued_reply_all_reports_the_threads_to_and_cc`.
- `test_draft.py` and `test_reply_draft.py` fakes updated for the widened `$select` and the `to`/`cc` fields on the draft result.
- `cd agent/skills/microsoft/cli && uv run pytest -q`: 426 passed.
- `uvx ruff format` + `uvx ruff check` on the changed Python: clean. `./check.sh guards`: passed. No em or en dashes in the changed Markdown.
- Flags in the recipe verified on master: `email list` takes `--folder` (`sent` is a well-known key), `--since`, `--limit`, `--json`; its rows carry `conversationId`, `from`, `receivedDateTime`.

fixes #2034
fixes #2299

Supersedes #2035, #2300.
