### PR TITLE
docs: close the linked issue when a PR resolves it

### DIFF
--- a/.claude/skills/upstream-triage/SKILL.md
+++ b/.claude/skills/upstream-triage/SKILL.md
@@ -50,6 +50,8 @@ Append an execution table to the report (item, sources, status) and keep it curr
 
 **Central close pass**, once every replacement PR has a number: close each superseded PR and the epic with one comment naming the replacement (`Superseded by #<new>: <one line on what changed in the fix>. Thank you for the diagnosis.`). Agents read PR comments, so the comment is how the filing agent learns what happened. Merge the fresh PRs in dependency order (the report names the order when PRs touch one file).
 
+**Close the linked issues too.** An agent files a PR and an issue as a pair, but a superseded PR is closed rather than merged, so its `Closes #N` never fires and the issue outlives the fix. So the backlog does not grow while PRs land: when a PR resolves an issue, close that issue in the same pass with a comment naming the PR that fixed it (a merged replacement) or the reason it will not be done (a `CLOSE` verdict). Find the linked issue in the superseded PR's body (`Closes #N` / `Fixes #N`) or by matching the problem. A fresh PR that itself carries `Closes #N` closes its issue on merge and needs no manual step.
+
 ## Files in this directory
 
 - `clusters.sh`: open bot PRs with touched files, grouped by shared file.

--- a/agent/skills/upstream/SKILL.md
+++ b/agent/skills/upstream/SKILL.md
@@ -113,9 +113,11 @@ are what separate the two.
   your problem, do not file a second: the maintainer keeps one fix per problem and closes
   the rest, so the duplicate costs a consolidation and adds nothing. Add your evidence as
   an issue if it is new.
-- **Issue, PR, or both?** Fix in your workspace: PR + issue, with `fixes #N` on its own
-  line in the PR body (never the commit). Problem in `agent/core/` (read-only): issue
-  only, with cause, file, line, and the fix you would make. No fix yet: issue only.
+- **Issue, PR, or both?** Fix in your workspace: PR + issue, with `Closes #N` on its own
+  line in the PR body (never the commit). GitHub closes the issue when that PR merges, so
+  the issue never lingers after the fix ships; a PR closed without merging does not fire it,
+  which is expected. Problem in `agent/core/` (read-only): issue only, with cause, file,
+  line, and the fix you would make. No fix yet: issue only.
 - **Strip the story.** Agent-facing files state mechanism and constraint, never what
   changed or the incident behind it; that goes in the commit and PR body. A code comment
   states the rule in one line, with no date and no PR number; a comment that needs a
@@ -146,7 +148,7 @@ git -C ~ remote set-url upstream https://github.com/elyxlz/vesta.git 2>/dev/null
 git -C ~ fetch upstream
 git -C ~ worktree add /tmp/vesta-pr -b feature/<name> upstream/master
 cd /tmp/vesta-pr   # apply changes, commit
-upstream gh pr create --title "fix(skills/x): ..." --body "...fixes #N"
+upstream gh pr create --title "fix(skills/x): ..." --body "...Closes #N"
 ```
 
 Branch off `upstream/master` only, never `agent-upstream` (a standalone snapshot with no


### PR DESCRIPTION
## Problem

A vesta agent files a PR and an issue as a pair, but when a PR is superseded it is closed, not merged, so its `Closes #N` never fires and the issue outlives the fix. Over two days ~30 PRs merged and ~50 closed, yet open issues barely moved (122 open, 89 agent-filed, most already resolved or obsolete).

## Change

- `agent/skills/upstream/SKILL.md`: an issue-resolving PR puts `Closes #N` in the body (was `fixes #N` in one narrow case); note that merge fires it and a closed-unmerged PR does not.
- `.claude/skills/upstream-triage/SKILL.md`: the central close pass now closes the linked issue too, naming the PR that fixed it or the reason it will not be done.

## Evidence

Docs only; `./check.sh guards` clean, no em/en dashes.