### PR TITLE
fix(skills/upstream): refuse to publish the owner's identity

### DIFF
--- a/agent/skills/upstream/SKILL.md
+++ b/agent/skills/upstream/SKILL.md
@@ -123,6 +123,15 @@ are what separate the two.
 - **Strip personal information.** Upstream is public: no names, addresses, credentials,
   or one user's quirks. Describe the pattern, not the instance. A script that encodes your
   user's file names, language, headings, or box paths is workspace tooling: keep it local.
+  The wrapper enforces the name half of this rule: `pr create`, `issue create`, `pr comment`,
+  and `issue comment` refuse a `--body` that carries, as a whole word in any case, your
+  user's name from the `- **Name**:` line of `~/agent/MEMORY.md` or the stem of a
+  `~/.contacts/*.md` file, and exit 1 naming only the kind of match (`the user's name`,
+  `a contact's name`), never the word, because the refusal is itself printed into your
+  history. Words under four letters are not checked, so a short name still needs your own
+  read, as do addresses, handles, and a paraphrase that identifies someone by circumstance.
+  A refusal means rewrite the sentence around the pattern, never route the same text through
+  another flag.
 - **Evidence names what is in the diff.** Every test the PR body mentions exists in the
   diff by name, and the body pastes the run's count. A claim the diff does not contain is
   read as the behavior being untested, and it costs the PR its credibility.

--- a/agent/skills/upstream/cli/src/upstream_cli/cli.py
+++ b/agent/skills/upstream/cli/src/upstream_cli/cli.py
@@ -4,6 +4,7 @@ import argparse
 import base64
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -526,6 +527,51 @@ def _refuse_bad_title(title):
         print(f"Warning: {warning}", file=sys.stderr)
 
 
