### PR TITLE
fix(flights): keep the cheapest nonstop when the page would drop every nonstop

### DIFF
--- a/agent/skills/flights/cli/src/flights_cli/cli.py
+++ b/agent/skills/flights/cli/src/flights_cli/cli.py
@@ -73,6 +73,13 @@ def _roundtrip_to_dict(outbound, inbound, currency: str = DEFAULT_CURRENCY) -> d
     }
 
 
+def _is_nonstop(row: dict) -> bool:
+    """A one-way row carries `stops`; a round-trip row is nonstop when both directions are."""
+    if "stops" in row:
+        return row["stops"] == 0
+    return row["outbound"]["stops"] == 0 and row["return"]["stops"] == 0
+
+
 @dataclasses.dataclass
 class FlightSearchQuery:
     """Bundled so adding a field does not trip PLR0913, the same reason DateSearchQuery exists."""
@@ -121,13 +128,19 @@ def _search_flights(query: FlightSearchQuery) -> list[dict]:
         if not results:
             return []
 
-        out = []
-        for r in results[: query.max_results]:
-            if isinstance(r, tuple):
-                out.append(_roundtrip_to_dict(r[0], r[1], query.currency))
-            else:
-                out.append(_flight_to_dict(r, query.currency))
-        return out
+        rows = [_roundtrip_to_dict(r[0], r[1], query.currency) if isinstance(r, tuple) else _flight_to_dict(r, query.currency) for r in results]
+        page = rows[: query.max_results]
+        # Short-haul connections often price below every nonstop, so a cheapest-first page can hold
+        # only connections while the nonstops sit past it and the route reads as connection-only.
+        omitted_nonstops = [row for row in rows[query.max_results :] if _is_nonstop(row)]
+        if omitted_nonstops and not any(_is_nonstop(row) for row in page):
+            page[-1] = min(omitted_nonstops, key=lambda row: row["price"])
+            print(
+                f"NOTE: omitted_nonstops: {len(omitted_nonstops) - 1}. The page held no nonstop, so the cheapest nonstop past "
+                "--max-results replaced its last row. Run the same search with --stops 0 to list every nonstop.",
+                file=sys.stderr,
+            )
+        return page
 
     except Exception as e:
         return [{"error": str(e), "origin": query.origin}]

--- a/agent/skills/flights/cli/tests/test_cli.py
+++ b/agent/skills/flights/cli/tests/test_cli.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import types
 from datetime import datetime
 
+import fli.search
+import pytest
 from fli.models import Airline, Airport, FlightLeg, FlightResult
 from flights_cli import cli as cli_mod
 
 
-def _flight() -> FlightResult:
+def _flight(price: float = 114.0, stops: int = 0) -> FlightResult:
     leg = FlightLeg(
         airline=Airline.BA,
         flight_number="BA123",
@@ -18,7 +21,34 @@ def _flight() -> FlightResult:
         arrival_datetime=datetime(2026, 9, 5, 12, 0),
         duration=120,
     )
-    return FlightResult(legs=[leg], price=114.0, currency="GBP", duration=120, stops=0)
+    return FlightResult(legs=[leg], price=price, currency="GBP", duration=120, stops=stops)
+
+
+def _search(monkeypatch: pytest.MonkeyPatch, results: list[FlightResult]) -> list[dict]:
+    monkeypatch.setattr(fli.search, "SearchFlights", lambda: types.SimpleNamespace(search=lambda filters, currency: results))
+    return cli_mod._search_flights(cli_mod.FlightSearchQuery(origin="FCO", destination="LHR", date="2026-09-05", max_results=10))
+
+
+def test_search_keeps_the_cheapest_nonstop_when_the_page_would_drop_every_nonstop(monkeypatch, capsys):
+    connections = [_flight(price=100.0 + i, stops=1) for i in range(10)]
+    out = _search(monkeypatch, [*connections, _flight(price=180.0), _flight(price=150.0)])
+    assert [r["price"] for r in out] == [100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0, 150.0]
+    assert [r["stops"] for r in out] == [1, 1, 1, 1, 1, 1, 1, 1, 1, 0]
+    assert "NOTE: omitted_nonstops: 1" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "results",
+    [
+        [_flight(price=100.0), *[_flight(price=101.0 + i, stops=1) for i in range(10)], _flight(price=120.0)],
+        [_flight(price=100.0 + i, stops=1) for i in range(12)],
+    ],
+    ids=["a nonstop already in the page", "no nonstop past the page"],
+)
+def test_search_returns_the_first_page_unchanged_otherwise(monkeypatch, capsys, results):
+    out = _search(monkeypatch, results)
+    assert [r["price"] for r in out] == [r.price for r in results[:10]]
+    assert capsys.readouterr().err == ""
 
 
 def test_flight_to_dict_reports_price_with_the_requested_currency():


### PR DESCRIPTION
## Problem

#2156 reported that a default `flights search` on some short-haul routes returns ten well-formed connecting itineraries and no nonstop, while the same search with `--stops 0` returns several. The output looks rich, so the agent reads it as "no direct flights" when several are bookable. The cause is not disjoint result sets from Google: `_search_flights` truncates fli's full result list at `[:max_results]` with no re-sort, and under the default `CHEAPEST` sort short-haul connections price below every nonstop, so the nonstops sit past position 10. #2156 read the truncated page and then paid a second `stops=0` network query, with a dedupe helper and a price re-sort, for rows the process already held.

## Change

- Build the result dicts for every row fli returned, then take the page. When the page holds no nonstop but the tail does, replace the page's last row with the cheapest tail nonstop and print one stderr NOTE in the CLI's existing note style: `NOTE: omitted_nonstops: K. ...` with the `--stops 0` follow-up. Zero extra network, no second query, no dedupe helper.
- A page that already holds a nonstop, or a tail with none, is returned unchanged, so an explicit `--stops 0` search and a route with no nonstop behave exactly as before.
- `_is_nonstop` reads a one-way row's `stops` and a round-trip row's `outbound`/`return` stops, so round trips get the same treatment (#2156 gated itself to one-way because its dict shape check could not see a round trip's stops).

## Evidence

`agent/skills/flights/cli/tests/test_cli.py`, no network (`SearchFlights` monkeypatched to return a fixed list):

- `test_search_keeps_the_cheapest_nonstop_when_the_page_would_drop_every_nonstop`: ten connections at 100..109 followed by nonstops at 180 and 150 returns the first nine connections plus the 150 nonstop, and stderr carries `NOTE: omitted_nonstops: 1`. Failed before the fix, passes after.
- `test_search_returns_the_first_page_unchanged_otherwise` (parametrized: a nonstop already in the page, no nonstop past the page): the first ten rows come back as-is with an empty stderr.

Commands: `cd agent/skills/flights/cli && uv run pytest -q` (5 passed), `uvx ruff format` + `uvx ruff check` from `agent/` on the two changed files (clean), `./check.sh guards` (All checks passed).

Supersedes #2156.
