### PR TITLE
fix(telegram,app-chat): protect bare domains in bubble lint

### DIFF
--- a/agent/skills/app-chat/cli/src/app_chat_cli/bubblelint.py
+++ b/agent/skills/app-chat/cli/src/app_chat_cli/bubblelint.py
@@ -19,6 +19,12 @@ BUBBLE_MAX_CHARS = 220  # a genuinely long single bubble
 _URL_RE = re.compile(r"https?://\S+")  # urls
 _DECIMAL_RE = re.compile(r"\b\d+[.,]\d+\b")  # decimals: 8.6, 86,5
 _INITIALISM_RE = re.compile(r"\b(?:[A-Za-z]\.){2,}")  # initialisms: W.A.S.T.E., U.K.
+# Bare, schemeless hostnames: UGG.co.uk, example.com, sub-domain.example.co.uk. A dot-connected
+# run with no interior whitespace is one token, never a full stop. Must run BEFORE _ABBR_RE, or an
+# interior segment on the abbreviation allowlist ("co.", "st.") gets blanked mid-host and forges a
+# false gap ("UGG.co.uk" -> "UGG. uk", which then trips). It matches no trailing dot, so a real stop
+# after a host ("go to example.com. then leave") is preserved and still caught.
+_HOST_RE = re.compile(r"\b[\w-]+(?:\.[\w-]+)+\b")
 # Abbreviations, an allowlist, so an unlisted one reads as a full stop. Every entry is a word
 # that is always followed by more, never one that can end a thought: protecting "etc." or "min."
 # would blank the stop in "eggs, milk, etc. also bread" and let the wall through. Dotted forms
@@ -40,7 +46,7 @@ _SPACE = " \t\r\n\v\f"
 
 def _strip_protected(text: str) -> str:
     """Blank out spans whose '.', '?' or '!' are not sentence boundaries."""
-    for rx in (_LIST_MARKER_RE, _URL_RE, _DECIMAL_RE, _INITIALISM_RE, _ABBR_RE, _ELLIPSIS_RE):
+    for rx in (_LIST_MARKER_RE, _URL_RE, _DECIMAL_RE, _INITIALISM_RE, _HOST_RE, _ABBR_RE, _ELLIPSIS_RE):
         text = rx.sub(" ", text)
     return text
 

--- a/agent/skills/app-chat/cli/tests/test_bubblelint.py
+++ b/agent/skills/app-chat/cli/tests/test_bubblelint.py
@@ -28,6 +28,10 @@ def test_bubble_lint_passes():
         "hmm... ok",
         "it's in main.py",
         "check example.com later",
+        # A bare multi-part domain is one token: an interior "co." must not read as a full
+        # stop, and a hyphenated multi-part host stays protected too.
+        "order off UGG.co.uk today, they do next-day",
+        "the site is sub-domain.example.co.uk honestly",
         # A multiline list is one send, each item a short thought: the line-leading
         # marker ("1.", "2)") must not read as a full stop.
         "1. eggs\n2. milk",
@@ -72,6 +76,8 @@ def test_text_after_full_stop():
         ("first. second.", True),
         ("first. second. third.", True),
         ("meet at 8.30 sharp", False),
+        ("order off ugg.co.uk today", False),
+        ("go to example.com. then leave", True),  # domain then a real second thought still trips
         ("the U.K. office opens at 9", False),
         ("check https://a.com/x.y now", False),
         ("e.g. this should not count", False),