+IDENTITY_SENTINEL = "[Unknown]"
+IDENTITY_WORD = re.compile(r"[^\W\d_]+")
+MIN_IDENTITY_WORD_LEN = 4
+
+
+def identity_words(home: Path) -> dict[str, str]:
+    """Every word that names the owner, mapped to the kind of source it came from: the
+    `- **Name**:` line of MEMORY.md section 4 and the stem of each `~/.contacts/*.md`. A word
+    shorter than four letters is skipped, since a two- or three-letter name is also a common
+    word and refusing every body that carries it would block ordinary prose."""
+    names: list[tuple[str, str]] = []
+    memory = home / "agent/MEMORY.md"
+    for line in memory.read_text().splitlines() if memory.is_file() else []:
+        if line.startswith("- **Name**:"):
+            name = line.removeprefix("- **Name**:").split("(", maxsplit=1)[0].strip()
+            names.append(("the user's name", "" if name == IDENTITY_SENTINEL else name))
+    names.extend(("a contact's name", path.stem) for path in (home / ".contacts").glob("*.md"))
+    return {word: kind for kind, name in names for word in IDENTITY_WORD.findall(name.lower()) if len(word) >= MIN_IDENTITY_WORD_LEN}
+
+
+def refuse_identifying(body: str) -> str | None:
+    """The kind of identity word the body carries as a whole word in any case, or None for a
+    clean body. Never the word itself: the answer is printed, and the transcript it lands in is
+    one more place the owner's name must not appear."""
+    words = identity_words(Path.home())
+    for word in IDENTITY_WORD.findall(body.lower()):
+        if word in words:
+            return words[word]
+    return None
+
+
+def _refuse_identifying_body(body):
+    kind = refuse_identifying(body)
+    if kind is not None:
+        print(f"Error: body names the owner ({kind}); describe the pattern, not the person.", file=sys.stderr)
+        sys.exit(1)
+
+
+def comment_body(rest) -> str:
+    """The `--body` text of a comment call, in every spelling gh accepts for the flag."""
+    parts = [rest[i + 1] for i, arg in enumerate(rest[:-1]) if arg in ("--body", "-b")]
+    parts += [arg.removeprefix("--body=") for arg in rest if arg.startswith("--body=")]
+    return "\n".join(parts)
+
+
 def pr_create(rest):
     args = _parse_intercepted(
         {
@@ -542,12 +588,14 @@ def pr_create(rest):
         CREATE_UNSUPPORTED_HELP,
     )
     _refuse_bad_title(args.title)
+    _refuse_identifying_body(args.body)
     submit_pr(args)
 
 
 def issue_create(rest):
     args = _parse_intercepted({"--title": {"required": True}, "--body": {"default": ""}}, rest, CREATE_UNSUPPORTED_HELP)
     _refuse_bad_title(args.title)
+    _refuse_identifying_body(args.body)
     agent_name, vesta_version = resolve_agent_identity()
     token = get_installation_token()
     body = body_with_attribution(args.body, agent_name, vesta_version)
@@ -609,6 +657,8 @@ def main():
     elif args[:2] == ["pr", "list"] and "--mine" in args:
         pr_list_mine(args[2:])
     else:
+        if args[:2] in (["pr", "comment"], ["issue", "comment"]):
+            _refuse_identifying_body(comment_body(args[2:]))
         completed = _run_gh(get_installation_token(), args, capture=False)
         sys.exit(completed.returncode)
 

--- a/agent/skills/upstream/cli/tests/conftest.py
+++ b/agent/skills/upstream/cli/tests/conftest.py
@@ -10,6 +10,15 @@ SENTINEL = "ghs_SENTINELtoken1234567890abcdef"
 AGENT_IDENTITY = ("tester", "9.9.9")
 
 
+@pytest.fixture(autouse=True)
+def scratch_home(tmp_path, monkeypatch):
+    """Every test runs under an empty HOME, so the identity check never reads this machine's owner."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
 @pytest.fixture
 def agent_identity(monkeypatch):
     monkeypatch.setattr(cli, "resolve_agent_identity", lambda: AGENT_IDENTITY)

--- a/agent/skills/upstream/cli/tests/test_refuse_identifying.py
+++ b/agent/skills/upstream/cli/tests/test_refuse_identifying.py
@@ -1,0 +1,96 @@
+"""A body that names the owner is refused before anything reaches GitHub.
+
+Identity is read from the box, so each test writes its own under the scratch HOME conftest gives
+every test; nothing here depends on the machine running the suite."""
+
+import json
+
+import pytest
+from upstream_cli import cli
+
+from tests.test_dispatch import run_main
+
+OWNER_PROFILE = "## 4. USER PROFILE\n- **Name**: Zephrine Al Quillbrook\n"
+UNBORN_PROFILE = "## 4. USER PROFILE\n- **Name**: [Unknown]  (identity sentinel: keep it verbatim until birth fills it)\n"
+
+
+@pytest.fixture
+def box(scratch_home):
+    """An owner in MEMORY.md section 4 and one contact file, laid out as a box holds them."""
+    (scratch_home / "agent").mkdir()
+    (scratch_home / "agent" / "MEMORY.md").write_text(OWNER_PROFILE)
+    (scratch_home / ".contacts").mkdir()
+    (scratch_home / ".contacts" / "vandersloot-cofounder.md").write_text("# Q Vandersloot\n")
+    return scratch_home
+
+
+@pytest.mark.parametrize(
+    ("body", "kind"),
+    [
+        ("Zephrine asked for this", "the user's name"),
+        ("as QUILLBROOK's box does", "the user's name"),
+        ("vandersloot reported it", "a contact's name"),
+        ("(Vandersloot)", "a contact's name"),
+    ],
+)
+def test_a_body_naming_the_owner_or_a_contact_is_refused_by_kind(box, body, kind):
+    assert cli.refuse_identifying(body) == kind
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "describe the pattern, not the person",
+        "Zephrines and Quillbrooks are not whole words",
+        "Al is under four letters and not checked",
+        "",
+    ],
+)
+def test_a_clean_body_passes(box, body):
+    assert cli.refuse_identifying(body) is None
+
+
+def test_the_identity_sentinel_and_its_annotation_name_nobody(scratch_home):
+    (scratch_home / "agent").mkdir()
+    (scratch_home / "agent" / "MEMORY.md").write_text(UNBORN_PROFILE)
+    assert cli.refuse_identifying("unknown identity sentinel, verbatim until birth") is None
+
+
+def test_a_box_with_no_memory_and_no_contacts_refuses_nothing(scratch_home):
+    assert cli.refuse_identifying("Zephrine") is None
+
+
+def test_pr_create_refuses_before_pushing_and_never_prints_the_name(box, monkeypatch, capsys):
+    monkeypatch.setattr(cli, "submit_pr", lambda args: pytest.fail("pushed a body naming the owner"))
+    assert run_main(monkeypatch, ["gh", "pr", "create", "--title", "fix(a): b", "--body", "Zephrine saw this"]) == 1
+    err = capsys.readouterr().err
+    assert "body names the owner (the user's name); describe the pattern, not the person" in err
+    assert "Zephrine" not in err
+
+
+def test_issue_create_refuses_before_any_gh_call(box, monkeypatch, fake_gh, agent_identity, capsys):
+    record, _, _ = fake_gh
+    assert run_main(monkeypatch, ["gh", "issue", "create", "--title", "fix(a): b", "--body", "for vandersloot"]) == 1
+    assert "a contact's name" in capsys.readouterr().err
+    assert not record.exists()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["pr", "comment", "12", "--body", "Zephrine again"],
+        ["pr", "comment", "12", "--body=Zephrine again"],
+        ["issue", "comment", "12", "-b", "Zephrine again"],
+    ],
+)
+def test_a_comment_body_is_checked_in_every_flag_spelling(box, monkeypatch, fake_gh, capsys, argv):
+    record, _, _ = fake_gh
+    assert run_main(monkeypatch, ["gh", *argv]) == 1
+    assert "the user's name" in capsys.readouterr().err
+    assert not record.exists()
+
+
+def test_a_clean_comment_passes_through_untouched(box, monkeypatch, fake_gh):
+    record, _, _ = fake_gh
+    assert run_main(monkeypatch, ["gh", "pr", "comment", "12", "--body", "the pattern, not the person"]) == 0
+    assert json.loads(record.read_text())["argv"] == ["pr", "comment", "12", "--body", "the pattern, not the person"]


### PR DESCRIPTION
## Problem

Every agent files upstream work on behalf of one identifiable private person, and the only thing keeping that person's name out of a public PR, issue, or comment body was the "Strip personal information" rule in `SKILL.md`, read at exactly the moment the concrete example looks persuasive. #2163 reported a live near miss (a comment about to name the owner and another agent) and shipped a guard for it, but as a 559-line PreToolUse hook nothing on master registers (plus a heartbeat file to prove it), keyed on a `VESTA_OWNER` variable that does not exist, matching public hosts the skill's own `upstream gh` path never spells.

## Change

- `refuse_identifying(body) -> str | None` in `cli.py`: builds the identity word set from the `- **Name**:` line of `~/agent/MEMORY.md` section 4 (the `[Unknown]` sentinel and its annotation contribute nothing) and the stems of `~/.contacts/*.md`, matches whole words case-insensitively against the body, and returns only the kind of match (`the user's name`, `a contact's name`), never the word, since stderr lands in the agent's own history.
- Words under four letters are skipped, stated in the docstring: a two- or three-letter name is a common word too, and refusing every body that carries it would block ordinary prose.
- Called at the existing body chokepoint: `pr create` (before the push) and `issue create` (before the POST) exit 1 with `Error: body names the owner (<kind>); describe the pattern, not the person.`; the passthrough intercepts `--body`, `--body=`, and `-b` on `pr comment` and `issue comment` the same way.
- `SKILL.md`, under "Strip personal information": one paragraph stating the mechanism, what it does not cover (short names, addresses, handles, paraphrase), and that a refusal means rewriting the sentence, never routing the text through another flag.
- `conftest.py`: an autouse scratch `HOME` for the whole suite, so no test ever reads the identity of the machine running it.

## Evidence

`cd agent/skills/upstream/cli && uv run pytest -q`: 89 passed (73 before, 16 new in `tests/test_refuse_identifying.py`):

- `test_a_body_naming_the_owner_or_a_contact_is_refused_by_kind` (4 cases: owner word, upper-case possessive, contact stem, parenthesised)
- `test_a_clean_body_passes` (4 cases: clean prose, non-whole-word superstrings, a two-letter name part, empty)
- `test_the_identity_sentinel_and_its_annotation_name_nobody`
- `test_a_box_with_no_memory_and_no_contacts_refuses_nothing`
- `test_pr_create_refuses_before_pushing_and_never_prints_the_name`
- `test_issue_create_refuses_before_any_gh_call`
- `test_a_comment_body_is_checked_in_every_flag_spelling` (3 cases: `--body`, `--body=`, `-b`)
- `test_a_clean_comment_passes_through_untouched`

`uvx ruff format` + `uvx ruff check` clean on the changed files; `./check.sh guards` exit 0; `grep -rnP '\x{2014}|\x{2013}' agent/skills/upstream/SKILL.md` empty.

Supersedes #2163.