--- a/agent/skills/telegram/cli/bubblelint.go
+++ b/agent/skills/telegram/cli/bubblelint.go
@@ -26,6 +26,12 @@ var (
 	bubbleURLRe        = regexp.MustCompile(`https?://\S+`)         // urls
 	bubbleDecimalRe    = regexp.MustCompile(`\b\d+[.,]\d+\b`)       // decimals: 8.6, 86,5
 	bubbleInitialismRe = regexp.MustCompile(`\b(?:[A-Za-z]\.){2,}`) // initialisms: W.A.S.T.E., U.K.
+	// Bare, schemeless hostnames: UGG.co.uk, example.com, sub-domain.example.co.uk. A dot-connected
+	// run with no interior whitespace is one token, never a full stop. Must run BEFORE bubbleAbbrRe,
+	// or an interior segment on the abbreviation allowlist ("co.", "st.") gets blanked mid-host and
+	// forges a false gap ("UGG.co.uk" -> "UGG. uk", which then trips). It matches no trailing dot, so
+	// a real stop after a host ("go to example.com. then leave") is preserved and still caught.
+	bubbleHostRe = regexp.MustCompile(`\b[\w-]+(?:\.[\w-]+)+\b`)
 	// Abbreviations, an allowlist, so an unlisted one reads as a full stop. Every entry is a word
 	// that is always followed by more, never one that can end a thought: protecting "etc." or "min."
 	// would blank the stop in "eggs, milk, etc. also bread" and let the wall through. Dotted forms
@@ -43,7 +49,7 @@ var (
 // stripProtected blanks out spans whose '.', '?' or '!' are not full stops, so
 // they cannot trip the lint.
 func stripProtected(text string) string {
-	for _, re := range []*regexp.Regexp{bubbleListMarkerRe, bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleAbbrRe, bubbleEllipsisRe} {
+	for _, re := range []*regexp.Regexp{bubbleListMarkerRe, bubbleURLRe, bubbleDecimalRe, bubbleInitialismRe, bubbleHostRe, bubbleAbbrRe, bubbleEllipsisRe} {
 		text = re.ReplaceAllString(text, " ")
 	}
 	return text

--- a/agent/skills/telegram/cli/bubblelint_test.go
+++ b/agent/skills/telegram/cli/bubblelint_test.go
@@ -28,6 +28,8 @@ func TestBubbleLintPasses(t *testing.T) {
 		"hmm... ok",                                     // ellipsis is a beat, not a full stop
 		"it's in main.py",                               // no whitespace gap, so not a full stop
 		"check example.com later",                       // no whitespace gap, so not a full stop
+		"order off UGG.co.uk today, they do next-day",   // bare multi-part domain: an interior "co." must not read as a full stop
+		"the site is sub-domain.example.co.uk honestly", // hyphenated multi-part host protected too
 		"1. eggs\n2. milk",                              // multiline numbered list: line-leading markers are not full stops
 		"1. eggs\n2) milk",                              // "2)" marker style is also exempt
 		"here are steps:\n1. open\n2. run",              // list under a lead-in line
@@ -84,6 +86,8 @@ func TestTextAfterFullStop(t *testing.T) {
 		{"first. second.", true},
 		{"first. second. third.", true},
 		{"meet at 8.30 sharp", false},
+		{"order off ugg.co.uk today", false},
+		{"go to example.com. then leave", true}, // domain then a real second thought still trips
 		{"the U.K. office opens at 9", false},
 		{"check https://a.com/x.y now", false},
 		{"e.g. this should not count", false},


### PR DESCRIPTION
## Problem

The bubble lint's `stripProtected` blanks each protected span with a space so its dots cannot read as full stops. The abbreviation allowlist contains `co.` and `st.`, so a bare schemeless domain like `UGG.co.uk` had its interior `co.` blanked mid-host, forging `UGG. uk`: a false full-stop gap that tripped the lint and blocked the send. The telegram and app-chat skills each carry their own copy of the lint and both had the bug.

## Change

- Add a host regex `\b[\w-]+(?:\.[\w-]+)+\b` (a dot-connected run with no interior whitespace and no trailing dot) to both skills' copies of the lint: `bubbleHostRe` in `agent/skills/telegram/cli/bubblelint.go` and `_HOST_RE` in `agent/skills/app-chat/cli/src/app_chat_cli/bubblelint.py`.
- Run the host regex before the abbreviation pass in the ordered strip list, so a bare multi-part host is consumed as one token before the abbreviation allowlist can blank an interior segment.
- The host regex matches no trailing dot, so a real full stop after a host (`go to example.com. then leave`) is preserved and still caught.

## Evidence

- telegram Go tests: `TestBubbleLintPasses` gains a bare multi-part domain and a hyphenated multi-part host; `TestTextAfterFullStop` gains `order off ugg.co.uk today -> false` and `go to example.com. then leave -> true`.
- app-chat Python tests: `test_bubble_lint_passes` and `test_text_after_full_stop` gain the same cases.
- `./check.sh telegram`, `./check.sh app-chat`, and `./check.sh guards` all pass locally.

Ports the fix from #2377 to the telegram and app-chat copies of the bubble lint.
